### PR TITLE
feat: add support for catalogs with glue implementation to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ lib/
 *.ipr
 *.iws
 *.iml
+
+.envrc*

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -1,0 +1,30 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+
+	"github.com/apache/iceberg-go/table"
+)
+
+type CatalogType string
+
+const (
+	REST     CatalogType = "rest"
+	Hive     CatalogType = "hive"
+	Glue     CatalogType = "glue"
+	DynamoDB CatalogType = "dynamodb"
+	SQL      CatalogType = "sql"
+)
+
+var (
+	// ErrNoSuchTable is returned when a table does not exist in the catalog.
+	ErrNoSuchTable = errors.New("table does not exist")
+)
+
+// Catalog for iceberg table operations like create, drop, load, list and others.
+type Catalog interface {
+	GetTable(ctx context.Context, identifier table.Identifier) (*table.Table, error)
+	ListTables(ctx context.Context, identifier table.Identifier) ([]*table.Table, error)
+	CatalogType() CatalogType
+}

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -24,7 +24,14 @@ var (
 
 // Catalog for iceberg table operations like create, drop, load, list and others.
 type Catalog interface {
-	GetTable(ctx context.Context, identifier table.Identifier) (*table.Table, error)
-	ListTables(ctx context.Context, identifier table.Identifier) ([]*table.Table, error)
+	GetTable(ctx context.Context, identifier table.Identifier) (CatalogTable, error)
+	ListTables(ctx context.Context, identifier table.Identifier) ([]CatalogTable, error)
 	CatalogType() CatalogType
+}
+
+// CatalogTable is the details of a table in a catalog.
+type CatalogTable struct {
+	Identifier  table.Identifier // this identifier may vary depending on the catalog implementation
+	Location    string           // URL to the table location
+	CatalogType CatalogType
 }

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -26,6 +26,7 @@ var (
 type Catalog interface {
 	GetTable(ctx context.Context, identifier table.Identifier) (CatalogTable, error)
 	ListTables(ctx context.Context, identifier table.Identifier) ([]CatalogTable, error)
+	LoadTable(ctx context.Context, table CatalogTable) (*table.Table, error)
 	CatalogType() CatalogType
 }
 

--- a/catalog/glue.go
+++ b/catalog/glue.go
@@ -104,6 +104,8 @@ func (c *GlueCatalog) LoadTable(ctx context.Context, catalogTable CatalogTable) 
 		return nil, err
 	}
 
+	fmt.Println("catalogTable.Location", catalogTable.Location)
+
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
 	iofs, err := io.LoadFS(map[string]string{}, catalogTable.Location)
 	if err != nil {

--- a/catalog/glue.go
+++ b/catalog/glue.go
@@ -1,0 +1,131 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+)
+
+var (
+	_ Catalog = (*GlueCatalog)(nil)
+)
+
+type GlueAPI interface {
+	GetTable(ctx context.Context, params *glue.GetTableInput, optFns ...func(*glue.Options)) (*glue.GetTableOutput, error)
+	GetTables(ctx context.Context, params *glue.GetTablesInput, optFns ...func(*glue.Options)) (*glue.GetTablesOutput, error)
+}
+
+type GlueCatalog struct {
+	glueSvc GlueAPI
+}
+
+func NewGlueCatalog(awscfg aws.Config) *GlueCatalog {
+	return &GlueCatalog{
+		glueSvc: glue.NewFromConfig(awscfg),
+	}
+}
+
+// GetTable loads a table from the Glue Catalog using the given database and table name.
+func (c *GlueCatalog) GetTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
+	database, tableName, err := identifierToGlueTable(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &glue.GetTableInput{DatabaseName: aws.String(database), Name: aws.String(tableName)}
+
+	tblRes, err := c.glueSvc.GetTable(ctx, params)
+	if err != nil {
+		if errors.Is(err, &types.EntityNotFoundException{}) {
+			return nil, ErrNoSuchTable
+		}
+		return nil, fmt.Errorf("failed to get table %s.%s: %w", database, tableName, err)
+	}
+
+	iofs, err := io.LoadFS(map[string]string{}, tblRes.Table.Parameters["metadata_location"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
+	}
+
+	icebergTable, err := table.NewFromLocation([]string{tableName}, tblRes.Table.Parameters["metadata_location"], iofs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create table from location %s.%s: %w", database, tableName, err)
+	}
+
+	return icebergTable, nil
+}
+
+// ListTables returns a list of iceberg tables in the given Glue database.
+func (c *GlueCatalog) ListTables(ctx context.Context, identifier table.Identifier) ([]*table.Table, error) {
+	database, err := identifierToGlueDatabase(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &glue.GetTablesInput{DatabaseName: aws.String(database)}
+
+	tblsRes, err := c.glueSvc.GetTables(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tables in namespace %s: %w", database, err)
+	}
+
+	var icebergTables []*table.Table
+
+	for _, tbl := range tblsRes.TableList {
+		// skip non iceberg tables
+		// TODO: consider what this would look like for non ICEBERG tables as you can convert them to ICEBERG tables via the Glue catalog API.
+		if tbl.Parameters["table_type"] != "ICEBERG" {
+			continue
+		}
+
+		iofs, err := io.LoadFS(map[string]string{}, tbl.Parameters["metadata_location"])
+		if err != nil {
+			return nil, fmt.Errorf("failed to load table %s.%s: %w", database, aws.ToString(tbl.Name), err)
+		}
+
+		icebergTable, err := table.NewFromLocation([]string{*tbl.Name}, tbl.Parameters["metadata_location"], iofs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create table from location %s.%s: %w", database, aws.ToString(tbl.Name), err)
+		}
+
+		icebergTables = append(icebergTables, icebergTable)
+	}
+
+	return icebergTables, nil
+}
+
+func (c *GlueCatalog) CatalogType() CatalogType {
+	return Glue
+}
+
+func identifierToGlueTable(identifier table.Identifier) (string, string, error) {
+	if len(identifier) != 2 {
+		return "", "", fmt.Errorf("invalid identifier, missing database name: %v", identifier)
+	}
+
+	return identifier[0], identifier[1], nil
+}
+
+func identifierToGlueDatabase(identifier table.Identifier) (string, error) {
+	if len(identifier) != 1 {
+		return "", fmt.Errorf("invalid identifier, missing database name: %v", identifier)
+	}
+
+	return identifier[0], nil
+}
+
+// GlueTableIdentifier returns a glue table identifier for an iceberg table in the format [database, table].
+func GlueTableIdentifier(database string, table string) table.Identifier {
+	return []string{database, table}
+}
+
+// GlueDatabaseIdentifier returns a database identifier for a Glue database in the format [database].
+func GlueDatabaseIdentifier(database string) table.Identifier {
+	return []string{database}
+}

--- a/catalog/glue_test.go
+++ b/catalog/glue_test.go
@@ -7,8 +7,83 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type mockGlueClient struct {
+	mock.Mock
+}
+
+func (m *mockGlueClient) GetTable(ctx context.Context, params *glue.GetTableInput, optFns ...func(*glue.Options)) (*glue.GetTableOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*glue.GetTableOutput), args.Error(1)
+}
+
+func (m *mockGlueClient) GetTables(ctx context.Context, params *glue.GetTablesInput, optFns ...func(*glue.Options)) (*glue.GetTablesOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*glue.GetTablesOutput), args.Error(1)
+}
+
+func TestGlueGetTable(t *testing.T) {
+	assert := require.New(t)
+
+	mockGlueSvc := &mockGlueClient{}
+
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Parameters: map[string]string{
+				"table_type":        "ICEBERG",
+				"metadata_location": "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
+			},
+		},
+	}, nil)
+
+	glueCatalog := &GlueCatalog{
+		glueSvc: mockGlueSvc,
+	}
+
+	table, err := glueCatalog.GetTable(context.TODO(), GlueTableIdentifier("test_database", "test_table"))
+	assert.NoError(err)
+	assert.Equal([]string{"test_database", "test_table"}, table.Identifier)
+	assert.Equal("s3://test-bucket/test_table/metadata/abc123-123.metadata.json", table.Location)
+	assert.Equal(table.CatalogType, Glue)
+}
+
+func TestGlueListTables(t *testing.T) {
+	assert := require.New(t)
+
+	mockGlueSvc := &mockGlueClient{}
+
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{
+		TableList: []types.Table{
+			{
+				Name: aws.String("test_table"),
+				Parameters: map[string]string{
+					"table_type":        "ICEBERG",
+					"metadata_location": "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
+				},
+			},
+		},
+	}, nil)
+
+	glueCatalog := &GlueCatalog{
+		glueSvc: mockGlueSvc,
+	}
+
+	tables, err := glueCatalog.ListTables(context.TODO(), GlueDatabaseIdentifier("test_database"))
+	assert.NoError(err)
+	assert.Equal([]string{"test_database", "test_table"}, tables[0].Identifier)
+	assert.Equal("s3://test-bucket/test_table/metadata/abc123-123.metadata.json", tables[0].Location)
+	assert.Equal(tables[0].CatalogType, Glue)
+}
 
 func TestGlueGetTableIntegration(t *testing.T) {
 	if os.Getenv("TEST_DATABASE_NAME") == "" {
@@ -19,14 +94,15 @@ func TestGlueGetTableIntegration(t *testing.T) {
 	}
 	assert := require.New(t)
 
-	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
+	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponseWithBody))
 	assert.NoError(err)
 
 	catalog := NewGlueCatalog(awscfg)
 
 	table, err := catalog.GetTable(context.TODO(), GlueTableIdentifier(os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")))
 	assert.NoError(err)
-	assert.Equal([]string{os.Getenv("TEST_TABLE_NAME")}, table.Identifier())
+	assert.Equal([]string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")}, table.Identifier)
+	assert.Equal(table.CatalogType, Glue)
 }
 
 func TestGlueListTableIntegration(t *testing.T) {
@@ -43,5 +119,5 @@ func TestGlueListTableIntegration(t *testing.T) {
 
 	tables, err := catalog.ListTables(context.TODO(), GlueDatabaseIdentifier(os.Getenv("TEST_DATABASE_NAME")))
 	assert.NoError(err)
-	assert.Equal([]string{os.Getenv("TEST_TABLE_NAME")}, tables[1].Identifier())
+	assert.Equal([]string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")}, tables[1].Identifier)
 }

--- a/catalog/glue_test.go
+++ b/catalog/glue_test.go
@@ -1,0 +1,47 @@
+package catalog
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlueGetTableIntegration(t *testing.T) {
+	if os.Getenv("TEST_DATABASE_NAME") == "" {
+		t.Skip()
+	}
+	if os.Getenv("TEST_TABLE_NAME") == "" {
+		t.Skip()
+	}
+	assert := require.New(t)
+
+	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
+	assert.NoError(err)
+
+	catalog := NewGlueCatalog(awscfg)
+
+	table, err := catalog.GetTable(context.TODO(), GlueTableIdentifier(os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")))
+	assert.NoError(err)
+	assert.Equal([]string{os.Getenv("TEST_TABLE_NAME")}, table.Identifier())
+}
+
+func TestGlueListTableIntegration(t *testing.T) {
+	if os.Getenv("TEST_DATABASE_NAME") == "" {
+		t.Skip()
+	}
+
+	assert := require.New(t)
+
+	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
+	assert.NoError(err)
+
+	catalog := NewGlueCatalog(awscfg)
+
+	tables, err := catalog.ListTables(context.TODO(), GlueDatabaseIdentifier(os.Getenv("TEST_DATABASE_NAME")))
+	assert.NoError(err)
+	assert.Equal([]string{os.Getenv("TEST_TABLE_NAME")}, tables[1].Identifier())
+}

--- a/catalog/glue_test.go
+++ b/catalog/glue_test.go
@@ -109,7 +109,9 @@ func TestGlueListTableIntegration(t *testing.T) {
 	if os.Getenv("TEST_DATABASE_NAME") == "" {
 		t.Skip()
 	}
-
+	if os.Getenv("TEST_TABLE_NAME") == "" {
+		t.Skip()
+	}
 	assert := require.New(t)
 
 	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
@@ -120,4 +122,31 @@ func TestGlueListTableIntegration(t *testing.T) {
 	tables, err := catalog.ListTables(context.TODO(), GlueDatabaseIdentifier(os.Getenv("TEST_DATABASE_NAME")))
 	assert.NoError(err)
 	assert.Equal([]string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")}, tables[1].Identifier)
+}
+
+func TestGlueLoadTableIntegration(t *testing.T) {
+	if os.Getenv("TEST_DATABASE_NAME") == "" {
+		t.Skip()
+	}
+	if os.Getenv("TEST_TABLE_NAME") == "" {
+		t.Skip()
+	}
+	if os.Getenv("TEST_TABLE_LOCATION") == "" {
+		t.Skip()
+	}
+
+	assert := require.New(t)
+
+	awscfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
+	assert.NoError(err)
+
+	catalog := NewGlueCatalog(awscfg)
+
+	table, err := catalog.LoadTable(context.TODO(), CatalogTable{
+		Identifier:  []string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")},
+		Location:    os.Getenv("TEST_TABLE_LOCATION"),
+		CatalogType: Glue,
+	})
+	assert.NoError(err)
+	assert.Equal([]string{os.Getenv("TEST_TABLE_NAME")}, table.Identifier())
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.14
+	github.com/aws/aws-sdk-go-v2/service/glue v1.73.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.0
 	github.com/google/uuid v1.3.1
 	github.com/hamba/avro/v2 v2.16.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 h1:GrSw8s0Gs/5zZ0SX+gX4zQjRnRsM
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2/go.mod h1:6fQQgfuGmw8Al/3M2IgIllycxV7ZW7WCdVSqfBeUiCY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.10 h1:5oE2WzJE56/mVveuDZPJESKlg/00AaS2pY2QZcnxg4M=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.10/go.mod h1:FHbKWQtRBYUz4vO5WBWjzMD2by126ny5y/1EoaWoLfI=
+github.com/aws/aws-sdk-go-v2/service/glue v1.73.1 h1:z/NBYW8RygzWrDgNWib10fuLUBl0SLj0KruGoEHxnKQ=
+github.com/aws/aws-sdk-go-v2/service/glue v1.73.1/go.mod h1:F3B9DC5FsIHAxUtHZdY5KUeqN+tHoGlRPzSSYdXjC38=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 h1:/b31bi3YVNlkzkBrm9LfpaKoaYZUxIAj4sHfOTmLfqw=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4/go.mod h1:2aGXHFmbInwgP9ZfpmdIfOELL79zhdNYNmReK8qDfdQ=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.10 h1:L0ai8WICYHozIKK+OtPzVJBugL7culcuM4E4JOpIEm8=


### PR DESCRIPTION
This PR adds an implementation of the catalog which is heavily inspired by iceberg-python, I have tried to keep it as minimal as possible to start somewhere, and get feedback.

This includes coverage for all the glue related operations which can be easily mocked, with some discussion needed around testing of the s3 access.

I am doing my best to follow the conventions in the existing code, with a few things needing discussion:

1. The table identifier is a bit confusing, I have done my best to follow the python structure in the catalog.
2. Need to do a bit of work around testing combined glue and s3 access, maybe start by exposing a way to load the s3fs directly so we can pass in a mock to test `LoadTable`.

I can easily use this as a basis for the dynamodb catalog, which would enable running both the iofs and catalog locally in an integration test environment at some point.