### PR TITLE
Add the build from source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@
 
 `iceberg` is a Golang implementation of the [Iceberg table spec](https://iceberg.apache.org/spec/).
 
+## Build From Source
+
+### Prerequisites
+
+* Go 1.21 or later
+
+### Build
+
+```shell
+$ git clone https://github.com/apache/iceberg-go.git
+$ cd iceberg-go/cmd/iceberg && go build .
+```
+
 ## Feature Support / Roadmap
 
 ### FileSystem Support


### PR DESCRIPTION
It will be better to add the build instruction for the newcomers
even though it might be straight for Go develop to find where's main.go file.

By the way, I'm wondering if adding the Makefile to manage the build and test instructions
is good. If yes,  I would submit a PR to resolve this.

