### PR TITLE
feat(manifest): fix partition data map

### DIFF
--- a/io/local.go
+++ b/io/local.go
@@ -17,14 +17,17 @@
 
 package io
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // LocalFS is an implementation of IO that implements interaction with
 // the local file system.
 type LocalFS struct{}
 
 func (LocalFS) Open(name string) (File, error) {
-	return os.Open(name)
+	return os.Open(strings.TrimPrefix(name, "file://"))
 }
 
 func (LocalFS) Remove(name string) error {

--- a/manifest.go
+++ b/manifest.go
@@ -378,7 +378,9 @@ func getFieldIDMap(sc avro.Schema) map[string]int {
 	partitionField := getField(entryField.Type().(*avro.RecordSchema), "partition")
 
 	for _, field := range partitionField.Type().(*avro.RecordSchema).Fields() {
-		result[field.Name()] = int(field.Prop("field-id").(float64))
+		if fid, ok := field.Prop("field-id").(float64); ok {
+			result[field.Name()] = int(fid)
+		}
 	}
 	return result
 }


### PR DESCRIPTION
Split out from #118 

Fixup the partition data map that we get from the manifest entry's datafile information and preserve the field name -> field-id mapping in partition data for a datafile.