### PR TITLE
fix: SIGSEGV when describe empty table

### DIFF
--- a/cmd/iceberg/output.go
+++ b/cmd/iceberg/output.go
@@ -96,9 +96,13 @@ func (t text) DescribeTable(tbl *table.Table) {
 		}).Render()
 
 	t.Schema(tbl.Schema())
+	snap := ""
+	if tbl.CurrentSnapshot() != nil {
+		snap = tbl.CurrentSnapshot().String()
+	}
 	pterm.DefaultTable.
 		WithData(pterm.TableData{
-			{"Current Snapshot", tbl.CurrentSnapshot().String()},
+			{"Current Snapshot", snap},
 		}).Render()
 	pterm.DefaultTree.WithRoot(snapshotTreeNode).Render()
 	pterm.Println("Properties")


### PR DESCRIPTION
Empty table does not have "Current Snapshot" causing describe command to be failed.
Added validation to replace with empty string `""`.

Steps to reproduce

1. Start env `docker-compose -f dev/docker-compose.yml up -d`
2. Create namespace
```
curl --location --request POST 'localhost:8181/v1/namespaces/public/tables' \
--header 'Content-Type: application/json' \
--data-raw '{
    "schema": {
        "type":"struct",
        "fields": [
            {
                "id":1,
                "name": "col1",
                "type": "boolean",
                "required": true
            }
        ]
    },
    "name": "t"
}
'
```
3. Describe table `t`: `iceberg describe public.t --uri=http://localhost:8181`

Actual result
```
Table format version | 2
Metadata location    | s3://warehouse/public/t/metadata/00000-c2e47505-8693-4254-b335-437111d400f0.metadata.json
Table UUID           | 552a9f6b-c96e-4816-957c-160b96d57a62
Last updated         | 1725807593801
Sort Order           | 0: []
Partition Spec       | []

Current Schema, id=0
└──1: col1: required boolean

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x925504]

goroutine 1 [running]:
main.text.DescribeTable({}, 0xc0001740a0)
        /home/alex/projects/opensource/iceberg-go/cmd/iceberg/output.go:101 +0xea4
main.describe({0xb3dfe8, 0xf85660}, {0xb3e0c8, 0xc000362ed0}, {0x7ffe86519d7c, 0x8}, {0xa44687, 0x3})
        /home/alex/projects/opensource/iceberg-go/cmd/iceberg/main.go:252 +0x3db
main.main()
        /home/alex/projects/opensource/iceberg-go/cmd/iceberg/main.go:149 +0x4ef
```

Fixed result
```
Table format version | 2
Metadata location    | s3://warehouse/public/t/metadata/00000-c2e47505-8693-4254-b335-437111d400f0.metadata.json
Table UUID           | 552a9f6b-c96e-4816-957c-160b96d57a62
Last updated         | 1725807593801
Sort Order           | 0: []
Partition Spec       | []

Current Schema, id=0
└──1: col1: required boolean

Current Snapshot | 

Snapshots

Properties
key                             | value
---------------------------------------
write.parquet.compression-codec | zstd
```