### PR TITLE
Test: Add coverage for Output

### DIFF
--- a/cmd/iceberg/output_test.go
+++ b/cmd/iceberg/output_test.go
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+	"github.com/apache/iceberg-go/table"
+	"github.com/pterm/pterm"
+)
+
+const ExampleTableMetadataV1 = `{
+    "format-version": 2,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "s3://bucket/test/location",
+    "last-sequence-number": 34,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 3,
+    "current-schema-id": 1,
+    "schemas": [
+        {"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "x", "required": true, "type": "long"}]},
+        {
+            "type": "struct",
+            "schema-id": 1,
+            "identifier-field-ids": [1, 2],
+            "fields": [
+                {"id": 1, "name": "x", "required": true, "type": "long"},
+                {"id": 2, "name": "y", "required": true, "type": "long", "doc": "comment"},
+                {"id": 3, "name": "z", "required": true, "type": "long"}
+            ]
+        }
+    ],
+    "default-spec-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": [{"name": "x", "transform": "identity", "source-id": 1, "field-id": 1000}]}],
+    "last-partition-id": 1000,
+    "default-sort-order-id": 3,
+    "sort-orders": [
+        {
+            "order-id": 3,
+            "fields": [
+                {"transform": "identity", "source-id": 2, "direction": "asc", "null-order": "nulls-first"},
+                {"transform": "bucket[4]", "source-id": 3, "direction": "desc", "null-order": "nulls-last"}
+            ]
+        }
+    ],
+    "properties": {"read.split.target.size": "134217728"},
+    "current-snapshot-id": 3055729675574597004,
+    "snapshots": [
+        {
+            "snapshot-id": 3051729675574597004,
+            "timestamp-ms": 1515100955770,
+            "sequence-number": 0,
+            "summary": {"operation": "append"},
+            "manifest-list": "s3://a/b/1.avro",
+	    "schema-id": 1
+        },
+        {
+            "snapshot-id": 3055729675574597004,
+            "parent-snapshot-id": 3051729675574597004,
+            "timestamp-ms": 1555100955770,
+            "sequence-number": 1,
+            "summary": {"operation": "append"},
+            "manifest-list": "s3://a/b/2.avro",
+            "schema-id": 1
+        }
+    ],
+    "snapshot-log": [
+        {"snapshot-id": 3051729675574597004, "timestamp-ms": 1515100955770},
+        {"snapshot-id": 3055729675574597004, "timestamp-ms": 1555100955770}
+    ],
+    "metadata-log": [{"metadata-file": "s3://bucket/.../v1.json", "timestamp-ms": 1515100}],
+    "refs": {"test": {"snapshot-id": 3051729675574597004, "type": "tag", "max-ref-age-ms": 10000000}}
+}`
+
+func TestDescribeTable(t *testing.T) {
+	var buf bytes.Buffer
+	meta, _ := table.ParseMetadataBytes([]byte(ExampleTableMetadataV1))
+	table := table.New([]string{"t"}, meta, "", nil)
+
+	pterm.SetDefaultOutput(&buf)
+	pterm.DisableColor()
+	text{}.DescribeTable(table)
+	var expected = `Table format version | 2
+Metadata location    | 
+Table UUID           | 9c12d441-03fe-4693-9a96-a0705ddf69c1
+Last updated         | 1602638573590
+Sort Order           | 3: [
+                     | 2 asc nulls-first
+                     | bucket[4](3) desc nulls-last
+                     | ]
+Partition Spec       | [
+                     | 	1000: x: identity(1)
+                     | ]
+
+Current Schema, id=1
+├──1: x: required long
+├──2: y: required long (comment)
+└──3: z: required long
+
+Current Snapshot | append, {}: id=3055729675574597004, parent_id=3051729675574597004, schema_id=1, sequence_number=1, timestamp_ms=1555100955770, manifest_list=s3://a/b/2.avro
+
+Snapshots
+├──Snapshot 3051729675574597004, schema 1: s3://a/b/1.avro
+└──Snapshot 3055729675574597004, schema 1: s3://a/b/2.avro
+
+Properties
+key                    | value
+----------------------------------
+read.split.target.size | 134217728
+
+`
+
+	testza.AssertEqual(t, expected, buf.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ module github.com/apache/iceberg-go
 go 1.21
 
 require (
+	github.com/MarvinJWendt/testza v0.5.2
 	github.com/apache/arrow/go/v16 v16.1.0
 	github.com/aws/aws-sdk-go-v2 v1.30.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.33
@@ -38,6 +39,7 @@ require (
 )
 
 require (
+	atomicgo.dev/assert v0.0.2 // indirect
 	atomicgo.dev/cursor v0.2.0 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
@@ -62,6 +64,7 @@ require (
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -69,6 +72,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/mod v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ module github.com/apache/iceberg-go
 go 1.21
 
 require (
-	github.com/MarvinJWendt/testza v0.5.2
 	github.com/apache/arrow/go/v16 v16.1.0
 	github.com/aws/aws-sdk-go-v2 v1.30.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.33
@@ -39,7 +38,6 @@ require (
 )
 
 require (
-	atomicgo.dev/assert v0.0.2 // indirect
 	atomicgo.dev/cursor v0.2.0 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
@@ -64,7 +62,6 @@ require (
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -72,7 +69,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/mod v0.19.0 // indirect


### PR DESCRIPTION
@zeroshade 
1. I've figured out how to run tests with pterm, but there are a few questions I need your input on.

```
var buf bytes.Buffer
pterm.SetDefaultOutput(&buf)

text{}.DescribeTable(table)

// compare buf.String() with expected result
```
or
```
pterm.SetDefaultOutput(os.Stdout)

text{}.DescribeTable(table)

// Output:
// Expected output
```
2. Also we need to disable colors. Otherwise output has ANSI codes, making comparison impossible.
```
pterm.DisableColor()
```

3. Not sure if we can reuse `Examples`.
https://github.com/golang/go/issues/26460
```
The trailing spaces cannot be handled by the // Output: of an Example
```
In our case, `Metadata location    | ` has whitespace after the pipe `|`, which is getting removed.
```
// Output:
// Table format version | 2
// Metadata location    |
// ...
```
And also `Examples` do not provide any diff when actual result doesn't match expected one.
So, for this matter I used 3rd party `github.com/MarvinJWendt/testza`, but maybe there is a better approach.

I've pushed some working version as an example of what I have so far. I'd appreciate some feedback before I proceed with covering all scenarios.