### PR TITLE
feat: more builders and writing manifests

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -441,7 +441,7 @@ func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) ([]M
 		var tmp ManifestEntry
 		if isVer1 {
 			if isFallback {
-				tmp = &fallbackManifestEntryV1{}
+				tmp = &fallbackManifestEntryV1{manifestEntryV1: manifestEntryV1{Data: &dataFile{}}}
 			} else {
 				tmp = &manifestEntryV1{Data: &dataFile{}}
 			}

--- a/manifest.go
+++ b/manifest.go
@@ -541,6 +541,10 @@ type ManifestFile interface {
 	// If discardDeleted is true, entries for files containing deleted rows
 	// will be skipped.
 	FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error)
+	// WriteManifestEntries writes a list of manifest entries to a provided
+	// io.Writer. The version of the manifest file is used to determine the
+	// schema to use for writing the entries.
+	WriteManifestEntries(out io.Writer, entries []ManifestEntry) error
 }
 
 // ReadManifestList reads in an avro manifest list file and returns a slice

--- a/manifest.go
+++ b/manifest.go
@@ -613,8 +613,8 @@ func writeManifestList(out io.Writer, files []ManifestFile, version int) error {
 		return fmt.Errorf("%w: non-recognized version %d", ErrInvalidArgument, version)
 	}
 
-	enc, err := ocf.NewEncoder(
-		internal.AvroSchemaCache.Get(key).String(),
+	enc, err := ocf.NewEncoderWithSchema(
+		internal.AvroSchemaCache.Get(key),
 		out, ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte(strconv.Itoa(version)),
 			"avro.codec":     []byte("deflate"),
@@ -655,8 +655,8 @@ func writeManifestEntries(out io.Writer, entries []ManifestEntry, version int) e
 		return fmt.Errorf("%w: non-recognized version %d", ErrInvalidArgument, version)
 	}
 
-	enc, err := ocf.NewEncoder(
-		internal.AvroSchemaCache.Get(key).String(),
+	enc, err := ocf.NewEncoderWithSchema(
+		internal.AvroSchemaCache.Get(key),
 		out, ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte(strconv.Itoa(version)),
 			"avro.codec":     []byte("deflate"),

--- a/manifest.go
+++ b/manifest.go
@@ -216,8 +216,8 @@ func (m *manifestFileV1) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manif
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
 
-// WriteManifestEntries writes a list of manifest entries to an avro file.
-func (m *manifestFileV1) WriteManifestEntries(out io.Writer, entries []ManifestEntry) error {
+// WriteEntries writes a list of manifest entries to an avro file.
+func (m *manifestFileV1) WriteEntries(out io.Writer, entries []ManifestEntry) error {
 	return writeManifestEntries(out, entries, m.Version())
 }
 
@@ -371,8 +371,8 @@ func (m *manifestFileV2) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manif
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
 
-// WriteManifestEntries writes a list of manifest entries to an avro file.
-func (m *manifestFileV2) WriteManifestEntries(out io.Writer, entries []ManifestEntry) error {
+// WriteEntries writes a list of manifest entries to an avro file.
+func (m *manifestFileV2) WriteEntries(out io.Writer, entries []ManifestEntry) error {
 	return writeManifestEntries(out, entries, m.Version())
 }
 
@@ -541,10 +541,10 @@ type ManifestFile interface {
 	// If discardDeleted is true, entries for files containing deleted rows
 	// will be skipped.
 	FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error)
-	// WriteManifestEntries writes a list of manifest entries to a provided
+	// WriteEntries writes a list of manifest entries to a provided
 	// io.Writer. The version of the manifest file is used to determine the
 	// schema to use for writing the entries.
-	WriteManifestEntries(out io.Writer, entries []ManifestEntry) error
+	WriteEntries(out io.Writer, entries []ManifestEntry) error
 }
 
 // ReadManifestList reads in an avro manifest list file and returns a slice

--- a/manifest.go
+++ b/manifest.go
@@ -617,7 +617,6 @@ func writeManifestList(out io.Writer, files []ManifestFile, version int) error {
 		internal.AvroSchemaCache.Get(key),
 		out, ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte(strconv.Itoa(version)),
-			"avro.codec":     []byte("deflate"),
 		}),
 		ocf.WithCodec(ocf.Deflate),
 	)
@@ -659,7 +658,6 @@ func writeManifestEntries(out io.Writer, entries []ManifestEntry, version int) e
 		internal.AvroSchemaCache.Get(key),
 		out, ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte(strconv.Itoa(version)),
-			"avro.codec":     []byte("deflate"),
 		}),
 		ocf.WithCodec(ocf.Deflate),
 	)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -743,7 +743,7 @@ func (m *ManifestTestSuite) TestManifestEntriesV2() {
 }
 
 func (m *ManifestTestSuite) TestManifestEntryBuilder() {
-	dataFileBuilder := NewDataFileBuilder(
+	dataFileBuilder, err := NewDataFileBuilder(
 		EntryContentData,
 		"sample.parquet",
 		ParquetFile,
@@ -751,6 +751,7 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 		1,
 		2,
 	)
+	m.Require().NoError(err)
 
 	dataFileBuilder.ColumnSizes(map[int]int64{
 		1: 1,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -378,8 +378,8 @@ type ManifestTestSuite struct {
 }
 
 func (m *ManifestTestSuite) writeManifestList() {
-	m.Require().NoError(WriteManifestListV1(&m.v1ManifestList, manifestFileRecordsV1))
-	m.Require().NoError(WriteManifestListV2(&m.v2ManifestList, manifestFileRecordsV2))
+	m.Require().NoError(WriteManifestList(&m.v1ManifestList, manifestFileRecordsV1))
+	m.Require().NoError(WriteManifestList(&m.v2ManifestList, manifestFileRecordsV2))
 }
 
 func (m *ManifestTestSuite) writeManifestEntries() {
@@ -393,8 +393,8 @@ func (m *ManifestTestSuite) writeManifestEntries() {
 		manifestEntryV2Recs[i] = rec
 	}
 
-	m.Require().NoError(WriteManifestEntriesV1(&m.v1ManifestEntries, manifestEntryV1Recs))
-	m.Require().NoError(WriteManifestEntriesV2(&m.v2ManifestEntries, manifestEntryV2Recs))
+	m.Require().NoError(writeManifestEntries(&m.v1ManifestEntries, manifestEntryV1Recs, 1))
+	m.Require().NoError(writeManifestEntries(&m.v2ManifestEntries, manifestEntryV2Recs, 2))
 }
 
 func (m *ManifestTestSuite) SetupSuite() {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -321,7 +321,7 @@ var (
 	}
 
 	dataRecord0 = manifestEntryV1Records[0].Data.(*dataFile)
-	dataRecord1 = manifestEntryV1Records[0].Data.(*dataFile)
+	dataRecord1 = manifestEntryV1Records[1].Data.(*dataFile)
 
 	manifestEntryV2Records = []*manifestEntryV2{
 		{

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -68,7 +68,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    entrySnapshotID,
-			Data: &dataFile{
+			Data: dataFile{
 				// bad value for Content but this field doesn't exist in V1
 				// so it shouldn't get written and shouldn't be read back out
 				// so the roundtrip test asserts that we get the default value
@@ -192,7 +192,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    8744736658442914487,
-			Data: &dataFile{
+			Data: dataFile{
 				Path:             "/home/iceberg/warehouse/nyc/taxis_partitioned/data/VendorID=1/00000-633-d8a4223e-dc97-45a1-86e1-adaba6e8abd7-00002.parquet",
 				Format:           ParquetFile,
 				PartitionData:    map[string]any{"VendorID": int(1), "tpep_pickup_datetime": time.Unix(1925, 0)},
@@ -320,14 +320,14 @@ var (
 		},
 	}
 
-	dataRecord0 = manifestEntryV1Records[0].Data.(*dataFile)
-	dataRecord1 = manifestEntryV1Records[1].Data.(*dataFile)
+	dataRecord0 = manifestEntryV1Records[0].Data
+	dataRecord1 = manifestEntryV1Records[1].Data
 
 	manifestEntryV2Records = []*manifestEntryV2{
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    &entrySnapshotID,
-			Data: &dataFile{
+			Data: dataFile{
 				Path:             dataRecord0.Path,
 				Format:           dataRecord0.Format,
 				PartitionData:    dataRecord0.PartitionData,
@@ -347,7 +347,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    &entrySnapshotID,
-			Data: &dataFile{
+			Data: dataFile{
 				Path:             dataRecord1.Path,
 				Format:           dataRecord1.Format,
 				PartitionData:    dataRecord1.PartitionData,
@@ -775,11 +775,12 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 		2: []byte("2020-04-30 23:5:"),
 	}).SplitOffsets([]int64{4}).EqualityFieldIDs([]int{1, 1}).SortOrderID(0)
 
-	builder := NewManifestEntryV1Builder(
+	builder, err := NewManifestEntryV1Builder(
 		EntryStatusEXISTING,
 		1,
 		dataFileBuilder.Build(),
 	)
+	m.Require().NoError(err)
 
 	entry := builder.Build()
 	m.Assert().Equal(EntryStatusEXISTING, entry.Status())

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -68,7 +68,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    entrySnapshotID,
-			Data: dataFile{
+			Data: &dataFile{
 				// bad value for Content but this field doesn't exist in V1
 				// so it shouldn't get written and shouldn't be read back out
 				// so the roundtrip test asserts that we get the default value
@@ -192,7 +192,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    8744736658442914487,
-			Data: dataFile{
+			Data: &dataFile{
 				Path:             "/home/iceberg/warehouse/nyc/taxis_partitioned/data/VendorID=1/00000-633-d8a4223e-dc97-45a1-86e1-adaba6e8abd7-00002.parquet",
 				Format:           ParquetFile,
 				PartitionData:    map[string]any{"VendorID": int(1), "tpep_pickup_datetime": time.Unix(1925, 0)},
@@ -320,14 +320,14 @@ var (
 		},
 	}
 
-	dataRecord0 = manifestEntryV1Records[0].Data
-	dataRecord1 = manifestEntryV1Records[1].Data
+	dataRecord0 = manifestEntryV1Records[0].Data.(*dataFile)
+	dataRecord1 = manifestEntryV1Records[1].Data.(*dataFile)
 
 	manifestEntryV2Records = []*manifestEntryV2{
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    &entrySnapshotID,
-			Data: dataFile{
+			Data: &dataFile{
 				Path:             dataRecord0.Path,
 				Format:           dataRecord0.Format,
 				PartitionData:    dataRecord0.PartitionData,
@@ -347,7 +347,7 @@ var (
 		{
 			EntryStatus: EntryStatusADDED,
 			Snapshot:    &entrySnapshotID,
-			Data: dataFile{
+			Data: &dataFile{
 				Path:             dataRecord1.Path,
 				Format:           dataRecord1.Format,
 				PartitionData:    dataRecord1.PartitionData,

--- a/utils.go
+++ b/utils.go
@@ -21,9 +21,14 @@ import (
 	"cmp"
 	"fmt"
 	"hash/maphash"
+	"io"
 	"maps"
 	"runtime/debug"
+	"strconv"
 	"strings"
+
+	"github.com/apache/iceberg-go/internal"
+	"github.com/hamba/avro/v2/ocf"
 )
 
 var version string
@@ -211,4 +216,25 @@ func Difference(a, b []string) []string {
 		}
 	}
 	return diff
+}
+
+func avroEncode[T any](key string, version int, vals []T, out io.Writer) error {
+	enc, err := ocf.NewEncoderWithSchema(
+		internal.AvroSchemaCache.Get(key),
+		out, ocf.WithMetadata(map[string][]byte{
+			"format-version": []byte(strconv.Itoa(version)),
+		}),
+		ocf.WithCodec(ocf.Deflate),
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range vals {
+		if err := enc.Encode(file); err != nil {
+			return err
+		}
+	}
+
+	return enc.Close()
 }


### PR DESCRIPTION
#172 

This PR adds Builders for v1/2 ManifestEntry and for DataFile as well as helper funcs to write ManifestLists and Manifest files.

Bonus: fixes a max recursion depth panic in `dataFile.EqualityFieldIDs()`

One thing I'm not super happy with is `manifestEntryV1/2.Data`'s type has been changed from `dataFile` to `DataFile` (the interface type). This was the best way I could come up with to make the builders for both work, but I also feel like it diverges from the pattern a little bit. This may not be a huge deal, but something to consider. You can see how the effects rippled out a little bit in the tests. 
