### PR TITLE
Fix infinite recursion bug in EqualityFieldIDs accessor

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -792,7 +792,7 @@ func (d *dataFile) EqualityFieldIDs() []int {
 	if d.EqualityIDs == nil {
 		return nil
 	}
-	return d.EqualityFieldIDs()
+	return *d.EqualityIDs
 }
 
 func (d *dataFile) SortOrderID() *int { return d.SortOrder }


### PR DESCRIPTION
I think the summary line is self-explanatory. There seems to be a typo in the `*dataFile.EqualityFieldIDs()` method that results in stack overflow.