### PR TITLE
Add option to set max concurrency for table scan operations

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
-
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/io"
 )

--- a/table/table.go
+++ b/table/table.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"runtime"
 	"slices"
 
 	"github.com/apache/iceberg-go"
@@ -110,6 +111,18 @@ func WithLimit(n int64) ScanOption {
 	}
 }
 
+// WitMaxConcurrency sets the maximum concurrency for table scan and plan
+// operations. When unset it defaults to runtime.GOMAXPROCS.
+func WitMaxConcurrency(n int) ScanOption {
+	if n <= 0 {
+		return noopOption
+	}
+
+	return func(scan *Scan) {
+		scan.concurrency = n
+	}
+}
+
 func WithOptions(opts iceberg.Properties) ScanOption {
 	if opts == nil {
 		return noopOption
@@ -128,6 +141,7 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 		selectedFields: []string{"*"},
 		caseSensitive:  true,
 		limit:          ScanNoLimit,
+		concurrency:    runtime.GOMAXPROCS(0),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
This PR introduces an option to set `MaxConcurrency` for the `Scanner`, allowing users to control the level of concurrent downloads in Scanner. This configuration can be beneficial for workloads running multiple simultaneous queries.

Additionally, this PR changes the default value of max concurrency from `runtime.NumCPU()` to `runtime.GOMAXPROCS`. While both are initially set to the number of available CPUs, `GOMAXPROCS` is adjustable by users, providing greater flexibility. This change addresses a limitation of using `runtime.NumCPU()`, which does not account for cgroup limits. For instance, in Kubernetes environments, using `runtime.NumCPU()` may incorrectly assume access to all CPU cores on a node, rather than only the cores allocated to the specific pod. This mismatch can lead to performance degradation in Kubernetes-deployed applications. See [uber-go/automaxprocs](https://pkg.go.dev/go.uber.org/automaxprocs).