### PR TITLE
use `dist/release` KEYS

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -53,7 +53,6 @@ may be helpful.
 
 Your PGP key must be registered to the following:
 
-    * https://dist.apache.org/repos/dist/dev/iceberg/KEYS
     * https://dist.apache.org/repos/dist/release/iceberg/KEYS
 
 See the header comment of them for how to add a PGP key.
@@ -62,7 +61,7 @@ Apache Iceberg committers can update them by Subversion client with their ASF ac
 e.g.:
 
 ```console
-$ svn co https://dist.apache.org/repos/dist/dev/iceberg
+$ svn co https://dist.apache.org/repos/dist/release/iceberg
 $ cd iceberg
 $ editor KEYS
 $ svn ci KEYS

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -53,7 +53,7 @@ may be helpful.
 
 Your PGP key must be registered to the following:
 
-    * https://dist.apache.org/repos/dist/release/iceberg/KEYS
+    * https://downloads.apache.org/iceberg/KEYS
 
 See the header comment of them for how to add a PGP key.
 

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -34,7 +34,7 @@ set -x
 VERSION="$1"
 RC="$2"
 
-ICEBERG_DIST_BASE_URL="https://downloads.apache.org/iceberg/KEYS"
+ICEBERG_DIST_BASE_URL="https://downloads.apache.org/iceberg"
 DOWNLOAD_RC_BASE_URL="https://github.com/apache/iceberg-go/releases/download/v${VERSION}-rc${RC}"
 ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}"
 

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -34,7 +34,7 @@ set -x
 VERSION="$1"
 RC="$2"
 
-ICEBERG_DIST_BASE_URL="https://dist.apache.org/repos/dist/release/iceberg"
+ICEBERG_DIST_BASE_URL="https://downloads.apache.org/iceberg/KEYS"
 DOWNLOAD_RC_BASE_URL="https://github.com/apache/iceberg-go/releases/download/v${VERSION}-rc${RC}"
 ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}"
 

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -34,7 +34,7 @@ set -x
 VERSION="$1"
 RC="$2"
 
-ICEBERG_DIST_BASE_URL="https://dist.apache.org/repos/dist/dev/iceberg"
+ICEBERG_DIST_BASE_URL="https://dist.apache.org/repos/dist/release/iceberg"
 DOWNLOAD_RC_BASE_URL="https://github.com/apache/iceberg-go/releases/download/v${VERSION}-rc${RC}"
 ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}"
 


### PR DESCRIPTION
Deprecate the use of 
- https://dist.apache.org/repos/dist/dev/iceberg/KEYS
in favor of 
- https://downloads.apache.org/iceberg/KEYS which is an alias for https://dist.apache.org/repos/dist/release/iceberg/KEYS



devlist discussion: https://lists.apache.org/thread/8j41w4y2jx6r3ybj0o82bfyn0npmhgx2