### PR TITLE
Fix `version` and `rc` in `rc.yml`

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -42,17 +42,25 @@ jobs:
       - name: Prepare for tag
         if: github.ref_type == 'tag'
         run: |
-          version=${GITHUB_REF_NAME%-rc}
-          version=${version#v}
-          rc=${GITHUB_REF_NAME#*-rc}
+          # Remove the 'v' prefix and any '-rc' suffix from the tag name to isolate the version number
+          # For a tag like 'v0.1.0-rc1', this will result in '0.1.0'
+          version=${GITHUB_REF_NAME#v}
+          version=${version%-rc*}
+          # Finds the last occurrence of `-rc` and returns everything after it
+          # For a tag like 'v0.1.0-rc1', this will result in '1'
+          rc=${GITHUB_REF_NAME##*-rc}
           echo "VERSION=${version}" >> ${GITHUB_ENV}
           echo "RC=${rc}" >> ${GITHUB_ENV}
+          echo "VERSION=${version}"
+          echo "RC=${rc}"
       - name: Prepare for branch
         if: github.ref_type == 'branch'
         run: |
           rc=100
           echo "VERSION=${version}" >> ${GITHUB_ENV}
           echo "RC=${rc}" >> ${GITHUB_ENV}
+          echo "VERSION=${version}"
+          echo "RC=${rc}"
       - name: Archive
         run: |
           id="apache-iceberg-go-${VERSION}-rc${RC}"
@@ -90,14 +98,20 @@ jobs:
       - name: Verify
         run: |
           tar_gz=$(echo apache-iceberg-go-*.tar.gz)
+          # Extract version by removing the 'apache-iceberg-go-' prefix, '.tar.gz' extension, and '-rc*' suffix
+          # For a file like 'apache-iceberg-go-0.1.0-rc1.tar.gz', this will result in '0.1.0'
           version=${tar_gz#apache-iceberg-go-}
-          version=${version%-rc*}
           version=${version%.tar.gz}
+          version=${version%%-rc*}
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            rc="${GITHUB_REF_NAME#*-rc}"
+            # Finds the last occurrence of `-rc` and returns everything after it
+            # For a tag like 'v0.1.0-rc1', this will result in '1'
+            rc=${GITHUB_REF_NAME##*-rc}
           else
             rc=100
           fi
+          echo "VERSION=${version}"
+          echo "RC=${rc}"
           VERIFY_DEFAULT=0 dev/release/verify_rc.sh "${version}" "${rc}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow up to #199.
For the RC workflow running on a tag, there was an issue resulting in the wrong filename used for the `tar.gz` file, for example, `apache-iceberg-go-0.1.0-rc1-rc1.tar.gz`. Notice the extra `-rc`. 

This is due to the parsing logic which is fixed in this PR.

For details, see https://github.com/apache/iceberg-go/actions/runs/11821595808/job/32936689238
where the `Archive` job's `Archive` step has the following
```
  env:
    VERSION: 0.1.0-rc1
    RC: 1
```

Tested in fork repo.
`v0.1.0-rc1` release https://github.com/kevinjqliu/iceberg-go/releases/tag/v0.1.0-rc1
https://github.com/kevinjqliu/iceberg-go/actions/runs/11824564368/job/32946341965
Downloaded artifacts in https://github.com/kevinjqliu/iceberg-go/actions/runs/11824501122 and checked the sha256 file is correct