### PR TITLE
Fix `release_rc.sh`, use the right artifact file name 

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -65,7 +65,7 @@ fi
 
 rc_hash="$(git rev-list --max-count=1 "${rc_tag}")"
 
-id="apache-iceberg-go-${version}"
+id="apache-iceberg-go-${version}-rc${rc}"
 tar_gz="${id}.tar.gz"
 
 if [ "${RELEASE_SIGN}" -gt 0 ]; then


### PR DESCRIPTION
#204

While running `release_rc.sh` for RC2, I noticed that the .asc file was not generated. 
There's a bug in the script similar to #199 and #202 where the filename does not include the RC version. 

This PR fixes the script to use the correct file name, `apache-iceberg-go-0.1.0-rc2.tar.gz`, which corresponds with the artifacts here https://github.com/apache/iceberg-go/releases/tag/v0.1.0-rc2

Tested in terminal

```
version=0.1.0                            
rc=2
id="apache-iceberg-go-${version}-rc${rc}" 
tar_gz="${id}.tar.gz"
echo $tar_gz
> apache-iceberg-go-0.1.0-rc2.tar.gz
```