### PR TITLE
Update `tabulario/iceberg-rest` to `apache/iceberg-rest-fixture`

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - 10000:10000
       - 10001:10001
   rest:
-    image: tabulario/iceberg-rest
+    image: apache/iceberg-rest-fixture
     container_name: iceberg-rest
     networks:
       iceberg_net:


### PR DESCRIPTION
# What

Updates docker compose file in `dev` to use `apache/iceberg-rest-fixture`

# Why

Closes https://github.com/apache/iceberg-go/issues/221