### PR TITLE
feat(catalog): Standardize Catalog create table function

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -212,25 +212,25 @@ type createTableCfg struct {
 	properties    iceberg.Properties
 }
 
-func WithLocation(location string) func(*createTableCfg) {
+func WithLocation(location string) createTableOpt {
 	return func(cfg *createTableCfg) {
 		cfg.location = strings.TrimRight(location, "/")
 	}
 }
 
-func WithPartitionSpec(spec *iceberg.PartitionSpec) func(*createTableCfg) {
+func WithPartitionSpec(spec *iceberg.PartitionSpec) createTableOpt {
 	return func(cfg *createTableCfg) {
 		cfg.partitionSpec = spec
 	}
 }
 
-func WithSortOrder(order table.SortOrder) func(*createTableCfg) {
+func WithSortOrder(order table.SortOrder) createTableOpt {
 	return func(cfg *createTableCfg) {
 		cfg.sortOrder = order
 	}
 }
 
-func WithProperties(props iceberg.Properties) func(*createTableCfg) {
+func WithProperties(props iceberg.Properties) createTableOpt {
 	return func(cfg *createTableCfg) {
 		cfg.properties = props
 	}

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
-	"maps"
 	"net/url"
 	"strings"
 
@@ -203,53 +201,6 @@ func TableNameFromIdent(ident table.Identifier) string {
 
 func NamespaceFromIdent(ident table.Identifier) table.Identifier {
 	return ident[:len(ident)-1]
-}
-
-func checkForOverlap(removals []string, updates iceberg.Properties) error {
-	overlap := []string{}
-	for _, key := range removals {
-		if _, ok := updates[key]; ok {
-			overlap = append(overlap, key)
-		}
-	}
-	if len(overlap) > 0 {
-		return fmt.Errorf("conflict between removals and updates for keys: %v", overlap)
-	}
-	return nil
-}
-
-func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals []string, updates iceberg.Properties) (iceberg.Properties, PropertiesUpdateSummary, error) {
-	if err := checkForOverlap(removals, updates); err != nil {
-		return nil, PropertiesUpdateSummary{}, err
-	}
-
-	var (
-		updatedProps = maps.Clone(currentProps)
-		removed      = make([]string, 0, len(removals))
-		updated      = make([]string, 0, len(updates))
-	)
-
-	for _, key := range removals {
-		if _, exists := updatedProps[key]; exists {
-			delete(updatedProps, key)
-			removed = append(removed, key)
-		}
-	}
-
-	for key, value := range updates {
-		if updatedProps[key] != value {
-			updated = append(updated, key)
-			updatedProps[key] = value
-		}
-	}
-
-	summary := PropertiesUpdateSummary{
-		Removed: removed,
-		Updated: updated,
-		Missing: iceberg.Difference(removals, removed),
-	}
-
-	return updatedProps, summary, nil
 }
 
 type createTableOpt func(*createTableCfg)

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -157,7 +157,7 @@ type Catalog interface {
 	// CatalogType returns the type of the catalog.
 	CatalogType() CatalogType
 
-	// CreateTable creates a new iceberg table in the catalog using the provided identiifer
+	// CreateTable creates a new iceberg table in the catalog using the provided identifier
 	// and schema. Options can be used to optionally provide location, partition spec, sort order,
 	// and custom properties.
 	CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...createTableOpt) (*table.Table, error)

--- a/catalog/glue.go
+++ b/catalog/glue.go
@@ -220,6 +220,10 @@ func (c *GlueCatalog) CatalogType() CatalogType {
 	return Glue
 }
 
+func (c *GlueCatalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...createTableOpt) (*table.Table, error) {
+	panic("create table not implemented for Glue Catalog")
+}
+
 // DropTable deletes an Iceberg table from the Glue catalog.
 func (c *GlueCatalog) DropTable(ctx context.Context, identifier table.Identifier) error {
 	database, tableName, err := identifierToGlueTable(identifier)

--- a/partitions.go
+++ b/partitions.go
@@ -236,13 +236,12 @@ func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
 	return &StructType{FieldList: nestedFields}
 }
 
+// AssignFreshPartitionSpecIDs creates a new PartitionSpec by reassigning the field IDs
+// from the old schema to the corresponding fields in the fresh schema, while re-assigning
+// the actual Spec IDs to 1000 + the position of the field in the partition spec.
 func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (PartitionSpec, error) {
 	if spec == nil {
 		return PartitionSpec{}, nil
-	}
-
-	if old == fresh {
-		return *spec, nil
 	}
 
 	newFields := make([]PartitionField, 0, len(spec.fields))

--- a/schema.go
+++ b/schema.go
@@ -1200,6 +1200,9 @@ func (s *setFreshIDs) Primitive(p PrimitiveType) Type {
 	return p
 }
 
+// AssignFreshSchemaIDs creates a new schema with fresh field IDs for all of the
+// fields in it. The nextID function is used to iteratively generate the ids, if
+// it is nil then a simple incrementing counter is used starting at 1.
 func AssignFreshSchemaIDs(sc *Schema, nextID func() int) (*Schema, error) {
 	if nextID == nil {
 		var id int = 0

--- a/schema.go
+++ b/schema.go
@@ -1216,14 +1216,14 @@ func AssignFreshSchemaIDs(sc *Schema, nextID func() int) (*Schema, error) {
 
 	fields := outType.(*StructType).FieldList
 	var newIdentifierIDs []int
-	if len(sc.IdentifierFieldIDs) == 0 {
+	if len(sc.IdentifierFieldIDs) != 0 {
 		newIdentifierIDs = make([]int, len(sc.IdentifierFieldIDs))
 		for i, id := range sc.IdentifierFieldIDs {
 			newIdentifierIDs[i] = visitor.oldIdToNew[id]
 		}
 	}
 
-	return NewSchemaWithIdentifiers(sc.ID, newIdentifierIDs, fields...), nil
+	return NewSchemaWithIdentifiers(0, newIdentifierIDs, fields...), nil
 }
 
 type SchemaWithPartnerVisitor[T, P any] interface {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1033,10 +1033,15 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 
 const DefaultFormatVersion = 2
 
+// NewMetadata creates a new table metadata object using the provided schema, information, generating a fresh UUID for
+// the new table metadata. By default, this will generate a V2 table metadata, but this can be modified
+// by adding a "format-version" property to the props map. An error will be returned if the "format-version"
+// property exists and is not a valid version number.
 func NewMetadata(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties) (Metadata, error) {
 	return NewMetadataWithUUID(sc, partitions, sortOrder, location, props, uuid.Nil)
 }
 
+// NewMetadataWithUUID is like NewMetadata, but allows the caller to specify the UUID of the table rather than creating a new one.
 func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties, tableUuid uuid.UUID) (Metadata, error) {
 	freshSchema, err := iceberg.AssignFreshSchemaIDs(sc, nil)
 	if err != nil {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -25,6 +25,7 @@ import (
 	"iter"
 	"maps"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -1028,4 +1029,68 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 
 	m.preValidate()
 	return m.validate()
+}
+
+const DefaultFormatVersion = 2
+
+func NewMetadata(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties, tableUuid uuid.UUID) (Metadata, error) {
+	freshSchema, err := iceberg.AssignFreshSchemaIDs(sc, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	freshPartitions, err := iceberg.AssignFreshPartitionSpecIDs(partitions, sc, freshSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	freshSortOrder, err := AssignFreshSortOrderIDs(sortOrder, sc, freshSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	if tableUuid == uuid.Nil {
+		tableUuid = uuid.New()
+	}
+
+	formatVersion := DefaultFormatVersion
+	if props != nil {
+		verStr, ok := props["format-version"]
+		if ok {
+			if formatVersion, err = strconv.Atoi(verStr); err != nil {
+				formatVersion = DefaultFormatVersion
+			}
+			delete(props, "format-version")
+		}
+	}
+
+	lastPartitionID := freshPartitions.LastAssignedFieldID()
+	common := commonMetadata{
+		LastUpdatedMS:      time.Now().UnixMilli(),
+		LastColumnId:       freshSchema.HighestFieldID(),
+		FormatVersion:      formatVersion,
+		UUID:               tableUuid,
+		Loc:                location,
+		SchemaList:         []*iceberg.Schema{freshSchema},
+		CurrentSchemaID:    freshSchema.ID,
+		Specs:              []iceberg.PartitionSpec{freshPartitions},
+		DefaultSpecID:      freshPartitions.ID(),
+		LastPartitionID:    &lastPartitionID,
+		Props:              props,
+		SortOrderList:      []SortOrder{freshSortOrder},
+		DefaultSortOrderID: freshSortOrder.OrderID,
+	}
+
+	switch formatVersion {
+	case 1:
+		return &metadataV1{
+			commonMetadata: common,
+			Schema:         freshSchema,
+			Partition:      slices.Collect(freshPartitions.Fields()),
+		}, nil
+	case 2:
+		return &metadataV2{commonMetadata: common}, nil
+	default:
+		return nil, fmt.Errorf("invalid format version: %d", formatVersion)
+	}
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1033,7 +1033,11 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 
 const DefaultFormatVersion = 2
 
-func NewMetadata(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties, tableUuid uuid.UUID) (Metadata, error) {
+func NewMetadata(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties) (Metadata, error) {
+	return NewMetadataWithUUID(sc, partitions, sortOrder, location, props, uuid.Nil)
+}
+
+func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties, tableUuid uuid.UUID) (Metadata, error) {
 	freshSchema, err := iceberg.AssignFreshSchemaIDs(sc, nil)
 	if err != nil {
 		return nil, err

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -176,10 +176,15 @@ func (s *SortOrder) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// AssignFreshSortOrderIDs updates and reassigns the field source IDs from the old schema
+// to the corresponding fields in the fresh schema, while also giving the Sort Order a fresh
+// ID of 0 (the initial Sort Order ID).
 func AssignFreshSortOrderIDs(sortOrder SortOrder, old, fresh *iceberg.Schema) (SortOrder, error) {
 	return AssignFreshSortOrderIDsWithID(sortOrder, old, fresh, InitialSortOrderID)
 }
 
+// AssignFreshSortOrderIDsWithID is like AssignFreshSortOrderIDs but allows specifying the id of the
+// returned SortOrder.
 func AssignFreshSortOrderIDsWithID(sortOrder SortOrder, old, fresh *iceberg.Schema, sortOrderID int) (SortOrder, error) {
 	if sortOrder.Equals(UnsortedSortOrder) {
 		return UnsortedSortOrder, nil
@@ -203,5 +208,5 @@ func AssignFreshSortOrderIDsWithID(sortOrder SortOrder, old, fresh *iceberg.Sche
 			NullOrder: field.NullOrder,
 		})
 	}
-	return SortOrder{OrderID: 1, Fields: fields}, nil
+	return SortOrder{OrderID: sortOrderID, Fields: fields}, nil
 }

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -203,5 +203,5 @@ func AssignFreshSortOrderIDsWithID(sortOrder SortOrder, old, fresh *iceberg.Sche
 			NullOrder: field.NullOrder,
 		})
 	}
-	return SortOrder{OrderID: sortOrderID, Fields: fields}, nil
+	return SortOrder{OrderID: 1, Fields: fields}, nil
 }


### PR DESCRIPTION
Adding a CreateTable function to the `Catalog` interface, standardizing the implementation that was initially created by #146 so that it isn't specific to the REST catalog and can be implemented by any catalog.

This also requires adding the `AssignFresh*IDs` functions so that the REST catalog implementation is correctly re-assigning IDs as other implementations do.