### PR TITLE
feat(catalog): Have Load use "type" property and "name" for config

### DIFF
--- a/catalog/registry_test.go
+++ b/catalog/registry_test.go
@@ -18,10 +18,15 @@
 package catalog_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,15 +54,28 @@ func TestCatalogRegistry(t *testing.T) {
 
 	c, err := catalog.Load("foobar", iceberg.Properties{"foo": "baz"})
 	assert.Nil(t, c)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, catalog.ErrCatalogNotFound)
 
 	catalog.Register("foobar", catalog.RegistrarFunc(func(s string, p iceberg.Properties) (catalog.Catalog, error) {
-		assert.Equal(t, "foobar://helloworld", s)
+		assert.Equal(t, "not found", s)
 		assert.Equal(t, "baz", p.Get("foo", ""))
 		return nil, nil
 	}))
 
-	c, err = catalog.Load("foobar://helloworld", iceberg.Properties{"foo": "baz"})
+	c, err = catalog.Load("not found", iceberg.Properties{"type": "foobar", "foo": "baz"})
+	assert.Nil(t, c)
+	assert.NoError(t, err)
+
+	catalog.Register("foobar", catalog.RegistrarFunc(func(s string, p iceberg.Properties) (catalog.Catalog, error) {
+		assert.Equal(t, "not found", s)
+		assert.Equal(t, "foobar://helloworld", p.Get("uri", ""))
+		assert.Equal(t, "baz", p.Get("foo", ""))
+		return nil, nil
+	}))
+
+	c, err = catalog.Load("not found", iceberg.Properties{
+		"uri": "foobar://helloworld",
+		"foo": "baz"})
 	assert.Nil(t, c)
 	assert.NoError(t, err)
 
@@ -68,4 +86,55 @@ func TestCatalogRegistry(t *testing.T) {
 		"https",
 		"glue",
 	}, catalog.GetRegisteredCatalogs())
+}
+
+func TestRegistryFromConfig(t *testing.T) {
+	var params url.Values
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		params = r.URL.Query()
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"default":   map[string]any{},
+			"overrides": map[string]any{},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+
+	defer func(cats map[string]config.CatalogConfig) {
+		config.EnvConfig.Catalogs = cats
+	}(config.EnvConfig.Catalogs)
+
+	config.EnvConfig.Catalogs = map[string]config.CatalogConfig{
+		"foobar": {
+			CatalogType: "rest",
+			URI:         srv.URL,
+			Warehouse:   "catalog_name",
+		},
+	}
+
+	c, err := catalog.Load("foobar", nil)
+	assert.NoError(t, err)
+	assert.IsType(t, &catalog.RestCatalog{}, c)
+	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.Equal(t, "catalog_name", params.Get("warehouse"))
+
+	c, err = catalog.Load("foobar", iceberg.Properties{"warehouse": "overriden"})
+	assert.NoError(t, err)
+	assert.IsType(t, &catalog.RestCatalog{}, c)
+	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.Equal(t, "overriden", params.Get("warehouse"))
+
+	srv.Close()
+
+	srv2 := httptest.NewServer(mux)
+	defer srv2.Close()
+
+	c, err = catalog.Load("foobar", iceberg.Properties{"uri": srv2.URL})
+	assert.NoError(t, err)
+	assert.IsType(t, &catalog.RestCatalog{}, c)
+	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.Equal(t, "catalog_name", params.Get("warehouse"))
 }

--- a/catalog/rest.go
+++ b/catalog/rest.go
@@ -74,8 +74,8 @@ var (
 )
 
 func init() {
-	reg := RegistrarFunc(func(endpoint string, p iceberg.Properties) (Catalog, error) {
-		return newRestCatalogFromProps(endpoint, p.Get("uri", endpoint), p)
+	reg := RegistrarFunc(func(name string, p iceberg.Properties) (Catalog, error) {
+		return newRestCatalogFromProps(name, p.Get("uri", ""), p)
 	})
 
 	Register(string(REST), reg)
@@ -595,6 +595,9 @@ func (r *RestCatalog) fetchConfig(opts *options) (*options, error) {
 	}
 
 	cfg := rsp.Defaults
+	if cfg == nil {
+		cfg = iceberg.Properties{}
+	}
 	maps.Copy(cfg, toProps(opts))
 	maps.Copy(cfg, rsp.Overrides)
 
@@ -613,6 +616,7 @@ func (r *RestCatalog) fetchConfig(opts *options) (*options, error) {
 	return o, nil
 }
 
+func (r *RestCatalog) Name() string             { return r.name }
 func (r *RestCatalog) CatalogType() CatalogType { return REST }
 
 func checkValidNamespace(ident table.Identifier) error {

--- a/catalog/rest_test.go
+++ b/catalog/rest_test.go
@@ -137,7 +137,8 @@ func (r *RestCatalogSuite) TestLoadRegisteredCatalog() {
 		})
 	})
 
-	cat, err := catalog.Load(r.srv.URL, iceberg.Properties{
+	cat, err := catalog.Load("restful", iceberg.Properties{
+		"uri":        r.srv.URL,
 		"warehouse":  "s3://some-bucket",
 		"credential": TestCreds,
 	})
@@ -758,42 +759,41 @@ func (r *RestCatalogSuite) TestCreateTable200() {
 }
 
 func (r *RestCatalogSuite) TestCreateTable409() {
-    // Mock the create table endpoint with 409 response
-    r.mux.HandleFunc("/v1/namespaces/fokko/tables", func(w http.ResponseWriter, req *http.Request) {
-        r.Require().Equal(http.MethodPost, req.Method)
+	// Mock the create table endpoint with 409 response
+	r.mux.HandleFunc("/v1/namespaces/fokko/tables", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodPost, req.Method)
 
-        for k, v := range TestHeaders {
-            r.Equal(v, req.Header.Values(k))
-        }
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
-        w.WriteHeader(http.StatusConflict)
-        errorResponse := map[string]interface{}{
-            "error": map[string]interface{}{
-                "message": "Table already exists: fokko.already_exists in warehouse 8bcb0838-50fc-472d-9ddb-8feb89ef5f1e",
-                "type":    "AlreadyExistsException",
-                "code":    409,
-            },
-        }
-        json.NewEncoder(w).Encode(errorResponse)
-    })
+		w.WriteHeader(http.StatusConflict)
+		errorResponse := map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": "Table already exists: fokko.already_exists in warehouse 8bcb0838-50fc-472d-9ddb-8feb89ef5f1e",
+				"type":    "AlreadyExistsException",
+				"code":    409,
+			},
+		}
+		json.NewEncoder(w).Encode(errorResponse)
+	})
 
-    cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
-    r.Require().NoError(err)
+	cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
 
-    // Attempt to create table with properties
-    _, err = cat.CreateTable(
-        context.Background(),
-        catalog.ToRestIdentifier("fokko", "fokko2"),
-        tableSchemaSimple,
-        catalog.WithProperties(map[string]string{"owner": "fokko"}),
-    )
+	// Attempt to create table with properties
+	_, err = cat.CreateTable(
+		context.Background(),
+		catalog.ToRestIdentifier("fokko", "fokko2"),
+		tableSchemaSimple,
+		catalog.WithProperties(map[string]string{"owner": "fokko"}),
+	)
 
-    // Verify error
-    r.Error(err)
-    r.Contains(err.Error(), "Table already exists")
-    r.ErrorIs(err, catalog.ErrTableAlreadyExists)
+	// Verify error
+	r.Error(err)
+	r.Contains(err.Error(), "Table already exists")
+	r.ErrorIs(err, catalog.ErrTableAlreadyExists)
 }
-
 
 func (r *RestCatalogSuite) TestLoadTable200() {
 	r.mux.HandleFunc("/v1/namespaces/fokko/tables/table", func(w http.ResponseWriter, req *http.Request) {
@@ -915,113 +915,112 @@ func (r *RestCatalogSuite) TestLoadTable200() {
 }
 
 func (r *RestCatalogSuite) TestRenameTable200() {
-    // Mock the rename table endpoint
-    r.mux.HandleFunc("/v1/tables/rename", func(w http.ResponseWriter, req *http.Request) {
-        r.Require().Equal(http.MethodPost, req.Method)
+	// Mock the rename table endpoint
+	r.mux.HandleFunc("/v1/tables/rename", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodPost, req.Method)
 
-        for k, v := range TestHeaders {
-            r.Equal(v, req.Header.Values(k))
-        }
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
-        var payload struct {
-            From struct {
-                Namespace []string `json:"namespace"`
-                Name     string   `json:"name"`
-            } `json:"from"`
-            To struct {
-                Namespace []string `json:"namespace"`
-                Name     string   `json:"name"`
-            } `json:"to"`
-        }
-        r.NoError(json.NewDecoder(req.Body).Decode(&payload))
-        r.Equal([]string{"fokko"}, payload.From.Namespace)
-        r.Equal("source", payload.From.Name)
-        r.Equal([]string{"fokko"}, payload.To.Namespace)
-        r.Equal("destination", payload.To.Name)
+		var payload struct {
+			From struct {
+				Namespace []string `json:"namespace"`
+				Name      string   `json:"name"`
+			} `json:"from"`
+			To struct {
+				Namespace []string `json:"namespace"`
+				Name      string   `json:"name"`
+			} `json:"to"`
+		}
+		r.NoError(json.NewDecoder(req.Body).Decode(&payload))
+		r.Equal([]string{"fokko"}, payload.From.Namespace)
+		r.Equal("source", payload.From.Name)
+		r.Equal([]string{"fokko"}, payload.To.Namespace)
+		r.Equal("destination", payload.To.Name)
 
-        w.WriteHeader(http.StatusOK)
-    })
+		w.WriteHeader(http.StatusOK)
+	})
 
-    // Mock the get table endpoint for loading the renamed table
-    r.mux.HandleFunc("/v1/namespaces/fokko/tables/destination", func(w http.ResponseWriter, req *http.Request) {
-        r.Require().Equal(http.MethodGet, req.Method)
+	// Mock the get table endpoint for loading the renamed table
+	r.mux.HandleFunc("/v1/namespaces/fokko/tables/destination", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
 
-        for k, v := range TestHeaders {
-            r.Equal(v, req.Header.Values(k))
-        }
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
-        w.Write([]byte(createTableRestExample))
-    })
+		w.Write([]byte(createTableRestExample))
+	})
 
-    cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
-    r.Require().NoError(err)
+	cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
 
-    fromIdent := catalog.ToRestIdentifier("fokko", "source")
-    toIdent := catalog.ToRestIdentifier("fokko", "destination")
+	fromIdent := catalog.ToRestIdentifier("fokko", "source")
+	toIdent := catalog.ToRestIdentifier("fokko", "destination")
 
-    renamedTable, err := cat.RenameTable(context.Background(), fromIdent, toIdent)
-    r.Require().NoError(err)
+	renamedTable, err := cat.RenameTable(context.Background(), fromIdent, toIdent)
+	r.Require().NoError(err)
 
-    r.Equal(catalog.ToRestIdentifier("rest", "fokko", "destination"), renamedTable.Identifier())
-    r.Equal("s3://warehouse/database/table/metadata.json", renamedTable.MetadataLocation())
-    r.EqualValues(1, renamedTable.Metadata().Version())
-    r.Equal("bf289591-dcc0-4234-ad4f-5c3eed811a29", renamedTable.Metadata().TableUUID().String())
-    r.EqualValues(1657810967051, renamedTable.Metadata().LastUpdatedMillis())
-    r.Equal(3, renamedTable.Metadata().LastColumnID())
-    r.Zero(renamedTable.Schema().ID)
-    r.Zero(renamedTable.Metadata().DefaultPartitionSpec())
-    r.Equal(999, *renamedTable.Metadata().LastPartitionSpecID())
-    r.Equal(table.UnsortedSortOrder, renamedTable.SortOrder())
+	r.Equal(catalog.ToRestIdentifier("rest", "fokko", "destination"), renamedTable.Identifier())
+	r.Equal("s3://warehouse/database/table/metadata.json", renamedTable.MetadataLocation())
+	r.EqualValues(1, renamedTable.Metadata().Version())
+	r.Equal("bf289591-dcc0-4234-ad4f-5c3eed811a29", renamedTable.Metadata().TableUUID().String())
+	r.EqualValues(1657810967051, renamedTable.Metadata().LastUpdatedMillis())
+	r.Equal(3, renamedTable.Metadata().LastColumnID())
+	r.Zero(renamedTable.Schema().ID)
+	r.Zero(renamedTable.Metadata().DefaultPartitionSpec())
+	r.Equal(999, *renamedTable.Metadata().LastPartitionSpecID())
+	r.Equal(table.UnsortedSortOrder, renamedTable.SortOrder())
 }
 
-
 func (r *RestCatalogSuite) TestDropTable204() {
-    // Mock the drop table endpoint
-    r.mux.HandleFunc("/v1/namespaces/fokko/tables/table", func(w http.ResponseWriter, req *http.Request) {
-        r.Require().Equal(http.MethodDelete, req.Method)
+	// Mock the drop table endpoint
+	r.mux.HandleFunc("/v1/namespaces/fokko/tables/table", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodDelete, req.Method)
 
-        for k, v := range TestHeaders {
-            r.Equal(v, req.Header.Values(k))
-        }
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
-        // Return 204 No Content for successful deletion
-        w.WriteHeader(http.StatusNoContent)
-    })
+		// Return 204 No Content for successful deletion
+		w.WriteHeader(http.StatusNoContent)
+	})
 
-    cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
-    r.Require().NoError(err)
+	cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
 
-    err = cat.DropTable(context.Background(), catalog.ToRestIdentifier("fokko", "table"))
-    r.NoError(err)
+	err = cat.DropTable(context.Background(), catalog.ToRestIdentifier("fokko", "table"))
+	r.NoError(err)
 }
 
 func (r *RestCatalogSuite) TestDropTable404() {
-    // Mock the drop table endpoint with 404 response
-    r.mux.HandleFunc("/v1/namespaces/fokko/tables/table", func(w http.ResponseWriter, req *http.Request) {
-        r.Require().Equal(http.MethodDelete, req.Method)
+	// Mock the drop table endpoint with 404 response
+	r.mux.HandleFunc("/v1/namespaces/fokko/tables/table", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodDelete, req.Method)
 
-        for k, v := range TestHeaders {
-            r.Equal(v, req.Header.Values(k))
-        }
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
-        w.WriteHeader(http.StatusNotFound)
-        errorResponse := map[string]interface{}{
-            "error": map[string]interface{}{
-                "message": "Table does not exist: fokko.table",
-                "type":    "NoSuchTableException",
-                "code":    404,
-            },
-        }
-        json.NewEncoder(w).Encode(errorResponse)
-    })
+		w.WriteHeader(http.StatusNotFound)
+		errorResponse := map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": "Table does not exist: fokko.table",
+				"type":    "NoSuchTableException",
+				"code":    404,
+			},
+		}
+		json.NewEncoder(w).Encode(errorResponse)
+	})
 
-    cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
-    r.Require().NoError(err)
+	cat, err := catalog.NewRestCatalog("rest", r.srv.URL, catalog.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
 
-    err = cat.DropTable(context.Background(), catalog.ToRestIdentifier("fokko", "table"))
-    r.Error(err)
-    r.ErrorIs(err, catalog.ErrNoSuchTable)
-    r.ErrorContains(err, "Table does not exist: fokko.table")
+	err = cat.DropTable(context.Background(), catalog.ToRestIdentifier("fokko", "table"))
+	r.Error(err)
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+	r.ErrorContains(err, "Table does not exist: fokko.table")
 }
 
 type RestTLSCatalogSuite struct {
@@ -1064,7 +1063,8 @@ func (r *RestTLSCatalogSuite) TestSSLFail() {
 }
 
 func (r *RestTLSCatalogSuite) TestSSLLoadRegisteredCatalog() {
-	cat, err := catalog.Load(r.srv.URL, iceberg.Properties{
+	cat, err := catalog.Load("foobar", iceberg.Properties{
+		"uri":                  r.srv.URL,
 		"warehouse":            "s3://some-bucket",
 		"token":                TestToken,
 		"rest.tls.skip-verify": "true",

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -395,7 +395,7 @@ func properties(output Output, cat catalog.Catalog, args propCmd) {
 
 func mergeConf(fileConf *config.CatalogConfig, resConfig *Config) {
 	if len(resConfig.Catalog) == 0 {
-		resConfig.Catalog = fileConf.Catalog
+		resConfig.Catalog = fileConf.CatalogType
 	}
 	if len(resConfig.URI) == 0 {
 		resConfig.URI = fileConf.URI

--- a/config/config.go
+++ b/config/config.go
@@ -24,18 +24,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const cfgFile = ".iceberg-go.yaml"
+const (
+	cfgFile = ".iceberg-go.yaml"
+)
 
 type Config struct {
-	Catalogs map[string]CatalogConfig `yaml:"catalog"`
+	DefaultCatalog string                   `yaml:"default-catalog"`
+	Catalogs       map[string]CatalogConfig `yaml:"catalog"`
 }
 
 type CatalogConfig struct {
-	Catalog    string `yaml:"catalog"`
-	URI        string `yaml:"uri"`
-	Output     string `yaml:"output"`
-	Credential string `yaml:"credential"`
-	Warehouse  string `yaml:"warehouse"`
+	CatalogType string `yaml:"type"`
+	URI         string `yaml:"uri"`
+	Output      string `yaml:"output"`
+	Credential  string `yaml:"credential"`
+	Warehouse   string `yaml:"warehouse"`
 }
 
 func LoadConfig(configPath string) []byte {
@@ -69,3 +72,23 @@ func ParseConfig(file []byte, catalogName string) *CatalogConfig {
 	}
 	return &res
 }
+
+func fromConfigFiles() Config {
+	dir := os.Getenv("GOICEBERG_HOME")
+	if dir != "" {
+		dir = filepath.Join(dir, cfgFile)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(LoadConfig(dir), &cfg); err != nil {
+		return cfg
+	}
+
+	if cfg.DefaultCatalog == "" {
+		cfg.DefaultCatalog = "default"
+	}
+
+	return cfg
+}
+
+var EnvConfig = fromConfigFiles()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ var testArgs = []struct {
 	{[]byte(`
 catalog:
   custom-catalog:
-    catalog: rest
+    type: rest
     uri: http://localhost:8181/
     output: text
     credential: client-id:client-secret
@@ -44,35 +44,35 @@ catalog:
 	{[]byte(`
 catalog:
   default:
-    catalog: rest
+    type: rest
     uri: http://localhost:8181/
     output: text
     credential: client-id:client-secret
     warehouse: catalog_name
 `), "default",
 		&CatalogConfig{
-			Catalog:    "rest",
-			URI:        "http://localhost:8181/",
-			Output:     "text",
-			Credential: "client-id:client-secret",
-			Warehouse:  "catalog_name",
+			CatalogType: "rest",
+			URI:         "http://localhost:8181/",
+			Output:      "text",
+			Credential:  "client-id:client-secret",
+			Warehouse:   "catalog_name",
 		}},
 	// custom catalog
 	{[]byte(`
 catalog:
   custom-catalog:
-    catalog: rest
+    type: rest
     uri: http://localhost:8181/
     output: text
     credential: client-id:client-secret
     warehouse: catalog_name
 `), "custom-catalog",
 		&CatalogConfig{
-			Catalog:    "rest",
-			URI:        "http://localhost:8181/",
-			Output:     "text",
-			Credential: "client-id:client-secret",
-			Warehouse:  "catalog_name",
+			CatalogType: "rest",
+			URI:         "http://localhost:8181/",
+			Output:      "text",
+			Credential:  "client-id:client-secret",
+			Warehouse:   "catalog_name",
 		}},
 }
 


### PR DESCRIPTION
As brought up in https://github.com/apache/iceberg-go/pull/244#discussion_r1911257805 this PR implements using a "type" property when loading catalogs and looking up catalog configurations using the provided "name", only using the uri scheme as a fallback when necessary.