### PR TITLE
feat(catalog): Add CommitTable method

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -161,6 +161,8 @@ type Catalog interface {
 	// and schema. Options can be used to optionally provide location, partition spec, sort order,
 	// and custom properties.
 	CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...createTableOpt) (*table.Table, error)
+	// CommitTable commits the table metadata and updates to the catalog, returning the new metadata
+	CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error)
 	// ListTables returns a list of table identifiers in the catalog, with the returned
 	// identifiers containing the information required to load the table via that catalog.
 	ListTables(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error)

--- a/catalog/glue.go
+++ b/catalog/glue.go
@@ -224,6 +224,10 @@ func (c *GlueCatalog) CreateTable(ctx context.Context, identifier table.Identifi
 	panic("create table not implemented for Glue Catalog")
 }
 
+func (c *GlueCatalog) CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error) {
+	panic("commit table not implemented for Glue Catalog")
+}
+
 // DropTable deletes an Iceberg table from the Glue catalog.
 func (c *GlueCatalog) DropTable(ctx context.Context, identifier table.Identifier) error {
 	database, tableName, err := identifierToGlueTable(identifier)


### PR DESCRIPTION
Continuing the march towards better catalog support and shrinking the size of the SQL Catalog PR, this smaller PR just includes adding a `CommitTable` method to the `Catalog` interface and implements it for the REST catalog.