### PR TITLE
feat(io): Add Create method for creating file writers

### DIFF
--- a/internal/mock_fs.go
+++ b/internal/mock_fs.go
@@ -35,6 +35,15 @@ func (m *MockFS) Open(name string) (io.File, error) {
 	return args.Get(0).(io.File), args.Error(1)
 }
 
+func (m *MockFS) Create(name string) (io.FileWriter, error) {
+	args := m.Called(name)
+	return args.Get(0).(io.FileWriter), args.Error(1)
+}
+
+func (m *MockFS) WriteFile(name string, content []byte) error {
+	return m.Called(name, content).Error(0)
+}
+
 func (m *MockFS) Remove(name string) error {
 	return m.Called(name).Error(0)
 }

--- a/io/blob.go
+++ b/io/blob.go
@@ -106,6 +106,10 @@ func (bfs *blobFileIO) Remove(name string) error {
 	return bfs.Bucket.Delete(context.Background(), name)
 }
 
+func (bfs *blobFileIO) Create(name string) (FileWriter, error) {
+	return bfs.NewWriter(name, true, nil)
+}
+
 // NewWriter returns a Writer that writes to the blob stored at path.
 // A nil WriterOptions is treated the same as the zero value.
 //

--- a/io/io.go
+++ b/io/io.go
@@ -74,8 +74,12 @@ type ReadFileIO interface {
 type WriteFileIO interface {
 	IO
 
+	// Create attempts to create the named file and return a writer
+	// for it.
+	Create(name string) (FileWriter, error)
+
 	// WriteFile writes p to the named file.
-	Write(name string, p []byte) error
+	WriteFile(name string, p []byte) error
 }
 
 // A File provides access to a single file. The File interface is the

--- a/io/local.go
+++ b/io/local.go
@@ -19,6 +19,7 @@ package io
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -30,6 +31,18 @@ func (LocalFS) Open(name string) (File, error) {
 	return os.Open(strings.TrimPrefix(name, "file://"))
 }
 
+func (LocalFS) Create(name string) (FileWriter, error) {
+	filename := strings.TrimPrefix(name, "file://")
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return nil, err
+	}
+	return os.Create(filename)
+}
+
+func (LocalFS) WriteFile(name string, content []byte) error {
+	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0644)
+}
+
 func (LocalFS) Remove(name string) error {
-	return os.Remove(name)
+	return os.Remove(strings.TrimPrefix(name, "file://"))
 }

--- a/io/local.go
+++ b/io/local.go
@@ -33,14 +33,14 @@ func (LocalFS) Open(name string) (File, error) {
 
 func (LocalFS) Create(name string) (FileWriter, error) {
 	filename := strings.TrimPrefix(name, "file://")
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
 		return nil, err
 	}
 	return os.Create(filename)
 }
 
 func (LocalFS) WriteFile(name string, content []byte) error {
-	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0644)
+	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0777)
 }
 
 func (LocalFS) Remove(name string) error {


### PR DESCRIPTION
Again, continuing the march towards better Catalog support, the SQL catalog needs to be able to write files (and we'll eventually need it for manifest and table updates) so this adds a `Create` method to the `WriteFileIO` interface and implements it for our supported file systems so that we can create a file and get a writer for it.