### PR TITLE
refactor(catalog): restructure catalog package

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -15,32 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package catalog provides an interface for Catalog implementations along with
+// a registry for registering catalog implementations.
+//
+// Subpackages of this package provide some default implementations for select
+// catalog types which will register themselves if imported. For instance,
+// adding the following import:
+//
+//	import _ "github.com/apache/iceberg-go/catalog/rest"
+//
+// Will register the REST catalog implementation.
 package catalog
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
-	"fmt"
-	"maps"
-	"net/url"
 	"strings"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/table"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-type CatalogType string
-
-type AwsProperties map[string]string
+type Type string
 
 const (
-	REST     CatalogType = "rest"
-	Hive     CatalogType = "hive"
-	Glue     CatalogType = "glue"
-	DynamoDB CatalogType = "dynamodb"
-	SQL      CatalogType = "sql"
+	REST     Type = "rest"
+	Hive     Type = "hive"
+	Glue     Type = "glue"
+	DynamoDB Type = "dynamodb"
+	SQL      Type = "sql"
 )
 
 var (
@@ -53,106 +57,6 @@ var (
 	ErrNamespaceNotEmpty      = errors.New("namespace is not empty")
 )
 
-// WithAwsConfig sets the AWS configuration for the catalog.
-func WithAwsConfig(cfg aws.Config) Option[GlueCatalog] {
-	return func(o *options) {
-		o.awsConfig = cfg
-	}
-}
-
-func WithAwsProperties(props AwsProperties) Option[GlueCatalog] {
-	return func(o *options) {
-		o.awsProperties = props
-	}
-}
-
-func WithCredential(cred string) Option[RestCatalog] {
-	return func(o *options) {
-		o.credential = cred
-	}
-}
-
-func WithOAuthToken(token string) Option[RestCatalog] {
-	return func(o *options) {
-		o.oauthToken = token
-	}
-}
-
-func WithTLSConfig(config *tls.Config) Option[RestCatalog] {
-	return func(o *options) {
-		o.tlsConfig = config
-	}
-}
-
-func WithWarehouseLocation(loc string) Option[RestCatalog] {
-	return func(o *options) {
-		o.warehouseLocation = loc
-	}
-}
-
-func WithMetadataLocation(loc string) Option[RestCatalog] {
-	return func(o *options) {
-		o.metadataLocation = loc
-	}
-}
-
-func WithSigV4() Option[RestCatalog] {
-	return func(o *options) {
-		o.enableSigv4 = true
-		o.sigv4Service = "execute-api"
-	}
-}
-
-func WithSigV4RegionSvc(region, service string) Option[RestCatalog] {
-	return func(o *options) {
-		o.enableSigv4 = true
-		o.sigv4Region = region
-
-		if service == "" {
-			o.sigv4Service = "execute-api"
-		} else {
-			o.sigv4Service = service
-		}
-	}
-}
-
-func WithAuthURI(uri *url.URL) Option[RestCatalog] {
-	return func(o *options) {
-		o.authUri = uri
-	}
-}
-
-func WithPrefix(prefix string) Option[RestCatalog] {
-	return func(o *options) {
-		o.prefix = prefix
-	}
-}
-
-func WithScope(scope string) Option[RestCatalog] {
-	return func(o *options) {
-		o.scope = scope
-	}
-}
-
-type Option[T GlueCatalog | RestCatalog] func(*options)
-
-type options struct {
-	awsConfig     aws.Config
-	awsProperties AwsProperties
-
-	tlsConfig         *tls.Config
-	credential        string
-	oauthToken        string
-	warehouseLocation string
-	metadataLocation  string
-	enableSigv4       bool
-	sigv4Region       string
-	sigv4Service      string
-	prefix            string
-	authUri           *url.URL
-	scope             string
-}
-
 type PropertiesUpdateSummary struct {
 	Removed []string `json:"removed"`
 	Updated []string `json:"updated"`
@@ -162,12 +66,12 @@ type PropertiesUpdateSummary struct {
 // Catalog for iceberg table operations like create, drop, load, list and others.
 type Catalog interface {
 	// CatalogType returns the type of the catalog.
-	CatalogType() CatalogType
+	CatalogType() Type
 
 	// CreateTable creates a new iceberg table in the catalog using the provided identifier
 	// and schema. Options can be used to optionally provide location, partition spec, sort order,
 	// and custom properties.
-	CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...createTableOpt) (*table.Table, error)
+	CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...CreateTableOpt) (*table.Table, error)
 	// CommitTable commits the table metadata and updates to the catalog, returning the new metadata
 	CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error)
 	// ListTables returns a list of table identifiers in the catalog, with the returned
@@ -195,12 +99,16 @@ type Catalog interface {
 		removals []string, updates iceberg.Properties) (PropertiesUpdateSummary, error)
 }
 
-const (
-	keyOauthToken        = "token"
-	keyWarehouseLocation = "warehouse"
-	keyMetadataLocation  = "metadata_location"
-	keyOauthCredential   = "credential"
-)
+func ToIdentifier(ident ...string) table.Identifier {
+	if len(ident) == 1 {
+		if ident[0] == "" {
+			return nil
+		}
+		return table.Identifier(strings.Split(ident[0], "."))
+	}
+
+	return table.Identifier(ident)
+}
 
 func TableNameFromIdent(ident table.Identifier) string {
 	if len(ident) == 0 {
@@ -214,80 +122,28 @@ func NamespaceFromIdent(ident table.Identifier) table.Identifier {
 	return ident[:len(ident)-1]
 }
 
-func checkForOverlap(removals []string, updates iceberg.Properties) error {
-	overlap := []string{}
-	for _, key := range removals {
-		if _, ok := updates[key]; ok {
-			overlap = append(overlap, key)
-		}
-	}
-	if len(overlap) > 0 {
-		return fmt.Errorf("conflict between removals and updates for keys: %v", overlap)
-	}
-	return nil
-}
+type CreateTableOpt func(*internal.CreateTableCfg)
 
-func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals []string, updates iceberg.Properties) (iceberg.Properties, PropertiesUpdateSummary, error) {
-	if err := checkForOverlap(removals, updates); err != nil {
-		return nil, PropertiesUpdateSummary{}, err
-	}
-	var (
-		updatedProps = maps.Clone(currentProps)
-		removed      = make([]string, 0, len(removals))
-		updated      = make([]string, 0, len(updates))
-	)
-
-	for _, key := range removals {
-		if _, exists := updatedProps[key]; exists {
-			delete(updatedProps, key)
-			removed = append(removed, key)
-		}
-	}
-
-	for key, value := range updates {
-		if updatedProps[key] != value {
-			updated = append(updated, key)
-			updatedProps[key] = value
-		}
-	}
-
-	summary := PropertiesUpdateSummary{
-		Removed: removed,
-		Updated: updated,
-		Missing: iceberg.Difference(removals, removed),
-	}
-	return updatedProps, summary, nil
-}
-
-type createTableOpt func(*createTableCfg)
-
-type createTableCfg struct {
-	location      string
-	partitionSpec *iceberg.PartitionSpec
-	sortOrder     table.SortOrder
-	properties    iceberg.Properties
-}
-
-func WithLocation(location string) createTableOpt {
-	return func(cfg *createTableCfg) {
-		cfg.location = strings.TrimRight(location, "/")
+func WithLocation(location string) CreateTableOpt {
+	return func(cfg *internal.CreateTableCfg) {
+		cfg.Location = strings.TrimRight(location, "/")
 	}
 }
 
-func WithPartitionSpec(spec *iceberg.PartitionSpec) createTableOpt {
-	return func(cfg *createTableCfg) {
-		cfg.partitionSpec = spec
+func WithPartitionSpec(spec *iceberg.PartitionSpec) CreateTableOpt {
+	return func(cfg *internal.CreateTableCfg) {
+		cfg.PartitionSpec = spec
 	}
 }
 
-func WithSortOrder(order table.SortOrder) createTableOpt {
-	return func(cfg *createTableCfg) {
-		cfg.sortOrder = order
+func WithSortOrder(order table.SortOrder) CreateTableOpt {
+	return func(cfg *internal.CreateTableCfg) {
+		cfg.SortOrder = order
 	}
 }
 
-func WithProperties(props iceberg.Properties) createTableOpt {
-	return func(cfg *createTableCfg) {
-		cfg.properties = props
+func WithProperties(props iceberg.Properties) CreateTableOpt {
+	return func(cfg *internal.CreateTableCfg) {
+		cfg.Properties = props
 	}
 }

--- a/catalog/glue/options.go
+++ b/catalog/glue/options.go
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package glue
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+type AwsProperties map[string]string
+
+type Option func(*options)
+
+// WithAwsConfig sets the AWS configuration for the catalog.
+func WithAwsConfig(cfg aws.Config) Option {
+	return func(o *options) {
+		o.awsConfig = cfg
+	}
+}
+
+func WithAwsProperties(props AwsProperties) Option {
+	return func(o *options) {
+		o.awsProperties = props
+	}
+}
+
+type options struct {
+	awsConfig     aws.Config
+	awsProperties AwsProperties
+}

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+)
+
+type CreateTableCfg struct {
+	Location      string
+	PartitionSpec *iceberg.PartitionSpec
+	SortOrder     table.SortOrder
+	Properties    iceberg.Properties
+}

--- a/catalog/registry_test.go
+++ b/catalog/registry_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	_ "github.com/apache/iceberg-go/catalog/glue"
+	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -178,14 +180,14 @@ func TestRegistryFromConfig(t *testing.T) {
 
 	c, err := catalog.Load("foobar", nil)
 	assert.NoError(t, err)
-	assert.IsType(t, &catalog.RestCatalog{}, c)
-	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.IsType(t, &rest.Catalog{}, c)
+	assert.Equal(t, "foobar", c.(*rest.Catalog).Name())
 	assert.Equal(t, "catalog_name", params.Get("warehouse"))
 
 	c, err = catalog.Load("foobar", iceberg.Properties{"warehouse": "overriden"})
 	assert.NoError(t, err)
-	assert.IsType(t, &catalog.RestCatalog{}, c)
-	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.IsType(t, &rest.Catalog{}, c)
+	assert.Equal(t, "foobar", c.(*rest.Catalog).Name())
 	assert.Equal(t, "overriden", params.Get("warehouse"))
 
 	srv.Close()
@@ -195,7 +197,7 @@ func TestRegistryFromConfig(t *testing.T) {
 
 	c, err = catalog.Load("foobar", iceberg.Properties{"uri": srv2.URL})
 	assert.NoError(t, err)
-	assert.IsType(t, &catalog.RestCatalog{}, c)
-	assert.Equal(t, "foobar", c.(*catalog.RestCatalog).Name())
+	assert.IsType(t, &rest.Catalog{}, c)
+	assert.Equal(t, "foobar", c.(*rest.Catalog).Name())
 	assert.Equal(t, "catalog_name", params.Get("warehouse"))
 }

--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"crypto/tls"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+type Option func(*options)
+
+func WithCredential(cred string) Option {
+	return func(o *options) {
+		o.credential = cred
+	}
+}
+
+func WithOAuthToken(token string) Option {
+	return func(o *options) {
+		o.oauthToken = token
+	}
+}
+
+func WithTLSConfig(config *tls.Config) Option {
+	return func(o *options) {
+		o.tlsConfig = config
+	}
+}
+
+func WithWarehouseLocation(loc string) Option {
+	return func(o *options) {
+		o.warehouseLocation = loc
+	}
+}
+
+func WithMetadataLocation(loc string) Option {
+	return func(o *options) {
+		o.metadataLocation = loc
+	}
+}
+
+func WithSigV4() Option {
+	return func(o *options) {
+		o.enableSigv4 = true
+		o.sigv4Service = "execute-api"
+	}
+}
+
+func WithSigV4RegionSvc(region, service string) Option {
+	return func(o *options) {
+		o.enableSigv4 = true
+		o.sigv4Region = region
+
+		if service == "" {
+			o.sigv4Service = "execute-api"
+		} else {
+			o.sigv4Service = service
+		}
+	}
+}
+
+func WithAuthURI(uri *url.URL) Option {
+	return func(o *options) {
+		o.authUri = uri
+	}
+}
+
+func WithPrefix(prefix string) Option {
+	return func(o *options) {
+		o.prefix = prefix
+	}
+}
+
+func WithAwsConfig(cfg aws.Config) Option {
+	return func(o *options) {
+		o.awsConfig = cfg
+	}
+}
+
+type options struct {
+	awsConfig         aws.Config
+	tlsConfig         *tls.Config
+	credential        string
+	oauthToken        string
+	warehouseLocation string
+	metadataLocation  string
+	enableSigv4       bool
+	sigv4Region       string
+	sigv4Service      string
+	prefix            string
+	authUri           *url.URL
+}

--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -94,6 +94,12 @@ func WithAwsConfig(cfg aws.Config) Option {
 	}
 }
 
+func WithScope(scope string) Option {
+	return func(o *options) {
+		o.scope = scope
+	}
+}
+
 type options struct {
 	awsConfig         aws.Config
 	tlsConfig         *tls.Config
@@ -106,4 +112,5 @@ type options struct {
 	sigv4Service      string
 	prefix            string
 	authUri           *url.URL
+	scope             string
 }

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package catalog
+package rest
 
 import (
 	"encoding/json"
@@ -59,7 +59,7 @@ func TestAuthHeader(t *testing.T) {
 		})
 	})
 
-	cat, err := NewRestCatalog("rest", srv.URL,
+	cat, err := NewCatalog("rest", srv.URL,
 		WithCredential("client:secret"))
 	require.NoError(t, err)
 	assert.NotNil(t, cat)
@@ -107,7 +107,7 @@ func TestAuthUriHeader(t *testing.T) {
 
 	authUri, err := url.Parse(srv.URL)
 	require.NoError(t, err)
-	cat, err := NewRestCatalog("rest", srv.URL,
+	cat, err := NewCatalog("rest", srv.URL,
 		WithCredential("client:secret"), WithAuthURI(authUri.JoinPath("auth-token-url")))
 	require.NoError(t, err)
 	assert.NotNil(t, cat)

--- a/table/scanner_test.go
+++ b/table/scanner_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/suite"
@@ -51,7 +52,7 @@ type ScannerSuite struct {
 func (s *ScannerSuite) SetupTest() {
 	s.ctx = context.Background()
 
-	cat, err := catalog.NewRestCatalog("rest", "http://localhost:8181")
+	cat, err := rest.NewCatalog("rest", "http://localhost:8181")
 	s.Require().NoError(err)
 
 	s.cat = cat
@@ -86,7 +87,7 @@ func (s *ScannerSuite) TestScanner() {
 
 	for _, tt := range tests {
 		s.Run(tt.table+" "+tt.expr.String(), func() {
-			ident := catalog.ToRestIdentifier("default", tt.table)
+			ident := catalog.ToIdentifier("default", tt.table)
 
 			tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 			s.Require().NoError(err)
@@ -101,7 +102,7 @@ func (s *ScannerSuite) TestScanner() {
 }
 
 func (s *ScannerSuite) TestScannerWithDeletes() {
-	ident := catalog.ToRestIdentifier("default", "test_positional_mor_deletes")
+	ident := catalog.ToIdentifier("default", "test_positional_mor_deletes")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -141,7 +142,7 @@ func (s *ScannerSuite) TestArrowNan() {
 
 	for _, name := range []string{"test_null_nan", "test_null_nan_rewritten"} {
 		s.Run(name, func() {
-			ident := catalog.ToRestIdentifier("default", name)
+			ident := catalog.ToIdentifier("default", name)
 			tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 			s.Require().NoError(err)
 
@@ -164,7 +165,7 @@ func (s *ScannerSuite) TestArrowNotNanCount() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_null_nan")
+	ident := catalog.ToIdentifier("default", "test_null_nan")
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
 
@@ -182,7 +183,7 @@ func (s *ScannerSuite) TestScanWithLimit() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_limit")
+	ident := catalog.ToIdentifier("default", "test_limit")
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
 
@@ -225,7 +226,7 @@ func (s *ScannerSuite) TestScannerRecordsDeletes() {
 	//  (10, 'j'),
 	//  (11, 'k'),
 	//  (12, 'l')
-	ident := catalog.ToRestIdentifier("default", "test_positional_mor_deletes")
+	ident := catalog.ToIdentifier("default", "test_positional_mor_deletes")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -314,7 +315,7 @@ func (s *ScannerSuite) TestScannerRecordsDoubleDeletes() {
 	//  (10, 'j'),
 	//  (11, 'k'),
 	//  (12, 'l')
-	ident := catalog.ToRestIdentifier("default", "test_positional_mor_double_deletes")
+	ident := catalog.ToIdentifier("default", "test_positional_mor_double_deletes")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -437,7 +438,7 @@ func (s *ScannerSuite) TestPartitionedTables() {
 			defer scopedMem.CheckSize(s.T())
 			ctx := compute.WithAllocator(s.ctx, mem)
 
-			ident := catalog.ToRestIdentifier("default", tt.table)
+			ident := catalog.ToIdentifier("default", tt.table)
 
 			tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 			s.Require().NoError(err)
@@ -465,7 +466,7 @@ func (s *ScannerSuite) TestUnpartitionedUUIDTable() {
 		{Name: "uuid_col", Type: extensions.NewUUIDType(), Nullable: true},
 	}, nil)
 
-	ident := catalog.ToRestIdentifier("default", "test_uuid_and_fixed_unpartitioned")
+	ident := catalog.ToIdentifier("default", "test_uuid_and_fixed_unpartitioned")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -505,7 +506,7 @@ func (s *ScannerSuite) TestUnpartitionedFixedTable() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_uuid_and_fixed_unpartitioned")
+	ident := catalog.ToIdentifier("default", "test_uuid_and_fixed_unpartitioned")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -544,7 +545,7 @@ func (s *ScannerSuite) TestScanTag() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_positional_mor_deletes")
+	ident := catalog.ToIdentifier("default", "test_positional_mor_deletes")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -565,7 +566,7 @@ func (s *ScannerSuite) TestScanBranch() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_positional_mor_deletes")
+	ident := catalog.ToIdentifier("default", "test_positional_mor_deletes")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)
@@ -586,7 +587,7 @@ func (s *ScannerSuite) TestFilterOnNewColumn() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(s.T(), 0)
 
-	ident := catalog.ToRestIdentifier("default", "test_table_add_column")
+	ident := catalog.ToIdentifier("default", "test_table_add_column")
 
 	tbl, err := s.cat.LoadTable(s.ctx, ident, s.props)
 	s.Require().NoError(err)


### PR DESCRIPTION
Refactoring and restructuring the `catalog` package based on discussions with others in the Go community. This achieves the following benefits:

* Improved, and shorter, naming of types and methods. Things that are specific to the REST catalog or Glue catalog can be put directly into those packages allowing for a public API such as `rest.NewCatalog` instead of `catalog.NewRestCatalog`. Options can be made specific to catalog implementations without weird generic handling, etc.
* Using the Registry allows consumers to only import the catalog implementations they care about, allowing any others to be pruned and removed by the compiler as unused and unreachable if not imported. This will enable smaller binaries if not all catalog implementations are needed.
