### PR TITLE
Do not set Content-type header in doPost

### DIFF
--- a/catalog/rest.go
+++ b/catalog/rest.go
@@ -287,8 +287,6 @@ func doPost[Payload, Result any](ctx context.Context, baseURI *url.URL, path []s
 		return
 	}
 
-	req.Header.Add("Content-Type", "application/json")
-
 	rsp, err = cl.Do(req)
 	if err != nil {
 		return


### PR DESCRIPTION
This change shouldn't really be necessary..... but I just spent the better part of an afternoon tracking it down. 

I've been testing against snowflake opencatalog and it appears that they're running some older version of `polaris` where a bug exists where if you specify a `Content-Type` header multiple times on a `POST` you'll get a cryptic 400 back from the server. I wasn't able to find a bug in `apache/polaris`, but the problem doesn't happen on main. 

Seems safe to do as the header is [defaulted here.](https://github.com/apache/iceberg-go/blob/main/catalog/rest.go#L555)

```
iceberg-go/rgc % curl -X GET -H "Authorization: Bearer xxx" \ 
        -H 'Accept: application/json' \
        -H 'Accept: application/json' \
        -H 'Content-Type: application/json' \
        -H 'Content-Type: application/json' \
        https:/*******.snowflakecomputing.com/polaris/api/catalog/v1/test-catalog/namespaces
{
"servlet":"com.sun.jersey.spi.container.servlet.ServletContainer-16626b18",
"message":"Bad Request",
"url":"/polaris/api/catalog/v1/test-catalog/namespaces",
"status":"400"
```