### PR TITLE
ci(catalog): Add tests for checkNamespaceExists method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,18 @@ $ cd iceberg-go/cmd/iceberg && go build .
 ### Catalog Support
 
 | Operation                | REST | Hive | DynamoDB | Glue |
-| :----------------------- | :--: | :--: | :------: | :--: |
+|:-------------------------|:----:| :--: | :------: | :--: |
 | Load Table               |  X   |      |          |  X   |
 | List Tables              |  X   |      |          |  X   |
 | Create Table             |      |      |          |  X   |
 | Update Current Snapshot  |      |      |          |      |
 | Create New Snapshot      |      |      |          |      |
-| Rename Table             |      |      |          |  X   |
-| Drop Table               |      |      |          |  X   |
+| Rename Table             |  X   |      |          |  X   |
+| Drop Table               |  X   |      |          |  X   |
 | Alter Table              |      |      |          |      |
 | Set Table Properties     |      |      |          |      |
 | Create Namespace         |  X   |      |          |  X   |
+| Check Namespace Exists   |  X   |      |          |     |
 | Drop Namespace           |  X   |      |          |  X   |
 | Set Namespace Properties |  X   |      |          |  X   |
 

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -445,6 +445,60 @@ func (r *RestCatalogSuite) TestCreateNamespace200() {
 	r.Require().NoError(cat.CreateNamespace(context.Background(), catalog.ToIdentifier("leden"), nil))
 }
 
+func (r *RestCatalogSuite) TestCheckNamespaceExists204() {
+	r.mux.HandleFunc("/v1/namespaces/leden", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"namespaces": []string{"leden"},
+			"properties": map[string]any{},
+		})
+		if err != nil {
+			return
+		}
+	})
+	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	exists, err := cat.CheckNamespaceExists(context.Background(), catalog.ToIdentifier("leden"))
+	r.Require().NoError(err)
+	r.Require().True(exists)
+}
+
+func (r *RestCatalogSuite) TestCheckNamespaceExists400() {
+	r.mux.HandleFunc("/v1/namespaces/noneexistent", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "The given namespace does not exist",
+				"type":    "NoSuchNamespaceException",
+				"code":    404,
+			},
+		})
+		if err != nil {
+			return
+		}
+	})
+
+	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	exists, err := cat.CheckNamespaceExists(context.Background(), catalog.ToIdentifier("noneexistent"))
+	r.Require().NoError(err)
+	r.False(exists)
+}
+
 func (r *RestCatalogSuite) TestCreateNamespaceWithProps200() {
 	r.mux.HandleFunc("/v1/namespaces", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)


### PR DESCRIPTION
I"m adding some test cases for `CheckNamespaceExists` method in `rest.go` that I stumbled across