### PR TITLE
Use aws config from glue catalog when creating table IO

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 const (
@@ -126,6 +127,7 @@ type glueAPI interface {
 type Catalog struct {
 	glueSvc   glueAPI
 	catalogId *string
+	s3Client  *s3.Client
 }
 
 // NewCatalog creates a new instance of glue.Catalog with the given options.
@@ -146,6 +148,7 @@ func NewCatalog(opts ...Option) *Catalog {
 	return &Catalog{
 		glueSvc:   glue.NewFromConfig(glueOps.awsConfig),
 		catalogId: catalogId,
+		s3Client:  s3.NewFromConfig(glueOps.awsConfig),
 	}
 }
 
@@ -205,7 +208,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	}
 
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
-	iofs, err := io.LoadFS(props, location)
+	iofs, err := io.LoadFS(props, location, c.s3Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -624,7 +624,7 @@ func (r *Catalog) tableFromResponse(identifier []string, metadata table.Metadata
 		id = append([]string{r.name}, identifier...)
 	}
 
-	iofs, err := iceio.LoadFS(config, loc)
+	iofs, err := iceio.LoadFS(config, loc, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/io/io.go
+++ b/io/io.go
@@ -229,7 +229,7 @@ func (f ioFile) ReadDir(count int) ([]fs.DirEntry, error) {
 	return d.ReadDir(count)
 }
 
-func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
+func inferFileIOFromSchema(path string, props map[string]string, client any) (IO, error) {
 	parsed, err := url.Parse(path)
 	if err != nil {
 		return nil, err
@@ -239,7 +239,7 @@ func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
 
 	switch parsed.Scheme {
 	case "s3", "s3a", "s3n":
-		bucket, err = createS3Bucket(ctx, parsed, props)
+		bucket, err = createS3Bucket(ctx, parsed, props, client)
 		if err != nil {
 			return nil, err
 		}
@@ -267,12 +267,12 @@ func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
 // does not yet have an implementation here.
 //
 // Currently local, S3, GCS, and In-Memory FSs are implemented.
-func LoadFS(props map[string]string, location string) (IO, error) {
+func LoadFS(props map[string]string, location string, client any) (IO, error) {
 	if location == "" {
 		location = props["warehouse"]
 	}
 
-	iofs, err := inferFileIOFromSchema(location, props)
+	iofs, err := inferFileIOFromSchema(location, props, client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm not sure if there is a better way to go about this change... but it's the last change I need so I can throw my internal fork away.

This PR updates the glue path to use s3 credentials that are passed as part of catalog creation. I'm open to suggestions for a better solution... It's sort of gross passing the `any`, but I wanted to minimize changes to the codebase.  