### PR TITLE
feat(catalog): Propagate ctx from catalog interface through call stack

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -68,8 +68,8 @@ var (
 )
 
 func init() {
-	catalog.Register("glue", catalog.RegistrarFunc(func(_ string, props iceberg.Properties) (catalog.Catalog, error) {
-		awsConfig, err := toAwsConfig(context.Background(), props)
+	catalog.Register("glue", catalog.RegistrarFunc(func(ctx context.Context, _ string, props iceberg.Properties) (catalog.Catalog, error) {
+		awsConfig, err := toAwsConfig(ctx, props)
 		if err != nil {
 			return nil, err
 		}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -69,7 +69,7 @@ var (
 
 func init() {
 	catalog.Register("glue", catalog.RegistrarFunc(func(_ string, props iceberg.Properties) (catalog.Catalog, error) {
-		awsConfig, err := toAwsConfig(props)
+		awsConfig, err := toAwsConfig(context.Background(), props)
 		if err != nil {
 			return nil, err
 		}
@@ -78,7 +78,7 @@ func init() {
 	}))
 }
 
-func toAwsConfig(p iceberg.Properties) (aws.Config, error) {
+func toAwsConfig(ctx context.Context, p iceberg.Properties) (aws.Config, error) {
 	opts := make([]func(*config.LoadOptions) error, 0)
 
 	for k, v := range p {
@@ -108,7 +108,7 @@ func toAwsConfig(p iceberg.Properties) (aws.Config, error) {
 			credentials.NewStaticCredentialsProvider(key, secret, token)))
 	}
 
-	return config.LoadDefaultConfig(context.Background(), opts...)
+	return config.LoadDefaultConfig(ctx, opts...)
 }
 
 type glueAPI interface {
@@ -205,7 +205,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	}
 
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
-	iofs, err := io.LoadFS(props, location)
+	iofs, err := io.LoadFS(ctx, props, location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
 	}

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -39,8 +40,8 @@ func GetMetadataLoc(location string, newVersion uint) string {
 		location, newVersion, uuid.New().String())
 }
 
-func WriteMetadata(metadata table.Metadata, loc string, props iceberg.Properties) error {
-	fs, err := io.LoadFS(props, loc)
+func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, props iceberg.Properties) error {
+	fs, err := io.LoadFS(ctx, props, loc)
 	if err != nil {
 		return err
 	}

--- a/catalog/registry.go
+++ b/catalog/registry.go
@@ -65,13 +65,13 @@ var (
 // Registrar is a factory for creating Catalog instances, used for registering to use
 // with LoadCatalog.
 type Registrar interface {
-	GetCatalog(ctx context.Context, catalogURI string, props iceberg.Properties) (Catalog, error)
+	GetCatalog(ctx context.Context, catalogName string, props iceberg.Properties) (Catalog, error)
 }
 
 type RegistrarFunc func(context.Context, string, iceberg.Properties) (Catalog, error)
 
-func (f RegistrarFunc) GetCatalog(ctx context.Context, catalogURI string, props iceberg.Properties) (Catalog, error) {
-	return f(ctx, catalogURI, props)
+func (f RegistrarFunc) GetCatalog(ctx context.Context, catalogName string, props iceberg.Properties) (Catalog, error) {
+	return f(ctx, catalogName, props)
 }
 
 // Register adds the new catalog type to the registry. If the catalog type is already registered, it will be replaced.

--- a/catalog/registry.go
+++ b/catalog/registry.go
@@ -18,6 +18,7 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"net/url"
@@ -64,13 +65,13 @@ var (
 // Registrar is a factory for creating Catalog instances, used for registering to use
 // with LoadCatalog.
 type Registrar interface {
-	GetCatalog(catalogURI string, props iceberg.Properties) (Catalog, error)
+	GetCatalog(ctx context.Context, catalogURI string, props iceberg.Properties) (Catalog, error)
 }
 
-type RegistrarFunc func(string, iceberg.Properties) (Catalog, error)
+type RegistrarFunc func(context.Context, string, iceberg.Properties) (Catalog, error)
 
-func (f RegistrarFunc) GetCatalog(catalogURI string, props iceberg.Properties) (Catalog, error) {
-	return f(catalogURI, props)
+func (f RegistrarFunc) GetCatalog(ctx context.Context, catalogURI string, props iceberg.Properties) (Catalog, error) {
+	return f(ctx, catalogURI, props)
 }
 
 // Register adds the new catalog type to the registry. If the catalog type is already registered, it will be replaced.
@@ -125,7 +126,7 @@ func GetRegisteredCatalogs() []string {
 //     as the REST endpoint, otherwise the URI is used as the endpoint. The REST catalog also
 //     registers "http" and "https" so that Load with a http/s URI will automatically
 //     load the REST Catalog.
-func Load(name string, props iceberg.Properties) (Catalog, error) {
+func Load(ctx context.Context, name string, props iceberg.Properties) (Catalog, error) {
 	if name == "" {
 		name = config.EnvConfig.DefaultCatalog
 	}
@@ -159,5 +160,5 @@ func Load(name string, props iceberg.Properties) (Catalog, error) {
 		return nil, fmt.Errorf("%w: %s", ErrCatalogNotFound, catalogType)
 	}
 
-	return cat.GetCatalog(name, props)
+	return cat.GetCatalog(ctx, name, props)
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -81,8 +81,8 @@ var (
 )
 
 func init() {
-	reg := catalog.RegistrarFunc(func(name string, p iceberg.Properties) (catalog.Catalog, error) {
-		return newCatalogFromProps(context.Background(), name, p.Get("uri", ""), p)
+	reg := catalog.RegistrarFunc(func(ctx context.Context, name string, p iceberg.Properties) (catalog.Catalog, error) {
+		return newCatalogFromProps(ctx, name, p.Get("uri", ""), p)
 	})
 
 	catalog.Register(string(catalog.REST), reg)

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,7 @@ func TestAuthHeader(t *testing.T) {
 		})
 	})
 
-	cat, err := NewCatalog("rest", srv.URL,
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL,
 		WithCredential("client:secret"))
 	require.NoError(t, err)
 	assert.NotNil(t, cat)
@@ -107,7 +108,7 @@ func TestAuthUriHeader(t *testing.T) {
 
 	authUri, err := url.Parse(srv.URL)
 	require.NoError(t, err)
-	cat, err := NewCatalog("rest", srv.URL,
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL,
 		WithCredential("client:secret"), WithAuthURI(authUri.JoinPath("auth-token-url")))
 	require.NoError(t, err)
 	assert.NotNil(t, cat)

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -118,6 +118,7 @@ func (r *RestCatalogSuite) TestToken200() {
 }
 
 func (r *RestCatalogSuite) TestLoadRegisteredCatalog() {
+	ctx := context.Background()
 	r.mux.HandleFunc("/v1/oauth/tokens", func(w http.ResponseWriter, req *http.Request) {
 		r.Equal(http.MethodPost, req.Method)
 
@@ -140,7 +141,7 @@ func (r *RestCatalogSuite) TestLoadRegisteredCatalog() {
 		})
 	})
 
-	cat, err := catalog.Load("restful", iceberg.Properties{
+	cat, err := catalog.Load(ctx, "restful", iceberg.Properties{
 		"uri":        r.srv.URL,
 		"warehouse":  "s3://some-bucket",
 		"credential": TestCreds,
@@ -1155,7 +1156,8 @@ func (r *RestTLSCatalogSuite) TestSSLFail() {
 }
 
 func (r *RestTLSCatalogSuite) TestSSLLoadRegisteredCatalog() {
-	cat, err := catalog.Load("foobar", iceberg.Properties{
+	ctx := context.Background()
+	cat, err := catalog.Load(ctx, "foobar", iceberg.Properties{
 		"uri":                  r.srv.URL,
 		"warehouse":            "s3://some-bucket",
 		"token":                TestToken,

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -455,7 +455,7 @@ func (r *RestCatalogSuite) TestCheckNamespaceExists204() {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	exists, err := cat.CheckNamespaceExists(context.Background(), catalog.ToIdentifier("leden"))
@@ -484,7 +484,7 @@ func (r *RestCatalogSuite) TestCheckNamespaceExists404() {
 		}
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	exists, err := cat.CheckNamespaceExists(context.Background(), catalog.ToIdentifier("noneexistent"))
@@ -855,7 +855,7 @@ func (r *RestCatalogSuite) TestCheckTableExists204() {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	exists, err := cat.CheckTableExists(context.Background(), catalog.ToIdentifier("fokko", "fokko2"))
@@ -880,7 +880,7 @@ func (r *RestCatalogSuite) TestCheckTableExists404() {
 			},
 		})
 	})
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	exists, err := cat.CheckTableExists(context.Background(), catalog.ToIdentifier("fokko", "nonexistent"))

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -107,7 +107,7 @@ func (r *RestCatalogSuite) TestToken200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL,
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
 		rest.WithWarehouseLocation("s3://some-bucket"),
 		rest.WithCredential(TestCreds),
 		rest.WithScope(scope))
@@ -165,7 +165,7 @@ func (r *RestCatalogSuite) TestToken400() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithCredential(TestCreds))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithCredential(TestCreds))
 	r.Nil(cat)
 
 	r.ErrorIs(err, rest.ErrRESTError)
@@ -198,7 +198,7 @@ func (r *RestCatalogSuite) TestToken200AuthUrl() {
 
 	authUri, err := url.Parse(r.srv.URL)
 	r.Require().NoError(err)
-	cat, err := rest.NewCatalog("rest", r.srv.URL,
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
 		rest.WithWarehouseLocation("s3://some-bucket"),
 		rest.WithCredential(TestCreds), rest.WithAuthURI(authUri.JoinPath("auth-token-url")))
 
@@ -222,7 +222,7 @@ func (r *RestCatalogSuite) TestToken401() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithCredential(TestCreds))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithCredential(TestCreds))
 	r.Nil(cat)
 
 	r.ErrorIs(err, rest.ErrRESTError)
@@ -249,7 +249,7 @@ func (r *RestCatalogSuite) TestListTables200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	tables, err := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
@@ -298,7 +298,7 @@ func (r *RestCatalogSuite) TestListTablesPrefixed200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL,
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
 		rest.WithPrefix("prefix"),
 		rest.WithWarehouseLocation("s3://some-bucket"),
 		rest.WithCredential(TestCreds))
@@ -331,7 +331,7 @@ func (r *RestCatalogSuite) TestListTables404() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	_, err = cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
@@ -354,7 +354,7 @@ func (r *RestCatalogSuite) TestListNamespaces200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	results, err := cat.ListNamespaces(context.Background(), nil)
@@ -379,7 +379,7 @@ func (r *RestCatalogSuite) TestListNamespaceWithParent200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	results, err := cat.ListNamespaces(context.Background(), catalog.ToIdentifier("accounting"))
@@ -406,7 +406,7 @@ func (r *RestCatalogSuite) TestListNamespaces400() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	_, err = cat.ListNamespaces(context.Background(), catalog.ToIdentifier("accounting"))
@@ -439,7 +439,7 @@ func (r *RestCatalogSuite) TestCreateNamespace200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	r.Require().NoError(cat.CreateNamespace(context.Background(), catalog.ToIdentifier("leden"), nil))
@@ -516,7 +516,7 @@ func (r *RestCatalogSuite) TestCreateNamespaceWithProps200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	r.Require().NoError(cat.CreateNamespace(context.Background(), catalog.ToIdentifier("leden"), iceberg.Properties{"foo": "bar", "super": "duper"}))
@@ -552,7 +552,7 @@ func (r *RestCatalogSuite) TestCreateNamespace409() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	err = cat.CreateNamespace(context.Background(), catalog.ToIdentifier("fokko"), nil)
@@ -571,7 +571,7 @@ func (r *RestCatalogSuite) TestDropNamespace204() {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	r.NoError(cat.DropNamespace(context.Background(), catalog.ToIdentifier("examples")))
@@ -595,7 +595,7 @@ func (r *RestCatalogSuite) TestDropNamespace404() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	err = cat.DropNamespace(context.Background(), catalog.ToIdentifier("examples"))
@@ -618,7 +618,7 @@ func (r *RestCatalogSuite) TestLoadNamespaceProps200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	props, err := cat.LoadNamespaceProperties(context.Background(), catalog.ToIdentifier("leden"))
@@ -644,7 +644,7 @@ func (r *RestCatalogSuite) TestLoadNamespaceProps404() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	_, err = cat.LoadNamespaceProperties(context.Background(), catalog.ToIdentifier("leden"))
@@ -667,7 +667,7 @@ func (r *RestCatalogSuite) TestUpdateNamespaceProps200() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	summary, err := cat.UpdateNamespaceProperties(context.Background(), table.Identifier([]string{"fokko"}),
@@ -699,7 +699,7 @@ func (r *RestCatalogSuite) TestUpdateNamespaceProps404() {
 		})
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	_, err = cat.UpdateNamespaceProperties(context.Background(),
@@ -785,7 +785,7 @@ func (r *RestCatalogSuite) TestCreateTable200() {
 
 	t := createTableRestExample
 	_ = t
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	tbl, err := cat.CreateTable(
@@ -827,7 +827,7 @@ func (r *RestCatalogSuite) TestCreateTable409() {
 		json.NewEncoder(w).Encode(errorResponse)
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	// Attempt to create table with properties
@@ -964,7 +964,7 @@ func (r *RestCatalogSuite) TestLoadTable200() {
 		}`))
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	tbl, err := cat.LoadTable(context.Background(), catalog.ToIdentifier("fokko", "table"), nil)
@@ -1045,7 +1045,7 @@ func (r *RestCatalogSuite) TestRenameTable200() {
 		w.Write([]byte(createTableRestExample))
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	fromIdent := catalog.ToIdentifier("fokko", "source")
@@ -1079,7 +1079,7 @@ func (r *RestCatalogSuite) TestDropTable204() {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	err = cat.DropTable(context.Background(), catalog.ToIdentifier("fokko", "table"))
@@ -1106,7 +1106,7 @@ func (r *RestCatalogSuite) TestDropTable404() {
 		json.NewEncoder(w).Encode(errorResponse)
 	})
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
 	err = cat.DropTable(context.Background(), catalog.ToIdentifier("fokko", "table"))
@@ -1148,7 +1148,7 @@ func (r *RestTLSCatalogSuite) TearDownTest() {
 }
 
 func (r *RestTLSCatalogSuite) TestSSLFail() {
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Nil(cat)
 
 	r.ErrorContains(err, "tls: failed to verify certificate")
@@ -1168,7 +1168,7 @@ func (r *RestTLSCatalogSuite) TestSSLLoadRegisteredCatalog() {
 }
 
 func (r *RestTLSCatalogSuite) TestSSLConfig() {
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken),
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken),
 		rest.WithWarehouseLocation("s3://some-bucket"),
 		rest.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
 	r.NoError(err)
@@ -1187,7 +1187,7 @@ func (r *RestTLSCatalogSuite) TestSSLCerts() {
 		}
 	}
 
-	cat, err := rest.NewCatalog("rest", r.srv.URL, rest.WithOAuthToken(TestToken),
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken),
 		rest.WithWarehouseLocation("s3://some-bucket"),
 		rest.WithTLSConfig(&tls.Config{RootCAs: certs}))
 	r.NoError(err)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -62,7 +62,7 @@ const (
 )
 
 func init() {
-	catalog.Register("sql", catalog.RegistrarFunc(func(name string, p iceberg.Properties) (c catalog.Catalog, err error) {
+	catalog.Register("sql", catalog.RegistrarFunc(func(ctx context.Context, name string, p iceberg.Properties) (c catalog.Catalog, err error) {
 		driver, ok := p[DriverKey]
 		if !ok {
 			return nil, errors.New("must provide driver to pass to sql.Open")
@@ -315,7 +315,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, err
 	}
 
-	if err := internal.WriteMetadata(metadata, metadataLocation, c.props); err != nil {
+	if err := internal.WriteMetadata(ctx, metadata, metadataLocation, c.props); err != nil {
 		return nil, err
 	}
 
@@ -379,7 +379,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	tblProps := maps.Clone(c.props)
 	maps.Copy(props, tblProps)
 
-	iofs, err := io.LoadFS(tblProps, result.MetadataLocation.String)
+	iofs, err := io.LoadFS(ctx, tblProps, result.MetadataLocation.String)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -90,15 +90,15 @@ var (
 )
 
 func TestCreateSQLCatalogNoDriverDialect(t *testing.T) {
-	_, err := catalog.Load("sql", iceberg.Properties{})
+	_, err := catalog.Load(context.Background(), "sql", iceberg.Properties{})
 	assert.Error(t, err)
 
-	_, err = catalog.Load("sql", iceberg.Properties{sqlcat.DriverKey: "sqlite"})
+	_, err = catalog.Load(context.Background(), "sql", iceberg.Properties{sqlcat.DriverKey: "sqlite"})
 	assert.Error(t, err)
 }
 
 func TestInvalidDialect(t *testing.T) {
-	_, err := catalog.Load("sql", iceberg.Properties{
+	_, err := catalog.Load(context.Background(), "sql", iceberg.Properties{
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: "foobar",
 	})
@@ -193,7 +193,7 @@ func (s *SqliteCatalogTestSuite) confirmTablesExist(db *sql.DB) {
 }
 
 func (s *SqliteCatalogTestSuite) loadCatalogForTableCreation() *sqlcat.Catalog {
-	cat, err := catalog.Load("default", iceberg.Properties{
+	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
 		"uri":                 s.catalogUri(),
 		sqlcat.DriverKey:      sqliteshim.ShimName,
 		sqlcat.DialectKey:     string(sqlcat.SQLite),
@@ -217,7 +217,7 @@ func (s *SqliteCatalogTestSuite) getDB() *sql.DB {
 }
 
 func (s *SqliteCatalogTestSuite) getCatalogMemory() *sqlcat.Catalog {
-	cat, err := catalog.Load("default", iceberg.Properties{
+	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
 		"uri":             ":memory:",
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: string(sqlcat.SQLite),
@@ -230,7 +230,7 @@ func (s *SqliteCatalogTestSuite) getCatalogMemory() *sqlcat.Catalog {
 }
 
 func (s *SqliteCatalogTestSuite) getCatalogSqlite() *sqlcat.Catalog {
-	cat, err := catalog.Load("default", iceberg.Properties{
+	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
 		"uri":             s.catalogUri(),
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: string(sqlcat.SQLite),

--- a/io/io.go
+++ b/io/io.go
@@ -229,13 +229,12 @@ func (f ioFile) ReadDir(count int) ([]fs.DirEntry, error) {
 	return d.ReadDir(count)
 }
 
-func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
+func inferFileIOFromSchema(ctx context.Context, path string, props map[string]string) (IO, error) {
 	parsed, err := url.Parse(path)
 	if err != nil {
 		return nil, err
 	}
 	var bucket *blob.Bucket
-	ctx := context.Background()
 
 	switch parsed.Scheme {
 	case "s3", "s3a", "s3n":
@@ -256,7 +255,7 @@ func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
 	default:
 		return nil, fmt.Errorf("IO for file '%s' not implemented", path)
 	}
-	return createBlobFS(bucket, parsed.Host), nil
+	return createBlobFS(ctx, bucket, parsed.Host), nil
 }
 
 // LoadFS takes a map of properties and an optional URI location
@@ -267,12 +266,12 @@ func inferFileIOFromSchema(path string, props map[string]string) (IO, error) {
 // does not yet have an implementation here.
 //
 // Currently local, S3, GCS, and In-Memory FSs are implemented.
-func LoadFS(props map[string]string, location string) (IO, error) {
+func LoadFS(ctx context.Context, props map[string]string, location string) (IO, error) {
 	if location == "" {
 		location = props["warehouse"]
 	}
 
-	iofs, err := inferFileIOFromSchema(location, props)
+	iofs, err := inferFileIOFromSchema(ctx, location, props)
 	if err != nil {
 		return nil, err
 	}

--- a/io/s3.go
+++ b/io/s3.go
@@ -55,7 +55,7 @@ var unsupportedS3Props = []string{
 }
 
 // ParseAWSConfig parses S3 properties and returns a configuration.
-func ParseAWSConfig(props map[string]string) (*aws.Config, error) {
+func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, error) {
 	// If any unsupported properties are set, return an error.
 	for k := range props {
 		if slices.Contains(unsupportedS3Props, k) {
@@ -98,7 +98,7 @@ func ParseAWSConfig(props map[string]string) (*aws.Config, error) {
 
 	awscfg := new(aws.Config)
 	var err error
-	*awscfg, err = config.LoadDefaultConfig(context.Background(), opts...)
+	*awscfg, err = config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func ParseAWSConfig(props map[string]string) (*aws.Config, error) {
 }
 
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
-	awscfg, err := ParseAWSConfig(props)
+	awscfg, err := ParseAWSConfig(ctx, props)
 	if err != nil {
 		return nil, err
 	}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -428,7 +428,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 
 	pipeline = append(pipeline, func(r arrow.Record) (arrow.Record, error) {
 		defer r.Release()
-		return ToRequestedSchema(as.projectedSchema, iceSchema, r, false, false, as.useLargeTypes)
+		return ToRequestedSchema(ctx, as.projectedSchema, iceSchema, r, false, false, as.useLargeTypes)
 	})
 
 	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, out)

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -840,13 +840,13 @@ func (a *arrowProjectionVisitor) Primitive(_ iceberg.PrimitiveType, arr arrow.Ar
 
 // ToRequestedSchema will construct a new record batch matching the requested iceberg schema
 // casting columns if necessary as appropriate.
-func ToRequestedSchema(requested, fileSchema *iceberg.Schema, batch arrow.Record, downcastTimestamp, includeFieldIDs, useLargeTypes bool) (arrow.Record, error) {
+func ToRequestedSchema(ctx context.Context, requested, fileSchema *iceberg.Schema, batch arrow.Record, downcastTimestamp, includeFieldIDs, useLargeTypes bool) (arrow.Record, error) {
 	st := array.RecordToStructArray(batch)
 	defer st.Release()
 
 	result, err := iceberg.VisitSchemaWithPartner[arrow.Array, arrow.Array](requested, st,
 		&arrowProjectionVisitor{
-			ctx:                 context.Background(),
+			ctx:                 ctx,
 			fileSchema:          fileSchema,
 			includeFieldIDs:     includeFieldIDs,
 			downcastNsTimestamp: downcastTimestamp,

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -481,6 +481,7 @@ func ArrowRecordWithAllTimestampPrec(mem memory.Allocator) arrow.Record {
 }
 
 func TestToRequestedSchemaTimestamps(t *testing.T) {
+	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
@@ -490,7 +491,7 @@ func TestToRequestedSchemaTimestamps(t *testing.T) {
 	requestedSchema := TableSchemaWithAllMicrosecondsTimestampPrec
 	fileSchema := requestedSchema
 
-	converted, err := table.ToRequestedSchema(requestedSchema, fileSchema, batch, true, false, false)
+	converted, err := table.ToRequestedSchema(ctx, requestedSchema, fileSchema, batch, true, false, false)
 	require.NoError(t, err)
 	defer converted.Release()
 

--- a/table/scanner_test.go
+++ b/table/scanner_test.go
@@ -52,7 +52,7 @@ type ScannerSuite struct {
 func (s *ScannerSuite) SetupTest() {
 	s.ctx = context.Background()
 
-	cat, err := rest.NewCatalog("rest", "http://localhost:8181")
+	cat, err := rest.NewCatalog(s.ctx, "rest", "http://localhost:8181")
 	s.Require().NoError(err)
 
 	s.cat = cat


### PR DESCRIPTION
In general we should pass `context.Context` through call path rather than creating `context.Background` at random places.

I made this change in response to [this comment](https://github.com/apache/iceberg-go/pull/275#issuecomment-2617075856). I'll fix the original problem in a subsequent PR.