### PR TITLE
feat(catalog/glue): Use awscfg from catalog creation when loading data from glue

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -126,6 +126,7 @@ type glueAPI interface {
 type Catalog struct {
 	glueSvc   glueAPI
 	catalogId *string
+	awsCfg    *aws.Config
 }
 
 // NewCatalog creates a new instance of glue.Catalog with the given options.
@@ -146,6 +147,7 @@ func NewCatalog(opts ...Option) *Catalog {
 	return &Catalog{
 		glueSvc:   glue.NewFromConfig(glueOps.awsConfig),
 		catalogId: catalogId,
+		awsCfg:    &glueOps.awsConfig,
 	}
 }
 
@@ -204,6 +206,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 		return nil, fmt.Errorf("missing metadata location for table %s.%s", database, tableName)
 	}
 
+	ctx = context.WithValue(ctx, io.AwsCfgCtxKey, c.awsCfg)
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
 	iofs, err := io.LoadFS(ctx, props, location)
 	if err != nil {

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -206,7 +207,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 		return nil, fmt.Errorf("missing metadata location for table %s.%s", database, tableName)
 	}
 
-	ctx = context.WithValue(ctx, io.AwsCfgCtxKey, c.awsCfg)
+	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
 	iofs, err := io.LoadFS(ctx, props, location)
 	if err != nil {

--- a/io/s3.go
+++ b/io/s3.go
@@ -106,10 +106,23 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	return awscfg, nil
 }
 
+const AwsCfgCtxKey string = "awsConfig"
+
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
-	awscfg, err := ParseAWSConfig(ctx, props)
-	if err != nil {
-		return nil, err
+	var (
+		awscfg *aws.Config
+		err    error
+	)
+	if v := ctx.Value(AwsCfgCtxKey); v != nil {
+		if a, ok := v.(*aws.Config); ok {
+			awscfg = a
+		}
+		return nil, fmt.Errorf("invalid awsConfig type: %T", v)
+	} else {
+		awscfg, err = ParseAWSConfig(ctx, props)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	endpoint, ok := props[S3EndpointURL]

--- a/io/s3.go
+++ b/io/s3.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/apache/iceberg-go/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -106,21 +107,13 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	return awscfg, nil
 }
 
-type ctxkey string
-
-const AwsCfgCtxKey ctxkey = "awsConfig"
-
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	var (
 		awscfg *aws.Config
 		err    error
 	)
-	if v := ctx.Value(AwsCfgCtxKey); v != nil {
-		if a, ok := v.(*aws.Config); ok {
-			awscfg = a
-		} else {
-			return nil, fmt.Errorf("invalid awsConfig type: %T", v)
-		}
+	if v := utils.GetAwsConfig(ctx); v != nil {
+		awscfg = v
 	} else {
 		awscfg, err = ParseAWSConfig(ctx, props)
 		if err != nil {

--- a/io/s3.go
+++ b/io/s3.go
@@ -106,7 +106,9 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	return awscfg, nil
 }
 
-const AwsCfgCtxKey string = "awsConfig"
+type ctxkey string
+
+const AwsCfgCtxKey ctxkey = "awsConfig"
 
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	var (
@@ -116,8 +118,9 @@ func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]strin
 	if v := ctx.Value(AwsCfgCtxKey); v != nil {
 		if a, ok := v.(*aws.Config); ok {
 			awscfg = a
+		} else {
+			return nil, fmt.Errorf("invalid awsConfig type: %T", v)
 		}
-		return nil, fmt.Errorf("invalid awsConfig type: %T", v)
 	} else {
 		awscfg, err = ParseAWSConfig(ctx, props)
 		if err != nil {

--- a/utils/context.go
+++ b/utils/context.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+type awsctxkey struct{}
+
+func WithAwsConfig(ctx context.Context, cfg *aws.Config) context.Context {
+	return context.WithValue(ctx, awsctxkey{}, cfg)
+}
+
+func GetAwsConfig(ctx context.Context) *aws.Config {
+	if v := ctx.Value(awsctxkey{}); v != nil {
+		return v.(*aws.Config)
+	}
+	return nil
+}

--- a/utils/context.go
+++ b/utils/context.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package utils
 
 import (
@@ -8,10 +25,13 @@ import (
 
 type awsctxkey struct{}
 
+// WithAwsConfig returns a new context with the given AWS config
 func WithAwsConfig(ctx context.Context, cfg *aws.Config) context.Context {
 	return context.WithValue(ctx, awsctxkey{}, cfg)
 }
 
+// GetAwsConfig returns the AWS config from the given context. Returns
+// nil if no config is set.
 func GetAwsConfig(ctx context.Context) *aws.Config {
 	if v := ctx.Value(awsctxkey{}); v != nil {
 		return v.(*aws.Config)


### PR DESCRIPTION
Store `aws.Config` in glue catalog so we don't need to pass config to `catalog.LoadTable(...`