### PR TITLE
chore: tweak dependabot to bundle all go mod upgrades into the same PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    groups:
+      gomod_updates:
+        applies-to: version-updates


### PR DESCRIPTION
The intent of this PR is to configure dependabot to bundle these dependency upgrades together in one PR instead of one PR per dependency bump.

It looks like #281, #282, #283, #284, and #285 are individual dependabot PRs that are causing some headaches for you, as related dependencies are trying to be bumped out of step.  #288 manually bundles some together and yields a working CI pipeline.

Maybe this proves useful to you, the documentation for it is [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)