### PR TITLE
feat(catalog/rest): Add support for view related operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ $ cd iceberg-go/cmd/iceberg && go build .
 | Check Namespace Exists   |  X   |      |          |      |  X  |
 | Drop Namespace           |  X   |      |          |  X   |  X  |
 | Set Namespace Properties |  X   |      |          |  X   |  X  |
+| List View                |  X   |      |          |      |     |
+| Drop View                |  X   |      |          |      |     |
+| Check View Exists        |  X   |      |          |      |     |
 
 ### Read/Write Data Support
 

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -57,6 +57,7 @@ var (
 	ErrTableAlreadyExists     = errors.New("table already exists")
 	ErrCatalogNotFound        = errors.New("catalog type not registered")
 	ErrNamespaceNotEmpty      = errors.New("namespace is not empty")
+	ErrNoSuchView             = errors.New("view does not exist")
 )
 
 type PropertiesUpdateSummary struct {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -50,6 +50,10 @@ var (
 )
 
 const (
+	pageSizeKey contextKey = "page_size"
+
+	defaultPageSize = 20
+
 	keyOauthToken        = "token"
 	keyWarehouseLocation = "warehouse"
 	keyMetadataLocation  = "metadata_location"
@@ -67,7 +71,6 @@ const (
 	keyRestSigV4Service = "rest.signing-name"
 	keyAuthUrl          = "rest.authorization-url"
 	keyTlsSkipVerify    = "rest.tls.skip-verify"
-	defaultPageSize     = 20
 )
 
 var (
@@ -100,6 +103,8 @@ type errorResponse struct {
 
 	wrapping error
 }
+
+type contextKey string
 
 func (e errorResponse) Unwrap() error { return e.wrapping }
 func (e errorResponse) Error() string {
@@ -1051,10 +1056,14 @@ func (r *Catalog) listViewsPage(ctx context.Context, namespace table.Identifier,
 }
 
 func (r *Catalog) getPageSize(ctx context.Context) int {
-	if pageSize, ok := ctx.Value("page_size").(int); ok {
+	if pageSize, ok := ctx.Value(pageSizeKey).(int); ok {
 		return pageSize
 	}
 	return defaultPageSize
+}
+
+func (r *Catalog) SetPageSize(ctx context.Context, sz int) context.Context {
+	return context.WithValue(ctx, pageSizeKey, sz)
 }
 
 func (r *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {


### PR DESCRIPTION
From the [REST catalog API](https://raw.githubusercontent.com/apache/iceberg/refs/heads/main/open-api/rest-catalog-open-api.yaml), we can support a few more operation related to views 