### PR TITLE
docs(cmd/iceberg): Added description of CLI usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ $ cd iceberg-go/cmd/iceberg && go build .
 * Plan to add [Apache Arrow](https://pkg.go.dev/github.com/apache/arrow-go/) support eventually.
 * Data can currently be read as an Arrow Table or as a stream of Arrow record batches.
 
+
+### CLI Usage
+The `iceberg` CLI usage is very similar to [pyiceberg CLI](https://py.iceberg.apache.org/cli/) \
+You can pass the catalog URI with `--uri` argument.
+
+Example:
+You can start the Iceberg REST API docker image which runs on default in port `8181`
+```
+docker pull tabulario/iceberg-rest:latest
+docker run -p 8181:8181 tabulario/iceberg-rest:latest
+```
+and run the `iceberg` CLI pointing to the REST API server.
+
+```
+ ./iceberg --uri http://0.0.0.0:8181 list
+┌─────┐
+| IDs |
+| --- |
+└─────┘
+```
+**Create Namespace**
+```
+./iceberg --uri http://0.0.0.0:8181 create namespace taxitrips
+```
+
+**List Namespace**
+```
+ ./iceberg --uri http://0.0.0.0:8181 list
+┌───────────┐
+| IDs       |
+| --------- |
+| taxitrips |
+└───────────┘
+
+
+```
 # Get in Touch
 
 - [Iceberg community](https://iceberg.apache.org/community/)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ $ cd iceberg-go/cmd/iceberg && go build .
 
 
 ### CLI Usage
+Run `go build` command to build the CLI command. 
+The CLI executable(`iceberg`) will be available in `cmd/iceberg` path.
+
 The `iceberg` CLI usage is very similar to [pyiceberg CLI](https://py.iceberg.apache.org/cli/) \
 You can pass the catalog URI with `--uri` argument.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ $ cd iceberg-go/cmd/iceberg && go build .
 
 
 ### CLI Usage
-Run `go build` command to build the CLI command. 
-The CLI executable(`iceberg`) will be available in `cmd/iceberg` path.
+Run `go build ./cmd/iceberg` from the root of this repository to build the CLI executable, alternately you can run `go install github.com/apache/iceberg-go/cmd/iceberg` to install it to the `bin` directory of your `GOPATH`.
 
 The `iceberg` CLI usage is very similar to [pyiceberg CLI](https://py.iceberg.apache.org/cli/) \
 You can pass the catalog URI with `--uri` argument.


### PR DESCRIPTION
Added description of CLI usage in README similar to pyiceberg.
https://py.iceberg.apache.org/cli/