### PR TITLE
feat(catalog): Add pagination for list table operation across different catalog types

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"strings"
 
@@ -79,7 +80,7 @@ type Catalog interface {
 	CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error)
 	// ListTables returns a list of table identifiers in the catalog, with the returned
 	// identifiers containing the information required to load the table via that catalog.
-	ListTables(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error)
+	ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error]
 	// LoadTable loads a table from the catalog and returns a Table with the metadata.
 	LoadTable(ctx context.Context, identifier table.Identifier, props iceberg.Properties) (*table.Table, error)
 	// DropTable tells the catalog to drop the table entirely.

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -20,6 +20,7 @@ package glue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -82,11 +83,40 @@ func (m *mockGlueClient) UpdateDatabase(ctx context.Context, params *glue.Update
 	return args.Get(0).(*glue.UpdateDatabaseOutput), args.Error(1)
 }
 
-var testIcebergGlueTable = types.Table{
+var testIcebergGlueTable1 = types.Table{
 	Name: aws.String("test_table"),
 	Parameters: map[string]string{
 		tableTypePropsKey:        "ICEBERG",
 		metadataLocationPropsKey: "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
+	},
+}
+var testIcebergGlueTable2 = types.Table{
+	Name: aws.String("test_table2"),
+	Parameters: map[string]string{
+		tableTypePropsKey:        "ICEBERG",
+		metadataLocationPropsKey: "s3://test-bucket/test_table/metadata/abc456-456.metadata.json",
+	},
+}
+
+var testIcebergGlueTable3 = types.Table{
+	Name: aws.String("test_table3"),
+	Parameters: map[string]string{
+		tableTypePropsKey:        "ICEBERG",
+		metadataLocationPropsKey: "s3://test-bucket/test_table/metadata/abc789-789.metadata.json",
+	},
+}
+var testIcebergGlueTable4 = types.Table{
+	Name: aws.String("test_table4"),
+	Parameters: map[string]string{
+		tableTypePropsKey:        "ICEBERG",
+		metadataLocationPropsKey: "s3://test-bucket/test_table/metadata/abc123-789.metadata.json",
+	},
+}
+var testIcebergGlueTable5 = types.Table{
+	Name: aws.String("test_table5"),
+	Parameters: map[string]string{
+		tableTypePropsKey:        "ICEBERG",
+		metadataLocationPropsKey: "s3://test-bucket/test_table/metadata/abc12345-789.metadata.json",
 	},
 }
 
@@ -105,7 +135,7 @@ func TestGlueGetTable(t *testing.T) {
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
 		DatabaseName: aws.String("test_database"),
 		Name:         aws.String("test_table"),
-	}, mock.Anything).Return(&glue.GetTableOutput{Table: &testIcebergGlueTable}, nil)
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &testIcebergGlueTable1}, nil)
 
 	glueCatalog := &Catalog{
 		glueSvc: mockGlueSvc,
@@ -124,7 +154,7 @@ func TestGlueListTables(t *testing.T) {
 	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
 		DatabaseName: aws.String("test_database"),
 	}, mock.Anything).Return(&glue.GetTablesOutput{
-		TableList: []types.Table{testIcebergGlueTable, testNonIcebergGlueTable},
+		TableList: []types.Table{testIcebergGlueTable1, testNonIcebergGlueTable},
 	}, nil).Once()
 
 	glueCatalog := &Catalog{
@@ -146,6 +176,114 @@ func TestGlueListTables(t *testing.T) {
 	assert.Equal([]string{"test_database", "test_table"}, tbls[0])
 }
 
+func TestGlueListTablesPagination(t *testing.T) {
+	assert := require.New(t)
+
+	mockGlueSvc := &mockGlueClient{}
+
+	// First page
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{
+		TableList: []types.Table{
+			testIcebergGlueTable1,
+			testIcebergGlueTable2,
+		},
+		NextToken: aws.String("token1"),
+	}, nil).Once()
+
+	// Second page
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+		NextToken:    aws.String("token1"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{
+		TableList: []types.Table{
+			testIcebergGlueTable3,
+			testIcebergGlueTable4,
+		},
+		NextToken: aws.String("token2"),
+	}, nil).Once()
+
+	// Third page
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+		NextToken:    aws.String("token2"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{
+		TableList: []types.Table{
+			testIcebergGlueTable5,
+			testNonIcebergGlueTable,
+		},
+	}, nil).Once()
+
+	glueCatalog := &Catalog{
+		glueSvc: mockGlueSvc,
+	}
+
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
+	iter := glueCatalog.ListTables(context.TODO(), DatabaseIdentifier("test_database"))
+
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			lastErr = err
+		}
+	}
+
+	assert.NoError(lastErr)
+	assert.Len(tbls, 5) // Only Iceberg tables should be included
+	assert.Equal([]string{"test_database", "test_table"}, tbls[0])
+	assert.Equal([]string{"test_database", "test_table2"}, tbls[1])
+	assert.Equal([]string{"test_database", "test_table3"}, tbls[2])
+	assert.Equal([]string{"test_database", "test_table4"}, tbls[3])
+	assert.Equal([]string{"test_database", "test_table5"}, tbls[4])
+
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGlueListTablesError(t *testing.T) {
+	assert := require.New(t)
+
+	mockGlueSvc := &mockGlueClient{}
+
+	// First page succeeds
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{
+		TableList: []types.Table{
+			testIcebergGlueTable1,
+		},
+		NextToken: aws.String("token1"),
+	}, nil).Once()
+
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_database"),
+		NextToken:    aws.String("token1"),
+	}, mock.Anything).Return(&glue.GetTablesOutput{}, fmt.Errorf("token expired")).Once()
+
+	glueCatalog := &Catalog{
+		glueSvc: mockGlueSvc,
+	}
+
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
+	iter := glueCatalog.ListTables(context.TODO(), DatabaseIdentifier("test_database"))
+
+	for tbl, err := range iter {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		tbls = append(tbls, tbl)
+	}
+
+	assert.Error(lastErr)
+	assert.Contains(lastErr.Error(), "token expired")
+	assert.Len(tbls, 1)
+	assert.Equal([]string{"test_database", "test_table"}, tbls[0])
+
+	mockGlueSvc.AssertExpectations(t)
+}
 func TestGlueListNamespaces(t *testing.T) {
 	assert := require.New(t)
 
@@ -185,7 +323,7 @@ func TestGlueDropTable(t *testing.T) {
 		DatabaseName: aws.String("test_database"),
 		Name:         aws.String("test_table"),
 	}, mock.Anything).Return(&glue.GetTableOutput{
-		Table: &testIcebergGlueTable,
+		Table: &testIcebergGlueTable1,
 	}, nil).Once()
 
 	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -20,11 +20,11 @@ package glue
 import (
 	"context"
 	"errors"
-	"github.com/apache/iceberg-go/table"
 	"os"
 	"testing"
 
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/glue"

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -649,27 +649,60 @@ func (r *Catalog) tableFromResponse(ctx context.Context, identifier []string, me
 	return table.New(id, metadata, loc, iofs), nil
 }
 
-func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
+func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
+	return func(yield func(table.Identifier, error) bool) {
+		pageSize := r.getPageSize(ctx)
+		var pageToken string
+
+		for {
+			tables, nextPageToken, err := r.ListTablesPage(ctx, namespace, pageToken, pageSize)
+			if err != nil {
+				yield(table.Identifier{}, err)
+				return
+			}
+			for _, tbl := range tables {
+				if !yield(tbl, nil) {
+					return
+				}
+			}
+			if nextPageToken == "" {
+				return
+			}
+			pageToken = nextPageToken
+		}
+	}
+}
+
+func (r *Catalog) ListTablesPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
 	if err := checkValidNamespace(namespace); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-
 	ns := strings.Join(namespace, namespaceSeparator)
-	path := []string{"namespaces", ns, "tables"}
+	uri := r.baseURI.JoinPath("namespaces", ns, "tables")
 
+	v := url.Values{}
+	if pageSize >= 0 {
+		v.Set("page-size", strconv.Itoa(pageSize))
+	}
+	if pageToken != "" {
+		v.Set("page-token", pageToken)
+	}
+
+	uri.RawQuery = v.Encode()
 	type resp struct {
-		Identifiers []identifier `json:"identifiers"`
+		Identifiers   []identifier `json:"identifiers"`
+		NextPageToken string       `json:"next-page-token,omitempty"`
 	}
-	rsp, err := doGet[resp](ctx, r.baseURI, path, r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
+	rsp, err := doGet[resp](ctx, uri, []string{}, r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-
 	out := make([]table.Identifier, len(rsp.Identifiers))
 	for i, id := range rsp.Identifiers {
 		out[i] = append(id.Namespace, id.Name)
 	}
-	return out, nil
+	return out, rsp.NextPageToken, nil
+
 }
 
 func splitIdentForPath(ident table.Identifier) (string, string, error) {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -655,7 +655,7 @@ func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 		var pageToken string
 
 		for {
-			tables, nextPageToken, err := r.ListTablesPage(ctx, namespace, pageToken, pageSize)
+			tables, nextPageToken, err := r.listTablesPage(ctx, namespace, pageToken, pageSize)
 			if err != nil {
 				yield(table.Identifier{}, err)
 				return
@@ -673,7 +673,7 @@ func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 	}
 }
 
-func (r *Catalog) ListTablesPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
+func (r *Catalog) listTablesPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
 	if err := checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	TestCreds        = "client:secret"
-	TestToken        = "some_jwt_token"
-	defaultPageToken = 20
+	TestCreds       = "client:secret"
+	TestToken       = "some_jwt_token"
+	defaultPageSize = 20
 )
 
 var (
@@ -310,7 +310,7 @@ func (r *RestCatalogSuite) TestListTablesPrefixed200() {
 		pageToken := req.URL.Query().Get("page-token")
 		pageSize := req.URL.Query().Get("page-size")
 		r.Equal("", pageToken)
-		r.Equal(strconv.Itoa(defaultPageToken), pageSize)
+		r.Equal(strconv.Itoa(defaultPageSize), pageSize)
 
 		json.NewEncoder(w).Encode(map[string]any{
 			"identifiers": []any{
@@ -509,7 +509,7 @@ func (r *RestCatalogSuite) TestListTables404() {
 		pageToken := req.URL.Query().Get("page-token")
 		pageSize := req.URL.Query().Get("page-size")
 		r.Equal("", pageToken)
-		r.Equal(strconv.Itoa(defaultPageToken), pageSize)
+		r.Equal(strconv.Itoa(defaultPageSize), pageSize)
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(map[string]any{
 			"error": map[string]any{

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	TestCreds = "client:secret"
-	TestToken = "some_jwt_token"
+	TestCreds        = "client:secret"
+	TestToken        = "some_jwt_token"
+	defaultPageToken = 20
 )
 
 var (
@@ -234,13 +235,17 @@ func (r *RestCatalogSuite) TestToken401() {
 
 func (r *RestCatalogSuite) TestListTables200() {
 	namespace := "examples"
+	customPageSize := 100
 	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodGet, req.Method)
 
 		for k, v := range TestHeaders {
 			r.Equal(v, req.Header.Values(k))
 		}
-
+		pageToken := req.URL.Query().Get("page-token")
+		pageSize := req.URL.Query().Get("page-size")
+		r.Equal("", pageToken)
+		r.Equal(strconv.Itoa(customPageSize), pageSize)
 		json.NewEncoder(w).Encode(map[string]any{
 			"identifiers": []any{
 				map[string]any{
@@ -254,9 +259,22 @@ func (r *RestCatalogSuite) TestListTables200() {
 	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
-	tables, err := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
-	r.Require().NoError(err)
-	r.Equal([]table.Identifier{{"examples", "fooshare"}}, tables)
+	ctx := cat.SetPageSize(context.Background(), customPageSize)
+
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
+
+	iter := cat.ListTables(ctx, catalog.ToIdentifier(namespace))
+
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			lastErr = err
+			r.FailNow("unexpected error:", err)
+		}
+	}
+	r.Require().NoError(lastErr)
+	r.Equal([]table.Identifier{{"examples", "fooshare"}}, tbls)
 }
 
 func (r *RestCatalogSuite) TestListTablesPrefixed200() {
@@ -289,6 +307,10 @@ func (r *RestCatalogSuite) TestListTablesPrefixed200() {
 		for k, v := range TestHeaders {
 			r.Equal(v, req.Header.Values(k))
 		}
+		pageToken := req.URL.Query().Get("page-token")
+		pageSize := req.URL.Query().Get("page-size")
+		r.Equal("", pageToken)
+		r.Equal(strconv.Itoa(defaultPageToken), pageSize)
 
 		json.NewEncoder(w).Encode(map[string]any{
 			"identifiers": []any{
@@ -309,11 +331,172 @@ func (r *RestCatalogSuite) TestListTablesPrefixed200() {
 	r.NotNil(cat)
 	r.Equal(r.configVals.Get("warehouse"), "s3://some-bucket")
 
-	tables, err := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
-	r.Require().NoError(err)
-	r.Equal([]table.Identifier{{"examples", "fooshare"}}, tables)
-}
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
 
+	iter := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
+
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			lastErr = err
+			r.FailNow("unexpected error:", err)
+		}
+	}
+	r.Require().NoError(lastErr)
+	r.Equal([]table.Identifier{{"examples", "fooshare"}}, tbls)
+}
+func (r *RestCatalogSuite) TestListTablesPagination() {
+	defaultPageSize := 20
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		pageToken := req.URL.Query().Get("page-token")
+		pageSize := req.URL.Query().Get("page-size")
+		r.Equal(strconv.Itoa(defaultPageSize), pageSize)
+
+		var response map[string]any
+		if pageToken == "" {
+			response = map[string]any{
+				"identifiers": []any{
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "paid1",
+					},
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "paid2",
+					},
+				},
+				"next-page-token": "token1",
+			}
+		} else if pageToken == "token1" {
+			r.Equal("token1", pageToken)
+			response = map[string]any{
+				"identifiers": []any{
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "pending1",
+					},
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "pending2",
+					},
+				},
+				"next-page-token": "token2",
+			}
+		} else {
+			r.Equal("token2", pageToken)
+			response = map[string]any{
+				"identifiers": []any{
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "owned",
+					},
+				},
+			}
+		}
+
+		json.NewEncoder(w).Encode(response)
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
+	iter := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			lastErr = err
+			r.FailNow("unexpected error:", err)
+		}
+	}
+
+	r.Equal([]table.Identifier{
+		{"accounting", "paid1"},
+		{"accounting", "paid2"},
+		{"accounting", "pending1"},
+		{"accounting", "pending2"},
+		{"accounting", "owned"},
+	}, tbls)
+	r.Require().NoError(lastErr)
+}
+func (r *RestCatalogSuite) TestListTablesPaginationErrorOnSubsequentPage() {
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		pageToken := req.URL.Query().Get("page-token")
+
+		// First page succeeds
+		if pageToken == "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"identifiers": []any{
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "paid1",
+					},
+					map[string]any{
+						"namespace": []string{namespace},
+						"name":      "paid2",
+					},
+				},
+				"next-page-token": "token1",
+			})
+			return
+		}
+
+		// Second page fails with an error
+		if pageToken == "token1" {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"message": "Token expired or invalid",
+					"type":    "NoSuchPageTokenException",
+					"code":    404,
+				},
+			})
+			return
+		}
+
+		r.FailNow("unexpected page token:", pageToken)
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	tbls := make([]table.Identifier, 0)
+	var lastErr error
+	iter := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
+	for tbl, err := range iter {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		tbls = append(tbls, tbl)
+	}
+
+	// Check that we got the views from the first page
+	r.Equal([]table.Identifier{
+		{"accounting", "paid1"},
+		{"accounting", "paid2"},
+	}, tbls)
+
+	// Check that we got the error from the second page
+	r.Error(lastErr)
+	r.ErrorContains(lastErr, "Token expired or invalid")
+}
 func (r *RestCatalogSuite) TestListTables404() {
 	namespace := "examples"
 	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
@@ -323,6 +506,10 @@ func (r *RestCatalogSuite) TestListTables404() {
 			r.Equal(v, req.Header.Values(k))
 		}
 
+		pageToken := req.URL.Query().Get("page-token")
+		pageSize := req.URL.Query().Get("page-size")
+		r.Equal("", pageToken)
+		r.Equal(strconv.Itoa(defaultPageToken), pageSize)
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(map[string]any{
 			"error": map[string]any{
@@ -336,9 +523,19 @@ func (r *RestCatalogSuite) TestListTables404() {
 	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
-	_, err = cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
-	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
-	r.ErrorContains(err, "Namespace does not exist: personal in warehouse 8bcb0838-50fc-472d-9ddb-8feb89ef5f1e")
+	var lastErr error
+	tbls := make([]table.Identifier, 0)
+
+	iter := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
+
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			lastErr = err
+		}
+	}
+	r.ErrorIs(lastErr, catalog.ErrNoSuchNamespace)
+	r.ErrorContains(lastErr, "Namespace does not exist")
 }
 
 func (r *RestCatalogSuite) TestListNamespaces200() {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -533,6 +533,7 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		if err != nil {
 			return err
 		}
+		break // there is already at least a table
 	}
 
 	if len(tbls) > 0 {
@@ -583,7 +584,7 @@ func (c *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 }
 
 func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
-	tables, err := c.ListTablesAll(ctx, namespace)
+	tables, err := c.listTablesAll(ctx, namespace)
 	if err != nil {
 		return func(yield func(table.Identifier, error) bool) {
 			yield(table.Identifier{}, err)
@@ -598,7 +599,7 @@ func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 	}
 }
 
-func (c *Catalog) ListTablesAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
+func (c *Catalog) listTablesAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
 	if len(namespace) > 0 {
 		exists, err := c.namespaceExists(ctx, strings.Join(namespace, "."))
 		if err != nil {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"path"
 	"slices"
@@ -524,9 +525,14 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, nsToDelete)
 	}
 
-	tbls, err := c.ListTables(ctx, namespace)
-	if err != nil {
-		return err
+	tbls := make([]table.Identifier, 0)
+	iter := c.ListTables(ctx, namespace)
+
+	for tbl, err := range iter {
+		tbls = append(tbls, tbl)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(tbls) > 0 {
@@ -576,7 +582,23 @@ func (c *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 	})
 }
 
-func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
+func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
+	tables, err := c.ListTablesAll(ctx, namespace)
+	if err != nil {
+		return func(yield func(table.Identifier, error) bool) {
+			yield(table.Identifier{}, err)
+		}
+	}
+	return func(yield func(table.Identifier, error) bool) {
+		for _, t := range tables {
+			if !yield(t, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (c *Catalog) ListTablesAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
 	if len(namespace) > 0 {
 		exists, err := c.namespaceExists(ctx, strings.Join(namespace, "."))
 		if err != nil {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -486,18 +486,41 @@ func (s *SqliteCatalogTestSuite) TestListTables() {
 		_, err = cat.CreateTable(ctx, tbl2, tableSchemaNested)
 		s.Require().NoError(err)
 
-		tables, err := cat.ListTables(ctx, ns1)
-		s.Require().NoError(err)
+		var lastErr error
+		tables := make([]table.Identifier, 0)
+		iter := cat.ListTables(ctx, ns1)
+		for tbl, err := range iter {
+			tables = append(tables, tbl)
+			if err != nil {
+				lastErr = err
+			}
+		}
+
+		s.Require().NoError(lastErr)
 		s.Len(tables, 1)
 		s.Equal(tbl1, tables[0])
 
-		tables, err = cat.ListTables(ctx, ns2)
-		s.Require().NoError(err)
-		s.Len(tables, 1)
-		s.Equal(tbl2, tables[0])
+		tables2 := make([]table.Identifier, 0)
+		iter = cat.ListTables(ctx, ns2)
+		for tbl, err := range iter {
+			tables2 = append(tables2, tbl)
+			if err != nil {
+				lastErr = err
+			}
+		}
+		s.Require().NoError(lastErr)
+		s.Len(tables2, 1)
+		s.Equal(tbl2, tables2[0])
 
-		_, err = cat.ListTables(ctx, table.Identifier{"does_not_exist"})
-		s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		table3 := make([]table.Identifier, 0)
+		iter = cat.ListTables(ctx, table.Identifier{"does_not_exist"})
+		for tbl, err := range iter {
+			table3 = append(table3, tbl)
+			if err != nil {
+				lastErr = err
+			}
+		}
+		s.ErrorIs(lastErr, catalog.ErrNoSuchNamespace)
 	}
 }
 

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -273,10 +273,12 @@ func list(ctx context.Context, output Output, cat catalog.Catalog, parent string
 	}
 
 	if len(ids) == 0 && parent != "" {
-		ids, err = cat.ListTables(ctx, prnt)
-		if err != nil {
-			output.Error(err)
-			os.Exit(1)
+		iter := cat.ListTables(ctx, prnt)
+		for id, err := range iter {
+			ids = append(ids, id)
+			if err != nil {
+				output.Error(err)
+			}
 		}
 	}
 	output.Identifiers(ids)


### PR DESCRIPTION
## **Goal**
To support pagination for ListTables method. Similar to `ListViews` operation in PR https://github.com/apache/iceberg-go/pull/290. We need to change the method interface in `catalog.go` , cascading changes into `glue.go` and `sql.go`. I'm not sure about the pagination in `sql.go` so I write a wrapper to convert the existing function to iter.Seq2[] type

## **TODO**:
- [ ] Get alignment on the wrapper of `ListTables` method in `sql.go`
- [ ] Add more test for sql.go and glue.go once the first point is aligned