### PR TITLE
feat(catalog/glue): add checkNamespaceExist

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ cd iceberg-go/cmd/iceberg && go build .
 | Alter Table              |      |      |          |      |  X  |
 | Set Table Properties     |  X   |      |          |      |  X  |
 | Create Namespace         |  X   |      |          |  X   |  X  |
-| Check Namespace Exists   |  X   |      |          |      |  X  |
+| Check Namespace Exists   |  X   |      |          |  X   |  X  |
 | Drop Namespace           |  X   |      |          |  X   |  X  |
 | Set Namespace Properties |  X   |      |          |  X   |  X  |
 | List View                |  X   |      |          |      |     |

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -365,6 +365,19 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 	return nil
 }
 
+func (c *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Identifier) (bool, error) {
+	databaseName, err := identifierToGlueDatabase(namespace)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = c.getDatabase(ctx, databaseName)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // DropNamespace deletes an Iceberg namespace from the Glue catalog.
 func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier) error {
 	databaseName, err := identifierToGlueDatabase(namespace)


### PR DESCRIPTION
Hi team,
Its a smaller PR this time round. I did a check in the https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/glue but couldnt find any method to directly check namespace's existance. Hence, I borrow similar logic from `DropNamespace` where we also check if a namespace exists before deleting it