### PR TITLE
refactor: move Difference to internal

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog/internal"
+	iceinternal "github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
 )
 
@@ -196,7 +197,7 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 	summary := PropertiesUpdateSummary{
 		Removed: removed,
 		Updated: updated,
-		Missing: iceberg.Difference(removals, removed),
+		Missing: iceinternal.Difference(removals, removed),
 	}
 
 	return updatedProps, summary, nil

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -30,5 +30,6 @@ func Difference(a, b []string) []string {
 			diff = append(diff, item)
 		}
 	}
+
 	return diff
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+// Helper function to find the difference between two slices (a - b).
+func Difference(a, b []string) []string {
+	m := make(map[string]bool)
+	for _, item := range b {
+		m[item] = true
+	}
+
+	diff := make([]string, 0)
+	for _, item := range a {
+		if !m[item] {
+			diff = append(diff, item)
+		}
+	}
+	return diff
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package iceberg
+package internal_test
 
 import (
 	"testing"
 
+	"github.com/apache/iceberg-go/internal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,7 +72,7 @@ func TestDifference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := require.New(t)
-			result := Difference(tt.a, tt.b)
+			result := internal.Difference(tt.a, tt.b)
 			assert.ElementsMatch(tt.expected, result)
 		})
 	}

--- a/utils.go
+++ b/utils.go
@@ -206,20 +206,3 @@ func (l literalSet) All(fn func(Literal) bool) bool {
 
 	return true
 }
-
-// Helper function to find the difference between two slices (a - b).
-func Difference(a, b []string) []string {
-	m := make(map[string]bool)
-	for _, item := range b {
-		m[item] = true
-	}
-
-	diff := make([]string, 0)
-	for _, item := range a {
-		if !m[item] {
-			diff = append(diff, item)
-		}
-	}
-
-	return diff
-}


### PR DESCRIPTION
Let's not expose this helper function, keep it as an internal util so we don't have it as part of the public API