### PR TITLE
feat: (catalog/glue) Add support for CreateTable

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -633,16 +633,3 @@ func filterDatabaseListByType(databases []types.Database, databaseType string) [
 
 	return filtered
 }
-
-func schemaToGlueColumns(schema *iceberg.Schema) []types.Column {
-	var columns []types.Column
-	for _, field := range schema.Fields() {
-		columns = append(columns, types.Column{
-			Name:    aws.String(field.Name),
-			Type:    aws.String(field.Type.String()),
-			Comment: aws.String(field.Doc),
-		})
-	}
-
-	return columns
-}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -21,13 +21,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/apache/iceberg-go/catalog/internal"
 	"iter"
 	"strconv"
 	_ "unsafe"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/utils"
@@ -239,7 +239,7 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		opt(&cfg)
 	}
 	if cfg.Location == "" {
-		return nil, fmt.Errorf("metadata location is required for table creation")
+		return nil, errors.New("metadata location is required for table creation")
 	}
 	parameters := map[string]string{
 		tableTypePropsKey:        glueTypeIceberg,
@@ -276,8 +276,10 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 			return nil, fmt.Errorf("failed to create table %s.%s and cleanup failed: %v (original error: %w)",
 				database, tableName, cleanupErr, err)
 		}
+
 		return nil, fmt.Errorf("failed to create table %s.%s: %w", database, tableName, err)
 	}
+
 	return createdTable, nil
 }
 
@@ -631,6 +633,7 @@ func filterDatabaseListByType(databases []types.Database, databaseType string) [
 
 	return filtered
 }
+
 func schemaToGlueColumns(schema *iceberg.Schema) []types.Column {
 	var columns []types.Column
 	for _, field := range schema.Fields() {
@@ -640,5 +643,6 @@ func schemaToGlueColumns(schema *iceberg.Schema) []types.Column {
 			Comment: aws.String(field.Doc),
 		})
 	}
+
 	return columns
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -869,14 +869,15 @@ func TestGlueCreateTableInvalidMetadataRollback(t *testing.T) {
 	assert.Error(err, "expected table to not exist after failed creation")
 	assert.True(strings.Contains(err.Error(), "EntityNotFoundException: Entity Not Found"), "expected EntityNotFoundException error")
 	// Verify that the table was not left in the catalog
-	tables := ctlg.ListTables(context.TODO(), DatabaseIdentifier(dbName)) // TODO: Implement CheckTableExists
+	tablesIter := ctlg.ListTables(context.TODO(), DatabaseIdentifier(dbName)) // TODO: Implement CheckTableExists
 	found := false
-	for tbl := range tables {
+	for tbl, err := range tablesIter {
 		if tbl[1] == newTableName {
 			found = true
 
 			break
 		}
+		assert.NoError(err)
 	}
 	assert.False(found, "expected table to be rolled back and not exist in the catalog")
 }

--- a/catalog/glue/schema.go
+++ b/catalog/glue/schema.go
@@ -49,6 +49,8 @@ func fieldToGlueColumn(field iceberg.NestedField) types.Column {
 
 // icebergTypeToGlueType converts an Iceberg type to a Glue type string representation.
 // It handles primitive types as well as nested types like structs, lists, and maps.
+// Reference: https://docs.aws.amazon.com/glue/latest/dg/glue-types.html#glue-types-cataloghttps://cwiki.apache.org/confluence/display/hive/languagemanual+types%23LanguageManualTypes-Date/TimeTypes
+// Apache Hive type: https://cwiki.apache.org/confluence/display/hive/languagemanual+types
 func icebergTypeToGlueType(typ iceberg.Type) string {
 	switch t := typ.(type) {
 	case iceberg.BooleanType:
@@ -64,11 +66,11 @@ func icebergTypeToGlueType(typ iceberg.Type) string {
 	case iceberg.DateType:
 		return "date"
 	case iceberg.TimeType:
-		return "string" // Glue doesn't have a time type. TODO: Double check if this is correct
+		return "string"
 	case iceberg.TimestampType:
 		return "timestamp"
 	case iceberg.TimestampTzType:
-		return "timestamp" // TODO: Double check if this is correct
+		return "timestamp"
 	case iceberg.StringType:
 		return "string"
 	case iceberg.UUIDType:

--- a/catalog/glue/schema.go
+++ b/catalog/glue/schema.go
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package glue
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/iceberg-go"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+)
+
+// schemaToGlueColumns converts an Iceberg schema to a list of Glue columns.
+func schemaToGlueColumns(schema *iceberg.Schema) []types.Column {
+	var columns []types.Column
+	for _, field := range schema.Fields() {
+		columns = append(columns, fieldToGlueColumn(field))
+	}
+
+	return columns
+}
+
+// fieldToGlueColumn converts an Iceberg nested field to a Glue column.
+func fieldToGlueColumn(field iceberg.NestedField) types.Column {
+	column := types.Column{
+		Name:    aws.String(field.Name),
+		Comment: aws.String(field.Doc),
+	}
+	column.Type = aws.String(icebergTypeToGlueType(field.Type))
+
+	return column
+}
+
+// icebergTypeToGlueType converts an Iceberg type to a Glue type string representation.
+// It handles primitive types as well as nested types like structs, lists, and maps.
+func icebergTypeToGlueType(typ iceberg.Type) string {
+	switch t := typ.(type) {
+	case iceberg.BooleanType:
+		return "boolean"
+	case iceberg.Int32Type:
+		return "int"
+	case iceberg.Int64Type:
+		return "bigint"
+	case iceberg.Float32Type:
+		return "float"
+	case iceberg.Float64Type:
+		return "double"
+	case iceberg.DateType:
+		return "date"
+	case iceberg.TimeType:
+		return "string" // Glue doesn't have a time type. TODO: Double check if this is correct
+	case iceberg.TimestampType:
+		return "timestamp"
+	case iceberg.TimestampTzType:
+		return "timestamp" // TODO: Double check if this is correct
+	case iceberg.StringType:
+		return "string"
+	case iceberg.UUIDType:
+		return "string" // Represent UUID as string
+	case iceberg.BinaryType:
+		return "binary"
+	case iceberg.DecimalType:
+		return fmt.Sprintf("decimal(%d,%d)", t.Precision(), t.Scale())
+	case iceberg.FixedType:
+		return fmt.Sprintf("binary(%d)", t.Len())
+	case *iceberg.StructType:
+		// For struct types, create a struct<field1:type1,field2:type2,...> representation
+		var fieldStrings []string
+		for _, field := range t.Fields() {
+			fieldStrings = append(fieldStrings,
+				fmt.Sprintf("%s:%s", field.Name, icebergTypeToGlueType(field.Type)))
+		}
+
+		return fmt.Sprintf("struct<%s>", strings.Join(fieldStrings, ","))
+	case *iceberg.ListType:
+		// For list types, create an array<type> representation
+		elementField := t.ElementField()
+
+		return fmt.Sprintf("array<%s>", icebergTypeToGlueType(elementField.Type))
+	case *iceberg.MapType:
+		// For map types, create a map<keyType,valueType> representation
+		keyField := t.KeyField()
+		valueField := t.ValueField()
+
+		return fmt.Sprintf("map<%s,%s>",
+			icebergTypeToGlueType(keyField.Type),
+			icebergTypeToGlueType(valueField.Type))
+	default:
+		return "string"
+	}
+}

--- a/catalog/glue/schema_test.go
+++ b/catalog/glue/schema_test.go
@@ -1,0 +1,353 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package glue
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIcebergTypeToGlueType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    iceberg.Type
+		expected string
+	}{
+		{
+			name:     "boolean type",
+			input:    iceberg.BooleanType{},
+			expected: "boolean",
+		},
+		{
+			name:     "int32 type",
+			input:    iceberg.Int32Type{},
+			expected: "int",
+		},
+		{
+			name:     "int64 type",
+			input:    iceberg.Int64Type{},
+			expected: "bigint",
+		},
+		{
+			name:     "float type",
+			input:    iceberg.Float32Type{},
+			expected: "float",
+		},
+		{
+			name:     "double type",
+			input:    iceberg.Float64Type{},
+			expected: "double",
+		},
+		{
+			name:     "date type",
+			input:    iceberg.DateType{},
+			expected: "date",
+		},
+		{
+			name:     "time type",
+			input:    iceberg.TimeType{},
+			expected: "string",
+		},
+		{
+			name:     "timestamp type",
+			input:    iceberg.TimestampType{},
+			expected: "timestamp",
+		},
+		{
+			name:     "timestamptz type",
+			input:    iceberg.TimestampTzType{},
+			expected: "timestamp",
+		},
+		{
+			name:     "string type",
+			input:    iceberg.StringType{},
+			expected: "string",
+		},
+		{
+			name:     "uuid type",
+			input:    iceberg.UUIDType{},
+			expected: "string",
+		},
+		{
+			name:     "binary type",
+			input:    iceberg.BinaryType{},
+			expected: "binary",
+		},
+		{
+			name:     "decimal type",
+			input:    iceberg.DecimalTypeOf(10, 2),
+			expected: "decimal(10,2)",
+		},
+		{
+			name:     "fixed type",
+			input:    iceberg.FixedTypeOf(16),
+			expected: "binary(16)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := icebergTypeToGlueType(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFieldToGlueColumn(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    iceberg.NestedField
+		expected types.Column
+	}{
+		{
+			name: "simple field",
+			field: iceberg.NestedField{
+				ID:       1,
+				Name:     "simple_field",
+				Type:     iceberg.StringType{},
+				Required: true,
+				Doc:      "A simple string field",
+			},
+			expected: types.Column{
+				Name:    aws.String("simple_field"),
+				Type:    aws.String("string"),
+				Comment: aws.String("A simple string field"),
+			},
+		},
+		{
+			name: "decimal field",
+			field: iceberg.NestedField{
+				ID:       2,
+				Name:     "price",
+				Type:     iceberg.DecimalTypeOf(10, 2),
+				Required: true,
+				Doc:      "Price with 2 decimal places",
+			},
+			expected: types.Column{
+				Name:    aws.String("price"),
+				Type:    aws.String("decimal(10,2)"),
+				Comment: aws.String("Price with 2 decimal places"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fieldToGlueColumn(tt.field)
+			assert.Equal(t, aws.ToString(tt.expected.Name), aws.ToString(result.Name))
+			assert.Equal(t, aws.ToString(tt.expected.Type), aws.ToString(result.Type))
+			assert.Equal(t, aws.ToString(tt.expected.Comment), aws.ToString(result.Comment))
+		})
+	}
+}
+
+func TestNestedStructType(t *testing.T) {
+	addressStruct := &iceberg.StructType{
+		FieldList: []iceberg.NestedField{
+			{
+				ID:       1,
+				Name:     "street",
+				Type:     iceberg.StringType{},
+				Required: true,
+			},
+			{
+				ID:       2,
+				Name:     "city",
+				Type:     iceberg.StringType{},
+				Required: true,
+			},
+			{
+				ID:       3,
+				Name:     "zip",
+				Type:     iceberg.Int32Type{},
+				Required: true,
+			},
+		},
+	}
+	structType := icebergTypeToGlueType(addressStruct)
+	expected := "struct<street:string,city:string,zip:int>"
+	assert.Equal(t, expected, structType)
+	field := iceberg.NestedField{
+		ID:       4,
+		Name:     "address",
+		Type:     addressStruct,
+		Required: true,
+		Doc:      "User address",
+	}
+	column := fieldToGlueColumn(field)
+	assert.Equal(t, "address", aws.ToString(column.Name))
+	assert.Equal(t, expected, aws.ToString(column.Type))
+	assert.Equal(t, "User address", aws.ToString(column.Comment))
+}
+
+func TestNestedListType(t *testing.T) {
+	stringList := &iceberg.ListType{
+		ElementID:       1,
+		Element:         iceberg.StringType{},
+		ElementRequired: true,
+	}
+	listType := icebergTypeToGlueType(stringList)
+	assert.Equal(t, "array<string>", listType)
+	field := iceberg.NestedField{
+		ID:       2,
+		Name:     "tags",
+		Type:     stringList,
+		Required: false,
+		Doc:      "User tags",
+	}
+	column := fieldToGlueColumn(field)
+	assert.Equal(t, "tags", aws.ToString(column.Name))
+	assert.Equal(t, "array<string>", aws.ToString(column.Type))
+	assert.Equal(t, "User tags", aws.ToString(column.Comment))
+}
+
+func TestNestedMapType(t *testing.T) {
+	stringIntMap := &iceberg.MapType{
+		KeyID:         1,
+		KeyType:       iceberg.StringType{},
+		ValueID:       2,
+		ValueType:     iceberg.Int32Type{},
+		ValueRequired: true,
+	}
+	mapType := icebergTypeToGlueType(stringIntMap)
+	assert.Equal(t, "map<string,int>", mapType)
+	field := iceberg.NestedField{
+		ID:       3,
+		Name:     "properties",
+		Type:     stringIntMap,
+		Required: true,
+		Doc:      "User properties",
+	}
+	column := fieldToGlueColumn(field)
+	assert.Equal(t, "properties", aws.ToString(column.Name))
+	assert.Equal(t, "map<string,int>", aws.ToString(column.Type))
+	assert.Equal(t, "User properties", aws.ToString(column.Comment))
+}
+
+func TestComplexNestedTypes(t *testing.T) {
+	stringIntMap := &iceberg.MapType{
+		KeyID:         1,
+		KeyType:       iceberg.StringType{},
+		ValueID:       2,
+		ValueType:     iceberg.Int32Type{},
+		ValueRequired: true,
+	}
+	mapList := &iceberg.ListType{
+		ElementID:       3,
+		Element:         stringIntMap,
+		ElementRequired: true,
+	}
+	complexStruct := &iceberg.StructType{
+		FieldList: []iceberg.NestedField{
+			{
+				ID:       4,
+				Name:     "name",
+				Type:     iceberg.StringType{},
+				Required: true,
+			},
+			{
+				ID:       5,
+				Name:     "attributes",
+				Type:     mapList,
+				Required: false,
+				Doc:      "List of attribute maps",
+			},
+		},
+	}
+	complexType := icebergTypeToGlueType(complexStruct)
+	expected := "struct<name:string,attributes:array<map<string,int>>>"
+	assert.Equal(t, expected, complexType)
+	field := iceberg.NestedField{
+		ID:       6,
+		Name:     "complex_field",
+		Type:     complexStruct,
+		Required: true,
+		Doc:      "A complex nested field",
+	}
+	column := fieldToGlueColumn(field)
+	assert.Equal(t, "complex_field", aws.ToString(column.Name))
+	assert.Equal(t, expected, aws.ToString(column.Type))
+	assert.Equal(t, "A complex nested field", aws.ToString(column.Comment))
+}
+
+func TestSchemaToGlueColumns(t *testing.T) {
+	addressStruct := &iceberg.StructType{
+		FieldList: []iceberg.NestedField{
+			{
+				ID:       7,
+				Name:     "street",
+				Type:     iceberg.StringType{},
+				Required: true,
+			},
+			{
+				ID:       6,
+				Name:     "city",
+				Type:     iceberg.StringType{},
+				Required: true,
+			},
+		},
+	}
+	stringList := &iceberg.ListType{
+		ElementID:       5,
+		Element:         iceberg.StringType{},
+		ElementRequired: true,
+	}
+	fields := []iceberg.NestedField{
+		{
+			ID:       1,
+			Name:     "id",
+			Type:     iceberg.Int64Type{},
+			Required: true,
+		},
+		{
+			ID:       2,
+			Name:     "name",
+			Type:     iceberg.StringType{},
+			Required: true,
+		},
+		{
+			ID:       3,
+			Name:     "address",
+			Type:     addressStruct,
+			Required: false,
+			Doc:      "User address",
+		},
+		{
+			ID:       4,
+			Name:     "tags",
+			Type:     stringList,
+			Required: false,
+			Doc:      "User tags",
+		},
+	}
+	schema := iceberg.NewSchema(1, fields...)
+	columns := schemaToGlueColumns(schema)
+	assert.Equal(t, 4, len(columns))
+	assert.Equal(t, "id", aws.ToString(columns[0].Name))
+	assert.Equal(t, "bigint", aws.ToString(columns[0].Type))
+	assert.Equal(t, "name", aws.ToString(columns[1].Name))
+	assert.Equal(t, "string", aws.ToString(columns[1].Type))
+	assert.Equal(t, "address", aws.ToString(columns[2].Name))
+	assert.Equal(t, "struct<street:string,city:string>", aws.ToString(columns[2].Type))
+	assert.Equal(t, "User address", aws.ToString(columns[2].Comment))
+	assert.Equal(t, "tags", aws.ToString(columns[3].Name))
+	assert.Equal(t, "array<string>", aws.ToString(columns[3].Type))
+	assert.Equal(t, "User tags", aws.ToString(columns[3].Comment))
+}


### PR DESCRIPTION
Hi team,
This PR aims to support CreateTable for glue catalog. Below are the list (I think) to be done:
- [x] Tested out on a real Glue Catalog .Table was created successfully
- [x] Add integration test to this new method. I have been struggling to create a unit test for it because after the table is created, we need to load the table state and return it. At this loading step, a call to s3 to check for the metadata file existence was made by `LoadTable()`. Hence, I'm taking reference from `TestGlueLoadTableIntegration` and create a few integration test cases. Ran the test successfully with a real table in AWS Glue by setting `TEST_DATABASE_NAME` , `TEST_TABLE_NAME` and `TEST_TABLE_LOCATION` env variables to an existing one in Glue Catalog