### PR TITLE
feat(table): Add computation of iceberg stats from parquet files

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -512,7 +512,7 @@ func (b *boundRef[T]) evalToLiteral(st structLike) Optional[Literal] {
 		return Optional[Literal]{}
 	}
 
-	lit := NewLiteral[T](v.Val)
+	lit := NewLiteral(v.Val)
 	if !lit.Type().Equals(b.field.Type) {
 		lit, _ = lit.To(b.field.Type)
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -140,5 +140,6 @@ type CountingWriter struct {
 func (w *CountingWriter) Write(p []byte) (int, error) {
 	n, err := w.W.Write(p)
 	w.Count += int64(n)
+
 	return n, err
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -140,6 +140,5 @@ type CountingWriter struct {
 func (w *CountingWriter) Write(p []byte) (int, error) {
 	n, err := w.W.Write(p)
 	w.Count += int64(n)
-
 	return n, err
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -19,6 +19,7 @@ package internal
 
 import (
 	"cmp"
+	"fmt"
 	"io"
 	"slices"
 )
@@ -142,4 +143,15 @@ func (w *CountingWriter) Write(p []byte) (int, error) {
 	w.Count += int64(n)
 
 	return n, err
+}
+
+func RecoverError(err *error) {
+	if r := recover(); r != nil {
+		switch e := r.(type) {
+		case string:
+			*err = fmt.Errorf("error encountered during arrow schema visitor: %s", e)
+		case error:
+			*err = fmt.Errorf("error encountered during arrow schema visitor: %w", e)
+		}
+	}
 }

--- a/name_mapping.go
+++ b/name_mapping.go
@@ -106,6 +106,7 @@ type NameMappingVisitor[S, T any] interface {
 func VisitNameMapping[S, T any](obj NameMapping, visitor NameMappingVisitor[S, T]) (res S, err error) {
 	if obj == nil {
 		err = fmt.Errorf("%w: cannot visit nil NameMapping", ErrInvalidArgument)
+
 		return
 	}
 
@@ -273,6 +274,7 @@ func (n *nameMapProjectVisitor) Map(m MapType, mapPartner *MappedField, keyResul
 
 	keyID := n.mappedFieldID(mapPartner, "key")
 	valID := n.mappedFieldID(mapPartner, "value")
+
 	return NestedField{
 		Type: &MapType{
 			KeyID:         keyID,
@@ -321,6 +323,7 @@ func (createMapping) Struct(st StructType, result [][]MappedField) []MappedField
 			Fields:  result[i],
 		}
 	}
+
 	return output
 }
 
@@ -357,5 +360,6 @@ func (createMapping) Primitive(_ PrimitiveType) []MappedField {
 
 func createMappingFromSchema(schema *Schema) NameMapping {
 	result, _ := Visit(schema, createMapping{})
+
 	return NameMapping(result)
 }

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -28,32 +28,32 @@ import (
 
 func makeID(v int) *int { return &v }
 
-var (
-	tableNameMappingNested = iceberg.NameMapping{
-		{FieldID: makeID(1), Names: []string{"foo"}},
-		{FieldID: makeID(2), Names: []string{"bar"}},
-		{FieldID: makeID(3), Names: []string{"baz"}},
-		{FieldID: makeID(4), Names: []string{"qux"},
-			Fields: []iceberg.MappedField{{FieldID: makeID(5), Names: []string{"element"}}}},
-		{FieldID: makeID(6), Names: []string{"quux"}, Fields: []iceberg.MappedField{
-			{FieldID: makeID(7), Names: []string{"key"}},
-			{FieldID: makeID(8), Names: []string{"value"}, Fields: []iceberg.MappedField{
-				{FieldID: makeID(9), Names: []string{"key"}},
-				{FieldID: makeID(10), Names: []string{"value"}},
-			}},
+var tableNameMappingNested = iceberg.NameMapping{
+	{FieldID: makeID(1), Names: []string{"foo"}},
+	{FieldID: makeID(2), Names: []string{"bar"}},
+	{FieldID: makeID(3), Names: []string{"baz"}},
+	{
+		FieldID: makeID(4), Names: []string{"qux"},
+		Fields: []iceberg.MappedField{{FieldID: makeID(5), Names: []string{"element"}}},
+	},
+	{FieldID: makeID(6), Names: []string{"quux"}, Fields: []iceberg.MappedField{
+		{FieldID: makeID(7), Names: []string{"key"}},
+		{FieldID: makeID(8), Names: []string{"value"}, Fields: []iceberg.MappedField{
+			{FieldID: makeID(9), Names: []string{"key"}},
+			{FieldID: makeID(10), Names: []string{"value"}},
 		}},
-		{FieldID: makeID(11), Names: []string{"location"}, Fields: []iceberg.MappedField{
-			{FieldID: makeID(12), Names: []string{"element"}, Fields: []iceberg.MappedField{
-				{FieldID: makeID(13), Names: []string{"latitude"}},
-				{FieldID: makeID(14), Names: []string{"longitude"}},
-			}},
+	}},
+	{FieldID: makeID(11), Names: []string{"location"}, Fields: []iceberg.MappedField{
+		{FieldID: makeID(12), Names: []string{"element"}, Fields: []iceberg.MappedField{
+			{FieldID: makeID(13), Names: []string{"latitude"}},
+			{FieldID: makeID(14), Names: []string{"longitude"}},
 		}},
-		{FieldID: makeID(15), Names: []string{"person"}, Fields: []iceberg.MappedField{
-			{FieldID: makeID(16), Names: []string{"name"}},
-			{FieldID: makeID(17), Names: []string{"age"}},
-		}},
-	}
-)
+	}},
+	{FieldID: makeID(15), Names: []string{"person"}, Fields: []iceberg.MappedField{
+		{FieldID: makeID(16), Names: []string{"name"}},
+		{FieldID: makeID(17), Names: []string{"age"}},
+	}},
+}
 
 func TestJsonMappedField(t *testing.T) {
 	tests := []struct {
@@ -61,10 +61,14 @@ func TestJsonMappedField(t *testing.T) {
 		str  string
 		exp  iceberg.MappedField
 	}{
-		{"simple", `{"field-id": 1, "names": ["id", "record_id"]}`,
-			iceberg.MappedField{FieldID: makeID(1), Names: []string{"id", "record_id"}}},
-		{"with null fields", `{"field-id": 1, "names": ["id", "record_id"], "fields": null}`,
-			iceberg.MappedField{FieldID: makeID(1), Names: []string{"id", "record_id"}}},
+		{
+			"simple", `{"field-id": 1, "names": ["id", "record_id"]}`,
+			iceberg.MappedField{FieldID: makeID(1), Names: []string{"id", "record_id"}},
+		},
+		{
+			"with null fields", `{"field-id": 1, "names": ["id", "record_id"], "fields": null}`,
+			iceberg.MappedField{FieldID: makeID(1), Names: []string{"id", "record_id"}},
+		},
 		{"no names", `{"field-id": 1, "names": []}`, iceberg.MappedField{FieldID: makeID(1), Names: []string{}}},
 	}
 

--- a/schema.go
+++ b/schema.go
@@ -342,8 +342,7 @@ func (s *Schema) Equals(other *Schema) bool {
 // HighestFieldID returns the value of the numerically highest field ID
 // in this schema.
 func (s *Schema) HighestFieldID() int {
-	id, _ := Visit[int](s, findLastFieldID{})
-
+	id, _ := Visit(s, findLastFieldID{})
 	return id
 }
 
@@ -742,7 +741,7 @@ func IndexByName(schema *Schema) (map[string]int, error) {
 			fieldNames:      make([]string, 0),
 			shortFieldNames: make([]string, 0),
 		}
-		if _, err := Visit[map[string]int](schema, indexer); err != nil {
+		if _, err := Visit(schema, indexer); err != nil {
 			return nil, err
 		}
 
@@ -761,7 +760,7 @@ func IndexNameByID(schema *Schema) (map[int]string, error) {
 		fieldNames:      make([]string, 0),
 		shortFieldNames: make([]string, 0),
 	}
-	if _, err := Visit[map[string]int](schema, indexer); err != nil {
+	if _, err := Visit(schema, indexer); err != nil {
 		return nil, err
 	}
 

--- a/schema.go
+++ b/schema.go
@@ -67,6 +67,7 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 	s.lazyNameMapping = sync.OnceValue(func() NameMapping {
 		return createMappingFromSchema(s)
 	})
+
 	return s
 }
 
@@ -343,6 +344,7 @@ func (s *Schema) Equals(other *Schema) bool {
 // in this schema.
 func (s *Schema) HighestFieldID() int {
 	id, _ := Visit(s, findLastFieldID{})
+
 	return id
 }
 

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -1,0 +1,403 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"cmp"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func constructTestTable(t *testing.T, writeStats bool) (*metadata.FileMetaData, Metadata) {
+	tableMeta, err := ParseMetadataString(`{
+		"format-version": 2,
+        "location": "s3://bucket/test/location",
+        "last-column-id": 7,
+        "current-schema-id": 0,
+		"last-updated-ms": -1,
+        "schemas": [
+            {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": [
+                    {"id": 1, "name": "strings", "required": false, "type": "string"},
+                    {"id": 2, "name": "floats", "required": false, "type": "float"},
+                    {
+                        "id": 3,
+                        "name": "list",
+                        "required": false,
+                        "type": {"type": "list", "element-id": 6, "element": "long", "element-required": false}
+                    },
+                    {
+                        "id": 4,
+                        "name": "maps",
+                        "required": false,
+                        "type": {
+                            "type": "map",
+                            "key-id": 7,
+                            "key": "long",
+                            "value-id": 8,
+                            "value": "long",
+                            "value-required": false
+                        }
+                    },
+                    {
+                        "id": 5,
+                        "name": "structs",
+                        "required": false,
+                        "type": {
+                            "type": "struct",
+                            "fields": [
+                                {"id": 9, "name": "x", "required": false, "type": "long"},
+                                {"id": 10, "name": "y", "required": false, "type": "float", "doc": "comment"}
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "default-spec-id": 0,
+        "partition-specs": [{"spec-id": 0, "fields": []}],
+        "properties": {}
+	}`)
+	require.NoError(t, err)
+
+	arrowSchema, err := SchemaToArrowSchema(tableMeta.Schemas()[0], nil, true, false)
+	require.NoError(t, err)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.StringBuilder).AppendValues([]string{
+		"zzzzzzzzzzzzzzzzzzzz", "rrrrrrrrrrrrrrrrrrrr", "", "aaaaaaaaaaaaaaaaaaaa"},
+		[]bool{true, true, false, true})
+	bldr.Field(1).(*array.Float32Builder).AppendValues(
+		[]float32{3.14, float32(math.NaN()), 1.69, 100}, nil)
+	lb := bldr.Field(2).(*array.ListBuilder)
+	vb := lb.ValueBuilder().(*array.Int64Builder)
+	lb.Append(true)
+	vb.AppendValues([]int64{1, 2, 3}, nil)
+	lb.Append(true)
+	vb.AppendValues([]int64{4, 5, 6}, nil)
+	lb.AppendNull()
+	lb.Append(true)
+	vb.AppendValues([]int64{7, 8, 9}, nil)
+
+	mb := bldr.Field(3).(*array.MapBuilder)
+	kb := mb.KeyBuilder().(*array.Int64Builder)
+	vb = mb.ItemBuilder().(*array.Int64Builder)
+	mb.Append(true)
+	kb.AppendValues([]int64{1, 2}, nil)
+	vb.AppendValues([]int64{3, 4}, nil)
+	mb.AppendNull()
+	mb.Append(true)
+	kb.Append(5)
+	vb.Append(6)
+	mb.Append(true)
+
+	sb := bldr.Field(4).(*array.StructBuilder)
+	xb := sb.FieldBuilder(0).(*array.Int64Builder)
+	yb := sb.FieldBuilder(1).(*array.Float32Builder)
+	sb.Append(true)
+	xb.Append(1)
+	yb.Append(0.2)
+	sb.Append(true)
+	xb.AppendNull()
+	yb.Append(-1.34)
+	sb.AppendNull()
+	sb.Append(true)
+	xb.Append(54)
+	yb.AppendNull()
+
+	rec := bldr.NewRecord()
+	defer rec.Release()
+
+	var buf bytes.Buffer
+	wr, err := pqarrow.NewFileWriter(arrowSchema, &buf,
+		parquet.NewWriterProperties(parquet.WithStats(writeStats)),
+		pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+
+	require.NoError(t, wr.Write(rec))
+	require.NoError(t, wr.Close())
+
+	rdr, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	return rdr.MetaData(), tableMeta
+}
+
+type FileStatsMetricsSuite struct {
+	suite.Suite
+}
+
+func (suite *FileStatsMetricsSuite) getDataFile(meta iceberg.Properties) iceberg.DataFile {
+	fileMeta, tableMeta := constructTestTable(suite.T(), true)
+	require.NotNil(suite.T(), tableMeta)
+	require.NotNil(suite.T(), fileMeta)
+
+	schema := tableMeta.CurrentSchema()
+	if len(meta) > 0 {
+		bldr, err := MetadataBuilderFromBase(tableMeta)
+		suite.Require().NoError(err)
+		_, err = bldr.SetProperties(meta)
+		suite.Require().NoError(err)
+		tableMeta, err = bldr.Build()
+		suite.Require().NoError(err)
+	}
+
+	collector, err := computeStatsPlan(schema, tableMeta.Properties())
+	suite.Require().NoError(err)
+	mapping, err := parquetPathToIDMapping(schema)
+	suite.Require().NoError(err)
+
+	stats := dataFileStatsFromParquetMetadata(fileMeta, collector, mapping)
+	df, err := stats.toDataFile(tableMeta.PartitionSpec(), "fake-path.parquet",
+		iceberg.ParquetFile, fileMeta.GetSourceFileSize())
+	suite.Require().NoError(err)
+
+	return df
+}
+
+func (suite *FileStatsMetricsSuite) TestRecordCount() {
+	df := suite.getDataFile(nil)
+	suite.EqualValues(int64(4), df.Count())
+}
+
+func (suite *FileStatsMetricsSuite) TestValueCounts() {
+	df := suite.getDataFile(nil)
+	suite.Len(df.ValueCounts(), 7)
+	suite.EqualValues(4, df.ValueCounts()[1])
+	suite.EqualValues(4, df.ValueCounts()[2])
+	suite.EqualValues(10, df.ValueCounts()[6])
+	suite.EqualValues(5, df.ValueCounts()[7])
+	suite.EqualValues(5, df.ValueCounts()[8])
+	suite.EqualValues(4, df.ValueCounts()[9])
+	suite.EqualValues(4, df.ValueCounts()[10])
+}
+
+func (suite *FileStatsMetricsSuite) TestColumnSizes() {
+	df := suite.getDataFile(nil)
+	suite.Len(df.ColumnSizes(), 7)
+	suite.Greater(df.ColumnSizes()[1], int64(0))
+	suite.Greater(df.ColumnSizes()[2], int64(0))
+	suite.Greater(df.ColumnSizes()[6], int64(0))
+	suite.Greater(df.ColumnSizes()[7], int64(0))
+	suite.Greater(df.ColumnSizes()[8], int64(0))
+}
+
+func (suite *FileStatsMetricsSuite) TestOffsets() {
+	df := suite.getDataFile(nil)
+	suite.Len(df.SplitOffsets(), 1)
+	suite.EqualValues(4, df.SplitOffsets()[0])
+}
+
+func (suite *FileStatsMetricsSuite) TestNullValueCounts() {
+	df := suite.getDataFile(nil)
+	suite.Len(df.NullValueCounts(), 7)
+	suite.EqualValues(1, df.NullValueCounts()[1])
+	suite.EqualValues(0, df.NullValueCounts()[2])
+	suite.EqualValues(1, df.NullValueCounts()[6])
+	suite.EqualValues(2, df.NullValueCounts()[7])
+	suite.EqualValues(2, df.NullValueCounts()[8])
+	suite.EqualValues(2, df.NullValueCounts()[9])
+	suite.EqualValues(2, df.NullValueCounts()[10])
+
+	// pqarrow doesn't currently write the NaN counts
+}
+
+func (suite *FileStatsMetricsSuite) TestMetricsModeNone() {
+	df := suite.getDataFile(iceberg.Properties{"write.metadata.metrics.default": "none"})
+	suite.Len(df.ValueCounts(), 0)
+	suite.Len(df.ColumnSizes(), 0)
+	suite.Len(df.NullValueCounts(), 0)
+	suite.Len(df.NaNValueCounts(), 0)
+	suite.Len(df.LowerBoundValues(), 0)
+	suite.Len(df.UpperBoundValues(), 0)
+}
+
+func (suite *FileStatsMetricsSuite) TestMetricsModeCounts() {
+	df := suite.getDataFile(iceberg.Properties{"write.metadata.metrics.default": "counts"})
+	suite.Len(df.ValueCounts(), 7)
+	suite.Len(df.NullValueCounts(), 7)
+	suite.Len(df.NaNValueCounts(), 0)
+	suite.Len(df.LowerBoundValues(), 0)
+	suite.Len(df.UpperBoundValues(), 0)
+}
+
+func (suite *FileStatsMetricsSuite) TestMetricsModeFull() {
+	df := suite.getDataFile(iceberg.Properties{"write.metadata.metrics.default": "full"})
+	suite.Len(df.ValueCounts(), 7)
+	suite.Len(df.NullValueCounts(), 7)
+	suite.Len(df.NaNValueCounts(), 0)
+	// bound values not yet implemented
+}
+
+func (suite *FileStatsMetricsSuite) TestMetricsModeNonDefaultTrunc() {
+	df := suite.getDataFile(iceberg.Properties{"write.metadata.metrics.default": "truncate(2)"})
+	suite.Len(df.ValueCounts(), 7)
+	suite.Len(df.NullValueCounts(), 7)
+	suite.Len(df.NaNValueCounts(), 0)
+	// bound values not yet implemented
+}
+
+func (suite *FileStatsMetricsSuite) TestColumnMetricsMode() {
+	df := suite.getDataFile(iceberg.Properties{
+		"write.metadata.metrics.default":        "truncate(2)",
+		"write.metadata.metrics.column.strings": "none",
+	})
+
+	suite.Len(df.ValueCounts(), 6)
+	suite.Len(df.NullValueCounts(), 6)
+	suite.Len(df.NaNValueCounts(), 0)
+	// bound values not yet implemented
+}
+
+func TestFileMetrics(t *testing.T) {
+	suite.Run(t, new(FileStatsMetricsSuite))
+}
+
+func TestMetricsModePairs(t *testing.T) {
+	tests := []struct {
+		str      string
+		expected metricsMode
+	}{
+		{"none", metricsMode{typ: metricModeNone}},
+		{"nOnE", metricsMode{typ: metricModeNone}},
+		{"counts", metricsMode{typ: metricModeCounts}},
+		{"Counts", metricsMode{typ: metricModeCounts}},
+		{"full", metricsMode{typ: metricModeFull}},
+		{"FuLl", metricsMode{typ: metricModeFull}},
+		{" FuLl", metricsMode{typ: metricModeFull}},
+		{"truncate(16)", metricsMode{typ: metricModeTruncate, len: 16}},
+		{"trUncatE(16)", metricsMode{typ: metricModeTruncate, len: 16}},
+		{"trUncatE(7)", metricsMode{typ: metricModeTruncate, len: 7}},
+		{"trUncatE(07)", metricsMode{typ: metricModeTruncate, len: 7}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			mode, err := matchMetricsMode(tt.str)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, mode)
+		})
+	}
+
+	_, err := matchMetricsMode("truncatE(-7)")
+	assert.ErrorContains(t, err, "malformed truncate metrics mode: truncatE(-7)")
+
+	_, err = matchMetricsMode("truncatE(0)")
+	assert.ErrorContains(t, err, "invalid truncate length: 0")
+}
+
+var (
+	tableSchemaNested = iceberg.NewSchemaWithIdentifiers(1,
+		[]int{1},
+		iceberg.NestedField{
+			ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{
+			ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{
+			ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool, Required: false},
+		iceberg.NestedField{
+			ID: 4, Name: "qux", Required: true, Type: &iceberg.ListType{
+				ElementID: 5, Element: iceberg.PrimitiveTypes.String, ElementRequired: true}},
+		iceberg.NestedField{
+			ID: 6, Name: "quux",
+			Type: &iceberg.MapType{
+				KeyID:   7,
+				KeyType: iceberg.PrimitiveTypes.String,
+				ValueID: 8,
+				ValueType: &iceberg.MapType{
+					KeyID:         9,
+					KeyType:       iceberg.PrimitiveTypes.String,
+					ValueID:       10,
+					ValueType:     iceberg.PrimitiveTypes.Int32,
+					ValueRequired: true,
+				},
+				ValueRequired: true,
+			},
+			Required: true},
+		iceberg.NestedField{
+			ID: 11, Name: "location", Type: &iceberg.ListType{
+				ElementID: 12, Element: &iceberg.StructType{
+					FieldList: []iceberg.NestedField{
+						{ID: 13, Name: "latitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+						{ID: 14, Name: "longitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+					},
+				},
+				ElementRequired: true},
+			Required: true},
+		iceberg.NestedField{
+			ID:   15,
+			Name: "person",
+			Type: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 16, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+					{ID: 17, Name: "age", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+				},
+			},
+			Required: false,
+		},
+	)
+)
+
+func TestStatsTypes(t *testing.T) {
+	statsCols, err := iceberg.PreOrderVisit(tableSchemaNested,
+		&arrowStatsCollector{schema: tableSchemaNested, defaultMode: "full"})
+
+	require.NoError(t, err)
+
+	// field ids should be sorted
+	assert.True(t, slices.IsSortedFunc(statsCols, func(a, b statisticsCollector) int {
+		return cmp.Compare(a.fieldID, b.fieldID)
+	}))
+
+	actual := make([]iceberg.Type, len(statsCols))
+	for i, col := range statsCols {
+		actual[i] = col.icebergTyp
+	}
+
+	assert.Equal(t, []iceberg.Type{
+		iceberg.PrimitiveTypes.String,
+		iceberg.PrimitiveTypes.Int32,
+		iceberg.PrimitiveTypes.Bool,
+		iceberg.PrimitiveTypes.String,
+		iceberg.PrimitiveTypes.String,
+		iceberg.PrimitiveTypes.String,
+		iceberg.PrimitiveTypes.Int32,
+		iceberg.PrimitiveTypes.Float32,
+		iceberg.PrimitiveTypes.Float32,
+		iceberg.PrimitiveTypes.String,
+		iceberg.PrimitiveTypes.Int32,
+	}, actual)
+}

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -97,7 +97,8 @@ func constructTestTable(t *testing.T, writeStats bool) (*metadata.FileMetaData, 
 	defer bldr.Release()
 
 	bldr.Field(0).(*array.StringBuilder).AppendValues([]string{
-		"zzzzzzzzzzzzzzzzzzzz", "rrrrrrrrrrrrrrrrrrrr", "", "aaaaaaaaaaaaaaaaaaaa"},
+		"zzzzzzzzzzzzzzzzzzzz", "rrrrrrrrrrrrrrrrrrrr", "", "aaaaaaaaaaaaaaaaaaaa",
+	},
 		[]bool{true, true, false, true})
 	bldr.Field(1).(*array.Float32Builder).AppendValues(
 		[]float32{3.14, float32(math.NaN()), 1.69, 100}, nil)
@@ -319,56 +320,62 @@ func TestMetricsModePairs(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid truncate length: 0")
 }
 
-var (
-	tableSchemaNested = iceberg.NewSchemaWithIdentifiers(1,
-		[]int{1},
-		iceberg.NestedField{
-			ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: false},
-		iceberg.NestedField{
-			ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{
-			ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool, Required: false},
-		iceberg.NestedField{
-			ID: 4, Name: "qux", Required: true, Type: &iceberg.ListType{
-				ElementID: 5, Element: iceberg.PrimitiveTypes.String, ElementRequired: true}},
-		iceberg.NestedField{
-			ID: 6, Name: "quux",
-			Type: &iceberg.MapType{
-				KeyID:   7,
-				KeyType: iceberg.PrimitiveTypes.String,
-				ValueID: 8,
-				ValueType: &iceberg.MapType{
-					KeyID:         9,
-					KeyType:       iceberg.PrimitiveTypes.String,
-					ValueID:       10,
-					ValueType:     iceberg.PrimitiveTypes.Int32,
-					ValueRequired: true,
-				},
+var tableSchemaNested = iceberg.NewSchemaWithIdentifiers(1,
+	[]int{1},
+	iceberg.NestedField{
+		ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: false,
+	},
+	iceberg.NestedField{
+		ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	},
+	iceberg.NestedField{
+		ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool, Required: false,
+	},
+	iceberg.NestedField{
+		ID: 4, Name: "qux", Required: true, Type: &iceberg.ListType{
+			ElementID: 5, Element: iceberg.PrimitiveTypes.String, ElementRequired: true,
+		},
+	},
+	iceberg.NestedField{
+		ID: 6, Name: "quux",
+		Type: &iceberg.MapType{
+			KeyID:   7,
+			KeyType: iceberg.PrimitiveTypes.String,
+			ValueID: 8,
+			ValueType: &iceberg.MapType{
+				KeyID:         9,
+				KeyType:       iceberg.PrimitiveTypes.String,
+				ValueID:       10,
+				ValueType:     iceberg.PrimitiveTypes.Int32,
 				ValueRequired: true,
 			},
-			Required: true},
-		iceberg.NestedField{
-			ID: 11, Name: "location", Type: &iceberg.ListType{
-				ElementID: 12, Element: &iceberg.StructType{
-					FieldList: []iceberg.NestedField{
-						{ID: 13, Name: "latitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
-						{ID: 14, Name: "longitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
-					},
-				},
-				ElementRequired: true},
-			Required: true},
-		iceberg.NestedField{
-			ID:   15,
-			Name: "person",
-			Type: &iceberg.StructType{
+			ValueRequired: true,
+		},
+		Required: true,
+	},
+	iceberg.NestedField{
+		ID: 11, Name: "location", Type: &iceberg.ListType{
+			ElementID: 12, Element: &iceberg.StructType{
 				FieldList: []iceberg.NestedField{
-					{ID: 16, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
-					{ID: 17, Name: "age", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+					{ID: 13, Name: "latitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+					{ID: 14, Name: "longitude", Type: iceberg.PrimitiveTypes.Float32, Required: false},
 				},
 			},
-			Required: false,
+			ElementRequired: true,
 		},
-	)
+		Required: true,
+	},
+	iceberg.NestedField{
+		ID:   15,
+		Name: "person",
+		Type: &iceberg.StructType{
+			FieldList: []iceberg.NestedField{
+				{ID: 16, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+				{ID: 17, Name: "age", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			},
+		},
+		Required: false,
+	},
 )
 
 func TestStatsTypes(t *testing.T) {

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -385,40 +385,38 @@ func TestArrowSchemaWithNameMapping(t *testing.T) {
 	tests := []struct {
 		name     string
 		schema   *arrow.Schema
-		mapping  table.NameMapping
+		mapping  iceberg.NameMapping
 		expected *iceberg.Schema
 		err      string
 	}{
-		{"simple", schemaWithoutIDs, table.NameMapping{
+		{"simple", schemaWithoutIDs, iceberg.NameMapping{
 			{FieldID: makeID(1), Names: []string{"foo"}},
 			{FieldID: makeID(2), Names: []string{"bar"}},
 			{FieldID: makeID(3), Names: []string{"baz"}},
 		}, icebergSchemaSimple, ""},
-		{"field missing", schemaWithoutIDs, table.NameMapping{
+		{"field missing", schemaWithoutIDs, iceberg.NameMapping{
 			{FieldID: makeID(1), Names: []string{"foo"}},
 		}, nil, "field missing from name mapping: bar"},
-		{"nested schema", schemaNestedWithoutIDs, table.NameMapping{
+		{"nested schema", schemaNestedWithoutIDs, iceberg.NameMapping{
 			{FieldID: makeID(1), Names: []string{"foo"}},
 			{FieldID: makeID(2), Names: []string{"bar"}},
 			{FieldID: makeID(3), Names: []string{"baz"}},
-			{
-				FieldID: makeID(4), Names: []string{"qux"},
-				Fields: []table.MappedField{{FieldID: makeID(5), Names: []string{"element"}}},
-			},
-			{FieldID: makeID(6), Names: []string{"quux"}, Fields: []table.MappedField{
+			{FieldID: makeID(4), Names: []string{"qux"},
+				Fields: []iceberg.MappedField{{FieldID: makeID(5), Names: []string{"element"}}}},
+			{FieldID: makeID(6), Names: []string{"quux"}, Fields: []iceberg.MappedField{
 				{FieldID: makeID(7), Names: []string{"key"}},
-				{FieldID: makeID(8), Names: []string{"value"}, Fields: []table.MappedField{
+				{FieldID: makeID(8), Names: []string{"value"}, Fields: []iceberg.MappedField{
 					{FieldID: makeID(9), Names: []string{"key"}},
 					{FieldID: makeID(10), Names: []string{"value"}},
 				}},
 			}},
-			{FieldID: makeID(11), Names: []string{"location"}, Fields: []table.MappedField{
-				{FieldID: makeID(12), Names: []string{"element"}, Fields: []table.MappedField{
+			{FieldID: makeID(11), Names: []string{"location"}, Fields: []iceberg.MappedField{
+				{FieldID: makeID(12), Names: []string{"element"}, Fields: []iceberg.MappedField{
 					{FieldID: makeID(13), Names: []string{"latitude"}},
 					{FieldID: makeID(14), Names: []string{"longitude"}},
 				}},
 			}},
-			{FieldID: makeID(15), Names: []string{"person"}, Fields: []table.MappedField{
+			{FieldID: makeID(15), Names: []string{"person"}, Fields: []iceberg.MappedField{
 				{FieldID: makeID(16), Names: []string{"name"}},
 				{FieldID: makeID(17), Names: []string{"age"}},
 			}},

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -401,8 +401,10 @@ func TestArrowSchemaWithNameMapping(t *testing.T) {
 			{FieldID: makeID(1), Names: []string{"foo"}},
 			{FieldID: makeID(2), Names: []string{"bar"}},
 			{FieldID: makeID(3), Names: []string{"baz"}},
-			{FieldID: makeID(4), Names: []string{"qux"},
-				Fields: []iceberg.MappedField{{FieldID: makeID(5), Names: []string{"element"}}}},
+			{
+				FieldID: makeID(4), Names: []string{"qux"},
+				Fields: []iceberg.MappedField{{FieldID: makeID(5), Names: []string{"element"}}},
+			},
 			{FieldID: makeID(6), Names: []string{"quux"}, Fields: []iceberg.MappedField{
 				{FieldID: makeID(7), Names: []string{"key"}},
 				{FieldID: makeID(8), Names: []string{"value"}, Fields: []iceberg.MappedField{

--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -58,7 +58,7 @@ type FileReader interface {
 	// that represents the underlying file schema with only the projected fields. It also
 	// returns the indexes of the projected columns to allow reading *only* the needed
 	// columns.
-	PrunedSchema(projectedIDs map[int]struct{}) (*arrow.Schema, []int, error)
+	PrunedSchema(projectedIDs map[int]struct{}, mapping iceberg.NameMapping) (*arrow.Schema, []int, error)
 	// GetRecords returns a record reader for only the provided columns (using nil will read
 	// all of the columns of the underlying file.) The `tester` is a function that can be used,
 	// if non-nil, to filter aspects of the file such as skipping row groups in a parquet file.

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -149,6 +149,7 @@ func visitParquetManifest[T any](manifest *pqarrow.SchemaManifest, visitor manif
 		res := visitManifestField(f, visitor, fieldMap)
 		results[i] = visitor.Field(f, res, fieldMap)
 	}
+
 	return visitor.Manifest(manifest, results, mapping), nil
 }
 
@@ -173,6 +174,7 @@ func visitManifestList[T any](field pqarrow.SchemaField, visitor manifestVisitor
 		elemMapping = mapping.GetField("element")
 	}
 	res := visitManifestField(elemField, visitor, elemMapping)
+
 	return visitor.List(field, res, mapping)
 }
 
@@ -184,6 +186,7 @@ func visitManifestMap[T any](field pqarrow.SchemaField, visitor manifestVisitor[
 		keyMapping = mapping.GetField("key")
 		valMapping = mapping.GetField("value")
 	}
+
 	return visitor.Map(field, visitManifestField(keyField, visitor, keyMapping), visitManifestField(valField, visitor, valMapping), mapping)
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,6 +43,24 @@ const (
 	addSnapshotAction    = "add-snapshot"
 	addSortOrderAction   = "add-sort-order"
 )
+
+func generateSnapshotID() int64 {
+	var (
+		rndUUID = uuid.New()
+		out     [8]byte
+	)
+
+	for i := range 8 {
+		lhs, rhs := rndUUID[i], rndUUID[i+8]
+		out[i] = lhs ^ rhs
+	}
+
+	snapshotID := int64(binary.LittleEndian.Uint64(out[:]))
+	if snapshotID < 0 {
+		snapshotID = -snapshotID
+	}
+	return snapshotID
+}
 
 // Metadata for an iceberg table as specified in the Iceberg spec
 //
@@ -114,8 +133,11 @@ type Metadata interface {
 	Properties() iceberg.Properties
 	// PreviousFiles returns the list of metadata log entries for the table.
 	PreviousFiles() iter.Seq[MetadataLogEntry]
-
 	Equals(Metadata) bool
+
+	NameMapping() iceberg.NameMapping
+
+	LastSequenceNumber() int64
 }
 
 type MetadataBuilder struct {
@@ -199,6 +221,36 @@ func MetadataBuilderFromBase(metadata Metadata) (*MetadataBuilder, error) {
 	}
 
 	return b, nil
+}
+
+func (b *MetadataBuilder) nextSequenceNumber() int64 {
+	if b.formatVersion > 1 {
+		if b.lastSequenceNumber == nil {
+			return 0
+		}
+
+		return *b.lastSequenceNumber + 1
+	}
+
+	return 0
+}
+
+func (b *MetadataBuilder) newSnapshotID() int64 {
+	snapshotID := generateSnapshotID()
+	for slices.ContainsFunc(b.snapshotList, func(s Snapshot) bool { return s.SnapshotID == snapshotID }) {
+		snapshotID = generateSnapshotID()
+	}
+
+	return snapshotID
+}
+
+func (b *MetadataBuilder) CurrentSpec() iceberg.PartitionSpec {
+	return b.specs[b.defaultSpecID]
+}
+
+func (b *MetadataBuilder) CurrentSchema() *iceberg.Schema {
+	s, _ := b.GetSchemaByID(b.currentSchemaID)
+	return s
 }
 
 func (b *MetadataBuilder) AddSchema(schema *iceberg.Schema, newLastColumnID int, initial bool) (*MetadataBuilder, error) {
@@ -592,6 +644,15 @@ func (b *MetadataBuilder) GetSortOrderByID(id int) (*SortOrder, error) {
 	return nil, fmt.Errorf("sort order with id %d not found", id)
 }
 
+func (b *MetadataBuilder) currentSnapshot() *Snapshot {
+	if b.currentSnapshotID == nil {
+		return nil
+	}
+
+	s, _ := b.SnapshotByID(*b.currentSnapshotID)
+	return s
+}
+
 func (b *MetadataBuilder) SnapshotByID(id int64) (*Snapshot, error) {
 	for _, s := range b.snapshotList {
 		if s.SnapshotID == id {
@@ -602,8 +663,22 @@ func (b *MetadataBuilder) SnapshotByID(id int64) (*Snapshot, error) {
 	return nil, fmt.Errorf("snapshot with id %d not found", id)
 }
 
+func (b *MetadataBuilder) NameMapping() iceberg.NameMapping {
+	if nameMappingJson, ok := b.props[DefaultNameMappingKey]; ok {
+		nm := iceberg.NameMapping{}
+		if err := json.Unmarshal([]byte(nameMappingJson), &nm); err == nil {
+			return nm
+		}
+	}
+	return nil
+}
+
 func (b *MetadataBuilder) Build() (Metadata, error) {
 	common := b.buildCommonMetadata()
+	if err := common.validate(); err != nil {
+		return nil, err
+	}
+
 	switch b.formatVersion {
 	case 1:
 		schema, err := b.GetSchemaByID(b.currentSchemaID)
@@ -635,8 +710,8 @@ func (b *MetadataBuilder) Build() (Metadata, error) {
 		}
 
 		return &metadataV2{
-			LastSequenceNumber: lastSequenceNumber,
-			commonMetadata:     *common,
+			LastSeqNum:     lastSequenceNumber,
+			commonMetadata: *common,
 		}, nil
 
 	default:
@@ -930,6 +1005,18 @@ func (c *commonMetadata) checkSortOrders() error {
 		ErrInvalidMetadata, c.DefaultSortOrderID, c.SortOrderList)
 }
 
+func (c *commonMetadata) constructRefs() {
+	if c.CurrentSnapshotID != nil {
+		_, ok := c.SnapshotRefs[MainBranch]
+		if !ok {
+			c.SnapshotRefs[MainBranch] = SnapshotRef{
+				SnapshotID:      *c.CurrentSnapshotID,
+				SnapshotRefType: BranchRef,
+			}
+		}
+	}
+}
+
 func (c *commonMetadata) validate() error {
 	if err := c.checkSchemas(); err != nil {
 		return err
@@ -943,6 +1030,8 @@ func (c *commonMetadata) validate() error {
 		return err
 	}
 
+	c.constructRefs()
+
 	switch {
 	case c.LastUpdatedMS == 0:
 		// last-updated-ms is required
@@ -955,6 +1044,16 @@ func (c *commonMetadata) validate() error {
 	return nil
 }
 
+func (c *commonMetadata) NameMapping() iceberg.NameMapping {
+	if nameMappingJson, ok := c.Props[DefaultNameMappingKey]; ok {
+		nm := iceberg.NameMapping{}
+		if err := json.Unmarshal([]byte(nameMappingJson), &nm); err == nil {
+			return nm
+		}
+	}
+	return nil
+}
+
 func (c *commonMetadata) Version() int { return c.FormatVersion }
 
 type metadataV1 struct {
@@ -963,6 +1062,8 @@ type metadataV1 struct {
 
 	commonMetadata
 }
+
+func (m *metadataV1) LastSequenceNumber() int64 { return 0 }
 
 func (m *metadataV1) Equals(other Metadata) bool {
 	rhs, ok := other.(*metadataV1)
@@ -1032,10 +1133,12 @@ func (m *metadataV1) ToV2() metadataV2 {
 }
 
 type metadataV2 struct {
-	LastSequenceNumber int64 `json:"last-sequence-number"`
+	LastSeqNum int64 `json:"last-sequence-number"`
 
 	commonMetadata
 }
+
+func (m *metadataV2) LastSequenceNumber() int64 { return m.LastSeqNum }
 
 func (m *metadataV2) Equals(other Metadata) bool {
 	rhs, ok := other.(*metadataV2)
@@ -1047,7 +1150,7 @@ func (m *metadataV2) Equals(other Metadata) bool {
 		return true
 	}
 
-	return m.LastSequenceNumber == rhs.LastSequenceNumber &&
+	return m.LastSeqNum == rhs.LastSeqNum &&
 		m.commonMetadata.Equals(&rhs.commonMetadata)
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -18,7 +18,6 @@
 package table
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,25 +42,6 @@ const (
 	addSnapshotAction    = "add-snapshot"
 	addSortOrderAction   = "add-sort-order"
 )
-
-func generateSnapshotID() int64 {
-	var (
-		rndUUID = uuid.New()
-		out     [8]byte
-	)
-
-	for i := range 8 {
-		lhs, rhs := rndUUID[i], rndUUID[i+8]
-		out[i] = lhs ^ rhs
-	}
-
-	snapshotID := int64(binary.LittleEndian.Uint64(out[:]))
-	if snapshotID < 0 {
-		snapshotID = -snapshotID
-	}
-
-	return snapshotID
-}
 
 // Metadata for an iceberg table as specified in the Iceberg spec
 //
@@ -222,27 +202,6 @@ func MetadataBuilderFromBase(metadata Metadata) (*MetadataBuilder, error) {
 	}
 
 	return b, nil
-}
-
-func (b *MetadataBuilder) nextSequenceNumber() int64 {
-	if b.formatVersion > 1 {
-		if b.lastSequenceNumber == nil {
-			return 0
-		}
-
-		return *b.lastSequenceNumber + 1
-	}
-
-	return 0
-}
-
-func (b *MetadataBuilder) newSnapshotID() int64 {
-	snapshotID := generateSnapshotID()
-	for slices.ContainsFunc(b.snapshotList, func(s Snapshot) bool { return s.SnapshotID == snapshotID }) {
-		snapshotID = generateSnapshotID()
-	}
-
-	return snapshotID
 }
 
 func (b *MetadataBuilder) CurrentSpec() iceberg.PartitionSpec {
@@ -644,16 +603,6 @@ func (b *MetadataBuilder) GetSortOrderByID(id int) (*SortOrder, error) {
 	}
 
 	return nil, fmt.Errorf("sort order with id %d not found", id)
-}
-
-func (b *MetadataBuilder) currentSnapshot() *Snapshot {
-	if b.currentSnapshotID == nil {
-		return nil
-	}
-
-	s, _ := b.SnapshotByID(*b.currentSnapshotID)
-
-	return s
 }
 
 func (b *MetadataBuilder) SnapshotByID(id int64) (*Snapshot, error) {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -59,6 +59,7 @@ func generateSnapshotID() int64 {
 	if snapshotID < 0 {
 		snapshotID = -snapshotID
 	}
+
 	return snapshotID
 }
 
@@ -250,6 +251,7 @@ func (b *MetadataBuilder) CurrentSpec() iceberg.PartitionSpec {
 
 func (b *MetadataBuilder) CurrentSchema() *iceberg.Schema {
 	s, _ := b.GetSchemaByID(b.currentSchemaID)
+
 	return s
 }
 
@@ -650,6 +652,7 @@ func (b *MetadataBuilder) currentSnapshot() *Snapshot {
 	}
 
 	s, _ := b.SnapshotByID(*b.currentSnapshotID)
+
 	return s
 }
 
@@ -670,6 +673,7 @@ func (b *MetadataBuilder) NameMapping() iceberg.NameMapping {
 			return nm
 		}
 	}
+
 	return nil
 }
 
@@ -1051,6 +1055,7 @@ func (c *commonMetadata) NameMapping() iceberg.NameMapping {
 			return nm
 		}
 	}
+
 	return nil
 }
 

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -169,7 +169,7 @@ func TestMetadataV2Parsing(t *testing.T) {
 	data := meta.(*metadataV2)
 	assert.Equal(t, uuid.MustParse("9c12d441-03fe-4693-9a96-a0705ddf69c1"), data.UUID)
 	assert.Equal(t, "s3://bucket/test/location", data.Location())
-	assert.Equal(t, int64(34), data.LastSequenceNumber)
+	assert.Equal(t, int64(34), data.LastSeqNum)
 	assert.Equal(t, int64(1602638573590), data.LastUpdatedMS)
 	assert.Equal(t, 3, data.LastColumnId)
 	assert.Equal(t, 0, data.SchemaList[0].ID)

--- a/table/properties.go
+++ b/table/properties.go
@@ -24,4 +24,11 @@ const (
 	WriteObjectStorePartitionedPathsDefault = true
 	ObjectStoreEnabledKey                   = "write.object-storage.enabled"
 	ObjectStoreEnabledDefault               = false
+
+	DefaultNameMappingKey = "schema.name-mapping.default"
+
+	MetricsModeColumnConfPrefix = "write.metadata.metrics.column"
+
+	DefaultWriteMetricsModeKey     = "write.metadata.metrics.default"
+	DefaultWriteMetricsModeDefault = "truncate(16)"
 )

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -120,7 +120,6 @@ func (m *updateMetrics) addDataFile(df iceberg.DataFile) error {
 	default:
 		return fmt.Errorf("unknown data file content: %s", df.ContentType())
 	}
-
 	return nil
 }
 
@@ -141,7 +140,6 @@ func (m *updateMetrics) removeFile(df iceberg.DataFile) error {
 	default:
 		return fmt.Errorf("unknown data file content: %s", df.ContentType())
 	}
-
 	return nil
 }
 
@@ -169,7 +167,6 @@ func (m *updateMetrics) toProps() iceberg.Properties {
 	setWhenPositive(props, removedPosDeletesKey, m.removedPosDeletes)
 	setWhenPositive(props, addedEqDeletesKey, m.addedEqDeletes)
 	setWhenPositive(props, removedEqDeletesKey, m.removedEqDeletes)
-
 	return props
 }
 
@@ -399,7 +396,6 @@ func (s *SnapshotSummaryCollector) build() iceberg.Properties {
 			}
 		}
 	}
-
 	return props
 }
 

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -120,6 +120,7 @@ func (m *updateMetrics) addDataFile(df iceberg.DataFile) error {
 	default:
 		return fmt.Errorf("unknown data file content: %s", df.ContentType())
 	}
+
 	return nil
 }
 
@@ -140,6 +141,7 @@ func (m *updateMetrics) removeFile(df iceberg.DataFile) error {
 	default:
 		return fmt.Errorf("unknown data file content: %s", df.ContentType())
 	}
+
 	return nil
 }
 
@@ -167,6 +169,7 @@ func (m *updateMetrics) toProps() iceberg.Properties {
 	setWhenPositive(props, removedPosDeletesKey, m.removedPosDeletes)
 	setWhenPositive(props, addedEqDeletesKey, m.addedEqDeletes)
 	setWhenPositive(props, removedEqDeletesKey, m.removedEqDeletes)
+
 	return props
 }
 
@@ -375,6 +378,7 @@ func (s *SnapshotSummaryCollector) removeFile(df iceberg.DataFile, sc *iceberg.S
 
 func (s *SnapshotSummaryCollector) partitionSummary(metrics *updateMetrics) string {
 	props := metrics.toProps()
+
 	return strings.Join(slices.Sorted(func(yield func(s string) bool) {
 		for k, v := range props {
 			if !yield(fmt.Sprintf("%s=%s", k, v)) {
@@ -395,6 +399,7 @@ func (s *SnapshotSummaryCollector) build() iceberg.Properties {
 			}
 		}
 	}
+
 	return props
 }
 

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -375,7 +375,6 @@ func (s *SnapshotSummaryCollector) removeFile(df iceberg.DataFile, sc *iceberg.S
 
 func (s *SnapshotSummaryCollector) partitionSummary(metrics *updateMetrics) string {
 	props := metrics.toProps()
-
 	return strings.Join(slices.Sorted(func(yield func(s string) bool) {
 		for k, v := range props {
 			if !yield(fmt.Sprintf("%s=%s", k, v)) {

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -32,14 +32,6 @@ var tableSchemaSimple = iceberg.NewSchemaWithIdentifiers(1,
 	iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool},
 )
 
-func must[T any](v T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-
-	return v
-}
-
 func TestSnapshotSummaryCollector(t *testing.T) {
 	var ssc SnapshotSummaryCollector
 

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -36,7 +36,6 @@ func must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)
 	}
-
 	return v
 }
 

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -36,6 +36,7 @@ func must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)
 	}
+
 	return v
 }
 


### PR DESCRIPTION
This one's a big one!

Adding initial implementation of deriving and computing the Iceberg metadata statistics from Parquet files in order to facilitate adding files directly. This includes utilizing the Parquet file metadata retrieve the typed statistics and collecting them based on optional metrics modes and so on. This also includes various unit tests to confirm it is working.