### PR TITLE
Supress version warning

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: "3"
-
 services:
   spark-iceberg:
     image: pyiceberg-spark


### PR DESCRIPTION
I'm getting this error for quite a while, I think we can remove the version:

```
WARN[0000] /Users/fokko.driesprong/work/iceberg-go/dev/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```