### PR TITLE
fix: Clickhouse does not support "null" as partition spec metadata

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -951,7 +951,14 @@ func (w *ManifestWriter) meta() (map[string][]byte, error) {
 		return nil, err
 	}
 
-	specFieldsJson, err := json.Marshal(w.spec.fields)
+	var specFields = w.spec.fields
+
+	if specFields == nil {
+		specFields = []PartitionField{}
+	}
+
+	specFieldsJson, err := json.Marshal(specFields)
+
 	if err != nil {
 		return nil, err
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -951,14 +951,13 @@ func (w *ManifestWriter) meta() (map[string][]byte, error) {
 		return nil, err
 	}
 
-	var specFields = w.spec.fields
+	specFields := w.spec.fields
 
 	if specFields == nil {
 		specFields = []PartitionField{}
 	}
 
 	specFieldsJson, err := json.Marshal(specFields)
-
 	if err != nil {
 		return nil, err
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -874,8 +874,8 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 	m.Require().NoError(err)
 	md, err := w.meta()
 	m.Require().NoError(err)
-	m.Assert().NotEqual("null", string(md["partition-spec"]))
-	m.Assert().Equal("[]", string(md["partition-spec"]))
+	m.NotEqual("null", string(md["partition-spec"]))
+	m.Equal("[]", string(md["partition-spec"]))
 }
 
 func TestManifests(t *testing.T) {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -19,6 +19,7 @@ package iceberg
 
 import (
 	"bytes"
+	"io"
 	"testing"
 	"time"
 
@@ -865,6 +866,16 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	m.Assert().Equal([]int64{4}, data.SplitOffsets())
 	m.Assert().Equal([]int{1, 1}, data.EqualityFieldIDs())
 	m.Assert().Equal(0, *data.SortOrderID())
+}
+
+func (m *ManifestTestSuite) TestManifestWriterMeta() {
+	sch := NewSchema(0, NestedField{ID: 0, Name: "test01", Type: StringType{}})
+	w, err := NewManifestWriter(2, io.Discard, *UnpartitionedSpec, sch, 1)
+	m.Require().NoError(err)
+	md, err := w.meta()
+	m.Require().NoError(err)
+	m.Assert().NotEqual("null", string(md["partition-spec"]))
+	m.Assert().Equal("[]", string(md["partition-spec"]))
 }
 
 func TestManifests(t *testing.T) {


### PR DESCRIPTION
Hi,

I'm working on [a tool that leverage this package](https://github.com/agnosticeng/icepq) to support adding / removing / merging Parquet files from ClickHouse with an UDF.  

After upgrading this package (and removing a lot of code thx to your last commits) I got errors from ClickHouse (again) at query time.

I nailed the issue down to the "partition-spec" metadata of the manifest file.
When there is no field in the partition spec, the current code write a "null" JSON document that cause errors with ClickHouse.
I just replaced "null" with "[]" in this case and things are working ok again.

Fixes #344