### PR TITLE
fix(table): fix funky test paths

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -308,11 +308,11 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 	return s
 }
 
-func New(ident Identifier, meta Metadata, location string, fs io.IO, cat CatalogIO) *Table {
+func New(ident Identifier, meta Metadata, metadataLocation string, fs io.IO, cat CatalogIO) *Table {
 	return &Table{
 		identifier:       ident,
 		metadata:         meta,
-		metadataLocation: location,
+		metadataLocation: metadataLocation,
 		fs:               fs,
 		cat:              cat,
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -280,10 +280,10 @@ func (t *TableWritingTestSuite) writeParquet(fio iceio.WriteFileIO, filePath str
 
 func (t *TableWritingTestSuite) createTable(identifier table.Identifier, formatVersion int, spec iceberg.PartitionSpec, sc *iceberg.Schema) *table.Table {
 	meta, err := table.NewMetadata(sc, &spec, table.UnsortedSortOrder,
-		t.getMetadataLoc(), iceberg.Properties{"format-version": strconv.Itoa(formatVersion)})
+		t.location, iceberg.Properties{"format-version": strconv.Itoa(formatVersion)})
 	t.Require().NoError(err)
 
-	return table.New(identifier, meta, t.location, iceio.LocalFS{}, nil)
+	return table.New(identifier, meta, t.getMetadataLoc(), iceio.LocalFS{}, nil)
 }
 
 func (t *TableWritingTestSuite) TestAddFilesUnpartitioned() {


### PR DESCRIPTION
fixes #346 

Was using the wrong path when generating the Metadata in the tests `createTable` method.