### PR TITLE
Implement MergeFiles operation

### DIFF
--- a/internal/must.go
+++ b/internal/must.go
@@ -24,3 +24,7 @@ func Must[T any](v T, err error) T {
 
 	return v
 }
+
+func ToPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This is the first working prototype of the MergeFiles operation discussed here: https://github.com/apache/iceberg-go/issues/348

I can see that on datafile file deletion, a new manifest with all files marked as DELETED is created. The spec seems to state that this is optional, and if it really is, we should have the option to opt out of it as it creates somewhat unnecessary metadata.
