### PR TITLE
feat(table): add ReplaceFiles method to transaction

### DIFF
--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -227,7 +227,7 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	defer tbl.FS().Remove(pqfile)
 
 	txn := tbl.NewTransaction()
-	s.Require().NoError(txn.AddFiles([]string{pqfile}, nil, false))
+	s.Require().NoError(txn.AddFiles(s.ctx, []string{pqfile}, nil, false))
 	updated, err := txn.Commit(s.ctx)
 	s.Require().NoError(err)
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,12 +25,14 @@ import (
 )
 
 const (
-	cfgFile = ".iceberg-go.yaml"
+	cfgFile           = ".iceberg-go.yaml"
+	defaultMaxWorkers = 5
 )
 
 type Config struct {
 	DefaultCatalog string                   `yaml:"default-catalog"`
 	Catalogs       map[string]CatalogConfig `yaml:"catalog"`
+	MaxWorkers     int                      `yaml:"max-workers"`
 }
 
 type CatalogConfig struct {
@@ -87,6 +89,9 @@ func fromConfigFiles() Config {
 
 	if cfg.DefaultCatalog == "" {
 		cfg.DefaultCatalog = "default"
+	}
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = defaultMaxWorkers
 	}
 
 	return cfg

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -501,6 +501,7 @@ func MapExec[T, S any](nWorkers int, slice []T, fn func(T) (S, error)) iter.Seq2
 				}
 				out <- result
 			}
+
 			return nil
 		})
 	}

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -481,6 +481,7 @@ func TruncateUpperBoundBinary(val []byte, trunc int) []byte {
 
 	return nil
 }
+
 func MapExec[T, S any](nWorkers int, slice []T, fn func(T) (S, error)) iter.Seq2[S, error] {
 	if nWorkers <= 0 {
 		nWorkers = runtime.GOMAXPROCS(0)

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -464,7 +464,7 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 	return updateSnapshotSummaries(Summary{
 		Operation:  sp.op,
 		Properties: summaryProps,
-	}, previousSummary, sp.op == OpOverwrite)
+	}, previousSummary)
 }
 
 func (sp *snapshotProducer) commit() ([]Update, []Requirement, error) {

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -147,6 +147,7 @@ func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 
 		if len(foundDeleted) == 0 {
 			existingFiles = append(existingFiles, m)
+
 			continue
 		}
 
@@ -219,6 +220,7 @@ func (of *overwriteFiles) deletedEntries() ([]iceberg.ManifestEntry, error) {
 						entry.DataFile()))
 			}
 		}
+
 		return result, nil
 	}
 
@@ -309,6 +311,7 @@ func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec) (*iceb
 		sp.txn.meta.CurrentSchema(), sp.snapshotID)
 	if err != nil {
 		defer out.Close()
+
 		return nil, "", nil, err
 	}
 

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/config"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
 	tblutils "github.com/apache/iceberg-go/table/internal"
@@ -224,7 +225,7 @@ func (of *overwriteFiles) deletedEntries() ([]iceberg.ManifestEntry, error) {
 		return result, nil
 	}
 
-	nWorkers := 5
+	nWorkers := config.EnvConfig.MaxWorkers
 	finalResult := make([]iceberg.ManifestEntry, 0, len(previousManifests))
 	for entries, err := range tblutils.MapExec(nWorkers, previousManifests, getEntries) {
 		if err != nil {

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -28,13 +28,21 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 )
 
 type producerImpl interface {
+	// to perform any post-processing on the manifests before writing them
+	// to the new snapshot. This will be called as the last step
+	// before writing a manifest list file, using the result of this function
+	// as the final list of manifests to write.
 	processManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error)
+	// perform any processing necessary and return the list of existing
+	// manifests that should be included in the snapshot
 	existingManifests() ([]iceberg.ManifestFile, error)
+	// return the deleted entries for writing delete file manifests
 	deletedEntries() ([]iceberg.ManifestEntry, error)
 }
 
@@ -87,7 +95,143 @@ func (fa *fastAppendFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 }
 
 func (fa *fastAppendFiles) deletedEntries() ([]iceberg.ManifestEntry, error) {
+	// for fast appends, there are no deleted entries
 	return nil, nil
+}
+
+type overwriteFiles struct {
+	base *snapshotProducer
+}
+
+func newOverwriteFilesProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO, commitUUID *uuid.UUID, snapshotProps iceberg.Properties) *snapshotProducer {
+	prod := createSnapshotProducer(op, txn, fs, commitUUID, snapshotProps)
+	prod.producerImpl = &overwriteFiles{base: prod}
+
+	return prod
+}
+
+func (of *overwriteFiles) processManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	// no post processing
+	return manifests, nil
+}
+
+func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
+	// determine if there are any existing manifest files
+	existingFiles := make([]iceberg.ManifestFile, 0)
+
+	snap := of.base.txn.meta.currentSnapshot()
+	if snap == nil {
+		return existingFiles, nil
+	}
+
+	manifestList, err := snap.Manifests(of.base.io)
+	if err != nil {
+		return existingFiles, err
+	}
+
+	for _, m := range manifestList {
+		entries, err := of.base.fetchManifestEntry(m, true)
+		if err != nil {
+			return existingFiles, err
+		}
+
+		foundDeleted := make([]iceberg.ManifestEntry, 0)
+		notDeleted := make([]iceberg.ManifestEntry, 0, len(entries))
+		for _, entry := range entries {
+			if _, ok := of.base.deletedFiles[entry.DataFile().FilePath()]; ok {
+				foundDeleted = append(foundDeleted, entry)
+			} else {
+				notDeleted = append(notDeleted, entry)
+			}
+		}
+
+		if len(foundDeleted) == 0 {
+			existingFiles = append(existingFiles, m)
+			continue
+		}
+
+		if len(notDeleted) == 0 {
+			continue
+		}
+
+		spec, err := of.base.txn.meta.GetSpecByID(int(m.PartitionSpecID()))
+		if err != nil {
+			return existingFiles, err
+		}
+
+		wr, path, counter, err := of.base.newManifestWriter(*spec)
+		if err != nil {
+			return existingFiles, err
+		}
+		defer counter.W.(io.Closer).Close()
+
+		for _, entry := range notDeleted {
+			if err := wr.Existing(entry); err != nil {
+				return existingFiles, err
+			}
+		}
+
+		mf, err := wr.ToManifestFile(path, counter.Count)
+		if err != nil {
+			return existingFiles, err
+		}
+
+		existingFiles = append(existingFiles, mf)
+	}
+
+	return existingFiles, nil
+}
+
+func (of *overwriteFiles) deletedEntries() ([]iceberg.ManifestEntry, error) {
+	// determine if we need to record any deleted entries
+	//
+	// with a full overwrite all the entries are considered deleted
+	// with partial overwrites we have to use the predicate to evaluate
+	// which entries are affected
+	if of.base.parentSnapshotID <= 0 {
+		return nil, nil
+	}
+
+	parent, err := of.base.txn.meta.SnapshotByID(of.base.parentSnapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cannot overwrite empty table", err)
+	}
+
+	previousManifests, err := parent.Manifests(of.base.io)
+	if err != nil {
+		return nil, err
+	}
+
+	getEntries := func(m iceberg.ManifestFile) ([]iceberg.ManifestEntry, error) {
+		entries, err := of.base.fetchManifestEntry(m, true)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make([]iceberg.ManifestEntry, 0, len(entries))
+		for _, entry := range entries {
+			_, ok := of.base.deletedFiles[entry.DataFile().FilePath()]
+			if ok && entry.DataFile().ContentType() == iceberg.EntryContentData {
+				seqNum := entry.SequenceNum()
+				result = append(result,
+					iceberg.NewManifestEntry(iceberg.EntryStatusDELETED,
+						&of.base.snapshotID, &seqNum, entry.FileSequenceNum(),
+						entry.DataFile()))
+			}
+		}
+		return result, nil
+	}
+
+	nWorkers := 5
+	finalResult := make([]iceberg.ManifestEntry, 0, len(previousManifests))
+	for entries, err := range tblutils.MapExec(nWorkers, previousManifests, getEntries) {
+		if err != nil {
+			return nil, err
+		}
+		finalResult = append(finalResult, entries...)
+	}
+
+	return finalResult, nil
 }
 
 type snapshotProducer struct {
@@ -148,6 +292,29 @@ func (sp *snapshotProducer) appendDataFile(df iceberg.DataFile) *snapshotProduce
 	return sp
 }
 
+func (sp *snapshotProducer) deleteDataFile(df iceberg.DataFile) *snapshotProducer {
+	sp.deletedFiles[df.FilePath()] = df
+
+	return sp
+}
+
+func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec) (*iceberg.ManifestWriter, string, *internal.CountingWriter, error) {
+	out, path, err := sp.newManifestOutput()
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	counter := &internal.CountingWriter{W: out}
+	wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter, spec,
+		sp.txn.meta.CurrentSchema(), sp.snapshotID)
+	if err != nil {
+		defer out.Close()
+		return nil, "", nil, err
+	}
+
+	return wr, path, counter, nil
+}
+
 func (sp *snapshotProducer) newManifestOutput() (io.WriteCloser, string, error) {
 	provider, err := sp.txn.tbl.LocationProvider()
 	if err != nil {
@@ -161,6 +328,10 @@ func (sp *snapshotProducer) newManifestOutput() (io.WriteCloser, string, error) 
 	}
 
 	return f, filepath, nil
+}
+
+func (sp *snapshotProducer) fetchManifestEntry(m iceberg.ManifestFile, discardDeleted bool) ([]iceberg.ManifestEntry, error) {
+	return m.FetchEntries(sp.io, discardDeleted)
 }
 
 func (sp *snapshotProducer) manifests() ([]iceberg.ManifestFile, error) {

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -435,31 +435,6 @@ func (s *SnapshotSummaryCollector) build() iceberg.Properties {
 	return props
 }
 
-func truncateTableSummary(sum Summary, previous iceberg.Properties) Summary {
-	keys := []string{
-		totalDataFilesKey, totalDeleteFilesKey, totalRecordsKey,
-		totalFileSizeKey, totalPosDeletesKey, totalEqDeletesKey,
-	}
-	for _, prop := range keys {
-		sum.Properties[prop] = "0"
-	}
-
-	updateProp := func(prop, prevProp string) {
-		if val := previous.GetInt(prevProp, 0); val > 0 {
-			sum.Properties[prop] = strconv.Itoa(val)
-		}
-	}
-
-	updateProp(deletedDataFilesKey, totalDataFilesKey)
-	updateProp(removedDeleteFilesKey, totalDeleteFilesKey)
-	updateProp(deletedRecordsKey, totalRecordsKey)
-	updateProp(removedFileSizeKey, totalFileSizeKey)
-	updateProp(removedPosDeletesKey, totalPosDeletesKey)
-	updateProp(removedEqDeletesKey, totalEqDeletesKey)
-
-	return sum
-}
-
 func updateSnapshotSummaries(sum Summary, previous iceberg.Properties, truncateFullTable bool) (Summary, error) {
 	switch sum.Operation {
 	case OpAppend, OpOverwrite, OpDelete:
@@ -469,10 +444,6 @@ func updateSnapshotSummaries(sum Summary, previous iceberg.Properties, truncateF
 
 	if sum.Properties == nil {
 		sum.Properties = make(iceberg.Properties)
-	}
-
-	if truncateFullTable && sum.Operation == OpOverwrite && previous != nil {
-		sum = truncateTableSummary(sum, previous)
 	}
 
 	if previous == nil {

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -435,7 +435,7 @@ func (s *SnapshotSummaryCollector) build() iceberg.Properties {
 	return props
 }
 
-func updateSnapshotSummaries(sum Summary, previous iceberg.Properties, truncateFullTable bool) (Summary, error) {
+func updateSnapshotSummaries(sum Summary, previous iceberg.Properties) (Summary, error) {
 	switch sum.Operation {
 	case OpAppend, OpOverwrite, OpDelete:
 	default:

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -142,55 +142,16 @@ func TestMergeSnapshotSummaries(t *testing.T) {
 				"total-equality-deletes": "3",
 			}},
 		},
-		{
-			Summary{Operation: OpOverwrite, Properties: iceberg.Properties{
-				"added-data-files":       "1",
-				"added-delete-files":     "2",
-				"added-equality-deletes": "3",
-				"added-files-size":       "4",
-				"added-position-deletes": "5",
-				"added-records":          "6",
-			}},
-			iceberg.Properties{
-				"total-data-files":       "1",
-				"total-delete-files":     "1",
-				"total-equality-deletes": "1",
-				"total-files-size":       "1",
-				"total-position-deletes": "1",
-				"total-records":          "1",
-			},
-			true,
-			Summary{Operation: OpOverwrite, Properties: iceberg.Properties{
-				"added-data-files":         "1",
-				"added-delete-files":       "2",
-				"added-equality-deletes":   "3",
-				"added-files-size":         "4",
-				"added-position-deletes":   "5",
-				"added-records":            "6",
-				"total-data-files":         "1",
-				"total-records":            "6",
-				"total-delete-files":       "2",
-				"total-equality-deletes":   "3",
-				"total-files-size":         "4",
-				"total-position-deletes":   "5",
-				"deleted-data-files":       "1",
-				"removed-delete-files":     "1",
-				"deleted-records":          "1",
-				"removed-files-size":       "1",
-				"removed-position-deletes": "1",
-				"removed-equality-deletes": "1",
-			}},
-		},
 	}
 
 	for _, tt := range tests {
-		result, err := updateSnapshotSummaries(tt.sum, tt.previous, tt.truncateTable)
+		result, err := updateSnapshotSummaries(tt.sum, tt.previous)
 		require.NoError(t, err)
 		assert.Equal(t, tt.expected, result)
 	}
 }
 
 func TestInvalidOperation(t *testing.T) {
-	_, err := updateSnapshotSummaries(Summary{Operation: OpReplace}, nil, false)
+	_, err := updateSnapshotSummaries(Summary{Operation: OpReplace}, nil)
 	assert.ErrorIs(t, err, iceberg.ErrNotImplemented)
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -781,7 +781,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFiles() {
 	tbl := table.New(ident, meta, t.getMetadataLoc(), fs, &mockedCatalog{})
 	for i := range 5 {
 		tx := tbl.NewTransaction()
-		t.Require().NoError(tx.AddFiles(files[i:i+1], nil, false))
+		t.Require().NoError(tx.AddFiles(ctx, files[i:i+1], nil, false))
 		tbl, err = tx.Commit(ctx)
 		t.Require().NoError(err)
 	}
@@ -811,7 +811,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFiles() {
 	t.writeParquet(fs, combinedFilePath, combined)
 
 	tx := tbl.NewTransaction()
-	t.Require().NoError(tx.ReplaceDataFiles(files[:2], []string{combinedFilePath}, nil))
+	t.Require().NoError(tx.ReplaceDataFiles(ctx, files[:2], []string{combinedFilePath}, nil))
 
 	staged, err := tx.StagedTable()
 	t.Require().NoError(err)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -735,6 +735,106 @@ func (t *TableWritingTestSuite) TestAddFilesReferencedCurrentSnapshotIgnoreDupli
 	t.Equal([]int32{0, 0, 0}, deleted)
 }
 
+type mockedCatalog struct{}
+
+func (m *mockedCatalog) LoadTable(ctx context.Context, ident table.Identifier, props iceberg.Properties) (*table.Table, error) {
+	return nil, nil
+}
+
+func (m *mockedCatalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	bldr, err := table.MetadataBuilderFromBase(tbl.Metadata())
+	if err != nil {
+		return nil, "", err
+	}
+
+	for _, u := range updates {
+		if err := u.Apply(bldr); err != nil {
+			return nil, "", err
+		}
+	}
+
+	meta, err := bldr.Build()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return meta, "", nil
+}
+
+func (t *TableWritingTestSuite) TestReplaceDataFiles() {
+	fs := iceio.LocalFS{}
+
+	files := make([]string, 0)
+	for i := range 5 {
+		filePath := fmt.Sprintf("%s/replace_data_files_v%d/data-%d.parquet", t.location, t.formatVersion, i)
+		t.writeParquet(fs, filePath, t.arrTablePromotedTypes)
+		files = append(files, filePath)
+	}
+
+	ident := table.Identifier{"default", "replace_data_files_v" + strconv.Itoa(t.formatVersion)}
+	meta, err := table.NewMetadata(t.tableSchemaPromotedTypes, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, t.location, iceberg.Properties{"format-version": strconv.Itoa(t.formatVersion)})
+	t.Require().NoError(err)
+
+	ctx := context.Background()
+
+	tbl := table.New(ident, meta, t.getMetadataLoc(), fs, &mockedCatalog{})
+	for i := range 5 {
+		tx := tbl.NewTransaction()
+		t.Require().NoError(tx.AddFiles(files[i:i+1], nil, false))
+		tbl, err = tx.Commit(ctx)
+		t.Require().NoError(err)
+	}
+
+	mflist, err := tbl.CurrentSnapshot().Manifests(tbl.FS())
+	t.Require().NoError(err)
+	t.Len(mflist, 5)
+
+	// create a parquet file that is essentially as if we merged two of
+	// the data files together
+	cols := make([]arrow.Column, 0, t.arrTablePromotedTypes.NumCols())
+	for i := range int(t.arrTablePromotedTypes.NumCols()) {
+		chkd := t.arrTablePromotedTypes.Column(i).Data()
+		duplicated := arrow.NewChunked(chkd.DataType(), append(chkd.Chunks(), chkd.Chunks()...))
+		defer duplicated.Release()
+
+		col := arrow.NewColumn(t.arrSchemaPromotedTypes.Fields()[i], duplicated)
+		defer col.Release()
+
+		cols = append(cols, *col)
+	}
+
+	combined := array.NewTable(t.arrSchemaPromotedTypes, cols, -1)
+	defer combined.Release()
+
+	combinedFilePath := fmt.Sprintf("%s/replace_data_files_v%d/combined.parquet", t.location, t.formatVersion)
+	t.writeParquet(fs, combinedFilePath, combined)
+
+	tx := tbl.NewTransaction()
+	t.Require().NoError(tx.ReplaceDataFiles(files[:2], []string{combinedFilePath}, nil))
+
+	staged, err := tx.StagedTable()
+	t.Require().NoError(err)
+
+	t.Equal(&table.Summary{
+		Operation: table.OpOverwrite,
+		Properties: iceberg.Properties{
+			"added-data-files":       "1",
+			"added-files-size":       "1082",
+			"added-records":          "4",
+			"deleted-data-files":     "2",
+			"deleted-records":        "4",
+			"removed-files-size":     "2164",
+			"total-data-files":       "4",
+			"total-delete-files":     "0",
+			"total-equality-deletes": "0",
+			"total-files-size":       "4328",
+			"total-position-deletes": "0",
+			"total-records":          "10",
+		},
+	}, staged.CurrentSnapshot().Summary)
+}
+
 func TestTableWriting(t *testing.T) {
 	suite.Run(t, &TableWritingTestSuite{formatVersion: 1})
 	suite.Run(t, &TableWritingTestSuite{formatVersion: 2})

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -183,6 +183,10 @@ func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snaps
 		}
 	}
 
+	if len(markedForDeletion) != len(setToDelete) {
+		return fmt.Errorf("cannot delete files that do not belong to the table")
+	}
+
 	if t.meta.NameMapping() == nil {
 		nameMapping := t.meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -129,7 +129,13 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 
 // ReplaceFiles is actually just an overwrite operation with multiple
 // files deleted and added.
-func (t *Transaction) ReplaceDataFiles(filesToDelete []string, filesToAdd []string, snapshotProps iceberg.Properties) error {
+//
+// TODO: technically, this could be a REPLACE operation but we aren't performing
+// any validation here that there are no changes to the underlying data. A REPLACE
+// operation is only valid if the data is exactly the same as the previous snapshot.
+//
+// For now, we'll keep using an overwrite operation.
+func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
 			return t.AddFiles(filesToAdd, snapshotProps, true)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -156,7 +156,7 @@ func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snaps
 	}
 
 	if len(setToDelete) != len(filesToDelete) {
-		return errors.New("file paths must be unique for ReplaceDataFiles")
+		return errors.New("delete file paths must be unique for ReplaceDataFiles")
 	}
 
 	if len(setToAdd) != len(filesToAdd) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -138,7 +138,7 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
-			return t.AddFiles(filesToAdd, snapshotProps, true)
+			return t.AddFiles(filesToAdd, snapshotProps, false)
 		}
 	}
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -184,7 +184,7 @@ func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snaps
 	}
 
 	if len(markedForDeletion) != len(setToDelete) {
-		return fmt.Errorf("cannot delete files that do not belong to the table")
+		return errors.New("cannot delete files that do not belong to the table")
 	}
 
 	if t.meta.NameMapping() == nil {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -135,10 +135,10 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 // operation is only valid if the data is exactly the same as the previous snapshot.
 //
 // For now, we'll keep using an overwrite operation.
-func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
+func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
-			return t.AddFiles(filesToAdd, snapshotProps, false)
+			return t.AddFiles(ctx, filesToAdd, snapshotProps, false)
 		}
 	}
 
@@ -206,7 +206,7 @@ func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snaps
 		updater.deleteDataFile(df)
 	}
 
-	dataFiles := parquetFilesToDataFiles(t.tbl.fs, t.meta, slices.Values(filesToAdd))
+	dataFiles := filesToDataFiles(ctx, t.tbl.fs, t.meta, slices.Values(filesToAdd))
 	for df, err := range dataFiles {
 		if err != nil {
 			return err

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -160,7 +160,7 @@ func (t *Transaction) ReplaceDataFiles(filesToDelete, filesToAdd []string, snaps
 	}
 
 	if len(setToAdd) != len(filesToAdd) {
-		return errors.New("file paths must be unique for ReplaceDataFiles")
+		return errors.New("add file paths must be unique for ReplaceDataFiles")
 	}
 
 	s := t.meta.currentSnapshot()


### PR DESCRIPTION
Implementing a simple `ReplaceDataFiles` method for transactions to create an `Overwrite` operation for deleting/adding files in a single operation for use with compaction operations or otherwise replacing one or more data files with new data files.