### PR TITLE
 feat: (catalog/glue): Add RegisterTable method in Glue catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ $ cd iceberg-go/cmd/iceberg && go build .
 | Load Table               |  X   |      |          |  X   |  X  |
 | List Tables              |  X   |      |          |  X   |  X  |
 | Create Table             |  X   |      |          |  X   |  X  |
+| Register Table           |  X   |      |          |  X   |     |
 | Update Current Snapshot  |  X   |      |          |      |     |
 | Create New Snapshot      |  X   |      |          |      |     |
 | Rename Table             |  X   |      |          |  X   |  X  |


### PR DESCRIPTION
Hi team,
Im adding RegisterTable implementation for Glue catalog to match what we currently have in py-iceberg and REST catalog
https://github.com/apache/iceberg-python/blob/83cc1783e20edf8998c20fed47b5f126481db4db/pyiceberg/catalog/glue.py#L443-L463