### PR TITLE
fix(catalog/rest): fix build

### DIFF
--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -227,7 +227,7 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	defer tbl.FS().Remove(pqfile)
 
 	txn := tbl.NewTransaction()
-	s.Require().NoError(txn.AddFiles([]string{pqfile}, nil, false))
+	s.Require().NoError(txn.AddFiles(s.ctx, []string{pqfile}, nil, false))
 	updated, err := txn.Commit(s.ctx)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
Don't know how this slipped past but it looks like the integration test has a bad merge or something causing a build failure