### PR TITLE
Repo: Set status checks to strict

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,10 @@ github:
 
   protected_branches:
     main:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+
       required_pull_request_reviews:
         required_approving_review_count: 1
 


### PR DESCRIPTION
This will prevent merge conflicts, such as #364 

We added it to pyiceberg, https://github.com/apache/iceberg-python/pull/1640