### PR TITLE
ci: fixing the golangci action

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -53,7 +53,7 @@ jobs:
       if: matrix.go == '1.23.6'
       run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.0
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcf # v7
       with:
         version: v1.64.5
         args: --timeout=10m

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
       with:
-        version: v1.64.5
+        version: v2.0.2
         args: --timeout=10m
     - name: Lint
       run: staticcheck ./...

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -53,7 +53,7 @@ jobs:
       if: matrix.go == '1.23.6'
       run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.0
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcf # v7
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
       with:
         version: v1.64.5
         args: --timeout=10m

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -15,32 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2"
 linters:
-  default: none
-  enable:
-    - misspell
-    - nlreturn
-    - perfsprint
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-formatters:
+  disable-all: true
   enable:
     - gofmt
-    - gofumpt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    - nlreturn
+    - perfsprint
+    - gofumpt
+    - misspell


### PR DESCRIPTION
Upgrade golangci-lint so Apache INFRA stops blocking it

Migrated config to v2 of golangci-lint.