### PR TITLE
feat (glue): Add Set Table property support for Glue

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -217,7 +217,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
 	}
 
-	icebergTable, err := table.NewFromLocation([]string{tableName}, location, iofs, c)
+	icebergTable, err := table.NewFromLocation(identifier, location, iofs, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table from location %s.%s: %w", database, tableName, err)
 	}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"strconv"
 	_ "unsafe"
 
@@ -117,6 +118,7 @@ type glueAPI interface {
 	GetTable(ctx context.Context, params *glue.GetTableInput, optFns ...func(*glue.Options)) (*glue.GetTableOutput, error)
 	GetTables(ctx context.Context, params *glue.GetTablesInput, optFns ...func(*glue.Options)) (*glue.GetTablesOutput, error)
 	DeleteTable(ctx context.Context, params *glue.DeleteTableInput, optFns ...func(*glue.Options)) (*glue.DeleteTableOutput, error)
+	UpdateTable(ctx context.Context, params *glue.UpdateTableInput, optFns ...func(*glue.Options)) (*glue.UpdateTableOutput, error)
 	GetDatabase(ctx context.Context, params *glue.GetDatabaseInput, optFns ...func(*glue.Options)) (*glue.GetDatabaseOutput, error)
 	GetDatabases(ctx context.Context, params *glue.GetDatabasesInput, optFns ...func(*glue.Options)) (*glue.GetDatabasesOutput, error)
 	CreateDatabase(ctx context.Context, params *glue.CreateDatabaseInput, optFns ...func(*glue.Options)) (*glue.CreateDatabaseOutput, error)
@@ -288,8 +290,50 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	return createdTable, nil
 }
 
-func (c *Catalog) CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error) {
-	panic("commit table not implemented for Glue Catalog")
+//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
+
+func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	for _, update := range updates {
+		if update.Action() != "set-properties" {
+			panic("Only set table property is supported ")
+		}
+	}
+
+	database, tableName, err := identifierToGlueTable(tbl.Identifier())
+	if err != nil {
+		return nil, "", err
+	}
+
+	current, err := c.LoadTable(ctx, tbl.Identifier(), nil)
+	if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
+		return nil, "", err
+	}
+
+	staged, err := updateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, *c)
+	if err != nil {
+		return nil, "", err
+	}
+	if current != nil && staged.Metadata().Equals(current.Metadata()) {
+		return current.Metadata(), current.MetadataLocation(), nil
+	}
+	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+		return nil, "", err
+	}
+
+	tableInput, err := buildGlueTableInput(ctx, database, tableName, staged, c)
+	if err != nil {
+		return nil, "", err
+	}
+	_, err = c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		TableInput:   tableInput,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return staged.Metadata(), staged.MetadataLocation(), err
 }
 
 // DropTable deletes an Iceberg table from the Glue catalog.
@@ -637,4 +681,50 @@ func filterDatabaseListByType(databases []types.Database, databaseType string) [
 	}
 
 	return filtered
+}
+
+func buildGlueTableInput(ctx context.Context, database string, tableName string, staged *table.StagedTable, cat *Catalog) (*types.TableInput, error) {
+	glueTable, err := cat.getTable(ctx, database, tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	glueProperties := prepareProperties(staged.Properties(), staged.MetadataLocation())
+	description := staged.Properties()["comment"]
+	if description == "" {
+		description = *glueTable.Description
+	}
+	existingColumnMap := map[string]string{}
+	for _, column := range glueTable.StorageDescriptor.Columns {
+		existingColumnMap[*column.Name] = *column.Comment
+	}
+	var glueColumns []types.Column
+	for _, column := range schemaToGlueColumns(staged.Metadata().CurrentSchema()) {
+		col := types.Column{
+			Name:    column.Name,
+			Comment: column.Comment,
+			Type:    column.Type,
+		}
+		if column.Comment == nil || *column.Comment == "" {
+			col.Comment = aws.String(existingColumnMap[*column.Name])
+		}
+		glueColumns = append(glueColumns, col)
+	}
+	return &types.TableInput{
+		Name:        aws.String(tableName),
+		Description: aws.String(description),
+		Parameters:  glueProperties,
+		StorageDescriptor: &types.StorageDescriptor{
+			Location: aws.String(staged.Location()),
+			Columns:  glueColumns,
+		},
+	}, nil
+}
+
+func prepareProperties(icebergProperties iceberg.Properties, newMetadataLocation string) iceberg.Properties {
+	glueProperties := maps.Clone(icebergProperties)
+	glueProperties[tableTypePropsKey] = glueTypeIceberg
+	glueProperties[metadataLocationPropsKey] = newMetadataLocation
+
+	return glueProperties
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -96,6 +96,12 @@ func (m *mockGlueClient) UpdateDatabase(ctx context.Context, params *glue.Update
 	return args.Get(0).(*glue.UpdateDatabaseOutput), args.Error(1)
 }
 
+func (m *mockGlueClient) UpdateTable(ctx context.Context, params *glue.UpdateTableInput, optFns ...func(*glue.Options)) (*glue.UpdateTableOutput, error) {
+	args := m.Called(ctx, params, optFns)
+
+	return args.Get(0).(*glue.UpdateTableOutput), args.Error(1)
+}
+
 var testIcebergGlueTable1 = types.Table{
 	Name: aws.String("test_table"),
 	Parameters: map[string]string{

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -344,52 +344,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	return c.LoadTable(ctx, ident, cfg.Properties)
 }
 
-func (c *Catalog) updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (*table.StagedTable, error) {
-	var (
-		baseMeta    table.Metadata
-		metadataLoc string
-	)
-
-	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, err
-			}
-		}
-
-		baseMeta = current.Metadata()
-		metadataLoc = current.MetadataLocation()
-	} else {
-		var err error
-		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	updated, err := internal.UpdateTableMetadata(baseMeta, updates, metadataLoc)
-	if err != nil {
-		return nil, err
-	}
-
-	provider, err := table.LoadLocationProvider(updated.Location(), updated.Properties())
-	if err != nil {
-		return nil, err
-	}
-
-	newVersion := internal.ParseMetadataVersion(metadataLoc) + 1
-	newLocation, err := provider.NewTableMetadataFileLocation(newVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &table.StagedTable{Table: table.New(ident, updated, newLocation, fs, c)}, nil
-}
+//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
 
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns := catalog.NamespaceFromIdent(tbl.Identifier())
@@ -400,7 +356,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []tabl
 		return nil, "", err
 	}
 
-	staged, err := c.updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates)
+	staged, err := updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, *c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -386,9 +386,15 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 
 			output.Text("updated " + args.propname + " on " + args.identifier)
 		case args.table:
-			loadTable(ctx, output, cat, args.identifier)
+			tbl := loadTable(ctx, output, cat, args.identifier)
 			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
-			output.Error(errors.New("not implemented: Writing is WIP"))
+			//ToDo handle other Update operations
+			_, _, err := cat.CommitTable(ctx, tbl, nil, []table.Update{
+				table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
 		}
 	case args.remove:
 		switch {

--- a/table/updates.go
+++ b/table/updates.go
@@ -33,6 +33,7 @@ const (
 	updateCurrentSchema    = "set-current-schema"
 	updateDefaultSortOrder = "set-default-sort-order"
 	updateUpgradeFormat    = "upgrade-format-version"
+	updateSetProperties    = "set-properties"
 )
 
 // Update represents a change to a table's metadata.
@@ -323,7 +324,7 @@ type setPropertiesUpdate struct {
 // table metadata.
 func NewSetPropertiesUpdate(updates iceberg.Properties) *setPropertiesUpdate {
 	return &setPropertiesUpdate{
-		baseUpdate: baseUpdate{ActionName: "set-properties"},
+		baseUpdate: baseUpdate{ActionName: updateSetProperties},
 		Updates:    updates,
 	}
 }


### PR DESCRIPTION
**Note**
- Added support to set new table properties 
- Refactored `updateAndStageTable` method to catalog to reuse it in glue.go

**ToDo**
- Add tests for new feature
- Updated go-cli to fail when other Update actions are passed