### PR TITLE
fix(catalog/rest): Fix concurrency bug in REST catalog request signing

### DIFF
--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -92,6 +92,7 @@ func WithPrefix(prefix string) Option {
 func WithAwsConfig(cfg aws.Config) Option {
 	return func(o *options) {
 		o.awsConfig = cfg
+		o.awsConfigSet = true
 	}
 }
 
@@ -109,6 +110,7 @@ func WithAdditionalProps(props iceberg.Properties) Option {
 
 type options struct {
 	awsConfig         aws.Config
+	awsConfigSet      bool
 	tlsConfig         *tls.Config
 	credential        string
 	oauthToken        string

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -226,7 +227,7 @@ func (s *sessionTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 				return nil, err
 			}
 
-			payloadHash = string(h.Sum(nil))
+			payloadHash = hex.EncodeToString(h.Sum(nil))
 		}
 
 		creds, err := s.cfg.Credentials.Retrieve(r.Context())

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -172,6 +172,7 @@ func TestSigv4ConcurrentSigners(t *testing.T) {
 				SecretAccessKey: "01234567abcdefgh01234567abcdefgh01234567abcdefgh01234567abcdefgh",
 			},
 		}
+
 		return nil
 	})
 	require.NoError(t, err)

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -18,18 +18,32 @@
 package rest
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestAuthHeader(t *testing.T) {
+	t.Parallel()
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
 
@@ -77,6 +91,7 @@ func TestAuthHeader(t *testing.T) {
 }
 
 func TestAuthUriHeader(t *testing.T) {
+	t.Parallel()
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
 
@@ -123,4 +138,90 @@ func TestAuthUriHeader(t *testing.T) {
 		"X-Client-Version":            {icebergRestSpecVersion},
 		"X-Iceberg-Access-Delegation": {"vended-credentials"},
 	}, cat.cl.Transport.(*sessionTransport).defaultHeaders)
+}
+
+func TestSigv4EmptyStringHash(t *testing.T) {
+	t.Parallel()
+	hash := sha256.New()
+	payloadHash := hex.EncodeToString(hash.Sum(nil))
+	// Sanity check the constant.
+	require.Equal(t, payloadHash, emptyStringHash)
+}
+
+func TestSigv4ConcurrentSigners(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	srv := httptest.NewUnstartedServer(mux)
+	// If we use HTTP 1.1, this test can try to make too many connections
+	// and exhaust ephemeral ports.
+	srv.EnableHTTP2 = true
+	srv.StartTLS() // Using TLS to easily support HTTP/2
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(srv.Certificate())
+
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{}, "overrides": map[string]any{},
+		})
+	})
+
+	cfg, err := config.LoadDefaultConfig(context.Background(), func(opts *config.LoadOptions) error {
+		opts.Credentials = credentials.StaticCredentialsProvider{
+			Value: aws.Credentials{
+				AccessKeyID:     "abcdefghjklmnop",
+				SecretAccessKey: "01234567abcdefgh01234567abcdefgh01234567abcdefgh01234567abcdefgh",
+			},
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL,
+		WithSigV4(),
+		WithSigV4RegionSvc("abc", "def"),
+		WithAwsConfig(cfg),
+		WithTLSConfig(&tls.Config{
+			RootCAs: rootCAs,
+		}))
+	require.NoError(t, err)
+	assert.NotNil(t, cat)
+
+	// We aren't recreating the signature logic to verify on the server. We're
+	// just running many concurrent requests to make sure the race detector
+	// doesn't find any data races with how the session transport and signer
+	// are used from concurrent goroutines.
+	ctx, cancel := context.WithCancel(context.Background())
+	grp, ctx := errgroup.WithContext(ctx)
+	var count atomic.Uint64
+	for range 10 {
+		grp.Go(func() error {
+			for {
+				if err := ctx.Err(); err != nil {
+					return nil
+				}
+				body := make([]byte, 1024)
+				if _, err := rand.Read(body); err != nil {
+					return err
+				}
+				// Intentionally using context.Background instead of ctx so that we
+				// don't get interrupted when context is cancelled.
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, bytes.NewReader(body))
+				if err != nil {
+					return err
+				}
+				resp, err := cat.cl.Do(req)
+				if err != nil {
+					return err
+				}
+				// We don't actually care about the response, only that it actually made it to the server.
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+				count.Add(1)
+			}
+		})
+	}
+	time.Sleep(5 * time.Second)
+	cancel()
+	require.NoError(t, grp.Wait())
+	t.Logf("issued %d requests", count.Load())
 }


### PR DESCRIPTION
A hasher is not thread-safe, yet the same hasher was being used for all requests. If applications made concurrent calls to the same REST catalog implementation, they could end up writing to the same hasher, corrupting the signatures for both concurrent requests.

This makes things thread-safe by creating a hasher for each signing operation. The could be safely re-used using a `sync.Pool`. But the hasher is only 116 bytes, and initialization just has to write 8 bytes (other than the zero'ing done by the allocator), so it doesn't seem worth trying to re-use them.