### PR TITLE
fix(manifests): Don't use avro.DefaultSchemaCache

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -456,10 +456,7 @@ func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) ([]M
 	}
 
 	metadata := dec.Metadata()
-	sc, err := avro.ParseBytes(dec.Metadata()["avro.schema"])
-	if err != nil {
-		return nil, err
-	}
+	sc := dec.Schema()
 
 	fieldNameToID, fieldIDToLogicalType := getFieldIDMap(sc)
 	isFallback := false

--- a/manifest.go
+++ b/manifest.go
@@ -450,7 +450,7 @@ func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) ([]M
 	}
 	defer f.Close()
 
-	dec, err := ocf.NewDecoder(f)
+	dec, err := ocf.NewDecoder(f, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +616,7 @@ func decodeManifests[I interface {
 // ReadManifestList reads in an avro manifest list file and returns a slice
 // of manifest files or an error if one is encountered.
 func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
-	dec, err := ocf.NewDecoder(in)
+	dec, err := ocf.NewDecoder(in, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
 	if err != nil {
 		return nil, err
 	}
@@ -896,6 +896,7 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 
 	enc, err := ocf.NewEncoderWithSchema(fileSchema, out,
 		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
 		ocf.WithMetadata(md),
 		ocf.WithCodec(ocf.Deflate))
 
@@ -1088,6 +1089,7 @@ func (m *ManifestListWriter) init(meta map[string][]byte) error {
 
 	enc, err := ocf.NewEncoderWithSchema(fileSchema, m.out,
 		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
 		ocf.WithMetadata(meta),
 		ocf.WithCodec(ocf.Deflate))
 	if err != nil {


### PR DESCRIPTION
The schemas in Avro manifest and manifest list files should be self-contain and not contain references to types that aren't defined in the OCF's schema metadata.

But, by default, encoders and decoders in Avro's `ocf` package use a global default schema cache, and can resolve named types using that cache.

This change avoids using the global default schema cache by effectively not using a cache at all. There's not an actul way to disable use of a schema cache, so the next best thing is to create a new, empty schema cache for each operation. This ensures when reading manifests and manifest lists that their schemas are self-contained (i.e. no named types can be inadvertently resolved via cache populated from some other package or OCF file) and also makes sure that schemas used to generate manifest and manifest list files don't "pollute" that global default cache.