### PR TITLE
fix(table): a bug in MapExec that triggers when len(slice) > nWorkers.

### DIFF
--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -509,14 +509,13 @@ func MapExec[T, S any](nWorkers int, slice iter.Seq[T], fn func(T) (S, error)) i
 		})
 	}
 
-	for v := range slice {
-		ch <- v
-	}
-	close(ch)
-
 	var err error
 	go func() {
 		defer close(out)
+		for v := range slice {
+			ch <- v
+		}
+		close(ch)
 		err = g.Wait()
 	}()
 

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -86,9 +86,5 @@ func TestMapExecFinish(t *testing.T) {
 		}
 	}()
 
-	select {
-	case <-time.After(time.Second * 1):
-		assert.FailNow(t, "MapExec took suspiciously long. Migh be a deadlock.")
-	case <-ch:
-	}
+	assert.Eventually(t, func() bool { <-ch; return true }, time.Second, 10*time.Millisecond)
 }

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -86,5 +86,13 @@ func TestMapExecFinish(t *testing.T) {
 		}
 	}()
 
-	assert.Eventually(t, func() bool { <-ch; return true }, time.Second, 10*time.Millisecond)
+	assert.Eventually(
+		t,
+		func() bool {
+			<-ch
+
+			return true
+		},
+		time.Second, 10*time.Millisecond,
+	)
 }

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -18,7 +18,9 @@
 package internal_test
 
 import (
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/assert"
@@ -67,4 +69,26 @@ func TestTruncateUpperBoundString(t *testing.T) {
 func TestTruncateUpperBoundBinary(t *testing.T) {
 	assert.Equal(t, []byte{0x01, 0x03}, internal.TruncateUpperBoundBinary([]byte{0x01, 0x02, 0x03}, 2))
 	assert.Nil(t, internal.TruncateUpperBoundBinary([]byte{0xff, 0xff, 0x00}, 2))
+}
+
+func TestMapExecFinish(t *testing.T) {
+	var (
+		ch = make(chan struct{}, 1)
+		f  = func(i int) (int, error) {
+			return i * 2, nil
+		}
+	)
+
+	go func() {
+		defer close(ch)
+		for _, err := range internal.MapExec(3, slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), f) {
+			assert.NoError(t, err)
+		}
+	}()
+
+	select {
+	case <-time.After(time.Second * 1):
+		assert.FailNow(t, "MapExec took suspiciously long. Migh be a deadlock.")
+	case <-ch:
+	}
 }


### PR DESCRIPTION
If pushing to chan ch is not done in a goroutine, we never reach the point where we return the iterator func to the caller.