### PR TITLE
refactor(table): move all action names to constants

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -372,7 +372,7 @@ func (b *MetadataBuilder) SetCurrentSchemaID(currentSchemaID int) (*MetadataBuil
 			return s.ID
 		})
 		if !slices.ContainsFunc(b.updates, func(u Update) bool {
-			return u.Action() == updateAddSchema && u.(*addSchemaUpdate).Schema.ID == currentSchemaID
+			return u.Action() == UpdateAddSchema && u.(*addSchemaUpdate).Schema.ID == currentSchemaID
 		}) {
 			return nil, errors.New("can't set current schema to last added schema, no schema has been added")
 		}
@@ -399,7 +399,7 @@ func (b *MetadataBuilder) SetDefaultSortOrderID(defaultSortOrderID int) (*Metada
 			return s.OrderID
 		})
 		if !slices.ContainsFunc(b.updates, func(u Update) bool {
-			return u.Action() == updateSortOrder && u.(*addSortOrderUpdate).SortOrder.OrderID == defaultSortOrderID
+			return u.Action() == UpdateAddSortOrder && u.(*addSortOrderUpdate).SortOrder.OrderID == defaultSortOrderID
 		}) {
 			return nil, errors.New("can't set default sort order to last added with no added sort orders")
 		}
@@ -425,7 +425,7 @@ func (b *MetadataBuilder) SetDefaultSpecID(defaultSpecID int) (*MetadataBuilder,
 			return s.ID()
 		})
 		if !slices.ContainsFunc(b.updates, func(u Update) bool {
-			return u.Action() == updateSpec && u.(*addPartitionSpecUpdate).Spec.ID() == defaultSpecID
+			return u.Action() == UpdateAddSpec && u.(*addPartitionSpecUpdate).Spec.ID() == defaultSpecID
 		}) {
 			return nil, errors.New("can't set default spec to last added with no added partition specs")
 		}
@@ -564,7 +564,7 @@ func (b *MetadataBuilder) SetSnapshotRef(
 	}
 
 	isAddedSnapshot := slices.ContainsFunc(b.updates, func(u Update) bool {
-		return u.Action() == updateSnapshot && u.(*addSnapshotUpdate).Snapshot.SnapshotID == snapshotID
+		return u.Action() == UpdateAddSnapshot && u.(*addSnapshotUpdate).Snapshot.SnapshotID == snapshotID
 	})
 	if isAddedSnapshot {
 		b.lastUpdatedMS = snapshot.TimestampMs
@@ -583,7 +583,7 @@ func (b *MetadataBuilder) SetSnapshotRef(
 	}
 
 	if slices.ContainsFunc(b.updates, func(u Update) bool {
-		return u.Action() == updateSnapshot && u.(*addSnapshotUpdate).Snapshot.SnapshotID == snapshotID
+		return u.Action() == UpdateAddSnapshot && u.(*addSnapshotUpdate).Snapshot.SnapshotID == snapshotID
 	}) {
 		b.lastUpdatedMS = snapshot.TimestampMs
 	}

--- a/table/updates.go
+++ b/table/updates.go
@@ -25,21 +25,25 @@ import (
 )
 
 const (
-	updateSpec              = "add-spec"
-	updateAddSchema         = "add-schema"
-	updateSnapshot          = "add-snapshot"
-	updateSortOrder         = "add-sort-order"
-	updateAssignUUID        = "assign-uuid"
-	updateDefaultSpec       = "set-default-spec"
-	updateCurrentSchema     = "set-current-schema"
-	updateDefaultSortOrder  = "set-default-sort-order"
-	updateSnapshotRef       = "set-snapshot-ref"
-	updateLocation          = "set-location"
-	updateProperties        = "set-properties"
-	updateRemoveProperties  = "remove-properties"
-	updateRemoveSnapshots   = "remove-snapshots"
-	updateRemoveSnapshotRef = "remove-snapshot-ref"
-	updateUpgradeFormat     = "upgrade-format-version"
+	UpdateAddSpec      = "add-spec"
+	UpdateAddSchema    = "add-schema"
+	UpdateAddSnapshot  = "add-snapshot"
+	UpdateAddSortOrder = "add-sort-order"
+
+	UpdateAssignUUID = "assign-uuid"
+
+	UpdateRemoveProperties  = "remove-properties"
+	UpdateRemoveSnapshots   = "remove-snapshots"
+	UpdateRemoveSnapshotRef = "remove-snapshot-ref"
+
+	UpdateSetCurrentSchema    = "set-current-schema"
+	UpdateSetDefaultSortOrder = "set-default-sort-order"
+	UpdateSetDefaultSpec      = "set-default-spec"
+	UpdateSetLocation         = "set-location"
+	UpdateSetProperties       = "set-properties"
+	UpdateSetSnapshotRef      = "set-snapshot-ref"
+
+	UpdateUpgradeFormatVersion = "upgrade-format-version"
 )
 
 // Update represents a change to a table's metadata.
@@ -68,7 +72,7 @@ type assignUUIDUpdate struct {
 // NewAssignUUIDUpdate creates a new update to assign a UUID to the table metadata.
 func NewAssignUUIDUpdate(uuid uuid.UUID) Update {
 	return &assignUUIDUpdate{
-		baseUpdate: baseUpdate{ActionName: updateAssignUUID},
+		baseUpdate: baseUpdate{ActionName: UpdateAssignUUID},
 		UUID:       uuid,
 	}
 }
@@ -88,7 +92,7 @@ type upgradeFormatVersionUpdate struct {
 // of the table metadata to the given formatVersion.
 func NewUpgradeFormatVersionUpdate(formatVersion int) Update {
 	return &upgradeFormatVersionUpdate{
-		baseUpdate:    baseUpdate{ActionName: updateUpgradeFormat},
+		baseUpdate:    baseUpdate{ActionName: UpdateUpgradeFormatVersion},
 		FormatVersion: formatVersion,
 	}
 }
@@ -111,7 +115,7 @@ type addSchemaUpdate struct {
 // schema of the table, and all previously added schemas in the metadata builder are removed.
 func NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID int, initial bool) Update {
 	return &addSchemaUpdate{
-		baseUpdate:   baseUpdate{ActionName: updateAddSchema},
+		baseUpdate:   baseUpdate{ActionName: UpdateAddSchema},
 		Schema:       schema,
 		LastColumnID: lastColumnID,
 		initial:      initial,
@@ -133,7 +137,7 @@ type setCurrentSchemaUpdate struct {
 // metadata to the given schema ID.
 func NewSetCurrentSchemaUpdate(id int) Update {
 	return &setCurrentSchemaUpdate{
-		baseUpdate: baseUpdate{ActionName: updateCurrentSchema},
+		baseUpdate: baseUpdate{ActionName: UpdateSetCurrentSchema},
 		SchemaID:   id,
 	}
 }
@@ -155,7 +159,7 @@ type addPartitionSpecUpdate struct {
 // and all other previously added specs in the metadata builder are removed.
 func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) Update {
 	return &addPartitionSpecUpdate{
-		baseUpdate: baseUpdate{ActionName: updateSpec},
+		baseUpdate: baseUpdate{ActionName: UpdateAddSpec},
 		Spec:       spec,
 		initial:    initial,
 	}
@@ -176,7 +180,7 @@ type setDefaultSpecUpdate struct {
 // table metadata to the given spec ID.
 func NewSetDefaultSpecUpdate(id int) Update {
 	return &setDefaultSpecUpdate{
-		baseUpdate: baseUpdate{ActionName: updateDefaultSpec},
+		baseUpdate: baseUpdate{ActionName: UpdateSetDefaultSpec},
 		SpecID:     id,
 	}
 }
@@ -198,7 +202,7 @@ type addSortOrderUpdate struct {
 // and all previously added sort orders in the metadata builder are removed.
 func NewAddSortOrderUpdate(sortOrder *SortOrder, initial bool) Update {
 	return &addSortOrderUpdate{
-		baseUpdate: baseUpdate{ActionName: updateSortOrder},
+		baseUpdate: baseUpdate{ActionName: UpdateAddSortOrder},
 		SortOrder:  sortOrder,
 		initial:    initial,
 	}
@@ -219,7 +223,7 @@ type setDefaultSortOrderUpdate struct {
 // to the given sort order ID.
 func NewSetDefaultSortOrderUpdate(id int) Update {
 	return &setDefaultSortOrderUpdate{
-		baseUpdate:  baseUpdate{ActionName: updateDefaultSortOrder},
+		baseUpdate:  baseUpdate{ActionName: UpdateSetDefaultSortOrder},
 		SortOrderID: id,
 	}
 }
@@ -238,7 +242,7 @@ type addSnapshotUpdate struct {
 // NewAddSnapshotUpdate creates a new update that adds the given snapshot to the table metadata.
 func NewAddSnapshotUpdate(snapshot *Snapshot) Update {
 	return &addSnapshotUpdate{
-		baseUpdate: baseUpdate{ActionName: updateSnapshot},
+		baseUpdate: baseUpdate{ActionName: UpdateAddSnapshot},
 		Snapshot:   snapshot,
 	}
 }
@@ -270,7 +274,7 @@ func NewSetSnapshotRefUpdate(
 	minSnapshotsToKeep int,
 ) Update {
 	return &setSnapshotRefUpdate{
-		baseUpdate:         baseUpdate{ActionName: updateSnapshotRef},
+		baseUpdate:         baseUpdate{ActionName: UpdateSetSnapshotRef},
 		RefName:            name,
 		RefType:            refType,
 		SnapshotID:         snapshotID,
@@ -310,7 +314,7 @@ type setLocationUpdate struct {
 // NewSetLocationUpdate creates a new update that sets the location of the table metadata.
 func NewSetLocationUpdate(loc string) Update {
 	return &setLocationUpdate{
-		baseUpdate: baseUpdate{ActionName: updateLocation},
+		baseUpdate: baseUpdate{ActionName: UpdateSetLocation},
 		Location:   loc,
 	}
 }
@@ -330,7 +334,7 @@ type setPropertiesUpdate struct {
 // table metadata.
 func NewSetPropertiesUpdate(updates iceberg.Properties) *setPropertiesUpdate {
 	return &setPropertiesUpdate{
-		baseUpdate: baseUpdate{ActionName: updateProperties},
+		baseUpdate: baseUpdate{ActionName: UpdateSetProperties},
 		Updates:    updates,
 	}
 }
@@ -351,7 +355,7 @@ type removePropertiesUpdate struct {
 // it is ignored.
 func NewRemovePropertiesUpdate(removals []string) Update {
 	return &removePropertiesUpdate{
-		baseUpdate: baseUpdate{ActionName: updateRemoveProperties},
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveProperties},
 		Removals:   removals,
 	}
 }
@@ -371,13 +375,13 @@ type removeSnapshotsUpdate struct {
 // the table metadata with the given snapshot IDs.
 func NewRemoveSnapshotsUpdate(ids []int64) Update {
 	return &removeSnapshotsUpdate{
-		baseUpdate:  baseUpdate{ActionName: updateRemoveSnapshots},
+		baseUpdate:  baseUpdate{ActionName: UpdateRemoveSnapshots},
 		SnapshotIDs: ids,
 	}
 }
 
 func (u *removeSnapshotsUpdate) Apply(builder *MetadataBuilder) error {
-	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, updateRemoveSnapshots)
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSnapshots)
 }
 
 type removeSnapshotRefUpdate struct {
@@ -389,11 +393,11 @@ type removeSnapshotRefUpdate struct {
 // from the table metadata.
 func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
 	return &removeSnapshotRefUpdate{
-		baseUpdate: baseUpdate{ActionName: updateRemoveSnapshotRef},
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveSnapshotRef},
 		RefName:    ref,
 	}
 }
 
 func (u *removeSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
-	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, updateRemoveSnapshotRef)
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSnapshotRef)
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -25,15 +25,21 @@ import (
 )
 
 const (
-	updateSpec             = "add-spec"
-	updateAddSchema        = "add-schema"
-	updateSnapshot         = "add-snapshot"
-	updateSortOrder        = "add-sort-order"
-	updateAssignUUID       = "assign-uuid"
-	updateDefaultSpec      = "set-default-spec"
-	updateCurrentSchema    = "set-current-schema"
-	updateDefaultSortOrder = "set-default-sort-order"
-	updateUpgradeFormat    = "upgrade-format-version"
+	updateSpec              = "add-spec"
+	updateAddSchema         = "add-schema"
+	updateSnapshot          = "add-snapshot"
+	updateSortOrder         = "add-sort-order"
+	updateAssignUUID        = "assign-uuid"
+	updateDefaultSpec       = "set-default-spec"
+	updateCurrentSchema     = "set-current-schema"
+	updateDefaultSortOrder  = "set-default-sort-order"
+	updateSnapshotRef       = "set-snapshot-ref"
+	updateLocation          = "set-location"
+	updateProperties        = "set-properties"
+	updateRemoveProperties  = "remove-properties"
+	updateRemoveSnapshots   = "remove-snapshots"
+	updateRemoveSnapshotRef = "remove-snapshot-ref"
+	updateUpgradeFormat     = "upgrade-format-version"
 )
 
 // Update represents a change to a table's metadata.
@@ -264,7 +270,7 @@ func NewSetSnapshotRefUpdate(
 	minSnapshotsToKeep int,
 ) Update {
 	return &setSnapshotRefUpdate{
-		baseUpdate:         baseUpdate{ActionName: "set-snapshot-ref"},
+		baseUpdate:         baseUpdate{ActionName: updateSnapshotRef},
 		RefName:            name,
 		RefType:            refType,
 		SnapshotID:         snapshotID,
@@ -304,7 +310,7 @@ type setLocationUpdate struct {
 // NewSetLocationUpdate creates a new update that sets the location of the table metadata.
 func NewSetLocationUpdate(loc string) Update {
 	return &setLocationUpdate{
-		baseUpdate: baseUpdate{ActionName: "set-location"},
+		baseUpdate: baseUpdate{ActionName: updateLocation},
 		Location:   loc,
 	}
 }
@@ -324,7 +330,7 @@ type setPropertiesUpdate struct {
 // table metadata.
 func NewSetPropertiesUpdate(updates iceberg.Properties) *setPropertiesUpdate {
 	return &setPropertiesUpdate{
-		baseUpdate: baseUpdate{ActionName: "set-properties"},
+		baseUpdate: baseUpdate{ActionName: updateProperties},
 		Updates:    updates,
 	}
 }
@@ -345,7 +351,7 @@ type removePropertiesUpdate struct {
 // it is ignored.
 func NewRemovePropertiesUpdate(removals []string) Update {
 	return &removePropertiesUpdate{
-		baseUpdate: baseUpdate{ActionName: "remove-properties"},
+		baseUpdate: baseUpdate{ActionName: updateRemoveProperties},
 		Removals:   removals,
 	}
 }
@@ -365,13 +371,13 @@ type removeSnapshotsUpdate struct {
 // the table metadata with the given snapshot IDs.
 func NewRemoveSnapshotsUpdate(ids []int64) Update {
 	return &removeSnapshotsUpdate{
-		baseUpdate:  baseUpdate{ActionName: "remove-snapshots"},
+		baseUpdate:  baseUpdate{ActionName: updateRemoveSnapshots},
 		SnapshotIDs: ids,
 	}
 }
 
 func (u *removeSnapshotsUpdate) Apply(builder *MetadataBuilder) error {
-	return fmt.Errorf("%w: remove-snapshots", iceberg.ErrNotImplemented)
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, updateRemoveSnapshots)
 }
 
 type removeSnapshotRefUpdate struct {
@@ -383,11 +389,11 @@ type removeSnapshotRefUpdate struct {
 // from the table metadata.
 func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
 	return &removeSnapshotRefUpdate{
-		baseUpdate: baseUpdate{ActionName: "remove-snapshot-ref"},
+		baseUpdate: baseUpdate{ActionName: updateRemoveSnapshotRef},
 		RefName:    ref,
 	}
 }
 
 func (u *removeSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
-	return fmt.Errorf("%w: remove-snapshot-ref", iceberg.ErrNotImplemented)
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, updateRemoveSnapshotRef)
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// These are the various update actions defined in the iceberg spec
 	UpdateAddSpec      = "add-spec"
 	UpdateAddSchema    = "add-schema"
 	UpdateAddSnapshot  = "add-snapshot"

--- a/table/updates.go
+++ b/table/updates.go
@@ -24,8 +24,8 @@ import (
 	"github.com/google/uuid"
 )
 
+// These are the various update actions defined in the iceberg spec
 const (
-	// These are the various update actions defined in the iceberg spec
 	UpdateAddSpec      = "add-spec"
 	UpdateAddSchema    = "add-schema"
 	UpdateAddSnapshot  = "add-snapshot"


### PR DESCRIPTION
Moved all action names in table updates to constants.

As a first step before implementing parsing of updates from bytes as described in #381 