### PR TITLE
feat(table): Add json parsing of table Requirement

### DIFF
--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRequirementBytes(t *testing.T) {
+	testCases := []struct {
+		name        string
+		data        []byte
+		expected    table.Requirement
+		expectedErr error
+	}{
+		{
+			name:        "Should parse an assert create",
+			data:        []byte(`{"type": "assert-create"}`),
+			expected:    table.AssertCreate(),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert table uuid",
+			data:        []byte(`{"type": "assert-table-uuid", "uuid": "550e8400-e29b-41d4-a716-446655440000"}`),
+			expected:    table.AssertTableUUID(uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert ref snapshot id",
+			data:        []byte(`{"type": "assert-ref-snapshot-id", "ref": "branch"}`),
+			expected:    table.AssertRefSnapshotID("branch", nil),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert default spec id",
+			data:        []byte(`{"type": "assert-default-spec-id", "default-spec-id": 42}`),
+			expected:    table.AssertDefaultSpecID(42),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert current schema id",
+			data:        []byte(`{"type": "assert-current-schema-id", "current-schema-id": 10}`),
+			expected:    table.AssertCurrentSchemaID(10),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert default sort order",
+			data:        []byte(`{"type": "assert-default-sort-order-id", "default-sort-order-id": 12}`),
+			expected:    table.AssertDefaultSortOrderID(12),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert last assigned field",
+			data:        []byte(`{"type": "assert-last-assigned-field-id", "last-assigned-field-id": 13}`),
+			expected:    table.AssertLastAssignedFieldID(13),
+			expectedErr: nil,
+		},
+		{
+			name:        "Should parse an assert last assigned partition",
+			data:        []byte(`{"type": "assert-last-assigned-partition-id", "last-assigned-partition-id": 13}`),
+			expected:    table.AssertLastAssignedPartitionID(13),
+			expectedErr: nil,
+		},
+		{
+			name:        "invalid requirement",
+			data:        []byte(`{"type": "invalid"}`),
+			expected:    nil,
+			expectedErr: table.ErrInvalidRequirement,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := table.ParseRequirementBytes(tc.data)
+			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -18,8 +18,10 @@
 package table
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 )
@@ -33,6 +35,10 @@ const (
 	reqAssertDefaultSortOrderID      = "assert-default-sort-order-id"
 	reqAssertLastAssignedFieldID     = "assert-last-assigned-field-id"
 	reqAssertLastAssignedPartitionID = "assert-last-assigned-partition-id"
+)
+
+var (
+	ErrInvalidRequirement = errors.New("invalid requirement")
 )
 
 // A Requirement is a validation rule that must be satisfied before attempting to
@@ -272,4 +278,82 @@ func (a *assertDefaultSortOrderId) Validate(meta Metadata) error {
 	}
 
 	return nil
+}
+
+// ParseRequirement parses json data provided by the reader into a Requirement
+func ParseRequirement(r io.Reader) (Requirement, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRequirementBytes(data)
+}
+
+// ParseRequirementString parses json string into a Requirement
+func ParseRequirementString(s string) (Requirement, error) {
+	return ParseRequirementBytes([]byte(s))
+}
+
+// ParseRequirementBytes parses json bytes into a Requirement
+func ParseRequirementBytes(b []byte) (Requirement, error) {
+	var base baseRequirement
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
+	}
+
+	switch base.Type {
+	case reqAssertCreate:
+		return AssertCreate(), nil
+
+	case reqAssertTableUUID:
+		var req assertTableUuid
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertTableUUID(req.UUID), nil
+
+	case reqAssertRefSnapshotID:
+		var req assertRefSnapshotID
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertRefSnapshotID(req.Ref, req.SnapshotID), nil
+
+	case reqAssertDefaultSpecID:
+		var req assertDefaultSpecId
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertDefaultSpecID(req.DefaultSpecID), nil
+
+	case reqAssertCurrentSchemaID:
+		var req assertCurrentSchemaId
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertCurrentSchemaID(req.CurrentSchemaID), nil
+
+	case reqAssertDefaultSortOrderID:
+		var req assertDefaultSortOrderId
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertDefaultSortOrderID(req.DefaultSortOrderID), nil
+
+	case reqAssertLastAssignedFieldID:
+		var req assertLastAssignedFieldId
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertLastAssignedFieldID(req.LastAssignedFieldID), nil
+
+	case reqAssertLastAssignedPartitionID:
+		var req assertLastAssignedPartitionId
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		return AssertLastAssignedPartitionID(req.LastAssignedPartitionID), nil
+	}
+
+	return nil, ErrInvalidRequirement
 }

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -37,9 +37,7 @@ const (
 	reqAssertLastAssignedPartitionID = "assert-last-assigned-partition-id"
 )
 
-var (
-	ErrInvalidRequirement = errors.New("invalid requirement")
-)
+var ErrInvalidRequirement = errors.New("invalid requirement")
 
 // A Requirement is a validation rule that must be satisfied before attempting to
 // make and commit changes to a table. Requirements are used to ensure that the
@@ -286,6 +284,7 @@ func ParseRequirement(r io.Reader) (Requirement, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return ParseRequirementBytes(data)
 }
 
@@ -310,6 +309,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertTableUUID(req.UUID), nil
 
 	case reqAssertRefSnapshotID:
@@ -317,6 +317,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertRefSnapshotID(req.Ref, req.SnapshotID), nil
 
 	case reqAssertDefaultSpecID:
@@ -324,6 +325,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertDefaultSpecID(req.DefaultSpecID), nil
 
 	case reqAssertCurrentSchemaID:
@@ -331,6 +333,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertCurrentSchemaID(req.CurrentSchemaID), nil
 
 	case reqAssertDefaultSortOrderID:
@@ -338,6 +341,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertDefaultSortOrderID(req.DefaultSortOrderID), nil
 
 	case reqAssertLastAssignedFieldID:
@@ -345,6 +349,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertLastAssignedFieldID(req.LastAssignedFieldID), nil
 
 	case reqAssertLastAssignedPartitionID:
@@ -352,6 +357,7 @@ func ParseRequirementBytes(b []byte) (Requirement, error) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			return nil, err
 		}
+
 		return AssertLastAssignedPartitionID(req.LastAssignedPartitionID), nil
 	}
 


### PR DESCRIPTION
Added `ParseRequirement` and its string and bytes counterpart to facilitate parsing the Requirement interface based on type.

Part of #381 