### PR TITLE
Add test to verify that no avro schema cache is used with manifest files

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -449,6 +449,7 @@ func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) ([]M
 		return nil, err
 	}
 	defer f.Close()
+
 	return readManifestEntries(m, f, discardDeleted)
 }
 

--- a/manifest.go
+++ b/manifest.go
@@ -449,7 +449,10 @@ func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) ([]M
 		return nil, err
 	}
 	defer f.Close()
+	return readManifestEntries(m, f, discardDeleted)
+}
 
+func readManifestEntries(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestEntry, error) {
 	dec, err := ocf.NewDecoder(f, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a follow-up to #385, which added a similar test for manifest _lists_ (but not for manifest files).

I verified the efficacy of this new test by commenting out the calls to `ocf.WithDecoderSchemaCache` in `readManifestEntries` and `NewManifestWriter` (which were added in #385). When they are commented out, the process uses avro's default global cache and the test then fails (as expected) with the following:

```
=== RUN   TestManifests/TestReadManifestIncompleteSchema
    manifest_test.go:911: 
        	Error Trace:	/Users/jhumphries/src/iceberg-go/manifest_test.go:911
        	Error:      	An error is expected but got nil.
        	Test:       	TestManifests/TestReadManifestIncompleteSchema
--- FAIL: TestManifests/TestReadManifestIncompleteSchema (0.00s)
```