### PR TITLE
feat: Add commit table support for Glue Catalog

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -218,7 +218,7 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 }
 
 //lint:ignore U1000 this is linked to by catalogs via go:linkname but we don't want to export it
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error) {
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
 	var (
 		baseMeta    table.Metadata
 		metadataLoc string

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -31,14 +31,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/apache/iceberg-go/catalog/internal"
-	"github.com/apache/iceberg-go/io"
 	"iter"
 	"maps"
 	"strings"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog/internal"
 	iceinternal "github.com/apache/iceberg-go/internal"
+	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 )
 

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
 	"iter"
 	"maps"

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/apache/iceberg-go/io"
 	"iter"
 	"maps"
 	"strings"
@@ -213,4 +214,51 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 	}
 
 	return updatedProps, summary, nil
+}
+
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error) {
+	var (
+		baseMeta    table.Metadata
+		metadataLoc string
+	)
+
+	if current != nil {
+		for _, r := range reqs {
+			if err := r.Validate(current.Metadata()); err != nil {
+				return nil, err
+			}
+		}
+
+		baseMeta = current.Metadata()
+		metadataLoc = current.MetadataLocation()
+	} else {
+		var err error
+		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	updated, err := internal.UpdateTableMetadata(baseMeta, updates, metadataLoc)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := table.LoadLocationProvider(updated.Location(), updated.Properties())
+	if err != nil {
+		return nil, err
+	}
+
+	newVersion := internal.ParseMetadataVersion(metadataLoc) + 1
+	newLocation, err := provider.NewTableMetadataFileLocation(newVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &table.StagedTable{Table: table.New(ident, updated, newLocation, fs, cat)}, nil
 }

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -217,6 +217,7 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 	return updatedProps, summary, nil
 }
 
+//lint:ignore U1000 this is linked to by catalogs via go:linkname but we don't want to export it
 func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error) {
 	var (
 		baseMeta    table.Metadata

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/apache/iceberg-go/catalog/internal"
 	"iter"
 	"maps"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/utils"
@@ -372,6 +372,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirement
 	if err != nil {
 		return nil, "", err
 	}
+
 	return staged.Metadata(), staged.MetadataLocation(), err
 }
 
@@ -774,6 +775,7 @@ func buildGlueTableInput(ctx context.Context, database string, tableName string,
 		}
 		glueColumns = append(glueColumns, col)
 	}
+
 	return &types.TableInput{
 		Name:        aws.String(tableName),
 		Description: aws.String(description),

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -334,7 +334,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 }
 
 //go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error)
 
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	// Load current table
@@ -348,7 +348,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirement
 	}
 
 	// Create a staging table with the updates applied
-	staged, err := updateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, *c)
+	staged, err := updateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/apache/iceberg-go/catalog/internal"
 	"iter"
+	"maps"
 	"strconv"
 	_ "unsafe"
 
@@ -116,6 +118,7 @@ type glueAPI interface {
 	GetTable(ctx context.Context, params *glue.GetTableInput, optFns ...func(*glue.Options)) (*glue.GetTableOutput, error)
 	GetTables(ctx context.Context, params *glue.GetTablesInput, optFns ...func(*glue.Options)) (*glue.GetTablesOutput, error)
 	DeleteTable(ctx context.Context, params *glue.DeleteTableInput, optFns ...func(*glue.Options)) (*glue.DeleteTableOutput, error)
+	UpdateTable(ctx context.Context, params *glue.UpdateTableInput, optFns ...func(*glue.Options)) (*glue.UpdateTableOutput, error)
 	GetDatabase(ctx context.Context, params *glue.GetDatabaseInput, optFns ...func(*glue.Options)) (*glue.GetDatabaseOutput, error)
 	GetDatabases(ctx context.Context, params *glue.GetDatabasesInput, optFns ...func(*glue.Options)) (*glue.GetDatabasesOutput, error)
 	CreateDatabase(ctx context.Context, params *glue.CreateDatabaseInput, optFns ...func(*glue.Options)) (*glue.CreateDatabaseOutput, error)
@@ -330,8 +333,50 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	return c.LoadTable(ctx, identifier, nil)
 }
 
-func (c *Catalog) CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error) {
-	panic("commit table not implemented for Glue Catalog")
+//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
+
+func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	for _, update := range updates {
+		if update.Action() != "set-properties" {
+			panic("Only set table property is supported ")
+		}
+	}
+
+	database, tableName, err := identifierToGlueTable(tbl.Identifier())
+	if err != nil {
+		return nil, "", err
+	}
+
+	current, err := c.LoadTable(ctx, tbl.Identifier(), nil)
+	if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
+		return nil, "", err
+	}
+
+	staged, err := updateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, *c)
+	if err != nil {
+		return nil, "", err
+	}
+	if current != nil && staged.Metadata().Equals(current.Metadata()) {
+		return current.Metadata(), current.MetadataLocation(), nil
+	}
+	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+		return nil, "", err
+	}
+
+	tableInput, err := buildGlueTableInput(ctx, database, tableName, staged, c)
+	if err != nil {
+		return nil, "", err
+	}
+	_, err = c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		TableInput:   tableInput,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return staged.Metadata(), staged.MetadataLocation(), err
 }
 
 // DropTable deletes an Iceberg table from the Glue catalog.
@@ -704,4 +749,50 @@ func filterDatabaseListByType(databases []types.Database, databaseType string) [
 	}
 
 	return filtered
+}
+
+func buildGlueTableInput(ctx context.Context, database string, tableName string, staged *table.StagedTable, cat *Catalog) (*types.TableInput, error) {
+	glueTable, err := cat.getTable(ctx, database, tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	glueProperties := prepareProperties(staged.Properties(), staged.MetadataLocation())
+	description := staged.Properties()["comment"]
+	if description == "" {
+		description = *glueTable.Description
+	}
+	existingColumnMap := map[string]string{}
+	for _, column := range glueTable.StorageDescriptor.Columns {
+		existingColumnMap[*column.Name] = *column.Comment
+	}
+	var glueColumns []types.Column
+	for _, column := range schemaToGlueColumns(staged.Metadata().CurrentSchema()) {
+		col := types.Column{
+			Name:    column.Name,
+			Comment: column.Comment,
+			Type:    column.Type,
+		}
+		if column.Comment == nil || *column.Comment == "" {
+			col.Comment = aws.String(existingColumnMap[*column.Name])
+		}
+		glueColumns = append(glueColumns, col)
+	}
+	return &types.TableInput{
+		Name:        aws.String(tableName),
+		Description: aws.String(description),
+		Parameters:  glueProperties,
+		StorageDescriptor: &types.StorageDescriptor{
+			Location: aws.String(staged.Location()),
+			Columns:  glueColumns,
+		},
+	}, nil
+}
+
+func prepareProperties(icebergProperties iceberg.Properties, newMetadataLocation string) iceberg.Properties {
+	glueProperties := maps.Clone(icebergProperties)
+	glueProperties[tableTypePropsKey] = glueTypeIceberg
+	glueProperties[metadataLocationPropsKey] = newMetadataLocation
+
+	return glueProperties
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -99,6 +99,12 @@ func (m *mockGlueClient) UpdateDatabase(ctx context.Context, params *glue.Update
 	return args.Get(0).(*glue.UpdateDatabaseOutput), args.Error(1)
 }
 
+func (m *mockGlueClient) UpdateTable(ctx context.Context, params *glue.UpdateTableInput, optFns ...func(*glue.Options)) (*glue.UpdateTableOutput, error) {
+	args := m.Called(ctx, params, optFns)
+
+	return args.Get(0).(*glue.UpdateTableOutput), args.Error(1)
+}
+
 var testIcebergGlueTable1 = types.Table{
 	Name: aws.String("test_table"),
 	Parameters: map[string]string{

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -152,7 +152,7 @@ var testNonIcebergGlueTable = types.Table{
 	},
 }
 
-var testSchema = iceberg.NewSchemaWithIdentifiers(0, []int{2},
+var testSchema = iceberg.NewSchemaWithIdentifiers(0, []int{},
 	iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String},
 	iceberg.NestedField{ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 	iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool})
@@ -1027,6 +1027,133 @@ func TestRegisterTableIntegration(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]string{tableName}, tbl.Identifier())
 	assert.Equal(metadataLocation, tbl.MetadataLocation())
+}
+
+func TestAlterTableIntegration(t *testing.T) {
+	if os.Getenv("TEST_DATABASE_NAME") == "" {
+		t.Skip()
+	}
+	if os.Getenv("TEST_TABLE_LOCATION") == "" {
+		t.Skip()
+	}
+
+	assert := require.New(t)
+	dbName := os.Getenv("TEST_DATABASE_NAME")
+	metadataLocation := os.Getenv("TEST_TABLE_LOCATION")
+	tbName := fmt.Sprintf("table_%d", time.Now().UnixNano())
+	tbIdent := TableIdentifier(dbName, tbName)
+
+	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
+	assert.NoError(err)
+	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+
+	// Create a table within the input database and location
+	testProps := iceberg.Properties{
+		"write.parquet.compression-codec": "zstd",
+	}
+	createOpts := []catalog.CreateTableOpt{
+		catalog.WithLocation(metadataLocation),
+		catalog.WithProperties(testProps),
+	}
+	_, err = ctlg.CreateTable(context.TODO(), tbIdent, testSchema, createOpts...)
+	assert.NoError(err)
+
+	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	assert.NoError(err)
+	assert.Equal(testProps, testTable.Properties())
+	assert.True(testSchema.Equals(testTable.Schema()))
+
+	// Clean up table and table location after tests
+	defer func() {
+		cleanupErr := ctlg.DropTable(context.TODO(), TableIdentifier(dbName, tbName))
+		if cleanupErr != nil {
+			t.Logf("Warning: Failed to clean up table %s.%s: %v", dbName, tbName, cleanupErr)
+		}
+		// Clean up the newly created metadata file in S3
+		if testTable != nil {
+			s3Client := s3.NewFromConfig(awsCfg)
+			metadataLoc := testTable.MetadataLocation()
+			if strings.HasPrefix(metadataLoc, "s3://") {
+				parts := strings.SplitN(strings.TrimPrefix(metadataLoc, "s3://"), "/", 2)
+				if len(parts) == 2 {
+					bucket := parts[0]
+					key := parts[1]
+					_, deleteErr := s3Client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+						Bucket: aws.String(bucket),
+						Key:    aws.String(key),
+					})
+					if deleteErr != nil {
+						t.Logf("Warning: Failed to delete metadata file at %s: %v", metadataLoc, deleteErr)
+					}
+				}
+			}
+		}
+	}()
+
+	// Test set table properties
+	updateProps := table.NewSetPropertiesUpdate(map[string]string{
+		"read.split.target-size": "134217728",
+		"key":                    "val",
+	})
+	_, _, err = ctlg.CommitTable(
+		context.TODO(),
+		testTable,
+		nil,
+		[]table.Update{updateProps},
+	)
+	assert.NoError(err)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	assert.NoError(err)
+	assert.Equal(iceberg.Properties{
+		"write.parquet.compression-codec": "zstd",
+		"read.split.target-size":          "134217728",
+		"key":                             "val",
+	}, testTable.Properties())
+
+	// Test unset table properties
+	removeProps := table.NewRemovePropertiesUpdate([]string{"key"})
+	_, _, err = ctlg.CommitTable(
+		context.TODO(),
+		testTable,
+		nil,
+		[]table.Update{removeProps},
+	)
+	assert.NoError(err)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	assert.NoError(err)
+	assert.Equal(iceberg.Properties{
+		"write.parquet.compression-codec": "zstd",
+		"read.split.target-size":          "134217728",
+	}, testTable.Properties())
+
+	// Test Alter Table Add / Drop Column
+	currentSchema := testTable.Schema()
+	newSchemaId := currentSchema.ID + 1
+	addField := iceberg.NestedField{
+		ID:       currentSchema.HighestFieldID() + 1,
+		Name:     "new_col",
+		Type:     iceberg.PrimitiveTypes.String,
+		Required: false,
+	}
+	newFields := append(currentSchema.Fields(), addField)
+	newFields = append(newFields[:1], newFields[2:]...) // drop column 'bar'
+	updateColumns := table.NewAddSchemaUpdate(
+		iceberg.NewSchemaWithIdentifiers(newSchemaId, currentSchema.IdentifierFieldIDs, newFields...),
+		addField.ID,
+		false,
+	)
+	setSchema := table.NewSetCurrentSchemaUpdate(newSchemaId)
+
+	_, _, err = ctlg.CommitTable(
+		context.TODO(),
+		testTable,
+		nil,
+		[]table.Update{updateColumns, setSchema},
+	)
+	assert.NoError(err)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	assert.NoError(err)
+	assert.Equal(newFields, testTable.Schema().Fields())
 }
 
 func TestGlueCheckTableExists(t *testing.T) {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -345,7 +345,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 }
 
 //go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error)
 
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns := catalog.NamespaceFromIdent(tbl.Identifier())
@@ -356,7 +356,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []tabl
 		return nil, "", err
 	}
 
-	staged, err := updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, *c)
+	staged, err := updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -344,52 +344,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	return c.LoadTable(ctx, ident, cfg.Properties)
 }
 
-func (c *Catalog) updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (*table.StagedTable, error) {
-	var (
-		baseMeta    table.Metadata
-		metadataLoc string
-	)
-
-	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, err
-			}
-		}
-
-		baseMeta = current.Metadata()
-		metadataLoc = current.MetadataLocation()
-	} else {
-		var err error
-		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	updated, err := internal.UpdateTableMetadata(baseMeta, updates, metadataLoc)
-	if err != nil {
-		return nil, err
-	}
-
-	provider, err := table.LoadLocationProvider(updated.Location(), updated.Properties())
-	if err != nil {
-		return nil, err
-	}
-
-	newVersion := internal.ParseMetadataVersion(metadataLoc) + 1
-	newLocation, err := provider.NewTableMetadataFileLocation(newVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &table.StagedTable{Table: table.New(ident, updated, newLocation, fs, c)}, nil
-}
+//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
+func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat Catalog) (*table.StagedTable, error)
 
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns := catalog.NamespaceFromIdent(tbl.Identifier())
@@ -400,7 +356,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []tabl
 		return nil, "", err
 	}
 
-	staged, err := c.updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates)
+	staged, err := updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, *c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -386,9 +386,15 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 
 			output.Text("updated " + args.propname + " on " + args.identifier)
 		case args.table:
-			loadTable(ctx, output, cat, args.identifier)
+			tbl := loadTable(ctx, output, cat, args.identifier)
 			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
-			output.Error(errors.New("not implemented: Writing is WIP"))
+			//ToDo handle other Update operations
+			_, _, err := cat.CommitTable(ctx, tbl, nil, []table.Update{
+				table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
 		}
 	case args.remove:
 		switch {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -388,6 +388,7 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 		case args.table:
 			tbl := loadTable(ctx, output, cat, args.identifier)
 			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
+
 			//ToDo handle other Update operations
 			_, _, err := cat.CommitTable(ctx, tbl, nil, []table.Update{
 				table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -389,9 +389,9 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 			tbl := loadTable(ctx, output, cat, args.identifier)
 			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
 
-			//ToDo handle other Update operations
-			_, _, err := cat.CommitTable(ctx, tbl, nil, []table.Update{
-				table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
+			// TODO: handle other Update operations
+			_, _, err := cat.CommitTable(ctx, tbl, nil,
+				[]table.Update{table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
 			if err != nil {
 				output.Error(err)
 				os.Exit(1)


### PR DESCRIPTION
### Description
* Implement `CommitTable` defined in the catalog interface
    * It will takes in `updates` and apply them on the base table and create a staging table
    * The table transaction will create a new metadata in the metadata location with the updated metadata / schema
    * The new metadata file will be committed to Glue catalog

@maninc is on leave, so I'm adding his previous work in https://github.com/apache/iceberg-go/pull/378 to this PR as well.

### Testing
Added `TestAlterTableIntegration` and tested locally