### PR TITLE
fix(catalog/glue): create table with required fields

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -36,9 +36,7 @@ import (
 	"strings"
 
 	"github.com/apache/iceberg-go"
-	"github.com/apache/iceberg-go/catalog/internal"
 	iceinternal "github.com/apache/iceberg-go/internal"
-	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 )
 
@@ -215,52 +213,4 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 	}
 
 	return updatedProps, summary, nil
-}
-
-//lint:ignore U1000 this is linked to by catalogs via go:linkname but we don't want to export it
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
-	var (
-		baseMeta    table.Metadata
-		metadataLoc string
-	)
-
-	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, err
-			}
-		}
-
-		baseMeta = current.Metadata()
-		metadataLoc = current.MetadataLocation()
-	} else {
-		var err error
-		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	updated, err := internal.UpdateTableMetadata(baseMeta, updates, metadataLoc)
-	if err != nil {
-		return nil, err
-	}
-
-	provider, err := table.LoadLocationProvider(updated.Location(), updated.Properties())
-	if err != nil {
-		return nil, err
-	}
-
-	newVersion := internal.ParseMetadataVersion(metadataLoc) + 1
-	newLocation, err := provider.NewTableMetadataFileLocation(newVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &table.StagedTable{Table: table.New(ident, updated, newLocation, fs, cat)}, nil
 }

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -348,9 +348,6 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	return c.LoadTable(ctx, identifier, nil)
 }
 
-//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error)
-
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	// Load current table
 	database, tableName, err := identifierToGlueTable(tbl.Identifier())
@@ -363,7 +360,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirement
 	}
 
 	// Create a staging table with the updates applied
-	staged, err := updateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, c)
+	staged, err := internal.UpdateAndStageTable(ctx, tbl, tbl.Identifier(), requirements, updates, c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -65,6 +65,10 @@ const (
 	Endpoint        = "glue.endpoint"
 	MaxRetries      = "glue.max-retries"
 	RetryMode       = "glue.retry-mode"
+
+	icebergFieldIDKey       = "iceberg.field.id"
+	icebergFieldOptionalKey = "iceberg.field.optional"
+	icebergFieldCurrentKey  = "iceberg.field.current"
 )
 
 var _ catalog.Catalog = (*Catalog)(nil)
@@ -130,6 +134,7 @@ type Catalog struct {
 	glueSvc   glueAPI
 	catalogId *string
 	awsCfg    *aws.Config
+	props     iceberg.Properties
 }
 
 // NewCatalog creates a new instance of glue.Catalog with the given options.
@@ -151,6 +156,7 @@ func NewCatalog(opts ...Option) *Catalog {
 		glueSvc:   glue.NewFromConfig(glueOps.awsConfig),
 		catalogId: catalogId,
 		awsCfg:    &glueOps.awsConfig,
+		props:     iceberg.Properties(glueOps.awsProperties),
 	}
 }
 
@@ -234,29 +240,42 @@ func (c *Catalog) CatalogType() catalog.Type {
 // CreateTable creates a new Iceberg table in the Glue catalog.
 // AWS Glue will create a new table and a new metadata file in S3 with the format: metadataLocation/metadata/00000-00000-00000-00000-00000.metadata.json.
 func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	database, tableName, err := identifierToGlueTable(identifier)
 	if err != nil {
 		return nil, err
 	}
-	var cfg catalog.CreateTableCfg
-	for _, opt := range opts {
-		opt(&cfg)
+
+	wfs, ok := staged.FS().(io.WriteFileIO)
+	if !ok {
+		return nil, errors.New("loaded filesystem IO does not support writing")
 	}
-	if cfg.Location == "" {
-		return nil, errors.New("metadata location is required for table creation")
+
+	if err := internal.WriteTableMetadata(staged.Metadata(), wfs, staged.MetadataLocation()); err != nil {
+		return nil, err
 	}
-	parameters := map[string]string{}
-	for k, v := range cfg.Properties {
-		parameters[k] = v
+
+	var tableDescription *string
+	if desc := staged.Properties().Get("Description", ""); desc != "" {
+		tableDescription = aws.String(desc)
 	}
+
 	tableInput := &types.TableInput{
-		Name:       aws.String(tableName),
-		Parameters: parameters,
-		TableType:  aws.String("EXTERNAL_TABLE"),
-		StorageDescriptor: &types.StorageDescriptor{
-			Location: aws.String(cfg.Location),
-			Columns:  schemaToGlueColumns(schema),
+		Name: aws.String(tableName),
+		Parameters: map[string]string{
+			tableTypePropsKey:        glueTypeIceberg,
+			metadataLocationPropsKey: staged.MetadataLocation(),
 		},
+		TableType: aws.String("EXTERNAL_TABLE"),
+		StorageDescriptor: &types.StorageDescriptor{
+			Location: aws.String(staged.Metadata().Location()),
+			Columns:  schemaToGlueColumns(schema, true),
+		},
+		Description: tableDescription,
 	}
 	_, err = c.glueSvc.CreateTable(ctx, &glue.CreateTableInput{
 		CatalogId:    c.catalogId,
@@ -271,7 +290,7 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table %s.%s: %w", database, tableName, err)
 	}
-	createdTable, err := c.LoadTable(ctx, identifier, cfg.Properties)
+	createdTable, err := c.LoadTable(ctx, identifier, nil)
 	if err != nil {
 		// Attempt to clean up the table if loading fails
 		_, cleanupErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
@@ -313,7 +332,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		TableType:  aws.String("EXTERNAL_TABLE"),
 		StorageDescriptor: &types.StorageDescriptor{
 			Location: aws.String(metadataLocation),
-			Columns:  schemaToGlueColumns(metadata.Schema()),
+			Columns:  schemaToGlueColumns(metadata.Schema(), true),
 		},
 	}
 	_, err = c.glueSvc.CreateTable(ctx, &glue.CreateTableInput{

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -47,6 +47,7 @@ func WriteTableMetadata(metadata table.Metadata, fs io.WriteFileIO, loc string) 
 		return nil
 	}
 	defer out.Close()
+
 	return json.NewEncoder(out).Encode(metadata)
 }
 
@@ -141,7 +142,8 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 	}
 
 	return table.StagedTable{
-		Table: table.New(ident, metadata, metadataLoc, fs, nil)}, nil
+		Table: table.New(ident, metadata, metadataLoc, fs, nil),
+	}, nil
 }
 
 type GetNamespacePropsFn func(context.Context, table.Identifier) (iceberg.Properties, error)
@@ -152,6 +154,7 @@ func ResolveTableLocation(ctx context.Context, loc, dbname, tablename string, ca
 		if err != nil {
 			return "", err
 		}
+
 		return getDefaultWarehouseLocation(dbname, tablename, dbprops, catprops)
 	}
 

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -22,11 +22,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"net/url"
 	"path"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
@@ -35,6 +39,15 @@ import (
 func GetMetadataLoc(location string, newVersion uint) string {
 	return fmt.Sprintf("%s/metadata/%05d-%s.metadata.json",
 		location, newVersion, uuid.New().String())
+}
+
+func WriteTableMetadata(metadata table.Metadata, fs io.WriteFileIO, loc string) error {
+	out, err := fs.Create(loc)
+	if err != nil {
+		return nil
+	}
+	defer out.Close()
+	return json.NewEncoder(out).Encode(metadata)
 }
 
 func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, props iceberg.Properties) error {
@@ -88,6 +101,73 @@ func UpdateTableMetadata(base table.Metadata, updates []table.Update, metadataLo
 	}
 
 	return bldr.Build()
+}
+
+func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nspropsFn GetNamespacePropsFn, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (table.StagedTable, error) {
+	var cfg catalog.CreateTableCfg
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	dbIdent := catalog.NamespaceFromIdent(ident)
+	tblname := catalog.TableNameFromIdent(ident)
+	dbname := strings.Join(dbIdent, ".")
+
+	loc, err := ResolveTableLocation(ctx, cfg.Location, dbname, tblname, catprops, nspropsFn)
+	if err != nil {
+		return table.StagedTable{}, err
+	}
+
+	provider, err := table.LoadLocationProvider(loc, cfg.Properties)
+	if err != nil {
+		return table.StagedTable{}, err
+	}
+
+	metadataLoc, err := provider.NewTableMetadataFileLocation(0)
+	if err != nil {
+		return table.StagedTable{}, err
+	}
+
+	metadata, err := table.NewMetadata(sc, cfg.PartitionSpec, cfg.SortOrder, loc, cfg.Properties)
+	if err != nil {
+		return table.StagedTable{}, err
+	}
+
+	ioProps := maps.Clone(catprops)
+	maps.Copy(ioProps, cfg.Properties)
+	fs, err := io.LoadFS(ctx, ioProps, metadataLoc)
+	if err != nil {
+		return table.StagedTable{}, err
+	}
+
+	return table.StagedTable{
+		Table: table.New(ident, metadata, metadataLoc, fs, nil)}, nil
+}
+
+type GetNamespacePropsFn func(context.Context, table.Identifier) (iceberg.Properties, error)
+
+func ResolveTableLocation(ctx context.Context, loc, dbname, tablename string, catprops iceberg.Properties, nsprops GetNamespacePropsFn) (string, error) {
+	if len(loc) == 0 {
+		dbprops, err := nsprops(ctx, strings.Split(dbname, "."))
+		if err != nil {
+			return "", err
+		}
+		return getDefaultWarehouseLocation(dbname, tablename, dbprops, catprops)
+	}
+
+	return strings.TrimSuffix(loc, "/"), nil
+}
+
+func getDefaultWarehouseLocation(dbname, tablename string, nsprops, catprops iceberg.Properties) (string, error) {
+	if dblocation := nsprops.Get("location", ""); dblocation != "" {
+		return url.JoinPath(dblocation, tablename)
+	}
+
+	if warehousepath := catprops.Get("warehouse", ""); warehousepath != "" {
+		return url.JoinPath(warehousepath, dbname+".db", tablename)
+	}
+
+	return "", errors.New("no default path set, please specify a location when creating a table")
 }
 
 // (\d+)            -> version number

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -199,3 +199,50 @@ func ParseMetadataVersion(location string) int {
 
 	return v
 }
+
+func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
+	var (
+		baseMeta    table.Metadata
+		metadataLoc string
+	)
+
+	if current != nil {
+		for _, r := range reqs {
+			if err := r.Validate(current.Metadata()); err != nil {
+				return nil, err
+			}
+		}
+
+		baseMeta = current.Metadata()
+		metadataLoc = current.MetadataLocation()
+	} else {
+		var err error
+		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	updated, err := UpdateTableMetadata(baseMeta, updates, metadataLoc)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := table.LoadLocationProvider(updated.Location(), updated.Properties())
+	if err != nil {
+		return nil, err
+	}
+
+	newVersion := ParseMetadataVersion(metadataLoc) + 1
+	newLocation, err := provider.NewTableMetadataFileLocation(newVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &table.StagedTable{Table: table.New(ident, updated, newLocation, fs, cat)}, nil
+}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -312,9 +312,6 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	return c.LoadTable(ctx, ident, staged.Properties())
 }
 
-//go:linkname updateAndStageTable github.com/apache/iceberg-go/catalog.updateAndStageTable
-func updateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error)
-
 func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns := catalog.NamespaceFromIdent(tbl.Identifier())
 	tblName := catalog.TableNameFromIdent(tbl.Identifier())
@@ -324,7 +321,7 @@ func (c *Catalog) CommitTable(ctx context.Context, tbl *table.Table, reqs []tabl
 		return nil, "", err
 	}
 
-	staged, err := updateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, c)
+	staged, err := internal.UpdateAndStageTable(ctx, current, tbl.Identifier(), reqs, updates, c)
 	if err != nil {
 		return nil, "", err
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -256,31 +255,6 @@ func (c *Catalog) namespaceExists(ctx context.Context, ns string) (bool, error) 
 			Where("catalog_name = ?", c.name).Where("namespace = ?", ns).
 			Limit(1).Exists(ctx)
 	})
-}
-
-func (c *Catalog) getDefaultWarehouseLocation(ctx context.Context, nsname, tableName string) (string, error) {
-	dbprops, err := c.LoadNamespaceProperties(ctx, strings.Split(nsname, "."))
-	if err != nil {
-		return "", err
-	}
-
-	if dblocation := dbprops.Get("location", ""); dblocation != "" {
-		return url.JoinPath(dblocation, tableName)
-	}
-
-	if warehousepath := c.props.Get("warehouse", ""); warehousepath != "" {
-		return url.JoinPath(warehousepath, nsname+".db", tableName)
-	}
-
-	return "", errors.New("no default path set, please specify a location when creating a table")
-}
-
-func (c *Catalog) resolveTableLocation(ctx context.Context, loc, nsname, tablename string) (string, error) {
-	if len(loc) == 0 {
-		return c.getDefaultWarehouseLocation(ctx, nsname, tablename)
-	}
-
-	return strings.TrimSuffix(loc, "/"), nil
 }
 
 func checkValidNamespace(ident table.Identifier) error {


### PR DESCRIPTION
fixes #407

Update and improve the Glue catalog CreateTable to properly set the parameters on the table itself and the columns (such as iceberg.field.id and iceberg.field.optional).

Also, write out the metadata first and then pass the location to Glue as part of creating the table.