### PR TITLE
Implement json output format

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -142,9 +142,9 @@ func main() {
 	var output Output
 	switch strings.ToLower(cfg.Output) {
 	case "text":
-		output = text{}
+		output = textOutput{}
 	case "json":
-		fallthrough
+		output = jsonOutput{}
 	default:
 		log.Fatal("unimplemented output type")
 	}

--- a/cmd/iceberg/output.go
+++ b/cmd/iceberg/output.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -44,9 +45,9 @@ type Output interface {
 	Error(error)
 }
 
-type text struct{}
+type textOutput struct{}
 
-func (text) Identifiers(idlist []table.Identifier) {
+func (textOutput) Identifiers(idlist []table.Identifier) {
 	data := pterm.TableData{[]string{"IDs"}}
 	for _, ids := range idlist {
 		data = append(data, []string{strings.Join(ids, ".")})
@@ -59,7 +60,7 @@ func (text) Identifiers(idlist []table.Identifier) {
 		WithData(data).Render()
 }
 
-func (t text) DescribeTable(tbl *table.Table) {
+func (t textOutput) DescribeTable(tbl *table.Table) {
 	propData := pterm.TableData{{"key", "value"}}
 	for k, v := range tbl.Metadata().Properties() {
 		propData = append(propData, []string{k, v})
@@ -109,7 +110,7 @@ func (t text) DescribeTable(tbl *table.Table) {
 	propTable.Render()
 }
 
-func (t text) Files(tbl *table.Table, history bool) {
+func (t textOutput) Files(tbl *table.Table, history bool) {
 	var snapshots []table.Snapshot
 	if history {
 		snapshots = tbl.Metadata().Snapshots()
@@ -161,7 +162,7 @@ func (t text) Files(tbl *table.Table, history bool) {
 	pterm.DefaultTree.WithRoot(node).Render()
 }
 
-func (text) DescribeProperties(props iceberg.Properties) {
+func (textOutput) DescribeProperties(props iceberg.Properties) {
 	data := pterm.TableData{[]string{"Key", "Value"}}
 	for k, v := range props {
 		data = append(data, []string{k, v})
@@ -174,11 +175,11 @@ func (text) DescribeProperties(props iceberg.Properties) {
 		WithData(data).Render()
 }
 
-func (text) Text(val string) {
+func (textOutput) Text(val string) {
 	fmt.Println(val)
 }
 
-func (text) Schema(schema *iceberg.Schema) {
+func (textOutput) Schema(schema *iceberg.Schema) {
 	schemaTree := pterm.LeveledList{}
 	var addChildren func(iceberg.NestedField, int)
 	addChildren = func(nf iceberg.NestedField, depth int) {
@@ -203,11 +204,11 @@ func (text) Schema(schema *iceberg.Schema) {
 	pterm.DefaultTree.WithRoot(schemaTreeNode).Render()
 }
 
-func (text) Spec(spec iceberg.PartitionSpec) {
+func (textOutput) Spec(spec iceberg.PartitionSpec) {
 	fmt.Println(spec)
 }
 
-func (text) Uuid(u uuid.UUID) {
+func (textOutput) Uuid(u uuid.UUID) {
 	if u.String() != "" {
 		fmt.Println(u.String())
 	} else {
@@ -215,6 +216,141 @@ func (text) Uuid(u uuid.UUID) {
 	}
 }
 
-func (text) Error(err error) {
+func (textOutput) Error(err error) {
+	log.Fatal(err)
+}
+
+type jsonOutput struct{}
+
+func (j jsonOutput) Identifiers(idList []table.Identifier) {
+	type dataType struct {
+		Identifiers []table.Identifier `json:"identifiers"`
+	}
+
+	var data dataType
+	data.Identifiers = idList
+
+	encodedData, err := json.Marshal(data)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) DescribeTable(tbl *table.Table) {
+	type dataType struct {
+		Metadata         table.Metadata        `json:"metadata,omitempty"`
+		MetadataLocation string                `json:"metadata-location,omitempty"`
+		SortOrder        table.SortOrder       `json:"sort-order,omitempty"`
+		CurrentSnapshot  *table.Snapshot       `json:"current-snapshot,omitempty"`
+		Spec             iceberg.PartitionSpec `json:"spec,omitempty"`
+		Schema           *iceberg.Schema       `json:"schema"`
+	}
+
+	var data dataType
+	data.Metadata = tbl.Metadata()
+	data.MetadataLocation = tbl.MetadataLocation()
+	data.SortOrder = tbl.SortOrder()
+	data.CurrentSnapshot = tbl.CurrentSnapshot()
+	data.Spec = tbl.Spec()
+	data.Schema = tbl.Schema()
+
+	encodedData, _ := json.Marshal(data)
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Files(tbl *table.Table, history bool) {
+	if history {
+		type dataType struct {
+			Snapshots []table.Snapshot `json:"snapshots"`
+		}
+
+		var data dataType
+		data.Snapshots = tbl.Metadata().Snapshots()
+
+		encodedData, err := json.Marshal(data)
+		if err != nil {
+			j.Error(err)
+		}
+
+		fmt.Println(string(encodedData))
+	} else {
+		type dataType struct {
+			Snapshot *table.Snapshot `json:"snapshot"`
+		}
+
+		var data dataType
+		data.Snapshot = tbl.CurrentSnapshot()
+
+		encodedData, err := json.Marshal(data)
+		if err != nil {
+			j.Error(err)
+		}
+
+		fmt.Println(string(encodedData))
+	}
+}
+
+func (j jsonOutput) DescribeProperties(props iceberg.Properties) {
+	encodedData, err := json.Marshal(props)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Text(s string) {
+	type dataType struct {
+		Data string `json:"data"`
+	}
+
+	var data dataType
+	data.Data = s
+
+	encodedData, err := json.Marshal(data)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Schema(schema *iceberg.Schema) {
+	encodedData, err := json.Marshal(schema)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Spec(spec iceberg.PartitionSpec) {
+	encodedData, err := json.Marshal(spec)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Uuid(u uuid.UUID) {
+	type dataType struct {
+		UUID uuid.UUID `json:"uuid"`
+	}
+
+	var data dataType
+	data.UUID = u
+
+	encodedData, err := json.Marshal(data)
+	if err != nil {
+		j.Error(err)
+	}
+
+	fmt.Println(string(encodedData))
+}
+
+func (j jsonOutput) Error(err error) {
 	log.Fatal(err)
 }

--- a/cmd/iceberg/output_test.go
+++ b/cmd/iceberg/output_test.go
@@ -191,7 +191,7 @@ func TestDescribeTable(t *testing.T) {
 		table := table.New([]string{"t"}, meta, "", nil, nil)
 		buf.Reset()
 
-		text{}.DescribeTable(table)
+		textOutput{}.DescribeTable(table)
 
 		assert.Equal(t, tt.expected, buf.String())
 	}


### PR DESCRIPTION
implements #325 

### Summary:
Implement `json` output format for the CLI tool.

### Changes:
* Implement `jsonOutput` type
* Rename `text` to `textOutput`

### Example:
```sh
$ go run ./cmd/iceberg --uri http://127.0.0.1:8181 --output json describe table 'nyc.taxis'
{"metadata":{"last-sequence-number":0,"format-version":2,"table-uuid":"643a61a3-32a3-4649-b6ce-e2aee49d8896","location":"s3://warehouse/nyc/taxis","last-updated-ms":1746128668331,"last-column-id":5,"schemas":[{"type":"struct","fields":[{"type":"long","id":1,"name":"vendor_id","required":false},{"type":"long","id":2,"name":"trip_id","required":false},{"type":"float","id":3,"name":"trip_distance","required":false},{"type":"double","id":4,"name":"fare_amount","required":false},{"type":"string","id":5,"name":"store_and_fwd_flag","required":false}],"schema-id":0,"identifier-field-ids":[]}],"current-schema-id":0,"partition-specs":[{"spec-id":0,"fields":[{"source-id":1,"field-id":1000,"name":"vendor_id","transform":"identity"}]}],"default-spec-id":0,"last-partition-id":1000,"properties":{"owner":"root","write.parquet.compression-codec":"zstd"},"sort-orders":[{"order-id":0,"fields":[]}],"default-sort-order-id":0},"metadata-location":"s3://warehouse/nyc/taxis/metadata/00000-e040619a-e417-4096-bbd8-d29333cbd6f9.metadata.json","sort-order":{"order-id":0,"fields":[]},"spec":{"spec-id":0,"fields":[{"source-id":1,"field-id":1000,"name":"vendor_id","transform":"identity"}]},"schema":{"type":"struct","fields":[{"type":"long","id":1,"name":"vendor_id","required":false},{"type":"long","id":2,"name":"trip_id","required":false},{"type":"float","id":3,"name":"trip_distance","required":false},{"type":"double","id":4,"name":"fare_amount","required":false},{"type":"string","id":5,"name":"store_and_fwd_flag","required":false}],"schema-id":0,"identifier-field-ids":[]}}
```