### PR TITLE
Add ManifestReader, which provides access to manifest metadata

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -560,6 +560,8 @@ func decodeManifests[I interface {
 }
 
 // ManifestReader reads the metadata and data from an avro manifest file.
+// This type is not thread-safe; its methods should not be called from
+// multiple goroutines.
 type ManifestReader struct {
 	dec           *ocf.Decoder
 	file          ManifestFile


### PR DESCRIPTION
This is an alternative to #415.

This closes #386.

This also exports the `ReadManifest` helper (previously named `readManifestEntries`), so the read flow has symmetry with the existing `NewManifestWriter` and `WriteManifest` for the write flow.
