### PR TITLE
Allow HTTP proxy to be used to talk to REST catalog server

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -558,7 +558,7 @@ func (r *Catalog) fetchAccessToken(cl *http.Client, creds string, opts *options)
 
 func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Client, error) {
 	session := &sessionTransport{
-		Transport:      http.Transport{TLSClientConfig: opts.tlsConfig},
+		Transport:      http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: opts.tlsConfig},
 		defaultHeaders: http.Header{},
 	}
 	cl := &http.Client{Transport: session}


### PR DESCRIPTION
This one-liner uses the "net/http" package's built-in support for HTTP proxies, activated via standard environment variables like `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.