### PR TITLE
feat: Add initial support for create table CLI through json schema

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -80,7 +80,7 @@ Options:
   --config TEXT      specify the path to the configuration file
   --description TEXT 	specify a description for the namespace
   --location-uri TEXT  	specify a location URI for the namespace
-  --schema TEXT        specify table schema in json (for create table use only)
+  --schema JSON        specify table schema in json (for create table use only)
                        Ex: [{"name":"id","type":"int","required":false,"doc":"unique id"}]`
 
 type Config struct {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -80,7 +80,7 @@ Options:
   --config TEXT      specify the path to the configuration file
   --description TEXT 	specify a description for the namespace
   --location-uri TEXT  	specify a location URI for the namespace
-  --fields TEXT        specify table schema fields in json (for create table use only).
+  --fields TEXT        specify table schema fields in json (for create table use only)
                        Ex: [{"id":1,"name":"id","type":"long","required":true,"doc":"unique id"}]`
 
 type Config struct {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -80,8 +80,8 @@ Options:
   --config TEXT      specify the path to the configuration file
   --description TEXT 	specify a description for the namespace
   --location-uri TEXT  	specify a location URI for the namespace
-  --fields TEXT        specify table schema fields in json (for create table use only)
-                       Ex: [{"id":1,"name":"id","type":"long","required":true,"doc":"unique id"}]`
+  --schema TEXT        specify table schema in json (for create table use only)
+                       Ex: [{"name":"id","type":"int","required":false,"doc":"unique id"}]`
 
 type Config struct {
 	List     bool `docopt:"list"`
@@ -121,7 +121,7 @@ type Config struct {
 	Config      string `docopt:"--config"`
 	Description string `docopt:"--description"`
 	LocationURI string `docopt:"--location-uri"`
-	FieldsStr   string `docopt:"--fields"`
+	SchemaStr   string `docopt:"--schema"`
 }
 
 func main() {
@@ -255,12 +255,12 @@ func main() {
 				os.Exit(1)
 			}
 		case cfg.Table:
-			if cfg.FieldsStr == "" {
-				output.Error(errors.New("missing --fields for table creation"))
+			if cfg.SchemaStr == "" {
+				output.Error(errors.New("missing --schema for table creation"))
 				os.Exit(1)
 			}
 
-			schema, err := iceberg.NewSchemaFromJsonFields(0, cfg.FieldsStr)
+			schema, err := iceberg.NewSchemaFromJsonFields(0, cfg.SchemaStr)
 			if err != nil {
 				output.Error(err)
 				os.Exit(1)

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -80,7 +80,8 @@ Options:
   --config TEXT      specify the path to the configuration file
   --description TEXT 	specify a description for the namespace
   --location-uri TEXT  	specify a location URI for the namespace
-  --schema TEXT        specify table schema in json`
+  --fields TEXT        specify table schema fields in json (for create table use only).
+                       Ex: [{"id":1,"name":"id","type":"long","required":true,"doc":"unique id"}]`
 
 type Config struct {
 	List     bool `docopt:"list"`
@@ -120,7 +121,7 @@ type Config struct {
 	Config      string `docopt:"--config"`
 	Description string `docopt:"--description"`
 	LocationURI string `docopt:"--location-uri"`
-	SchemaStr   string `docopt:"--schema"`
+	FieldsStr   string `docopt:"--fields"`
 }
 
 func main() {
@@ -254,12 +255,12 @@ func main() {
 				os.Exit(1)
 			}
 		case cfg.Table:
-			if cfg.SchemaStr == "" {
-				output.Error(errors.New("missing --schema for table creation"))
+			if cfg.FieldsStr == "" {
+				output.Error(errors.New("missing --fields for table creation"))
 				os.Exit(1)
 			}
 
-			schema, err := iceberg.NewSchemaFromJson(0, cfg.SchemaStr)
+			schema, err := iceberg.NewSchemaFromJsonFields(0, cfg.FieldsStr)
 			if err != nil {
 				output.Error(err)
 				os.Exit(1)

--- a/schema.go
+++ b/schema.go
@@ -51,6 +51,17 @@ type Schema struct {
 	lazyNameMapping func() NameMapping
 }
 
+// NewSchemaFromJson constructs a new schema with the provided ID and a string in json form
+func NewSchemaFromJson(id int, jsonStr string) (*Schema, error) {
+	var fields []NestedField
+	err := json.Unmarshal([]byte(jsonStr), &fields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse schema JSON: %w", err)
+	}
+
+	return NewSchema(id, fields...), nil
+}
+
 // NewSchema constructs a new schema with the provided ID
 // and list of fields.
 func NewSchema(id int, fields ...NestedField) *Schema {

--- a/schema.go
+++ b/schema.go
@@ -52,9 +52,9 @@ type Schema struct {
 }
 
 // NewSchemaFromJson constructs a new schema with the provided ID and a string in json form
-func NewSchemaFromJson(id int, jsonStr string) (*Schema, error) {
+func NewSchemaFromJsonFields(id int, jsonFieldsStr string) (*Schema, error) {
 	var fields []NestedField
-	err := json.Unmarshal([]byte(jsonStr), &fields)
+	err := json.Unmarshal([]byte(jsonFieldsStr), &fields)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse schema JSON: %w", err)
 	}

--- a/schema.go
+++ b/schema.go
@@ -51,7 +51,7 @@ type Schema struct {
 	lazyNameMapping func() NameMapping
 }
 
-// NewSchemaFromJson constructs a new schema with the provided ID and a string in json form
+// NewSchemaFromJsonFields constructs a new schema with the provided ID and fields in json form
 func NewSchemaFromJsonFields(id int, jsonFieldsStr string) (*Schema, error) {
 	var fields []NestedField
 	err := json.Unmarshal([]byte(jsonFieldsStr), &fields)

--- a/schema_test.go
+++ b/schema_test.go
@@ -96,33 +96,38 @@ var (
 )
 
 func TestSchemaFromJson(t *testing.T) {
-	testSchemaStr := `[{"id":1,"name":"foo","type":"string","required":false},
-						{"id":2,"name":"bar","type":"int","required":true},
-						{"id":3,"name":"baz","type":"boolean","required":false}]`
-	simpleSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	testFieldsStr := `[
+		{"id":1,"name":"foo","type":"string","required":false},
+		{"id":2,"name":"bar","type":"int","required":true},
+		{"id":3,"name":"baz","type":"boolean","required":false}
+	]`
+
+	simpleSchema, err := iceberg.NewSchemaFromJsonFields(1, testFieldsStr)
 	assert.NoError(t, err)
 	assert.Equal(t, tableSchemaSimple.Fields(), simpleSchema.Fields())
 
-	testSchemaStr = `[{"id":1,"name":"id","type":"int","required":true,"doc":"primary key"},
-						{"id":2,"name":"name","type":"string","required":false,"doc":"user name"}]`
-	commentSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	testFieldsStr = `[
+		{"id":1,"name":"id","type":"int","required":true,"doc":"primary key"},
+		{"id":2,"name":"name","type":"string","required":false,"doc":"user name"}
+	]`
+	commentSchema, err := iceberg.NewSchemaFromJsonFields(1, testFieldsStr)
 	assert.NoError(t, err)
 	assert.Equal(t, "primary key", commentSchema.Fields()[0].Doc)
 	assert.Equal(t, "user name", commentSchema.Fields()[1].Doc)
 
-	testSchemaStr = `[{
-						"id": 1,
-						"name": "location",
-						"type": {
-						  "type": "struct",
-						  "fields": [
-							{"id": 11, "name": "address", "type": "string", "required": true},
-							{"id": 12, "name": "zip", "type": "int", "required": false}
-						  ]
-						},
-						"required": true
-					  }]`
-	nestedSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	testFieldsStr = `[{
+		"id": 1,
+		"name": "location",
+		"type": {
+			"type": "struct",
+			"fields": [
+				{"id": 11, "name": "address", "type": "string", "required": true},
+				{"id": 12, "name": "zip", "type": "int", "required": false}
+			]
+		},
+		"required": true
+	}]`
+	nestedSchema, err := iceberg.NewSchemaFromJsonFields(1, testFieldsStr)
 	assert.NoError(t, err)
 	assert.Len(t, nestedSchema.Fields(), 1)
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -95,6 +95,46 @@ var (
 	)
 )
 
+func TestSchemaFromJson(t *testing.T) {
+	testSchemaStr := `[{"id":1,"name":"foo","type":"string","required":false},
+						{"id":2,"name":"bar","type":"int","required":true},
+						{"id":3,"name":"baz","type":"boolean","required":false}]`
+	simpleSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	assert.NoError(t, err)
+	assert.Equal(t, tableSchemaSimple.Fields(), simpleSchema.Fields())
+
+	testSchemaStr = `[{"id":1,"name":"id","type":"int","required":true,"doc":"primary key"},
+						{"id":2,"name":"name","type":"string","required":false,"doc":"user name"}]`
+	commentSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	assert.NoError(t, err)
+	assert.Equal(t, "primary key", commentSchema.Fields()[0].Doc)
+	assert.Equal(t, "user name", commentSchema.Fields()[1].Doc)
+
+	testSchemaStr = `[{
+						"id": 1,
+						"name": "location",
+						"type": {
+						  "type": "struct",
+						  "fields": [
+							{"id": 11, "name": "address", "type": "string", "required": true},
+							{"id": 12, "name": "zip", "type": "int", "required": false}
+						  ]
+						},
+						"required": true
+					  }]`
+	nestedSchema, err := iceberg.NewSchemaFromJson(1, testSchemaStr)
+	assert.NoError(t, err)
+	assert.Len(t, nestedSchema.Fields(), 1)
+
+	structType, ok := nestedSchema.Fields()[0].Type.(*iceberg.StructType)
+	assert.True(t, ok)
+	assert.Len(t, structType.Fields(), 2)
+	assert.Equal(t, "address", structType.Fields()[0].Name)
+	assert.Equal(t, iceberg.PrimitiveTypes.String, structType.Fields()[0].Type)
+	assert.Equal(t, "zip", structType.Fields()[1].Name)
+	assert.Equal(t, iceberg.PrimitiveTypes.Int32, structType.Fields()[1].Type)
+}
+
 func TestSchemaToString(t *testing.T) {
 	assert.Equal(t, 3, tableSchemaSimple.NumFields())
 	assert.Equal(t, `table {


### PR DESCRIPTION
### Description
* Adds support for creating table through CLI
* The schema needs to be provided in json form
    * An alternative idea is to use SQL like form like `id bigint NOT NULL COMMENT 'unique id'`, but the parsing may get complicated with nestings.

### Testings
```
go run . create table lliangyu_test_db.test_tbl \                         
  --catalog glue \
  --schema '[{"name":"id","type":"int","required":false},{"name":"name","type":"string","required":true}]' \
--location-uri s3://xxxxx/xxxxx
```
Result metadata file
```
{"last-sequence-number":0,"format-version":2,"table-uuid":"bc6fd1b7-6855-428b-a5f3-65b8fa742e84","location":"s3://xxxxx/xxxxx","last-updated-ms":1746826023185,"last-column-id":2,"schemas":[{"type":"struct","fields":[{"type":"int","id":1,"name":"id","required":false},{"type":"string","id":2,"name":"name","required":true}],"schema-id":0,"identifier-field-ids":[]}],"current-schema-id":0,"partition-specs":[{"spec-id":0,"fields":[]}],"default-spec-id":0,"last-partition-id":999,"sort-orders":[{"order-id":0,"fields":[]}],"default-sort-order-id":0}
```