### PR TITLE
fix: Improve list logic to fallback from tables to namespaces

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -266,21 +266,28 @@ func main() {
 func list(ctx context.Context, output Output, cat catalog.Catalog, parent string) {
 	prnt := catalog.ToIdentifier(parent)
 
-	ids, err := cat.ListNamespaces(ctx, prnt)
-	if err != nil {
-		output.Error(err)
-		os.Exit(1)
-	}
+	var ids []table.Identifier
 
-	if len(ids) == 0 && parent != "" {
+	if parent != "" {
 		iter := cat.ListTables(ctx, prnt)
 		for id, err := range iter {
-			ids = append(ids, id)
 			if err != nil {
 				output.Error(err)
+				os.Exit(1)
 			}
+			ids = append(ids, id)
 		}
 	}
+
+	if len(ids) == 0 {
+		ns, err := cat.ListNamespaces(ctx, prnt)
+		if err != nil {
+			output.Error(err)
+			os.Exit(1)
+		}
+		ids = ns
+	}
+
 	output.Identifiers(ids)
 }
 


### PR DESCRIPTION
### Description
* This make sure that catalog doesn't support hierarchical namespaces will be able to run the list tables correctly.
* This change also aligned with the current behavior in iceberg-python https://github.com/apache/iceberg-python/blob/main/pyiceberg/cli/console.py#L114-L121

### Testing
```
go run . list --catalog glue                         
┌────────────────────┐
| IDs                |
| ------------------ |
| lliangyu_test_db   |
| lliangyu_test_db_2 |
└────────────────────┘

go run . list lliangyu_test_db_2 --catalog glue
┌─────────────────────────┐
| IDs                     |
| ----------------------- |
| lliangyu_test_db_2.tb1  |
| lliangyu_test_db_2.tb2  |
| lliangyu_test_db_2.tb3  |
| lliangyu_test_db_2.tbl4 |
| lliangyu_test_db_2.tbl5 |
| lliangyu_test_db_2.tbl6 |
| lliangyu_test_db_2.tbl7 |
| lliangyu_test_db_2.tbl8 |
| lliangyu_test_db_2.tbl9 |
└─────────────────────────┘
```

Fixes #425 