### PR TITLE
feat: Implement remove properties CLI using catalog commit table API and improve references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ $ cd iceberg-go/cmd/iceberg && go build .
 | Create New Snapshot         |  X   |      |          |      |  X  |
 | Rename Table                |  X   |      |          |  X   |  X  |
 | Drop Table                  |  X   |      |          |  X   |  X  |
-| Alter Table                 |  X   |      |          |      |  X  |
+| Alter Table                 |  X   |      |          |  X   |  X  |
 | Check Table Exists          |  X   |      |          |  X   |  X  |
-| Set Table Properties        |  X   |      |          |      |  X  |
+| Set Table Properties        |  X   |      |          |  X   |  X  |
 | List Namespaces             |  X   |      |          |  X   |  X  |
 | Create Namespace            |  X   |      |          |  X   |  X  |
 | Check Namespace Exists      |  X   |      |          |  X   |  X  |

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -430,7 +430,7 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 		}
 		output.Text("Updated " + args.propname + " on " + args.identifier)
 	case args.remove:
-		output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
+		output.Text("Removing " + args.propname + " on " + args.identifier)
 		switch {
 		case args.namespace:
 			_, err := cat.UpdateNamespaceProperties(ctx, ident,

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -55,6 +55,7 @@ Commands:
   describe    Describe a namespace or a table.
   list        List tables or namespaces.
   schema      Get the schema of the table.
+  create      Create a namespace or a table.
   spec        Return the partition spec of the table.
   uuid        Return the UUID of the table.
   location    Return the location of the table.
@@ -71,17 +72,17 @@ Arguments:
   VALUE          value to set
 
 Options:
-  -h --help          show this help messages and exit
-  --catalog TEXT     specify the catalog type [default: rest]
-  --uri TEXT         specify the catalog URI
-  --output TYPE      output type (json/text) [default: text]
-  --credential TEXT  specify credentials for the catalog
-  --warehouse TEXT   specify the warehouse to use
-  --config TEXT      specify the path to the configuration file
+  -h --help          	show this help messages and exit
+  --catalog TEXT     	specify the catalog type [default: rest]
+  --uri TEXT         	specify the catalog URI
+  --output TYPE      	output type (json/text) [default: text]
+  --credential TEXT  	specify credentials for the catalog
+  --warehouse TEXT   	specify the warehouse to use
+  --config TEXT      	specify the path to the configuration file
   --description TEXT 	specify a description for the namespace
   --location-uri TEXT  	specify a location URI for the namespace
-  --schema JSON        specify table schema in json (for create table use only)
-                       Ex: [{"name":"id","type":"int","required":false,"doc":"unique id"}]`
+  --schema JSON        	specify table schema in json (for create table use only)
+                       	Ex: [{"name":"id","type":"int","required":false,"doc":"unique id"}]`
 
 type Config struct {
 	List     bool `docopt:"list"`
@@ -254,6 +255,7 @@ func main() {
 				output.Error(err)
 				os.Exit(1)
 			}
+			output.Text("Namespace " + cfg.Ident + " created successfully")
 		case cfg.Table:
 			if cfg.SchemaStr == "" {
 				output.Error(errors.New("missing --schema for table creation"))
@@ -278,6 +280,7 @@ func main() {
 				output.Error(fmt.Errorf("failed to create table: %w", err))
 				os.Exit(1)
 			}
+			output.Text("Table " + cfg.Ident + " created successfully")
 		default:
 			output.Error(errors.New("not implemented"))
 			os.Exit(1)
@@ -407,6 +410,7 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 			os.Exit(1)
 		}
 	case args.set:
+		output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
 		switch {
 		case args.namespace:
 			_, err := cat.UpdateNamespaceProperties(ctx, ident,
@@ -415,13 +419,8 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 				output.Error(err)
 				os.Exit(1)
 			}
-
-			output.Text("updated " + args.propname + " on " + args.identifier)
 		case args.table:
 			tbl := loadTable(ctx, output, cat, args.identifier)
-			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
-
-			// TODO: handle other Update operations
 			_, _, err := cat.CommitTable(ctx, tbl, nil,
 				[]table.Update{table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
 			if err != nil {
@@ -429,7 +428,9 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 				os.Exit(1)
 			}
 		}
+		output.Text("Updated " + args.propname + " on " + args.identifier)
 	case args.remove:
+		output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
 		switch {
 		case args.namespace:
 			_, err := cat.UpdateNamespaceProperties(ctx, ident,
@@ -438,13 +439,17 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 				output.Error(err)
 				os.Exit(1)
 			}
-
-			output.Text("removing " + args.propname + " from " + args.identifier)
 		case args.table:
-			loadTable(ctx, output, cat, args.identifier)
-			output.Text("Setting " + args.propname + "=" + args.value + " on " + args.identifier)
-			output.Error(errors.New("not implemented: Writing is WIP"))
+			tbl := loadTable(ctx, output, cat, args.identifier)
+
+			_, _, err := cat.CommitTable(ctx, tbl, nil,
+				[]table.Update{table.NewRemovePropertiesUpdate([]string{args.propname})})
+			if err != nil {
+				output.Error(err)
+				os.Exit(1)
+			}
 		}
+		output.Text("Removed " + args.propname + " from " + args.identifier)
 	}
 }
 


### PR DESCRIPTION
### Description
* Close the gap in properties CLI using the commit table implementation
* Update references and loggings as mentioned in #424

### Testing
```
go run . properties get table lliangyu_test_db.tbl1 --catalog glue                  
┌──────────────┐
| Key  | Value |
| ------------ |
| key1 | val1  |
└──────────────┘

go run . properties set table lliangyu_test_db.tbl1 write.object-storage.enabled true --catalog glue
Setting write.object-storage.enabled=true on lliangyu_test_db.tbl1
Updated write.object-storage.enabled on lliangyu_test_db.tbl1

go run . properties get table lliangyu_test_db.tbl1 --catalog glue                                  
┌──────────────────────────────────────┐
| Key                          | Value |
| ------------------------------------ |
| key1                         | val1  |
| write.object-storage.enabled | true  |
└──────────────────────────────────────┘