### PR TITLE
fix(table): ensure manifest length matches file size

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1373,6 +1373,11 @@ func WriteManifest(
 		}
 	}
 
+	// flush the writer to ensure cnt.Count is accurate
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
 	return w.ToManifestFile(filename, cnt.Count)
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -426,13 +426,17 @@ func (m *ManifestTestSuite) writeManifestEntries() {
 		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
 		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 
-	_, err := WriteManifest("/home/iceberg/warehouse/nyc/taxis_partitioned/metadata/0125c686-8aa6-4502-bdcc-b6d17ca41a3b-m0.avro",
+	mf, err := WriteManifest("/home/iceberg/warehouse/nyc/taxis_partitioned/metadata/0125c686-8aa6-4502-bdcc-b6d17ca41a3b-m0.avro",
 		&m.v1ManifestEntries, 1, partitionSpec, testSchema, entrySnapshotID, manifestEntryV1Recs)
 	m.Require().NoError(err)
 
-	_, err = WriteManifest("/home/iceberg/warehouse/nyc/taxis_partitioned/metadata/0125c686-8aa6-4502-bdcc-b6d17ca41a3b-m0.avro",
+	m.EqualValues(m.v1ManifestEntries.Len(), mf.Length())
+
+	mf, err = WriteManifest("/home/iceberg/warehouse/nyc/taxis_partitioned/metadata/0125c686-8aa6-4502-bdcc-b6d17ca41a3b-m0.avro",
 		&m.v2ManifestEntries, 2, partitionSpec, testSchema, entrySnapshotID, manifestEntryV2Recs)
 	m.Require().NoError(err)
+
+	m.EqualValues(m.v2ManifestEntries.Len(), mf.Length())
 }
 
 func (m *ManifestTestSuite) SetupSuite() {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -21,9 +21,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -38,6 +40,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/sql"
 	"github.com/apache/iceberg-go/internal"
+	"github.com/apache/iceberg-go/io"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
@@ -269,7 +272,7 @@ func (t *TableWritingTestSuite) SetupSuite() {
 }
 
 func (t *TableWritingTestSuite) SetupTest() {
-	t.location = strings.Replace(t.T().TempDir(), "#", "", -1)
+	t.location = filepath.ToSlash(strings.Replace(t.T().TempDir(), "#", "", -1))
 }
 
 func (t *TableWritingTestSuite) TearDownSuite() {
@@ -364,7 +367,7 @@ func (t *TableWritingTestSuite) TestAddFilesFileNotFound() {
 	tx := tbl.NewTransaction()
 	err := tx.AddFiles(t.ctx, files, nil, false)
 	t.Error(err)
-	t.ErrorContains(err, "no such file or directory")
+	t.ErrorIs(err, fs.ErrNotExist)
 }
 
 func (t *TableWritingTestSuite) TestAddFilesUnpartitionedHasFieldIDs() {
@@ -936,7 +939,7 @@ func (t *TableWritingTestSuite) createTableWithProps(identifier table.Identifier
 
 	t.Require().NoError(cat.CreateNamespace(t.ctx, catalog.NamespaceFromIdent(identifier), nil))
 	tbl, err := cat.CreateTable(t.ctx, identifier, sc, catalog.WithProperties(props),
-		catalog.WithLocation(t.location))
+		catalog.WithLocation("file://"+t.location))
 
 	t.Require().NoError(err)
 
@@ -1039,6 +1042,17 @@ func arrowTableWithNull() arrow.Table {
 	return arrTable
 }
 
+func (t *TableWritingTestSuite) validateManifestFileLength(fs io.IO, m iceberg.ManifestFile) {
+	f, err := fs.Open(m.FilePath())
+	t.Require().NoError(err)
+	defer f.Close()
+
+	info, err := f.Stat()
+	t.Require().NoError(err)
+
+	t.EqualValues(info.Size(), m.Length(), "expected size: %d, got: %d", info.Size(), m.Length())
+}
+
 func (t *TableWritingTestSuite) TestMergeManifests() {
 	tblA := t.createTableWithProps(table.Identifier{"default", "merge_manifest_a"},
 		iceberg.Properties{
@@ -1095,6 +1109,7 @@ func (t *TableWritingTestSuite) TestMergeManifests() {
 	manifestList, err := tblA.CurrentSnapshot().Manifests(tblA.FS())
 	t.Require().NoError(err)
 	t.Len(manifestList, 1)
+	t.validateManifestFileLength(tblA.FS(), manifestList[0])
 
 	entries, err := manifestList[0].FetchEntries(tblA.FS(), false)
 	t.Require().NoError(err)
@@ -1114,9 +1129,17 @@ func (t *TableWritingTestSuite) TestMergeManifests() {
 	t.Require().NoError(err)
 	t.Len(manifestList, 3)
 
+	for _, m := range manifestList {
+		t.validateManifestFileLength(tblB.FS(), m)
+	}
+
 	manifestList, err = tblC.CurrentSnapshot().Manifests(tblC.FS())
 	t.Require().NoError(err)
 	t.Len(manifestList, 3)
+
+	for _, m := range manifestList {
+		t.validateManifestFileLength(tblC.FS(), m)
+	}
 
 	resultA, err := tblA.Scan().ToArrowTable(t.ctx)
 	t.Require().NoError(err)
@@ -1142,7 +1165,7 @@ func TestTableWriting(t *testing.T) {
 }
 
 func TestNullableStructRequiredField(t *testing.T) {
-	loc := t.TempDir()
+	loc := filepath.ToSlash(t.TempDir())
 
 	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
 		"uri":          ":memory:",
@@ -1186,7 +1209,7 @@ func TestNullableStructRequiredField(t *testing.T) {
 	require.NoError(t, cat.CreateNamespace(ctx, table.Identifier{"testing"}, nil))
 	tbl, err := cat.CreateTable(ctx, table.Identifier{"testing", "nullable_struct_required_field"}, sc,
 		catalog.WithProperties(iceberg.Properties{"format-version": "2"}),
-		catalog.WithLocation(loc))
+		catalog.WithLocation("file://"+loc))
 	require.NoError(t, err)
 	require.NotNil(t, tbl)
 
@@ -1300,7 +1323,11 @@ func (t *TableWritingTestSuite) TestDeleteOldMetadataLogsErrorOnFileNotFound() {
 	// validate that error is logged
 	logOutput := logBuf.String()
 	t.Contains(logOutput, "Warning: Failed to delete old metadata file")
-	t.Contains(logOutput, "no such file or directory")
+	if runtime.GOOS == "windows" {
+		t.Contains(logOutput, "The system cannot find the file specified")
+	} else {
+		t.Contains(logOutput, "no such file or directory")
+	}
 }
 
 func (t *TableWritingTestSuite) TestDeleteOldMetadataNoErrorLogsOnFileFound() {


### PR DESCRIPTION
fixes #438

We need to ensure that we flush the manifest that we're writing before we construct the `ManifestFile` object we want to add to the snapshot so that our length is correct when we write the manifest list itself. This change adds unit tests to ensure that the lengths match up correctly with what we write, and also ensures the tests work on windows (ran into some problems when putting this PR together that I had to fix).