### PR TITLE
fix(ci): Fix the minio config

### DIFF
--- a/internal/recipe/docker-compose.yml
+++ b/internal/recipe/docker-compose.yml
@@ -85,12 +85,29 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;
       tail -f /dev/null
       "
+  clickhouse:
+    image: clickhouse/clickhouse-server
+    container_name: clickhouse
+    networks:
+      iceberg_net:
+    ports:
+      - 8123:8123
+      - 9002:9000
+  trino:
+    image: trinodb/trino
+    container_name: trino
+    networks:
+      iceberg_net:
+    environment:
+      - CATALOG_MANAGEMENT=dynamic
+    ports:
+      - 8088:8080
 
 networks:
   iceberg_net:


### PR DESCRIPTION
taken from https://github.com/apache/iceberg-python/pull/2049

Looks like `mc config` is deprecated https://github.com/minio/mc/issues/5206