### PR TITLE
fix(table): fix race condition in scanner

### DIFF
--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -751,11 +751,18 @@ func (m *inclusiveMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 		return rowsCannotMatch, nil
 	}
 
-	m.valueCounts, m.nullCounts = file.ValueCounts(), file.NullValueCounts()
-	m.nanCounts = file.NaNValueCounts()
-	m.lowerBounds, m.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
+	// avoid race condition while maintaining existing state
+	ev := inclusiveMetricsEval{
+		st:                m.st,
+		includeEmptyFiles: m.includeEmptyFiles,
+		expr:              m.expr,
+	}
 
-	return iceberg.VisitExpr(m.expr, m)
+	ev.valueCounts, ev.nullCounts = file.ValueCounts(), file.NullValueCounts()
+	ev.nanCounts = file.NaNValueCounts()
+	ev.lowerBounds, ev.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
+
+	return iceberg.VisitExpr(m.expr, &ev)
 }
 
 func (m *inclusiveMetricsEval) mayContainNull(fieldID int) bool {


### PR DESCRIPTION
fixes #443

Eliminates potential race condition in scanning caused by the metrics evaluator used for manifest pruning.

Since the stats are only used for a given run of Eval, we don't need to modify the bound version of the `inclusiveMetricsEval` object and can instead copy the type and expression (cheap) to populate for the call. This avoids the race condition without giving up performance (no locking needed).