### PR TITLE
fix(catalog/glue): Fix nil map assignment issue in glue catalog

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -145,6 +145,10 @@ func NewCatalog(opts ...Option) *Catalog {
 		o(glueOps)
 	}
 
+	if glueOps.awsProperties == nil {
+		glueOps.awsProperties = AwsProperties{}
+	}
+
 	var catalogId *string
 	if val, ok := glueOps.awsProperties[CatalogIdKey]; ok {
 		catalogId = &val
@@ -800,7 +804,8 @@ func buildGlueTableInput(ctx context.Context, database string, tableName string,
 }
 
 func prepareProperties(icebergProperties iceberg.Properties, newMetadataLocation string) iceberg.Properties {
-	glueProperties := maps.Clone(icebergProperties)
+	glueProperties := make(iceberg.Properties)
+	maps.Copy(glueProperties, icebergProperties)
 	glueProperties[tableTypePropsKey] = glueTypeIceberg
 	glueProperties[metadataLocationPropsKey] = newMetadataLocation
 


### PR DESCRIPTION
### Description
When calling NewCatalog in glue catalog without any AWS properties, causing the catalog properties to be nil
```
props:     iceberg.Properties(glueOps.awsProperties),
```
Hence, when creating a staged table and need to clone the catalog properties in https://github.com/apache/iceberg-go/blob/d51f8b8c5b8249a706467910d42ee51eb6032ccd/catalog/internal/utils.go#L137-L138, it will result in nil map assignment.

Similar is happening in 
```
func prepareProperties(icebergProperties iceberg.Properties, newMetadataLocation string) iceberg.Properties {
	glueProperties := maps.Clone(icebergProperties)
```
where if staged table has no properties in the metadata, it will return nil and causing nil map.

### Testing
Glue integration tests were failing because they are using `NewCatalog(WithAwsConfig(awsCfg))`. Re-ran the Glue integration tests with the fix, and now they are passing