### PR TITLE
testing(catalog/glue): Verify glue catalog snapshot management is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ $ cd iceberg-go/cmd/iceberg && go build .
 | List Tables                 |  X   |      |          |  X   |  X  |
 | Create Table                |  X   |      |          |  X   |  X  |
 | Register Table              |  X   |      |          |  X   |     |
-| Update Current Snapshot     |  X   |      |          |      |  X  |
-| Create New Snapshot         |  X   |      |          |      |  X  |
+| Update Current Snapshot     |  X   |      |          |  X   |  X  |
+| Create New Snapshot         |  X   |      |          |  X   |  X  |
 | Rename Table                |  X   |      |          |  X   |  X  |
 | Drop Table                  |  X   |      |          |  X   |  X  |
 | Alter Table                 |  X   |      |          |  X   |  X  |

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1154,6 +1154,7 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 	_, _, err = ctlg.CommitTable(context.TODO(), testTable, nil, []table.Update{
 		table.NewAddSnapshotUpdate(&newSnap),
 	})
+	assert.NoError(err)
 
 	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
 	assert.NoError(err)
@@ -1172,6 +1173,7 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 		table.NewSetSnapshotRefUpdate(table.MainBranch, 25, table.BranchRef,
 			-1, -1, -1),
 	})
+	assert.NoError(err)
 
 	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
 	assert.NoError(err)

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1160,6 +1160,7 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 
 	actualSnap := testTable.SnapshotByID(25)
 	assert.Equal(newSnap.SnapshotID, actualSnap.SnapshotID)
+	assert.Equal(newSnap.ParentSnapshotID, actualSnap.ParentSnapshotID)
 	assert.Equal(newSnap.SequenceNumber, actualSnap.SequenceNumber)
 	assert.Equal(newSnap.ManifestList, actualSnap.ManifestList)
 	assert.Equal(newSnap.TimestampMs, actualSnap.TimestampMs)
@@ -1177,6 +1178,7 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 
 	currSnap := testTable.CurrentSnapshot()
 	assert.Equal(newSnap.SnapshotID, currSnap.SnapshotID)
+	assert.Equal(newSnap.ParentSnapshotID, actualSnap.ParentSnapshotID)
 	assert.Equal(newSnap.SequenceNumber, currSnap.SequenceNumber)
 	assert.Equal(newSnap.ManifestList, currSnap.ManifestList)
 	assert.Equal(newSnap.TimestampMs, currSnap.TimestampMs)


### PR DESCRIPTION
### Description
* With commit table implemented in glue catalog https://github.com/apache/iceberg-go/pull/403, snapshot management is supported. 
* Add integration test to verify and showcase the usage
* Update README to reflect the status
* Reuse `cleanupTable` as a private util method 

### Testing
```
--- PASS: TestSnapshotManagementIntegration (7.10s)
PASS
```