### PR TITLE
refactor: pass context into actual IO

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -229,7 +229,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
 	}
 
-	icebergTable, err := table.NewFromLocation(identifier, location, iofs, c)
+	icebergTable, err := table.NewFromLocation(context.TODO(), identifier, location, iofs, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table from location %s.%s: %w", database, tableName, err)
 	}
@@ -255,7 +255,11 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
-	wfs, ok := staged.FS().(io.WriteFileIO)
+	afs, err := staged.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wfs, ok := afs.(io.WriteFileIO)
 	if !ok {
 		return nil, errors.New("loaded filesystem IO does not support writing")
 	}
@@ -322,7 +326,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		return nil, fmt.Errorf("failed to load metadata file at %s: %w", metadataLocation, err)
 	}
 	// Read the metadata file
-	metadata, err := table.NewFromLocation([]string{tableName}, metadataLocation, iofs, c)
+	metadata, err := table.NewFromLocation(context.TODO(), []string{tableName}, metadataLocation, iofs, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read table metadata from %s: %w", metadataLocation, err)
 	}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -223,13 +223,15 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	}
 
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
-	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
-	iofs, err := io.LoadFS(ctx, props, location)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
-	}
 
-	icebergTable, err := table.NewFromLocation(context.TODO(), identifier, location, iofs, c)
+	icebergTable, err := table.NewFromLocation(ctx, identifier, location, func(ctx context.Context) (io.IO, error) {
+		// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
+		iofs, err := io.LoadFS(ctx, props, location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
+		}
+		return iofs, nil
+	}, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table from location %s.%s: %w", database, tableName, err)
 	}
@@ -321,12 +323,20 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
-	iofs, err := io.LoadFS(ctx, nil, metadataLocation)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load metadata file at %s: %w", metadataLocation, err)
-	}
 	// Read the metadata file
-	metadata, err := table.NewFromLocation(context.TODO(), []string{tableName}, metadataLocation, iofs, c)
+	metadata, err := table.NewFromLocation(
+		ctx,
+		[]string{tableName},
+		metadataLocation,
+		func(ctx context.Context) (io.IO, error) {
+			iofs, err := io.LoadFS(ctx, nil, metadataLocation)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load metadata file at %s: %w", metadataLocation, err)
+			}
+			return iofs, nil
+		},
+		c,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read table metadata from %s: %w", metadataLocation, err)
 	}

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -138,14 +138,13 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 	maps.Copy(ioProps, cfg.Properties)
 
 	return table.StagedTable{
-		Table: table.New(ident, metadata, metadataLoc, func(ctx context.Context) (io.IO, error) {
-			fs, err := io.LoadFS(ctx, ioProps, metadataLoc)
-			if err != nil {
-				return nil, err
-			}
-
-			return fs, nil
-		}, nil),
+		Table: table.New(
+			ident,
+			metadata,
+			metadataLoc,
+			io.LoadFSFunc(ioProps, metadataLoc),
+			nil,
+		),
 	}, nil
 }
 
@@ -247,14 +246,7 @@ func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.
 			ident,
 			updated,
 			newLocation,
-			func(ctx context.Context) (io.IO, error) {
-				fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
-				if err != nil {
-					return nil, err
-				}
-
-				return fs, nil
-			},
+			io.LoadFSFunc(updated.Properties(), newLocation),
 			cat,
 		),
 	}, nil

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -143,6 +143,7 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 			if err != nil {
 				return nil, err
 			}
+
 			return fs, nil
 		}, nil),
 	}, nil
@@ -251,6 +252,7 @@ func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.
 				if err != nil {
 					return nil, err
 				}
+
 				return fs, nil
 			},
 			cat,

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -657,13 +657,7 @@ func (r *Catalog) tableFromResponse(ctx context.Context, identifier []string, me
 		identifier,
 		metadata,
 		loc,
-		func(ctx context.Context) (iceio.IO, error) {
-			iofs, err := iceio.LoadFS(ctx, config, loc)
-			if err != nil {
-				return nil, err
-			}
-			return iofs, nil
-		},
+		iceio.LoadFSFunc(config, loc),
 		r,
 	), nil
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -653,12 +653,19 @@ func checkValidNamespace(ident table.Identifier) error {
 }
 
 func (r *Catalog) tableFromResponse(ctx context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties) (*table.Table, error) {
-	iofs, err := iceio.LoadFS(ctx, config, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	return table.New(identifier, metadata, loc, iofs, r), nil
+	return table.New(
+		identifier,
+		metadata,
+		loc,
+		func(ctx context.Context) (iceio.IO, error) {
+			iofs, err := iceio.LoadFS(ctx, config, loc)
+			if err != nil {
+				return nil, err
+			}
+			return iofs, nil
+		},
+		r,
+	), nil
 }
 
 func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {

--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -254,11 +255,11 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	pqfile, err := url.JoinPath(location, "data", "test_commit_table_data", "test.parquet")
 	s.Require().NoError(err)
 
-	fw, err := tbl.FS().(io.WriteFileIO).Create(pqfile)
+	fw, err := mustFS(s.T(), tbl).(io.WriteFileIO).Create(pqfile)
 	s.Require().NoError(err)
 	s.Require().NoError(pqarrow.WriteTable(table, fw, table.NumRows(),
 		nil, pqarrow.DefaultWriterProps()))
-	defer tbl.FS().Remove(pqfile)
+	defer mustFS(s.T(), tbl).Remove(pqfile)
 
 	txn := tbl.NewTransaction()
 	s.Require().NoError(txn.AddFiles(s.ctx, []string{pqfile}, nil, false))
@@ -266,7 +267,7 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	s.Require().NoError(err)
 
 	mf := []iceberg.ManifestFile{}
-	for m, err := range updated.AllManifests() {
+	for m, err := range updated.AllManifests(context.TODO()) {
 		s.Require().NoError(err)
 		s.Require().NotNil(m)
 		mf = append(mf, m)
@@ -274,11 +275,17 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 
 	s.Len(mf, 1)
 	s.EqualValues(1, mf[0].AddedDataFiles())
-	entries, err := mf[0].FetchEntries(updated.FS(), false)
+	entries, err := mf[0].FetchEntries(mustFS(s.T(), updated), false)
 	s.Require().NoError(err)
 
 	s.Len(entries, 1)
 	s.Equal(pqfile, entries[0].DataFile().FilePath())
+}
+
+func mustFS(t *testing.T, tbl *table.Table) io.IO {
+	r, err := tbl.FS(context.Background())
+	require.NoError(t, err)
+	return r
 }
 
 func TestRestIntegration(t *testing.T) {

--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -267,7 +267,7 @@ func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	s.Require().NoError(err)
 
 	mf := []iceberg.ManifestFile{}
-	for m, err := range updated.AllManifests(context.TODO()) {
+	for m, err := range updated.AllManifests(s.ctx) {
 		s.Require().NoError(err)
 		s.Require().NotNil(m)
 		mf = append(mf, m)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -424,14 +424,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 		ctx,
 		identifier,
 		result.MetadataLocation.String,
-		func(ctx context.Context) (io.IO, error) {
-			iofs, err := io.LoadFS(ctx, tblProps, result.MetadataLocation.String)
-			if err != nil {
-				return nil, err
-			}
-
-			return iofs, nil
-		},
+		io.LoadFSFunc(tblProps, result.MetadataLocation.String),
 		c,
 	)
 }

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -283,7 +283,11 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
 	}
 
-	wfs, ok := staged.FS().(io.WriteFileIO)
+	afs, err := staged.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wfs, ok := afs.(io.WriteFileIO)
 	if !ok {
 		return nil, errors.New("loaded filesystem IO does not support writing")
 	}
@@ -416,12 +420,19 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	tblProps := maps.Clone(c.props)
 	maps.Copy(props, tblProps)
 
-	iofs, err := io.LoadFS(ctx, tblProps, result.MetadataLocation.String)
-	if err != nil {
-		return nil, err
-	}
-
-	return table.NewFromLocation(identifier, result.MetadataLocation.String, iofs, c)
+	return table.NewFromLocation(
+		ctx,
+		identifier,
+		result.MetadataLocation.String,
+		func(ctx context.Context) (io.IO, error) {
+			iofs, err := io.LoadFS(ctx, tblProps, result.MetadataLocation.String)
+			if err != nil {
+				return nil, err
+			}
+			return iofs, nil
+		},
+		c,
+	)
 }
 
 func (c *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -429,6 +429,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 			if err != nil {
 				return nil, err
 			}
+
 			return iofs, nil
 		},
 		c,

--- a/cmd/iceberg/output.go
+++ b/cmd/iceberg/output.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -134,7 +135,12 @@ func (t textOutput) Files(tbl *table.Table, history bool) {
 				snap.SnapshotID, *snap.SchemaID, manifest),
 		})
 
-		manifestList, err := snap.Manifests(tbl.FS())
+		afs, err := tbl.FS(context.TODO())
+		if err != nil {
+			t.Error(err)
+			os.Exit(1)
+		}
+		manifestList, err := snap.Manifests(afs)
 		if err != nil {
 			t.Error(err)
 			os.Exit(1)
@@ -144,7 +150,7 @@ func (t textOutput) Files(tbl *table.Table, history bool) {
 			snapshotTree = append(snapshotTree, pterm.LeveledListItem{
 				Level: 1, Text: "Manifest: " + m.FilePath(),
 			})
-			datafiles, err := m.FetchEntries(tbl.FS(), false)
+			datafiles, err := m.FetchEntries(afs, false)
 			if err != nil {
 				t.Error(err)
 				os.Exit(1)

--- a/io/io.go
+++ b/io/io.go
@@ -294,3 +294,15 @@ func LoadFS(ctx context.Context, props map[string]string, location string) (IO, 
 
 	return iofs, nil
 }
+
+// LoadFSFunc is a helper function to create IO Func factory for later usage
+func LoadFSFunc(props map[string]string, location string) func(ctx context.Context) (IO, error) {
+	return func(ctx context.Context) (IO, error) {
+		iofs, err := LoadFS(ctx, props, location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load metadata file at %s: %w", location, err)
+		}
+
+		return iofs, nil
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -33,6 +33,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type FSysF func(ctx context.Context) (io.IO, error)
+
 type Identifier = []string
 
 type CatalogIO interface {
@@ -44,8 +46,8 @@ type Table struct {
 	identifier       Identifier
 	metadata         Metadata
 	metadataLocation string
-	fs               io.IO
 	cat              CatalogIO
+	fsF              FSysF
 }
 
 func (t Table) Equals(other Table) bool {
@@ -54,19 +56,19 @@ func (t Table) Equals(other Table) bool {
 		t.metadata.Equals(other.metadata)
 }
 
-func (t Table) Identifier() Identifier               { return t.identifier }
-func (t Table) Metadata() Metadata                   { return t.metadata }
-func (t Table) MetadataLocation() string             { return t.metadataLocation }
-func (t Table) FS() io.IO                            { return t.fs }
-func (t Table) Schema() *iceberg.Schema              { return t.metadata.CurrentSchema() }
-func (t Table) Spec() iceberg.PartitionSpec          { return t.metadata.PartitionSpec() }
-func (t Table) SortOrder() SortOrder                 { return t.metadata.SortOrder() }
-func (t Table) Properties() iceberg.Properties       { return t.metadata.Properties() }
-func (t Table) NameMapping() iceberg.NameMapping     { return t.metadata.NameMapping() }
-func (t Table) Location() string                     { return t.metadata.Location() }
-func (t Table) CurrentSnapshot() *Snapshot           { return t.metadata.CurrentSnapshot() }
-func (t Table) SnapshotByID(id int64) *Snapshot      { return t.metadata.SnapshotByID(id) }
-func (t Table) SnapshotByName(name string) *Snapshot { return t.metadata.SnapshotByName(name) }
+func (t Table) Identifier() Identifier                { return t.identifier }
+func (t Table) Metadata() Metadata                    { return t.metadata }
+func (t Table) MetadataLocation() string              { return t.metadataLocation }
+func (t Table) FS(ctx context.Context) (io.IO, error) { return t.fsF(ctx) }
+func (t Table) Schema() *iceberg.Schema               { return t.metadata.CurrentSchema() }
+func (t Table) Spec() iceberg.PartitionSpec           { return t.metadata.PartitionSpec() }
+func (t Table) SortOrder() SortOrder                  { return t.metadata.SortOrder() }
+func (t Table) Properties() iceberg.Properties        { return t.metadata.Properties() }
+func (t Table) NameMapping() iceberg.NameMapping      { return t.metadata.NameMapping() }
+func (t Table) Location() string                      { return t.metadata.Location() }
+func (t Table) CurrentSnapshot() *Snapshot            { return t.metadata.CurrentSnapshot() }
+func (t Table) SnapshotByID(id int64) *Snapshot       { return t.metadata.SnapshotByID(id) }
+func (t Table) SnapshotByName(name string) *Snapshot  { return t.metadata.SnapshotByName(name) }
 func (t Table) Schemas() map[int]*iceberg.Schema {
 	m := make(map[int]*iceberg.Schema)
 	for _, s := range t.metadata.Schemas() {
@@ -110,7 +112,7 @@ func (t Table) Append(ctx context.Context, rdr array.RecordReader, snapshotProps
 	return txn.Commit(ctx)
 }
 
-func (t Table) AllManifests() iter.Seq2[iceberg.ManifestFile, error] {
+func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile, error] {
 	type list = tblutils.Enumerated[[]iceberg.ManifestFile]
 	g := errgroup.Group{}
 
@@ -118,7 +120,11 @@ func (t Table) AllManifests() iter.Seq2[iceberg.ManifestFile, error] {
 	ch := make(chan list, n)
 	for i, sn := range t.metadata.Snapshots() {
 		g.Go(func() error {
-			manifests, err := sn.Manifests(t.fs)
+			fs, err := t.fsF(ctx)
+			if err != nil {
+				return err
+			}
+			manifests, err := sn.Manifests(fs)
 			if err != nil {
 				return err
 			}
@@ -195,10 +201,13 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 	if err != nil {
 		return nil, err
 	}
+	fs, err := t.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deleteOldMetadata(fs, t.metadata, newMeta)
 
-	deleteOldMetadata(t.fs, t.metadata, newMeta)
-
-	return New(t.identifier, newMeta, newLoc, t.fs, t.cat), nil
+	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
 }
 
 func getFiles(it iter.Seq[MetadataLogEntry]) iter.Seq[string] {
@@ -310,7 +319,7 @@ func WithOptions(opts iceberg.Properties) ScanOption {
 func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
 		metadata:       t.metadata,
-		io:             t.fs,
+		ioF:            t.fsF,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},
 		caseSensitive:  true,
@@ -327,19 +336,29 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 	return s
 }
 
-func New(ident Identifier, meta Metadata, metadataLocation string, fs io.IO, cat CatalogIO) *Table {
+func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, cat CatalogIO) *Table {
 	return &Table{
 		identifier:       ident,
 		metadata:         meta,
 		metadataLocation: metadataLocation,
-		fs:               fs,
+		fsF:              fsF,
 		cat:              cat,
 	}
 }
 
-func NewFromLocation(ident Identifier, metalocation string, fsys io.IO, cat CatalogIO) (*Table, error) {
+func NewFromLocation(
+	ctx context.Context,
+	ident Identifier,
+	metalocation string,
+	fsysF FSysF,
+	cat CatalogIO,
+) (*Table, error) {
 	var meta Metadata
 
+	fsys, err := fsysF(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if rf, ok := fsys.(io.ReadFileIO); ok {
 		data, err := rf.ReadFile(metalocation)
 		if err != nil {
@@ -361,5 +380,5 @@ func NewFromLocation(ident Identifier, metalocation string, fsys io.IO, cat Cata
 		}
 	}
 
-	return New(ident, meta, metalocation, fsys, cat), nil
+	return New(ident, meta, metalocation, fsysF, cat), nil
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -62,6 +62,7 @@ func TestTable(t *testing.T) {
 func mustFS(t *testing.T, tbl *table.Table) iceio.IO {
 	r, err := tbl.FS(context.Background())
 	require.NoError(t, err)
+
 	return r
 }
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -99,7 +99,7 @@ func (t *TableTestSuite) TestNewTableFromReadFile() {
 	defer mockfsReadFile.AssertExpectations(t.T())
 
 	tbl2, err := table.NewFromLocation(
-		context.TODO(),
+		t.T().Context(),
 		[]string{"foo"},
 		"s3://bucket/test/location/uuid.metadata.json",
 		func(ctx context.Context) (iceio.IO, error) {
@@ -765,7 +765,7 @@ func (t *TableWritingTestSuite) TestAddFilesReferencedCurrentSnapshotIgnoreDupli
 	t.Require().NoError(err)
 
 	added, existing, deleted := []int32{}, []int32{}, []int32{}
-	for m, err := range staged.AllManifests(context.TODO()) {
+	for m, err := range staged.AllManifests(t.T().Context()) {
 		t.Require().NoError(err)
 		added = append(added, m.AddedDataFiles())
 		existing = append(existing, m.ExistingDataFiles())
@@ -1242,9 +1242,8 @@ func TestNullableStructRequiredField(t *testing.T) {
 	sc, err := table.ArrowSchemaToIcebergWithFreshIDs(arrowSchema, false)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
-	require.NoError(t, cat.CreateNamespace(ctx, table.Identifier{"testing"}, nil))
-	tbl, err := cat.CreateTable(ctx, table.Identifier{"testing", "nullable_struct_required_field"}, sc,
+	require.NoError(t, cat.CreateNamespace(t.Context(), table.Identifier{"testing"}, nil))
+	tbl, err := cat.CreateTable(t.Context(), table.Identifier{"testing", "nullable_struct_required_field"}, sc,
 		catalog.WithProperties(iceberg.Properties{"format-version": "2"}),
 		catalog.WithLocation("file://"+loc))
 	require.NoError(t, err)
@@ -1264,7 +1263,7 @@ func TestNullableStructRequiredField(t *testing.T) {
 	defer arrTable.Release()
 
 	tx := tbl.NewTransaction()
-	require.NoError(t, tx.AppendTable(ctx, arrTable, N, nil))
+	require.NoError(t, tx.AppendTable(t.Context(), arrTable, N, nil))
 	stagedTbl, err := tx.StagedTable()
 	require.NoError(t, err)
 	require.NotNil(t, stagedTbl)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -116,9 +116,9 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 	return nil
 }
 
-func (t *Transaction) appendSnapshotProducer(props iceberg.Properties) *snapshotProducer {
+func (t *Transaction) appendSnapshotProducer(afs io.IO, props iceberg.Properties) *snapshotProducer {
 	manifestMerge := t.meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault)
-	updateSnapshot := t.updateSnapshot(props)
+	updateSnapshot := t.updateSnapshot(afs, props)
 	if manifestMerge {
 		return updateSnapshot.mergeAppend()
 	}
@@ -126,10 +126,10 @@ func (t *Transaction) appendSnapshotProducer(props iceberg.Properties) *snapshot
 	return updateSnapshot.fastAppend()
 }
 
-func (t *Transaction) updateSnapshot(props iceberg.Properties) snapshotUpdate {
+func (t *Transaction) updateSnapshot(fs io.IO, props iceberg.Properties) snapshotUpdate {
 	return snapshotUpdate{
 		txn:           t,
-		io:            t.tbl.fs.(io.WriteFileIO),
+		io:            fs.(io.WriteFileIO),
 		snapshotProps: props,
 	}
 }
@@ -150,12 +150,15 @@ func (t *Transaction) AppendTable(ctx context.Context, tbl arrow.Table, batchSiz
 }
 
 func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapshotProps iceberg.Properties) error {
-	appendFiles := t.appendSnapshotProducer(snapshotProps)
-
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
+	appendFiles := t.appendSnapshotProducer(fs, snapshotProps)
 	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
 		sc:        rdr.Schema(),
 		itr:       array.IterFromReader(rdr),
-		fs:        t.tbl.fs.(io.WriteFileIO),
+		fs:        fs.(io.WriteFileIO),
 		writeUUID: &appendFiles.commitUuid,
 	})
 
@@ -215,8 +218,12 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 		return fmt.Errorf("%w: cannot replace files in a table without an existing snapshot", ErrInvalidOperation)
 	}
 
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
 	markedForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
-	for df, err := range s.dataFiles(t.tbl.fs, nil) {
+	for df, err := range s.dataFiles(fs, nil) {
 		if err != nil {
 			return err
 		}
@@ -247,13 +254,13 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(snapshotProps).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
 	}
 
-	dataFiles := filesToDataFiles(ctx, t.tbl.fs, t.meta, slices.Values(filesToAdd))
+	dataFiles := filesToDataFiles(ctx, fs, t.meta, slices.Values(filesToAdd))
 	for df, err := range dataFiles {
 		if err != nil {
 			return err
@@ -282,7 +289,11 @@ func (t *Transaction) AddFiles(ctx context.Context, files []string, snapshotProp
 	if !ignoreDuplicates {
 		if s := t.meta.currentSnapshot(); s != nil {
 			referenced := make([]string, 0)
-			for df, err := range s.dataFiles(t.tbl.fs, nil) {
+			fs, err := t.tbl.fsF(ctx)
+			if err != nil {
+				return err
+			}
+			for df, err := range s.dataFiles(fs, nil) {
 				if err != nil {
 					return err
 				}
@@ -309,9 +320,14 @@ func (t *Transaction) AddFiles(ctx context.Context, files []string, snapshotProp
 		}
 	}
 
-	updater := t.updateSnapshot(snapshotProps).fastAppend()
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
 
-	dataFiles := filesToDataFiles(ctx, t.tbl.fs, t.meta, slices.Values(files))
+	updater := t.updateSnapshot(fs, snapshotProps).fastAppend()
+
+	dataFiles := filesToDataFiles(ctx, fs, t.meta, slices.Values(files))
 	for df, err := range dataFiles {
 		if err != nil {
 			return err
@@ -335,7 +351,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 
 	s := &Scan{
 		metadata:       updatedMeta,
-		io:             t.tbl.fs,
+		ioF:            t.tbl.fsF,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},
 		caseSensitive:  true,
@@ -358,8 +374,15 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 		return nil, err
 	}
 
-	return &StagedTable{Table: New(t.tbl.identifier, updatedMeta,
-		updatedMeta.Location(), t.tbl.fs, t.tbl.cat)}, nil
+	return &StagedTable{
+		Table: New(
+			t.tbl.identifier,
+			updatedMeta,
+			updatedMeta.Location(),
+			t.tbl.fsF,
+			t.tbl.cat,
+		),
+	}, nil
 }
 
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {

--- a/table/transaction_test.go
+++ b/table/transaction_test.go
@@ -97,7 +97,7 @@ func (s *SparkIntegrationTestSuite) TestAddFile() {
 	rec := bldr.NewRecord()
 	defer rec.Release()
 
-	fw, err := tbl.FS().(iceio.WriteFileIO).Create(filename)
+	fw, err := mustFS(s.T(), tbl).(iceio.WriteFileIO).Create(filename)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
related https://github.com/apache/iceberg-go/issues/437

All I/O operations must respect the context passed to PlanFiles(ctx) and simmilar methods.

To support that, we stop passing pre-constructed I/O objects and instead construct them ad hoc within PlanFiles, using the provided context