### PR TITLE
feat: add IO registry

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -220,7 +220,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
 	// TODO: consider providing a way to directly access the S3 iofs to enable testing of the catalog.
-	iofs, err := io.LoadFS(ctx, props, location)
+	iofs, err := io.Load(ctx, props, location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load table %s.%s: %w", database, tableName, err)
 	}
@@ -313,7 +313,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
-	iofs, err := io.LoadFS(ctx, nil, metadataLocation)
+	iofs, err := io.Load(ctx, nil, metadataLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load metadata file at %s: %w", metadataLocation, err)
 	}

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -52,7 +52,7 @@ func WriteTableMetadata(metadata table.Metadata, fs io.WriteFileIO, loc string) 
 }
 
 func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, props iceberg.Properties) error {
-	fs, err := io.LoadFS(ctx, props, loc)
+	fs, err := io.Load(ctx, props, loc)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 
 	ioProps := maps.Clone(catprops)
 	maps.Copy(ioProps, cfg.Properties)
-	fs, err := io.LoadFS(ctx, ioProps, metadataLoc)
+	fs, err := io.Load(ctx, ioProps, metadataLoc)
 	if err != nil {
 		return table.StagedTable{}, err
 	}
@@ -239,7 +239,7 @@ func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.
 		return nil, err
 	}
 
-	fs, err := io.LoadFS(ctx, updated.Properties(), newLocation)
+	fs, err := io.Load(ctx, updated.Properties(), newLocation)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -653,7 +653,7 @@ func checkValidNamespace(ident table.Identifier) error {
 }
 
 func (r *Catalog) tableFromResponse(ctx context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties) (*table.Table, error) {
-	iofs, err := iceio.LoadFS(ctx, config, loc)
+	iofs, err := iceio.Load(ctx, config, loc)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -416,7 +416,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	tblProps := maps.Clone(c.props)
 	maps.Copy(props, tblProps)
 
-	iofs, err := io.LoadFS(ctx, tblProps, result.MetadataLocation.String)
+	iofs, err := io.Load(ctx, tblProps, result.MetadataLocation.String)
 	if err != nil {
 		return nil, err
 	}

--- a/io/local.go
+++ b/io/local.go
@@ -18,6 +18,7 @@
 package io
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,4 +47,13 @@ func (LocalFS) WriteFile(name string, content []byte) error {
 
 func (LocalFS) Remove(name string) error {
 	return os.Remove(strings.TrimPrefix(name, "file://"))
+}
+
+func init() {
+	Register("file", RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		return LocalFS{}, nil
+	}))
+	Register("", RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		return LocalFS{}, nil
+	}))
 }

--- a/io/mem.go
+++ b/io/mem.go
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package io
+
+import (
+	"context"
+
+	"gocloud.dev/blob/memblob"
+)
+
+func init() {
+	Register("mem", RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		// memblob doesn't use the URL host or path
+		bucket := memblob.OpenBucket(nil)
+		return createBlobFS(ctx, bucket, ""), nil
+	}))
+}

--- a/io/registry.go
+++ b/io/registry.go
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package io
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+)
+
+type registry map[string]Registrar
+
+func (r registry) getKeys() []string {
+	regMutex.Lock()
+	defer regMutex.Unlock()
+
+	return slices.Collect(maps.Keys(r))
+}
+
+func (r registry) set(ioType string, reg Registrar) {
+	regMutex.Lock()
+	defer regMutex.Unlock()
+	r[ioType] = reg
+}
+
+func (r registry) get(ioType string) (Registrar, bool) {
+	regMutex.Lock()
+	defer regMutex.Unlock()
+	reg, ok := r[ioType]
+
+	return reg, ok
+}
+
+func (r registry) remove(ioType string) {
+	regMutex.Lock()
+	defer regMutex.Unlock()
+	delete(r, ioType)
+}
+
+var (
+	regMutex        sync.Mutex
+	defaultRegistry = registry{}
+	ErrIONotFound   = errors.New("IO type not registered")
+)
+
+// Registrar is a factory for creating IO instances, used for registering to use
+// with Load.
+type Registrar interface {
+	GetIO(ctx context.Context, props map[string]string) (IO, error)
+}
+
+type RegistrarFunc func(context.Context, map[string]string) (IO, error)
+
+func (f RegistrarFunc) GetIO(ctx context.Context, props map[string]string) (IO, error) {
+	return f(ctx, props)
+}
+
+// Register adds the new IO type to the registry. If the IO type is already registered, it will be replaced.
+func Register(ioType string, reg Registrar) {
+	if reg == nil {
+		panic("io: RegisterIO factory is nil")
+	}
+	defaultRegistry.set(ioType, reg)
+}
+
+// Unregister removes the requested IO factory from the registry.
+func Unregister(ioType string) {
+	defaultRegistry.remove(ioType)
+}
+
+// GetRegisteredIOs returns the list of registered IO names that can
+// be looked up via Load.
+func GetRegisteredIOs() []string {
+	return defaultRegistry.getKeys()
+}
+
+// Load allows loading a specific IO implementation by scheme and properties.
+//
+// This is utilized alongside Register/Unregister to not only allow
+// easier IO loading but also to allow for custom IO implementations to
+// be registered and loaded external to this module.
+//
+// The scheme parameter is extracted from the URI to determine which IO
+// implementation to use. For example, "s3://bucket/path" would use the
+// "s3" IO implementation.
+//
+// Currently, the following IO types are supported by default:
+//
+//   - "file" or "" for local filesystem
+//   - "s3", "s3a", "s3n" for Amazon S3
+//   - "gs" for Google Cloud Storage
+//   - "abfs", "abfss", "wasb", "wasbs" for Azure Blob Storage
+//   - "mem" for in-memory storage
+func Load(ctx context.Context, props map[string]string, location string) (IO, error) {
+	if location == "" {
+		location = props["warehouse"]
+	}
+
+	scheme := ""
+	if strings.Contains(location, "://") {
+		parsed, err := url.Parse(location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse IO location: %w", err)
+		}
+		scheme = parsed.Scheme
+	}
+
+	// Default to local filesystem if no scheme
+	if scheme == "" {
+		scheme = "file"
+	}
+
+	reg, ok := defaultRegistry.get(scheme)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrIONotFound, location)
+	}
+
+	return reg.GetIO(ctx, props)
+}

--- a/io/registry_test.go
+++ b/io/registry_test.go
@@ -82,7 +82,7 @@ func TestDefaultRegisteredIOs(t *testing.T) {
 }
 
 func TestLoadWithRegisteredIO(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test loading local filesystem
 	io, err := Load(ctx, map[string]string{}, "file:///tmp/test")
@@ -101,8 +101,21 @@ func TestLoadWithRegisteredIO(t *testing.T) {
 	assert.NotNil(t, io)
 }
 
+func TestDefaultsCanBeOverridden(t *testing.T) {
+	ctx := t.Context()
+	registrar := RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		return LocalFS{}, nil
+	})
+
+	// override default registration for mem scheme
+	Register("mem", registrar)
+	io, err := Load(ctx, map[string]string{}, "mem://bucket/path")
+	require.NoError(t, err)
+	assert.IsType(t, LocalFS{}, io)
+}
+
 func TestLoadWithWarehouseFromProps(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test loading from warehouse property
 	io, err := Load(ctx, map[string]string{"warehouse": "file:///tmp/warehouse"}, "")
@@ -111,7 +124,7 @@ func TestLoadWithWarehouseFromProps(t *testing.T) {
 }
 
 func TestLoadWhenUnknownScheme(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := Load(ctx, map[string]string{}, "unknown://bucket/path")
 	assert.Error(t, err)
@@ -126,7 +139,7 @@ func TestRegisterPanic(t *testing.T) {
 
 func TestConcurrentAccess(t *testing.T) {
 	// Test that concurrent access to registry doesn't cause data races
-	ctx := context.Background()
+	ctx := t.Context()
 
 	done := make(chan bool, 100)
 

--- a/io/registry_test.go
+++ b/io/registry_test.go
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package io
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegister(t *testing.T) {
+	// Save original registry state
+	original := make(registry)
+	for k, v := range defaultRegistry {
+		original[k] = v
+	}
+	defer func() {
+		// Restore original registry
+		defaultRegistry = original
+	}()
+
+	// Clear registry for clean test
+	defaultRegistry = make(registry)
+
+	testRegistrar := RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		return LocalFS{}, nil
+	})
+
+	Register("test", testRegistrar)
+
+	registeredIOs := GetRegisteredIOs()
+	assert.Contains(t, registeredIOs, "test")
+}
+
+func TestUnregister(t *testing.T) {
+	// Save original registry state
+	original := make(registry)
+	for k, v := range defaultRegistry {
+		original[k] = v
+	}
+	defer func() {
+		// Restore original registry
+		defaultRegistry = original
+	}()
+
+	testRegistrar := RegistrarFunc(func(ctx context.Context, props map[string]string) (IO, error) {
+		return LocalFS{}, nil
+	})
+
+	Register("test", testRegistrar)
+	assert.Contains(t, GetRegisteredIOs(), "test")
+
+	Unregister("test")
+	assert.NotContains(t, GetRegisteredIOs(), "test")
+}
+
+func TestDefaultRegisteredIOs(t *testing.T) {
+	registeredIOs := GetRegisteredIOs()
+
+	// Check that default IO implementations are registered
+	expectedIOs := []string{"file", "", "s3", "s3a", "s3n", "gs", "abfs", "abfss", "wasb", "wasbs", "mem"}
+	for _, expected := range expectedIOs {
+		assert.Contains(t, registeredIOs, expected, "IO type %s should be registered", expected)
+	}
+}
+
+func TestLoadWithRegisteredIO(t *testing.T) {
+	ctx := context.Background()
+
+	// Test loading local filesystem
+	io, err := Load(ctx, map[string]string{}, "file:///tmp/test")
+	require.NoError(t, err)
+	assert.IsType(t, LocalFS{}, io)
+
+	// Test loading with empty scheme (defaults to local)
+	io, err = Load(ctx, map[string]string{}, "/tmp/test")
+	require.NoError(t, err)
+	assert.IsType(t, LocalFS{}, io)
+
+	// Test loading memory filesystem
+	io, err = Load(ctx, map[string]string{}, "mem://bucket/path")
+	require.NoError(t, err)
+	// Should return a blobFileIO (which implements IO)
+	assert.NotNil(t, io)
+}
+
+func TestLoadWithWarehouseFromProps(t *testing.T) {
+	ctx := context.Background()
+
+	// Test loading from warehouse property
+	io, err := Load(ctx, map[string]string{"warehouse": "file:///tmp/warehouse"}, "")
+	require.NoError(t, err)
+	assert.IsType(t, LocalFS{}, io)
+}
+
+func TestLoadWhenUnknownScheme(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := Load(ctx, map[string]string{}, "unknown://bucket/path")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrIONotFound)
+}
+
+func TestRegisterPanic(t *testing.T) {
+	assert.Panics(t, func() {
+		Register("test", nil)
+	})
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	// Test that concurrent access to registry doesn't cause data races
+	ctx := context.Background()
+
+	done := make(chan bool, 100)
+
+	// Start multiple goroutines doing registry operations
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			defer func() { done <- true }()
+
+			// Get registered IOs
+			GetRegisteredIOs()
+
+			// Try to load IO
+			_, err := Load(ctx, map[string]string{}, "file:///tmp")
+			require.NoError(t, err)
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
Introduces IO registry (similar to catalog registry). 
Default IO implementations (S3, Azure, GSC, local, memory) are pre-registered.
Custom IO implementations can be registered with `io.Register` and looked up with `io.Load`