### PR TITLE
fix(cli/rest) Support Glue REST operations with Iceberg-Go CLI

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,11 +36,20 @@ type Config struct {
 }
 
 type CatalogConfig struct {
-	CatalogType string `yaml:"type"`
-	URI         string `yaml:"uri"`
-	Output      string `yaml:"output"`
-	Credential  string `yaml:"credential"`
-	Warehouse   string `yaml:"warehouse"`
+	CatalogType string            `yaml:"type"`
+	URI         string            `yaml:"uri"`
+	Output      string            `yaml:"output"`
+	Credential  string            `yaml:"credential"`
+	Warehouse   string            `yaml:"warehouse"`
+	RestConfig  RestCatalogConfig `yaml:"rest-config"`
+}
+
+type RestCatalogConfig struct {
+	AuthUrl       string `yaml:"auth-url"`
+	SigV4Enabled  bool   `yaml:"sigv4-enabled"`
+	SigV4Region   string `yaml:"sigv4-region"`
+	SigV4Service  string `yaml:"sigv4-service"`
+	TlsSkipVerify bool   `yaml:"tls-skip-verify"`
 }
 
 func LoadConfig(configPath string) []byte {


### PR DESCRIPTION
#### Motivation
 To Support AWS Glue Iceberg endpoint using Iceberg-Go CLI. `Forbidden error` is thrown when Iceberg tables in glue are queried using CLI. 

https://docs.aws.amazon.com/glue/latest/dg/connect-glu-iceberg-rest.html

#### Fix:
- Added `RestCatalogConfig` struct to `CatalogConfig` struct 
- `RestCatalogConfig` contains rest catalog configuration properties. 
- Above values are used before creating rest catalog
- Use AWS environment credentials when Credentials property is not set


#### Testing: 
- Added unit test for new configuration
- Used below `rest_config.yaml` to query Iceberg tables in AWS Glue.
```yaml
catalog:
  default:
    type: rest
    uri: https://glue.us-east-1.amazonaws.com/iceberg
    region: us-east-1
    warehouse: YOUR_AWS_ACCOUNT_ID
    rest-config:
      sigv4-region: us-east-1
      sigv4-service: glue
```

