### PR TITLE
fix(transforms): Add can transform method to transform interface

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -107,6 +107,7 @@ func (IdentityTransform) String() string { return "identity" }
 
 func (IdentityTransform) CanTransform(t Type) bool {
 	_, ok := t.(PrimitiveType)
+
 	return ok
 }
 func (IdentityTransform) ResultType(t Type) Type { return t }
@@ -562,6 +563,7 @@ func canTransformTime(t timeTransform, sourceType Type) bool {
 		return false
 	}
 }
+
 func projectTimeTransform(t timeTransform, name string, pred BoundPredicate) (UnboundPredicate, error) {
 	if _, ok := pred.Term().(*BoundTransform); ok {
 		return projectTransformPredicate(t, name, pred)

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -251,7 +251,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				&iceberg.DecimalType{}, &iceberg.FixedType{},
+				iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2),
 			},
 			notAllowed: []iceberg.Type{
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
@@ -264,7 +264,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2), &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 			notAllowed: []iceberg.Type{},
 		},
@@ -273,7 +273,7 @@ func TestCanTransform(t *testing.T) {
 			allowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
-				&iceberg.DecimalType{}, iceberg.PrimitiveTypes.String, &iceberg.FixedType{}, iceberg.PrimitiveTypes.Binary,
+				iceberg.DecimalTypeOf(2, 1), iceberg.PrimitiveTypes.String, iceberg.FixedTypeOf(2), iceberg.PrimitiveTypes.Binary,
 				iceberg.PrimitiveTypes.UUID,
 			},
 			notAllowed: []iceberg.Type{
@@ -285,12 +285,12 @@ func TestCanTransform(t *testing.T) {
 			transform: iceberg.TruncateTransform{},
 			allowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.String,
-				iceberg.PrimitiveTypes.Binary, &iceberg.DecimalType{},
+				iceberg.PrimitiveTypes.Binary, iceberg.DecimalTypeOf(2, 1),
 			},
 			notAllowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64,
 				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp,
-				iceberg.PrimitiveTypes.TimestampTz, iceberg.PrimitiveTypes.UUID, &iceberg.FixedType{},
+				iceberg.PrimitiveTypes.TimestampTz, iceberg.PrimitiveTypes.UUID, iceberg.FixedTypeOf(2),
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
@@ -303,7 +303,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2), &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2), &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2), &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -339,7 +339,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.PrimitiveTypes.Date, &iceberg.DecimalType{}, &iceberg.FixedType{},
+				iceberg.PrimitiveTypes.Date, iceberg.DecimalTypeOf(2, 1), iceberg.FixedTypeOf(2),
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -251,7 +251,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.DecimalType{}, iceberg.FixedType{},
+				&iceberg.DecimalType{}, &iceberg.FixedType{},
 			},
 			notAllowed: []iceberg.Type{
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
@@ -264,7 +264,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 			notAllowed: []iceberg.Type{},
 		},
@@ -273,7 +273,7 @@ func TestCanTransform(t *testing.T) {
 			allowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.Date,
 				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
-				iceberg.DecimalType{}, iceberg.PrimitiveTypes.String, iceberg.FixedType{}, iceberg.PrimitiveTypes.Binary,
+				&iceberg.DecimalType{}, iceberg.PrimitiveTypes.String, &iceberg.FixedType{}, iceberg.PrimitiveTypes.Binary,
 				iceberg.PrimitiveTypes.UUID,
 			},
 			notAllowed: []iceberg.Type{
@@ -285,12 +285,12 @@ func TestCanTransform(t *testing.T) {
 			transform: iceberg.TruncateTransform{},
 			allowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.String,
-				iceberg.PrimitiveTypes.Binary, iceberg.DecimalType{},
+				iceberg.PrimitiveTypes.Binary, &iceberg.DecimalType{},
 			},
 			notAllowed: []iceberg.Type{
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64,
 				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp,
-				iceberg.PrimitiveTypes.TimestampTz, iceberg.PrimitiveTypes.UUID, iceberg.FixedType{},
+				iceberg.PrimitiveTypes.TimestampTz, iceberg.PrimitiveTypes.UUID, &iceberg.FixedType{},
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
@@ -303,7 +303,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+				&iceberg.DecimalType{}, &iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
 		{
@@ -339,7 +339,7 @@ func TestCanTransform(t *testing.T) {
 				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
 				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
 				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
-				iceberg.PrimitiveTypes.Date, iceberg.DecimalType{}, iceberg.FixedType{},
+				iceberg.PrimitiveTypes.Date, &iceberg.DecimalType{}, &iceberg.FixedType{},
 				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
 			},
 		},
@@ -353,5 +353,4 @@ func TestCanTransform(t *testing.T) {
 			assert.False(t, tt.transform.CanTransform(typ), "%s: expected CanTransform(%T) to be false", tt.transform.String(), typ)
 		}
 	}
-
 }

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -237,3 +237,121 @@ func TestManifestPartitionVals(t *testing.T) {
 		})
 	}
 }
+
+func TestCanTransform(t *testing.T) {
+	tests := []struct {
+		transform  iceberg.Transform
+		allowed    []iceberg.Type
+		notAllowed []iceberg.Type
+	}{
+		{
+			transform: iceberg.IdentityTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
+				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.DecimalType{}, iceberg.FixedType{},
+			},
+			notAllowed: []iceberg.Type{
+				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.VoidTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Date,
+				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+			notAllowed: []iceberg.Type{},
+		},
+		{
+			transform: iceberg.BucketTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.Date,
+				iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+				iceberg.DecimalType{}, iceberg.PrimitiveTypes.String, iceberg.FixedType{}, iceberg.PrimitiveTypes.Binary,
+				iceberg.PrimitiveTypes.UUID,
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64,
+				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.TruncateTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.String,
+				iceberg.PrimitiveTypes.Binary, iceberg.DecimalType{},
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64,
+				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Time, iceberg.PrimitiveTypes.Timestamp,
+				iceberg.PrimitiveTypes.TimestampTz, iceberg.PrimitiveTypes.UUID, iceberg.FixedType{},
+				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.YearTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.MonthTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.DayTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.DecimalType{}, iceberg.FixedType{}, &iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+		{
+			transform: iceberg.HourTransform{},
+			allowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Timestamp, iceberg.PrimitiveTypes.TimestampTz,
+			},
+			notAllowed: []iceberg.Type{
+				iceberg.PrimitiveTypes.Bool, iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64,
+				iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Time,
+				iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.UUID,
+				iceberg.PrimitiveTypes.Date, iceberg.DecimalType{}, iceberg.FixedType{},
+				&iceberg.StructType{}, &iceberg.ListType{}, &iceberg.MapType{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, typ := range tt.allowed {
+			assert.True(t, tt.transform.CanTransform(typ), "%s: expected CanTransform(%T) to be true", tt.transform.String(), typ)
+		}
+		for _, typ := range tt.notAllowed {
+			assert.False(t, tt.transform.CanTransform(typ), "%s: expected CanTransform(%T) to be false", tt.transform.String(), typ)
+		}
+	}
+
+}


### PR DESCRIPTION
### Description
* While implementing `UpdateSpec`, I noticed that some helper methods for transforms are missing. Both Iceberg Python and Java expose a `canTransform` method in the `Transform` interface to validate if a transform can be applied to a given type. Adding this check would help validate inputs before applying spec updates.
* https://github.com/apache/iceberg-python/blob/main/pyiceberg/transforms.py#L157
* https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/transforms/Transform.java#L69

### Testing
Added `TestCanTransform`