### PR TITLE
feat(partitions): Add support for get partition field name

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -295,6 +295,7 @@ func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (Parti
 }
 
 // GeneratePartitionFieldName returns default partition field name based on field transform type
+//
 // The default names are aligned with other client implementations
 // https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L518-L563
 func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, error) {

--- a/partitions.go
+++ b/partitions.go
@@ -299,10 +299,15 @@ func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (Parti
 // The default names are aligned with other client implementations
 // https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L518-L563
 func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, error) {
+	if len(field.Name) > 0 {
+		return field.Name, nil
+	}
+
 	sourceName, exists := schema.FindColumnName(field.SourceID)
 	if !exists {
 		return "", fmt.Errorf("could not find field with id %d", field.SourceID)
 	}
+
 	transform := field.Transform
 	switch t := transform.(type) {
 	case IdentityTransform:

--- a/partitions.go
+++ b/partitions.go
@@ -303,21 +303,9 @@ func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, e
 	switch t := transform.(type) {
 	case IdentityTransform:
 		return sourceName, nil
-	case BucketTransform:
-		return fmt.Sprintf("%s_bucket_%d", sourceName, t.NumBuckets), nil
-	case TruncateTransform:
-		return fmt.Sprintf("%s_trunc_%d", sourceName, t.Width), nil
-	case YearTransform:
-		return sourceName + "_year", nil
-	case MonthTransform:
-		return sourceName + "_month", nil
-	case DayTransform:
-		return sourceName + "_day", nil
-	case HourTransform:
-		return sourceName + "_hour", nil
 	case VoidTransform:
 		return sourceName + "_null", nil
 	default:
-		return "", fmt.Errorf("unknown transform type: %T", transform)
+		return sourceName + "_" + t.String(), nil
 	}
 }

--- a/partitions.go
+++ b/partitions.go
@@ -294,7 +294,7 @@ func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (Parti
 	return NewPartitionSpec(newFields...), nil
 }
 
-func GetPartitionFieldName(schema *Schema, field PartitionField) (string, error) {
+func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, error) {
 	sourceName, exists := schema.FindColumnName(field.SourceID)
 	if !exists {
 		return "", fmt.Errorf("could not find field with id %d", field.SourceID)

--- a/partitions.go
+++ b/partitions.go
@@ -293,3 +293,77 @@ func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (Parti
 
 	return NewPartitionSpec(newFields...), nil
 }
+
+type PartitionSpecVisitor[T any] interface {
+	Identity(fieldId int, sourceName string, sourceId int) T
+	Bucket(fieldId int, sourceName string, sourceId int, numBuckets int) T
+	Truncate(fieldId int, sourceName string, sourceId int, width int) T
+	Year(fieldId int, sourceName string, sourceId int) T
+	Month(fieldId int, sourceName string, sourceId int) T
+	Day(fieldId int, sourceName string, sourceId int) T
+	Hour(fieldId int, sourceName string, sourceId int) T
+	Void(fieldId int, sourceName string, sourceId int) T
+}
+
+type PartitionNameGenerator struct{}
+
+func (g PartitionNameGenerator) Identity(fieldID int, sourceName string, sourceID int) string {
+	return sourceName
+}
+
+func (g PartitionNameGenerator) Bucket(fieldID int, sourceName string, sourceID int, numBuckets int) string {
+	return fmt.Sprintf("%s_bucket_%d", sourceName, numBuckets)
+}
+
+func (g PartitionNameGenerator) Truncate(fieldID int, sourceName string, sourceID int, width int) string {
+	return fmt.Sprintf("%s_trunc_%d", sourceName, width)
+}
+
+func (g PartitionNameGenerator) Year(fieldID int, sourceName string, sourceID int) string {
+	return sourceName + "_year"
+}
+
+func (g PartitionNameGenerator) Month(fieldID int, sourceName string, sourceID int) string {
+	return sourceName + "_month"
+}
+
+func (g PartitionNameGenerator) Day(fieldID int, sourceName string, sourceID int) string {
+	return sourceName + "_day"
+}
+
+func (g PartitionNameGenerator) Hour(fieldID int, sourceName string, sourceID int) string {
+	return sourceName + "_hour"
+}
+
+func (g PartitionNameGenerator) Void(fieldID int, sourceName string, sourceID int) string {
+	return sourceName + "_null"
+}
+
+func VisitPartitionField[R any](schema *Schema, field PartitionField, visitor PartitionSpecVisitor[R]) (R, error) {
+	sourceName, exists := schema.FindColumnName(field.SourceID)
+	var empty R
+	if !exists {
+		return empty, fmt.Errorf("could not find field with id %d", field.SourceID)
+	}
+	transform := field.Transform
+	switch t := transform.(type) {
+	case IdentityTransform:
+		return visitor.Identity(field.FieldID, sourceName, field.SourceID), nil
+	case BucketTransform:
+		return visitor.Bucket(field.FieldID, sourceName, field.SourceID, t.NumBuckets), nil
+	case TruncateTransform:
+		return visitor.Truncate(field.FieldID, sourceName, field.SourceID, t.Width), nil
+	case DayTransform:
+		return visitor.Day(field.FieldID, sourceName, field.SourceID), nil
+	case HourTransform:
+		return visitor.Hour(field.FieldID, sourceName, field.SourceID), nil
+	case MonthTransform:
+		return visitor.Month(field.FieldID, sourceName, field.SourceID), nil
+	case YearTransform:
+		return visitor.Year(field.FieldID, sourceName, field.SourceID), nil
+	case VoidTransform:
+		return visitor.Void(field.FieldID, sourceName, field.SourceID), nil
+	default:
+		return empty, fmt.Errorf("unknown transform type: %T", transform)
+	}
+}

--- a/partitions.go
+++ b/partitions.go
@@ -294,6 +294,9 @@ func AssignFreshPartitionSpecIDs(spec *PartitionSpec, old, fresh *Schema) (Parti
 	return NewPartitionSpec(newFields...), nil
 }
 
+// GeneratePartitionFieldName returns default partition field name based on field transform type
+// The default names are aligned with other client implementations
+// https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L518-L563
 func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, error) {
 	sourceName, exists := schema.FindColumnName(field.SourceID)
 	if !exists {
@@ -305,6 +308,10 @@ func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, e
 		return sourceName, nil
 	case VoidTransform:
 		return sourceName + "_null", nil
+	case BucketTransform:
+		return fmt.Sprintf("%s_bucket_%d", sourceName, t.NumBuckets), nil
+	case TruncateTransform:
+		return fmt.Sprintf("%s_trunc_%d", sourceName, t.Width), nil
 	default:
 		return sourceName + "_" + t.String(), nil
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -201,35 +201,35 @@ func TestGetPartitionFieldName(t *testing.T) {
 		expectedName string
 	}{
 		{
-			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: ""},
 			expectedName: "str",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1001, Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: "bar"},
+			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1001, Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: ""},
 			expectedName: "int_bucket_7",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1002, Transform: iceberg.TruncateTransform{Width: 19}, Name: "baz"},
+			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1002, Transform: iceberg.TruncateTransform{Width: 19}, Name: ""},
 			expectedName: "int_trunc_19",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1003, Transform: iceberg.VoidTransform{}, Name: "qux"},
+			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1003, Transform: iceberg.VoidTransform{}, Name: ""},
 			expectedName: "ts_null",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.YearTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.YearTransform{}, Name: ""},
 			expectedName: "ts_year",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.MonthTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.MonthTransform{}, Name: ""},
 			expectedName: "ts_month",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.DayTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.DayTransform{}, Name: ""},
 			expectedName: "ts_day",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.HourTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.HourTransform{}, Name: ""},
 			expectedName: "ts_hour",
 		},
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -201,6 +201,10 @@ func TestGetPartitionFieldName(t *testing.T) {
 		expectedName string
 	}{
 		{
+			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "foo"},
+			expectedName: "foo",
+		},
+		{
 			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: ""},
 			expectedName: "str",
 		},

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -190,27 +190,25 @@ func TestPartitionSpecToPath(t *testing.T) {
 		spec.PartitionToPath(record, schema))
 }
 
-func TestVisitPartitionField(t *testing.T) {
+func TestGetPartitionFieldName(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "str", Type: iceberg.PrimitiveTypes.String},
 		iceberg.NestedField{ID: 2, Name: "other_str", Type: iceberg.PrimitiveTypes.String},
 		iceberg.NestedField{ID: 3, Name: "int", Type: iceberg.PrimitiveTypes.Int32, Required: true})
 
-	t.Run("visit partition field with partition name generator", func(t *testing.T) {
-		field := iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
-			Transform: iceberg.TruncateTransform{Width: 19}, Name: "random_name",
-		}
-		name, err := iceberg.VisitPartitionField(schema, field, iceberg.PartitionNameGenerator{})
-		assert.NoError(t, err)
-		assert.Equal(t, "str_trunc_19", name)
+	field := iceberg.PartitionField{
+		SourceID: 1, FieldID: 1000,
+		Transform: iceberg.TruncateTransform{Width: 19}, Name: "random_name",
+	}
+	name, err := iceberg.GetPartitionFieldName(schema, field)
+	assert.NoError(t, err)
+	assert.Equal(t, "str_trunc_19", name)
 
-		field = iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
-			Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: "another_random_name",
-		}
-		name, err = iceberg.VisitPartitionField(schema, field, iceberg.PartitionNameGenerator{})
-		assert.NoError(t, err)
-		assert.Equal(t, "other_str_bucket_7", name)
-	})
+	field = iceberg.PartitionField{
+		SourceID: 2, FieldID: 1001,
+		Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: "another_random_name",
+	}
+	name, err = iceberg.GetPartitionFieldName(schema, field)
+	assert.NoError(t, err)
+	assert.Equal(t, "other_str_bucket_7", name)
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -202,7 +202,7 @@ func TestGetPartitionFieldName(t *testing.T) {
 	}
 	name, err := iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
-	assert.Equal(t, "str_truncate[19]", name)
+	assert.Equal(t, "str_trunc_19", name)
 
 	field = iceberg.PartitionField{
 		SourceID: 2, FieldID: 1001,
@@ -210,7 +210,7 @@ func TestGetPartitionFieldName(t *testing.T) {
 	}
 	name, err = iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
-	assert.Equal(t, "other_str_bucket[7]", name)
+	assert.Equal(t, "other_str_bucket_7", name)
 
 	field = iceberg.PartitionField{
 		SourceID: 2, FieldID: 1001,

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -200,7 +200,7 @@ func TestGetPartitionFieldName(t *testing.T) {
 		SourceID: 1, FieldID: 1000,
 		Transform: iceberg.TruncateTransform{Width: 19}, Name: "random_name",
 	}
-	name, err := iceberg.GetPartitionFieldName(schema, field)
+	name, err := iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
 	assert.Equal(t, "str_trunc_19", name)
 
@@ -208,7 +208,7 @@ func TestGetPartitionFieldName(t *testing.T) {
 		SourceID: 2, FieldID: 1001,
 		Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: "another_random_name",
 	}
-	name, err = iceberg.GetPartitionFieldName(schema, field)
+	name, err = iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
 	assert.Equal(t, "other_str_bucket_7", name)
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -202,7 +202,7 @@ func TestGetPartitionFieldName(t *testing.T) {
 	}
 	name, err := iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
-	assert.Equal(t, "str_trunc_19", name)
+	assert.Equal(t, "str_truncate[19]", name)
 
 	field = iceberg.PartitionField{
 		SourceID: 2, FieldID: 1001,
@@ -210,5 +210,21 @@ func TestGetPartitionFieldName(t *testing.T) {
 	}
 	name, err = iceberg.GeneratePartitionFieldName(schema, field)
 	assert.NoError(t, err)
-	assert.Equal(t, "other_str_bucket_7", name)
+	assert.Equal(t, "other_str_bucket[7]", name)
+
+	field = iceberg.PartitionField{
+		SourceID: 2, FieldID: 1001,
+		Transform: iceberg.IdentityTransform{}, Name: "name",
+	}
+	name, err = iceberg.GeneratePartitionFieldName(schema, field)
+	assert.NoError(t, err)
+	assert.Equal(t, "other_str", name)
+
+	field = iceberg.PartitionField{
+		SourceID: 3, FieldID: 1001,
+		Transform: iceberg.VoidTransform{}, Name: "name",
+	}
+	name, err = iceberg.GeneratePartitionFieldName(schema, field)
+	assert.NoError(t, err)
+	assert.Equal(t, "int_null", name)
 }


### PR DESCRIPTION
### Description
* Added method to get default partition field name based on transform type
* This method will be a helper for update spec when the partition field is not given (such as `AddIdentity`) and creates default partition field name
    * https://github.com/apache/iceberg-go/pull/467/files#diff-eb806166d1b9d570a36b8506d2b9ada56126a32ca94b1eb12d6de03973e292c2R147
    * https://github.com/apache/iceberg-python/blob/main/pyiceberg/partitioning.py#L275-L376
    * https://github.com/apache/iceberg-go/pull/467

### Testing
Added unit tests `TestGetPartitionFieldName `