### PR TITLE
feat(table/updates): add stubs for the remove schemas & remove partition specs table updates

### DIFF
--- a/table/updates.go
+++ b/table/updates.go
@@ -474,6 +474,8 @@ type removeSpecUpdate struct {
 	SpecIds []int64 `json:"spec-ids"`
 }
 
+// NewRemoveSpecUpdate creates a new Update that removes a list of partition specs
+// from the table metadata.
 func NewRemoveSpecUpdate(specIds []int64) *removeSpecUpdate {
 	return &removeSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSpec},
@@ -490,6 +492,8 @@ type removeSchemasUpdate struct {
 	SchemaIds []int64 `json:"schema-ids"`
 }
 
+// NewRemoveSchemasUpdate creates a new Update that removes a list of schemas from
+// the table metadata.
 func NewRemoveSchemasUpdate(schemaIds []int64) *removeSchemasUpdate {
 	return &removeSchemasUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSchemas},

--- a/table/updates.go
+++ b/table/updates.go
@@ -35,8 +35,10 @@ const (
 	UpdateAssignUUID = "assign-uuid"
 
 	UpdateRemoveProperties  = "remove-properties"
+	UpdateRemoveSchemas     = "remove-schemas"
 	UpdateRemoveSnapshots   = "remove-snapshots"
 	UpdateRemoveSnapshotRef = "remove-snapshot-ref"
+	UpdateRemoveSpec        = "remove-partition-specs"
 
 	UpdateSetCurrentSchema    = "set-current-schema"
 	UpdateSetDefaultSortOrder = "set-default-sort-order"
@@ -72,6 +74,10 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 
 		var upd Update
 		switch base.ActionName {
+		case UpdateAssignUUID:
+			upd = &assignUUIDUpdate{}
+		case UpdateUpgradeFormatVersion:
+			upd = &upgradeFormatVersionUpdate{}
 		case UpdateAddSchema:
 			upd = &addSchemaUpdate{}
 		case UpdateSetCurrentSchema:
@@ -88,20 +94,20 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			upd = &addSnapshotUpdate{}
 		case UpdateSetSnapshotRef:
 			upd = &setSnapshotRefUpdate{}
+		case UpdateRemoveSnapshots:
+			upd = &removeSnapshotsUpdate{}
+		case UpdateRemoveSnapshotRef:
+			upd = &removeSnapshotRefUpdate{}
 		case UpdateSetLocation:
 			upd = &setLocationUpdate{}
 		case UpdateSetProperties:
 			upd = &setPropertiesUpdate{}
 		case UpdateRemoveProperties:
 			upd = &removePropertiesUpdate{}
-		case UpdateRemoveSnapshots:
-			upd = &removeSnapshotsUpdate{}
-		case UpdateRemoveSnapshotRef:
-			upd = &removeSnapshotRefUpdate{}
-		case UpdateAssignUUID:
-			upd = &assignUUIDUpdate{}
-		case UpdateUpgradeFormatVersion:
-			upd = &upgradeFormatVersionUpdate{}
+		case UpdateRemoveSpec:
+			upd = &removeSpecUpdate{}
+		case UpdateRemoveSchemas:
+			upd = &removeSchemasUpdate{}
 		default:
 			return fmt.Errorf("unknown update action: %s", base.ActionName)
 		}
@@ -452,7 +458,7 @@ type removeSnapshotRefUpdate struct {
 
 // NewRemoveSnapshotRefUpdate creates a new update that removes a snapshot reference
 // from the table metadata.
-func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
+func NewRemoveSnapshotRefUpdate(ref string) Update {
 	return &removeSnapshotRefUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSnapshotRef},
 		RefName:    ref,
@@ -461,4 +467,36 @@ func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
 
 func (u *removeSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
 	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSnapshotRef)
+}
+
+type removeSpecUpdate struct {
+	baseUpdate
+	SpecIds []int64 `json:"spec-ids"`
+}
+
+func NewRemoveSpecUpdate(specIds []int64) Update {
+	return &removeSpecUpdate{
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveSpec},
+		SpecIds:    specIds,
+	}
+}
+
+func (u *removeSpecUpdate) Apply(builder *MetadataBuilder) error {
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSpec)
+}
+
+type removeSchemasUpdate struct {
+	baseUpdate
+	SchemaIds []int64 `json:"schema-ids"`
+}
+
+func NewRemoveSchemasUpdate(specIds []int64) Update {
+	return &removeSpecUpdate{
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveSchemas},
+		SpecIds:    specIds,
+	}
+}
+
+func (u *removeSchemasUpdate) Apply(builder *MetadataBuilder) error {
+	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSchemas)
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -137,7 +137,7 @@ type assignUUIDUpdate struct {
 }
 
 // NewAssignUUIDUpdate creates a new update to assign a UUID to the table metadata.
-func NewAssignUUIDUpdate(uuid uuid.UUID) Update {
+func NewAssignUUIDUpdate(uuid uuid.UUID) *assignUUIDUpdate {
 	return &assignUUIDUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAssignUUID},
 		UUID:       uuid,
@@ -157,7 +157,7 @@ type upgradeFormatVersionUpdate struct {
 
 // NewUpgradeFormatVersionUpdate creates a new update that upgrades the format version
 // of the table metadata to the given formatVersion.
-func NewUpgradeFormatVersionUpdate(formatVersion int) Update {
+func NewUpgradeFormatVersionUpdate(formatVersion int) *upgradeFormatVersionUpdate {
 	return &upgradeFormatVersionUpdate{
 		baseUpdate:    baseUpdate{ActionName: UpdateUpgradeFormatVersion},
 		FormatVersion: formatVersion,
@@ -180,7 +180,7 @@ type addSchemaUpdate struct {
 // NewAddSchemaUpdate creates a new update that adds the given schema and last column ID to
 // the table metadata. If the initial flag is set to true, the schema is considered the initial
 // schema of the table, and all previously added schemas in the metadata builder are removed.
-func NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID int, initial bool) Update {
+func NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID int, initial bool) *addSchemaUpdate {
 	return &addSchemaUpdate{
 		baseUpdate:   baseUpdate{ActionName: UpdateAddSchema},
 		Schema:       schema,
@@ -202,7 +202,7 @@ type setCurrentSchemaUpdate struct {
 
 // NewSetCurrentSchemaUpdate creates a new update that sets the current schema of the table
 // metadata to the given schema ID.
-func NewSetCurrentSchemaUpdate(id int) Update {
+func NewSetCurrentSchemaUpdate(id int) *setCurrentSchemaUpdate {
 	return &setCurrentSchemaUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateSetCurrentSchema},
 		SchemaID:   id,
@@ -224,7 +224,7 @@ type addPartitionSpecUpdate struct {
 // NewAddPartitionSpecUpdate creates a new update that adds the given partition spec to the table
 // metadata. If the initial flag is set to true, the spec is considered the initial spec of the table,
 // and all other previously added specs in the metadata builder are removed.
-func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) Update {
+func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) *addPartitionSpecUpdate {
 	return &addPartitionSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSpec},
 		Spec:       spec,
@@ -245,7 +245,7 @@ type setDefaultSpecUpdate struct {
 
 // NewSetDefaultSpecUpdate creates a new update that sets the default partition spec of the
 // table metadata to the given spec ID.
-func NewSetDefaultSpecUpdate(id int) Update {
+func NewSetDefaultSpecUpdate(id int) *setDefaultSpecUpdate {
 	return &setDefaultSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateSetDefaultSpec},
 		SpecID:     id,
@@ -267,7 +267,7 @@ type addSortOrderUpdate struct {
 // NewAddSortOrderUpdate creates a new update that adds the given sort order to the table metadata.
 // If the initial flag is set to true, the sort order is considered the initial sort order of the table,
 // and all previously added sort orders in the metadata builder are removed.
-func NewAddSortOrderUpdate(sortOrder *SortOrder, initial bool) Update {
+func NewAddSortOrderUpdate(sortOrder *SortOrder, initial bool) *addSortOrderUpdate {
 	return &addSortOrderUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSortOrder},
 		SortOrder:  sortOrder,
@@ -288,7 +288,7 @@ type setDefaultSortOrderUpdate struct {
 
 // NewSetDefaultSortOrderUpdate creates a new update that sets the default sort order of the table metadata
 // to the given sort order ID.
-func NewSetDefaultSortOrderUpdate(id int) Update {
+func NewSetDefaultSortOrderUpdate(id int) *setDefaultSortOrderUpdate {
 	return &setDefaultSortOrderUpdate{
 		baseUpdate:  baseUpdate{ActionName: UpdateSetDefaultSortOrder},
 		SortOrderID: id,
@@ -307,7 +307,7 @@ type addSnapshotUpdate struct {
 }
 
 // NewAddSnapshotUpdate creates a new update that adds the given snapshot to the table metadata.
-func NewAddSnapshotUpdate(snapshot *Snapshot) Update {
+func NewAddSnapshotUpdate(snapshot *Snapshot) *addSnapshotUpdate {
 	return &addSnapshotUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSnapshot},
 		Snapshot:   snapshot,
@@ -339,7 +339,7 @@ func NewSetSnapshotRefUpdate(
 	refType RefType,
 	maxRefAgeMs, maxSnapshotAgeMs int64,
 	minSnapshotsToKeep int,
-) Update {
+) *setSnapshotRefUpdate {
 	return &setSnapshotRefUpdate{
 		baseUpdate:         baseUpdate{ActionName: UpdateSetSnapshotRef},
 		RefName:            name,
@@ -420,7 +420,7 @@ type removePropertiesUpdate struct {
 // NewRemovePropertiesUpdate creates a new update that removes properties from the table metadata.
 // The properties are identified by their names, and if a property with the given name does not exist,
 // it is ignored.
-func NewRemovePropertiesUpdate(removals []string) Update {
+func NewRemovePropertiesUpdate(removals []string) *removePropertiesUpdate {
 	return &removePropertiesUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveProperties},
 		Removals:   removals,
@@ -440,7 +440,7 @@ type removeSnapshotsUpdate struct {
 
 // NewRemoveSnapshotsUpdate creates a new update that removes all snapshots from
 // the table metadata with the given snapshot IDs.
-func NewRemoveSnapshotsUpdate(ids []int64) Update {
+func NewRemoveSnapshotsUpdate(ids []int64) *removeSnapshotsUpdate {
 	return &removeSnapshotsUpdate{
 		baseUpdate:  baseUpdate{ActionName: UpdateRemoveSnapshots},
 		SnapshotIDs: ids,
@@ -458,7 +458,7 @@ type removeSnapshotRefUpdate struct {
 
 // NewRemoveSnapshotRefUpdate creates a new update that removes a snapshot reference
 // from the table metadata.
-func NewRemoveSnapshotRefUpdate(ref string) Update {
+func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
 	return &removeSnapshotRefUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSnapshotRef},
 		RefName:    ref,
@@ -474,7 +474,7 @@ type removeSpecUpdate struct {
 	SpecIds []int64 `json:"spec-ids"`
 }
 
-func NewRemoveSpecUpdate(specIds []int64) Update {
+func NewRemoveSpecUpdate(specIds []int64) *removeSpecUpdate {
 	return &removeSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSpec},
 		SpecIds:    specIds,
@@ -490,10 +490,10 @@ type removeSchemasUpdate struct {
 	SchemaIds []int64 `json:"schema-ids"`
 }
 
-func NewRemoveSchemasUpdate(specIds []int64) Update {
-	return &removeSpecUpdate{
+func NewRemoveSchemasUpdate(schemaIds []int64) *removeSchemasUpdate {
+	return &removeSchemasUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSchemas},
-		SpecIds:    specIds,
+		SchemaIds:  schemaIds,
 	}
 }
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -219,4 +220,28 @@ func TestUnmarshalUpdates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoveSchemas(t *testing.T) {
+	var builder *MetadataBuilder
+	removeSchemas := removeSchemasUpdate{
+		SchemaIds: []int64{},
+	}
+	t.Run("remove schemas should fail", func(t *testing.T) {
+		if err := removeSchemas.Apply(builder); !errors.Is(err, iceberg.ErrNotImplemented) {
+			t.Fatalf("Expected unimplemented error, got %v", err)
+		}
+	})
+}
+
+func TestRemovePartitionSpecs(t *testing.T) {
+	var builder *MetadataBuilder
+	removeSpecs := removeSpecUpdate{
+		SpecIds: []int64{},
+	}
+	t.Run("remove specs should fail", func(t *testing.T) {
+		if err := removeSpecs.Apply(builder); !errors.Is(err, iceberg.ErrNotImplemented) {
+			t.Fatalf("Expected unimplemented error, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
This adds stubs for two of the still missing table updates, remove schemas & remove specs, after that we're still missing:

- UpdateSetStatistics:
- UpdateRemoveStatistics:
- UpdateAddEncryptionKey:
- UpdateRemoveEncryptionKey:
