### PR TITLE
feat: reuse schemas & increment their IDS

### DIFF
--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1148,7 +1148,7 @@ func TestAlterTableIntegration(t *testing.T) {
 	}
 	newFields := append(currentSchema.Fields(), addField) // add column 'new_col'
 	newFields = append(newFields[:1], newFields[2:]...)   // drop column 'bar'
-	updateColumns := table.NewAddSchemaUpdate(iceberg.NewSchemaWithIdentifiers(newSchemaId, currentSchema.IdentifierFieldIDs, newFields...), false)
+	updateColumns := table.NewAddSchemaUpdate(iceberg.NewSchemaWithIdentifiers(newSchemaId, currentSchema.IdentifierFieldIDs, newFields...))
 	setSchema := table.NewSetCurrentSchemaUpdate(newSchemaId)
 
 	_, _, err = ctlg.CommitTable(

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1148,11 +1148,7 @@ func TestAlterTableIntegration(t *testing.T) {
 	}
 	newFields := append(currentSchema.Fields(), addField) // add column 'new_col'
 	newFields = append(newFields[:1], newFields[2:]...)   // drop column 'bar'
-	updateColumns := table.NewAddSchemaUpdate(
-		iceberg.NewSchemaWithIdentifiers(newSchemaId, currentSchema.IdentifierFieldIDs, newFields...),
-		addField.ID,
-		false,
-	)
+	updateColumns := table.NewAddSchemaUpdate(iceberg.NewSchemaWithIdentifiers(newSchemaId, currentSchema.IdentifierFieldIDs, newFields...), false)
 	setSchema := table.NewSetCurrentSchemaUpdate(newSchemaId)
 
 	_, _, err = ctlg.CommitTable(

--- a/schema.go
+++ b/schema.go
@@ -78,10 +78,6 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 	return s
 }
 
-func (s *Schema) WithID(id int) {
-	s.ID = id
-}
-
 func (s *Schema) init() {
 	s.lazyIDToParent = sync.OnceValues(func() (map[int]int, error) {
 		return IndexParents(s)

--- a/schema.go
+++ b/schema.go
@@ -78,6 +78,10 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 	return s
 }
 
+func (s *Schema) WithID(id int) {
+	s.ID = id
+}
+
 func (s *Schema) init() {
 	s.lazyIDToParent = sync.OnceValues(func() (map[int]int, error) {
 		return IndexParents(s)

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1299,7 +1299,7 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 		panic(fmt.Errorf("%w: cannot write files without a current spec", err))
 	}
 	nextCount, stopCount := iter.Pull(args.counter)
-	if (*currentSpec).IsUnpartitioned() {
+	if currentSpec.IsUnpartitioned() {
 		tasks := func(yield func(WriteTask) bool) {
 			defer stopCount()
 

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1190,7 +1190,14 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 			}
 		}()
 
-		currentSchema, currentSpec := meta.CurrentSchema(), meta.CurrentSpec()
+		partitionSpec, err := meta.CurrentSpec()
+		if err != nil || partitionSpec == nil {
+			yield(nil, fmt.Errorf("%w: cannot add files without a current spec", err))
+
+			return
+		}
+
+		currentSchema, currentSpec := meta.CurrentSchema(), *partitionSpec
 
 		for filePath := range paths {
 			format := tblutils.FormatFromFileName(filePath)
@@ -1287,9 +1294,12 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 	if err != nil {
 		panic(err)
 	}
-
+	currentSpec, err := meta.CurrentSpec()
+	if err != nil || currentSpec == nil {
+		panic(fmt.Errorf("%w: cannot write files without a current spec", err))
+	}
 	nextCount, stopCount := iter.Pull(args.counter)
-	if meta.CurrentSpec().IsUnpartitioned() {
+	if (*currentSpec).IsUnpartitioned() {
 		tasks := func(yield func(WriteTask) bool) {
 			defer stopCount()
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -276,6 +276,7 @@ func (b *MetadataBuilder) AddSchema(schema *iceberg.Schema) (*MetadataBuilder, e
 			b.updates = append(b.updates, NewAddSchemaUpdate(schema))
 			b.lastAddedSchemaID = &newSchemaID
 		}
+
 		return b, nil
 	}
 
@@ -809,6 +810,7 @@ func (b *MetadataBuilder) reuseOrCreateNewSchemaID(newSchema *iceberg.Schema) in
 			newSchemaID = schema.ID + 1
 		}
 	}
+
 	return newSchemaID
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -217,9 +217,8 @@ func MetadataBuilderFromBase(metadata Metadata) (*MetadataBuilder, error) {
 
 func (b *MetadataBuilder) HasChanges() bool { return len(b.updates) > 0 }
 
-func (b *MetadataBuilder) CurrentSpec() iceberg.PartitionSpec {
-	// FIXME: this should return a pointer which can be nil to avoid out of bounds indexing / np derefs
-	return b.specs[b.defaultSpecID]
+func (b *MetadataBuilder) CurrentSpec() (*iceberg.PartitionSpec, error) {
+	return b.GetSpecByID(b.defaultSpecID)
 }
 
 func (b *MetadataBuilder) CurrentSchema() *iceberg.Schema {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -816,7 +816,6 @@ func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
 	assert.Equal(t, 1, builder.schemaList[0].ID)
 	assert.Equal(t, 3, builder.schemaList[1].ID)
 	assert.Equal(t, 4, builder.schemaList[2].ID)
-
 }
 
 func TestMetadataBuilderReuseSchema(t *testing.T) {
@@ -834,7 +833,6 @@ func TestMetadataBuilderReuseSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(builder.schemaList), 1)
 	assert.Equal(t, *builder.lastAddedSchemaID, 1)
-
 }
 
 func TestMetadataV1Validation(t *testing.T) {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -764,6 +764,79 @@ func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
 	assert.Equal(t, 0, builder.defaultSpecID)
 }
 
+func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	assert.NoError(t, err)
+	_, err = builder.SetFormatVersion(2)
+	assert.NoError(t, err)
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema)
+	assert.NoError(t, err)
+	_, err = builder.SetCurrentSchemaID(-1)
+	assert.NoError(t, err)
+
+	partitionSpec := iceberg.NewPartitionSpecID(0)
+	_, err = builder.AddPartitionSpec(&partitionSpec, false)
+	assert.NoError(t, err)
+
+	_, err = builder.SetDefaultSpecID(-1)
+	assert.NoError(t, err)
+
+	meta, err := builder.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, schema.ID, meta.CurrentSchema().ID)
+	assert.True(t, schema.Equals(meta.CurrentSchema()))
+}
+
+func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	assert.NoError(t, err)
+	_, err = builder.SetFormatVersion(2)
+	assert.NoError(t, err)
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema)
+	assert.NoError(t, err)
+
+	schema = iceberg.NewSchema(3,
+		iceberg.NestedField{ID: 3, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema)
+	assert.NoError(t, err)
+
+	schema = iceberg.NewSchema(2,
+		iceberg.NestedField{ID: 4, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, builder.schemaList[0].ID)
+	assert.Equal(t, 3, builder.schemaList[1].ID)
+	assert.Equal(t, 4, builder.schemaList[2].ID)
+
+}
+
+func TestMetadataBuilderReuseSchema(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	assert.NoError(t, err)
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema)
+	assert.NoError(t, err)
+	schema2 := iceberg.NewSchema(15,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
+	)
+	_, err = builder.AddSchema(schema2)
+	assert.NoError(t, err)
+	assert.Equal(t, len(builder.schemaList), 1)
+	assert.Equal(t, *builder.lastAddedSchemaID, 1)
+
+}
+
 func TestMetadataV1Validation(t *testing.T) {
 	// Test case 1: JSON with no last-column-id field
 	noColumnID := `{

--- a/table/updates.go
+++ b/table/updates.go
@@ -180,25 +180,20 @@ func (u *upgradeFormatVersionUpdate) Apply(builder *MetadataBuilder) error {
 
 type addSchemaUpdate struct {
 	baseUpdate
-	Schema       *iceberg.Schema `json:"schema"`
-	LastColumnID int             `json:"last-column-id"`
-	initial      bool
+	Schema  *iceberg.Schema `json:"schema"`
+	initial bool
 }
 
-// NewAddSchemaUpdate creates a new update that adds the given schema and last column ID to
-// the table metadata. If the initial flag is set to true, the schema is considered the initial
-// schema of the table, and all previously added schemas in the metadata builder are removed.
-func NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID int, initial bool) *addSchemaUpdate {
+// NewAddSchemaUpdate creates a new update that adds the given schema and updates the lastColumnID based on the schema.
+func NewAddSchemaUpdate(schema *iceberg.Schema) *addSchemaUpdate {
 	return &addSchemaUpdate{
-		baseUpdate:   baseUpdate{ActionName: UpdateAddSchema},
-		Schema:       schema,
-		LastColumnID: lastColumnID,
-		initial:      initial,
+		baseUpdate: baseUpdate{ActionName: UpdateAddSchema},
+		Schema:     schema,
 	}
 }
 
 func (u *addSchemaUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.AddSchema(u.Schema, u.LastColumnID, u.initial)
+	_, err := builder.AddSchema(u.Schema)
 
 	return err
 }

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -145,7 +145,7 @@ func TestUnmarshalUpdates(t *testing.T) {
 			expected: Updates{
 				NewAddSchemaUpdate(iceberg.NewSchema(1,
 					iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
-				), false),
+				)),
 				NewAddPartitionSpecUpdate(
 					&spec, false),
 				NewAddSortOrderUpdate(&sortOrder, false),

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -143,11 +143,9 @@ func TestUnmarshalUpdates(t *testing.T) {
   }
 ]`),
 			expected: Updates{
-				NewAddSchemaUpdate(
-					iceberg.NewSchema(1,
-						iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
-					), 1, false,
-				),
+				NewAddSchemaUpdate(iceberg.NewSchema(1,
+					iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
+				), false),
 				NewAddPartitionSpecUpdate(
 					&spec, false),
 				NewAddSortOrderUpdate(&sortOrder, false),
@@ -202,7 +200,6 @@ func TestUnmarshalUpdates(t *testing.T) {
 						actualAddSchema := actual[idx].(*addSchemaUpdate)
 						assert.True(t, expectedAddSchema.Schema.Equals(actualAddSchema.Schema))
 						assert.Equal(t, actualAddSchema.initial, expectedAddSchema.initial)
-						assert.Equal(t, actualAddSchema.LastColumnID, expectedAddSchema.LastColumnID)
 					case "add-partition-spec":
 						expectedAddPartitionSpec := u.(*addPartitionSpecUpdate)
 						actualAddPartitionSpec := actual[idx].(*addPartitionSpecUpdate)


### PR DESCRIPTION
Aligns us a bit more with the Java & Rust implementations where functionally equivalent schemas don't get added a second time. It also aligns renumbering of schemas to be equivalent to java/rust.

Java source: https://github.com/apache/iceberg/blob/41c0b17a20c522e4df519bcc429f413e6a2855e5/core/src/main/java/org/apache/iceberg/TableMetadata.java#L117-L138
Rust source: https://github.com/apache/iceberg-rust/blob/c4c006939a3cb3bf684a0d10ba0e66cac484befe/crates/iceberg/src/spec/table_metadata_builder.rs#L1068

