### PR TITLE
REDRES-3671 Bootstrap fork with tooling to make it workable

### DIFF
--- a/DataDog.md
+++ b/DataDog.md
@@ -1,0 +1,31 @@
+# iceberg-go fork
+
+This fork of [iceberg-go](https://github.com/apache/iceberg-go) exists because it has a dependency on 
+[gocloud.dev](https://github.com/google/go-cloud) which has been problematic enough with many API breaking changes
+that blocked important dependency upgrades in repos like [dd-go](https://github.com/DataDog/dd-go) and 
+[dd-source](https://github.com/DataDog/dd-source). 
+
+Because of this, [the guideline](https://datadoghq.atlassian.net/wiki/spaces/ENG/pages/5335876583/Blob+storage+in+Go) 
+was put in place for anything that depends on gocloud.dev to vendor that dependency and
+prevent it leaking through in our main repositories. 
+
+# Synch with upstream
+This README comes with tooling that will:
+* Add the `go mod replace` directive to allow this fork to compile without any iceberg-go import changes
+* Add `gocloud.dev` as a git subtree 
+* Rewrite `gocloud.dev` import paths
+
+This commit should include all that's needed to recreate a working fork from a fresh copy of iceberg-go. The idea being
+that we could always just `git reset --hard` from the upstream repository, cherry-pick this commit and re-run the
+`./initialize-fork.sh` to get the repo back to a up-to-date working state. Note that this approach would involve 
+rewriting git history and might be reserved in case the merging/rebasing from upstream is too messy or involved.
+
+To find the fork-initializing commit, look up the commit by the tag:
+```shell
+git rev-list -n 1 fork-initialization
+```
+
+# The Path To Irrelevance
+
+If [iceberg-go](https://github.com/apache/iceberg-go) ever breaks free from [gocloud.dev](https://github.com/google/go-cloud), we could potentially remove the 
+need for this fork and go back to the upstream repo.

--- a/initialize-fork.sh
+++ b/initialize-fork.sh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+if [ ! -d "./go-cloud" ]; then
+    # Update the version if it gets updated upstream
+    git subtree add --prefix=go-cloud git@github.com:google/go-cloud.git v0.43.0
+    # Remove the go module definition to make go-cloud dev a sub-package
+    git rm go-cloud/go.*
+fi
+
+# Allow iceberg-go to compile by pointing the self-dependencies to this fork
+go mod edit -replace github.com/apache/iceberg-go=.
+
+# Replace all gocloud.dev import paths to the inlined subtree of the repo (effectivement vendoring gocloud.dev)
+go run github.com/sirkon/go-imports-rename@latest --save 'gocloud.dev => github.com/apache/iceberg-go/go-cloud'
+
+# Tidy up the dependencies
+go mod tidy


### PR DESCRIPTION
![creation](https://media1.tenor.com/m/8EIM9j-q-iEAAAAd/creation-of-adam-fist-bump.gif)

This PR adds the fork README and the script to initialize the fork to a working state. The idea being that we could want to re-sync [from upstream](https://github.com/apache/iceberg-go) and do so without having to bother with rebasing or merging and dealing with conflicts. With that in mind, it would be possible to find the fork initialization commit by doing this

```shell
git rev-list -n 1 fork-initialization
```

And then cherry-picking that commit and running `./initialize-fork.sh`. 

This script does the following:
* Checks out `gocloud.dev` as a git subtree in the `go-cloud` subdirectory
* Removes the go module files from `gocloud.dev` so it appears as a regular sub-package
* Runs `go mod tidy` to remove the `gocloud.dev` dependency
* Replaces all `gocloud.dev` imports to point to the vendored sub-package
* Adds the go mod replace line to allow this fork to compile without changing the self-referencing imports