### PR TITLE
fix: SetSnapshotRef has to produce updates for all branches

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -570,8 +570,8 @@ func (b *MetadataBuilder) SetSnapshotRef(
 		b.lastUpdatedMS = snapshot.TimestampMs
 	}
 
+	b.updates = append(b.updates, NewSetSnapshotRefUpdate(name, snapshotID, refType, maxRefAgeMs, maxSnapshotAgeMs, minSnapshotsToKeep))
 	if name == MainBranch {
-		b.updates = append(b.updates, NewSetSnapshotRefUpdate(name, snapshotID, refType, maxRefAgeMs, maxSnapshotAgeMs, minSnapshotsToKeep))
 		b.currentSnapshotID = &snapshotID
 		if !isAddedSnapshot {
 			b.lastUpdatedMS = time.Now().Local().UnixMilli()


### PR DESCRIPTION
Java, PyIceberg and Rust add the update unconditionally:
 
```java
    public Builder setRef(String name, SnapshotRef ref) {
      SnapshotRef existingRef = refs.get(name);
      if (existingRef != null && existingRef.equals(ref)) {
        return this;
      }
      ...
      refs.put(name, ref);
      MetadataUpdate.SetSnapshotRef refUpdate =
          new MetadataUpdate.SetSnapshotRef(
              name,
              ref.snapshotId(),
              ref.type(),
              ref.minSnapshotsToKeep(),
              ref.maxSnapshotAgeMs(),
              ref.maxRefAgeMs());
      changes.add(refUpdate);
      return this;
    }
```


```python
@_apply_table_update.register(SetSnapshotRefUpdate)
   ...

    if update.ref_name == MAIN_BRANCH:
        metadata_updates["current_snapshot_id"] = snapshot_ref.snapshot_id
        if "last_updated_ms" not in metadata_updates:
            metadata_updates["last_updated_ms"] = datetime_to_millis(datetime.now().astimezone())

        metadata_updates["snapshot_log"] = base_metadata.snapshot_log + [
            SnapshotLogEntry(
                snapshot_id=snapshot_ref.snapshot_id,
                timestamp_ms=metadata_updates["last_updated_ms"],
            )
        ]

    metadata_updates["refs"] = {**base_metadata.refs, update.ref_name: snapshot_ref}
    context.add_update(update)
    return base_metadata.model_copy(update=metadata_updates)
 ```

```rust
    /// Set a reference to a snapshot.
    ///
    /// # Errors
    /// - The snapshot id is unknown.
    pub fn set_ref(mut self, ref_name: &str, reference: SnapshotReference) -> Result<Self> {
        if self
            .metadata
            .refs
            .get(ref_name)
            .is_some_and(|snap_ref| snap_ref.eq(&reference))
        {
            return Ok(self);
        }

        ...
        self.changes.push(TableUpdate::SetSnapshotRef {
            ref_name: ref_name.to_string(),
            reference: reference.clone(),
        });
        self.metadata.refs.insert(ref_name.to_string(), reference);

        Ok(self)
    }
```
