### PR TITLE
feat(table): add Refresh method to reload table metadata

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -101,6 +101,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.metadata = fresh.metadata
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
+
 	return nil
 }
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1450,7 +1450,7 @@ func (t *TableTestSuite) TestRefresh() {
 	_, _, err = cat.CommitTable(context.Background(), tbl, nil, []table.Update{
 		table.NewSetPropertiesUpdate(iceberg.Properties{
 			"refreshed": "true",
-			"timestamp": fmt.Sprintf("%d", time.Now().Unix()),
+			"timestamp": strconv.FormatInt(time.Now().Unix(), 10),
 		}),
 	})
 	t.Require().NoError(err)


### PR DESCRIPTION
## Description
Add `Refresh` method to `Table` struct for reloading table metadata.

## Changes
- Add `Refresh` method in `table/table.go`
- Add corresponding test cases in `table/table_test.go`

## Use Case
When table metadata changes (e.g., modified by other processes), you can call `Refresh` to get the latest table state.