### PR TITLE
feat(table): Add cleanup orphan files features

### DIFF
--- a/io/blob.go
+++ b/io/blob.go
@@ -20,11 +20,12 @@ package io
 import (
 	"context"
 	"errors"
-	"gocloud.dev/blob"
 	"io"
 	"io/fs"
 	"path/filepath"
 	"strings"
+
+	"gocloud.dev/blob"
 )
 
 // blobOpenFile describes a single open blob as a File.
@@ -117,16 +118,6 @@ func (bfs *blobFileIO) WriteFile(name string, content []byte) error {
 	name = bfs.preprocess(name)
 
 	return bfs.Bucket.WriteAll(bfs.ctx, name, content, nil)
-}
-
-func (bfs *blobFileIO) As(target interface{}) bool {
-	if bucket, ok := target.(**blob.Bucket); ok {
-		*bucket = bfs.Bucket
-
-		return true
-	}
-
-	return false
 }
 
 // NewWriter returns a Writer that writes to the blob stored at path.

--- a/io/blob.go
+++ b/io/blob.go
@@ -24,6 +24,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gocloud.dev/blob"
 )
@@ -75,6 +76,7 @@ type blobFileIO struct {
 	*blob.Bucket
 
 	bucketName string
+	scheme     string
 	ctx        context.Context
 }
 
@@ -119,6 +121,64 @@ func (bfs *blobFileIO) WriteFile(name string, content []byte) error {
 	return bfs.Bucket.WriteAll(bfs.ctx, name, content, nil)
 }
 
+// ListObjects implements the ListIO interface for blob-based file systems
+func (bfs *blobFileIO) ListObjects(prefix string, fn func(path string, info fs.FileInfo) error) error {
+	processedPrefix := bfs.preprocess(prefix)
+	if processedPrefix != "" && !strings.HasSuffix(processedPrefix, "/") {
+		processedPrefix += "/"
+	}
+
+	iter := bfs.Bucket.List(&blob.ListOptions{
+		Prefix: processedPrefix,
+		// No delimiter to get all files recursively
+	})
+
+	for {
+		obj, err := iter.Next(bfs.ctx)
+		if err == io.EOF {
+			break // No more objects
+		}
+		if err != nil {
+			return err
+		}
+
+		if obj.IsDir {
+			continue
+		}
+
+		fullPath := obj.Key
+		if bfs.bucketName != "" && bfs.scheme != "" {
+			fullPath = bfs.scheme + "://" + bfs.bucketName + "/" + obj.Key
+		}
+
+		fileInfo := &blobObjectInfo{
+			name:    filepath.Base(obj.Key),
+			size:    obj.Size,
+			modTime: obj.ModTime,
+		}
+
+		// Call the callback function
+		if err := fn(fullPath, fileInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type blobObjectInfo struct {
+	name    string
+	size    int64
+	modTime time.Time
+}
+
+func (info *blobObjectInfo) Name() string       { return info.name }
+func (info *blobObjectInfo) Size() int64        { return info.size }
+func (info *blobObjectInfo) Mode() fs.FileMode  { return fs.ModeIrregular }
+func (info *blobObjectInfo) ModTime() time.Time { return info.modTime }
+func (info *blobObjectInfo) IsDir() bool        { return false }
+func (info *blobObjectInfo) Sys() interface{}   { return nil }
+
 // NewWriter returns a Writer that writes to the blob stored at path.
 // A nil WriterOptions is treated the same as the zero value.
 //
@@ -154,8 +214,8 @@ func (io *blobFileIO) NewWriter(ctx context.Context, path string, overwrite bool
 		nil
 }
 
-func createBlobFS(ctx context.Context, bucket *blob.Bucket, bucketName string) IO {
-	return &blobFileIO{Bucket: bucket, bucketName: bucketName, ctx: ctx}
+func createBlobFS(ctx context.Context, bucket *blob.Bucket, bucketName, scheme string) IO {
+	return &blobFileIO{Bucket: bucket, bucketName: bucketName, scheme: scheme, ctx: ctx}
 }
 
 type blobWriteFile struct {

--- a/io/io.go
+++ b/io/io.go
@@ -82,14 +82,6 @@ type WriteFileIO interface {
 	WriteFile(name string, p []byte) error
 }
 
-type WalkIO interface {
-	IO
-
-	// Walk the file tree at root, calling fn for each file or
-	// directory in the tree, including root.
-	Walk(root string, fn func(path string, info fs.FileInfo) error) error
-}
-
 // A File provides access to a single file. The File interface is the
 // minimum implementation required for Iceberg to interact with a file.
 // Directory files should also implement

--- a/io/io.go
+++ b/io/io.go
@@ -82,6 +82,17 @@ type WriteFileIO interface {
 	WriteFile(name string, p []byte) error
 }
 
+// ListIO is the interface implemented by a file system that
+// provides listing functionality for object stores
+type ListIO interface {
+	IO
+
+	// ListObjects lists all objects with the given prefix.
+	// For object stores like S3, this provides proper prefix-based listing.
+	// The callback function is called for each object found.
+	ListObjects(prefix string, fn func(path string, info fs.FileInfo) error) error
+}
+
 // A File provides access to a single file. The File interface is the
 // minimum implementation required for Iceberg to interact with a file.
 // Directory files should also implement
@@ -267,7 +278,7 @@ func inferFileIOFromSchema(ctx context.Context, path string, props map[string]st
 		return nil, fmt.Errorf("IO for file '%s' not implemented", path)
 	}
 
-	return createBlobFS(ctx, bucket, parsed.Host), nil
+	return createBlobFS(ctx, bucket, parsed.Host, parsed.Scheme), nil
 }
 
 // LoadFS takes a map of properties and an optional URI location

--- a/io/io.go
+++ b/io/io.go
@@ -82,15 +82,12 @@ type WriteFileIO interface {
 	WriteFile(name string, p []byte) error
 }
 
-// ListIO is the interface implemented by a file system that
-// provides listing functionality for object stores
-type ListIO interface {
+type WalkIO interface {
 	IO
 
-	// ListObjects lists all objects with the given prefix.
-	// For object stores like S3, this provides proper prefix-based listing.
-	// The callback function is called for each object found.
-	ListObjects(prefix string, fn func(path string, info fs.FileInfo) error) error
+	// Walk the file tree at root, calling fn for each file or
+	// directory in the tree, including root.
+	Walk(root string, fn func(path string, info fs.FileInfo) error) error
 }
 
 // A File provides access to a single file. The File interface is the

--- a/io/local.go
+++ b/io/local.go
@@ -18,7 +18,6 @@
 package io
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,24 +46,4 @@ func (LocalFS) WriteFile(name string, content []byte) error {
 
 func (LocalFS) Remove(name string) error {
 	return os.Remove(strings.TrimPrefix(name, "file://"))
-}
-
-func (LocalFS) Walk(root string, fn func(path string, info os.FileInfo) error) error {
-	cleanRoot := strings.TrimPrefix(root, "file://")
-
-	return filepath.WalkDir(cleanRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		return fn(path, info)
-	})
 }

--- a/io/local.go
+++ b/io/local.go
@@ -18,6 +18,7 @@
 package io
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,4 +47,24 @@ func (LocalFS) WriteFile(name string, content []byte) error {
 
 func (LocalFS) Remove(name string) error {
 	return os.Remove(strings.TrimPrefix(name, "file://"))
+}
+
+func (LocalFS) Walk(root string, fn func(path string, info os.FileInfo) error) error {
+	cleanRoot := strings.TrimPrefix(root, "file://")
+
+	return filepath.WalkDir(cleanRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		return fn(path, info)
+	})
 }

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -555,10 +555,7 @@ func normalizeURLPath(path string, cfg *orphanCleanupConfig) string {
 func normalizeNonURLPath(path string) string {
 	normalized := filepath.Clean(path)
 
-	// Use manual replacement to handle Windows paths on all platforms
-	// filepath.ToSlash only converts the current OS separator, but we need
-	// cross-platform normalization to handle paths from different systems
-	return strings.ReplaceAll(normalized, "\\", "/")
+	return filepath.ToSlash(normalized)
 }
 
 // applySchemeEquivalence maps schemes to their equivalent canonical form.

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -1,0 +1,593 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	stdfs "io/fs"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+type PrefixMismatchMode int
+
+const (
+	PrefixMismatchError PrefixMismatchMode = iota // default
+	PrefixMismatchIgnore
+	PrefixMismatchDelete
+)
+
+func (p PrefixMismatchMode) String() string {
+	switch p {
+	case PrefixMismatchError:
+		return "ERROR"
+	case PrefixMismatchIgnore:
+		return "IGNORE"
+	case PrefixMismatchDelete:
+		return "DELETE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// OrphanCleanupConfig holds configuration for orphan file cleanup operations.
+type OrphanCleanupConfig struct {
+	location           string
+	olderThan          time.Time
+	dryRun             bool
+	deleteFunc         func(string) error
+	maxConcurrency     int
+	prefixMismatchMode PrefixMismatchMode
+	equalSchemes       map[string]string
+	equalAuthorities   map[string]string
+}
+
+type OrphanCleanupOption func(*OrphanCleanupConfig)
+
+func WithLocation(location string) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		cfg.location = location
+	}
+}
+
+func WithOlderThan(timestamp time.Time) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		cfg.olderThan = timestamp
+	}
+}
+
+func WithDryRun(enabled bool) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		cfg.dryRun = enabled
+	}
+}
+
+// WithDeleteFunc sets a custom delete function. If not provided, the table's FileIO
+// delete method will be used.
+func WithDeleteFunc(deleteFunc func(string) error) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		cfg.deleteFunc = deleteFunc
+	}
+}
+
+// WithMaxConcurrency sets the maximum number of goroutines for parallel deletion.
+// Defaults to a reasonable number based on the system. Only used when deleteFunc is nil or when
+// the FileIO doesn't support bulk operations.
+func WithMaxConcurrency(maxWorkers int) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		if maxWorkers > 0 {
+			cfg.maxConcurrency = maxWorkers
+		}
+	}
+}
+
+// WithPrefixMismatchMode sets how to handle situations when metadata references files
+// that match listed files except for authority/scheme differences.
+func WithPrefixMismatchMode(mode PrefixMismatchMode) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		cfg.prefixMismatchMode = mode
+	}
+}
+
+// WithEqualSchemes specifies schemes that should be considered equivalent.
+// For example, map["s3,s3a,s3n"] = "s3" treats all S3 scheme variants as equivalent.
+// The key can be a comma-separated list of schemes that map to the value scheme.
+func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		if cfg.equalSchemes == nil {
+			cfg.equalSchemes = make(map[string]string)
+		}
+		for k, v := range schemes {
+			cfg.equalSchemes[k] = v
+		}
+	}
+}
+
+// WithEqualAuthorities specifies authorities that should be considered equivalent.
+// For example, map["endpoint1.s3.amazonaws.com,endpoint2.s3.amazonaws.com"] = "s3.amazonaws.com"
+// treats different S3 endpoints as equivalent. The key can be a comma-separated list.
+func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
+	return func(cfg *OrphanCleanupConfig) {
+		if cfg.equalAuthorities == nil {
+			cfg.equalAuthorities = make(map[string]string)
+		}
+		for k, v := range authorities {
+			cfg.equalAuthorities[k] = v
+		}
+	}
+}
+
+type OrphanCleanupResult struct {
+	OrphanFileLocations []string
+	DeletedFiles        []string
+	TotalSizeBytes      int64
+}
+
+func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (*OrphanCleanupResult, error) {
+	cfg := &OrphanCleanupConfig{
+		location:           "",                           // empty means use table's data location
+		olderThan:          time.Now().AddDate(0, 0, -3), // 3 days ago
+		dryRun:             false,
+		deleteFunc:         nil,
+		maxConcurrency:     runtime.GOMAXPROCS(0), // default to number of CPUs
+		prefixMismatchMode: PrefixMismatchError,   // default to safest mode
+		equalSchemes:       nil,                   // no scheme equivalence by default
+		equalAuthorities:   nil,                   // no authority equivalence by default
+	}
+
+	// Apply functional options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return t.executeOrphanCleanup(ctx, cfg)
+}
+
+func (t Table) executeOrphanCleanup(ctx context.Context, cfg *OrphanCleanupConfig) (*OrphanCleanupResult, error) {
+	fs, err := t.fsF(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filesystem: %w", err)
+	}
+
+	scanLocation := cfg.location
+	if scanLocation == "" {
+		scanLocation = t.metadata.Location()
+	}
+
+	referencedFiles, err := t.getReferencedFiles(fs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get referenced files: %w", err)
+	}
+
+	allFiles, totalSize, err := t.scanFiles(fs, scanLocation, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan files: %w", err)
+	}
+
+	orphanFiles, err := identifyOrphanFiles(allFiles, referencedFiles, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to identify orphan files: %w", err)
+	}
+
+	result := &OrphanCleanupResult{
+		OrphanFileLocations: orphanFiles,
+		TotalSizeBytes:      totalSize,
+	}
+
+	if cfg.dryRun {
+		return result, nil
+	}
+	deletedFiles, err := deleteFiles(fs, orphanFiles, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete orphan files: %w", err)
+	}
+
+	result.DeletedFiles = deletedFiles
+
+	return result, nil
+}
+
+// getReferencedFiles collects all files referenced by current snapshots
+func (t Table) getReferencedFiles(fs iceio.IO) (map[string]bool, error) {
+	referenced := make(map[string]bool)
+	metadata := t.metadata
+
+	for entry := range metadata.PreviousFiles() {
+		referenced[entry.MetadataFile] = true
+	}
+	referenced[t.metadataLocation] = true
+
+	// Add version hint file (for Hadoop-style tables)
+	// Following Java's ReachableFileUtil.versionHintLocation() logic:
+	versionHintPath := filepath.Join(metadata.Location(), "metadata", "version-hint.text")
+	referenced[versionHintPath] = true
+
+	// TODO: Add statistics files support once iceberg-go exposes statisticsFiles()
+
+	for _, snapshot := range metadata.Snapshots() {
+		if snapshot.ManifestList != "" {
+			referenced[snapshot.ManifestList] = true
+		}
+
+		manifestFiles, err := snapshot.Manifests(fs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifests for snapshot %d: %w", snapshot.SnapshotID, err)
+		}
+
+		for _, manifest := range manifestFiles {
+			referenced[manifest.FilePath()] = true
+
+			entries, err := manifest.FetchEntries(fs, false)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read manifest entries: %w", err)
+			}
+
+			for _, entry := range entries {
+				referenced[entry.DataFile().FilePath()] = true
+			}
+		}
+	}
+
+	return referenced, nil
+}
+
+func (t Table) scanFiles(fs iceio.IO, location string, cfg *OrphanCleanupConfig) ([]string, int64, error) {
+	var allFiles []string
+	var totalSize int64
+
+	err := walkDirectory(fs, location, func(path string, info stdfs.FileInfo) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		if !info.ModTime().Before(cfg.olderThan) {
+			return nil // Skip files that are newer than or equal to the threshold
+		}
+
+		allFiles = append(allFiles, path)
+		totalSize += info.Size()
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return allFiles, totalSize, nil
+}
+
+func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
+	// Object stores (S3, GCS, etc.) - use ListIO interface for efficient listing
+	if strings.Contains(root, "://") {
+		if listFS, ok := fsys.(iceio.ListIO); ok {
+			return listFS.ListObjects(root, fn)
+		}
+
+		return fmt.Errorf("cannot list directory %s: storage system does not support listing operations", root)
+	}
+
+	// Local filesystem - use traditional recursive traversal
+	return walkLocalFileSystem(fsys, root, fn)
+}
+
+func walkLocalFileSystem(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
+	f, err := fsys.Open(root)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fn(root, info)
+	}
+
+	dirFile, ok := f.(iceio.ReadDirFile)
+	if !ok {
+		return fmt.Errorf("directory %s does not support ReadDir", root)
+	}
+
+	entries, err := dirFile.ReadDir(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(root, entry.Name())
+		entryInfo, err := entry.Info()
+		if err != nil {
+			continue // Skip entries we can't get info for
+		}
+		if entry.IsDir() {
+			if err := walkDirectory(fsys, entryPath, fn); err != nil {
+				return err
+			}
+		} else {
+			if err := fn(entryPath, entryInfo); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func identifyOrphanFiles(allFiles []string, referencedFiles map[string]bool, cfg *OrphanCleanupConfig) ([]string, error) {
+	var orphans []string
+
+	for _, file := range allFiles {
+		isOrphan, err := isFileOrphan(file, referencedFiles, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine if file %s is orphan: %w", file, err)
+		}
+
+		if isOrphan {
+			orphans = append(orphans, file)
+		}
+	}
+
+	return orphans, nil
+}
+
+func isFileOrphan(file string, referencedFiles map[string]bool, cfg *OrphanCleanupConfig) (bool, error) {
+	normalizedFile := normalizeFilePath(file, cfg)
+
+	if referencedFiles[file] || referencedFiles[normalizedFile] {
+		return false, nil
+	}
+
+	for referencedPath := range referencedFiles {
+		normalizedRef := normalizeFilePath(referencedPath, cfg)
+
+		if normalizedRef == normalizedFile {
+			err := checkPrefixMismatch(referencedPath, file, cfg)
+			if err != nil {
+				return false, err
+			}
+
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func deleteFiles(fs iceio.IO, orphanFiles []string, cfg *OrphanCleanupConfig) ([]string, error) {
+	if len(orphanFiles) == 0 {
+		return nil, nil
+	}
+
+	if cfg.maxConcurrency == 1 {
+		return deleteFilesSequential(fs, orphanFiles, cfg)
+	}
+
+	return deleteFilesParallel(fs, orphanFiles, cfg)
+}
+
+func deleteFilesSequential(fs iceio.IO, orphanFiles []string, cfg *OrphanCleanupConfig) ([]string, error) {
+	var deletedFiles []string
+
+	for _, file := range orphanFiles {
+		var err error
+
+		if cfg.deleteFunc != nil {
+			err = cfg.deleteFunc(file)
+		} else {
+			err = fs.Remove(file)
+		}
+
+		if err != nil {
+			// Log warning but continue with other files
+			fmt.Printf("Warning: failed to delete orphan file %s: %v\n", file, err)
+
+			continue
+		}
+
+		deletedFiles = append(deletedFiles, file)
+	}
+
+	return deletedFiles, nil
+}
+
+func deleteFilesParallel(fs iceio.IO, orphanFiles []string, cfg *OrphanCleanupConfig) ([]string, error) {
+	workChan := make(chan string, len(orphanFiles))
+	resultChan := make(chan deleteResult, len(orphanFiles))
+
+	var wg sync.WaitGroup
+	numWorkers := cfg.maxConcurrency
+	if numWorkers > len(orphanFiles) {
+		numWorkers = len(orphanFiles) // Don't create more workers than files
+	}
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go deleteWorker(&wg, workChan, resultChan, fs, cfg)
+	}
+
+	for _, file := range orphanFiles {
+		workChan <- file
+	}
+	close(workChan)
+
+	wg.Wait()
+	close(resultChan)
+
+	var deletedFiles []string
+	for result := range resultChan {
+		if result.err != nil {
+			fmt.Printf("Warning: failed to delete orphan file %s: %v\n", result.file, result.err)
+
+			continue
+		}
+		deletedFiles = append(deletedFiles, result.file)
+	}
+
+	return deletedFiles, nil
+}
+
+type deleteResult struct {
+	file string
+	err  error
+}
+
+func deleteWorker(wg *sync.WaitGroup, workChan <-chan string, resultChan chan<- deleteResult, fs iceio.IO, cfg *OrphanCleanupConfig) {
+	defer wg.Done()
+
+	for file := range workChan {
+		var err error
+
+		if cfg.deleteFunc != nil {
+			err = cfg.deleteFunc(file)
+		} else {
+			err = fs.Remove(file)
+		}
+
+		resultChan <- deleteResult{file: file, err: err}
+	}
+}
+
+// normalizeFilePath normalizes file paths for comparison by handling different
+// path representations that might refer to the same file, with support for
+// scheme/authority equivalence as specified in the configuration.
+func normalizeFilePath(path string, cfg *OrphanCleanupConfig) string {
+	// Handle URL-based paths (s3://, gs://, etc.)
+	if strings.Contains(path, "://") {
+		return normalizeURLPath(path, cfg)
+	} else {
+		return normalizeNonURLPath(path)
+	}
+}
+
+// normalizeURLPath normalizes URL-based file paths with scheme/authority equivalence
+func normalizeURLPath(path string, cfg *OrphanCleanupConfig) string {
+	parsedURL, err := url.Parse(path)
+	if err != nil {
+		return normalizeNonURLPath(path)
+	}
+
+	normalizedScheme := applySchemeEquivalence(parsedURL.Scheme, cfg.equalSchemes)
+	normalizedAuthority := applyAuthorityEquivalence(parsedURL.Host, cfg.equalAuthorities)
+	normalizedURL := &url.URL{
+		Scheme: normalizedScheme,
+		Host:   normalizedAuthority,
+		Path:   filepath.Clean(parsedURL.Path),
+	}
+
+	return normalizedURL.String()
+}
+
+// normalizeNonURLPath provides basic path normalization for non-URL paths
+func normalizeNonURLPath(path string) string {
+	normalized := filepath.Clean(path)
+
+	return strings.ReplaceAll(normalized, "\\", "/")
+}
+
+// applySchemeEquivalence maps schemes to their equivalent canonical form
+func applySchemeEquivalence(scheme string, equalSchemes map[string]string) string {
+	if equalSchemes == nil {
+		return scheme
+	}
+	if canonical, exists := equalSchemes[scheme]; exists {
+		return canonical
+	}
+
+	// Check comma-separated lists (e.g., "s3,s3a,s3n" -> "s3")
+	for schemes, canonical := range equalSchemes {
+		if strings.Contains(schemes, ",") {
+			for _, s := range strings.Split(schemes, ",") {
+				if strings.TrimSpace(s) == scheme {
+					return canonical
+				}
+			}
+		}
+	}
+
+	return scheme
+}
+
+// applyAuthorityEquivalence maps authorities to their equivalent canonical form
+func applyAuthorityEquivalence(authority string, equalAuthorities map[string]string) string {
+	if equalAuthorities == nil {
+		return authority
+	}
+
+	if canonical, exists := equalAuthorities[authority]; exists {
+		return canonical
+	}
+
+	for authorities, canonical := range equalAuthorities {
+		if strings.Contains(authorities, ",") {
+			for _, a := range strings.Split(authorities, ",") {
+				if strings.TrimSpace(a) == authority {
+					return canonical
+				}
+			}
+		}
+	}
+
+	return authority
+}
+
+// checkPrefixMismatch detects and handles prefix mismatches between referenced files and filesystem files
+func checkPrefixMismatch(referencedPath, filesystemPath string, cfg *OrphanCleanupConfig) error {
+	// Parse both paths as URLs to compare schemes and authorities
+	refURL, refErr := url.Parse(referencedPath)
+	fsURL, fsErr := url.Parse(filesystemPath)
+
+	if refErr != nil || fsErr != nil {
+		return nil
+	}
+
+	refScheme := applySchemeEquivalence(refURL.Scheme, cfg.equalSchemes)
+	fsScheme := applySchemeEquivalence(fsURL.Scheme, cfg.equalSchemes)
+	refAuth := applyAuthorityEquivalence(refURL.Host, cfg.equalAuthorities)
+	fsAuth := applyAuthorityEquivalence(fsURL.Host, cfg.equalAuthorities)
+
+	// Check for mismatches
+	schemeMismatch := refScheme != fsScheme
+	authMismatch := refAuth != fsAuth
+
+	if !schemeMismatch && !authMismatch {
+		return nil // No mismatch
+	}
+
+	switch cfg.prefixMismatchMode {
+	case PrefixMismatchError:
+		return fmt.Errorf("prefix mismatch detected: referenced=%s (scheme=%s, auth=%s) vs filesystem=%s (scheme=%s, auth=%s)",
+			referencedPath, refScheme, refAuth, filesystemPath, fsScheme, fsAuth)
+	case PrefixMismatchIgnore:
+		return nil // Silently ignore mismatch
+	case PrefixMismatchDelete:
+		return nil // Allow deletion (treat as orphan)
+	default:
+		return fmt.Errorf("unknown prefix mismatch mode: %d", cfg.prefixMismatchMode)
+	}
+}

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -288,7 +288,6 @@ func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig)
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, 0, err
 	}

--- a/table/orphan_cleanup_integration_test.go
+++ b/table/orphan_cleanup_integration_test.go
@@ -220,8 +220,8 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupDryRun() {
 	s.T().Logf("Scanning location: %s", tbl.Location())
 	result, err := tbl.DeleteOrphanFiles(s.ctx,
 		table.WithDryRun(true),
-		table.WithLocation(tbl.Location()),               // Scan the table root location
-		table.WithOlderThan(time.Now().Add(1*time.Hour)), // Consider all files (including future timestamp)
+		table.WithLocation(tbl.Location()),     // Scan the table root location
+		table.WithFilesOlderThan(-1*time.Hour), // Consider all files (including future timestamp)
 	)
 
 	s.Require().NoError(err)
@@ -268,7 +268,7 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupActualDeletion() {
 	// Run actual orphan cleanup
 	result, err := tbl.DeleteOrphanFiles(s.ctx,
 		table.WithDryRun(false),
-		table.WithOlderThan(time.Now().Add(1*time.Hour)), // Consider all files
+		table.WithFilesOlderThan(-1*time.Hour), // Consider all files
 	)
 
 	s.Require().NoError(err)
@@ -311,7 +311,7 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupCustomLocation() {
 	// Run orphan cleanup on table root (which includes the custom subdirectory)
 	result, err := tbl.DeleteOrphanFiles(s.ctx,
 		table.WithLocation(tbl.Location()), // Scan table root to find all subdirectories
-		table.WithOlderThan(time.Now().Add(1*time.Hour)),
+		table.WithFilesOlderThan(-1*time.Hour),
 		table.WithDryRun(false),
 	)
 
@@ -360,7 +360,7 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupWithConcurrency() {
 			// Run orphan cleanup with specific concurrency
 			result, err := tbl.DeleteOrphanFiles(s.ctx,
 				table.WithMaxConcurrency(tc.concurrency),
-				table.WithOlderThan(time.Now().Add(1*time.Hour)),
+				table.WithFilesOlderThan(-1*time.Hour),
 				table.WithDryRun(false),
 			)
 
@@ -400,7 +400,8 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupCustomDeleteFunction() 
 
 	result, err := tbl.DeleteOrphanFiles(s.ctx,
 		table.WithDeleteFunc(customDeleteFunc),
-		table.WithOlderThan(time.Now().Add(1*time.Hour)),
+		table.WithFilesOlderThan(-1*time.Hour),
+		table.WithDryRun(false),
 		table.WithDryRun(false),
 	)
 

--- a/table/orphan_cleanup_integration_test.go
+++ b/table/orphan_cleanup_integration_test.go
@@ -1,0 +1,431 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package table_test
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/rest"
+	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/suite"
+)
+
+type OrphanCleanupIntegrationSuite struct {
+	suite.Suite
+
+	ctx      context.Context
+	cat      *rest.Catalog
+	location string
+}
+
+const (
+	TestNamespace     = "orphan_test_ns"
+	TestTableName     = "orphan_test_table"
+	TestTableLocation = "s3://warehouse/iceberg/orphan_test"
+	OrphanFilePrefix  = "orphan_"
+)
+
+var (
+	tableSchemaSimple = iceberg.NewSchemaWithIdentifiers(1,
+		[]int{1},
+		iceberg.NestedField{
+			ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{
+			ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{
+			ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+	)
+)
+
+func (s *OrphanCleanupIntegrationSuite) loadCatalog() *rest.Catalog {
+	cat, err := catalog.Load(s.ctx, "local", iceberg.Properties{
+		"type":               "rest",
+		"uri":                "http://localhost:8181",
+		io.S3Region:          "us-east-1",
+		io.S3AccessKeyID:     "admin",
+		io.S3SecretAccessKey: "password",
+	})
+	s.Require().NoError(err)
+	s.Require().IsType(&rest.Catalog{}, cat)
+	return cat.(*rest.Catalog)
+}
+
+func (s *OrphanCleanupIntegrationSuite) SetupSuite() {
+	s.ctx = context.Background()
+	s.cat = s.loadCatalog()
+	s.location = TestTableLocation
+
+	// Ensure namespace exists
+	s.ensureNamespace()
+}
+
+func (s *OrphanCleanupIntegrationSuite) TearDownSuite() {
+	if exists, err := s.cat.CheckTableExists(s.ctx, catalog.ToIdentifier(TestNamespace, TestTableName)); err == nil && exists {
+		s.NoError(s.cat.DropTable(s.ctx, catalog.ToIdentifier(TestNamespace, TestTableName)))
+	}
+
+	if exists, err := s.cat.CheckNamespaceExists(s.ctx, catalog.ToIdentifier(TestNamespace)); err == nil && exists {
+		s.NoError(s.cat.DropNamespace(s.ctx, catalog.ToIdentifier(TestNamespace)))
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) SetupTest() {
+	if exists, err := s.cat.CheckTableExists(s.ctx, catalog.ToIdentifier(TestNamespace, TestTableName)); err == nil && exists {
+		s.Require().NoError(s.cat.DropTable(s.ctx, catalog.ToIdentifier(TestNamespace, TestTableName)))
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) ensureNamespace() {
+	namespace := catalog.ToIdentifier(TestNamespace)
+	exists, err := s.cat.CheckNamespaceExists(s.ctx, namespace)
+	s.Require().NoError(err)
+
+	if exists {
+		for tbl, err := range s.cat.ListTables(s.ctx, namespace) {
+			if err != nil {
+				break
+			}
+			err := s.cat.DropTable(s.ctx, tbl)
+			s.Require().NoError(err)
+		}
+
+		s.Require().NoError(s.cat.DropNamespace(s.ctx, namespace))
+	}
+
+	s.NoError(s.cat.CreateNamespace(s.ctx, namespace,
+		iceberg.Properties{"description": "Namespace for orphan cleanup integration tests"}))
+}
+
+func (s *OrphanCleanupIntegrationSuite) createTableWithData() *table.Table {
+	tbl, err := s.cat.CreateTable(s.ctx, catalog.ToIdentifier(TestNamespace, TestTableName), tableSchemaSimple,
+		catalog.WithLocation(s.location))
+	s.Require().NoError(err)
+	s.Require().NotNil(tbl)
+
+	// Create an arrow table with test data
+	arrSchema, err := table.SchemaToArrowSchema(tableSchemaSimple, nil, false, false)
+	s.Require().NoError(err)
+
+	arrowTable, err := array.TableFromJSON(memory.DefaultAllocator, arrSchema,
+		[]string{`[
+		{"id": 1, "name": "alice", "value": 100.5},
+		{"id": 2, "name": "bob", "value": 200.7},
+		{"id": 3, "name": "charlie", "value": 300.9}
+	]`})
+	s.Require().NoError(err)
+	defer arrowTable.Release()
+
+	dataFile, err := url.JoinPath(s.location, "data", "test_data.parquet")
+	s.Require().NoError(err)
+
+	fs := s.mustFS(tbl)
+	fw, err := fs.(io.WriteFileIO).Create(dataFile)
+	s.Require().NoError(err)
+	s.Require().NoError(pqarrow.WriteTable(arrowTable, fw, arrowTable.NumRows(),
+		nil, pqarrow.DefaultWriterProps()))
+
+	// Commit the data file to the table
+	txn := tbl.NewTransaction()
+	s.Require().NoError(txn.AddFiles(s.ctx, []string{dataFile}, nil, false))
+	updatedTable, err := txn.Commit(s.ctx)
+	s.Require().NoError(err)
+
+	return updatedTable
+}
+
+func (s *OrphanCleanupIntegrationSuite) createOrphanFiles(tbl *table.Table, location string, fileNames []string) []string {
+	fs := s.mustFS(tbl)
+	var createdPaths []string
+
+	for _, fileName := range fileNames {
+		// Create orphan files in the data directory
+		orphanPath, err := url.JoinPath(location, "data", OrphanFilePrefix+fileName)
+		s.Require().NoError(err)
+
+		// Write some fake contents to the orphan file
+		fw, err := fs.(io.WriteFileIO).Create(orphanPath)
+		s.Require().NoError(err)
+
+		content := []byte("This is an orphan file: " + fileName)
+		_, err = fw.Write(content)
+		s.Require().NoError(err)
+		s.Require().NoError(fw.Close())
+
+		createdPaths = append(createdPaths, orphanPath)
+	}
+
+	return createdPaths
+}
+
+func (s *OrphanCleanupIntegrationSuite) mustFS(tbl *table.Table) io.IO {
+	fs, err := tbl.FS(s.ctx)
+	s.Require().NoError(err)
+	return fs
+}
+
+func (s *OrphanCleanupIntegrationSuite) fileExists(fs io.IO, path string) bool {
+	f, err := fs.Open(path)
+	if err != nil {
+		return false
+	}
+	err = f.Close()
+	s.Require().NoError(err)
+	return true
+}
+
+func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupDryRun() {
+	// Create a table with real data
+	tbl := s.createTableWithData()
+
+	// Debug: Print locations
+	s.T().Logf("Table location: %s", tbl.Location())
+	s.T().Logf("Test location: %s", s.location)
+
+	orphanFiles := s.createOrphanFiles(tbl, s.location, []string{"old1.parquet", "old2.parquet", "old3.parquet"})
+
+	fs := s.mustFS(tbl)
+	for _, orphanFile := range orphanFiles {
+		s.True(s.fileExists(fs, orphanFile), "Orphan file should exist: %s", orphanFile)
+	}
+
+	// Run dry-run orphan cleanup (scan table root where both data and metadata exist)
+	s.T().Logf("Scanning location: %s", tbl.Location())
+	result, err := tbl.DeleteOrphanFiles(s.ctx,
+		table.WithDryRun(true),
+		table.WithLocation(tbl.Location()),               // Scan the table root location
+		table.WithOlderThan(time.Now().Add(1*time.Hour)), // Consider all files (including future timestamp)
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.GreaterOrEqual(len(result.OrphanFileLocations), 3, "Should identify at least 3 orphan files")
+	s.Empty(result.DeletedFiles, "Dry run should not delete any files")
+
+	for _, orphanFile := range orphanFiles {
+		s.True(s.fileExists(fs, orphanFile), "Orphan file should still exist after dry run: %s", orphanFile)
+	}
+
+	for _, orphanFile := range orphanFiles {
+		found := false
+		for _, identified := range result.OrphanFileLocations {
+			if strings.Contains(identified, filepath.Base(orphanFile)) {
+				found = true
+				break
+			}
+		}
+		s.True(found, "Created orphan file should be identified: %s", orphanFile)
+	}
+
+	for _, orphanFile := range orphanFiles {
+		s.NoError(fs.Remove(orphanFile))
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupActualDeletion() {
+	tbl := s.createTableWithData()
+
+	// Create some orphan files that are old enough to be deleted
+	orphanFiles := s.createOrphanFiles(tbl, s.location, []string{"delete1.parquet", "delete2.parquet"})
+
+	// Wait a moment to ensure files are old enough
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify orphan files exist
+	fs := s.mustFS(tbl)
+	for _, orphanFile := range orphanFiles {
+		s.True(s.fileExists(fs, orphanFile), "Orphan file should exist: %s", orphanFile)
+	}
+
+	// Run actual orphan cleanup
+	result, err := tbl.DeleteOrphanFiles(s.ctx,
+		table.WithDryRun(false),
+		table.WithOlderThan(time.Now().Add(1*time.Hour)), // Consider all files
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.GreaterOrEqual(len(result.OrphanFileLocations), 2, "Should identify at least 2 orphan files")
+	s.GreaterOrEqual(len(result.DeletedFiles), 2, "Should delete at least 2 orphan files")
+
+	for _, orphanFile := range orphanFiles {
+		s.False(s.fileExists(fs, orphanFile), "Orphan file should be deleted: %s", orphanFile)
+	}
+
+	for manifest, err := range tbl.AllManifests(s.ctx) {
+		s.Require().NoError(err)
+		entries, err := manifest.FetchEntries(fs, false)
+		s.Require().NoError(err)
+
+		for _, entry := range entries {
+			dataFile := entry.DataFile().FilePath()
+			s.True(s.fileExists(fs, dataFile), "Data file should still exist: %s", dataFile)
+		}
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupCustomLocation() {
+	tbl := s.createTableWithData()
+
+	customLocation, err := url.JoinPath(s.location, "custom_data")
+	s.Require().NoError(err)
+	orphanFiles := s.createOrphanFiles(tbl, customLocation, []string{"custom1.parquet", "custom2.parquet"})
+
+	fs := s.mustFS(tbl)
+	for _, orphanFile := range orphanFiles {
+		s.True(s.fileExists(fs, orphanFile), "Orphan file should exist: %s", orphanFile)
+	}
+
+	// Wait to ensure files are old enough
+	time.Sleep(100 * time.Millisecond)
+
+	// Run orphan cleanup on table root (which includes the custom subdirectory)
+	result, err := tbl.DeleteOrphanFiles(s.ctx,
+		table.WithLocation(tbl.Location()), // Scan table root to find all subdirectories
+		table.WithOlderThan(time.Now().Add(1*time.Hour)),
+		table.WithDryRun(false),
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.GreaterOrEqual(len(result.DeletedFiles), 2, "Should delete at least 2 files from custom location")
+
+	for _, orphanFile := range orphanFiles {
+		s.False(s.fileExists(fs, orphanFile), "Custom location orphan file should be deleted: %s", orphanFile)
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupWithConcurrency() {
+	// Create table with real data
+	tbl := s.createTableWithData()
+
+	// Create multiple orphan files for concurrent deletion testing
+	orphanFiles := s.createOrphanFiles(tbl, s.location, []string{
+		"concurrent1.parquet", "concurrent2.parquet", "concurrent3.parquet",
+		"concurrent4.parquet", "concurrent5.parquet",
+	})
+
+	// Wait to ensure files are old enough
+	time.Sleep(100 * time.Millisecond)
+
+	// Test different concurrency levels
+	testCases := []struct {
+		name        string
+		concurrency int
+	}{
+		{"sequential", 1},
+		{"parallel_2", 2},
+		{"parallel_4", 4},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create fresh orphan files for this test case
+			freshOrphanFiles := s.createOrphanFiles(tbl, s.location, []string{
+				tc.name + "_1.parquet", tc.name + "_2.parquet", tc.name + "_3.parquet",
+			})
+
+			time.Sleep(100 * time.Millisecond)
+
+			// Run orphan cleanup with specific concurrency
+			result, err := tbl.DeleteOrphanFiles(s.ctx,
+				table.WithMaxConcurrency(tc.concurrency),
+				table.WithOlderThan(time.Now().Add(1*time.Hour)),
+				table.WithDryRun(false),
+			)
+
+			s.Require().NoError(err)
+			s.Require().NotNil(result)
+
+			// Verify files were deleted regardless of concurrency level
+			s.GreaterOrEqual(len(result.DeletedFiles), 3, "Should delete at least 3 files with concurrency %d", tc.concurrency)
+
+			fs := s.mustFS(tbl)
+			for _, orphanFile := range freshOrphanFiles {
+				s.False(s.fileExists(fs, orphanFile), "Orphan file should be deleted with concurrency %d: %s", tc.concurrency, orphanFile)
+			}
+		})
+	}
+
+	// Clean up original orphan files
+	fs := s.mustFS(tbl)
+	for _, orphanFile := range orphanFiles {
+		fs.Remove(orphanFile) // Ignore errors, might already be deleted
+	}
+}
+
+func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupCustomDeleteFunction() {
+	tbl := s.createTableWithData()
+	orphanFiles := s.createOrphanFiles(tbl, s.location, []string{"custom_delete.parquet"})
+
+	// Wait to ensure files are old enough
+	time.Sleep(100 * time.Millisecond)
+
+	var deletedByCustomFunc []string
+	customDeleteFunc := func(filePath string) error {
+		deletedByCustomFunc = append(deletedByCustomFunc, filePath)
+		fs := s.mustFS(tbl)
+		return fs.Remove(filePath)
+	}
+
+	result, err := tbl.DeleteOrphanFiles(s.ctx,
+		table.WithDeleteFunc(customDeleteFunc),
+		table.WithOlderThan(time.Now().Add(1*time.Hour)),
+		table.WithDryRun(false),
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.GreaterOrEqual(len(deletedByCustomFunc), 1, "Custom delete function should be called")
+
+	fs := s.mustFS(tbl)
+	for _, orphanFile := range orphanFiles {
+		s.False(s.fileExists(fs, orphanFile), "Orphan file should be deleted by custom function: %s", orphanFile)
+	}
+
+	for _, orphanFile := range orphanFiles {
+		found := false
+		for _, deletedFile := range deletedByCustomFunc {
+			if strings.Contains(deletedFile, filepath.Base(orphanFile)) {
+				found = true
+				break
+			}
+		}
+		s.True(found, "Orphan file should be processed by custom delete function: %s", orphanFile)
+	}
+}
+
+func TestOrphanCleanupIntegration(t *testing.T) {
+	suite.Run(t, new(OrphanCleanupIntegrationSuite))
+}

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -49,9 +49,9 @@ func TestOrphanCleanupOptions(t *testing.T) {
 	WithLocation("/test/location")(cfg)
 	assert.Equal(t, "/test/location", cfg.location)
 
-	testTime := time.Now()
-	WithOlderThan(testTime)(cfg)
-	assert.Equal(t, testTime, cfg.olderThan)
+	testDuration := 24 * time.Hour
+	WithFilesOlderThan(testDuration)(cfg)
+	assert.Equal(t, testDuration, cfg.olderThan)
 
 	WithDryRun(true)(cfg)
 	assert.True(t, cfg.dryRun)

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -360,7 +360,6 @@ func TestIsFileOrphan(t *testing.T) {
 	for refPath := range referencedFiles {
 		normalizedPath := normalizeFilePath(refPath, cfg)
 		normalizedReferencedFiles[normalizedPath] = refPath
-		normalizedPath = normalizeNonURLPath(refPath)
 	}
 
 	for _, tt := range tests {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -44,7 +44,7 @@ func TestPrefixMismatchMode_String(t *testing.T) {
 }
 
 func TestOrphanCleanupOptions(t *testing.T) {
-	cfg := &OrphanCleanupConfig{}
+	cfg := &orphanCleanupConfig{}
 
 	WithLocation("/test/location")(cfg)
 	assert.Equal(t, "/test/location", cfg.location)
@@ -76,7 +76,7 @@ func TestOrphanCleanupOptions(t *testing.T) {
 }
 
 func TestNormalizeFilePath(t *testing.T) {
-	cfg := &OrphanCleanupConfig{
+	cfg := &orphanCleanupConfig{
 		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
 		equalAuthorities: map[string]string{"endpoint1,endpoint2": "canonical"},
 	}
@@ -235,7 +235,7 @@ func TestApplyAuthorityEquivalence(t *testing.T) {
 }
 
 func TestCheckPrefixMismatch(t *testing.T) {
-	cfg := &OrphanCleanupConfig{
+	cfg := &orphanCleanupConfig{
 		prefixMismatchMode: PrefixMismatchError,
 		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
 		equalAuthorities:   map[string]string{"host1,host2": "canonical"},
@@ -314,7 +314,7 @@ func TestCheckPrefixMismatch(t *testing.T) {
 }
 
 func TestIsFileOrphan(t *testing.T) {
-	cfg := &OrphanCleanupConfig{
+	cfg := &orphanCleanupConfig{
 		prefixMismatchMode: PrefixMismatchIgnore,
 		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
 	}
@@ -373,7 +373,7 @@ func TestIsFileOrphan(t *testing.T) {
 }
 
 func TestIdentifyOrphanFiles(t *testing.T) {
-	cfg := &OrphanCleanupConfig{
+	cfg := &orphanCleanupConfig{
 		prefixMismatchMode: PrefixMismatchIgnore,
 	}
 
@@ -401,7 +401,7 @@ func TestIdentifyOrphanFiles(t *testing.T) {
 }
 
 func TestNormalizeURLPath(t *testing.T) {
-	cfg := &OrphanCleanupConfig{
+	cfg := &orphanCleanupConfig{
 		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
 		equalAuthorities: map[string]string{"host1,host2": "canonical"},
 	}
@@ -442,7 +442,7 @@ func TestNormalizeURLPath(t *testing.T) {
 }
 
 func TestNormalizeURLPath_InvalidURL(t *testing.T) {
-	cfg := &OrphanCleanupConfig{}
+	cfg := &orphanCleanupConfig{}
 
 	result := normalizeURLPath("not-a-valid-url", cfg)
 	expected := normalizeNonURLPath("not-a-valid-url")
@@ -451,7 +451,7 @@ func TestNormalizeURLPath_InvalidURL(t *testing.T) {
 
 func TestOrphanCleanup_EdgeCases(t *testing.T) {
 	t.Run("prefix_mismatch_unknown_mode", func(t *testing.T) {
-		cfg := &OrphanCleanupConfig{
+		cfg := &orphanCleanupConfig{
 			prefixMismatchMode: PrefixMismatchMode(999), // Invalid mode
 		}
 

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -356,10 +356,16 @@ func TestIsFileOrphan(t *testing.T) {
 			expectOrphan: true,
 		},
 	}
+	normalizedReferencedFiles := make(map[string]string)
+	for refPath := range referencedFiles {
+		normalizedPath := normalizeFilePath(refPath, cfg)
+		normalizedReferencedFiles[normalizedPath] = refPath
+		normalizedPath = normalizeNonURLPath(refPath)
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isOrphan, err := isFileOrphan(tt.file, referencedFiles, cfg)
+			isOrphan, err := isFileOrphan(tt.file, referencedFiles, normalizedReferencedFiles, cfg)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectOrphan, isOrphan)
 		})

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -1,0 +1,465 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixMismatchMode_String(t *testing.T) {
+	tests := []struct {
+		mode     PrefixMismatchMode
+		expected string
+	}{
+		{PrefixMismatchError, "ERROR"},
+		{PrefixMismatchIgnore, "IGNORE"},
+		{PrefixMismatchDelete, "DELETE"},
+		{PrefixMismatchMode(999), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.mode.String())
+		})
+	}
+}
+
+func TestOrphanCleanupOptions(t *testing.T) {
+	cfg := &OrphanCleanupConfig{}
+
+	WithLocation("/test/location")(cfg)
+	assert.Equal(t, "/test/location", cfg.location)
+
+	testTime := time.Now()
+	WithOlderThan(testTime)(cfg)
+	assert.Equal(t, testTime, cfg.olderThan)
+
+	WithDryRun(true)(cfg)
+	assert.True(t, cfg.dryRun)
+
+	deleteFunc := func(string) error { return nil }
+	WithDeleteFunc(deleteFunc)(cfg)
+	assert.NotNil(t, cfg.deleteFunc)
+
+	WithMaxConcurrency(8)(cfg)
+	assert.Equal(t, 8, cfg.maxConcurrency)
+
+	WithPrefixMismatchMode(PrefixMismatchIgnore)(cfg)
+	assert.Equal(t, PrefixMismatchIgnore, cfg.prefixMismatchMode)
+
+	schemes := map[string]string{"s3,s3a,s3n": "s3"}
+	WithEqualSchemes(schemes)(cfg)
+	assert.Equal(t, schemes, cfg.equalSchemes)
+
+	authorities := map[string]string{"host1,host2": "canonical"}
+	WithEqualAuthorities(authorities)(cfg)
+	assert.Equal(t, authorities, cfg.equalAuthorities)
+}
+
+func TestNormalizeFilePath(t *testing.T) {
+	cfg := &OrphanCleanupConfig{
+		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
+		equalAuthorities: map[string]string{"endpoint1,endpoint2": "canonical"},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "local_path",
+			input:    "/local/path/file.txt",
+			expected: "/local/path/file.txt",
+		},
+		{
+			name:     "windows_path",
+			input:    "C:\\Windows\\path\\file.txt",
+			expected: "C:/Windows/path/file.txt",
+		},
+		{
+			name:     "s3_url",
+			input:    "s3://bucket/path/file.txt",
+			expected: "s3://bucket/path/file.txt",
+		},
+		{
+			name:     "s3a_to_s3_scheme_equivalence",
+			input:    "s3a://bucket/path/file.txt",
+			expected: "s3://bucket/path/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeFilePath(tt.input, cfg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeNonURLPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unix_path",
+			input:    "/path/to/file.txt",
+			expected: "/path/to/file.txt",
+		},
+		{
+			name:     "windows_path",
+			input:    "C:\\Windows\\path\\file.txt",
+			expected: "C:/Windows/path/file.txt",
+		},
+		{
+			name:     "relative_path",
+			input:    "./relative/path/../file.txt",
+			expected: "relative/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeNonURLPath(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestApplySchemeEquivalence(t *testing.T) {
+	equalSchemes := map[string]string{
+		"s3,s3a,s3n": "s3",
+		"gs":         "gs",
+	}
+
+	tests := []struct {
+		name     string
+		scheme   string
+		expected string
+	}{
+		{
+			name:     "s3_unchanged",
+			scheme:   "s3",
+			expected: "s3",
+		},
+		{
+			name:     "s3a_to_s3",
+			scheme:   "s3a",
+			expected: "s3",
+		},
+		{
+			name:     "s3n_to_s3",
+			scheme:   "s3n",
+			expected: "s3",
+		},
+		{
+			name:     "gs_unchanged",
+			scheme:   "gs",
+			expected: "gs",
+		},
+		{
+			name:     "unknown_scheme",
+			scheme:   "unknown",
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applySchemeEquivalence(tt.scheme, equalSchemes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestApplyAuthorityEquivalence(t *testing.T) {
+	equalAuthorities := map[string]string{
+		"host1,host2": "canonical",
+		"single":      "single",
+	}
+
+	tests := []struct {
+		name      string
+		authority string
+		expected  string
+	}{
+		{
+			name:      "host1_to_canonical",
+			authority: "host1",
+			expected:  "canonical",
+		},
+		{
+			name:      "host2_to_canonical",
+			authority: "host2",
+			expected:  "canonical",
+		},
+		{
+			name:      "single_unchanged",
+			authority: "single",
+			expected:  "single",
+		},
+		{
+			name:      "unknown_authority",
+			authority: "unknown",
+			expected:  "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyAuthorityEquivalence(tt.authority, equalAuthorities)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCheckPrefixMismatch(t *testing.T) {
+	cfg := &OrphanCleanupConfig{
+		prefixMismatchMode: PrefixMismatchError,
+		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
+		equalAuthorities:   map[string]string{"host1,host2": "canonical"},
+	}
+
+	tests := []struct {
+		name           string
+		referencedPath string
+		filesystemPath string
+		mode           PrefixMismatchMode
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "no_mismatch",
+			referencedPath: "s3://bucket/path/file.txt",
+			filesystemPath: "s3://bucket/path/file.txt",
+			mode:           PrefixMismatchError,
+			expectError:    false,
+		},
+		{
+			name:           "scheme_mismatch_error_mode",
+			referencedPath: "s3://bucket/path/file.txt",
+			filesystemPath: "gs://bucket/path/file.txt",
+			mode:           PrefixMismatchError,
+			expectError:    true,
+			errorContains:  "prefix mismatch detected",
+		},
+		{
+			name:           "scheme_mismatch_ignore_mode",
+			referencedPath: "s3://bucket/path/file.txt",
+			filesystemPath: "gs://bucket/path/file.txt",
+			mode:           PrefixMismatchIgnore,
+			expectError:    false,
+		},
+		{
+			name:           "scheme_mismatch_delete_mode",
+			referencedPath: "s3://bucket/path/file.txt",
+			filesystemPath: "gs://bucket/path/file.txt",
+			mode:           PrefixMismatchDelete,
+			expectError:    false,
+		},
+		{
+			name:           "equivalent_schemes",
+			referencedPath: "s3://bucket/path/file.txt",
+			filesystemPath: "s3a://bucket/path/file.txt",
+			mode:           PrefixMismatchError,
+			expectError:    false,
+		},
+		{
+			name:           "non_url_paths",
+			referencedPath: "/local/path/file.txt",
+			filesystemPath: "/local/path/file.txt",
+			mode:           PrefixMismatchError,
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testCfg := *cfg
+			testCfg.prefixMismatchMode = tt.mode
+
+			err := checkPrefixMismatch(tt.referencedPath, tt.filesystemPath, &testCfg)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsFileOrphan(t *testing.T) {
+	cfg := &OrphanCleanupConfig{
+		prefixMismatchMode: PrefixMismatchIgnore,
+		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
+	}
+
+	referencedFiles := map[string]bool{
+		"s3://bucket/data/file1.parquet":     true,
+		"s3://bucket/metadata/manifest.avro": true,
+		"/local/path/file2.parquet":          true,
+	}
+
+	tests := []struct {
+		name         string
+		file         string
+		expectOrphan bool
+	}{
+		{
+			name:         "referenced_file_exact_match",
+			file:         "s3://bucket/data/file1.parquet",
+			expectOrphan: false,
+		},
+		{
+			name:         "referenced_file_scheme_equivalence",
+			file:         "s3a://bucket/data/file1.parquet",
+			expectOrphan: false,
+		},
+		{
+			name:         "orphan_file",
+			file:         "s3://bucket/data/orphan.parquet",
+			expectOrphan: true,
+		},
+		{
+			name:         "local_referenced_file",
+			file:         "/local/path/file2.parquet",
+			expectOrphan: false,
+		},
+		{
+			name:         "local_orphan_file",
+			file:         "/local/path/orphan.parquet",
+			expectOrphan: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isOrphan, err := isFileOrphan(tt.file, referencedFiles, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectOrphan, isOrphan)
+		})
+	}
+}
+
+func TestIdentifyOrphanFiles(t *testing.T) {
+	cfg := &OrphanCleanupConfig{
+		prefixMismatchMode: PrefixMismatchIgnore,
+	}
+
+	allFiles := []string{
+		"s3://bucket/data/file1.parquet",
+		"s3://bucket/data/file2.parquet",
+		"s3://bucket/data/orphan1.parquet",
+		"s3://bucket/data/orphan2.parquet",
+	}
+
+	referencedFiles := map[string]bool{
+		"s3://bucket/data/file1.parquet": true,
+		"s3://bucket/data/file2.parquet": true,
+	}
+
+	orphans, err := identifyOrphanFiles(allFiles, referencedFiles, cfg)
+	require.NoError(t, err)
+
+	expectedOrphans := []string{
+		"s3://bucket/data/orphan1.parquet",
+		"s3://bucket/data/orphan2.parquet",
+	}
+
+	assert.ElementsMatch(t, expectedOrphans, orphans)
+}
+
+func TestNormalizeURLPath(t *testing.T) {
+	cfg := &OrphanCleanupConfig{
+		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
+		equalAuthorities: map[string]string{"host1,host2": "canonical"},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple_s3_url",
+			input:    "s3://bucket/path/file.txt",
+			expected: "s3://bucket/path/file.txt",
+		},
+		{
+			name:     "s3a_to_s3_conversion",
+			input:    "s3a://bucket/path/file.txt",
+			expected: "s3://bucket/path/file.txt",
+		},
+		{
+			name:     "authority_equivalence",
+			input:    "s3://host1/path/file.txt",
+			expected: "s3://canonical/path/file.txt",
+		},
+		{
+			name:     "complex_path_cleaning",
+			input:    "s3://bucket/path/../other/./file.txt",
+			expected: "s3://bucket/other/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeURLPath(tt.input, cfg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeURLPath_InvalidURL(t *testing.T) {
+	cfg := &OrphanCleanupConfig{}
+
+	result := normalizeURLPath("not-a-valid-url", cfg)
+	expected := normalizeNonURLPath("not-a-valid-url")
+	assert.Equal(t, expected, result)
+}
+
+func TestOrphanCleanup_EdgeCases(t *testing.T) {
+	t.Run("prefix_mismatch_unknown_mode", func(t *testing.T) {
+		cfg := &OrphanCleanupConfig{
+			prefixMismatchMode: PrefixMismatchMode(999), // Invalid mode
+		}
+
+		err := checkPrefixMismatch("s3://bucket/file", "gs://bucket/file", cfg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown prefix mismatch mode")
+	})
+
+	t.Run("empty_scheme_authority_maps", func(t *testing.T) {
+		// Test with nil maps
+		result := applySchemeEquivalence("s3", nil)
+		assert.Equal(t, "s3", result)
+
+		result = applyAuthorityEquivalence("host", nil)
+		assert.Equal(t, "host", result)
+	})
+}


### PR DESCRIPTION
Hi team,

I believe the `DeleteOrphanFiles` functionality is a valuable addition toward making iceberg-go more feature-complete. This implementation was drafted with reference to the official [Iceberg Java API specification](https://iceberg.apache.org/javadoc/1.2.0/org/apache/iceberg/actions/DeleteOrphanFiles.html).

The PR also includes corresponding unit and integration tests to ensure reliability. Below is some example usages:
```
// Example usage:

// Dry run to see what would be deleted
result, err := table.DeleteOrphanFiles(ctx,
	WithDryRun(true),
	WithOlderThan(time.Now().AddDate(0, 0, -7)),
)

// Actually delete orphan files with parallel execution
result, err = table.DeleteOrphanFiles(ctx,
	WithOlderThan(time.Now().AddDate(0, 0, -3)),
	WithMaxConcurrency(8),
)

// Advanced usage with scheme equivalence and prefix mismatch handling
result, err = table.DeleteOrphanFiles(ctx,
	WithLocation("s3://my-bucket/table/data"),
	WithOlderThan(time.Now().AddDate(0, 0, -7)),
	WithEqualSchemes(map[string]string{"s3,s3a,s3n": "s3"}),
	WithPrefixMismatchMode(PrefixMismatchIgnore),
	WithDeleteFunc(customDeleteFunction),
)

```