### PR TITLE
feat(table): Implement delete files snapshot producer API

### DIFF
--- a/table/transaction.go
+++ b/table/transaction.go
@@ -58,6 +58,10 @@ func (s snapshotUpdate) mergeAppend() *snapshotProducer {
 	return newMergeAppendFilesProducer(OpAppend, s.txn, s.io, nil, s.snapshotProps)
 }
 
+func (s snapshotUpdate) delete() *snapshotProducer {
+	return newDeleteFilesProducer(OpDelete, s.txn, s.io, nil, s.snapshotProps)
+}
+
 type Transaction struct {
 	tbl  *Table
 	meta *MetadataBuilder


### PR DESCRIPTION
### Description
* Add delete files snapshot producer API for marking manifest entry as deleted based on a predicate
* Being used as part of https://github.com/apache/iceberg-go/pull/518
* This only helps deletes on manifest level when the entire partition or data file matched the predicate. For partial matched data file, a rewrite is still needed in the table delete.

### Testing
Pending to add unit tests