### PR TITLE
refactor(catalog/glue): remove database_type parameter in Glue catalog operations

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -43,10 +43,9 @@ import (
 const (
 	// Use the same conventions as in the pyiceberg project.
 	// See: https://github.com/apache/iceberg-python/blob/main/pyiceberg/catalog/__init__.py#L82-L96
-	glueTypeIceberg      = "ICEBERG"
-	databaseTypePropsKey = "database_type"
-	tableTypePropsKey    = "table_type"
-	descriptionPropsKey  = "Description"
+	glueTypeIceberg     = "ICEBERG"
+	tableTypePropsKey   = "table_type"
+	descriptionPropsKey = "Description"
 
 	// Database location.
 	locationPropsKey = "Location"
@@ -519,10 +518,7 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
-	databaseParameters := map[string]string{
-		databaseTypePropsKey: glueTypeIceberg,
-	}
-
+	databaseParameters := map[string]string{}
 	description := props[descriptionPropsKey]
 	locationURI := props[locationPropsKey]
 
@@ -708,10 +704,6 @@ func (c *Catalog) getDatabase(ctx context.Context, databaseName string) (*types.
 		}
 
 		return nil, fmt.Errorf("failed to get namespace %s: %w", databaseName, err)
-	}
-
-	if database.Database.Parameters[databaseTypePropsKey] != glueTypeIceberg {
-		return nil, fmt.Errorf("namespace %s is not an iceberg namespace", databaseName)
 	}
 
 	return database.Database, nil

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -411,7 +411,7 @@ func TestGlueListNamespaces(t *testing.T) {
 
 	databases, err := glueCatalog.ListNamespaces(context.TODO(), nil)
 	assert.NoError(err)
-	assert.Len(databases, 1)
+	assert.Len(databases, 2)
 	assert.Equal([]string{"test_database"}, databases[0])
 }
 
@@ -449,9 +449,8 @@ func TestGlueCreateNamespace(t *testing.T) {
 		DatabaseInput: &types.DatabaseInput{
 			Name: aws.String("test_namespace"),
 			Parameters: map[string]string{
-				databaseTypePropsKey: glueTypeIceberg,
-				descriptionPropsKey:  "Test Description",
-				locationPropsKey:     "s3://test-location",
+				descriptionPropsKey: "Test Description",
+				locationPropsKey:    "s3://test-location",
 			},
 		},
 	}, mock.Anything).Return(&glue.CreateDatabaseOutput{}, nil).Once()
@@ -651,8 +650,6 @@ func TestGlueUpdateNamespaceProperties(t *testing.T) {
 			assert := require.New(t)
 
 			mockGlueSvc := &mockGlueClient{}
-
-			tt.initial[databaseTypePropsKey] = glueTypeIceberg
 
 			mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 				Name: aws.String("test_namespace"),


### PR DESCRIPTION
### Description

This PR removes the requirement for the `database_type` parameter in both `ListNamespaces` and `CreateNamespace` operations for the Glue catalog to align with the Java and Python versions of Apache Iceberg.

### Background

After reviewing the Java and Python implementations of Apache Iceberg, we found that neither version uses the `database_type` parameter in their Glue catalog operations. The Go implementation was unnecessarily handling this parameter, which was inconsistent with the reference implementations.

This inconsistency caused a practical issue: namespaces created using pyiceberg could not be listed in the Go implementation because pyiceberg doesn't set the `database_type` parameter, while the Go version required it for filtering.

### Changes

- **ListNamespaces**: Removed filtering logic that checked `database_type` in database parameters
- **CreateNamespace**: Removed the `database_type` parameter from database creation
- Updated to use AWS SDK paginator for improved reliability
