### PR TITLE
refactor(metadata): remove newLastColumnID check in AddSchema method

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -261,11 +261,6 @@ func (b *MetadataBuilder) currentSnapshot() *Snapshot {
 }
 
 func (b *MetadataBuilder) AddSchema(schema *iceberg.Schema) (*MetadataBuilder, error) {
-	newLastColumnID := schema.HighestFieldID()
-	if newLastColumnID < b.lastColumnId {
-		return nil, fmt.Errorf("%w: newLastColumnID %d, must be >= %d", iceberg.ErrInvalidArgument, newLastColumnID, b.lastColumnId)
-	}
-
 	newSchemaID := b.reuseOrCreateNewSchemaID(schema)
 
 	if _, err := b.GetSchemaByID(newSchemaID); err == nil {


### PR DESCRIPTION
This PR removes the newLastColumnID validation check in the MetadataBuilder.AddSchema method. The previous validation required that the new schema's highest field ID must be greater than or equal to the current lastColumnId, but this constraint was incorrect because when columns are deleted from a schema, the HighestFieldID() can legitimately be smaller than the existing lastColumnId.