### PR TITLE
refactor(catalog/internal): Improve error handling in WriteTableMetadata and WriteMetadata functions

### DIFF
--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -47,9 +47,11 @@ func WriteTableMetadata(metadata table.Metadata, fs io.WriteFileIO, loc string) 
 	if err != nil {
 		return nil
 	}
-	defer out.Close()
 
-	return json.NewEncoder(out).Encode(metadata)
+	return errors.Join(
+		json.NewEncoder(out).Encode(metadata),
+		out.Close(),
+	)
 }
 
 func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, props iceberg.Properties) error {
@@ -68,9 +70,10 @@ func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, pro
 		return nil
 	}
 
-	defer out.Close()
-
-	return json.NewEncoder(out).Encode(metadata)
+	return errors.Join(
+		json.NewEncoder(out).Encode(metadata),
+		out.Close(),
+	)
 }
 
 func UpdateTableMetadata(base table.Metadata, updates []table.Update, metadataLoc string) (table.Metadata, error) {


### PR DESCRIPTION
### Changes

- Updated the `WriteTableMetadata` and `WriteMetadata` functions to use `errors.Join` for better error handling, ensuring that both JSON encoding errors and file close errors are properly captured and returned.
- This fix is particularly important for S3 storage where the actual upload happens during `Close()`, and previous implementation would silently ignore S3 upload failures.