### PR TITLE
refactor(catalog): remove `props` parameter from LoadTable and change `table.Table` to `table.Identifier` in CommitTable

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -86,12 +86,12 @@ type Catalog interface {
 	// and custom properties.
 	CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...CreateTableOpt) (*table.Table, error)
 	// CommitTable commits the table metadata and updates to the catalog, returning the new metadata
-	CommitTable(context.Context, *table.Table, []table.Requirement, []table.Update) (table.Metadata, string, error)
+	CommitTable(ctx context.Context, identifier table.Identifier, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error)
 	// ListTables returns a list of table identifiers in the catalog, with the returned
 	// identifiers containing the information required to load the table via that catalog.
 	ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error]
 	// LoadTable loads a table from the catalog and returns a Table with the metadata.
-	LoadTable(ctx context.Context, identifier table.Identifier, props iceberg.Properties) (*table.Table, error)
+	LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error)
 	// DropTable tells the catalog to drop the table entirely.
 	DropTable(ctx context.Context, identifier table.Identifier) error
 	// RenameTable tells the catalog to rename a given table by the identifiers

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -871,7 +871,7 @@ func TestGlueLoadTableIntegration(t *testing.T) {
 
 	ctlg := NewCatalog(WithAwsConfig(awsCfg))
 
-	tbl, err := ctlg.LoadTable(context.TODO(), []string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")}, nil)
+	tbl, err := ctlg.LoadTable(context.TODO(), []string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")})
 	assert.NoError(err)
 	assert.Equal([]string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")}, tbl.Identifier())
 }
@@ -909,7 +909,7 @@ func TestGlueCreateTableSuccessIntegration(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 	ctlg := NewCatalog(WithAwsConfig(awsCfg))
-	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName}, nil)
+	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName})
 	assert.NoError(err)
 	assert.Equal([]string{dbName, sourceTableName}, sourceTable.Identifier())
 	newTableName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), sourceTableName)
@@ -921,7 +921,7 @@ func TestGlueCreateTableSuccessIntegration(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]string{dbName, newTableName}, newTable.Identifier())
 
-	tableNewLoaded, err := ctlg.LoadTable(context.TODO(), []string{dbName, newTableName}, nil)
+	tableNewLoaded, err := ctlg.LoadTable(context.TODO(), []string{dbName, newTableName})
 	assert.NoError(err)
 	assert.Equal([]string{dbName, newTableName}, tableNewLoaded.Identifier())
 	assert.Equal(sourceTable.Schema().Fields(), tableNewLoaded.Schema().Fields())
@@ -952,7 +952,7 @@ func TestGlueCreateTableInvalidMetadataRollback(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 	ctlg := NewCatalog(WithAwsConfig(awsCfg))
-	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName}, nil)
+	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName})
 	assert.NoError(err)
 	newTableName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), sourceTableName)
 	createOpts := []catalog.CreateTableOpt{
@@ -960,7 +960,7 @@ func TestGlueCreateTableInvalidMetadataRollback(t *testing.T) {
 	}
 	_, err = ctlg.CreateTable(context.TODO(), TableIdentifier(dbName, newTableName), sourceTable.Schema(), createOpts...)
 	assert.Error(err, "expected error when creating table with invalid metadata location")
-	_, err = ctlg.LoadTable(context.TODO(), []string{dbName, newTableName}, nil)
+	_, err = ctlg.LoadTable(context.TODO(), []string{dbName, newTableName})
 	assert.Error(err, "expected table to not exist after failed creation")
 	assert.True(strings.Contains(err.Error(), "table does not exist"), "expected EntityNotFoundException error")
 	// Verify that the table was not left in the catalog
@@ -1090,7 +1090,7 @@ func TestAlterTableIntegration(t *testing.T) {
 	_, err = ctlg.CreateTable(context.TODO(), tbIdent, schema, createOpts...)
 	assert.NoError(err)
 
-	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 	assert.Equal(testProps, testTable.Properties())
 	assert.True(schema.Equals(testTable.Schema()))
@@ -1105,12 +1105,12 @@ func TestAlterTableIntegration(t *testing.T) {
 	})
 	_, _, err = ctlg.CommitTable(
 		context.TODO(),
-		testTable,
+		testTable.Identifier(),
 		nil,
 		[]table.Update{updateProps},
 	)
 	assert.NoError(err)
-	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 	assert.Equal(iceberg.Properties{
 		"write.parquet.compression-codec": "zstd",
@@ -1122,12 +1122,12 @@ func TestAlterTableIntegration(t *testing.T) {
 	removeProps := table.NewRemovePropertiesUpdate([]string{"key"})
 	_, _, err = ctlg.CommitTable(
 		context.TODO(),
-		testTable,
+		testTable.Identifier(),
 		nil,
 		[]table.Update{removeProps},
 	)
 	assert.NoError(err)
-	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 	assert.Equal(iceberg.Properties{
 		"write.parquet.compression-codec": "zstd",
@@ -1150,12 +1150,12 @@ func TestAlterTableIntegration(t *testing.T) {
 
 	_, _, err = ctlg.CommitTable(
 		context.TODO(),
-		testTable,
+		testTable.Identifier(),
 		nil,
 		[]table.Update{updateColumns, setSchema},
 	)
 	assert.NoError(err)
-	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 	assert.Equal(newFields, testTable.Schema().Fields())
 }
@@ -1184,7 +1184,7 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 	_, err = ctlg.CreateTable(context.TODO(), tbIdent, testSchema, createOpts...)
 	assert.NoError(err)
 
-	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 
 	// Test add new snapshot
@@ -1200,12 +1200,12 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 		},
 	}
 
-	_, _, err = ctlg.CommitTable(context.TODO(), testTable, nil, []table.Update{
+	_, _, err = ctlg.CommitTable(context.TODO(), testTable.Identifier(), nil, []table.Update{
 		table.NewAddSnapshotUpdate(&newSnap),
 	})
 	assert.NoError(err)
 
-	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 
 	actualSnap := testTable.SnapshotByID(25)
@@ -1218,13 +1218,13 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 	assert.Equal(newSnap.Summary.Operation, actualSnap.Summary.Operation)
 
 	// Test update current snapshot
-	_, _, err = ctlg.CommitTable(context.TODO(), testTable, nil, []table.Update{
+	_, _, err = ctlg.CommitTable(context.TODO(), testTable.Identifier(), nil, []table.Update{
 		table.NewSetSnapshotRefUpdate(table.MainBranch, 25, table.BranchRef,
 			-1, -1, -1),
 	})
 	assert.NoError(err)
 
-	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err = ctlg.LoadTable(context.TODO(), tbIdent)
 	assert.NoError(err)
 
 	currSnap := testTable.CurrentSnapshot()
@@ -1274,7 +1274,7 @@ func TestGlueCheckTableNotExists(t *testing.T) {
 func cleanupTable(t *testing.T, ctlg catalog.Catalog, tbIdent table.Identifier, awsCfg aws.Config) {
 	t.Helper()
 
-	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent, nil)
+	testTable, err := ctlg.LoadTable(context.TODO(), tbIdent)
 	if err != nil {
 		t.Logf("Warning: Failed to load table %s: %v", tbIdent, err)
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -780,9 +780,7 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config)
 }
 
-func (r *Catalog) CommitTable(ctx context.Context, tbl *table.Table, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
-	ident := tbl.Identifier()
-
+func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns, tblName, err := splitIdentForPath(ident)
 	if err != nil {
 		return nil, "", err
@@ -838,7 +836,7 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config)
 }
 
-func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, props iceberg.Properties) (*table.Table, error) {
+func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
@@ -851,7 +849,6 @@ func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier, pr
 	}
 
 	config := maps.Clone(r.props)
-	maps.Copy(config, props)
 	maps.Copy(config, ret.Metadata.Properties())
 	for k, v := range ret.Config {
 		config[k] = v
@@ -937,7 +934,7 @@ func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		return nil, err
 	}
 
-	return r.LoadTable(ctx, to, nil)
+	return r.LoadTable(ctx, to)
 }
 
 func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1173,7 +1173,7 @@ func (r *RestCatalogSuite) TestLoadTable200() {
 	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
-	tbl, err := cat.LoadTable(context.Background(), catalog.ToIdentifier("fokko", "table"), nil)
+	tbl, err := cat.LoadTable(context.Background(), catalog.ToIdentifier("fokko", "table"))
 	r.Require().NoError(err)
 
 	r.Equal(catalog.ToIdentifier("fokko", "table"), tbl.Identifier())

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -609,11 +609,11 @@ func (s *SqliteCatalogTestSuite) TestLoadTableFromSelfIdentifier() {
 		table, err := tt.cat.CreateTable(context.Background(), tt.tblID, tableSchemaNested)
 		s.Require().NoError(err)
 
-		intermediate, err := tt.cat.LoadTable(context.Background(), tt.tblID, nil)
+		intermediate, err := tt.cat.LoadTable(context.Background(), tt.tblID)
 		s.Require().NoError(err)
 		s.Equal(intermediate.Identifier(), table.Identifier())
 
-		loaded, err := tt.cat.LoadTable(context.Background(), intermediate.Identifier(), nil)
+		loaded, err := tt.cat.LoadTable(context.Background(), intermediate.Identifier())
 		s.Require().NoError(err)
 
 		s.Equal(table.Identifier(), loaded.Identifier())
@@ -639,10 +639,10 @@ func (s *SqliteCatalogTestSuite) TestDropTable() {
 
 		s.Equal(tt.tblID, table.Identifier())
 		s.NoError(tt.cat.DropTable(context.Background(), tt.tblID))
-		_, err = tt.cat.LoadTable(context.Background(), tt.tblID, nil)
+		_, err = tt.cat.LoadTable(context.Background(), tt.tblID)
 		s.ErrorIs(err, catalog.ErrNoSuchTable)
 
-		_, err = tt.cat.LoadTable(context.Background(), table.Identifier(), nil)
+		_, err = tt.cat.LoadTable(context.Background(), table.Identifier())
 		s.ErrorIs(err, catalog.ErrNoSuchTable)
 	}
 }
@@ -651,7 +651,7 @@ func (s *SqliteCatalogTestSuite) TestLoadTableNotExists() {
 	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
 
 	for _, cat := range catalogs {
-		_, err := cat.LoadTable(context.Background(), s.randomTableIdentifier(), nil)
+		_, err := cat.LoadTable(context.Background(), s.randomTableIdentifier())
 		s.ErrorIs(err, catalog.ErrNoSuchTable)
 	}
 }
@@ -664,7 +664,7 @@ func (s *SqliteCatalogTestSuite) TestLoadTableInvalidMetadata() {
 			VALUES ('default', 'default', 'invalid_metadata')`)
 	s.Require().NoError(err)
 
-	_, err = cat.LoadTable(context.Background(), table.Identifier{"default", "invalid_metadata"}, nil)
+	_, err = cat.LoadTable(context.Background(), table.Identifier{"default", "invalid_metadata"})
 	s.ErrorIs(err, catalog.ErrNoSuchTable)
 }
 
@@ -704,7 +704,7 @@ func (s *SqliteCatalogTestSuite) TestRenameTable() {
 		s.Equal(tt.toTable, renamed.Identifier())
 		s.Equal(table.MetadataLocation(), renamed.MetadataLocation())
 
-		_, err = tt.cat.LoadTable(ctx, tt.fromTable, nil)
+		_, err = tt.cat.LoadTable(ctx, tt.fromTable)
 		s.ErrorIs(err, catalog.ErrNoSuchTable)
 	}
 }

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -381,7 +381,7 @@ func describe(ctx context.Context, output Output, cat catalog.Catalog, id string
 	}
 
 	if (entityType == "any" || entityType == "tbl") && len(ident) > 1 {
-		tbl, err := cat.LoadTable(ctx, ident, nil)
+		tbl, err := cat.LoadTable(ctx, ident)
 		if err != nil {
 			if !errors.Is(err, catalog.ErrNoSuchTable) || entityType != "any" {
 				output.Error(err)
@@ -401,7 +401,7 @@ func describe(ctx context.Context, output Output, cat catalog.Catalog, id string
 }
 
 func loadTable(ctx context.Context, output Output, cat catalog.Catalog, id string) *table.Table {
-	tbl, err := cat.LoadTable(ctx, catalog.ToIdentifier(id), nil)
+	tbl, err := cat.LoadTable(ctx, catalog.ToIdentifier(id))
 	if err != nil {
 		output.Error(err)
 		os.Exit(1)
@@ -460,7 +460,7 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 			}
 		case args.table:
 			tbl := loadTable(ctx, output, cat, args.identifier)
-			_, _, err := cat.CommitTable(ctx, tbl, nil,
+			_, _, err := cat.CommitTable(ctx, tbl.Identifier(), nil,
 				[]table.Update{table.NewSetPropertiesUpdate(iceberg.Properties{args.propname: args.value})})
 			if err != nil {
 				output.Error(err)
@@ -481,7 +481,7 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 		case args.table:
 			tbl := loadTable(ctx, output, cat, args.identifier)
 
-			_, _, err := cat.CommitTable(ctx, tbl, nil,
+			_, _, err := cat.CommitTable(ctx, tbl.Identifier(), nil,
 				[]table.Update{table.NewRemovePropertiesUpdate([]string{args.propname})})
 			if err != nil {
 				output.Error(err)

--- a/table/table.go
+++ b/table/table.go
@@ -38,8 +38,8 @@ type FSysF func(ctx context.Context) (io.IO, error)
 type Identifier = []string
 
 type CatalogIO interface {
-	LoadTable(context.Context, Identifier, iceberg.Properties) (*Table, error)
-	CommitTable(context.Context, *Table, []Requirement, []Update) (Metadata, string, error)
+	LoadTable(context.Context, Identifier) (*Table, error)
+	CommitTable(context.Context, Identifier, []Requirement, []Update) (Metadata, string, error)
 }
 
 type Table struct {
@@ -93,7 +93,7 @@ func (t Table) NewTransaction() *Transaction {
 }
 
 func (t *Table) Refresh(ctx context.Context) error {
-	fresh, err := t.cat.LoadTable(ctx, t.identifier, nil)
+	fresh, err := t.cat.LoadTable(ctx, t.identifier)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 }
 
 func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requirement) (*Table, error) {
-	newMeta, newLoc, err := t.cat.CommitTable(ctx, &t, reqs, updates)
+	newMeta, newLoc, err := t.cat.CommitTable(ctx, t.identifier, reqs, updates)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### PR Description

In our team's usage of the `Catalog` interface, we found the `LoadTable` and `CommitTable` methods to be somewhat confusing.

1. **LoadTable**: The `props` parameter was included in the interface, but it was not actually used. All IO-related properties are already encapsulated within the catalog's own properties. In practice, this parameter was often set to `nil`, which made its presence unnecessary. Notably, in the Python, Rust, and Java implementations, the `LoadTable` method does not include the `props` parameter at all.

2. **CommitTable**: Across all catalog implementations, including `rest`, `glue`, and `sql`, the `tbl.Identifier()` was consistently used. When calculating the `StageTable`, the current table was reloaded using `LoadTable`, yet the parameter required was a `table.Table`. This inconsistency prompted the need for change. In the Rust and Java implementations, `CommitTable` already uses `table.Identifier`. In the Python implementation, while it uses `table.Table`, it similarly does not utilize any methods other than `tbl.Identifier()`.

To address these issues, I have made the following changes in this PR:
- Removed the `props` parameter from the `LoadTable` method.
- Changed the `table.Table` parameter to `table.Identifier` in the `CommitTable` method.

If there are any misunderstandings or if I've missed something, please let me know so we can clarify or close this PR.
