### PR TITLE
fix(manifest): Interpret manifest files written without `content` metadata as `data` files

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -601,6 +601,13 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 
 	var content ManifestContent
 	switch contentStr := string(metadata["content"]); contentStr {
+	case "":
+		if formatVersion != 1 {
+			return nil, fmt.Errorf("manifest file's 'content' metadata is missing and 'format-version' is %d, but the field is required for 'format-version' 2 and beyond",
+				formatVersion)
+		}
+		// V1 manifests do not contain the 'content' field, but should be interpretted as 'data' files
+		content = ManifestContentData
 	case "data":
 		content = ManifestContentData
 	case "deletes":


### PR DESCRIPTION
fixes: #544 

V1 writers may not specify `content` at all when writing manifest files, but since this predates `delete` files these should be interpretted as `data` files ([https://iceberg.apache.org/spec/#manifests](https://iceberg.apache.org/spec/#manifests)).

_Side Note: It could be helpful to have a `iceberg-testing` repo similar to `parquet-testing` or `arrow-testing` that contains a bunch of files serialized to different standards of the spec. I don't know if this exists already but it was a bit tricky producing a manifest file to use for a unit test since the V1 writer included writes `content=data` for compatibility. I started creating new writer that omits that one field but it seemed like more to maintain than it was worth for that one test._