### PR TITLE
feat: Add `rest.Catalog` Option to provide custom `http.RoundTripper`

### DIFF
--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -19,6 +19,7 @@ package rest
 
 import (
 	"crypto/tls"
+	"net/http"
 	"net/url"
 
 	"github.com/apache/iceberg-go"
@@ -108,6 +109,12 @@ func WithAdditionalProps(props iceberg.Properties) Option {
 	}
 }
 
+func WithCustomTransport(transport http.RoundTripper) Option {
+	return func(o *options) {
+		o.transport = transport
+	}
+}
+
 type options struct {
 	awsConfig         aws.Config
 	awsConfigSet      bool
@@ -122,6 +129,7 @@ type options struct {
 	prefix            string
 	authUri           *url.URL
 	scope             string
+	transport         http.RoundTripper
 
 	additionalProps iceberg.Properties
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2112,3 +2112,39 @@ func (r *RestCatalogSuite) TestCreateView404() {
 	r.Error(err)
 	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
+
+type mockTransport struct {
+	calls []struct {
+		method, path string
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (m *mockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	m.calls = append(m.calls, struct {
+		method string
+		path   string
+	}{method: r.Method, path: r.URL.Path})
+	return http.DefaultTransport.RoundTrip(r)
+}
+
+func (r *RestCatalogSuite) TestCatalogWithCustomTransport() {
+	var transport mockTransport
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithCustomTransport(&transport))
+	r.NoError(err)
+	r.NotNil(cat)
+
+	r.Len(transport.calls, 1)
+	r.Equal("GET", transport.calls[0].method)
+	r.Equal("/v1/config", transport.calls[0].path)
+
+	// Not expected to succeed
+	tbl, err := cat.LoadTable(context.Background(), table.Identifier{"unknown"})
+	r.Error(err)
+	r.Nil(tbl)
+
+	r.Len(transport.calls, 2)
+	r.Equal("GET", transport.calls[1].method)
+	r.Equal("/v1/namespaces/tables/unknown", transport.calls[1].path)
+}


### PR DESCRIPTION
fixes: #551

Enables customization of the catalog's `http.Client.Transport` via the `http.RoundTripper` interface. Technically certain existing options such as `options.tlsConfig` could be achieved by specifying a `options.transport` with that config set, but the option is left in for compatibility.