### PR TITLE
feat(metadata): PartitionSpec builder & validations

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -76,6 +76,15 @@ type CreateTableCfg struct {
 	Properties    iceberg.Properties
 }
 
+func NewCreateTableCfg() CreateTableCfg {
+	return CreateTableCfg{
+		Location:      "",
+		PartitionSpec: nil,
+		SortOrder:     table.UnsortedSortOrder,
+		Properties:    nil,
+	}
+}
+
 // Catalog for iceberg table operations like create, drop, load, list and others.
 type Catalog interface {
 	// CatalogType returns the type of the catalog.

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -750,27 +750,12 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		o(&cfg)
 	}
 
-	freshSchema, err := iceberg.AssignFreshSchemaIDs(schema, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	freshPartitionSpec, err := iceberg.AssignFreshPartitionSpecIDs(cfg.PartitionSpec, schema, freshSchema)
-	if err != nil {
-		return nil, err
-	}
-
-	freshSortOrder, err := table.AssignFreshSortOrderIDs(cfg.SortOrder, schema, freshSchema)
-	if err != nil {
-		return nil, err
-	}
-
 	payload := createTableRequest{
 		Name:          tbl,
-		Schema:        freshSchema,
+		Schema:        schema,
 		Location:      cfg.Location,
-		PartitionSpec: &freshPartitionSpec,
-		WriteOrder:    &freshSortOrder,
+		PartitionSpec: cfg.PartitionSpec,
+		WriteOrder:    &cfg.SortOrder,
 		StageCreate:   false,
 		Props:         cfg.Properties,
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -745,9 +745,13 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
-	var cfg catalog.CreateTableCfg
+	cfg := catalog.NewCreateTableCfg()
 	for _, o := range opts {
 		o(&cfg)
+	}
+
+	if cfg.SortOrder.Fields == nil && cfg.SortOrder.OrderID == 0 {
+		cfg.SortOrder = table.UnsortedSortOrder
 	}
 
 	payload := createTableRequest{

--- a/partitions.go
+++ b/partitions.go
@@ -120,7 +120,7 @@ func AddPartitionFieldBySourceID(sourceID int, targetName string, transform Tran
 		if !ok {
 			return fmt.Errorf("cannot find source column with id: %d in schema", sourceID)
 		}
-		err := addSpecFieldInternal(p, targetName, field, transform, fieldID)
+		err := p.addSpecFieldInternal(targetName, field, transform, fieldID)
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ func AddPartitionFieldBySourceID(sourceID int, targetName string, transform Tran
 	}
 }
 
-func addSpecFieldInternal(p *PartitionSpec, targetName string, field NestedField, transform Transform, fieldID *int) error {
+func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedField, transform Transform, fieldID *int) error {
 	if targetName == "" {
 		return errors.New("cannot use empty partition name")
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -189,9 +189,14 @@ func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedFiel
 }
 
 func (p *PartitionSpec) checkForRedundantPartitions(sourceID int, transform Transform) error {
-	for _, field := range p.fields {
-		if field.SourceID == sourceID && field.Transform.String() == transform.String() {
-			return fmt.Errorf("cannot add redundant partition with source id %d and transform %s. A partition with the same source id and transform already exists with name: %s", sourceID, transform, field.Name)
+	if fields, ok := p.sourceIdToFields[sourceID]; ok {
+		for _, f := range fields {
+			if f.Transform.Equals(transform) {
+				return fmt.Errorf("cannot add redundant partition with source id %d and transform %s. A partition with the same source id and transform already exists with name: %s",
+					sourceID,
+					transform,
+					f.Name)
+			}
 		}
 	}
 

--- a/partitions.go
+++ b/partitions.go
@@ -19,6 +19,7 @@ package iceberg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"net/url"
@@ -30,6 +31,7 @@ import (
 const (
 	PartitionDataIDStart   = 1000
 	InitialPartitionSpecID = 0
+	unassignedFieldID      = 0
 )
 
 // UnpartitionedSpec is the default unpartitioned spec which can
@@ -83,6 +85,130 @@ type PartitionSpec struct {
 
 	// this is populated by initialize after creation
 	sourceIdToFields map[int][]PartitionField
+}
+
+type PartitionOption func(*PartitionSpec) error
+
+func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
+	spec := PartitionSpec{
+		id: 0,
+	}
+	for _, opt := range opts {
+		if err := opt(&spec); err != nil {
+			return PartitionSpec{}, err
+		}
+	}
+	spec.initialize()
+
+	return spec, nil
+}
+
+func WithSpecID(id int) PartitionOption {
+	return func(p *PartitionSpec) error {
+		p.id = id
+
+		return nil
+	}
+}
+
+func AddPartitionFieldBySourceID(sourceID int, targetName string, transform Transform, schema *Schema, fieldID *int) PartitionOption {
+	return func(p *PartitionSpec) error {
+		if schema == nil {
+			return errors.New("cannot add partition field with nil schema")
+		}
+		field, ok := schema.FindFieldByID(sourceID)
+		if !ok {
+			return fmt.Errorf("cannot find source column with id: %d in schema", sourceID)
+		}
+		err := addSpecFieldInternal(p, targetName, field, transform, fieldID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func addSpecFieldInternal(p *PartitionSpec, targetName string, field NestedField, transform Transform, fieldID *int) error {
+	if targetName == "" {
+		return errors.New("cannot use empty partition name")
+	}
+	for _, existingField := range p.fields {
+		if existingField.Name == targetName {
+			return errors.New("duplicate partition name: " + targetName)
+		}
+	}
+	var fieldIDValue int
+	if fieldID == nil {
+		fieldIDValue = unassignedFieldID
+	} else {
+		fieldIDValue = *fieldID
+	}
+	if err := p.checkForRedundantPartitions(field.ID, transform); err != nil {
+		return err
+	}
+	unboundField := PartitionField{
+		SourceID:  field.ID,
+		FieldID:   fieldIDValue,
+		Name:      targetName,
+		Transform: transform,
+	}
+	p.fields = append(p.fields, unboundField)
+
+	return nil
+}
+
+func (p *PartitionSpec) checkForRedundantPartitions(sourceID int, transform Transform) error {
+	for _, field := range p.fields {
+		if field.SourceID == sourceID && field.Transform.String() == transform.String() {
+			return fmt.Errorf("cannot add redundant partition with source id %d and transform %s. A partition with the same source id and transform already exists with name: %s", sourceID, transform, field.Name)
+		}
+	}
+
+	return nil
+}
+
+func (p *PartitionSpec) SetID(id int) {
+	p.id = id
+}
+
+func (ps *PartitionSpec) AssignPartitionFieldIds(lastAssignedFieldIDPtr *int) error {
+	// This is set_field_ids from iceberg-rust
+	// Already assigned partition ids. If we see one of these during iteration,
+	// we skip it.
+	assignedIds := make(map[int]struct{})
+	for _, field := range ps.fields {
+		if field.FieldID != unassignedFieldID {
+			if _, exists := assignedIds[field.FieldID]; exists {
+				return fmt.Errorf("duplicate field ID provided: %d", field.FieldID)
+			}
+			assignedIds[field.FieldID] = struct{}{}
+		}
+	}
+
+	lastAssignedFieldID := ps.LastAssignedFieldID()
+	if lastAssignedFieldIDPtr != nil {
+		lastAssignedFieldID = *lastAssignedFieldIDPtr
+	}
+	for i := range ps.fields {
+		if ps.fields[i].FieldID == unassignedFieldID {
+			// Find the next available ID by incrementing from the last known good ID.
+			lastAssignedFieldID++
+			for {
+				if _, exists := assignedIds[lastAssignedFieldID]; !exists {
+					break // Found an unused ID.
+				}
+				lastAssignedFieldID++
+			}
+
+			// Assign the new ID and immediately record it as used.
+			ps.fields[i].FieldID = lastAssignedFieldID
+		} else {
+			lastAssignedFieldID = max(lastAssignedFieldID, ps.fields[i].FieldID)
+		}
+	}
+
+	return nil
 }
 
 func NewPartitionSpec(fields ...PartitionField) PartitionSpec {
@@ -207,6 +333,11 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 		if f.FieldID > id {
 			id = f.FieldID
 		}
+	}
+
+	if id == unassignedFieldID {
+		// If no fields have been assigned an ID, return the default starting ID.
+		return PartitionDataIDStart - 1
 	}
 
 	return id

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -44,6 +44,7 @@ func constructTestTable(t *testing.T, writeStats []string) (*metadata.FileMetaDa
         "last-column-id": 7,
         "current-schema-id": 0,
 		"last-updated-ms": -1,
+		"last-partition-id": 0,
         "schemas": [
             {
                 "type": "struct",

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -68,6 +68,7 @@ func constructTestTablePrimitiveTypes(t *testing.T) (*metadata.FileMetaData, tab
                 ]
             }
         ],
+		"last-partition-id": 0,	
 		"last-updated-ms": -1,
         "default-spec-id": 0,
         "partition-specs": [{"spec-id": 0, "fields": []}],

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -134,8 +134,6 @@ type Metadata interface {
 	NameMapping() iceberg.NameMapping
 
 	LastSequenceNumber() int64
-
-	FormatVersion() int
 }
 
 type MetadataBuilder struct {
@@ -1243,10 +1241,6 @@ func initMetadataV1Deser() *metadataV1 {
 	}
 }
 
-func (m *metadataV1) FormatVersion() int {
-	return 1
-}
-
 func (m *metadataV1) LastSequenceNumber() int64 { return 0 }
 
 func (m *metadataV1) Equals(other Metadata) bool {
@@ -1344,10 +1338,6 @@ func initMetadataV2Deser() *metadataV2 {
 		LastSeqNum:     -1,
 		commonMetadata: initCommonMetadataForDeserialization(),
 	}
-}
-
-func (m *metadataV2) FormatVersion() int {
-	return 2
 }
 
 func (m *metadataV2) LastSequenceNumber() int64 { return m.LastSeqNum }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -958,24 +958,10 @@ type commonMetadata struct {
 
 func initCommonMetadataForDeserialization() commonMetadata {
 	return commonMetadata{
-		FormatVersion:      0,
-		UUID:               uuid.UUID{},
-		Loc:                "",
-		LastUpdatedMS:      -1,
-		LastColumnId:       -1,
-		SchemaList:         nil,
-		CurrentSchemaID:    -1,
-		Specs:              nil,
-		DefaultSpecID:      -1,
-		LastPartitionID:    nil,
-		Props:              nil,
-		SnapshotList:       nil,
-		CurrentSnapshotID:  nil,
-		SnapshotLog:        nil,
-		MetadataLog:        nil,
-		SortOrderList:      nil,
-		DefaultSortOrderID: 0,
-		SnapshotRefs:       nil,
+		LastUpdatedMS:   -1,
+		LastColumnId:    -1,
+		CurrentSchemaID: -1,
+		DefaultSpecID:   -1,
 	}
 }
 
@@ -1253,8 +1239,6 @@ type metadataV1 struct {
 
 func initMetadataV1Deser() *metadataV1 {
 	return &metadataV1{
-		Schema:         nil,
-		Partition:      nil,
 		commonMetadata: initCommonMetadataForDeserialization(),
 	}
 }

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -18,9 +18,11 @@
 package table
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,6 +96,129 @@ func builderWithoutChanges(formatVersion int) MetadataBuilder {
 	return *builder
 }
 
+func TestAddRemovePartitionSpec(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	builderRef := &builder
+	i := 1000
+	addedSpec, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(10), iceberg.AddPartitionFieldBySourceID(2, "y", iceberg.IdentityTransform{}, builder.schemaList[0], &i), iceberg.AddPartitionFieldBySourceID(3, "z", iceberg.IdentityTransform{}, builder.schemaList[0], nil))
+	require.NoError(t, err)
+
+	builderRef, err = builderRef.AddPartitionSpec(&addedSpec, false)
+	require.NoError(t, err)
+	metadata, err := builderRef.Build()
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	i2 := 1001
+	expectedSpec, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(1), iceberg.AddPartitionFieldBySourceID(2, "y", iceberg.IdentityTransform{}, builder.schemaList[0], &i), iceberg.AddPartitionFieldBySourceID(3, "z", iceberg.IdentityTransform{}, builder.schemaList[0], &i2))
+	require.NoError(t, err)
+	require.Equal(t, metadata.DefaultPartitionSpec(), 0)
+	require.Equal(t, *metadata.LastPartitionSpecID(), i2)
+	found := false
+	for _, part := range metadata.PartitionSpecs() {
+		if part.ID() == 1 {
+			found = true
+			require.True(t, part.Equals(expectedSpec), "expected partition spec to match added spec")
+		}
+	}
+	require.True(t, found, "expected partition spec to be added")
+
+	newBuilder, err := MetadataBuilderFromBase(metadata)
+	require.NoError(t, err)
+	// Remove the spec
+	newBuilderRef, err := newBuilder.RemovePartitionSpecs([]int{1})
+	require.NoError(t, err)
+	newBuild, err := newBuilderRef.Build()
+	require.NoError(t, err)
+	require.NotNil(t, newBuild)
+	require.Len(t, newBuilder.updates, 1)
+	require.Len(t, newBuild.PartitionSpecs(), 1)
+	_, err = newBuilder.GetSpecByID(1)
+	require.ErrorContains(t, err, "partition spec with id 1 not found")
+}
+
+func TestSetDefaultPartitionSpec(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	curSchema, err := builder.GetSchemaByID(builder.currentSchemaID)
+	require.NoError(t, err)
+	// Add a partition spec
+	addedSpec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(10),
+		iceberg.AddPartitionFieldBySourceID(1, "y_bucket[2]", iceberg.BucketTransform{NumBuckets: 2}, curSchema, nil))
+	require.NoError(t, err)
+	builderRef, err := builder.AddPartitionSpec(&addedSpec, false)
+	require.NoError(t, err)
+	// Set the default partition spec
+	builderRef, err = builderRef.SetDefaultSpecID(-1)
+	require.NoError(t, err)
+
+	id := 1001
+	expectedSpec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldBySourceID(1, "y_bucket[2]", iceberg.BucketTransform{NumBuckets: 2}, curSchema, &id))
+	require.NoError(t, err)
+	require.True(t, builderRef.HasChanges())
+	require.Equal(t, len(builderRef.updates), 2)
+	require.True(t, builderRef.updates[0].(*addPartitionSpecUpdate).Spec.Equals(addedSpec))
+	require.Equal(t, -1, builderRef.updates[1].(*setDefaultSpecUpdate).SpecID)
+	metadata, err := builderRef.Build()
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	require.Equal(t, metadata.DefaultPartitionSpec(), 1)
+	require.True(t, expectedSpec.Equals(metadata.PartitionSpec()), fmt.Sprintf("expected partition spec to match added spec %s, %s", spew.Sdump(expectedSpec), spew.Sdump(metadata.PartitionSpec())))
+	require.Equal(t, *metadata.LastPartitionSpecID(), 1001)
+}
+
+func TestSetExistingDefaultPartitionSpec(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	curSchema, err := builder.GetSchemaByID(builder.currentSchemaID)
+	require.NoError(t, err)
+
+	addedSpec, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(10), iceberg.AddPartitionFieldBySourceID(1, "y_bucket[2]", iceberg.BucketTransform{NumBuckets: 2}, curSchema, nil))
+	require.NoError(t, err)
+
+	builderRef, err := builder.AddPartitionSpec(&addedSpec, false)
+	require.NoError(t, err)
+
+	builderRef, err = builderRef.SetDefaultSpecID(-1)
+	require.NoError(t, err)
+
+	require.True(t, builderRef.HasChanges())
+	require.Len(t, builderRef.updates, 2)
+	require.True(t, builderRef.updates[0].(*addPartitionSpecUpdate).Spec.Equals(addedSpec))
+	require.Equal(t, -1, builderRef.updates[1].(*setDefaultSpecUpdate).SpecID)
+
+	metadata, err := builderRef.Build()
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	require.Equal(t, 1, metadata.DefaultPartitionSpec())
+
+	id := 1001
+	expectedSpec, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(1), iceberg.AddPartitionFieldBySourceID(1, "y_bucket[2]", iceberg.BucketTransform{NumBuckets: 2}, curSchema, &id))
+	require.NoError(t, err)
+	require.True(t, expectedSpec.Equals(metadata.PartitionSpec()), "expected partition spec to match added spec")
+
+	newBuilder, err := MetadataBuilderFromBase(metadata)
+	require.NoError(t, err)
+	require.NotNil(t, newBuilder)
+
+	newBuilderRef, err := newBuilder.SetDefaultSpecID(0)
+	require.NoError(t, err)
+
+	require.True(t, newBuilderRef.HasChanges(), "expected changes after setting default spec")
+	require.Len(t, newBuilderRef.updates, 1, "expected one update")
+	require.Equal(t, 0, newBuilderRef.updates[0].(*setDefaultSpecUpdate).SpecID, "expected default partition spec to be set to 0")
+
+	newBuild, err := newBuilderRef.Build()
+	require.NoError(t, err)
+	require.NotNil(t, newBuild)
+	require.Equal(t, 0, newBuild.DefaultPartitionSpec(), "expected default partition spec to be set to 0")
+
+	newWithoutChanges := builderWithoutChanges(2)
+	require.True(t, newWithoutChanges.specs[0].Equals(newBuild.PartitionSpec()), "expected partition spec to match added spec")
+}
+
 func TestSetRef(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	schemaID := 0
@@ -127,6 +252,21 @@ func TestSetRef(t *testing.T) {
 	require.Equal(t, snap.SnapshotID, int64(1))
 	require.True(t, snap.Equals(snapshot), "expected snapshot to match added snapshot")
 	require.Len(t, builder.snapshotLog, 1)
+}
+
+func TestAddPartitionSpecForV1RequiresSequentialIDs(t *testing.T) {
+	builder := builderWithoutChanges(1)
+
+	// Add a partition spec with non-sequential IDs
+	id := 1000
+	id2 := 1002
+	addedSpec, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(10),
+		iceberg.AddPartitionFieldBySourceID(2, "y", iceberg.IdentityTransform{}, builder.CurrentSchema(), &id),
+		iceberg.AddPartitionFieldBySourceID(3, "z", iceberg.IdentityTransform{}, builder.CurrentSchema(), &id2))
+	require.NoError(t, err)
+
+	_, err = builder.AddPartitionSpec(&addedSpec, false)
+	require.ErrorContains(t, err, "v1 constraint: partition field IDs are not sequential: expected 1001, got 1002")
 }
 
 func TestSetBranchSnapshotCreatesBranchIfNotExists(t *testing.T) {
@@ -212,4 +352,11 @@ func TestRemoveMainSnapshotRef(t *testing.T) {
 	meta, err = builder.Build()
 	require.NoError(t, err)
 	require.NotNil(t, meta)
+}
+
+func TestDefaultSpecCannotBeRemoved(t *testing.T) {
+	builder := builderWithoutChanges(2)
+
+	_, err := builder.RemovePartitionSpecs([]int{0})
+	require.ErrorContains(t, err, "can't remove default partition spec with id 0")
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -959,7 +959,7 @@ func TestTableMetadataV1PartitionSpecsWithoutDefaultId(t *testing.T) {
 	// Deserialize the JSON - this should succeed by inferring default_spec_id as the max spec ID
 	meta, err := getTestTableMetadata("TableMetadataV1PartitionSpecsWithoutDefaultId.json")
 	require.NoError(t, err)
-	require.Equal(t, meta.(*metadataV1).FormatVersion(), 1)
+	require.Equal(t, meta.Version(), 1)
 	require.Equal(t, meta.TableUUID(), uuid.MustParse("d20125c8-7284-442c-9aea-15fee620737c"))
 	require.Equal(t, meta.DefaultPartitionSpec(), 2)
 	require.Equal(t, len(meta.PartitionSpecs()), 2)

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -902,6 +902,7 @@ func TestMetadataV2Validation(t *testing.T) {
 		"last-sequence-number": 34,
 		"current-schema-id": 0,
 		"last-updated-ms": 1602638573590,
+		"last-partition-id": 1000,
 		"schemas": [{"type":"struct","schema-id":0,"fields":[]}],
 		"default-spec-id": 0,
 		"partition-specs": [{"spec-id": 0, "fields": []}],
@@ -917,6 +918,7 @@ func TestMetadataV2Validation(t *testing.T) {
 		"last-updated-ms": 1602638573874,
 		"last-column-id": 5,
 		"current-schema-id": 0,
+		"last-partition-id": 1000,
 		"schemas": [{"type":"struct","schema-id":0,"fields":[]}],
 		"partition-specs": [{"spec-id": 0, "fields": []}],
 		"properties": {},
@@ -933,6 +935,7 @@ func TestMetadataV2Validation(t *testing.T) {
 		"current-schema-id": 0,
 		"last-updated-ms": 1602638573590,
 		"last-column-id": 0,
+		"last-partition-id": 1000,
 		"schemas": [{"type":"struct","schema-id":0,"fields":[]}],
 		"partition-specs": [{"spec-id": 0, "fields": []}],
 		"sort-orders": [],
@@ -950,6 +953,50 @@ func TestMetadataV2Validation(t *testing.T) {
 
 	// Test case 3: Verify LastColumnId maintains 0 when explicitly set
 	require.NoError(t, meta3.UnmarshalJSON([]byte(zeroColumnID)))
+}
+
+func TestTableMetadataV1PartitionSpecsWithoutDefaultId(t *testing.T) {
+	// Deserialize the JSON - this should succeed by inferring default_spec_id as the max spec ID
+	meta, err := getTestTableMetadata("TableMetadataV1PartitionSpecsWithoutDefaultId.json")
+	require.NoError(t, err)
+	require.Equal(t, meta.(*metadataV1).FormatVersion(), 1)
+	require.Equal(t, meta.TableUUID(), uuid.MustParse("d20125c8-7284-442c-9aea-15fee620737c"))
+	require.Equal(t, meta.DefaultPartitionSpec(), 2)
+	require.Equal(t, len(meta.PartitionSpecs()), 2)
+	spec := meta.PartitionSpec()
+	require.Equal(t, spec.ID(), 2)
+	require.Equal(t, spec.NumFields(), 1)
+	require.Equal(t, spec.Field(0).Name, "y")
+	require.Equal(t, spec.Field(0).Transform, iceberg.IdentityTransform{})
+	require.Equal(t, spec.Field(0).SourceID, 2)
+}
+
+func TestTableMetadataV2MissingPartitionSpecs(t *testing.T) {
+	meta, err := getTestTableMetadata("TableMetadataV2MissingPartitionSpecs.json")
+	require.Error(t, err)
+	require.Nil(t, meta)
+	// TODO: check for specific error
+}
+
+func TestTableMetadataV2MissingLastPartitionId(t *testing.T) {
+	// Similarly to above, this should fail but isn't since Go's lack of an Option type means it will just put a 0 for
+	// the missing lastPartitionId.
+	meta, err := getTestTableMetadata("TableMetadataV2MissingLastPartitionId.json")
+	require.Error(t, err)
+	require.Nil(t, meta)
+	// TODO: check for specific error
+}
+
+func TestDefaultPartitionSpec(t *testing.T) {
+	defaultSpecID := 1234
+	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")
+	require.NoError(t, err)
+	spec := iceberg.NewPartitionSpecID(1234)
+
+	meta.(*metadataV2).DefaultSpecID = spec.ID()
+	meta.(*metadataV2).Specs = append(meta.(*metadataV2).Specs, spec)
+	partitionSpec := meta.PartitionSpec()
+	require.Equal(t, partitionSpec.ID(), defaultSpecID)
 }
 
 func getTestTableMetadata(fileName string) (Metadata, error) {

--- a/table/orphan_cleanup_integration_test.go
+++ b/table/orphan_cleanup_integration_test.go
@@ -53,16 +53,17 @@ const (
 	OrphanFilePrefix  = "orphan_"
 )
 
-var (
-	tableSchemaSimple = iceberg.NewSchemaWithIdentifiers(1,
-		[]int{1},
-		iceberg.NestedField{
-			ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
-		iceberg.NestedField{
-			ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: true},
-		iceberg.NestedField{
-			ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Float64, Required: false},
-	)
+var tableSchemaSimple = iceberg.NewSchemaWithIdentifiers(1,
+	[]int{1},
+	iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	},
+	iceberg.NestedField{
+		ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: true,
+	},
+	iceberg.NestedField{
+		ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Float64, Required: false,
+	},
 )
 
 func (s *OrphanCleanupIntegrationSuite) loadCatalog() *rest.Catalog {

--- a/table/testdata/TableMetadataV1PartitionSpecsWithoutDefaultId.json
+++ b/table/testdata/TableMetadataV1PartitionSpecsWithoutDefaultId.json
@@ -1,0 +1,58 @@
+{
+  "format-version": 1,
+  "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+  "location": "s3://bucket/test/location",
+  "last-updated-ms": 1602638573874,
+  "last-column-id": 3,
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  },
+  "partition-specs": [
+    {
+      "spec-id": 1,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    },
+    {
+      "spec-id": 2,
+      "fields": [
+        {
+          "name": "y",
+          "transform": "identity",
+          "source-id": 2,
+          "field-id": 1001
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": []
+}

--- a/table/testdata/TableMetadataV2MissingLastPartitionId.json
+++ b/table/testdata/TableMetadataV2MissingLastPartitionId.json
@@ -1,0 +1,73 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [{
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  }],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/table/testdata/TableMetadataV2MissingPartitionSpecs.json
+++ b/table/testdata/TableMetadataV2MissingPartitionSpecs.json
@@ -1,0 +1,67 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [{
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  }],
+  "partition-spec": [
+    {
+      "name": "x",
+      "transform": "identity",
+      "source-id": 1,
+      "field-id": 1000
+    }
+  ],
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/table/transaction_test.go
+++ b/table/transaction_test.go
@@ -189,9 +189,11 @@ func (s *SparkIntegrationTestSuite) TestDifferentDataTypes() {
 		iceberg.NestedField{ID: 14, Name: "small_dec", Type: iceberg.DecimalTypeOf(8, 2)},
 		iceberg.NestedField{ID: 15, Name: "med_dec", Type: iceberg.DecimalTypeOf(16, 2)},
 		iceberg.NestedField{ID: 16, Name: "large_dec", Type: iceberg.DecimalTypeOf(24, 2)},
-		iceberg.NestedField{ID: 17, Name: "list", Type: &iceberg.ListType{
-			ElementID: 18,
-			Element:   iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{
+			ID: 17, Name: "list", Type: &iceberg.ListType{
+				ElementID: 18,
+				Element:   iceberg.PrimitiveTypes.Int32,
+			},
 		},
 	)
 

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -75,7 +75,8 @@ func TestUpdateSpecAddField(t *testing.T) {
 		assert.NotNil(t, updates)
 		assert.NotNil(t, reqs)
 
-		newSpec := specUpdate.Apply()
+		newSpec, err := specUpdate.Apply()
+		assert.NoError(t, err)
 		assert.NotNil(t, newSpec)
 		assert.Equal(t, 1, newSpec.ID())
 		assert.Equal(t, 1003, newSpec.LastAssignedFieldID())
@@ -198,7 +199,8 @@ func TestUpdateSpecAddField(t *testing.T) {
 		assert.NotNil(t, updates)
 		assert.NotNil(t, reqs)
 
-		newSpec := specUpdate.Apply()
+		newSpec, err := specUpdate.Apply()
+		assert.NoError(t, err)
 		assert.NotNil(t, newSpec)
 		assert.Equal(t, "street_void_1001", newSpec.FieldsBySourceID(5)[0].Name)
 	})
@@ -218,7 +220,8 @@ func TestUpdateSpecAddIdentityField(t *testing.T) {
 		assert.NotNil(t, updates)
 		assert.NotNil(t, reqs)
 
-		newSpec := specUpdate.Apply()
+		newSpec, err := specUpdate.Apply()
+		assert.NoError(t, err)
 		assert.NotNil(t, newSpec)
 		assert.Equal(t, 1, newSpec.ID())
 		assert.Equal(t, 1003, newSpec.LastAssignedFieldID())
@@ -254,7 +257,8 @@ func TestUpdateSpecRenameField(t *testing.T) {
 		assert.NotNil(t, updates)
 		assert.NotNil(t, reqs)
 
-		newSpec := updateSpec.Apply()
+		newSpec, err := updateSpec.Apply()
+		assert.NoError(t, err)
 		assert.NotNil(t, newSpec)
 		assert.Equal(t, 1, newSpec.ID())
 		assert.Equal(t, "new_id_identity", newSpec.FieldsBySourceID(1)[0].Name)
@@ -318,7 +322,8 @@ func TestUpdateSpecRemoveField(t *testing.T) {
 		assert.NotNil(t, updates)
 		assert.NotNil(t, reqs)
 
-		newSpec := updateSpec.Apply()
+		newSpec, err := updateSpec.Apply()
+		assert.NoError(t, err)
 		assert.NotNil(t, newSpec)
 		assert.Equal(t, 1, newSpec.ID())
 		assert.Equal(t, 999, newSpec.LastAssignedFieldID())

--- a/table/updates.go
+++ b/table/updates.go
@@ -553,12 +553,12 @@ func (u *removeSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
 
 type removeSpecUpdate struct {
 	baseUpdate
-	SpecIds []int64 `json:"spec-ids"`
+	SpecIds []int `json:"spec-ids"`
 }
 
 // NewRemoveSpecUpdate creates a new Update that removes a list of partition specs
 // from the table metadata.
-func NewRemoveSpecUpdate(specIds []int64) *removeSpecUpdate {
+func NewRemoveSpecUpdate(specIds []int) *removeSpecUpdate {
 	return &removeSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveSpec},
 		SpecIds:    specIds,
@@ -566,7 +566,9 @@ func NewRemoveSpecUpdate(specIds []int64) *removeSpecUpdate {
 }
 
 func (u *removeSpecUpdate) Apply(builder *MetadataBuilder) error {
-	return fmt.Errorf("%w: %s", iceberg.ErrNotImplemented, UpdateRemoveSpec)
+	_, err := builder.RemovePartitionSpecs(u.SpecIds)
+
+	return err
 }
 
 type removeSchemasUpdate struct {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -230,15 +230,3 @@ func TestRemoveSchemas(t *testing.T) {
 		}
 	})
 }
-
-func TestRemovePartitionSpecs(t *testing.T) {
-	var builder *MetadataBuilder
-	removeSpecs := removeSpecUpdate{
-		SpecIds: []int64{},
-	}
-	t.Run("remove specs should fail", func(t *testing.T) {
-		if err := removeSpecs.Apply(builder); !errors.Is(err, iceberg.ErrNotImplemented) {
-			t.Fatalf("Expected unimplemented error, got %v", err)
-		}
-	})
-}


### PR DESCRIPTION
This PR:

1. adds a funct-opts builder for PartitionSpec
2. implements the remove PartitionSpec Update
3. ports test relating to PartitionSpecs from iceberg-rust
4. port missing validations from iceberg-rust to metadataBuilder


It's mostly contained within partitions, there's a more fundamental change to json deserialization in there which initializes the deserialization target with `-1` in all int fields so that we are able to determine if we received / did not receive a certain field and are consequently able to reject requests where mandatory IDs are missing.

There's currently still some duplication between the funct-opts constructor of `PartitionSpec` and `update_spec.go`. I'm still working on that one, I hope to arrive at something close to [java's apply() of BaseUpdatePartitionSpec](https://github.com/apache/iceberg/blob/8871bbcf4ffce83be7d1be8d75bf06e5ce7b36e4/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L304)