### PR TITLE
chore(metadata): remove Builder returns from MetadataBuilder

### DIFF
--- a/catalog/glue/schema_test.go
+++ b/catalog/glue/schema_test.go
@@ -440,9 +440,9 @@ func TestSchemasToGlueColumns(t *testing.T) {
 	mb, err := table.MetadataBuilderFromBase(metadata)
 	assert.NoError(t, err)
 
-	mb, err = mb.AddSchema(schemas[1])
+	err = mb.AddSchema(schemas[1])
 	assert.NoError(t, err)
-	mb, err = mb.SetCurrentSchemaID(1)
+	err = mb.SetCurrentSchemaID(1)
 	assert.NoError(t, err)
 
 	metadata, err = mb.Build()

--- a/io/azure_integration_test.go
+++ b/io/azure_integration_test.go
@@ -95,10 +95,10 @@ func (s *AzureBlobIOTestSuite) TestAzuriteWarehouseConnectionString() {
 	path := "iceberg-test-azure/test-table-azure"
 	containerName := "warehouse"
 	properties := iceberg.Properties{
-		"uri":                       ":memory:",
-		sqlcat.DriverKey:            sqliteshim.ShimName,
-		sqlcat.DialectKey:           string(sqlcat.SQLite),
-		"type":                      "sql",
+		"uri":             ":memory:",
+		sqlcat.DriverKey:  sqliteshim.ShimName,
+		sqlcat.DialectKey: string(sqlcat.SQLite),
+		"type":            "sql",
 		io.AdlsConnectionStringPrefix + accountName: connectionString,
 	}
 

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -184,7 +184,7 @@ func (suite *FileStatsMetricsSuite) getDataFile(meta iceberg.Properties, writeSt
 	if len(meta) > 0 {
 		bldr, err := MetadataBuilderFromBase(tableMeta)
 		suite.Require().NoError(err)
-		_, err = bldr.SetProperties(meta)
+		err = bldr.SetProperties(meta)
 		suite.Require().NoError(err)
 		tableMeta, err = bldr.Build()
 		suite.Require().NoError(err)

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -757,11 +757,9 @@ func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
 	assert.NoError(t, err)
 
 	partitionSpec := iceberg.NewPartitionSpecID(0)
-	_, err = builder.AddPartitionSpec(&partitionSpec, false)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddPartitionSpec(&partitionSpec, false))
 
-	_, err = builder.SetDefaultSpecID(-1)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.SetDefaultSpecID(-1))
 
 	assert.Equal(t, 0, builder.defaultSpecID)
 }
@@ -769,22 +767,17 @@ func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
 func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
 	builder, err := NewMetadataBuilder()
 	assert.NoError(t, err)
-	_, err = builder.SetFormatVersion(2)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.SetFormatVersion(2))
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema)
-	assert.NoError(t, err)
-	_, err = builder.SetCurrentSchemaID(-1)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema))
+	assert.NoError(t, builder.SetCurrentSchemaID(-1))
 
 	partitionSpec := iceberg.NewPartitionSpecID(0)
-	_, err = builder.AddPartitionSpec(&partitionSpec, false)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddPartitionSpec(&partitionSpec, false))
 
-	_, err = builder.SetDefaultSpecID(-1)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.SetDefaultSpecID(-1))
 
 	meta, err := builder.Build()
 	assert.NoError(t, err)
@@ -795,25 +788,21 @@ func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
 func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
 	builder, err := NewMetadataBuilder()
 	assert.NoError(t, err)
-	_, err = builder.SetFormatVersion(2)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.SetFormatVersion(2))
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema))
 
 	schema = iceberg.NewSchema(3,
 		iceberg.NestedField{ID: 3, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema))
 
 	schema = iceberg.NewSchema(2,
 		iceberg.NestedField{ID: 4, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema))
 
 	assert.Equal(t, 1, builder.schemaList[0].ID)
 	assert.Equal(t, 3, builder.schemaList[1].ID)
@@ -826,13 +815,11 @@ func TestMetadataBuilderReuseSchema(t *testing.T) {
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema))
 	schema2 := iceberg.NewSchema(15,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
-	_, err = builder.AddSchema(schema2)
-	assert.NoError(t, err)
+	assert.NoError(t, builder.AddSchema(schema2))
 	assert.Equal(t, len(builder.schemaList), 1)
 	assert.Equal(t, *builder.lastAddedSchemaID, 1)
 }

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -287,8 +287,7 @@ func createTestMetadata(snapshots []Snapshot, snapshotLog []SnapshotLogEntry) (M
 
 		// Add snapshots if provided
 		for _, snapshot := range snapshots {
-			builder, err = builder.AddSnapshot(&snapshot)
-			if err != nil {
+			if err = builder.AddSnapshot(&snapshot); err != nil {
 				return nil, err
 			}
 		}

--- a/table/updates.go
+++ b/table/updates.go
@@ -153,9 +153,7 @@ func NewAssignUUIDUpdate(uuid uuid.UUID) *assignUUIDUpdate {
 }
 
 func (u *assignUUIDUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetUUID(u.UUID)
-
-	return err
+	return builder.SetUUID(u.UUID)
 }
 
 type upgradeFormatVersionUpdate struct {
@@ -173,9 +171,7 @@ func NewUpgradeFormatVersionUpdate(formatVersion int) *upgradeFormatVersionUpdat
 }
 
 func (u *upgradeFormatVersionUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetFormatVersion(u.FormatVersion)
-
-	return err
+	return builder.SetFormatVersion(u.FormatVersion)
 }
 
 type addSchemaUpdate struct {
@@ -193,9 +189,7 @@ func NewAddSchemaUpdate(schema *iceberg.Schema) *addSchemaUpdate {
 }
 
 func (u *addSchemaUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.AddSchema(u.Schema)
-
-	return err
+	return builder.AddSchema(u.Schema)
 }
 
 type setCurrentSchemaUpdate struct {
@@ -213,9 +207,7 @@ func NewSetCurrentSchemaUpdate(id int) *setCurrentSchemaUpdate {
 }
 
 func (u *setCurrentSchemaUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetCurrentSchemaID(u.SchemaID)
-
-	return err
+	return builder.SetCurrentSchemaID(u.SchemaID)
 }
 
 type addPartitionSpecUpdate struct {
@@ -236,9 +228,7 @@ func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) *addPa
 }
 
 func (u *addPartitionSpecUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.AddPartitionSpec(u.Spec, u.initial)
-
-	return err
+	return builder.AddPartitionSpec(u.Spec, u.initial)
 }
 
 type setDefaultSpecUpdate struct {
@@ -256,9 +246,7 @@ func NewSetDefaultSpecUpdate(id int) *setDefaultSpecUpdate {
 }
 
 func (u *setDefaultSpecUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetDefaultSpecID(u.SpecID)
-
-	return err
+	return builder.SetDefaultSpecID(u.SpecID)
 }
 
 type addSortOrderUpdate struct {
@@ -279,9 +267,7 @@ func NewAddSortOrderUpdate(sortOrder *SortOrder, initial bool) *addSortOrderUpda
 }
 
 func (u *addSortOrderUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.AddSortOrder(u.SortOrder, u.initial)
-
-	return err
+	return builder.AddSortOrder(u.SortOrder, u.initial)
 }
 
 type setDefaultSortOrderUpdate struct {
@@ -299,9 +285,7 @@ func NewSetDefaultSortOrderUpdate(id int) *setDefaultSortOrderUpdate {
 }
 
 func (u *setDefaultSortOrderUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetDefaultSortOrderID(u.SortOrderID)
-
-	return err
+	return builder.SetDefaultSortOrderID(u.SortOrderID)
 }
 
 type addSnapshotUpdate struct {
@@ -318,9 +302,7 @@ func NewAddSnapshotUpdate(snapshot *Snapshot) *addSnapshotUpdate {
 }
 
 func (u *addSnapshotUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.AddSnapshot(u.Snapshot)
-
-	return err
+	return builder.AddSnapshot(u.Snapshot)
 }
 
 type setSnapshotRefUpdate struct {
@@ -366,14 +348,12 @@ func (u *setSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
 		opts = append(opts, WithMinSnapshotsToKeep(u.MinSnapshotsToKeep))
 	}
 
-	_, err := builder.SetSnapshotRef(
+	return builder.SetSnapshotRef(
 		u.RefName,
 		u.SnapshotID,
 		u.RefType,
 		opts...,
 	)
-
-	return err
 }
 
 type setLocationUpdate struct {
@@ -390,9 +370,7 @@ func NewSetLocationUpdate(loc string) Update {
 }
 
 func (u *setLocationUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetLoc(u.Location)
-
-	return err
+	return builder.SetLoc(u.Location)
 }
 
 type setPropertiesUpdate struct {
@@ -410,9 +388,7 @@ func NewSetPropertiesUpdate(updates iceberg.Properties) *setPropertiesUpdate {
 }
 
 func (u *setPropertiesUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.SetProperties(u.Updates)
-
-	return err
+	return builder.SetProperties(u.Updates)
 }
 
 type removePropertiesUpdate struct {
@@ -431,9 +407,7 @@ func NewRemovePropertiesUpdate(removals []string) *removePropertiesUpdate {
 }
 
 func (u *removePropertiesUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.RemoveProperties(u.Removals)
-
-	return err
+	return builder.RemoveProperties(u.Removals)
 }
 
 type removeSnapshotsUpdate struct {
@@ -451,9 +425,7 @@ func NewRemoveSnapshotsUpdate(ids []int64) *removeSnapshotsUpdate {
 }
 
 func (u *removeSnapshotsUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.RemoveSnapshots(u.SnapshotIDs)
-
-	return err
+	return builder.RemoveSnapshots(u.SnapshotIDs)
 }
 
 func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table, postTable *Table) error {
@@ -546,9 +518,7 @@ func NewRemoveSnapshotRefUpdate(ref string) *removeSnapshotRefUpdate {
 }
 
 func (u *removeSnapshotRefUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.RemoveSnapshotRef(u.RefName)
-
-	return err
+	return builder.RemoveSnapshotRef(u.RefName)
 }
 
 type removeSpecUpdate struct {
@@ -566,9 +536,7 @@ func NewRemoveSpecUpdate(specIds []int) *removeSpecUpdate {
 }
 
 func (u *removeSpecUpdate) Apply(builder *MetadataBuilder) error {
-	_, err := builder.RemovePartitionSpecs(u.SpecIds)
-
-	return err
+	return builder.RemovePartitionSpecs(u.SpecIds)
 }
 
 type removeSchemasUpdate struct {


### PR DESCRIPTION
This removes the `MetadataBuilder` return value from the mutators of `MetadataBuilder`. Since all those functions are fallible, we cannot use it as a builder anyways. Removing them makes the API more concise and simpler.