### PR TITLE
fix: correct release_upload in release_rc script

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -113,7 +113,7 @@ if [ "${RELEASE_UPLOAD}" -gt 0 ]; then
   echo "Uploading to ASF dist/dev..."
   # rename files to remove -rc${rc} suffix before uploading
   pushd "${id}"
-  for fname in "./*"; do
+  for fname in ./*; do
     mv "${fname}" "${fname//-rc${rc}/}"
   done
   popd


### PR DESCRIPTION
`release_rc.sh` needs to use `for fname in ./*` instead of `for fname in "./*"` so that it gets the proper results.