### PR TITLE
feat(metadata): Add support for Statistics and PartitionStatistics in table metadata

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -134,19 +134,19 @@ type Metadata interface {
 	NameMapping() iceberg.NameMapping
 
 	LastSequenceNumber() int64
-	// Statistics is an optional list of table statistics.
+	// StatisticsFile is an optional list of table statistics.
 	// Table statistics files are valid Puffin files.
-	// Statistics are informational. A reader can choose to ignore statistics information.
-	// Statistics support is not required to read the table correctly.
+	// StatisticsFile are informational. A reader can choose to ignore statistics information.
+	// StatisticsFile support is not required to read the table correctly.
 	// A table can contain many statistics files associated with different table snapshots.
-	Statistics() []Statistics
-	// PartitionStatistics is an optional list of partition statistics files.
+	Statistics() []StatisticsFile
+	// PartitionStatisticsFile is an optional list of partition statistics files.
 	// Partition statistics are not required for reading or planning
 	// and readers may ignore them. Each table snapshot may be associated
 	// with at most one partition statistics file. A writer can optionally
 	// write the partition statistics file during each write operation,
 	// or it can also be computed on demand.
-	PartitionStatistics() []PartitionStatistics
+	PartitionStatistics() []PartitionStatisticsFile
 }
 
 type MetadataBuilder struct {
@@ -1030,26 +1030,26 @@ func sliceEqualHelper[T interface{ Equals(T) bool }](s1, s2 []T) bool {
 
 // https://iceberg.apache.org/spec/#iceberg-table-spec
 type commonMetadata struct {
-	FormatVersion      int                     `json:"format-version"`
-	UUID               uuid.UUID               `json:"table-uuid"`
-	Loc                string                  `json:"location"`
-	LastUpdatedMS      int64                   `json:"last-updated-ms"`
-	LastColumnId       int                     `json:"last-column-id"`
-	SchemaList         []*iceberg.Schema       `json:"schemas"`
-	CurrentSchemaID    int                     `json:"current-schema-id"`
-	Specs              []iceberg.PartitionSpec `json:"partition-specs"`
-	DefaultSpecID      int                     `json:"default-spec-id"`
-	LastPartitionID    *int                    `json:"last-partition-id,omitempty"`
-	Props              iceberg.Properties      `json:"properties,omitempty"`
-	SnapshotList       []Snapshot              `json:"snapshots,omitempty"`
-	CurrentSnapshotID  *int64                  `json:"current-snapshot-id,omitempty"`
-	SnapshotLog        []SnapshotLogEntry      `json:"snapshot-log,omitempty"`
-	MetadataLog        []MetadataLogEntry      `json:"metadata-log,omitempty"`
-	SortOrderList      []SortOrder             `json:"sort-orders"`
-	DefaultSortOrderID int                     `json:"default-sort-order-id"`
-	SnapshotRefs       map[string]SnapshotRef  `json:"refs,omitempty"`
-	StatisticsList     []Statistics            `json:"statistics,omitempty"`
-	PartitionStatsList []PartitionStatistics   `json:"partition-statistics,omitempty"`
+	FormatVersion      int                       `json:"format-version"`
+	UUID               uuid.UUID                 `json:"table-uuid"`
+	Loc                string                    `json:"location"`
+	LastUpdatedMS      int64                     `json:"last-updated-ms"`
+	LastColumnId       int                       `json:"last-column-id"`
+	SchemaList         []*iceberg.Schema         `json:"schemas"`
+	CurrentSchemaID    int                       `json:"current-schema-id"`
+	Specs              []iceberg.PartitionSpec   `json:"partition-specs"`
+	DefaultSpecID      int                       `json:"default-spec-id"`
+	LastPartitionID    *int                      `json:"last-partition-id,omitempty"`
+	Props              iceberg.Properties        `json:"properties,omitempty"`
+	SnapshotList       []Snapshot                `json:"snapshots,omitempty"`
+	CurrentSnapshotID  *int64                    `json:"current-snapshot-id,omitempty"`
+	SnapshotLog        []SnapshotLogEntry        `json:"snapshot-log,omitempty"`
+	MetadataLog        []MetadataLogEntry        `json:"metadata-log,omitempty"`
+	SortOrderList      []SortOrder               `json:"sort-orders"`
+	DefaultSortOrderID int                       `json:"default-sort-order-id"`
+	SnapshotRefs       map[string]SnapshotRef    `json:"refs,omitempty"`
+	StatisticsList     []StatisticsFile          `json:"statistics,omitempty"`
+	PartitionStatsList []PartitionStatisticsFile `json:"partition-statistics,omitempty"`
 }
 
 func initCommonMetadataForDeserialization() commonMetadata {
@@ -1196,11 +1196,11 @@ func (c *commonMetadata) Properties() iceberg.Properties {
 	return c.Props
 }
 
-func (c *commonMetadata) Statistics() []Statistics {
+func (c *commonMetadata) Statistics() []StatisticsFile {
 	return c.StatisticsList
 }
 
-func (c *commonMetadata) PartitionStatistics() []PartitionStatistics {
+func (c *commonMetadata) PartitionStatistics() []PartitionStatisticsFile {
 	return c.PartitionStatsList
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -134,6 +134,19 @@ type Metadata interface {
 	NameMapping() iceberg.NameMapping
 
 	LastSequenceNumber() int64
+	// Statistics is an optional list of table statistics.
+	// Table statistics files are valid Puffin files.
+	// Statistics are informational. A reader can choose to ignore statistics information.
+	// Statistics support is not required to read the table correctly.
+	// A table can contain many statistics files associated with different table snapshots.
+	Statistics() []Statistics
+	// PartitionStatistics is an optional list of partition statistics files.
+	// Partition statistics are not required for reading or planning
+	// and readers may ignore them. Each table snapshot may be associated
+	// with at most one partition statistics file. A writer can optionally
+	// write the partition statistics file during each write operation,
+	// or it can also be computed on demand.
+	PartitionStatistics() []PartitionStatistics
 }
 
 type MetadataBuilder struct {
@@ -1035,6 +1048,8 @@ type commonMetadata struct {
 	SortOrderList      []SortOrder             `json:"sort-orders"`
 	DefaultSortOrderID int                     `json:"default-sort-order-id"`
 	SnapshotRefs       map[string]SnapshotRef  `json:"refs,omitempty"`
+	StatisticsList     []Statistics            `json:"statistics,omitempty"`
+	PartitionStatsList []PartitionStatistics   `json:"partition-statistics,omitempty"`
 }
 
 func initCommonMetadataForDeserialization() commonMetadata {
@@ -1179,6 +1194,14 @@ func (c *commonMetadata) DefaultSortOrder() int {
 
 func (c *commonMetadata) Properties() iceberg.Properties {
 	return c.Props
+}
+
+func (c *commonMetadata) Statistics() []Statistics {
+	return c.StatisticsList
+}
+
+func (c *commonMetadata) PartitionStatistics() []PartitionStatistics {
+	return c.PartitionStatsList
 }
 
 // preValidate updates values in the metadata struct with defaults based on

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -134,19 +134,19 @@ type Metadata interface {
 	NameMapping() iceberg.NameMapping
 
 	LastSequenceNumber() int64
-	// StatisticsFile is an optional list of table statistics.
+	// Statistics returns an optional list of table statistics.
 	// Table statistics files are valid Puffin files.
 	// StatisticsFile are informational. A reader can choose to ignore statistics information.
 	// StatisticsFile support is not required to read the table correctly.
 	// A table can contain many statistics files associated with different table snapshots.
-	Statistics() []StatisticsFile
-	// PartitionStatisticsFile is an optional list of partition statistics files.
+	Statistics() iter.Seq[StatisticsFile]
+	// PartitionStatistics returns an optional list of partition statistics files.
 	// Partition statistics are not required for reading or planning
 	// and readers may ignore them. Each table snapshot may be associated
 	// with at most one partition statistics file. A writer can optionally
 	// write the partition statistics file during each write operation,
 	// or it can also be computed on demand.
-	PartitionStatistics() []PartitionStatisticsFile
+	PartitionStatistics() iter.Seq[PartitionStatisticsFile]
 }
 
 type MetadataBuilder struct {
@@ -1196,12 +1196,12 @@ func (c *commonMetadata) Properties() iceberg.Properties {
 	return c.Props
 }
 
-func (c *commonMetadata) Statistics() []StatisticsFile {
-	return c.StatisticsList
+func (c *commonMetadata) Statistics() iter.Seq[StatisticsFile] {
+	return slices.Values(c.StatisticsList)
 }
 
-func (c *commonMetadata) PartitionStatistics() []PartitionStatisticsFile {
-	return c.PartitionStatsList
+func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile] {
+	return slices.Values(c.PartitionStatsList)
 }
 
 // preValidate updates values in the metadata struct with defaults based on

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -673,7 +673,7 @@ func TestMetadataV1Serialize(t *testing.T) {
 			DefaultSpecID:      0,
 			SortOrderList:      []SortOrder{UnsortedSortOrder},
 			DefaultSortOrderID: 0,
-			StatisticsList: []Statistics{
+			StatisticsList: []StatisticsFile{
 				{
 					SnapshotID:            1234567890,
 					StatisticsPath:        "s3://bucket/statistics/stats1.puffin",
@@ -691,7 +691,7 @@ func TestMetadataV1Serialize(t *testing.T) {
 					},
 				},
 			},
-			PartitionStatsList: []PartitionStatistics{
+			PartitionStatsList: []PartitionStatisticsFile{
 				{
 					SnapshotID:      1234567890,
 					StatisticsPath:  "s3://bucket/partition-stats/part1.parquet",
@@ -766,7 +766,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 			DefaultSpecID:      0,
 			SortOrderList:      []SortOrder{UnsortedSortOrder},
 			DefaultSortOrderID: 0,
-			StatisticsList: []Statistics{
+			StatisticsList: []StatisticsFile{
 				{
 					SnapshotID:            9876543210,
 					StatisticsPath:        "s3://bucket/v2/statistics/stats2.puffin",
@@ -783,7 +783,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 					},
 				},
 			},
-			PartitionStatsList: []PartitionStatistics{
+			PartitionStatsList: []PartitionStatisticsFile{
 				{
 					SnapshotID:      9876543210,
 					StatisticsPath:  "s3://bucket/v2/partition-stats/part2.parquet",

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -673,12 +673,37 @@ func TestMetadataV1Serialize(t *testing.T) {
 			DefaultSpecID:      0,
 			SortOrderList:      []SortOrder{UnsortedSortOrder},
 			DefaultSortOrderID: 0,
+			StatisticsList: []Statistics{
+				{
+					SnapshotID:            1234567890,
+					StatisticsPath:        "s3://bucket/statistics/stats1.puffin",
+					FileSizeInBytes:       1024000,
+					FileFooterSizeInBytes: 512,
+					KeyMetadata:           nil,
+					BlobMetadata: []BlobMetadata{
+						{
+							Type:           BlobTypeApacheDatasketchesThetaV1,
+							SnapshotID:     1234567890,
+							SequenceNumber: 1,
+							Fields:         []int32{1, 2},
+							Properties:     map[string]string{"ndv": "1000"},
+						},
+					},
+				},
+			},
+			PartitionStatsList: []PartitionStatistics{
+				{
+					SnapshotID:      1234567890,
+					StatisticsPath:  "s3://bucket/partition-stats/part1.parquet",
+					FileSizeInBytes: 512000,
+				},
+			},
 		},
 	}
 
 	data, err := json.Marshal(toserialize)
 	require.NoError(t, err)
-	assert.JSONEq(t, `{		
+	assert.JSONEq(t, `{
 		"format-version":1,
 		"table-uuid":"dd93fa46-a1a7-43bb-8748-6cc7eff107a3",
 		"location":"s3a://warehouse/iceberg/iceberg-test-2.db/test-table-2",
@@ -696,7 +721,31 @@ func TestMetadataV1Serialize(t *testing.T) {
 		"partition-specs":[{"spec-id":0,"fields":[]}],
 		"default-spec-id":0,
 		"sort-orders":[{"order-id":0,"fields":[]}],
-		"default-sort-order-id":0
+		"default-sort-order-id":0,
+		"statistics": [
+			{
+				"snapshot-id": 1234567890,
+				"statistics-path": "s3://bucket/statistics/stats1.puffin",
+				"file-size-in-bytes": 1024000,
+				"file-footer-size-in-bytes": 512,
+				"blob-metadata": [
+					{
+						"type": "apache-datasketches-theta-v1",
+						"snapshot-id": 1234567890,
+						"sequence-number": 1,
+						"fields": [1, 2],
+						"properties": {"ndv": "1000"}
+					}
+				]
+			}
+		],
+		"partition-statistics": [
+			{
+				"snapshot-id": 1234567890,
+				"statistics-path": "s3://bucket/partition-stats/part1.parquet",
+				"file-size-in-bytes": 512000
+			}
+		]
 	}`, string(data))
 }
 
@@ -706,7 +755,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 	toserialize := &metadataV2{
 		LastSeqNum: 1,
 		commonMetadata: commonMetadata{
-			FormatVersion:      1,
+			FormatVersion:      2,
 			UUID:               uuid.MustParse("dd93fa46-a1a7-43bb-8748-6cc7eff107a3"),
 			Loc:                "s3a://warehouse/iceberg/iceberg-test-2.db/test-table-2",
 			LastUpdatedMS:      1742412491193,
@@ -717,6 +766,30 @@ func TestMetadataV2Serialize(t *testing.T) {
 			DefaultSpecID:      0,
 			SortOrderList:      []SortOrder{UnsortedSortOrder},
 			DefaultSortOrderID: 0,
+			StatisticsList: []Statistics{
+				{
+					SnapshotID:            9876543210,
+					StatisticsPath:        "s3://bucket/v2/statistics/stats2.puffin",
+					FileSizeInBytes:       2048000,
+					FileFooterSizeInBytes: 1024,
+					BlobMetadata: []BlobMetadata{
+						{
+							Type:           BlobTypeDeletionVectorV1,
+							SnapshotID:     9876543210,
+							SequenceNumber: 5,
+							Fields:         []int32{1},
+							Properties:     map[string]string{"deletion-vector-size": "500"},
+						},
+					},
+				},
+			},
+			PartitionStatsList: []PartitionStatistics{
+				{
+					SnapshotID:      9876543210,
+					StatisticsPath:  "s3://bucket/v2/partition-stats/part2.parquet",
+					FileSizeInBytes: 768000,
+				},
+			},
 		},
 	}
 
@@ -724,7 +797,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"last-sequence-number": 1,
-		"format-version":1,
+		"format-version": 2,
 		"table-uuid":"dd93fa46-a1a7-43bb-8748-6cc7eff107a3",
 		"location":"s3a://warehouse/iceberg/iceberg-test-2.db/test-table-2",
 		"last-updated-ms":1742412491193,
@@ -741,7 +814,31 @@ func TestMetadataV2Serialize(t *testing.T) {
 		"partition-specs":[{"spec-id":0,"fields":[]}],
 		"default-spec-id":0,
 		"sort-orders":[{"order-id":0,"fields":[]}],
-		"default-sort-order-id":0
+		"default-sort-order-id":0,
+		"statistics": [
+			{
+				"snapshot-id": 9876543210,
+				"statistics-path": "s3://bucket/v2/statistics/stats2.puffin",
+				"file-size-in-bytes": 2048000,
+				"file-footer-size-in-bytes": 1024,
+				"blob-metadata": [
+					{
+						"type": "deletion-vector-v1",
+						"snapshot-id": 9876543210,
+						"sequence-number": 5,
+						"fields": [1],
+						"properties": {"deletion-vector-size": "500"}
+					}
+				]
+			}
+		],
+		"partition-statistics": [
+			{
+				"snapshot-id": 9876543210,
+				"statistics-path": "s3://bucket/v2/partition-stats/part2.parquet",
+				"file-size-in-bytes": 768000
+			}
+		]
 	}`, string(data))
 }
 

--- a/table/statistics.go
+++ b/table/statistics.go
@@ -1,0 +1,59 @@
+package table
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type BlobType string
+
+const (
+	BlobTypeApacheDatasketchesThetaV1 BlobType = "apache-datasketches-theta-v1"
+	BlobTypeDeletionVectorV1          BlobType = "deletion-vector-v1"
+)
+
+func (bt *BlobType) IsValid() bool {
+	switch *bt {
+	case BlobTypeApacheDatasketchesThetaV1, BlobTypeDeletionVectorV1:
+		return true
+	default:
+		return false
+	}
+}
+
+func (bt *BlobType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	*bt = BlobType(s)
+	if !bt.IsValid() {
+		return fmt.Errorf("invalid blob type: %s", s)
+	}
+
+	return nil
+}
+
+type Statistics struct {
+	SnapshotID            int64          `json:"snapshot-id"`
+	StatisticsPath        string         `json:"statistics-path"`
+	FileSizeInBytes       int64          `json:"file-size-in-bytes"`
+	FileFooterSizeInBytes int64          `json:"file-footer-size-in-bytes"`
+	KeyMetadata           *string        `json:"key-metadata,omitempty"`
+	BlobMetadata          []BlobMetadata `json:"blob-metadata"`
+}
+
+type BlobMetadata struct {
+	Type           BlobType          `json:"type"`
+	SnapshotID     int64             `json:"snapshot-id"`
+	SequenceNumber int64             `json:"sequence-number"`
+	Fields         []int32           `json:"fields"`
+	Properties     map[string]string `json:"properties"`
+}
+
+type PartitionStatistics struct {
+	SnapshotID      int64  `json:"snapshot-id"`
+	StatisticsPath  string `json:"statistics-path"`
+	FileSizeInBytes int64  `json:"file-size-in-bytes"`
+}

--- a/table/statistics.go
+++ b/table/statistics.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package table
 
 import (

--- a/table/statistics.go
+++ b/table/statistics.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 )
 
+// BlobType is the type of blob in a Puffin file
 type BlobType string
 
 const (
@@ -52,7 +53,12 @@ func (bt *BlobType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type Statistics struct {
+// StatisticsFile represents a statistics file in the Puffin format, that can be used to read table data more
+// efficiently.
+//
+// Statistics are informational. A reader can choose to ignore statistics information.
+// Statistics support is not required to read the table correctly.
+type StatisticsFile struct {
 	SnapshotID            int64          `json:"snapshot-id"`
 	StatisticsPath        string         `json:"statistics-path"`
 	FileSizeInBytes       int64          `json:"file-size-in-bytes"`
@@ -61,6 +67,7 @@ type Statistics struct {
 	BlobMetadata          []BlobMetadata `json:"blob-metadata"`
 }
 
+// BlobMetadata is the metadata of a statistics or indices blob.
 type BlobMetadata struct {
 	Type           BlobType          `json:"type"`
 	SnapshotID     int64             `json:"snapshot-id"`
@@ -69,7 +76,11 @@ type BlobMetadata struct {
 	Properties     map[string]string `json:"properties"`
 }
 
-type PartitionStatistics struct {
+// PartitionStatisticsFile represents a partition statistics file that can be used to read table data more efficiently.
+//
+// Statistics are informational. A reader can choose to ignore statistics information. Statistics
+// support is not required to read the table correctly.
+type PartitionStatisticsFile struct {
 	SnapshotID      int64  `json:"snapshot-id"`
 	StatisticsPath  string `json:"statistics-path"`
 	FileSizeInBytes int64  `json:"file-size-in-bytes"`


### PR DESCRIPTION
This PR adds support for reading Iceberg table metadata containing statistics and partition statistics fields, as specified in https://iceberg.apache.org/spec/#table-statistics.