### PR TITLE
feat(metadata): export UpdateTable & fixes

### DIFF
--- a/catalog/glue/schema_test.go
+++ b/catalog/glue/schema_test.go
@@ -437,7 +437,7 @@ func TestSchemasToGlueColumns(t *testing.T) {
 	metadata, err := table.NewMetadata(schemas[0], nil, table.SortOrder{}, "s3://example/path", nil)
 	assert.NoError(t, err)
 
-	mb, err := table.MetadataBuilderFromBase(metadata)
+	mb, err := table.MetadataBuilderFromBase(metadata, "")
 	assert.NoError(t, err)
 
 	err = mb.AddSchema(schemas[1])

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -69,35 +69,7 @@ func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, pro
 }
 
 func UpdateTableMetadata(base table.Metadata, updates []table.Update, metadataLoc string) (table.Metadata, error) {
-	bldr, err := table.MetadataBuilderFromBase(base)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, update := range updates {
-		if err := update.Apply(bldr); err != nil {
-			return nil, err
-		}
-	}
-
-	if bldr.HasChanges() {
-		if metadataLoc != "" {
-			maxMetadataLogEntries := max(1,
-				base.Properties().GetInt(
-					table.MetadataPreviousVersionsMaxKey, table.MetadataPreviousVersionsMaxDefault))
-
-			bldr.TrimMetadataLogs(maxMetadataLogEntries + 1).
-				AppendMetadataLog(table.MetadataLogEntry{
-					MetadataFile: metadataLoc,
-					TimestampMs:  base.LastUpdatedMillis(),
-				})
-		}
-		if base.LastUpdatedMillis() == bldr.LastUpdatedMS() {
-			bldr.SetLastUpdatedMS()
-		}
-	}
-
-	return bldr.Build()
+	return table.UpdateTableMetadata(base, updates, metadataLoc)
 }
 
 func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nspropsFn GetNamespacePropsFn, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (table.StagedTable, error) {

--- a/errors.go
+++ b/errors.go
@@ -17,12 +17,16 @@
 
 package iceberg
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrInvalidTypeString       = errors.New("invalid type")
 	ErrNotImplemented          = errors.New("not implemented")
 	ErrInvalidArgument         = errors.New("invalid argument")
+	ErrInvalidFormatVersion    = fmt.Errorf("%w: invalid format version", ErrInvalidArgument)
 	ErrInvalidSchema           = errors.New("invalid schema")
 	ErrInvalidTransform        = errors.New("invalid transform syntax")
 	ErrType                    = errors.New("type error")

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -184,7 +184,7 @@ func (suite *FileStatsMetricsSuite) getDataFile(meta iceberg.Properties, writeSt
 
 	schema := tableMeta.CurrentSchema()
 	if len(meta) > 0 {
-		bldr, err := MetadataBuilderFromBase(tableMeta)
+		bldr, err := MetadataBuilderFromBase(tableMeta, "")
 		suite.Require().NoError(err)
 		err = bldr.SetProperties(meta)
 		suite.Require().NoError(err)

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -175,6 +175,7 @@ type MetadataBuilder struct {
 	defaultSortOrderID int
 	refs               map[string]SnapshotRef
 
+	previousFileEntry *MetadataLogEntry
 	// >v1 specific
 	lastSequenceNumber *int64
 	// update tracking
@@ -183,28 +184,37 @@ type MetadataBuilder struct {
 	lastAddedSortOrderID *int
 }
 
-func NewMetadataBuilder() (*MetadataBuilder, error) {
+func NewMetadataBuilder(formatVersion int) (*MetadataBuilder, error) {
 	return &MetadataBuilder{
-		updates:       make([]Update, 0),
-		schemaList:    make([]*iceberg.Schema, 0),
-		specs:         make([]iceberg.PartitionSpec, 0),
-		props:         make(iceberg.Properties),
-		snapshotList:  make([]Snapshot, 0),
-		snapshotLog:   make([]SnapshotLogEntry, 0),
-		metadataLog:   make([]MetadataLogEntry, 0),
-		sortOrderList: make([]SortOrder, 0),
-		refs:          make(map[string]SnapshotRef),
+		updates:            make([]Update, 0),
+		schemaList:         make([]*iceberg.Schema, 0),
+		specs:              make([]iceberg.PartitionSpec, 0),
+		props:              make(iceberg.Properties),
+		snapshotList:       make([]Snapshot, 0),
+		snapshotLog:        make([]SnapshotLogEntry, 0),
+		metadataLog:        make([]MetadataLogEntry, 0),
+		sortOrderList:      make([]SortOrder, 0),
+		refs:               make(map[string]SnapshotRef),
+		currentSchemaID:    -1,
+		defaultSortOrderID: -1,
+		defaultSpecID:      -1,
+		lastColumnId:       -1,
+		formatVersion:      formatVersion,
 	}, nil
 }
 
-func MetadataBuilderFromBase(metadata Metadata) (*MetadataBuilder, error) {
+// MetadataBuilderFromBase creates a MetadataBuilder from an existing Metadata object.
+// currentFileLocation is the location where the current version of the metadata
+// file is stored. This is used to update the metadata log. If currentFileLocation is
+// empty, the metadata log will not be updated. This should only be used to stage-create tables.
+func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*MetadataBuilder, error) {
 	b := &MetadataBuilder{}
 	b.base = metadata
 
 	b.formatVersion = metadata.Version()
 	b.uuid = metadata.TableUUID()
 	b.loc = metadata.Location()
-	b.lastUpdatedMS = metadata.LastUpdatedMillis()
+	b.lastUpdatedMS = 0
 	b.lastColumnId = metadata.LastColumnID()
 	b.schemaList = slices.Clone(metadata.Schemas())
 	b.currentSchemaID = metadata.CurrentSchema().ID
@@ -228,6 +238,13 @@ func MetadataBuilderFromBase(metadata Metadata) (*MetadataBuilder, error) {
 	b.refs = maps.Collect(metadata.Refs())
 	b.snapshotLog = slices.Collect(metadata.SnapshotLogs())
 	b.metadataLog = slices.Collect(metadata.PreviousFiles())
+
+	if currentFileLocation != "" {
+		b.previousFileEntry = &MetadataLogEntry{
+			MetadataFile: currentFileLocation,
+			TimestampMs:  metadata.LastUpdatedMillis(),
+		}
+	}
 
 	return b, nil
 }
@@ -451,6 +468,7 @@ func (b *MetadataBuilder) AddSortOrder(sortOrder *SortOrder) error {
 	}
 
 	b.sortOrderList = append(sortOrders, *sortOrder)
+	b.lastAddedSortOrderID = &sortOrder.orderID
 	b.updates = append(b.updates, NewAddSortOrderUpdate(sortOrder))
 
 	return nil
@@ -474,8 +492,7 @@ func (b *MetadataBuilder) RemoveProperties(keys []string) error {
 }
 
 func (b *MetadataBuilder) SetCurrentSchemaID(currentSchemaID int) error {
-	takeLast := currentSchemaID == -1
-	if takeLast {
+	if currentSchemaID == -1 {
 		if b.lastAddedSchemaID == nil {
 			return errors.New("can't set current schema to last added schema, no schema has been added")
 		}
@@ -491,7 +508,7 @@ func (b *MetadataBuilder) SetCurrentSchemaID(currentSchemaID int) error {
 		return fmt.Errorf("can't set current schema to schema with id %d: %w", currentSchemaID, err)
 	}
 
-	if takeLast {
+	if b.lastAddedSchemaID != nil && currentSchemaID == *b.lastAddedSchemaID {
 		b.updates = append(b.updates, NewSetCurrentSchemaUpdate(-1))
 	} else {
 		b.updates = append(b.updates, NewSetCurrentSchemaUpdate(currentSchemaID))
@@ -503,14 +520,10 @@ func (b *MetadataBuilder) SetCurrentSchemaID(currentSchemaID int) error {
 
 func (b *MetadataBuilder) SetDefaultSortOrderID(defaultSortOrderID int) error {
 	if defaultSortOrderID == -1 {
-		defaultSortOrderID = maxBy(b.sortOrderList, func(s SortOrder) int {
-			return s.OrderID()
-		})
-		if !slices.ContainsFunc(b.updates, func(u Update) bool {
-			return u.Action() == UpdateAddSortOrder && u.(*addSortOrderUpdate).SortOrder.OrderID() == defaultSortOrderID
-		}) {
+		if b.lastAddedSortOrderID == nil {
 			return errors.New("can't set default sort order to last added with no added sort orders")
 		}
+		defaultSortOrderID = *b.lastAddedSortOrderID
 	}
 
 	if defaultSortOrderID == b.defaultSortOrderID {
@@ -521,17 +534,20 @@ func (b *MetadataBuilder) SetDefaultSortOrderID(defaultSortOrderID int) error {
 		return fmt.Errorf("can't set default sort order to sort order with id %d: %w", defaultSortOrderID, err)
 	}
 
-	b.updates = append(b.updates, NewSetDefaultSortOrderUpdate(defaultSortOrderID))
+	if b.lastAddedSortOrderID != nil && defaultSortOrderID == *b.lastAddedSortOrderID {
+		b.updates = append(b.updates, NewSetDefaultSortOrderUpdate(-1))
+	} else {
+		b.updates = append(b.updates, NewSetDefaultSortOrderUpdate(defaultSortOrderID))
+	}
+
 	b.defaultSortOrderID = defaultSortOrderID
 
 	return nil
 }
 
 func (b *MetadataBuilder) SetDefaultSpecID(defaultSpecID int) error {
-	lastUsed := false
 	if defaultSpecID == -1 {
 		if b.lastAddedPartitionID != nil {
-			lastUsed = true
 			defaultSpecID = *b.lastAddedPartitionID
 		} else {
 			return errors.New("can't set default spec to last added with no added partition specs")
@@ -546,7 +562,7 @@ func (b *MetadataBuilder) SetDefaultSpecID(defaultSpecID int) error {
 		return fmt.Errorf("can't set default spec to spec with id %d: %w", defaultSpecID, err)
 	}
 
-	if lastUsed {
+	if b.lastAddedPartitionID != nil && defaultSpecID == *b.lastAddedPartitionID {
 		b.updates = append(b.updates, NewSetDefaultSpecUpdate(-1))
 	} else {
 		b.updates = append(b.updates, NewSetDefaultSpecUpdate(defaultSpecID))
@@ -755,6 +771,16 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 
 	if b.lastUpdatedMS == 0 {
 		b.lastUpdatedMS = time.Now().UnixMilli()
+	}
+
+	if b.previousFileEntry != nil && b.HasChanges() {
+		maxMetadataLogEntries := max(1,
+			b.base.Properties().GetInt(
+				MetadataPreviousVersionsMaxKey, MetadataPreviousVersionsMaxDefault))
+
+		b.AppendMetadataLog(*b.previousFileEntry)
+		b.TrimMetadataLogs(maxMetadataLogEntries)
+
 	}
 
 	return &commonMetadata{
@@ -1702,12 +1728,8 @@ func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, 
 		return nil, err
 	}
 
-	builder, err := NewMetadataBuilder()
+	builder, err := NewMetadataBuilder(formatVersion)
 	if err != nil {
-		return nil, err
-	}
-
-	if err = builder.SetFormatVersion(formatVersion); err != nil {
 		return nil, err
 	}
 
@@ -1790,4 +1812,19 @@ func reassignIDs(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrde
 		partitionSpec: &freshPartitions,
 		sortOrder:     freshSortOrder,
 	}, nil
+}
+
+func UpdateTableMetadata(base Metadata, updates []Update, metadataLoc string) (Metadata, error) {
+	bldr, err := MetadataBuilderFromBase(base, metadataLoc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, update := range updates {
+		if err := update.Apply(bldr); err != nil {
+			return nil, err
+		}
+	}
+
+	return bldr.Build()
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -846,7 +846,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 }
 
 func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
-	builder, err := NewMetadataBuilder()
+	builder, err := NewMetadataBuilder(0)
 	assert.NoError(t, err)
 	schema := schema()
 	assert.NoError(t, builder.AddSchema(&schema))
@@ -860,9 +860,8 @@ func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
 }
 
 func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
-	builder, err := NewMetadataBuilder()
+	builder, err := NewMetadataBuilder(2)
 	assert.NoError(t, err)
-	assert.NoError(t, builder.SetFormatVersion(2))
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},
 	)
@@ -874,6 +873,10 @@ func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
 
 	assert.NoError(t, builder.SetDefaultSpecID(-1))
 
+	unsorted := UnsortedSortOrder
+	require.NoError(t, builder.AddSortOrder(&unsorted))
+	require.NoError(t, builder.SetDefaultSortOrderID(-1))
+
 	meta, err := builder.Build()
 	assert.NoError(t, err)
 	assert.Equal(t, schema.ID, meta.CurrentSchema().ID)
@@ -881,7 +884,7 @@ func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
 }
 
 func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
-	builder, err := NewMetadataBuilder()
+	builder, err := NewMetadataBuilder(0)
 	assert.NoError(t, err)
 	assert.NoError(t, builder.SetFormatVersion(2))
 	schema := iceberg.NewSchema(1,
@@ -905,7 +908,7 @@ func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
 }
 
 func TestMetadataBuilderReuseSchema(t *testing.T) {
-	builder, err := NewMetadataBuilder()
+	builder, err := NewMetadataBuilder(0)
 	assert.NoError(t, err)
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -846,7 +846,7 @@ func TestMetadataV2Serialize(t *testing.T) {
 }
 
 func TestMetadataBuilderSetDefaultSpecIDLastPartition(t *testing.T) {
-	builder, err := NewMetadataBuilder(0)
+	builder, err := NewMetadataBuilder(2)
 	assert.NoError(t, err)
 	schema := schema()
 	assert.NoError(t, builder.AddSchema(&schema))
@@ -884,7 +884,7 @@ func TestMetadataBuilderSetLastAddedSchema(t *testing.T) {
 }
 
 func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
-	builder, err := NewMetadataBuilder(0)
+	builder, err := NewMetadataBuilder(2)
 	assert.NoError(t, err)
 	assert.NoError(t, builder.SetFormatVersion(2))
 	schema := iceberg.NewSchema(1,
@@ -908,7 +908,7 @@ func TestMetadataBuilderSchemaIncreasingNumbering(t *testing.T) {
 }
 
 func TestMetadataBuilderReuseSchema(t *testing.T) {
-	builder, err := NewMetadataBuilder(0)
+	builder, err := NewMetadataBuilder(2)
 	assert.NoError(t, err)
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.StringType{}, Required: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -106,7 +106,7 @@ func (s *FanoutWriterTestSuite) testTransformPartition(transform iceberg.Transfo
 	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
 	s.Require().NoError(err)
 
-	metaBuilder, err := MetadataBuilderFromBase(meta)
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
 	s.Require().NoError(err)
 
 	args := recordWritingArgs{

--- a/table/table.go
+++ b/table/table.go
@@ -83,7 +83,7 @@ func (t Table) LocationProvider() (LocationProvider, error) {
 }
 
 func (t Table) NewTransaction() *Transaction {
-	meta, _ := MetadataBuilderFromBase(t.metadata)
+	meta, _ := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
 
 	return &Transaction{
 		tbl:  &t,

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -789,18 +789,7 @@ func (m *mockedCatalog) LoadTable(ctx context.Context, ident table.Identifier) (
 }
 
 func (m *mockedCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
-	bldr, err := table.MetadataBuilderFromBase(m.metadata)
-	if err != nil {
-		return nil, "", err
-	}
-
-	for _, u := range updates {
-		if err := u.Apply(bldr); err != nil {
-			return nil, "", err
-		}
-	}
-
-	meta, err := bldr.Build()
+	meta, err := table.UpdateTableMetadata(m.metadata, updates, "")
 	if err != nil {
 		return nil, "", err
 	}
@@ -1336,7 +1325,7 @@ func (m *DeleteOldMetadataMockedCatalog) LoadTable(ctx context.Context, ident ta
 }
 
 func (m *DeleteOldMetadataMockedCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
-	bldr, err := table.MetadataBuilderFromBase(m.metadata)
+	bldr, err := table.MetadataBuilderFromBase(m.metadata, "")
 	if err != nil {
 		return nil, "", err
 	}

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -280,7 +280,7 @@ func createTestMetadata(snapshots []Snapshot, snapshotLog []SnapshotLogEntry) (M
 
 	// If we have custom snapshots or logs, we need to modify the metadata
 	if len(snapshots) > 0 || len(snapshotLog) > 0 {
-		builder, err := MetadataBuilderFromBase(meta)
+		builder, err := MetadataBuilderFromBase(meta, "")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- exports UpdateTable so that outside packages can use it
- adds metadata log maintenance to the builder, i.e. based on currentFileLocation, an entry is added to the metadata log & on Build, we trim the metadata log
- ports remaining tests from iceberg-rust and implements fixes for them
