### PR TITLE
infra: fix artifact name in verify_rc.sh 

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -36,7 +36,8 @@ RC="$2"
 
 ICEBERG_DIST_BASE_URL="https://downloads.apache.org/iceberg"
 DOWNLOAD_RC_BASE_URL="https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-${VERSION}-rc${RC}"
-ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}-rc${RC}"
+ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}"
+SOURCE_DIR_NAME="apache-iceberg-go-${VERSION}-rc${RC}"
 
 : "${VERIFY_DEFAULT:=1}"
 : "${VERIFY_DOWNLOAD:=${VERIFY_DEFAULT}}"
@@ -193,7 +194,7 @@ import_gpg_keys
 fetch_archive
 ensure_source_directory
 ensure_go
-pushd "${ARCHIVE_BASE_NAME}"
+pushd "${SOURCE_DIR_NAME}"
 test_source_distribution
 popd
 


### PR DESCRIPTION
The tar file is named `apache-iceberg-go-0.4.0.tar.gz` but the folder inside is named `apache-iceberg-go-0.4.0-rc0`

This unblocks us from verifying an RC release. 

We should follow up and fix the underlying issue by renaming the folder inside `apache-iceberg-go-0.4.0` 

#### Testing
Tested with https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-0.4.0-rc0/
```
wget https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-0.4.0-rc0/
tar -xzf apache-iceberg-go-*.tar.gz
cd apache-iceberg-go-0.4.0-rc0
cp ~/repos/iceberg-go/dev/release/verify_rc.sh ./dev/release/verify_rc.sh
dev/release/verify_rc.sh 0.4.0 0
```
