### PR TITLE
infra: fix rc artifact structure

### DIFF
--- a/.github/workflows/audit-and-verify.yml
+++ b/.github/workflows/audit-and-verify.yml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Audit and Verify
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+  pull_request:
+
+env: # Set default VERSION and RC to simulate inputs for push to branch
+  VERSION: 0.0.1
+  RC: 0
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+
+jobs:
+  audit-and-verify:
+    name: Audit and Verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Archive
+        run: |
+          id="apache-iceberg-go-${VERSION}"
+          tar_gz="${id}.tar.gz"
+          git archive HEAD --prefix "${id}/" --output "${tar_gz}"
+          sha512sum "${tar_gz}" > "${tar_gz}.sha512"
+          echo "TAR_GZ=${tar_gz}" >> ${GITHUB_ENV}
+      - name: RAT Check
+        run: |
+          dev/release/run_rat.sh "${TAR_GZ}"
+      - name: Verify
+        run: |
+          VERIFY_DEFAULT=0 dev/release/verify_rc.sh "${VERSION}" "${RC}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -18,12 +18,8 @@
 name: RC
 on:
   push:
-    branches:
-      - '**'
-      - '!dependabot/**'
     tags:
       - '*-rc*'
-  pull_request:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -40,7 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Prepare for tag
-        if: github.ref_type == 'tag'
         run: |
           # Remove the 'v' prefix and any '-rc' suffix from the tag name to isolate the version number
           # For a tag like 'v0.1.0-rc1', this will result in '0.1.0'
@@ -53,72 +48,24 @@ jobs:
           echo "RC=${rc}" >> ${GITHUB_ENV}
           echo "VERSION=${version}"
           echo "RC=${rc}"
-      - name: Prepare for branch
-        if: github.ref_type == 'branch'
-        run: |
-          rc=100
-          echo "VERSION=${version}" >> ${GITHUB_ENV}
-          echo "RC=${rc}" >> ${GITHUB_ENV}
-          echo "VERSION=${version}"
-          echo "RC=${rc}"
       - name: Archive
         run: |
-          id="apache-iceberg-go-${VERSION}-rc${RC}"
-          tar_gz="${id}.tar.gz"
-          echo "TAR_GZ=${tar_gz}" >> ${GITHUB_ENV}
-          git archive HEAD --prefix "${id}/" --output "${tar_gz}"
+          # tar.gz file has the format apache-iceberg-go-<version>-rc<rc>.tar.gz
+          # and contains a directory named apache-iceberg-go-<version> with the source
+          dir="apache-iceberg-go-${VERSION}"
+          tar_gz="apache-iceberg-go-${VERSION}-rc${RC}.tar.gz"
+          git archive HEAD --prefix "${dir}/" --output "${tar_gz}"
           sha512sum "${tar_gz}" > "${tar_gz}.sha512"
-      - name: Audit
-        run: |
-          dev/release/run_rat.sh "${TAR_GZ}"
       - uses: actions/upload-artifact@v4
         with:
           name: archive
           path: |
             apache-iceberg-go-*
-  
-  verify:
-    name: Verify
-    needs:
-      - archive
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: archive
-      - name: Verify
-        run: |
-          tar_gz=$(echo apache-iceberg-go-*.tar.gz)
-          # Extract version by removing the 'apache-iceberg-go-' prefix, '.tar.gz' extension, and '-rc*' suffix
-          # For a file like 'apache-iceberg-go-0.1.0-rc1.tar.gz', this will result in '0.1.0'
-          version=${tar_gz#apache-iceberg-go-}
-          version=${version%.tar.gz}
-          version=${version%%-rc*}
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            # Finds the last occurrence of `-rc` and returns everything after it
-            # For a tag like 'v0.1.0-rc1', this will result in '1'
-            rc=${GITHUB_REF_NAME##*-rc}
-          else
-            rc=100
-          fi
-          echo "VERSION=${version}"
-          echo "RC=${rc}"
-          VERIFY_DEFAULT=0 dev/release/verify_rc.sh "${version}" "${rc}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   upload:
     name: upload
-    if: github.ref_type == 'tag'
     needs:
-      - verify
+      - archive
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -36,7 +36,7 @@ RC="$2"
 
 ICEBERG_DIST_BASE_URL="https://downloads.apache.org/iceberg"
 DOWNLOAD_RC_BASE_URL="https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-${VERSION}-rc${RC}"
-ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}-rc${RC}"
+ARCHIVE_BASE_NAME="apache-iceberg-go-${VERSION}"
 
 : "${VERIFY_DEFAULT:=1}"
 : "${VERIFY_DOWNLOAD:=${VERIFY_DEFAULT}}"


### PR DESCRIPTION
Closes #587

Fixes RC artifact. It now produces this structure
```
https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-0.4.0-rc0/
  apache-iceberg-go-0.4.0.tar.gz
  apache-iceberg-go-0.4.0 (untar)
```
Additionally, the github release page should have artifacts with 
```
apache-iceberg-go-0.4.0-rc0.tar.gz
apache-iceberg-go-0.4.0-rc0.tar.gz.asc
apache-iceberg-go-0.4.0-rc0.tar.gz.sha512
```

#### Tested on my fork
https://github.com/apache/iceberg-go/compare/main...kevinjqliu:iceberg-go:main

`dev/release/release_rc.sh 0.4.0 7`
Release tag: https://github.com/kevinjqliu/iceberg-go/releases/tag/v0.4.0-rc7
rc.yml: https://github.com/kevinjqliu/iceberg-go/actions/runs/18294724035
audit-and-verify.yml: https://github.com/kevinjqliu/iceberg-go/actions/runs/18294715754

Log:
```
➜  iceberg-go git:(main) dev/release/release_rc.sh 0.4.0 7 
Tagging for RC: v0.4.0-rc7
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 168 bytes | 168.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/kevinjqliu/iceberg-go
 * [new tag]         v0.4.0-rc7 -> v0.4.0-rc7
Looking for GitHub Actions workflow on kevinjqliu/iceberg-go:v0.4.0-rc7
Waiting for run to start...
Waiting for run to start...
Found GitHub Actions workflow with ID: 18294724035
✓ v0.4.0-rc7 RC · 18294724035
Triggered via push less than a minute ago

JOBS
✓ Archive in 6s (ID 52090335320)
  ✓ Set up job
  ✓ Checkout
  ✓ Prepare for tag
  ✓ Archive
  ✓ Run actions/upload-artifact@v4
  ✓ Post Checkout
  ✓ Complete job
✓ upload in 10s (ID 52090347350)
  ✓ Set up job
  ✓ Checkout
  ✓ Run actions/download-artifact@v4
  ✓ Upload
  ✓ Post Checkout
  ✓ Complete job

✓ Run RC (18294724035) completed with 'success'
Downloading .tar.gz from GitHub Releases
Signing tar.gz
gpg: WARNING: unsafe permissions on homedir '/Users/kevinliu/.gnupg'
Add signature to GitHub release
Successfully uploaded 1 asset to v0.4.0-rc7
~/repos/iceberg-go/apache-iceberg-go-0.4.0-rc7 ~/repos/iceberg-go
~/repos/iceberg-go
Draft email for dev@iceberg.apache.org mailing list

---------------------------------------------------------
To: dev@iceberg.apache.org
Subject: [VOTE][Go] Release Apache Iceberg Go v0.4.0 RC7

Hi,

I would like to propose the following release candidate (RC7) of
Apache Iceberg Go version v0.4.0.

This release candidate is based on commit:
1b84f50031a3011d89b2397649a707fad7b33166 [1]

The source release rc7 is hosted at [2].

Please download, verify checksums and signatures, run the unit tests,
and vote on the release. See [3] for how to validate a release candidate.

The vote will be open for at least 72 hours.

[ ] +1 Release this as Apache Iceberg Go v0.4.0
[ ] +0
[ ] -1 Do not release this as Apache Iceberg Go v0.4.0 because...

[1]: https://github.com/apache/iceberg-go/tree/1b84f50031a3011d89b2397649a707fad7b33166
[2]: https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-0.4.0-rc7
[3]: https://github.com/apache/iceberg-go/blob/main/dev/release/README.md#verify
---------------------------------------------------------
```

After untar:
```
➜  iceberg-go git:(main) ✗ tree apache-iceberg-go-0.4.0-rc7 -L 1
apache-iceberg-go-0.4.0-rc7
├── apache-iceberg-go-0.4.0
├── apache-iceberg-go-0.4.0.tar.gz
└── apache-iceberg-go-0.4.0.tar.gz.asc

2 directories, 2 files
```