### PR TITLE
infra: release_rc.sh regenerate sha512 file after rename

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -94,6 +94,7 @@ if [ "${RELEASE_SIGN}" -gt 0 ]; then
   echo "Downloading .tar.gz from GitHub Releases"
   gh release download "${rc_tag}" \
     --dir "${id}" \
+    --pattern "${tar_gz}" \
     --repo "${repository}" \
     --skip-existing
 
@@ -115,6 +116,11 @@ if [ "${RELEASE_UPLOAD}" -gt 0 ]; then
   for fname in ./*; do
     mv "${fname}" "${fname//-rc${rc}/}"
   done
+
+  # regenerating checksum after rename because the one in gh release refers to the tar.gz file with -rc suffix
+  echo "Generating SHA512 checksum"
+  tar_gz="apache-iceberg-go-${version}.tar.gz"
+  sha512sum "${tar_gz}" > "${tar_gz}.sha512"
   popd
   svn import "${id}" "https://dist.apache.org/repos/dist/dev/iceberg/${id}" -m "Apache Iceberg Go ${version} RC${rc}"
 fi


### PR DESCRIPTION
we cannot reuse the sha512 file from gh release because it referring to the tar.gz file with -rc suffix

regenerate the sha512 file after rename and then upload to apache svn 

Tested generating shasum locally, uploaded to https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-go-0.4.0-rc1/
and now `dev/release/verify_rc.sh 0.4.0 1` passes