### PR TITLE
infra: just run `audit-and-verify.yml` once

### DIFF
--- a/.github/workflows/audit-and-verify.yml
+++ b/.github/workflows/audit-and-verify.yml
@@ -36,13 +36,7 @@ permissions:
 jobs:
   audit-and-verify:
     name: Audit and Verify
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
otherwise one of the run will 403 from querying github

Example: https://github.com/apache/iceberg-go/actions/runs/18289853638/job/52074150686
```
++ curl --fail --location --show-error --silent https://api.github.com/repos/golang/go/git/matching-refs/tags/go
++ jq -r ' .[] | .ref'
++ sort -V
++ tail -1
++ sed s,refs/tags/go,,g
curl: (56) The requested URL returned error: 403
```