### PR TITLE
infra: add rat check to verify_rc.sh

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -185,6 +185,10 @@ test_source_distribution() {
   # TODO: run integration tests
 }
 
+run_rat_check() {
+  "${TOP_SOURCE_DIR}/dev/release/run_rat.sh" "${VERIFY_TMPDIR}/${ARCHIVE_BASE_NAME}.tar.gz"
+}
+
 setup_tmpdir "iceberg-go-${VERSION}-${RC}"
 echo "Working in sandbox ${VERIFY_TMPDIR}"
 cd "${VERIFY_TMPDIR}"
@@ -192,6 +196,7 @@ cd "${VERIFY_TMPDIR}"
 import_gpg_keys
 fetch_archive
 ensure_source_directory
+run_rat_check
 ensure_go
 pushd "${ARCHIVE_BASE_NAME}"
 test_source_distribution


### PR DESCRIPTION
ran `dev/release/verify_rc.sh 0.4.0 1` succesfully

Log:
```
+ ensure_source_directory
+ tar xf apache-iceberg-go-0.4.0.tar.gz
+ run_rat_check
+ /Users/kevinliu/repos/iceberg-go/dev/release/run_rat.sh /var/folders/wq/mxmvfjtd1kjcrm3bdfrn2zd80000gn/T/iceberg-go-0.4.0-1.XXXXX.2eyy25Ku5o/apache-iceberg-go-0.4.0.tar.gz
No unapproved licenses
```