### PR TITLE
fix(metadata): wrap errors with exported types

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrInvalidArgument         = errors.New("invalid argument")
 	ErrInvalidFormatVersion    = fmt.Errorf("%w: invalid format version", ErrInvalidArgument)
 	ErrInvalidSchema           = errors.New("invalid schema")
+	ErrInvalidPartitionSpec    = errors.New("invalid partition spec")
 	ErrInvalidTransform        = errors.New("invalid transform syntax")
 	ErrType                    = errors.New("type error")
 	ErrBadCast                 = errors.New("could not cast value")

--- a/partitions.go
+++ b/partitions.go
@@ -125,7 +125,7 @@ func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
 	}
 	for _, opt := range opts {
 		if err := opt(&spec); err != nil {
-			return PartitionSpec{}, err
+			return PartitionSpec{}, fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 		}
 	}
 	spec.initialize()


### PR DESCRIPTION
This wraps all errors in metadata with exported variants to allow users to match on our errors. 