### PR TITLE
fix(catalog:rest): Fix RegisterTable endpoint

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -819,7 +819,7 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		MetadataLoc string `json:"metadata-location"`
 	}
 
-	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl},
+	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "register"},
 		payload{Name: tbl, MetadataLoc: metadataLoc}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrTableAlreadyExists,
 		})

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1322,7 +1322,7 @@ func (r *RestCatalogSuite) TestDropTable404() {
 }
 
 func (r *RestCatalogSuite) TestRegisterTable200() {
-	r.mux.HandleFunc("/v1/namespaces/fokko/tables/fokko2", func(w http.ResponseWriter, req *http.Request) {
+	r.mux.HandleFunc("/v1/namespaces/fokko/register", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
 
 		for k, v := range TestHeaders {
@@ -1470,7 +1470,7 @@ func (r *RestCatalogSuite) TestRegisterTable200() {
 }
 
 func (r *RestCatalogSuite) TestRegisterTable404() {
-	r.mux.HandleFunc("/v1/namespaces/nonexistent/tables/fokko2", func(w http.ResponseWriter, req *http.Request) {
+	r.mux.HandleFunc("/v1/namespaces/nonexistent/register", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
 
 		for k, v := range TestHeaders {
@@ -1503,7 +1503,7 @@ func (r *RestCatalogSuite) TestRegisterTable404() {
 }
 
 func (r *RestCatalogSuite) TestRegisterTable409() {
-	r.mux.HandleFunc("/v1/namespaces/fokko/tables/alreadyexist", func(w http.ResponseWriter, req *http.Request) {
+	r.mux.HandleFunc("/v1/namespaces/fokko/register", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
 
 		for k, v := range TestHeaders {


### PR DESCRIPTION
The `RegisterTable` in the REST implementation was actually calling the `UpdateTable` endpoint of the REST catalog.

Updated this to call `RegisterTable`, according to the [Apache Iceberg REST API spec](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml).

Tested with a local catalog.
