### PR TITLE
fix(catalog/rest): Handle 204 No Content response in doPost for renameTable

### DIFF
--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1212,7 +1212,7 @@ func (r *RestCatalogSuite) TestLoadTable200() {
 	}))
 }
 
-func (r *RestCatalogSuite) TestRenameTable200() {
+func (r *RestCatalogSuite) TestRenameTable204() {
 	// Mock the rename table endpoint
 	r.mux.HandleFunc("/v1/tables/rename", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
@@ -1237,7 +1237,7 @@ func (r *RestCatalogSuite) TestRenameTable200() {
 		r.Equal([]string{"fokko"}, payload.Destination.Namespace)
 		r.Equal("destination", payload.Destination.Name)
 
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	// Mock the get table endpoint for loading the renamed table


### PR DESCRIPTION
Fix `doPost` function to handle `204 No Content` responses, which is the spec-compliant 
response for the `POST /v1/{prefix}/tables/rename` endpoint.

The Iceberg REST Catalog OpenAPI spec defines `renameTable` as returning `204 No Content`:

```
/v1/{prefix}/tables/rename:
  post:
    operationId: renameTable
    responses:
      204:
        description: Success, no contentHowever, the current `doPost` implementation only accepts `200 OK`:
```

Current implementation expected `200` status code:
```
if rsp.StatusCode != http.StatusOK {
    return ret, handleNon200(rsp, override)
}
```

This causes `RenameTable` to fail with an empty error when interacting with 
spec-compliant REST catalog servers, even though the rename operation succeeds.


### Related

- Iceberg REST OpenAPI Spec: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
- Similar handling already exists in `do()` function via `allowNoContent` parameter
