### PR TITLE
infra: automatically delete head branches after merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,6 +47,10 @@ github:
 
       required_linear_history: true
 
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
+
 notifications:
   commits:      commits@iceberg.apache.org
   issues:       issues@iceberg.apache.org


### PR DESCRIPTION
set `.asf.yaml` to automatically delete head branches after merge
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#pull_requests

already set in other iceberg subprojects