### PR TITLE
fix: preserve snapshot log history

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -754,7 +754,6 @@ func (b *MetadataBuilder) RemoveSnapshotRef(name string) error {
 
 	if name == MainBranch {
 		b.currentSnapshotID = nil
-		b.snapshotLog = b.snapshotLog[:0]
 	}
 
 	delete(b.refs, name)


### PR DESCRIPTION
Fixed RemoveSnapshotRef() to preserve snapshot log when removing MainBranch reference during CREATE OR REPLACE TABLE operations. Previously cleared entire snapshot history, causing testReplaceTableKeepsSnapshotLog RCK test to fail. Now only resets current snapshot pointer while maintaining historical log entries, matching Apache Iceberg Java spec behavior.

Below RCK test fails
```
RESTCompatibilityKitCatalogTests > testReplaceTableKeepsSnapshotLog() FAILED
    java.lang.IndexOutOfBoundsException: index (1) must be less than size (1)
        at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1369)
        at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1351)
        at org.apache.iceberg.relocated.com.google.common.collect.SingletonImmutableList.get(SingletonImmutableList.java:46)
        at org.apache.iceberg.catalog.CatalogTests.testReplaceTableKeepsSnapshotLog(CatalogTests.java:2611)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```