### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the table, the following tracks the current write support:
 
 
 ### CLI Usage
-Run `go build ./cmd/iceberg` from the root of this repository to build the CLI executable, alternately you can run `go install github.com/apache/iceberg-go/cmd/iceberg` to install it to the `bin` directory of your `GOPATH`.
+Run `go build ./cmd/iceberg` from the root of this repository to build the CLI executable, alternately you can run `go install github.com/apache/iceberg-go/cmd/iceberg@latest` to install it to the `bin` directory of your `GOPATH`.
 
 The `iceberg` CLI usage is very similar to [pyiceberg CLI](https://py.iceberg.apache.org/cli/) \
 You can pass the catalog URI with `--uri` argument.


### PR DESCRIPTION
Hey folks, big fan of the Iceberg project! Found a tiny improvement in the docs to go install iceberg correctly 

```
$ go install github.com/apache/iceberg-go/cmd/iceberg
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/apache/iceberg-go/cmd/iceberg@latest' to install the latest version
```

after adding `@latest`

```
$ go install github.com/apache/iceberg-go/cmd/iceberg@latest
go: downloading github.com/apache/iceberg-go v0.4.0                                                                                     
go: downloading github.com/aws/aws-sdk-go-v2/config v1.31.12   
go: downloading github.com/pterm/pterm v0.12.81 
go: downloading github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
...
```