### PR TITLE
fix(view): field ID preservation and error handling for RCK compatibility

### DIFF
--- a/view/metadata_builder.go
+++ b/view/metadata_builder.go
@@ -183,7 +183,7 @@ func (b *MetadataBuilder) addVersion(newVersion *Version) (int64, error) {
 	for _, repr := range version.Representations {
 		normalizedDialect := strings.ToLower(repr.Dialect)
 		if _, ok := dialects[normalizedDialect]; ok {
-			return 0, fmt.Errorf("invalid view version: cannot add multiple queries for dialect %s", normalizedDialect)
+			return 0, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, normalizedDialect)
 		}
 		dialects[normalizedDialect] = struct{}{}
 	}

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -473,7 +473,7 @@ func TestAddVersion_MultipleSQLForSameDialect(t *testing.T) {
 		).
 		SetCurrentVersionID(1).
 		Build()
-	assert.ErrorContains(t, err, "invalid view version: cannot add multiple queries for dialect spark")
+	assert.ErrorContains(t, err, "Invalid view version: Cannot add multiple queries for dialect spark")
 }
 
 func TestSetCurrentVersionID_NoLastAddedSchema(t *testing.T) {


### PR DESCRIPTION
1. Field ID Reassignment: NewMetadataWithUUID() was calling iceberg.AssignFreshSchemaIDs() which reassigned all field IDs starting from 1, breaking clients that expect their original field IDs to be preserved.
2. Error Message Format: Duplicate dialect validation error wasn't wrapped with ErrInvalidViewMetadata and lacked proper capitalization, preventing MinIO from mapping it to IllegalArgumentException.
3. Schema ID Handling: While MetadataBuilder.addSchema() already normalizes schema IDs to 0 for new views, the test expected consistent behavior across view version updates.

## Problem it solves
Three RCK (REST Compatibility Kit) view tests were failing:
1. basicCreateView / completeCreateView: Field ID mismatch
expected: struct<3: id: required int, 4: data: required string>
but was:  struct<1: id: required int, 2: data: required string>
2. createViewErrorCases: Incorrect error message format
Expected: "Invalid view version: Cannot add multiple queries for dialect trino"
Actual:   "cannot add multiple queries for dialect trino"
3. concurrentReplaceViewVersion: Schema ID not normalized
expected: schemaId=0
but was:  schemaId=2
