### PR TITLE
feat(metadata): Add support for source-ids

### DIFF
--- a/partitions_test.go
+++ b/partitions_test.go
@@ -246,3 +246,84 @@ func TestGetPartitionFieldName(t *testing.T) {
 		})
 	}
 }
+
+func TestPartitionFieldUnmarshalJSON(t *testing.T) {
+	t.Run("unmarshal with source-id", func(t *testing.T) {
+		jsonData := `
+		{
+			"source-id": 1,
+			"field-id": 1000,
+			"transform": "truncate[19]",
+			"name": "str_truncate"
+		}`
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(jsonData), &field)
+		require.NoError(t, err)
+		assert.Equal(t, 1, field.SourceID)
+		assert.Equal(t, 1000, field.FieldID)
+		assert.Equal(t, "str_truncate", field.Name)
+		assert.Equal(t, iceberg.TruncateTransform{Width: 19}, field.Transform)
+	})
+
+	t.Run("unmarshal with source-ids", func(t *testing.T) {
+		jsonData := `
+		{
+			"source-ids": [2],
+			"field-id": 1001,
+			"transform": "bucket[25]",
+			"name": "int_bucket"
+		}`
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(jsonData), &field)
+		require.NoError(t, err)
+		assert.Equal(t, 2, field.SourceID)
+		assert.Equal(t, 1001, field.FieldID)
+		assert.Equal(t, "int_bucket", field.Name)
+		assert.Equal(t, iceberg.BucketTransform{NumBuckets: 25}, field.Transform)
+	})
+
+	t.Run("unmarshal with multiple source-ids should fail", func(t *testing.T) {
+		jsonData := `
+		{
+			"source-ids": [2, 3],
+			"field-id": 1001,
+			"transform": "bucket[25]",
+			"name": "int_bucket"
+		}`
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(jsonData), &field)
+		require.Error(t, err)
+		assert.EqualError(t, err, "partition field source-ids must contain exactly one id")
+	})
+
+	t.Run("unmarshal with both source-id and source-ids", func(t *testing.T) {
+		jsonData := `
+		{
+			"source-id": 1,
+			"source-ids": [2],
+			"field-id": 1002,
+			"transform": "identity",
+			"name": "identity"
+		}`
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(jsonData), &field)
+		require.Error(t, err)
+		assert.EqualError(t, err, "partition field cannot contain both source-id and source-ids")
+	})
+
+	t.Run("unmarshal with no source id", func(t *testing.T) {
+		jsonData := `
+		{
+			"field-id": 1003,
+			"transform": "void",
+			"name": "void"
+		}`
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(jsonData), &field)
+		require.NoError(t, err)
+		assert.Zero(t, field.SourceID)
+		assert.Equal(t, 1003, field.FieldID)
+		assert.Equal(t, "void", field.Name)
+		assert.Equal(t, iceberg.VoidTransform{}, field.Transform)
+	})
+}


### PR DESCRIPTION
Part of #589 

We don't currently support the `source-ids` field on PartitionFields. This will be more important when we have support for multi-arg transforms.

Since we don't have support for them, I'm just using the UnmarshalJSON field to set SourceID. We'll need a (much larger) refactor eventually to support an array of SourceIDs.