### PR TITLE
fix(catalog,manifest): handle some ignored errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,15 @@ version: "2"
 linters:
   default: none
   enable:
+    - errcheck
     - misspell
     - nlreturn
     - perfsprint
+  settings:
+    errcheck:
+      exclude-functions:
+        - (github.com/pterm/pterm.TablePrinter).Render
+        - (github.com/pterm/pterm.TreePrinter).Render
   exclusions:
     generated: lax
     presets:
@@ -29,6 +35,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test\.go$
     paths:
       - third_party$
       - builtin$

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -154,7 +154,7 @@ type sqlIcebergNamespaceProps struct {
 }
 
 func withReadTx[R any](ctx context.Context, db *bun.DB, fn func(context.Context, bun.Tx) (R, error)) (result R, err error) {
-	db.RunInTx(ctx, &sql.TxOptions{ReadOnly: true}, func(ctx context.Context, tx bun.Tx) error {
+	err = db.RunInTx(ctx, &sql.TxOptions{ReadOnly: true}, func(ctx context.Context, tx bun.Tx) error {
 		result, err = fn(ctx, tx)
 
 		return err

--- a/manifest.go
+++ b/manifest.go
@@ -1026,7 +1026,9 @@ func constructPartitionSummaries(spec PartitionSpec, schema *Schema, partitions 
 
 	for _, part := range partitions {
 		for i, field := range partType.FieldList {
-			fieldStats[i].update(part[field.ID])
+			if err := fieldStats[i].update(part[field.ID]); err != nil {
+				return nil, fmt.Errorf("error updating field stats for partition %d: %s: %s", i, field.Name, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Also enable errcheck linter for future.
Ignore table printer errors for cli which are
self observable and mostly fine. Ignoring it
in tests. There are many violations, could be
enabled separately if needed.