### PR TITLE
chore(ci): add simplify into formatters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,12 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
+  settings:
+    gofmt:
+      simplify: true
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
   exclusions:
     generated: lax
     paths:

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1150,8 +1150,8 @@ func (r *RestCatalogSuite) TestCreateTable409() {
 		}
 
 		w.WriteHeader(http.StatusConflict)
-		errorResponse := map[string]interface{}{
-			"error": map[string]interface{}{
+		errorResponse := map[string]any{
+			"error": map[string]any{
 				"message": "Table already exists: fokko.already_exists in warehouse 8bcb0838-50fc-472d-9ddb-8feb89ef5f1e",
 				"type":    "AlreadyExistsException",
 				"code":    409,
@@ -1429,8 +1429,8 @@ func (r *RestCatalogSuite) TestDropTable404() {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-		errorResponse := map[string]interface{}{
-			"error": map[string]interface{}{
+		errorResponse := map[string]any{
+			"error": map[string]any{
 				"message": "Table does not exist: fokko.table",
 				"type":    "NoSuchTableException",
 				"code":    404,
@@ -1933,8 +1933,8 @@ func (r *RestCatalogSuite) TestDropView404() {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-		errorResponse := map[string]interface{}{
-			"error": map[string]interface{}{
+		errorResponse := map[string]any{
+			"error": map[string]any{
 				"message": "The given view does not exist",
 				"type":    "NoSuchViewException",
 				"code":    404,

--- a/io/blob.go
+++ b/io/blob.go
@@ -68,7 +68,7 @@ func (f *blobOpenFile) ReadAt(p []byte, off int64) (int, error) {
 
 func (f *blobOpenFile) Name() string               { return f.name }
 func (f *blobOpenFile) Mode() fs.FileMode          { return fs.ModeIrregular }
-func (f *blobOpenFile) Sys() interface{}           { return f.b }
+func (f *blobOpenFile) Sys() any                   { return f.b }
 func (f *blobOpenFile) IsDir() bool                { return false }
 func (f *blobOpenFile) Stat() (fs.FileInfo, error) { return f, nil }
 
@@ -198,6 +198,6 @@ type blobWriteFile struct {
 }
 
 func (f *blobWriteFile) Name() string                { return f.name }
-func (f *blobWriteFile) Sys() interface{}            { return f.b }
+func (f *blobWriteFile) Sys() any                    { return f.b }
 func (f *blobWriteFile) Close() error                { return f.Writer.Close() }
 func (f *blobWriteFile) Write(p []byte) (int, error) { return f.Writer.Write(p) }

--- a/manifest.go
+++ b/manifest.go
@@ -1788,7 +1788,7 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 
 			return Timestamp(v.(int64))
 		case avro.Decimal:
-			if unionMap, ok := v.(map[string]interface{}); ok {
+			if unionMap, ok := v.(map[string]any); ok {
 				if val, ok := unionMap["fixed"]; ok {
 					if bigRatValue, ok := val.(*big.Rat); ok {
 						scale := d.fieldIDToFixedSize[fieldID]
@@ -1807,7 +1807,7 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 
 			return v
 		case avro.UUID:
-			if unionMap, ok := v.(map[string]interface{}); ok {
+			if unionMap, ok := v.(map[string]any); ok {
 				if val, ok := unionMap["uuid"]; ok {
 					if uuidArr, ok := val.([16]byte); ok {
 						return uuid.UUID(uuidArr)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -2023,7 +2023,7 @@ func (t *TableTestSuite) TestMetadataCompressionRoundTrip() {
 	t.Require().NoError(err)
 
 	// Verify the decompressed content is valid JSON
-	var metadata map[string]interface{}
+	var metadata map[string]any
 	err = json.Unmarshal(decompressed, &metadata)
 	t.Require().NoError(err)
 


### PR DESCRIPTION
and prefer `any` over `interface{}`. 

A suggestion, feel free to close if not needed.