### PR TITLE
fix(table): handle race for key map getter

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -55,6 +55,11 @@ func (k *keyDefaultMap[K, V]) Get(key K) V {
 	k.mx.Lock()
 	defer k.mx.Unlock()
 
+	// race check between RLock and Lock
+	if v, ok := k.data[key]; ok {
+		return v
+	}
+
 	v := k.defaultFactory(key)
 	k.data[key] = v
 


### PR DESCRIPTION
* wasted resources (unnecessary calls to factory)
* references can be different between goroutines that could cause inconsistency
* if factory has side effects, it might happen multiple times 