### PR TITLE
feat(ci): enable govet for lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - govet
     - misspell
     - nlreturn
     - perfsprint
@@ -29,6 +30,11 @@ linters:
       exclude-functions:
         - (github.com/pterm/pterm.TablePrinter).Render
         - (github.com/pterm/pterm.TreePrinter).Render
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
A suggestion to improve lint process. Feel free to ignore. 

This change doesn't enable `fieldalignment` and `shadow` because they have many issues to be fixed and require a huge diff. 
Still better to do them separately because they would improve performance and readability.


