### PR TITLE
fix: explicitly pass purgeRequested=false in DropTable

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -855,7 +855,12 @@ func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) er
 		return err
 	}
 
-	_, err = doDelete[struct{}](ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl}, r.cl,
+	uri := r.baseURI.JoinPath("namespaces", ns, "tables", tbl)
+	v := url.Values{}
+	v.Set("purgeRequested", "false")
+	uri.RawQuery = v.Encode()
+
+	_, err = doDelete[struct{}](ctx, uri, []string{}, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 
 	return err


### PR DESCRIPTION
Summary

- DropTable now explicitly passes ?purgeRequested=false query parameter
- Ensures consistent behavior with catalog implementations that default purge to true

Background

Some catalog implementations (e.g., MinIO) have changed their backend to enable purge by default when no purgeRequested parameter is provided. This caused DropTable to silently purge table data along with metadata, which is unexpected behavior for users who only want to drop the table metadata.