### PR TITLE
refactor: Update Overwrite API to Use Options

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1628,7 +1628,7 @@ func (t *TableWritingTestSuite) TestOverwriteTable() {
 	})
 	t.Require().NoError(err)
 	defer newTable.Release()
-	resultTbl, err := tbl.OverwriteTable(t.ctx, newTable, 1, nil, true, 0, nil)
+	resultTbl, err := tbl.OverwriteTable(t.ctx, newTable, 1, nil)
 	t.Require().NoError(err)
 	t.NotNil(resultTbl)
 
@@ -1653,7 +1653,7 @@ func (t *TableWritingTestSuite) TestOverwriteRecord() {
 	defer rdr.Release()
 
 	// Test that Table.Overwrite works (delegates to transaction)
-	resultTbl, err := tbl.Overwrite(t.ctx, rdr, nil, true, 0, nil)
+	resultTbl, err := tbl.Overwrite(t.ctx, rdr, nil, table.WithOverwriteConcurrency(1))
 	t.Require().NoError(err)
 	t.NotNil(resultTbl)
 

--- a/table/transaction_test.go
+++ b/table/transaction_test.go
@@ -135,7 +135,7 @@ func (s *SparkIntegrationTestSuite) TestAddFile() {
 	bldr.Field(2).(*array.Int32Builder).Append(13)
 	bldr.Field(3).(*array.StringBuilder).Append("m")
 
-	rec := bldr.NewRecord()
+	rec := bldr.NewRecordBatch()
 	defer rec.Release()
 
 	fw, err := mustFS(s.T(), tbl).(iceio.WriteFileIO).Create(filename)
@@ -402,7 +402,7 @@ func (s *SparkIntegrationTestSuite) TestOverwriteBasic() {
 	defer overwriteTable.Release()
 
 	tx = tbl.NewTransaction()
-	err = tx.OverwriteTable(s.ctx, overwriteTable, 2, nil, true, 0, nil)
+	err = tx.OverwriteTable(s.ctx, overwriteTable, 2, nil)
 	s.Require().NoError(err)
 	_, err = tx.Commit(s.ctx)
 	s.Require().NoError(err)
@@ -469,7 +469,7 @@ func (s *SparkIntegrationTestSuite) TestOverwriteWithFilter() {
 
 	filter := iceberg.EqualTo(iceberg.Reference("foo"), true)
 	tx = tbl.NewTransaction()
-	err = tx.OverwriteTable(s.ctx, overwriteTable, 1, filter, true, 0, nil)
+	err = tx.OverwriteTable(s.ctx, overwriteTable, 1, nil, table.WithOverwriteFilter(filter))
 	s.Require().NoError(err)
 	_, err = tx.Commit(s.ctx)
 	s.Require().NoError(err)


### PR DESCRIPTION
![little change](https://media1.tenor.com/m/x5h2y8ZpkUYAAAAC/it-weill-change-a-little-bit-it-will-change.gif)

This makes a few tweaks to the API for the [recently added](https://github.com/apache/iceberg-go/pull/674) `Overwrite` API to favor options for parameters that have a reasonable sensible default and migrates them to `OverwriteOptions`. 

Technically, it also fixes an issue that was introduced where the caseSensitive parameter was just ignored and hardcoded to `true` in the functions that support the `Overwrite` functionality but this wasn't the primary motivation on my end. I just happened to notice it as I was refactoring. 