### PR TITLE
Add SkipIfReferenced flag to removeSnapshotsUpdate

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -505,6 +505,16 @@ func (b *MetadataBuilder) RemoveSnapshots(snapshotIds []int64) error {
 	return nil
 }
 
+func (b *MetadataBuilder) isSnapshotReferenced(snapshotID int64) bool {
+	for _, ref := range b.refs {
+		if ref.SnapshotID == snapshotID {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (b *MetadataBuilder) AddSortOrder(sortOrder *SortOrder) error {
 	curSchema := b.CurrentSchema()
 	if curSchema == nil {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -291,7 +291,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 
 	// Only add the update if there are actually snapshots to delete
 	if len(snapsToDelete) > 0 {
-		update := NewRemoveSnapshotsUpdate(snapsToDelete)
+		update := NewRemoveSnapshotsUpdate(snapsToDelete).SetSkipIfReferenced()
 		update.postCommit = cfg.postCommit
 		updates = append(updates, update)
 	}


### PR DESCRIPTION
ExpireSnapshots computes candidate snapshots for deletion at time T1, but by the time CommitTable applies the update at T2, a concurrent client might link one of these snapshots to a new branch or tag. Without protection, the snapshot is deleted and its new ref is silently cleaned up.

This change adds a SkipIfReferenced flag to removeSnapshotsUpdate. When set, Apply() filters out any snapshot that is still referenced before calling RemoveSnapshots(). ExpireSnapshots sets this flag via SetSkipIfReferenced().

The default behavior (SkipIfReferenced=false) is unchanged: snapshots are removed and orphaned refs are silently cleaned up, preserving backward compatibility with explicit client-driven remove-snapshot updates.