### PR TITLE
infra: remove explicit GITHUB_TOKEN export from labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,5 +28,4 @@ jobs:
     steps:
     - uses: actions/labeler@v4
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Remove the explicit `repo-token` parameter from the labeler workflow to comply with the [Apache Infrastructure GitHub Actions policy](https://infra.apache.org/github-actions-policy.html), which prohibits exporting confidential tokens in `pull_request_target` triggered workflows. 

The `actions/labeler@v6` action [defaults to using `github.token` automatically](https://github.com/actions/labeler?tab=readme-ov-file#inputs), so behavior is unchanged.

Related to https://github.com/apache/iceberg/pull/15335