### PR TITLE
fix(manifest): correct v3 manifest-list first row id assigment for row-lineage

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1406,7 +1406,8 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 				// Ref: https://github.com/apache/iceberg/blob/ea2071568dc66148b483a82eefedcd2992b435f7/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L157-L168
 				if wrapped.Content == ManifestContentData && wrapped.FirstRowId == nil {
 					if m.nextRowID != nil {
-						wrapped.FirstRowId = m.nextRowID
+						firstRowID := *m.nextRowID
+						wrapped.FirstRowId = &firstRowID
 						*m.nextRowID += wrapped.ExistingRowsCount + wrapped.AddedRowsCount
 					}
 				}


### PR DESCRIPTION
Pointer is aliased and then mutated before encode. Start becomes end of range. With wiring snapshot lineage from writer delta (#728), this can cause overlaps/gaps between commits.