### PR TITLE
fix(io): update sas token behaviour to mimic java implementation

### DIFF
--- a/io/azure.go
+++ b/io/azure.go
@@ -54,6 +54,7 @@ const (
 type adlsLocation struct {
 	accountName   string // Azure storage account name
 	containerName string // Container (bucket) name
+	hostname      string // Hostname of the Azure storage account
 	path          string // Object path within the container
 }
 
@@ -113,6 +114,7 @@ func newAdlsLocation(adlsURI *url.URL) (*adlsLocation, error) {
 	return &adlsLocation{
 		accountName:   accountName,
 		containerName: containerName,
+		hostname:      hostname,
 		path:          path,
 	}, nil
 }
@@ -154,7 +156,7 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		if err != nil {
 			return nil, fmt.Errorf("failed container.NewClientWithSharedKeyCredential: %w", err)
 		}
-	} else if sasToken, ok := adlsSasTokens[location.accountName]; ok {
+	} else if sasToken, ok := adlsSasTokens[location.hostname]; ok {
 		containerURL, err := createContainerURL(location.accountName, protocol, endpoint, sasToken, location.containerName)
 		if err != nil {
 			return nil, err

--- a/io/azure_test.go
+++ b/io/azure_test.go
@@ -95,6 +95,7 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 		uri               string
 		expectedAccount   string
 		expectedContainer string
+		expectedHostname  string
 		expectedPath      string
 		shouldFail        bool
 	}{
@@ -102,6 +103,7 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 			uri:               "abfs://container@account.dfs.core.windows.net/file.txt",
 			expectedAccount:   "account",
 			expectedContainer: "container",
+			expectedHostname:  "account.dfs.core.windows.net",
 			expectedPath:      "/file.txt",
 			shouldFail:        false,
 		},
@@ -109,6 +111,7 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 			uri:               "abfs://container@account.dfs.core.usgovcloudapi.net/file.txt",
 			expectedAccount:   "account",
 			expectedContainer: "container",
+			expectedHostname:  "account.dfs.core.usgovcloudapi.net",
 			expectedPath:      "/file.txt",
 			shouldFail:        false,
 		},
@@ -116,6 +119,7 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 			uri:               "wasb://container@account.blob.core.windows.net/file.txt",
 			expectedAccount:   "account",
 			expectedContainer: "container",
+			expectedHostname:  "account.blob.core.windows.net",
 			expectedPath:      "/file.txt",
 			shouldFail:        false,
 		},
@@ -140,6 +144,7 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 				assert.NotNil(t, location)
 				assert.Equal(t, test.expectedAccount, location.accountName, "Account name mismatch for URI: %s", test.uri)
 				assert.Equal(t, test.expectedContainer, location.containerName, "Container name mismatch for URI: %s", test.uri)
+				assert.Equal(t, test.expectedHostname, location.hostname, "Hostname mismatch for URI: %s", test.uri)
 				assert.Equal(t, test.expectedPath, location.path, "Path mismatch for URI: %s", test.uri)
 			}
 		})


### PR DESCRIPTION
Use the full hostname to get adls SAS token from table configs.

Closes https://github.com/apache/iceberg-go/issues/738.