### PR TITLE
chore(ci): add explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,15 @@ on:
   schedule:
     - cron: '16 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Actions
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       packages: read
 

--- a/.github/workflows/go-release-docs.yml
+++ b/.github/workflows/go-release-docs.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -18,6 +18,9 @@
 name: "Run License Check"
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   rat:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Added explicit permissions blocks to GitHub Actions workflows to satisfy CodeQL actions/missing-workflow-permissions. (See the [Security tab on Github](https://github.com/apache/iceberg-go/security/code-scanning))
Defaulted workflows to `contents: read`.

