### PR TITLE
Revert "ci: replace pull_request_target with pull_request"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: "Pull Request Labeler"
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts apache/iceberg-go#751

ugh we must use `pull_request_target` for the forked repo workflow to work... otherwise PR opened from forked repo wont get labelled. I tested that in #755