### PR TITLE
chore: use ubuntu-slim for lightweight jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/go-release-docs.yml
+++ b/.github/workflows/go-release-docs.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
ubuntu-slim is a new cost-efficient runner to fit lightweight jobs. We can use this to save ASF infra usage (if possible).

By *lightweight* I mean jobs that run for less than a minute and are not easily affected by other concurrently running jobs on the same host.

This topic was raised in the Apache ORC project and later adopted by iceberg-cpp. We believe it could also benefit other projects under the Apache Iceberg umbrella.

Refs:

- https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/
- https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md