### PR TITLE
fix(manifest): handle lifecycle of the decoder in reader

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -605,9 +605,6 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = dec.Close()
-	}()
 
 	metadata := dec.Metadata()
 	sc := dec.Schema()
@@ -667,6 +664,11 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		fieldIDToType: fieldIDToType,
 		fieldIDToSize: fieldIDToSize,
 	}, nil
+}
+
+// Close releases decoder resources associated with this manifest reader.
+func (c *ManifestReader) Close() error {
+	return c.dec.Close()
 }
 
 // Version returns the file's format version.
@@ -779,6 +781,10 @@ func ReadManifest(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestE
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = manifestReader.Close()
+	}()
+
 	var results []ManifestEntry
 	for {
 		entry, err := manifestReader.ReadEntry()

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1274,6 +1274,62 @@ func (m *ManifestTestSuite) TestManifestEntriesV3() {
 	m.Zero(*datafile.SortOrderID())
 }
 
+func (m *ManifestTestSuite) TestNewManifestReaderZstdManifestEntriesV2() {
+	manifest := manifestFile{
+		version: 2,
+		SpecID:  1,
+		Path:    manifestFileRecordsV2[0].FilePath(),
+	}
+
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+
+	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
+	m.Require().NoError(err)
+
+	entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 2)
+	m.Require().NoError(err)
+
+	mw := ManifestWriter{
+		version: 2,
+		spec:    partitionSpec,
+		schema:  testSchema,
+		content: ManifestContentData,
+	}
+	md, err := mw.meta()
+	m.Require().NoError(err)
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(entrySchema, &buf,
+		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+		ocf.WithMetadata(md),
+		ocf.WithCodec(ocf.ZStandard))
+	m.Require().NoError(err)
+
+	m.Require().NoError(enc.Encode(manifestEntryV2Records[0]))
+	m.Require().NoError(enc.Encode(manifestEntryV2Records[1]))
+	m.Require().NoError(enc.Close())
+
+	manifestReader, err := NewManifestReader(&manifest, bytes.NewReader(buf.Bytes()))
+	m.Require().NoError(err)
+	defer func() {
+		m.Require().NoError(manifestReader.Close())
+	}()
+
+	entry1, err := manifestReader.ReadEntry()
+	m.Require().NoError(err)
+	m.Equal(manifestEntryV2Records[0].DataFile().FilePath(), entry1.DataFile().FilePath())
+
+	entry2, err := manifestReader.ReadEntry()
+	m.Require().NoError(err)
+	m.Equal(manifestEntryV2Records[1].DataFile().FilePath(), entry2.DataFile().FilePath())
+
+	_, err = manifestReader.ReadEntry()
+	m.Require().ErrorIs(err, io.EOF)
+}
+
 func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	dataFileBuilder, err := NewDataFileBuilder(
 		NewPartitionSpec(),


### PR DESCRIPTION
related to #721

* remove premature decoder close in the constructor so that reader can actually read the entries

* add explicit close method for resource cleanup

* call close in ReadManifest to prevent leak

* add zstd codec based regression test