### PR TITLE
fix(table): stop iter.Pull counter goroutine in partitioned write paths

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1373,6 +1373,7 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 		return cw.writeFiles(ctx, rootLocation, args.fs, meta, meta.props, nil, tasks)
 	}
 
+	stopCount()
 	factory := NewWriterFactory(rootLocation, args, meta, taskSchema, targetFileSize)
 	partitionWriter := newPartitionedFanoutWriter(*currentSpec, cw, meta.CurrentSchema(), args.itr, &factory)
 	workers := config.EnvConfig.MaxWorkers
@@ -1448,6 +1449,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 
 		return cw.writeFiles(ctx, rootLocation, args.fs, meta, meta.props, nil, tasks)
 	}
+	stopCount()
 	writerFactory := NewWriterFactory(rootLocation, args, meta, iceberg.PositionalDeleteSchema, targetFileSize)
 	partitionWriter := newPositionDeletePartitionedFanoutWriter(latestMetadata, cw, partitionContextByFilePath, args.itr, &writerFactory)
 	workers := config.EnvConfig.MaxWorkers


### PR DESCRIPTION
Follow-up to #721. Test TBD.