### PR TITLE
fix(table): deadlock in MapExec when workers error

### DIFF
--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -521,12 +521,12 @@ func TruncateUpperBoundBinary(val []byte, trunc int) []byte {
 	return nil
 }
 
-func MapExec[T, S any](nWorkers int, slice iter.Seq[T], fn func(T) (S, error)) iter.Seq2[S, error] {
+func MapExec[T, S any](ctx context.Context, nWorkers int, slice iter.Seq[T], fn func(T) (S, error)) iter.Seq2[S, error] {
 	if nWorkers <= 0 {
 		nWorkers = runtime.GOMAXPROCS(0)
 	}
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 	ch := make(chan T, nWorkers)
 	out := make(chan S, nWorkers)
 
@@ -550,19 +550,19 @@ func MapExec[T, S any](nWorkers int, slice iter.Seq[T], fn func(T) (S, error)) i
 
 	var err error
 	go func() {
-		defer close(out)
+		defer func() {
+			close(ch)
+			err = g.Wait()
+			close(out)
+		}()
+
 		for v := range slice {
 			select {
 			case ch <- v:
 			case <-ctx.Done():
-				close(ch)
-				err = g.Wait()
-
 				return
 			}
 		}
-		close(ch)
-		err = g.Wait()
 	}()
 
 	return func(yield func(S, error) bool) {

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -18,6 +18,7 @@
 package internal_test
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"testing"
@@ -79,7 +80,7 @@ func TestMapExecAllWorkersError(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for _, err := range internal.MapExec(2, slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), func(i int) (int, error) {
+		for _, err := range internal.MapExec(context.Background(), 2, slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), func(i int) (int, error) {
 			return 0, errFail
 		}) {
 			_ = err
@@ -103,7 +104,7 @@ func TestMapExecFinish(t *testing.T) {
 
 	go func() {
 		defer close(ch)
-		for _, err := range internal.MapExec(3, slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), f) {
+		for _, err := range internal.MapExec(context.Background(), 3, slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), f) {
 			assert.NoError(t, err)
 		}
 	}()

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -239,7 +240,7 @@ func (of *overwriteFiles) deletedEntries() ([]iceberg.ManifestEntry, error) {
 
 	nWorkers := config.EnvConfig.MaxWorkers
 	finalResult := make([]iceberg.ManifestEntry, 0, len(previousManifests))
-	for entries, err := range tblutils.MapExec(nWorkers, slices.Values(previousManifests), getEntries) {
+	for entries, err := range tblutils.MapExec(context.TODO(), nWorkers, slices.Values(previousManifests), getEntries) {
 		if err != nil {
 			return nil, err
 		}

--- a/table/writer.go
+++ b/table/writer.go
@@ -210,7 +210,7 @@ func (w *concurrentDataFileWriter) writeFiles(ctx context.Context, rootLocation 
 		}
 	}
 
-	return internal.MapExec(config.EnvConfig.MaxWorkers, tasks, func(t WriteTask) (iceberg.DataFile, error) {
+	return internal.MapExec(ctx, config.EnvConfig.MaxWorkers, tasks, func(t WriteTask) (iceberg.DataFile, error) {
 		return fw.writeFile(ctx, partitionValues, t)
 	})
 }


### PR DESCRIPTION
Use errgroup.WithContext so the first worker error cancels a derived context. Add select on ctx.Done() for both the feeder (ch <- v) and worker (out <- result) sends, allowing them to unblock when the context is cancelled instead of blocking forever.

Closes #796