### PR TITLE
fix(table): add warnings for silent data-affecting behavior

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -343,7 +344,7 @@ func (c convertToIceberg) Primitive(dt arrow.DataType) (result iceberg.NestedFie
 			if !c.downcastTimestamp {
 				panic(fmt.Errorf("%w: 'ns' timestamp precision not supported", iceberg.ErrType))
 			}
-			// TODO: log something
+			slog.Warn("downcasting nanosecond timestamp to microsecond, precision loss may occur")
 		}
 
 		if slices.Contains(utcAliases, dt.TimeZone) {

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"slices"
 	"strconv"
@@ -237,7 +238,7 @@ func (parquetFormat) GetWriteProperties(props iceberg.Properties) any {
 	case "lzo":
 		codec = compress.Codecs.Lzo
 	default:
-		// warn
+		slog.Warn("unrecognized compression codec, falling back to uncompressed", "codec", compression)
 	}
 
 	return append(writerProps, parquet.WithCompression(codec),


### PR DESCRIPTION
Replace TODO/placeholder comments with log.Printf warnings for two cases that silently affect data without notifying the caller:

- Nanosecond timestamp downcast to microsecond (precision loss)
- Unrecognized compression codec falling back to uncompressed

It's better then nothing

Closes #797