### PR TITLE
feat(hive): adding register table in hive catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ make lint-install
 | Load Table                  |  X   |  X   |   X    |  X   |
 | List Tables                 |  X   |  X   |   X    |  X   |
 | Create Table                |  X   |  X   |   X    |  X   |
-| Register Table              |  X   |      |   X    |      |
+| Register Table              |  X   |  X   |   X    |      |
 | Update Current Snapshot     |  X   |  X   |   X    |  X   |
 | Create New Snapshot         |  X   |  X   |   X    |  X   |
 | Rename Table                |  X   |  X   |   X    |  X   |

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -202,6 +202,61 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	return c.LoadTable(ctx, identifier)
 }
 
+// RegisterTable adds an existing Iceberg table to the Hive metastore
+func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier, metadataLocation string) (*table.Table, error) {
+	database, tableName, err := identifierToTableName(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	exists, err := c.CheckNamespaceExists(ctx, DatabaseIdentifier(database))
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, database)
+	}
+
+	viewExists, err := c.CheckViewExists(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if viewExists {
+		return nil, fmt.Errorf("%w: %s.%s", catalog.ErrViewAlreadyExists, database, tableName)
+	}
+
+	tableExists, err := c.CheckTableExists(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if tableExists {
+		return nil, fmt.Errorf("%w: %s.%s", catalog.ErrTableAlreadyExists, database, tableName)
+	}
+
+	tbl, err := table.NewFromLocation(
+		ctx,
+		identifier,
+		metadataLocation,
+		io.LoadFSFunc(c.opts.props, metadataLocation),
+		c,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read table metadata from %s: %s", metadataLocation, err)
+	}
+
+	hiveTbl := constructHiveTable(database, tableName, tbl.Location(), metadataLocation, tbl.Metadata().CurrentSchema(), maps.Clone(tbl.Metadata().Properties()))
+
+	if err := c.client.CreateTable(ctx, hiveTbl); err != nil {
+		if isAlreadyExistsError(err) {
+			return nil, fmt.Errorf("%w: %s.%s", catalog.ErrTableAlreadyExists, database, tableName)
+		}
+
+		return nil, fmt.Errorf("failed to register table %s.%s: %s", database, tableName, err)
+	}
+
+	return c.LoadTable(ctx, identifier)
+}
+
 // CreateView creates a new view in the catalog. It uses the same signature as the REST catalog:
 // identifier, version (with SQL representations), schema, and optional CreateViewOpt for location and properties.
 // Returns the created *view.View, or an error if the namespace is missing, a view/table already exists, or creation fails.

--- a/catalog/hive/hive_integration_test.go
+++ b/catalog/hive/hive_integration_test.go
@@ -232,6 +232,48 @@ func TestHiveIntegrationCreateAndListTables(t *testing.T) {
 	assert.True(schema.Equals(loadedTable.Schema()))
 }
 
+func TestHiveIntegrationRegisterTable(t *testing.T) {
+	assert := require.New(t)
+
+	cat := createTestCatalog(t)
+	defer cat.Close()
+
+	dbName := fmt.Sprintf("test_db_%d", time.Now().UnixNano())
+	origName := "orig_table"
+	regName := "registered_table"
+
+	err := cat.CreateNamespace(context.TODO(), DatabaseIdentifier(dbName), iceberg.Properties{
+		"location": getTestTableLocation() + "/" + dbName,
+	})
+	assert.NoError(err)
+	defer cat.DropNamespace(context.TODO(), DatabaseIdentifier(dbName))
+
+	schema := iceberg.NewSchemaWithIdentifiers(0, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+	)
+
+	tableLocation := getTestTableLocation() + "/" + dbName + "/" + origName
+	origTbl, err := cat.CreateTable(context.TODO(), TableIdentifier(dbName, origName), schema,
+		catalog.WithLocation(tableLocation),
+	)
+	assert.NoError(err)
+	metadataLocation := origTbl.MetadataLocation()
+
+	err = cat.DropTable(context.TODO(), TableIdentifier(dbName, origName))
+	assert.NoError(err)
+
+	regTbl, err := cat.RegisterTable(context.TODO(), TableIdentifier(dbName, regName), metadataLocation)
+	assert.NoError(err)
+	assert.NotNil(regTbl)
+	assert.Equal(metadataLocation, regTbl.MetadataLocation())
+	assert.True(schema.Equals(regTbl.Schema()))
+
+	defer func() {
+		assert.NoError(cat.DropTable(context.TODO(), TableIdentifier(dbName, regName)))
+	}()
+}
+
 func TestHiveIntegrationRenameTable(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -583,6 +584,140 @@ func TestHiveCreateTableConflictsWithView(t *testing.T) {
 	)
 	assert.Error(err)
 	assert.True(errors.Is(err, catalog.ErrViewAlreadyExists))
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveRegisterTableNoSuchNamespace(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "missing_db").
+		Return(nil, errNoSuchObject).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	_, err := hiveCatalog.RegisterTable(context.TODO(),
+		TableIdentifier("missing_db", "t"),
+		"s3://bucket/metadata/v1.metadata.json",
+	)
+	assert.Error(err)
+	assert.True(errors.Is(err, catalog.ErrNoSuchNamespace))
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveRegisterTableConflictsWithView(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").
+		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(testIcebergHiveView, nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	_, err := hiveCatalog.RegisterTable(context.TODO(),
+		TableIdentifier("test_database", "test_table"),
+		"s3://bucket/metadata/v1.metadata.json",
+	)
+	assert.Error(err)
+	assert.True(errors.Is(err, catalog.ErrViewAlreadyExists))
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveRegisterTableAlreadyExists(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").
+		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(nil, errNoSuchObject).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(testIcebergHiveTable1, nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	_, err := hiveCatalog.RegisterTable(context.TODO(),
+		TableIdentifier("test_database", "test_table"),
+		"s3://bucket/metadata/v1.metadata.json",
+	)
+	assert.Error(err)
+	assert.True(errors.Is(err, catalog.ErrTableAlreadyExists))
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveRegisterTableMetadataNotFound(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").
+		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "new_table").
+		Return(nil, errNoSuchObject).Times(2)
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	_, err := hiveCatalog.RegisterTable(context.TODO(),
+		TableIdentifier("test_database", "new_table"),
+		"s3://nonexistent-bucket/metadata/metadata.json",
+	)
+	assert.Error(err)
+	assert.Contains(err.Error(), "failed to read table metadata from s3://nonexistent-bucket/metadata/metadata.json")
+
+	mockClient.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveRegisterTableSuccess(t *testing.T) {
+	assert := require.New(t)
+
+	metaPath, err := filepath.Abs(filepath.Join("..", "..", "table", "testdata", "TableMetadataV2Valid.json"))
+	assert.NoError(err)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").
+		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "reg_table").
+		Return(nil, errNoSuchObject).Times(2)
+
+	mockClient.On("CreateTable", mock.Anything, mock.MatchedBy(func(ht *hive_metastore.Table) bool {
+		return ht.DbName == "test_database" && ht.TableName == "reg_table" &&
+			ht.Parameters[MetadataLocationKey] == metaPath &&
+			strings.EqualFold(ht.Parameters[TableTypeKey], TableTypeIceberg)
+	})).Return(nil).Once()
+
+	hiveTblForLoad := &hive_metastore.Table{
+		TableName: "reg_table",
+		DbName:    "test_database",
+		TableType: TableTypeExternalTable,
+		Parameters: map[string]string{
+			TableTypeKey:        TableTypeIceberg,
+			MetadataLocationKey: metaPath,
+		},
+		Sd: &hive_metastore.StorageDescriptor{
+			Location: "s3://bucket/test/location",
+		},
+	}
+
+	mockClient.On("GetTable", mock.Anything, "test_database", "reg_table").
+		Return(hiveTblForLoad, nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	// TODO: should we drop table here
+
+	tbl, err := hiveCatalog.RegisterTable(context.TODO(),
+		TableIdentifier("test_database", "reg_table"),
+		metaPath,
+	)
+	assert.NoError(err)
+	assert.NotNil(tbl)
+	assert.Equal(metaPath, tbl.MetadataLocation())
 
 	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
## Description
Adding hive register table functionality, where the user can register different catalog iceberg tables in the Hive catalog. 

## Changes 
-> catalog/hive/hive.go:  added function for registering catalog 
-> catalog/hive/hive_integration_test.go: integration test for function
-> catalog/hive/hive_test.go: unit tests for register table function

## Issue
Closes https://github.com/apache/iceberg-go/issues/790

## Test
1. Created a JDBC catalog table 
2. verified in pg and collected metadata location 
3. Registered it with Hive 
4. checked in Hive metastore as well as queried through Spark