### PR TITLE
feat(table): reject reserved metadata column IDs in user schemas

### DIFF
--- a/metadata_columns.go
+++ b/metadata_columns.go
@@ -3,7 +3,7 @@
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
-// "License"); you may not use it except in compliance
+// "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -1812,6 +1812,22 @@ func TestUnknownTypeValidation(t *testing.T) {
 		require.ErrorContains(t, err, "must be optional")
 	})
 
+	t.Run("ReservedFieldIDRowID", func(t *testing.T) {
+		schema := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: iceberg.RowIDFieldID, Name: "bad_field", Type: iceberg.PrimitiveTypes.Int64},
+		)
+		err := checkSchemaCompatibility(schema, 3)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reserved metadata column ID")
+	})
+	t.Run("ReservedFieldIDLastUpdatedSeqNum", func(t *testing.T) {
+		schema := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: iceberg.LastUpdatedSequenceNumberFieldID, Name: "bad_field", Type: iceberg.PrimitiveTypes.Int64},
+		)
+		err := checkSchemaCompatibility(schema, 3)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reserved metadata column ID")
+	})
 	t.Run("InvalidUnknownMapValue", func(t *testing.T) {
 		invalidSchema := iceberg.NewSchema(1,
 			iceberg.NestedField{ID: 2, Name: "invalid_map", Type: &iceberg.MapType{KeyID: 3, KeyType: iceberg.StringType{}, ValueID: 4, ValueType: iceberg.UnknownType{}, ValueRequired: true}, Required: false},

--- a/table/metadata_schema_compatibility.go
+++ b/table/metadata_schema_compatibility.go
@@ -95,6 +95,11 @@ func checkSchemaCompatibility(sc *iceberg.Schema, formatVersion int) error {
 			panic("invalid schema: field with id " + strconv.Itoa(field.ID) + " not found, this is a bug, please report.")
 		}
 
+		if iceberg.IsMetadataColumn(field.ID) {
+			return fmt.Errorf("%w: field '%s' uses reserved metadata column ID %d",
+				iceberg.ErrInvalidSchema, colName, field.ID)
+		}
+
 		minFormatVersion := minFormatVersionForType(field.Type)
 		if formatVersion < minFormatVersion {
 			problems = append(problems, IncompatibleField{


### PR DESCRIPTION
Add validation in checkSchemaCompatibility to reject schemas that use reserved metadata column field IDs (2147483540 for _row_id, 2147483539 for _last_updated_sequence_number). These IDs are reserved by the Iceberg v3 spec for row lineage and must not be used by user-defined fields. 

Together with #735  should close #727