### PR TITLE
feat(table): multi-arg transforms in partition and sort fields

### DIFF
--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -179,11 +179,11 @@ var testSchema = iceberg.NewSchemaWithIdentifiers(0, []int{},
 	iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool})
 
 var testPartitionSpec = iceberg.NewPartitionSpec(
-	iceberg.PartitionField{SourceID: 2, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
+	iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
 
 var testSortOrder, _ = table.NewSortOrder(1, []table.SortField{
 	{
-		SourceID: 1, Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1}, Transform: iceberg.IdentityTransform{},
 		Direction: table.SortASC, NullOrder: table.NullsLast,
 	},
 })

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -412,7 +412,7 @@ func (s *SqliteCatalogTestSuite) TestCreateTableCustomSortOrder() {
 		s.Require().NoError(tt.cat.CreateNamespace(context.Background(), ns, nil))
 
 		order, err := table.NewSortOrder(1, []table.SortField{
-			{SourceID: 2, Transform: iceberg.IdentityTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
+			{SourceIDs: []int{2}, Transform: iceberg.IdentityTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
 		})
 		s.Require().NoError(err)
 		tbl, err := tt.cat.CreateTable(context.Background(), tt.tblID, tableSchemaNested,

--- a/cmd/iceberg/utils.go
+++ b/cmd/iceberg/utils.go
@@ -63,7 +63,7 @@ func parsePartitionSpec(specStr string) (*iceberg.PartitionSpec, error) {
 		}
 
 		partitionFields = append(partitionFields, iceberg.PartitionField{
-			SourceID:  i + 1,
+			SourceIDs: []int{i + 1},
 			FieldID:   i + iceberg.PartitionDataIDStart,
 			Name:      field,
 			Transform: iceberg.IdentityTransform{},
@@ -128,7 +128,7 @@ func parseSortOrder(sortStr string) (table.SortOrder, error) {
 			}
 		}
 		sortFields = append(sortFields, table.SortField{
-			SourceID:  i + 1,
+			SourceIDs: []int{i + 1},
 			Transform: iceberg.IdentityTransform{},
 			Direction: sortDirection,
 			NullOrder: nullOrder,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -506,8 +506,8 @@ func (m *ManifestTestSuite) writeManifestEntries() {
 	}
 
 	partitionSpec := NewPartitionSpecID(1,
-		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
-		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 
 	mf, err := WriteManifest("/home/iceberg/warehouse/nyc/taxis_partitioned/metadata/0125c686-8aa6-4502-bdcc-b6d17ca41a3b-m0.avro",
 		&m.v1ManifestEntries, 1, partitionSpec, testSchema, entrySnapshotID, manifestEntryV1Recs)
@@ -1083,8 +1083,8 @@ func (m *ManifestTestSuite) TestManifestEntriesV2() {
 	}
 
 	partitionSpec := NewPartitionSpecID(1,
-		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
-		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 
 	mockedFile := &internal.MockFile{
 		Contents: bytes.NewReader(m.v2ManifestEntries.Bytes()),
@@ -1239,8 +1239,8 @@ func (m *ManifestTestSuite) TestManifestEntriesV3() {
 		Path:    manifestFileRecordsV3[0].FilePath(),
 	}
 	partitionSpec := NewPartitionSpecID(1,
-		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
-		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 	mockedFile := &internal.MockFile{
 		Contents: bytes.NewReader(m.v3ManifestEntries.Bytes()),
 	}
@@ -1320,8 +1320,8 @@ func (m *ManifestTestSuite) TestNewManifestReaderZstdManifestEntriesV2() {
 	}
 
 	partitionSpec := NewPartitionSpecID(1,
-		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
-		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 
 	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
 	m.Require().NoError(err)
@@ -1655,8 +1655,8 @@ func (m *ManifestTestSuite) TestWriteManifestListClosesWriterOnError() {
 
 func (m *ManifestTestSuite) TestWriteManifestClosesWriterOnEntryError() {
 	partitionSpec := NewPartitionSpecID(1,
-		PartitionField{FieldID: 1000, SourceID: 1, Name: "VendorID", Transform: IdentityTransform{}},
-		PartitionField{FieldID: 1001, SourceID: 2, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 
 	var header bytes.Buffer
 	writer, err := NewManifestWriter(2, &header, partitionSpec, testSchema, entrySnapshotID)

--- a/partitions.go
+++ b/partitions.go
@@ -41,12 +41,9 @@ var UnpartitionedSpec = &PartitionSpec{id: 0}
 // PartitionField represents how one partition value is derived from the
 // source column by transformation.
 type PartitionField struct {
-	// SourceID is the source column id of the table's schema.
-	// For multi-argument transforms, this is the first source column;
-	// use SourceIDs to get all source columns.
-	SourceID int `json:"source-id"`
-	// SourceIDs contains all source column ids for multi-argument transforms.
-	// For single-argument transforms this is nil and SourceID should be used.
+	// SourceIDs contains the source column ids from the table's schema.
+	// For single-argument transforms this will have exactly one element.
+	// For multi-argument transforms this will have multiple elements.
 	SourceIDs []int `json:"-"`
 	// FieldID is the partition field id across all the table partition specs
 	FieldID int `json:"field-id"`
@@ -60,6 +57,17 @@ type PartitionField struct {
 	escapedName string
 }
 
+// SourceID returns the first source column id. For single-argument transforms
+// this is the only source column. For multi-argument transforms this is the
+// first source column.
+func (p PartitionField) SourceID() int {
+	if len(p.SourceIDs) == 0 {
+		return 0
+	}
+
+	return p.SourceIDs[0]
+}
+
 // EscapedName returns the URL-escaped version of the partition field name.
 func (p *PartitionField) EscapedName() string {
 	if p.escapedName == "" {
@@ -71,7 +79,6 @@ func (p *PartitionField) EscapedName() string {
 
 func (p PartitionField) MarshalJSON() ([]byte, error) {
 	if len(p.SourceIDs) > 1 {
-		// Multi-argument transform: write source-ids instead of source-id
 		return json.Marshal(struct {
 			SourceIDs []int     `json:"source-ids"`
 			FieldID   int       `json:"field-id"`
@@ -80,21 +87,19 @@ func (p PartitionField) MarshalJSON() ([]byte, error) {
 		}{p.SourceIDs, p.FieldID, p.Name, p.Transform})
 	}
 
-	// Single-argument transform: write source-id
 	return json.Marshal(struct {
 		SourceID  int       `json:"source-id"`
 		FieldID   int       `json:"field-id"`
 		Name      string    `json:"name"`
 		Transform Transform `json:"transform"`
-	}{p.SourceID, p.FieldID, p.Name, p.Transform})
+	}{p.SourceID(), p.FieldID, p.Name, p.Transform})
 }
 
 func (p PartitionField) Equals(other PartitionField) bool {
-	return p.SourceID == other.SourceID &&
+	return slices.Equal(p.SourceIDs, other.SourceIDs) &&
 		p.FieldID == other.FieldID &&
 		p.Name == other.Name &&
-		p.Transform.Equals(other.Transform) &&
-		slices.Equal(p.SourceIDs, other.SourceIDs)
+		p.Transform.Equals(other.Transform)
 }
 
 func (p *PartitionField) String() string {
@@ -102,7 +107,7 @@ func (p *PartitionField) String() string {
 		return fmt.Sprintf("%d: %s: %s(%v)", p.FieldID, p.Name, p.Transform, p.SourceIDs)
 	}
 
-	return fmt.Sprintf("%d: %s: %s(%d)", p.FieldID, p.Name, p.Transform, p.SourceID)
+	return fmt.Sprintf("%d: %s: %s(%d)", p.FieldID, p.Name, p.Transform, p.SourceID())
 }
 
 func (p *PartitionField) UnmarshalJSON(b []byte) error {
@@ -117,27 +122,28 @@ func (p *PartitionField) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	type Alias PartitionField
 	aux := struct {
-		TransformString string `json:"transform"`
+		SourceID        int    `json:"source-id"`
 		SourceIDs       []int  `json:"source-ids,omitempty"`
-		*Alias
-	}{
-		Alias: (*Alias)(p),
-	}
+		FieldID         int    `json:"field-id"`
+		Name            string `json:"name"`
+		TransformString string `json:"transform"`
+	}{}
 
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
+	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
+	p.FieldID = aux.FieldID
+	p.Name = aux.Name
+
 	if len(aux.SourceIDs) > 0 {
-		p.SourceID = aux.SourceIDs[0]
-		if len(aux.SourceIDs) > 1 {
-			p.SourceIDs = aux.SourceIDs
-		}
+		p.SourceIDs = aux.SourceIDs
+	} else {
+		p.SourceIDs = []int{aux.SourceID}
 	}
 
+	var err error
 	if p.Transform, err = ParseTransform(aux.TransformString); err != nil {
 		return err
 	}
@@ -173,7 +179,7 @@ func (p *PartitionSpec) BindToSchema(schema *Schema, lastPartitionID *int, newSp
 	}
 
 	for _, field := range p.Fields() {
-		opts = append(opts, AddPartitionFieldBySourceID(field.SourceID, field.Name, field.Transform, schema, &field.FieldID))
+		opts = append(opts, AddPartitionFieldBySourceID(field.SourceID(), field.Name, field.Transform, schema, &field.FieldID))
 	}
 
 	freshSpec, err := NewPartitionSpecOpts(opts...)
@@ -265,7 +271,7 @@ func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedFiel
 		return err
 	}
 	unboundField := PartitionField{
-		SourceID:  field.ID,
+		SourceIDs: []int{field.ID},
 		FieldID:   fieldIDValue,
 		Name:      targetName,
 		Transform: transform,
@@ -363,7 +369,7 @@ func (ps *PartitionSpec) CompatibleWith(other *PartitionSpec) bool {
 	}
 
 	return slices.EqualFunc(ps.fields, other.fields, func(left, right PartitionField) bool {
-		return left.SourceID == right.SourceID && left.Name == right.Name &&
+		return slices.Equal(left.SourceIDs, right.SourceIDs) && left.Name == right.Name &&
 			left.Transform == right.Transform
 	})
 }
@@ -412,7 +418,7 @@ func (ps *PartitionSpec) initialize() {
 	ps.sourceIdToFields = make(map[int][]PartitionField)
 
 	for i := range ps.fields {
-		ps.sourceIdToFields[ps.fields[i].SourceID] = append(ps.sourceIdToFields[ps.fields[i].SourceID], ps.fields[i])
+		ps.sourceIdToFields[ps.fields[i].SourceID()] = append(ps.sourceIdToFields[ps.fields[i].SourceID()], ps.fields[i])
 	}
 }
 
@@ -488,7 +494,7 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
 	nestedFields := []NestedField{}
 	for _, field := range ps.fields {
-		sourceType, ok := schema.FindTypeByID(field.SourceID)
+		sourceType, ok := schema.FindTypeByID(field.SourceID())
 		if !ok {
 			continue
 		}
@@ -553,9 +559,9 @@ func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, e
 		return field.Name, nil
 	}
 
-	sourceName, exists := schema.FindColumnName(field.SourceID)
+	sourceName, exists := schema.FindColumnName(field.SourceID())
 	if !exists {
-		return "", fmt.Errorf("could not find field with id %d", field.SourceID)
+		return "", fmt.Errorf("could not find field with id %d", field.SourceID())
 	}
 
 	transform := field.Transform

--- a/partitions_bench_test.go
+++ b/partitions_bench_test.go
@@ -38,23 +38,23 @@ func BenchmarkPartitionToPath(b *testing.B) {
 	// Create a partition spec with fields that need URL escaping
 	spec := iceberg.NewPartitionSpecID(1,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "my#str%bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.IdentityTransform{}, Name: "other str+bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1002,
+			SourceIDs: []int{3}, FieldID: 1002,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "my!int:bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 4, FieldID: 1003,
+			SourceIDs: []int{4}, FieldID: 1003,
 			Transform: iceberg.DayTransform{}, Name: "date/day",
 		},
 		iceberg.PartitionField{
-			SourceID: 5, FieldID: 1004,
+			SourceIDs: []int{5}, FieldID: 1004,
 			Transform: iceberg.HourTransform{}, Name: "ts/hour",
 		},
 	)
@@ -82,7 +82,7 @@ func BenchmarkPartitionToPathManyFields(b *testing.B) {
 			Type: iceberg.PrimitiveTypes.String, Required: false,
 		})
 		partitionFields = append(partitionFields, iceberg.PartitionField{
-			SourceID: i, FieldID: 1000 + i,
+			SourceIDs: []int{i}, FieldID: 1000 + i,
 			Transform: iceberg.IdentityTransform{}, Name: "part_field_" + string(rune('a'+i-1)),
 		})
 		recordValues = append(recordValues, "value_"+string(rune('a'+i-1)))
@@ -111,15 +111,15 @@ func BenchmarkPartitionType(b *testing.B) {
 
 	spec := iceberg.NewPartitionSpecID(1,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "str_truncate",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "int_bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1002,
+			SourceIDs: []int{3}, FieldID: 1002,
 			Transform: iceberg.IdentityTransform{}, Name: "bool_identity",
 		},
 	)
@@ -144,11 +144,11 @@ func BenchmarkPartitionTypeMultipleSchemas(b *testing.B) {
 
 	spec := iceberg.NewPartitionSpecID(1,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.IdentityTransform{}, Name: "str_identity",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 10}, Name: "int_bucket",
 		},
 	)
@@ -173,15 +173,15 @@ func BenchmarkPartitionToPathRepeated(b *testing.B) {
 	// Use field names that require URL escaping to maximize the benefit of caching
 	spec := iceberg.NewPartitionSpecID(1,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "my#str%bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.IdentityTransform{}, Name: "other str+bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1002,
+			SourceIDs: []int{3}, FieldID: 1002,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "my!int:bucket",
 		},
 	)
@@ -209,7 +209,7 @@ func BenchmarkPartitionSpecInitialize(b *testing.B) {
 	fields := make([]iceberg.PartitionField, 10)
 	for i := range fields {
 		fields[i] = iceberg.PartitionField{
-			SourceID: i + 1, FieldID: 1000 + i,
+			SourceIDs: []int{i + 1}, FieldID: 1000 + i,
 			Transform: iceberg.IdentityTransform{}, Name: "field#with%special&chars=" + string(rune('a'+i)),
 		}
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -31,7 +31,7 @@ func TestPartitionSpec(t *testing.T) {
 
 	bucket := iceberg.BucketTransform{NumBuckets: 4}
 	idField1 := iceberg.PartitionField{
-		SourceID: 3, FieldID: 1001, Name: "id", Transform: bucket,
+		SourceIDs: []int{3}, FieldID: 1001, Name: "id", Transform: bucket,
 	}
 	spec1 := iceberg.NewPartitionSpec(idField1)
 
@@ -47,7 +47,7 @@ func TestPartitionSpec(t *testing.T) {
 
 	// only differs by PartitionField FieldID
 	idField2 := iceberg.PartitionField{
-		SourceID: 3, FieldID: 1002, Name: "id", Transform: bucket,
+		SourceIDs: []int{3}, FieldID: 1002, Name: "id", Transform: bucket,
 	}
 	spec2 := iceberg.NewPartitionSpec(idField2)
 
@@ -63,15 +63,15 @@ func TestPartitionSpec(t *testing.T) {
 
 func TestUnpartitionedWithVoidField(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 3, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},
+		SourceIDs: []int{3}, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},
 	})
 
 	assert.True(t, spec.IsUnpartitioned())
 
 	spec2 := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 3, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},
+		SourceIDs: []int{3}, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},
 	}, iceberg.PartitionField{
-		SourceID: 3, FieldID: 1002, Name: "bucket", Transform: iceberg.BucketTransform{NumBuckets: 2},
+		SourceIDs: []int{3}, FieldID: 1002, Name: "bucket", Transform: iceberg.BucketTransform{NumBuckets: 2},
 	})
 
 	assert.False(t, spec2.IsUnpartitioned())
@@ -88,11 +88,11 @@ func TestSerializeUnpartitionedSpec(t *testing.T) {
 func TestSerializePartitionSpec(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "str_truncate",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "int_bucket",
 		},
 	)
@@ -127,19 +127,19 @@ func TestSerializePartitionSpec(t *testing.T) {
 func TestPartitionType(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "str_truncate",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "int_bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1002,
+			SourceIDs: []int{3}, FieldID: 1002,
 			Transform: iceberg.IdentityTransform{}, Name: "bool_identity",
 		},
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1003,
+			SourceIDs: []int{1}, FieldID: 1003,
 			Transform: iceberg.VoidTransform{}, Name: "str_void",
 		},
 	)
@@ -170,15 +170,15 @@ func TestPartitionSpecToPath(t *testing.T) {
 
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "my#str%bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.IdentityTransform{}, Name: "other str+bucket",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1002,
+			SourceIDs: []int{3}, FieldID: 1002,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "my!int:bucket",
 		})
 
@@ -201,39 +201,39 @@ func TestGetPartitionFieldName(t *testing.T) {
 		expectedName string
 	}{
 		{
-			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "foo"},
+			field:        iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "foo"},
 			expectedName: "foo",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: ""},
 			expectedName: "str",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1001, Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1001, Transform: iceberg.BucketTransform{NumBuckets: 7}, Name: ""},
 			expectedName: "int_bucket_7",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 2, FieldID: 1002, Transform: iceberg.TruncateTransform{Width: 19}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1002, Transform: iceberg.TruncateTransform{Width: 19}, Name: ""},
 			expectedName: "int_trunc_19",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1003, Transform: iceberg.VoidTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1003, Transform: iceberg.VoidTransform{}, Name: ""},
 			expectedName: "ts_null",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.YearTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1004, Transform: iceberg.YearTransform{}, Name: ""},
 			expectedName: "ts_year",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.MonthTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1004, Transform: iceberg.MonthTransform{}, Name: ""},
 			expectedName: "ts_month",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.DayTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1004, Transform: iceberg.DayTransform{}, Name: ""},
 			expectedName: "ts_day",
 		},
 		{
-			field:        iceberg.PartitionField{SourceID: 3, FieldID: 1004, Transform: iceberg.HourTransform{}, Name: ""},
+			field:        iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1004, Transform: iceberg.HourTransform{}, Name: ""},
 			expectedName: "ts_hour",
 		},
 	}
@@ -259,7 +259,7 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var field iceberg.PartitionField
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.NoError(t, err)
-		assert.Equal(t, 1, field.SourceID)
+		assert.Equal(t, 1, field.SourceID())
 		assert.Equal(t, 1000, field.FieldID)
 		assert.Equal(t, "str_truncate", field.Name)
 		assert.Equal(t, iceberg.TruncateTransform{Width: 19}, field.Transform)
@@ -276,7 +276,7 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var field iceberg.PartitionField
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.NoError(t, err)
-		assert.Equal(t, 2, field.SourceID)
+		assert.Equal(t, 2, field.SourceID())
 		assert.Equal(t, 1001, field.FieldID)
 		assert.Equal(t, "int_bucket", field.Name)
 		assert.Equal(t, iceberg.BucketTransform{NumBuckets: 25}, field.Transform)
@@ -293,7 +293,7 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var field iceberg.PartitionField
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.NoError(t, err)
-		assert.Equal(t, 2, field.SourceID, "SourceID should be first element")
+		assert.Equal(t, 2, field.SourceID(), "SourceID should be first element")
 		assert.Equal(t, []int{2, 3}, field.SourceIDs, "SourceIDs should contain all elements")
 		assert.Equal(t, 1001, field.FieldID)
 		assert.Equal(t, "int_bucket", field.Name)
@@ -301,7 +301,6 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 
 	t.Run("marshal multi-arg round-trip", func(t *testing.T) {
 		field := iceberg.PartitionField{
-			SourceID:  2,
 			SourceIDs: []int{2, 3},
 			FieldID:   1001,
 			Name:      "multi_arg",
@@ -315,13 +314,13 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var decoded iceberg.PartitionField
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		assert.Equal(t, 2, decoded.SourceID)
+		assert.Equal(t, 2, decoded.SourceID())
 		assert.Equal(t, []int{2, 3}, decoded.SourceIDs)
 	})
 
 	t.Run("marshal single-arg uses source-id", func(t *testing.T) {
 		field := iceberg.PartitionField{
-			SourceID:  1,
+			SourceIDs: []int{1},
 			FieldID:   1000,
 			Name:      "single_arg",
 			Transform: iceberg.IdentityTransform{},
@@ -357,7 +356,7 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var field iceberg.PartitionField
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.NoError(t, err)
-		assert.Zero(t, field.SourceID)
+		assert.Zero(t, field.SourceID())
 		assert.Equal(t, 1003, field.FieldID)
 		assert.Equal(t, "void", field.Name)
 		assert.Equal(t, iceberg.VoidTransform{}, field.Transform)

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -235,14 +235,14 @@ func equalityDeleteWriteSchema(tableSchema *iceberg.Schema, equalityFieldIDs []i
 
 	// Partition source columns not already in the equality key.
 	for _, f := range spec.Fields() {
-		if _, ok := seen[f.SourceID]; ok {
+		if _, ok := seen[f.SourceID()]; ok {
 			continue
 		}
-		name, ok := tableSchema.FindColumnName(f.SourceID)
+		name, ok := tableSchema.FindColumnName(f.SourceID())
 		if !ok {
-			return nil, fmt.Errorf("%w: partition source field ID %d not found in table schema", iceberg.ErrInvalidSchema, f.SourceID)
+			return nil, fmt.Errorf("%w: partition source field ID %d not found in table schema", iceberg.ErrInvalidSchema, f.SourceID())
 		}
-		seen[f.SourceID] = struct{}{}
+		seen[f.SourceID()] = struct{}{}
 		names = append(names, name)
 	}
 

--- a/table/equality_delete_writer_test.go
+++ b/table/equality_delete_writer_test.go
@@ -237,7 +237,7 @@ func newPartitionedEqDeleteTestTable(t *testing.T) *table.Table {
 	)
 
 	partSpec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 2, FieldID: 1000, Name: "category", Transform: iceberg.IdentityTransform{}},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Name: "category", Transform: iceberg.IdentityTransform{}},
 	)
 
 	meta, err := table.NewMetadata(iceSchema, &partSpec,

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -101,7 +101,7 @@ func TestManifestEvaluator(t *testing.T) {
 	for _, f := range testSchema.Fields() {
 		partFields = append(partFields, iceberg.PartitionField{
 			Name:      f.Name,
-			SourceID:  f.ID,
+			SourceIDs: []int{f.ID},
 			FieldID:   f.ID,
 			Transform: iceberg.IdentityTransform{},
 		})
@@ -735,7 +735,7 @@ func (*ProjectionTestSuite) emptySpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) idSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.IdentityTransform{}, Name: "id_part",
 		},
 	)
@@ -744,7 +744,7 @@ func (*ProjectionTestSuite) idSpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) bucketSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1000,
+			SourceIDs: []int{2}, FieldID: 1000,
 			Transform: iceberg.BucketTransform{NumBuckets: 16}, Name: "data_bucket",
 		},
 	)
@@ -753,11 +753,11 @@ func (*ProjectionTestSuite) bucketSpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) daySpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 4, FieldID: 1000,
+			SourceIDs: []int{4}, FieldID: 1000,
 			Transform: iceberg.DayTransform{}, Name: "date",
 		},
 		iceberg.PartitionField{
-			SourceID: 3, FieldID: 1001,
+			SourceIDs: []int{3}, FieldID: 1001,
 			Transform: iceberg.DayTransform{}, Name: "ddate",
 		},
 	)
@@ -766,7 +766,7 @@ func (*ProjectionTestSuite) daySpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) hourSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 4, FieldID: 1000,
+			SourceIDs: []int{4}, FieldID: 1000,
 			Transform: iceberg.HourTransform{}, Name: "hour",
 		},
 	)
@@ -775,7 +775,7 @@ func (*ProjectionTestSuite) hourSpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) truncateStrSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1000,
+			SourceIDs: []int{2}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 2}, Name: "data_trunc",
 		},
 	)
@@ -784,7 +784,7 @@ func (*ProjectionTestSuite) truncateStrSpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) truncateIntSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 10}, Name: "id_trunc",
 		},
 	)
@@ -793,11 +793,11 @@ func (*ProjectionTestSuite) truncateIntSpec() iceberg.PartitionSpec {
 func (*ProjectionTestSuite) idAndBucketSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.IdentityTransform{}, Name: "id_part",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 16}, Name: "data_bucket",
 		},
 	)

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -159,7 +159,7 @@ func PartitionRecordValue(field iceberg.PartitionField, val iceberg.Literal, sch
 		return ret, nil
 	}
 
-	f, ok := schema.FindFieldByID(field.SourceID)
+	f, ok := schema.FindFieldByID(field.SourceID())
 	if !ok {
 		return ret, fmt.Errorf("%w: could not find source field in schema for %s",
 			iceberg.ErrInvalidSchema, field.String())
@@ -209,7 +209,7 @@ type DataFileStatistics struct {
 }
 
 func (d *DataFileStatistics) PartitionValue(field iceberg.PartitionField, sc *iceberg.Schema) any {
-	agg, ok := d.ColAggs[field.SourceID]
+	agg, ok := d.ColAggs[field.SourceID()]
 	if !ok {
 		return nil
 	}
@@ -256,7 +256,7 @@ func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.Par
 				fieldIDToPartitionData[field.FieldID] = nil
 			}
 
-			if sourceField, ok := schema.FindFieldByID(field.SourceID); ok {
+			if sourceField, ok := schema.FindFieldByID(field.SourceID()); ok {
 				resultType := field.Transform.ResultType(sourceField.Type)
 
 				switch rt := resultType.(type) {

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -165,7 +165,7 @@ func TestPartitionValue_LinearTransforms(t *testing.T) {
 			maxLit := iceberg.NewLiteral(iceberg.Timestamp(tc.max.UnixMicro()))
 
 			partitionField := iceberg.PartitionField{
-				SourceID:  1,
+				SourceIDs: []int{1},
 				FieldID:   100,
 				Name:      tc.name + "_part",
 				Transform: tc.transform,
@@ -192,7 +192,7 @@ func TestPartitionValue_MismatchPanics(t *testing.T) {
 		Type: iceberg.TimestampType{},
 	})
 	partitionField := iceberg.PartitionField{
-		SourceID:  1,
+		SourceIDs: []int{1},
 		FieldID:   100,
 		Name:      "date_part",
 		Transform: iceberg.DayTransform{},

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1990,7 +1990,7 @@ func reassignIDs(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrde
 	for _, f := range partitions.Fields() {
 		var s string
 		var ok bool
-		if s, ok = previousMapFn(f.SourceID); !ok {
+		if s, ok = previousMapFn(f.SourceID()); !ok {
 			return nil, fmt.Errorf("%w: field %d not found in schema", ErrInvalidMetadata, f.FieldID)
 		}
 		opts = append(opts, iceberg.AddPartitionFieldByName(s, f.Name, f.Transform, freshSc, nil))

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -42,7 +42,7 @@ func sortOrder() SortOrder {
 		1,
 		[]SortField{
 			{
-				SourceID:  3,
+				SourceIDs: []int{3},
 				Direction: SortDESC,
 				NullOrder: NullsFirst,
 				Transform: iceberg.BucketTransform{NumBuckets: 4},
@@ -59,7 +59,7 @@ func sortOrder() SortOrder {
 func partitionSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpecID(0,
 		iceberg.PartitionField{
-			SourceID:  2,
+			SourceIDs: []int{2},
 			Name:      "y",
 			Transform: iceberg.IdentityTransform{},
 		},
@@ -192,7 +192,7 @@ func TestReassignIds(t *testing.T) {
 
 	sortOrder, err := NewSortOrder(10, []SortField{
 		{
-			SourceID:  11,
+			SourceIDs: []int{11},
 			Transform: iceberg.IdentityTransform{},
 			Direction: SortASC,
 			NullOrder: NullsFirst,
@@ -252,7 +252,7 @@ func TestReassignIds(t *testing.T) {
 
 	expectedSortOrder, err := NewSortOrder(1, []SortField{
 		{
-			SourceID:  1,
+			SourceIDs: []int{1},
 			Transform: iceberg.IdentityTransform{},
 			Direction: SortASC,
 			NullOrder: NullsFirst,
@@ -395,7 +395,7 @@ func TestSetSortOrder(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	added, err := NewSortOrder(10, []SortField{
 		{
-			SourceID:  1,
+			SourceIDs: []int{1},
 			Transform: iceberg.IdentityTransform{}, Direction: SortASC, NullOrder: NullsFirst,
 		},
 	})
@@ -405,7 +405,7 @@ func TestSetSortOrder(t *testing.T) {
 	require.NoError(t, builder.AddSortOrder(&added))
 	expected, err := NewSortOrder(2, []SortField{
 		{
-			SourceID:  1,
+			SourceIDs: []int{1},
 			Transform: iceberg.IdentityTransform{}, Direction: SortASC, NullOrder: NullsFirst,
 		},
 	})

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -208,12 +208,12 @@ func TestMetadataV1Parsing(t *testing.T) {
 	assert.True(t, meta.CurrentSchema().Equals(expected))
 	assert.Equal(t, []iceberg.PartitionSpec{
 		iceberg.NewPartitionSpec(iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x",
+			SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x",
 		}),
 	}, meta.PartitionSpecs())
 
 	assert.Equal(t, iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x",
+		SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x",
 	}), meta.PartitionSpec())
 
 	assert.Equal(t, 0, meta.DefaultPartitionSpec())
@@ -723,10 +723,10 @@ func TestNewMetadataWithExplicitV1Format(t *testing.T) {
 	)
 
 	partitionSpec := iceberg.NewPartitionSpecID(10,
-		iceberg.PartitionField{SourceID: 22, FieldID: 1022, Transform: iceberg.IdentityTransform{}, Name: "bar"})
+		iceberg.PartitionField{SourceIDs: []int{22}, FieldID: 1022, Transform: iceberg.IdentityTransform{}, Name: "bar"})
 
 	sortOrder, err := NewSortOrder(10, []SortField{{
-		SourceID:  10,
+		SourceIDs: []int{10},
 		Transform: iceberg.IdentityTransform{},
 		Direction: SortASC, NullOrder: NullsLast,
 	}})
@@ -741,10 +741,10 @@ func TestNewMetadataWithExplicitV1Format(t *testing.T) {
 		iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool})
 
 	expectedSpec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 2, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
 
 	expectedSortOrder, err := NewSortOrder(1, []SortField{{
-		SourceID: 1, Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1}, Transform: iceberg.IdentityTransform{},
 		Direction: SortASC, NullOrder: NullsLast,
 	}})
 	require.NoError(t, err)
@@ -786,10 +786,10 @@ func TestNewMetadataV2Format(t *testing.T) {
 	)
 
 	partitionSpec := iceberg.NewPartitionSpecID(10,
-		iceberg.PartitionField{SourceID: 22, FieldID: 1022, Transform: iceberg.IdentityTransform{}, Name: "bar"})
+		iceberg.PartitionField{SourceIDs: []int{22}, FieldID: 1022, Transform: iceberg.IdentityTransform{}, Name: "bar"})
 
 	sortOrder, err := NewSortOrder(10, []SortField{{
-		SourceID:  10,
+		SourceIDs: []int{10},
 		Transform: iceberg.IdentityTransform{},
 		Direction: SortASC, NullOrder: NullsLast,
 	}})
@@ -806,10 +806,10 @@ func TestNewMetadataV2Format(t *testing.T) {
 		iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool})
 
 	expectedSpec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 2, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "bar"})
 
 	expectedSortOrder, err := NewSortOrder(1, []SortField{{
-		SourceID: 1, Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1}, Transform: iceberg.IdentityTransform{},
 		Direction: SortASC, NullOrder: NullsLast,
 	}})
 	require.NoError(t, err)
@@ -1230,7 +1230,7 @@ func TestTableMetadataV1PartitionSpecsWithoutDefaultId(t *testing.T) {
 	require.Equal(t, spec.NumFields(), 1)
 	require.Equal(t, spec.Field(0).Name, "y")
 	require.Equal(t, spec.Field(0).Transform, iceberg.IdentityTransform{})
-	require.Equal(t, spec.Field(0).SourceID, 2)
+	require.Equal(t, spec.Field(0).SourceID(), 2)
 }
 
 func TestTableMetadataV2MissingPartitionSpecs(t *testing.T) {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -202,7 +202,7 @@ func (p *partitionedFanoutWriter) getPartitions(record arrow.RecordBatch) ([]*pa
 
 	for i := range partitionFields {
 		sourceField := p.partitionSpec.Field(i)
-		colName, _ := p.schema.FindColumnName(sourceField.SourceID)
+		colName, _ := p.schema.FindColumnName(sourceField.SourceID())
 		colIdx := record.Schema().FieldIndices(colName)[0]
 		partitionColumns[i] = record.Column(colIdx)
 		partitionFieldsInfo[i] = struct {

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -95,7 +95,7 @@ func (s *FanoutWriterTestSuite) testTransformPartition(transform iceberg.Transfo
 
 	spec := iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
-			SourceID:  sourceField.ID,
+			SourceIDs: []int{sourceField.ID},
 			FieldID:   1000,
 			Transform: transform,
 			Name:      "test_%s" + transformName,
@@ -324,12 +324,12 @@ func (s *FanoutWriterTestSuite) TestPartitionedLogicalTypesRequireIntFieldIDCase
 	)
 
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 2, FieldID: 4008, Transform: iceberg.IdentityTransform{}, Name: "decimal_col"},
-		iceberg.PartitionField{SourceID: 3, FieldID: 4009, Transform: iceberg.IdentityTransform{}, Name: "time_col"},
-		iceberg.PartitionField{SourceID: 4, FieldID: 4010, Transform: iceberg.IdentityTransform{}, Name: "timestamp_col"},
-		iceberg.PartitionField{SourceID: 5, FieldID: 4011, Transform: iceberg.IdentityTransform{}, Name: "timestamptz_col"},
-		iceberg.PartitionField{SourceID: 6, FieldID: 4014, Transform: iceberg.IdentityTransform{}, Name: "uuid_col"},
-		iceberg.PartitionField{SourceID: 7, FieldID: 4015, Transform: iceberg.IdentityTransform{}, Name: "date_col"},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 4008, Transform: iceberg.IdentityTransform{}, Name: "decimal_col"},
+		iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 4009, Transform: iceberg.IdentityTransform{}, Name: "time_col"},
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 4010, Transform: iceberg.IdentityTransform{}, Name: "timestamp_col"},
+		iceberg.PartitionField{SourceIDs: []int{5}, FieldID: 4011, Transform: iceberg.IdentityTransform{}, Name: "timestamptz_col"},
+		iceberg.PartitionField{SourceIDs: []int{6}, FieldID: 4014, Transform: iceberg.IdentityTransform{}, Name: "uuid_col"},
+		iceberg.PartitionField{SourceIDs: []int{7}, FieldID: 4015, Transform: iceberg.IdentityTransform{}, Name: "date_col"},
 	)
 
 	loc := filepath.ToSlash(s.T().TempDir())

--- a/table/partitioned_throughput_bench_test.go
+++ b/table/partitioned_throughput_bench_test.go
@@ -48,8 +48,8 @@ func runBenchmark(b *testing.B, icebergSchema *iceberg.Schema, arrSchema *arrow.
 
 	// Define partition spec (partitioned by day(ts) and host)
 	spec := iceberg.NewPartitionSpecID(1,
-		iceberg.PartitionField{SourceID: 2, FieldID: 1000, Transform: iceberg.DayTransform{}, Name: "ts_day"},
-		iceberg.PartitionField{SourceID: 3, FieldID: 1001, Transform: iceberg.IdentityTransform{}, Name: "host"},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.DayTransform{}, Name: "ts_day"},
+		iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1001, Transform: iceberg.IdentityTransform{}, Name: "host"},
 	)
 
 	for _, bs := range benchSizes {
@@ -507,7 +507,7 @@ func BenchmarkPartitionedWriteThroughput_PartitionCount(b *testing.B) {
 
 	// Partition spec - only by partition_key
 	spec := iceberg.NewPartitionSpecID(1,
-		iceberg.PartitionField{SourceID: 3, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "partition_key"},
+		iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "partition_key"},
 	)
 
 	numRecords := 100_000

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -96,8 +96,8 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			}
 
 			partitionSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-				SourceID: 2,
-				Name:     "age_bucket",
+				SourceIDs: []int{2},
+				Name:      "age_bucket",
 				Transform: iceberg.BucketTransform{
 					NumBuckets: 2,
 				},
@@ -114,7 +114,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			err = metadataBuilder.SetDefaultSpecID(0)
 			require.NoError(t, err)
 			sortOrder, err := NewSortOrder(1, []SortField{{
-				SourceID:  2,
+				SourceIDs: []int{2},
 				Direction: SortASC,
 				Transform: iceberg.IdentityTransform{},
 				NullOrder: NullsFirst,
@@ -168,20 +168,20 @@ func TestPositionDeletePartitionedFanoutWriterPartitionPathIsDeterministic(t *te
 	partitionSpec := iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
 			FieldID:   1000,
-			SourceID:  2147483546, // file_path
+			SourceIDs: []int{2147483546}, // file_path
 			Name:      "file_path",
 			Transform: iceberg.IdentityTransform{},
 		},
 		iceberg.PartitionField{
 			FieldID:   1001,
-			SourceID:  2147483545, // pos
+			SourceIDs: []int{2147483545}, // pos
 			Name:      "pos",
 			Transform: iceberg.IdentityTransform{},
 		},
 		iceberg.PartitionField{
-			FieldID:  1002,
-			SourceID: 2147483545, // pos
-			Name:     "pos_bucket",
+			FieldID:   1002,
+			SourceIDs: []int{2147483545}, // pos
+			Name:      "pos_bucket",
 			Transform: iceberg.BucketTransform{
 				NumBuckets: 128,
 			},
@@ -199,7 +199,7 @@ func TestPositionDeletePartitionedFanoutWriterPartitionPathIsDeterministic(t *te
 	err = metadataBuilder.SetDefaultSpecID(0)
 	require.NoError(t, err)
 	sortOrder, err := NewSortOrder(1, []SortField{{
-		SourceID:  2147483546,
+		SourceIDs: []int{2147483546},
 		Direction: SortASC,
 		Transform: iceberg.IdentityTransform{},
 		NullOrder: NullsFirst,
@@ -250,8 +250,8 @@ func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {
 	t.Parallel()
 
 	partitionSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 2,
-		Name:     "age_bucket",
+		SourceIDs: []int{2},
+		Name:      "age_bucket",
 		Transform: iceberg.BucketTransform{
 			NumBuckets: 2,
 		},
@@ -268,7 +268,7 @@ func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {
 	err = metadataBuilder.SetDefaultSpecID(0)
 	require.NoError(t, err)
 	sortOrder, err := NewSortOrder(1, []SortField{{
-		SourceID:  2,
+		SourceIDs: []int{2},
 		Direction: SortASC,
 		Transform: iceberg.IdentityTransform{},
 		NullOrder: NullsFirst,

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -167,7 +167,7 @@ func simpleSchema() *iceberg.Schema {
 
 func partitionedSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 1, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
 	})
 }
 

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -59,7 +59,7 @@ func TestSnapshotSummaryCollectorWithPartition(t *testing.T) {
 		iceberg.NestedField{ID: 3, Name: "int_field", Type: iceberg.PrimitiveTypes.Int32},
 	)
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		Name: "int_field", SourceID: 3, FieldID: 1001, Transform: iceberg.IdentityTransform{},
+		Name: "int_field", SourceIDs: []int{3}, FieldID: 1001, Transform: iceberg.IdentityTransform{},
 	})
 
 	dataFile1 := must(iceberg.NewDataFileBuilder(

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -51,12 +51,9 @@ var (
 
 // SortField describes a field used in a sort order definition.
 type SortField struct {
-	// SourceID is the source column id from the table's schema.
-	// For multi-argument transforms, this is the first source column;
-	// use SourceIDs to get all source columns.
-	SourceID int `json:"source-id"`
-	// SourceIDs contains all source column ids for multi-argument transforms.
-	// For single-argument transforms this is nil and SourceID should be used.
+	// SourceIDs contains the source column ids from the table's schema.
+	// For single-argument transforms this will have exactly one element.
+	// For multi-argument transforms this will have multiple elements.
 	SourceIDs []int `json:"-"`
 	// Transform is the tranformation used to produce values to be
 	// sorted on from the source column.
@@ -68,12 +65,20 @@ type SortField struct {
 	NullOrder NullOrder `json:"null-order"`
 }
 
+// SourceID returns the first source column id.
+func (s SortField) SourceID() int {
+	if len(s.SourceIDs) == 0 {
+		return 0
+	}
+
+	return s.SourceIDs[0]
+}
+
 func (s SortField) Equals(other SortField) bool {
-	return s.SourceID == other.SourceID &&
+	return slices.Equal(s.SourceIDs, other.SourceIDs) &&
 		s.Transform.Equals(other.Transform) &&
 		s.Direction == other.Direction &&
-		s.NullOrder == other.NullOrder &&
-		slices.Equal(s.SourceIDs, other.SourceIDs)
+		s.NullOrder == other.NullOrder
 }
 
 func (s *SortField) String() string {
@@ -82,14 +87,14 @@ func (s *SortField) String() string {
 			return fmt.Sprintf("%v %s %s", s.SourceIDs, s.Direction, s.NullOrder)
 		}
 
-		return fmt.Sprintf("%d %s %s", s.SourceID, s.Direction, s.NullOrder)
+		return fmt.Sprintf("%d %s %s", s.SourceID(), s.Direction, s.NullOrder)
 	}
 
 	if len(s.SourceIDs) > 1 {
 		return fmt.Sprintf("%s(%v) %s %s", s.Transform, s.SourceIDs, s.Direction, s.NullOrder)
 	}
 
-	return fmt.Sprintf("%s(%d) %s %s", s.Transform, s.SourceID, s.Direction, s.NullOrder)
+	return fmt.Sprintf("%s(%d) %s %s", s.Transform, s.SourceID(), s.Direction, s.NullOrder)
 }
 
 func (s *SortField) MarshalJSON() ([]byte, error) {
@@ -114,9 +119,12 @@ func (s *SortField) MarshalJSON() ([]byte, error) {
 		}{s.SourceIDs, s.Transform, s.Direction, s.NullOrder})
 	}
 
-	type Alias SortField
-
-	return json.Marshal((*Alias)(s))
+	return json.Marshal(struct {
+		SourceID  int               `json:"source-id"`
+		Transform iceberg.Transform `json:"transform"`
+		Direction SortDirection     `json:"direction"`
+		NullOrder NullOrder         `json:"null-order"`
+	}{s.SourceID(), s.Transform, s.Direction, s.NullOrder})
 }
 
 func (s *SortField) UnmarshalJSON(b []byte) error {
@@ -131,27 +139,28 @@ func (s *SortField) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	type Alias SortField
 	aux := struct {
-		TransformString string `json:"transform"`
-		SourceIDs       []int  `json:"source-ids,omitempty"`
-		*Alias
-	}{
-		Alias: (*Alias)(s),
-	}
+		SourceID        int           `json:"source-id"`
+		SourceIDs       []int         `json:"source-ids,omitempty"`
+		TransformString string        `json:"transform"`
+		Direction       SortDirection `json:"direction"`
+		NullOrder       NullOrder     `json:"null-order"`
+	}{}
 
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
+	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
+	s.Direction = aux.Direction
+	s.NullOrder = aux.NullOrder
+
 	if len(aux.SourceIDs) > 0 {
-		s.SourceID = aux.SourceIDs[0]
-		if len(aux.SourceIDs) > 1 {
-			s.SourceIDs = aux.SourceIDs
-		}
+		s.SourceIDs = aux.SourceIDs
+	} else {
+		s.SourceIDs = []int{aux.SourceID}
 	}
 
+	var err error
 	if s.Transform, err = iceberg.ParseTransform(aux.TransformString); err != nil {
 		return err
 	}
@@ -286,9 +295,9 @@ func (s *SortOrder) CheckCompatibility(schema *iceberg.Schema) error {
 	}
 
 	for _, field := range s.fields {
-		f, ok := schema.FindFieldByID(field.SourceID)
+		f, ok := schema.FindFieldByID(field.SourceID())
 		if !ok {
-			return fmt.Errorf("sort field with source id %d not found in schema", field.SourceID)
+			return fmt.Errorf("sort field with source id %d not found in schema", field.SourceID())
 		}
 
 		if _, ok := f.Type.(iceberg.PrimitiveType); !ok {
@@ -343,7 +352,7 @@ func AssignFreshSortOrderIDsWithID(sortOrder SortOrder, old, fresh *iceberg.Sche
 
 	fields := make([]SortField, 0, len(sortOrder.fields))
 	for _, field := range sortOrder.fields {
-		originalField, ok := old.FindColumnName(field.SourceID)
+		originalField, ok := old.FindColumnName(field.SourceID())
 		if !ok {
 			return SortOrder{}, fmt.Errorf("cannot find source column id %s in old schema", field.String())
 		}
@@ -353,7 +362,7 @@ func AssignFreshSortOrderIDsWithID(sortOrder SortOrder, old, fresh *iceberg.Sche
 		}
 
 		fields = append(fields, SortField{
-			SourceID:  freshField.ID,
+			SourceIDs: []int{freshField.ID},
 			Transform: field.Transform,
 			Direction: field.Direction,
 			NullOrder: field.NullOrder,

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -37,9 +37,9 @@ func TestSerializeSortOrder(t *testing.T) {
 	sortOrder, err := table.NewSortOrder(
 		22,
 		[]table.SortField{
-			{SourceID: 19, Transform: iceberg.IdentityTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
-			{SourceID: 25, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: table.NullsLast, Direction: table.SortDESC},
-			{SourceID: 22, Transform: iceberg.VoidTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
+			{SourceIDs: []int{19}, Transform: iceberg.IdentityTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
+			{SourceIDs: []int{25}, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: table.NullsLast, Direction: table.SortDESC},
+			{SourceIDs: []int{22}, Transform: iceberg.VoidTransform{}, NullOrder: table.NullsFirst, Direction: table.SortASC},
 		},
 	)
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 		var field table.SortField
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.NoError(t, err)
-		assert.Equal(t, 2, field.SourceID)
+		assert.Equal(t, 2, field.SourceID())
 		assert.Equal(t, []int{2, 3}, field.SourceIDs)
 	})
 
@@ -134,7 +134,6 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 
 	t.Run("marshal multi-arg round-trip", func(t *testing.T) {
 		field := table.SortField{
-			SourceID:  2,
 			SourceIDs: []int{2, 3},
 			Transform: iceberg.IdentityTransform{},
 			Direction: table.SortASC,
@@ -148,13 +147,13 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 		var decoded table.SortField
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		assert.Equal(t, 2, decoded.SourceID)
+		assert.Equal(t, 2, decoded.SourceID())
 		assert.Equal(t, []int{2, 3}, decoded.SourceIDs)
 	})
 
 	t.Run("marshal single-arg uses source-id", func(t *testing.T) {
 		field := table.SortField{
-			SourceID:  1,
+			SourceIDs: []int{1},
 			Transform: iceberg.IdentityTransform{},
 			Direction: table.SortASC,
 			NullOrder: table.NullsFirst,

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -180,7 +180,7 @@ func (t *TableTestSuite) TestSchema() {
 
 func (t *TableTestSuite) TestPartitionSpec() {
 	t.Equal(iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 1, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x"},
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "x"},
 	), t.tbl.Spec())
 }
 
@@ -188,8 +188,8 @@ func (t *TableTestSuite) TestSortOrder() {
 	expected, err := table.NewSortOrder(
 		3,
 		[]table.SortField{
-			{SourceID: 2, Transform: iceberg.IdentityTransform{}, Direction: table.SortASC, NullOrder: table.NullsFirst},
-			{SourceID: 3, Transform: iceberg.BucketTransform{NumBuckets: 4}, Direction: table.SortDESC, NullOrder: table.NullsLast},
+			{SourceIDs: []int{2}, Transform: iceberg.IdentityTransform{}, Direction: table.SortASC, NullOrder: table.NullsFirst},
+			{SourceIDs: []int{3}, Transform: iceberg.BucketTransform{NumBuckets: 4}, Direction: table.SortDESC, NullOrder: table.NullsLast},
 		},
 	)
 	require.NoError(t.T(), err)
@@ -608,8 +608,8 @@ func (t *TableWritingTestSuite) TestAddFilesFailsSchemaMismatch() {
 func (t *TableWritingTestSuite) TestAddFilesPartitionedTable() {
 	ident := table.Identifier{"default", "partitioned_table_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
-		iceberg.PartitionField{SourceID: 10, FieldID: 1001, Transform: iceberg.MonthTransform{}, Name: "qux_month"})
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+		iceberg.PartitionField{SourceIDs: []int{10}, FieldID: 1001, Transform: iceberg.MonthTransform{}, Name: "qux_month"})
 
 	tbl := t.createTable(ident, t.formatVersion,
 		spec, t.tableSchema)
@@ -675,7 +675,7 @@ func (t *TableWritingTestSuite) TestAddFilesPartitionedTable() {
 func (t *TableWritingTestSuite) TestAddFilesToBucketPartitionedTableFails() {
 	ident := table.Identifier{"default", "partitioned_table_bucket_fails_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.BucketTransform{NumBuckets: 3}, Name: "baz_bucket_3"})
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.BucketTransform{NumBuckets: 3}, Name: "baz_bucket_3"})
 
 	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
 	files := make([]string, 0)
@@ -700,7 +700,7 @@ func (t *TableWritingTestSuite) TestAddFilesToBucketPartitionedTableFails() {
 func (t *TableWritingTestSuite) TestAddFilesToPartitionedTableFailsLowerAndUpperMismatch() {
 	ident := table.Identifier{"default", "partitioned_table_bucket_fails_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"})
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"})
 
 	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
 	files := make([]string, 0)
@@ -1158,7 +1158,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFiles() {
 func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartitionSpecID() {
 	ident := table.Identifier{"default", "replace_data_files_with_datafiles_spec_validation_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
 	)
 	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
 
@@ -1171,7 +1171,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartit
 	t.Require().NoError(err)
 
 	invalidSpec := iceberg.NewPartitionSpecID(999,
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
 	)
 
 	deleteFile := mustDataFile(t.T(), spec, existingPath, map[int]any{1000: int32(123)}, 1, mustFileSize(t.T(), existingPath))
@@ -1188,7 +1188,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartit
 func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartitionData() {
 	ident := table.Identifier{"default", "replace_data_files_with_datafiles_partition_validation_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 4, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
 	)
 	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
 

--- a/table/transaction_test.go
+++ b/table/transaction_test.go
@@ -310,7 +310,7 @@ func (s *SparkIntegrationTestSuite) TestUpdateSpec() {
 	)
 
 	partitionSpec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceID: 2, FieldID: 1000, Transform: iceberg.TruncateTransform{Width: 5}, Name: "bar_truncate"},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.TruncateTransform{Width: 5}, Name: "bar_truncate"},
 	)
 
 	tbl, err := s.cat.CreateTable(
@@ -596,8 +596,8 @@ func (s *SparkIntegrationTestSuite) TestDeleteMergeOnReadPartitioned() {
 	)
 
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceID: 3,
-		Name:     "age_bucket",
+		SourceIDs: []int{3},
+		Name:      "age_bucket",
 		Transform: iceberg.BucketTransform{
 			NumBuckets: 2,
 		},

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -59,7 +59,7 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 	partitionSpec := t.tbl.Metadata().PartitionSpec()
 	for _, partitionField := range partitionSpec.Fields() {
 		transformToField[transformKey{
-			SourceId:  partitionField.SourceID,
+			SourceId:  partitionField.SourceID(),
 			Transform: partitionField.Transform.String(),
 		}] = partitionField
 		nameToField[partitionField.Name] = partitionField
@@ -144,9 +144,9 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 		var err error
 		if _, deleted := us.deletes[field.FieldID]; !deleted {
 			if rename, renamed := us.renames[field.Name]; renamed {
-				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID, field.FieldID, rename, field.Transform, partitionNames)
+				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID(), field.FieldID, rename, field.Transform, partitionNames)
 			} else {
-				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID, field.FieldID, field.Name, field.Transform, partitionNames)
+				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID(), field.FieldID, field.Name, field.Transform, partitionNames)
 			}
 			if err != nil {
 				return iceberg.PartitionSpec{}, err
@@ -154,9 +154,9 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 			partitionFields = append(partitionFields, newField)
 		} else if us.txn.tbl.Metadata().Version() == 1 {
 			if rename, renamed := us.renames[field.Name]; renamed {
-				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID, field.FieldID, rename, iceberg.VoidTransform{}, partitionNames)
+				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID(), field.FieldID, rename, iceberg.VoidTransform{}, partitionNames)
 			} else {
-				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID, field.FieldID, field.Name, iceberg.VoidTransform{}, partitionNames)
+				newField, err = us.addNewField(us.txn.tbl.Schema(), field.SourceID(), field.FieldID, field.Name, iceberg.VoidTransform{}, partitionNames)
 			}
 			if err != nil {
 				return iceberg.PartitionSpec{}, err
@@ -168,7 +168,7 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 	partitionFields = append(partitionFields, us.adds...)
 	opts := make([]iceberg.PartitionOption, len(partitionFields))
 	for i, field := range partitionFields {
-		opts[i] = iceberg.AddPartitionFieldBySourceID(field.SourceID, field.Name, field.Transform, us.txn.tbl.Schema(), &field.FieldID)
+		opts[i] = iceberg.AddPartitionFieldBySourceID(field.SourceID(), field.Name, field.Transform, us.txn.tbl.Schema(), &field.FieldID)
 	}
 
 	newSpec, err := iceberg.NewPartitionSpecOpts(opts...)
@@ -245,10 +245,10 @@ func (us *UpdateSpec) addField(sourceColName string, transform iceberg.Transform
 
 		// Handle special case for time transforms
 		if _, isTimeTransform := newField.Transform.(iceberg.TimeTransform); isTimeTransform {
-			if existingTimeField, exists := us.addedTimeFields[newField.SourceID]; exists {
+			if existingTimeField, exists := us.addedTimeFields[newField.SourceID()]; exists {
 				return fmt.Errorf("cannot add time partition field: %s conflicts with %s", newField.Name, existingTimeField.Name)
 			}
-			us.addedTimeFields[newField.SourceID] = newField
+			us.addedTimeFields[newField.SourceID()] = newField
 		}
 		us.transformToAddedField[key] = newField
 
@@ -330,10 +330,10 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 			}
 		}
 		for _, field := range historicalFields {
-			if field.SourceID == sourceId && field.Transform.String() == transform {
+			if field.SourceID() == sourceId && field.Transform.String() == transform {
 				if len(name) > 0 && field.Name == name {
 					return iceberg.PartitionField{
-						SourceID:  sourceId,
+						SourceIDs: []int{sourceId},
 						FieldID:   field.FieldID,
 						Name:      name,
 						Transform: field.Transform,
@@ -346,7 +346,7 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 	transform, _ := iceberg.ParseTransform(key.Transform)
 	if name == "" {
 		tmpField := iceberg.PartitionField{
-			SourceID:  key.SourceId,
+			SourceIDs: []int{key.SourceId},
 			FieldID:   newFieldId,
 			Name:      "",
 			Transform: transform,
@@ -359,7 +359,7 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 	}
 
 	return iceberg.PartitionField{
-		SourceID:  key.SourceId,
+		SourceIDs: []int{key.SourceId},
 		FieldID:   newFieldId,
 		Name:      name,
 		Transform: transform,
@@ -398,7 +398,7 @@ func (us *UpdateSpec) addNewField(schema *iceberg.Schema, sourceId int, fieldId 
 	}
 
 	return iceberg.PartitionField{
-		SourceID:  sourceId,
+		SourceIDs: []int{sourceId},
 		FieldID:   fieldId,
 		Name:      name,
 		Transform: transform,

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -40,13 +40,13 @@ var testSchema = iceberg.NewSchema(1,
 
 var partitionSpec = iceberg.NewPartitionSpec(
 	iceberg.PartitionField{
-		SourceID:  1,
+		SourceIDs: []int{1},
 		FieldID:   iceberg.PartitionDataIDStart,
 		Name:      "id_identity",
 		Transform: iceberg.IdentityTransform{},
 	},
 	iceberg.PartitionField{
-		SourceID:  5,
+		SourceIDs: []int{5},
 		FieldID:   iceberg.PartitionDataIDStart + 1,
 		Name:      "street_void",
 		Transform: iceberg.VoidTransform{},
@@ -85,13 +85,13 @@ func TestUpdateSpecAddField(t *testing.T) {
 		assert.Equal(t, "street_void", newSpec.FieldsBySourceID(5)[0].Name)
 
 		addedField := newSpec.FieldsBySourceID(3)[0]
-		assert.Equal(t, 3, addedField.SourceID)
+		assert.Equal(t, 3, addedField.SourceID())
 		assert.Equal(t, 1002, addedField.FieldID)
 		assert.Equal(t, "year_transform", addedField.Name)
 		assert.Equal(t, iceberg.YearTransform{}, addedField.Transform)
 
 		addedField = newSpec.FieldsBySourceID(7)[0]
-		assert.Equal(t, 7, addedField.SourceID)
+		assert.Equal(t, 7, addedField.SourceID())
 		assert.Equal(t, 1003, addedField.FieldID)
 		assert.Equal(t, "zipcode_bucket", addedField.Name)
 		assert.Equal(t, iceberg.BucketTransform{NumBuckets: 5}, addedField.Transform)
@@ -230,13 +230,13 @@ func TestUpdateSpecAddIdentityField(t *testing.T) {
 		assert.Equal(t, "street_void", newSpec.FieldsBySourceID(5)[0].Name)
 
 		addedField := newSpec.FieldsBySourceID(3)[0]
-		assert.Equal(t, 3, addedField.SourceID)
+		assert.Equal(t, 3, addedField.SourceID())
 		assert.Equal(t, 1002, addedField.FieldID)
 		assert.Equal(t, "ts", addedField.Name)
 		assert.Equal(t, iceberg.IdentityTransform{}, addedField.Transform)
 
 		addedField = newSpec.FieldsBySourceID(2)[0]
-		assert.Equal(t, 2, addedField.SourceID)
+		assert.Equal(t, 2, addedField.SourceID())
 		assert.Equal(t, 1003, addedField.FieldID)
 		assert.Equal(t, "name", addedField.Name)
 		assert.Equal(t, iceberg.IdentityTransform{}, addedField.Transform)
@@ -461,13 +461,13 @@ func TestUpdateSpecCommit(t *testing.T) {
 		assert.Equal(t, []iceberg.PartitionField(nil), currSpec.FieldsBySourceID(1))
 
 		addedField := currSpec.FieldsBySourceID(6)[0]
-		assert.Equal(t, 6, addedField.SourceID)
+		assert.Equal(t, 6, addedField.SourceID())
 		assert.Equal(t, 1002, addedField.FieldID)
 		assert.Equal(t, "address.city_trunc_3", addedField.Name)
 		assert.Equal(t, iceberg.TruncateTransform{Width: 3}, addedField.Transform)
 
 		addedIdentity := currSpec.FieldsBySourceID(7)[0]
-		assert.Equal(t, 7, addedIdentity.SourceID)
+		assert.Equal(t, 7, addedIdentity.SourceID())
 		assert.Equal(t, 1003, addedIdentity.FieldID)
 		assert.Equal(t, "address.zip_code", addedIdentity.Name)
 		assert.Equal(t, iceberg.IdentityTransform{}, addedIdentity.Transform)

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -40,20 +40,20 @@ func TestRemoveSnapshotsPostCommitSkipped(t *testing.T) {
 func TestUnmarshalUpdates(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{
-			SourceID: 1, FieldID: 1000,
+			SourceIDs: []int{1}, FieldID: 1000,
 			Transform: iceberg.TruncateTransform{Width: 19}, Name: "str_truncate",
 		},
 		iceberg.PartitionField{
-			SourceID: 2, FieldID: 1001,
+			SourceIDs: []int{2}, FieldID: 1001,
 			Transform: iceberg.BucketTransform{NumBuckets: 25}, Name: "int_bucket",
 		},
 	)
 	sortOrder, err := NewSortOrder(
 		22,
 		[]SortField{
-			{SourceID: 19, Transform: iceberg.IdentityTransform{}, NullOrder: NullsFirst, Direction: SortASC},
-			{SourceID: 25, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: NullsFirst, Direction: SortDESC},
-			{SourceID: 22, Transform: iceberg.VoidTransform{}, NullOrder: NullsFirst, Direction: SortASC},
+			{SourceIDs: []int{19}, Transform: iceberg.IdentityTransform{}, NullOrder: NullsFirst, Direction: SortASC},
+			{SourceIDs: []int{25}, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: NullsFirst, Direction: SortDESC},
+			{SourceIDs: []int{22}, Transform: iceberg.VoidTransform{}, NullOrder: NullsFirst, Direction: SortASC},
 		},
 	)
 	require.NoError(t, err)

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -203,7 +203,7 @@ func TestManifestPartitionVals(t *testing.T) {
 			})
 			partitionSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 				Name:      "transformed_abc",
-				SourceID:  1,
+				SourceIDs: []int{1},
 				FieldID:   1000,
 				Transform: tt.transform,
 			})


### PR DESCRIPTION
Add SourceIDs field to PartitionField and SortField for multi-argument transform support per the Iceberg v3 spec. The spec defines source-ids as infrastructure for future multi-argument transforms — no concrete transforms exist yet, but metadata must be readable and writable.

Changes:
- PartitionField: add SourceIDs []int, MarshalJSON writes source-ids when len > 1, UnmarshalJSON accepts multiple source-ids
- SortField: same treatment with source-ids support
- Update Equals methods to compare SourceIDs
- Fix slices.Equal calls for non-comparable types (use EqualFunc)