### PR TITLE
fix(manifest): default to v1 files

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -805,6 +805,10 @@ func ReadManifest(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestE
 
 // ReadManifestList reads in an avro manifest list file and returns a slice
 // of manifest files or an error if one is encountered.
+//
+// Per the Iceberg spec, manifest list files are not required to carry a
+// "format-version" metadata key (only manifest files are). When the key is
+// absent, version 1 is assumed.
 func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 	dec, err := ocf.NewDecoder(in, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
 	if err != nil {
@@ -816,9 +820,12 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 		return nil, err
 	}
 
-	version, err := strconv.Atoi(string(dec.Metadata()["format-version"]))
-	if err != nil {
-		return nil, fmt.Errorf("invalid format-version: %w", err)
+	version := 1
+	if raw := dec.Metadata()["format-version"]; len(raw) > 0 {
+		version, err = strconv.Atoi(string(raw))
+		if err != nil {
+			return nil, fmt.Errorf("invalid format-version: %w", err)
+		}
 	}
 
 	if version == 1 {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -767,6 +767,44 @@ func (m *ManifestTestSuite) TestReadManifestListV3() {
 	m.Equal([]byte{0x02, 0x00, 0x00, 0x00}, *part.UpperBound)
 }
 
+// writeManifestListNoFormatVersion writes a valid v2 manifest list Avro file that
+// omits the "format-version" metadata key, simulating a file produced by a
+// non-Java Iceberg implementation that strictly follows the spec.
+func writeManifestListNoFormatVersion(t *testing.T, version int) bytes.Buffer {
+	t.Helper()
+
+	fileSchema, err := internal.NewManifestFileSchema(version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(fileSchema, &buf,
+		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+		ocf.WithMetadata(map[string][]byte{
+			"snapshot-id":     []byte("1234"),
+			"sequence-number": []byte("0"),
+		}),
+		ocf.WithCodec(ocf.Deflate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}
+
+func (m *ManifestTestSuite) TestReadManifestListMissingFormatVersion() {
+	// A manifest list without "format-version" should succeed, defaulting to v1.
+	buf := writeManifestListNoFormatVersion(m.T(), 1)
+	files, err := ReadManifestList(&buf)
+	m.NoError(err)
+	m.Empty(files) // the file has no entries, just headers
+}
+
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
 	// This prevents a regression that could be caused by using a schema cache
 	// across multiple read/write operations of an avro file. While it may sound


### PR DESCRIPTION
When reading manifests, if there is no format-version, then we default the version to v1, which did not require this field.

Fixes: #416
