### PR TITLE
feat(table): add Transaction.UpgradeFormatVersion

### DIFF
--- a/table/commit_test.go
+++ b/table/commit_test.go
@@ -126,6 +126,68 @@ func TestTableCommitReturnsCopies(t *testing.T) {
 	assert.NotEmpty(t, tc2.Requirements)
 }
 
+func newV1CommitTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, "s3://bucket/test",
+		iceberg.Properties{table.PropertyFormatVersion: "1"})
+	require.NoError(t, err)
+
+	return table.New(
+		table.Identifier{"db", "test_table"},
+		meta, "s3://bucket/test/metadata/v1.metadata.json",
+		nil, nil,
+	)
+}
+
+func TestUpgradeFormatVersionV1ToV2(t *testing.T) {
+	tbl := newV1CommitTestTable(t)
+	assert.Equal(t, 1, tbl.Metadata().Version())
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.UpgradeFormatVersion(2))
+
+	tc, err := tx.TableCommit()
+	require.NoError(t, err)
+
+	var found bool
+	for _, u := range tc.Updates {
+		if u.Action() == "upgrade-format-version" {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found, "expected upgrade-format-version update")
+}
+
+func TestUpgradeFormatVersionNoOpWhenSameVersion(t *testing.T) {
+	tbl := newCommitTestTable(t) // v2 table
+	tx := tbl.NewTransaction()
+
+	require.NoError(t, tx.UpgradeFormatVersion(2))
+
+	tc, err := tx.TableCommit()
+	require.NoError(t, err)
+
+	// No updates should be staged — it's a no-op
+	assert.Empty(t, tc.Updates)
+}
+
+func TestUpgradeFormatVersionDowngradeErrors(t *testing.T) {
+	tbl := newCommitTestTable(t) // v2 table
+	tx := tbl.NewTransaction()
+
+	err := tx.UpgradeFormatVersion(1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downgrading")
+}
+
 func TestMarkCommittedPreventsCommit(t *testing.T) {
 	tbl := newCommitTestTable(t)
 	tx := tbl.NewTransaction()

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -149,6 +149,12 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 	return nil
 }
 
+// UpgradeFormatVersion upgrades the table to the given format version. Downgrading
+// is not allowed. If the table is already at the given version, this is a no-op.
+func (t *Transaction) UpgradeFormatVersion(version int) error {
+	return t.apply([]Update{NewUpgradeFormatVersionUpdate(version)}, nil)
+}
+
 func (t *Transaction) UpdateSpec(caseSensitive bool) *UpdateSpec {
 	return NewUpdateSpec(t, caseSensitive)
 }


### PR DESCRIPTION
Adds a public method to upgrade a table's format version via a transaction, following the pattern of PyIceberg's `transaction.upgrade_table_version()`:

```go
tx := tbl.NewTransaction()
if err := tx.UpgradeFormatVersion(2); err != nil {
    return err
}
newTable, err := tx.Commit(ctx)
```

- Downgrading returns an error
- Upgrading to the current version is a no-op
- Both behaviours are enforced by the existing `MetadataBuilder.SetFormatVersion` logic