### PR TITLE
feat(table): support delete file removal in overwrite commits

### DIFF
--- a/table/replace_files_test.go
+++ b/table/replace_files_test.go
@@ -1,0 +1,239 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newReplaceFilesTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	return table.New(
+		table.Identifier{"db", "replace_files_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(ctx context.Context) (iceio.IO, error) {
+			return iceio.LocalFS{}, nil
+		},
+		&rowDeltaCatalog{metadata: meta},
+	)
+}
+
+func TestReplaceFiles_DataAndDeleteFiles(t *testing.T) {
+	tbl := newReplaceFilesTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	// Step 1: Write and commit a data file with 3 rows
+	dataPath := tbl.Location() + "/data/data-001.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[
+		{"id": 1, "data": "alpha"},
+		{"id": 2, "data": "beta"},
+		{"id": 3, "data": "gamma"}
+	]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 3)
+
+	// Step 2: Add a position delete file via RowDelta
+	posDelPath := tbl.Location() + "/data/pos-del-001.parquet"
+	writeParquetFile(t, posDelPath, table.PositionalDeleteArrowSchema,
+		fmt.Sprintf(`[{"file_path": "%s", "pos": 1}]`, dataPath))
+
+	posDelBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		posDelPath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	posDelFile := posDelBuilder.Build()
+
+	tx2 := tbl.NewTransaction()
+	rd := tx2.NewRowDelta(nil)
+	rd.AddDeletes(posDelFile)
+	require.NoError(t, rd.Commit(t.Context()))
+	tbl, err = tx2.Commit(t.Context())
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 2) // beta deleted
+
+	// Step 3: Get existing data + delete files from scan tasks
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	oldDataFile := tasks[0].File
+	var deleteFilesToRemove []iceberg.DataFile
+	deleteFilesToRemove = append(deleteFilesToRemove, tasks[0].DeleteFiles...)
+	require.Len(t, deleteFilesToRemove, 1)
+
+	// Step 4: Write a compacted data file (without deleted row)
+	newDataPath := tbl.Location() + "/data/data-compacted.parquet"
+	writeParquetFile(t, newDataPath, arrowSc, `[
+		{"id": 1, "data": "alpha"},
+		{"id": 3, "data": "gamma"}
+	]`)
+
+	// Build new DataFile directly (not via AddFiles which would commit it)
+	newDataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		newDataPath, iceberg.ParquetFile, nil, nil, nil, 2, 512)
+	require.NoError(t, err)
+	newDataFile := newDataFileBuilder.Build()
+
+	// Step 5: ReplaceFiles — swap old data + remove delete file
+	tx3 := tbl.NewTransaction()
+	err = tx3.ReplaceFiles(t.Context(),
+		[]iceberg.DataFile{oldDataFile},
+		[]iceberg.DataFile{newDataFile},
+		deleteFilesToRemove,
+		nil,
+	)
+	require.NoError(t, err)
+
+	tbl, err = tx3.Commit(t.Context())
+	require.NoError(t, err)
+
+	// Verify: 2 rows, snapshot committed
+	assertRowCount(t, tbl, 2)
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, table.OpOverwrite, snap.Summary.Operation)
+}
+
+func TestReplaceFiles_DelegatesToReplaceDataFilesWhenNoDeleteFiles(t *testing.T) {
+	tbl := newReplaceFilesTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	dataPath := tbl.Location() + "/data/data-001.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "hello"}]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	oldDataFile := tasks[0].File
+
+	newDataPath := tbl.Location() + "/data/data-new.parquet"
+	writeParquetFile(t, newDataPath, arrowSc, `[{"id": 1, "data": "hello"}]`)
+
+	newBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		newDataPath, iceberg.ParquetFile, nil, nil, nil, 1, 256)
+	require.NoError(t, err)
+
+	tx2 := tbl.NewTransaction()
+	err = tx2.ReplaceFiles(t.Context(),
+		[]iceberg.DataFile{oldDataFile},
+		[]iceberg.DataFile{newBuilder.Build()},
+		nil, // no delete files
+		nil,
+	)
+	require.NoError(t, err)
+
+	tbl, err = tx2.Commit(t.Context())
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 1)
+}
+
+func TestReplaceFiles_ValidationErrors(t *testing.T) {
+	tbl := newReplaceFilesTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	dataPath := tbl.Location() + "/data/data-001.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "hello"}]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	t.Run("nil delete file", func(t *testing.T) {
+		tx := tbl.NewTransaction()
+		err := tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{nil},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil delete file")
+	})
+
+	t.Run("duplicate delete file paths", func(t *testing.T) {
+		posDelBuilder, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+			"s3://bucket/del.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 128)
+		require.NoError(t, err)
+		df := posDelBuilder.Build()
+
+		tx := tbl.NewTransaction()
+		err = tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{df, df},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unique")
+	})
+
+	t.Run("delete file not in table", func(t *testing.T) {
+		posDelBuilder, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+			"s3://bucket/nonexistent-del.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 128)
+		require.NoError(t, err)
+
+		tx := tbl.NewTransaction()
+		err = tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{posDelBuilder.Build()},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot remove delete files")
+	})
+}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -141,7 +141,14 @@ func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 		foundDeleted := make([]iceberg.ManifestEntry, 0)
 		notDeleted := make([]iceberg.ManifestEntry, 0, len(entries))
 		for _, entry := range entries {
-			if _, ok := of.base.deletedFiles[entry.DataFile().FilePath()]; ok {
+			path := entry.DataFile().FilePath()
+			content := entry.DataFile().ContentType()
+			_, isDeletedData := of.base.deletedFiles[path]
+			_, isDeletedDelete := of.base.deletedDeleteFiles[path]
+
+			isData := content == iceberg.EntryContentData
+			matched := (isDeletedData && isData) || (isDeletedDelete && !isData)
+			if matched {
 				foundDeleted = append(foundDeleted, entry)
 			} else {
 				notDeleted = append(notDeleted, entry)
@@ -165,7 +172,7 @@ func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 				return nil, err
 			}
 
-			wr, path, counter, fileCloser, err := of.base.newManifestWriter(*spec)
+			wr, path, counter, fileCloser, err := of.base.newManifestWriter(*spec, iceberg.WithManifestWriterContent(m.ManifestContent()))
 			if err != nil {
 				return nil, err
 			}
@@ -225,8 +232,14 @@ func (of *overwriteFiles) deletedEntries(ctx context.Context) ([]iceberg.Manifes
 
 		result := make([]iceberg.ManifestEntry, 0, len(entries))
 		for _, entry := range entries {
-			_, ok := of.base.deletedFiles[entry.DataFile().FilePath()]
-			if ok && entry.DataFile().ContentType() == iceberg.EntryContentData {
+			path := entry.DataFile().FilePath()
+			content := entry.DataFile().ContentType()
+
+			_, isDeletedData := of.base.deletedFiles[path]
+			_, isDeletedDelete := of.base.deletedDeleteFiles[path]
+
+			if (isDeletedData && content == iceberg.EntryContentData) ||
+				(isDeletedDelete && content != iceberg.EntryContentData) {
 				seqNum := entry.SequenceNum()
 				result = append(result,
 					iceberg.NewManifestEntry(iceberg.EntryStatusDELETED,
@@ -428,17 +441,18 @@ func (m *mergeAppendFiles) processManifests(manifests []iceberg.ManifestFile) ([
 type snapshotProducer struct {
 	producerImpl
 
-	commitUuid       uuid.UUID
-	io               iceio.WriteFileIO
-	txn              *Transaction
-	op               Operation
-	snapshotID       int64
-	parentSnapshotID int64
-	addedFiles       []iceberg.DataFile
-	addedDeleteFiles []iceberg.DataFile
-	manifestCount    atomic.Int32
-	deletedFiles     map[string]iceberg.DataFile
-	snapshotProps    iceberg.Properties
+	commitUuid         uuid.UUID
+	io                 iceio.WriteFileIO
+	txn                *Transaction
+	op                 Operation
+	snapshotID         int64
+	parentSnapshotID   int64
+	addedFiles         []iceberg.DataFile
+	addedDeleteFiles   []iceberg.DataFile
+	manifestCount      atomic.Int32
+	deletedFiles       map[string]iceberg.DataFile
+	deletedDeleteFiles map[string]iceberg.DataFile
+	snapshotProps      iceberg.Properties
 }
 
 func createSnapshotProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO, commitUUID *uuid.UUID, snapshotProps iceberg.Properties) *snapshotProducer {
@@ -458,15 +472,16 @@ func createSnapshotProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO
 	}
 
 	return &snapshotProducer{
-		commitUuid:       commit,
-		io:               fs,
-		txn:              txn,
-		op:               op,
-		snapshotID:       txn.meta.newSnapshotID(),
-		parentSnapshotID: parentSnapshot,
-		addedFiles:       []iceberg.DataFile{},
-		deletedFiles:     make(map[string]iceberg.DataFile),
-		snapshotProps:    snapshotProps,
+		commitUuid:         commit,
+		io:                 fs,
+		txn:                txn,
+		op:                 op,
+		snapshotID:         txn.meta.newSnapshotID(),
+		parentSnapshotID:   parentSnapshot,
+		addedFiles:         []iceberg.DataFile{},
+		deletedFiles:       make(map[string]iceberg.DataFile),
+		deletedDeleteFiles: make(map[string]iceberg.DataFile),
+		snapshotProps:      snapshotProps,
 	}
 }
 
@@ -496,7 +511,13 @@ func (sp *snapshotProducer) deleteDataFile(df iceberg.DataFile) *snapshotProduce
 	return sp
 }
 
-func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec) (_ *iceberg.ManifestWriter, _ string, _ *internal.CountingWriter, _ io.Closer, err error) {
+func (sp *snapshotProducer) removeDeleteFile(df iceberg.DataFile) *snapshotProducer {
+	sp.deletedDeleteFiles[df.FilePath()] = df
+
+	return sp
+}
+
+func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec, opts ...iceberg.ManifestWriterOption) (_ *iceberg.ManifestWriter, _ string, _ *internal.CountingWriter, _ io.Closer, err error) {
 	out, path, err := sp.newManifestOutput()
 	if err != nil {
 		return nil, "", nil, nil, err
@@ -504,7 +525,7 @@ func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec) (_ *ic
 
 	counter := &internal.CountingWriter{W: out}
 	wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter, spec,
-		sp.txn.meta.CurrentSchema(), sp.snapshotID)
+		sp.txn.meta.CurrentSchema(), sp.snapshotID, opts...)
 	if err != nil {
 		return nil, "", nil, nil, errors.Join(err, out.Close())
 	}
@@ -554,32 +575,54 @@ func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.Manifest
 
 	if len(deleted) > 0 {
 		g.Go(func() error {
-			partitionGroups := map[int][]iceberg.ManifestEntry{}
+			// Group deleted entries by (specID, contentType) to ensure data and
+			// delete file entries are written to separate manifests with the
+			// correct ManifestContent.
+			type groupKey struct {
+				specID  int
+				content iceberg.ManifestContent
+			}
+			groups := map[groupKey][]iceberg.ManifestEntry{}
 			for _, entry := range deleted {
-				specid := int(entry.DataFile().SpecID())
-
-				group := partitionGroups[specid]
-				partitionGroups[specid] = append(group, entry)
+				content := iceberg.ManifestContentData
+				if entry.DataFile().ContentType() != iceberg.EntryContentData {
+					content = iceberg.ManifestContentDeletes
+				}
+				key := groupKey{specID: int(entry.DataFile().SpecID()), content: content}
+				groups[key] = append(groups[key], entry)
 			}
 
-			writeGroup := func(specid int, entries []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
+			writeGroup := func(key groupKey, entries []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
 				out, path, err := sp.newManifestOutput()
 				if err != nil {
 					return nil, err
 				}
 				defer internal.CheckedClose(out, &retErr)
 
-				mf, err := iceberg.WriteManifest(path, out, sp.txn.meta.formatVersion,
-					sp.spec(specid), sp.txn.meta.CurrentSchema(), sp.snapshotID, entries)
+				counter := &internal.CountingWriter{W: out}
+				wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter,
+					sp.spec(key.specID), sp.txn.meta.CurrentSchema(),
+					sp.snapshotID, iceberg.WithManifestWriterContent(key.content))
 				if err != nil {
 					return nil, err
 				}
+				defer internal.CheckedClose(wr, &retErr)
 
-				return mf, nil
+				for _, entry := range entries {
+					if err := wr.Delete(entry); err != nil {
+						return nil, err
+					}
+				}
+
+				if err := wr.Close(); err != nil {
+					return nil, err
+				}
+
+				return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(key.content))
 			}
 
-			for specid, entries := range partitionGroups {
-				mf, err := writeGroup(specid, entries)
+			for key, entries := range groups {
+				mf, err := writeGroup(key, entries)
 				if err != nil {
 					return err
 				}
@@ -678,6 +721,15 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 	if len(sp.deletedFiles) > 0 {
 		specs := sp.txn.meta.specs
 		for _, df := range sp.deletedFiles {
+			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+				return Summary{}, err
+			}
+		}
+	}
+
+	if len(sp.deletedDeleteFiles) > 0 {
+		specs := sp.txn.meta.specs
+		for _, df := range sp.deletedDeleteFiles {
 			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
 				return Summary{}, err
 			}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -733,6 +733,121 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	return t.apply(updates, reqs)
 }
 
+// ReplaceFiles atomically replaces data files and removes associated delete files
+// in a single snapshot. This is the commit primitive for compaction: old data files
+// are replaced with new (compacted) data files, and delete files that are fully
+// applied are removed.
+func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataFilesToAdd, deleteFilesToRemove []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
+	// Delegate data file replacement to existing logic.
+	if len(deleteFilesToRemove) == 0 {
+		return t.ReplaceDataFilesWithDataFiles(ctx, dataFilesToDelete, dataFilesToAdd, snapshotProps, opts...)
+	}
+
+	var cfg dataFileCfg
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	setToAdd, err := t.validateDataFilesToAdd(dataFilesToAdd, "ReplaceFiles")
+	if err != nil {
+		return err
+	}
+
+	setToDelete := make(map[string]struct{}, len(dataFilesToDelete))
+	for i, df := range dataFilesToDelete {
+		if df == nil {
+			return fmt.Errorf("nil data file at index %d for ReplaceFiles", i)
+		}
+		path := df.FilePath()
+		if path == "" {
+			return errors.New("delete data file paths must be non-empty for ReplaceFiles")
+		}
+		if _, ok := setToDelete[path]; ok {
+			return errors.New("delete data file paths must be unique for ReplaceFiles")
+		}
+		setToDelete[path] = struct{}{}
+	}
+
+	setDeleteFilesToRemove := make(map[string]struct{}, len(deleteFilesToRemove))
+	for i, df := range deleteFilesToRemove {
+		if df == nil {
+			return fmt.Errorf("nil delete file at index %d for ReplaceFiles", i)
+		}
+		path := df.FilePath()
+		if path == "" {
+			return errors.New("delete file paths must be non-empty for ReplaceFiles")
+		}
+		if _, ok := setDeleteFilesToRemove[path]; ok {
+			return errors.New("delete file paths must be unique for ReplaceFiles")
+		}
+		setDeleteFilesToRemove[path] = struct{}{}
+	}
+
+	s := t.meta.currentSnapshot()
+	if s == nil {
+		return fmt.Errorf("%w: cannot replace files in a table without an existing snapshot", ErrInvalidOperation)
+	}
+
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Scan all entries (data + delete files) in a single pass to validate
+	// that all files to delete/remove actually exist in the table.
+	markedDataForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
+	markedDeleteForRemoval := make([]iceberg.DataFile, 0, len(setDeleteFilesToRemove))
+	for df, err := range s.dataFiles(fs, nil) {
+		if err != nil {
+			return err
+		}
+		path := df.FilePath()
+		isData := df.ContentType() == iceberg.EntryContentData
+		if _, ok := setToDelete[path]; ok && isData {
+			markedDataForDeletion = append(markedDataForDeletion, df)
+		}
+		if _, ok := setDeleteFilesToRemove[path]; ok && !isData {
+			markedDeleteForRemoval = append(markedDeleteForRemoval, df)
+		}
+		if _, ok := setToAdd[path]; ok {
+			return fmt.Errorf("cannot add files that are already referenced by table, files: %s", path)
+		}
+	}
+
+	if len(markedDataForDeletion) != len(setToDelete) {
+		return errors.New("cannot delete data files that do not belong to the table")
+	}
+	if len(markedDeleteForRemoval) != len(setDeleteFilesToRemove) {
+		return errors.New("cannot remove delete files that do not belong to the table")
+	}
+
+	if !cfg.skipAutoNameMapping {
+		if err := t.ensureNameMapping(); err != nil {
+			return err
+		}
+	}
+
+	commitUUID := uuid.New()
+	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+
+	for _, df := range markedDataForDeletion {
+		updater.deleteDataFile(df)
+	}
+	for _, df := range dataFilesToAdd {
+		updater.appendDataFile(df)
+	}
+	for _, df := range markedDeleteForRemoval {
+		updater.removeDeleteFile(df)
+	}
+
+	updates, reqs, err := updater.commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	return t.apply(updates, reqs)
+}
+
 type AddFilesOption func(addFilesOp *addFilesOperation)
 
 type addFilesOperation struct {


### PR DESCRIPTION
Extend the overwrite snapshot producer to atomically remove delete files (position + equality) alongside data file replacement. This is the commit primitive needed for compaction (#832) to clean up fully-applied delete files.

- Add deletedDeleteFiles tracking to snapshotProducer with removeDeleteFile()
- existingManifests() cross-checks content type when filtering entries
- deletedEntries() splits by content type into separate data/delete manifests with correct ManifestContent in both Avro metadata and manifest list
- newManifestWriter accepts ManifestWriterOption for content type propagation
- New Transaction.ReplaceFiles() validates both data and delete files exist in the table with content-type gating before commit