### PR TITLE
feat(table): strengthen orphan-cleanup stats referenced-set tests and document empty-path guard

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -243,11 +243,13 @@ func (t Table) getReferencedFiles(fs iceio.IO) (map[string]bool, error) {
 	referenced[versionHintPath] = true
 
 	for sf := range metadata.Statistics() {
+		// Guard against malformed metadata; statistics-path is required per spec.
 		if sf.StatisticsPath != "" {
 			referenced[sf.StatisticsPath] = true
 		}
 	}
 	for psf := range metadata.PartitionStatistics() {
+		// Guard against malformed metadata; statistics-path is required per spec.
 		if psf.StatisticsPath != "" {
 			referenced[psf.StatisticsPath] = true
 		}

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -495,6 +495,13 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
       "file-size-in-bytes": 1024,
       "file-footer-size-in-bytes": 512,
       "blob-metadata": []
+    },
+    {
+      "snapshot-id": 2,
+      "statistics-path": "",
+      "file-size-in-bytes": 0,
+      "file-footer-size-in-bytes": 0,
+      "blob-metadata": []
     }
   ],
   "partition-statistics": [
@@ -521,4 +528,6 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
 	assert.True(t, refs["s3://bucket/stats/table-stats.puffin"])
 	assert.True(t, refs["s3://bucket/stats/part-stats.puffin"])
 	assert.True(t, refs[tbl.metadataLocation])
+	assert.False(t, refs["s3://bucket/stats/not-referenced.puffin"])
+	assert.False(t, refs[""])
 }


### PR DESCRIPTION
This follow-up addresses review feedback on [PR #848](https://github.com/apache/iceberg-go/pull/848) ([discussion](https://github.com/apache/iceberg-go/pull/848#discussion_r3034275179)) from @laskoviymishka