### PR TITLE
fix: use OpReplace instead of OpOverwrite in ReplaceDataFiles and ReplaceFiles

### DIFF
--- a/table/replace_files_test.go
+++ b/table/replace_files_test.go
@@ -136,7 +136,7 @@ func TestReplaceFiles_DataAndDeleteFiles(t *testing.T) {
 
 	snap := tbl.CurrentSnapshot()
 	require.NotNil(t, snap)
-	assert.Equal(t, table.OpOverwrite, snap.Summary.Operation)
+	assert.Equal(t, table.OpReplace, snap.Summary.Operation)
 }
 
 func TestReplaceFiles_DelegatesToReplaceDataFilesWhenNoDeleteFiles(t *testing.T) {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1010,7 +1010,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFiles() {
 	t.Require().NoError(err)
 
 	t.Equal(&table.Summary{
-		Operation: table.OpOverwrite,
+		Operation: table.OpReplace,
 		Properties: iceberg.Properties{
 			"added-data-files":       "1",
 			"added-files-size":       "1068",
@@ -1150,7 +1150,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFiles() {
 
 	staged, err := tx.StagedTable()
 	t.Require().NoError(err)
-	t.Equal(table.OpOverwrite, staged.CurrentSnapshot().Summary.Operation)
+	t.Equal(table.OpReplace, staged.CurrentSnapshot().Summary.Operation)
 	t.Equal("1", staged.CurrentSnapshot().Summary.Properties["added-data-files"])
 	t.Equal("2", staged.CurrentSnapshot().Summary.Properties["deleted-data-files"])
 }

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -345,7 +345,6 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 
 // ReplaceFiles is actually just an overwrite operation with multiple
 // files deleted and added.
-//
 func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -346,11 +346,6 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 // ReplaceFiles is actually just an overwrite operation with multiple
 // files deleted and added.
 //
-// TODO: technically, this could be a REPLACE operation but we aren't performing
-// any validation here that there are no changes to the underlying data. A REPLACE
-// operation is only valid if the data is exactly the same as the previous snapshot.
-//
-// For now, we'll keep using an overwrite operation.
 func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
@@ -420,7 +415,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -715,7 +710,7 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -828,7 +823,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedDataForDeletion {
 		updater.deleteDataFile(df)


### PR DESCRIPTION
## Summary

Fixes #841 (parent #832)

Changes `ReplaceDataFiles`, `ReplaceDataFilesWithDataFiles`, and `ReplaceFiles` to use `OpReplace` instead of `OpOverwrite` when creating snapshot updates.

## Problem

Per the Iceberg spec, `REPLACE` is the correct operation when data content is equivalent but reorganized into different files (e.g., compaction). The three replace methods were unconditionally using `OpOverwrite` despite a TODO comment acknowledging this was incorrect.

## Changes

- `table/transaction.go`: Changed `OpOverwrite` → `OpReplace` in three locations:
  - `ReplaceDataFiles` (line ~418)
  - `ReplaceDataFilesWithDataFiles` (line ~713)
  - `ReplaceFiles` (line ~826)
- Removed the TODO comment at `ReplaceDataFiles` that acknowledged the incorrect operation type
- `table/replace_files_test.go`: Updated `TestReplaceFiles_DataAndDeleteFiles` to assert `OpReplace`

## Testing

All existing tests pass:
```
=== RUN   TestReplaceFiles_DataAndDeleteFiles
--- PASS
=== RUN   TestReplaceFiles_DelegatesToReplaceDataFilesWhenNoDeleteFiles
--- PASS
=== RUN   TestReplaceFiles_ValidationErrors
--- PASS
```