### PR TITLE
fix: handle missing format-version in NewManifestReader for v1 manifests

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -610,9 +610,13 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 	metadata := dec.Metadata()
 	sc := dec.Schema()
 
-	formatVersion, err := strconv.Atoi(string(metadata["format-version"]))
-	if err != nil {
-		return nil, fmt.Errorf("manifest file's 'format-version' metadata is invalid: %w", err)
+	formatVersion := 1
+	// format-version is optional for v1 manifest files, so default to v1
+	if raw := metadata["format-version"]; len(raw) > 0 {
+		formatVersion, err = strconv.Atoi(string(raw))
+		if err != nil {
+			return nil, fmt.Errorf("manifest file's 'format-version' metadata is invalid: %w", err)
+		}
 	}
 	if formatVersion != file.Version() {
 		return nil, fmt.Errorf("manifest file's 'format-version' metadata indicates version %d, but entry from manifest list indicates version %d",

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -19,8 +19,10 @@ package iceberg
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -803,6 +805,61 @@ func (m *ManifestTestSuite) TestReadManifestListMissingFormatVersion() {
 	files, err := ReadManifestList(&buf)
 	m.NoError(err)
 	m.Empty(files) // the file has no entries, just headers
+}
+
+// writeManifestNoFormatVersion writes a valid v1 manifest entry Avro file that
+// omits the "format-version" metadata key, simulating files produced by the Java
+// Iceberg library (format-version is optional for v1 per the Iceberg spec).
+func writeManifestNoFormatVersion(t *testing.T) bytes.Buffer {
+	t.Helper()
+
+	partitionSpec := NewPartitionSpec()
+	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schemaJSON, err := json.Marshal(testSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(entrySchema, &buf,
+		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+		ocf.WithMetadata(map[string][]byte{
+			// intentionally omit "format-version" to simulate Java Iceberg v1 files
+			"schema":            schemaJSON,
+			"schema-id":         []byte(strconv.Itoa(testSchema.ID)),
+			"partition-spec":    []byte("[]"),
+			"partition-spec-id": []byte("0"),
+			"content":           []byte("data"),
+		}),
+		ocf.WithCodec(ocf.Deflate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}
+
+func (m *ManifestTestSuite) TestNewManifestReaderMissingFormatVersion() {
+	// A v1 manifest file without "format-version" should succeed, defaulting to the
+	// version from the manifest list entry (matching the Java Iceberg behavior).
+	buf := writeManifestNoFormatVersion(m.T())
+	manifest := manifestFile{version: 1}
+	reader, err := NewManifestReader(&manifest, &buf)
+	m.Require().NoError(err)
+	m.Equal(1, reader.Version())
+	m.NoError(reader.Close())
 }
 
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {


### PR DESCRIPTION
## Problem

`NewManifestReader` in `manifest.go` calls `strconv.Atoi` unconditionally on `metadata["format-version"]`. The Java Iceberg library omits this key from v1 manifest file Avro OCF headers — `format-version` is optional for v1 per the spec. When iceberg-go reads those files, `metadata["format-version"]` returns `nil` → empty string → `Atoi("")` → error:

```
manifest file's 'format-version' metadata is invalid: strconv.Atoi: parsing "": invalid syntax
```

## Fix

Default `formatVersion` to `1` and only parse the metadata key when it is present. This matches the spec (`format-version` is optional for v1, required for v2+) and the same pattern already used in `ReadManifestList` since #826.

The existing `formatVersion != file.Version()` check below is unaffected and still catches real version mismatches.

## Testing

Added `TestNewManifestReaderMissingFormatVersion`: writes a v1 manifest Avro file without the `format-version` metadata key (simulating Java Iceberg output) and verifies `NewManifestReader` succeeds and reports version 1.

## Related

- Follows the same pattern as #826 which fixed `ReadManifestList`
- Spec reference: `format/spec.md` Avro manifest file metadata table — `format-version` is `optional` for v1, `required` for v2