### PR TITLE
fix(table): fast-append must inherit all parent manifests unconditionally

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -75,26 +75,16 @@ func (fa *fastAppendFiles) processManifests(manifests []iceberg.ManifestFile) ([
 }
 
 func (fa *fastAppendFiles) existingManifests() ([]iceberg.ManifestFile, error) {
-	existing := make([]iceberg.ManifestFile, 0)
-	if fa.base.parentSnapshotID > 0 {
-		previous, err := fa.base.txn.meta.SnapshotByID(fa.base.parentSnapshotID)
-		if err != nil {
-			return nil, fmt.Errorf("could not find parent snapshot %d", fa.base.parentSnapshotID)
-		}
-
-		manifests, err := previous.Manifests(fa.base.io)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, m := range manifests {
-			if m.HasAddedFiles() || m.HasExistingFiles() || m.SnapshotID() == fa.base.snapshotID {
-				existing = append(existing, m)
-			}
-		}
+	if fa.base.parentSnapshotID <= 0 {
+		return nil, nil
 	}
 
-	return existing, nil
+	previous, err := fa.base.txn.meta.SnapshotByID(fa.base.parentSnapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("could not find parent snapshot %d: %w", fa.base.parentSnapshotID, err)
+	}
+
+	return previous.Manifests(fa.base.io)
 }
 
 func (fa *fastAppendFiles) deletedEntries(_ context.Context) ([]iceberg.ManifestEntry, error) {

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -785,3 +785,96 @@ func TestManifestsClosesWriterWhenDeletedEntriesFails(t *testing.T) {
 		require.Zero(t, writerCount, "expected no writerFactory to be created when deletedEntries is called first")
 	}
 }
+
+// TestFastAppendInheritsZeroCountManifests verifies that fastAppendFiles.existingManifests
+// includes manifests with added_files_count=0 and existing_files_count=0. This is the
+// standard Iceberg v2 "inherited manifest" representation written by Athena and other
+// external writers. The previous filter (HasAddedFiles || HasExistingFiles) silently
+// dropped these manifests, causing data written by Athena to disappear after any
+// iceberg-go fast-append.
+func TestFastAppendInheritsZeroCountManifests(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+
+	// Use the mem blob FS so that files written via Create() can be read back.
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+
+	// Snapshot 1: a snapshot whose manifest list contains two manifest entries
+	// with added_files_count=0 and existing_files_count=0, simulating what
+	// Athena (and other Iceberg v2 writers) produce.
+	snap1ID := int64(1001)
+	seqNum1 := int64(1)
+
+	// These paths must be under the table location so the mem FS can locate them.
+	athenaManifest1 := iceberg.NewManifestFile(2,
+		"mem://default/table-location/metadata/athena-m0.avro", 512, 0, snap1ID).Build()
+	athenaManifest2 := iceberg.NewManifestFile(2,
+		"mem://default/table-location/metadata/athena-m1.avro", 256, 0, snap1ID).Build()
+
+	// Sanity check: both manifests have zero counts, so the old filter would drop them.
+	require.False(t, athenaManifest1.HasAddedFiles(), "test setup: manifest1 must have zero added count")
+	require.False(t, athenaManifest1.HasExistingFiles(), "test setup: manifest1 must have zero existing count")
+	require.False(t, athenaManifest2.HasAddedFiles(), "test setup: manifest2 must have zero added count")
+	require.False(t, athenaManifest2.HasExistingFiles(), "test setup: manifest2 must have zero existing count")
+
+	snap1ListPath := "mem://default/table-location/metadata/snap-1001.avro"
+
+	var listBuf bytes.Buffer
+	err := iceberg.WriteManifestList(2, &listBuf, snap1ID, nil, &seqNum1, 0,
+		[]iceberg.ManifestFile{athenaManifest1, athenaManifest2})
+	require.NoError(t, err, "write manifest list for snap1")
+	require.NoError(t, wfs.WriteFile(snap1ListPath, listBuf.Bytes()))
+
+	// Inject snap1 as the current snapshot in the transaction metadata.
+	txn.meta.snapshotList = []Snapshot{
+		{
+			SnapshotID:     snap1ID,
+			SequenceNumber: seqNum1,
+			TimestampMs:    time.Now().UnixMilli(),
+			ManifestList:   snap1ListPath,
+			Summary:        &Summary{Operation: OpAppend},
+		},
+	}
+	txn.meta.currentSnapshotID = &snap1ID
+
+	// Snapshot 2: fast-append one new data file on top of snap1.
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+	df := newTestDataFile(t, spec, "file://new-data.parquet", nil)
+	sp.appendDataFile(df)
+
+	updates, reqs, err := sp.commit(context.Background())
+	require.NoError(t, err, "fast-append commit must succeed")
+	require.NotEmpty(t, updates, "must produce updates")
+	require.NotEmpty(t, reqs, "must produce requirements")
+
+	addSnap, ok := updates[0].(*addSnapshotUpdate)
+	require.True(t, ok, "first update must be AddSnapshot")
+
+	// Read back the new manifest list and verify it contains all three manifests:
+	// the two Athena-written zero-count manifests plus the new one.
+	snap2Manifests := readManifestListFromPath(t, wfs, addSnap.Snapshot.ManifestList)
+
+	// Collect the manifest paths in the new snapshot.
+	paths := make([]string, 0, len(snap2Manifests))
+	for _, m := range snap2Manifests {
+		paths = append(paths, m.FilePath())
+	}
+
+	require.Contains(t, paths, athenaManifest1.FilePath(),
+		"new snapshot must carry forward the first Athena manifest (zero added_files_count)")
+	require.Contains(t, paths, athenaManifest2.FilePath(),
+		"new snapshot must carry forward the second Athena manifest (zero existing_files_count)")
+	require.Len(t, snap2Manifests, 3,
+		"new snapshot must have exactly 3 manifests: 2 inherited + 1 newly written")
+
+	// Verify the newly written manifest belongs to snap2.
+	snap2ID := addSnap.Snapshot.SnapshotID
+	var newManifestFound bool
+	for _, m := range snap2Manifests {
+		if m.SnapshotID() == snap2ID {
+			newManifestFound = true
+
+			break
+		}
+	}
+	require.True(t, newManifestFound, "new snapshot must include a manifest written by snap2")
+}


### PR DESCRIPTION
## Problem

`fastAppendFiles.existingManifests()` filters parent manifests using:

```go
if m.HasAddedFiles() || m.HasExistingFiles() || m.SnapshotID() == fa.base.snapshotID {
    existing = append(existing, m)
}
```

`HasAddedFiles()` returns `AddedFilesCount != 0` and `HasExistingFiles()` returns `ExistingFilesCount != 0` (v2 manifest file). Both return `false` when a manifest list entry has `added_files_count=0` and `existing_files_count=0`, which is the standard Iceberg v2 representation for **inherited manifests** written by external writers (Athena, Spark, Trino, etc.).

As a result, any data written by an external writer is **silently dropped** from the snapshot on the next iceberg-go fast-append. After the append, queries return only the iceberg-go-written rows; all previously existing data becomes invisible.

## Root Cause Confirmed

Reproduction: create a table with Athena, insert 2 rows, append 1 row with iceberg-go. After the append the parent snapshot's manifest list entries have `added_files_count=0, existing_files_count=0`. Both manifests are filtered out. Athena queries the new snapshot and sees only the 1 iceberg-go row.

Diagnostic output from the new test (before fix):
```
Parent has 2 manifests:
[0] snapshot_id=... added_files=0 existing_files=0 HasAdded=false HasExisting=false
[1] snapshot_id=... added_files=0 existing_files=0 HasAdded=false HasExisting=false
```

This was discovered and confirmed during a production Iceberg table remediation at Docker. See [docker/data-platform#406](https://github.com/docker/data-platform/pull/406) for the full investigation.

## Fix

A fast-append never removes or overwrites data files, so all parent manifests should be inherited unconditionally. Remove the filter and return `previous.Manifests()` directly.

## Testing

- New test `TestFastAppendInheritsZeroCountManifests` reproduces the bug (FAIL before patch, PASS after): creates two zero-count manifests simulating an Athena-written snapshot, fast-appends one new data file, asserts all 3 manifests are present in the resulting snapshot.
- Full `./table/...` suite passes with no regressions.