### PR TITLE
treewide: replace hamba/avro with twmb/avro

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        go: [ '1.23.6', '1.24.9' ]
+        go: [ '1.26.2' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
     steps:
     - uses: actions/checkout@v4
@@ -51,9 +51,9 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+      uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
       with:
-        version: v2.8.0
+        version: v2.11.4
         args: --timeout=10m
     - name: Run tests
       run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@
 
 module github.com/apache/iceberg-go
 
-go 1.25.5
+go 1.26
 
 require (
 	cloud.google.com/go/storage v1.61.3
@@ -37,11 +37,11 @@ require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/hamba/avro/v2 v2.31.0
 	github.com/pterm/pterm v0.12.83
 	github.com/stretchr/testify v1.11.1
 	github.com/substrait-io/substrait-go/v7 v7.6.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.41.0
+	github.com/twmb/avro v1.3.4
 	github.com/twmb/murmur3 v1.1.8
 	github.com/uptrace/bun v1.2.18
 	github.com/uptrace/bun/dialect/mssqldialect v1.2.18
@@ -168,7 +168,6 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -199,8 +198,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,7 +351,6 @@ github.com/google/go-replayers/grpcreplay v1.3.0 h1:1Keyy0m1sIpqstQmgz307zhiJ1pV
 github.com/google/go-replayers/grpcreplay v1.3.0/go.mod h1:v6NgKtkijC0d3e3RW8il6Sy5sqRVUwoQa4mHOGEy8DI=
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
 github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
-github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 h1:EEHtgt9IwisQ2AZ4pIsMjahcegHh6rmhqxzIRQIyepY=
@@ -378,8 +377,6 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
-github.com/hamba/avro/v2 v2.31.0 h1:wv3nmua7lCEIwWsb6vqsTS3pXktTxcKg5eoyNu0VhrU=
-github.com/hamba/avro/v2 v2.31.0/go.mod h1:t6lJYAGE5Mswfn17zjtyQsssRQgnqO6TXLBCHHWRqrw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -401,8 +398,6 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -484,12 +479,6 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
-github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
 github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -629,6 +618,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/twmb/avro v1.3.4 h1:4tTV207HOUHKTdAMv6fGPyqgwmGfMLUfnFg5R4cfIX0=
+github.com/twmb/avro v1.3.4/go.mod h1:TUQS96Ptl8tDRyK0Jw91FXIVCoPKz4sXxvUSShiG5FA=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uptrace/bun v1.2.18 h1:3HnRcMfS6OBPMG1eSOzlbFJ/X/AyMEJb7rMxE6VQvDU=

--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -88,7 +88,6 @@ const fieldSummaryJSON = `{
 	]
 }`
 
-
 func init() {
 	avroSchemas["field_summary"] = Must(avro.Parse(fieldSummaryJSON))
 
@@ -302,6 +301,7 @@ func newDataFileSchema(partitionType *avro.Schema, version int) (*avro.Schema, e
 
 	// Use a fresh cache so named types from the base schema are re-parsed cleanly.
 	var cache avro.SchemaCache
+
 	return cache.Parse(string(newJSON))
 }
 
@@ -362,5 +362,6 @@ func NewManifestEntrySchema(partitionType *avro.Schema, version int) (*avro.Sche
 
 	// Use a fresh cache so named types are re-parsed cleanly.
 	var cache avro.SchemaCache
+
 	return cache.Parse(string(newJSON))
 }

--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -18,15 +18,15 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"github.com/hamba/avro/v2"
+	"github.com/twmb/avro"
 )
 
-func NullableSchema(schema avro.Schema) avro.Schema {
-	return Must(avro.NewUnionSchema([]avro.Schema{
-		NullSchema, schema,
-	}))
+// NullableSchema wraps schema in a nullable union ["null", schema].
+func NullableSchema(schema *avro.Schema) *avro.Schema {
+	return Must(avro.Parse(`["null",` + schema.String() + `]`))
 }
 
 var requiredLength = [...]int{
@@ -46,495 +46,268 @@ func DecimalRequiredBytes(precision int) int {
 	return requiredLength[precision]
 }
 
-func DecimalSchema(precision, scale int) avro.Schema {
-	return Must(avro.NewFixedSchema("fixed", "",
-		DecimalRequiredBytes(precision), avro.NewDecimalLogicalSchema(precision, scale)))
+// DecimalSchema returns an Avro fixed schema for a decimal with the given precision and scale.
+func DecimalSchema(precision, scale int) *avro.Schema {
+	return Must(avro.Parse(fmt.Sprintf(
+		`{"type":"fixed","name":"fixed","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}`,
+		DecimalRequiredBytes(precision), precision, scale)))
 }
 
 var (
-	NullSchema           = avro.NewNullSchema()
-	BoolSchema           = avro.NewPrimitiveSchema(avro.Boolean, nil)
+	NullSchema           = Must(avro.Parse(`"null"`))
+	BoolSchema           = Must(avro.Parse(`"boolean"`))
 	NullableBoolSchema   = NullableSchema(BoolSchema)
-	BinarySchema         = avro.NewPrimitiveSchema(avro.Bytes, nil)
+	BinarySchema         = Must(avro.Parse(`"bytes"`))
 	NullableBinarySchema = NullableSchema(BinarySchema)
-	StringSchema         = avro.NewPrimitiveSchema(avro.String, nil)
-	IntSchema            = avro.NewPrimitiveSchema(avro.Int, nil)
+	StringSchema         = Must(avro.Parse(`"string"`))
+	IntSchema            = Must(avro.Parse(`"int"`))
 	NullableIntSchema    = NullableSchema(IntSchema)
-	LongSchema           = avro.NewPrimitiveSchema(avro.Long, nil)
+	LongSchema           = Must(avro.Parse(`"long"`))
 	NullableLongSchema   = NullableSchema(LongSchema)
-	FloatSchema          = avro.NewPrimitiveSchema(avro.Float, nil)
-	DoubleSchema         = avro.NewPrimitiveSchema(avro.Double, nil)
-	DateSchema           = avro.NewPrimitiveSchema(avro.Int, avro.NewPrimitiveLogicalSchema(avro.Date))
-	TimeSchema           = avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimeMicros))
-	TimestampSchema      = avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimestampMicros),
-		avro.WithProps(map[string]any{"adjust-to-utc": false}))
-	TimestampTzSchema = avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimestampMicros),
-		avro.WithProps(map[string]any{"adjust-to-utc": true}))
-	UUIDSchema = Must(avro.NewFixedSchema("uuid", "", 16, avro.NewPrimitiveLogicalSchema(avro.UUID)))
-
-	AvroSchemaCache avro.SchemaCache
+	FloatSchema          = Must(avro.Parse(`"float"`))
+	DoubleSchema         = Must(avro.Parse(`"double"`))
+	DateSchema           = Must(avro.Parse(`{"type":"int","logicalType":"date"}`))
+	TimeSchema           = Must(avro.Parse(`{"type":"long","logicalType":"time-micros"}`))
+	TimestampSchema      = Must(avro.Parse(`{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":false}`))
+	TimestampTzSchema    = Must(avro.Parse(`{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":true}`))
+	UUIDSchema           = Must(avro.Parse(`{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}`))
 )
 
-func newMapSchema(name string, keySchema, valueSchema avro.Schema, keyFieldID, valueFieldID int) avro.Schema {
-	return avro.NewArraySchema(
-		Must(avro.NewRecordSchema(name, "", []*avro.Field{
-			Must(avro.NewField("key", keySchema, WithFieldID(keyFieldID))),
-			Must(avro.NewField("value", valueSchema, WithFieldID(valueFieldID))),
-		})), avro.WithProps(map[string]any{"logicalType": "map"}))
-}
+// avroSchemas stores pre-built Avro schemas by name for reuse in dynamic schema construction.
+var avroSchemas = make(map[string]*avro.Schema)
 
-func WithFieldID(id int) avro.SchemaOption {
-	return avro.WithProps(map[string]any{"field-id": id})
-}
+const fieldSummaryJSON = `{
+	"type": "record",
+	"name": "r508",
+	"field-id": 508,
+	"fields": [
+		{"name": "contains_null", "type": "boolean", "doc": "true if the field contains null values", "field-id": 509},
+		{"name": "contains_nan", "type": ["null", "boolean"], "doc": "true if the field contains NaN values", "field-id": 518},
+		{"name": "lower_bound", "type": ["null", "bytes"], "doc": "serialized lower bound", "field-id": 510},
+		{"name": "upper_bound", "type": ["null", "bytes"], "doc": "serialized upper bound", "field-id": 511}
+	]
+}`
 
-func WithElementID(id int) avro.SchemaOption {
-	return avro.WithProps(map[string]any{"element-id": id})
-}
 
 func init() {
-	AvroSchemaCache.Add("field_summary", Must(avro.NewRecordSchema("r508", "", []*avro.Field{
-		Must(avro.NewField("contains_null",
-			BoolSchema,
-			avro.WithDoc("true if the field contains null values"),
-			WithFieldID(509))),
-		Must(avro.NewField("contains_nan",
-			NullableBoolSchema,
-			avro.WithDoc("true if the field contains NaN values"),
-			WithFieldID(518))),
-		Must(avro.NewField("lower_bound", NullableBinarySchema,
-			avro.WithDoc("serialized lower bound"),
-			WithFieldID(510))),
-		Must(avro.NewField("upper_bound", NullableBinarySchema,
-			avro.WithDoc("serialized upper bound"),
-			WithFieldID(511))),
-	}, WithFieldID(508))))
+	avroSchemas["field_summary"] = Must(avro.Parse(fieldSummaryJSON))
 
-	AvroSchemaCache.Add("manifest_list_file_v1", Must(avro.NewRecordSchema("manifest_file", "", []*avro.Field{
-		Must(avro.NewField("manifest_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(500))),
-		Must(avro.NewField("manifest_length",
-			LongSchema,
-			avro.WithDoc("Total file size in bytes"),
-			WithFieldID(501))),
-		Must(avro.NewField("partition_spec_id",
-			IntSchema,
-			avro.WithDoc("Spec ID used to write"),
-			WithFieldID(502))),
-		Must(avro.NewField("added_snapshot_id",
-			LongSchema,
-			avro.WithDoc("Snapshot ID that added the manifest"),
-			WithFieldID(503))),
-		Must(avro.NewField("added_files_count",
-			NullableIntSchema,
-			avro.WithDoc("Added entry count"),
-			WithFieldID(504))),
-		Must(avro.NewField("existing_files_count",
-			NullableIntSchema,
-			avro.WithDoc("Existing entry count"),
-			WithFieldID(505))),
-		Must(avro.NewField("deleted_files_count",
-			NullableIntSchema,
-			avro.WithDoc("Deleted entry count"),
-			WithFieldID(506))),
-		Must(avro.NewField("partitions",
-			NullableSchema(
-				avro.NewArraySchema(AvroSchemaCache.Get("field_summary"),
-					WithElementID(508))),
-			avro.WithDoc("Partition field summaries"),
-			WithFieldID(507))),
-		Must(avro.NewField("added_rows_count",
-			NullableLongSchema,
-			avro.WithDoc("Added row count"),
-			WithFieldID(512))),
-		Must(avro.NewField("existing_rows_count",
-			NullableLongSchema,
-			avro.WithDoc("Existing row count"),
-			WithFieldID(513))),
-		Must(avro.NewField("deleted_rows_count",
-			NullableLongSchema,
-			avro.WithDoc("Deleted row count"),
-			WithFieldID(514))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Key metadata"),
-			WithFieldID(519))),
-	})))
+	avroSchemas["manifest_list_file_v1"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 500},
+			{"name": "manifest_length", "type": "long", "doc": "Total file size in bytes", "field-id": 501},
+			{"name": "partition_spec_id", "type": "int", "doc": "Spec ID used to write", "field-id": 502},
+			{"name": "added_snapshot_id", "type": "long", "doc": "Snapshot ID that added the manifest", "field-id": 503},
+			{"name": "added_files_count", "type": ["null", "int"], "doc": "Added entry count", "field-id": 504},
+			{"name": "existing_files_count", "type": ["null", "int"], "doc": "Existing entry count", "field-id": 505},
+			{"name": "deleted_files_count", "type": ["null", "int"], "doc": "Deleted entry count", "field-id": 506},
+			{"name": "partitions", "type": ["null", {"type": "array", "items": {"type": "record", "name": "r508", "field-id": 508, "fields": [{"name": "contains_null", "type": "boolean", "doc": "true if the field contains null values", "field-id": 509}, {"name": "contains_nan", "type": ["null", "boolean"], "doc": "true if the field contains NaN values", "field-id": 518}, {"name": "lower_bound", "type": ["null", "bytes"], "doc": "serialized lower bound", "field-id": 510}, {"name": "upper_bound", "type": ["null", "bytes"], "doc": "serialized upper bound", "field-id": 511}]}, "element-id": 508}], "doc": "Partition field summaries", "field-id": 507},
+			{"name": "added_rows_count", "type": ["null", "long"], "doc": "Added row count", "field-id": 512},
+			{"name": "existing_rows_count", "type": ["null", "long"], "doc": "Existing row count", "field-id": 513},
+			{"name": "deleted_rows_count", "type": ["null", "long"], "doc": "Deleted row count", "field-id": 514},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Key metadata", "field-id": 519}
+		]
+	}`))
 
-	AvroSchemaCache.Add("manifest_list_file_v2", Must(avro.NewRecordSchema("manifest_file", "", []*avro.Field{
-		Must(avro.NewField("manifest_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(500))),
-		Must(avro.NewField("manifest_length",
-			LongSchema,
-			avro.WithDoc("Total file size in bytes"),
-			WithFieldID(501))),
-		Must(avro.NewField("partition_spec_id",
-			IntSchema,
-			avro.WithDoc("Spec ID used to write"),
-			WithFieldID(502))),
-		Must(avro.NewField("content", IntSchema,
-			avro.WithDoc("Content type"),
-			avro.WithDefault(0),
-			WithFieldID(517))),
-		Must(avro.NewField("sequence_number", LongSchema,
-			avro.WithDoc("Sequence number"),
-			avro.WithDefault(int64(0)),
-			WithFieldID(515))),
-		Must(avro.NewField("min_sequence_number", LongSchema,
-			avro.WithDoc("Minimum sequence number"),
-			avro.WithDefault(int64(0)),
-			WithFieldID(516))),
-		Must(avro.NewField("added_snapshot_id",
-			LongSchema,
-			avro.WithDoc("Snapshot ID that added the manifest"),
-			WithFieldID(503))),
-		Must(avro.NewField("added_files_count",
-			IntSchema,
-			avro.WithDoc("Added entry count"),
-			WithFieldID(504))),
-		Must(avro.NewField("existing_files_count",
-			IntSchema,
-			avro.WithDoc("Existing entry count"),
-			WithFieldID(505))),
-		Must(avro.NewField("deleted_files_count",
-			IntSchema,
-			avro.WithDoc("Deleted entry count"),
-			WithFieldID(506))),
-		Must(avro.NewField("partitions",
-			NullableSchema(
-				avro.NewArraySchema(AvroSchemaCache.Get("field_summary"),
-					WithElementID(508))),
-			avro.WithDoc("Partition field summaries"),
-			WithFieldID(507))),
-		Must(avro.NewField("added_rows_count",
-			LongSchema,
-			avro.WithDoc("Added row count"),
-			WithFieldID(512))),
-		Must(avro.NewField("existing_rows_count",
-			LongSchema,
-			avro.WithDoc("Existing row count"),
-			WithFieldID(513))),
-		Must(avro.NewField("deleted_rows_count",
-			LongSchema,
-			avro.WithDoc("Deleted row count"),
-			WithFieldID(514))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Key metadata"),
-			WithFieldID(519))),
-	})))
+	avroSchemas["manifest_list_file_v2"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 500},
+			{"name": "manifest_length", "type": "long", "doc": "Total file size in bytes", "field-id": 501},
+			{"name": "partition_spec_id", "type": "int", "doc": "Spec ID used to write", "field-id": 502},
+			{"name": "content", "type": "int", "doc": "Content type", "default": 0, "field-id": 517},
+			{"name": "sequence_number", "type": "long", "doc": "Sequence number", "default": 0, "field-id": 515},
+			{"name": "min_sequence_number", "type": "long", "doc": "Minimum sequence number", "default": 0, "field-id": 516},
+			{"name": "added_snapshot_id", "type": "long", "doc": "Snapshot ID that added the manifest", "field-id": 503},
+			{"name": "added_files_count", "type": "int", "doc": "Added entry count", "field-id": 504},
+			{"name": "existing_files_count", "type": "int", "doc": "Existing entry count", "field-id": 505},
+			{"name": "deleted_files_count", "type": "int", "doc": "Deleted entry count", "field-id": 506},
+			{"name": "partitions", "type": ["null", {"type": "array", "items": {"type": "record", "name": "r508", "field-id": 508, "fields": [{"name": "contains_null", "type": "boolean", "doc": "true if the field contains null values", "field-id": 509}, {"name": "contains_nan", "type": ["null", "boolean"], "doc": "true if the field contains NaN values", "field-id": 518}, {"name": "lower_bound", "type": ["null", "bytes"], "doc": "serialized lower bound", "field-id": 510}, {"name": "upper_bound", "type": ["null", "bytes"], "doc": "serialized upper bound", "field-id": 511}]}, "element-id": 508}], "doc": "Partition field summaries", "field-id": 507},
+			{"name": "added_rows_count", "type": "long", "doc": "Added row count", "field-id": 512},
+			{"name": "existing_rows_count", "type": "long", "doc": "Existing row count", "field-id": 513},
+			{"name": "deleted_rows_count", "type": "long", "doc": "Deleted row count", "field-id": 514},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Key metadata", "field-id": 519}
+		]
+	}`))
 
-	AvroSchemaCache.Add("data_file_v1", Must(avro.NewRecordSchema("r2", "", []*avro.Field{
-		Must(avro.NewField("file_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(100))),
-		Must(avro.NewField("file_format",
-			StringSchema,
-			avro.WithDoc("File format name: avro, orc, parquet"),
-			WithFieldID(101))),
-		// skip partition field, we'll add that dynamically as needed
-		Must(avro.NewField("record_count",
-			LongSchema,
-			avro.WithDoc("Number of records in the file"),
-			WithFieldID(103))),
-		Must(avro.NewField("file_size_in_bytes",
-			LongSchema,
-			avro.WithDoc("Size of the file in bytes"),
-			WithFieldID(104))),
-		Must(avro.NewField("block_size_in_bytes",
-			LongSchema,
-			avro.WithDoc("Deprecated. Always write default in v1. Do not write in v2."),
-			avro.WithDefault(int64(64*1024*1024)),
-			WithFieldID(105))),
-		Must(avro.NewField("column_sizes",
-			NullableSchema(newMapSchema("k117_v118", IntSchema, LongSchema, 117, 118)),
-			avro.WithDoc("map of column id to total size on disk"),
-			WithFieldID(108))),
-		Must(avro.NewField("value_counts",
-			NullableSchema(newMapSchema("k119_v120", IntSchema, LongSchema, 119, 120)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(109))),
-		Must(avro.NewField("null_value_counts",
-			NullableSchema(newMapSchema("k121_v122", IntSchema, LongSchema, 121, 122)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(110))),
-		Must(avro.NewField("nan_value_counts",
-			NullableSchema(newMapSchema("k138_v139", IntSchema, LongSchema, 138, 139)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(137))),
-		Must(avro.NewField("lower_bounds",
-			NullableSchema(newMapSchema("k126_v127", IntSchema, BinarySchema, 126, 127)),
-			avro.WithDoc("map of column id to lower bound"),
-			WithFieldID(125))),
-		Must(avro.NewField("upper_bounds",
-			NullableSchema(newMapSchema("k129_v130", IntSchema, BinarySchema, 129, 130)),
-			avro.WithDoc("map of column id to upper bound"),
-			WithFieldID(128))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Encryption Key Metadata Blob"),
-			WithFieldID(131))),
-		Must(avro.NewField("split_offsets",
-			NullableSchema(avro.NewArraySchema(LongSchema,
-				WithElementID(133))),
-			avro.WithDoc("splitable offsets"),
-			WithFieldID(132))),
-		Must(avro.NewField("sort_order_id",
-			NullableIntSchema,
-			avro.WithDoc("Sort order ID"),
-			WithFieldID(140))),
-	})))
+	avroSchemas["data_file_v1"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "r2",
+		"fields": [
+			{"name": "file_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 100},
+			{"name": "file_format", "type": "string", "doc": "File format name: avro, orc, parquet", "field-id": 101},
+			{"name": "record_count", "type": "long", "doc": "Number of records in the file", "field-id": 103},
+			{"name": "file_size_in_bytes", "type": "long", "doc": "Size of the file in bytes", "field-id": 104},
+			{"name": "block_size_in_bytes", "type": "long", "doc": "Deprecated. Always write default in v1. Do not write in v2.", "default": 67108864, "field-id": 105},
+			{"name": "column_sizes", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k117_v118", "fields": [{"name": "key", "type": "int", "field-id": 117}, {"name": "value", "type": "long", "field-id": 118}]}, "logicalType": "map"}], "doc": "map of column id to total size on disk", "field-id": 108},
+			{"name": "value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k119_v120", "fields": [{"name": "key", "type": "int", "field-id": 119}, {"name": "value", "type": "long", "field-id": 120}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 109},
+			{"name": "null_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k121_v122", "fields": [{"name": "key", "type": "int", "field-id": 121}, {"name": "value", "type": "long", "field-id": 122}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 110},
+			{"name": "nan_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k138_v139", "fields": [{"name": "key", "type": "int", "field-id": 138}, {"name": "value", "type": "long", "field-id": 139}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 137},
+			{"name": "lower_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k126_v127", "fields": [{"name": "key", "type": "int", "field-id": 126}, {"name": "value", "type": "bytes", "field-id": 127}]}, "logicalType": "map"}], "doc": "map of column id to lower bound", "field-id": 125},
+			{"name": "upper_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k129_v130", "fields": [{"name": "key", "type": "int", "field-id": 129}, {"name": "value", "type": "bytes", "field-id": 130}]}, "logicalType": "map"}], "doc": "map of column id to upper bound", "field-id": 128},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Encryption Key Metadata Blob", "field-id": 131},
+			{"name": "split_offsets", "type": ["null", {"type": "array", "items": "long", "element-id": 133}], "doc": "splitable offsets", "field-id": 132},
+			{"name": "sort_order_id", "type": ["null", "int"], "doc": "Sort order ID", "field-id": 140}
+		]
+	}`))
 
-	AvroSchemaCache.Add("data_file_v2", Must(avro.NewRecordSchema("r2", "", []*avro.Field{
-		Must(avro.NewField("content", IntSchema,
-			avro.WithDoc("Content type"),
-			avro.WithDefault(0),
-			WithFieldID(134))),
-		Must(avro.NewField("file_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(100))),
-		Must(avro.NewField("file_format",
-			StringSchema,
-			avro.WithDoc("File format name: avro, orc, parquet"),
-			WithFieldID(101))),
-		// skip partition field, we'll add that dynamically as needed
-		Must(avro.NewField("record_count",
-			LongSchema,
-			avro.WithDoc("Number of records in the file"),
-			WithFieldID(103))),
-		Must(avro.NewField("file_size_in_bytes",
-			LongSchema,
-			avro.WithDoc("Size of the file in bytes"),
-			WithFieldID(104))),
-		Must(avro.NewField("column_sizes",
-			NullableSchema(newMapSchema("k117_v118", IntSchema, LongSchema, 117, 118)),
-			avro.WithDoc("map of column id to total size on disk"),
-			WithFieldID(108))),
-		Must(avro.NewField("value_counts",
-			NullableSchema(newMapSchema("k119_v120", IntSchema, LongSchema, 119, 120)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(109))),
-		Must(avro.NewField("null_value_counts",
-			NullableSchema(newMapSchema("k121_v122", IntSchema, LongSchema, 121, 122)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(110))),
-		Must(avro.NewField("nan_value_counts",
-			NullableSchema(newMapSchema("k138_v139", IntSchema, LongSchema, 138, 139)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(137))),
-		Must(avro.NewField("lower_bounds",
-			NullableSchema(newMapSchema("k126_v127", IntSchema, BinarySchema, 126, 127)),
-			avro.WithDoc("map of column id to lower bound"),
-			WithFieldID(125))),
-		Must(avro.NewField("upper_bounds",
-			NullableSchema(newMapSchema("k129_v130", IntSchema, BinarySchema, 129, 130)),
-			avro.WithDoc("map of column id to upper bound"),
-			WithFieldID(128))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Encryption Key Metadata Blob"),
-			WithFieldID(131))),
-		Must(avro.NewField("split_offsets",
-			NullableSchema(avro.NewArraySchema(LongSchema,
-				WithElementID(133))),
-			avro.WithDoc("splitable offsets"),
-			WithFieldID(132))),
-		Must(avro.NewField("equality_ids",
-			NullableSchema(avro.NewArraySchema(LongSchema,
-				WithElementID(136))),
-			avro.WithDoc("field ids used to determine row equality in equality delete files"),
-			WithFieldID(135))),
-		Must(avro.NewField("sort_order_id",
-			NullableIntSchema,
-			avro.WithDoc("Sort order ID"),
-			WithFieldID(140))),
-	})))
+	avroSchemas["data_file_v2"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "r2",
+		"fields": [
+			{"name": "content", "type": "int", "doc": "Content type", "default": 0, "field-id": 134},
+			{"name": "file_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 100},
+			{"name": "file_format", "type": "string", "doc": "File format name: avro, orc, parquet", "field-id": 101},
+			{"name": "record_count", "type": "long", "doc": "Number of records in the file", "field-id": 103},
+			{"name": "file_size_in_bytes", "type": "long", "doc": "Size of the file in bytes", "field-id": 104},
+			{"name": "column_sizes", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k117_v118", "fields": [{"name": "key", "type": "int", "field-id": 117}, {"name": "value", "type": "long", "field-id": 118}]}, "logicalType": "map"}], "doc": "map of column id to total size on disk", "field-id": 108},
+			{"name": "value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k119_v120", "fields": [{"name": "key", "type": "int", "field-id": 119}, {"name": "value", "type": "long", "field-id": 120}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 109},
+			{"name": "null_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k121_v122", "fields": [{"name": "key", "type": "int", "field-id": 121}, {"name": "value", "type": "long", "field-id": 122}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 110},
+			{"name": "nan_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k138_v139", "fields": [{"name": "key", "type": "int", "field-id": 138}, {"name": "value", "type": "long", "field-id": 139}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 137},
+			{"name": "lower_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k126_v127", "fields": [{"name": "key", "type": "int", "field-id": 126}, {"name": "value", "type": "bytes", "field-id": 127}]}, "logicalType": "map"}], "doc": "map of column id to lower bound", "field-id": 125},
+			{"name": "upper_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k129_v130", "fields": [{"name": "key", "type": "int", "field-id": 129}, {"name": "value", "type": "bytes", "field-id": 130}]}, "logicalType": "map"}], "doc": "map of column id to upper bound", "field-id": 128},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Encryption Key Metadata Blob", "field-id": 131},
+			{"name": "split_offsets", "type": ["null", {"type": "array", "items": "long", "element-id": 133}], "doc": "splitable offsets", "field-id": 132},
+			{"name": "equality_ids", "type": ["null", {"type": "array", "items": "long", "element-id": 136}], "doc": "field ids used to determine row equality in equality delete files", "field-id": 135},
+			{"name": "sort_order_id", "type": ["null", "int"], "doc": "Sort order ID", "field-id": 140}
+		]
+	}`))
 
-	AvroSchemaCache.Add("manifest_entry_v1", Must(avro.NewRecordSchema("manifest_entry", "", []*avro.Field{
-		Must(avro.NewField("status", IntSchema, WithFieldID(0))),
-		Must(avro.NewField("snapshot_id", LongSchema, WithFieldID(1))),
-		// leave data_file for dyanmic generation
-	})))
+	avroSchemas["manifest_entry_v1"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_entry",
+		"fields": [
+			{"name": "status", "type": "int", "field-id": 0},
+			{"name": "snapshot_id", "type": "long", "field-id": 1}
+		]
+	}`))
 
-	AvroSchemaCache.Add("manifest_entry_v2", Must(avro.NewRecordSchema("manifest_entry", "", []*avro.Field{
-		Must(avro.NewField("status", IntSchema, WithFieldID(0))),
-		Must(avro.NewField("snapshot_id", NullableLongSchema, WithFieldID(1))),
-		Must(avro.NewField("sequence_number", NullableLongSchema, WithFieldID(3))),
-		Must(avro.NewField("file_sequence_number", NullableLongSchema, WithFieldID(4))),
-		// leave data_file for dynamic generation
-	})))
+	avroSchemas["manifest_entry_v2"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_entry",
+		"fields": [
+			{"name": "status", "type": "int", "field-id": 0},
+			{"name": "snapshot_id", "type": ["null", "long"], "field-id": 1},
+			{"name": "sequence_number", "type": ["null", "long"], "field-id": 3},
+			{"name": "file_sequence_number", "type": ["null", "long"], "field-id": 4}
+		]
+	}`))
 
-	AvroSchemaCache.Add("manifest_list_file_v3", Must(avro.NewRecordSchema("manifest_file", "", []*avro.Field{
-		Must(avro.NewField("manifest_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(500))),
-		Must(avro.NewField("manifest_length",
-			LongSchema,
-			avro.WithDoc("Total file size in bytes"),
-			WithFieldID(501))),
-		Must(avro.NewField("partition_spec_id",
-			IntSchema,
-			avro.WithDoc("Spec ID used to write"),
-			WithFieldID(502))),
-		Must(avro.NewField("content", IntSchema,
-			avro.WithDoc("Content type"),
-			avro.WithDefault(0),
-			WithFieldID(517))),
-		Must(avro.NewField("sequence_number", LongSchema,
-			avro.WithDoc("Sequence number"),
-			avro.WithDefault(int64(0)),
-			WithFieldID(515))),
-		Must(avro.NewField("min_sequence_number", LongSchema,
-			avro.WithDoc("Minimum sequence number"),
-			avro.WithDefault(int64(0)),
-			WithFieldID(516))),
-		Must(avro.NewField("added_snapshot_id",
-			LongSchema,
-			avro.WithDoc("Snapshot ID that added the manifest"),
-			WithFieldID(503))),
-		Must(avro.NewField("added_files_count",
-			IntSchema,
-			avro.WithDoc("Added entry count"),
-			WithFieldID(504))),
-		Must(avro.NewField("existing_files_count",
-			IntSchema,
-			avro.WithDoc("Existing entry count"),
-			WithFieldID(505))),
-		Must(avro.NewField("deleted_files_count",
-			IntSchema,
-			avro.WithDoc("Deleted entry count"),
-			WithFieldID(506))),
-		Must(avro.NewField("partitions",
-			NullableSchema(
-				avro.NewArraySchema(AvroSchemaCache.Get("field_summary"),
-					WithElementID(508))),
-			avro.WithDoc("Partition field summaries"),
-			WithFieldID(507))),
-		Must(avro.NewField("added_rows_count",
-			LongSchema,
-			avro.WithDoc("Added row count"),
-			WithFieldID(512))),
-		Must(avro.NewField("existing_rows_count",
-			LongSchema,
-			avro.WithDoc("Existing row count"),
-			WithFieldID(513))),
-		Must(avro.NewField("deleted_rows_count",
-			LongSchema,
-			avro.WithDoc("Deleted row count"),
-			WithFieldID(514))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Key metadata"),
-			WithFieldID(519))),
-		Must(avro.NewField("first_row_id", NullableLongSchema,
-			avro.WithDoc("First row ID"),
-			WithFieldID(520))),
-	})))
-	AvroSchemaCache.Add("data_file_v3", Must(avro.NewRecordSchema("r2", "", []*avro.Field{
-		Must(avro.NewField("content", IntSchema,
-			avro.WithDoc("Content type"),
-			avro.WithDefault(0),
-			WithFieldID(134))),
-		Must(avro.NewField("file_path",
-			StringSchema,
-			avro.WithDoc("Location URI with FS scheme"),
-			WithFieldID(100))),
-		Must(avro.NewField("file_format",
-			StringSchema,
-			avro.WithDoc("File format name: avro, orc, parquet"),
-			WithFieldID(101))),
-		// skip partition field, we'll add that dynamically as needed
-		Must(avro.NewField("record_count",
-			LongSchema,
-			avro.WithDoc("Number of records in the file"),
-			WithFieldID(103))),
-		Must(avro.NewField("file_size_in_bytes",
-			LongSchema,
-			avro.WithDoc("Size of the file in bytes"),
-			WithFieldID(104))),
-		Must(avro.NewField("column_sizes",
-			NullableSchema(newMapSchema("k117_v118", IntSchema, LongSchema, 117, 118)),
-			avro.WithDoc("map of column id to total size on disk"),
-			WithFieldID(108))),
-		Must(avro.NewField("value_counts",
-			NullableSchema(newMapSchema("k119_v120", IntSchema, LongSchema, 119, 120)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(109))),
-		Must(avro.NewField("null_value_counts",
-			NullableSchema(newMapSchema("k121_v122", IntSchema, LongSchema, 121, 122)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(110))),
-		Must(avro.NewField("nan_value_counts",
-			NullableSchema(newMapSchema("k138_v139", IntSchema, LongSchema, 138, 139)),
-			avro.WithDoc("map of value to count"),
-			WithFieldID(137))),
-		Must(avro.NewField("lower_bounds",
-			NullableSchema(newMapSchema("k126_v127", IntSchema, BinarySchema, 126, 127)),
-			avro.WithDoc("map of column id to lower bound"),
-			WithFieldID(125))),
-		Must(avro.NewField("upper_bounds",
-			NullableSchema(newMapSchema("k129_v130", IntSchema, BinarySchema, 129, 130)),
-			avro.WithDoc("map of column id to upper bound"),
-			WithFieldID(128))),
-		Must(avro.NewField("key_metadata", NullableBinarySchema,
-			avro.WithDoc("Encryption Key Metadata Blob"),
-			WithFieldID(131))),
-		Must(avro.NewField("split_offsets",
-			NullableSchema(avro.NewArraySchema(LongSchema,
-				WithElementID(133))),
-			avro.WithDoc("splitable offsets"),
-			WithFieldID(132))),
-		Must(avro.NewField("equality_ids",
-			NullableSchema(avro.NewArraySchema(LongSchema,
-				WithElementID(136))),
-			avro.WithDoc("field ids used to determine row equality in equality delete files"),
-			WithFieldID(135))),
-		Must(avro.NewField("sort_order_id",
-			NullableIntSchema,
-			avro.WithDoc("Sort order ID"),
-			WithFieldID(140))),
-		Must(avro.NewField("first_row_id",
-			NullableLongSchema,
-			avro.WithDoc("The _row_id for the first row in the data file"),
-			WithFieldID(142))),
-		Must(avro.NewField("referenced_data_file",
-			NullableSchema(StringSchema),
-			avro.WithDoc("Fully qualified location of a data file that all deletes reference"),
-			WithFieldID(143))),
-		Must(avro.NewField("content_offset",
-			NullableLongSchema,
-			avro.WithDoc("The offset in the file where the content starts"),
-			WithFieldID(144))),
-		Must(avro.NewField("content_size_in_bytes",
-			NullableLongSchema,
-			avro.WithDoc("The length of the referenced content stored in the file"),
-			WithFieldID(145))),
-	})))
-	AvroSchemaCache.Add("manifest_entry_v3", Must(avro.NewRecordSchema("manifest_entry", "", []*avro.Field{
-		Must(avro.NewField("status", IntSchema, WithFieldID(0))),
-		Must(avro.NewField("snapshot_id", NullableLongSchema, WithFieldID(1))),
-		Must(avro.NewField("sequence_number", NullableLongSchema, WithFieldID(3))),
-		Must(avro.NewField("file_sequence_number", NullableLongSchema, WithFieldID(4))),
-		// leave data_file for dynamic generation
-	})))
+	avroSchemas["manifest_list_file_v3"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 500},
+			{"name": "manifest_length", "type": "long", "doc": "Total file size in bytes", "field-id": 501},
+			{"name": "partition_spec_id", "type": "int", "doc": "Spec ID used to write", "field-id": 502},
+			{"name": "content", "type": "int", "doc": "Content type", "default": 0, "field-id": 517},
+			{"name": "sequence_number", "type": "long", "doc": "Sequence number", "default": 0, "field-id": 515},
+			{"name": "min_sequence_number", "type": "long", "doc": "Minimum sequence number", "default": 0, "field-id": 516},
+			{"name": "added_snapshot_id", "type": "long", "doc": "Snapshot ID that added the manifest", "field-id": 503},
+			{"name": "added_files_count", "type": "int", "doc": "Added entry count", "field-id": 504},
+			{"name": "existing_files_count", "type": "int", "doc": "Existing entry count", "field-id": 505},
+			{"name": "deleted_files_count", "type": "int", "doc": "Deleted entry count", "field-id": 506},
+			{"name": "partitions", "type": ["null", {"type": "array", "items": {"type": "record", "name": "r508", "field-id": 508, "fields": [{"name": "contains_null", "type": "boolean", "doc": "true if the field contains null values", "field-id": 509}, {"name": "contains_nan", "type": ["null", "boolean"], "doc": "true if the field contains NaN values", "field-id": 518}, {"name": "lower_bound", "type": ["null", "bytes"], "doc": "serialized lower bound", "field-id": 510}, {"name": "upper_bound", "type": ["null", "bytes"], "doc": "serialized upper bound", "field-id": 511}]}, "element-id": 508}], "doc": "Partition field summaries", "field-id": 507},
+			{"name": "added_rows_count", "type": "long", "doc": "Added row count", "field-id": 512},
+			{"name": "existing_rows_count", "type": "long", "doc": "Existing row count", "field-id": 513},
+			{"name": "deleted_rows_count", "type": "long", "doc": "Deleted row count", "field-id": 514},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Key metadata", "field-id": 519},
+			{"name": "first_row_id", "type": ["null", "long"], "doc": "First row ID", "field-id": 520}
+		]
+	}`))
+
+	avroSchemas["data_file_v3"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "r2",
+		"fields": [
+			{"name": "content", "type": "int", "doc": "Content type", "default": 0, "field-id": 134},
+			{"name": "file_path", "type": "string", "doc": "Location URI with FS scheme", "field-id": 100},
+			{"name": "file_format", "type": "string", "doc": "File format name: avro, orc, parquet", "field-id": 101},
+			{"name": "record_count", "type": "long", "doc": "Number of records in the file", "field-id": 103},
+			{"name": "file_size_in_bytes", "type": "long", "doc": "Size of the file in bytes", "field-id": 104},
+			{"name": "column_sizes", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k117_v118", "fields": [{"name": "key", "type": "int", "field-id": 117}, {"name": "value", "type": "long", "field-id": 118}]}, "logicalType": "map"}], "doc": "map of column id to total size on disk", "field-id": 108},
+			{"name": "value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k119_v120", "fields": [{"name": "key", "type": "int", "field-id": 119}, {"name": "value", "type": "long", "field-id": 120}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 109},
+			{"name": "null_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k121_v122", "fields": [{"name": "key", "type": "int", "field-id": 121}, {"name": "value", "type": "long", "field-id": 122}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 110},
+			{"name": "nan_value_counts", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k138_v139", "fields": [{"name": "key", "type": "int", "field-id": 138}, {"name": "value", "type": "long", "field-id": 139}]}, "logicalType": "map"}], "doc": "map of value to count", "field-id": 137},
+			{"name": "lower_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k126_v127", "fields": [{"name": "key", "type": "int", "field-id": 126}, {"name": "value", "type": "bytes", "field-id": 127}]}, "logicalType": "map"}], "doc": "map of column id to lower bound", "field-id": 125},
+			{"name": "upper_bounds", "type": ["null", {"type": "array", "items": {"type": "record", "name": "k129_v130", "fields": [{"name": "key", "type": "int", "field-id": 129}, {"name": "value", "type": "bytes", "field-id": 130}]}, "logicalType": "map"}], "doc": "map of column id to upper bound", "field-id": 128},
+			{"name": "key_metadata", "type": ["null", "bytes"], "doc": "Encryption Key Metadata Blob", "field-id": 131},
+			{"name": "split_offsets", "type": ["null", {"type": "array", "items": "long", "element-id": 133}], "doc": "splitable offsets", "field-id": 132},
+			{"name": "equality_ids", "type": ["null", {"type": "array", "items": "long", "element-id": 136}], "doc": "field ids used to determine row equality in equality delete files", "field-id": 135},
+			{"name": "sort_order_id", "type": ["null", "int"], "doc": "Sort order ID", "field-id": 140},
+			{"name": "first_row_id", "type": ["null", "long"], "doc": "The _row_id for the first row in the data file", "field-id": 142},
+			{"name": "referenced_data_file", "type": ["null", "string"], "doc": "Fully qualified location of a data file that all deletes reference", "field-id": 143},
+			{"name": "content_offset", "type": ["null", "long"], "doc": "The offset in the file where the content starts", "field-id": 144},
+			{"name": "content_size_in_bytes", "type": ["null", "long"], "doc": "The length of the referenced content stored in the file", "field-id": 145}
+		]
+	}`))
+
+	avroSchemas["manifest_entry_v3"] = Must(avro.Parse(`{
+		"type": "record",
+		"name": "manifest_entry",
+		"fields": [
+			{"name": "status", "type": "int", "field-id": 0},
+			{"name": "snapshot_id", "type": ["null", "long"], "field-id": 1},
+			{"name": "sequence_number", "type": ["null", "long"], "field-id": 3},
+			{"name": "file_sequence_number", "type": ["null", "long"], "field-id": 4}
+		]
+	}`))
 }
 
-func newDataFileSchema(partitionType avro.Schema, version int) (avro.Schema, error) {
+// newDataFileSchema builds the full data file Avro schema by inserting a partition field
+// into the base data file schema for the given spec version.
+func newDataFileSchema(partitionType *avro.Schema, version int) (*avro.Schema, error) {
 	key := fmt.Sprintf("data_file_v%d", version)
-	schema := AvroSchemaCache.Get(key)
-
-	partField, err := avro.NewField("partition",
-		partitionType, WithFieldID(102))
-	if err != nil {
-		return nil, err
+	baseSchema, ok := avroSchemas[key]
+	if !ok {
+		return nil, fmt.Errorf("no data file schema for version %d", version)
 	}
 
-	return avro.NewRecordSchema("r2", "",
-		append(schema.(*avro.RecordSchema).Fields(), partField))
+	// Unmarshal the base schema JSON and inject the partition field.
+	var base map[string]any
+	if err := json.Unmarshal([]byte(baseSchema.String()), &base); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal base data file schema: %w", err)
+	}
+
+	var partType any
+	if err := json.Unmarshal([]byte(partitionType.String()), &partType); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal partition type schema: %w", err)
+	}
+
+	partitionField := map[string]any{
+		"name":     "partition",
+		"type":     partType,
+		"field-id": 102,
+	}
+
+	fields := base["fields"].([]any)
+	// Insert partition field after file_format (index 1 in v1, index 2 in v2/v3).
+	insertAt := 2
+	if version == 1 {
+		insertAt = 2
+	}
+	newFields := make([]any, 0, len(fields)+1)
+	newFields = append(newFields, fields[:insertAt]...)
+	newFields = append(newFields, partitionField)
+	newFields = append(newFields, fields[insertAt:]...)
+	base["fields"] = newFields
+
+	newJSON, err := json.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal data file schema with partition: %w", err)
+	}
+
+	// Use a fresh cache so named types from the base schema are re-parsed cleanly.
+	var cache avro.SchemaCache
+	return cache.Parse(string(newJSON))
 }
 
-func NewManifestFileSchema(version int) (avro.Schema, error) {
+// NewManifestFileSchema returns the Avro schema for a manifest list file entry
+// for the given Iceberg spec version (1, 2, or 3).
+func NewManifestFileSchema(version int) (*avro.Schema, error) {
 	switch version {
 	case 1, 2, 3:
 	default:
@@ -543,29 +316,51 @@ func NewManifestFileSchema(version int) (avro.Schema, error) {
 
 	key := fmt.Sprintf("manifest_list_file_v%d", version)
 
-	return AvroSchemaCache.Get(key), nil
+	return avroSchemas[key], nil
 }
 
-func NewManifestEntrySchema(partitionType avro.Schema, version int) (avro.Schema, error) {
+// NewManifestEntrySchema returns the full Avro schema for a manifest entry,
+// including the data file sub-schema with the given partition type.
+func NewManifestEntrySchema(partitionType *avro.Schema, version int) (*avro.Schema, error) {
 	switch version {
 	case 1, 2, 3:
 	default:
 		return nil, fmt.Errorf("unsupported iceberg spec version: %d", version)
 	}
 
-	dfschema, err := newDataFileSchema(partitionType, version)
+	dfSchema, err := newDataFileSchema(partitionType, version)
 	if err != nil {
 		return nil, err
 	}
 
-	dfField, err := avro.NewField("data_file", dfschema, WithFieldID(2))
-	if err != nil {
-		return nil, err
-	}
-
+	// Unmarshal the base manifest entry schema and append the data_file field.
 	key := fmt.Sprintf("manifest_entry_v%d", version)
-	schema := AvroSchemaCache.Get(key)
+	baseSchema := avroSchemas[key]
 
-	return avro.NewRecordSchema("manifest_entry", "",
-		append(schema.(*avro.RecordSchema).Fields(), dfField))
+	var base map[string]any
+	if err := json.Unmarshal([]byte(baseSchema.String()), &base); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest entry schema: %w", err)
+	}
+
+	var dfType any
+	if err := json.Unmarshal([]byte(dfSchema.String()), &dfType); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal data file schema: %w", err)
+	}
+
+	dfField := map[string]any{
+		"name":     "data_file",
+		"type":     dfType,
+		"field-id": 2,
+	}
+
+	base["fields"] = append(base["fields"].([]any), dfField)
+
+	newJSON, err := json.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest entry schema: %w", err)
+	}
+
+	// Use a fresh cache so named types are re-parsed cleanly.
+	var cache avro.SchemaCache
+	return cache.Parse(string(newJSON))
 }

--- a/manifest.go
+++ b/manifest.go
@@ -424,6 +424,7 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 				return &fields[i]
 			}
 		}
+
 		return nil
 	}
 
@@ -458,6 +459,7 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 			for _, branch := range typeNode.Branches {
 				if branch.Type != "null" {
 					typeNode = branch
+
 					break
 				}
 			}
@@ -673,6 +675,7 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 				if f.Type.Type != "union" {
 					isFallback = true
 				}
+				
 				break
 			}
 		}
@@ -850,6 +853,7 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 				if f.Type.Type == "union" {
 					return decodeManifestsWithFallback[*fallbackManifestFileV1](reader)
 				}
+
 				break
 			}
 		}

--- a/manifest.go
+++ b/manifest.go
@@ -36,8 +36,8 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 
-	"github.com/hamba/avro/v2"
-	"github.com/hamba/avro/v2/ocf"
+	"github.com/twmb/avro"
+	"github.com/twmb/avro/ocf"
 )
 
 // ManifestContent indicates the type of data inside of the files
@@ -158,27 +158,37 @@ func (b *ManifestBuilder) Build() ManifestFile {
 	return b.m
 }
 
+// fallbackManifestFileV1 is used for V1 manifest lists where added_snapshot_id
+// may be null. The pointer field must come before the embedded struct so that
+// twmb/avro's depth-first field resolution picks the pointer field over the
+// non-pointer field in the embedded manifestFile.
 type fallbackManifestFileV1 struct {
-	manifestFileV1
 	AddedSnapshotID *int64 `avro:"added_snapshot_id"`
+	manifestFileV1
 }
 
 func (f *fallbackManifestFileV1) toFile() *manifestFile {
 	if f.AddedSnapshotID == nil {
 		f.manifestFileV1.AddedSnapshotID = -1
+	} else {
+		f.manifestFileV1.AddedSnapshotID = *f.AddedSnapshotID
 	}
 
 	return f.manifestFileV1.toFile()
 }
 
+// manifestFileV1 is used for V1 manifest lists where count fields are optional
+// (nullable). The pointer fields must come before the embedded struct so that
+// twmb/avro's depth-first field resolution picks the pointer fields over the
+// non-pointer fields in the embedded manifestFile.
 type manifestFileV1 struct {
-	manifestFile
 	AddedFilesCount    *int32 `avro:"added_files_count"`
 	ExistingFilesCount *int32 `avro:"existing_files_count"`
 	DeletedFilesCount  *int32 `avro:"deleted_files_count"`
 	AddedRowsCount     *int64 `avro:"added_rows_count"`
 	ExistingRowsCount  *int64 `avro:"existing_rows_count"`
 	DeletedRowsCount   *int64 `avro:"deleted_rows_count"`
+	manifestFile
 }
 
 func (m *manifestFileV1) toFile() *manifestFile {
@@ -407,27 +417,33 @@ func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manifes
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
 
-func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, map[int]int) {
-	getField := func(rs *avro.RecordSchema, name string) *avro.Field {
-		for _, f := range rs.Fields() {
-			if f.Name() == name {
-				return f
+func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int) {
+	findField := func(fields []avro.SchemaField, name string) *avro.SchemaField {
+		for i := range fields {
+			if fields[i].Name == name {
+				return &fields[i]
 			}
 		}
-
 		return nil
 	}
 
 	result := make(map[string]int)
-	logicalTypes := make(map[int]avro.LogicalType)
+	logicalTypes := make(map[int]string)
 	fixedSizes := make(map[int]int)
 
-	entryField := getField(sc.(*avro.RecordSchema), "data_file")
-	partitionField := getField(entryField.Type().(*avro.RecordSchema), "partition")
+	root := sc.Root()
+	entryField := findField(root.Fields, "data_file")
+	if entryField == nil {
+		return result, logicalTypes, fixedSizes
+	}
+	partitionField := findField(entryField.Type.Fields, "partition")
+	if partitionField == nil {
+		return result, logicalTypes, fixedSizes
+	}
 
-	for _, field := range partitionField.Type().(*avro.RecordSchema).Fields() {
+	for _, field := range partitionField.Type.Fields {
 		var fid int
-		switch v := field.Prop("field-id").(type) {
+		switch v := field.Props["field-id"].(type) {
 		case int:
 			fid = v
 		case float64:
@@ -436,18 +452,20 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 			continue
 		}
 
-		result[field.Name()] = fid
-		avroTyp := field.Type()
-		if us, ok := avroTyp.(*avro.UnionSchema); ok {
-			typeList := us.Types()
-			avroTyp = typeList[len(typeList)-1]
+		result[field.Name] = fid
+		typeNode := field.Type
+		if typeNode.Type == "union" {
+			for _, branch := range typeNode.Branches {
+				if branch.Type != "null" {
+					typeNode = branch
+					break
+				}
+			}
 		}
-		if ps, ok := avroTyp.(*avro.PrimitiveSchema); ok && ps.Logical() != nil {
-			logicalTypes[fid] = ps.Logical().Type()
-		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok && fs.Logical() != nil {
-			logicalTypes[int(fid)] = fs.Logical().Type()
-			if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
-				fixedSizes[int(fid)] = decimalLogical.Scale()
+		if typeNode.LogicalType != "" {
+			logicalTypes[fid] = typeNode.LogicalType
+			if typeNode.LogicalType == "decimal" {
+				fixedSizes[fid] = typeNode.Scale
 			}
 		}
 	}
@@ -457,7 +475,7 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 
 type hasFieldToIDMap interface {
 	setFieldNameToIDMap(map[string]int)
-	setFieldIDToLogicalTypeMap(map[int]avro.LogicalType)
+	setFieldIDToLogicalTypeMap(map[int]string)
 	setFieldIDToFixedSizeMap(map[int]int)
 }
 
@@ -545,28 +563,34 @@ type fallbackManifest[T any] interface {
 	*T
 }
 
-func decodeManifestsWithFallback[P fallbackManifest[T], T any](dec *ocf.Decoder) ([]ManifestFile, error) {
+func decodeManifestsWithFallback[P fallbackManifest[T], T any](reader *ocf.Reader) ([]ManifestFile, error) {
 	results := make([]ManifestFile, 0)
-	for dec.HasNext() {
+	for {
 		tmp := P(new(T))
-		if err := dec.Decode(tmp); err != nil {
+		if err := reader.Decode(tmp); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			return nil, err
 		}
 
 		results = append(results, tmp.toFile())
 	}
 
-	return results, dec.Error()
+	return results, nil
 }
 
 func decodeManifests[I interface {
 	ManifestFile
 	*T
-}, T any](dec *ocf.Decoder, version int) ([]ManifestFile, error) {
+}, T any](reader *ocf.Reader, version int) ([]ManifestFile, error) {
 	results := make([]ManifestFile, 0)
-	for dec.HasNext() {
+	for {
 		tmp := I(new(T))
-		if err := dec.Decode(tmp); err != nil {
+		if err := reader.Decode(tmp); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			return nil, err
 		}
 
@@ -574,20 +598,20 @@ func decodeManifests[I interface {
 		results = append(results, tmp)
 	}
 
-	return results, dec.Error()
+	return results, nil
 }
 
 // ManifestReader reads the metadata and data from an avro manifest file.
 // This type is not thread-safe; its methods should not be called from
 // multiple goroutines.
 type ManifestReader struct {
-	dec           *ocf.Decoder
+	dec           *ocf.Reader
 	file          ManifestFile
 	formatVersion int
 	isFallback    bool
 	content       ManifestContent
 	fieldNameToID map[string]int
-	fieldIDToType map[int]avro.LogicalType
+	fieldIDToType map[int]string
 	fieldIDToSize map[int]int
 
 	// The rest are lazily populated, on demand. Most readers
@@ -602,7 +626,7 @@ type ManifestReader struct {
 // file. If the caller is interested in the manifest entries in the file, it must call
 // [ManifestReader.Entries] before closing the provided reader.
 func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error) {
-	dec, err := ocf.NewDecoder(in, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
+	dec, err := ocf.NewReader(in)
 	if err != nil {
 		return nil, err
 	}
@@ -643,12 +667,12 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 
 	isFallback := false
 	if formatVersion == 1 {
-		for _, f := range sc.(*avro.RecordSchema).Fields() {
-			if f.Name() == "snapshot_id" {
-				if f.Type().Type() != avro.Union {
+		root := sc.Root()
+		for _, f := range root.Fields {
+			if f.Name == "snapshot_id" {
+				if f.Type.Type != "union" {
 					isFallback = true
 				}
-
 				break
 			}
 		}
@@ -743,12 +767,6 @@ func (c *ManifestReader) PartitionSpec() (*PartitionSpec, error) {
 
 // ReadEntry reads the next manifest entry in the avro file's data.
 func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
-	if err := c.dec.Error(); err != nil {
-		return nil, err
-	}
-	if !c.dec.HasNext() {
-		return nil, io.EOF
-	}
 	var tmp ManifestEntry
 	if c.isFallback {
 		tmp = &fallbackManifestEntry{
@@ -810,18 +828,15 @@ func ReadManifest(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestE
 // "format-version" metadata key (only manifest files are). When the key is
 // absent, version 1 is assumed.
 func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
-	dec, err := ocf.NewDecoder(in, ocf.WithDecoderSchemaCache(&avro.SchemaCache{}))
+	reader, err := ocf.NewReader(in)
 	if err != nil {
 		return nil, err
 	}
 
-	sc, err := avro.ParseBytes(dec.Metadata()["avro.schema"])
-	if err != nil {
-		return nil, err
-	}
+	sc := reader.Schema()
 
 	version := 1
-	if raw := dec.Metadata()["format-version"]; len(raw) > 0 {
+	if raw := reader.Metadata()["format-version"]; len(raw) > 0 {
 		version, err = strconv.Atoi(string(raw))
 		if err != nil {
 			return nil, fmt.Errorf("invalid format-version: %w", err)
@@ -829,12 +844,12 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 	}
 
 	if version == 1 {
-		for _, f := range sc.(*avro.RecordSchema).Fields() {
-			if f.Name() == "added_snapshot_id" {
-				if f.Type().Type() == avro.Union {
-					return decodeManifestsWithFallback[*fallbackManifestFileV1](dec)
+		root := sc.Root()
+		for _, f := range root.Fields {
+			if f.Name == "added_snapshot_id" {
+				if f.Type.Type == "union" {
+					return decodeManifestsWithFallback[*fallbackManifestFileV1](reader)
 				}
-
 				break
 			}
 		}
@@ -842,9 +857,9 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 
 	switch version {
 	case 1:
-		return decodeManifestsWithFallback[*manifestFileV1](dec)
+		return decodeManifestsWithFallback[*manifestFileV1](reader)
 	default:
-		return decodeManifests[*manifestFile](dec, version)
+		return decodeManifests[*manifestFile](reader, version)
 	}
 }
 
@@ -1059,14 +1074,14 @@ type ManifestWriter struct {
 	impl    writerImpl
 
 	output io.Writer
-	writer *ocf.Encoder
+	writer *ocf.Writer
 
 	spec    PartitionSpec
 	schema  *Schema
 	content ManifestContent
 
 	partFieldNameToID map[string]int
-	partFieldIDToType map[int]avro.LogicalType
+	partFieldIDToType map[int]string
 
 	snapshotID    int64
 	addedFiles    int32
@@ -1141,11 +1156,10 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	enc, err := ocf.NewEncoderWithSchema(fileSchema, out,
-		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+	enc, err := ocf.NewWriter(out, fileSchema,
+		ocf.WithSchema(fileSchema.String()),
 		ocf.WithMetadata(md),
-		ocf.WithCodec(ocf.Deflate))
+		ocf.WithCodec(ocf.DeflateCodec(0)))
 
 	w.writer = enc
 
@@ -1320,7 +1334,7 @@ type ManifestListWriter struct {
 	out              io.Writer
 	commitSnapshotID int64
 	sequenceNumber   int64
-	writer           *ocf.Encoder
+	writer           *ocf.Writer
 	nextRowID        *int64
 }
 
@@ -1393,11 +1407,10 @@ func (m *ManifestListWriter) init(meta map[string][]byte) error {
 		return err
 	}
 
-	enc, err := ocf.NewEncoderWithSchema(fileSchema, m.out,
-		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+	enc, err := ocf.NewWriter(m.out, fileSchema,
+		ocf.WithSchema(fileSchema.String()),
 		ocf.WithMetadata(meta),
-		ocf.WithCodec(ocf.Deflate))
+		ocf.WithCodec(ocf.DeflateCodec(0)))
 	if err != nil {
 		return err
 	}
@@ -1637,7 +1650,7 @@ func mapToAvroColMap[K comparable, V any](m map[K]V) *[]colMap[K, V] {
 	return &out
 }
 
-func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType) map[int]any {
+func avroPartitionData(input map[int]any, logicalTypes map[int]string) map[int]any {
 	out := make(map[int]any)
 	for k, v := range input {
 		if logical, ok := logicalTypes[k]; ok {
@@ -1650,17 +1663,17 @@ func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType)
 	return out
 }
 
-func convertLogicalTypeValue(v any, logicalType avro.LogicalType) any {
+func convertLogicalTypeValue(v any, logicalType string) any {
 	switch logicalType {
-	case avro.Date:
+	case "date":
 		return convertDateValue(v)
-	case avro.TimeMicros:
+	case "time-micros":
 		return convertTimeMicrosValue(v)
-	case avro.TimestampMicros:
+	case "timestamp-micros":
 		return convertTimestampMicrosValue(v)
-	case avro.Decimal:
+	case "decimal":
 		return convertDecimalValue(v)
-	case avro.UUID:
+	case "uuid":
 		return convertUUIDValue(v)
 	default:
 		return v
@@ -1669,7 +1682,7 @@ func convertLogicalTypeValue(v any, logicalType avro.LogicalType) any {
 
 func convertDateValue(v any) any {
 	if v == nil {
-		return map[string]any{"null": nil}
+		return nil
 	}
 
 	if d, ok := v.(Date); ok {
@@ -1681,7 +1694,7 @@ func convertDateValue(v any) any {
 
 func convertTimeMicrosValue(v any) any {
 	if v == nil {
-		return map[string]any{"null": nil}
+		return nil
 	}
 
 	if t, ok := v.(Time); ok {
@@ -1693,7 +1706,7 @@ func convertTimeMicrosValue(v any) any {
 
 func convertTimestampMicrosValue(v any) any {
 	if v == nil {
-		return map[string]any{"null": nil}
+		return nil
 	}
 
 	if ts, ok := v.(Timestamp); ok {
@@ -1705,7 +1718,7 @@ func convertTimestampMicrosValue(v any) any {
 
 func convertDecimalValue(v any) any {
 	if v == nil {
-		return map[string]any{"null": nil}
+		return nil
 	}
 
 	if dec, ok := v.(Decimal); ok {
@@ -1716,7 +1729,7 @@ func convertDecimalValue(v any) any {
 		}
 		fixedArray := convertToFixedArray(padOrTruncateBytes(bytes, fixedSize), fixedSize)
 
-		return map[string]any{"fixed": fixedArray}
+		return map[string]any{"fixed.decimal": fixedArray}
 	}
 
 	return v
@@ -1724,7 +1737,7 @@ func convertDecimalValue(v any) any {
 
 func convertUUIDValue(v any) any {
 	if v == nil {
-		return map[string]any{"null": nil}
+		return nil
 	}
 
 	if uuidVal, ok := v.(uuid.UUID); ok {
@@ -1784,7 +1797,7 @@ type dataFile struct {
 
 	// used for partition retrieval
 	fieldNameToID          map[string]int
-	fieldIDToLogicalType   map[int]avro.LogicalType
+	fieldIDToLogicalType   map[int]string
 	fieldIDToPartitionData map[int]any
 	fieldIDToFixedSize     map[int]int
 
@@ -1817,37 +1830,37 @@ func (d *dataFile) initializeMapData() {
 func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 	if logicalType, ok := d.fieldIDToLogicalType[fieldID]; ok {
 		switch logicalType {
-		case avro.Date:
+		case "date":
 			if val, ok := v.(time.Time); ok {
 				return Date(val.Truncate(24*time.Hour).Unix() / int64((time.Hour * 24).Seconds()))
 			}
 
 			return Date(v.(int32))
-		case avro.TimeMillis:
+		case "time-millis":
 			if val, ok := v.(time.Duration); ok {
 				return Time(val.Milliseconds())
 			}
 
 			return Time(v.(int64))
-		case avro.TimeMicros:
+		case "time-micros":
 			if val, ok := v.(time.Duration); ok {
 				return Time(val.Microseconds())
 			}
 
 			return Time(v.(int64))
-		case avro.TimestampMillis:
+		case "timestamp-millis":
 			if val, ok := v.(time.Time); ok {
 				return Timestamp(val.UTC().UnixMilli())
 			}
 
 			return Timestamp(v.(int64))
-		case avro.TimestampMicros:
+		case "timestamp-micros":
 			if val, ok := v.(time.Time); ok {
 				return Timestamp(val.UTC().UnixMicro())
 			}
 
 			return Timestamp(v.(int64))
-		case avro.Decimal:
+		case "decimal":
 			if unionMap, ok := v.(map[string]any); ok {
 				if val, ok := unionMap["fixed"]; ok {
 					if bigRatValue, ok := val.(*big.Rat); ok {
@@ -1866,7 +1879,7 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 			}
 
 			return v
-		case avro.UUID:
+		case "uuid":
 			if unionMap, ok := v.(map[string]any); ok {
 				if val, ok := unionMap["uuid"]; ok {
 					if uuidArr, ok := val.([16]byte); ok {
@@ -1883,7 +1896,7 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 }
 
 func (d *dataFile) setFieldNameToIDMap(m map[string]int) { d.fieldNameToID = m }
-func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]avro.LogicalType) {
+func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]string) {
 	d.fieldIDToLogicalType = m
 }
 func (d *dataFile) setFieldIDToFixedSizeMap(m map[int]int) { d.fieldIDToFixedSize = m }
@@ -2072,8 +2085,8 @@ func (m *manifestEntry) wrap(status ManifestEntryStatus, newSnapID, newSeq, newF
 }
 
 type fallbackManifestEntry struct {
-	manifestEntry
 	Snapshot int64 `avro:"snapshot_id"`
+	manifestEntry
 }
 
 func (f *fallbackManifestEntry) toEntry() *manifestEntry {
@@ -2107,7 +2120,7 @@ func NewDataFileBuilder(
 	path string,
 	format FileFormat,
 	fieldIDToPartitionData map[int]any,
-	fieldIDToLogicalType map[int]avro.LogicalType,
+	fieldIDToLogicalType map[int]string,
 	fieldIDToFixedSize map[int]int,
 	recordCount int64,
 	fileSize int64,

--- a/manifest.go
+++ b/manifest.go
@@ -573,6 +573,7 @@ func decodeManifestsWithFallback[P fallbackManifest[T], T any](reader *ocf.Reade
 			if errors.Is(err, io.EOF) {
 				break
 			}
+
 			return nil, err
 		}
 
@@ -593,6 +594,7 @@ func decodeManifests[I interface {
 			if errors.Is(err, io.EOF) {
 				break
 			}
+
 			return nil, err
 		}
 
@@ -675,7 +677,7 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 				if f.Type.Type != "union" {
 					isFallback = true
 				}
-				
+
 				break
 			}
 		}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"github.com/apache/iceberg-go/internal"
+	"github.com/stretchr/testify/suite"
 	"github.com/twmb/avro"
 	"github.com/twmb/avro/ocf"
-	"github.com/stretchr/testify/suite"
 )
 
 var (

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/apache/iceberg-go/internal"
-	"github.com/hamba/avro/v2"
-	"github.com/hamba/avro/v2/ocf"
+	"github.com/twmb/avro"
+	"github.com/twmb/avro/ocf"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -779,14 +779,13 @@ func writeManifestListNoFormatVersion(t *testing.T, version int) bytes.Buffer {
 	}
 
 	var buf bytes.Buffer
-	enc, err := ocf.NewEncoderWithSchema(fileSchema, &buf,
-		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+	enc, err := ocf.NewWriter(&buf, fileSchema,
+		ocf.WithSchema(fileSchema.String()),
 		ocf.WithMetadata(map[string][]byte{
 			"snapshot-id":     []byte("1234"),
 			"sequence-number": []byte("0"),
 		}),
-		ocf.WithCodec(ocf.Deflate))
+		ocf.WithCodec(ocf.DeflateCodec(0)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -928,14 +927,10 @@ func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
 	}`
 
 	// We'll generate a file that is missing part of its schema
-	cache := &avro.SchemaCache{}
 	sch, err := internal.NewManifestFileSchema(2)
 	m.NoError(err)
-	enc, err := ocf.NewEncoderWithSchema(sch, &buf,
-		ocf.WithEncoderSchemaCache(cache),
-		ocf.WithSchemaMarshaler(func(schema avro.Schema) ([]byte, error) {
-			return []byte(incompleteSchema), nil
-		}),
+	enc, err := ocf.NewWriter(&buf, sch,
+		ocf.WithSchema(incompleteSchema),
 		ocf.WithMetadata(map[string][]byte{
 			"format-version":     {'2'},
 			"snapshot-id":        []byte("1234"),
@@ -947,10 +942,11 @@ func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
 	for _, file := range files {
 		m.NoError(enc.Encode(file))
 	}
+	m.NoError(enc.Close())
 
 	// This should fail because the file's schema is incomplete.
 	_, err = ReadManifestList(&buf)
-	m.ErrorContains(err, "unknown type: field_summary")
+	m.ErrorContains(err, "field_summary")
 }
 
 func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
@@ -973,7 +969,7 @@ func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
 		"s3://bucket/namespace/table/data/abcd-0123.parquet",
 		ParquetFile,
 		map[int]any{},
-		map[int]avro.LogicalType{},
+		map[int]string{},
 		map[int]int{},
 		100,
 		100*1000*1000,
@@ -1049,16 +1045,11 @@ func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
 	}`
 
 	// We'll generate a file that is missing part of its schema
-	cache := &avro.SchemaCache{}
-	partitionSchema, err := avro.NewRecordSchema("r102", "", nil) // empty struct
-	m.NoError(err)
+	partitionSchema := avro.MustParse(`{"type":"record","name":"r102","fields":[]}`)
 	sch, err := internal.NewManifestEntrySchema(partitionSchema, 2)
 	m.NoError(err)
-	enc, err := ocf.NewEncoderWithSchema(sch, &buf,
-		ocf.WithEncoderSchemaCache(cache),
-		ocf.WithSchemaMarshaler(func(schema avro.Schema) ([]byte, error) {
-			return []byte(incompleteSchema), nil
-		}),
+	enc, err := ocf.NewWriter(&buf, sch,
+		ocf.WithSchema(incompleteSchema),
 		ocf.WithMetadata(map[string][]byte{
 			"format-version": {'2'},
 			// TODO: spec says other things are required, like schema and partition-spec info,
@@ -1069,10 +1060,11 @@ func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
 	for _, entry := range entries {
 		m.NoError(enc.Encode(entry))
 	}
+	m.NoError(enc.Close())
 
 	// This should fail because the file's schema is incomplete.
 	_, err = ReadManifest(file, &buf, false)
-	m.ErrorContains(err, "unknown type: r2")
+	m.ErrorContains(err, "r2")
 }
 
 func (m *ManifestTestSuite) TestManifestEntriesV2() {
@@ -1339,11 +1331,10 @@ func (m *ManifestTestSuite) TestNewManifestReaderZstdManifestEntriesV2() {
 	m.Require().NoError(err)
 
 	var buf bytes.Buffer
-	enc, err := ocf.NewEncoderWithSchema(entrySchema, &buf,
-		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+	enc, err := ocf.NewWriter(&buf, entrySchema,
+		ocf.WithSchema(entrySchema.String()),
 		ocf.WithMetadata(md),
-		ocf.WithCodec(ocf.ZStandard))
+		ocf.WithCodec(ocf.MustZstdCodec(nil, nil)))
 	m.Require().NoError(err)
 
 	m.Require().NoError(enc.Encode(manifestEntryV2Records[0]))
@@ -1375,7 +1366,7 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 		"sample.parquet",
 		ParquetFile,
 		map[int]any{1001: int(1), 1002: time.Unix(1925, 0).UnixMicro()},
-		map[int]avro.LogicalType{},
+		map[int]string{},
 		map[int]int{},
 		1,
 		2,

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -74,6 +74,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 			definedNames["uuid"] = true
 			return `["null",{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}]`, nil
 		}
+
 		return `["null","uuid"]`, nil
 	case BooleanType:
 		return `["null","boolean"]`, nil
@@ -85,6 +86,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 			definedNames[fixedName] = true
 			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d}]`, fixedName, t.len), nil
 		}
+
 		return fmt.Sprintf(`["null","%s"]`, fixedName), nil
 	case DecimalType:
 		size := internal.DecimalRequiredBytes(t.precision)
@@ -94,6 +96,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}]`,
 				decName, size, t.precision, t.scale), nil
 		}
+
 		return fmt.Sprintf(`["null","%s"]`, decName), nil
 	default:
 		return "", fmt.Errorf("unsupported partition type: %s", typ.String())

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -72,6 +72,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 	case UUIDType:
 		if !definedNames["uuid"] {
 			definedNames["uuid"] = true
+
 			return `["null",{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}]`, nil
 		}
 
@@ -84,6 +85,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 		fixedName := fmt.Sprintf("fixed_%d", t.len)
 		if !definedNames[fixedName] {
 			definedNames[fixedName] = true
+
 			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d}]`, fixedName, t.len), nil
 		}
 
@@ -93,6 +95,7 @@ func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, err
 		decName := fmt.Sprintf("fixed_%d_%d", t.precision, t.scale)
 		if !definedNames[decName] {
 			definedNames[decName] = true
+
 			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}]`,
 				decName, size, t.precision, t.scale), nil
 		}

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -19,54 +19,83 @@ package iceberg
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/apache/iceberg-go/internal"
-	"github.com/hamba/avro/v2"
+	"github.com/twmb/avro"
 )
 
-func partitionTypeToAvroSchema(t *StructType) (avro.Schema, error) {
-	fields := make([]*avro.Field, len(t.FieldList))
-	for i, f := range t.FieldList {
-		var sc avro.Schema
-		switch typ := f.Type.(type) {
-		case Int32Type:
-			sc = internal.NullableSchema(internal.IntSchema)
-		case Int64Type:
-			sc = internal.NullableSchema(internal.LongSchema)
-		case Float32Type:
-			sc = internal.NullableSchema(internal.FloatSchema)
-		case Float64Type:
-			sc = internal.NullableSchema(internal.DoubleSchema)
-		case StringType:
-			sc = internal.NullableSchema(internal.StringSchema)
-		case DateType:
-			sc = internal.NullableSchema(internal.DateSchema)
-		case TimeType:
-			sc = internal.NullableSchema(internal.TimeSchema)
-		case TimestampType:
-			sc = internal.NullableSchema(internal.TimestampSchema)
-		case TimestampTzType:
-			sc = internal.NullableSchema(internal.TimestampTzSchema)
-		case UUIDType:
-			sc = internal.NullableSchema(internal.UUIDSchema)
-		case BooleanType:
-			sc = internal.NullableSchema(internal.BoolSchema)
-		case BinaryType:
-			sc = internal.NullableSchema(internal.BinarySchema)
-		case FixedType:
-			// Currently the hamba/avro library couldn't resolve the [n]byte array types for fixed schemas in unions.
-			// https://github.com/hamba/avro/issues/571
-			// TODO: Create the proper Fixed Schema for Avro that can match the use case
-			sc = internal.NullableSchema(internal.BinarySchema)
-		case DecimalType:
-			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
-			sc = internal.NullableSchema(decimalSchema)
-		default:
-			return nil, fmt.Errorf("unsupported partition type: %s", f.Type.String())
-		}
-
-		fields[i], _ = avro.NewField(f.Name, sc, internal.WithFieldID(f.ID))
+func partitionTypeToAvroSchema(t *StructType) (*avro.Schema, error) {
+	if len(t.FieldList) == 0 {
+		return avro.Parse(`{"type":"record","name":"r102","fields":[]}`)
 	}
 
-	return avro.NewRecordSchema("r102", "", fields)
+	definedNames := make(map[string]bool)
+
+	fieldJSONs := make([]string, 0, len(t.FieldList))
+	for _, f := range t.FieldList {
+		typeJSON, err := partitionFieldTypeJSON(f.Type, definedNames)
+		if err != nil {
+			return nil, err
+		}
+		fieldJSONs = append(fieldJSONs, fmt.Sprintf(`{"name":%q,"type":%s,"field-id":%d,"default":null}`,
+			f.Name, typeJSON, f.ID))
+	}
+
+	schemaJSON := fmt.Sprintf(`{"type":"record","name":"r102","fields":[%s]}`,
+		strings.Join(fieldJSONs, ","))
+
+	return avro.Parse(schemaJSON)
+}
+
+// partitionFieldTypeJSON returns the nullable union JSON for the given partition field type.
+func partitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, error) {
+	switch t := typ.(type) {
+	case Int32Type:
+		return `["null","int"]`, nil
+	case Int64Type:
+		return `["null","long"]`, nil
+	case Float32Type:
+		return `["null","float"]`, nil
+	case Float64Type:
+		return `["null","double"]`, nil
+	case StringType:
+		return `["null","string"]`, nil
+	case DateType:
+		return `["null",{"type":"int","logicalType":"date"}]`, nil
+	case TimeType:
+		return `["null",{"type":"long","logicalType":"time-micros"}]`, nil
+	case TimestampType:
+		return `["null",{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":false}]`, nil
+	case TimestampTzType:
+		return `["null",{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":true}]`, nil
+	case UUIDType:
+		if !definedNames["uuid"] {
+			definedNames["uuid"] = true
+			return `["null",{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}]`, nil
+		}
+		return `["null","uuid"]`, nil
+	case BooleanType:
+		return `["null","boolean"]`, nil
+	case BinaryType:
+		return `["null","bytes"]`, nil
+	case FixedType:
+		fixedName := fmt.Sprintf("fixed_%d", t.len)
+		if !definedNames[fixedName] {
+			definedNames[fixedName] = true
+			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d}]`, fixedName, t.len), nil
+		}
+		return fmt.Sprintf(`["null","%s"]`, fixedName), nil
+	case DecimalType:
+		size := internal.DecimalRequiredBytes(t.precision)
+		decName := fmt.Sprintf("fixed_%d_%d", t.precision, t.scale)
+		if !definedNames[decName] {
+			definedNames[decName] = true
+			return fmt.Sprintf(`["null",{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}]`,
+				decName, size, t.precision, t.scale), nil
+		}
+		return fmt.Sprintf(`["null","%s"]`, decName), nil
+	default:
+		return "", fmt.Errorf("unsupported partition type: %s", typ.String())
+	}
 }

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -76,6 +76,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 	case UUIDType:
 		if !definedNames["uuid"] {
 			definedNames["uuid"] = true
+
 			return `{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}`, nil
 		}
 
@@ -88,6 +89,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 		fixedName := fmt.Sprintf("fixed_%d", t.len)
 		if !definedNames[fixedName] {
 			definedNames[fixedName] = true
+
 			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d}`, fixedName, t.len), nil
 		}
 
@@ -97,6 +99,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 		decName := fmt.Sprintf("fixed_%d_%d", t.precision, t.scale)
 		if !definedNames[decName] {
 			definedNames[decName] = true
+
 			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}`,
 				decName, size, t.precision, t.scale), nil
 		}

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -19,56 +19,89 @@ package iceberg
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/apache/iceberg-go/internal"
-	"github.com/hamba/avro/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro"
 )
 
-func partitionTypeToAvroSchemaNonNullable(t *StructType) (avro.Schema, error) {
-	fields := make([]*avro.Field, len(t.FieldList))
-	for i, f := range t.FieldList {
-		var sc avro.Schema
-		switch typ := f.Type.(type) {
-		case Int32Type:
-			sc = internal.IntSchema
-		case Int64Type:
-			sc = internal.LongSchema
-		case Float32Type:
-			sc = internal.FloatSchema
-		case Float64Type:
-			sc = internal.DoubleSchema
-		case StringType:
-			sc = internal.StringSchema
-		case DateType:
-			sc = internal.DateSchema
-		case TimeType:
-			sc = internal.TimeSchema
-		case TimestampType:
-			sc = internal.TimestampSchema
-		case TimestampTzType:
-			sc = internal.TimestampTzSchema
-		case UUIDType:
-			sc = internal.UUIDSchema
-		case BooleanType:
-			sc = internal.BoolSchema
-		case BinaryType:
-			sc = internal.BinarySchema
-		case FixedType:
-			sc = internal.BinarySchema
-		case DecimalType:
-			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
-			sc = decimalSchema
-		default:
-			return nil, fmt.Errorf("unsupported partition type: %s", f.Type.String())
-		}
-
-		fields[i], _ = avro.NewField(f.Name, sc, internal.WithFieldID(f.ID))
+// partitionTypeToAvroSchemaNonNullable builds a partition schema where fields are NOT wrapped
+// in a nullable union. Used in tests to verify that nil values cause encoding failures.
+func partitionTypeToAvroSchemaNonNullable(t *StructType) (*avro.Schema, error) {
+	if len(t.FieldList) == 0 {
+		return avro.Parse(`{"type":"record","name":"r102","fields":[]}`)
 	}
 
-	return avro.NewRecordSchema("r102", "", fields)
+	definedNames := make(map[string]bool)
+
+	fieldJSONs := make([]string, 0, len(t.FieldList))
+	for _, f := range t.FieldList {
+		typeJSON, err := nonNullablePartitionFieldTypeJSON(f.Type, definedNames)
+		if err != nil {
+			return nil, err
+		}
+		fieldJSONs = append(fieldJSONs, fmt.Sprintf(`{"name":%q,"type":%s,"field-id":%d}`,
+			f.Name, typeJSON, f.ID))
+	}
+
+	schemaJSON := fmt.Sprintf(`{"type":"record","name":"r102","fields":[%s]}`,
+		strings.Join(fieldJSONs, ","))
+
+	return avro.Parse(schemaJSON)
+}
+
+func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (string, error) {
+	switch t := typ.(type) {
+	case Int32Type:
+		return `"int"`, nil
+	case Int64Type:
+		return `"long"`, nil
+	case Float32Type:
+		return `"float"`, nil
+	case Float64Type:
+		return `"double"`, nil
+	case StringType:
+		return `"string"`, nil
+	case DateType:
+		return `{"type":"int","logicalType":"date"}`, nil
+	case TimeType:
+		return `{"type":"long","logicalType":"time-micros"}`, nil
+	case TimestampType:
+		return `{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":false}`, nil
+	case TimestampTzType:
+		return `{"type":"long","logicalType":"timestamp-micros","adjust-to-utc":true}`, nil
+	case UUIDType:
+		if !definedNames["uuid"] {
+			definedNames["uuid"] = true
+			return `{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}`, nil
+		}
+		return `"uuid"`, nil
+	case BooleanType:
+		return `"boolean"`, nil
+	case BinaryType:
+		return `"bytes"`, nil
+	case FixedType:
+		fixedName := fmt.Sprintf("fixed_%d", t.len)
+		if !definedNames[fixedName] {
+			definedNames[fixedName] = true
+			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d}`, fixedName, t.len), nil
+		}
+		return fmt.Sprintf(`"%s"`, fixedName), nil
+	case DecimalType:
+		size := internal.DecimalRequiredBytes(t.precision)
+		decName := fmt.Sprintf("fixed_%d_%d", t.precision, t.scale)
+		if !definedNames[decName] {
+			definedNames[decName] = true
+			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}`,
+				decName, size, t.precision, t.scale), nil
+		}
+		return fmt.Sprintf(`"%s"`, decName), nil
+	default:
+		return "", fmt.Errorf("unsupported partition type: %s", typ.String())
+	}
 }
 
 func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {
@@ -113,12 +146,12 @@ func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, schemaNullable)
 
-		encoded, err := avro.Marshal(schemaNullable, partitionData)
+		encoded, err := schemaNullable.Encode(partitionData)
 		require.NoError(t, err)
 		require.NotEmpty(t, encoded)
 
 		var decoded map[string]any
-		err = avro.Unmarshal(schemaNullable, encoded, &decoded)
+		_, err = schemaNullable.Decode(encoded, &decoded)
 		require.NoError(t, err)
 
 		assert.Nil(t, decoded["int32_col"])
@@ -142,7 +175,7 @@ func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, schemaNonNullable)
 
-		encoded, err := avro.Marshal(schemaNonNullable, partitionData)
+		encoded, err := schemaNonNullable.Encode(partitionData)
 		require.Error(t, err, "expected marshal to fail when values are nil for non-nullable schema")
 		assert.Empty(t, encoded)
 	})

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -78,6 +78,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 			definedNames["uuid"] = true
 			return `{"type":"fixed","name":"uuid","size":16,"logicalType":"uuid"}`, nil
 		}
+
 		return `"uuid"`, nil
 	case BooleanType:
 		return `"boolean"`, nil
@@ -89,6 +90,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 			definedNames[fixedName] = true
 			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d}`, fixedName, t.len), nil
 		}
+
 		return fmt.Sprintf(`"%s"`, fixedName), nil
 	case DecimalType:
 		size := internal.DecimalRequiredBytes(t.precision)
@@ -98,6 +100,7 @@ func nonNullablePartitionFieldTypeJSON(typ Type, definedNames map[string]bool) (
 			return fmt.Sprintf(`{"type":"fixed","name":"%s","size":%d,"logicalType":"decimal","precision":%d,"scale":%d}`,
 				decName, size, t.precision, t.scale), nil
 		}
+
 		return fmt.Sprintf(`"%s"`, decName), nil
 	default:
 		return "", fmt.Errorf("unsupported partition type: %s", typ.String())

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -35,7 +35,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
-	"github.com/hamba/avro/v2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -238,7 +237,7 @@ func (d *DataFileStatistics) PartitionValue(field iceberg.PartitionField, sc *ic
 
 func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.PartitionSpec, path string, format iceberg.FileFormat, content iceberg.ManifestEntryContent, filesize int64, partitionValues map[int]any) iceberg.DataFile {
 	var fieldIDToPartitionData map[int]any
-	fieldIDToLogicalType := make(map[int]avro.LogicalType)
+	fieldIDToLogicalType := make(map[int]string)
 	fieldIDToFixedSize := make(map[int]int)
 
 	if !spec.Equals(*iceberg.UnpartitionedSpec) {
@@ -261,18 +260,18 @@ func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.Par
 
 				switch rt := resultType.(type) {
 				case iceberg.DateType:
-					fieldIDToLogicalType[field.FieldID] = avro.Date
+					fieldIDToLogicalType[field.FieldID] = "date"
 				case iceberg.TimeType:
-					fieldIDToLogicalType[field.FieldID] = avro.TimeMicros
+					fieldIDToLogicalType[field.FieldID] = "time-micros"
 				case iceberg.TimestampType:
-					fieldIDToLogicalType[field.FieldID] = avro.TimestampMicros
+					fieldIDToLogicalType[field.FieldID] = "timestamp-micros"
 				case iceberg.TimestampTzType:
-					fieldIDToLogicalType[field.FieldID] = avro.TimestampMicros
+					fieldIDToLogicalType[field.FieldID] = "timestamp-micros"
 				case iceberg.DecimalType:
-					fieldIDToLogicalType[field.FieldID] = avro.Decimal
+					fieldIDToLogicalType[field.FieldID] = "decimal"
 					fieldIDToFixedSize[field.FieldID] = rt.Scale()
 				case iceberg.UUIDType:
-					fieldIDToLogicalType[field.FieldID] = avro.UUID
+					fieldIDToLogicalType[field.FieldID] = "uuid"
 				}
 			}
 		}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -666,7 +666,7 @@ func (t *TableWritingTestSuite) TestAddFilesPartitionedTable() {
 
 		for _, e := range entries {
 			t.Equal(map[int]any{
-				1000: 123, 1001: 650,
+				1000: int32(123), 1001: int32(650),
 			}, e.DataFile().Partition())
 		}
 	}


### PR DESCRIPTION
Currently hamba/avro is archived, so switch to a new library from twmb
(who maintains a number of popular go libraries such as franz-go and
murmur3).
