### PR TITLE
fix: delete statistics files for expired snapshots in PostCommit

### DIFF
--- a/table/updates.go
+++ b/table/updates.go
@@ -475,6 +475,35 @@ func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table,
 		}
 	}
 
+	// Collect statistics files belonging to the removed snapshots so they
+	// can be deleted from object storage. Without this, statistics files
+	// for expired snapshots remain in storage forever, leaking space.
+	removedSnapshotIDs := make(map[int64]struct{}, len(u.SnapshotIDs))
+	for _, id := range u.SnapshotIDs {
+		removedSnapshotIDs[id] = struct{}{}
+	}
+
+	for stat := range preTable.Metadata().Statistics() {
+		if _, ok := removedSnapshotIDs[stat.SnapshotID]; ok {
+			filesToDelete[stat.StatisticsPath] = struct{}{}
+		}
+	}
+
+	for stat := range preTable.Metadata().PartitionStatistics() {
+		if _, ok := removedSnapshotIDs[stat.SnapshotID]; ok {
+			filesToDelete[stat.StatisticsPath] = struct{}{}
+		}
+	}
+
+	// Statistics that still exist in postTable (e.g. because of overlap)
+	// must not be deleted.
+	for stat := range postTable.Metadata().Statistics() {
+		delete(filesToDelete, stat.StatisticsPath)
+	}
+	for stat := range postTable.Metadata().PartitionStatistics() {
+		delete(filesToDelete, stat.StatisticsPath)
+	}
+
 	for _, snap := range postTable.Metadata().Snapshots() {
 		mans, err := snap.Manifests(prefs)
 		if err != nil {


### PR DESCRIPTION
## Summary

`removeSnapshotsUpdate.PostCommit()` collects manifest lists, manifests, and data files for deletion from object storage when snapshots are expired. It did not collect `StatisticsFile` or `PartitionStatisticsFile` paths, so those files were leaked indefinitely after expiration.

Fixes #837

## Changes (`table/updates.go`)

After the existing snapshot/manifest/data-file collection in `PostCommit`:

1. Build a set of removed snapshot IDs.
2. Iterate `preTable.Metadata().Statistics()` and `PartitionStatistics()`; for any entry whose `SnapshotID` is in the removed set, queue its `StatisticsPath` for deletion.
3. Symmetric to the existing manifest/data-file logic, remove from the deletion set any `StatisticsPath` that still exists in `postTable.Metadata().Statistics()` / `PartitionStatistics()` so we do not delete files that are still referenced.

## Dependency

This depends on the prune-on-`RemoveSnapshots` fix in #873. Without that, `postTable.Metadata().Statistics()` would still contain the removed snapshot's entries and the post-commit loop would skip the deletion. Either ordering of the merges works as long as both land.

## Verification

- `go build ./table/` passes
- `go vet ./table/` passes
- `go test ./table/` passes (existing `TestRemoveSnapshotsPostCommitSkipped` still passes)

Fixes #837