### PR TITLE
fix(table): populate WriteTask.SortOrderID in data file writers

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1653,6 +1653,55 @@ func (m *ManifestTestSuite) TestWriteManifestListClosesWriterOnError() {
 	m.Require().ErrorIs(err, errLimitedWrite)
 }
 
+// TestManifestRoundTripSortOrderID verifies that a sort_order_id written onto
+// a data file survives an avro manifest round-trip (write → read). This
+// backs the end-to-end guarantee that callers of WriteTask/WriteFileInfo see
+// the value they set on disk.
+func (m *ManifestTestSuite) TestManifestRoundTripSortOrderID() {
+	var buf bytes.Buffer
+	partitionSpec := NewPartitionSpecID(0)
+	snapshotID := int64(12345678)
+	seqNum := int64(9876)
+	const expectedSortOrderID = 3
+
+	dataFileBuilder, err := NewDataFileBuilder(
+		partitionSpec,
+		EntryContentData,
+		"s3://bucket/ns/table/data/round-trip.parquet",
+		ParquetFile,
+		map[int]any{},
+		map[int]avro.LogicalType{},
+		map[int]int{},
+		10,
+		10*1000,
+	)
+	m.Require().NoError(err)
+	dataFileBuilder.SortOrderID(expectedSortOrderID)
+
+	file, err := WriteManifest(
+		"s3://bucket/ns/table/metadata/round-trip.avro", &buf, 2,
+		partitionSpec,
+		NewSchema(0,
+			NestedField{ID: 1, Name: "id", Type: Int64Type{}},
+		),
+		snapshotID,
+		[]ManifestEntry{NewManifestEntry(
+			EntryStatusADDED,
+			&snapshotID,
+			&seqNum, &seqNum,
+			dataFileBuilder.Build(),
+		)},
+	)
+	m.Require().NoError(err)
+
+	entries, err := ReadManifest(file, &buf, false)
+	m.Require().NoError(err)
+	m.Require().Len(entries, 1)
+	got := entries[0].DataFile().SortOrderID()
+	m.Require().NotNil(got, "SortOrderID must round-trip to a non-nil value")
+	m.Equal(expectedSortOrderID, *got)
+}
+
 func (m *ManifestTestSuite) TestWriteManifestClosesWriterOnEntryError() {
 	partitionSpec := NewPartitionSpecID(1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1371,7 +1371,7 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 				}
 			}()
 
-			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.props)
+			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.defaultSortOrderID, meta.props)
 
 			return nil
 		})
@@ -1384,7 +1384,7 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 	return dataFiles, nil
 }
 
-func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties) iceberg.DataFile {
+func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, sortOrderID int, props iceberg.Properties) iceberg.DataFile {
 	format := tblutils.FormatFromFileName(filePath)
 	rdr := must(format.Open(ctx, fileIO, filePath))
 	defer rdr.Close()
@@ -1418,7 +1418,7 @@ func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, curre
 		}
 	}
 
-	return statistics.ToDataFile(currentSchema, currentSpec, filePath, iceberg.ParquetFile, iceberg.EntryContentData, rdr.SourceFileSize(), partitionValues)
+	return statistics.ToDataFile(currentSchema, currentSpec, filePath, iceberg.ParquetFile, iceberg.EntryContentData, rdr.SourceFileSize(), partitionValues, sortOrderID)
 }
 
 func recordNBytes(rec arrow.RecordBatch) (total int64) {
@@ -1617,6 +1617,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 					FileCount:   fileCount,
 					Schema:      iceberg.PositionalDeleteSchema,
 					Batches:     batch,
+					SortOrderID: meta.defaultSortOrderID,
 				}
 				if !yield(t) {
 					return

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -200,7 +200,7 @@ func (suite *FileStatsMetricsSuite) getDataFile(meta iceberg.Properties, writeSt
 	stats := format.DataFileStatsFromMeta(fileMeta, collector, mapping)
 
 	return stats.ToDataFile(tableMeta.CurrentSchema(), tableMeta.PartitionSpec(), "fake-path.parquet",
-		iceberg.ParquetFile, iceberg.EntryContentData, fileMeta.GetSourceFileSize(), nil)
+		iceberg.ParquetFile, iceberg.EntryContentData, fileMeta.GetSourceFileSize(), nil, tableMeta.SortOrder().OrderID())
 }
 
 func (suite *FileStatsMetricsSuite) TestRecordCount() {

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -205,6 +205,7 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 				FileCount:   fileCount,
 				Schema:      deleteSchema,
 				Batches:     batch,
+				SortOrderID: meta.defaultSortOrderID,
 			}
 			if !yield(t) {
 				return

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -1083,7 +1083,8 @@ type mockDataFile struct {
 	lowerBounds map[int][]byte
 	upperBounds map[int][]byte
 
-	specid int32
+	specid      int32
+	sortOrderID *int
 }
 
 func (m *mockDataFile) ContentType() iceberg.ManifestEntryContent { return m.contentType }
@@ -1102,7 +1103,7 @@ func (m *mockDataFile) UpperBoundValues() map[int][]byte          { return m.upp
 func (*mockDataFile) KeyMetadata() []byte                         { return nil }
 func (*mockDataFile) SplitOffsets() []int64                       { return nil }
 func (*mockDataFile) EqualityFieldIDs() []int                     { return nil }
-func (*mockDataFile) SortOrderID() *int                           { return nil }
+func (m *mockDataFile) SortOrderID() *int                         { return m.sortOrderID }
 func (m *mockDataFile) SpecID() int32                             { return m.specid }
 func (*mockDataFile) FirstRowID() *int64                          { return nil }
 func (*mockDataFile) ReferencedDataFile() *string                 { return nil }

--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -117,6 +117,10 @@ type WriteFileInfo struct {
 	WriteProps       any
 	Content          iceberg.ManifestEntryContent
 	EqualityFieldIDs []int
+	// SortOrderID is the sort order id used when writing the data file.
+	// Used to populate the manifest entry's sort_order_id. Defaults to
+	// table.UnsortedSortOrderID (0) for unsorted writes.
+	SortOrderID int
 }
 
 type tablePropertiesContextKey struct{}

--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -117,10 +117,7 @@ type WriteFileInfo struct {
 	WriteProps       any
 	Content          iceberg.ManifestEntryContent
 	EqualityFieldIDs []int
-	// SortOrderID is the sort order id used when writing the data file.
-	// Used to populate the manifest entry's sort_order_id. Defaults to
-	// table.UnsortedSortOrderID (0) for unsorted writes.
-	SortOrderID int
+	SortOrderID      int
 }
 
 type tablePropertiesContextKey struct{}

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -361,7 +361,7 @@ func (w *ParquetFileWriter) Close() (_ iceberg.DataFile, err error) {
 	stats := w.format.DataFileStatsFromMeta(filemeta, w.info.StatsCols, w.colMapping)
 	stats.EqualityFieldIDs = w.info.EqualityFieldIDs
 
-	return stats.ToDataFile(w.info.FileSchema, w.info.Spec, w.info.FileName, iceberg.ParquetFile, w.info.Content, w.counter.Count, w.partition), nil
+	return stats.ToDataFile(w.info.FileSchema, w.info.Spec, w.info.FileName, iceberg.ParquetFile, w.info.Content, w.counter.Count, w.partition, w.info.SortOrderID), nil
 }
 
 type decAsIntAgg[T int32 | int64] struct {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -261,7 +261,7 @@ func TestMetricsPrimitiveTypes(t *testing.T) {
 
 	stats := format.DataFileStatsFromMeta(internal.Metadata(meta), getCollector(), mapping)
 	df := stats.ToDataFile(tblMeta.CurrentSchema(), tblMeta.PartitionSpec(), "fake-path.parquet",
-		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil)
+		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil, 0)
 
 	assert.Len(t, df.ValueCounts(), 15)
 	assert.Len(t, df.NullValueCounts(), 15)
@@ -412,7 +412,7 @@ func TestNanosecondTimestampMetrics(t *testing.T) {
 
 	stats := format.DataFileStatsFromMeta(internal.Metadata(meta), collector, mapping)
 	df := stats.ToDataFile(tableMeta.CurrentSchema(), tableMeta.PartitionSpec(), "fake-path.parquet",
-		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil)
+		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil, 0)
 
 	assert.Len(t, df.ValueCounts(), 2)
 	assert.Len(t, df.NullValueCounts(), 2)
@@ -557,7 +557,7 @@ func TestDecimalPhysicalTypes(t *testing.T) {
 			require.NotNil(t, stats)
 
 			df := stats.ToDataFile(tableMeta.CurrentSchema(), tableMeta.PartitionSpec(), "test.parquet",
-				iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil)
+				iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil, 0)
 
 			// Verify bounds are correctly extracted
 			require.Contains(t, df.LowerBoundValues(), 1)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -260,8 +260,12 @@ func TestMetricsPrimitiveTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	stats := format.DataFileStatsFromMeta(internal.Metadata(meta), getCollector(), mapping)
+	const sortOrderID = 7
 	df := stats.ToDataFile(tblMeta.CurrentSchema(), tblMeta.PartitionSpec(), "fake-path.parquet",
-		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil, 0)
+		iceberg.ParquetFile, iceberg.EntryContentData, meta.GetSourceFileSize(), nil, sortOrderID)
+
+	require.NotNil(t, df.SortOrderID())
+	assert.Equal(t, sortOrderID, *df.SortOrderID())
 
 	assert.Len(t, df.ValueCounts(), 15)
 	assert.Len(t, df.NullValueCounts(), 15)

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -236,7 +236,7 @@ func (d *DataFileStatistics) PartitionValue(field iceberg.PartitionField, sc *ic
 	return lowerT.Val.Any()
 }
 
-func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.PartitionSpec, path string, format iceberg.FileFormat, content iceberg.ManifestEntryContent, filesize int64, partitionValues map[int]any) iceberg.DataFile {
+func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.PartitionSpec, path string, format iceberg.FileFormat, content iceberg.ManifestEntryContent, filesize int64, partitionValues map[int]any, sortOrderID int) iceberg.DataFile {
 	var fieldIDToPartitionData map[int]any
 	fieldIDToLogicalType := make(map[int]avro.LogicalType)
 	fieldIDToFixedSize := make(map[int]int)
@@ -314,6 +314,8 @@ func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.Par
 	if len(d.EqualityFieldIDs) > 0 {
 		bldr.EqualityFieldIDs(d.EqualityFieldIDs)
 	}
+
+	bldr.SortOrderID(sortOrderID)
 
 	return bldr.Build()
 }

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -74,7 +74,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "success",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 88, 2147483546: 174}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 88, 2147483546: 174}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: intPtr(1)},
 		},
 		// This test case illustrates how the positionDeletePartitionedFanoutWriter does not validate that all records
 		// in a batch have the same file path. Doing so would be prohibitive in the current implementation and
@@ -84,7 +84,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "batch with records having different file paths",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}, {"file_path": "file://namespace/age_bucket=0/test.parquet", "pos": 10}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 96, 2147483546: 187}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 96, 2147483546: 187}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: intPtr(1)},
 		},
 	}
 
@@ -503,7 +503,9 @@ func (m *dataFileMatcher) Format(val iceberg.DataFile) string {
 }
 
 // defaultPositionDeleteMatching is a convenience preset for the options we want to match for position delete matching
-var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatching(), withColumnSizesMatching(), withCountMatching(), withFileFormatMatching(), withSpecIDMatching(), withPartitionMatching(), withCountMatching()}
+var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatching(), withColumnSizesMatching(), withCountMatching(), withFileFormatMatching(), withSpecIDMatching(), withPartitionMatching(), withCountMatching(), withSortOrderIDMatching()}
+
+func intPtr(i int) *int { return &i }
 
 // equalsDataFile invokes a dataFileMatcher with the specified matching options and compares two DataFile values.
 // Its return value is nil if both values are equal and an error with a meaningful formatted message to help

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -74,7 +74,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "success",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 88, 2147483546: 174}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: intPtr(1)},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 88, 2147483546: 174}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: ptr(1)},
 		},
 		// This test case illustrates how the positionDeletePartitionedFanoutWriter does not validate that all records
 		// in a batch have the same file path. Doing so would be prohibitive in the current implementation and
@@ -84,7 +84,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "batch with records having different file paths",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}, {"file_path": "file://namespace/age_bucket=0/test.parquet", "pos": 10}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 96, 2147483546: 187}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: intPtr(1)},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 96, 2147483546: 187}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: ptr(1)},
 		},
 	}
 
@@ -505,7 +505,9 @@ func (m *dataFileMatcher) Format(val iceberg.DataFile) string {
 // defaultPositionDeleteMatching is a convenience preset for the options we want to match for position delete matching
 var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatching(), withColumnSizesMatching(), withCountMatching(), withFileFormatMatching(), withSpecIDMatching(), withPartitionMatching(), withCountMatching(), withSortOrderIDMatching()}
 
-func intPtr(i int) *int { return &i }
+// ptr returns a pointer to v. A generic stand-in for the various one-off
+// ptr-helpers previously sprinkled across the internal package tests.
+func ptr[T any](v T) *T { return &v }
 
 // TestPositionDeleteUnpartitionedSortOrderID covers the unpartitioned branch
 // of positionDeleteRecordsToDataFiles: the resulting DataFiles must carry

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -507,6 +507,122 @@ var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatch
 
 func intPtr(i int) *int { return &i }
 
+// TestPositionDeleteUnpartitionedSortOrderID covers the unpartitioned branch
+// of positionDeleteRecordsToDataFiles: the resulting DataFiles must carry
+// the table's default sort order id exactly like the partitioned branch does.
+func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
+	t.Parallel()
+
+	metadataBuilder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSchema(iceberg.PositionalDeleteSchema))
+	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
+	unpartitioned := *iceberg.UnpartitionedSpec
+	require.NoError(t, metadataBuilder.AddPartitionSpec(&unpartitioned, true))
+	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
+	sortOrder, err := NewSortOrder(1, []SortField{{
+		SourceIDs: []int{2147483546}, // file_path
+		Direction: SortASC,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: NullsFirst,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSortOrder(&sortOrder))
+	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(-1))
+
+	built, err := metadataBuilder.Build()
+	require.NoError(t, err)
+	expectedID := built.DefaultSortOrder()
+	require.NotZero(t, expectedID, "sanity: sort order id should be non-zero")
+
+	writeUUID := uuid.New()
+	rb := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://unpartitioned/test.parquet", "pos": 0}]`)
+	itr := func(yield func(arrow.RecordBatch, error) bool) {
+		rb.Retain()
+		yield(rb, nil)
+	}
+	seq := positionDeleteRecordsToDataFiles(t.Context(), t.TempDir(), metadataBuilder, nil, recordWritingArgs{
+		sc:        PositionalDeleteArrowSchema,
+		itr:       itr,
+		fs:        &io.LocalFS{},
+		writeUUID: &writeUUID,
+		counter:   internal.Counter(0),
+	})
+
+	var files []iceberg.DataFile
+	for df, err := range seq {
+		require.NoError(t, err)
+		files = append(files, df)
+	}
+	require.NotEmpty(t, files, "expected at least one data file")
+	for _, df := range files {
+		require.NotNil(t, df.SortOrderID(), "unpartitioned pos-delete DataFile must carry sort order id")
+		assert.Equal(t, expectedID, *df.SortOrderID())
+	}
+}
+
+// TestEqualityDeleteUnpartitionedSortOrderID covers the unpartitioned branch
+// of equalityDeleteRecordsToDataFiles: the resulting DataFiles must carry
+// the table's default sort order id.
+func TestEqualityDeleteUnpartitionedSortOrderID(t *testing.T) {
+	t.Parallel()
+
+	delSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	metadataBuilder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSchema(delSchema))
+	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
+	unpartitioned := *iceberg.UnpartitionedSpec
+	require.NoError(t, metadataBuilder.AddPartitionSpec(&unpartitioned, true))
+	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
+	sortOrder, err := NewSortOrder(1, []SortField{{
+		SourceIDs: []int{1},
+		Direction: SortASC,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: NullsFirst,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSortOrder(&sortOrder))
+	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(-1))
+
+	built, err := metadataBuilder.Build()
+	require.NoError(t, err)
+	expectedID := built.DefaultSortOrder()
+	require.NotZero(t, expectedID, "sanity: sort order id should be non-zero")
+
+	delArrowSc, err := SchemaToArrowSchema(delSchema, nil, true, false)
+	require.NoError(t, err)
+
+	writeUUID := uuid.New()
+	rb := mustLoadRecordBatchFromJSON(delArrowSc, `[{"id": 2}, {"id": 4}]`)
+	itr := func(yield func(arrow.RecordBatch, error) bool) {
+		rb.Retain()
+		yield(rb, nil)
+	}
+	seq, err := equalityDeleteRecordsToDataFiles(t.Context(), t.TempDir(), metadataBuilder, delSchema, []int{1}, recordWritingArgs{
+		sc:        delArrowSc,
+		itr:       itr,
+		fs:        &io.LocalFS{},
+		writeUUID: &writeUUID,
+		counter:   internal.Counter(0),
+	})
+	require.NoError(t, err)
+
+	var files []iceberg.DataFile
+	for df, err := range seq {
+		require.NoError(t, err)
+		files = append(files, df)
+	}
+	require.NotEmpty(t, files, "expected at least one data file")
+	for _, df := range files {
+		require.NotNil(t, df.SortOrderID(), "unpartitioned eq-delete DataFile must carry sort order id")
+		assert.Equal(t, expectedID, *df.SortOrderID())
+	}
+}
+
 // equalsDataFile invokes a dataFileMatcher with the specified matching options and compares two DataFile values.
 // Its return value is nil if both values are equal and an error with a meaningful formatted message to help
 // show the mismatch in case they are not. This is meant to be used with testify like:

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -54,6 +54,7 @@ type writerFactory struct {
 	format           tblutils.FileFormat
 	content          iceberg.ManifestEntryContent
 	equalityFieldIDs []int
+	sortOrderID      int
 
 	writers               sync.Map
 	partitionLocProviders sync.Map
@@ -159,6 +160,7 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		format:         format,
 		nextCount:      nextCount,
 		stopCount:      stopCount,
+		sortOrderID:    meta.defaultSortOrderID,
 	}
 	for _, apply := range opts {
 		apply(f)
@@ -207,6 +209,7 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		Spec:             w.currentSpec,
 		Content:          w.content,
 		EqualityFieldIDs: w.equalityFieldIDs,
+		SortOrderID:      w.sortOrderID,
 	}, w.arrowSchema)
 }
 

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -216,6 +216,80 @@ func (s *RollingDataWriterTestSuite) TestBytesWrittenNoDoubleCountAcrossRowGroup
 		"DataFile.FileSizeBytes should match actual file size on disk")
 }
 
+// TestWriterFactoryPropagatesSortOrderID covers the standard data write path:
+// the rolling data writer must stamp each emitted DataFile with the table's
+// default sort order id, mirroring how the partitioned fanout writer uses
+// writerFactory under the hood.
+func (s *RollingDataWriterTestSuite) TestWriterFactoryPropagatesSortOrderID() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
+	s.Require().NoError(err)
+
+	spec := iceberg.NewPartitionSpec()
+	sortOrder, err := NewSortOrder(1, []SortField{{
+		SourceIDs: []int{icebergSchema.Fields()[0].ID},
+		Direction: SortASC,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: NullsFirst,
+	}})
+	s.Require().NoError(err)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	s.Require().NoError(err)
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	s.Require().NoError(err)
+	s.Require().NoError(metaBuilder.AddSortOrder(&sortOrder))
+	// -1 means "use the sort order that was just added". AddSortOrder
+	// re-maps the caller-supplied ID, so we can't refer to it by literal.
+	s.Require().NoError(metaBuilder.SetDefaultSortOrderID(-1))
+	builtMeta, err := metaBuilder.Build()
+	s.Require().NoError(err)
+	expectedSortOrderID := builtMeta.DefaultSortOrder()
+	s.Require().NotEqual(UnsortedSortOrderID, expectedSortOrderID, "sanity: sort order id should be non-zero")
+
+	writeUUID := uuid.New()
+	args := recordWritingArgs{
+		sc:        arrSchema,
+		fs:        iceio.LocalFS{},
+		writeUUID: &writeUUID,
+		counter: func(yield func(int) bool) {
+			for i := 0; ; i++ {
+				if !yield(i) {
+					break
+				}
+			}
+		},
+	}
+
+	factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, 1024*1024)
+	s.Require().NoError(err)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+
+	record := s.buildRecord(arrSchema, 5)
+	defer record.Release()
+
+	s.Require().NoError(writer.Add(record))
+	s.Require().NoError(writer.closeAndWait())
+	close(outputCh)
+
+	var dataFiles []iceberg.DataFile
+	for df := range outputCh {
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Len(dataFiles, 1)
+	s.Require().NotNil(dataFiles[0].SortOrderID(), "SortOrderID must be set on the emitted DataFile")
+	s.Equal(expectedSortOrderID, *dataFiles[0].SortOrderID())
+}
+
 func (s *RollingDataWriterTestSuite) TestBytesWrittenReflectsCompressedSize() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/writer.go
+++ b/table/writer.go
@@ -154,6 +154,7 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 		WriteProps:       w.format.GetWriteProperties(w.props),
 		Spec:             *currentSpec,
 		EqualityFieldIDs: w.equalityFieldIDs,
+		SortOrderID:      task.SortOrderID,
 	}, batches)
 }
 


### PR DESCRIPTION
## Summary

The `SortOrderID` field on `WriteTask` was declared but never set by any producer, so every data file written via the standard/partitioned/rolling/equality-delete paths ended up with a nil `sort_order_id` in the manifest entry. This leaves readers with no way to know which sort order the file was written against.

This PR threads `SortOrderID` end-to-end:

* `WriteFileInfo` gains a `SortOrderID` field and `DataFileStatistics.ToDataFile` now calls `DataFileBuilder.SortOrderID` so the value lands on the final `DataFile`.
* `arrow_utils.filesToDataFiles`, `writer.writeFile`, and `writerFactory` all pass the table's default sort order id down to `WriteFileInfo`, and the equality-delete / position-delete / rolling data writer paths populate the `WriteTask.SortOrderID` accordingly.

Fixes #842

## Test plan

- [x] `go test ./table/...`
- [x] `go vet ./...`
- [x] New assertion: `withSortOrderIDMatching` added to `defaultPositionDeleteMatching` in `TestPositionDeletePartitionedFanoutWriterProcessBatch`; `mockDataFile` gains an overridable sort order id so this path is covered end-to-end.

Signed-off-by: Ali <ali@kscope.ai>