### PR TITLE
fix(manifest): emit Avro fixed schema for FixedType partition columns

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1673,25 +1673,36 @@ func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType,
 // accept the explicit {"<fixed-name>": [N]byte} form used elsewhere for
 // UUID and decimal fixed branches. Nil (the other union arm) is passed
 // through untouched.
+//
+// The caller must supply a []byte whose length equals size exactly. A
+// wrong-length slice is a data-corruption risk (the value would land in the
+// wrong partition) so we panic rather than silently truncating or padding.
 func convertFixedValue(v any, size int) any {
 	if v == nil {
 		return map[string]any{"null": nil}
 	}
 
-	switch b := v.(type) {
-	case []byte:
-		return map[string]any{fixedSchemaName(size): convertToFixedArray(padOrTruncateBytes(b, size), size)}
-	case FixedLiteral:
-		return map[string]any{fixedSchemaName(size): convertToFixedArray(padOrTruncateBytes([]byte(b), size), size)}
+	b, ok := v.([]byte)
+	if !ok {
+		return v
+	}
+	if len(b) != size {
+		panic(fmt.Sprintf(
+			"FixedType partition value has length %d, expected %d; wrong-length value would corrupt partition assignment",
+			len(b), size))
 	}
 
-	return v
+	return map[string]any{fixedSchemaName(size): convertToFixedArray(b, size)}
 }
 
 // unwrapFixedValue reverses [convertFixedValue]: hamba/avro surfaces a
 // nullable fixed branch as map[string]any{"<fixed-name>": [N]byte}. We
 // flatten that back into the []byte slice shape Iceberg partition data
 // uses everywhere else.
+//
+// Note: hamba/avro decodes a fixed union branch as a Go [N]byte array (not a
+// []byte slice). reflect is the only portable way to copy out of an array
+// whose element count is not known at compile time.
 func unwrapFixedValue(v any, size int) any {
 	if unionMap, ok := v.(map[string]any); ok {
 		if inner, ok := unionMap[fixedSchemaName(size)]; ok {

--- a/manifest.go
+++ b/manifest.go
@@ -590,11 +590,11 @@ func decodeManifests[I interface {
 // This type is not thread-safe; its methods should not be called from
 // multiple goroutines.
 type ManifestReader struct {
-	dec           *ocf.Decoder
-	file          ManifestFile
-	formatVersion int
-	isFallback    bool
-	content       ManifestContent
+	dec                    *ocf.Decoder
+	file                   ManifestFile
+	formatVersion          int
+	isFallback             bool
+	content                ManifestContent
 	fieldNameToID          map[string]int
 	fieldIDToType          map[int]avro.LogicalType
 	fieldIDToSize          map[int]int
@@ -666,15 +666,15 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 	fieldNameToID, fieldIDToType, fieldIDToSize, fieldIDToFixedPartSize := getFieldIDMap(sc)
 
 	return &ManifestReader{
-		dec:                     dec,
-		file:                    file,
-		formatVersion:           formatVersion,
-		isFallback:              isFallback,
-		content:                 content,
-		fieldNameToID:           fieldNameToID,
-		fieldIDToType:           fieldIDToType,
-		fieldIDToSize:           fieldIDToSize,
-		fieldIDToFixedPartSize:  fieldIDToFixedPartSize,
+		dec:                    dec,
+		file:                   file,
+		formatVersion:          formatVersion,
+		isFallback:             isFallback,
+		content:                content,
+		fieldNameToID:          fieldNameToID,
+		fieldIDToType:          fieldIDToType,
+		fieldIDToSize:          fieldIDToSize,
+		fieldIDToFixedPartSize: fieldIDToFixedPartSize,
 	}, nil
 }
 
@@ -1842,11 +1842,11 @@ type dataFile struct {
 	upperBoundMap  map[int][]byte
 
 	// used for partition retrieval
-	fieldNameToID           map[string]int
-	fieldIDToLogicalType    map[int]avro.LogicalType
-	fieldIDToPartitionData  map[int]any
-	fieldIDToFixedSize      map[int]int
-	fieldIDToFixedPartSize  map[int]int
+	fieldNameToID          map[string]int
+	fieldIDToLogicalType   map[int]avro.LogicalType
+	fieldIDToPartitionData map[int]any
+	fieldIDToFixedSize     map[int]int
+	fieldIDToFixedPartSize map[int]int
 
 	specID   int32
 	initMaps sync.Once

--- a/manifest.go
+++ b/manifest.go
@@ -407,7 +407,18 @@ func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manifes
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
 
-func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, map[int]int, map[int]int) {
+// partitionFieldIDMap groups the four per-field mappings derived from a
+// manifest entry Avro schema. Using a struct rather than four bare return
+// values avoids confusion between the two map[int]int members, which carry
+// completely different semantics (decimal scale vs FixedType byte length).
+type partitionFieldIDMap struct {
+	nameToID       map[string]int
+	logicalTypes   map[int]avro.LogicalType
+	decimalScales  map[int]int // field id → decimal scale (for Decimal partition columns)
+	fixedByteSizes map[int]int // field id → byte length (for FixedType partition columns)
+}
+
+func getFieldIDMap(sc avro.Schema) partitionFieldIDMap {
 	getField := func(rs *avro.RecordSchema, name string) *avro.Field {
 		for _, f := range rs.Fields() {
 			if f.Name() == name {
@@ -418,10 +429,12 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 		return nil
 	}
 
-	result := make(map[string]int)
-	logicalTypes := make(map[int]avro.LogicalType)
-	fixedSizes := make(map[int]int)
-	fixedPartSizes := make(map[int]int)
+	m := partitionFieldIDMap{
+		nameToID:       make(map[string]int),
+		logicalTypes:   make(map[int]avro.LogicalType),
+		decimalScales:  make(map[int]int),
+		fixedByteSizes: make(map[int]int),
+	}
 
 	entryField := getField(sc.(*avro.RecordSchema), "data_file")
 	partitionField := getField(entryField.Type().(*avro.RecordSchema), "partition")
@@ -437,30 +450,30 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 			continue
 		}
 
-		result[field.Name()] = fid
+		m.nameToID[field.Name()] = fid
 		avroTyp := field.Type()
 		if us, ok := avroTyp.(*avro.UnionSchema); ok {
 			typeList := us.Types()
 			avroTyp = typeList[len(typeList)-1]
 		}
 		if ps, ok := avroTyp.(*avro.PrimitiveSchema); ok && ps.Logical() != nil {
-			logicalTypes[fid] = ps.Logical().Type()
+			m.logicalTypes[fid] = ps.Logical().Type()
 		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok {
 			if fs.Logical() != nil {
-				logicalTypes[int(fid)] = fs.Logical().Type()
+				m.logicalTypes[fid] = fs.Logical().Type()
 				if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
-					fixedSizes[int(fid)] = decimalLogical.Scale()
+					m.decimalScales[fid] = decimalLogical.Scale()
 				}
 			} else {
 				// FixedType partition column (no logical type): record its
 				// byte length so encode/decode can wrap/unwrap the union
 				// branch correctly.
-				fixedPartSizes[int(fid)] = fs.Size()
+				m.fixedByteSizes[fid] = fs.Size()
 			}
 		}
 	}
 
-	return result, logicalTypes, fixedSizes, fixedPartSizes
+	return m
 }
 
 type hasFieldToIDMap interface {
@@ -663,7 +676,7 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 			}
 		}
 	}
-	fieldNameToID, fieldIDToType, fieldIDToSize, fieldIDToFixedPartSize := getFieldIDMap(sc)
+	fim := getFieldIDMap(sc)
 
 	return &ManifestReader{
 		dec:                    dec,
@@ -671,10 +684,10 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		formatVersion:          formatVersion,
 		isFallback:             isFallback,
 		content:                content,
-		fieldNameToID:          fieldNameToID,
-		fieldIDToType:          fieldIDToType,
-		fieldIDToSize:          fieldIDToSize,
-		fieldIDToFixedPartSize: fieldIDToFixedPartSize,
+		fieldNameToID:          fim.nameToID,
+		fieldIDToType:          fim.logicalTypes,
+		fieldIDToSize:          fim.decimalScales,
+		fieldIDToFixedPartSize: fim.fixedByteSizes,
 	}, nil
 }
 
@@ -1126,7 +1139,7 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	nameToID, idToType, _, idToFixedPartSize := getFieldIDMap(fileSchema)
+	fim := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
 		impl:                       impl,
@@ -1135,9 +1148,9 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		spec:                       spec,
 		content:                    ManifestContentData,
 		schema:                     schema,
-		partFieldNameToID:          nameToID,
-		partFieldIDToType:          idToType,
-		partFieldIDToFixedPartSize: idToFixedPartSize,
+		partFieldNameToID:          fim.nameToID,
+		partFieldIDToType:          fim.logicalTypes,
+		partFieldIDToFixedPartSize: fim.fixedByteSizes,
 		snapshotID:                 snapshotID,
 		minSeqNum:                  -1,
 		partitions:                 make([]map[int]any, 0),

--- a/manifest.go
+++ b/manifest.go
@@ -407,7 +407,7 @@ func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manifes
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
 
-func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, map[int]int) {
+func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, map[int]int, map[int]int) {
 	getField := func(rs *avro.RecordSchema, name string) *avro.Field {
 		for _, f := range rs.Fields() {
 			if f.Name() == name {
@@ -421,6 +421,7 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 	result := make(map[string]int)
 	logicalTypes := make(map[int]avro.LogicalType)
 	fixedSizes := make(map[int]int)
+	fixedPartSizes := make(map[int]int)
 
 	entryField := getField(sc.(*avro.RecordSchema), "data_file")
 	partitionField := getField(entryField.Type().(*avro.RecordSchema), "partition")
@@ -444,21 +445,29 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 		}
 		if ps, ok := avroTyp.(*avro.PrimitiveSchema); ok && ps.Logical() != nil {
 			logicalTypes[fid] = ps.Logical().Type()
-		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok && fs.Logical() != nil {
-			logicalTypes[int(fid)] = fs.Logical().Type()
-			if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
-				fixedSizes[int(fid)] = decimalLogical.Scale()
+		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok {
+			if fs.Logical() != nil {
+				logicalTypes[int(fid)] = fs.Logical().Type()
+				if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
+					fixedSizes[int(fid)] = decimalLogical.Scale()
+				}
+			} else {
+				// FixedType partition column (no logical type): record its
+				// byte length so encode/decode can wrap/unwrap the union
+				// branch correctly.
+				fixedPartSizes[int(fid)] = fs.Size()
 			}
 		}
 	}
 
-	return result, logicalTypes, fixedSizes
+	return result, logicalTypes, fixedSizes, fixedPartSizes
 }
 
 type hasFieldToIDMap interface {
 	setFieldNameToIDMap(map[string]int)
 	setFieldIDToLogicalTypeMap(map[int]avro.LogicalType)
 	setFieldIDToFixedSizeMap(map[int]int)
+	setFieldIDToFixedPartSizeMap(map[int]int)
 }
 
 func fetchManifestEntries(m ManifestFile, fs iceio.IO, discardDeleted bool) (_ []ManifestEntry, err error) {
@@ -586,9 +595,10 @@ type ManifestReader struct {
 	formatVersion int
 	isFallback    bool
 	content       ManifestContent
-	fieldNameToID map[string]int
-	fieldIDToType map[int]avro.LogicalType
-	fieldIDToSize map[int]int
+	fieldNameToID          map[string]int
+	fieldIDToType          map[int]avro.LogicalType
+	fieldIDToSize          map[int]int
+	fieldIDToFixedPartSize map[int]int
 
 	// The rest are lazily populated, on demand. Most readers
 	// will likely only try to load the entries.
@@ -653,17 +663,18 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 			}
 		}
 	}
-	fieldNameToID, fieldIDToType, fieldIDToSize := getFieldIDMap(sc)
+	fieldNameToID, fieldIDToType, fieldIDToSize, fieldIDToFixedPartSize := getFieldIDMap(sc)
 
 	return &ManifestReader{
-		dec:           dec,
-		file:          file,
-		formatVersion: formatVersion,
-		isFallback:    isFallback,
-		content:       content,
-		fieldNameToID: fieldNameToID,
-		fieldIDToType: fieldIDToType,
-		fieldIDToSize: fieldIDToSize,
+		dec:                     dec,
+		file:                    file,
+		formatVersion:           formatVersion,
+		isFallback:              isFallback,
+		content:                 content,
+		fieldNameToID:           fieldNameToID,
+		fieldIDToType:           fieldIDToType,
+		fieldIDToSize:           fieldIDToSize,
+		fieldIDToFixedPartSize:  fieldIDToFixedPartSize,
 	}, nil
 }
 
@@ -769,6 +780,7 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 		fieldToIDMap.setFieldNameToIDMap(c.fieldNameToID)
 		fieldToIDMap.setFieldIDToLogicalTypeMap(c.fieldIDToType)
 		fieldToIDMap.setFieldIDToFixedSizeMap(c.fieldIDToSize)
+		fieldToIDMap.setFieldIDToFixedPartSizeMap(c.fieldIDToFixedPartSize)
 	}
 
 	return tmp, nil
@@ -1065,8 +1077,9 @@ type ManifestWriter struct {
 	schema  *Schema
 	content ManifestContent
 
-	partFieldNameToID map[string]int
-	partFieldIDToType map[int]avro.LogicalType
+	partFieldNameToID          map[string]int
+	partFieldIDToType          map[int]avro.LogicalType
+	partFieldIDToFixedPartSize map[int]int
 
 	snapshotID    int64
 	addedFiles    int32
@@ -1113,20 +1126,21 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	nameToID, idToType, _ := getFieldIDMap(fileSchema)
+	nameToID, idToType, _, idToFixedPartSize := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
-		impl:              impl,
-		version:           version,
-		output:            out,
-		spec:              spec,
-		content:           ManifestContentData,
-		schema:            schema,
-		partFieldNameToID: nameToID,
-		partFieldIDToType: idToType,
-		snapshotID:        snapshotID,
-		minSeqNum:         -1,
-		partitions:        make([]map[int]any, 0),
+		impl:                       impl,
+		version:                    version,
+		output:                     out,
+		spec:                       spec,
+		content:                    ManifestContentData,
+		schema:                     schema,
+		partFieldNameToID:          nameToID,
+		partFieldIDToType:          idToType,
+		partFieldIDToFixedPartSize: idToFixedPartSize,
+		snapshotID:                 snapshotID,
+		minSeqNum:                  -1,
+		partitions:                 make([]map[int]any, 0),
 	}
 
 	for _, apply := range opts {
@@ -1264,10 +1278,11 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	if setter, ok := entry.DataFile().(hasFieldToIDMap); ok {
 		setter.setFieldNameToIDMap(w.partFieldNameToID)
 		setter.setFieldIDToLogicalTypeMap(w.partFieldIDToType)
+		setter.setFieldIDToFixedPartSizeMap(w.partFieldIDToFixedPartSize)
 	}
 
 	w.partitions = append(w.partitions, entry.Data.Partition())
-	partitionData := avroPartitionData(entry.Data.Partition(), w.partFieldIDToType)
+	partitionData := avroPartitionData(entry.Data.Partition(), w.partFieldIDToType, w.partFieldIDToFixedPartSize)
 
 	if dataFile, ok := entry.DataFile().(*dataFile); ok {
 		convertedPartitionData := make(map[string]any)
@@ -1637,17 +1652,61 @@ func mapToAvroColMap[K comparable, V any](m map[K]V) *[]colMap[K, V] {
 	return &out
 }
 
-func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType) map[int]any {
+func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType, fixedPartSizes map[int]int) map[int]any {
 	out := make(map[int]any)
 	for k, v := range input {
 		if logical, ok := logicalTypes[k]; ok {
 			out[k] = convertLogicalTypeValue(v, logical)
+		} else if size, ok := fixedPartSizes[k]; ok {
+			out[k] = convertFixedValue(v, size)
 		} else {
 			out[k] = v
 		}
 	}
 
 	return out
+}
+
+// convertFixedValue wraps a FixedType partition value for hamba/avro's
+// union encoder. The encoder cannot dispatch a bare [N]byte array inside
+// a union (see https://github.com/hamba/avro/issues/571), but it does
+// accept the explicit {"<fixed-name>": [N]byte} form used elsewhere for
+// UUID and decimal fixed branches. Nil (the other union arm) is passed
+// through untouched.
+func convertFixedValue(v any, size int) any {
+	if v == nil {
+		return map[string]any{"null": nil}
+	}
+
+	switch b := v.(type) {
+	case []byte:
+		return map[string]any{fixedSchemaName(size): convertToFixedArray(padOrTruncateBytes(b, size), size)}
+	case FixedLiteral:
+		return map[string]any{fixedSchemaName(size): convertToFixedArray(padOrTruncateBytes([]byte(b), size), size)}
+	}
+
+	return v
+}
+
+// unwrapFixedValue reverses [convertFixedValue]: hamba/avro surfaces a
+// nullable fixed branch as map[string]any{"<fixed-name>": [N]byte}. We
+// flatten that back into the []byte slice shape Iceberg partition data
+// uses everywhere else.
+func unwrapFixedValue(v any, size int) any {
+	if unionMap, ok := v.(map[string]any); ok {
+		if inner, ok := unionMap[fixedSchemaName(size)]; ok {
+			v = inner
+		}
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Array && rv.Type().Elem().Kind() == reflect.Uint8 {
+		out := make([]byte, rv.Len())
+		reflect.Copy(reflect.ValueOf(out), rv)
+
+		return out
+	}
+
+	return v
 }
 
 func convertLogicalTypeValue(v any, logicalType avro.LogicalType) any {
@@ -1783,10 +1842,11 @@ type dataFile struct {
 	upperBoundMap  map[int][]byte
 
 	// used for partition retrieval
-	fieldNameToID          map[string]int
-	fieldIDToLogicalType   map[int]avro.LogicalType
-	fieldIDToPartitionData map[int]any
-	fieldIDToFixedSize     map[int]int
+	fieldNameToID           map[string]int
+	fieldIDToLogicalType    map[int]avro.LogicalType
+	fieldIDToPartitionData  map[int]any
+	fieldIDToFixedSize      map[int]int
+	fieldIDToFixedPartSize  map[int]int
 
 	specID   int32
 	initMaps sync.Once
@@ -1815,6 +1875,9 @@ func (d *dataFile) initializeMapData() {
 }
 
 func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
+	if size, ok := d.fieldIDToFixedPartSize[fieldID]; ok {
+		return unwrapFixedValue(v, size)
+	}
 	if logicalType, ok := d.fieldIDToLogicalType[fieldID]; ok {
 		switch logicalType {
 		case avro.Date:
@@ -1886,7 +1949,8 @@ func (d *dataFile) setFieldNameToIDMap(m map[string]int) { d.fieldNameToID = m }
 func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]avro.LogicalType) {
 	d.fieldIDToLogicalType = m
 }
-func (d *dataFile) setFieldIDToFixedSizeMap(m map[int]int) { d.fieldIDToFixedSize = m }
+func (d *dataFile) setFieldIDToFixedSizeMap(m map[int]int)     { d.fieldIDToFixedSize = m }
+func (d *dataFile) setFieldIDToFixedPartSizeMap(m map[int]int) { d.fieldIDToFixedPartSize = m }
 
 func (d *dataFile) ContentType() ManifestEntryContent { return d.Content }
 func (d *dataFile) FilePath() string                  { return d.Path }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1653,6 +1653,112 @@ func (m *ManifestTestSuite) TestWriteManifestListClosesWriterOnError() {
 	m.Require().ErrorIs(err, errLimitedWrite)
 }
 
+// TestFixedTypePartitionManifestRoundTrip exercises the actual manifest
+// read/write path for a FixedType partition column — the end-to-end
+// complement of TestFixedPartitionColumnAvroSchema which only tests raw
+// avro marshal/unmarshal.
+//
+// Flow: table schema + FixedType partition spec → WriteManifest → ReadManifest
+//
+//	→ assert partition value survives byte-for-byte.
+func (m *ManifestTestSuite) TestFixedTypePartitionManifestRoundTrip() {
+	const fixedLen = 8
+	fixedValue := []byte("abcdefgh") // exactly fixedLen bytes
+
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "id", Type: PrimitiveTypes.Int64, Required: true},
+		NestedField{ID: 2, Name: "key", Type: FixedTypeOf(fixedLen), Required: false},
+	)
+	spec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{2}, Name: "key", Transform: IdentityTransform{}},
+	)
+
+	snapshotID := int64(1)
+	seqNum := int64(1)
+	df, err := NewDataFileBuilder(spec, EntryContentData, "s3://bucket/data/fixed-part.parquet", ParquetFile,
+		map[int]any{1000: fixedValue}, map[int]avro.LogicalType{}, map[int]int{}, 10, 10_000)
+	m.Require().NoError(err)
+	entry := NewManifestEntry(EntryStatusADDED, &snapshotID, &seqNum, &seqNum, df.Build())
+
+	var buf bytes.Buffer
+	mf, err := WriteManifest("s3://bucket/meta/fixed-part.avro", &buf, 2, spec, schema, snapshotID, []ManifestEntry{entry})
+	m.Require().NoError(err)
+
+	entries, err := ReadManifest(mf, &buf, false)
+	m.Require().NoError(err)
+	m.Require().Len(entries, 1)
+
+	partitionMap := entries[0].DataFile().Partition()
+	got, ok := partitionMap[1000].([]byte)
+	m.Require().True(ok, "partition value should round-trip as []byte, got %T", partitionMap[1000])
+	m.Equal(fixedValue, got)
+}
+
+// TestFixedTypePartitionBackwardCompatibility checks that manifests written
+// by old code — where a FixedType partition column was encoded as Avro
+// "bytes" instead of "fixed_N" — are still decoded correctly by the new
+// code. The old encoding is simulated by constructing the Avro payload
+// directly with a bytes-typed partition field.
+func (m *ManifestTestSuite) TestFixedTypePartitionBackwardCompatibility() {
+	const fixedLen = 8
+	fixedValue := []byte("abcdefgh")
+
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "id", Type: PrimitiveTypes.Int64, Required: true},
+		NestedField{ID: 2, Name: "key", Type: FixedTypeOf(fixedLen), Required: false},
+	)
+	spec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{2}, Name: "key", Transform: IdentityTransform{}},
+	)
+
+	// Construct the Avro entry schema using the old "bytes" partition type
+	// rather than the new "fixed_N". This simulates what old code wrote.
+	bytesUnion, err := avro.NewUnionSchema([]avro.Schema{avro.NewNullSchema(), avro.NewPrimitiveSchema(avro.Bytes, nil)})
+	m.Require().NoError(err)
+	keyField, err := avro.NewField("key", bytesUnion, internal.WithFieldID(1000))
+	m.Require().NoError(err)
+	oldPartSchema, err := avro.NewRecordSchema("r102", "", []*avro.Field{keyField})
+	m.Require().NoError(err)
+	entrySchema, err := internal.NewManifestEntrySchema(oldPartSchema, 2)
+	m.Require().NoError(err)
+
+	mw := ManifestWriter{version: 2, spec: spec, schema: schema, content: ManifestContentData}
+	md, err := mw.meta()
+	m.Require().NoError(err)
+
+	snapshotID := int64(1)
+	seqNum := int64(1)
+	df, err := NewDataFileBuilder(spec, EntryContentData, "s3://bucket/data/old.parquet", ParquetFile,
+		map[int]any{1000: fixedValue}, map[int]avro.LogicalType{}, map[int]int{}, 5, 5_000)
+	m.Require().NoError(err)
+	entry := NewManifestEntry(EntryStatusADDED, &snapshotID, &seqNum, &seqNum, df.Build())
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(entrySchema, &buf,
+		ocf.WithSchemaMarshaler(ocf.FullSchemaMarshaler),
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+		ocf.WithMetadata(md),
+		ocf.WithCodec(ocf.Deflate),
+	)
+	m.Require().NoError(err)
+	m.Require().NoError(enc.Encode(entry))
+	m.Require().NoError(enc.Close())
+
+	// Wrap in a minimal ManifestFile so ReadManifest can verify version/content.
+	mf := NewManifestFile(2, "s3://bucket/meta/old.avro", int64(buf.Len()), 1, snapshotID).Build()
+
+	entries, err := ReadManifest(mf, &buf, false)
+	m.Require().NoError(err)
+	m.Require().Len(entries, 1)
+
+	// Old-code manifests carry a bytes-typed partition; the reader must hand
+	// the value back as []byte without panicking or corrupting the value.
+	partitionMap := entries[0].DataFile().Partition()
+	got, ok := partitionMap[1000].([]byte)
+	m.Require().True(ok, "old bytes-encoded fixed partition should decode as []byte, got %T", partitionMap[1000])
+	m.Equal(fixedValue, got)
+}
+
 func (m *ManifestTestSuite) TestWriteManifestClosesWriterOnEntryError() {
 	partitionSpec := NewPartitionSpecID(1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -24,6 +24,15 @@ import (
 	"github.com/hamba/avro/v2"
 )
 
+// fixedSchemaName returns the deterministic Avro named-type used for
+// Iceberg FixedType partition columns of the given byte length. Using a
+// stable, length-qualified name makes the union encoding self-describing
+// (hamba/avro encodes fixed branches in a union as {"<name>": [N]byte})
+// and keeps the schema spec-compliant.
+func fixedSchemaName(size int) string {
+	return fmt.Sprintf("fixed_%d", size)
+}
+
 func partitionTypeToAvroSchema(t *StructType) (avro.Schema, error) {
 	fields := make([]*avro.Field, len(t.FieldList))
 	for i, f := range t.FieldList {
@@ -54,10 +63,11 @@ func partitionTypeToAvroSchema(t *StructType) (avro.Schema, error) {
 		case BinaryType:
 			sc = internal.NullableSchema(internal.BinarySchema)
 		case FixedType:
-			// Currently the hamba/avro library couldn't resolve the [n]byte array types for fixed schemas in unions.
-			// https://github.com/hamba/avro/issues/571
-			// TODO: Create the proper Fixed Schema for Avro that can match the use case
-			sc = internal.NullableSchema(internal.BinarySchema)
+			fixedSchema, err := avro.NewFixedSchema(fixedSchemaName(typ.len), "", typ.len, nil)
+			if err != nil {
+				return nil, fmt.Errorf("fixed partition column %q: %w", f.Name, err)
+			}
+			sc = internal.NullableSchema(fixedSchema)
 		case DecimalType:
 			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
 			sc = internal.NullableSchema(decimalSchema)

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -57,7 +57,11 @@ func partitionTypeToAvroSchemaNonNullable(t *StructType) (avro.Schema, error) {
 		case BinaryType:
 			sc = internal.BinarySchema
 		case FixedType:
-			sc = internal.BinarySchema
+			fixedSchema, err := avro.NewFixedSchema(fixedSchemaName(typ.len), "", typ.len, nil)
+			if err != nil {
+				return nil, fmt.Errorf("fixed partition column %q: %w", f.Name, err)
+			}
+			sc = fixedSchema
 		case DecimalType:
 			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
 			sc = decimalSchema
@@ -146,4 +150,53 @@ func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {
 		require.Error(t, err, "expected marshal to fail when values are nil for non-nullable schema")
 		assert.Empty(t, encoded)
 	})
+}
+
+// TestFixedPartitionColumnAvroSchema exercises the full encode/decode path
+// for a FixedType partition column. Before #845 was fixed the partition
+// schema emitted Avro "bytes" (a spec violation); the round-trip here
+// pins the behaviour to a true Avro "fixed" branch.
+func TestFixedPartitionColumnAvroSchema(t *testing.T) {
+	partitionType := &StructType{
+		FieldList: []NestedField{
+			{ID: 1, Name: "fixed_col", Type: FixedType{len: 8}, Required: false},
+		},
+	}
+
+	sc, err := partitionTypeToAvroSchema(partitionType)
+	require.NoError(t, err)
+
+	// The partition schema must describe the column as Avro "fixed", not
+	// "bytes" — that is the entire point of #845. Introspect the union
+	// branch and verify both the type and the size.
+	recSchema, ok := sc.(*avro.RecordSchema)
+	require.True(t, ok)
+	require.Len(t, recSchema.Fields(), 1)
+	union, ok := recSchema.Fields()[0].Type().(*avro.UnionSchema)
+	require.True(t, ok, "fixed partition column must be a nullable union")
+	var fixedSchema *avro.FixedSchema
+	for _, branch := range union.Types() {
+		if fs, ok := branch.(*avro.FixedSchema); ok {
+			fixedSchema = fs
+
+			break
+		}
+	}
+	require.NotNil(t, fixedSchema, "expected a fixed branch in the nullable union")
+	assert.Equal(t, 8, fixedSchema.Size())
+	assert.Equal(t, fixedSchemaName(8), fixedSchema.Name())
+
+	payload := []byte("abcdefgh")
+	encoded, err := avro.Marshal(sc, map[string]any{
+		"fixed_col": convertFixedValue(payload, 8),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	var decoded map[string]any
+	require.NoError(t, avro.Unmarshal(sc, encoded, &decoded))
+	unwrapped := unwrapFixedValue(decoded["fixed_col"], 8)
+	got, ok := unwrapped.([]byte)
+	require.True(t, ok, "unwrapped fixed partition value should be []byte, got %T", unwrapped)
+	assert.Equal(t, payload, got)
 }


### PR DESCRIPTION
## Summary

Partition columns of Iceberg `FixedType` were being written into manifest partition schemas as Avro `bytes` with a stale TODO in `schema_conversions.go`, because hamba/avro cannot dispatch `[N]byte` arrays inside a union (hamba/avro#571). That silently produced spec-non-compliant manifests — any compliant reader expects `fixed[N]` for those columns and sees a type mismatch on round-trip.

This PR works around the upstream limitation and emits the correct schema:

* `partitionTypeToAvroSchema` now builds a per-length named fixed schema (`fixed_N`) wrapped in the usual nullable union.
* Track FixedType partition fields in a new `partFieldIDToFixedPartSize` map threaded from `getFieldIDMap` through both `ManifestWriter` and `ManifestReader`. The existing decimal-scale tracking (stored in the misleadingly named `fieldIDToFixedSize`) is unchanged.
* At encode time, `convertFixedValue` pads/truncates the partition `[]byte` to the declared size and hands hamba/avro a `{"fixed_N": [N]byte}` union branch, which it does accept.
* At decode time, `unwrapFixedValue` reverses the wrap back into `[]byte` so downstream Iceberg code keeps its existing slice-based shape.

Fixes #845

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] New regression test `TestFixedPartitionColumnAvroSchema` asserts both the on-wire schema (fixed branch with the right size) and that a non-nil fixed partition value survives encode → decode as the original `[]byte`.

Signed-off-by: Ali <ali@kscope.ai>