### PR TITLE
fix(table): read retention table properties as defaults in ExpireSnapshots

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1726,7 +1726,8 @@ func (t *TableWritingTestSuite) TestExpireSnapshotsUsesTableProperties() {
 			table.PropertyFormatVersion: strconv.Itoa(t.formatVersion),
 			table.MinSnapshotsToKeepKey: "2",
 			table.MaxSnapshotAgeMsKey:   "0", // expire everything older than "now"
-			table.MaxRefAgeMsKey:        strconv.FormatInt(int64(table.MaxRefAgeMsDefault), 10),
+			// max-ref-age-ms is intentionally absent to prove that a missing
+			// property correctly falls back to the math.MaxInt default.
 		})
 	t.Require().NoError(err)
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1705,6 +1705,62 @@ func (t *TableWritingTestSuite) TestExpireSnapshotsNoOpWhenNothingToExpire() {
 		"metadata location should not change when there are no snapshots to expire")
 }
 
+// TestExpireSnapshotsUsesTableProperties verifies that ExpireSnapshots reads
+// min-snapshots-to-keep and max-snapshot-age-ms from table properties when
+// no explicit options are provided by the caller (mirrors Java behaviour).
+func (t *TableWritingTestSuite) TestExpireSnapshotsUsesTableProperties() {
+	fs := iceio.LocalFS{}
+
+	files := make([]string, 0)
+	for i := range 5 {
+		filePath := fmt.Sprintf("%s/expire_props_v%d/data-%d.parquet", t.location, t.formatVersion, i)
+		t.writeParquet(fs, filePath, t.arrTablePromotedTypes)
+		files = append(files, filePath)
+	}
+
+	ident := table.Identifier{"default", "expire_props_v" + strconv.Itoa(t.formatVersion)}
+	// Set table-level retention properties — no caller options will be passed to
+	// ExpireSnapshots, so these must be picked up automatically.
+	meta, err := table.NewMetadata(t.tableSchemaPromotedTypes, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, t.location, iceberg.Properties{
+			table.PropertyFormatVersion: strconv.Itoa(t.formatVersion),
+			table.MinSnapshotsToKeepKey: "2",
+			table.MaxSnapshotAgeMsKey:   "0", // expire everything older than "now"
+			table.MaxRefAgeMsKey:        strconv.FormatInt(int64(table.MaxRefAgeMsDefault), 10),
+		})
+	t.Require().NoError(err)
+
+	ctx := context.Background()
+
+	tbl := table.New(
+		ident,
+		meta,
+		t.getMetadataLoc(),
+		func(ctx context.Context) (iceio.IO, error) {
+			return fs, nil
+		},
+		&mockedCatalog{meta},
+	)
+
+	for i := range 5 {
+		tx := tbl.NewTransaction()
+		t.Require().NoError(tx.AddFiles(ctx, files[i:i+1], nil, false))
+		tbl, err = tx.Commit(ctx)
+		t.Require().NoError(err)
+	}
+
+	t.Require().Equal(5, len(tbl.Metadata().Snapshots()))
+
+	// Call ExpireSnapshots with NO options — must rely entirely on table properties.
+	tx := tbl.NewTransaction()
+	t.Require().NoError(tx.ExpireSnapshots())
+	tbl, err = tx.Commit(ctx)
+	t.Require().NoError(err)
+
+	// min-snapshots-to-keep=2, so exactly 2 snapshots should survive.
+	t.Require().Equal(2, len(tbl.Metadata().Snapshots()))
+}
+
 func (t *TableWritingTestSuite) TestExpireSnapshotsWithMissingParent() {
 	// This test validates the fix for handling missing parent snapshots.
 	// After expiring snapshots, remaining snapshots may have parent-snapshot-id

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -220,6 +220,15 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 		opt(&cfg)
 	}
 
+	// Read table-level retention properties as the last-resort defaults,
+	// mirroring the Java implementation. When neither the ref nor the
+	// caller provides a value, fall back to the table property; when the
+	// table property is also absent use the constant default (math.MaxInt,
+	// meaning "keep everything").
+	propMaxRefAgeMs := int64(t.meta.props.GetInt(MaxRefAgeMsKey, MaxRefAgeMsDefault))
+	propMinSnapshotsToKeep := t.meta.props.GetInt(MinSnapshotsToKeepKey, MinSnapshotsToKeepDefault)
+	propMaxSnapshotAgeMs := int64(t.meta.props.GetInt(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault))
+
 	for refName, ref := range t.meta.refs {
 		// Assert that this ref's snapshot ID hasn't changed concurrently.
 		// This ensures we don't accidentally expire snapshots that are now
@@ -236,10 +245,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 			return err
 		}
 
-		maxRefAgeMs := cmp.Or(ref.MaxRefAgeMs, cfg.maxSnapshotAgeMs)
-		if maxRefAgeMs == nil {
-			return errors.New("cannot find a valid value for maxRefAgeMs")
-		}
+		maxRefAgeMs := cmp.Or(ref.MaxRefAgeMs, cfg.maxSnapshotAgeMs, &propMaxRefAgeMs)
 
 		refAge := nowMs - snap.TimestampMs
 		if refAge > *maxRefAgeMs && refName != MainBranch {
@@ -249,13 +255,9 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 		}
 
 		var (
-			minSnapshotsToKeep = cmp.Or(ref.MinSnapshotsToKeep, cfg.minSnapshotsToKeep)
-			maxSnapshotAgeMs   = cmp.Or(ref.MaxSnapshotAgeMs, cfg.maxSnapshotAgeMs)
+			minSnapshotsToKeep = cmp.Or(ref.MinSnapshotsToKeep, cfg.minSnapshotsToKeep, &propMinSnapshotsToKeep)
+			maxSnapshotAgeMs   = cmp.Or(ref.MaxSnapshotAgeMs, cfg.maxSnapshotAgeMs, &propMaxSnapshotAgeMs)
 		)
-
-		if minSnapshotsToKeep == nil || maxSnapshotAgeMs == nil {
-			return errors.New("cannot find a valid value for minSnapshotsToKeep and maxSnapshotAgeMs")
-		}
 
 		if ref.SnapshotRefType != BranchRef {
 			snapsToKeep[ref.SnapshotID] = struct{}{}


### PR DESCRIPTION
## Summary

`ExpireSnapshots` required callers to always pass `WithRetainLast` and `WithOlderThan`; it never consulted the table-level retention properties (`min-snapshots-to-keep`, `max-snapshot-age-ms`, `max-ref-age-ms`), even though their keys and defaults are defined in `properties.go`. Tables that set these properties via a catalog would not honor them during snapshot expiry, diverging from the Java implementation.

**Fix:** read the three retention properties from table metadata and use them as the last-resort fallback in the `cmp.Or` chains for `maxRefAgeMs`, `minSnapshotsToKeep`, and `maxSnapshotAgeMs`. When a property is absent the `math.MaxInt` constants apply, preserving current behaviour for callers that pass explicit options.

Fixes #839

## Test plan

- [x] `go test ./...`
- [x] `gofmt -l` clean
- [x] New test `TestExpireSnapshotsUsesTableProperties`: creates a table with `min-snapshots-to-keep=2` and `max-snapshot-age-ms=0` set as properties, calls `ExpireSnapshots()` with no options, and asserts exactly 2 snapshots survive.

Signed-off-by: Ali <alliasgher123@gmail.com>