### PR TITLE
feat(table): wire bloom filter properties into Parquet writer

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -275,6 +275,9 @@ func (parquetFormat) GetWriteProperties(props iceberg.Properties) any {
 		if !ok || colName == "" {
 			continue
 		}
+		// EqualFold matches Java's Boolean.parseBoolean: only "true"
+		// (case-insensitive) is true; anything else, including "1" or
+		// "yes", is false. strconv.ParseBool behaves differently ("1" → true).
 		enabled := strings.EqualFold(val, "true")
 		writerProps = append(writerProps, parquet.WithBloomFilterEnabledFor(colName, enabled))
 	}

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -259,8 +259,27 @@ func (parquetFormat) GetWriteProperties(props iceberg.Properties) any {
 		slog.Warn("unrecognized compression codec, falling back to uncompressed", "codec", compression)
 	}
 
-	return append(writerProps, parquet.WithCompression(codec),
+	writerProps = append(writerProps, parquet.WithCompression(codec),
 		parquet.WithCompressionLevel(compressionLevel))
+
+	// Bloom filter properties.
+	// write.parquet.bloom-filter-max-bytes caps the per-column bloom filter size.
+	bloomMaxBytes := props.GetInt(ParquetBloomFilterMaxBytesKey, ParquetBloomFilterMaxBytesDefault)
+	writerProps = append(writerProps, parquet.WithMaxBloomFilterBytes(int64(bloomMaxBytes)))
+
+	// write.parquet.bloom-filter-enabled.column.<col-name> enables bloom filters
+	// for individual columns. Scan all properties for the prefix.
+	prefix := ParquetBloomFilterColumnEnabledKeyPrefix + "."
+	for key, val := range props {
+		colName, ok := strings.CutPrefix(key, prefix)
+		if !ok || colName == "" {
+			continue
+		}
+		enabled := strings.EqualFold(val, "true")
+		writerProps = append(writerProps, parquet.WithBloomFilterEnabledFor(colName, enabled))
+	}
+
+	return writerProps
 }
 
 func (p parquetFormat) WriteDataFile(ctx context.Context, fs iceio.WriteFileIO, partitionValues map[int]any, info WriteFileInfo, batches []arrow.RecordBatch) (iceberg.DataFile, error) {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -715,6 +715,7 @@ func TestGetWritePropertiesBloomFilter(t *testing.T) {
 		wp := parquet.NewWriterProperties(format.GetWriteProperties(props).([]parquet.WriterProperty)...)
 		assert.True(t, wp.BloomFilterEnabledFor("id"))
 		assert.False(t, wp.BloomFilterEnabledFor("name"))
+		assert.False(t, wp.BloomFilterEnabledFor("unmentioned_col"), "columns absent from properties must default to no bloom filter")
 	})
 }
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -691,6 +691,33 @@ func TestGetWritePropertiesPageVersion(t *testing.T) {
 	}
 }
 
+func TestGetWritePropertiesBloomFilter(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	t.Run("default max bloom filter bytes", func(t *testing.T) {
+		wp := parquet.NewWriterProperties(format.GetWriteProperties(iceberg.Properties{}).([]parquet.WriterProperty)...)
+		assert.Equal(t, int64(internal.ParquetBloomFilterMaxBytesDefault), wp.MaxBloomFilterBytes())
+	})
+
+	t.Run("custom max bloom filter bytes", func(t *testing.T) {
+		props := iceberg.Properties{
+			internal.ParquetBloomFilterMaxBytesKey: "2097152",
+		}
+		wp := parquet.NewWriterProperties(format.GetWriteProperties(props).([]parquet.WriterProperty)...)
+		assert.Equal(t, int64(2097152), wp.MaxBloomFilterBytes())
+	})
+
+	t.Run("per-column bloom filter enabled", func(t *testing.T) {
+		props := iceberg.Properties{
+			internal.ParquetBloomFilterColumnEnabledKeyPrefix + ".id":   "true",
+			internal.ParquetBloomFilterColumnEnabledKeyPrefix + ".name": "false",
+		}
+		wp := parquet.NewWriterProperties(format.GetWriteProperties(props).([]parquet.WriterProperty)...)
+		assert.True(t, wp.BloomFilterEnabledFor("id"))
+		assert.False(t, wp.BloomFilterEnabledFor("name"))
+	})
+}
+
 func TestParquetBatchSizeFromTableProperties(t *testing.T) {
 	t.Run("default batch size when no properties in context", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
## Summary

`GetWriteProperties` read compression, page size, row group size etc. but silently ignored the two bloom filter properties defined in the same file:

- `write.parquet.bloom-filter-max-bytes` — caps the per-column bloom filter size (default 1 MB)
- `write.parquet.bloom-filter-enabled.column.<name>` — enables bloom filters per column

Wire them through to the Arrow Parquet writer:

- `WithMaxBloomFilterBytes` is always applied (defaults to the existing `ParquetBloomFilterMaxBytesDefault` constant).
- All table properties whose key starts with `write.parquet.bloom-filter-enabled.column.` are scanned; for each match `WithBloomFilterEnabledFor` is called with the column name and parsed boolean.

Fixes #844

## Test plan

- [x] `go test ./...`
- [x] `gofmt` clean
- [x] New `TestGetWritePropertiesBloomFilter` covering default max-bytes, custom max-bytes, and per-column enable/disable.

Signed-off-by: Ali <alliasgher123@gmail.com>