### PR TITLE
fix(schema): reject duplicate field IDs at schema construction

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -80,8 +80,7 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 	// We use a lightweight walker that only inspects IDs and does not
 	// dereference field types, so schemas with nil types (used in some
 	// tests) are not affected.
-	seen := make(map[int]string)
-	if err := checkDuplicateFieldIDs(seen, fields); err != nil {
+	if err := checkDuplicateFieldIDs(nil, fields); err != nil {
 		panic(err)
 	}
 
@@ -89,8 +88,13 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 }
 
 // checkDuplicateFieldIDs recursively walks a list of fields and returns an
-// error if any field ID appears more than once anywhere in the tree.
+// error if any field ID appears more than once anywhere in the tree. The
+// seen map is lazily created on the first call so the top-level caller can
+// pass nil.
 func checkDuplicateFieldIDs(seen map[int]string, fields []NestedField) error {
+	if seen == nil {
+		seen = make(map[int]string)
+	}
 	for _, f := range fields {
 		// Negative IDs (e.g. -1) are used as unassigned placeholders during
 		// schema construction; only positive IDs must be unique per the spec.

--- a/schema.go
+++ b/schema.go
@@ -76,7 +76,58 @@ func NewSchemaWithIdentifiers(id int, identifierIDs []int, fields ...NestedField
 	s := &Schema{ID: id, fields: fields, IdentifierFieldIDs: identifierIDs}
 	s.init()
 
+	// Eagerly check for duplicate field IDs, mirroring Java's Schema.<init>.
+	// We use a lightweight walker that only inspects IDs and does not
+	// dereference field types, so schemas with nil types (used in some
+	// tests) are not affected.
+	seen := make(map[int]string)
+	if err := checkDuplicateFieldIDs(seen, fields); err != nil {
+		panic(err)
+	}
+
 	return s
+}
+
+// checkDuplicateFieldIDs recursively walks a list of fields and returns an
+// error if any field ID appears more than once anywhere in the tree.
+func checkDuplicateFieldIDs(seen map[int]string, fields []NestedField) error {
+	for _, f := range fields {
+		// Negative IDs (e.g. -1) are used as unassigned placeholders during
+		// schema construction; only positive IDs must be unique per the spec.
+		if f.ID > 0 {
+			if prev, ok := seen[f.ID]; ok {
+				return fmt.Errorf("%w: multiple fields for id %d: %s and %s",
+					ErrInvalidSchema, f.ID, prev, f.Name)
+			}
+			seen[f.ID] = f.Name
+		}
+
+		// Recurse into nested types without touching the type pointer for
+		// primitives — only StructType, ListType, and MapType carry child fields.
+		switch t := f.Type.(type) {
+		case *StructType:
+			if t != nil {
+				if err := checkDuplicateFieldIDs(seen, t.FieldList); err != nil {
+					return err
+				}
+			}
+		case *ListType:
+			if t != nil {
+				elem := t.ElementField()
+				if err := checkDuplicateFieldIDs(seen, []NestedField{elem}); err != nil {
+					return err
+				}
+			}
+		case *MapType:
+			if t != nil {
+				if err := checkDuplicateFieldIDs(seen, []NestedField{t.KeyField(), t.ValueField()}); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *Schema) init() {

--- a/schema_test.go
+++ b/schema_test.go
@@ -934,6 +934,42 @@ func TestIndexByNameDuplicateFieldNames(t *testing.T) {
 	assert.ErrorContains(t, err, "multiple fields for name col")
 }
 
+func TestNewSchemaPanicsOnDuplicateFieldIDs(t *testing.T) {
+	typ := iceberg.PrimitiveTypes.Int32
+
+	// Duplicate at the top level.
+	assert.PanicsWithError(t,
+		"invalid schema: multiple fields for id 1: foo and bar",
+		func() {
+			iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "foo", Type: typ},
+				iceberg.NestedField{ID: 1, Name: "bar", Type: typ},
+			)
+		},
+	)
+
+	// Duplicate inside a nested struct — the case from the bug report.
+	assert.PanicsWithError(t,
+		"invalid schema: multiple fields for id 6: inner_op and inner_req",
+		func() {
+			iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+				iceberg.NestedField{
+					ID:   5,
+					Name: "struct",
+					Type: &iceberg.StructType{
+						FieldList: []iceberg.NestedField{
+							{ID: 6, Name: "inner_op", Type: typ},
+							{ID: 6, Name: "inner_req", Type: typ, Required: true},
+						},
+					},
+					Required: true,
+				},
+			)
+		},
+	)
+}
+
 func TestSanitizeColumnNamesEmptyFieldName(t *testing.T) {
 	sc := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "", Type: iceberg.PrimitiveTypes.String, Required: false},

--- a/schema_test.go
+++ b/schema_test.go
@@ -968,6 +968,62 @@ func TestNewSchemaPanicsOnDuplicateFieldIDs(t *testing.T) {
 			)
 		},
 	)
+
+	// List element ID collides with a top-level field ID.
+	assert.PanicsWithError(t,
+		"invalid schema: multiple fields for id 2: data and element",
+		func() {
+			iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+				iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+				iceberg.NestedField{
+					ID:   3,
+					Name: "items",
+					Type: &iceberg.ListType{ElementID: 2, Element: iceberg.PrimitiveTypes.Int32, ElementRequired: false},
+				},
+			)
+		},
+	)
+
+	// Map key or value ID collides with an existing field ID.
+	assert.PanicsWithError(t,
+		"invalid schema: multiple fields for id 1: id and key",
+		func() {
+			iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+				iceberg.NestedField{
+					ID:   2,
+					Name: "m",
+					Type: &iceberg.MapType{KeyID: 1, ValueID: 3, KeyType: iceberg.PrimitiveTypes.String, ValueType: iceberg.PrimitiveTypes.Int32},
+				},
+			)
+		},
+	)
+
+	// Deeply nested: struct inside a list inside a map, duplicate at depth.
+	assert.PanicsWithError(t,
+		"invalid schema: multiple fields for id 1: id and deep",
+		func() {
+			innerStruct := &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 1, Name: "deep", Type: iceberg.PrimitiveTypes.String},
+				},
+			}
+			iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+				iceberg.NestedField{
+					ID:   2,
+					Name: "m",
+					Type: &iceberg.MapType{
+						KeyID:     3,
+						ValueID:   4,
+						KeyType:   iceberg.PrimitiveTypes.String,
+						ValueType: &iceberg.ListType{ElementID: 5, Element: innerStruct, ElementRequired: false},
+					},
+				},
+			)
+		},
+	)
 }
 
 func TestSanitizeColumnNamesEmptyFieldName(t *testing.T) {


### PR DESCRIPTION
## Summary

`NewSchema` silently accepted multiple fields sharing the same positive integer ID. The Java implementation throws `IllegalArgumentException` at construction time with _"Multiple entries with same key: 6=struct.inner_req and 6=struct.inner_op"_.

Adds `checkDuplicateFieldIDs` — a lightweight recursive walk over `NestedField`, `*StructType`, `*ListType`, and `*MapType` that only reads field IDs without dereferencing type pointers. It is called from `NewSchemaWithIdentifiers` before returning the schema. A duplicate positive ID panics with `ErrInvalidSchema`, consistent with the `indexByName` panic for duplicate field names (schema.go line 851).

Non-positive IDs (`-1` etc. used as "unassigned" placeholders in schema builders) are skipped so existing internal usage is unaffected.

Fixes #593

## Test plan

- [x] `go test ./...`
- [x] `gofmt` clean
- [x] `TestNewSchemaPanicsOnDuplicateFieldIDs`: top-level duplicate + the exact nested-struct case from the bug report.

Signed-off-by: Ali <alliasgher123@gmail.com>