### PR TITLE
fix: emit proper Avro fixed schema for FixedType partition columns (#845)

### DIFF
--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -51,6 +51,10 @@ func DecimalSchema(precision, scale int) avro.Schema {
 		DecimalRequiredBytes(precision), avro.NewDecimalLogicalSchema(precision, scale)))
 }
 
+func FixedSchema(size int) avro.Schema {
+	return Must(avro.NewFixedSchema(fmt.Sprintf("fixed_%d", size), "", size, nil))
+}
+
 var (
 	NullSchema           = avro.NewNullSchema()
 	BoolSchema           = avro.NewPrimitiveSchema(avro.Boolean, nil)

--- a/manifest.go
+++ b/manifest.go
@@ -444,10 +444,14 @@ func getFieldIDMap(sc avro.Schema) (map[string]int, map[int]avro.LogicalType, ma
 		}
 		if ps, ok := avroTyp.(*avro.PrimitiveSchema); ok && ps.Logical() != nil {
 			logicalTypes[fid] = ps.Logical().Type()
-		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok && fs.Logical() != nil {
-			logicalTypes[int(fid)] = fs.Logical().Type()
-			if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
-				fixedSizes[int(fid)] = decimalLogical.Scale()
+		} else if fs, ok := avroTyp.(*avro.FixedSchema); ok {
+			if fs.Logical() != nil {
+				logicalTypes[int(fid)] = fs.Logical().Type()
+				if decimalLogical, ok := fs.Logical().(*avro.DecimalLogicalSchema); ok {
+					fixedSizes[int(fid)] = decimalLogical.Scale()
+				}
+			} else {
+				fixedSizes[int(fid)] = fs.Size()
 			}
 		}
 	}
@@ -1065,8 +1069,9 @@ type ManifestWriter struct {
 	schema  *Schema
 	content ManifestContent
 
-	partFieldNameToID map[string]int
-	partFieldIDToType map[int]avro.LogicalType
+	partFieldNameToID    map[string]int
+	partFieldIDToType    map[int]avro.LogicalType
+	partFieldIDToFixSize map[int]int
 
 	snapshotID    int64
 	addedFiles    int32
@@ -1113,20 +1118,21 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	nameToID, idToType, _ := getFieldIDMap(fileSchema)
+	nameToID, idToType, idToFixSize := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
-		impl:              impl,
-		version:           version,
-		output:            out,
-		spec:              spec,
-		content:           ManifestContentData,
-		schema:            schema,
-		partFieldNameToID: nameToID,
-		partFieldIDToType: idToType,
-		snapshotID:        snapshotID,
-		minSeqNum:         -1,
-		partitions:        make([]map[int]any, 0),
+		impl:                 impl,
+		version:              version,
+		output:               out,
+		spec:                 spec,
+		content:              ManifestContentData,
+		schema:               schema,
+		partFieldNameToID:    nameToID,
+		partFieldIDToType:    idToType,
+		partFieldIDToFixSize: idToFixSize,
+		snapshotID:           snapshotID,
+		minSeqNum:            -1,
+		partitions:           make([]map[int]any, 0),
 	}
 
 	for _, apply := range opts {
@@ -1264,10 +1270,11 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	if setter, ok := entry.DataFile().(hasFieldToIDMap); ok {
 		setter.setFieldNameToIDMap(w.partFieldNameToID)
 		setter.setFieldIDToLogicalTypeMap(w.partFieldIDToType)
+		setter.setFieldIDToFixedSizeMap(w.partFieldIDToFixSize)
 	}
 
 	w.partitions = append(w.partitions, entry.Data.Partition())
-	partitionData := avroPartitionData(entry.Data.Partition(), w.partFieldIDToType)
+	partitionData := avroPartitionData(entry.Data.Partition(), w.partFieldIDToType, w.partFieldIDToFixSize)
 
 	if dataFile, ok := entry.DataFile().(*dataFile); ok {
 		convertedPartitionData := make(map[string]any)
@@ -1637,17 +1644,33 @@ func mapToAvroColMap[K comparable, V any](m map[K]V) *[]colMap[K, V] {
 	return &out
 }
 
-func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType) map[int]any {
+func avroPartitionData(input map[int]any, logicalTypes map[int]avro.LogicalType, fixedSizes map[int]int) map[int]any {
 	out := make(map[int]any)
 	for k, v := range input {
 		if logical, ok := logicalTypes[k]; ok {
 			out[k] = convertLogicalTypeValue(v, logical)
+		} else if size, ok := fixedSizes[k]; ok {
+			out[k] = convertFixedValue(v, size)
 		} else {
 			out[k] = v
 		}
 	}
 
 	return out
+}
+
+func convertFixedValue(v any, size int) any {
+	if v == nil {
+		return map[string]any{"null": nil}
+	}
+
+	if bytes, ok := v.([]byte); ok {
+		fixedArray := convertToFixedArray(padOrTruncateBytes(bytes, size), size)
+
+		return map[string]any{fmt.Sprintf("fixed_%d", size): fixedArray}
+	}
+
+	return v
 }
 
 func convertLogicalTypeValue(v any, logicalType avro.LogicalType) any {
@@ -1876,6 +1899,18 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 			}
 
 			return v
+		}
+	}
+
+	if size, ok := d.fieldIDToFixedSize[fieldID]; ok {
+		if unionMap, ok := v.(map[string]any); ok {
+			key := fmt.Sprintf("fixed_%d", size)
+			if val, ok := unionMap[key]; ok {
+				rv := reflect.ValueOf(val)
+				if rv.Kind() == reflect.Array {
+					return rv.Slice(0, rv.Len()).Bytes()
+				}
+			}
 		}
 	}
 

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -54,10 +54,8 @@ func partitionTypeToAvroSchema(t *StructType) (avro.Schema, error) {
 		case BinaryType:
 			sc = internal.NullableSchema(internal.BinarySchema)
 		case FixedType:
-			// Currently the hamba/avro library couldn't resolve the [n]byte array types for fixed schemas in unions.
-			// https://github.com/hamba/avro/issues/571
-			// TODO: Create the proper Fixed Schema for Avro that can match the use case
-			sc = internal.NullableSchema(internal.BinarySchema)
+			fixedSchema := internal.FixedSchema(typ.Len())
+			sc = internal.NullableSchema(fixedSchema)
 		case DecimalType:
 			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
 			sc = internal.NullableSchema(decimalSchema)

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -57,7 +57,8 @@ func partitionTypeToAvroSchemaNonNullable(t *StructType) (avro.Schema, error) {
 		case BinaryType:
 			sc = internal.BinarySchema
 		case FixedType:
-			sc = internal.BinarySchema
+			fixedSchema := internal.FixedSchema(typ.Len())
+			sc = fixedSchema
 		case DecimalType:
 			decimalSchema := internal.DecimalSchema(typ.precision, typ.scale)
 			sc = decimalSchema
@@ -69,6 +70,73 @@ func partitionTypeToAvroSchemaNonNullable(t *StructType) (avro.Schema, error) {
 	}
 
 	return avro.NewRecordSchema("r102", "", fields)
+}
+
+func TestPartitionTypeToAvroSchemaFixedType(t *testing.T) {
+	partitionType := &StructType{
+		FieldList: []NestedField{
+			{ID: 1, Name: "fixed4_col", Type: FixedType{len: 4}, Required: false},
+			{ID: 2, Name: "fixed16_col", Type: FixedType{len: 16}, Required: false},
+		},
+	}
+
+	schema, err := partitionTypeToAvroSchema(partitionType)
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	rec := schema.(*avro.RecordSchema)
+	require.Len(t, rec.Fields(), 2)
+
+	for _, f := range rec.Fields() {
+		union, ok := f.Type().(*avro.UnionSchema)
+		require.True(t, ok, "field %s should be a union schema", f.Name())
+		require.Len(t, union.Types(), 2)
+
+		fixed, ok := union.Types()[1].(*avro.FixedSchema)
+		require.True(t, ok, "non-null branch of field %s should be avro.FixedSchema, got %T", f.Name(), union.Types()[1])
+
+		switch f.Name() {
+		case "fixed4_col":
+			assert.Equal(t, 4, fixed.Size())
+		case "fixed16_col":
+			assert.Equal(t, 16, fixed.Size())
+		}
+	}
+
+	t.Run("round-trip non-nil fixed data", func(t *testing.T) {
+		data := map[string]any{
+			"fixed4_col":  map[string]any{"fixed_4": [4]byte{0x01, 0x02, 0x03, 0x04}},
+			"fixed16_col": map[string]any{"fixed_16": [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}},
+		}
+
+		encoded, err := avro.Marshal(schema, data)
+		require.NoError(t, err)
+		require.NotEmpty(t, encoded)
+
+		var decoded map[string]any
+		err = avro.Unmarshal(schema, encoded, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, data["fixed4_col"], decoded["fixed4_col"])
+		assert.Equal(t, data["fixed16_col"], decoded["fixed16_col"])
+	})
+
+	t.Run("round-trip nil fixed data", func(t *testing.T) {
+		data := map[string]any{
+			"fixed4_col":  nil,
+			"fixed16_col": nil,
+		}
+
+		encoded, err := avro.Marshal(schema, data)
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		err = avro.Unmarshal(schema, encoded, &decoded)
+		require.NoError(t, err)
+
+		assert.Nil(t, decoded["fixed4_col"])
+		assert.Nil(t, decoded["fixed16_col"])
+	})
 }
 
 func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {


### PR DESCRIPTION
Replace the bytes fallback with avro.NewFixedSchema of the correct size. Update write path to encode []byte as [N]byte fixed arrays, and read path to decode them back. Adds round-trip test for fixed partition columns.