### PR TITLE
fix(table): populate WriteTask.SortOrderID from table metadata (#842)

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1371,7 +1371,7 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 				}
 			}()
 
-			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.props)
+			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.props, meta.defaultSortOrderID)
 
 			return nil
 		})
@@ -1384,7 +1384,7 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 	return dataFiles, nil
 }
 
-func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties) iceberg.DataFile {
+func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties, sortOrderID int) iceberg.DataFile {
 	format := tblutils.FormatFromFileName(filePath)
 	rdr := must(format.Open(ctx, fileIO, filePath))
 	defer rdr.Close()
@@ -1403,6 +1403,7 @@ func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, curre
 		must(computeStatsPlan(currentSchema, props)),
 		must(format.PathToIDMapping(pathToIDSchema)),
 	)
+	statistics.SortOrderID = sortOrderID
 
 	partitionValues := make(map[int]any)
 	if !currentSpec.Equals(*iceberg.UnpartitionedSpec) {

--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -117,6 +117,7 @@ type WriteFileInfo struct {
 	WriteProps       any
 	Content          iceberg.ManifestEntryContent
 	EqualityFieldIDs []int
+	SortOrderID      int
 }
 
 type tablePropertiesContextKey struct{}

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -360,6 +360,7 @@ func (w *ParquetFileWriter) Close() (_ iceberg.DataFile, err error) {
 
 	stats := w.format.DataFileStatsFromMeta(filemeta, w.info.StatsCols, w.colMapping)
 	stats.EqualityFieldIDs = w.info.EqualityFieldIDs
+	stats.SortOrderID = w.info.SortOrderID
 
 	return stats.ToDataFile(w.info.FileSchema, w.info.Spec, w.info.FileName, iceberg.ParquetFile, w.info.Content, w.counter.Count, w.partition), nil
 }

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -206,6 +206,7 @@ type DataFileStatistics struct {
 	ColAggs          map[int]StatsAgg
 	SplitOffsets     []int64
 	EqualityFieldIDs []int
+	SortOrderID      int
 }
 
 func (d *DataFileStatistics) PartitionValue(field iceberg.PartitionField, sc *iceberg.Schema) any {
@@ -313,6 +314,10 @@ func (d *DataFileStatistics) ToDataFile(schema *iceberg.Schema, spec iceberg.Par
 
 	if len(d.EqualityFieldIDs) > 0 {
 		bldr.EqualityFieldIDs(d.EqualityFieldIDs)
+	}
+
+	if d.SortOrderID >= 0 {
+		bldr.SortOrderID(d.SortOrderID)
 	}
 
 	return bldr.Build()

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -62,6 +62,7 @@ type writerFactory struct {
 	countMu               sync.Mutex
 	partitionIDCounter    atomic.Int64
 	mu                    sync.Mutex
+	sortOrderID           int
 }
 
 type writerFactoryOption func(*writerFactory)
@@ -159,6 +160,7 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		format:         format,
 		nextCount:      nextCount,
 		stopCount:      stopCount,
+		sortOrderID:    meta.defaultSortOrderID,
 	}
 	for _, apply := range opts {
 		apply(f)
@@ -207,6 +209,7 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		Spec:             w.currentSpec,
 		Content:          w.content,
 		EqualityFieldIDs: w.equalityFieldIDs,
+		SortOrderID:      w.sortOrderID,
 	}, w.arrowSchema)
 }
 

--- a/table/writer.go
+++ b/table/writer.go
@@ -154,6 +154,7 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 		WriteProps:       w.format.GetWriteProperties(w.props),
 		Spec:             *currentSpec,
 		EqualityFieldIDs: w.equalityFieldIDs,
+		SortOrderID:      w.meta.defaultSortOrderID,
 	}, batches)
 }
 


### PR DESCRIPTION
Thread MetadataBuilder.defaultSortOrderID through WriteFileInfo and DataFileStatistics so that DataFile.SortOrderID() is correctly stamped in manifest entries for all write paths (batch, streaming, add-files).

Added a >= 0 guard in ToDataFile() to safely handle the -1 sentinel used by freshly constructed MetadataBuilders in tests.