### PR TITLE
fix: decode pre-1.4 Java Iceberg legacy manifest list field names (#889)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/substrait-io/substrait-go/v7 v7.6.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/twmb/avro v1.6.0
+	github.com/twmb/avro v1.7.0
 	github.com/twmb/murmur3 v1.1.8
 	github.com/uptrace/bun v1.2.18
 	github.com/uptrace/bun/dialect/mssqldialect v1.2.18

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/substrait-io/substrait-go/v7 v7.6.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/twmb/avro v1.5.0
+	github.com/twmb/avro v1.6.0
 	github.com/twmb/murmur3 v1.1.8
 	github.com/uptrace/bun v1.2.18
 	github.com/uptrace/bun/dialect/mssqldialect v1.2.18

--- a/go.sum
+++ b/go.sum
@@ -621,6 +621,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/twmb/avro v1.5.0 h1:9jmbvVQQBcyWHv/6zS+q5+nmASiR8/GwhKF/sU7u71c=
 github.com/twmb/avro v1.5.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
+github.com/twmb/avro v1.6.0 h1:9oUok2HAI+VJ8XpkVppV+e7Pz7AAcuq2r98gGCYUwGM=
+github.com/twmb/avro v1.6.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uptrace/bun v1.2.18 h1:3HnRcMfS6OBPMG1eSOzlbFJ/X/AyMEJb7rMxE6VQvDU=

--- a/go.sum
+++ b/go.sum
@@ -619,10 +619,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/twmb/avro v1.5.0 h1:9jmbvVQQBcyWHv/6zS+q5+nmASiR8/GwhKF/sU7u71c=
-github.com/twmb/avro v1.5.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
-github.com/twmb/avro v1.6.0 h1:9oUok2HAI+VJ8XpkVppV+e7Pz7AAcuq2r98gGCYUwGM=
-github.com/twmb/avro v1.6.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
+github.com/twmb/avro v1.7.0 h1:5mM+zfbj3REXpwkWjP3DHS89TanFF3wDRtl/wVnOyrA=
+github.com/twmb/avro v1.7.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uptrace/bun v1.2.18 h1:3HnRcMfS6OBPMG1eSOzlbFJ/X/AyMEJb7rMxE6VQvDU=

--- a/manifest.go
+++ b/manifest.go
@@ -192,7 +192,7 @@ func (m *manifestFileV1) toFile() *manifestFile {
 		SeqNumber:       initialSequenceNumber,
 		MinSeqNumber:    initialSequenceNumber,
 		AddedSnapshotID: snapshotID,
-		PartitionList: m.PartitionList,
+		PartitionList:   m.PartitionList,
 	}
 
 	if m.Key != nil {
@@ -314,24 +314,15 @@ func (m *manifestFile) Length() int64                    { return m.Len }
 func (m *manifestFile) PartitionSpecID() int32           { return m.SpecID }
 func (m *manifestFile) ManifestContent() ManifestContent { return m.Content }
 func (m *manifestFile) SnapshotID() int64                { return m.AddedSnapshotID }
-func (m *manifestFile) AddedDataFiles() int32 {
-	return m.AddedFilesCount
-}
-
-func (m *manifestFile) ExistingDataFiles() int32 {
-	return m.ExistingFilesCount
-}
-
-func (m *manifestFile) DeletedDataFiles() int32 {
-	return m.DeletedFilesCount
-}
-func (m *manifestFile) AddedRows() int64      { return m.AddedRowsCount }
-func (m *manifestFile) ExistingRows() int64   { return m.ExistingRowsCount }
-func (m *manifestFile) DeletedRows() int64    { return m.DeletedRowsCount }
-func (m *manifestFile) SequenceNum() int64    { return m.SeqNumber }
-func (m *manifestFile) MinSequenceNum() int64 { return m.MinSeqNumber }
-func (m *manifestFile) KeyMetadata() []byte   { return m.Key }
-
+func (m *manifestFile) AddedDataFiles() int32            { return m.AddedFilesCount }
+func (m *manifestFile) ExistingDataFiles() int32         { return m.ExistingFilesCount }
+func (m *manifestFile) DeletedDataFiles() int32          { return m.DeletedFilesCount }
+func (m *manifestFile) AddedRows() int64                 { return m.AddedRowsCount }
+func (m *manifestFile) ExistingRows() int64              { return m.ExistingRowsCount }
+func (m *manifestFile) DeletedRows() int64               { return m.DeletedRowsCount }
+func (m *manifestFile) SequenceNum() int64               { return m.SeqNumber }
+func (m *manifestFile) MinSequenceNum() int64            { return m.MinSeqNumber }
+func (m *manifestFile) KeyMetadata() []byte              { return m.Key }
 func (m *manifestFile) Partitions() []FieldSummary {
 	if m.PartitionList == nil {
 		return nil
@@ -342,14 +333,8 @@ func (m *manifestFile) Partitions() []FieldSummary {
 
 func (m *manifestFile) FirstRowID() *int64 { return m.FirstRowIDValue }
 
-func (m *manifestFile) HasAddedFiles() bool {
-	return m.AddedFilesCount != 0
-}
-
-func (m *manifestFile) HasExistingFiles() bool {
-	return m.ExistingFilesCount != 0
-}
-
+func (m *manifestFile) HasAddedFiles() bool    { return m.AddedFilesCount != 0 }
+func (m *manifestFile) HasExistingFiles() bool { return m.ExistingFilesCount != 0 }
 func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error) {
 	return fetchManifestEntries(m, fs, discardDeleted)
 }
@@ -500,6 +485,22 @@ var manifestFileV1Reader = avro.MustSchemaFor[manifestFileV1](
 var manifestFileReader = avro.MustSchemaFor[manifestFile](
 	avro.WithName("manifest_file"),
 )
+
+func decodeV1Manifests(rd *ocf.Reader) ([]ManifestFile, error) {
+	results := make([]ManifestFile, 0)
+	for {
+		tmp := new(manifestFileV1)
+		if err := rd.Decode(tmp); err != nil {
+			if errors.Is(err, io.EOF) {
+				return results, nil
+			}
+
+			return nil, err
+		}
+
+		results = append(results, tmp.toFile())
+	}
+}
 
 func decodeManifests[I interface {
 	ManifestFile
@@ -806,19 +807,7 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 	}
 
 	if version == 1 {
-		results := make([]ManifestFile, 0)
-		for {
-			tmp := new(manifestFileV1)
-			if err := rd.Decode(tmp); err != nil {
-				if errors.Is(err, io.EOF) {
-					return results, nil
-				}
-
-				return nil, err
-			}
-
-			results = append(results, tmp.toFile())
-		}
+		return decodeV1Manifests(rd)
 	}
 
 	return decodeManifests[*manifestFile](rd, version)

--- a/manifest.go
+++ b/manifest.go
@@ -173,12 +173,15 @@ func (f *fallbackManifestFileV1) toFile() *manifestFile {
 
 type manifestFileV1 struct {
 	manifestFile
-	AddedFilesCount    *int32 `avro:"added_files_count"`
-	ExistingFilesCount *int32 `avro:"existing_files_count"`
-	DeletedFilesCount  *int32 `avro:"deleted_files_count"`
-	AddedRowsCount     *int64 `avro:"added_rows_count"`
-	ExistingRowsCount  *int64 `avro:"existing_rows_count"`
-	DeletedRowsCount   *int64 `avro:"deleted_rows_count"`
+	AddedFilesCount        *int32 `avro:"added_files_count"`
+	AddedDataFilesCount    *int32 `avro:"added_data_files_count"` // pre-1.4 Java legacy name
+	ExistingFilesCount     *int32 `avro:"existing_files_count"`
+	ExistingDataFilesCount *int32 `avro:"existing_data_files_count"` // pre-1.4 Java legacy name
+	DeletedFilesCount      *int32 `avro:"deleted_files_count"`
+	DeletedDataFilesCount  *int32 `avro:"deleted_data_files_count"` // pre-1.4 Java legacy name
+	AddedRowsCount         *int64 `avro:"added_rows_count"`
+	ExistingRowsCount      *int64 `avro:"existing_rows_count"`
+	DeletedRowsCount       *int64 `avro:"deleted_rows_count"`
 }
 
 func (m *manifestFileV1) toFile() *manifestFile {
@@ -186,20 +189,35 @@ func (m *manifestFileV1) toFile() *manifestFile {
 	m.Content = ManifestContentData
 	m.SeqNumber, m.MinSeqNumber = initialSequenceNumber, initialSequenceNumber
 
-	if m.AddedFilesCount != nil {
-		m.manifestFile.AddedFilesCount = *m.AddedFilesCount
+	addedCount := m.AddedFilesCount
+	if addedCount == nil {
+		addedCount = m.AddedDataFilesCount
+	}
+
+	if addedCount != nil {
+		m.manifestFile.AddedFilesCount = *addedCount
 	} else {
 		m.manifestFile.AddedFilesCount = -1
 	}
 
-	if m.ExistingFilesCount != nil {
-		m.manifestFile.ExistingFilesCount = *m.ExistingFilesCount
+	existingCount := m.ExistingFilesCount
+	if existingCount == nil {
+		existingCount = m.ExistingDataFilesCount
+	}
+
+	if existingCount != nil {
+		m.manifestFile.ExistingFilesCount = *existingCount
 	} else {
 		m.manifestFile.ExistingFilesCount = -1
 	}
 
-	if m.DeletedFilesCount != nil {
-		m.manifestFile.DeletedFilesCount = *m.DeletedFilesCount
+	deletedCount := m.DeletedFilesCount
+	if deletedCount == nil {
+		deletedCount = m.DeletedDataFilesCount
+	}
+
+	if deletedCount != nil {
+		m.manifestFile.DeletedFilesCount = *deletedCount
 	} else {
 		m.manifestFile.DeletedFilesCount = -1
 	}
@@ -238,27 +256,39 @@ func (m *manifestFileV1) SnapshotID() int64 {
 }
 
 func (m *manifestFileV1) AddedDataFiles() int32 {
-	if m.AddedFilesCount == nil {
-		return 0
+	if m.AddedFilesCount != nil {
+		return *m.AddedFilesCount
 	}
 
-	return *m.AddedFilesCount
+	if m.AddedDataFilesCount != nil {
+		return *m.AddedDataFilesCount
+	}
+
+	return 0
 }
 
 func (m *manifestFileV1) ExistingDataFiles() int32 {
-	if m.ExistingFilesCount == nil {
-		return 0
+	if m.ExistingFilesCount != nil {
+		return *m.ExistingFilesCount
 	}
 
-	return *m.ExistingFilesCount
+	if m.ExistingDataFilesCount != nil {
+		return *m.ExistingDataFilesCount
+	}
+
+	return 0
 }
 
 func (m *manifestFileV1) DeletedDataFiles() int32 {
-	if m.DeletedFilesCount == nil {
-		return 0
+	if m.DeletedFilesCount != nil {
+		return *m.DeletedFilesCount
 	}
 
-	return *m.DeletedFilesCount
+	if m.DeletedDataFilesCount != nil {
+		return *m.DeletedDataFilesCount
+	}
+
+	return 0
 }
 
 func (m *manifestFileV1) AddedRows() int64 {
@@ -286,11 +316,27 @@ func (m *manifestFileV1) DeletedRows() int64 {
 }
 
 func (m *manifestFileV1) HasAddedFiles() bool {
-	return m.AddedFilesCount == nil || *m.AddedFilesCount > 0
+	if m.AddedFilesCount != nil {
+		return *m.AddedFilesCount > 0
+	}
+
+	if m.AddedDataFilesCount != nil {
+		return *m.AddedDataFilesCount > 0
+	}
+
+	return true
 }
 
 func (m *manifestFileV1) HasExistingFiles() bool {
-	return m.ExistingFilesCount == nil || *m.ExistingFilesCount > 0
+	if m.ExistingFilesCount != nil {
+		return *m.ExistingFilesCount > 0
+	}
+
+	if m.ExistingDataFilesCount != nil {
+		return *m.ExistingDataFilesCount > 0
+	}
+
+	return true
 }
 
 func (m *manifestFileV1) SequenceNum() int64    { return 0 }
@@ -311,22 +357,25 @@ func (m *manifestFileV1) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manif
 }
 
 type manifestFile struct {
-	Path               string          `avro:"manifest_path"`
-	Len                int64           `avro:"manifest_length"`
-	SpecID             int32           `avro:"partition_spec_id"`
-	Content            ManifestContent `avro:"content"`
-	SeqNumber          int64           `avro:"sequence_number"`
-	MinSeqNumber       int64           `avro:"min_sequence_number"`
-	AddedSnapshotID    int64           `avro:"added_snapshot_id"`
-	AddedFilesCount    int32           `avro:"added_files_count"`
-	ExistingFilesCount int32           `avro:"existing_files_count"`
-	DeletedFilesCount  int32           `avro:"deleted_files_count"`
-	AddedRowsCount     int64           `avro:"added_rows_count"`
-	ExistingRowsCount  int64           `avro:"existing_rows_count"`
-	DeletedRowsCount   int64           `avro:"deleted_rows_count"`
-	PartitionList      *[]FieldSummary `avro:"partitions"`
-	Key                []byte          `avro:"key_metadata"`
-	FirstRowIDValue    *int64          `avro:"first_row_id"`
+	Path                   string          `avro:"manifest_path"`
+	Len                    int64           `avro:"manifest_length"`
+	SpecID                 int32           `avro:"partition_spec_id"`
+	Content                ManifestContent `avro:"content"`
+	SeqNumber              int64           `avro:"sequence_number"`
+	MinSeqNumber           int64           `avro:"min_sequence_number"`
+	AddedSnapshotID        int64           `avro:"added_snapshot_id"`
+	AddedFilesCount        int32           `avro:"added_files_count"`
+	AddedDataFilesCount    int32           `avro:"added_data_files_count"` // pre-1.4 Java legacy name
+	ExistingFilesCount     int32           `avro:"existing_files_count"`
+	ExistingDataFilesCount int32           `avro:"existing_data_files_count"` // pre-1.4 Java legacy name
+	DeletedFilesCount      int32           `avro:"deleted_files_count"`
+	DeletedDataFilesCount  int32           `avro:"deleted_data_files_count"` // pre-1.4 Java legacy name
+	AddedRowsCount         int64           `avro:"added_rows_count"`
+	ExistingRowsCount      int64           `avro:"existing_rows_count"`
+	DeletedRowsCount       int64           `avro:"deleted_rows_count"`
+	PartitionList          *[]FieldSummary `avro:"partitions"`
+	Key                    []byte          `avro:"key_metadata"`
+	FirstRowIDValue        *int64          `avro:"first_row_id"`
 
 	version int `avro:"-"`
 }
@@ -386,15 +435,35 @@ func (m *manifestFile) Length() int64                    { return m.Len }
 func (m *manifestFile) PartitionSpecID() int32           { return m.SpecID }
 func (m *manifestFile) ManifestContent() ManifestContent { return m.Content }
 func (m *manifestFile) SnapshotID() int64                { return m.AddedSnapshotID }
-func (m *manifestFile) AddedDataFiles() int32            { return m.AddedFilesCount }
-func (m *manifestFile) ExistingDataFiles() int32         { return m.ExistingFilesCount }
-func (m *manifestFile) DeletedDataFiles() int32          { return m.DeletedFilesCount }
-func (m *manifestFile) AddedRows() int64                 { return m.AddedRowsCount }
-func (m *manifestFile) ExistingRows() int64              { return m.ExistingRowsCount }
-func (m *manifestFile) DeletedRows() int64               { return m.DeletedRowsCount }
-func (m *manifestFile) SequenceNum() int64               { return m.SeqNumber }
-func (m *manifestFile) MinSequenceNum() int64            { return m.MinSeqNumber }
-func (m *manifestFile) KeyMetadata() []byte              { return m.Key }
+func (m *manifestFile) AddedDataFiles() int32 {
+	if m.AddedFilesCount != 0 {
+		return m.AddedFilesCount
+	}
+
+	return m.AddedDataFilesCount
+}
+
+func (m *manifestFile) ExistingDataFiles() int32 {
+	if m.ExistingFilesCount != 0 {
+		return m.ExistingFilesCount
+	}
+
+	return m.ExistingDataFilesCount
+}
+
+func (m *manifestFile) DeletedDataFiles() int32 {
+	if m.DeletedFilesCount != 0 {
+		return m.DeletedFilesCount
+	}
+
+	return m.DeletedDataFilesCount
+}
+func (m *manifestFile) AddedRows() int64      { return m.AddedRowsCount }
+func (m *manifestFile) ExistingRows() int64   { return m.ExistingRowsCount }
+func (m *manifestFile) DeletedRows() int64    { return m.DeletedRowsCount }
+func (m *manifestFile) SequenceNum() int64    { return m.SeqNumber }
+func (m *manifestFile) MinSequenceNum() int64 { return m.MinSeqNumber }
+func (m *manifestFile) KeyMetadata() []byte   { return m.Key }
 func (m *manifestFile) Partitions() []FieldSummary {
 	if m.PartitionList == nil {
 		return nil
@@ -405,8 +474,14 @@ func (m *manifestFile) Partitions() []FieldSummary {
 
 func (m *manifestFile) FirstRowID() *int64 { return m.FirstRowIDValue }
 
-func (m *manifestFile) HasAddedFiles() bool    { return m.AddedFilesCount != 0 }
-func (m *manifestFile) HasExistingFiles() bool { return m.ExistingFilesCount != 0 }
+func (m *manifestFile) HasAddedFiles() bool {
+	return m.AddedFilesCount != 0 || m.AddedDataFilesCount != 0
+}
+
+func (m *manifestFile) HasExistingFiles() bool {
+	return m.ExistingFilesCount != 0 || m.ExistingDataFilesCount != 0
+}
+
 func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error) {
 	return fetchManifestEntries(m, fs, discardDeleted)
 }

--- a/manifest.go
+++ b/manifest.go
@@ -487,8 +487,6 @@ type ManifestFile interface {
 	setVersion(int)
 }
 
-// fieldSummarySchemaNode is the FieldSummary Avro schema with "r508" as an
-// alias. The alias lets avro.Resolve match the record name used by the
 // manifestFileV1Reader is the Avro reader schema for V1 manifest list entries.
 // It handles both spec-correct field names and pre-1.4 Java Iceberg legacy
 // names (added_data_files_count etc.) via the alias tags on manifestFileV1,

--- a/manifest.go
+++ b/manifest.go
@@ -158,224 +158,103 @@ func (b *ManifestBuilder) Build() ManifestFile {
 	return b.m
 }
 
-type fallbackManifestFileV1 struct {
-	manifestFileV1
-	AddedSnapshotID *int64 `avro:"added_snapshot_id"`
-}
-
-func (f *fallbackManifestFileV1) toFile() *manifestFile {
-	if f.AddedSnapshotID == nil {
-		f.manifestFileV1.AddedSnapshotID = -1
-	}
-
-	return f.manifestFileV1.toFile()
-}
-
+// manifestFileV1 is a read/write struct for V1 manifest list entries.
+// Pointer fields handle nullable Avro types (["null", T] unions).
+// The three count fields carry aliases for pre-1.4 Java Iceberg legacy names
+// (apache/iceberg#5338) so that avro.Resolve maps them transparently.
 type manifestFileV1 struct {
-	manifestFile
-	AddedFilesCount        *int32 `avro:"added_files_count"`
-	AddedDataFilesCount    *int32 `avro:"added_data_files_count"` // pre-1.4 Java legacy name
-	ExistingFilesCount     *int32 `avro:"existing_files_count"`
-	ExistingDataFilesCount *int32 `avro:"existing_data_files_count"` // pre-1.4 Java legacy name
-	DeletedFilesCount      *int32 `avro:"deleted_files_count"`
-	DeletedDataFilesCount  *int32 `avro:"deleted_data_files_count"` // pre-1.4 Java legacy name
-	AddedRowsCount         *int64 `avro:"added_rows_count"`
-	ExistingRowsCount      *int64 `avro:"existing_rows_count"`
-	DeletedRowsCount       *int64 `avro:"deleted_rows_count"`
+	Path               string          `avro:"manifest_path"`
+	Len                int64           `avro:"manifest_length"`
+	SpecID             int32           `avro:"partition_spec_id"`
+	AddedSnapshotID    *int64          `avro:"added_snapshot_id"`
+	AddedFilesCount    *int32          `avro:"added_files_count,alias=added_data_files_count"`
+	ExistingFilesCount *int32          `avro:"existing_files_count,alias=existing_data_files_count"`
+	DeletedFilesCount  *int32          `avro:"deleted_files_count,alias=deleted_data_files_count"`
+	AddedRowsCount     *int64          `avro:"added_rows_count"`
+	ExistingRowsCount  *int64          `avro:"existing_rows_count"`
+	DeletedRowsCount   *int64          `avro:"deleted_rows_count"`
+	PartitionList      *[]FieldSummary `avro:"partitions"`
+	Key                *[]byte         `avro:"key_metadata"`
 }
 
 func (m *manifestFileV1) toFile() *manifestFile {
-	m.version = 1
-	m.Content = ManifestContentData
-	m.SeqNumber, m.MinSeqNumber = initialSequenceNumber, initialSequenceNumber
-
-	addedCount := m.AddedFilesCount
-	if addedCount == nil {
-		addedCount = m.AddedDataFilesCount
+	snapshotID := int64(-1)
+	if m.AddedSnapshotID != nil {
+		snapshotID = *m.AddedSnapshotID
 	}
 
-	if addedCount != nil {
-		m.manifestFile.AddedFilesCount = *addedCount
+	f := &manifestFile{
+		version:         1,
+		Path:            m.Path,
+		Len:             m.Len,
+		SpecID:          m.SpecID,
+		Content:         ManifestContentData,
+		SeqNumber:       initialSequenceNumber,
+		MinSeqNumber:    initialSequenceNumber,
+		AddedSnapshotID: snapshotID,
+		PartitionList: m.PartitionList,
+	}
+
+	if m.Key != nil {
+		f.Key = *m.Key
+	}
+
+	if m.AddedFilesCount != nil {
+		f.AddedFilesCount = *m.AddedFilesCount
 	} else {
-		m.manifestFile.AddedFilesCount = -1
+		f.AddedFilesCount = -1
 	}
 
-	existingCount := m.ExistingFilesCount
-	if existingCount == nil {
-		existingCount = m.ExistingDataFilesCount
-	}
-
-	if existingCount != nil {
-		m.manifestFile.ExistingFilesCount = *existingCount
+	if m.ExistingFilesCount != nil {
+		f.ExistingFilesCount = *m.ExistingFilesCount
 	} else {
-		m.manifestFile.ExistingFilesCount = -1
+		f.ExistingFilesCount = -1
 	}
 
-	deletedCount := m.DeletedFilesCount
-	if deletedCount == nil {
-		deletedCount = m.DeletedDataFilesCount
-	}
-
-	if deletedCount != nil {
-		m.manifestFile.DeletedFilesCount = *deletedCount
+	if m.DeletedFilesCount != nil {
+		f.DeletedFilesCount = *m.DeletedFilesCount
 	} else {
-		m.manifestFile.DeletedFilesCount = -1
+		f.DeletedFilesCount = -1
 	}
 
 	if m.AddedRowsCount != nil {
-		m.manifestFile.AddedRowsCount = *m.AddedRowsCount
+		f.AddedRowsCount = *m.AddedRowsCount
 	} else {
-		m.manifestFile.AddedRowsCount = -1
+		f.AddedRowsCount = -1
 	}
 
 	if m.ExistingRowsCount != nil {
-		m.manifestFile.ExistingRowsCount = *m.ExistingRowsCount
+		f.ExistingRowsCount = *m.ExistingRowsCount
 	} else {
-		m.manifestFile.ExistingRowsCount = -1
+		f.ExistingRowsCount = -1
 	}
 
 	if m.DeletedRowsCount != nil {
-		m.manifestFile.DeletedRowsCount = *m.DeletedRowsCount
+		f.DeletedRowsCount = *m.DeletedRowsCount
 	} else {
-		m.manifestFile.DeletedRowsCount = -1
+		f.DeletedRowsCount = -1
 	}
 
-	return &m.manifestFile
-}
-
-func (*manifestFileV1) Version() int             { return 1 }
-func (m *manifestFileV1) FilePath() string       { return m.Path }
-func (m *manifestFileV1) Length() int64          { return m.Len }
-func (m *manifestFileV1) PartitionSpecID() int32 { return m.SpecID }
-func (m *manifestFileV1) ManifestContent() ManifestContent {
-	return ManifestContentData
-}
-
-func (m *manifestFileV1) SnapshotID() int64 {
-	return m.AddedSnapshotID
-}
-
-func (m *manifestFileV1) AddedDataFiles() int32 {
-	if m.AddedFilesCount != nil {
-		return *m.AddedFilesCount
-	}
-
-	if m.AddedDataFilesCount != nil {
-		return *m.AddedDataFilesCount
-	}
-
-	return 0
-}
-
-func (m *manifestFileV1) ExistingDataFiles() int32 {
-	if m.ExistingFilesCount != nil {
-		return *m.ExistingFilesCount
-	}
-
-	if m.ExistingDataFilesCount != nil {
-		return *m.ExistingDataFilesCount
-	}
-
-	return 0
-}
-
-func (m *manifestFileV1) DeletedDataFiles() int32 {
-	if m.DeletedFilesCount != nil {
-		return *m.DeletedFilesCount
-	}
-
-	if m.DeletedDataFilesCount != nil {
-		return *m.DeletedDataFilesCount
-	}
-
-	return 0
-}
-
-func (m *manifestFileV1) AddedRows() int64 {
-	if m.AddedRowsCount == nil {
-		return 0
-	}
-
-	return *m.AddedRowsCount
-}
-
-func (m *manifestFileV1) ExistingRows() int64 {
-	if m.ExistingRowsCount == nil {
-		return 0
-	}
-
-	return *m.ExistingRowsCount
-}
-
-func (m *manifestFileV1) DeletedRows() int64 {
-	if m.DeletedRowsCount == nil {
-		return 0
-	}
-
-	return *m.DeletedRowsCount
-}
-
-func (m *manifestFileV1) HasAddedFiles() bool {
-	if m.AddedFilesCount != nil {
-		return *m.AddedFilesCount > 0
-	}
-
-	if m.AddedDataFilesCount != nil {
-		return *m.AddedDataFilesCount > 0
-	}
-
-	return true
-}
-
-func (m *manifestFileV1) HasExistingFiles() bool {
-	if m.ExistingFilesCount != nil {
-		return *m.ExistingFilesCount > 0
-	}
-
-	if m.ExistingDataFilesCount != nil {
-		return *m.ExistingDataFilesCount > 0
-	}
-
-	return true
-}
-
-func (m *manifestFileV1) SequenceNum() int64    { return 0 }
-func (m *manifestFileV1) MinSequenceNum() int64 { return 0 }
-func (m *manifestFileV1) KeyMetadata() []byte   { return m.Key }
-func (m *manifestFileV1) Partitions() []FieldSummary {
-	if m.PartitionList == nil {
-		return nil
-	}
-
-	return *m.PartitionList
-}
-
-func (*manifestFileV1) FirstRowID() *int64 { return nil }
-
-func (m *manifestFileV1) FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error) {
-	return fetchManifestEntries(m, fs, discardDeleted)
+	return f
 }
 
 type manifestFile struct {
-	Path                   string          `avro:"manifest_path"`
-	Len                    int64           `avro:"manifest_length"`
-	SpecID                 int32           `avro:"partition_spec_id"`
-	Content                ManifestContent `avro:"content"`
-	SeqNumber              int64           `avro:"sequence_number"`
-	MinSeqNumber           int64           `avro:"min_sequence_number"`
-	AddedSnapshotID        int64           `avro:"added_snapshot_id"`
-	AddedFilesCount        int32           `avro:"added_files_count"`
-	AddedDataFilesCount    int32           `avro:"added_data_files_count"` // pre-1.4 Java legacy name
-	ExistingFilesCount     int32           `avro:"existing_files_count"`
-	ExistingDataFilesCount int32           `avro:"existing_data_files_count"` // pre-1.4 Java legacy name
-	DeletedFilesCount      int32           `avro:"deleted_files_count"`
-	DeletedDataFilesCount  int32           `avro:"deleted_data_files_count"` // pre-1.4 Java legacy name
-	AddedRowsCount         int64           `avro:"added_rows_count"`
-	ExistingRowsCount      int64           `avro:"existing_rows_count"`
-	DeletedRowsCount       int64           `avro:"deleted_rows_count"`
-	PartitionList          *[]FieldSummary `avro:"partitions"`
-	Key                    []byte          `avro:"key_metadata"`
-	FirstRowIDValue        *int64          `avro:"first_row_id"`
+	Path               string          `avro:"manifest_path"`
+	Len                int64           `avro:"manifest_length"`
+	SpecID             int32           `avro:"partition_spec_id"`
+	Content            ManifestContent `avro:"content"`
+	SeqNumber          int64           `avro:"sequence_number"`
+	MinSeqNumber       int64           `avro:"min_sequence_number"`
+	AddedSnapshotID    int64           `avro:"added_snapshot_id"`
+	AddedFilesCount    int32           `avro:"added_files_count,alias=added_data_files_count"`
+	ExistingFilesCount int32           `avro:"existing_files_count,alias=existing_data_files_count"`
+	DeletedFilesCount  int32           `avro:"deleted_files_count,alias=deleted_data_files_count"`
+	AddedRowsCount     int64           `avro:"added_rows_count"`
+	ExistingRowsCount  int64           `avro:"existing_rows_count"`
+	DeletedRowsCount   int64           `avro:"deleted_rows_count"`
+	PartitionList      *[]FieldSummary `avro:"partitions"`
+	Key                []byte          `avro:"key_metadata"`
+	FirstRowIDValue    *int64          `avro:"first_row_id"`
 
 	version int `avro:"-"`
 }
@@ -388,9 +267,9 @@ func (m *manifestFile) toV1(v1file *manifestFileV1) {
 	v1file.Path = m.Path
 	v1file.Len = m.Len
 	v1file.SpecID = m.SpecID
-	v1file.AddedSnapshotID = m.AddedSnapshotID
+	v1file.AddedSnapshotID = &m.AddedSnapshotID
 	v1file.PartitionList = m.PartitionList
-	v1file.Key = m.Key
+	v1file.Key = &m.Key
 
 	if m.AddedFilesCount >= 0 {
 		v1file.AddedFilesCount = &m.AddedFilesCount
@@ -436,27 +315,15 @@ func (m *manifestFile) PartitionSpecID() int32           { return m.SpecID }
 func (m *manifestFile) ManifestContent() ManifestContent { return m.Content }
 func (m *manifestFile) SnapshotID() int64                { return m.AddedSnapshotID }
 func (m *manifestFile) AddedDataFiles() int32 {
-	if m.AddedFilesCount != 0 {
-		return m.AddedFilesCount
-	}
-
-	return m.AddedDataFilesCount
+	return m.AddedFilesCount
 }
 
 func (m *manifestFile) ExistingDataFiles() int32 {
-	if m.ExistingFilesCount != 0 {
-		return m.ExistingFilesCount
-	}
-
-	return m.ExistingDataFilesCount
+	return m.ExistingFilesCount
 }
 
 func (m *manifestFile) DeletedDataFiles() int32 {
-	if m.DeletedFilesCount != 0 {
-		return m.DeletedFilesCount
-	}
-
-	return m.DeletedDataFilesCount
+	return m.DeletedFilesCount
 }
 func (m *manifestFile) AddedRows() int64      { return m.AddedRowsCount }
 func (m *manifestFile) ExistingRows() int64   { return m.ExistingRowsCount }
@@ -464,6 +331,7 @@ func (m *manifestFile) DeletedRows() int64    { return m.DeletedRowsCount }
 func (m *manifestFile) SequenceNum() int64    { return m.SeqNumber }
 func (m *manifestFile) MinSequenceNum() int64 { return m.MinSeqNumber }
 func (m *manifestFile) KeyMetadata() []byte   { return m.Key }
+
 func (m *manifestFile) Partitions() []FieldSummary {
 	if m.PartitionList == nil {
 		return nil
@@ -475,11 +343,11 @@ func (m *manifestFile) Partitions() []FieldSummary {
 func (m *manifestFile) FirstRowID() *int64 { return m.FirstRowIDValue }
 
 func (m *manifestFile) HasAddedFiles() bool {
-	return m.AddedFilesCount != 0 || m.AddedDataFilesCount != 0
+	return m.AddedFilesCount != 0
 }
 
 func (m *manifestFile) HasExistingFiles() bool {
-	return m.ExistingFilesCount != 0 || m.ExistingDataFilesCount != 0
+	return m.ExistingFilesCount != 0
 }
 
 func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) ([]ManifestEntry, error) {
@@ -619,27 +487,37 @@ type ManifestFile interface {
 	setVersion(int)
 }
 
-type fallbackManifest[T any] interface {
-	ManifestFile
-	toFile() *manifestFile
-	*T
-}
+// fieldSummarySchemaNode is the FieldSummary Avro schema with "r508" as an
+// alias. The alias lets avro.Resolve match the record name used by the
+// internal manifest list schemas.
+var fieldSummarySchemaNode = func() avro.SchemaNode {
+	n := avro.MustSchemaFor[FieldSummary]().Root()
+	n.Aliases = []string{"r508"}
 
-func decodeManifestsWithFallback[P fallbackManifest[T], T any](rd *ocf.Reader) ([]ManifestFile, error) {
-	results := make([]ManifestFile, 0)
-	for {
-		tmp := P(new(T))
-		if err := rd.Decode(tmp); err != nil {
-			if errors.Is(err, io.EOF) {
-				return results, nil
-			}
+	return n
+}()
 
-			return nil, err
-		}
+// manifestFileV1Reader is the Avro reader schema for V1 manifest list entries.
+// It handles both spec-correct field names and pre-1.4 Java Iceberg legacy
+// names (added_data_files_count etc.) via the alias tags on manifestFileV1,
+// and both nullable and non-nullable added_snapshot_id via *int64.
+var manifestFileV1Reader = avro.MustSchemaFor[manifestFileV1](
+	avro.WithName("manifest_file"),
+	avro.CustomType{
+		GoType: reflect.TypeOf(FieldSummary{}),
+		Schema: &fieldSummarySchemaNode,
+	},
+)
 
-		results = append(results, tmp.toFile())
-	}
-}
+// manifestFileReader is the Avro reader schema for V2+ manifest list entries.
+// Alias tags on manifestFile handle pre-1.4 Java Iceberg legacy field names.
+var manifestFileReader = avro.MustSchemaFor[manifestFile](
+	avro.WithName("manifest_file"),
+	avro.CustomType{
+		GoType: reflect.TypeOf(FieldSummary{}),
+		Schema: &fieldSummarySchemaNode,
+	},
+)
 
 func decodeManifests[I interface {
 	ManifestFile
@@ -922,43 +800,46 @@ func ReadManifest(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestE
 // "format-version" metadata key (only manifest files are). When the key is
 // absent, version 1 is assumed.
 func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
-	rd, err := ocf.NewReader(in)
-	if err != nil {
-		return nil, err
-	}
+	var version int
 
-	sc, err := avro.Parse(string(rd.Metadata()["avro.schema"]))
-	if err != nil {
-		return nil, err
-	}
+	rd, err := ocf.NewReader(in, ocf.WithReaderSchemaFunc(func(rd *ocf.Reader) (*avro.Schema, error) {
+		version = 1
+		if raw := rd.Metadata()["format-version"]; len(raw) > 0 {
+			v, err := strconv.Atoi(string(raw))
+			if err != nil {
+				return nil, fmt.Errorf("invalid format-version: %w", err)
+			}
 
-	version := 1
-	if raw := rd.Metadata()["format-version"]; len(raw) > 0 {
-		version, err = strconv.Atoi(string(raw))
-		if err != nil {
-			return nil, fmt.Errorf("invalid format-version: %w", err)
+			version = v
 		}
+
+		if version == 1 {
+			return manifestFileV1Reader, nil
+		}
+
+		return manifestFileReader, nil
+	}))
+	if err != nil {
+		return nil, err
 	}
 
 	if version == 1 {
-		root := sc.Root()
-		for _, f := range root.Fields {
-			if f.Name == "added_snapshot_id" {
-				if f.Type.Type == "union" {
-					return decodeManifestsWithFallback[*fallbackManifestFileV1](rd)
+		results := make([]ManifestFile, 0)
+		for {
+			tmp := new(manifestFileV1)
+			if err := rd.Decode(tmp); err != nil {
+				if errors.Is(err, io.EOF) {
+					return results, nil
 				}
 
-				break
+				return nil, err
 			}
+
+			results = append(results, tmp.toFile())
 		}
 	}
 
-	switch version {
-	case 1:
-		return decodeManifestsWithFallback[*manifestFileV1](rd)
-	default:
-		return decodeManifests[*manifestFile](rd, version)
-	}
+	return decodeManifests[*manifestFile](rd, version)
 }
 
 type writerImpl interface {

--- a/manifest.go
+++ b/manifest.go
@@ -149,7 +149,7 @@ func (b *ManifestBuilder) Partitions(p []FieldSummary) *ManifestBuilder {
 }
 
 func (b *ManifestBuilder) KeyMetadata(km []byte) *ManifestBuilder {
-	b.m.Key = km
+	b.m.Key = &km
 
 	return b
 }
@@ -193,10 +193,7 @@ func (m *manifestFileV1) toFile() *manifestFile {
 		MinSeqNumber:    initialSequenceNumber,
 		AddedSnapshotID: snapshotID,
 		PartitionList:   m.PartitionList,
-	}
-
-	if m.Key != nil {
-		f.Key = *m.Key
+		Key:             m.Key,
 	}
 
 	if m.AddedFilesCount != nil {
@@ -253,7 +250,7 @@ type manifestFile struct {
 	ExistingRowsCount  int64           `avro:"existing_rows_count"`
 	DeletedRowsCount   int64           `avro:"deleted_rows_count"`
 	PartitionList      *[]FieldSummary `avro:"partitions,type-alias=r508"`
-	Key                []byte          `avro:"key_metadata"`
+	Key                *[]byte         `avro:"key_metadata"`
 	FirstRowIDValue    *int64          `avro:"first_row_id"`
 
 	version int `avro:"-"`
@@ -269,7 +266,7 @@ func (m *manifestFile) toV1(v1file *manifestFileV1) {
 	v1file.SpecID = m.SpecID
 	v1file.AddedSnapshotID = &m.AddedSnapshotID
 	v1file.PartitionList = m.PartitionList
-	v1file.Key = &m.Key
+	v1file.Key = m.Key
 
 	if m.AddedFilesCount >= 0 {
 		v1file.AddedFilesCount = &m.AddedFilesCount
@@ -322,7 +319,14 @@ func (m *manifestFile) ExistingRows() int64              { return m.ExistingRows
 func (m *manifestFile) DeletedRows() int64               { return m.DeletedRowsCount }
 func (m *manifestFile) SequenceNum() int64               { return m.SeqNumber }
 func (m *manifestFile) MinSequenceNum() int64            { return m.MinSeqNumber }
-func (m *manifestFile) KeyMetadata() []byte              { return m.Key }
+func (m *manifestFile) KeyMetadata() []byte {
+	if m.Key == nil {
+		return nil
+	}
+
+	return *m.Key
+}
+
 func (m *manifestFile) Partitions() []FieldSummary {
 	if m.PartitionList == nil {
 		return nil

--- a/manifest.go
+++ b/manifest.go
@@ -173,7 +173,7 @@ type manifestFileV1 struct {
 	AddedRowsCount     *int64          `avro:"added_rows_count"`
 	ExistingRowsCount  *int64          `avro:"existing_rows_count"`
 	DeletedRowsCount   *int64          `avro:"deleted_rows_count"`
-	PartitionList      *[]FieldSummary `avro:"partitions"`
+	PartitionList      *[]FieldSummary `avro:"partitions,type-alias=r508"`
 	Key                *[]byte         `avro:"key_metadata"`
 }
 
@@ -252,7 +252,7 @@ type manifestFile struct {
 	AddedRowsCount     int64           `avro:"added_rows_count"`
 	ExistingRowsCount  int64           `avro:"existing_rows_count"`
 	DeletedRowsCount   int64           `avro:"deleted_rows_count"`
-	PartitionList      *[]FieldSummary `avro:"partitions"`
+	PartitionList      *[]FieldSummary `avro:"partitions,type-alias=r508"`
 	Key                []byte          `avro:"key_metadata"`
 	FirstRowIDValue    *int64          `avro:"first_row_id"`
 
@@ -489,34 +489,18 @@ type ManifestFile interface {
 
 // fieldSummarySchemaNode is the FieldSummary Avro schema with "r508" as an
 // alias. The alias lets avro.Resolve match the record name used by the
-// internal manifest list schemas.
-var fieldSummarySchemaNode = func() avro.SchemaNode {
-	n := avro.MustSchemaFor[FieldSummary]().Root()
-	n.Aliases = []string{"r508"}
-
-	return n
-}()
-
 // manifestFileV1Reader is the Avro reader schema for V1 manifest list entries.
 // It handles both spec-correct field names and pre-1.4 Java Iceberg legacy
 // names (added_data_files_count etc.) via the alias tags on manifestFileV1,
 // and both nullable and non-nullable added_snapshot_id via *int64.
 var manifestFileV1Reader = avro.MustSchemaFor[manifestFileV1](
 	avro.WithName("manifest_file"),
-	avro.CustomType{
-		GoType: reflect.TypeOf(FieldSummary{}),
-		Schema: &fieldSummarySchemaNode,
-	},
 )
 
 // manifestFileReader is the Avro reader schema for V2+ manifest list entries.
 // Alias tags on manifestFile handle pre-1.4 Java Iceberg legacy field names.
 var manifestFileReader = avro.MustSchemaFor[manifestFile](
 	avro.WithName("manifest_file"),
-	avro.CustomType{
-		GoType: reflect.TypeOf(FieldSummary{}),
-		Schema: &fieldSummarySchemaNode,
-	},
 )
 
 func decodeManifests[I interface {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -821,8 +821,7 @@ func writeLegacyManifestListV1(t *testing.T) bytes.Buffer {
 	}
 
 	var buf bytes.Buffer
-	enc, err := ocf.NewEncoderWithSchema(sc, &buf,
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}))
+	enc, err := ocf.NewWriter(&buf, sc, ocf.WithSchema(schemaJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -899,8 +898,8 @@ func writeLegacyManifestListV2(t *testing.T) bytes.Buffer {
 	}
 
 	var buf bytes.Buffer
-	enc, err := ocf.NewEncoderWithSchema(sc, &buf,
-		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+	enc, err := ocf.NewWriter(&buf, sc,
+		ocf.WithSchema(schemaJSON),
 		ocf.WithMetadata(map[string][]byte{"format-version": []byte("2")}))
 	if err != nil {
 		t.Fatal(err)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -780,6 +780,185 @@ func (m *ManifestTestSuite) TestReadManifestListV3() {
 	m.Equal([]byte{0x02, 0x00, 0x00, 0x00}, *part.UpperBound)
 }
 
+// writeLegacyManifestListV1 creates a V1 manifest list OCF using the pre-1.4 Java
+// Iceberg field names (added_data_files_count etc.) as writer schema field names.
+func writeLegacyManifestListV1(t *testing.T) bytes.Buffer {
+	t.Helper()
+
+	const schemaJSON = `{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path", "type": "string", "field-id": 500},
+			{"name": "manifest_length", "type": "long", "field-id": 501},
+			{"name": "partition_spec_id", "type": "int", "field-id": 502},
+			{"name": "added_snapshot_id", "type": "long", "field-id": 503},
+			{"name": "added_data_files_count", "type": ["null", "int"], "default": null, "field-id": 504},
+			{"name": "existing_data_files_count", "type": ["null", "int"], "default": null, "field-id": 505},
+			{"name": "deleted_data_files_count", "type": ["null", "int"], "default": null, "field-id": 506},
+			{"name": "added_rows_count", "type": ["null", "long"], "default": null, "field-id": 512},
+			{"name": "existing_rows_count", "type": ["null", "long"], "default": null, "field-id": 513},
+			{"name": "deleted_rows_count", "type": ["null", "long"], "default": null, "field-id": 514}
+		]
+	}`
+
+	type legacyRecord struct {
+		Path                   string `avro:"manifest_path"`
+		Len                    int64  `avro:"manifest_length"`
+		SpecID                 int32  `avro:"partition_spec_id"`
+		AddedSnapshotID        int64  `avro:"added_snapshot_id"`
+		AddedDataFilesCount    *int32 `avro:"added_data_files_count"`
+		ExistingDataFilesCount *int32 `avro:"existing_data_files_count"`
+		DeletedDataFilesCount  *int32 `avro:"deleted_data_files_count"`
+		AddedRowsCount         *int64 `avro:"added_rows_count"`
+		ExistingRowsCount      *int64 `avro:"existing_rows_count"`
+		DeletedRowsCount       *int64 `avro:"deleted_rows_count"`
+	}
+
+	sc, err := avro.Parse(schemaJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(sc, &buf,
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added := int32(3)
+	existing := int32(1)
+	deleted := int32(2)
+	addedR := int64(100)
+
+	if err := enc.Encode(legacyRecord{
+		Path:                   "/path/to/manifest.avro",
+		Len:                    1234,
+		SpecID:                 0,
+		AddedSnapshotID:        snapshotID,
+		AddedDataFilesCount:    &added,
+		ExistingDataFilesCount: &existing,
+		DeletedDataFilesCount:  &deleted,
+		AddedRowsCount:         &addedR,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}
+
+// writeLegacyManifestListV2 creates a V2 manifest list OCF using the pre-1.4 Java
+// Iceberg field names (added_data_files_count etc.) as writer schema field names.
+func writeLegacyManifestListV2(t *testing.T) bytes.Buffer {
+	t.Helper()
+
+	const schemaJSON = `{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path", "type": "string", "field-id": 500},
+			{"name": "manifest_length", "type": "long", "field-id": 501},
+			{"name": "partition_spec_id", "type": "int", "field-id": 502},
+			{"name": "content", "type": "int", "field-id": 517},
+			{"name": "sequence_number", "type": "long", "field-id": 515},
+			{"name": "min_sequence_number", "type": "long", "field-id": 516},
+			{"name": "added_snapshot_id", "type": "long", "field-id": 503},
+			{"name": "added_data_files_count", "type": "int", "field-id": 504},
+			{"name": "existing_data_files_count", "type": "int", "field-id": 505},
+			{"name": "deleted_data_files_count", "type": "int", "field-id": 506},
+			{"name": "added_rows_count", "type": "long", "field-id": 512},
+			{"name": "existing_rows_count", "type": "long", "field-id": 513},
+			{"name": "deleted_rows_count", "type": "long", "field-id": 514}
+		]
+	}`
+
+	type legacyRecord struct {
+		Path                   string `avro:"manifest_path"`
+		Len                    int64  `avro:"manifest_length"`
+		SpecID                 int32  `avro:"partition_spec_id"`
+		Content                int32  `avro:"content"`
+		SeqNumber              int64  `avro:"sequence_number"`
+		MinSeqNumber           int64  `avro:"min_sequence_number"`
+		AddedSnapshotID        int64  `avro:"added_snapshot_id"`
+		AddedDataFilesCount    int32  `avro:"added_data_files_count"`
+		ExistingDataFilesCount int32  `avro:"existing_data_files_count"`
+		DeletedDataFilesCount  int32  `avro:"deleted_data_files_count"`
+		AddedRowsCount         int64  `avro:"added_rows_count"`
+		ExistingRowsCount      int64  `avro:"existing_rows_count"`
+		DeletedRowsCount       int64  `avro:"deleted_rows_count"`
+	}
+
+	sc, err := avro.Parse(schemaJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoderWithSchema(sc, &buf,
+		ocf.WithEncoderSchemaCache(&avro.SchemaCache{}),
+		ocf.WithMetadata(map[string][]byte{"format-version": []byte("2")}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := enc.Encode(legacyRecord{
+		Path:                   "/path/to/manifest.avro",
+		Len:                    1234,
+		SpecID:                 0,
+		Content:                0,
+		SeqNumber:              3,
+		MinSeqNumber:           3,
+		AddedSnapshotID:        snapshotID,
+		AddedDataFilesCount:    3,
+		ExistingDataFilesCount: 1,
+		DeletedDataFilesCount:  2,
+		AddedRowsCount:         100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf
+}
+
+// TestReadManifestListLegacyFieldNamesV1 verifies that V1 manifest lists written
+// by pre-1.4 Java Iceberg (with added_data_files_count etc.) are decoded correctly.
+func (m *ManifestTestSuite) TestReadManifestListLegacyFieldNamesV1() {
+	buf := writeLegacyManifestListV1(m.T())
+	list, err := ReadManifestList(&buf)
+	m.Require().NoError(err)
+	m.Len(list, 1)
+	m.Equal(1, list[0].Version())
+	m.EqualValues(3, list[0].AddedDataFiles())
+	m.True(list[0].HasAddedFiles())
+	m.EqualValues(1, list[0].ExistingDataFiles())
+	m.True(list[0].HasExistingFiles())
+	m.EqualValues(2, list[0].DeletedDataFiles())
+}
+
+// TestReadManifestListLegacyFieldNamesV2 verifies that V2 manifest lists written
+// by pre-1.4 Java Iceberg (with added_data_files_count etc.) are decoded correctly.
+func (m *ManifestTestSuite) TestReadManifestListLegacyFieldNamesV2() {
+	buf := writeLegacyManifestListV2(m.T())
+	list, err := ReadManifestList(&buf)
+	m.Require().NoError(err)
+	m.Len(list, 1)
+	m.Equal(2, list[0].Version())
+	m.EqualValues(3, list[0].AddedDataFiles())
+	m.True(list[0].HasAddedFiles())
+	m.EqualValues(1, list[0].ExistingDataFiles())
+	m.True(list[0].HasExistingFiles())
+	m.EqualValues(2, list[0].DeletedDataFiles())
+}
+
 // writeManifestListNoFormatVersion writes a valid v2 manifest list Avro file that
 // omits the "format-version" metadata key, simulating a file produced by a
 // non-Java Iceberg implementation that strictly follows the spec.


### PR DESCRIPTION
Iceberg Java used added_data_files_count, existing_data_files_count, and deleted_data_files_count as manifest list field names (IDs 504/505/506) until apache/iceberg#5338 renamed them to match the spec in the 1.4 release.

Tables written before that fix, or by engines still on older Java versions (Athena, some Trino deployments), embed the legacy names in the writer schema of every manifest list OCF file. When iceberg-go read such a file, hamba/avro could not match writer-schema fields to struct tags and silently left the three count fields at zero.

Zero counts caused HasAddedFiles() and HasExistingFiles() to return false, which broke fast-append manifest inheritance and caused Table.Scan() to return no data.

Fix: add parallel struct fields with the legacy avro tags to manifestFileV1 and manifestFile. Accessors coalesce — preferring the spec-correct name, falling back to the legacy name. No write-path or schema-registration changes are made.

Adds two tests (V1 and V2) that write raw Avro OCF using the pre-1.4 field names and assert the counts decode correctly.

Fixes #889 