### PR TITLE
feat(table): bloom filter scan pruning for Parquet row groups (#834)

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -402,9 +402,19 @@ func (as *arrowScan) processRecords(
 
 	switch task.Value.File.FileFormat() {
 	case iceberg.ParquetFile:
-		testRowGroups, err = newParquetRowGroupStatsEvaluator(fileSchema, as.boundRowFilter, false)
+		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, as.boundRowFilter, false)
 		if err != nil {
 			return err
+		}
+
+		bloomPreds, err := newBloomFilterPredicates(as.boundRowFilter)
+		if err != nil {
+			return err
+		}
+
+		testRowGroups = &internal.ParquetRowGroupTester{
+			StatsFn:    statsFn,
+			BloomPreds: bloomPreds,
 		}
 	}
 

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -18,7 +18,6 @@
 package table
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math"
 	"slices"
@@ -1567,90 +1566,67 @@ func (m *strictMetricsEval) canContainNans(fieldID int) bool {
 }
 
 // literalToPhysBytes converts an Iceberg literal to the physical byte
-// representation that the Parquet bloom filter writer hashes. The encoding
-// must match Arrow's internal getBytes[T] (little-endian for numerics, raw
-// bytes for byte-array types).
-func literalToPhysBytes(typ iceberg.PrimitiveType, lit iceberg.Literal) ([]byte, bool) {
-	switch typ.(type) {
-	case iceberg.Int32Type:
-		v := lit.(iceberg.TypedLiteral[int32]).Value()
-		b := make([]byte, 4)
-		binary.LittleEndian.PutUint32(b, uint32(v))
+// representation that the Parquet bloom filter writer hashes, using the
+// literal's MarshalBinary encoding. Float types are normalized before
+// encoding (-0.0 → 0.0, NaN → canonical NaN) to match Parquet/Java writer
+// behavior and avoid false-negative bloom filter results.
+func literalToPhysBytes(lit iceberg.Literal) ([]byte, bool) {
+	switch v := lit.(type) {
+	case iceberg.Float32Literal:
+		// Normalize: -0.0 and 0.0 have different bit patterns, so without this
+		// a query for 0.0 won't match a row group where -0.0 was written.
+		f := float32(v)
+		if f == 0 {
+			f = 0
+		} else if math.IsNaN(float64(f)) {
+			f = float32(math.NaN())
+		}
 
-		return b, true
+		lit = iceberg.Float32Literal(f)
 
-	case iceberg.DateType:
-		v := lit.(iceberg.TypedLiteral[iceberg.Date]).Value()
-		b := make([]byte, 4)
-		binary.LittleEndian.PutUint32(b, uint32(v))
+	case iceberg.Float64Literal:
+		f := float64(v)
+		if f == 0 {
+			f = 0
+		} else if math.IsNaN(f) {
+			f = math.NaN()
+		}
 
-		return b, true
+		lit = iceberg.Float64Literal(f)
 
-	case iceberg.Int64Type:
-		v := lit.(iceberg.TypedLiteral[int64]).Value()
-		b := make([]byte, 8)
-		binary.LittleEndian.PutUint64(b, uint64(v))
+	case iceberg.BoolLiteral:
+		// Low cardinality; bloom filters not useful.
+		return nil, false
 
-		return b, true
+	case iceberg.DecimalLiteral:
+		// Physical representation depends on precision (INT32/INT64/FIXED_LEN_BYTE_ARRAY).
+		// TODO: add decimal bloom filter support once schema-level precision lookup is wired in.
+		_ = v
 
-	case iceberg.TimeType:
-		v := lit.(iceberg.TypedLiteral[iceberg.Time]).Value()
-		b := make([]byte, 8)
-		binary.LittleEndian.PutUint64(b, uint64(v))
+		return nil, false
 
-		return b, true
+	case iceberg.TimestampNsLiteral:
+		// Not yet handled by all expression machinery; skip for safety.
+		_ = v
 
-	case iceberg.TimestampType, iceberg.TimestampTzType:
-		v := lit.(iceberg.TypedLiteral[iceberg.Timestamp]).Value()
-		b := make([]byte, 8)
-		binary.LittleEndian.PutUint64(b, uint64(v))
-
-		return b, true
-
-	case iceberg.Float32Type:
-		v := lit.(iceberg.TypedLiteral[float32]).Value()
-		b := make([]byte, 4)
-		binary.LittleEndian.PutUint32(b, math.Float32bits(v))
-
-		return b, true
-
-	case iceberg.Float64Type:
-		v := lit.(iceberg.TypedLiteral[float64]).Value()
-		b := make([]byte, 8)
-		binary.LittleEndian.PutUint64(b, math.Float64bits(v))
-
-		return b, true
-
-	case iceberg.StringType:
-		v := lit.(iceberg.TypedLiteral[string]).Value()
-
-		return []byte(v), true
-
-	case iceberg.BinaryType:
-		v := lit.(iceberg.TypedLiteral[[]byte]).Value()
-
-		return v, true
-
-	case iceberg.UUIDType:
-		v := lit.(iceberg.TypedLiteral[uuid.UUID]).Value()
-
-		return v[:], true
-
-	case iceberg.FixedType:
-		v := lit.(iceberg.TypedLiteral[[]byte]).Value()
-
-		return v, true
-
-	default:
-		// BooleanType: low cardinality, bloom filters not effective.
-		// DecimalType: physical representation depends on precision
-		//   (INT32 for p≤9, INT64 for p≤18, FIXED_LEN_BYTE_ARRAY otherwise).
-		//   TODO: add decimal bloom filter support once schema-level precision
-		//   lookup is wired in.
-		// TimestampNsType / TimestampTzNsType: literal type is TimestampNano
-		//   which is not yet handled by all expression machinery; skip for safety.
 		return nil, false
 	}
+
+	type binaryMarshaler interface {
+		MarshalBinary() ([]byte, error)
+	}
+
+	m, ok := lit.(binaryMarshaler)
+	if !ok {
+		return nil, false
+	}
+
+	b, err := m.MarshalBinary()
+	if err != nil {
+		return nil, false
+	}
+
+	return b, true
 }
 
 // bloomPredicateCollector walks a bound expression and collects EqualTo/In
@@ -1683,12 +1659,11 @@ func (c *bloomPredicateCollector) VisitBound(pred iceberg.BoundPredicate) []inte
 
 func (c *bloomPredicateCollector) VisitEqual(t iceberg.BoundTerm, lit iceberg.Literal) []internal.RowGroupBloomPred {
 	field := t.Ref().Field()
-	typ, ok := field.Type.(iceberg.PrimitiveType)
-	if !ok {
+	if _, ok := field.Type.(iceberg.PrimitiveType); !ok {
 		return nil
 	}
 
-	b, ok := literalToPhysBytes(typ, lit)
+	b, ok := literalToPhysBytes(lit)
 	if !ok {
 		return nil
 	}
@@ -1702,14 +1677,13 @@ func (c *bloomPredicateCollector) VisitIn(t iceberg.BoundTerm, s iceberg.Set[ice
 	}
 
 	field := t.Ref().Field()
-	typ, ok := field.Type.(iceberg.PrimitiveType)
-	if !ok {
+	if _, ok := field.Type.(iceberg.PrimitiveType); !ok {
 		return nil
 	}
 
 	physBytes := make([][]byte, 0, s.Len())
 	for _, lit := range s.Members() {
-		b, ok := literalToPhysBytes(typ, lit)
+		b, ok := literalToPhysBytes(lit)
 		if !ok {
 			return nil
 		}

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -18,12 +18,14 @@
 package table
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
 	"slices"
 
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
 )
 
@@ -1562,4 +1564,213 @@ func (m *strictMetricsEval) canContainNans(fieldID int) bool {
 	cnt, exists := m.nanCounts[fieldID]
 
 	return exists && cnt > 0
+}
+
+// literalToPhysBytes converts an Iceberg literal to the physical byte
+// representation that the Parquet bloom filter writer hashes. The encoding
+// must match Arrow's internal getBytes[T] (little-endian for numerics, raw
+// bytes for byte-array types).
+func literalToPhysBytes(typ iceberg.PrimitiveType, lit iceberg.Literal) ([]byte, bool) {
+	switch typ.(type) {
+	case iceberg.Int32Type:
+		v := lit.(iceberg.TypedLiteral[int32]).Value()
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, uint32(v))
+
+		return b, true
+
+	case iceberg.DateType:
+		v := lit.(iceberg.TypedLiteral[iceberg.Date]).Value()
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, uint32(v))
+
+		return b, true
+
+	case iceberg.Int64Type:
+		v := lit.(iceberg.TypedLiteral[int64]).Value()
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, uint64(v))
+
+		return b, true
+
+	case iceberg.TimeType:
+		v := lit.(iceberg.TypedLiteral[iceberg.Time]).Value()
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, uint64(v))
+
+		return b, true
+
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		v := lit.(iceberg.TypedLiteral[iceberg.Timestamp]).Value()
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, uint64(v))
+
+		return b, true
+
+	case iceberg.Float32Type:
+		v := lit.(iceberg.TypedLiteral[float32]).Value()
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, math.Float32bits(v))
+
+		return b, true
+
+	case iceberg.Float64Type:
+		v := lit.(iceberg.TypedLiteral[float64]).Value()
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, math.Float64bits(v))
+
+		return b, true
+
+	case iceberg.StringType:
+		v := lit.(iceberg.TypedLiteral[string]).Value()
+
+		return []byte(v), true
+
+	case iceberg.BinaryType:
+		v := lit.(iceberg.TypedLiteral[[]byte]).Value()
+
+		return v, true
+
+	case iceberg.UUIDType:
+		v := lit.(iceberg.TypedLiteral[uuid.UUID]).Value()
+
+		return v[:], true
+
+	case iceberg.FixedType:
+		v := lit.(iceberg.TypedLiteral[[]byte]).Value()
+
+		return v, true
+
+	default:
+		// BooleanType: low cardinality, bloom filters not effective.
+		// DecimalType: physical representation depends on precision
+		//   (INT32 for p≤9, INT64 for p≤18, FIXED_LEN_BYTE_ARRAY otherwise).
+		//   TODO: add decimal bloom filter support once schema-level precision
+		//   lookup is wired in.
+		// TimestampNsType / TimestampTzNsType: literal type is TimestampNano
+		//   which is not yet handled by all expression machinery; skip for safety.
+		return nil, false
+	}
+}
+
+// bloomPredicateCollector walks a bound expression and collects EqualTo/In
+// predicates as RowGroupBloomPred values. Only conjuncts (And chains) are
+// collected; Or suppresses collection because a row group can only be skipped
+// when ALL disjuncts are absent — which we do not evaluate here.
+type bloomPredicateCollector struct{}
+
+func (c *bloomPredicateCollector) VisitTrue() []internal.RowGroupBloomPred  { return nil }
+func (c *bloomPredicateCollector) VisitFalse() []internal.RowGroupBloomPred { return nil }
+func (c *bloomPredicateCollector) VisitNot(_ []internal.RowGroupBloomPred) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitAnd(left, right []internal.RowGroupBloomPred) []internal.RowGroupBloomPred {
+	return append(left, right...)
+}
+
+func (c *bloomPredicateCollector) VisitOr(_, _ []internal.RowGroupBloomPred) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitUnbound(_ iceberg.UnboundPredicate) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitBound(pred iceberg.BoundPredicate) []internal.RowGroupBloomPred {
+	return iceberg.VisitBoundPredicate(pred, c)
+}
+
+func (c *bloomPredicateCollector) VisitEqual(t iceberg.BoundTerm, lit iceberg.Literal) []internal.RowGroupBloomPred {
+	field := t.Ref().Field()
+	typ, ok := field.Type.(iceberg.PrimitiveType)
+	if !ok {
+		return nil
+	}
+
+	b, ok := literalToPhysBytes(typ, lit)
+	if !ok {
+		return nil
+	}
+
+	return []internal.RowGroupBloomPred{{FieldID: field.ID, PhysBytes: [][]byte{b}}}
+}
+
+func (c *bloomPredicateCollector) VisitIn(t iceberg.BoundTerm, s iceberg.Set[iceberg.Literal]) []internal.RowGroupBloomPred {
+	if s.Len() > inPredicateLimit {
+		return nil
+	}
+
+	field := t.Ref().Field()
+	typ, ok := field.Type.(iceberg.PrimitiveType)
+	if !ok {
+		return nil
+	}
+
+	physBytes := make([][]byte, 0, s.Len())
+	for _, lit := range s.Members() {
+		b, ok := literalToPhysBytes(typ, lit)
+		if !ok {
+			return nil
+		}
+
+		physBytes = append(physBytes, b)
+	}
+
+	return []internal.RowGroupBloomPred{{FieldID: field.ID, PhysBytes: physBytes}}
+}
+
+func (c *bloomPredicateCollector) VisitNotIn(_ iceberg.BoundTerm, _ iceberg.Set[iceberg.Literal]) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitIsNan(_ iceberg.BoundTerm) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitNotNan(_ iceberg.BoundTerm) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitIsNull(_ iceberg.BoundTerm) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitNotNull(_ iceberg.BoundTerm) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitNotEqual(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitGreaterEqual(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitGreater(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitLessEqual(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitLess(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitStartsWith(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+func (c *bloomPredicateCollector) VisitNotStartsWith(_ iceberg.BoundTerm, _ iceberg.Literal) []internal.RowGroupBloomPred {
+	return nil
+}
+
+// newBloomFilterPredicates walks expr and returns bloom-filter-checkable
+// predicates for row group pruning. Returns nil (no predicates) for
+// AlwaysTrue or any expression with no EqualTo/In conjuncts.
+func newBloomFilterPredicates(expr iceberg.BooleanExpression) ([]internal.RowGroupBloomPred, error) {
+	return iceberg.VisitExpr(expr, &bloomPredicateCollector{})
 }

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding"
 	"fmt"
 	"math"
 	"slices"
@@ -1612,11 +1613,7 @@ func literalToPhysBytes(lit iceberg.Literal) ([]byte, bool) {
 		return nil, false
 	}
 
-	type binaryMarshaler interface {
-		MarshalBinary() ([]byte, error)
-	}
-
-	m, ok := lit.(binaryMarshaler)
+	m, ok := lit.(encoding.BinaryMarshaler)
 	if !ok {
 		return nil, false
 	}

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -2729,3 +2729,113 @@ func TestEvaluators(t *testing.T) {
 	suite.Run(t, &InclusiveMetricsTestSuite{})
 	suite.Run(t, &StrictMetricsTestSuite{})
 }
+
+func TestLiteralToPhysBytes(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Int32, iceberg.Int32Literal(1))
+		require.True(t, ok)
+		assert.Equal(t, []byte{0x01, 0x00, 0x00, 0x00}, b)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Int64, iceberg.Int64Literal(1))
+		require.True(t, ok)
+		assert.Equal(t, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, b)
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Float32, iceberg.Float32Literal(1.0))
+		require.True(t, ok)
+		assert.Equal(t, 4, len(b))
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Float64, iceberg.Float64Literal(1.0))
+		require.True(t, ok)
+		assert.Equal(t, 8, len(b))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.String, iceberg.StringLiteral("hello"))
+		require.True(t, ok)
+		assert.Equal(t, []byte("hello"), b)
+	})
+
+	t.Run("binary", func(t *testing.T) {
+		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Binary, iceberg.BinaryLiteral([]byte{0xDE, 0xAD}))
+		require.True(t, ok)
+		assert.Equal(t, []byte{0xDE, 0xAD}, b)
+	})
+
+	t.Run("boolean_unsupported", func(t *testing.T) {
+		_, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Bool, iceberg.BoolLiteral(true))
+		assert.False(t, ok)
+	})
+}
+
+func TestBloomPredicateCollector(t *testing.T) {
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+
+	bind := func(expr iceberg.BooleanExpression) iceberg.BooleanExpression {
+		rewritten, err := iceberg.RewriteNotExpr(expr)
+		require.NoError(t, err)
+		bound, err := iceberg.BindExpr(sc, rewritten, true)
+		require.NoError(t, err)
+
+		return bound
+	}
+
+	t.Run("EqualTo produces one predicate with one hash entry", func(t *testing.T) {
+		expr := bind(iceberg.EqualTo(iceberg.Reference("id"), int64(42)))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+		assert.Equal(t, 1, preds[0].FieldID)
+		assert.Len(t, preds[0].PhysBytes, 1)
+	})
+
+	t.Run("In produces one predicate with multiple hash entries", func(t *testing.T) {
+		expr := bind(iceberg.IsIn(iceberg.Reference("id"), int64(1), int64(2), int64(3)))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+		assert.Equal(t, 1, preds[0].FieldID)
+		assert.Len(t, preds[0].PhysBytes, 3)
+	})
+
+	t.Run("And merges predicates from both sides", func(t *testing.T) {
+		expr := bind(iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+			iceberg.EqualTo(iceberg.Reference("name"), "alice"),
+		))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		assert.Len(t, preds, 2)
+	})
+
+	t.Run("Or returns nil — cannot prune on disjunction", func(t *testing.T) {
+		expr := bind(iceberg.NewOr(
+			iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+			iceberg.EqualTo(iceberg.Reference("name"), "alice"),
+		))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		assert.Empty(t, preds)
+	})
+
+	t.Run("AlwaysTrue returns nil", func(t *testing.T) {
+		preds, err := newBloomFilterPredicates(iceberg.AlwaysTrue{})
+		require.NoError(t, err)
+		assert.Empty(t, preds)
+	})
+
+	t.Run("range predicate returns nil", func(t *testing.T) {
+		expr := bind(iceberg.GreaterThan(iceberg.Reference("id"), int64(5)))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		assert.Empty(t, preds)
+	})
+}

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -2732,43 +2732,43 @@ func TestEvaluators(t *testing.T) {
 
 func TestLiteralToPhysBytes(t *testing.T) {
 	t.Run("int32", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Int32, iceberg.Int32Literal(1))
+		b, ok := literalToPhysBytes(iceberg.Int32Literal(1))
 		require.True(t, ok)
 		assert.Equal(t, []byte{0x01, 0x00, 0x00, 0x00}, b)
 	})
 
 	t.Run("int64", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Int64, iceberg.Int64Literal(1))
+		b, ok := literalToPhysBytes(iceberg.Int64Literal(1))
 		require.True(t, ok)
 		assert.Equal(t, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, b)
 	})
 
 	t.Run("float32", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Float32, iceberg.Float32Literal(1.0))
+		b, ok := literalToPhysBytes(iceberg.Float32Literal(1.0))
 		require.True(t, ok)
 		assert.Equal(t, 4, len(b))
 	})
 
 	t.Run("float64", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Float64, iceberg.Float64Literal(1.0))
+		b, ok := literalToPhysBytes(iceberg.Float64Literal(1.0))
 		require.True(t, ok)
 		assert.Equal(t, 8, len(b))
 	})
 
 	t.Run("string", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.String, iceberg.StringLiteral("hello"))
+		b, ok := literalToPhysBytes(iceberg.StringLiteral("hello"))
 		require.True(t, ok)
 		assert.Equal(t, []byte("hello"), b)
 	})
 
 	t.Run("binary", func(t *testing.T) {
-		b, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Binary, iceberg.BinaryLiteral([]byte{0xDE, 0xAD}))
+		b, ok := literalToPhysBytes(iceberg.BinaryLiteral([]byte{0xDE, 0xAD}))
 		require.True(t, ok)
 		assert.Equal(t, []byte{0xDE, 0xAD}, b)
 	})
 
 	t.Run("boolean_unsupported", func(t *testing.T) {
-		_, ok := literalToPhysBytes(iceberg.PrimitiveTypes.Bool, iceberg.BoolLiteral(true))
+		_, ok := literalToPhysBytes(iceberg.BoolLiteral(true))
 		assert.False(t, ok)
 	})
 }

--- a/table/internal/export_test.go
+++ b/table/internal/export_test.go
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import "github.com/apache/arrow-go/v18/parquet/pqarrow"
+
+// WrapParquetFileReader exposes wrapPqArrowReader for testing.
+func WrapParquetFileReader(fr *pqarrow.FileReader) FileReader {
+	return wrapPqArrowReader{fr}
+}

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -720,7 +720,7 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 	}
 
 	var rgList []int
-	if rowGroupTester != nil && rowGroupTester.StatsFn != nil {
+	if rowGroupTester != nil && (rowGroupTester.StatsFn != nil || len(rowGroupTester.BloomPreds) > 0) {
 		fileMeta := w.ParquetReader().MetaData()
 		numRg := w.ParquetReader().NumRowGroups()
 
@@ -736,10 +736,16 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 
 		rgList = make([]int, 0)
 		for rg := 0; rg < numRg; rg++ {
-			rgMeta := fileMeta.RowGroup(rg)
-			use, err := rowGroupTester.StatsFn(rgMeta, cols)
-			if err != nil {
-				return nil, err
+			use := true
+
+			if rowGroupTester.StatsFn != nil {
+				rgMeta := fileMeta.RowGroup(rg)
+
+				var err error
+				use, err = rowGroupTester.StatsFn(rgMeta, cols)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			if !use {
@@ -747,6 +753,7 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 			}
 
 			if bfReader != nil {
+				var err error
 				use, err = checkRowGroupBloomFilters(bfReader, rg, fieldIDToColIdx, rowGroupTester.BloomPreds)
 				if err != nil {
 					return nil, err
@@ -788,7 +795,11 @@ func checkRowGroupBloomFilters(
 	preds []RowGroupBloomPred,
 ) (bool, error) {
 	rgBFReader, err := bfReader.RowGroup(rg)
-	if err != nil || rgBFReader == nil {
+	if err != nil {
+		return false, err
+	}
+
+	if rgBFReader == nil {
 		return true, nil
 	}
 

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -673,6 +673,21 @@ type ParquetFileSource struct {
 	file iceberg.DataFile
 }
 
+// RowGroupBloomPred holds the physical-encoded bytes for each literal in a
+// bloom-filterable predicate on one field. A row group can be skipped when
+// NONE of the bytes appear in the column's bloom filter.
+type RowGroupBloomPred struct {
+	FieldID   int
+	PhysBytes [][]byte // one entry for EqualTo; one per value for In
+}
+
+// ParquetRowGroupTester combines stats-based and bloom filter row group pruning.
+// Pass it as the tester argument to wrapPqArrowReader.GetRecords.
+type ParquetRowGroupTester struct {
+	StatsFn    func(*metadata.RowGroupMetaData, []int) (bool, error)
+	BloomPreds []RowGroupBloomPred // nil = no bloom filter pass
+}
+
 type wrapPqArrowReader struct {
 	*pqarrow.FileReader
 }
@@ -694,27 +709,48 @@ func (w wrapPqArrowReader) PrunedSchema(projectedIDs map[int]struct{}, mapping i
 }
 
 func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester any) (array.RecordReader, error) {
-	var (
-		testRg func(*metadata.RowGroupMetaData, []int) (bool, error)
-		ok     bool
-	)
+	var rowGroupTester *ParquetRowGroupTester
 
 	if tester != nil {
-		testRg, ok = tester.(func(*metadata.RowGroupMetaData, []int) (bool, error))
+		var ok bool
+		rowGroupTester, ok = tester.(*ParquetRowGroupTester)
 		if !ok {
-			return nil, fmt.Errorf("%w: invalid tester function", iceberg.ErrInvalidArgument)
+			return nil, fmt.Errorf("%w: invalid tester type", iceberg.ErrInvalidArgument)
 		}
 	}
 
 	var rgList []int
-	if testRg != nil {
+	if rowGroupTester != nil && rowGroupTester.StatsFn != nil {
+		fileMeta := w.ParquetReader().MetaData()
+		numRg := w.ParquetReader().NumRowGroups()
+
+		var (
+			fieldIDToColIdx map[int]int
+			bfReader        *metadata.BloomFilterReader
+		)
+
+		if len(rowGroupTester.BloomPreds) > 0 {
+			fieldIDToColIdx = buildFieldIDToColIdx(fileMeta)
+			bfReader = w.ParquetReader().GetBloomFilterReader()
+		}
+
 		rgList = make([]int, 0)
-		fileMeta, numRg := w.ParquetReader().MetaData(), w.ParquetReader().NumRowGroups()
 		for rg := 0; rg < numRg; rg++ {
 			rgMeta := fileMeta.RowGroup(rg)
-			use, err := testRg(rgMeta, cols)
+			use, err := rowGroupTester.StatsFn(rgMeta, cols)
 			if err != nil {
 				return nil, err
+			}
+
+			if !use {
+				continue
+			}
+
+			if bfReader != nil {
+				use, err = checkRowGroupBloomFilters(bfReader, rg, fieldIDToColIdx, rowGroupTester.BloomPreds)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			if use {
@@ -724,6 +760,65 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 	}
 
 	return w.GetRecordReader(ctx, cols, rgList)
+}
+
+// buildFieldIDToColIdx maps each Iceberg field ID to its 0-based column index in
+// the Parquet file schema. Used to translate bloom filter predicates (which carry
+// field IDs) into the column positions required by BloomFilterReader.
+func buildFieldIDToColIdx(meta *metadata.FileMetaData) map[int]int {
+	sc := meta.Schema
+	result := make(map[int]int, sc.NumColumns())
+	for i := 0; i < sc.NumColumns(); i++ {
+		fieldID := int(sc.Column(i).SchemaNode().FieldID())
+		result[fieldID] = i
+	}
+
+	return result
+}
+
+// checkRowGroupBloomFilters checks each bloom predicate against the bloom filter
+// for its column in row group rg. Returns false (skip) if ANY predicate has none
+// of its values present in the bloom filter. Returns true (keep) on any error or
+// missing bloom filter data — bloom filters are an optimisation, never a
+// correctness gate.
+func checkRowGroupBloomFilters(
+	bfReader *metadata.BloomFilterReader,
+	rg int,
+	fieldIDToColIdx map[int]int,
+	preds []RowGroupBloomPred,
+) (bool, error) {
+	rgBFReader, err := bfReader.RowGroup(rg)
+	if err != nil || rgBFReader == nil {
+		return true, nil
+	}
+
+	for _, pred := range preds {
+		colIdx, ok := fieldIDToColIdx[pred.FieldID]
+		if !ok {
+			continue
+		}
+
+		bf, err := rgBFReader.GetColumnBloomFilter(colIdx)
+		if err != nil || bf == nil {
+			continue
+		}
+
+		hasher := bf.Hasher()
+		anyFound := false
+		for _, physBytes := range pred.PhysBytes {
+			if bf.CheckHash(hasher.Sum64(physBytes)) {
+				anyFound = true
+
+				break
+			}
+		}
+
+		if !anyFound {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func (pfs *ParquetFileSource) GetReader(ctx context.Context) (FileReader, error) {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -20,6 +20,7 @@ package internal_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"strings"
@@ -762,5 +763,187 @@ func TestParquetBatchSizeFromTableProperties(t *testing.T) {
 		ctx := internal.WithTableProperties(context.Background(), props)
 		got := internal.TablePropertiesFromContext(ctx)
 		assert.Equal(t, internal.ParquetBatchSizeDefault, got.GetInt(internal.ParquetBatchSizeKey, internal.ParquetBatchSizeDefault))
+	})
+}
+
+// buildBloomTestParquet writes a Parquet file with two row groups into buf.
+// The single required INT32 column "id" has Iceberg field_id=1 and bloom
+// filters enabled. RG0 holds values [1..rgSize], RG1 holds [rgSize+1..2*rgSize].
+func buildBloomTestParquet(t *testing.T, rgSize int) []byte {
+	t.Helper()
+
+	idNode := schema.NewInt32Node("id", parquet.Repetitions.Required, 1)
+
+	rootNode, err := schema.NewGroupNode("schema", parquet.Repetitions.Required,
+		schema.FieldList{idNode}, -1)
+	require.NoError(t, err)
+
+	writerProps := parquet.NewWriterProperties(
+		parquet.WithStats(true),
+		parquet.WithBloomFilterEnabledFor("id", true),
+	)
+
+	var buf bytes.Buffer
+	pw := file.NewParquetWriter(&buf, rootNode, file.WithWriterProps(writerProps))
+
+	writeRG := func(start, end int) {
+		rgw := pw.AppendRowGroup()
+		cw, werr := rgw.NextColumn()
+		require.NoError(t, werr)
+
+		vals := make([]int32, end-start+1)
+		for i := range vals {
+			vals[i] = int32(start + i)
+		}
+
+		_, werr = cw.(*file.Int32ColumnChunkWriter).WriteBatch(vals, nil, nil)
+		require.NoError(t, werr)
+		require.NoError(t, cw.Close())
+		require.NoError(t, rgw.Close())
+	}
+
+	writeRG(1, rgSize)          // RG0
+	writeRG(rgSize+1, 2*rgSize) // RG1
+
+	require.NoError(t, pw.Close())
+
+	return buf.Bytes()
+}
+
+// openBloomTestReader creates a fresh FileReader from raw Parquet bytes for
+// each subtest call, so row-group state is not shared between subtests.
+func openBloomTestReader(t *testing.T, data []byte) internal.FileReader {
+	t.Helper()
+
+	pqRdr, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	arrRdr, err := pqarrow.NewFileReader(pqRdr, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+
+	return internal.WrapParquetFileReader(arrRdr)
+}
+
+func int32PhysBytes(v int32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, uint32(v))
+
+	return b
+}
+
+func countRecords(t *testing.T, rr array.RecordReader) int64 {
+	t.Helper()
+	defer rr.Release()
+
+	var n int64
+	for rr.Next() {
+		n += rr.RecordBatch().NumRows()
+	}
+
+	return n
+}
+
+// TestBloomFilterRowGroupPruning verifies that ParquetRowGroupTester's bloom
+// filter pass correctly skips row groups that definitively do not contain a
+// queried value, while keeping row groups where the value is present.
+func TestBloomFilterRowGroupPruning(t *testing.T) {
+	const rgSize = 100 // 100 rows per row group
+
+	data := buildBloomTestParquet(t, rgSize)
+
+	// Stats function that always keeps the row group (isolates bloom logic).
+	alwaysKeep := func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) {
+		return true, nil
+	}
+
+	ctx := context.Background()
+	cols := []int{0}
+
+	t.Run("value in RG0 prunes RG1", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn: alwaysKeep,
+			BloomPreds: []internal.RowGroupBloomPred{
+				{FieldID: 1, PhysBytes: [][]byte{int32PhysBytes(50)}}, // 50 is in RG0
+			},
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(rgSize), countRecords(t, rr), "only RG0 rows expected")
+	})
+
+	t.Run("value in RG1 prunes RG0", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn: alwaysKeep,
+			BloomPreds: []internal.RowGroupBloomPred{
+				{FieldID: 1, PhysBytes: [][]byte{int32PhysBytes(150)}}, // 150 is in RG1
+			},
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(rgSize), countRecords(t, rr), "only RG1 rows expected")
+	})
+
+	t.Run("value absent from all row groups skips all", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn: alwaysKeep,
+			BloomPreds: []internal.RowGroupBloomPred{
+				{FieldID: 1, PhysBytes: [][]byte{int32PhysBytes(999)}}, // 999 not in either RG
+			},
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(0), countRecords(t, rr), "no rows expected when value absent")
+	})
+
+	t.Run("In predicate with a value in each RG keeps both", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn: alwaysKeep,
+			BloomPreds: []internal.RowGroupBloomPred{
+				{
+					FieldID: 1,
+					PhysBytes: [][]byte{
+						int32PhysBytes(50),  // in RG0
+						int32PhysBytes(150), // in RG1
+					},
+				},
+			},
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2*rgSize), countRecords(t, rr), "both row groups expected")
+	})
+
+	t.Run("nil bloom preds reads all row groups", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn:    alwaysKeep,
+			BloomPreds: nil,
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2*rgSize), countRecords(t, rr), "all rows expected without bloom preds")
+	})
+
+	t.Run("unknown field ID is ignored and row group kept", func(t *testing.T) {
+		rdr := openBloomTestReader(t, data)
+		tester := &internal.ParquetRowGroupTester{
+			StatsFn: alwaysKeep,
+			BloomPreds: []internal.RowGroupBloomPred{
+				{FieldID: 999, PhysBytes: [][]byte{int32PhysBytes(50)}}, // field 999 does not exist
+			},
+		}
+		rr, err := rdr.GetRecords(ctx, cols, tester)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2*rgSize), countRecords(t, rr), "all rows expected when field ID unknown")
 	})
 }


### PR DESCRIPTION
After stats-based row group filtering, apply an additional bloom filter check for EqualTo and In predicates. Row groups where none of the queried values appear in the column bloom filter are skipped, reducing I/O for selective point lookups.

- Add RowGroupBloomPred and ParquetRowGroupTester types to parquet_files.go; GetRecords runs stats then bloom filter checks per row group using the physical-byte hasher from the bloom filter itself to guarantee algorithm consistency with the writer
- Add literalToPhysBytes and bloomPredicateCollector in evaluators.go to extract bloom-filterable predicates from bound expressions; And merges predicates from both sides, Or suppresses collection
- Wire ParquetRowGroupTester in arrow_scanner.go processRecords
- Add TestBloomFilterRowGroupPruning covering present/absent/In/unknown field ID cases; add TestLiteralToPhysBytes and TestBloomPredicateCollector

 