### PR TITLE
feat(catalog): add `WithOAuthTLSConfig` for separate OAuth server TLS

### DIFF
--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -58,6 +58,19 @@ func WithTLSConfig(config *tls.Config) Option {
 	}
 }
 
+// WithOAuthTLSConfig sets a separate TLS configuration for the HTTP client
+// used to communicate with the OAuth2 server. This is useful when the OAuth2
+// server (oauth2-server-uri) is a different host than the catalog and requires
+// different TLS settings (e.g. a different CA or client certificate).
+//
+// If not set, the OAuth2 client reuses the catalog's HTTP client (and its TLS
+// configuration).
+func WithOAuthTLSConfig(config *tls.Config) Option {
+	return func(o *options) {
+		o.oauthTLSConfig = config
+	}
+}
+
 func WithWarehouseLocation(loc string) Option {
 	return func(o *options) {
 		o.warehouseLocation = loc
@@ -164,6 +177,8 @@ type options struct {
 	resource          string
 	transport         http.RoundTripper
 	headers           map[string]string
+
+	oauthTLSConfig *tls.Config
 
 	additionalProps iceberg.Properties
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -575,7 +575,21 @@ func setupOAuthManager(r *Catalog, cl *http.Client, opts *options) AuthManager {
 
 	// Add skip oauth so we don't get in cycles trying to refresh the token
 	ctx := context.WithValue(context.Background(), skipOAuth, true)
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, cl)
+
+	// If a separate TLS config is provided for the OAuth2 server, create a
+	// dedicated HTTP client for token requests instead of reusing the catalog
+	// client. This is needed when the OAuth2 server is a different host with
+	// different TLS requirements.
+	oauthClient := cl
+	if opts.oauthTLSConfig != nil {
+		oauthClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: opts.oauthTLSConfig,
+			},
+		}
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, oauthClient)
 
 	return &Oauth2AuthManager{
 		tokenSource: cfg.TokenSource(ctx),

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -20,6 +20,8 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
@@ -28,6 +30,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -226,6 +230,135 @@ func TestOAuthTokenRequestParams(t *testing.T) {
 			assert.NotNil(t, cat)
 		})
 	}
+}
+
+func TestOAuthTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	// Helper that returns a config endpoint handler.
+	configHandler := func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{}, "overrides": map[string]any{},
+		})
+	}
+
+	// Helper that returns an oauth token endpoint handler.
+	tokenHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok",
+			"token_type":   "Bearer",
+			"expires_in":   86400,
+		})
+	}
+
+	// generateTLSCert creates a self-signed CA and leaf certificate for
+	// use with an httptest server. The returned tls.Certificate can be
+	// assigned to the server's TLS config, and the CA cert can be added
+	// to a client's root CA pool.
+	generateTLSCert := func(t *testing.T) (tls.Certificate, *x509.Certificate) {
+		t.Helper()
+
+		// Generate a CA key pair.
+		caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		caTemplate := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(time.Hour),
+			KeyUsage:              x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+		require.NoError(t, err)
+		caCert, err := x509.ParseCertificate(caDER)
+		require.NoError(t, err)
+
+		// Generate a leaf certificate signed by this CA.
+		leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		leafTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		}
+		leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+		require.NoError(t, err)
+
+		tlsCert := tls.Certificate{
+			Certificate: [][]byte{leafDER},
+			PrivateKey:  leafKey,
+		}
+
+		return tlsCert, caCert
+	}
+
+	// startTLSServer creates an httptest server using the provided
+	// certificate instead of the default shared one.
+	startTLSServer := func(handler http.Handler, cert tls.Certificate) *httptest.Server {
+		srv := httptest.NewUnstartedServer(handler)
+		srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+		srv.StartTLS()
+
+		return srv
+	}
+
+	catalogCert, catalogCA := generateTLSCert(t)
+	oauthCert, oauthCA := generateTLSCert(t)
+
+	catalogMux := http.NewServeMux()
+	catalogMux.HandleFunc("/v1/config", configHandler)
+	catalogSrv := startTLSServer(catalogMux, catalogCert)
+	t.Cleanup(catalogSrv.Close)
+
+	oauthMux := http.NewServeMux()
+	oauthMux.HandleFunc("/oauth/tokens", tokenHandler)
+	oauthSrv := startTLSServer(oauthMux, oauthCert)
+	t.Cleanup(oauthSrv.Close)
+
+	authURI, err := url.Parse(oauthSrv.URL + "/oauth/tokens")
+	require.NoError(t, err)
+
+	catalogPool := x509.NewCertPool()
+	catalogPool.AddCert(catalogCA)
+	oauthPool := x509.NewCertPool()
+	oauthPool.AddCert(oauthCA)
+
+	t.Run("separate oauth tls config", func(t *testing.T) {
+		t.Parallel()
+
+		// Each TLS config trusts only its respective server.
+		cat, err := NewCatalog(context.Background(), "rest", catalogSrv.URL,
+			WithCredential("secret"),
+			WithAuthURI(authURI),
+			WithTLSConfig(&tls.Config{RootCAs: catalogPool}),
+			WithOAuthTLSConfig(&tls.Config{RootCAs: oauthPool}),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, cat)
+	})
+
+	t.Run("fails without separate oauth tls config", func(t *testing.T) {
+		t.Parallel()
+
+		// Only the catalog TLS config is set — the OAuth token request
+		// should fail because the catalog's CA doesn't trust the OAuth
+		// server's certificate.
+		_, err := NewCatalog(context.Background(), "rest", catalogSrv.URL,
+			WithCredential("secret"),
+			WithAuthURI(authURI),
+			WithTLSConfig(&tls.Config{RootCAs: catalogPool}),
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrOAuthError)
+		assert.Contains(t, err.Error(), "ECDSA verification failure")
+	})
 }
 
 func TestAuthHeader(t *testing.T) {


### PR DESCRIPTION
The Iceberg REST spec allows configuring the OAuth2 server separately from the catalog via `oauth2-server-uri`. When the OAuth2 server is a different host, it may require different TLS settings (different CA, client certificates, etc.).

Currently `setupOAuthManager` reuses the catalog's HTTP client for token requests, making it impossible to configure separate TLS trust without creating a custom AuthManager.

This adds `WithOAuthTLSConfig(*tls.Config)` which creates a dedicated HTTP client for OAuth token requests. When not set, behavior is unchanged.