### PR TITLE
feat(table): make Parquet root schema repetition configurable

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -68,6 +68,9 @@ const (
 
 	ParquetBatchSizeKey     = "read.parquet.batch-size"
 	ParquetBatchSizeDefault = 1 << 17 // 131072 rows
+
+	ParquetRootRepetitionKey     = "write.parquet.root-repetition"
+	ParquetRootRepetitionDefault = "required"
 )
 
 type parquetFormat struct{}
@@ -259,8 +262,23 @@ func (parquetFormat) GetWriteProperties(props iceberg.Properties) any {
 		slog.Warn("unrecognized compression codec, falling back to uncompressed", "codec", compression)
 	}
 
+	var rootRepetition parquet.Repetition
+	switch props.Get(ParquetRootRepetitionKey, ParquetRootRepetitionDefault) {
+	case "required":
+		rootRepetition = parquet.Repetitions.Required
+	case "optional":
+		rootRepetition = parquet.Repetitions.Optional
+	case "repeated":
+		rootRepetition = parquet.Repetitions.Repeated
+	default:
+		slog.Warn("unrecognized root repetition, falling back to required",
+			"repetition", props.Get(ParquetRootRepetitionKey, ParquetRootRepetitionDefault))
+		rootRepetition = parquet.Repetitions.Required
+	}
+
 	writerProps = append(writerProps, parquet.WithCompression(codec),
-		parquet.WithCompressionLevel(compressionLevel))
+		parquet.WithCompressionLevel(compressionLevel),
+		parquet.WithRootRepetition(rootRepetition))
 
 	// Bloom filter properties.
 	// write.parquet.bloom-filter-max-bytes caps the per-column bloom filter size.

--- a/table/properties.go
+++ b/table/properties.go
@@ -56,6 +56,8 @@ const (
 	ParquetBloomFilterMaxBytesKey            = internal.ParquetBloomFilterMaxBytesKey
 	ParquetBloomFilterMaxBytesDefault        = internal.ParquetBloomFilterMaxBytesDefault
 	ParquetBloomFilterColumnEnabledKeyPrefix = internal.ParquetBloomFilterColumnEnabledKeyPrefix
+	ParquetRootRepetitionKey                = internal.ParquetRootRepetitionKey
+	ParquetRootRepetitionDefault            = internal.ParquetRootRepetitionDefault
 
 	ParquetBatchSizeKey     = internal.ParquetBatchSizeKey
 	ParquetBatchSizeDefault = internal.ParquetBatchSizeDefault

--- a/table/properties.go
+++ b/table/properties.go
@@ -56,8 +56,8 @@ const (
 	ParquetBloomFilterMaxBytesKey            = internal.ParquetBloomFilterMaxBytesKey
 	ParquetBloomFilterMaxBytesDefault        = internal.ParquetBloomFilterMaxBytesDefault
 	ParquetBloomFilterColumnEnabledKeyPrefix = internal.ParquetBloomFilterColumnEnabledKeyPrefix
-	ParquetRootRepetitionKey                = internal.ParquetRootRepetitionKey
-	ParquetRootRepetitionDefault            = internal.ParquetRootRepetitionDefault
+	ParquetRootRepetitionKey                 = internal.ParquetRootRepetitionKey
+	ParquetRootRepetitionDefault             = internal.ParquetRootRepetitionDefault
 
 	ParquetBatchSizeKey     = internal.ParquetBatchSizeKey
 	ParquetBatchSizeDefault = internal.ParquetBatchSizeDefault


### PR DESCRIPTION
## Problem

arrow-go defaults the Parquet root schema element repetition to `Repeated`. Snowflake (and some other readers) interpret `Repeated` at the root as one-level list encoding and reject files that contain list columns. This causes write failures when targeting Snowflake-managed Iceberg tables.

## Fix

Add a `write.parquet.root-repetition` table property (values: `required` / `optional` / `repeated`, default: `required`). The default `required` aligns with the Parquet spec and matches the behaviour of arrow-rs, pyarrow, and parquet-java.

The property is applied in `parquetFormat.GetWriteProperties` via `parquet.WithRootRepetition`.

## Why this default is correct

The Parquet spec defines the root message element as a container, not a repeated field. Defaulting to `Required` is the most interoperable choice and is what every major Parquet writer already does. arrow-go's `Repeated` default is an outlier.

## Testing

Existing `./table/...` suite passes. The property is exercised end-to-end in the Docker data platform against Snowflake-managed Iceberg tables (docker/data-platform#406).

---

*Original implementation by @hcrosse.*