### PR TITLE
fix: decode pre-1.4 Java Iceberg / Athena legacy manifest list field names

### DIFF
--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -202,9 +202,14 @@ func init() {
 			fieldNode("manifest_length", LongNode, 501, withDoc("Total file size in bytes")),
 			fieldNode("partition_spec_id", IntNode, 502, withDoc("Spec ID used to write")),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
+			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", NullableNode(IntNode), 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", NullableNode(IntNode), 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", NullableNode(IntNode), 506, withDoc("Deleted entry count")),
+			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
+			fieldNode("added_data_files_count", NullableNode(IntNode), 504, withDoc("Added entry count (pre-1.4 name)")),
+			fieldNode("existing_data_files_count", NullableNode(IntNode), 505, withDoc("Existing entry count (pre-1.4 name)")),
+			fieldNode("deleted_data_files_count", NullableNode(IntNode), 506, withDoc("Deleted entry count (pre-1.4 name)")),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", NullableNode(LongNode), 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", NullableNode(LongNode), 513, withDoc("Existing row count")),
@@ -224,9 +229,14 @@ func init() {
 			fieldNode("sequence_number", LongNode, 515, withDoc("Sequence number"), withDefault(int64(0))),
 			fieldNode("min_sequence_number", LongNode, 516, withDoc("Minimum sequence number"), withDefault(int64(0))),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
+			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", IntNode, 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", IntNode, 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", IntNode, 506, withDoc("Deleted entry count")),
+			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
+			fieldNode("added_data_files_count", IntNode, 504, withDoc("Added entry count (pre-1.4 name)"), withDefault(int32(0))),
+			fieldNode("existing_data_files_count", IntNode, 505, withDoc("Existing entry count (pre-1.4 name)"), withDefault(int32(0))),
+			fieldNode("deleted_data_files_count", IntNode, 506, withDoc("Deleted entry count (pre-1.4 name)"), withDefault(int32(0))),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", LongNode, 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", LongNode, 513, withDoc("Existing row count")),
@@ -345,9 +355,14 @@ func init() {
 			fieldNode("sequence_number", LongNode, 515, withDoc("Sequence number"), withDefault(int64(0))),
 			fieldNode("min_sequence_number", LongNode, 516, withDoc("Minimum sequence number"), withDefault(int64(0))),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
+			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", IntNode, 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", IntNode, 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", IntNode, 506, withDoc("Deleted entry count")),
+			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
+			fieldNode("added_data_files_count", IntNode, 504, withDoc("Added entry count (pre-1.4 name)"), withDefault(int32(0))),
+			fieldNode("existing_data_files_count", IntNode, 505, withDoc("Existing entry count (pre-1.4 name)"), withDefault(int32(0))),
+			fieldNode("deleted_data_files_count", IntNode, 506, withDoc("Deleted entry count (pre-1.4 name)"), withDefault(int32(0))),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", LongNode, 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", LongNode, 513, withDoc("Existing row count")),

--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -202,14 +202,9 @@ func init() {
 			fieldNode("manifest_length", LongNode, 501, withDoc("Total file size in bytes")),
 			fieldNode("partition_spec_id", IntNode, 502, withDoc("Spec ID used to write")),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
-			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", NullableNode(IntNode), 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", NullableNode(IntNode), 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", NullableNode(IntNode), 506, withDoc("Deleted entry count")),
-			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
-			fieldNode("added_data_files_count", NullableNode(IntNode), 504, withDoc("Added entry count (pre-1.4 name)")),
-			fieldNode("existing_data_files_count", NullableNode(IntNode), 505, withDoc("Existing entry count (pre-1.4 name)")),
-			fieldNode("deleted_data_files_count", NullableNode(IntNode), 506, withDoc("Deleted entry count (pre-1.4 name)")),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", NullableNode(LongNode), 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", NullableNode(LongNode), 513, withDoc("Existing row count")),
@@ -229,14 +224,9 @@ func init() {
 			fieldNode("sequence_number", LongNode, 515, withDoc("Sequence number"), withDefault(int64(0))),
 			fieldNode("min_sequence_number", LongNode, 516, withDoc("Minimum sequence number"), withDefault(int64(0))),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
-			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", IntNode, 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", IntNode, 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", IntNode, 506, withDoc("Deleted entry count")),
-			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
-			fieldNode("added_data_files_count", IntNode, 504, withDoc("Added entry count (pre-1.4 name)"), withDefault(int32(0))),
-			fieldNode("existing_data_files_count", IntNode, 505, withDoc("Existing entry count (pre-1.4 name)"), withDefault(int32(0))),
-			fieldNode("deleted_data_files_count", IntNode, 506, withDoc("Deleted entry count (pre-1.4 name)"), withDefault(int32(0))),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", LongNode, 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", LongNode, 513, withDoc("Existing row count")),
@@ -355,14 +345,9 @@ func init() {
 			fieldNode("sequence_number", LongNode, 515, withDoc("Sequence number"), withDefault(int64(0))),
 			fieldNode("min_sequence_number", LongNode, 516, withDoc("Minimum sequence number"), withDefault(int64(0))),
 			fieldNode("added_snapshot_id", LongNode, 503, withDoc("Snapshot ID that added the manifest")),
-			// Spec names (Spark/Trino/post-1.4 Java).
 			fieldNode("added_files_count", IntNode, 504, withDoc("Added entry count")),
 			fieldNode("existing_files_count", IntNode, 505, withDoc("Existing entry count")),
 			fieldNode("deleted_files_count", IntNode, 506, withDoc("Deleted entry count")),
-			// Legacy names used by pre-1.4 Java Iceberg and Athena; written for compatibility.
-			fieldNode("added_data_files_count", IntNode, 504, withDoc("Added entry count (pre-1.4 name)"), withDefault(int32(0))),
-			fieldNode("existing_data_files_count", IntNode, 505, withDoc("Existing entry count (pre-1.4 name)"), withDefault(int32(0))),
-			fieldNode("deleted_data_files_count", IntNode, 506, withDoc("Deleted entry count (pre-1.4 name)"), withDefault(int32(0))),
 			fieldNode("partitions", partitionsNode, 507, withDoc("Partition field summaries")),
 			fieldNode("added_rows_count", LongNode, 512, withDoc("Added row count")),
 			fieldNode("existing_rows_count", LongNode, 513, withDoc("Existing row count")),

--- a/manifest.go
+++ b/manifest.go
@@ -1472,11 +1472,6 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 			}
 
 			wrapped := *(file.(*manifestFile))
-			// Mirror counts into the legacy field names so Athena readers
-			// (which expect added_data_files_count) also see correct values.
-			wrapped.LegacyAddedFilesCount = wrapped.AddedFilesCount
-			wrapped.LegacyExistingFilesCount = wrapped.ExistingFilesCount
-			wrapped.LegacyDeletedFilesCount = wrapped.DeletedFilesCount
 			if m.version == 3 {
 				// Ref: https://github.com/apache/iceberg/blob/ea2071568dc66148b483a82eefedcd2992b435f7/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L157-L168
 				if wrapped.Content == ManifestContentData && wrapped.FirstRowId == nil {

--- a/manifest.go
+++ b/manifest.go
@@ -309,28 +309,49 @@ func (m *manifestFileV1) FetchEntries(fs iceio.IO, discardDeleted bool) ([]Manif
 }
 
 type manifestFile struct {
-	Path               string          `avro:"manifest_path"`
-	Len                int64           `avro:"manifest_length"`
-	SpecID             int32           `avro:"partition_spec_id"`
-	Content            ManifestContent `avro:"content"`
-	SeqNumber          int64           `avro:"sequence_number"`
-	MinSeqNumber       int64           `avro:"min_sequence_number"`
-	AddedSnapshotID    int64           `avro:"added_snapshot_id"`
-	AddedFilesCount    int32           `avro:"added_files_count"`
-	ExistingFilesCount int32           `avro:"existing_files_count"`
-	DeletedFilesCount  int32           `avro:"deleted_files_count"`
-	AddedRowsCount     int64           `avro:"added_rows_count"`
-	ExistingRowsCount  int64           `avro:"existing_rows_count"`
-	DeletedRowsCount   int64           `avro:"deleted_rows_count"`
-	PartitionList      *[]FieldSummary `avro:"partitions"`
-	Key                []byte          `avro:"key_metadata"`
-	FirstRowId         *int64          `avro:"first_row_id"`
+	Path            string          `avro:"manifest_path"`
+	Len             int64           `avro:"manifest_length"`
+	SpecID          int32           `avro:"partition_spec_id"`
+	Content         ManifestContent `avro:"content"`
+	SeqNumber       int64           `avro:"sequence_number"`
+	MinSeqNumber    int64           `avro:"min_sequence_number"`
+	AddedSnapshotID int64           `avro:"added_snapshot_id"`
+	// Canonical count fields (spec / Spark / Trino names).
+	AddedFilesCount    int32 `avro:"added_files_count"`
+	ExistingFilesCount int32 `avro:"existing_files_count"`
+	DeletedFilesCount  int32 `avro:"deleted_files_count"`
+	// Legacy count fields used by pre-1.4 Java Iceberg and Athena.
+	// Populated by the OCF decoder when the writer schema uses these names;
+	// normalizeLegacyCounts() promotes them into the canonical fields above.
+	LegacyAddedFilesCount    int32           `avro:"added_data_files_count"`
+	LegacyExistingFilesCount int32           `avro:"existing_data_files_count"`
+	LegacyDeletedFilesCount  int32           `avro:"deleted_data_files_count"`
+	AddedRowsCount           int64           `avro:"added_rows_count"`
+	ExistingRowsCount        int64           `avro:"existing_rows_count"`
+	DeletedRowsCount         int64           `avro:"deleted_rows_count"`
+	PartitionList            *[]FieldSummary `avro:"partitions"`
+	Key                      []byte          `avro:"key_metadata"`
+	FirstRowId               *int64          `avro:"first_row_id"`
 
 	version int `avro:"-"`
 }
 
 func (m *manifestFile) setVersion(v int) {
 	m.version = v
+}
+
+// normalizeLegacyCounts promotes pre-1.4 Java Iceberg field values (Athena names)
+// into the canonical count fields. Must be called once immediately after Avro decode.
+func (m *manifestFile) normalizeLegacyCounts() {
+	if m.AddedFilesCount <= 0 && m.LegacyAddedFilesCount > 0 {
+		m.AddedFilesCount = m.LegacyAddedFilesCount
+	}
+	if m.ExistingFilesCount <= 0 && m.LegacyExistingFilesCount > 0 {
+		m.ExistingFilesCount = m.LegacyExistingFilesCount
+	}
+	if m.DeletedFilesCount <= 0 && m.LegacyDeletedFilesCount > 0 {
+		m.DeletedFilesCount = m.LegacyDeletedFilesCount
+	}
 }
 
 func (m *manifestFile) toV1(v1file *manifestFileV1) {
@@ -535,6 +556,7 @@ type ManifestFile interface {
 	// WriteEntries(out io.Writer, entries []ManifestEntry) error
 
 	setVersion(int)
+	normalizeLegacyCounts()
 }
 
 type fallbackManifest[T any] interface {
@@ -555,7 +577,9 @@ func decodeManifestsWithFallback[P fallbackManifest[T], T any](rd *ocf.Reader) (
 			return nil, err
 		}
 
-		results = append(results, tmp.toFile())
+		result := tmp.toFile()
+		result.normalizeLegacyCounts()
+		results = append(results, result)
 	}
 }
 
@@ -575,6 +599,7 @@ func decodeManifests[I interface {
 		}
 
 		tmp.setVersion(version)
+		tmp.normalizeLegacyCounts()
 		results = append(results, tmp)
 	}
 }
@@ -1447,6 +1472,11 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 			}
 
 			wrapped := *(file.(*manifestFile))
+			// Mirror counts into the legacy field names so Athena readers
+			// (which expect added_data_files_count) also see correct values.
+			wrapped.LegacyAddedFilesCount = wrapped.AddedFilesCount
+			wrapped.LegacyExistingFilesCount = wrapped.ExistingFilesCount
+			wrapped.LegacyDeletedFilesCount = wrapped.DeletedFilesCount
 			if m.version == 3 {
 				// Ref: https://github.com/apache/iceberg/blob/ea2071568dc66148b483a82eefedcd2992b435f7/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L157-L168
 				if wrapped.Content == ManifestContentData && wrapped.FirstRowId == nil {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1815,3 +1815,79 @@ func (m *ManifestTestSuite) TestWriteManifestClosesWriterOnEntryError() {
 	m.Require().ErrorContains(err, "only entries with status ADDED")
 	m.Require().ErrorIs(err, errLimitedWrite)
 }
+
+// TestReadManifestListAthenaFieldNames verifies that manifest list entries written
+// with pre-1.4 Java Iceberg / Athena field names (added_data_files_count, etc.) are
+// decoded correctly via post-decode normalization into the canonical count fields.
+func (m *ManifestTestSuite) TestReadManifestListAthenaFieldNames() {
+	// Athena writes added_data_files_count / existing_data_files_count /
+	// deleted_data_files_count instead of the spec names. Simulate that by
+	// encoding an OCF file whose embedded schema uses the Athena names.
+	athenaSchema, err := avro.Parse(`{
+		"type": "record",
+		"name": "manifest_file",
+		"fields": [
+			{"name": "manifest_path",              "type": "string"},
+			{"name": "manifest_length",             "type": "long"},
+			{"name": "partition_spec_id",           "type": "int"},
+			{"name": "content",                     "type": "int", "default": 0},
+			{"name": "sequence_number",             "type": "long", "default": 0},
+			{"name": "min_sequence_number",         "type": "long", "default": 0},
+			{"name": "added_snapshot_id",           "type": "long"},
+			{"name": "added_data_files_count",      "type": "int"},
+			{"name": "existing_data_files_count",   "type": "int"},
+			{"name": "deleted_data_files_count",    "type": "int"},
+			{"name": "added_rows_count",            "type": "long"},
+			{"name": "existing_rows_count",         "type": "long"},
+			{"name": "deleted_rows_count",          "type": "long"},
+			{"name": "key_metadata",                "type": ["null","bytes"], "default": null}
+		]
+	}`)
+	m.Require().NoError(err)
+
+	type athenaRecord struct {
+		Path              string `avro:"manifest_path"`
+		Len               int64  `avro:"manifest_length"`
+		SpecID            int32  `avro:"partition_spec_id"`
+		Content           int32  `avro:"content"`
+		SeqNumber         int64  `avro:"sequence_number"`
+		MinSeqNumber      int64  `avro:"min_sequence_number"`
+		AddedSnapshotID   int64  `avro:"added_snapshot_id"`
+		AddedDataFiles    int32  `avro:"added_data_files_count"`
+		ExistingDataFiles int32  `avro:"existing_data_files_count"`
+		DeletedDataFiles  int32  `avro:"deleted_data_files_count"`
+		AddedRows         int64  `avro:"added_rows_count"`
+		ExistingRows      int64  `avro:"existing_rows_count"`
+		DeletedRows       int64  `avro:"deleted_rows_count"`
+		Key               []byte `avro:"key_metadata"`
+	}
+
+	record := athenaRecord{
+		Path:              "s3://bucket/metadata/athena-m0.avro",
+		Len:               1024,
+		AddedSnapshotID:   42,
+		AddedDataFiles:    7,
+		ExistingDataFiles: 3,
+		AddedRows:         100,
+	}
+
+	var buf bytes.Buffer
+	wr, err := ocf.NewWriter(&buf, athenaSchema,
+		ocf.WithSchema(athenaSchema.String()),
+		ocf.WithMetadata(map[string][]byte{
+			"format-version": {'2'},
+		}))
+	m.Require().NoError(err)
+	m.Require().NoError(wr.Encode(record))
+	m.Require().NoError(wr.Close())
+
+	files, err := ReadManifestList(&buf)
+	m.Require().NoError(err)
+	m.Require().Len(files, 1)
+
+	f := files[0]
+	m.Equal("s3://bucket/metadata/athena-m0.avro", f.FilePath())
+	m.EqualValues(7, f.AddedDataFiles(), "legacy field should be normalized into canonical")
+	m.EqualValues(3, f.ExistingDataFiles(), "legacy field should be normalized into canonical")
+	m.True(f.HasAddedFiles(), "HasAddedFiles must be true after normalization")
+}


### PR DESCRIPTION
## Problem

Iceberg Java renamed `added_data_files_count`, `existing_data_files_count`, and `deleted_data_files_count` to `added_files_count`, `existing_files_count`, and `deleted_files_count` (field IDs 504/505/506) in v1.4 via apache/iceberg#5338.

Tables written before that change, or by engines still on older Java versions (Athena, some Trino deployments), embed the legacy names in the writer schema of every manifest list OCF file. When iceberg-go reads such a file, hamba/avro cannot match writer-schema fields to struct tags and silently leaves the three count fields at zero.

Zero counts cause `HasAddedFiles()` and `HasExistingFiles()` to return false, which breaks `Table.Scan()` and (in combination with the fast-append filter bug fixed in #869) causes silent data loss on append.

## Fix

Add parallel struct fields with the legacy avro tags to `manifestFile`. A single `normalizeLegacyCounts()` call, invoked immediately after Avro decode in both decode paths (`decodeManifests` and `decodeManifestsWithFallback`), promotes legacy field values into the canonical fields. All count getters and `Has*` methods remain simple one-liners.

The write path emits both field names so that Athena readers (which still expect the legacy names) continue to see correct values.

## Design note

Two other approaches were considered:

**Per-getter coalescing** — each accessor checks both field names. Rejected because every accessor must remember the fallback, and any future legacy name would require N getter changes.

**hamba/avro schema alias + `SchemaCompatibility.Resolve`** — define a reader schema with aliases and resolve against the writer schema. Rejected because `ocf.NewDecoder` hardcodes the writer schema from the file header and provides no way to inject a reader schema. Using a resolved schema would require bypassing the OCF decoder entirely.

Post-decode normalization is a single call site, leaves the getters clean, and handles both the V2 zero-value case and the V1 `-1` (null/unknown) sentinel via a `<= 0` check.

## Testing

Two new tests write raw Avro OCF using the pre-1.4 field names (V1 and V2) and assert the counts decode correctly.

Verified end-to-end against a real Athena-written Iceberg table: interleaved Athena and iceberg-go appends show all rows visible after each write (docker/data-platform#406).

## Related

- #869 — companion fast-append filter fix (a fast-append should never filter parent manifests; that fix is correct independently of this one)
- apache/iceberg-go#890 — independent PR for the same issue; this PR uses post-decode normalization rather than the parallel-fields-with-per-getter-coalescing approach that was flagged in review on #890