### PR TITLE
cmd/iceberg: fix CLI YAML config being ignored when docopt sets defaults

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -153,9 +153,21 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Determine which flags were explicitly supplied on the command line so
+	// that mergeConf can apply file-config values only for flags that were
+	// not explicitly provided (i.e. still at their docopt default).
+	explicitFlags := make(map[string]bool)
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "--") {
+			// --flag=value or --flag (bare boolean)
+			name := strings.SplitN(strings.TrimPrefix(arg, "--"), "=", 2)[0]
+			explicitFlags[name] = true
+		}
+	}
+
 	fileCfg := config.ParseConfig(config.LoadConfig(cfg.Config), "default")
 	if fileCfg != nil {
-		mergeConf(fileCfg, &cfg)
+		mergeConf(fileCfg, &cfg, explicitFlags)
 	}
 
 	var output Output
@@ -508,20 +520,24 @@ func properties(ctx context.Context, output Output, cat catalog.Catalog, args pr
 	}
 }
 
-func mergeConf(fileConf *config.CatalogConfig, resConfig *Config) {
-	if len(resConfig.Catalog) == 0 {
+// mergeConf applies values from the file config into resConfig for any option
+// that was not explicitly provided on the command line. explicitFlags is a set
+// of flag names (without the "--" prefix) that appeared in os.Args so that
+// CLI-provided values always take precedence over the file config.
+func mergeConf(fileConf *config.CatalogConfig, resConfig *Config, explicitFlags map[string]bool) {
+	if !explicitFlags["catalog"] && len(fileConf.CatalogType) > 0 {
 		resConfig.Catalog = fileConf.CatalogType
 	}
-	if len(resConfig.URI) == 0 {
+	if !explicitFlags["uri"] && len(fileConf.URI) > 0 {
 		resConfig.URI = fileConf.URI
 	}
-	if len(resConfig.Output) == 0 {
+	if !explicitFlags["output"] && len(fileConf.Output) > 0 {
 		resConfig.Output = fileConf.Output
 	}
-	if len(resConfig.Cred) == 0 {
+	if !explicitFlags["credential"] && len(fileConf.Credential) > 0 {
 		resConfig.Cred = fileConf.Credential
 	}
-	if len(resConfig.Warehouse) == 0 {
+	if !explicitFlags["warehouse"] && len(fileConf.Warehouse) > 0 {
 		resConfig.Warehouse = fileConf.Warehouse
 	}
 }


### PR DESCRIPTION
Fixes #324.

`mergeConf` was checking `len(resConfig.Field) == 0` before applying
values from the YAML config file. Since `docopt` populates `resConfig`
with default values (e.g. `Output="text"`) before `mergeConf` runs,
the file-config was silently ignored for any option that has a docopt
default.

**Fix:** scan `os.Args` to record which flags were explicitly provided,
then apply the file-config value only when the corresponding flag was
absent from the command line. CLI-provided values always take
precedence; file-config fills in everything else.

**Precedence after this change:**
1. Explicit CLI flag (highest)
2. YAML config file
3. docopt default (lowest)