### PR TITLE
feat(table): support committing snapshots to branches other than main

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -814,10 +814,15 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 		snapshot.AddedRows = &addedRows
 	}
 
+	branch := sp.txn.branch
+	if branch == "" {
+		branch = MainBranch
+	}
+
 	return []Update{
 			NewAddSnapshotUpdate(&snapshot),
-			NewSetSnapshotRefUpdate("main", sp.snapshotID, BranchRef, -1, -1, -1),
+			NewSetSnapshotRefUpdate(branch, sp.snapshotID, BranchRef, -1, -1, -1),
 		}, []Requirement{
-			AssertRefSnapshotID("main", sp.txn.meta.currentSnapshotID),
+			AssertRefSnapshotID(branch, sp.txn.meta.currentSnapshotID),
 		}, nil
 }

--- a/table/table.go
+++ b/table/table.go
@@ -87,12 +87,19 @@ func (t Table) LocationProvider() (LocationProvider, error) {
 }
 
 func (t Table) NewTransaction() *Transaction {
+	return t.NewTransactionOnBranch(MainBranch)
+}
+
+// NewTransactionOnBranch creates a new transaction that commits to the named
+// branch. Use [NewTransaction] to commit to the default "main" branch.
+func (t Table) NewTransactionOnBranch(branch string) *Transaction {
 	meta, _ := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
 
 	return &Transaction{
-		tbl:  &t,
-		meta: meta,
-		reqs: []Requirement{},
+		tbl:    &t,
+		meta:   meta,
+		branch: branch,
+		reqs:   []Requirement{},
 	}
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -64,8 +64,9 @@ func (s snapshotUpdate) mergeAppend() *snapshotProducer {
 }
 
 type Transaction struct {
-	tbl  *Table
-	meta *MetadataBuilder
+	tbl    *Table
+	meta   *MetadataBuilder
+	branch string
 
 	reqs []Requirement
 


### PR DESCRIPTION
Fixes #714.

Adds `Table.NewTransactionOnBranch(branch string)` so callers can commit
to a named branch. The existing `NewTransaction()` becomes a convenience
wrapper for `NewTransactionOnBranch(MainBranch)`.

The branch name flows through `Transaction.branch` into
`snapshotProducer`, replacing the two hardcoded `"main"` strings in
`NewSetSnapshotRefUpdate` and `AssertRefSnapshotID`.

```go
// Commit to a feature branch
txn := tbl.NewTransactionOnBranch("my-feature-branch")
if err := txn.Append(ctx, reader, nil); err != nil { ... }
if _, err := txn.Commit(ctx); err != nil { ... }
```