### PR TITLE
feat(table): Add idle-based file flushing and a reaper RollingDataWriter for streaming pipelines

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1455,12 +1455,13 @@ func binPackRecords(itr iter.Seq2[arrow.RecordBatch, error], recordLookback int,
 }
 
 type recordWritingArgs struct {
-	sc          *arrow.Schema
-	itr         iter.Seq2[arrow.RecordBatch, error]
-	fs          iceio.WriteFileIO
-	writeUUID   *uuid.UUID
-	counter     iter.Seq[int]
-	idleTimeout time.Duration
+	sc            *arrow.Schema
+	itr           iter.Seq2[arrow.RecordBatch, error]
+	fs            iceio.WriteFileIO
+	writeUUID     *uuid.UUID
+	counter       iter.Seq[int]
+	idleTimeout   time.Duration
+	reaperTimeout time.Duration
 }
 
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -1454,11 +1455,12 @@ func binPackRecords(itr iter.Seq2[arrow.RecordBatch, error], recordLookback int,
 }
 
 type recordWritingArgs struct {
-	sc        *arrow.Schema
-	itr       iter.Seq2[arrow.RecordBatch, error]
-	fs        iceio.WriteFileIO
-	writeUUID *uuid.UUID
-	counter   iter.Seq[int]
+	sc          *arrow.Schema
+	itr         iter.Seq2[arrow.RecordBatch, error]
+	fs          iceio.WriteFileIO
+	writeUUID   *uuid.UUID
+	counter     iter.Seq[int]
+	idleTimeout time.Duration
 }
 
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -404,13 +404,13 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 				return
 			}
 
-			if err := writeRecord(record); err != nil {
-				record.Release()
+			err := writeRecord(record)
+			record.Release()
+			if err != nil {
 				r.sendError(err)
 
 				return
 			}
-			record.Release()
 
 			// Reset idle timer only when a file is open.
 			if idleTimer != nil && currentWriter != nil {
@@ -435,28 +435,29 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 
 		case <-r.ctx.Done():
 			// Drain any buffered records before finalizing.
+		drain:
 			for {
 				select {
 				case record, ok := <-r.recordCh:
 					if !ok {
-						break
+						break drain
 					}
-					if err := writeRecord(record); err != nil {
-						record.Release()
+					err := writeRecord(record)
+					record.Release()
+					if err != nil {
 						r.sendError(err)
 
 						return
 					}
-					record.Release()
-					continue
 				default:
+					break drain
 				}
-				if err := closeWriter(); err != nil {
-					r.sendError(err)
-				}
-
-				return
 			}
+			if err := closeWriter(); err != nil {
+				r.sendError(err)
+			}
+
+			return
 		}
 	}
 }
@@ -491,7 +492,7 @@ func (r *RollingDataWriter) closeAndWait() error {
 }
 
 // reapIdleWriters periodically scans all writers and tears down any whose
-// goroutine has been idle (no record writes) for longer than idleTimeout.
+// goroutine has been idle (no record writes) for longer than reaperTimeout.
 // This prevents long-lived partitions (e.g. hour=2024010100) from
 // accumulating goroutines that will never receive data again.
 func (w *writerFactory) reapIdleWriters(ctx context.Context) {
@@ -518,9 +519,8 @@ func (w *writerFactory) reapIdleWriters(ctx context.Context) {
 					return true
 				}
 
-				// Remove from map first so no new callers get this writer.
-				w.writers.Delete(key)
-				// Cancel + wait for the goroutine to drain and exit.
+				// closeAndWait cancels the goroutine, waits for it to
+				// drain, and removes the writer from the map.
 				writer.closeAndWait()
 
 				return true

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -45,6 +45,9 @@ type writerFactory struct {
 	taskSchema     *iceberg.Schema
 	targetFileSize int64
 	idleTimeout    time.Duration
+	reaperTimeout  time.Duration
+	reaperCancel   context.CancelFunc
+	reaperDone     chan struct{}
 
 	locProvider      LocationProvider
 	fileSchema       *iceberg.Schema
@@ -164,6 +167,7 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		stopCount:      stopCount,
 		sortOrderID:    meta.defaultSortOrderID,
 		idleTimeout:    args.idleTimeout,
+		reaperTimeout:  args.reaperTimeout,
 	}
 	for _, apply := range opts {
 		apply(f)
@@ -174,6 +178,16 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		stopCount()
 
 		return nil, err
+	}
+
+	if f.idleTimeout > 0 && f.reaperTimeout >= 0 {
+		if f.reaperTimeout == 0 {
+			f.reaperTimeout = 10 * f.idleTimeout
+		}
+		reaperCtx, reaperCancel := context.WithCancel(context.Background())
+		f.reaperCancel = reaperCancel
+		f.reaperDone = make(chan struct{})
+		go f.reapIdleWriters(reaperCtx)
 	}
 
 	return f, nil
@@ -239,6 +253,7 @@ type RollingDataWriter struct {
 	partitionKey     string
 	partitionID      int
 	fileCount        atomic.Int64
+	lastWriteTime    atomic.Int64 // unix nanos; updated on each record write
 	recordCh         chan arrow.RecordBatch
 	errorCh          chan error
 	factory          *writerFactory
@@ -354,6 +369,8 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 			return err
 		}
 
+		r.lastWriteTime.Store(time.Now().UnixNano())
+
 		if currentWriter.BytesWritten() >= r.factory.targetFileSize {
 			return closeWriter()
 		}
@@ -361,37 +378,25 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 		return nil
 	}
 
+	// Both the idle-timeout and non-idle-timeout paths use a select loop
+	// so the goroutine can be stopped via context cancellation (used by
+	// the reaper and closeAndWait) without closing recordCh.
 	idleTimeout := r.factory.idleTimeout
-	if idleTimeout <= 0 {
-		// No idle timeout configured: use the original simple loop.
-		for record := range r.recordCh {
-			if err := writeRecord(record); err != nil {
-				record.Release()
-				r.sendError(err)
 
-				return
-			}
-			record.Release()
-		}
-
-		if err := closeWriter(); err != nil {
-			r.sendError(err)
-		}
-
-		return
+	var idleTimerC <-chan time.Time
+	var idleTimer *time.Timer
+	if idleTimeout > 0 {
+		idleTimer = time.NewTimer(idleTimeout)
+		idleTimer.Stop()
+		defer idleTimer.Stop()
+		idleTimerC = idleTimer.C
 	}
-
-	// Idle timeout enabled: use a select loop with a timer.
-	idleTimer := time.NewTimer(idleTimeout)
-	idleTimer.Stop()
-	defer idleTimer.Stop()
 
 	for {
 		select {
 		case record, ok := <-r.recordCh:
 			if !ok {
-				// Channel closed, finalize the last file.
-				idleTimer.Stop()
+				// Channel closed; finalize any open file.
 				if err := closeWriter(); err != nil {
 					r.sendError(err)
 				}
@@ -408,18 +413,20 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 			record.Release()
 
 			// Reset idle timer only when a file is open.
-			if currentWriter != nil {
+			if idleTimer != nil && currentWriter != nil {
 				if !idleTimer.Stop() {
 					select {
-					case <-idleTimer.C:
+					case <-idleTimerC:
 					default:
 					}
 				}
 				idleTimer.Reset(idleTimeout)
 			}
 
-		case <-idleTimer.C:
-			// No records arrived for idleTimeout; flush the current file.
+		case <-idleTimerC:
+			// No records arrived for idleTimeout; flush the current
+			// file. The goroutine stays alive — same as a size-based
+			// roll — and will open a new file on the next record.
 			if err := closeWriter(); err != nil {
 				r.sendError(err)
 
@@ -427,13 +434,29 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 			}
 
 		case <-r.ctx.Done():
-			// Context cancelled (e.g. via closeAndWait). Finalize any open
-			// file so buffered data is not lost.
-			if err := closeWriter(); err != nil {
-				r.sendError(err)
-			}
+			// Drain any buffered records before finalizing.
+			for {
+				select {
+				case record, ok := <-r.recordCh:
+					if !ok {
+						break
+					}
+					if err := writeRecord(record); err != nil {
+						record.Release()
+						r.sendError(err)
 
-			return
+						return
+					}
+					record.Release()
+					continue
+				default:
+				}
+				if err := closeWriter(); err != nil {
+					r.sendError(err)
+				}
+
+				return
+			}
 		}
 	}
 }
@@ -447,7 +470,6 @@ func (r *RollingDataWriter) sendError(err error) {
 
 func (r *RollingDataWriter) close() {
 	r.cancel()
-	close(r.recordCh)
 }
 
 func (r *RollingDataWriter) closeAndWait() error {
@@ -468,8 +490,52 @@ func (r *RollingDataWriter) closeAndWait() error {
 	}
 }
 
+// reapIdleWriters periodically scans all writers and tears down any whose
+// goroutine has been idle (no record writes) for longer than idleTimeout.
+// This prevents long-lived partitions (e.g. hour=2024010100) from
+// accumulating goroutines that will never receive data again.
+func (w *writerFactory) reapIdleWriters(ctx context.Context) {
+	defer close(w.reaperDone)
+	ticker := time.NewTicker(w.reaperTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now().UnixNano()
+			threshold := w.reaperTimeout.Nanoseconds()
+
+			w.writers.Range(func(key, value any) bool {
+				writer, ok := value.(*RollingDataWriter)
+				if !ok {
+					return true
+				}
+
+				lastWrite := writer.lastWriteTime.Load()
+				if lastWrite == 0 || (now-lastWrite) < threshold {
+					return true
+				}
+
+				// Remove from map first so no new callers get this writer.
+				w.writers.Delete(key)
+				// Cancel + wait for the goroutine to drain and exit.
+				writer.closeAndWait()
+
+				return true
+			})
+		}
+	}
+}
+
 func (w *writerFactory) closeAll() error {
 	defer w.stopCount()
+	if w.reaperCancel != nil {
+		w.reaperCancel()
+		<-w.reaperDone
+	}
+
 	var writers []*RollingDataWriter
 	w.writers.Range(func(key, value any) bool {
 		writer, ok := value.(*RollingDataWriter)

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -521,7 +521,7 @@ func (w *writerFactory) reapIdleWriters(ctx context.Context) {
 
 				// closeAndWait cancels the goroutine, waits for it to
 				// drain, and removes the writer from the map.
-				writer.closeAndWait()
+				_ = writer.closeAndWait()
 
 				return true
 			})

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/iceberg-go"
@@ -43,6 +44,7 @@ type writerFactory struct {
 	writeUUID      *uuid.UUID
 	taskSchema     *iceberg.Schema
 	targetFileSize int64
+	idleTimeout    time.Duration
 
 	locProvider      LocationProvider
 	fileSchema       *iceberg.Schema
@@ -161,6 +163,7 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		nextCount:      nextCount,
 		stopCount:      stopCount,
 		sortOrderID:    meta.defaultSortOrderID,
+		idleTimeout:    args.idleTimeout,
 	}
 	for _, apply := range opts {
 		apply(f)
@@ -327,7 +330,7 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 		return nil
 	}
 
-	for record := range r.recordCh {
+	writeRecord := func(record arrow.RecordBatch) error {
 		if currentWriter == nil {
 			fileCount := int(r.fileCount.Add(1))
 			var err error
@@ -335,42 +338,103 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 				r.ctx, r.partitionKey, r.partitionValues,
 				r.partitionID, fileCount)
 			if err != nil {
-				record.Release()
-				r.sendError(err)
-
-				return
+				return err
 			}
 		}
 
 		converted, err := ToRequestedSchema(r.ctx, r.factory.fileSchema,
 			r.factory.taskSchema, record, SchemaOptions{IncludeFieldIDs: true, UseWriteDefault: true})
 		if err != nil {
-			record.Release()
-			r.sendError(err)
-
-			return
+			return err
 		}
 
 		err = currentWriter.Write(converted)
 		converted.Release()
-		record.Release()
 		if err != nil {
-			r.sendError(err)
-
-			return
+			return err
 		}
 
 		if currentWriter.BytesWritten() >= r.factory.targetFileSize {
+			return closeWriter()
+		}
+
+		return nil
+	}
+
+	idleTimeout := r.factory.idleTimeout
+	if idleTimeout <= 0 {
+		// No idle timeout configured: use the original simple loop.
+		for record := range r.recordCh {
+			if err := writeRecord(record); err != nil {
+				record.Release()
+				r.sendError(err)
+
+				return
+			}
+			record.Release()
+		}
+
+		if err := closeWriter(); err != nil {
+			r.sendError(err)
+		}
+
+		return
+	}
+
+	// Idle timeout enabled: use a select loop with a timer.
+	idleTimer := time.NewTimer(idleTimeout)
+	idleTimer.Stop()
+	defer idleTimer.Stop()
+
+	for {
+		select {
+		case record, ok := <-r.recordCh:
+			if !ok {
+				// Channel closed, finalize the last file.
+				idleTimer.Stop()
+				if err := closeWriter(); err != nil {
+					r.sendError(err)
+				}
+
+				return
+			}
+
+			if err := writeRecord(record); err != nil {
+				record.Release()
+				r.sendError(err)
+
+				return
+			}
+			record.Release()
+
+			// Reset idle timer only when a file is open.
+			if currentWriter != nil {
+				if !idleTimer.Stop() {
+					select {
+					case <-idleTimer.C:
+					default:
+					}
+				}
+				idleTimer.Reset(idleTimeout)
+			}
+
+		case <-idleTimer.C:
+			// No records arrived for idleTimeout; flush the current file.
 			if err := closeWriter(); err != nil {
 				r.sendError(err)
 
 				return
 			}
-		}
-	}
 
-	if err := closeWriter(); err != nil {
-		r.sendError(err)
+		case <-r.ctx.Done():
+			// Context cancelled (e.g. via closeAndWait). Finalize any open
+			// file so buffered data is not lost.
+			if err := closeWriter(); err != nil {
+				r.sendError(err)
+			}
+
+			return
+		}
 	}
 }
 

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -50,6 +51,10 @@ func TestRollingDataWriter(t *testing.T) {
 }
 
 func (s *RollingDataWriterTestSuite) createWriterFactory(loc string, arrSchema *arrow.Schema, targetFileSize int64) (*writerFactory, *iceberg.Schema) {
+	return s.createWriterFactoryWithIdleTimeout(loc, arrSchema, targetFileSize, 0)
+}
+
+func (s *RollingDataWriterTestSuite) createWriterFactoryWithIdleTimeout(loc string, arrSchema *arrow.Schema, targetFileSize int64, idleTimeout time.Duration) (*writerFactory, *iceberg.Schema) {
 	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
 	s.Require().NoError(err)
 
@@ -62,9 +67,10 @@ func (s *RollingDataWriterTestSuite) createWriterFactory(loc string, arrSchema *
 
 	writeUUID := uuid.New()
 	args := recordWritingArgs{
-		sc:        arrSchema,
-		fs:        iceio.LocalFS{},
-		writeUUID: &writeUUID,
+		sc:          arrSchema,
+		fs:          iceio.LocalFS{},
+		writeUUID:   &writeUUID,
+		idleTimeout: idleTimeout,
 		counter: func(yield func(int) bool) {
 			for i := 0; ; i++ {
 				if !yield(i) {
@@ -332,4 +338,112 @@ func (s *RollingDataWriterTestSuite) TestBytesWrittenReflectsCompressedSize() {
 	df, err := fw.Close()
 	s.Require().NoError(err)
 	s.Equal(int64(100), df.Count())
+}
+
+func (s *RollingDataWriterTestSuite) TestIdleTimeoutFlushesFile() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 100*time.Millisecond)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+
+	record := s.buildRecord(arrSchema, 5)
+	defer record.Release()
+
+	s.Require().NoError(writer.Add(record))
+
+	// Wait for the idle timer to fire and flush the file.
+	select {
+	case df := <-outputCh:
+		s.Equal(int64(5), df.Count())
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for idle flush")
+	}
+}
+
+func (s *RollingDataWriterTestSuite) TestIdleTimerResetsOnActivity() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 200*time.Millisecond)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+
+	// Send records at intervals shorter than the idle timeout so the timer
+	// keeps resetting and does not flush prematurely.
+	for range 5 {
+		record := s.buildRecord(arrSchema, 3)
+		s.Require().NoError(writer.Add(record))
+		record.Release()
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// No file should have been flushed yet (all 15 rows still in one file).
+	select {
+	case <-outputCh:
+		s.Fail("idle flush should not have fired while records were being added")
+	default:
+	}
+
+	// Now wait for the idle timeout to fire.
+	select {
+	case df := <-outputCh:
+		s.Equal(int64(15), df.Count())
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for idle flush after activity stopped")
+	}
+}
+
+func (s *RollingDataWriterTestSuite) TestWriterReopensAfterIdleFlush() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 100*time.Millisecond)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+
+	// First batch: write and let idle flush.
+	record1 := s.buildRecord(arrSchema, 5)
+	s.Require().NoError(writer.Add(record1))
+	record1.Release()
+
+	select {
+	case df := <-outputCh:
+		s.Equal(int64(5), df.Count())
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for first idle flush")
+	}
+
+	// Second batch: writer should reopen a new file.
+	record2 := s.buildRecord(arrSchema, 7)
+	s.Require().NoError(writer.Add(record2))
+	record2.Release()
+
+	// Close the writer to finalize the second file.
+	s.Require().NoError(writer.closeAndWait())
+	close(outputCh)
+
+	var dataFiles []iceberg.DataFile
+	for df := range outputCh {
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Len(dataFiles, 1)
+	s.Equal(int64(7), dataFiles[0].Count())
 }

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -526,6 +526,7 @@ func TestReaperCleansUpIdleWriters(t *testing.T) {
 	// Wait for the reaper to sweep.
 	assert.Eventually(t, func() bool {
 		_, ok := factory.writers.Load("part=a")
+
 		return !ok
 	}, 5*time.Second, 50*time.Millisecond, "reaper should have removed the idle writer from the map")
 }

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -31,6 +31,8 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -54,7 +56,7 @@ func (s *RollingDataWriterTestSuite) createWriterFactory(loc string, arrSchema *
 	return s.createWriterFactoryWithIdleTimeout(loc, arrSchema, targetFileSize, 0)
 }
 
-func (s *RollingDataWriterTestSuite) createWriterFactoryWithIdleTimeout(loc string, arrSchema *arrow.Schema, targetFileSize int64, idleTimeout time.Duration) (*writerFactory, *iceberg.Schema) {
+func (s *RollingDataWriterTestSuite) createWriterFactoryWithIdleTimeout(loc string, arrSchema *arrow.Schema, targetFileSize int64, idleTimeout time.Duration, reaperTimeout ...time.Duration) (*writerFactory, *iceberg.Schema) {
 	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
 	s.Require().NoError(err)
 
@@ -78,6 +80,9 @@ func (s *RollingDataWriterTestSuite) createWriterFactoryWithIdleTimeout(loc stri
 				}
 			}
 		},
+	}
+	if len(reaperTimeout) > 0 {
+		args.reaperTimeout = reaperTimeout[0]
 	}
 
 	factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, targetFileSize)
@@ -340,103 +345,145 @@ func (s *RollingDataWriterTestSuite) TestBytesWrittenReflectsCompressedSize() {
 	s.Equal(int64(100), df.Count())
 }
 
-func (s *RollingDataWriterTestSuite) TestIdleTimeoutFlushesFile() {
-	arrSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
-		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
+// newTestWriterFactory creates a writerFactory with the given idle and reaper
+// timeouts for use in standalone (non-suite) tests.
+func newTestWriterFactory(t *testing.T, loc string, arrSchema *arrow.Schema, targetFileSize int64, idleTimeout, reaperTimeout time.Duration) *writerFactory {
+	t.Helper()
 
-	loc := filepath.ToSlash(s.T().TempDir())
-	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 100*time.Millisecond)
+	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
+	require.NoError(t, err)
+
+	spec := iceberg.NewPartitionSpec()
+	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	require.NoError(t, err)
+
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	writeUUID := uuid.New()
+	args := recordWritingArgs{
+		sc:            arrSchema,
+		fs:            iceio.LocalFS{},
+		writeUUID:     &writeUUID,
+		idleTimeout:   idleTimeout,
+		reaperTimeout: reaperTimeout,
+		counter: func(yield func(int) bool) {
+			for i := 0; ; i++ {
+				if !yield(i) {
+					break
+				}
+			}
+		},
+	}
+
+	factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, targetFileSize)
+	require.NoError(t, err)
+
+	return factory
+}
+
+func buildTestRecord(t *testing.T, mem memory.Allocator, arrSchema *arrow.Schema, numRows int) arrow.RecordBatch {
+	t.Helper()
+
+	bldr := array.NewRecordBuilder(mem, arrSchema)
+	defer bldr.Release()
+
+	for i := range numRows {
+		bldr.Field(0).(*array.Int32Builder).Append(int32(i))
+		bldr.Field(1).(*array.StringBuilder).Append("value")
+	}
+
+	return bldr.NewRecordBatch()
+}
+
+var testSchema = arrow.NewSchema([]arrow.Field{
+	{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+}, nil)
+
+func TestIdleTimeoutFlushesFile(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	loc := filepath.ToSlash(t.TempDir())
+	// reaperTimeout=-1 disables the reaper for this test.
+	factory := newTestWriterFactory(t, loc, testSchema, 1024*1024, 200*time.Millisecond, -1)
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(context.Background(), nil, "", nil, outputCh)
 
-	record := s.buildRecord(arrSchema, 5)
-	defer record.Release()
+	record := buildTestRecord(t, mem, testSchema, 5)
+	require.NoError(t, writer.Add(record))
+	record.Release()
 
-	s.Require().NoError(writer.Add(record))
-
-	// Wait for the idle timer to fire and flush the file.
 	select {
 	case df := <-outputCh:
-		s.Equal(int64(5), df.Count())
-	case <-time.After(2 * time.Second):
-		s.Fail("timed out waiting for idle flush")
+		assert.Equal(t, int64(5), df.Count())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for idle flush")
 	}
 }
 
-func (s *RollingDataWriterTestSuite) TestIdleTimerResetsOnActivity() {
-	arrSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
-		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	loc := filepath.ToSlash(s.T().TempDir())
-	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 200*time.Millisecond)
+func TestIdleTimerResetsOnActivity(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	loc := filepath.ToSlash(t.TempDir())
+	factory := newTestWriterFactory(t, loc, testSchema, 1024*1024, 300*time.Millisecond, -1)
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(context.Background(), nil, "", nil, outputCh)
 
-	// Send records at intervals shorter than the idle timeout so the timer
-	// keeps resetting and does not flush prematurely.
+	// Send records at intervals shorter than the idle timeout so
+	// the timer keeps resetting and does not flush prematurely.
 	for range 5 {
-		record := s.buildRecord(arrSchema, 3)
-		s.Require().NoError(writer.Add(record))
+		record := buildTestRecord(t, mem, testSchema, 3)
+		require.NoError(t, writer.Add(record))
 		record.Release()
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
-	// No file should have been flushed yet (all 15 rows still in one file).
+	// No file should have been flushed yet (all 15 rows in one file).
 	select {
 	case <-outputCh:
-		s.Fail("idle flush should not have fired while records were being added")
+		t.Fatal("idle flush should not have fired while records were being added")
 	default:
 	}
 
 	// Now wait for the idle timeout to fire.
 	select {
 	case df := <-outputCh:
-		s.Equal(int64(15), df.Count())
-	case <-time.After(2 * time.Second):
-		s.Fail("timed out waiting for idle flush after activity stopped")
+		assert.Equal(t, int64(15), df.Count())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for idle flush")
 	}
 }
 
-func (s *RollingDataWriterTestSuite) TestWriterReopensAfterIdleFlush() {
-	arrSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
-		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	loc := filepath.ToSlash(s.T().TempDir())
-	factory, _ := s.createWriterFactoryWithIdleTimeout(loc, arrSchema, 1024*1024, 100*time.Millisecond)
+func TestWriterReopensAfterIdleFlush(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	loc := filepath.ToSlash(t.TempDir())
+	factory := newTestWriterFactory(t, loc, testSchema, 1024*1024, 200*time.Millisecond, -1)
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(context.Background(), nil, "", nil, outputCh)
 
-	// First batch: write and let idle flush.
-	record1 := s.buildRecord(arrSchema, 5)
-	s.Require().NoError(writer.Add(record1))
+	// First batch: write and let idle flush close the file.
+	record1 := buildTestRecord(t, mem, testSchema, 5)
+	require.NoError(t, writer.Add(record1))
 	record1.Release()
 
 	select {
 	case df := <-outputCh:
-		s.Equal(int64(5), df.Count())
-	case <-time.After(2 * time.Second):
-		s.Fail("timed out waiting for first idle flush")
+		assert.Equal(t, int64(5), df.Count())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first idle flush")
 	}
 
-	// Second batch: writer should reopen a new file.
-	record2 := s.buildRecord(arrSchema, 7)
-	s.Require().NoError(writer.Add(record2))
+	// Second batch: same writer reopens a new file automatically.
+	record2 := buildTestRecord(t, mem, testSchema, 7)
+	require.NoError(t, writer.Add(record2))
 	record2.Release()
 
-	// Close the writer to finalize the second file.
-	s.Require().NoError(writer.closeAndWait())
+	require.NoError(t, writer.closeAndWait())
 	close(outputCh)
 
 	var dataFiles []iceberg.DataFile
@@ -444,6 +491,41 @@ func (s *RollingDataWriterTestSuite) TestWriterReopensAfterIdleFlush() {
 		dataFiles = append(dataFiles, df)
 	}
 
-	s.Require().Len(dataFiles, 1)
-	s.Equal(int64(7), dataFiles[0].Count())
+	require.Len(t, dataFiles, 1)
+	assert.Equal(t, int64(7), dataFiles[0].Count())
+}
+
+func TestReaperCleansUpIdleWriters(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	loc := filepath.ToSlash(t.TempDir())
+	factory := newTestWriterFactory(t, loc, testSchema, 1024*1024, 200*time.Millisecond, 500*time.Millisecond)
+	defer factory.closeAll()
+
+	ctx := context.Background()
+	outputCh := make(chan iceberg.DataFile, 10)
+
+	writer, err := factory.getOrCreateRollingDataWriter(ctx, nil, "part=a", nil, outputCh)
+	require.NoError(t, err)
+
+	record := buildTestRecord(t, mem, testSchema, 5)
+	require.NoError(t, writer.Add(record))
+	record.Release()
+
+	// Wait for the idle timer to flush the file.
+	select {
+	case df := <-outputCh:
+		assert.Equal(t, int64(5), df.Count())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for idle flush")
+	}
+
+	// Writer should still be in the map right after flush.
+	_, ok := factory.writers.Load("part=a")
+	assert.True(t, ok, "writer should still be in map right after idle flush")
+
+	// Wait for the reaper to sweep.
+	assert.Eventually(t, func() bool {
+		_, ok := factory.writers.Load("part=a")
+		return !ok
+	}, 5*time.Second, 50*time.Millisecond, "reaper should have removed the idle writer from the map")
 }

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"iter"
 	"strconv"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/iceberg-go"
@@ -36,12 +37,25 @@ type WriteRecordOption func(*writeRecordConfig)
 type writeRecordConfig struct {
 	targetFileSize int64
 	writeUUID      *uuid.UUID
+	idleTimeout    time.Duration
 }
 
 // WithTargetFileSize overrides the table's default target file size.
 func WithTargetFileSize(size int64) WriteRecordOption {
 	return func(c *writeRecordConfig) {
 		c.targetFileSize = size
+	}
+}
+
+// WithIdleTimeout configures the writer to flush the current data file
+// when no records have been written for the specified duration. This is
+// useful for long-running writers with time-based partitions where
+// low-volume partitions may not reach the target file size. After an
+// idle flush, the writer remains open and will start a new file when
+// the next record arrives.
+func WithIdleTimeout(d time.Duration) WriteRecordOption {
+	return func(c *writeRecordConfig) {
+		c.idleTimeout = d
 	}
 }
 
@@ -119,10 +133,11 @@ func WriteRecords(ctx context.Context, tbl *Table,
 	}
 
 	args := recordWritingArgs{
-		sc:        schema,
-		itr:       releasing,
-		fs:        writeFS,
-		writeUUID: cfg.writeUUID,
+		sc:          schema,
+		itr:         releasing,
+		fs:          writeFS,
+		writeUUID:   cfg.writeUUID,
+		idleTimeout: cfg.idleTimeout,
 	}
 
 	return recordsToDataFiles(ctx, tbl.Location(), meta, args)

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -38,6 +38,7 @@ type writeRecordConfig struct {
 	targetFileSize int64
 	writeUUID      *uuid.UUID
 	idleTimeout    time.Duration
+	reaperTimeout  time.Duration
 }
 
 // WithTargetFileSize overrides the table's default target file size.
@@ -56,6 +57,18 @@ func WithTargetFileSize(size int64) WriteRecordOption {
 func WithIdleTimeout(d time.Duration) WriteRecordOption {
 	return func(c *writeRecordConfig) {
 		c.idleTimeout = d
+	}
+}
+
+// WithReaperTimeout configures how long an idle writer goroutine is kept
+// alive after its last record write before being torn down to free
+// resources. This is independent of WithIdleTimeout which controls when
+// buffered data is flushed to a file. A reaper timeout only takes effect
+// when WithIdleTimeout is also set. If omitted, the reaper defaults to
+// 10x the idle timeout.
+func WithReaperTimeout(d time.Duration) WriteRecordOption {
+	return func(c *writeRecordConfig) {
+		c.reaperTimeout = d
 	}
 }
 
@@ -133,11 +146,12 @@ func WriteRecords(ctx context.Context, tbl *Table,
 	}
 
 	args := recordWritingArgs{
-		sc:          schema,
-		itr:         releasing,
-		fs:          writeFS,
-		writeUUID:   cfg.writeUUID,
-		idleTimeout: cfg.idleTimeout,
+		sc:            schema,
+		itr:           releasing,
+		fs:            writeFS,
+		writeUUID:     cfg.writeUUID,
+		idleTimeout:   cfg.idleTimeout,
+		reaperTimeout: cfg.reaperTimeout,
 	}
 
 	return recordsToDataFiles(ctx, tbl.Location(), meta, args)


### PR DESCRIPTION
WriteRecords only rolls files when they hit targetFileSize. When the input is a long-lived channel (e.g. streaming events into time-based partitions like hour=2024010100), low-volume partitions may never reach the target size. Additionally, writers for older time partitions (yesterday's or 5 hours ago) will no longer receive any data, but will continue to use up resources. This means:

  - Buffered data stays invisible to readers until the file is eventually closed
  - Open file writers and goroutines accumulate for stale partitions 
  - Buffered data is lost on crash

 **table/write_records.go**

  New public API options:

  - WithIdleTimeout(d) — flush the current data file when no records arrive for d. After flush, the writer stays alive and opens a new file on the next record.
  - WithReaperTimeout(d) — tear down writer goroutines that have been idle for d, freeing resources. Independent from idle flush. Defaults to 10x idle timeout if omitted.

  Both are threaded through writeRecordConfig → recordWritingArgs.

  **table/arrow_utils.go**

  Added idleTimeout and reaperTimeout fields to recordWritingArgs so they flow from the public API down to newWriterFactory.

  **table/rolling_data_writer.go**

  writerFactory changes:
  - New fields: idleTimeout, reaperTimeout, reaperCancel, reaperDone
  - newWriterFactory starts a reapIdleWriters goroutine when idleTimeout > 0 && reaperTimeout >= 0. A negative reaper timeout disables it.
  - reapIdleWriters ticks at reaperTimeout, scans all writers, and tears down any whose lastWriteTime exceeds the threshold.
  - closeAll stops the reaper and waits for it before closing writers.

  RollingDataWriter changes:
  - New field: lastWriteTime atomic.Int64 — updated on every record write.
  - stream() rewritten from for range recordCh to an explicit select loop with three cases:
    a. recordCh — write record, reset idle timer if file is open
    b. idleTimerC — flush current file (identical to size-based roll)
    c. ctx.Done() — drain buffered records, flush, exit
  - close() calls cancel() only (not close(recordCh)) to avoid send-on-closed-channel panics when the reaper races with Add.