### PR TITLE
perf(table): Add optional skip duplicate check on AddDataFiles

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1250,6 +1250,36 @@ func (t *TableWritingTestSuite) TestAddDataFilesAlreadyReferencedByTable() {
 	t.ErrorContains(err, "cannot add files that are already referenced by table")
 }
 
+func (t *TableWritingTestSuite) TestAddDataFilesWithoutDuplicateCheck() {
+	ident := table.Identifier{"default", "add_data_files_skip_dup_check_v" + strconv.Itoa(t.formatVersion)}
+	tbl := t.createTable(ident, t.formatVersion, *iceberg.UnpartitionedSpec, t.tableSchema)
+
+	filePath := fmt.Sprintf("%s/add_data_files_skip_dup_check_v%d/test.parquet", t.location, t.formatVersion)
+	t.writeParquet(mustFS(t.T(), tbl).(iceio.WriteFileIO), filePath, t.arrTbl)
+
+	df := mustDataFile(t.T(), *iceberg.UnpartitionedSpec, filePath, nil, 1, mustFileSize(t.T(), filePath))
+
+	// Seed the table with an initial file.
+	tx := tbl.NewTransaction()
+	t.Require().NoError(tx.AddDataFiles(t.ctx, []iceberg.DataFile{df}, nil))
+	tbl, err := tx.Commit(t.ctx)
+	t.Require().NoError(err)
+
+	// Adding the same file again without the option should fail.
+	tx = tbl.NewTransaction()
+	err = tx.AddDataFiles(t.ctx, []iceberg.DataFile{df}, nil)
+	t.Error(err)
+	t.ErrorContains(err, "cannot add files that are already referenced by table")
+
+	// Adding the same file again with WithoutDuplicateCheck should succeed.
+	tx = tbl.NewTransaction()
+	t.Require().NoError(tx.AddDataFiles(t.ctx, []iceberg.DataFile{df}, nil, table.WithoutDuplicateCheck()))
+
+	staged, err := tx.StagedTable()
+	t.Require().NoError(err)
+	t.Equal(table.OpAppend, staged.CurrentSnapshot().Summary.Operation)
+}
+
 func (t *TableWritingTestSuite) TestAddDataFilesNilDataFile() {
 	ident := table.Identifier{"default", "add_data_files_nil_v" + strconv.Itoa(t.formatVersion)}
 	tbl := t.createTable(ident, t.formatVersion, *iceberg.UnpartitionedSpec, t.tableSchema)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -524,6 +524,7 @@ type WriteOption func(*dataFileCfg)
 
 type dataFileCfg struct {
 	skipAutoNameMapping bool
+	skipDuplicateCheck  bool
 }
 
 // WithoutAutoNameMapping disables the automatic setting of the schema name
@@ -534,6 +535,18 @@ type dataFileCfg struct {
 func WithoutAutoNameMapping() WriteOption {
 	return func(cfg *dataFileCfg) {
 		cfg.skipAutoNameMapping = true
+	}
+}
+
+// WithoutDuplicateCheck disables the duplicate file path check against
+// existing data files in the current snapshot. By default, [Transaction.AddDataFiles]
+// scans all manifests to ensure no file being added already exists in the
+// table. For tables with many manifests this scan can be expensive because
+// each manifest must be read from storage. Use this option when the caller
+// can guarantee that the files being added are not already in the table.
+func WithoutDuplicateCheck() WriteOption {
+	return func(cfg *dataFileCfg) {
+		cfg.skipDuplicateCheck = true
 	}
 }
 
@@ -594,20 +607,22 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 		return err
 	}
 
-	if s := t.meta.currentSnapshot(); s != nil {
-		referenced := make([]string, 0)
-		for df, err := range s.dataFiles(fs, nil) {
-			if err != nil {
-				return err
+	if !cfg.skipDuplicateCheck {
+		if s := t.meta.currentSnapshot(); s != nil {
+			referenced := make([]string, 0)
+			for df, err := range s.dataFiles(fs, nil) {
+				if err != nil {
+					return err
+				}
+
+				if _, ok := setToAdd[df.FilePath()]; ok {
+					referenced = append(referenced, df.FilePath())
+				}
 			}
 
-			if _, ok := setToAdd[df.FilePath()]; ok {
-				referenced = append(referenced, df.FilePath())
+			if len(referenced) > 0 {
+				return fmt.Errorf("cannot add files that are already referenced by table, files: %v", referenced)
 			}
-		}
-
-		if len(referenced) > 0 {
-			return fmt.Errorf("cannot add files that are already referenced by table, files: %v", referenced)
 		}
 	}
 


### PR DESCRIPTION
AddDataFiles unconditionally scans every manifest in the current snapshot to check whether any file being added already exists in the table. Each manifest requires a storage read (e.g. an S3 GET). For tables with many commits and manifests this means hundreds of sequential reads, easily pushing the operation past reasonable processing time.

AddFiles method already has an ignoreDuplicates parameter that skips this scan, but AddDataFiles has no equivalent.

WithoutDuplicateCheck() fills this gap. Callers who can guarantee the files being added are new (e.g. freshly written by a compaction job or an ingestion pipeline with unique naming) can opt out of the scan and avoid the I/O cost entirely.