### PR TITLE
feat(#492): implement SetStatistics, RemoveStatistics, AddEncryptionKey, RemoveEncryptionKey updates

### DIFF
--- a/table/encryption.go
+++ b/table/encryption.go
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+// EncryptionKey represents an encryption key stored in table metadata (V3+).
+// Keys are indexed by KeyID in the metadata encryption-keys map.
+type EncryptionKey struct {
+	KeyID        string  `json:"key-id"`
+	KeyMetadata  *string `json:"key-metadata,omitempty"`
+	KeyAlgorithm *string `json:"key-algorithm,omitempty"`
+}

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -36,15 +36,15 @@ func (e EncryptionKey) Equals(other EncryptionKey) bool {
 		return false
 	}
 
-        if e.EncryptedByID != other.EncryptedByID { // skip the whole thing if both are nil
-                if e.EncryptedByID == nil || other.EncryptedByID == nil { 
-                        // if either is nil, the other is not due to previous if
-                        return false
-                } else if *e.EncryptedByID != *other.EncryptedByID { 
-                        // if neither is nil, we can dereference them both safely
-                        return false
-                }
-        }
+	if e.EncryptedByID != other.EncryptedByID { // skip the whole thing if both are nil
+		if e.EncryptedByID == nil || other.EncryptedByID == nil {
+			// if either is nil, the other is not due to previous if
+			return false
+		} else if *e.EncryptedByID != *other.EncryptedByID {
+			// if neither is nil, we can dereference them both safely
+			return false
+		}
+	}
 
 	return maps.Equal(e.Properties, other.Properties)
 }

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -36,16 +36,15 @@ func (e EncryptionKey) Equals(other EncryptionKey) bool {
 		return false
 	}
 
-	switch {
-	case e.EncryptedByID == nil && other.EncryptedByID != nil:
-		return false
-	case e.EncryptedByID != nil && other.EncryptedByID == nil:
-		return false
-	case e.EncryptedByID != nil && other.EncryptedByID != nil:
-		if *e.EncryptedByID != *other.EncryptedByID {
-			return false
-		}
-	}
+        if e.EncryptedByID != other.EncryptedByID { // skip the whole thing if both are nil
+                if e.EncryptedByID == nil || other.EncryptedByID == nil { 
+                        // if either is nil, the other is not due to previous if
+                        return false
+                } else if *e.EncryptedByID != *other.EncryptedByID { 
+                        // if neither is nil, we can dereference them both safely
+                        return false
+                }
+        }
 
 	return maps.Equal(e.Properties, other.Properties)
 }

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -17,10 +17,35 @@
 
 package table
 
+import "maps"
+
 // EncryptionKey represents an encryption key stored in table metadata (V3+).
-// Keys are indexed by KeyID in the metadata encryption-keys map.
 type EncryptionKey struct {
-	KeyID        string  `json:"key-id"`
-	KeyMetadata  *string `json:"key-metadata,omitempty"`
-	KeyAlgorithm *string `json:"key-algorithm,omitempty"`
+	KeyID                string            `json:"key-id"`
+	EncryptedKeyMetadata string            `json:"encrypted-key-metadata"`
+	EncryptedByID        *string           `json:"encrypted-by-id,omitempty"`
+	Properties           map[string]string `json:"properties,omitempty"`
+}
+
+func (e EncryptionKey) Equals(other EncryptionKey) bool {
+	if e.KeyID != other.KeyID {
+		return false
+	}
+
+	if e.EncryptedKeyMetadata != other.EncryptedKeyMetadata {
+		return false
+	}
+
+	switch {
+	case e.EncryptedByID == nil && other.EncryptedByID != nil:
+		return false
+	case e.EncryptedByID != nil && other.EncryptedByID == nil:
+		return false
+	case e.EncryptedByID != nil && other.EncryptedByID != nil:
+		if *e.EncryptedByID != *other.EncryptedByID {
+			return false
+		}
+	}
+
+	return maps.Equal(e.Properties, other.Properties)
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -157,9 +157,9 @@ type Metadata interface {
 	// write the partition statistics file during each write operation,
 	// or it can also be computed on demand.
 	PartitionStatistics() iter.Seq[PartitionStatisticsFile]
-	// EncryptionKeys returns the map of encryption keys stored in table metadata (V3+).
-	// Keys are indexed by their key-id. Returns an empty sequence for V1/V2 tables.
-	EncryptionKeys() iter.Seq2[string, EncryptionKey]
+	// EncryptionKeys returns the list of encryption keys stored in table metadata (V3+).
+	// Returns an empty sequence for V1/V2 tables.
+	EncryptionKeys() iter.Seq[EncryptionKey]
 }
 
 // MetadataBuilder is a struct used for building and updating Iceberg table metadata.
@@ -191,7 +191,7 @@ type MetadataBuilder struct {
 	refs               map[string]SnapshotRef
 	statisticsList     []StatisticsFile
 	partitionStatsList []PartitionStatisticsFile
-	encryptionKeyMap   map[string]EncryptionKey
+	encryptionKeyList  []EncryptionKey
 
 	previousFileEntry *MetadataLogEntry
 	// >v1 specific
@@ -219,7 +219,7 @@ func NewMetadataBuilder(formatVersion int) (*MetadataBuilder, error) {
 		metadataLog:        make([]MetadataLogEntry, 0),
 		sortOrderList:      make([]SortOrder, 0),
 		refs:               make(map[string]SnapshotRef),
-		encryptionKeyMap:   make(map[string]EncryptionKey),
+		encryptionKeyList:  make([]EncryptionKey, 0),
 		currentSchemaID:    -1,
 		defaultSortOrderID: -1,
 		defaultSpecID:      -1,
@@ -270,7 +270,7 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 	b.metadataLog = slices.Collect(metadata.PreviousFiles())
 	b.statisticsList = slices.Collect(metadata.Statistics())
 	b.partitionStatsList = slices.Collect(metadata.PartitionStatistics())
-	b.encryptionKeyMap = maps.Collect(metadata.EncryptionKeys())
+	b.encryptionKeyList = slices.Collect(metadata.EncryptionKeys())
 
 	if currentFileLocation != "" {
 		b.previousFileEntry = &MetadataLogEntry{
@@ -892,7 +892,7 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 		SnapshotRefs:       b.refs,
 		StatisticsList:     b.statisticsList,
 		PartitionStatsList: b.partitionStatsList,
-		EncryptionKeyMap:   b.encryptionKeyMap,
+		EncryptionKeyList:  b.encryptionKeyList,
 	}, nil
 }
 
@@ -1205,8 +1205,27 @@ func (b *MetadataBuilder) RemoveStatistics(snapshotID int64) error {
 }
 
 // AddEncryptionKey adds or replaces an encryption key indexed by its key-id.
+// Encryption keys are only supported for format version 3 and above.
 func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
-	b.encryptionKeyMap[key.KeyID] = key
+	if b.formatVersion < 3 {
+		return fmt.Errorf("%w: encryption keys are only supported for format version 3 or higher, current version: %d",
+			iceberg.ErrInvalidArgument, b.formatVersion)
+	}
+
+	replaced := false
+	for i, k := range b.encryptionKeyList {
+		if k.KeyID == key.KeyID {
+			b.encryptionKeyList[i] = key
+			replaced = true
+
+			break
+		}
+	}
+
+	if !replaced {
+		b.encryptionKeyList = append(b.encryptionKeyList, key)
+	}
+
 	b.updates = append(b.updates, NewAddEncryptionKeyUpdate(key))
 
 	return nil
@@ -1215,7 +1234,9 @@ func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
 // RemoveEncryptionKey removes the encryption key with the given key-id.
 // It is not an error if no such key exists.
 func (b *MetadataBuilder) RemoveEncryptionKey(keyID string) error {
-	delete(b.encryptionKeyMap, keyID)
+	b.encryptionKeyList = slices.DeleteFunc(b.encryptionKeyList, func(k EncryptionKey) bool {
+		return k.KeyID == keyID
+	})
 	b.updates = append(b.updates, NewRemoveEncryptionKeyUpdate(keyID))
 
 	return nil
@@ -1301,7 +1322,7 @@ type commonMetadata struct {
 	SnapshotRefs       map[string]SnapshotRef    `json:"refs,omitempty"`
 	StatisticsList     []StatisticsFile          `json:"statistics,omitempty"`
 	PartitionStatsList []PartitionStatisticsFile `json:"partition-statistics,omitempty"`
-	EncryptionKeyMap   map[string]EncryptionKey  `json:"encryption-keys,omitempty"`
+	EncryptionKeyList  []EncryptionKey           `json:"encryption-keys,omitempty"`
 	// V2+ fields
 	LastSequenceNumber *int64 `json:"last-sequence-number,omitempty"`
 	// V3+ fields
@@ -1371,7 +1392,7 @@ func (c *commonMetadata) Equals(other *commonMetadata) bool {
 		c.DefaultSpecID == other.DefaultSpecID && c.DefaultSortOrderID == other.DefaultSortOrderID &&
 		slices.Equal(c.SnapshotLog, other.SnapshotLog) && slices.Equal(c.MetadataLog, other.MetadataLog) &&
 		iceinternal.SliceEqualHelper(c.SortOrderList, other.SortOrderList) &&
-		maps.Equal(c.EncryptionKeyMap, other.EncryptionKeyMap)
+		iceinternal.SliceEqualHelper(c.EncryptionKeyList, other.EncryptionKeyList)
 }
 
 func (c *commonMetadata) TableUUID() uuid.UUID       { return c.UUID }
@@ -1471,8 +1492,8 @@ func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile]
 	return slices.Values(c.PartitionStatsList)
 }
 
-func (c *commonMetadata) EncryptionKeys() iter.Seq2[string, EncryptionKey] {
-	return maps.All(c.EncryptionKeyMap)
+func (c *commonMetadata) EncryptionKeys() iter.Seq[EncryptionKey] {
+	return slices.Values(c.EncryptionKeyList)
 }
 
 // preValidate updates values in the metadata struct with defaults based on

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -157,6 +157,9 @@ type Metadata interface {
 	// write the partition statistics file during each write operation,
 	// or it can also be computed on demand.
 	PartitionStatistics() iter.Seq[PartitionStatisticsFile]
+	// EncryptionKeys returns the map of encryption keys stored in table metadata (V3+).
+	// Keys are indexed by their key-id. Returns an empty sequence for V1/V2 tables.
+	EncryptionKeys() iter.Seq2[string, EncryptionKey]
 }
 
 // MetadataBuilder is a struct used for building and updating Iceberg table metadata.
@@ -188,6 +191,7 @@ type MetadataBuilder struct {
 	refs               map[string]SnapshotRef
 	statisticsList     []StatisticsFile
 	partitionStatsList []PartitionStatisticsFile
+	encryptionKeyMap   map[string]EncryptionKey
 
 	previousFileEntry *MetadataLogEntry
 	// >v1 specific
@@ -215,6 +219,7 @@ func NewMetadataBuilder(formatVersion int) (*MetadataBuilder, error) {
 		metadataLog:        make([]MetadataLogEntry, 0),
 		sortOrderList:      make([]SortOrder, 0),
 		refs:               make(map[string]SnapshotRef),
+		encryptionKeyMap:   make(map[string]EncryptionKey),
 		currentSchemaID:    -1,
 		defaultSortOrderID: -1,
 		defaultSpecID:      -1,
@@ -265,6 +270,7 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 	b.metadataLog = slices.Collect(metadata.PreviousFiles())
 	b.statisticsList = slices.Collect(metadata.Statistics())
 	b.partitionStatsList = slices.Collect(metadata.PartitionStatistics())
+	b.encryptionKeyMap = maps.Collect(metadata.EncryptionKeys())
 
 	if currentFileLocation != "" {
 		b.previousFileEntry = &MetadataLogEntry{
@@ -886,6 +892,7 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 		SnapshotRefs:       b.refs,
 		StatisticsList:     b.statisticsList,
 		PartitionStatsList: b.partitionStatsList,
+		EncryptionKeyMap:   b.encryptionKeyMap,
 	}, nil
 }
 
@@ -1164,6 +1171,56 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 	return nil
 }
 
+// SetStatistics adds or replaces a statistics file for the given snapshot. If a statistics
+// file with the same snapshot ID already exists it is replaced, otherwise the file is appended.
+func (b *MetadataBuilder) SetStatistics(stats StatisticsFile) error {
+	replaced := false
+	for i, s := range b.statisticsList {
+		if s.SnapshotID == stats.SnapshotID {
+			b.statisticsList[i] = stats
+			replaced = true
+
+			break
+		}
+	}
+
+	if !replaced {
+		b.statisticsList = append(b.statisticsList, stats)
+	}
+
+	b.updates = append(b.updates, NewSetStatisticsUpdate(stats))
+
+	return nil
+}
+
+// RemoveStatistics removes the statistics file associated with the given snapshot ID.
+// It is not an error if no such file exists.
+func (b *MetadataBuilder) RemoveStatistics(snapshotID int64) error {
+	b.statisticsList = slices.DeleteFunc(b.statisticsList, func(s StatisticsFile) bool {
+		return s.SnapshotID == snapshotID
+	})
+	b.updates = append(b.updates, NewRemoveStatisticsUpdate(snapshotID))
+
+	return nil
+}
+
+// AddEncryptionKey adds or replaces an encryption key indexed by its key-id.
+func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
+	b.encryptionKeyMap[key.KeyID] = key
+	b.updates = append(b.updates, NewAddEncryptionKeyUpdate(key))
+
+	return nil
+}
+
+// RemoveEncryptionKey removes the encryption key with the given key-id.
+// It is not an error if no such key exists.
+func (b *MetadataBuilder) RemoveEncryptionKey(keyID string) error {
+	delete(b.encryptionKeyMap, keyID)
+	b.updates = append(b.updates, NewRemoveEncryptionKeyUpdate(keyID))
+
+	return nil
+}
+
 // maxBy returns the maximum value of extract(e) for all e in elems.
 // If elems is empty, returns 0.
 func maxBy[S ~[]E, E any](elems S, extract func(e E) int) int {
@@ -1244,6 +1301,7 @@ type commonMetadata struct {
 	SnapshotRefs       map[string]SnapshotRef    `json:"refs,omitempty"`
 	StatisticsList     []StatisticsFile          `json:"statistics,omitempty"`
 	PartitionStatsList []PartitionStatisticsFile `json:"partition-statistics,omitempty"`
+	EncryptionKeyMap   map[string]EncryptionKey  `json:"encryption-keys,omitempty"`
 	// V2+ fields
 	LastSequenceNumber *int64 `json:"last-sequence-number,omitempty"`
 	// V3+ fields
@@ -1312,7 +1370,8 @@ func (c *commonMetadata) Equals(other *commonMetadata) bool {
 		c.LastColumnId == other.LastColumnId && c.CurrentSchemaID == other.CurrentSchemaID &&
 		c.DefaultSpecID == other.DefaultSpecID && c.DefaultSortOrderID == other.DefaultSortOrderID &&
 		slices.Equal(c.SnapshotLog, other.SnapshotLog) && slices.Equal(c.MetadataLog, other.MetadataLog) &&
-		iceinternal.SliceEqualHelper(c.SortOrderList, other.SortOrderList)
+		iceinternal.SliceEqualHelper(c.SortOrderList, other.SortOrderList) &&
+		maps.Equal(c.EncryptionKeyMap, other.EncryptionKeyMap)
 }
 
 func (c *commonMetadata) TableUUID() uuid.UUID       { return c.UUID }
@@ -1410,6 +1469,10 @@ func (c *commonMetadata) Statistics() iter.Seq[StatisticsFile] {
 
 func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile] {
 	return slices.Values(c.PartitionStatsList)
+}
+
+func (c *commonMetadata) EncryptionKeys() iter.Seq2[string, EncryptionKey] {
+	return maps.All(c.EncryptionKeyMap)
 }
 
 // preValidate updates values in the metadata struct with defaults based on

--- a/table/updates.go
+++ b/table/updates.go
@@ -36,11 +36,14 @@ const (
 
 	UpdateAssignUUID = "assign-uuid"
 
-	UpdateRemoveProperties  = "remove-properties"
-	UpdateRemoveSchemas     = "remove-schemas"
-	UpdateRemoveSnapshots   = "remove-snapshots"
-	UpdateRemoveSnapshotRef = "remove-snapshot-ref"
-	UpdateRemoveSpec        = "remove-partition-specs"
+	UpdateAddEncryptionKey    = "add-encryption-key"
+	UpdateRemoveEncryptionKey = "remove-encryption-key"
+	UpdateRemoveProperties    = "remove-properties"
+	UpdateRemoveSchemas       = "remove-schemas"
+	UpdateRemoveSnapshots     = "remove-snapshots"
+	UpdateRemoveSnapshotRef   = "remove-snapshot-ref"
+	UpdateRemoveSpec          = "remove-partition-specs"
+	UpdateRemoveStatistics    = "remove-statistics"
 
 	UpdateSetCurrentSchema    = "set-current-schema"
 	UpdateSetDefaultSortOrder = "set-default-sort-order"
@@ -48,6 +51,7 @@ const (
 	UpdateSetLocation         = "set-location"
 	UpdateSetProperties       = "set-properties"
 	UpdateSetSnapshotRef      = "set-snapshot-ref"
+	UpdateSetStatistics       = "set-statistics"
 
 	UpdateUpgradeFormatVersion = "upgrade-format-version"
 )
@@ -112,6 +116,14 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			upd = &removeSpecUpdate{}
 		case UpdateRemoveSchemas:
 			upd = &removeSchemasUpdate{}
+		case UpdateSetStatistics:
+			upd = &setStatisticsUpdate{}
+		case UpdateRemoveStatistics:
+			upd = &removeStatisticsUpdate{}
+		case UpdateAddEncryptionKey:
+			upd = &addEncryptionKeyUpdate{}
+		case UpdateRemoveEncryptionKey:
+			upd = &removeEncryptionKeyUpdate{}
 		default:
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
@@ -585,4 +597,78 @@ func NewRemoveSchemasUpdate(schemaIds []int) *removeSchemasUpdate {
 
 func (u *removeSchemasUpdate) Apply(builder *MetadataBuilder) error {
 	return builder.RemoveSchemas(u.SchemaIDs)
+}
+
+type setStatisticsUpdate struct {
+	baseUpdate
+	SnapshotID int64          `json:"snapshot-id"`
+	Statistics StatisticsFile `json:"statistics"`
+}
+
+// NewSetStatisticsUpdate creates a new Update that adds or replaces the statistics file
+// for the given snapshot ID in the table metadata.
+func NewSetStatisticsUpdate(stats StatisticsFile) *setStatisticsUpdate {
+	return &setStatisticsUpdate{
+		baseUpdate: baseUpdate{ActionName: UpdateSetStatistics},
+		SnapshotID: stats.SnapshotID,
+		Statistics: stats,
+	}
+}
+
+func (u *setStatisticsUpdate) Apply(builder *MetadataBuilder) error {
+	return builder.SetStatistics(u.Statistics)
+}
+
+type removeStatisticsUpdate struct {
+	baseUpdate
+	SnapshotID int64 `json:"snapshot-id"`
+}
+
+// NewRemoveStatisticsUpdate creates a new Update that removes the statistics file
+// for the given snapshot ID from the table metadata.
+func NewRemoveStatisticsUpdate(snapshotID int64) *removeStatisticsUpdate {
+	return &removeStatisticsUpdate{
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveStatistics},
+		SnapshotID: snapshotID,
+	}
+}
+
+func (u *removeStatisticsUpdate) Apply(builder *MetadataBuilder) error {
+	return builder.RemoveStatistics(u.SnapshotID)
+}
+
+type addEncryptionKeyUpdate struct {
+	baseUpdate
+	EncryptionKey EncryptionKey `json:"encryption-key"`
+}
+
+// NewAddEncryptionKeyUpdate creates a new Update that adds or replaces an encryption key
+// (indexed by its key-id) in the table metadata.
+func NewAddEncryptionKeyUpdate(key EncryptionKey) *addEncryptionKeyUpdate {
+	return &addEncryptionKeyUpdate{
+		baseUpdate:    baseUpdate{ActionName: UpdateAddEncryptionKey},
+		EncryptionKey: key,
+	}
+}
+
+func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
+	return builder.AddEncryptionKey(u.EncryptionKey)
+}
+
+type removeEncryptionKeyUpdate struct {
+	baseUpdate
+	KeyID string `json:"key-id"`
+}
+
+// NewRemoveEncryptionKeyUpdate creates a new Update that removes the encryption key
+// with the given key-id from the table metadata.
+func NewRemoveEncryptionKeyUpdate(keyID string) *removeEncryptionKeyUpdate {
+	return &removeEncryptionKeyUpdate{
+		baseUpdate: baseUpdate{ActionName: UpdateRemoveEncryptionKey},
+		KeyID:      keyID,
+	}
+}
+
+func (u *removeEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
+	return builder.RemoveEncryptionKey(u.KeyID)
 }

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -538,7 +538,7 @@ func TestRemoveStatisticsUpdate_Apply_NoOp(t *testing.T) {
 func TestAddEncryptionKeyUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{
 		"action": "add-encryption-key",
-		"encryption-key": {"key-id": "key-1", "key-metadata": "c2VjcmV0"}
+		"encryption-key": {"key-id": "key-1", "encrypted-key-metadata": "c2VjcmV0"}
 	}]`)
 
 	var updates Updates
@@ -548,13 +548,42 @@ func TestAddEncryptionKeyUpdate_Unmarshal(t *testing.T) {
 	u, ok := updates[0].(*addEncryptionKeyUpdate)
 	require.True(t, ok)
 	assert.Equal(t, "key-1", u.EncryptionKey.KeyID)
-	require.NotNil(t, u.EncryptionKey.KeyMetadata)
-	assert.Equal(t, "c2VjcmV0", *u.EncryptionKey.KeyMetadata)
+	assert.Equal(t, "c2VjcmV0", u.EncryptionKey.EncryptedKeyMetadata)
+}
+
+// baseMetaV3JSON is a minimal valid V3 metadata document used by encryption key tests.
+const baseMetaV3JSON = `{
+  "format-version": 3,
+  "table-uuid": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+  "location": "s3://bucket/table",
+  "last-sequence-number": 1,
+  "last-updated-ms": 1000,
+  "last-column-id": 1,
+  "current-schema-id": 0,
+  "schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+  "default-spec-id": 0,
+  "partition-specs": [{"spec-id":0,"fields":[]}],
+  "last-partition-id": 0,
+  "default-sort-order-id": 0,
+  "sort-orders": [{"order-id":0,"fields":[]}],
+  "snapshot-log": [],
+  "metadata-log": [],
+  "next-row-id": 0
+}`
+
+func buildFromBaseV3(t *testing.T) *MetadataBuilder {
+	t.Helper()
+	meta, err := ParseMetadataString(baseMetaV3JSON)
+	require.NoError(t, err)
+	b, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	return b
 }
 
 func TestAddEncryptionKeyUpdate_Apply(t *testing.T) {
-	b := buildFromBase(t)
-	key := EncryptionKey{KeyID: "my-key", KeyMetadata: nil}
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: "dGVzdA=="}
 
 	require.NoError(t, NewAddEncryptionKeyUpdate(key).Apply(b))
 
@@ -562,13 +591,22 @@ func TestAddEncryptionKeyUpdate_Apply(t *testing.T) {
 	require.NoError(t, err)
 
 	found := false
-	for id, k := range meta.EncryptionKeys() {
-		if id == "my-key" {
+	for k := range meta.EncryptionKeys() {
+		if k.KeyID == "my-key" {
 			found = true
-			assert.Equal(t, key, k)
+			assert.True(t, key.Equals(k))
 		}
 	}
 	assert.True(t, found)
+}
+
+func TestAddEncryptionKeyUpdate_Apply_RejectsV2(t *testing.T) {
+	b := buildFromBase(t) // V2 base
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: "dGVzdA=="}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "format version 3")
 }
 
 func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {
@@ -584,8 +622,8 @@ func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {
 }
 
 func TestRemoveEncryptionKeyUpdate_Apply(t *testing.T) {
-	b := buildFromBase(t)
-	key := EncryptionKey{KeyID: "key-to-remove"}
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "key-to-remove", EncryptedKeyMetadata: "dGVzdA=="}
 	require.NoError(t, NewAddEncryptionKeyUpdate(key).Apply(b))
 
 	require.NoError(t, NewRemoveEncryptionKeyUpdate("key-to-remove").Apply(b))
@@ -593,8 +631,8 @@ func TestRemoveEncryptionKeyUpdate_Apply(t *testing.T) {
 	meta, err := b.Build()
 	require.NoError(t, err)
 
-	for id := range meta.EncryptionKeys() {
-		assert.NotEqual(t, "key-to-remove", id)
+	for k := range meta.EncryptionKeys() {
+		assert.NotEqual(t, "key-to-remove", k.KeyID)
 	}
 }
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -400,3 +400,206 @@ func TestUnmarshalUpdates(t *testing.T) {
 		})
 	}
 }
+
+// baseMetaJSON is a minimal valid V2 metadata document used by the Apply tests below.
+const baseMetaJSON = `{
+  "format-version": 2,
+  "table-uuid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "location": "s3://bucket/table",
+  "last-sequence-number": 1,
+  "last-updated-ms": 1000,
+  "last-column-id": 1,
+  "current-schema-id": 0,
+  "schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+  "default-spec-id": 0,
+  "partition-specs": [{"spec-id":0,"fields":[]}],
+  "last-partition-id": 0,
+  "default-sort-order-id": 0,
+  "sort-orders": [{"order-id":0,"fields":[]}],
+  "snapshot-log": [],
+  "metadata-log": []
+}`
+
+func buildFromBase(t *testing.T) *MetadataBuilder {
+	t.Helper()
+	meta, err := ParseMetadataString(baseMetaJSON)
+	require.NoError(t, err)
+	b, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	return b
+}
+
+func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {
+	data := []byte(`[{
+		"action": "set-statistics",
+		"snapshot-id": 42,
+		"statistics": {
+			"snapshot-id": 42,
+			"statistics-path": "s3://bucket/stats.puffin",
+			"file-size-in-bytes": 100,
+			"file-footer-size-in-bytes": 10,
+			"blob-metadata": [{"type":"apache-datasketches-theta-v1","snapshot-id":42,"sequence-number":1,"fields":[1]}]
+		}
+	}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	u, ok := updates[0].(*setStatisticsUpdate)
+	require.True(t, ok)
+	assert.Equal(t, int64(42), u.SnapshotID)
+	assert.Equal(t, "s3://bucket/stats.puffin", u.Statistics.StatisticsPath)
+}
+
+func TestSetStatisticsUpdate_Apply(t *testing.T) {
+	b := buildFromBase(t)
+	stats := StatisticsFile{
+		SnapshotID:            1,
+		StatisticsPath:        "s3://bucket/stats.puffin",
+		FileSizeInBytes:       200,
+		FileFooterSizeInBytes: 20,
+		BlobMetadata:          []BlobMetadata{},
+	}
+
+	upd := NewSetStatisticsUpdate(stats)
+	require.NoError(t, upd.Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	var found *StatisticsFile
+	for s := range meta.Statistics() {
+		sc := s
+		found = &sc
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, stats.StatisticsPath, found.StatisticsPath)
+}
+
+func TestSetStatisticsUpdate_Apply_Replaces(t *testing.T) {
+	// Applying set-statistics twice for the same snapshot ID should replace, not append.
+	b := buildFromBase(t)
+	first := StatisticsFile{SnapshotID: 5, StatisticsPath: "s3://first.puffin", FileSizeInBytes: 10, BlobMetadata: []BlobMetadata{}}
+	second := StatisticsFile{SnapshotID: 5, StatisticsPath: "s3://second.puffin", FileSizeInBytes: 20, BlobMetadata: []BlobMetadata{}}
+
+	require.NoError(t, NewSetStatisticsUpdate(first).Apply(b))
+	require.NoError(t, NewSetStatisticsUpdate(second).Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	count := 0
+	var got StatisticsFile
+	for s := range meta.Statistics() {
+		count++
+		got = s
+	}
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "s3://second.puffin", got.StatisticsPath)
+}
+
+func TestRemoveStatisticsUpdate_Unmarshal(t *testing.T) {
+	data := []byte(`[{"action":"remove-statistics","snapshot-id":7}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	u, ok := updates[0].(*removeStatisticsUpdate)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), u.SnapshotID)
+}
+
+func TestRemoveStatisticsUpdate_Apply(t *testing.T) {
+	b := buildFromBase(t)
+	stats := StatisticsFile{SnapshotID: 3, StatisticsPath: "s3://bucket/stats.puffin", BlobMetadata: []BlobMetadata{}}
+	require.NoError(t, NewSetStatisticsUpdate(stats).Apply(b))
+
+	require.NoError(t, NewRemoveStatisticsUpdate(3).Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	count := 0
+	for range meta.Statistics() {
+		count++
+	}
+	assert.Equal(t, 0, count)
+}
+
+func TestRemoveStatisticsUpdate_Apply_NoOp(t *testing.T) {
+	// Removing a statistics file that does not exist should not error.
+	b := buildFromBase(t)
+	require.NoError(t, NewRemoveStatisticsUpdate(999).Apply(b))
+}
+
+func TestAddEncryptionKeyUpdate_Unmarshal(t *testing.T) {
+	data := []byte(`[{
+		"action": "add-encryption-key",
+		"encryption-key": {"key-id": "key-1", "key-metadata": "c2VjcmV0"}
+	}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	u, ok := updates[0].(*addEncryptionKeyUpdate)
+	require.True(t, ok)
+	assert.Equal(t, "key-1", u.EncryptionKey.KeyID)
+	require.NotNil(t, u.EncryptionKey.KeyMetadata)
+	assert.Equal(t, "c2VjcmV0", *u.EncryptionKey.KeyMetadata)
+}
+
+func TestAddEncryptionKeyUpdate_Apply(t *testing.T) {
+	b := buildFromBase(t)
+	key := EncryptionKey{KeyID: "my-key", KeyMetadata: nil}
+
+	require.NoError(t, NewAddEncryptionKeyUpdate(key).Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	found := false
+	for id, k := range meta.EncryptionKeys() {
+		if id == "my-key" {
+			found = true
+			assert.Equal(t, key, k)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {
+	data := []byte(`[{"action":"remove-encryption-key","key-id":"key-42"}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	u, ok := updates[0].(*removeEncryptionKeyUpdate)
+	require.True(t, ok)
+	assert.Equal(t, "key-42", u.KeyID)
+}
+
+func TestRemoveEncryptionKeyUpdate_Apply(t *testing.T) {
+	b := buildFromBase(t)
+	key := EncryptionKey{KeyID: "key-to-remove"}
+	require.NoError(t, NewAddEncryptionKeyUpdate(key).Apply(b))
+
+	require.NoError(t, NewRemoveEncryptionKeyUpdate("key-to-remove").Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	for id := range meta.EncryptionKeys() {
+		assert.NotEqual(t, "key-to-remove", id)
+	}
+}
+
+func TestRemoveEncryptionKeyUpdate_Apply_NoOp(t *testing.T) {
+	// Removing a key that doesn't exist should not error.
+	b := buildFromBase(t)
+	require.NoError(t, NewRemoveEncryptionKeyUpdate("nonexistent").Apply(b))
+}


### PR DESCRIPTION


Adds the four remaining table update types required for REST catalog compatibility. Without these, any commit response containing these actions fails with "unknown update action".

Changes:
- table/encryption.go: new file; defines EncryptionKey type (key-id, key-metadata, key-algorithm) separate from statistics types
- table/statistics.go: remove EncryptionKey (moved to encryption.go)
- table/updates.go: add constants and update structs for set-statistics, remove-statistics, add-encryption-key, remove-encryption-key; register all four in UnmarshalJSON
- table/metadata.go:
  - add EncryptionKeys() iter.Seq2[string, EncryptionKey] to Metadata interface and implement on commonMetadata
  - add EncryptionKeyMap field to commonMetadata with JSON tag encryption-keys (omitempty; inert on V1/V2 tables)
  - add encryptionKeyMap to MetadataBuilder; initialize in NewMetadataBuilder alongside refs; copy in MetadataBuilderFromBase; write through in buildCommonMetadata
  - add SetStatistics (upsert by snapshot-id), RemoveStatistics, AddEncryptionKey, RemoveEncryptionKey builder methods
  - include EncryptionKeyMap in commonMetadata.Equals
- table/updates_test.go: unmarshal and Apply tests for all four update types including replace-not-append semantics for SetStatistics and no-op remove cases


Feature #492 