### PR TITLE
feat(cli): add compact analyze and compact run commands

### DIFF
--- a/cmd/iceberg/compact.go
+++ b/cmd/iceberg/compact.go
@@ -52,9 +52,9 @@ func compact(ctx context.Context, output Output, cat catalog.Catalog, cfg Config
 		return
 	}
 
-	if cfg.Analyze {
-		printCompactionPlan(output, plan)
+	printCompactionPlan(output, plan)
 
+	if cfg.Analyze {
 		return
 	}
 

--- a/cmd/iceberg/compact.go
+++ b/cmd/iceberg/compact.go
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/table/compaction"
+	"github.com/pterm/pterm"
+)
+
+func compact(ctx context.Context, output Output, cat catalog.Catalog, cfg Config) {
+	tbl := loadTable(ctx, output, cat, cfg.TableID)
+
+	compCfg := compaction.DefaultConfig()
+	if cfg.TargetFileSize > 0 {
+		compCfg.TargetFileSizeBytes = cfg.TargetFileSize
+		// Derive min/max using the same ratios as DefaultConfig (75%/180%).
+		compCfg.MinFileSizeBytes = compCfg.TargetFileSizeBytes * 3 / 4
+		compCfg.MaxFileSizeBytes = compCfg.TargetFileSizeBytes * 9 / 5
+	}
+
+	plan, err := compaction.Analyze(ctx, tbl, compCfg)
+	if err != nil {
+		output.Error(err)
+		os.Exit(1)
+	}
+
+	if len(plan.Groups) == 0 {
+		output.Text("No files need compaction.")
+
+		return
+	}
+
+	if cfg.Analyze {
+		printCompactionPlan(output, plan)
+
+		return
+	}
+
+	compactRun(ctx, output, tbl, plan, cfg)
+}
+
+func printCompactionPlan(output Output, plan compaction.Plan) {
+	var candidateBytes int64
+	for _, g := range plan.Groups {
+		candidateBytes += g.TotalSizeBytes
+	}
+
+	candidateFiles := plan.TotalInputFiles - plan.SkippedFiles
+
+	output.Text(fmt.Sprintf("Compaction Plan: %d files scanned, %d to rewrite, %d already optimal",
+		plan.TotalInputFiles, candidateFiles, plan.SkippedFiles))
+	output.Text(fmt.Sprintf("  Groups:            %d", len(plan.Groups)))
+	output.Text(fmt.Sprintf("  Est. output files: %d", plan.EstOutputFiles))
+	output.Text("  Input size:        " + formatBytes(candidateBytes))
+
+	// Only render the per-group table for text output.
+	// JSON output uses output.Text() above which wraps in structured format.
+	if _, ok := output.(textOutput); ok {
+		data := pterm.TableData{{"#", "Partition", "Files", "Size", "Delete Files"}}
+		for i, g := range plan.Groups {
+			partKey := g.PartitionKey
+			if partKey == "" {
+				partKey = "(unpartitioned)"
+			}
+
+			data = append(data, []string{
+				strconv.Itoa(i + 1),
+				partKey,
+				strconv.Itoa(len(g.Tasks)),
+				formatBytes(g.TotalSizeBytes),
+				strconv.Itoa(g.DeleteFileCount),
+			})
+		}
+
+		pterm.DefaultTable.
+			WithHasHeader(true).
+			WithHeaderRowSeparator("-").
+			WithData(data).Render()
+	}
+}
+
+func compactRun(ctx context.Context, output Output, tbl *table.Table, plan compaction.Plan, cfg Config) {
+	candidateFiles := plan.TotalInputFiles - plan.SkippedFiles
+	output.Text(fmt.Sprintf("Compacting %d groups (%d files)...",
+		len(plan.Groups), candidateFiles))
+
+	groups := make([]table.CompactionTaskGroup, len(plan.Groups))
+	for i, g := range plan.Groups {
+		groups[i] = table.CompactionTaskGroup{
+			PartitionKey:   g.PartitionKey,
+			Tasks:          g.Tasks,
+			TotalSizeBytes: g.TotalSizeBytes,
+		}
+	}
+
+	tx := tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(ctx, groups, cfg.PartialProgress, nil)
+	if err != nil {
+		if result != nil && result.RewrittenGroups > 0 {
+			output.Text(fmt.Sprintf("  (partial: %d groups committed before failure)", result.RewrittenGroups))
+		}
+		output.Error(fmt.Errorf("compaction failed: %w", err))
+		os.Exit(1)
+	}
+
+	if _, err := tx.Commit(ctx); err != nil {
+		output.Error(fmt.Errorf("commit failed: %w", err))
+		os.Exit(1)
+	}
+
+	output.Text(fmt.Sprintf("Done. Rewrote %d -> %d files. Removed %d delete files.",
+		result.RemovedDataFiles, result.AddedDataFiles, result.RemovedDeleteFiles))
+	output.Text(fmt.Sprintf("  Size: %s -> %s",
+		formatBytes(result.BytesBefore), formatBytes(result.BytesAfter)))
+}
+
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(1<<10))
+	default:
+		return strconv.FormatInt(b, 10) + " B"
+	}
+}

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -51,6 +51,7 @@ Usage:
   iceberg properties [options] get (namespace | table) IDENTIFIER [PROPNAME]
   iceberg properties [options] set (namespace | table) IDENTIFIER PROPNAME VALUE
   iceberg properties [options] remove (namespace | table) IDENTIFIER PROPNAME
+  iceberg compact [options] (analyze | run) TABLE_ID [--target-file-size BYTES] [--partial-progress]
   iceberg -h | --help | --version
 
 Commands:
@@ -65,6 +66,7 @@ Commands:
   files       List all the files of the table.
   rename      Rename a table.
   properties  Properties on tables/namespaces.
+  compact     Analyze or run bin-pack compaction on a table.
 
 Arguments:
   PARENT         Catalog parent namespace
@@ -92,7 +94,9 @@ Options:
   --partition-spec TEXT specify partition spec as comma-separated field names(for create table use only)
 						Ex:"field1,field2"
   --sort-order TEXT 	specify sort order as field:direction[:null-order] format(for create table use only)
-						Ex:"field1:asc,field2:desc:nulls-first,field3:asc:nulls-last"`
+						Ex:"field1:asc,field2:desc:nulls-first,field3:asc:nulls-last"
+  --target-file-size BYTES  target output file size in bytes for compaction [default: 0]
+  --partial-progress        stage each compaction group as a separate snapshot update`
 
 type Config struct {
 	List     bool `docopt:"list"`
@@ -106,10 +110,13 @@ type Config struct {
 	Drop     bool `docopt:"drop"`
 	Files    bool `docopt:"files"`
 	Rename   bool `docopt:"rename"`
+	Compact  bool `docopt:"compact"`
 
-	Get    bool `docopt:"get"`
-	Set    bool `docopt:"set"`
-	Remove bool `docopt:"remove"`
+	Get     bool `docopt:"get"`
+	Set     bool `docopt:"set"`
+	Remove  bool `docopt:"remove"`
+	Analyze bool `docopt:"analyze"`
+	Run     bool `docopt:"run"`
 
 	Namespace bool `docopt:"namespace"`
 	Table     bool `docopt:"table"`
@@ -123,21 +130,23 @@ type Config struct {
 	PropName string `docopt:"PROPNAME"`
 	Value    string `docopt:"VALUE"`
 
-	Catalog       string `docopt:"--catalog"`
-	URI           string `docopt:"--uri"`
-	Output        string `docopt:"--output"`
-	History       bool   `docopt:"--history"`
-	Cred          string `docopt:"--credential"`
-	Token         string `docopt:"--token"`
-	Warehouse     string `docopt:"--warehouse"`
-	Config        string `docopt:"--config"`
-	Scope         string `docopt:"--scope"`
-	Description   string `docopt:"--description"`
-	LocationURI   string `docopt:"--location-uri"`
-	SchemaStr     string `docopt:"--schema"`
-	TableProps    string `docopt:"--properties"`
-	PartitionSpec string `docopt:"--partition-spec"`
-	SortOrder     string `docopt:"--sort-order"`
+	Catalog         string `docopt:"--catalog"`
+	URI             string `docopt:"--uri"`
+	Output          string `docopt:"--output"`
+	History         bool   `docopt:"--history"`
+	Cred            string `docopt:"--credential"`
+	Token           string `docopt:"--token"`
+	Warehouse       string `docopt:"--warehouse"`
+	Config          string `docopt:"--config"`
+	Scope           string `docopt:"--scope"`
+	Description     string `docopt:"--description"`
+	LocationURI     string `docopt:"--location-uri"`
+	SchemaStr       string `docopt:"--schema"`
+	TableProps      string `docopt:"--properties"`
+	PartitionSpec   string `docopt:"--partition-spec"`
+	SortOrder       string `docopt:"--sort-order"`
+	TargetFileSize  int64  `docopt:"--target-file-size"`
+	PartialProgress bool   `docopt:"--partial-progress"`
 }
 
 func main() {
@@ -355,6 +364,8 @@ func main() {
 	case cfg.Files:
 		tbl := loadTable(ctx, output, cat, cfg.TableID)
 		output.Files(tbl, cfg.History)
+	case cfg.Compact:
+		compact(ctx, output, cat, cfg)
 	}
 }
 


### PR DESCRIPTION
Add `iceberg compact analyze TABLE_ID` for dry-run compaction planning and `iceberg compact run TABLE_ID` for executing bin-pack compaction.

- Plans via compaction.Analyze, executes via Transaction.RewriteDataFiles
- Flags: --target-file-size, --partial-progress
- Prints per-group breakdown table with partition, file count, size, deletes
- Partial progress message printed before fatal error on failure

Part of #832 (table compaction).