### PR TITLE
feat(table): retry doCommit on commit-conflict errors (#830)

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -90,9 +90,12 @@ var (
 	ErrAuthorizationExpired = fmt.Errorf("%w: authorization expired", ErrRESTError)
 	ErrServiceUnavailable   = fmt.Errorf("%w: service unavailable", ErrRESTError)
 	ErrServerError          = fmt.Errorf("%w: server error", ErrRESTError)
-	ErrCommitFailed         = fmt.Errorf("%w: commit failed, refresh and try again", ErrRESTError)
-	ErrCommitStateUnknown   = fmt.Errorf("%w: commit failed due to unknown reason", ErrRESTError)
-	ErrOAuthError           = fmt.Errorf("%w: oauth error", ErrRESTError)
+	// ErrCommitFailed wraps both ErrRESTError and table.ErrCommitFailed
+	// so that callers can detect retryable commit conflicts via
+	// errors.Is(err, table.ErrCommitFailed).
+	ErrCommitFailed       = fmt.Errorf("%w: %w", ErrRESTError, table.ErrCommitFailed)
+	ErrCommitStateUnknown = fmt.Errorf("%w: commit failed due to unknown reason", ErrRESTError)
+	ErrOAuthError         = fmt.Errorf("%w: oauth error", ErrRESTError)
 )
 
 func init() {

--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -238,16 +238,27 @@ func TestBackoffDuration_ExponentialWithJitter(t *testing.T) {
 	}
 }
 
-func TestBackoffDuration_HandlesZeroOrNegativeInputs(t *testing.T) {
-	// Should fall back to defaults rather than panic or return garbage.
+func TestBackoffDuration_HandlesZeroInputs(t *testing.T) {
+	// Zero min/max should fall back to defaults rather than return garbage.
 	d := backoffDuration(0, 0, 0)
-	assert.Equal(t, time.Duration(CommitMinRetryWaitMsDefault)*time.Millisecond, d)
-
-	d = backoffDuration(0, -1, -1)
 	assert.Equal(t, time.Duration(CommitMinRetryWaitMsDefault)*time.Millisecond, d)
 
 	// Very large attempt counts must not panic on shift; clamps to maxMs.
 	d = backoffDuration(100, 100, 60000)
 	assert.GreaterOrEqual(t, d, 100*time.Millisecond)
 	assert.LessOrEqual(t, d, 60000*time.Millisecond)
+}
+
+func TestReadRetryConfig_ClampsNegativeProperties(t *testing.T) {
+	// Negative values in properties should be replaced with defaults.
+	cfg := readRetryConfig(iceberg.Properties{
+		CommitNumRetriesKey:          "-1",
+		CommitMinRetryWaitMsKey:      "-100",
+		CommitMaxRetryWaitMsKey:      "-1000",
+		CommitTotalRetryTimeoutMsKey: "-5",
+	})
+	assert.Equal(t, uint(CommitNumRetriesDefault), cfg.numRetries)
+	assert.Equal(t, uint(CommitMinRetryWaitMsDefault), cfg.minWaitMs)
+	assert.Equal(t, uint(CommitMaxRetryWaitMsDefault), cfg.maxWaitMs)
+	assert.Equal(t, uint(CommitTotalRetryTimeoutMsDefault), cfg.totalTimeoutMs)
 }

--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -1,0 +1,252 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flakyCatalog commits successfully only on a specified attempt number.
+// Earlier attempts return the given error.
+type flakyCatalog struct {
+	metadata         Metadata
+	failUntilAttempt int
+	failWith         error
+	attempts         atomic.Int32
+}
+
+func (c *flakyCatalog) LoadTable(ctx context.Context, ident Identifier) (*Table, error) {
+	return nil, nil
+}
+
+func (c *flakyCatalog) CommitTable(ctx context.Context, ident Identifier, reqs []Requirement, updates []Update) (Metadata, string, error) {
+	n := c.attempts.Add(1)
+	if int(n) <= c.failUntilAttempt {
+		return nil, "", c.failWith
+	}
+
+	meta, err := UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = meta
+
+	return meta, "", nil
+}
+
+func newRetryTestTable(t *testing.T, cat CatalogIO, props iceberg.Properties) *Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	if props == nil {
+		props = iceberg.Properties{}
+	}
+	props[PropertyFormatVersion] = "2"
+
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec,
+		UnsortedSortOrder, location, props)
+	require.NoError(t, err)
+
+	return New(
+		Identifier{"db", "retry_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(ctx context.Context) (iceio.IO, error) {
+			return iceio.LocalFS{}, nil
+		},
+		cat,
+	)
+}
+
+func TestDoCommit_SucceedsFirstTry(t *testing.T) {
+	cat := &flakyCatalog{}
+	tbl := newRetryTestTable(t, cat, nil)
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), cat.attempts.Load())
+}
+
+func TestDoCommit_RetriesOnCommitFailed(t *testing.T) {
+	cat := &flakyCatalog{
+		failUntilAttempt: 2,
+		failWith:         fmt.Errorf("REST: %w", ErrCommitFailed),
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "4",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), cat.attempts.Load(), "should retry 2x then succeed on 3rd")
+}
+
+func TestDoCommit_GivesUpAfterMaxRetries(t *testing.T) {
+	cat := &flakyCatalog{
+		failUntilAttempt: 100,
+		failWith:         fmt.Errorf("REST: %w", ErrCommitFailed),
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "2",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCommitFailed)
+	// 1 initial + 2 retries = 3 attempts
+	assert.Equal(t, int32(3), cat.attempts.Load())
+}
+
+func TestDoCommit_DoesNotRetryUnknownStateError(t *testing.T) {
+	unknownErr := errors.New("500 internal server error")
+	cat := &flakyCatalog{
+		failUntilAttempt: 5,
+		failWith:         unknownErr,
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "10",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, unknownErr)
+	// Must not retry — unknown state could mean the commit actually succeeded.
+	assert.Equal(t, int32(1), cat.attempts.Load())
+}
+
+func TestDoCommit_DoesNotRetryUnrelatedError(t *testing.T) {
+	otherErr := errors.New("network unreachable")
+	cat := &flakyCatalog{
+		failUntilAttempt: 5,
+		failWith:         otherErr,
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "10",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, otherErr)
+	assert.Equal(t, int32(1), cat.attempts.Load())
+}
+
+func TestDoCommit_RespectsContextCancellation(t *testing.T) {
+	cat := &flakyCatalog{
+		failUntilAttempt: 100,
+		failWith:         fmt.Errorf("REST: %w", ErrCommitFailed),
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "10",
+		CommitMinRetryWaitMsKey: "50",
+		CommitMaxRetryWaitMsKey: "200",
+	})
+	cat.metadata = tbl.Metadata()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := tbl.doCommit(ctx, nil, nil)
+	require.Error(t, err)
+	// Either the commit error bubbles up or context cancellation does.
+	// Both are acceptable outcomes — the test just verifies we don't hang.
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrCommitFailed))
+	assert.Less(t, cat.attempts.Load(), int32(10), "should stop retrying after context cancels")
+}
+
+func TestDoCommit_ZeroRetriesOnlyOneAttempt(t *testing.T) {
+	cat := &flakyCatalog{
+		failUntilAttempt: 5,
+		failWith:         fmt.Errorf("REST: %w", ErrCommitFailed),
+	}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitNumRetriesKey:     "0",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), cat.attempts.Load())
+}
+
+func TestBackoffDuration_ExponentialWithJitter(t *testing.T) {
+	const minMs, maxMs = 100, 60000
+	minWait := time.Duration(minMs) * time.Millisecond
+
+	// Attempt 0: cap == minMs, wait is exactly minMs.
+	for range 20 {
+		d := backoffDuration(0, minMs, maxMs)
+		assert.Equal(t, minWait, d)
+	}
+
+	// Attempt 3: cap = 800ms (100 << 3), wait in [minMs, 800ms].
+	for range 20 {
+		d := backoffDuration(3, minMs, maxMs)
+		assert.GreaterOrEqual(t, d, minWait)
+		assert.LessOrEqual(t, d, 800*time.Millisecond)
+	}
+
+	// Attempt 20: overflow protection, wait in [minMs, maxMs].
+	for range 20 {
+		d := backoffDuration(20, minMs, maxMs)
+		assert.GreaterOrEqual(t, d, minWait)
+		assert.LessOrEqual(t, d, time.Duration(maxMs)*time.Millisecond)
+	}
+}
+
+func TestBackoffDuration_HandlesZeroOrNegativeInputs(t *testing.T) {
+	// Should fall back to defaults rather than panic or return garbage.
+	d := backoffDuration(0, 0, 0)
+	assert.Equal(t, time.Duration(CommitMinRetryWaitMsDefault)*time.Millisecond, d)
+
+	d = backoffDuration(0, -1, -1)
+	assert.Equal(t, time.Duration(CommitMinRetryWaitMsDefault)*time.Millisecond, d)
+
+	// Negative attempt must not panic on shift.
+	d = backoffDuration(-5, 100, 60000)
+	assert.Equal(t, 100*time.Millisecond, d)
+}

--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -246,7 +246,8 @@ func TestBackoffDuration_HandlesZeroOrNegativeInputs(t *testing.T) {
 	d = backoffDuration(0, -1, -1)
 	assert.Equal(t, time.Duration(CommitMinRetryWaitMsDefault)*time.Millisecond, d)
 
-	// Negative attempt must not panic on shift.
-	d = backoffDuration(-5, 100, 60000)
-	assert.Equal(t, 100*time.Millisecond, d)
+	// Very large attempt counts must not panic on shift; clamps to maxMs.
+	d = backoffDuration(100, 100, 60000)
+	assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+	assert.LessOrEqual(t, d, 60000*time.Millisecond)
 }

--- a/table/properties.go
+++ b/table/properties.go
@@ -98,6 +98,33 @@ const (
 
 	MaxRefAgeMsKey     = "max-ref-age-ms"
 	MaxRefAgeMsDefault = math.MaxInt
+
+	// CommitNumRetriesKey is the number of commit retry attempts before
+	// giving up on ErrCommitFailed from the catalog.
+	//
+	// The default is 0 (no retries) until refresh-and-replay lands; a
+	// retry loop that reuses the original updates/requirements will
+	// fail deterministically on genuine OCC conflicts and only slow
+	// down the final error. Callers that observe transient catalog
+	// flakiness (dropped connections, brief 409 during leader
+	// election) can raise this to recover.
+	CommitNumRetriesKey     = "commit.retry.num-retries"
+	CommitNumRetriesDefault = 0
+
+	// CommitMinRetryWaitMsKey is the initial wait time in milliseconds
+	// for exponential backoff between commit retry attempts. Default: 100ms.
+	CommitMinRetryWaitMsKey     = "commit.retry.min-wait-ms"
+	CommitMinRetryWaitMsDefault = 100
+
+	// CommitMaxRetryWaitMsKey is the maximum wait time in milliseconds
+	// between commit retry attempts. Default: 60s.
+	CommitMaxRetryWaitMsKey     = "commit.retry.max-wait-ms"
+	CommitMaxRetryWaitMsDefault = 60 * 1000
+
+	// CommitTotalRetryTimeoutMsKey bounds the total time spent across all
+	// retry attempts. Default: 30 minutes.
+	CommitTotalRetryTimeoutMsKey     = "commit.retry.total-timeout-ms"
+	CommitTotalRetryTimeoutMsDefault = 30 * 60 * 1000
 )
 
 // Reserved properties

--- a/table/table.go
+++ b/table/table.go
@@ -399,10 +399,10 @@ type retryConfig struct {
 
 func readRetryConfig(props iceberg.Properties) retryConfig {
 	return retryConfig{
-		numRetries:     iceberg.PropUint(props, CommitNumRetriesKey, CommitNumRetriesDefault),
-		minWaitMs:      iceberg.PropUint(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
-		maxWaitMs:      iceberg.PropUint(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
-		totalTimeoutMs: iceberg.PropUint(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+		numRetries:     iceberg.PropUInt(props, CommitNumRetriesKey, CommitNumRetriesDefault),
+		minWaitMs:      iceberg.PropUInt(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      iceberg.PropUInt(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: iceberg.PropUInt(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
 	}
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -21,12 +21,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"iter"
 	"log"
+	"math/rand/v2"
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -36,6 +39,26 @@ import (
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"golang.org/x/sync/errgroup"
 )
+
+// ErrCommitFailed is the sentinel error returned by catalogs when a
+// commit fails due to a concurrent modification (e.g. HTTP 409 Conflict
+// from the REST catalog). Catalog implementations should wrap this
+// error so that callers using errors.Is(err, table.ErrCommitFailed)
+// can detect retryable commit conflicts.
+//
+// Currently only catalog/rest wraps this sentinel; Glue, SQL, and Hive
+// catalogs return their conflict errors raw and will not trigger
+// retries until follow-up work wires them through (tracked under
+// issue #830).
+//
+// The retry loop in doCommit re-issues the original updates and
+// requirements unchanged. This recovers only from transient catalog
+// errors (dropped connections, brief 409 during leader election); it
+// does not yet refresh the table metadata between attempts, so a
+// contended commit whose AssertRefSnapshotID requirement has been
+// invalidated by a peer will fail deterministically on every retry.
+// Refresh-and-replay is tracked separately (issue #830).
+var ErrCommitFailed = errors.New("commit failed, refresh and try again")
 
 type FSysF func(ctx context.Context) (icebergio.IO, error)
 
@@ -303,10 +326,55 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 }
 
 func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requirement) (*Table, error) {
-	newMeta, newLoc, err := t.cat.CommitTable(ctx, t.identifier, reqs, updates)
+	cfg := readRetryConfig(t.metadata.Properties())
+
+	// Bound total retry time with a derived context so both the wait loop
+	// and the CommitTable call itself respect the deadline uniformly.
+	retryCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.totalTimeoutMs)*time.Millisecond)
+	defer cancel()
+
+	var (
+		newMeta Metadata
+		newLoc  string
+		err     error
+	)
+
+	for attempt := 0; attempt <= cfg.numRetries; attempt++ {
+		if retryCtx.Err() != nil {
+			return nil, context.Cause(retryCtx)
+		}
+
+		newMeta, newLoc, err = t.cat.CommitTable(retryCtx, t.identifier, reqs, updates)
+		if err == nil {
+			break
+		}
+
+		// Only retry on retryable commit conflicts. Unknown-state errors
+		// (5xx, gateway timeouts) must NOT be retried because the commit
+		// may have actually succeeded — retrying could duplicate work.
+		if !errors.Is(err, ErrCommitFailed) {
+			return nil, err
+		}
+
+		if attempt == cfg.numRetries {
+			break
+		}
+
+		wait := backoffDuration(attempt, cfg.minWaitMs, cfg.maxWaitMs)
+		timer := time.NewTimer(wait)
+		select {
+		case <-retryCtx.Done():
+			timer.Stop()
+
+			return nil, context.Cause(retryCtx)
+		case <-timer.C:
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	fs, err := t.fsF(ctx)
 	if err != nil {
 		return nil, err
@@ -314,6 +382,68 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
 	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
+}
+
+type retryConfig struct {
+	numRetries     int
+	minWaitMs      int
+	maxWaitMs      int
+	totalTimeoutMs int
+}
+
+func readRetryConfig(props iceberg.Properties) retryConfig {
+	cfg := retryConfig{
+		numRetries:     props.GetInt(CommitNumRetriesKey, CommitNumRetriesDefault),
+		minWaitMs:      props.GetInt(CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      props.GetInt(CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: props.GetInt(CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+	}
+	if cfg.numRetries < 0 {
+		cfg.numRetries = 0
+	}
+
+	return cfg
+}
+
+// backoffDuration computes wait time for the given 0-based retry attempt
+// using exponential backoff (minMs << attempt) clamped to maxMs, with
+// jitter in [minMs, ceiling] to avoid retry stampedes while keeping a
+// non-zero floor between attempts. Java Iceberg uses a deterministic
+// exponential backoff here; we add jitter to reduce stampede risk on
+// concurrent Go writers. Backoff is client-local, so this does not
+// affect cross-client interop.
+func backoffDuration(attempt, minMs, maxMs int) time.Duration {
+	if minMs <= 0 {
+		minMs = CommitMinRetryWaitMsDefault
+	}
+	if maxMs <= 0 {
+		maxMs = CommitMaxRetryWaitMsDefault
+	}
+	if minMs > maxMs {
+		minMs = maxMs
+	}
+	// Guard the shift count: negative shifts panic, and shifts at or
+	// beyond the operand width overflow the signed int64 to 0 or a
+	// negative value which we'd then clamp anyway. Clamping here keeps
+	// the math obvious at the call site below.
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt > 62 {
+		attempt = 62
+	}
+
+	ceiling := int64(minMs) << attempt
+	if ceiling <= 0 || ceiling > int64(maxMs) {
+		ceiling = int64(maxMs)
+	}
+
+	// Jitter in [minMs, ceiling]: keeps a non-zero floor so concurrent
+	// writers don't all sample 0 and retry in lockstep.
+	//nolint:gosec // non-security randomness, jitter for retry spread
+	wait := int64(minMs) + rand.Int64N(ceiling-int64(minMs)+1)
+
+	return time.Duration(wait) * time.Millisecond
 }
 
 // SnapshotAsOf finds the snapshot that was current as of or right before the given timestamp.

--- a/table/table.go
+++ b/table/table.go
@@ -399,23 +399,11 @@ type retryConfig struct {
 
 func readRetryConfig(props iceberg.Properties) retryConfig {
 	return retryConfig{
-		numRetries:     positiveIntProp(props, CommitNumRetriesKey, CommitNumRetriesDefault),
-		minWaitMs:      positiveIntProp(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
-		maxWaitMs:      positiveIntProp(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
-		totalTimeoutMs: positiveIntProp(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+		numRetries:     iceberg.PropUint(props, CommitNumRetriesKey, CommitNumRetriesDefault),
+		minWaitMs:      iceberg.PropUint(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      iceberg.PropUint(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: iceberg.PropUint(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
 	}
-}
-
-// positiveIntProp reads an int property and returns it as uint, falling
-// back to the default when the configured value is negative. The default
-// is also non-negative, so the result is always safe to use as uint.
-func positiveIntProp(props iceberg.Properties, key string, fallback int) uint {
-	v := props.GetInt(key, fallback)
-	if v < 0 {
-		v = fallback
-	}
-
-	return uint(v)
 }
 
 // backoffDuration computes wait time for the given 0-based retry attempt

--- a/table/table.go
+++ b/table/table.go
@@ -337,9 +337,29 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		newMeta Metadata
 		newLoc  string
 		err     error
+		timer   *time.Timer
 	)
 
-	for attempt := 0; attempt <= cfg.numRetries; attempt++ {
+	// numRetries counts retries; total attempts = 1 initial + numRetries.
+	totalAttempts := cfg.numRetries + 1
+
+	for attempt := range totalAttempts {
+		if attempt != 0 {
+			wait := backoffDuration(uint(attempt-1), cfg.minWaitMs, cfg.maxWaitMs)
+			if timer == nil {
+				timer = time.NewTimer(wait)
+			} else {
+				timer.Reset(wait)
+			}
+			select {
+			case <-retryCtx.Done():
+				timer.Stop()
+
+				return nil, context.Cause(retryCtx)
+			case <-timer.C:
+			}
+		}
+
 		if retryCtx.Err() != nil {
 			return nil, context.Cause(retryCtx)
 		}
@@ -354,20 +374,6 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		// may have actually succeeded — retrying could duplicate work.
 		if !errors.Is(err, ErrCommitFailed) {
 			return nil, err
-		}
-
-		if attempt == cfg.numRetries {
-			break
-		}
-
-		wait := backoffDuration(attempt, cfg.minWaitMs, cfg.maxWaitMs)
-		timer := time.NewTimer(wait)
-		select {
-		case <-retryCtx.Done():
-			timer.Stop()
-
-			return nil, context.Cause(retryCtx)
-		case <-timer.C:
 		}
 	}
 
@@ -412,7 +418,7 @@ func readRetryConfig(props iceberg.Properties) retryConfig {
 // exponential backoff here; we add jitter to reduce stampede risk on
 // concurrent Go writers. Backoff is client-local, so this does not
 // affect cross-client interop.
-func backoffDuration(attempt, minMs, maxMs int) time.Duration {
+func backoffDuration(attempt uint, minMs, maxMs int) time.Duration {
 	if minMs <= 0 {
 		minMs = CommitMinRetryWaitMsDefault
 	}
@@ -422,13 +428,9 @@ func backoffDuration(attempt, minMs, maxMs int) time.Duration {
 	if minMs > maxMs {
 		minMs = maxMs
 	}
-	// Guard the shift count: negative shifts panic, and shifts at or
-	// beyond the operand width overflow the signed int64 to 0 or a
-	// negative value which we'd then clamp anyway. Clamping here keeps
-	// the math obvious at the call site below.
-	if attempt < 0 {
-		attempt = 0
-	}
+	// Cap the shift count so the signed int64 below does not overflow
+	// past its operand width; overflow would just be clamped to maxMs
+	// anyway, so keep the math obvious instead.
 	if attempt > 62 {
 		attempt = 62
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -345,7 +345,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 	for attempt := range totalAttempts {
 		if attempt != 0 {
-			wait := backoffDuration(uint(attempt-1), cfg.minWaitMs, cfg.maxWaitMs)
+			wait := backoffDuration(attempt-1, cfg.minWaitMs, cfg.maxWaitMs)
 			if timer == nil {
 				timer = time.NewTimer(wait)
 			} else {
@@ -391,24 +391,31 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 }
 
 type retryConfig struct {
-	numRetries     int
-	minWaitMs      int
-	maxWaitMs      int
-	totalTimeoutMs int
+	numRetries     uint
+	minWaitMs      uint
+	maxWaitMs      uint
+	totalTimeoutMs uint
 }
 
 func readRetryConfig(props iceberg.Properties) retryConfig {
-	cfg := retryConfig{
-		numRetries:     props.GetInt(CommitNumRetriesKey, CommitNumRetriesDefault),
-		minWaitMs:      props.GetInt(CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
-		maxWaitMs:      props.GetInt(CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
-		totalTimeoutMs: props.GetInt(CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+	return retryConfig{
+		numRetries:     positiveIntProp(props, CommitNumRetriesKey, CommitNumRetriesDefault),
+		minWaitMs:      positiveIntProp(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      positiveIntProp(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: positiveIntProp(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
 	}
-	if cfg.numRetries < 0 {
-		cfg.numRetries = 0
+}
+
+// positiveIntProp reads an int property and returns it as uint, falling
+// back to the default when the configured value is negative. The default
+// is also non-negative, so the result is always safe to use as uint.
+func positiveIntProp(props iceberg.Properties, key string, fallback int) uint {
+	v := props.GetInt(key, fallback)
+	if v < 0 {
+		v = fallback
 	}
 
-	return cfg
+	return uint(v)
 }
 
 // backoffDuration computes wait time for the given 0-based retry attempt
@@ -418,11 +425,14 @@ func readRetryConfig(props iceberg.Properties) retryConfig {
 // exponential backoff here; we add jitter to reduce stampede risk on
 // concurrent Go writers. Backoff is client-local, so this does not
 // affect cross-client interop.
-func backoffDuration(attempt uint, minMs, maxMs int) time.Duration {
-	if minMs <= 0 {
+//
+// Inputs are trusted: readRetryConfig is responsible for normalizing
+// user-supplied properties (negatives, zero, min > max).
+func backoffDuration(attempt, minMs, maxMs uint) time.Duration {
+	if minMs == 0 {
 		minMs = CommitMinRetryWaitMsDefault
 	}
-	if maxMs <= 0 {
+	if maxMs == 0 {
 		maxMs = CommitMaxRetryWaitMsDefault
 	}
 	if minMs > maxMs {

--- a/types.go
+++ b/types.go
@@ -71,6 +71,23 @@ func (p Properties) GetInt(key string, defVal int) int {
 	return defVal
 }
 
+// PropUint reads an unsigned-integer property by key. A missing key,
+// an unparseable value, or a negative value returns defVal — PropUint
+// uses strconv.ParseUint, which rejects negatives rather than silently
+// wrapping them to a large positive number.
+func PropUint(p Properties, key string, defVal uint) uint {
+	v, ok := p[key]
+	if !ok {
+		return defVal
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return defVal
+	}
+
+	return uint(n)
+}
+
 // Type is an interface representing any of the available iceberg types,
 // such as primitives (int32/int64/etc.) or nested types (list/struct/map).
 type Type interface {

--- a/types.go
+++ b/types.go
@@ -71,11 +71,11 @@ func (p Properties) GetInt(key string, defVal int) int {
 	return defVal
 }
 
-// PropUint reads an unsigned-integer property by key. A missing key,
-// an unparseable value, or a negative value returns defVal — PropUint
+// PropUInt reads an unsigned-integer property by key. A missing key,
+// an unparseable value, or a negative value returns defVal — PropUInt
 // uses strconv.ParseUint, which rejects negatives rather than silently
 // wrapping them to a large positive number.
-func PropUint(p Properties, key string, defVal uint) uint {
+func PropUInt(p Properties, key string, defVal uint) uint {
 	v, ok := p[key]
 	if !ok {
 		return defVal

--- a/types_test.go
+++ b/types_test.go
@@ -466,16 +466,16 @@ func TestTypeIFaceMarshalJSONNilType(t *testing.T) {
 	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 }
 
-func TestPropUint(t *testing.T) {
+func TestPropUInt(t *testing.T) {
 	props := iceberg.Properties{
 		"n":       "42",
 		"neg":     "-7",
 		"garbage": "not-a-number",
 	}
 
-	assert.Equal(t, uint(42), iceberg.PropUint(props, "n", 0))
-	assert.Equal(t, uint(99), iceberg.PropUint(props, "neg", 99),
+	assert.Equal(t, uint(42), iceberg.PropUInt(props, "n", 0))
+	assert.Equal(t, uint(99), iceberg.PropUInt(props, "neg", 99),
 		"negative string must fall back, not wrap to a huge positive")
-	assert.Equal(t, uint(77), iceberg.PropUint(props, "garbage", 77), "falls back on parse error")
-	assert.Equal(t, uint(5), iceberg.PropUint(props, "missing", 5), "falls back on missing key")
+	assert.Equal(t, uint(77), iceberg.PropUInt(props, "garbage", 77), "falls back on parse error")
+	assert.Equal(t, uint(5), iceberg.PropUInt(props, "missing", 5), "falls back on missing key")
 }

--- a/types_test.go
+++ b/types_test.go
@@ -465,3 +465,17 @@ func TestTypeIFaceMarshalJSONNilType(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 }
+
+func TestPropUint(t *testing.T) {
+	props := iceberg.Properties{
+		"n":       "42",
+		"neg":     "-7",
+		"garbage": "not-a-number",
+	}
+
+	assert.Equal(t, uint(42), iceberg.PropUint(props, "n", 0))
+	assert.Equal(t, uint(99), iceberg.PropUint(props, "neg", 99),
+		"negative string must fall back, not wrap to a huge positive")
+	assert.Equal(t, uint(77), iceberg.PropUint(props, "garbage", 77), "falls back on parse error")
+	assert.Equal(t, uint(5), iceberg.PropUint(props, "missing", 5), "falls back on missing key")
+}


### PR DESCRIPTION
Wrap Table.doCommit in an exponential-backoff retry loop that retries only on errors.Is(err, table.ErrCommitFailed). 5xx/unknown-state errors are never retried because the commit may have actually succeeded.

ErrCommitFailed is a new sentinel in the table package; catalog/rest's existing sentinel now wraps it via fmt.Errorf("%w: %w", ...) so callers can detect retryable conflicts with errors.Is(err, table.ErrCommitFailed).

Retry budget is enforced via context.WithTimeout so both the sleep loop and the CommitTable call itself respect the deadline. Backoff is minMs << attempt clamped to maxMs, with jitter in [minMs, ceiling] to avoid zero-wait retry stampedes.

The default num-retries is 0 until refresh-and-replay lands in a follow-up; without refreshing requirements between attempts, retrying a contended OCC commit would fail deterministically and just delay the eventual error. Glue/SQL/Hive catalogs do not yet wrap the sentinel, so retries only engage for the REST catalog today.

Configurable via:
  commit.retry.num-retries       (default 0)
  commit.retry.min-wait-ms       (default 100)
  commit.retry.max-wait-ms       (default 60000)
  commit.retry.total-timeout-ms  (default 1800000)

Part of #830 (concurrent writer conflict detection).