### PR TITLE
feat(io): add ListableIO interface to replace reflect-based directory walking (#913)

### DIFF
--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -29,7 +29,6 @@ import (
 
 	icebergio "github.com/apache/iceberg-go/io"
 	"gocloud.dev/blob"
-	"gocloud.dev/gcerrors"
 )
 
 // blobOpenFile describes a single open blob as a File.
@@ -208,42 +207,6 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		return fn(parsed.JoinPath(path).String(), d, err)
 	})
-}
-
-func (bfs *blobFileIO) DeleteFiles(ctx context.Context, paths []string) ([]string, error) {
-	if len(paths) == 0 {
-		return nil, nil
-	}
-
-	deleted := make([]string, 0, len(paths))
-
-	var errs error
-
-	for _, p := range paths {
-		key, err := bfs.preprocess(p)
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
-
-			continue
-		}
-
-		if err := bfs.Delete(ctx, key); err != nil {
-			// Missing files are not errors per the interface contract.
-			if gcerrors.Code(err) == gcerrors.NotFound {
-				deleted = append(deleted, p)
-
-				continue
-			}
-
-			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
-
-			continue
-		}
-
-		deleted = append(deleted, p)
-	}
-
-	return deleted, errs
 }
 
 type blobWriteFile struct {

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -202,7 +202,11 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 		walkPath = "."
 	}
 
-	prefix := parsed.Scheme + "://" + parsed.Host + "/"
+	prefix := parsed.Scheme + "://"
+	if parsed.User != nil {
+		prefix += parsed.User.String() + "@"
+	}
+	prefix += parsed.Host + "/"
 
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		return fn(prefix+path, d, err)

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -188,6 +189,24 @@ func (bfs *blobFileIO) NewWriter(ctx context.Context, path string, overwrite boo
 
 func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor) icebergio.IO {
 	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, ctx: ctx}
+}
+
+func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
+	parsed, err := url.Parse(root)
+	if err != nil {
+		return fmt.Errorf("invalid URL %s: %w", root, err)
+	}
+
+	walkPath := strings.TrimPrefix(parsed.Path, "/")
+	if walkPath == "" {
+		walkPath = "."
+	}
+
+	prefix := parsed.Scheme + "://" + parsed.Host + "/"
+
+	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
+		return fn(prefix+path, d, err)
+	})
 }
 
 type blobWriteFile struct {

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -29,6 +29,7 @@ import (
 
 	icebergio "github.com/apache/iceberg-go/io"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 )
 
 // blobOpenFile describes a single open blob as a File.
@@ -211,6 +212,42 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		return fn(prefix+path, d, err)
 	})
+}
+
+func (bfs *blobFileIO) DeleteFiles(ctx context.Context, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	deleted := make([]string, 0, len(paths))
+
+	var errs error
+
+	for _, p := range paths {
+		key, err := bfs.preprocess(p)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
+
+			continue
+		}
+
+		if err := bfs.Delete(ctx, key); err != nil {
+			// Missing files are not errors per the interface contract.
+			if gcerrors.Code(err) == gcerrors.NotFound {
+				deleted = append(deleted, p)
+
+				continue
+			}
+
+			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
+
+			continue
+		}
+
+		deleted = append(deleted, p)
+	}
+
+	return deleted, errs
 }
 
 type blobWriteFile struct {

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -203,14 +203,10 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 		walkPath = "."
 	}
 
-	prefix := parsed.Scheme + "://"
-	if parsed.User != nil {
-		prefix += parsed.User.String() + "@"
-	}
-	prefix += parsed.Host + "/"
+	parsed.Path = ""
 
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
-		return fn(prefix+path, d, err)
+		return fn(parsed.JoinPath(path).String(), d, err)
 	})
 }
 

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	icebergio "github.com/apache/iceberg-go/io"
-
 	"gocloud.dev/blob/memblob"
 )
 
@@ -306,77 +304,4 @@ func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
 		"abfs://container@account.dfs.core.windows.net/path/to/file.parquet",
 	}
 	assert.Equal(t, expected, walked)
-}
-
-func TestBlobFileIOImplementsBulkRemovableIO(t *testing.T) {
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	bfs := createBlobFS(context.Background(), bucket, defaultKeyExtractor("test-bucket"))
-
-	_, ok := bfs.(icebergio.BulkRemovableIO)
-	assert.True(t, ok, "blobFileIO should implement BulkRemovableIO")
-}
-
-func TestBlobFileIODeleteFiles(t *testing.T) {
-	ctx := context.Background()
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	// Write test files.
-	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("data1"), nil))
-	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("data2"), nil))
-	require.NoError(t, bucket.WriteAll(ctx, "data/file3.parquet", []byte("data3"), nil))
-
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
-	bulk := bfs.(icebergio.BulkRemovableIO)
-
-	deleted, err := bulk.DeleteFiles(ctx, []string{
-		"s3://test-bucket/data/file1.parquet",
-		"s3://test-bucket/data/file2.parquet",
-	})
-	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{
-		"s3://test-bucket/data/file1.parquet",
-		"s3://test-bucket/data/file2.parquet",
-	}, deleted)
-
-	// file3 should still exist.
-	exists, err := bucket.Exists(ctx, "data/file3.parquet")
-	require.NoError(t, err)
-	assert.True(t, exists)
-
-	// file1 should be gone.
-	exists, err = bucket.Exists(ctx, "data/file1.parquet")
-	require.NoError(t, err)
-	assert.False(t, exists)
-}
-
-func TestBlobFileIODeleteFilesMissingFilesAreNotErrors(t *testing.T) {
-	ctx := context.Background()
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
-	bulk := bfs.(icebergio.BulkRemovableIO)
-
-	// Deleting non-existent files should succeed.
-	deleted, err := bulk.DeleteFiles(ctx, []string{
-		"s3://test-bucket/data/nonexistent.parquet",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, []string{"s3://test-bucket/data/nonexistent.parquet"}, deleted)
-}
-
-func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
-	ctx := context.Background()
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
-	bulk := bfs.(icebergio.BulkRemovableIO)
-
-	deleted, err := bulk.DeleteFiles(ctx, nil)
-	require.NoError(t, err)
-	assert.Nil(t, deleted)
 }

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -190,3 +190,83 @@ func TestReadAtResourceCleanup(t *testing.T) {
 		})
 	}
 }
+
+func TestBlobFileIOWalkDir(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	files := []string{
+		"data/file1.parquet",
+		"data/file2.parquet",
+		"metadata/snap-123.avro",
+	}
+	for _, f := range files {
+		require.NoError(t, bucket.WriteAll(ctx, f, []byte("content"), nil))
+	}
+
+	bfs := &blobFileIO{
+		Bucket:       bucket,
+		keyExtractor: defaultKeyExtractor("test-bucket"),
+		ctx:          ctx,
+	}
+
+	var walked []string
+	err := bfs.WalkDir("s3://test-bucket/", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			walked = append(walked, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expected := []string{
+		"s3://test-bucket/data/file1.parquet",
+		"s3://test-bucket/data/file2.parquet",
+		"s3://test-bucket/metadata/snap-123.avro",
+	}
+	assert.ElementsMatch(t, expected, walked)
+}
+
+func TestBlobFileIOWalkDirSubPath(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("a"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("b"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, "metadata/v1.json", []byte("c"), nil))
+
+	bfs := &blobFileIO{
+		Bucket:       bucket,
+		keyExtractor: defaultKeyExtractor("mybucket"),
+		ctx:          ctx,
+	}
+
+	var walked []string
+	err := bfs.WalkDir("s3://mybucket/data", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			walked = append(walked, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expected := []string{
+		"s3://mybucket/data/file1.parquet",
+		"s3://mybucket/data/file2.parquet",
+	}
+	assert.ElementsMatch(t, expected, walked)
+}

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -270,3 +270,37 @@ func TestBlobFileIOWalkDirSubPath(t *testing.T) {
 	}
 	assert.ElementsMatch(t, expected, walked)
 }
+
+func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	require.NoError(t, bucket.WriteAll(ctx, "path/to/file.parquet", []byte("data"), nil))
+
+	bfs := &blobFileIO{
+		Bucket:       bucket,
+		keyExtractor: defaultKeyExtractor("container@account.dfs.core.windows.net"),
+		ctx:          ctx,
+	}
+
+	var walked []string
+	err := bfs.WalkDir("abfs://container@account.dfs.core.windows.net/path", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			walked = append(walked, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expected := []string{
+		"abfs://container@account.dfs.core.windows.net/path/to/file.parquet",
+	}
+	assert.Equal(t, expected, walked)
+}

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	icebergio "github.com/apache/iceberg-go/io"
+
 	"gocloud.dev/blob/memblob"
 )
 
@@ -303,4 +306,77 @@ func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
 		"abfs://container@account.dfs.core.windows.net/path/to/file.parquet",
 	}
 	assert.Equal(t, expected, walked)
+}
+
+func TestBlobFileIOImplementsBulkRemovableIO(t *testing.T) {
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := createBlobFS(context.Background(), bucket, defaultKeyExtractor("test-bucket"))
+
+	_, ok := bfs.(icebergio.BulkRemovableIO)
+	assert.True(t, ok, "blobFileIO should implement BulkRemovableIO")
+}
+
+func TestBlobFileIODeleteFiles(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	// Write test files.
+	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("data1"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("data2"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, "data/file3.parquet", []byte("data3"), nil))
+
+	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	bulk := bfs.(icebergio.BulkRemovableIO)
+
+	deleted, err := bulk.DeleteFiles(ctx, []string{
+		"s3://test-bucket/data/file1.parquet",
+		"s3://test-bucket/data/file2.parquet",
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"s3://test-bucket/data/file1.parquet",
+		"s3://test-bucket/data/file2.parquet",
+	}, deleted)
+
+	// file3 should still exist.
+	exists, err := bucket.Exists(ctx, "data/file3.parquet")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// file1 should be gone.
+	exists, err = bucket.Exists(ctx, "data/file1.parquet")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestBlobFileIODeleteFilesMissingFilesAreNotErrors(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	bulk := bfs.(icebergio.BulkRemovableIO)
+
+	// Deleting non-existent files should succeed.
+	deleted, err := bulk.DeleteFiles(ctx, []string{
+		"s3://test-bucket/data/nonexistent.parquet",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"s3://test-bucket/data/nonexistent.parquet"}, deleted)
+}
+
+func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	bulk := bfs.(icebergio.BulkRemovableIO)
+
+	deleted, err := bulk.DeleteFiles(ctx, nil)
+	require.NoError(t, err)
+	assert.Nil(t, deleted)
 }

--- a/io/io.go
+++ b/io/io.go
@@ -107,6 +107,25 @@ type ListableIO interface {
 	WalkDir(root string, fn fs.WalkDirFunc) error
 }
 
+// BulkRemovableIO is an optional interface for IO implementations that
+// support deleting multiple files in a single batch operation.
+// Cloud object stores (S3 DeleteObjects, GCS batch, Azure batch) can
+// implement this for significantly better throughput than single-file Remove.
+type BulkRemovableIO interface {
+	IO
+
+	// DeleteFiles deletes all named files. Implementations should make a
+	// best-effort attempt to delete as many files as possible, returning
+	// the list of successfully deleted paths and a joined error
+	// (via [errors.Join]) for any individual failures.
+	//
+	// Missing files are not considered errors — if a path does not exist,
+	// it should be treated as a successful deletion.
+	//
+	// An empty paths slice is a no-op and must not error.
+	DeleteFiles(ctx context.Context, paths []string) (deleted []string, err error)
+}
+
 // A File provides access to a single file. The File interface is the
 // minimum implementation required for Iceberg to interact with a file.
 // Directory files should also implement

--- a/io/io.go
+++ b/io/io.go
@@ -107,25 +107,6 @@ type ListableIO interface {
 	WalkDir(root string, fn fs.WalkDirFunc) error
 }
 
-// BulkRemovableIO is an optional interface for IO implementations that
-// support deleting multiple files in a single batch operation.
-// Cloud object stores (S3 DeleteObjects, GCS batch, Azure batch) can
-// implement this for significantly better throughput than single-file Remove.
-type BulkRemovableIO interface {
-	IO
-
-	// DeleteFiles deletes all named files. Implementations should make a
-	// best-effort attempt to delete as many files as possible, returning
-	// the list of successfully deleted paths and a joined error
-	// (via [errors.Join]) for any individual failures.
-	//
-	// Missing files are not considered errors — if a path does not exist,
-	// it should be treated as a successful deletion.
-	//
-	// An empty paths slice is a no-op and must not error.
-	DeleteFiles(ctx context.Context, paths []string) (deleted []string, err error)
-}
-
 // A File provides access to a single file. The File interface is the
 // minimum implementation required for Iceberg to interact with a file.
 // Directory files should also implement

--- a/io/io.go
+++ b/io/io.go
@@ -90,6 +90,23 @@ type WriteFileIO interface {
 	WriteFile(name string, p []byte) error
 }
 
+// ListableIO is the interface implemented by a file system that
+// supports directory walking. This replaces the need for reflect-based
+// access to internal file system structures (e.g., blob storage buckets).
+//
+// The root parameter is a full URI (e.g., "s3://bucket/path" or
+// "/local/path") as used throughout the iceberg-go codebase.
+// The fn callback receives full URI paths consistent with the root's
+// scheme and authority.
+type ListableIO interface {
+	IO
+
+	// WalkDir walks the file tree rooted at root, calling fn for each
+	// file or directory in the tree, including root. Paths passed to fn
+	// are full URIs consistent with the root's scheme and authority.
+	WalkDir(root string, fn fs.WalkDirFunc) error
+}
+
 // A File provides access to a single file. The File interface is the
 // minimum implementation required for Iceberg to interact with a file.
 // Directory files should also implement

--- a/io/local.go
+++ b/io/local.go
@@ -50,10 +50,5 @@ func (LocalFS) Remove(name string) error {
 }
 
 func (LocalFS) WalkDir(root string, fn fs.WalkDirFunc) error {
-	cleanRoot := strings.TrimPrefix(root, "file://")
-	if cleanRoot == "" {
-		cleanRoot = "."
-	}
-
-	return filepath.WalkDir(cleanRoot, fn)
+	return filepath.WalkDir(strings.TrimPrefix(root, "file://"), fn)
 }

--- a/io/local.go
+++ b/io/local.go
@@ -18,6 +18,7 @@
 package io
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,4 +47,13 @@ func (LocalFS) WriteFile(name string, content []byte) error {
 
 func (LocalFS) Remove(name string) error {
 	return os.Remove(strings.TrimPrefix(name, "file://"))
+}
+
+func (LocalFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	cleanRoot := strings.TrimPrefix(root, "file://")
+	if cleanRoot == "" {
+		cleanRoot = "."
+	}
+
+	return filepath.WalkDir(cleanRoot, fn)
 }

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -90,9 +90,3 @@ func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }
-
-func TestLocalFSDoesNotImplementBulkRemovableIO(t *testing.T) {
-	var fs IO = LocalFS{}
-	_, ok := fs.(BulkRemovableIO)
-	assert.False(t, ok, "LocalFS should not implement BulkRemovableIO")
-}

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package io
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalFSWalkDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a directory structure.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "data"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "metadata"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data", "file1.parquet"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data", "file2.parquet"), []byte("b"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata", "v1.json"), []byte("c"), 0o644))
+
+	lfs := LocalFS{}
+
+	var files []string
+	err := lfs.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	sort.Strings(files)
+	expected := []string{
+		filepath.Join(dir, "data", "file1.parquet"),
+		filepath.Join(dir, "data", "file2.parquet"),
+		filepath.Join(dir, "metadata", "v1.json"),
+	}
+	sort.Strings(expected)
+	assert.Equal(t, expected, files)
+}
+
+func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0o644))
+
+	lfs := LocalFS{}
+
+	var files []string
+	err := lfs.WalkDir("file://"+dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(dir, "test.txt")}, files)
+}
+
+func TestLocalFSImplementsListableIO(t *testing.T) {
+	var _ ListableIO = LocalFS{}
+}

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -90,3 +90,9 @@ func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }
+
+func TestLocalFSDoesNotImplementBulkRemovableIO(t *testing.T) {
+	var fs IO = LocalFS{}
+	_, ok := fs.(BulkRemovableIO)
+	assert.False(t, ok, "LocalFS should not implement BulkRemovableIO")
+}

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -215,7 +215,7 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	if cfg.dryRun {
 		return result, nil
 	}
-	deletedFiles, err := deleteFiles(ctx, fs, orphanFiles, cfg)
+	deletedFiles, err := deleteFiles(fs, orphanFiles, cfg)
 	if err != nil {
 		return OrphanCleanupResult{}, fmt.Errorf("failed to delete orphan files: %w", err)
 	}
@@ -309,6 +309,7 @@ func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig)
 }
 
 func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
+	// Prefer ListableIO when available.
 	if listable, ok := fsys.(iceio.ListableIO); ok {
 		return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {
 			if err != nil {
@@ -328,21 +329,49 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 		})
 	}
 
-	// Fallback: reflect-based access for IO implementations that don't
-	// yet implement ListableIO (e.g. blob storage).
-	bucket := getBucket(fsys)
+	// Fallback to original implementation for IO types that don't
+	// implement ListableIO yet.
+	switch v := fsys.(type) {
+	case iceio.LocalFS:
+		cleanRoot := strings.TrimPrefix(root, "file://")
+		if cleanRoot == "" {
+			cleanRoot = "."
+		}
 
-	parsed, err := url.Parse(root)
-	if err != nil {
-		return fmt.Errorf("invalid URL %s: %w", root, err)
+		return filepath.WalkDir(cleanRoot, makeFileWalkFunc(fn, func(path string) string {
+			return path
+		}))
+
+	default:
+		// For blob storage: direct field access since we know the structure.
+		bucket := getBucketName(v)
+
+		parsed, err := url.Parse(root)
+		if err != nil {
+			return fmt.Errorf("invalid URL %s: %w", root, err)
+		}
+
+		walkPath := strings.TrimPrefix(parsed.Path, "/")
+		if walkPath == "" {
+			walkPath = "."
+		}
+
+		return stdfs.WalkDir(bucket, walkPath, makeFileWalkFunc(fn, func(path string) string {
+			return parsed.Scheme + "://" + parsed.Host + "/" + path
+		}))
 	}
+}
 
-	walkPath := strings.TrimPrefix(parsed.Path, "/")
-	if walkPath == "" {
-		walkPath = "."
-	}
+// getBucketName gets the Bucket field from blob storage - absolute minimal approach.
+func getBucketName(fsys iceio.IO) stdfs.FS {
+	v := reflect.ValueOf(fsys).Elem()
 
-	return stdfs.WalkDir(bucket, walkPath, func(path string, d stdfs.DirEntry, err error) error {
+	return v.FieldByName("Bucket").Interface().(stdfs.FS)
+}
+
+// makeFileWalkFunc creates a WalkDirFunc that processes only files with path transformation.
+func makeFileWalkFunc(fn func(path string, info stdfs.FileInfo) error, pathTransform func(string) string) stdfs.WalkDirFunc {
+	return func(path string, d stdfs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -356,17 +385,8 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 			return err
 		}
 
-		return fn(parsed.Scheme+"://"+parsed.Host+"/"+path, info)
-	})
-}
-
-// getBucket extracts the Bucket field from blob storage IO implementations
-// via reflect. This is a temporary fallback until all IO implementations
-// implement ListableIO.
-func getBucket(fsys iceio.IO) stdfs.FS {
-	v := reflect.ValueOf(fsys).Elem()
-
-	return v.FieldByName("Bucket").Interface().(stdfs.FS)
+		return fn(pathTransform(path), info)
+	}
 }
 
 func identifyOrphanFiles(allFiles []string, referencedFiles map[string]bool, cfg *orphanCleanupConfig) ([]string, error) {
@@ -413,16 +433,9 @@ func isFileOrphan(file string, referencedFiles map[string]bool, normalizedRefere
 	return true, nil
 }
 
-func deleteFiles(ctx context.Context, fs iceio.IO, orphanFiles []string, cfg *orphanCleanupConfig) ([]string, error) {
+func deleteFiles(fs iceio.IO, orphanFiles []string, cfg *orphanCleanupConfig) ([]string, error) {
 	if len(orphanFiles) == 0 {
 		return nil, nil
-	}
-
-	// Use bulk delete when available and no custom deleteFunc is set.
-	if cfg.deleteFunc == nil {
-		if bulk, ok := fs.(iceio.BulkRemovableIO); ok {
-			return bulk.DeleteFiles(ctx, orphanFiles)
-		}
 	}
 
 	if cfg.maxConcurrency == 1 {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -24,6 +24,7 @@ import (
 	stdfs "io/fs"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -308,12 +309,40 @@ func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig)
 }
 
 func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
-	listable, ok := fsys.(iceio.ListableIO)
-	if !ok {
-		return fmt.Errorf("IO implementation %T does not support directory listing for %s (does not implement ListableIO)", fsys, root)
+	if listable, ok := fsys.(iceio.ListableIO); ok {
+		return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+
+			return fn(path, info)
+		})
 	}
 
-	return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {
+	// Fallback: reflect-based access for IO implementations that don't
+	// yet implement ListableIO (e.g. blob storage).
+	bucket := getBucket(fsys)
+
+	parsed, err := url.Parse(root)
+	if err != nil {
+		return fmt.Errorf("invalid URL %s: %w", root, err)
+	}
+
+	walkPath := strings.TrimPrefix(parsed.Path, "/")
+	if walkPath == "" {
+		walkPath = "."
+	}
+
+	return stdfs.WalkDir(bucket, walkPath, func(path string, d stdfs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -327,8 +356,17 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 			return err
 		}
 
-		return fn(path, info)
+		return fn(parsed.Scheme+"://"+parsed.Host+"/"+path, info)
 	})
+}
+
+// getBucket extracts the Bucket field from blob storage IO implementations
+// via reflect. This is a temporary fallback until all IO implementations
+// implement ListableIO.
+func getBucket(fsys iceio.IO) stdfs.FS {
+	v := reflect.ValueOf(fsys).Elem()
+
+	return v.FieldByName("Bucket").Interface().(stdfs.FS)
 }
 
 func identifyOrphanFiles(allFiles []string, referencedFiles map[string]bool, cfg *orphanCleanupConfig) ([]string, error) {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -310,7 +310,7 @@ func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig)
 func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
 	listable, ok := fsys.(iceio.ListableIO)
 	if !ok {
-		return fmt.Errorf("IO implementation %T does not support directory listing (does not implement ListableIO)", fsys)
+		return fmt.Errorf("IO implementation %T does not support directory listing for %s (does not implement ListableIO)", fsys, root)
 	}
 
 	return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -24,7 +24,6 @@ import (
 	stdfs "io/fs"
 	"net/url"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -308,62 +307,28 @@ func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig)
 	return allFiles, totalSize, nil
 }
 
-// getBucket gets the Bucket field from blob storage - absolute minimal approach
-func getBucketName(fsys iceio.IO) stdfs.FS {
-	v := reflect.ValueOf(fsys).Elem() // We know it's a pointer to struct
+func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
+	listable, ok := fsys.(iceio.ListableIO)
+	if !ok {
+		return fmt.Errorf("IO implementation %T does not support directory listing (does not implement ListableIO)", fsys)
+	}
 
-	return v.FieldByName("Bucket").Interface().(stdfs.FS)
-}
-
-// makeFileWalkFunc creates a WalkDirFunc that processes only files with path transformation
-func makeFileWalkFunc(fn func(path string, info stdfs.FileInfo) error, pathTransform func(string) string) stdfs.WalkDirFunc {
-	return func(path string, d stdfs.DirEntry, err error) error {
+	return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+
 		if d.IsDir() {
 			return nil
 		}
+
 		info, err := d.Info()
 		if err != nil {
 			return err
 		}
 
-		return fn(pathTransform(path), info)
-	}
-}
-
-func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
-	switch v := fsys.(type) {
-	case iceio.LocalFS:
-		cleanRoot := strings.TrimPrefix(root, "file://")
-		if cleanRoot == "" {
-			cleanRoot = "."
-		}
-
-		return filepath.WalkDir(cleanRoot, makeFileWalkFunc(fn, func(path string) string {
-			return path
-		}))
-
-	default:
-		// For blob storage: direct field access since we know the structure
-		bucket := getBucketName(v)
-
-		parsed, err := url.Parse(root)
-		if err != nil {
-			return fmt.Errorf("invalid URL %s: %w", root, err)
-		}
-
-		walkPath := strings.TrimPrefix(parsed.Path, "/")
-		if walkPath == "" {
-			walkPath = "."
-		}
-
-		// URL transform - reconstruct full URL path
-		return stdfs.WalkDir(bucket, walkPath, makeFileWalkFunc(fn, func(path string) string {
-			return parsed.Scheme + "://" + parsed.Host + "/" + path
-		}))
-	}
+		return fn(path, info)
+	})
 }
 
 func identifyOrphanFiles(allFiles []string, referencedFiles map[string]bool, cfg *orphanCleanupConfig) ([]string, error) {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -214,7 +214,7 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	if cfg.dryRun {
 		return result, nil
 	}
-	deletedFiles, err := deleteFiles(fs, orphanFiles, cfg)
+	deletedFiles, err := deleteFiles(ctx, fs, orphanFiles, cfg)
 	if err != nil {
 		return OrphanCleanupResult{}, fmt.Errorf("failed to delete orphan files: %w", err)
 	}
@@ -375,9 +375,16 @@ func isFileOrphan(file string, referencedFiles map[string]bool, normalizedRefere
 	return true, nil
 }
 
-func deleteFiles(fs iceio.IO, orphanFiles []string, cfg *orphanCleanupConfig) ([]string, error) {
+func deleteFiles(ctx context.Context, fs iceio.IO, orphanFiles []string, cfg *orphanCleanupConfig) ([]string, error) {
 	if len(orphanFiles) == 0 {
 		return nil, nil
+	}
+
+	// Use bulk delete when available and no custom deleteFunc is set.
+	if cfg.deleteFunc == nil {
+		if bulk, ok := fs.(iceio.BulkRemovableIO); ok {
+			return bulk.DeleteFiles(ctx, orphanFiles)
+		}
 	}
 
 	if cfg.maxConcurrency == 1 {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -18,9 +18,12 @@
 package table
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -530,4 +533,89 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
 	assert.True(t, refs[tbl.metadataLocation])
 	assert.False(t, refs["s3://bucket/stats/not-referenced.puffin"])
 	assert.False(t, refs[""])
+}
+
+// mockBulkRemovableIO is a test double that implements BulkRemovableIO.
+type mockBulkRemovableIO struct {
+	bulkCalled bool
+	bulkPaths  []string
+}
+
+func (m *mockBulkRemovableIO) Open(string) (io.File, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockBulkRemovableIO) Remove(string) error {
+	return errors.New("Remove should not be called when BulkRemovableIO is available")
+}
+
+func (m *mockBulkRemovableIO) DeleteFiles(_ context.Context, paths []string) ([]string, error) {
+	m.bulkCalled = true
+	m.bulkPaths = paths
+
+	return paths, nil
+}
+
+func TestDeleteFilesUsesBulkRemovableIO(t *testing.T) {
+	mock := &mockBulkRemovableIO{}
+	orphans := []string{"s3://bucket/data/orphan1.parquet", "s3://bucket/data/orphan2.parquet"}
+	cfg := &orphanCleanupConfig{}
+
+	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
+	require.NoError(t, err)
+	assert.True(t, mock.bulkCalled)
+	assert.Equal(t, orphans, mock.bulkPaths)
+	assert.Equal(t, orphans, deleted)
+}
+
+func TestDeleteFilesWithCustomDeleteFunc(t *testing.T) {
+	mock := &mockBulkRemovableIO{}
+	var customDeleted []string
+	cfg := &orphanCleanupConfig{
+		deleteFunc: func(path string) error {
+			customDeleted = append(customDeleted, path)
+
+			return nil
+		},
+		maxConcurrency: 1,
+	}
+	orphans := []string{"s3://bucket/data/orphan1.parquet"}
+
+	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
+	require.NoError(t, err)
+	assert.False(t, mock.bulkCalled, "BulkRemovableIO should not be used when deleteFunc is set")
+	assert.Equal(t, orphans, customDeleted)
+	assert.Equal(t, orphans, deleted)
+}
+
+func TestDeleteFilesEmpty(t *testing.T) {
+	deleted, err := deleteFiles(context.Background(), nil, nil, &orphanCleanupConfig{})
+	require.NoError(t, err)
+	assert.Nil(t, deleted)
+}
+
+// mockPlainIO implements only IO (no BulkRemovableIO) to verify fallback behavior.
+type mockPlainIO struct {
+	removed []string
+}
+
+func (m *mockPlainIO) Open(string) (io.File, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPlainIO) Remove(name string) error {
+	m.removed = append(m.removed, name)
+
+	return nil
+}
+
+func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
+	mock := &mockPlainIO{}
+	orphans := []string{"s3://bucket/data/orphan1.parquet", "s3://bucket/data/orphan2.parquet"}
+	cfg := &orphanCleanupConfig{maxConcurrency: 1}
+
+	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, orphans, mock.removed)
+	assert.ElementsMatch(t, orphans, deleted)
 }

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -18,7 +18,6 @@
 package table
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -535,65 +534,6 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
 	assert.False(t, refs[""])
 }
 
-// mockBulkRemovableIO is a test double that implements BulkRemovableIO.
-type mockBulkRemovableIO struct {
-	bulkCalled bool
-	bulkPaths  []string
-}
-
-func (m *mockBulkRemovableIO) Open(string) (io.File, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (m *mockBulkRemovableIO) Remove(string) error {
-	return errors.New("Remove should not be called when BulkRemovableIO is available")
-}
-
-func (m *mockBulkRemovableIO) DeleteFiles(_ context.Context, paths []string) ([]string, error) {
-	m.bulkCalled = true
-	m.bulkPaths = paths
-
-	return paths, nil
-}
-
-func TestDeleteFilesUsesBulkRemovableIO(t *testing.T) {
-	mock := &mockBulkRemovableIO{}
-	orphans := []string{"s3://bucket/data/orphan1.parquet", "s3://bucket/data/orphan2.parquet"}
-	cfg := &orphanCleanupConfig{}
-
-	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
-	require.NoError(t, err)
-	assert.True(t, mock.bulkCalled)
-	assert.Equal(t, orphans, mock.bulkPaths)
-	assert.Equal(t, orphans, deleted)
-}
-
-func TestDeleteFilesWithCustomDeleteFunc(t *testing.T) {
-	mock := &mockBulkRemovableIO{}
-	var customDeleted []string
-	cfg := &orphanCleanupConfig{
-		deleteFunc: func(path string) error {
-			customDeleted = append(customDeleted, path)
-
-			return nil
-		},
-		maxConcurrency: 1,
-	}
-	orphans := []string{"s3://bucket/data/orphan1.parquet"}
-
-	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
-	require.NoError(t, err)
-	assert.False(t, mock.bulkCalled, "BulkRemovableIO should not be used when deleteFunc is set")
-	assert.Equal(t, orphans, customDeleted)
-	assert.Equal(t, orphans, deleted)
-}
-
-func TestDeleteFilesEmpty(t *testing.T) {
-	deleted, err := deleteFiles(context.Background(), nil, nil, &orphanCleanupConfig{})
-	require.NoError(t, err)
-	assert.Nil(t, deleted)
-}
-
 // mockPlainIO implements only IO (no BulkRemovableIO) to verify fallback behavior.
 type mockPlainIO struct {
 	removed []string
@@ -609,12 +549,18 @@ func (m *mockPlainIO) Remove(name string) error {
 	return nil
 }
 
+func TestDeleteFilesEmpty(t *testing.T) {
+	deleted, err := deleteFiles(nil, nil, &orphanCleanupConfig{})
+	require.NoError(t, err)
+	assert.Nil(t, deleted)
+}
+
 func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
 	mock := &mockPlainIO{}
 	orphans := []string{"s3://bucket/data/orphan1.parquet", "s3://bucket/data/orphan2.parquet"}
 	cfg := &orphanCleanupConfig{maxConcurrency: 1}
 
-	deleted, err := deleteFiles(context.Background(), mock, orphans, cfg)
+	deleted, err := deleteFiles(mock, orphans, cfg)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, orphans, mock.removed)
 	assert.ElementsMatch(t, orphans, deleted)

--- a/table/updates.go
+++ b/table/updates.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 )
 
@@ -534,9 +535,42 @@ func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table,
 		delete(filesToDelete, psf.StatisticsPath)
 	}
 
+	if len(filesToDelete) == 0 {
+		return nil
+	}
+
+	paths := make([]string, 0, len(filesToDelete))
+	for f := range filesToDelete {
+		paths = append(paths, f)
+	}
+
+	// Try bulk delete first; on failure fall through to per-file delete.
+	if bulk, ok := prefs.(io.BulkRemovableIO); ok {
+		deleted, err := bulk.DeleteFiles(ctx, paths)
+		if err == nil {
+			return nil
+		}
+
+		// Remove successfully deleted files so the fallback loop
+		// only retries what the bulk call missed.
+		deletedSet := make(map[string]struct{}, len(deleted))
+		for _, d := range deleted {
+			deletedSet[d] = struct{}{}
+		}
+
+		remaining := paths[:0]
+		for _, p := range paths {
+			if _, ok := deletedSet[p]; !ok {
+				remaining = append(remaining, p)
+			}
+		}
+
+		paths = remaining
+	}
+
 	var res error
 
-	for f := range filesToDelete {
+	for _, f := range paths {
 		if err := prefs.Remove(f); err != nil {
 			res = errors.Join(res, err)
 		}

--- a/table/updates.go
+++ b/table/updates.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/apache/iceberg-go"
-	"github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 )
 
@@ -535,42 +534,9 @@ func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table,
 		delete(filesToDelete, psf.StatisticsPath)
 	}
 
-	if len(filesToDelete) == 0 {
-		return nil
-	}
-
-	paths := make([]string, 0, len(filesToDelete))
-	for f := range filesToDelete {
-		paths = append(paths, f)
-	}
-
-	// Try bulk delete first; on failure fall through to per-file delete.
-	if bulk, ok := prefs.(io.BulkRemovableIO); ok {
-		deleted, err := bulk.DeleteFiles(ctx, paths)
-		if err == nil {
-			return nil
-		}
-
-		// Remove successfully deleted files so the fallback loop
-		// only retries what the bulk call missed.
-		deletedSet := make(map[string]struct{}, len(deleted))
-		for _, d := range deleted {
-			deletedSet[d] = struct{}{}
-		}
-
-		remaining := paths[:0]
-		for _, p := range paths {
-			if _, ok := deletedSet[p]; !ok {
-				remaining = append(remaining, p)
-			}
-		}
-
-		paths = remaining
-	}
-
 	var res error
 
-	for _, f := range paths {
+	for f := range filesToDelete {
 		if err := prefs.Remove(f); err != nil {
 			res = errors.Join(res, err)
 		}


### PR DESCRIPTION

 Why: Orphan cleanup's walkDirectory used reflect to reach into blob storage internals (extracting the Bucket field by name). This is fragile — it breaks if the struct changes, bypasses Go's type system, and panics on unexpected IO types.                                                                   
                                                                                                                                                                                                                                                                                                                  
This PR introduces a ListableIO interface with a WalkDir method so directory walking works through a proper type assertion. Both LocalFS and blobFileIO implement it. Orphan cleanup prefers ListableIO when available, falling back to the original reflect-based implementation for IO types that don't   implement it yet. Includes Azure URI userinfo preservation and tests for local, cloud, and Azure paths.

Fixes: #913 