### PR TITLE
docs(website): sync feature tables with README.md

### DIFF
--- a/website/src/introduction.md
+++ b/website/src/introduction.md
@@ -47,8 +47,8 @@ Iceberg Go is a go-native implementation for accessing iceberg tables.
 | Get Partition Specs      |     X     |
 | Get Manifests            |     X     |
 | Create New Manifests     |     X     |
-| Plan Scan                |     x     |
-| Plan Scan for Snapshot   |     x     |
+| Plan Scan                |     X     |
+| Plan Scan for Snapshot   |     X     |
 
 ### Catalog Support
 

--- a/website/src/introduction.md
+++ b/website/src/introduction.md
@@ -47,34 +47,34 @@ Iceberg Go is a go-native implementation for accessing iceberg tables.
 | Get Partition Specs      |     X     |
 | Get Manifests            |     X     |
 | Create New Manifests     |     X     |
-| Plan Scan                |     X     |
-| Plan Scan for Snapshot   |     X     |
+| Plan Scan                |     x     |
+| Plan Scan for Snapshot   |     x     |
 
 ### Catalog Support
 
 | Operation                   | REST | Hive |  Glue  | SQL  |
-|:----------------------------|:----:| :--: |:------:|:----:|
-| Load Table                  |  X   |      |   X    |  X   |
-| List Tables                 |  X   |      |   X    |  X   |
-| Create Table                |  X   |      |   X    |  X   |
-| Register Table              |  X   |      |   X    |      |
-| Update Current Snapshot     |  X   |      |   X    |  X   |
-| Create New Snapshot         |  X   |      |   X    |  X   |
-| Rename Table                |  X   |      |   X    |  X   |
-| Drop Table                  |  X   |      |   X    |  X   |
-| Alter Table                 |  X   |      |   X    |  X   |
-| Check Table Exists          |  X   |      |   X    |  X   |
-| Set Table Properties        |  X   |      |   X    |  X   |
-| List Namespaces             |  X   |      |   X    |  X   |
-| Create Namespace            |  X   |      |   X    |  X   |
-| Check Namespace Exists      |  X   |      |   X    |  X   |
-| Drop Namespace              |  X   |      |   X    |  X   |
-| Update Namespace Properties |  X   |      |   X    |  X   |
-| Create View                 |  X   |      |        |  X   |
-| Load View                   |      |      |        |  X   |
-| List View                   |  X   |      |        |  X   |
-| Drop View                   |  X   |      |        | X    |
-| Check View Exists           |  X   |      |        |  X   |
+|:----------------------------|:----:|:----:|:------:|:----:|
+| Load Table                  |  X   |  X   |   X    |  X   |
+| List Tables                 |  X   |  X   |   X    |  X   |
+| Create Table                |  X   |  X   |   X    |  X   |
+| Register Table              |  X   |  X   |   X    |      |
+| Update Current Snapshot     |  X   |  X   |   X    |  X   |
+| Create New Snapshot         |  X   |  X   |   X    |  X   |
+| Rename Table                |  X   |  X   |   X    |  X   |
+| Drop Table                  |  X   |  X   |   X    |  X   |
+| Alter Table                 |  X   |  X   |   X    |  X   |
+| Check Table Exists          |  X   |  X   |   X    |  X   |
+| Set Table Properties        |  X   |  X   |   X    |  X   |
+| List Namespaces             |  X   |  X   |   X    |  X   |
+| Create Namespace            |  X   |  X   |   X    |  X   |
+| Check Namespace Exists      |  X   |  X   |   X    |  X   |
+| Drop Namespace              |  X   |  X   |   X    |  X   |
+| Update Namespace Properties |  X   |  X   |   X    |  X   |
+| Create View                 |  X   |  X   |        |  X   |
+| Load View                   |      |  X   |        |  X   |
+| List View                   |  X   |  X   |        |  X   |
+| Drop View                   |  X   |  X   |        |  X   |
+| Check View Exists           |  X   |  X   |        |  X   |
 
 ### Read/Write Data Support
 
@@ -85,16 +85,17 @@ Iceberg Go is a go-native implementation for accessing iceberg tables.
 As long as the FileSystem is supported and the Catalog supports altering
 the table, the following tracks the current write support:
 
-| Operation         |Supported|
-|:-----------------:|:-------:|
-| Append Stream     |   X     |
-| Append Data Files |   X     |
-| Rewrite Files     |         |
-| Rewrite manifests |         |
-| Overwrite Files   |         |
-| Write Pos Delete  |         |
-| Write Eq Delete   |         |
-| Row Delta         |         |
+| Operation            | Supported |
+|:---------------------|:---------:|
+| Append Stream        |     X     |
+| Append Data Files    |     X     |
+| Rewrite Files        |           |
+| Rewrite manifests    |           |
+| Overwrite Files      |     X     |
+| Copy-On-Write Delete |     X     |
+| Write Pos Delete     |     X     |
+| Write Eq Delete      |           |
+| Row Delta            |           |
 
 
 ## Get in Touch


### PR DESCRIPTION
The feature support tables in website/src/introduction.md had diverged from README.md:

- Hive catalog: shown as unsupported despite full implementation
- Write operations: missing Overwrite Files, Copy-On-Write Delete, and Write Pos Delete which are all implemented 
- Catalog table header alignment was inconsistent

Sync all tables to match README.md, which reflects the actual code.