### PR TITLE
fix(rest): apply header.* additional props as HTTP headers on all requests

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -629,6 +629,12 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 		session.defaultHeaders.Set(k, v)
 	}
 
+	for k, v := range opts.additionalProps {
+		if headerKey, found := strings.CutPrefix(k, "header."); found {
+			session.defaultHeaders.Set(headerKey, v)
+		}
+	}
+
 	if opts.authManager != nil {
 		session.authManager = opts.authManager
 	}

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -291,6 +291,32 @@ func (r *RestCatalogSuite) TestWithHeaders() {
 	}
 }
 
+func (r *RestCatalogSuite) TestAdditionalPropsHeaderPrefix() {
+	// Properties prefixed with "header." should be applied as HTTP headers on
+	// every request, including the initial /v1/config call (needed for e.g.
+	// Google BigLake which requires x-goog-user-project on the config call).
+	namespace := "examples"
+	customHeaderValue := "my-project"
+
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+		r.Equal(customHeaderValue, req.Header.Get("x-goog-user-project"))
+		json.NewEncoder(w).Encode(map[string]any{"identifiers": []any{}})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
+		rest.WithOAuthToken(TestToken),
+		rest.WithAdditionalProps(iceberg.Properties{
+			"header.x-goog-user-project": customHeaderValue,
+		}))
+	r.Require().NoError(err)
+
+	iter := cat.ListTables(context.Background(), catalog.ToIdentifier(namespace))
+	for _, err := range iter {
+		r.Require().NoError(err)
+	}
+}
+
 func (r *RestCatalogSuite) TestWithHeadersOnOAuthRoute() {
 	customHeaders := map[string]string{
 		"X-Custom-Header": "custom-value",


### PR DESCRIPTION
## What

Properties with a `"header."` prefix passed via `WithAdditionalProps` were stored in `additionalProps` but never converted to HTTP request headers, so they had no effect on any request — including the initial `/v1/config` call.

This PR applies `header.*` keys from `additionalProps` as session `defaultHeaders` in `createSession`, alongside the explicitly-set `WithHeaders` map. This matches the behavior of `iceberg-python` and the [iceberg REST spec convention](https://github.com/apache/iceberg/blob/main/docs/rest-catalog.md) for `header.*` config properties.

## Why

Google BigLake requires the `x-goog-user-project` header on **every** request, including the initial `/v1/config` call, for quota attribution. Without this fix, connecting to BigLake with:

```go
rest.WithAdditionalProps(iceberg.Properties{
    "header.x-goog-user-project": "my-project",
})
```

fails with `"biglake.googleapis.com API requires a quota project"` because the header is absent from the config request.

After this fix, both `WithHeaders` and `header.*` additional props apply headers to all requests.

## Testing

Added `TestAdditionalPropsHeaderPrefix` to `rest_test.go` verifying that a `header.*` prop appears on subsequent requests. All existing tests pass.

Fixes #532