### PR TITLE
fix(table): re-add optional last-column-id to AddSchema update payload

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -633,7 +633,7 @@ func (u *UpdateSchema) BuildUpdates() ([]Update, []Requirement, error) {
 		if existingSchemaID == -1 {
 			updates = append(
 				updates,
-				NewAddSchemaUpdate(newSchema),
+				NewAddSchemaUpdate(newSchema, u.lastColumnID),
 				NewSetCurrentSchemaUpdate(newSchema.ID),
 			)
 		} else {

--- a/table/updates.go
+++ b/table/updates.go
@@ -188,16 +188,25 @@ func (u *upgradeFormatVersionUpdate) Apply(builder *MetadataBuilder) error {
 
 type addSchemaUpdate struct {
 	baseUpdate
-	Schema  *iceberg.Schema `json:"schema"`
-	initial bool
+	Schema       *iceberg.Schema `json:"schema"`
+	LastColumnId *int            `json:"last-column-id,omitempty"`
+	initial      bool
 }
 
-// NewAddSchemaUpdate creates a new update that adds the given schema and updates the lastColumnID based on the schema.
-func NewAddSchemaUpdate(schema *iceberg.Schema) *addSchemaUpdate {
-	return &addSchemaUpdate{
+// NewAddSchemaUpdate creates a new update that adds the given schema.
+// An optional lastColumnID may be provided to populate the last-column-id field
+// in the request payload; some servers (e.g. AWS s3tables) require this field.
+func NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID ...int) *addSchemaUpdate {
+	u := &addSchemaUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSchema},
 		Schema:     schema,
 	}
+	if len(lastColumnID) > 0 {
+		id := lastColumnID[0]
+		u.LastColumnId = &id
+	}
+
+	return u
 }
 
 func (u *addSchemaUpdate) Apply(builder *MetadataBuilder) error {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -430,6 +430,27 @@ func buildFromBase(t *testing.T) *MetadataBuilder {
 	return b
 }
 
+func TestAddSchemaUpdate_LastColumnId(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "x", Type: iceberg.PrimitiveTypes.Int64},
+	)
+
+	// Without lastColumnID — field should be absent from JSON.
+	uNoID := NewAddSchemaUpdate(schema)
+	assert.Nil(t, uNoID.LastColumnId)
+	data, err := json.Marshal(uNoID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "last-column-id")
+
+	// With lastColumnID — field must appear in JSON.
+	uWithID := NewAddSchemaUpdate(schema, 42)
+	require.NotNil(t, uWithID.LastColumnId)
+	assert.Equal(t, 42, *uWithID.LastColumnId)
+	data, err = json.Marshal(uWithID)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"last-column-id":42`)
+}
+
 func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{
 		"action": "set-statistics",


### PR DESCRIPTION
## What

In v0.3.1 the `lastColumnID` parameter was removed from `NewAddSchemaUpdate`. Some servers (e.g. AWS s3tables) still validate `last-column-id` in their commit logic and return `invalid_metadata` when the field is absent from the `AddSchema` update payload.

This PR re-introduces `last-column-id` as an **optional** field:

- `NewAddSchemaUpdate(schema *iceberg.Schema, lastColumnID ...int)` — backward-compatible variadic parameter. When omitted the field is absent from the JSON payload (existing behaviour). When provided it is serialised as `"last-column-id"`.
- The internal call in `UpdateSchema.apply()` now passes the builder's tracked `lastColumnID` so the field is always populated when the schema change flows through a transaction.

## Why

AWS s3tables uses a Spark-compatible REST catalog that validates `last-column-id` and rejects commits without it. Discussion in the issue confirmed this is a server compatibility requirement, not an iceberg spec requirement.

## Testing

- `TestAddSchemaUpdate_LastColumnId` — verifies omitempty behaviour when no ID is provided, and correct JSON serialisation when one is.
- All existing `table/` tests pass.

Fixes #538