### PR TITLE
feat(catalog/sql): implement TransactionalCatalog to support atomic multi-table transactions

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -62,6 +62,7 @@ var (
 	ErrViewAlreadyExists      = errors.New("view already exists")
 	ErrEmptyCommitList        = errors.New("commit list must not be empty")
 	ErrMissingIdentifier      = errors.New("every table commit must have a valid identifier")
+	ErrCommitFailed           = errors.New("commit failed")
 )
 
 type PropertiesUpdateSummary struct {
@@ -162,6 +163,12 @@ type Catalog interface {
 // atomically, or none are. On success the method returns nil; the caller
 // must LoadTable individually to obtain updated metadata because the
 // server returns 204 No Content.
+//
+// Note: Implementations typically follow a preparation phase where metadata
+// files are written to storage before the atomic commit point in the
+// catalog. If the atomic commit fails and the transaction is rolled back,
+// metadata files written during the preparation phase may remain as
+// orphaned files.
 type TransactionalCatalog interface {
 	CommitTransaction(ctx context.Context, commits []table.TableCommit) error
 }

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -95,7 +95,10 @@ func init() {
 	}))
 }
 
-var _ catalog.Catalog = (*Catalog)(nil)
+var (
+	_ catalog.Catalog              = (*Catalog)(nil)
+	_ catalog.TransactionalCatalog = (*Catalog)(nil)
+)
 
 var (
 	minimalNamespaceProps = iceberg.Properties{"exists": "true"}
@@ -1047,4 +1050,118 @@ func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (vi
 	}
 
 	return loadedView.Metadata(), nil
+}
+
+// CommitTransaction atomically commits changes to multiple tables in a
+// single database transaction. It implements [catalog.TransactionalCatalog].
+//
+// All table changes are applied within one DB transaction, guaranteeing
+// all-or-nothing semantics. Metadata files are written before the DB
+// commit; if the transaction rolls back, orphaned metadata files may
+// remain (consistent with single-table CommitTable behavior).
+//
+// On success the method returns nil. Callers must LoadTable individually
+// to obtain updated metadata.
+func (c *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCommit) error {
+	if len(commits) == 0 {
+		return catalog.ErrEmptyCommitList
+	}
+
+	for _, commit := range commits {
+		if len(commit.Identifier) == 0 {
+			return catalog.ErrMissingIdentifier
+		}
+	}
+
+	// Phase 1: Load current state and stage all table updates.
+	// We do this outside the write transaction to minimize the time
+	// the DB transaction is held open.
+	type stagedCommit struct {
+		ident   table.Identifier
+		current *table.Table
+		ns      string
+		tblName string
+		staged  *table.StagedTable
+	}
+
+	stagedCommits := make([]stagedCommit, 0, len(commits))
+	for _, commit := range commits {
+		ns := catalog.NamespaceFromIdent(commit.Identifier)
+		tblName := catalog.TableNameFromIdent(commit.Identifier)
+
+		current, err := c.LoadTable(ctx, commit.Identifier)
+		if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
+			return err
+		}
+
+		staged, err := internal.UpdateAndStageTable(ctx, current, commit.Identifier, commit.Requirements, commit.Updates, c)
+		if err != nil {
+			return err
+		}
+
+		// Skip tables with no actual changes.
+		if current != nil && staged.Metadata().Equals(current.Metadata()) {
+			continue
+		}
+
+		// Write the metadata file before the DB transaction.
+		if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+			return err
+		}
+
+		stagedCommits = append(stagedCommits, stagedCommit{
+			ident:   commit.Identifier,
+			current: current,
+			ns:      strings.Join(ns, "."),
+			tblName: tblName,
+			staged:  staged,
+		})
+	}
+
+	if len(stagedCommits) == 0 {
+		return nil // all tables had no changes
+	}
+
+	// Phase 2: Apply all DB changes atomically in a single transaction.
+	return withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		for _, sc := range stagedCommits {
+			if sc.current != nil {
+				res, err := tx.NewUpdate().Model(&sqlIcebergTable{
+					CatalogName:              c.name,
+					TableNamespace:           sc.ns,
+					TableName:                sc.tblName,
+					IcebergType:              TableType,
+					MetadataLocation:         sql.NullString{Valid: true, String: sc.staged.MetadataLocation()},
+					PreviousMetadataLocation: sql.NullString{Valid: true, String: sc.current.MetadataLocation()},
+				}).WherePK().Where("metadata_location = ?", sc.current.MetadataLocation()).
+					Where("iceberg_type = ?", TableType).
+					Exec(ctx)
+				if err != nil {
+					return fmt.Errorf("error updating table information: %w", err)
+				}
+
+				n, err := res.RowsAffected()
+				if err != nil {
+					return fmt.Errorf("error updating table information: %w", err)
+				}
+
+				if n == 0 {
+					return fmt.Errorf("table has been updated by another process: %s.%s", sc.ns, sc.tblName)
+				}
+			} else {
+				_, err := tx.NewInsert().Model(&sqlIcebergTable{
+					CatalogName:      c.name,
+					TableNamespace:   sc.ns,
+					TableName:        sc.tblName,
+					IcebergType:      TableType,
+					MetadataLocation: sql.NullString{Valid: true, String: sc.staged.MetadataLocation()},
+				}).Exec(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to create table: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
 }

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -18,6 +18,7 @@
 package sql
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
@@ -1055,10 +1056,17 @@ func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (vi
 // CommitTransaction atomically commits changes to multiple tables in a
 // single database transaction. It implements [catalog.TransactionalCatalog].
 //
-// All table changes are applied within one DB transaction, guaranteeing
-// all-or-nothing semantics. Metadata files are written before the DB
-// commit; if the transaction rolls back, orphaned metadata files may
-// remain (consistent with single-table CommitTable behavior).
+// This method provides "commit-point atomicity". To avoid long-running DB
+// transactions involving I/O (like uploading metadata files), table state
+// is loaded and metadata files are written outside the write transaction.
+// Atomicity is guaranteed at the commit point within the database; concurrent
+// updates are detected using per-row optimistic concurrency control (OCC)
+// based on the metadata_location.
+//
+// If any table update fails due to an OCC conflict or database error, the
+// entire transaction is rolled back, ensuring all-or-nothing database updates.
+// Note that metadata files written during the preparation phase may remain
+// as orphaned files if the transaction is rolled back.
 //
 // On success the method returns nil. Callers must LoadTable individually
 // to obtain updated metadata.
@@ -1067,10 +1075,18 @@ func (c *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 		return catalog.ErrEmptyCommitList
 	}
 
+	seen := make(map[string]struct{})
+
 	for _, commit := range commits {
 		if len(commit.Identifier) == 0 {
 			return catalog.ErrMissingIdentifier
 		}
+
+		key := strings.Join(commit.Identifier, ".")
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate table in commit list: %s", key)
+		}
+		seen[key] = struct{}{}
 	}
 
 	// Phase 1: Load current state and stage all table updates.
@@ -1122,43 +1138,37 @@ func (c *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 		return nil // all tables had no changes
 	}
 
+	// Sort stagedCommits by identifier to prevent deadlocks in databases with
+	// row-level locking (e.g., Postgres, MySQL) when multiple transactions
+	// commit the same tables in different orders.
+	slices.SortFunc(stagedCommits, func(a, b stagedCommit) int {
+		return cmp.Compare(strings.Join(a.ident, "."), strings.Join(b.ident, "."))
+	})
+
 	// Phase 2: Apply all DB changes atomically in a single transaction.
 	return withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
 		for _, sc := range stagedCommits {
-			if sc.current != nil {
-				res, err := tx.NewUpdate().Model(&sqlIcebergTable{
-					CatalogName:              c.name,
-					TableNamespace:           sc.ns,
-					TableName:                sc.tblName,
-					IcebergType:              TableType,
-					MetadataLocation:         sql.NullString{Valid: true, String: sc.staged.MetadataLocation()},
-					PreviousMetadataLocation: sql.NullString{Valid: true, String: sc.current.MetadataLocation()},
-				}).WherePK().Where("metadata_location = ?", sc.current.MetadataLocation()).
-					Where("iceberg_type = ?", TableType).
-					Exec(ctx)
-				if err != nil {
-					return fmt.Errorf("error updating table information: %w", err)
-				}
+			res, err := tx.NewUpdate().Model(&sqlIcebergTable{
+				CatalogName:              c.name,
+				TableNamespace:           sc.ns,
+				TableName:                sc.tblName,
+				IcebergType:              TableType,
+				MetadataLocation:         sql.NullString{Valid: true, String: sc.staged.MetadataLocation()},
+				PreviousMetadataLocation: sql.NullString{Valid: true, String: sc.current.MetadataLocation()},
+			}).WherePK().Where("metadata_location = ?", sc.current.MetadataLocation()).
+				Where("iceberg_type = ?", TableType).
+				Exec(ctx)
+			if err != nil {
+				return fmt.Errorf("%w: error updating table information: %v", catalog.ErrCommitFailed, err)
+			}
 
-				n, err := res.RowsAffected()
-				if err != nil {
-					return fmt.Errorf("error updating table information: %w", err)
-				}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("%w: error updating table information: %v", catalog.ErrCommitFailed, err)
+			}
 
-				if n == 0 {
-					return fmt.Errorf("table has been updated by another process: %s.%s", sc.ns, sc.tblName)
-				}
-			} else {
-				_, err := tx.NewInsert().Model(&sqlIcebergTable{
-					CatalogName:      c.name,
-					TableNamespace:   sc.ns,
-					TableName:        sc.tblName,
-					IcebergType:      TableType,
-					MetadataLocation: sql.NullString{Valid: true, String: sc.staged.MetadataLocation()},
-				}).Exec(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to create table: %w", err)
-				}
+			if n == 0 {
+				return fmt.Errorf("%w: table has been updated by another process: %s.%s", catalog.ErrCommitFailed, sc.ns, sc.tblName)
 			}
 		}
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1106,7 +1106,7 @@ func (c *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 		tblName := catalog.TableNameFromIdent(commit.Identifier)
 
 		current, err := c.LoadTable(ctx, commit.Identifier)
-		if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
+		if err != nil {
 			return err
 		}
 

--- a/catalog/sql/sql_integration_test.go
+++ b/catalog/sql/sql_integration_test.go
@@ -320,6 +320,60 @@ func (s *SQLIntegrationSuite) TestWriteCommitTable() {
 	s.Equal(pqfile, entries[0].DataFile().FilePath())
 }
 
+func (s *SQLIntegrationSuite) TestMultiTableTransaction() {
+	s.ensureNamespace()
+
+	// Create two tables.
+	tbl1, err := s.cat.CreateTable(s.ctx,
+		catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-1"),
+		tableSchemaSimple, catalog.WithLocation(location))
+	s.Require().NoError(err)
+	s.Require().NotNil(tbl1)
+
+	tbl2, err := s.cat.CreateTable(s.ctx,
+		catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-2"),
+		tableSchemaSimple, catalog.WithLocation(location))
+	s.Require().NoError(err)
+	s.Require().NotNil(tbl2)
+
+	defer func() {
+		s.Require().NoError(s.cat.DropTable(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-1")))
+		s.Require().NoError(s.cat.DropTable(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-2")))
+	}()
+
+	// Build a multi-table transaction using the high-level API.
+	mtx, err := catalog.NewMultiTableTransaction(s.cat)
+	s.Require().NoError(err)
+
+	tx1 := tbl1.NewTransaction()
+	s.Require().NoError(tx1.SetProperties(map[string]string{"pipeline": "v2", "owner": "team-a"}))
+	s.Require().NoError(mtx.AddTransaction(tx1))
+
+	tx2 := tbl2.NewTransaction()
+	s.Require().NoError(tx2.SetProperties(map[string]string{"pipeline": "v2", "owner": "team-b"}))
+	s.Require().NoError(mtx.AddTransaction(tx2))
+
+	// CommitAndReload commits atomically and reloads both tables.
+	tables, err := mtx.CommitAndReload(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Len(tables, 2)
+
+	// Verify both tables have the new properties.
+	s.Equal("v2", tables[0].Properties()["pipeline"])
+	s.Equal("team-a", tables[0].Properties()["owner"])
+	s.Equal("v2", tables[1].Properties()["pipeline"])
+	s.Equal("team-b", tables[1].Properties()["owner"])
+
+	// Also verify via independent LoadTable calls.
+	loaded1, err := s.cat.LoadTable(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-1"))
+	s.Require().NoError(err)
+	s.Equal("v2", loaded1.Properties()["pipeline"])
+
+	loaded2, err := s.cat.LoadTable(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "mtx-table-2"))
+	s.Require().NoError(err)
+	s.Equal("v2", loaded2.Properties()["pipeline"])
+}
+
 func TestSQLIntegration(t *testing.T) {
 	suite.Run(t, new(SQLIntegrationSuite))
 }

--- a/catalog/sql/sql_integration_test.go
+++ b/catalog/sql/sql_integration_test.go
@@ -374,6 +374,53 @@ func (s *SQLIntegrationSuite) TestMultiTableTransaction() {
 	s.Equal("v2", loaded2.Properties()["pipeline"])
 }
 
+func (s *SQLIntegrationSuite) TestMultiTableTransactionWriteData() {
+	s.ensureNamespace()
+
+	ident1 := catalog.ToIdentifier(TestNamespaceIdent, "mtx-write-1")
+	ident2 := catalog.ToIdentifier(TestNamespaceIdent, "mtx-write-2")
+
+	tbl1, err := s.cat.CreateTable(s.ctx, ident1, tableSchemaSimple, catalog.WithLocation(location))
+	s.Require().NoError(err)
+	tbl2, err := s.cat.CreateTable(s.ctx, ident2, tableSchemaSimple, catalog.WithLocation(location))
+	s.Require().NoError(err)
+
+	defer func() {
+		_ = s.cat.DropTable(s.ctx, ident1)
+		_ = s.cat.DropTable(s.ctx, ident2)
+	}()
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(s.T(), 0)
+
+	arrSchema, err := table.SchemaToArrowSchema(tbl1.Schema(), nil, false, false)
+	s.Require().NoError(err)
+
+	tblData, err := array.TableFromJSON(mem, arrSchema, []string{`[{"foo": "data", "bar": 42, "baz": true}]`})
+	s.Require().NoError(err)
+	defer tblData.Release()
+
+	mtx, err := catalog.NewMultiTableTransaction(s.cat)
+	s.Require().NoError(err)
+
+	tx1 := tbl1.NewTransaction()
+	s.Require().NoError(tx1.AppendTable(s.ctx, tblData, 100, nil))
+	s.Require().NoError(mtx.AddTransaction(tx1))
+
+	tx2 := tbl2.NewTransaction()
+	s.Require().NoError(tx2.SetProperties(map[string]string{"status": "linked"}))
+	s.Require().NoError(mtx.AddTransaction(tx2))
+
+	s.Require().NoError(mtx.Commit(s.ctx))
+
+	loaded1, _ := s.cat.LoadTable(s.ctx, ident1)
+	s.NotNil(loaded1.CurrentSnapshot())
+	s.Equal("1", loaded1.CurrentSnapshot().Summary.Properties["total-records"])
+
+	loaded2, _ := s.cat.LoadTable(s.ctx, ident2)
+	s.Equal("linked", loaded2.Properties()["status"])
+}
+
 func TestSQLIntegration(t *testing.T) {
 	suite.Run(t, new(SQLIntegrationSuite))
 }

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -38,6 +38,7 @@ import (
 	sqlcat "github.com/apache/iceberg-go/catalog/sql"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/uptrace/bun/driver/sqliteshim"
@@ -1219,6 +1220,160 @@ func (s *SqliteCatalogTestSuite) TestLoadView() {
 	_, err = db.LoadView(context.Background(), []string{nsName, "nonexistent"})
 	s.Error(err)
 	s.ErrorIs(err, catalog.ErrNoSuchView)
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionInterface() {
+	cat := s.getCatalogMemory()
+	_, ok := any(cat).(catalog.TransactionalCatalog)
+	s.True(ok, "sql.Catalog must implement catalog.TransactionalCatalog")
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionEmptyList() {
+	cat := s.getCatalogMemory()
+	err := cat.CommitTransaction(context.Background(), nil)
+	s.ErrorIs(err, catalog.ErrEmptyCommitList)
+
+	err = cat.CommitTransaction(context.Background(), []table.TableCommit{})
+	s.ErrorIs(err, catalog.ErrEmptyCommitList)
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionMissingIdentifier() {
+	cat := s.getCatalogMemory()
+	err := cat.CommitTransaction(context.Background(), []table.TableCommit{
+		{Identifier: table.Identifier{}},
+	})
+	s.ErrorIs(err, catalog.ErrMissingIdentifier)
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionSetProperties() {
+	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
+
+	ctx := context.Background()
+	for _, cat := range catalogs {
+		tbl1ID := s.randomTableIdentifier()
+		tbl2ID := s.randomTableIdentifier()
+		ns1 := catalog.NamespaceFromIdent(tbl1ID)
+		ns2 := catalog.NamespaceFromIdent(tbl2ID)
+		s.Require().NoError(cat.CreateNamespace(ctx, ns1, nil))
+		if strings.Join(ns1, ".") != strings.Join(ns2, ".") {
+			s.Require().NoError(cat.CreateNamespace(ctx, ns2, nil))
+		}
+
+		tbl1, err := cat.CreateTable(ctx, tbl1ID, tableSchemaNested)
+		s.Require().NoError(err)
+		tbl2, err := cat.CreateTable(ctx, tbl2ID, tableSchemaNested)
+		s.Require().NoError(err)
+
+		// Build transactions on each table.
+		tx1 := tbl1.NewTransaction()
+		s.Require().NoError(tx1.SetProperties(map[string]string{"pipeline": "v2"}))
+		tc1, err := tx1.TableCommit()
+		s.Require().NoError(err)
+
+		tx2 := tbl2.NewTransaction()
+		s.Require().NoError(tx2.SetProperties(map[string]string{"pipeline": "v2"}))
+		tc2, err := tx2.TableCommit()
+		s.Require().NoError(err)
+
+		// Commit atomically.
+		s.Require().NoError(cat.CommitTransaction(ctx, []table.TableCommit{tc1, tc2}))
+
+		// Verify both tables have updated properties.
+		loaded1, err := cat.LoadTable(ctx, tbl1ID)
+		s.Require().NoError(err)
+		s.Equal("v2", loaded1.Properties()["pipeline"])
+
+		loaded2, err := cat.LoadTable(ctx, tbl2ID)
+		s.Require().NoError(err)
+		s.Equal("v2", loaded2.Properties()["pipeline"])
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionPartialRollback() {
+	// Test that when a requirement validation fails for one table,
+	// no changes are applied to any table. We use a bogus
+	// AssertTableUUID requirement for the second table to force
+	// the validation failure during staging.
+	cat := s.getCatalogMemory()
+	ctx := context.Background()
+
+	tbl1ID := s.randomTableIdentifier()
+	tbl2ID := s.randomTableIdentifier()
+	ns1 := catalog.NamespaceFromIdent(tbl1ID)
+	ns2 := catalog.NamespaceFromIdent(tbl2ID)
+	s.Require().NoError(cat.CreateNamespace(ctx, ns1, nil))
+	if strings.Join(ns1, ".") != strings.Join(ns2, ".") {
+		s.Require().NoError(cat.CreateNamespace(ctx, ns2, nil))
+	}
+
+	tbl1, err := cat.CreateTable(ctx, tbl1ID, tableSchemaNested)
+	s.Require().NoError(err)
+	_, err = cat.CreateTable(ctx, tbl2ID, tableSchemaNested)
+	s.Require().NoError(err)
+
+	// Build a valid TableCommit for tbl1.
+	tx1 := tbl1.NewTransaction()
+	s.Require().NoError(tx1.SetProperties(map[string]string{"key1": "val1"}))
+	tc1, err := tx1.TableCommit()
+	s.Require().NoError(err)
+
+	// Build a TableCommit for tbl2 with a wrong UUID requirement.
+	// This will cause UpdateAndStageTable to fail during requirement validation.
+	bogusUUID := uuid.New()
+	tc2 := table.TableCommit{
+		Identifier:   tbl2ID,
+		Requirements: []table.Requirement{table.AssertTableUUID(bogusUUID)},
+		Updates:      []table.Update{table.NewSetPropertiesUpdate(map[string]string{"key2": "val2"})},
+	}
+
+	// The commit should fail because of the bogus UUID requirement on tbl2.
+	err = cat.CommitTransaction(ctx, []table.TableCommit{tc1, tc2})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "UUID")
+
+	// tbl1 should remain unchanged — no DB changes were applied.
+	loaded1, err := cat.LoadTable(ctx, tbl1ID)
+	s.Require().NoError(err)
+	_, hasKey := loaded1.Properties()["key1"]
+	s.False(hasKey, "tbl1 should not have been updated because tbl2 failed validation")
+}
+
+func (s *SqliteCatalogTestSuite) TestMultiTableTransactionViaSQLCatalog() {
+	cat := s.getCatalogMemory()
+	ctx := context.Background()
+
+	tbl1ID := s.randomTableIdentifier()
+	tbl2ID := s.randomTableIdentifier()
+	ns1 := catalog.NamespaceFromIdent(tbl1ID)
+	ns2 := catalog.NamespaceFromIdent(tbl2ID)
+	s.Require().NoError(cat.CreateNamespace(ctx, ns1, nil))
+	if strings.Join(ns1, ".") != strings.Join(ns2, ".") {
+		s.Require().NoError(cat.CreateNamespace(ctx, ns2, nil))
+	}
+
+	tbl1, err := cat.CreateTable(ctx, tbl1ID, tableSchemaNested)
+	s.Require().NoError(err)
+	tbl2, err := cat.CreateTable(ctx, tbl2ID, tableSchemaNested)
+	s.Require().NoError(err)
+
+	// Use the high-level MultiTableTransaction API.
+	mtx, err := catalog.NewMultiTableTransaction(cat)
+	s.Require().NoError(err)
+
+	tx1 := tbl1.NewTransaction()
+	s.Require().NoError(tx1.SetProperties(map[string]string{"env": "prod"}))
+	s.Require().NoError(mtx.AddTransaction(tx1))
+
+	tx2 := tbl2.NewTransaction()
+	s.Require().NoError(tx2.SetProperties(map[string]string{"env": "prod"}))
+	s.Require().NoError(mtx.AddTransaction(tx2))
+
+	tables, err := mtx.CommitAndReload(ctx)
+	s.Require().NoError(err)
+	s.Require().Len(tables, 2)
+
+	s.Equal("prod", tables[0].Properties()["env"])
+	s.Equal("prod", tables[1].Properties()["env"])
 }
 
 func TestSqlCatalog(t *testing.T) {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"maps"
 	"math/rand/v2"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -36,6 +37,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/internal"
 	sqlcat "github.com/apache/iceberg-go/catalog/sql"
+	"github.com/apache/iceberg-go/io"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
@@ -1374,6 +1376,119 @@ func (s *SqliteCatalogTestSuite) TestMultiTableTransactionViaSQLCatalog() {
 
 	s.Equal("prod", tables[0].Properties()["env"])
 	s.Equal("prod", tables[1].Properties()["env"])
+}
+
+type mockConflictFS struct {
+	io.LocalFS
+	onWrite func(string)
+}
+
+func (m *mockConflictFS) strip(name string) string {
+	return strings.TrimPrefix(name, "mock://")
+}
+
+func (m *mockConflictFS) Create(name string) (io.FileWriter, error) {
+	if m.onWrite != nil {
+		m.onWrite(name)
+	}
+
+	return m.LocalFS.Create(m.strip(name))
+}
+
+func (m *mockConflictFS) WriteFile(name string, p []byte) error {
+	if m.onWrite != nil {
+		m.onWrite(name)
+	}
+
+	return m.LocalFS.WriteFile(m.strip(name), p)
+}
+
+func (m *mockConflictFS) Open(name string) (io.File, error) {
+	return m.LocalFS.Open(m.strip(name))
+}
+
+func (m *mockConflictFS) Remove(name string) error {
+	return m.LocalFS.Remove(m.strip(name))
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTransactionDeterministicRollback() {
+	ctx := context.Background()
+
+	// 1. Register mock protocol
+	conflictFS := &mockConflictFS{LocalFS: io.LocalFS{}}
+	io.Register("mock", func(ctx context.Context, u *url.URL, p map[string]string) (io.IO, error) {
+		return conflictFS, nil
+	})
+
+	// 2. Create a catalog with mock:// warehouse
+	cat, err := catalog.Load(ctx, "mock_cat", iceberg.Properties{
+		"uri":             s.catalogUri(),
+		sqlcat.DriverKey:  sqliteshim.ShimName,
+		sqlcat.DialectKey: string(sqlcat.SQLite),
+		"type":            "sql",
+		"warehouse":       "mock://" + s.warehouse,
+	})
+	s.Require().NoError(err)
+	sqlCat := cat.(*sqlcat.Catalog)
+	s.Require().NoError(sqlCat.CreateSQLTables(ctx))
+
+	identA := s.randomTableIdentifier()
+	identB := s.randomTableIdentifier()
+
+	// Ensure A is committed before B by sorting identifiers
+	if strings.Join(identA, ".") > strings.Join(identB, ".") {
+		identA, identB = identB, identA
+	}
+
+	s.Require().NoError(sqlCat.CreateNamespace(ctx, catalog.NamespaceFromIdent(identA), nil))
+	s.Require().NoError(sqlCat.CreateNamespace(ctx, catalog.NamespaceFromIdent(identB), nil))
+
+	tblA, _ := sqlCat.CreateTable(ctx, identA, tableSchemaNested)
+	tblB, _ := sqlCat.CreateTable(ctx, identB, tableSchemaNested)
+
+	// Prepare commits
+	txA := tblA.NewTransaction()
+	s.Require().NoError(txA.SetProperties(map[string]string{"tx": "success_initially"}))
+	tcA, _ := txA.TableCommit()
+
+	txB := tblB.NewTransaction()
+	s.Require().NoError(txB.SetProperties(map[string]string{"tx": "should_fail"}))
+	tcB, _ := txB.TableCommit()
+
+	// 3. Setup the "backstab":
+	// When any table writes its metadata during Phase 1, we check if it's Table B.
+	// If so, we mutate Table B's record in the DB to cause Phase 2 OCC failure.
+	hookFired := false
+	conflictFS.onWrite = func(path string) {
+		// Only fire if the path belongs to Table B.
+		// This ensures Table B has already been Loaded and Staged in Phase 1.
+		if strings.Contains(path, catalog.TableNameFromIdent(identB)) {
+			sqldb := s.getDB()
+			defer sqldb.Close()
+
+			// Mutate Table B's record so its metadata_location no longer matches sc.current.MetadataLocation()
+			res, err := sqldb.Exec("UPDATE iceberg_tables SET metadata_location = 'corrupted' WHERE table_namespace = ? AND table_name = ?",
+				strings.Join(catalog.NamespaceFromIdent(identB), "."), catalog.TableNameFromIdent(identB))
+			s.Require().NoError(err)
+			affected, _ := res.RowsAffected()
+			if affected == 1 {
+				hookFired = true
+			}
+		}
+	}
+
+	// 4. Execute Transaction: A should succeed in DB, then B should fail in DB.
+	err = sqlCat.CommitTransaction(ctx, []table.TableCommit{tcA, tcB})
+	s.Require().Error(err)
+	s.True(hookFired, "The hook should have fired during Phase 1 for Table B")
+	s.ErrorIs(err, catalog.ErrCommitFailed)
+	s.Contains(err.Error(), catalog.TableNameFromIdent(identB))
+
+	// 5. VERIFY ATOMICITY:
+	// Table A must have been rolled back despite its UPDATE statement having executed successfully.
+	loadedA, _ := sqlCat.LoadTable(ctx, identA)
+	_, hasProp := loadedA.Properties()["tx"]
+	s.False(hasProp, "Table A should have rolled back its property update!")
 }
 
 func TestSqlCatalog(t *testing.T) {


### PR DESCRIPTION
This PR implements the catalog.TransactionalCatalog interface for the SQL catalog to support atomic, all-or-nothing commits across multiple tables.

Key implementations:

Two-phase commit: Metadatas validations and I/O writes are performed outside the DB transaction to minimize database lock contention.
Optimistic Concurrency Control (OCC): Performs an atomic DB update using WHERE metadata_location = ? to prevent concurrent modification issues.
Add comprehensive Unit & Integration tests for multi-table rollbacks and high-level wrappers.