### PR TITLE
fix: use floored division in HourTransform for pre-epoch timestamps (#924)

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/google/uuid"
 	"github.com/twmb/murmur3"
+	"golang.org/x/exp/constraints"
 )
 
 // ParseTransform takes the string representation of a transform as
@@ -565,7 +566,7 @@ type TimeTransform interface {
 // Unlike Go's truncated division (which rounds toward zero), this correctly
 // handles negative dividends — e.g., floorDiv(-1, 3600000000) = -1, not 0.
 // This matches the behavior of Java's Math.floorDiv.
-func floorDiv(a, b int64) int64 {
+func floorDiv[T constraints.Integer](a, b T) T {
 	d := a / b
 	if (a^b) < 0 && d*b != a {
 		d--
@@ -821,6 +822,17 @@ func (DayTransform) Transformer(src Type) (func(any) Optional[int32], error) {
 				Val:   int32(v.(Timestamp).ToDate()),
 			}
 		}, nil
+	case TimestampNsType, TimestampTzNsType:
+		return func(v any) Optional[int32] {
+			if v == nil {
+				return Optional[int32]{}
+			}
+
+			return Optional[int32]{
+				Valid: true,
+				Val:   int32(v.(TimestampNano).ToDate()),
+			}
+		}, nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot apply day transform for type %s",
@@ -837,6 +849,8 @@ func (DayTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 		out.Valid, out.Val = true, Int32Literal(v)
 	case TimestampLiteral:
 		out.Valid, out.Val = true, Int32Literal(Timestamp(v).ToDate())
+	case TimestampNsLiteral:
+		out.Valid, out.Val = true, Int32Literal(TimestampNano(v).ToDate())
 	}
 
 	return out
@@ -898,6 +912,19 @@ func (HourTransform) Transformer(src Type) (func(any) Optional[int32], error) {
 				Val:   int32(floorDiv(int64(v.(Timestamp)), factor)),
 			}
 		}, nil
+	case TimestampNsType, TimestampTzNsType:
+		const factor = int64(time.Hour)
+
+		return func(v any) Optional[int32] {
+			if v == nil {
+				return Optional[int32]{}
+			}
+
+			return Optional[int32]{
+				Valid: true,
+				Val:   int32(floorDiv(int64(v.(TimestampNano)), factor)),
+			}
+		}, nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot apply hour transform for type %s",
@@ -912,6 +939,9 @@ func (HourTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 	switch v := value.Val.(type) {
 	case TimestampLiteral:
 		const factor = int64(time.Hour / time.Microsecond)
+		out.Valid, out.Val = true, Int32Literal(int32(floorDiv(int64(v), factor)))
+	case TimestampNsLiteral:
+		const factor = int64(time.Hour)
 		out.Valid, out.Val = true, Int32Literal(int32(floorDiv(int64(v), factor)))
 	}
 

--- a/transforms.go
+++ b/transforms.go
@@ -561,6 +561,19 @@ type TimeTransform interface {
 	Transformer(Type) (func(any) Optional[int32], error)
 }
 
+// floorDiv performs floored integer division, rounding toward negative infinity.
+// Unlike Go's truncated division (which rounds toward zero), this correctly
+// handles negative dividends — e.g., floorDiv(-1, 3600000000) = -1, not 0.
+// This matches the behavior of Java's Math.floorDiv.
+func floorDiv(a, b int64) int64 {
+	d := a / b
+	if (a^b) < 0 && d*b != a {
+		d--
+	}
+
+	return d
+}
+
 func canTransformTime(t TimeTransform, sourceType Type) bool {
 	switch sourceType.(type) {
 	case DateType, TimestampType, TimestampTzType, TimestampNsType, TimestampTzNsType:
@@ -882,7 +895,7 @@ func (HourTransform) Transformer(src Type) (func(any) Optional[int32], error) {
 
 			return Optional[int32]{
 				Valid: true,
-				Val:   int32(int64(v.(Timestamp)) / factor),
+				Val:   int32(floorDiv(int64(v.(Timestamp)), factor)),
 			}
 		}, nil
 	}
@@ -899,7 +912,7 @@ func (HourTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 	switch v := value.Val.(type) {
 	case TimestampLiteral:
 		const factor = int64(time.Hour / time.Microsecond)
-		out.Valid, out.Val = true, Int32Literal(int32(int64(v)/factor))
+		out.Valid, out.Val = true, Int32Literal(int32(floorDiv(int64(v), factor)))
 	}
 
 	return out

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -365,6 +365,57 @@ func TestCanTransform(t *testing.T) {
 	}
 }
 
+func TestHourTransformPreEpoch(t *testing.T) {
+	const microsecondsPerHour = int64(time.Hour / time.Microsecond)
+
+	tests := []struct {
+		name     string
+		micros   int64
+		expected int32
+	}{
+		// post-epoch sanity checks
+		{"epoch", 0, 0},
+		{"1us after epoch", 1, 0},
+		{"exactly 1 hour", microsecondsPerHour, 1},
+		{"1.5 hours", microsecondsPerHour + microsecondsPerHour/2, 1},
+
+		// pre-epoch: the bug produced 0 for all of these
+		{"1us before epoch", -1, -1},
+		{"half hour before epoch", -microsecondsPerHour / 2, -1},
+		{"exactly 1 hour before epoch", -microsecondsPerHour, -1},
+		{"1us more than 1 hour before epoch", -microsecondsPerHour - 1, -2},
+		{"exactly 2 hours before epoch", -2 * microsecondsPerHour, -2},
+	}
+
+	transform := iceberg.HourTransform{}
+
+	t.Run("Transformer", func(t *testing.T) {
+		fn, err := transform.Transformer(iceberg.PrimitiveTypes.Timestamp)
+		require.NoError(t, err)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := fn(iceberg.Timestamp(tt.micros))
+				require.True(t, result.Valid)
+				assert.Equal(t, tt.expected, result.Val)
+			})
+		}
+	})
+
+	t.Run("Apply", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := transform.Apply(iceberg.Optional[iceberg.Literal]{
+					Valid: true,
+					Val:   iceberg.TimestampLiteral(tt.micros),
+				})
+				require.True(t, result.Valid)
+				assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
+			})
+		}
+	})
+}
+
 func TestTruncateTransform(t *testing.T) {
 	tests := []struct {
 		width    int

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -416,6 +416,163 @@ func TestHourTransformPreEpoch(t *testing.T) {
 	})
 }
 
+func TestDayTransformPreEpoch(t *testing.T) {
+	const microsecondsPerDay = int64((time.Hour * 24) / time.Microsecond)
+
+	tests := []struct {
+		name     string
+		micros   int64
+		expected int32
+	}{
+		// post-epoch sanity checks
+		{"epoch", 0, 0},
+		{"1us after epoch", 1, 0},
+		{"exactly 1 day", microsecondsPerDay, 1},
+		{"1.5 days", microsecondsPerDay + microsecondsPerDay/2, 1},
+
+		// pre-epoch: truncated division would produce 0 for these
+		{"1us before epoch", -1, -1},
+		{"half day before epoch", -microsecondsPerDay / 2, -1},
+		{"exactly 1 day before epoch", -microsecondsPerDay, -1},
+		{"1us more than 1 day before epoch", -microsecondsPerDay - 1, -2},
+		{"exactly 2 days before epoch", -2 * microsecondsPerDay, -2},
+	}
+
+	transform := iceberg.DayTransform{}
+
+	t.Run("Transformer", func(t *testing.T) {
+		fn, err := transform.Transformer(iceberg.PrimitiveTypes.Timestamp)
+		require.NoError(t, err)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := fn(iceberg.Timestamp(tt.micros))
+				require.True(t, result.Valid)
+				assert.Equal(t, tt.expected, result.Val)
+			})
+		}
+	})
+
+	t.Run("Apply", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := transform.Apply(iceberg.Optional[iceberg.Literal]{
+					Valid: true,
+					Val:   iceberg.TimestampLiteral(tt.micros),
+				})
+				require.True(t, result.Valid)
+				assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
+			})
+		}
+	})
+}
+
+func TestHourTransformNanoseconds(t *testing.T) {
+	const nanosecondsPerHour = int64(time.Hour)
+
+	tests := []struct {
+		name     string
+		nanos    int64
+		expected int32
+	}{
+		{"epoch", 0, 0},
+		{"1ns after epoch", 1, 0},
+		{"exactly 1 hour", nanosecondsPerHour, 1},
+		{"1.5 hours", nanosecondsPerHour + nanosecondsPerHour/2, 1},
+		{"1ns before epoch", -1, -1},
+		{"half hour before epoch", -nanosecondsPerHour / 2, -1},
+		{"exactly 1 hour before epoch", -nanosecondsPerHour, -1},
+		{"1ns more than 1 hour before epoch", -nanosecondsPerHour - 1, -2},
+		{"exactly 2 hours before epoch", -2 * nanosecondsPerHour, -2},
+	}
+
+	transform := iceberg.HourTransform{}
+
+	for _, srcType := range []iceberg.Type{
+		iceberg.PrimitiveTypes.TimestampNs,
+		iceberg.PrimitiveTypes.TimestampTzNs,
+	} {
+		t.Run("Transformer/"+srcType.String(), func(t *testing.T) {
+			fn, err := transform.Transformer(srcType)
+			require.NoError(t, err)
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					result := fn(iceberg.TimestampNano(tt.nanos))
+					require.True(t, result.Valid)
+					assert.Equal(t, tt.expected, result.Val)
+				})
+			}
+		})
+	}
+
+	t.Run("Apply", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := transform.Apply(iceberg.Optional[iceberg.Literal]{
+					Valid: true,
+					Val:   iceberg.TimestampNsLiteral(tt.nanos),
+				})
+				require.True(t, result.Valid)
+				assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
+			})
+		}
+	})
+}
+
+func TestDayTransformNanoseconds(t *testing.T) {
+	const nanosecondsPerDay = int64(time.Hour * 24)
+
+	tests := []struct {
+		name     string
+		nanos    int64
+		expected int32
+	}{
+		{"epoch", 0, 0},
+		{"1ns after epoch", 1, 0},
+		{"exactly 1 day", nanosecondsPerDay, 1},
+		{"1.5 days", nanosecondsPerDay + nanosecondsPerDay/2, 1},
+		{"1ns before epoch", -1, -1},
+		{"half day before epoch", -nanosecondsPerDay / 2, -1},
+		{"exactly 1 day before epoch", -nanosecondsPerDay, -1},
+		{"1ns more than 1 day before epoch", -nanosecondsPerDay - 1, -2},
+		{"exactly 2 days before epoch", -2 * nanosecondsPerDay, -2},
+	}
+
+	transform := iceberg.DayTransform{}
+
+	for _, srcType := range []iceberg.Type{
+		iceberg.PrimitiveTypes.TimestampNs,
+		iceberg.PrimitiveTypes.TimestampTzNs,
+	} {
+		t.Run("Transformer/"+srcType.String(), func(t *testing.T) {
+			fn, err := transform.Transformer(srcType)
+			require.NoError(t, err)
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					result := fn(iceberg.TimestampNano(tt.nanos))
+					require.True(t, result.Valid)
+					assert.Equal(t, tt.expected, result.Val)
+				})
+			}
+		})
+	}
+
+	t.Run("Apply", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := transform.Apply(iceberg.Optional[iceberg.Literal]{
+					Valid: true,
+					Val:   iceberg.TimestampNsLiteral(tt.nanos),
+				})
+				require.True(t, result.Valid)
+				assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
+			})
+		}
+	})
+}
+
 func TestTruncateTransform(t *testing.T) {
 	tests := []struct {
 		width    int

--- a/types.go
+++ b/types.go
@@ -648,9 +648,9 @@ func (t Timestamp) ToTime() time.Time {
 }
 
 func (t Timestamp) ToDate() Date {
-	tm := time.UnixMicro(int64(t)).UTC()
+	const microsecondsPerDay = int64((time.Hour * 24) / time.Microsecond)
 
-	return Date(tm.Truncate(24*time.Hour).Unix() / int64((time.Hour * 24).Seconds()))
+	return Date(int32(floorDiv(int64(t), microsecondsPerDay)))
 }
 
 func (t Timestamp) ToNanos() TimestampNano {
@@ -668,9 +668,9 @@ func (t TimestampNano) ToMicros() Timestamp {
 }
 
 func (t TimestampNano) ToDate() Date {
-	tm := time.Unix(0, int64(t)).UTC()
+	const nanosecondsPerDay = int64(time.Hour * 24)
 
-	return Date(tm.Truncate(24*time.Hour).Unix() / int64((time.Hour * 24).Seconds()))
+	return Date(int32(floorDiv(int64(t), nanosecondsPerDay)))
 }
 
 // TimestampType represents a number of microseconds since the unix epoch


### PR DESCRIPTION
HourTransform used truncated division (rounds toward zero) which produced incorrect hour buckets for pre-epoch timestamps. Switch to floored division to match Java's Math.floorDiv behavior.