### PR TITLE
feat(table): add conflict validation framework

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -38,12 +38,18 @@ package table
 // assumption about the branch head still holds, and if it does not
 // the retry loop re-fetches metadata; these validators then check
 // whether the semantic invariants still hold against the new head.
+//
+// The validators themselves are unexported: they are producer-facing
+// plumbing, not a library API. The only user-visible surface is
+// IsolationLevel, the isolation property keys, and the conflict
+// error sentinels — mirroring Java's split where validators are
+// `protected` on MergingSnapshotProducer and only the inputs and
+// outputs are public.
 
 import (
 	"errors"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
@@ -89,10 +95,10 @@ const (
 	WriteUpdateIsolationLevelDefault = IsolationSerializable
 )
 
-// ReadIsolationLevel returns the isolation level for the given
+// readIsolationLevel returns the isolation level for the given
 // property key, falling back to defVal for a missing or unrecognized
 // value.
-func ReadIsolationLevel(props iceberg.Properties, key string, defVal IsolationLevel) IsolationLevel {
+func readIsolationLevel(props iceberg.Properties, key string, defVal IsolationLevel) IsolationLevel {
 	v, ok := props[key]
 	if !ok {
 		return defVal
@@ -136,9 +142,9 @@ var (
 	ErrDataFilesMissing = fmt.Errorf("%w: referenced data files missing", ErrCommitFailed)
 )
 
-// ConflictContext carries the inputs every validator needs: the
+// conflictContext carries the inputs every validator needs: the
 // latest catalog state (current) and the filesystem used to read
-// manifest content on demand. Build it with NewConflictContext.
+// manifest content on demand. Build it with newConflictContext.
 //
 // A validator inspects snapshots committed on the committer's branch
 // between the writer's base and the current head. When both metadata
@@ -146,12 +152,12 @@ var (
 // concurrent commits and validators return nil without reading
 // manifests.
 //
-// ConflictContext is immutable once constructed — do NOT reuse the
+// conflictContext is immutable once constructed — do NOT reuse the
 // same context across retry attempts that re-fetch catalog state,
 // because the cached concurrent-snapshot walk becomes stale. There
 // is deliberately no Refresh or mutator method; a refresh must flow
-// as a fresh call to NewConflictContext(newBase, newCurrent, ...).
-type ConflictContext struct {
+// as a fresh call to newConflictContext(newBase, newCurrent, ...).
+type conflictContext struct {
 	current       Metadata
 	branch        string
 	fs            iceio.IO
@@ -161,7 +167,7 @@ type ConflictContext struct {
 	concurrent []Snapshot
 }
 
-// NewConflictContext builds a validation context for the given
+// newConflictContext builds a validation context for the given
 // branch. It walks the ancestry of the branch's current head back to
 // the writer's base snapshot to enumerate concurrent commits.
 //
@@ -172,10 +178,10 @@ type ConflictContext struct {
 // When base and current point at the same snapshot on the branch, the
 // returned context has no concurrent snapshots and validators
 // short-circuit to nil. When the base snapshot is no longer on the
-// branch (divergent commit, expired base), NewConflictContext returns
+// branch (divergent commit, expired base), newConflictContext returns
 // ErrCommitDiverged; the commit cannot be safely revalidated without
 // a refresh-and-rebuild.
-func NewConflictContext(base, current Metadata, branch string, fs iceio.IO, caseSensitive bool) (*ConflictContext, error) {
+func newConflictContext(base, current Metadata, branch string, fs iceio.IO, caseSensitive bool) (*conflictContext, error) {
 	currentHead := current.SnapshotByName(branch)
 	if currentHead == nil {
 		// Branch does not exist on the current side — either it was
@@ -189,7 +195,7 @@ func NewConflictContext(base, current Metadata, branch string, fs iceio.IO, case
 		// Writer has no view of this branch yet (e.g. creating it) —
 		// by definition there are no concurrent commits to validate
 		// against.
-		return &ConflictContext{current: current, branch: branch, fs: fs, caseSensitive: caseSensitive}, nil
+		return &conflictContext{current: current, branch: branch, fs: fs, caseSensitive: caseSensitive}, nil
 	}
 
 	concurrent, baseFound := AncestorsBetween(currentHead.SnapshotID, baseHead.SnapshotID, current.SnapshotByID)
@@ -198,7 +204,7 @@ func NewConflictContext(base, current Metadata, branch string, fs iceio.IO, case
 			ErrCommitDiverged, baseHead.SnapshotID, branch, currentHead.SnapshotID)
 	}
 
-	return &ConflictContext{
+	return &conflictContext{
 		current:       current,
 		branch:        branch,
 		fs:            fs,
@@ -214,37 +220,27 @@ func NewConflictContext(base, current Metadata, branch string, fs iceio.IO, case
 // happens to carry it today — a manifest-rewrite (e.g. the merging
 // append producer) can carry ADDED entries from a prior snapshot
 // into a newer manifest whose added-snapshot-id is the committing
-// one, so per-manifest filtering alone would miss or
-// mis-attribute entries. Filtering on entry.SnapshotID() is the
-// only attribution that survives manifest rewrites.
+// one, so per-manifest filtering alone would miss or mis-attribute
+// entries. Filtering on entry.SnapshotID() is the only attribution
+// that survives manifest rewrites.
 //
 // The visitor returns early if the callback returns a non-nil error.
-func (c *ConflictContext) forEachAddedEntry(content iceberg.ManifestContent, visit func(Snapshot, iceberg.ManifestEntry) error) error {
+func (c *conflictContext) forEachAddedEntry(content iceberg.ManifestContent, visit func(Snapshot, iceberg.ManifestEntry) error) error {
 	for _, snap := range c.concurrent {
-		manifests, err := snap.Manifests(c.fs)
-		if err != nil {
-			return fmt.Errorf("loading manifests for concurrent snapshot %d: %w", snap.SnapshotID, err)
-		}
-		for _, mf := range manifests {
-			if mf.ManifestContent() != content {
+		for entry, err := range snap.entries(c.fs, content) {
+			if err != nil {
+				return fmt.Errorf("loading entries for concurrent snapshot %d: %w", snap.SnapshotID, err)
+			}
+			if entry.Status() != iceberg.EntryStatusADDED {
 				continue
 			}
-			entries, err := mf.FetchEntries(c.fs, false)
-			if err != nil {
-				return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
+			if entry.SnapshotID() != snap.SnapshotID {
+				// Entry was inherited from a prior snapshot and is
+				// not attributable to this concurrent commit.
+				continue
 			}
-			for _, e := range entries {
-				if e.Status() != iceberg.EntryStatusADDED {
-					continue
-				}
-				if e.SnapshotID() != snap.SnapshotID {
-					// Entry was inherited from a prior snapshot and
-					// is not attributable to this concurrent commit.
-					continue
-				}
-				if err := visit(snap, e); err != nil {
-					return err
-				}
+			if err := visit(snap, entry); err != nil {
+				return err
 			}
 		}
 	}
@@ -252,7 +248,7 @@ func (c *ConflictContext) forEachAddedEntry(content iceberg.ManifestContent, vis
 	return nil
 }
 
-// ValidateDataFilesExist verifies that every file path in
+// validateDataFilesExist verifies that every file path in
 // referencedPaths is still reachable from the current branch head.
 // This is the check a position-delete commit performs to prove the
 // files it references have not been removed by a concurrent commit
@@ -267,7 +263,7 @@ func (c *ConflictContext) forEachAddedEntry(content iceberg.ManifestContent, vis
 // Cost is O(all data manifests × all entries) regardless of
 // len(referencedPaths); callers MUST batch referenced paths into a
 // single call rather than calling once per path.
-func ValidateDataFilesExist(ctx *ConflictContext, referencedPaths []string) error {
+func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) error {
 	if len(referencedPaths) == 0 {
 		return nil
 	}
@@ -281,25 +277,14 @@ func ValidateDataFilesExist(ctx *ConflictContext, referencedPaths []string) erro
 		return fmt.Errorf("%w: branch %q missing on current metadata", ErrCommitDiverged, ctx.branch)
 	}
 
-	manifests, err := head.Manifests(ctx.fs)
-	if err != nil {
-		return fmt.Errorf("loading manifests for current head %d: %w", head.SnapshotID, err)
-	}
-	for _, mf := range manifests {
-		if mf.ManifestContent() != iceberg.ManifestContentData {
-			continue
-		}
-		entries, err := mf.FetchEntries(ctx.fs, true) // discardDeleted=true: reachable entries only
+	for df, err := range head.dataFiles(ctx.fs, nil) {
 		if err != nil {
-			return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
+			return fmt.Errorf("iterating data files for current head %d: %w", head.SnapshotID, err)
 		}
-		for _, e := range entries {
-			path := e.DataFile().FilePath()
-			if _, ok := needed[path]; ok {
-				delete(needed, path)
-				if len(needed) == 0 {
-					return nil
-				}
+		if _, ok := needed[df.FilePath()]; ok {
+			delete(needed, df.FilePath())
+			if len(needed) == 0 {
+				return nil
 			}
 		}
 	}
@@ -321,7 +306,7 @@ func ValidateDataFilesExist(ctx *ConflictContext, referencedPaths []string) erro
 	return fmt.Errorf("%w: %d files missing, e.g. %v", ErrDataFilesMissing, len(missing), sample)
 }
 
-// ValidateAddedDataFilesMatchingFilter returns an error if any
+// validateAddedDataFilesMatchingFilter returns an error if any
 // concurrent snapshot added a data file whose partition satisfies the
 // given filter. Overwrite and delete operations that declare a
 // predicate call this so that a concurrent append into the same
@@ -339,7 +324,7 @@ func ValidateDataFilesExist(ctx *ConflictContext, referencedPaths []string) erro
 // Per-file metric evaluation (a third pass in Java that refines
 // beyond partition for columns not in the spec) is TODO and tracked
 // under issue #830 follow-ups.
-func ValidateAddedDataFilesMatchingFilter(ctx *ConflictContext, filter iceberg.BooleanExpression) error {
+func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.BooleanExpression) error {
 	if len(ctx.concurrent) == 0 {
 		return nil
 	}
@@ -347,43 +332,21 @@ func ValidateAddedDataFilesMatchingFilter(ctx *ConflictContext, filter iceberg.B
 		filter = iceberg.AlwaysTrue{}
 	}
 
-	schema := ctx.current.CurrentSchema()
-	filters := newPerSpecFilterCache(filter)
-
-	manifestEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
-		projected, err := filters.projectFor(specID, ctx.current, schema, ctx.caseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		spec := ctx.current.PartitionSpecByID(specID)
-		if spec == nil {
-			return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
-				iceberg.ErrInvalidArgument, specID)
-		}
-
-		return newManifestEvaluator(*spec, schema, projected, ctx.caseSensitive)
+	// Per-spec projected filter, memoized per spec id. Concurrent
+	// snapshots may have been written against different spec ids
+	// after a spec evolution, so each needs its own projection.
+	// Reuses the same projection/evaluator helpers the scanner uses
+	// (buildPartitionProjection, buildManifestEvaluator,
+	// buildPartitionEvaluator) so there is one code path that pruning
+	// semantics flow through.
+	partitionFilters := newKeyDefaultMapWrapErr(func(specID int) (iceberg.BooleanExpression, error) {
+		return buildPartitionProjection(specID, ctx.current, filter, ctx.caseSensitive)
 	})
-
+	manifestEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
+		return buildManifestEvaluator(specID, ctx.current, partitionFilters, ctx.caseSensitive)
+	})
 	partitionEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
-		projected, err := filters.projectFor(specID, ctx.current, schema, ctx.caseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		spec := ctx.current.PartitionSpecByID(specID)
-		if spec == nil {
-			return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
-				iceberg.ErrInvalidArgument, specID)
-		}
-		partType := spec.PartitionType(schema)
-		partSchema := iceberg.NewSchema(0, partType.FieldList...)
-		eval, err := iceberg.ExpressionEvaluator(partSchema, projected, ctx.caseSensitive)
-		if err != nil {
-			return nil, err
-		}
-
-		return func(d iceberg.DataFile) (bool, error) {
-			return eval(GetPartitionRecord(d, partType))
-		}, nil
+		return buildPartitionEvaluator(specID, ctx.current, partitionFilters, ctx.caseSensitive)
 	})
 
 	for _, snap := range ctx.concurrent {
@@ -431,7 +394,7 @@ func ValidateAddedDataFilesMatchingFilter(ctx *ConflictContext, filter iceberg.B
 	return nil
 }
 
-// ValidateNoConflictingDataFiles is the serializable-isolation check
+// validateNoConflictingDataFiles is the serializable-isolation check
 // used by RowDelta and other delete operations. It rejects the commit
 // if any concurrent snapshot added data files into the partition(s)
 // the committer is modifying.
@@ -439,15 +402,15 @@ func ValidateAddedDataFilesMatchingFilter(ctx *ConflictContext, filter iceberg.B
 // Under IsolationSnapshot this validator is a no-op: concurrent
 // appends are allowed and will simply land in the same partition
 // alongside the new deletes.
-func ValidateNoConflictingDataFiles(ctx *ConflictContext, filter iceberg.BooleanExpression, level IsolationLevel) error {
+func validateNoConflictingDataFiles(ctx *conflictContext, filter iceberg.BooleanExpression, level IsolationLevel) error {
 	if level != IsolationSerializable {
 		return nil
 	}
 
-	return ValidateAddedDataFilesMatchingFilter(ctx, filter)
+	return validateAddedDataFilesMatchingFilter(ctx, filter)
 }
 
-// ValidateNoNewDeletesForRewrittenFiles rejects the commit if any
+// validateNoNewDeletesForRewrittenFiles rejects the commit if any
 // concurrent snapshot added delete files that would be lost when the
 // committer's rewrite replaces a data file.
 //
@@ -465,7 +428,7 @@ func ValidateNoConflictingDataFiles(ctx *ConflictContext, filter iceberg.Boolean
 //     which matches Java's approach for RewriteFiles and avoids
 //     silently losing deletes. A follow-up PR will accept optional
 //     partition-overlap hints and narrow this check.
-func ValidateNoNewDeletesForRewrittenFiles(ctx *ConflictContext, rewrittenPaths []string) error {
+func validateNoNewDeletesForRewrittenFiles(ctx *conflictContext, rewrittenPaths []string) error {
 	if len(rewrittenPaths) == 0 || len(ctx.concurrent) == 0 {
 		return nil
 	}
@@ -498,44 +461,4 @@ func ValidateNoNewDeletesForRewrittenFiles(ctx *ConflictContext, rewrittenPaths 
 
 		return nil
 	})
-}
-
-// perSpecFilterCache memoizes inclusive partition-level projections
-// of the conflict filter onto each partition spec the table has seen.
-// Different concurrent snapshots may have been written against
-// different spec ids after a spec evolution, so each needs its own
-// projection.
-//
-// Access is guarded by a mutex to keep the cache safe when a future
-// caller evaluates validators across multiple goroutines.
-type perSpecFilterCache struct {
-	orig iceberg.BooleanExpression
-
-	mu   sync.Mutex
-	memo map[int]iceberg.BooleanExpression
-}
-
-func newPerSpecFilterCache(filter iceberg.BooleanExpression) *perSpecFilterCache {
-	return &perSpecFilterCache{orig: filter, memo: map[int]iceberg.BooleanExpression{}}
-}
-
-func (p *perSpecFilterCache) projectFor(specID int, meta Metadata, schema *iceberg.Schema, caseSensitive bool) (iceberg.BooleanExpression, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if cached, ok := p.memo[specID]; ok {
-		return cached, nil
-	}
-	spec := meta.PartitionSpecByID(specID)
-	if spec == nil {
-		return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
-			iceberg.ErrInvalidArgument, specID)
-	}
-	projected, err := newInclusiveProjection(schema, *spec, caseSensitive)(p.orig)
-	if err != nil {
-		return nil, err
-	}
-	p.memo[specID] = projected
-
-	return projected, nil
 }

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -1,0 +1,541 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+// This file is the client-side conflict-validation framework for
+// concurrent commits. It lives alongside the catalog-side Requirement
+// machinery in requirements.go, and the two serve different roles:
+//
+//   - A Requirement (requirements.go) is asserted by the catalog on
+//     commit. It can only check invariants visible to the catalog
+//     (branch heads, schema ids, spec ids, table UUID) and has no
+//     access to manifest or data-file content.
+//
+//   - A validator in this file runs client-side against a freshly
+//     loaded Metadata, walks the concurrent snapshots added on the
+//     committer's branch since the committer's base, and rejects
+//     commits whose semantics would be violated by those concurrent
+//     snapshots (e.g. a concurrent append into a partition the
+//     committer is overwriting, or a concurrent pos-delete against a
+//     file the committer is rewriting).
+//
+// Both systems cooperate: Requirement ensures the committer's base
+// assumption about the branch head still holds, and if it does not
+// the retry loop re-fetches metadata; these validators then check
+// whether the semantic invariants still hold against the new head.
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// IsolationLevel controls how strictly a commit rejects concurrent
+// writes on the same branch. It mirrors
+// org.apache.iceberg.IsolationLevel from the Java reference.
+type IsolationLevel string
+
+const (
+	// IsolationSerializable rejects any concurrent commit that added
+	// data files matching the committer's filter since the base
+	// snapshot. This is the strongest guarantee: a serializable commit
+	// behaves as if it ran in isolation against the base snapshot.
+	IsolationSerializable IsolationLevel = "serializable"
+
+	// IsolationSnapshot only rejects concurrent commits that touched
+	// files the committer explicitly references (e.g. a position
+	// delete whose referenced data file was removed). Concurrent
+	// appends into the committer's filter region are allowed.
+	IsolationSnapshot IsolationLevel = "snapshot"
+)
+
+// Property keys for configuring isolation per write operation. Names
+// match the Java TableProperties constants so configs can be ported
+// directly between engines.
+const (
+	// WriteDeleteIsolationLevelKey controls isolation for DeleteFiles
+	// and RowDelta eq-delete commits. Default: serializable (matches
+	// Java trunk). Older Java releases and some pyiceberg codepaths
+	// used "snapshot"; set this property explicitly to snapshot if
+	// you are migrating from a pipeline that relied on that behavior.
+	WriteDeleteIsolationLevelKey     = "write.delete.isolation-level"
+	WriteDeleteIsolationLevelDefault = IsolationSerializable
+
+	// WriteUpdateIsolationLevelKey controls isolation for overwrite /
+	// merge commits. Default: serializable (matches Java trunk).
+	// Older Java releases and some pyiceberg codepaths used
+	// "snapshot"; set this property explicitly to snapshot if you are
+	// migrating from a pipeline that relied on that behavior.
+	WriteUpdateIsolationLevelKey     = "write.update.isolation-level"
+	WriteUpdateIsolationLevelDefault = IsolationSerializable
+)
+
+// ReadIsolationLevel returns the isolation level for the given
+// property key, falling back to defVal for a missing or unrecognized
+// value.
+func ReadIsolationLevel(props iceberg.Properties, key string, defVal IsolationLevel) IsolationLevel {
+	v, ok := props[key]
+	if !ok {
+		return defVal
+	}
+	switch IsolationLevel(v) {
+	case IsolationSerializable, IsolationSnapshot:
+		return IsolationLevel(v)
+	default:
+		return defVal
+	}
+}
+
+// ErrCommitDiverged is returned when the committer's base snapshot is
+// no longer on the branch, so conflict validation cannot enumerate
+// concurrent snapshots. The committer must refresh and rebuild their
+// commit from the new base — naive retry would fail identically.
+//
+// Unlike the other conflict sentinels in this file, ErrCommitDiverged
+// does NOT wrap ErrCommitFailed: it is terminal for the current
+// attempt. This mirrors Java's ValidationException, which the
+// SnapshotProducer retry machinery does not catch.
+var ErrCommitDiverged = errors.New("commit diverged: base snapshot is no longer on the branch")
+
+// Retryable conflict sentinels. All wrap ErrCommitFailed so the retry
+// loop in doCommit treats them as retryable. Callers that need to
+// distinguish which kind of conflict occurred can match on the
+// specific sentinel via errors.Is.
+var (
+	// ErrConflictingDataFiles is returned when a concurrent commit
+	// added data files that satisfy the committer's filter.
+	ErrConflictingDataFiles = fmt.Errorf("%w: concurrent data files added", ErrCommitFailed)
+
+	// ErrConflictingDeleteFiles is returned when a concurrent commit
+	// added delete files that could mask rows the committer is
+	// writing or replacing.
+	ErrConflictingDeleteFiles = fmt.Errorf("%w: concurrent delete files added", ErrCommitFailed)
+
+	// ErrDataFilesMissing is returned when a concurrent commit deleted
+	// data files the committer explicitly references (e.g. a position
+	// delete pointing at a file that is no longer reachable).
+	ErrDataFilesMissing = fmt.Errorf("%w: referenced data files missing", ErrCommitFailed)
+)
+
+// ConflictContext carries the inputs every validator needs: the
+// latest catalog state (current) and the filesystem used to read
+// manifest content on demand. Build it with NewConflictContext.
+//
+// A validator inspects snapshots committed on the committer's branch
+// between the writer's base and the current head. When both metadata
+// values refer to the same snapshot on the branch, there are no
+// concurrent commits and validators return nil without reading
+// manifests.
+//
+// ConflictContext is immutable once constructed — do NOT reuse the
+// same context across retry attempts that re-fetch catalog state,
+// because the cached concurrent-snapshot walk becomes stale. There
+// is deliberately no Refresh or mutator method; a refresh must flow
+// as a fresh call to NewConflictContext(newBase, newCurrent, ...).
+type ConflictContext struct {
+	current       Metadata
+	branch        string
+	fs            iceio.IO
+	caseSensitive bool
+
+	// Resolved once; subsequent validator calls reuse the walk.
+	concurrent []Snapshot
+}
+
+// NewConflictContext builds a validation context for the given
+// branch. It walks the ancestry of the branch's current head back to
+// the writer's base snapshot to enumerate concurrent commits.
+//
+// caseSensitive must match the value the committer used when it bound
+// its filter (typically the scan's case-sensitivity) so
+// partition-spec projection resolves the same column identifiers.
+//
+// When base and current point at the same snapshot on the branch, the
+// returned context has no concurrent snapshots and validators
+// short-circuit to nil. When the base snapshot is no longer on the
+// branch (divergent commit, expired base), NewConflictContext returns
+// ErrCommitDiverged; the commit cannot be safely revalidated without
+// a refresh-and-rebuild.
+func NewConflictContext(base, current Metadata, branch string, fs iceio.IO, caseSensitive bool) (*ConflictContext, error) {
+	currentHead := current.SnapshotByName(branch)
+	if currentHead == nil {
+		// Branch does not exist on the current side — either it was
+		// deleted concurrently or the writer is creating it. Treat as
+		// divergent; refresh-and-replay will decide.
+		return nil, fmt.Errorf("%w: branch %q missing on current metadata", ErrCommitDiverged, branch)
+	}
+
+	baseHead := base.SnapshotByName(branch)
+	if baseHead == nil {
+		// Writer has no view of this branch yet (e.g. creating it) —
+		// by definition there are no concurrent commits to validate
+		// against.
+		return &ConflictContext{current: current, branch: branch, fs: fs, caseSensitive: caseSensitive}, nil
+	}
+
+	concurrent, baseFound := AncestorsBetween(currentHead.SnapshotID, baseHead.SnapshotID, current.SnapshotByID)
+	if !baseFound {
+		return nil, fmt.Errorf("%w: base snapshot %d not found in %s ancestry from %d",
+			ErrCommitDiverged, baseHead.SnapshotID, branch, currentHead.SnapshotID)
+	}
+
+	return &ConflictContext{
+		current:       current,
+		branch:        branch,
+		fs:            fs,
+		caseSensitive: caseSensitive,
+		concurrent:    concurrent,
+	}, nil
+}
+
+// forEachAddedEntry visits every ManifestEntry with status ADDED
+// whose snapshot id equals one of the concurrent snapshots. This
+// matches Java's per-entry filter: an ADDED entry is attributed to
+// the snapshot that produced it, independent of which manifest
+// happens to carry it today — a manifest-rewrite (e.g. the merging
+// append producer) can carry ADDED entries from a prior snapshot
+// into a newer manifest whose added-snapshot-id is the committing
+// one, so per-manifest filtering alone would miss or
+// mis-attribute entries. Filtering on entry.SnapshotID() is the
+// only attribution that survives manifest rewrites.
+//
+// The visitor returns early if the callback returns a non-nil error.
+func (c *ConflictContext) forEachAddedEntry(content iceberg.ManifestContent, visit func(Snapshot, iceberg.ManifestEntry) error) error {
+	for _, snap := range c.concurrent {
+		manifests, err := snap.Manifests(c.fs)
+		if err != nil {
+			return fmt.Errorf("loading manifests for concurrent snapshot %d: %w", snap.SnapshotID, err)
+		}
+		for _, mf := range manifests {
+			if mf.ManifestContent() != content {
+				continue
+			}
+			entries, err := mf.FetchEntries(c.fs, false)
+			if err != nil {
+				return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
+			}
+			for _, e := range entries {
+				if e.Status() != iceberg.EntryStatusADDED {
+					continue
+				}
+				if e.SnapshotID() != snap.SnapshotID {
+					// Entry was inherited from a prior snapshot and
+					// is not attributable to this concurrent commit.
+					continue
+				}
+				if err := visit(snap, e); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateDataFilesExist verifies that every file path in
+// referencedPaths is still reachable from the current branch head.
+// This is the check a position-delete commit performs to prove the
+// files it references have not been removed by a concurrent commit
+// (at which point the pos-delete would apply to rewritten data and
+// produce incorrect results).
+//
+// Returns ErrDataFilesMissing listing the first few missing paths.
+// The committer should treat this as unrecoverable for the current
+// commit attempt and rebuild the delete against the current
+// snapshot's data files.
+//
+// Cost is O(all data manifests × all entries) regardless of
+// len(referencedPaths); callers MUST batch referenced paths into a
+// single call rather than calling once per path.
+func ValidateDataFilesExist(ctx *ConflictContext, referencedPaths []string) error {
+	if len(referencedPaths) == 0 {
+		return nil
+	}
+	needed := make(map[string]struct{}, len(referencedPaths))
+	for _, p := range referencedPaths {
+		needed[p] = struct{}{}
+	}
+
+	head := ctx.current.SnapshotByName(ctx.branch)
+	if head == nil {
+		return fmt.Errorf("%w: branch %q missing on current metadata", ErrCommitDiverged, ctx.branch)
+	}
+
+	manifests, err := head.Manifests(ctx.fs)
+	if err != nil {
+		return fmt.Errorf("loading manifests for current head %d: %w", head.SnapshotID, err)
+	}
+	for _, mf := range manifests {
+		if mf.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		entries, err := mf.FetchEntries(ctx.fs, true) // discardDeleted=true: reachable entries only
+		if err != nil {
+			return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
+		}
+		for _, e := range entries {
+			path := e.DataFile().FilePath()
+			if _, ok := needed[path]; ok {
+				delete(needed, path)
+				if len(needed) == 0 {
+					return nil
+				}
+			}
+		}
+	}
+
+	if len(needed) == 0 {
+		return nil
+	}
+
+	missing := make([]string, 0, len(needed))
+	for p := range needed {
+		missing = append(missing, p)
+	}
+	sort.Strings(missing)
+	sample := missing
+	if len(sample) > 5 {
+		sample = sample[:5]
+	}
+
+	return fmt.Errorf("%w: %d files missing, e.g. %v", ErrDataFilesMissing, len(missing), sample)
+}
+
+// ValidateAddedDataFilesMatchingFilter returns an error if any
+// concurrent snapshot added a data file whose partition satisfies the
+// given filter. Overwrite and delete operations that declare a
+// predicate call this so that a concurrent append into the same
+// partition is rejected before the commit overwrites it.
+//
+// The check runs in two layers:
+//  1. A manifest-level partition-summary evaluator prunes manifests
+//     whose summaries cannot overlap the filter.
+//  2. Inside surviving manifests, every ADDED entry attributed to the
+//     concurrent snapshot is evaluated against a per-spec partition
+//     evaluator on its partition tuple, so a manifest whose summary
+//     straddles the filter only triggers a conflict when at least
+//     one actual added file's partition value satisfies the filter.
+//
+// Per-file metric evaluation (a third pass in Java that refines
+// beyond partition for columns not in the spec) is TODO and tracked
+// under issue #830 follow-ups.
+func ValidateAddedDataFilesMatchingFilter(ctx *ConflictContext, filter iceberg.BooleanExpression) error {
+	if len(ctx.concurrent) == 0 {
+		return nil
+	}
+	if filter == nil {
+		filter = iceberg.AlwaysTrue{}
+	}
+
+	schema := ctx.current.CurrentSchema()
+	filters := newPerSpecFilterCache(filter)
+
+	manifestEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
+		projected, err := filters.projectFor(specID, ctx.current, schema, ctx.caseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		spec := ctx.current.PartitionSpecByID(specID)
+		if spec == nil {
+			return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
+				iceberg.ErrInvalidArgument, specID)
+		}
+
+		return newManifestEvaluator(*spec, schema, projected, ctx.caseSensitive)
+	})
+
+	partitionEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
+		projected, err := filters.projectFor(specID, ctx.current, schema, ctx.caseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		spec := ctx.current.PartitionSpecByID(specID)
+		if spec == nil {
+			return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
+				iceberg.ErrInvalidArgument, specID)
+		}
+		partType := spec.PartitionType(schema)
+		partSchema := iceberg.NewSchema(0, partType.FieldList...)
+		eval, err := iceberg.ExpressionEvaluator(partSchema, projected, ctx.caseSensitive)
+		if err != nil {
+			return nil, err
+		}
+
+		return func(d iceberg.DataFile) (bool, error) {
+			return eval(GetPartitionRecord(d, partType))
+		}, nil
+	})
+
+	for _, snap := range ctx.concurrent {
+		manifests, err := snap.Manifests(ctx.fs)
+		if err != nil {
+			return fmt.Errorf("loading manifests for concurrent snapshot %d: %w", snap.SnapshotID, err)
+		}
+		for _, mf := range manifests {
+			if mf.ManifestContent() != iceberg.ManifestContentData {
+				continue
+			}
+
+			mEval := manifestEvals.Get(int(mf.PartitionSpecID()))
+			keep, err := mEval(mf)
+			if err != nil {
+				return err
+			}
+			if !keep {
+				continue
+			}
+
+			pEval := partitionEvals.Get(int(mf.PartitionSpecID()))
+			entries, err := mf.FetchEntries(ctx.fs, false)
+			if err != nil {
+				return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
+			}
+			for _, e := range entries {
+				if e.Status() != iceberg.EntryStatusADDED || e.SnapshotID() != snap.SnapshotID {
+					continue
+				}
+				matches, err := pEval(e.DataFile())
+				if err != nil {
+					return err
+				}
+				if !matches {
+					continue
+				}
+
+				return fmt.Errorf("%w: snapshot %d added data file %s matching filter %s",
+					ErrConflictingDataFiles, snap.SnapshotID, e.DataFile().FilePath(), filter)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateNoConflictingDataFiles is the serializable-isolation check
+// used by RowDelta and other delete operations. It rejects the commit
+// if any concurrent snapshot added data files into the partition(s)
+// the committer is modifying.
+//
+// Under IsolationSnapshot this validator is a no-op: concurrent
+// appends are allowed and will simply land in the same partition
+// alongside the new deletes.
+func ValidateNoConflictingDataFiles(ctx *ConflictContext, filter iceberg.BooleanExpression, level IsolationLevel) error {
+	if level != IsolationSerializable {
+		return nil
+	}
+
+	return ValidateAddedDataFilesMatchingFilter(ctx, filter)
+}
+
+// ValidateNoNewDeletesForRewrittenFiles rejects the commit if any
+// concurrent snapshot added delete files that would be lost when the
+// committer's rewrite replaces a data file.
+//
+// Two cases are flagged:
+//
+//   - A position-delete whose referenced-data-file path is one of
+//     rewrittenPaths — the delete applies to a file the rewrite is
+//     removing, so the delete would be orphaned and its semantics
+//     lost.
+//
+//   - An equality-delete added by a concurrent snapshot — these apply
+//     by predicate, not by path, so we cannot precisely check
+//     overlap without the rewritten files' partition tuples. The
+//     conservative behavior is to reject any concurrent eq-delete,
+//     which matches Java's approach for RewriteFiles and avoids
+//     silently losing deletes. A follow-up PR will accept optional
+//     partition-overlap hints and narrow this check.
+func ValidateNoNewDeletesForRewrittenFiles(ctx *ConflictContext, rewrittenPaths []string) error {
+	if len(rewrittenPaths) == 0 || len(ctx.concurrent) == 0 {
+		return nil
+	}
+	rewritten := make(map[string]struct{}, len(rewrittenPaths))
+	for _, p := range rewrittenPaths {
+		rewritten[p] = struct{}{}
+	}
+
+	return ctx.forEachAddedEntry(iceberg.ManifestContentDeletes, func(snap Snapshot, e iceberg.ManifestEntry) error {
+		df := e.DataFile()
+		switch df.ContentType() {
+		case iceberg.EntryContentPosDeletes:
+			if ref := df.ReferencedDataFile(); ref != nil {
+				if _, overlap := rewritten[*ref]; overlap {
+					return fmt.Errorf("%w: snapshot %d added pos-delete %s referencing rewritten file %s",
+						ErrConflictingDeleteFiles, snap.SnapshotID, df.FilePath(), *ref)
+				}
+			}
+
+			return nil
+
+		case iceberg.EntryContentEqDeletes:
+			// Conservative: any concurrent eq-delete is a conflict
+			// for a rewrite, because the predicate could cover a
+			// rewritten file. Follow-up: accept partition-overlap
+			// hints to narrow this.
+			return fmt.Errorf("%w: snapshot %d added equality delete %s during rewrite",
+				ErrConflictingDeleteFiles, snap.SnapshotID, df.FilePath())
+		}
+
+		return nil
+	})
+}
+
+// perSpecFilterCache memoizes inclusive partition-level projections
+// of the conflict filter onto each partition spec the table has seen.
+// Different concurrent snapshots may have been written against
+// different spec ids after a spec evolution, so each needs its own
+// projection.
+//
+// Access is guarded by a mutex to keep the cache safe when a future
+// caller evaluates validators across multiple goroutines.
+type perSpecFilterCache struct {
+	orig iceberg.BooleanExpression
+
+	mu   sync.Mutex
+	memo map[int]iceberg.BooleanExpression
+}
+
+func newPerSpecFilterCache(filter iceberg.BooleanExpression) *perSpecFilterCache {
+	return &perSpecFilterCache{orig: filter, memo: map[int]iceberg.BooleanExpression{}}
+}
+
+func (p *perSpecFilterCache) projectFor(specID int, meta Metadata, schema *iceberg.Schema, caseSensitive bool) (iceberg.BooleanExpression, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if cached, ok := p.memo[specID]; ok {
+		return cached, nil
+	}
+	spec := meta.PartitionSpecByID(specID)
+	if spec == nil {
+		return nil, fmt.Errorf("%w: partition spec %d not found on current metadata",
+			iceberg.ErrInvalidArgument, specID)
+	}
+	projected, err := newInclusiveProjection(schema, *spec, caseSensitive)(p.orig)
+	if err != nil {
+		return nil, err
+	}
+	p.memo[specID] = projected
+
+	return projected, nil
+}

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -73,7 +73,7 @@ func TestReadIsolationLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ReadIsolationLevel(tt.props, tt.key, tt.defVal)
+			got := readIsolationLevel(tt.props, tt.key, tt.defVal)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -139,7 +139,7 @@ func TestNewConflictContext_NoConcurrentCommits(t *testing.T) {
 	head := int64(42)
 	meta := newConflictTestMetadata(t, &head)
 
-	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 	assert.Empty(t, ctx.concurrent)
 }
@@ -151,7 +151,7 @@ func TestNewConflictContext_WriterHasNoBranchView(t *testing.T) {
 	head := int64(7)
 	current := newConflictTestMetadata(t, &head)
 
-	ctx, err := NewConflictContext(base, current, MainBranch, nil, true)
+	ctx, err := newConflictContext(base, current, MainBranch, nil, true)
 	require.NoError(t, err)
 	assert.Empty(t, ctx.concurrent)
 }
@@ -163,7 +163,7 @@ func TestNewConflictContext_MissingCurrentBranch(t *testing.T) {
 	base := newConflictTestMetadata(t, &head)
 	current := newConflictTestMetadata(t, nil)
 
-	_, err := NewConflictContext(base, current, MainBranch, nil, true)
+	_, err := newConflictContext(base, current, MainBranch, nil, true)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCommitDiverged)
 	assert.False(t, errors.Is(err, ErrCommitFailed),
@@ -179,7 +179,7 @@ func TestNewConflictContext_BaseNotInCurrentAncestry(t *testing.T) {
 	base := newConflictTestMetadata(t, &baseHead)
 	current := newConflictTestMetadata(t, &currentHead)
 
-	_, err := NewConflictContext(base, current, MainBranch, nil, true)
+	_, err := newConflictContext(base, current, MainBranch, nil, true)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCommitDiverged)
 	assert.False(t, errors.Is(err, ErrCommitFailed),
@@ -192,11 +192,11 @@ func TestValidateDataFilesExist_EmptyInput(t *testing.T) {
 	// touching metadata or the filesystem.
 	head := int64(1)
 	meta := newConflictTestMetadata(t, &head)
-	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 
-	require.NoError(t, ValidateDataFilesExist(ctx, nil))
-	require.NoError(t, ValidateDataFilesExist(ctx, []string{}))
+	require.NoError(t, validateDataFilesExist(ctx, nil))
+	require.NoError(t, validateDataFilesExist(ctx, []string{}))
 }
 
 func TestValidateNoNewDeletesForRewrittenFiles_EmptyInputs(t *testing.T) {
@@ -204,15 +204,15 @@ func TestValidateNoNewDeletesForRewrittenFiles_EmptyInputs(t *testing.T) {
 	// short-circuit to nil.
 	head := int64(1)
 	meta := newConflictTestMetadata(t, &head)
-	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 
 	// Empty rewrittenPaths.
-	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, nil))
-	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, []string{}))
+	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, nil))
+	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []string{}))
 
 	// Non-empty rewrittenPaths but no concurrent snapshots.
-	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, []string{"a.parquet"}))
+	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []string{"a.parquet"}))
 }
 
 func TestValidateAddedDataFilesMatchingFilter_NoConcurrent(t *testing.T) {
@@ -220,11 +220,11 @@ func TestValidateAddedDataFilesMatchingFilter_NoConcurrent(t *testing.T) {
 	// regardless of filter.
 	head := int64(1)
 	meta := newConflictTestMetadata(t, &head)
-	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 
-	require.NoError(t, ValidateAddedDataFilesMatchingFilter(ctx, iceberg.AlwaysTrue{}))
-	require.NoError(t, ValidateAddedDataFilesMatchingFilter(ctx, nil))
+	require.NoError(t, validateAddedDataFilesMatchingFilter(ctx, iceberg.AlwaysTrue{}))
+	require.NoError(t, validateAddedDataFilesMatchingFilter(ctx, nil))
 }
 
 func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
@@ -232,42 +232,8 @@ func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
 	// even attempt to enumerate concurrent snapshots.
 	head := int64(1)
 	meta := newConflictTestMetadata(t, &head)
-	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 
-	require.NoError(t, ValidateNoConflictingDataFiles(ctx, iceberg.AlwaysTrue{}, IsolationSnapshot))
-}
-
-func TestPerSpecFilterCache_ProjectForReusesPerSpec(t *testing.T) {
-	// projectFor must memoize on spec id and look specs up by id
-	// rather than slice index.
-	head := int64(1)
-	meta := newConflictTestMetadata(t, &head)
-
-	cache := newPerSpecFilterCache(iceberg.AlwaysTrue{})
-
-	first, err := cache.projectFor(meta.DefaultPartitionSpec(), meta, meta.CurrentSchema(), true)
-	require.NoError(t, err)
-	require.NotNil(t, first)
-
-	second, err := cache.projectFor(meta.DefaultPartitionSpec(), meta, meta.CurrentSchema(), true)
-	require.NoError(t, err)
-	assert.True(t, first.Equals(second), "second call should return a projection equal to the first")
-
-	// Direct memo inspection to lock the caching invariant beyond
-	// Equals semantics (which could hide a re-projection that
-	// happens to produce an equal expression).
-	assert.Len(t, cache.memo, 1, "projectFor should memoize a single entry per spec id")
-}
-
-func TestPerSpecFilterCache_UnknownSpecReturnsError(t *testing.T) {
-	// Asking for a spec id that does not exist must return a
-	// descriptive error, not panic or return a wrong spec.
-	head := int64(1)
-	meta := newConflictTestMetadata(t, &head)
-
-	cache := newPerSpecFilterCache(iceberg.AlwaysTrue{})
-	_, err := cache.projectFor(999, meta, meta.CurrentSchema(), true)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.NoError(t, validateNoConflictingDataFiles(ctx, iceberg.AlwaysTrue{}, IsolationSnapshot))
 }

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -1,0 +1,273 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadIsolationLevel(t *testing.T) {
+	tests := []struct {
+		name   string
+		props  iceberg.Properties
+		key    string
+		defVal IsolationLevel
+		want   IsolationLevel
+	}{
+		{
+			name:   "missing key falls back to default",
+			props:  iceberg.Properties{},
+			key:    WriteDeleteIsolationLevelKey,
+			defVal: IsolationSerializable,
+			want:   IsolationSerializable,
+		},
+		{
+			name:   "explicit serializable",
+			props:  iceberg.Properties{WriteDeleteIsolationLevelKey: "serializable"},
+			key:    WriteDeleteIsolationLevelKey,
+			defVal: IsolationSnapshot,
+			want:   IsolationSerializable,
+		},
+		{
+			name:   "explicit snapshot",
+			props:  iceberg.Properties{WriteDeleteIsolationLevelKey: "snapshot"},
+			key:    WriteDeleteIsolationLevelKey,
+			defVal: IsolationSerializable,
+			want:   IsolationSnapshot,
+		},
+		{
+			name:   "unrecognized value falls back to default",
+			props:  iceberg.Properties{WriteDeleteIsolationLevelKey: "repeatable-read"},
+			key:    WriteDeleteIsolationLevelKey,
+			defVal: IsolationSerializable,
+			want:   IsolationSerializable,
+		},
+		{
+			name:   "empty string falls back to default",
+			props:  iceberg.Properties{WriteDeleteIsolationLevelKey: ""},
+			key:    WriteDeleteIsolationLevelKey,
+			defVal: IsolationSnapshot,
+			want:   IsolationSnapshot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReadIsolationLevel(tt.props, tt.key, tt.defVal)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRetryableConflictErrors_WrapCommitFailed(t *testing.T) {
+	// The retryable sentinels must be recognizable to the retry
+	// machinery as a commit-level conflict.
+	retryable := []error{
+		ErrConflictingDataFiles,
+		ErrConflictingDeleteFiles,
+		ErrDataFilesMissing,
+	}
+	for _, s := range retryable {
+		assert.ErrorIsf(t, s, ErrCommitFailed, "%v should wrap ErrCommitFailed", s)
+	}
+}
+
+func TestErrCommitDiverged_IsTerminal(t *testing.T) {
+	// Divergence is terminal for the current attempt — retrying the
+	// same updates will produce the same divergence. It therefore
+	// MUST NOT wrap ErrCommitFailed, which is the retry machinery's
+	// trigger.
+	assert.False(t, errors.Is(ErrCommitDiverged, ErrCommitFailed),
+		"ErrCommitDiverged must not wrap ErrCommitFailed — it is a terminal error")
+}
+
+func newConflictTestMetadata(t *testing.T, branchHead *int64) Metadata {
+	t.Helper()
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/conflict-test", props)
+	require.NoError(t, err)
+
+	if branchHead == nil {
+		return meta
+	}
+
+	// Graft a synthetic snapshot whose timestamp sits just past the
+	// metadata's last-updated timestamp so AddSnapshot's monotonicity
+	// check accepts it.
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	snap := Snapshot{
+		SnapshotID:     *branchHead,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		Summary:        &Summary{Operation: OpAppend},
+	}
+	require.NoError(t, builder.AddSnapshot(&snap))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, *branchHead, BranchRef))
+	out, err := builder.Build()
+	require.NoError(t, err)
+
+	return out
+}
+
+func TestNewConflictContext_NoConcurrentCommits(t *testing.T) {
+	// base and current point at the same snapshot → zero concurrent
+	// snapshots, no error.
+	head := int64(42)
+	meta := newConflictTestMetadata(t, &head)
+
+	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+	assert.Empty(t, ctx.concurrent)
+}
+
+func TestNewConflictContext_WriterHasNoBranchView(t *testing.T) {
+	// Writer is creating the branch for the first time (base has no
+	// ref yet) — there is nothing concurrent to validate against.
+	base := newConflictTestMetadata(t, nil)
+	head := int64(7)
+	current := newConflictTestMetadata(t, &head)
+
+	ctx, err := NewConflictContext(base, current, MainBranch, nil, true)
+	require.NoError(t, err)
+	assert.Empty(t, ctx.concurrent)
+}
+
+func TestNewConflictContext_MissingCurrentBranch(t *testing.T) {
+	// Branch was deleted concurrently — cannot validate, must refresh
+	// and rebuild. The error is terminal, not retryable.
+	head := int64(5)
+	base := newConflictTestMetadata(t, &head)
+	current := newConflictTestMetadata(t, nil)
+
+	_, err := NewConflictContext(base, current, MainBranch, nil, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCommitDiverged)
+	assert.False(t, errors.Is(err, ErrCommitFailed),
+		"divergence must not be retryable")
+}
+
+func TestNewConflictContext_BaseNotInCurrentAncestry(t *testing.T) {
+	// base and current both have the branch ref, but current's head
+	// ancestry does not reach base's head (forked history, expired
+	// base). Must return ErrCommitDiverged, not retryable.
+	baseHead := int64(50)
+	currentHead := int64(99)
+	base := newConflictTestMetadata(t, &baseHead)
+	current := newConflictTestMetadata(t, &currentHead)
+
+	_, err := NewConflictContext(base, current, MainBranch, nil, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCommitDiverged)
+	assert.False(t, errors.Is(err, ErrCommitFailed),
+		"divergent ancestry must not be retryable")
+	assert.Contains(t, err.Error(), "ancestry", "message should explain the ancestry gap")
+}
+
+func TestValidateDataFilesExist_EmptyInput(t *testing.T) {
+	// Empty referencedPaths must short-circuit to nil without
+	// touching metadata or the filesystem.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+
+	require.NoError(t, ValidateDataFilesExist(ctx, nil))
+	require.NoError(t, ValidateDataFilesExist(ctx, []string{}))
+}
+
+func TestValidateNoNewDeletesForRewrittenFiles_EmptyInputs(t *testing.T) {
+	// Empty rewrittenPaths OR empty concurrent snapshots must both
+	// short-circuit to nil.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+
+	// Empty rewrittenPaths.
+	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, nil))
+	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, []string{}))
+
+	// Non-empty rewrittenPaths but no concurrent snapshots.
+	require.NoError(t, ValidateNoNewDeletesForRewrittenFiles(ctx, []string{"a.parquet"}))
+}
+
+func TestValidateAddedDataFilesMatchingFilter_NoConcurrent(t *testing.T) {
+	// With zero concurrent snapshots the validator must return nil
+	// regardless of filter.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+
+	require.NoError(t, ValidateAddedDataFilesMatchingFilter(ctx, iceberg.AlwaysTrue{}))
+	require.NoError(t, ValidateAddedDataFilesMatchingFilter(ctx, nil))
+}
+
+func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
+	// Under snapshot isolation the validator is a no-op — it must not
+	// even attempt to enumerate concurrent snapshots.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+	ctx, err := NewConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+
+	require.NoError(t, ValidateNoConflictingDataFiles(ctx, iceberg.AlwaysTrue{}, IsolationSnapshot))
+}
+
+func TestPerSpecFilterCache_ProjectForReusesPerSpec(t *testing.T) {
+	// projectFor must memoize on spec id and look specs up by id
+	// rather than slice index.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+
+	cache := newPerSpecFilterCache(iceberg.AlwaysTrue{})
+
+	first, err := cache.projectFor(meta.DefaultPartitionSpec(), meta, meta.CurrentSchema(), true)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := cache.projectFor(meta.DefaultPartitionSpec(), meta, meta.CurrentSchema(), true)
+	require.NoError(t, err)
+	assert.True(t, first.Equals(second), "second call should return a projection equal to the first")
+
+	// Direct memo inspection to lock the caching invariant beyond
+	// Equals semantics (which could hide a re-projection that
+	// happens to produce an equal expression).
+	assert.Len(t, cache.memo, 1, "projectFor should memoize a single entry per spec id")
+}
+
+func TestPerSpecFilterCache_UnknownSpecReturnsError(t *testing.T) {
+	// Asking for a spec id that does not exist must return a
+	// descriptive error, not panic or return a wrong spec.
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+
+	cache := newPerSpecFilterCache(iceberg.AlwaysTrue{})
+	_, err := cache.projectFor(999, meta, meta.CurrentSchema(), true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -294,15 +294,18 @@ func buildManifestEvaluator(specID int, metadata Metadata, partitionFilters *key
 }
 
 func (scan *Scan) buildPartitionEvaluator(specID int) (func(iceberg.DataFile) (bool, error), error) {
-	spec := scan.metadata.PartitionSpecByID(specID)
+	return buildPartitionEvaluator(specID, scan.metadata, scan.partitionFilters, scan.caseSensitive)
+}
+
+func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMap[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {
+	spec := metadata.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
 	}
-	partType := spec.PartitionType(scan.metadata.CurrentSchema())
+	partType := spec.PartitionType(metadata.CurrentSchema())
 	partSchema := iceberg.NewSchema(0, partType.FieldList...)
-	partExpr := scan.partitionFilters.Get(specID)
 
-	fn, err := iceberg.ExpressionEvaluator(partSchema, partExpr, scan.caseSensitive)
+	fn, err := iceberg.ExpressionEvaluator(partSchema, partitionFilters.Get(specID), caseSensitive)
 	if err != nil {
 		return nil, err
 	}

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -366,6 +366,45 @@ func (s Snapshot) dataFiles(fio iceio.IO, fileFilter set[iceberg.ManifestEntryCo
 	}
 }
 
+// entries iterates every manifest entry in the snapshot, filtered by
+// manifest content (data or deletes). It is the entry-level analog
+// of dataFiles and exposes the underlying ManifestEntry so callers
+// can inspect Status / SnapshotID / DataFile — needed by conflict
+// validation where attribution of an entry to a specific snapshot
+// matters.
+//
+// manifestContent < 0 yields entries across both data and delete
+// manifests.
+func (s Snapshot) entries(fio iceio.IO, manifestContent iceberg.ManifestContent) iter.Seq2[iceberg.ManifestEntry, error] {
+	return func(yield func(iceberg.ManifestEntry, error) bool) {
+		manifests, err := s.Manifests(fio)
+		if err != nil {
+			yield(nil, err)
+
+			return
+		}
+
+		for _, m := range manifests {
+			if manifestContent >= 0 && m.ManifestContent() != manifestContent {
+				continue
+			}
+
+			entries, err := m.FetchEntries(fio, false)
+			if err != nil {
+				yield(nil, err)
+
+				return
+			}
+
+			for _, e := range entries {
+				if !yield(e, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
 type MetadataLogEntry struct {
 	MetadataFile string `json:"metadata-file"`
 	TimestampMs  int64  `json:"timestamp-ms"`


### PR DESCRIPTION
Adds the foundational types, errors, and validator functions that a producer uses to detect conflicting concurrent commits before re-issuing its updates. Framework part of #830.

No producer is wired to use these yet, that step lands with next slice; this change is library plumbing only and has no behavior impact on existing paths.

  - IsolationLevel type with SERIALIZABLE and SNAPSHOT constants, plus write.delete.isolation-level / write.update.isolation-level property keys (matching Java's TableProperties names).
  - Four conflict sentinels that wrap table.ErrCommitFailed so the existing retry loop in doCommit continues to treat them as retryable conflicts.
  - ConflictContext walks AncestorsBetween (from the snapshot ancestry utility) to enumerate concurrent snapshots on the committer's branch and returns ErrCommitDiverged if the base snapshot is no longer on the branch.
  - Four validators matching Java's BaseRowDelta / BaseOverwriteFiles / BaseRewriteFiles:
      * ValidateDataFilesExist — pos-delete referenced files still reachable from current head.
      * ValidateAddedDataFilesMatchingFilter — no concurrent data-file add in the committer's filter region (manifest-level partition-summary pruning via the existing evaluators). * ValidateNoConflictingDataFiles — isolation-level-gated variant of the above for RowDelta eq-delete commits. * ValidateNoNewDeletesForRewrittenFiles — no concurrent position deletes targeting files a rewrite is replacing.
  - Per-spec filter projection cache so a walk across snapshots written under different partition spec ids reuses its projection work.

Tests cover the framework's logic (isolation-level parsing, error wrapping, ConflictContext edge cases, validator short-circuit paths). 

End-to-end conflict detection under real concurrent-snapshot conditions lives with the producer-wiring follow up PR.