### PR TITLE
fix(table): ReplaceDataFiles should emit OpReplace instead of OpOverwrite

### DIFF
--- a/table/replace_files_test.go
+++ b/table/replace_files_test.go
@@ -136,7 +136,7 @@ func TestReplaceFiles_DataAndDeleteFiles(t *testing.T) {
 
 	snap := tbl.CurrentSnapshot()
 	require.NotNil(t, snap)
-	assert.Equal(t, table.OpOverwrite, snap.Summary.Operation)
+	assert.Equal(t, table.OpReplace, snap.Summary.Operation)
 }
 
 func TestReplaceFiles_DelegatesToReplaceDataFilesWhenNoDeleteFiles(t *testing.T) {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1011,7 +1011,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFiles() {
 	t.Require().NoError(err)
 
 	t.Equal(&table.Summary{
-		Operation: table.OpOverwrite,
+		Operation: table.OpReplace,
 		Properties: iceberg.Properties{
 			"added-data-files":       "1",
 			"added-files-size":       "1068",
@@ -1151,7 +1151,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFiles() {
 
 	staged, err := tx.StagedTable()
 	t.Require().NoError(err)
-	t.Equal(table.OpOverwrite, staged.CurrentSnapshot().Summary.Operation)
+	t.Equal(table.OpReplace, staged.CurrentSnapshot().Summary.Operation)
 	t.Equal("1", staged.CurrentSnapshot().Summary.Properties["added-data-files"])
 	t.Equal("2", staged.CurrentSnapshot().Summary.Properties["deleted-data-files"])
 }

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -347,14 +347,13 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 	return t.apply(updates, reqs)
 }
 
-// ReplaceFiles is actually just an overwrite operation with multiple
-// files deleted and added.
-//
-// TODO: technically, this could be a REPLACE operation but we aren't performing
-// any validation here that there are no changes to the underlying data. A REPLACE
-// operation is only valid if the data is exactly the same as the previous snapshot.
-//
-// For now, we'll keep using an overwrite operation.
+// ReplaceDataFiles atomically removes filesToDelete and adds filesToAdd,
+// emitting a REPLACE snapshot per the Iceberg spec. REPLACE denotes that
+// the underlying row-level data is unchanged and has only been
+// reorganized into different files (the canonical use case is
+// compaction). It is the caller's responsibility to uphold that
+// invariant -- this API does not verify row equivalence. If you need to
+// rewrite rows, use OverwriteFiles / RowDelta instead.
 func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
@@ -424,7 +423,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -734,7 +733,7 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -847,7 +846,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpReplace).mergeOverwrite(&commitUUID)
 
 	for _, df := range markedDataForDeletion {
 		updater.deleteDataFile(df)


### PR DESCRIPTION
Closes #841.

\`ReplaceDataFiles\`, \`ReplaceDataFilesWithDataFiles\` and \`ReplaceFiles\` all produced snapshots with \`Operation = \"overwrite\"\` because of a leftover TODO in \`table/transaction.go\` noting that no validation enforces row-content equivalence. The three APIs are named \`Replace*\` for a reason: callers use them for compaction and delete-file GC where the row-level data is unchanged and only reorganized into different physical files. Per the Iceberg spec that's a REPLACE operation; emitting \`OVERWRITE\` masks those snapshots from downstream tooling that treats overwrite as a data-content change (incremental scans, table-maintenance logic, etc.).

## Change

- \`table/transaction.go:427\` — \`ReplaceDataFiles\` now passes \`OpReplace\` to \`updateSnapshot\`.
- \`table/transaction.go:736\` — \`ReplaceDataFilesWithDataFiles\` does the same.
- \`table/transaction.go:849\` — \`ReplaceFiles\` does the same (this path also covers removing pre-existing delete files as part of a compaction rewrite).
- \`ReplaceDataFiles\` doc comment rewritten to state the caller-held invariant (row content must be equivalent) explicitly instead of punting with a TODO.
- \`table/replace_files_test.go\` — single assertion flipped from \`OpOverwrite\` to \`OpReplace\` in \`TestReplaceFiles_DataAndDeleteFiles\` to match the new behaviour.

## Verification

\`\`\`
$ go build ./...
(clean)

$ go test -count=1 -run 'TestReplace|TestCompact' -timeout 180s ./table/...
ok  github.com/apache/iceberg-go/table           5.554s
ok  github.com/apache/iceberg-go/table/compaction  6.270s
ok  github.com/apache/iceberg-go/table/internal    3.488s
ok  github.com/apache/iceberg-go/table/substrait   2.015s
\`\`\`