### PR TITLE
feat(config,cmd/iceberg): support more rest options in config

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -78,6 +78,7 @@ Arguments:
 Options:
   -h --help          	show this help messages and exit
   --catalog TEXT     	specify the catalog type [default: rest]
+  --catalog-name TEXT   specify the catalog name to use from the config [default: default]
   --uri TEXT         	specify the catalog URI
   --output TYPE      	output type (json/text) [default: text]
   --credential TEXT  	specify credentials for the catalog
@@ -131,6 +132,7 @@ type Config struct {
 	Value    string `docopt:"VALUE"`
 
 	Catalog         string `docopt:"--catalog"`
+	CatalogName     string `docopt:"--catalog-name"`
 	URI             string `docopt:"--uri"`
 	Output          string `docopt:"--output"`
 	History         bool   `docopt:"--history"`
@@ -147,6 +149,8 @@ type Config struct {
 	SortOrder       string `docopt:"--sort-order"`
 	TargetFileSize  int64  `docopt:"--target-file-size"`
 	PartialProgress bool   `docopt:"--partial-progress"`
+
+	RestOptions *config.RestOptions `docopt:"-"`
 }
 
 func main() {
@@ -174,7 +178,7 @@ func main() {
 		}
 	}
 
-	fileCfg := config.ParseConfig(config.LoadConfig(cfg.Config), "default")
+	fileCfg := config.ParseConfig(config.LoadConfig(cfg.Config), cfg.CatalogName)
 	if fileCfg != nil {
 		mergeConf(fileCfg, &cfg, explicitFlags)
 	}
@@ -205,6 +209,15 @@ func main() {
 
 		if len(cfg.Scope) > 0 {
 			opts = append(opts, rest.WithScope(cfg.Scope))
+		}
+
+		if cfg.RestOptions != nil {
+			if cfg.RestOptions.SigV4Enabled {
+				opts = append(opts, rest.WithSigV4())
+			}
+			if cfg.RestOptions.SigningName != "" || cfg.RestOptions.SigningRegion != "" {
+				opts = append(opts, rest.WithSigV4RegionSvc(cfg.RestOptions.SigningRegion, cfg.RestOptions.SigningName))
+			}
 		}
 
 		if cat, err = rest.NewCatalog(ctx, "rest", cfg.URI, opts...); err != nil {
@@ -550,5 +563,9 @@ func mergeConf(fileConf *config.CatalogConfig, resConfig *Config, explicitFlags 
 	}
 	if !explicitFlags["warehouse"] && len(fileConf.Warehouse) > 0 {
 		resConfig.Warehouse = fileConf.Warehouse
+	}
+
+	if fileConf.RestOptions != nil {
+		resConfig.RestOptions = fileConf.RestOptions
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -35,12 +35,19 @@ type Config struct {
 	MaxWorkers     int                      `yaml:"max-workers"`
 }
 
+type RestOptions struct {
+	SigV4Enabled  bool   `yaml:"sigv4-enabled"`
+	SigningName   string `yaml:"signing-name"`
+	SigningRegion string `yaml:"signing-region"`
+}
+
 type CatalogConfig struct {
-	CatalogType string `yaml:"type"`
-	URI         string `yaml:"uri"`
-	Output      string `yaml:"output"`
-	Credential  string `yaml:"credential"`
-	Warehouse   string `yaml:"warehouse"`
+	CatalogType string       `yaml:"type"`
+	URI         string       `yaml:"uri"`
+	Output      string       `yaml:"output"`
+	Credential  string       `yaml:"credential"`
+	Warehouse   string       `yaml:"warehouse"`
+	RestOptions *RestOptions `yaml:"rest,omitempty"`
 }
 
 func LoadConfig(configPath string) []byte {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,6 +78,30 @@ catalog:
 			Warehouse:   "catalog_name",
 		},
 	},
+	// include rest options
+	{
+		[]byte(`
+catalog:
+  default:
+    type: rest
+    warehouse: "arn:aws:s3tables:us-east-1:account-id:bucket/bucketname"
+    uri: "https://s3tables.us-east-1.amazonaws.com/iceberg"
+    rest:
+      sigv4-enabled: true
+      signing-name: "s3tables"
+      signing-region: "us-east-1"
+`), "default",
+		&CatalogConfig{
+			CatalogType: "rest",
+			URI:         "https://s3tables.us-east-1.amazonaws.com/iceberg",
+			Warehouse:   "arn:aws:s3tables:us-east-1:account-id:bucket/bucketname",
+			RestOptions: &RestOptions{
+				SigV4Enabled:  true,
+				SigningName:   "s3tables",
+				SigningRegion: "us-east-1",
+			},
+		},
+	},
 }
 
 func TestParseConfig(t *testing.T) {


### PR DESCRIPTION
When testing and playing around with AWS S3 Tables, I discovered that we need a way to specify more of the REST options (and likely more for other catalogs in the future) to be able to leverage and connect to s3 tables using the `iceberg` binary that is created here. 

This PR creates an initial pattern (modeled somewhat on how pyiceberg manages it's config) that introduces a subsection in the catalog yaml definition for adding more options. I also add a test case here that matches what you'd have to do for the `cmd/iceberg` mainprog to be able to access s3 tables using the yaml config. 

More options for rest and other catalogs can be added in follow-up PRs now that this establishes a pattern to follow.