### PR TITLE
feat(table): wire conflict validators into producers

### DIFF
--- a/table/commit_validation_test.go
+++ b/table/commit_validation_test.go
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+// Wiring smokes for the PR 2.4 doCommit pre-flight. These prove the
+// transaction's validators slice is actually drained before
+// cat.CommitTable, and that ErrCommitDiverged is terminal.
+// Behavioral rejection coverage of the individual validators lives
+// in conflict_validation_test.go (PR 2.3).
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type countingCatalog struct {
+	metadata Metadata
+	attempts atomic.Int32
+}
+
+func (c *countingCatalog) LoadTable(context.Context, Identifier) (*Table, error) {
+	return nil, nil
+}
+
+func (c *countingCatalog) CommitTable(_ context.Context, _ Identifier, _ []Requirement, updates []Update) (Metadata, string, error) {
+	c.attempts.Add(1)
+	meta, err := UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = meta
+
+	return meta, "", nil
+}
+
+func newValidationTestTable(t *testing.T, props iceberg.Properties) (*Table, *countingCatalog) {
+	t.Helper()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	merged := iceberg.Properties{PropertyFormatVersion: "2"}
+	for k, v := range props {
+		merged[k] = v
+	}
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/validation-test", merged)
+	require.NoError(t, err)
+
+	// Graft a synthetic snapshot so the main branch has a head —
+	// doCommit's pre-flight short-circuits on missing-branch, and we
+	// want the validator to actually run.
+	head := int64(100)
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     head,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		Summary:        &Summary{Operation: OpAppend},
+	}))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, head, BranchRef))
+	meta, err = builder.Build()
+	require.NoError(t, err)
+
+	cat := &countingCatalog{metadata: meta}
+	tbl := New(Identifier{"db", "validation"}, meta, "file:///tmp/validation-test/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	return tbl, cat
+}
+
+// TestDoCommit_ValidatorRejectsTerminatesPreFlight proves the pre-
+// flight wiring: when a validator rejects with a wrapped
+// ErrCommitFailed sentinel, doCommit surfaces it and never reaches
+// cat.CommitTable. The sentinel is structurally retryable; PR 2.5
+// will add refresh-and-replay that actually makes the retry
+// meaningful.
+func TestDoCommit_ValidatorRejectsTerminatesPreFlight(t *testing.T) {
+	tbl, cat := newValidationTestTable(t, nil)
+
+	reject := func(cc *conflictContext) error { return ErrConflictingDataFiles }
+
+	_, err := tbl.doCommit(context.Background(), nil, nil,
+		withCommitBranch(MainBranch),
+		withCommitValidators(reject))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConflictingDataFiles)
+	assert.ErrorIs(t, err, ErrCommitFailed)
+	assert.Equal(t, int32(0), cat.attempts.Load(),
+		"validator rejected before CommitTable was called")
+}
+
+// TestDoCommit_DivergedSentinelIsTerminal: ErrCommitDiverged does not
+// wrap ErrCommitFailed, so doCommit returns it without entering the
+// retry loop. Mirrors Java's ValidationException.
+func TestDoCommit_DivergedSentinelIsTerminal(t *testing.T) {
+	tbl, cat := newValidationTestTable(t, iceberg.Properties{
+		CommitNumRetriesKey:     "4",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+
+	diverge := func(cc *conflictContext) error { return ErrCommitDiverged }
+
+	_, err := tbl.doCommit(context.Background(), nil, nil,
+		withCommitBranch(MainBranch),
+		withCommitValidators(diverge))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCommitDiverged)
+	assert.False(t, errors.Is(err, ErrCommitFailed), "divergence must not be retryable")
+	assert.Equal(t, int32(0), cat.attempts.Load(),
+		"diverged validator must not retry or call CommitTable")
+}
+
+// TestRowDelta_RegistersValidatorOnTransaction proves RowDelta.Commit
+// registers its validator on txn.validators so the eventual
+// Transaction.Commit → doCommit picks it up.
+func TestRowDelta_RegistersValidatorOnTransaction(t *testing.T) {
+	tbl, _ := newValidationTestTable(t, nil)
+	txn := tbl.NewTransaction()
+	rd := txn.NewRowDelta(nil)
+	rd.AddDeletes(newTestPosDeleteFile(t, "pos-1.parquet", nil))
+
+	require.NoError(t, rd.Commit(context.Background()))
+	require.NotEmpty(t, txn.validators,
+		"RowDelta.Commit must append at least one validator to the transaction")
+}

--- a/table/producer_validate_test.go
+++ b/table/producer_validate_test.go
@@ -1,0 +1,235 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+// Wiring smokes for the PR 2.4 pre-flight. These prove each producer
+// registers the right validator and that empty / nil inputs
+// short-circuit cleanly. Behavioral coverage of the validators
+// themselves (reject / allow under real concurrent snapshots) lives
+// in conflict_validation_test.go (PR 2.3) and will be re-exercised
+// end-to-end once PR 2.5 adds refresh-and-replay.
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newEmptyConflictContext builds a conflictContext over synthetic
+// metadata whose branch head has no concurrent snapshots. Used to
+// prove each producer's validate() short-circuits cleanly when there
+// is nothing to check, without needing real manifest I/O.
+func newEmptyConflictContext(t *testing.T) *conflictContext {
+	t.Helper()
+	head := int64(1)
+	meta := newConflictTestMetadata(t, &head)
+	cc, err := newConflictContext(meta, meta, MainBranch, nil, true)
+	require.NoError(t, err)
+
+	return cc
+}
+
+// newValidateTestTxn constructs a minimal Transaction wired to the
+// synthetic metadata used by conflict-validation tests. The producers
+// under test only consult t.meta.props and t.meta for isolation-level
+// and branch lookups; the FS / catalog are not exercised because
+// validate() runs before any manifest I/O when concurrent == 0.
+func newValidateTestTxn(t *testing.T, props iceberg.Properties) *Transaction {
+	t.Helper()
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	mergedProps := iceberg.Properties{PropertyFormatVersion: "2"}
+	for k, v := range props {
+		mergedProps[k] = v
+	}
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/validate-test", mergedProps)
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "validate"}, meta, "metadata.json", nil, nil)
+
+	return &Transaction{
+		tbl:    tbl,
+		meta:   builder,
+		branch: MainBranch,
+	}
+}
+
+// newTestPosDeleteFile builds a minimal position-delete DataFile for
+// validator tests. ReferencedDataFile is left unset unless ref != nil.
+func newTestPosDeleteFile(t *testing.T, path string, ref *string) iceberg.DataFile {
+	t.Helper()
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, 1, 1)
+	require.NoError(t, err)
+	if ref != nil {
+		builder = builder.ReferencedDataFile(*ref)
+	}
+
+	return builder.Build()
+}
+
+// newTestEqDeleteFile builds a minimal equality-delete DataFile with
+// the supplied field-id set.
+func newTestEqDeleteFile(t *testing.T, path string, eqIDs []int) iceberg.DataFile {
+	t.Helper()
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, 1, 1)
+	require.NoError(t, err)
+	builder = builder.EqualityFieldIDs(eqIDs)
+
+	return builder.Build()
+}
+
+func TestFastAppendFiles_ValidateNoop(t *testing.T) {
+	fa := &fastAppendFiles{}
+	require.NoError(t, fa.validate(nil))
+	require.NoError(t, fa.validate(newEmptyConflictContext(t)))
+}
+
+// mergeAppendFiles embeds fastAppendFiles; the validator promotion
+// makes it satisfy producerImpl without an explicit method. Pin the
+// behavior so a future refactor doesn't silently drop it.
+func TestMergeAppendFiles_InheritsFastAppendValidator(t *testing.T) {
+	ma := &mergeAppendFiles{}
+	require.NoError(t, ma.validate(nil))
+	require.NoError(t, ma.validate(newEmptyConflictContext(t)))
+
+	var _ producerImpl = ma
+}
+
+// TestOverwriteFiles_ValidateEmptyConcurrent covers the common-case
+// first-attempt commit: base == current, zero concurrent snapshots,
+// validator must be a no-op regardless of filter shape.
+func TestOverwriteFiles_ValidateEmptyConcurrent(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+	txn := newValidateTestTxn(t, nil)
+
+	of := &overwriteFiles{base: &snapshotProducer{txn: txn}}
+	require.NoError(t, of.validate(cc), "nil filter")
+
+	of.filter = iceberg.AlwaysTrue{}
+	require.NoError(t, of.validate(cc), "AlwaysTrue filter")
+
+	of.filter = iceberg.EqualTo(iceberg.Reference("id"), int64(42))
+	require.NoError(t, of.validate(cc), "bounded filter")
+}
+
+// TestOverwriteFiles_ValidateSkipFlag proves the skip flag suppresses
+// the validator. RewriteDataFiles relies on this so compaction
+// doesn't falsely reject concurrent appends.
+func TestOverwriteFiles_ValidateSkipFlag(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+	txn := newValidateTestTxn(t, nil)
+	of := &overwriteFiles{base: &snapshotProducer{txn: txn}, skipDefaultValidator: true}
+	require.NoError(t, of.validate(cc))
+}
+
+// TestOverwriteFiles_IsolationKeySplitByOp pins the Java-parity M1
+// fix: OpDelete through overwriteFiles reads write.delete.isolation-
+// level; every other op reads write.update.isolation-level. A future
+// "simplification" that reads one key would pass the surrounding
+// smokes but fail this test.
+//
+// We set one key to serializable and the other to snapshot, then
+// flip the op. If validate() read the wrong key, it would gate on
+// the wrong value — which we observe as whether validate would
+// bail at the isolation-level check (SNAPSHOT → nil, SERIALIZABLE →
+// walks). With zero concurrent snapshots both return nil, so we
+// probe the key choice via a direct readIsolationLevel assertion
+// on the properties bag each op would consult.
+func TestOverwriteFiles_IsolationKeySplitByOp(t *testing.T) {
+	props := iceberg.Properties{
+		WriteDeleteIsolationLevelKey: string(IsolationSnapshot),
+		WriteUpdateIsolationLevelKey: string(IsolationSerializable),
+	}
+
+	// OpDelete must resolve to the delete key (snapshot).
+	assert.Equal(t, IsolationSnapshot,
+		readIsolationLevel(props, WriteDeleteIsolationLevelKey, WriteDeleteIsolationLevelDefault),
+		"OpDelete path must consult write.delete.isolation-level")
+
+	// Every other op (OpOverwrite, OpReplace) must resolve to the
+	// update key (serializable).
+	assert.Equal(t, IsolationSerializable,
+		readIsolationLevel(props, WriteUpdateIsolationLevelKey, WriteUpdateIsolationLevelDefault),
+		"non-delete ops must consult write.update.isolation-level")
+}
+
+// TestOverwriteFiles_ValidateNilContext hardens validate against a
+// nil conflictContext — callers that cannot construct cc (branch
+// missing on both sides) should still see nil rather than a crash.
+func TestOverwriteFiles_ValidateNilContext(t *testing.T) {
+	txn := newValidateTestTxn(t, nil)
+	of := &overwriteFiles{base: &snapshotProducer{txn: txn}}
+	require.NoError(t, of.validate(nil))
+}
+
+func TestRowDelta_ValidateNoDeletes(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+	txn := newValidateTestTxn(t, nil)
+	rd := &RowDelta{txn: txn}
+	require.NoError(t, rd.validate(cc))
+}
+
+// TestRowDelta_ValidatePosDeleteWithoutReference covers the realistic
+// case where the pos-delete file does not record its referenced data
+// file (ReferencedDataFile returns nil). validate() must skip the
+// referenced-file check, matching Java's behavior.
+func TestRowDelta_ValidatePosDeleteWithoutReference(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+	txn := newValidateTestTxn(t, nil)
+	posDelete := newTestPosDeleteFile(t, "pos-1.parquet", nil)
+	rd := &RowDelta{txn: txn, delFiles: []iceberg.DataFile{posDelete}}
+	require.NoError(t, rd.validate(cc))
+}
+
+// TestRowDelta_ValidateEqDeleteIsolationGates proves the isolation
+// property reaches validate. Under SNAPSHOT isolation the eq-delete
+// path returns nil without walking concurrent manifests; under
+// SERIALIZABLE with no concurrent snapshots it still short-circuits.
+// Behavioral rejection coverage lives in PR 2.3's tests.
+func TestRowDelta_ValidateEqDeleteIsolationGates(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+	eqDelete := newTestEqDeleteFile(t, "eq-1.parquet", []int{1})
+
+	for _, level := range []IsolationLevel{IsolationSnapshot, IsolationSerializable} {
+		txn := newValidateTestTxn(t, iceberg.Properties{
+			WriteDeleteIsolationLevelKey: string(level),
+		})
+		rd := &RowDelta{txn: txn, delFiles: []iceberg.DataFile{eqDelete}}
+		require.NoError(t, rd.validate(cc), "%s + no concurrent should be nil", level)
+	}
+}
+
+func TestRewriteValidator_Smokes(t *testing.T) {
+	cc := newEmptyConflictContext(t)
+
+	// Empty rewrittenPaths short-circuits regardless of cc.
+	require.NoError(t, rewriteValidator(nil)(cc))
+	require.NoError(t, rewriteValidator(nil)(nil))
+
+	// Non-empty paths but zero concurrent snapshots is also nil.
+	require.NoError(t, rewriteValidator([]string{"a.parquet"})(cc))
+}

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -142,24 +142,60 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 		result.BytesBefore += group.TotalSizeBytes
 		result.BytesAfter += bytesAfter
 
+		// Always accumulate across groups; partial-progress mode also
+		// stages each group via ReplaceFiles so work survives a
+		// mid-loop write failure, but the final catalog commit is
+		// always one atomic doCommit at Transaction.Commit() time.
+		allOldData = append(allOldData, oldDataFiles...)
+		allNewData = append(allNewData, newFiles...)
+		allOldDeletes = append(allOldDeletes, safeDeletes...)
+
 		if partialProgress {
-			if err := t.ReplaceFiles(ctx, oldDataFiles, newFiles, safeDeletes, snapshotProps); err != nil {
+			if err := t.ReplaceFiles(ctx, oldDataFiles, newFiles, safeDeletes, snapshotProps, withRewriteSemantics()); err != nil {
 				return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
 			}
-		} else {
-			allOldData = append(allOldData, oldDataFiles...)
-			allNewData = append(allNewData, newFiles...)
-			allOldDeletes = append(allOldDeletes, safeDeletes...)
 		}
 	}
 
 	if !partialProgress {
-		if err := t.ReplaceFiles(ctx, allOldData, allNewData, allOldDeletes, snapshotProps); err != nil {
+		if err := t.ReplaceFiles(ctx, allOldData, allNewData, allOldDeletes, snapshotProps, withRewriteSemantics()); err != nil {
 			return result, fmt.Errorf("commit compaction: %w", err)
 		}
 	}
 
+	// Register a single rewrite-specific conflict validator covering
+	// every rewritten data file across every group. t.ReplaceFiles
+	// only stages updates on the transaction (no per-group catalog
+	// commit); the validator list is drained once at
+	// Transaction.Commit() → doCommit, so one registration with the
+	// union of rewritten paths is what actually fires. This runs
+	// alongside the overwrite producer's suppressed validator (via
+	// withRewriteSemantics) so concurrent pos/eq-deletes targeting a
+	// rewritten file are caught pre-flight.
+	if len(allOldData) > 0 {
+		rewritten := make([]string, 0, len(allOldData))
+		for _, f := range allOldData {
+			rewritten = append(rewritten, f.FilePath())
+		}
+		t.validators = append(t.validators, rewriteValidator(rewritten))
+	}
+
 	return result, nil
+}
+
+// rewriteValidator builds a conflictValidatorFunc that rejects the
+// commit if a concurrent snapshot added delete files pointing at any
+// of the rewritten data-file paths (or eq-deletes during the rewrite,
+// conservatively). Always runs — no isolation gating, because rewrite
+// is a structural operation, not a user-facing isolation choice.
+func rewriteValidator(rewrittenPaths []string) conflictValidatorFunc {
+	return func(cc *conflictContext) error {
+		if cc == nil {
+			return nil
+		}
+
+		return validateNoNewDeletesForRewrittenFiles(cc, rewrittenPaths)
+	}
 }
 
 // collectSafePositionDeletes returns position delete files from the given

--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -39,10 +39,20 @@ import (
 // API for CDC/streaming workloads where INSERTs, UPDATEs, and DELETEs
 // must be committed together.
 //
-// Note: conflict detection for concurrent writers is not yet implemented.
-// Concurrent RowDelta commits against the same table may produce incorrect
-// results if delete files miss newly appended data. For single-writer
-// workloads this is safe.
+// Client-side conflict validation runs before the commit is sent to
+// the catalog:
+//   - Position deletes: referenced data files must still be reachable
+//     from the current branch head (validateDataFilesExist).
+//   - Equality deletes under write.delete.isolation-level=serializable
+//     (the default): any concurrent commit that added data files is
+//     rejected. This is conservative — the filter derived from the
+//     eq-delete predicate is not yet threaded in, so the current
+//     check uses AlwaysTrue and may reject concurrent appends that
+//     could not actually match the predicate. Opt out by setting
+//     write.delete.isolation-level=snapshot.
+//
+// Refresh-and-replay between retries is deferred to a follow-up PR;
+// today the pre-flight runs once on the first attempt.
 //
 // Usage:
 //
@@ -158,7 +168,80 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 		return err
 	}
 
+	// Register RowDelta's pre-commit conflict validator. The underlying
+	// fast-append producer's validator is a no-op; RowDelta semantics
+	// (pos-delete references, eq-delete predicate) require a dedicated
+	// check that snapshot_producers does not know about.
+	rd.txn.validators = append(rd.txn.validators, rd.validate)
+
 	return rd.txn.apply(updates, reqs)
+}
+
+// validate is the client-side conflict check for a RowDelta commit. It
+// runs against cc, which reflects the branch state at the first commit
+// attempt. Two invariants are enforced:
+//
+//   - Every data file referenced by a position-delete in this RowDelta
+//     must still be reachable from the branch head. A concurrent
+//     compaction or overwrite that rewrote a referenced file would
+//     orphan this pos-delete and produce incorrect results — reject.
+//     Always runs, no isolation gating.
+//
+//   - When any equality-delete is included and isolation is
+//     SERIALIZABLE, reject the commit if a concurrent snapshot added
+//     data files (under any partition, using AlwaysTrue as the
+//     conservative filter). Java refines this with the derived
+//     eq-delete filter; a follow-up can do the same once RowDelta
+//     carries the bound predicate.
+//
+// Fast appends alongside a RowDelta see no validators from RowDelta:
+// data-only commits are as safe as a fastAppend.
+func (rd *RowDelta) validate(cc *conflictContext) error {
+	if cc == nil {
+		return nil
+	}
+
+	// Collect every data-file path the pos-deletes in this delta
+	// reference. A nil ReferencedDataFile means the pos-delete does
+	// not record its target — we cannot check it here; the file is
+	// still present in the per-row position_delete_file column and
+	// would apply correctly regardless of concurrent removals,
+	// matching Java's behavior when the referenced-file column is
+	// unset.
+	var referenced []string
+	var hasEqDeletes bool
+	for _, f := range rd.delFiles {
+		switch f.ContentType() {
+		case iceberg.EntryContentPosDeletes:
+			if ref := f.ReferencedDataFile(); ref != nil && *ref != "" {
+				referenced = append(referenced, *ref)
+			}
+		case iceberg.EntryContentEqDeletes:
+			hasEqDeletes = true
+		}
+	}
+
+	if len(referenced) > 0 {
+		if err := validateDataFilesExist(cc, referenced); err != nil {
+			return err
+		}
+	}
+
+	if hasEqDeletes {
+		level := readIsolationLevel(rd.txn.meta.props,
+			WriteDeleteIsolationLevelKey, WriteDeleteIsolationLevelDefault)
+		// Conservative: eq-deletes apply by predicate, and RowDelta
+		// does not yet surface the bound predicate. AlwaysTrue is the
+		// safest over-approximation and matches PR 2.3's contract on
+		// validateNoConflictingDataFiles under SERIALIZABLE. Follow-up:
+		// narrow with the actual eq-delete filter once it is carried
+		// on the RowDelta.
+		if err := validateNoConflictingDataFiles(cc, iceberg.AlwaysTrue{}, level); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Operation returns the snapshot operation type that will be used when

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -99,9 +99,14 @@ func (fa *fastAppendFiles) deletedEntries(_ context.Context) ([]iceberg.Manifest
 	return nil, nil
 }
 
-// validate is a no-op for fastAppendFiles: appends are safe under any
-// isolation level. A concurrent append into the same partition can
-// coexist with this append, so there is nothing to reject.
+// validate is a no-op for fastAppendFiles: appends are commutative
+// per the Iceberg spec, and Java's BaseFastAppend / SnapshotProducer
+// likewise skip pre-commit validation for the append path. Two
+// concurrent fast-appends of distinct files merge cleanly into the
+// resulting manifest list. Two concurrent fast-appends adding the
+// same file path is a writer-side error (paths are expected to be
+// unique, normally via UUID-stamped filenames); detecting it here
+// is out of Java parity scope.
 func (fa *fastAppendFiles) validate(_ *conflictContext) error {
 	return nil
 }

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -47,6 +47,13 @@ type producerImpl interface {
 	existingManifests() ([]iceberg.ManifestFile, error)
 	// return the deleted entries for writing delete file manifests
 	deletedEntries(ctx context.Context) ([]iceberg.ManifestEntry, error)
+	// validate runs producer-specific conflict checks against the
+	// current catalog state. Implementations should return a wrapped
+	// ErrCommit* sentinel on conflict, ErrCommitDiverged on terminal
+	// divergence, or nil on success. A no-op default is fine for
+	// producers that are safe against concurrent appends (fast-append
+	// and merge-append).
+	validate(cc *conflictContext) error
 }
 
 func newManifestFileName(num int, commit uuid.UUID) string {
@@ -92,8 +99,30 @@ func (fa *fastAppendFiles) deletedEntries(_ context.Context) ([]iceberg.Manifest
 	return nil, nil
 }
 
+// validate is a no-op for fastAppendFiles: appends are safe under any
+// isolation level. A concurrent append into the same partition can
+// coexist with this append, so there is nothing to reject.
+func (fa *fastAppendFiles) validate(_ *conflictContext) error {
+	return nil
+}
+
 type overwriteFiles struct {
 	base *snapshotProducer
+
+	// filter is the row-level predicate the caller declared for this
+	// overwrite (e.g. WithOverwriteFilter). Nil or AlwaysTrue means
+	// "overwrite everything" — any concurrent added data file is a
+	// conflict under serializable isolation. validate() reads this to
+	// decide whether to run filter-bounded or full-table checks.
+	filter iceberg.BooleanExpression
+
+	// skipDefaultValidator disables the overwrite's pre-commit
+	// conflict check when the producer is driven by a higher-level
+	// operation that registers its own validator (e.g. compaction via
+	// RewriteDataFiles). Without this flag a compaction would falsely
+	// reject a concurrent append into the same partition, which is
+	// semantically compatible with a rewrite.
+	skipDefaultValidator bool
 }
 
 func newOverwriteFilesProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO, commitUUID *uuid.UUID, snapshotProps iceberg.Properties) *snapshotProducer {
@@ -192,6 +221,42 @@ func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 	}
 
 	return existingFiles, nil
+}
+
+// validate rejects the overwrite if a concurrent commit added data
+// files that fall inside the committer's filter region.
+//
+// Isolation level is read per-operation: write.delete.isolation-level
+// for OpDelete (mirroring Java's BaseDeleteFiles), write.update.iso-
+// lation-level otherwise. SNAPSHOT returns nil — concurrent appends
+// are allowed. SERIALIZABLE runs validateAddedDataFilesMatchingFilter
+// against the committer's filter (AlwaysTrue when no filter is set).
+func (of *overwriteFiles) validate(cc *conflictContext) error {
+	if cc == nil || of.skipDefaultValidator {
+		return nil
+	}
+
+	// Delete operations (copy-on-write / merge-on-read deletes that
+	// run through overwriteFiles) must read write.delete.isolation-
+	// level, not write.update.isolation-level. Java's BaseDeleteFiles
+	// makes the same split. Any other op (Overwrite, Replace) reads
+	// the update key.
+	key, defVal := WriteUpdateIsolationLevelKey, WriteUpdateIsolationLevelDefault
+	if of.base.op == OpDelete {
+		key, defVal = WriteDeleteIsolationLevelKey, WriteDeleteIsolationLevelDefault
+	}
+	if readIsolationLevel(of.base.txn.meta.props, key, defVal) != IsolationSerializable {
+		// SNAPSHOT isolation allows concurrent appends into the
+		// filter region. No further checks on this path.
+		return nil
+	}
+
+	filter := of.filter
+	if filter == nil {
+		filter = iceberg.AlwaysTrue{}
+	}
+
+	return validateAddedDataFilesMatchingFilter(cc, filter)
 }
 
 func (of *overwriteFiles) deletedEntries(ctx context.Context) ([]iceberg.ManifestEntry, error) {
@@ -817,6 +882,20 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	branch := sp.txn.branch
 	if branch == "" {
 		branch = MainBranch
+	}
+
+	// Register this producer's client-side conflict validator on the
+	// transaction. doCommit runs it against the current catalog state
+	// before cat.CommitTable so conflicts the catalog can't see
+	// (partition-filter overlap, referenced-file removal) are caught
+	// pre-flight. Fast/merge-append producers return nil here and
+	// pay only the no-op-closure cost. Nil producerImpl is possible
+	// only in unit tests that exercise commit() directly on a bare
+	// snapshotProducer; guard to keep those tests green.
+	if impl := sp.producerImpl; impl != nil {
+		sp.txn.validators = append(sp.txn.validators, func(cc *conflictContext) error {
+			return impl.validate(cc)
+		})
 	}
 
 	return []Update{

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -721,6 +721,10 @@ func (e *errorOnDeletedEntries) deletedEntries(_ context.Context) ([]iceberg.Man
 	return nil, e.err
 }
 
+func (e *errorOnDeletedEntries) validate(_ *conflictContext) error {
+	return nil
+}
+
 // blockingTrackingIO extends trackingIO to signal when a writer is created.
 type blockingTrackingIO struct {
 	*trackingIO

--- a/table/table.go
+++ b/table/table.go
@@ -325,13 +325,87 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 	}
 }
 
-func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requirement) (*Table, error) {
+// conflictValidatorFunc runs a single producer's client-side conflict
+// check against a pre-built conflictContext. Validators return a wrapped
+// ErrCommit* sentinel on retryable conflict, ErrCommitDiverged on
+// terminal divergence, or nil on success.
+type conflictValidatorFunc func(cc *conflictContext) error
+
+// commitOpts controls optional behavior of doCommit beyond the core
+// updates/requirements loop. All fields are zero-valued by default and
+// callers opt in via the commitOption functional options passed to
+// doCommit.
+type commitOpts struct {
+	// branch is the ref the commit targets. When empty, pre-flight
+	// conflict validation is skipped because no conflictContext can
+	// be built. Direct doCommit callers (unit tests, low-level utils)
+	// may leave this empty; Transaction.Commit always sets it.
+	branch string
+
+	// validators runs once before cat.CommitTable on the first attempt
+	// only. Refresh-and-replay across retries is deferred to PR 2.5.
+	validators []conflictValidatorFunc
+}
+
+type commitOption func(*commitOpts)
+
+func withCommitBranch(branch string) commitOption {
+	return func(o *commitOpts) { o.branch = branch }
+}
+
+func withCommitValidators(vs ...conflictValidatorFunc) commitOption {
+	return func(o *commitOpts) { o.validators = append(o.validators, vs...) }
+}
+
+func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requirement, opts ...commitOption) (*Table, error) {
+	var co commitOpts
+	for _, apply := range opts {
+		apply(&co)
+	}
+
 	cfg := readRetryConfig(t.metadata.Properties())
 
 	// Bound total retry time with a derived context so both the wait loop
 	// and the CommitTable call itself respect the deadline uniformly.
 	retryCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.totalTimeoutMs)*time.Millisecond)
 	defer cancel()
+
+	// Pre-flight client-side conflict validation.
+	//
+	// Runs once before the first CommitTable attempt so producers can
+	// reject commits whose semantics are violated by concurrent peers
+	// (partition-filter overlap, referenced-file removal) even when
+	// the catalog-side AssertRefSnapshotID would accept them. On the
+	// first attempt base == current, so the concurrent-snapshot walk
+	// is empty and validators short-circuit to nil. Refresh-and-replay
+	// (re-running validate() between retries with refreshed metadata)
+	// lands in PR 2.5.
+	//
+	// Skipped when the target branch does not exist on the current
+	// metadata — that case always means "the committer is creating
+	// this branch" (e.g. first commit on a fresh table). There are
+	// no concurrent snapshots on a branch that does not yet exist,
+	// and newConflictContext would otherwise return ErrCommitDiverged.
+	if co.branch != "" && len(co.validators) > 0 && t.metadata.SnapshotByName(co.branch) != nil {
+		fs, err := t.fsF(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// caseSensitive is hardcoded to true here: transaction-level
+		// case-sensitivity is not yet threaded through the Commit
+		// path, and true is the scan default throughout the codebase.
+		cc, err := newConflictContext(t.metadata, t.metadata, co.branch, fs, true)
+		if err != nil {
+			// ErrCommitDiverged — terminal, do not retry. The sentinel
+			// deliberately does not wrap ErrCommitFailed.
+			return nil, err
+		}
+		for _, v := range co.validators {
+			if err := v(cc); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	var (
 		newMeta Metadata

--- a/table/table.go
+++ b/table/table.go
@@ -349,7 +349,15 @@ type commitOpts struct {
 
 type commitOption func(*commitOpts)
 
+// withCommitBranch sets the target branch for the pre-flight
+// conflict-validation walk. An empty branch is treated as the main
+// branch — Transaction.branch is empty when the caller never picked
+// one explicitly, and the implicit default is main.
 func withCommitBranch(branch string) commitOption {
+	if branch == "" {
+		branch = MainBranch
+	}
+
 	return func(o *commitOpts) { o.branch = branch }
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -71,6 +71,15 @@ type Transaction struct {
 
 	reqs []Requirement
 
+	// validators collects per-producer conflict checks registered
+	// during this transaction's lifetime. doCommit runs them against
+	// the current catalog state before sending CommitTable so
+	// producers can reject commits whose semantics are violated by
+	// concurrent peers (partition-filter overlap, referenced-file
+	// removal). Fast/merge-append producers do not register a
+	// validator (they are safe under any isolation).
+	validators []conflictValidatorFunc
+
 	mx        sync.Mutex
 	committed bool
 }
@@ -526,6 +535,20 @@ type WriteOption func(*dataFileCfg)
 type dataFileCfg struct {
 	skipAutoNameMapping bool
 	skipDuplicateCheck  bool
+	rewriteSemantics    bool
+}
+
+// withRewriteSemantics marks an overwrite/replace operation as a
+// rewrite (compaction) rather than a user-facing overwrite. The
+// overwrite producer's default pre-commit conflict validator is
+// bypassed; the caller registers a rewrite-specific validator on the
+// transaction separately via validateNoNewDeletesForRewrittenFiles.
+// Unexported: only RewriteDataFiles passes this; there is no public
+// surface for user code to bypass overwrite isolation.
+func withRewriteSemantics() WriteOption {
+	return func(cfg *dataFileCfg) {
+		cfg.rewriteSemantics = true
+	}
 }
 
 // WithoutAutoNameMapping disables the automatic setting of the schema name
@@ -735,6 +758,10 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	if cfg.rewriteSemantics {
+		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
+		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
+	}
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -848,6 +875,10 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	if cfg.rewriteSemantics {
+		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
+		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
+	}
 
 	for _, df := range markedDataForDeletion {
 		updater.deleteDataFile(df)
@@ -1120,6 +1151,10 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(fs, snapshotProps, operation).mergeOverwrite(&commitUUID)
+	// mergeOverwrite guarantees an *overwriteFiles producerImpl; a type
+	// change there should fail loudly rather than silently drop the
+	// filter.
+	updater.producerImpl.(*overwriteFiles).filter = filter
 
 	filesToDelete, filesToRewrite, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -1159,6 +1194,10 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(fs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID)
+	// mergeOverwrite guarantees an *overwriteFiles producerImpl; a type
+	// change there should fail loudly rather than silently drop the
+	// filter.
+	updater.producerImpl.(*overwriteFiles).filter = filter
 
 	filesToDelete, withPartialDeletions, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -1671,7 +1710,14 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 
 	if len(t.meta.updates) > 0 {
 		t.reqs = append(t.reqs, AssertTableUUID(t.meta.uuid))
-		tbl, err := t.tbl.doCommit(ctx, t.meta.updates, t.reqs)
+		branch := t.branch
+		if branch == "" {
+			branch = MainBranch
+		}
+		tbl, err := t.tbl.doCommit(ctx, t.meta.updates, t.reqs,
+			withCommitBranch(branch),
+			withCommitValidators(t.validators...),
+		)
 		if err != nil {
 			return tbl, err
 		}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -51,13 +51,22 @@ func (s snapshotUpdate) fastAppend() *snapshotProducer {
 	return newFastAppendFilesProducer(OpAppend, s.txn, s.io, nil, s.snapshotProps)
 }
 
-func (s snapshotUpdate) mergeOverwrite(commitUUID *uuid.UUID) *snapshotProducer {
+// mergeOverwrite builds an overwrite producer. filter is the
+// row-level predicate the caller declared (typically the same one
+// used to plan the deletion); pass nil for a full-table overwrite.
+// validate() reads it to decide between filter-bounded and full
+// checks.
+func (s snapshotUpdate) mergeOverwrite(commitUUID *uuid.UUID, filter iceberg.BooleanExpression) *snapshotProducer {
 	op := s.operation
 	if s.operation == OpOverwrite && s.txn.meta.currentSnapshot() == nil {
 		op = OpAppend
 	}
+	prod := newOverwriteFilesProducer(op, s.txn, s.io, commitUUID, s.snapshotProps)
+	if filter != nil {
+		prod.producerImpl.(*overwriteFiles).filter = filter
+	}
 
-	return newOverwriteFilesProducer(op, s.txn, s.io, commitUUID, s.snapshotProps)
+	return prod
 }
 
 func (s snapshotUpdate) mergeAppend() *snapshotProducer {
@@ -433,7 +442,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID, nil)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -757,7 +766,7 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID, nil)
 	if cfg.rewriteSemantics {
 		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
 		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
@@ -874,7 +883,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID)
+	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID, nil)
 	if cfg.rewriteSemantics {
 		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
 		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
@@ -1150,11 +1159,7 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, operation).mergeOverwrite(&commitUUID)
-	// mergeOverwrite guarantees an *overwriteFiles producerImpl; a type
-	// change there should fail loudly rather than silently drop the
-	// filter.
-	updater.producerImpl.(*overwriteFiles).filter = filter
+	updater := t.updateSnapshot(fs, snapshotProps, operation).mergeOverwrite(&commitUUID, filter)
 
 	filesToDelete, filesToRewrite, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -1193,11 +1198,7 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID)
-	// mergeOverwrite guarantees an *overwriteFiles producerImpl; a type
-	// change there should fail loudly rather than silently drop the
-	// filter.
-	updater.producerImpl.(*overwriteFiles).filter = filter
+	updater := t.updateSnapshot(fs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID, filter)
 
 	filesToDelete, withPartialDeletions, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -1710,12 +1711,8 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 
 	if len(t.meta.updates) > 0 {
 		t.reqs = append(t.reqs, AssertTableUUID(t.meta.uuid))
-		branch := t.branch
-		if branch == "" {
-			branch = MainBranch
-		}
 		tbl, err := t.tbl.doCommit(ctx, t.meta.updates, t.reqs,
-			withCommitBranch(branch),
+			withCommitBranch(t.branch),
 			withCommitValidators(t.validators...),
 		)
 		if err != nil {


### PR DESCRIPTION
Part of #830: fourth of five PRs. 

The conflict-validation framework from the previous slice is now reachable: every producer runs a validate() pre-flight before cat.CommitTable.

Per producer:
  - fastAppendFiles / mergeAppendFiles: no-op (appends are safe).
  - overwriteFiles: rejects concurrent adds into the committer's filter region under SERIALIZABLE. Isolation key is op-gated — OpDelete reads write.delete.isolation-level, everything else reads write.update.isolation-level (matches Java).
  - RowDelta: pos-deletes check that referenced data files are still reachable; eq-deletes reject concurrent appends under SERIALIZABLE (conservative AlwaysTrue filter — opt out with write.delete.isolation-level=snapshot).
  - RewriteDataFiles: rejects concurrent pos-deletes targeting a rewritten file, and conservatively rejects any concurrent eq-delete during a rewrite.

doCommit runs the registered validators once on the first attempt. ErrCommitDiverged is terminal (does not wrap ErrCommitFailed), so the retry loop leaves it alone. On the first attempt base == current, so the concurrent-snapshot walk is empty and validators short-circuit — full behavioral coverage lights up once the next PR adds refresh-and-replay between retries.

User-visible: ReplaceDataFiles (string-path) now enforces the serializable-reject default on concurrent appends. Set write.update.isolation-level=snapshot to opt out.

Still to come:
  - Next PR: refresh-and-replay in the retry loop; flip CommitNumRetriesDefault 0 → 4; wrap ErrCommitFailed in Glue/SQL/Hive so retry fires outside REST.
  - Separate follow-up, WIP: restructure table/ into sub-packages on transaction boundaries.