### PR TITLE
feat(catalog): wrap concurrent-write conflicts with ErrCommitFailed

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -344,6 +344,15 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 			SkipArchive: aws.Bool(c.props.GetBool(SkipArchive, SkipArchiveDefault)),
 		})
 		if err != nil {
+			// Glue's optimistic locking surfaces a VersionId mismatch
+			// as ConcurrentModificationException. Wrap with
+			// table.ErrCommitFailed so the retry loop in
+			// Table.doCommit treats it as a retryable conflict.
+			var concurrentModErr *types.ConcurrentModificationException
+			if errors.As(err, &concurrentModErr) {
+				return nil, "", fmt.Errorf("%w: %w", table.ErrCommitFailed, err)
+			}
+
 			return nil, "", err
 		}
 	} else {

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -347,9 +347,11 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 			// Glue's optimistic locking surfaces a VersionId mismatch
 			// as ConcurrentModificationException. Wrap with
 			// table.ErrCommitFailed so the retry loop in
-			// Table.doCommit treats it as a retryable conflict.
-			var concurrentModErr *types.ConcurrentModificationException
-			if errors.As(err, &concurrentModErr) {
+			// Table.doCommit treats it as a retryable conflict. The
+			// SDK type has no Is(error) bool, so errors.Is doesn't
+			// help here — errors.As with a throwaway target is the
+			// idiomatic type-only check.
+			if errors.As(err, new(*types.ConcurrentModificationException)) {
 				return nil, "", fmt.Errorf("%w: %w", table.ErrCommitFailed, err)
 			}
 

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -347,11 +347,8 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 			// Glue's optimistic locking surfaces a VersionId mismatch
 			// as ConcurrentModificationException. Wrap with
 			// table.ErrCommitFailed so the retry loop in
-			// Table.doCommit treats it as a retryable conflict. The
-			// SDK type has no Is(error) bool, so errors.Is doesn't
-			// help here — errors.As with a throwaway target is the
-			// idiomatic type-only check.
-			if errors.As(err, new(*types.ConcurrentModificationException)) {
+			// Table.doCommit treats it as a retryable conflict.
+			if isConcurrentModificationException(err) {
 				return nil, "", fmt.Errorf("%w: %w", table.ErrCommitFailed, err)
 			}
 
@@ -810,4 +807,14 @@ func constructDatabaseInput(database string, props iceberg.Properties) *types.Da
 	databaseInput.Parameters = parameters
 
 	return databaseInput
+}
+
+// isConcurrentModificationException reports whether err is or wraps
+// Glue's optimistic-locking conflict signal. The SDK type has no
+// Is(error) bool, so errors.Is would do interface-value equality
+// against a fresh empty struct and never match — errors.As with a
+// throwaway target is the idiomatic type-only check, and we cannot
+// add an Is method to a type from another package.
+func isConcurrentModificationException(err error) bool {
+	return errors.As(err, new(*types.ConcurrentModificationException))
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1436,3 +1436,14 @@ func TestCommitTableOptimisticLockingIntegration(t *testing.T) {
 		}
 	})
 }
+
+func TestIsConcurrentModificationException(t *testing.T) {
+	sdkErr := &types.ConcurrentModificationException{Message: aws.String("oops")}
+	require.True(t, isConcurrentModificationException(sdkErr))
+
+	wrapped := fmt.Errorf("during update: %w", sdkErr)
+	require.True(t, isConcurrentModificationException(wrapped), "must walk the wrap chain")
+
+	require.False(t, isConcurrentModificationException(errors.New("network timeout")))
+	require.False(t, isConcurrentModificationException(nil))
+}

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -433,7 +433,11 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 
 	lock, err := acquireLock(ctx, c.client, database, tableName, c.opts)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to acquire lock for %s.%s: %w", database, tableName, err)
+		// Lock contention is Hive's primary concurrent-writer signal.
+		// Wrap with table.ErrCommitFailed so the retry loop in
+		// Table.doCommit treats it as a retryable conflict.
+		return nil, "", fmt.Errorf("%w: failed to acquire lock for %s.%s: %w",
+			table.ErrCommitFailed, database, tableName, err)
 	}
 	defer func() {
 		_ = lock.Release(ctx)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -370,7 +370,11 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 			}
 
 			if n == 0 {
-				return fmt.Errorf("table has been updated by another process: %s.%s", strings.Join(ns, "."), tblName)
+				// Wrap with table.ErrCommitFailed so the retry loop in
+				// Table.doCommit treats this as a retryable conflict
+				// (matches catalog/rest's HTTP 409 mapping).
+				return fmt.Errorf("%w: table %s.%s metadata-location moved underneath us",
+					table.ErrCommitFailed, strings.Join(ns, "."), tblName)
 			}
 
 			return nil


### PR DESCRIPTION
Part of #830 (concurrent-writer conflict detection). Today only the REST catalog wraps its 409 response with table.ErrCommitFailed, so the retry loop in Table.doCommit only fires on REST. Glue, SQL, and Hive return their native conflict errors raw, leaving users on those catalogs unable to opt into commit retries via commit.retry.num-retries.

Per catalog:
  - Glue: catch *types.ConcurrentModificationException from the AWS SDK (Glue's VersionId optimistic-locking signal) and wrap.
  - SQL: the conditional UPDATE returns 0 rows affected when metadata_location moved underneath us — wrap that path.
  - Hive: lock-acquire failure is the primary concurrent-writer signal under Hive's lock-based concurrency model — wrap.

No behavior change with the default `commit.retry.num-retries=0` (set in #912) — the retry loop remains opt-in. Once users set `num-retries > 0`, retries now engage on all four catalogs uniformly.

Per-catalog unit tests are skipped: each conflict path requires real concurrency (SQL's `n==0` race) or live infrastructure (Glue SDK error injection, Hive lock contention) to exercise. CI integration tests cover the real race paths.

Still to come for #830 closure:
  - refresh-and-replay in the retry loop so retries are not just no-op spin
  - flip CommitNumRetriesDefault 0 → 4 once retry actually helps