### PR TITLE
feat(table): refresh-and-replay between commit retries

### DIFF
--- a/table/commit_refresh_replay_test.go
+++ b/table/commit_refresh_replay_test.go
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+// End-to-end coverage for refresh-and-replay in doCommit's retry
+// loop. The framework was wired in #934; this PR makes it close the
+// loop:
+//
+//   - On ErrCommitFailed, reload the catalog's current metadata.
+//   - Build a fresh conflictContext and re-run the registered
+//     validators against (base = writer's view, current = fresh).
+//   - Rewrite AssertRefSnapshotID requirements to point at the new
+//     branch head before re-submitting, so a non-conflicting peer
+//     advance does not deterministically reject every retry.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headTrackingCatalog enforces Requirement.Validate against its
+// current metadata on every CommitTable call and returns
+// ErrCommitFailed-wrapped errors on assertion failures. Successful
+// commits advance the metadata (mirroring the REST catalog's
+// optimistic-concurrency behavior). The seedHead variant lets a test
+// initialize the catalog with metadata at a different head from the
+// writer's view, simulating a concurrent peer that already committed.
+type headTrackingCatalog struct {
+	metadata Metadata
+	attempts atomic.Int32
+}
+
+func (c *headTrackingCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
+	return New(ident, c.metadata, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c), nil
+}
+
+func (c *headTrackingCatalog) CommitTable(_ context.Context, _ Identifier, reqs []Requirement, updates []Update) (Metadata, string, error) {
+	c.attempts.Add(1)
+	for _, req := range reqs {
+		if err := req.Validate(c.metadata); err != nil {
+			return nil, "", fmt.Errorf("%w: %w", ErrCommitFailed, err)
+		}
+	}
+	meta, err := UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = meta
+
+	return meta, "", nil
+}
+
+// graftSnapshotOnto builds a metadata that adds a child snapshot on
+// top of base's current branch head. Returns the post-graft metadata
+// and the new head id.
+func graftSnapshotOnto(t *testing.T, base Metadata, branch string, childID int64) Metadata {
+	t.Helper()
+
+	parent := base.SnapshotByName(branch)
+	require.NotNil(t, parent, "branch %q must exist on base", branch)
+
+	builder, err := MetadataBuilderFromBase(base, "")
+	require.NoError(t, err)
+	parentID := parent.SnapshotID
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:       childID,
+		ParentSnapshotID: &parentID,
+		SequenceNumber:   parent.SequenceNumber + 1,
+		TimestampMs:      base.LastUpdatedMillis() + 1,
+		Summary:          &Summary{Operation: OpAppend},
+	}))
+	require.NoError(t, builder.SetSnapshotRef(branch, childID, BranchRef))
+
+	out, err := builder.Build()
+	require.NoError(t, err)
+
+	return out
+}
+
+// TestDoCommit_RefreshAndReplaySucceedsAfterPeerAdvance is the
+// headline scenario for #830: a peer advanced the branch with a
+// non-conflicting commit, the writer's first attempt fails on
+// AssertRefSnapshotID, and the retry refreshes, validates against
+// the new head (no conflict), rewrites the assertion, and succeeds.
+//
+// Without requirement-rewriting the retry would re-submit the same
+// stale assertion and burn the entire retry budget.
+func TestDoCommit_RefreshAndReplaySucceedsAfterPeerAdvance(t *testing.T) {
+	writerHead := int64(100)
+	peerHead := int64(200)
+
+	// Writer's view of the table — branch points at S100.
+	writerBase := newConflictTestMetadataWithProps(t, &writerHead, iceberg.Properties{
+		CommitNumRetriesKey:     "4",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+
+	// Peer commit that already happened: catalog state has S200 on
+	// top of S100 as the branch head.
+	advanced := graftSnapshotOnto(t, writerBase, MainBranch, peerHead)
+	cat := &headTrackingCatalog{metadata: advanced}
+
+	tbl := New(Identifier{"db", "refresh-test"}, writerBase, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	reqs := []Requirement{AssertRefSnapshotID(MainBranch, &writerHead)}
+	noOpValidator := func(*conflictContext) error { return nil }
+
+	_, err := tbl.doCommit(context.Background(), nil, reqs,
+		withCommitBranch(MainBranch),
+		withCommitValidators(noOpValidator))
+
+	require.NoError(t, err, "retry must succeed once the assertion is rewritten to the peer head")
+	assert.Equal(t, int32(2), cat.attempts.Load(),
+		"first attempt fails on stale assertion; second attempt succeeds with rewritten assertion")
+}
+
+// TestDoCommit_ValidatorRejectsOnRefresh proves the loop bails
+// terminally when refresh-and-replay surfaces a real semantic
+// conflict — refresh runs, the validator decides the commit cannot
+// safely replay, and we exit immediately instead of burning the
+// retry budget.
+func TestDoCommit_ValidatorRejectsOnRefresh(t *testing.T) {
+	writerHead := int64(100)
+	peerHead := int64(200)
+
+	writerBase := newConflictTestMetadataWithProps(t, &writerHead, iceberg.Properties{
+		CommitNumRetriesKey:     "4",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	advanced := graftSnapshotOnto(t, writerBase, MainBranch, peerHead)
+	cat := &headTrackingCatalog{metadata: advanced}
+	tbl := New(Identifier{"db", "refresh-reject"}, writerBase, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	reqs := []Requirement{AssertRefSnapshotID(MainBranch, &writerHead)}
+	// Reject only when the cc actually walks a concurrent snapshot —
+	// otherwise the validator would also fire on attempt 0 (where
+	// base == current and cc.concurrent is empty), and the test
+	// would not be exercising the refresh-and-replay path.
+	rejectOnConcurrent := func(cc *conflictContext) error {
+		if len(cc.concurrent) > 0 {
+			return ErrConflictingDataFiles
+		}
+
+		return nil
+	}
+
+	_, err := tbl.doCommit(context.Background(), nil, reqs,
+		withCommitBranch(MainBranch),
+		withCommitValidators(rejectOnConcurrent))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConflictingDataFiles)
+	// First attempt: catalog rejects (stale assertion). Retry: refresh
+	// + validator rejects → terminal exit before any further attempts.
+	assert.Equal(t, int32(1), cat.attempts.Load(),
+		"validator rejection on retry must abort before re-issuing CommitTable")
+}
+
+// TestRewriteRefSnapshotRequirements covers the helper directly:
+// only the matching ref's assertion is rewritten; other requirements
+// pass through untouched; an empty-branch / nil-fresh / missing-
+// branch input returns the slice unchanged.
+func TestRewriteRefSnapshotRequirements(t *testing.T) {
+	old := int64(50)
+	other := int64(60)
+	uid := uuid.New()
+
+	mainAssert := AssertRefSnapshotID(MainBranch, &old)
+	otherAssert := AssertRefSnapshotID("other-branch", &other)
+	uuidAssert := AssertTableUUID(uid)
+	reqs := []Requirement{mainAssert, otherAssert, uuidAssert}
+
+	newHead := int64(99)
+	fresh := newConflictTestMetadata(t, &newHead)
+
+	out := rewriteRefSnapshotRequirements(reqs, MainBranch, fresh)
+	require.Len(t, out, 3)
+
+	a, ok := out[0].(*assertRefSnapshotID)
+	require.True(t, ok)
+	require.Equal(t, MainBranch, a.Ref)
+	require.NotNil(t, a.SnapshotID)
+	assert.Equal(t, newHead, *a.SnapshotID, "main ref assertion must point at the fresh head")
+
+	// Other-branch assertion and UUID assertion pass through unchanged.
+	assert.Same(t, otherAssert, out[1])
+	assert.Same(t, uuidAssert, out[2])
+
+	// Edge cases: empty branch / nil fresh / branch missing on fresh
+	// return the slice unchanged.
+	noBranchOut := rewriteRefSnapshotRequirements(reqs, "", fresh)
+	assert.Equal(t, reqs, noBranchOut)
+
+	nilFreshOut := rewriteRefSnapshotRequirements(reqs, MainBranch, nil)
+	assert.Equal(t, reqs, nilFreshOut)
+
+	missingBranchOut := rewriteRefSnapshotRequirements(reqs, "non-existent", fresh)
+	assert.Equal(t, reqs, missingBranchOut)
+}

--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -41,8 +41,12 @@ type flakyCatalog struct {
 	attempts         atomic.Int32
 }
 
-func (c *flakyCatalog) LoadTable(ctx context.Context, ident Identifier) (*Table, error) {
-	return nil, nil
+func (c *flakyCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
+	if c.metadata == nil {
+		return nil, nil
+	}
+
+	return New(ident, c.metadata, "", func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c), nil
 }
 
 func (c *flakyCatalog) CommitTable(ctx context.Context, ident Identifier, reqs []Requirement, updates []Update) (Metadata, string, error) {

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -103,10 +103,22 @@ func TestErrCommitDiverged_IsTerminal(t *testing.T) {
 
 func newConflictTestMetadata(t *testing.T, branchHead *int64) Metadata {
 	t.Helper()
+
+	return newConflictTestMetadataWithProps(t, branchHead, nil)
+}
+
+// newConflictTestMetadataWithProps mirrors newConflictTestMetadata but
+// merges extraProps over the default property set. Used by tests that
+// need to drive doCommit's retry budget knobs.
+func newConflictTestMetadataWithProps(t *testing.T, branchHead *int64, extraProps iceberg.Properties) Metadata {
+	t.Helper()
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 	)
 	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	for k, v := range extraProps {
+		props[k] = v
+	}
 	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/conflict-test", props)
 	require.NoError(t, err)
 

--- a/table/table.go
+++ b/table/table.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"log"
@@ -378,49 +379,22 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 	retryCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.totalTimeoutMs)*time.Millisecond)
 	defer cancel()
 
-	// Pre-flight client-side conflict validation.
-	//
-	// Runs once before the first CommitTable attempt so producers can
-	// reject commits whose semantics are violated by concurrent peers
-	// (partition-filter overlap, referenced-file removal) even when
-	// the catalog-side AssertRefSnapshotID would accept them. On the
-	// first attempt base == current, so the concurrent-snapshot walk
-	// is empty and validators short-circuit to nil. Refresh-and-replay
-	// (re-running validate() between retries with refreshed metadata)
-	// lands in PR 2.5.
-	//
-	// Skipped when the target branch does not exist on the current
-	// metadata — that case always means "the committer is creating
-	// this branch" (e.g. first commit on a fresh table). There are
-	// no concurrent snapshots on a branch that does not yet exist,
-	// and newConflictContext would otherwise return ErrCommitDiverged.
-	if co.branch != "" && len(co.validators) > 0 && t.metadata.SnapshotByName(co.branch) != nil {
-		fs, err := t.fsF(ctx)
-		if err != nil {
-			return nil, err
-		}
-		// caseSensitive is hardcoded to true here: transaction-level
-		// case-sensitivity is not yet threaded through the Commit
-		// path, and true is the scan default throughout the codebase.
-		cc, err := newConflictContext(t.metadata, t.metadata, co.branch, fs, true)
-		if err != nil {
-			// ErrCommitDiverged — terminal, do not retry. The sentinel
-			// deliberately does not wrap ErrCommitFailed.
-			return nil, err
-		}
-		for _, v := range co.validators {
-			if err := v(cc); err != nil {
-				return nil, err
-			}
-		}
+	fs, err := t.fsF(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var (
 		newMeta Metadata
 		newLoc  string
-		err     error
 		timer   *time.Timer
 	)
+
+	// current tracks the catalog state between retries. On attempt 0 it
+	// equals t.metadata (so the conflict context's concurrent-snapshot
+	// walk is empty and validators short-circuit). On subsequent
+	// attempts it is the freshly-loaded post-conflict state.
+	current := t.metadata
 
 	// numRetries counts retries; total attempts = 1 initial + numRetries.
 	totalAttempts := cfg.numRetries + 1
@@ -439,6 +413,52 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 				return nil, context.Cause(retryCtx)
 			case <-timer.C:
+			}
+
+			// Refresh-and-replay: reload the catalog's current state,
+			// run the producers' validators against the fresh
+			// (base=t.metadata, current=fresh) conflict context, and
+			// rewrite any AssertRefSnapshotID requirements to target
+			// the new branch head so re-submission is not rejected
+			// just because a peer advanced the head with a
+			// non-conflicting commit.
+			fresh, refreshErr := t.cat.LoadTable(retryCtx, t.identifier)
+			if refreshErr != nil {
+				return nil, fmt.Errorf("refresh table for retry: %w", refreshErr)
+			}
+			current = fresh.metadata
+			reqs = rewriteRefSnapshotRequirements(reqs, co.branch, current)
+		}
+
+		// Pre-flight client-side conflict validation. Producers can
+		// reject commits whose semantics are violated by concurrent
+		// peers (partition-filter overlap, referenced-file removal)
+		// even when the catalog-side AssertRefSnapshotID would accept
+		// them. On attempt 0 base == current → no concurrent
+		// snapshots → validators short-circuit. Real divergence
+		// detection fires on attempts > 0 once `current` is the
+		// post-conflict state.
+		//
+		// Skipped when the branch does not exist on `current` — that
+		// always means "the committer is creating this branch" (e.g.
+		// first commit on a fresh table). There are no concurrent
+		// snapshots on a branch that does not yet exist, and
+		// newConflictContext would otherwise return ErrCommitDiverged.
+		if co.branch != "" && len(co.validators) > 0 && current.SnapshotByName(co.branch) != nil {
+			// caseSensitive is hardcoded to true here: transaction-
+			// level case-sensitivity is not yet threaded through the
+			// Commit path, and true is the scan default throughout the
+			// codebase.
+			cc, ccErr := newConflictContext(t.metadata, current, co.branch, fs, true)
+			if ccErr != nil {
+				// ErrCommitDiverged — terminal, do not retry. The
+				// sentinel deliberately does not wrap ErrCommitFailed.
+				return nil, ccErr
+			}
+			for _, v := range co.validators {
+				if vErr := v(cc); vErr != nil {
+					return nil, vErr
+				}
 			}
 		}
 
@@ -463,13 +483,47 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		return nil, err
 	}
 
-	fs, err := t.fsF(ctx)
-	if err != nil {
-		return nil, err
-	}
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
 	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
+}
+
+// rewriteRefSnapshotRequirements returns a copy of reqs with every
+// AssertRefSnapshotID targeting `branch` rewritten to point at the
+// branch head on `fresh`. Other requirements pass through untouched.
+//
+// Producers register AssertRefSnapshotID at commit-build time with the
+// committer's base snapshot id. After a peer advances the branch head
+// with a non-conflicting commit, that assertion no longer matches the
+// catalog. Without rewriting the retry would burn the budget on the
+// same stale requirement; with it, validators get to decide if the
+// commit is still safe to replay against the new head.
+//
+// Java's SnapshotProducer rewrites the same way between retries. If
+// the branch is empty or the new head cannot be resolved (branch
+// deleted underneath us), reqs is returned unchanged — newConflict-
+// Context will surface the divergence on the next pre-flight pass.
+func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Metadata) []Requirement {
+	if branch == "" || fresh == nil {
+		return reqs
+	}
+	head := fresh.SnapshotByName(branch)
+	if head == nil {
+		return reqs
+	}
+
+	out := make([]Requirement, len(reqs))
+	for i, r := range reqs {
+		if a, ok := r.(*assertRefSnapshotID); ok && a.Ref == branch {
+			newID := head.SnapshotID
+			out[i] = AssertRefSnapshotID(branch, &newID)
+
+			continue
+		}
+		out[i] = r
+	}
+
+	return out
 }
 
 type retryConfig struct {


### PR DESCRIPTION
Closes #830 (concurrent-writer conflict detection) — fifth and final PR in the sequence. The retry loop in Table.doCommit now actually does something useful for contended commits.

Before this change, doCommit's retry loop re-issued the same updates and requirements between attempts. After a peer advanced the branch with a non-conflicting commit, AssertRefSnapshotID deterministically failed on every retry and the budget was wasted. The default num-retries was set to 0 in #912 precisely to avoid this slow-fail.

What changes:

  - On ErrCommitFailed mid-loop, reload the catalog's current metadata via cat.LoadTable.
  - Build a fresh conflictContext with (base = writer's view, current = freshly loaded). Validators now run against real concurrent-snapshot state — the framework wired in #934 finally fires.
  - Rewrite AssertRefSnapshotID requirements to point at the new branch head before re-submitting. Mirrors Java's SnapshotProducer between-retry behavior.
  - The pre-flight pass moved inside the loop so attempt 0 still gets a no-op validation (base == current → empty concurrent list) without a separate code path.

Behavior matrix after this PR (with num-retries > 0):

  - Peer advance with no semantic conflict: validators pass on refresh, requirements rewritten, retry succeeds. Was: spin to exhaustion.
  - Peer advance with semantic conflict (e.g. same partition overwrite): validators reject on refresh, retry exits terminally. Was: spin to exhaustion.
  - Diverged base (branch deleted): newConflictContext returns ErrCommitDiverged, terminal exit. Same as before.

Also tightens flakyCatalog's LoadTable to return a real Table backed by its current metadata, so refresh paths in retry tests no longer dereference nil.

E2E tests cover the headline success path (peer advance, retry succeeds with rewritten assertion), the terminal-on-conflict path (validator rejects on refresh), and the rewriteRefSnapshot- Requirements helper directly.