### PR TITLE
feat(table): drop dangling equality deletes during RewriteDataFiles

### DIFF
--- a/cmd/iceberg/compact.go
+++ b/cmd/iceberg/compact.go
@@ -116,7 +116,38 @@ func compactRun(ctx context.Context, output Output, tbl *table.Table, plan compa
 	}
 
 	tx := tbl.NewTransaction()
-	result, err := tx.RewriteDataFiles(ctx, groups, cfg.PartialProgress, nil)
+	rewriteOpts := table.RewriteDataFilesOptions{
+		PartialProgress: cfg.PartialProgress,
+	}
+
+	// Cleanup of dead equality-delete files. The executor only
+	// orchestrates the commit; the policy + walk live in
+	// table/compaction. Skipped in partial-progress mode (per-group
+	// cleanup is a follow-up) and when the caller opts out.
+	if !cfg.PartialProgress && !cfg.PreserveDeadEqualityDeletes {
+		snap := tbl.CurrentSnapshot()
+		if snap != nil {
+			fs, err := tbl.FS(ctx)
+			if err != nil {
+				output.Error(fmt.Errorf("open fs for eq-delete cleanup: %w", err))
+				os.Exit(1)
+			}
+			rewrittenSet := make(map[string]struct{})
+			for _, g := range plan.Groups {
+				for _, task := range g.Tasks {
+					rewrittenSet[task.File.FilePath()] = struct{}{}
+				}
+			}
+			deadEqDeletes, err := compaction.CollectDeadEqualityDeletes(ctx, fs, snap, rewrittenSet)
+			if err != nil {
+				output.Error(fmt.Errorf("collect dead equality deletes: %w", err))
+				os.Exit(1)
+			}
+			rewriteOpts.ExtraDeleteFilesToRemove = deadEqDeletes
+		}
+	}
+
+	result, err := tx.RewriteDataFiles(ctx, groups, rewriteOpts)
 	if err != nil {
 		if result != nil && result.RewrittenGroups > 0 {
 			output.Text(fmt.Sprintf("  (partial: %d groups committed before failure)", result.RewrittenGroups))
@@ -130,8 +161,10 @@ func compactRun(ctx context.Context, output Output, tbl *table.Table, plan compa
 		os.Exit(1)
 	}
 
-	output.Text(fmt.Sprintf("Done. Rewrote %d -> %d files. Removed %d delete files.",
-		result.RemovedDataFiles, result.AddedDataFiles, result.RemovedDeleteFiles))
+	totalRemovedDeletes := result.RemovedPositionDeleteFiles + result.RemovedEqualityDeleteFiles
+	output.Text(fmt.Sprintf("Done. Rewrote %d -> %d files. Removed %d delete files (%d position, %d equality).",
+		result.RemovedDataFiles, result.AddedDataFiles,
+		totalRemovedDeletes, result.RemovedPositionDeleteFiles, result.RemovedEqualityDeleteFiles))
 	output.Text(fmt.Sprintf("  Size: %s -> %s",
 		formatBytes(result.BytesBefore), formatBytes(result.BytesAfter)))
 }

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -55,7 +55,7 @@ Usage:
   iceberg properties [options] get (namespace | table) IDENTIFIER [PROPNAME]
   iceberg properties [options] set (namespace | table) IDENTIFIER PROPNAME VALUE
   iceberg properties [options] remove (namespace | table) IDENTIFIER PROPNAME
-  iceberg compact [options] (analyze | run) TABLE_ID [--target-file-size BYTES] [--partial-progress]
+  iceberg compact [options] (analyze | run) TABLE_ID [--target-file-size BYTES] [--partial-progress] [--preserve-dead-equality-deletes]
   iceberg -h | --help | --version
 
 Commands:
@@ -103,7 +103,10 @@ Options:
   --sort-order TEXT 	specify sort order as field:direction[:null-order] format(for create table use only)
 						Ex:"field1:asc,field2:desc:nulls-first,field3:asc:nulls-last"
   --target-file-size BYTES  target output file size in bytes for compaction [default: 0]
-  --partial-progress        stage each compaction group as a separate snapshot update`
+  --partial-progress        stage each compaction group as a separate snapshot update
+  --preserve-dead-equality-deletes
+                            keep equality-delete files that are provably dead after the rewrite
+                            (default: drop them — recommended for sustained CDC workloads)`
 
 type Config struct {
 	List     bool `docopt:"list"`
@@ -137,25 +140,26 @@ type Config struct {
 	PropName string `docopt:"PROPNAME"`
 	Value    string `docopt:"VALUE"`
 
-	Catalog         string `docopt:"--catalog"`
-	CatalogName     string `docopt:"--catalog-name"`
-	URI             string `docopt:"--uri"`
-	Output          string `docopt:"--output"`
-	History         bool   `docopt:"--history"`
-	Cred            string `docopt:"--credential"`
-	Token           string `docopt:"--token"`
-	Warehouse       string `docopt:"--warehouse"`
-	Config          string `docopt:"--config"`
-	Scope           string `docopt:"--scope"`
-	Description     string `docopt:"--description"`
-	LocationURI     string `docopt:"--location-uri"`
-	SchemaStr       string `docopt:"--schema"`
-	InferSchema     string `docopt:"--infer-schema"`
-	TableProps      string `docopt:"--properties"`
-	PartitionSpec   string `docopt:"--partition-spec"`
-	SortOrder       string `docopt:"--sort-order"`
-	TargetFileSize  int64  `docopt:"--target-file-size"`
-	PartialProgress bool   `docopt:"--partial-progress"`
+	Catalog                     string `docopt:"--catalog"`
+	CatalogName                 string `docopt:"--catalog-name"`
+	URI                         string `docopt:"--uri"`
+	Output                      string `docopt:"--output"`
+	History                     bool   `docopt:"--history"`
+	Cred                        string `docopt:"--credential"`
+	Token                       string `docopt:"--token"`
+	Warehouse                   string `docopt:"--warehouse"`
+	Config                      string `docopt:"--config"`
+	Scope                       string `docopt:"--scope"`
+	Description                 string `docopt:"--description"`
+	LocationURI                 string `docopt:"--location-uri"`
+	SchemaStr                   string `docopt:"--schema"`
+	InferSchema                 string `docopt:"--infer-schema"`
+	TableProps                  string `docopt:"--properties"`
+	PartitionSpec               string `docopt:"--partition-spec"`
+	SortOrder                   string `docopt:"--sort-order"`
+	TargetFileSize              int64  `docopt:"--target-file-size"`
+	PartialProgress             bool   `docopt:"--partial-progress"`
+	PreserveDeadEqualityDeletes bool   `docopt:"--preserve-dead-equality-deletes"`
 
 	RestOptions *config.RestOptions `docopt:"-"`
 }

--- a/table/compaction/cdc_stress_test.go
+++ b/table/compaction/cdc_stress_test.go
@@ -1,0 +1,327 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/table/compaction"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCDCStress emulates sustained Postgres → Iceberg CDC replication:
+// many small commits, each adding one data file and one equality
+// delete. This is the workload from issue apache/iceberg-go#946.
+//
+// Without dead-eq-delete cleanup, every preserved eq-delete sits in
+// every future snapshot's manifests forever, and scan latency degrades
+// linearly with the number of accumulated commits. With cleanup
+// (compaction.CollectDeadEqualityDeletes threaded through
+// table.RewriteDataFilesOptions.ExtraDeleteFilesToRemove), a single
+// compaction collapses both data files and eq-deletes back to
+// near-baseline.
+//
+// The test asserts:
+//  1. Pre-compaction: data files and eq-delete files both equal
+//     numCDCCycles (we wrote one of each per cycle).
+//  2. Post-compaction: a single data file remains and zero eq-deletes
+//     are referenced from any surviving scan task.
+//  3. Scan correctness: every row that was deleted stays deleted, and
+//     every row that wasn't survives.
+//
+// Skipped under -short.
+func TestCDCStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CDC stress test in short mode")
+	}
+
+	const (
+		numCDCCycles = 80   // ~one snapshot per CDC tick
+		baselineRows = 1000 // initial table size
+	)
+
+	tbl := newCDCStressTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	delSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	delArrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
+	require.NoError(t, err)
+
+	// Step 1: seed the table with baseline rows in a single data file.
+	seedPath := tbl.Location() + "/data/seed.parquet"
+	writeParquet(t, seedPath, arrowSc, generateRowsJSON(baselineRows))
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{seedPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	// Step 2: simulate the CDC replication stream. Each cycle commits
+	// (1) a tiny data file and (2) one eq-delete file in separate
+	// snapshots — this is the worst case for manifest fanout.
+	deletedIDs := make(map[int64]struct{}, numCDCCycles)
+	for cycle := range numCDCCycles {
+		// (a) Append one small data file (e.g. INSERT replica).
+		extraID := int64(baselineRows + cycle + 1)
+		dataPath := tbl.Location() + fmt.Sprintf("/data/cdc-%05d.parquet", cycle)
+		writeParquet(t, dataPath, arrowSc,
+			fmt.Sprintf(`[{"id": %d, "data": "cdc-%d"}]`, extraID, cycle))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+
+		// (b) Commit one eq-delete (UPDATE/DELETE replica). Cycle
+		// through the seeded baseline rows so each eq-delete actually
+		// applies to a real surviving row.
+		victim := int64((cycle % baselineRows) + 1)
+		deletedIDs[victim] = struct{}{}
+
+		rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, delArrowSc,
+			strings.NewReader(fmt.Sprintf(`[{"id": %d}]`, victim)))
+		require.NoError(t, err)
+
+		records := func(yield func(arrow.RecordBatch, error) bool) {
+			yield(rec, nil)
+		}
+
+		tx = tbl.NewTransaction()
+		deleteFiles, err := tx.WriteEqualityDeletes(t.Context(), []int{1}, records)
+		rec.Release()
+		require.NoError(t, err)
+
+		rd := tx.NewRowDelta(nil)
+		for _, df := range deleteFiles {
+			rd.AddDeletes(df)
+		}
+		require.NoError(t, rd.Commit(t.Context()))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	// Step 3: pre-compaction observations.
+	preTasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+
+	preDataFiles := len(preTasks)
+	preEqDeleteRefs := countDistinctEqDeletePaths(preTasks)
+	t.Logf("pre-compaction: %d data files, %d distinct eq-deletes referenced",
+		preDataFiles, preEqDeleteRefs)
+	require.Equal(t, 1+numCDCCycles, preDataFiles,
+		"every CDC cycle should have produced one new data file (plus seed)")
+	require.Equal(t, numCDCCycles, preEqDeleteRefs,
+		"every CDC cycle should have produced one eq-delete referenced by the surviving data files")
+
+	// Step 4: plan + compact. DeleteFileThreshold=1 forces compaction
+	// even though the data files are tiny.
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 64 * 1024 * 1024,
+		MinFileSizeBytes:    32 * 1024 * 1024,
+		MaxFileSizeBytes:    128 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 1,
+		PackingLookback:     compaction.DefaultPackingLookback,
+	}
+	plan, err := cfg.PlanCompaction(preTasks)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Groups, "planner must select something to compact")
+
+	groups := make([]table.CompactionTaskGroup, len(plan.Groups))
+	for i, g := range plan.Groups {
+		groups[i] = table.CompactionTaskGroup{
+			PartitionKey:   g.PartitionKey,
+			Tasks:          g.Tasks,
+			TotalSizeBytes: g.TotalSizeBytes,
+		}
+	}
+
+	// Step 5: compute dead eq-deletes against the pre-rewrite snapshot.
+	// This is the orchestration the CLI / library caller does.
+	rewrittenSet := make(map[string]struct{})
+	for _, g := range plan.Groups {
+		for _, task := range g.Tasks {
+			rewrittenSet[task.File.FilePath()] = struct{}{}
+		}
+	}
+	fs := iceio.LocalFS{}
+	deadEqDeletes, err := compaction.CollectDeadEqualityDeletes(
+		t.Context(), fs, tbl.CurrentSnapshot(), rewrittenSet)
+	require.NoError(t, err)
+
+	tx = tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress:          false,
+		ExtraDeleteFilesToRemove: deadEqDeletes,
+	})
+	require.NoError(t, err)
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	t.Logf("compaction: %d groups, +%d / -%d data files, removed %d position + %d equality delete files",
+		result.RewrittenGroups, result.AddedDataFiles, result.RemovedDataFiles,
+		result.RemovedPositionDeleteFiles, result.RemovedEqualityDeleteFiles)
+
+	// Step 6: post-compaction observations.
+	postTasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+
+	postDataFiles := len(postTasks)
+	postEqDeleteRefs := countDistinctEqDeletePaths(postTasks)
+	t.Logf("post-compaction: %d data files, %d distinct eq-deletes referenced",
+		postDataFiles, postEqDeleteRefs)
+
+	assert.Less(t, postDataFiles, preDataFiles,
+		"compaction must reduce data file count")
+	assert.Equal(t, 0, postEqDeleteRefs,
+		"all dead eq-deletes must be expunged after CDC compaction")
+	assert.GreaterOrEqual(t, result.RemovedEqualityDeleteFiles, numCDCCycles,
+		"every CDC cycle's eq-delete should be reported as removed")
+
+	// Step 7: row-level correctness. Every deleted id must stay deleted.
+	_, itr, err := tbl.Scan(table.WithSelectedFields("id")).ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	survivors := make(map[int64]struct{})
+	for rec, err := range itr {
+		require.NoError(t, err)
+		col := rec.Column(0).(*array.Int64)
+		for i := 0; i < col.Len(); i++ {
+			survivors[col.Value(i)] = struct{}{}
+		}
+		rec.Release()
+	}
+
+	for id := range deletedIDs {
+		_, present := survivors[id]
+		assert.False(t, present, "deleted row id=%d must not reappear after compaction", id)
+	}
+	for i := int64(1); i <= int64(baselineRows); i++ {
+		if _, deleted := deletedIDs[i]; deleted {
+			continue
+		}
+		_, present := survivors[i]
+		assert.True(t, present, "surviving baseline row id=%d must be visible", i)
+	}
+}
+
+// stubCatalog is a minimal catalog implementation that holds metadata
+// in memory for the stress test's commits. The CDC test does many
+// small commits but never hits the catalog from outside.
+type stubCatalog struct {
+	metadata table.Metadata
+}
+
+func (s *stubCatalog) LoadTable(ctx context.Context, ident table.Identifier) (*table.Table, error) {
+	return nil, nil
+}
+
+func (s *stubCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	meta, err := table.UpdateTableMetadata(s.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	s.metadata = meta
+
+	return meta, "", nil
+}
+
+func newCDCStressTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	return table.New(
+		table.Identifier{"db", "cdc_stress_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(ctx context.Context) (iceio.IO, error) {
+			return iceio.LocalFS{}, nil
+		},
+		&stubCatalog{metadata: meta},
+	)
+}
+
+func writeParquet(t testing.TB, path string, sc *arrow.Schema, jsonData string) {
+	t.Helper()
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, sc, strings.NewReader(jsonData))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	fs := iceio.LocalFS{}
+	fw, err := fs.Create(path)
+	require.NoError(t, err)
+
+	tbl := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)),
+		pqarrow.DefaultWriterProps()))
+}
+
+func generateRowsJSON(n int) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := range n {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id": %d, "data": "row-%06d"}`, i+1, i+1)
+	}
+	b.WriteByte(']')
+
+	return b.String()
+}
+
+func countDistinctEqDeletePaths(tasks []table.FileScanTask) int {
+	seen := make(map[string]struct{})
+	for _, task := range tasks {
+		for _, df := range task.EqualityDeleteFiles {
+			seen[df.FilePath()] = struct{}{}
+		}
+	}
+
+	return len(seen)
+}

--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -55,6 +55,28 @@ type Config struct {
 	// before evicting. Higher values produce better packing at the cost
 	// of memory. Default: DefaultPackingLookback.
 	PackingLookback uint
+
+	// PreserveDeadEqualityDeletes, when true, retains equality delete
+	// files that are provably dead after the rewrite. The cleanup
+	// predicate matches the v2 reader (see scanner.go
+	// matchEqualityDeletesToData and DecideDeadEqualityDeletes): an
+	// eq-delete is dead iff no surviving applicable data file has
+	// seq < eq-delete.seq, where "applicable" means same partition
+	// tuple OR either side has empty partition. SpecID is NOT part of
+	// the predicate.
+	//
+	// Zero value (false) is the recommended default: dead eq-deletes are
+	// expunged during the rewrite commit, which keeps manifest fanout
+	// bounded under sustained CDC workloads where eq-deletes accumulate
+	// one-per-snapshot. Set to true only if a downstream consumer
+	// depends on the historical eq-delete files surviving in the live
+	// snapshot's manifests (rare).
+	//
+	// Honored only in atomic mode (RewriteDataFilesOptions.PartialProgress=false).
+	// The CLI / library caller is responsible for translating this flag
+	// into the snapshot walk + RewriteDataFilesOptions.ExtraDeleteFilesToRemove
+	// — see CollectDeadEqualityDeletes.
+	PreserveDeadEqualityDeletes bool
 }
 
 const (
@@ -171,7 +193,7 @@ func (cfg Config) PlanCompaction(tasks []table.FileScanTask) (Plan, error) {
 	var partitionOrder []string
 
 	for _, t := range tasks {
-		key := fmt.Sprintf("%d:%v", t.File.SpecID(), t.File.Partition())
+		key := partitionBucketKey(t.File.SpecID(), t.File.Partition())
 		bucket, ok := partitions[key]
 		if !ok {
 			bucket = partitionBucket{key: key}

--- a/table/compaction/eq_delete_collect.go
+++ b/table/compaction/eq_delete_collect.go
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction
+
+import (
+	"context"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+)
+
+// CollectDeadEqualityDeletes walks the given snapshot's manifests and
+// returns the equality delete files that are provably dead after a
+// rewrite removes the data files in rewrittenPaths.
+//
+// "Dead" means: no surviving data file in the snapshot (excluding
+// rewrittenPaths) could ever apply to the eq-delete per the v2 reader
+// predicate (see DecideDeadEqualityDeletes for the exact rule).
+//
+// rewrittenPaths is the union of every old data file path being
+// replaced by a planned rewrite (across all groups). The caller
+// typically computes this from a compaction plan.
+//
+// The returned files are safe to remove during the same commit that
+// stages the rewrite — they cannot be resurrected by any concurrent
+// commit because (1) any concurrent eq-delete is rejected by the
+// rewrite-validator, and (2) any concurrent data file gets a fresh
+// sequence number strictly greater than every preexisting eq-delete,
+// so it cannot satisfy E.seq > D.seq for any preexisting E.
+//
+// Two-pass design: the first pass walks delete manifests only to
+// discover candidate eq-deletes; if there are none, the more
+// expensive data-manifest walk is skipped.
+func CollectDeadEqualityDeletes(
+	ctx context.Context,
+	fs iceio.IO,
+	snap *table.Snapshot,
+	rewrittenPaths map[string]struct{},
+) ([]iceberg.DataFile, error) {
+	if snap == nil || len(rewrittenPaths) == 0 {
+		return nil, nil
+	}
+
+	manifests, err := snap.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	// First pass: delete manifests only, collecting eq-delete candidates.
+	var candidates []iceberg.ManifestEntry
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		entries, err := m.FetchEntries(fs, false)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			if e.DataFile().ContentType() != iceberg.EntryContentEqDeletes {
+				continue
+			}
+			candidates = append(candidates, e)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Second pass: data manifests, building the survivor survey.
+	survey := NewSurvivorSurvey()
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		entries, err := m.FetchEntries(fs, false)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentData {
+				continue
+			}
+			if _, beingRewritten := rewrittenPaths[df.FilePath()]; beingRewritten {
+				continue
+			}
+			survey.AddSurvivor(df.Partition(), e.SequenceNum())
+		}
+	}
+
+	return DecideDeadEqualityDeletes(survey, candidates), nil
+}

--- a/table/compaction/eq_delete_collect.go
+++ b/table/compaction/eq_delete_collect.go
@@ -31,7 +31,7 @@ import (
 //
 // "Dead" means: no surviving data file in the snapshot (excluding
 // rewrittenPaths) could ever apply to the eq-delete per the v2 reader
-// predicate (see DecideDeadEqualityDeletes for the exact rule).
+// predicate (see [DecideDeadEqualityDeletes] for the exact rule).
 //
 // rewrittenPaths is the union of every old data file path being
 // replaced by a planned rewrite (across all groups). The caller
@@ -71,14 +71,11 @@ func CollectDeadEqualityDeletes(
 		if m.ManifestContent() != iceberg.ManifestContentDeletes {
 			continue
 		}
-		entries, err := m.FetchEntries(fs, false)
+		entries, err := m.FetchEntries(fs, true)
 		if err != nil {
 			return nil, err
 		}
 		for _, e := range entries {
-			if e.Status() == iceberg.EntryStatusDELETED {
-				continue
-			}
 			if e.DataFile().ContentType() != iceberg.EntryContentEqDeletes {
 				continue
 			}
@@ -98,14 +95,11 @@ func CollectDeadEqualityDeletes(
 		if m.ManifestContent() != iceberg.ManifestContentData {
 			continue
 		}
-		entries, err := m.FetchEntries(fs, false)
+		entries, err := m.FetchEntries(fs, true)
 		if err != nil {
 			return nil, err
 		}
 		for _, e := range entries {
-			if e.Status() == iceberg.EntryStatusDELETED {
-				continue
-			}
 			df := e.DataFile()
 			if df.ContentType() != iceberg.EntryContentData {
 				continue

--- a/table/compaction/eq_delete_decision.go
+++ b/table/compaction/eq_delete_decision.go
@@ -19,6 +19,7 @@ package compaction
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 
@@ -27,7 +28,7 @@ import (
 
 // SurvivorSurvey describes the surviving data files in a snapshot
 // AFTER a planned rewrite has logically removed its rewrite set. It
-// is the input to DecideDeadEqualityDeletes.
+// is the input to [DecideDeadEqualityDeletes].
 //
 // EmptyPartMinSeq is the smallest sequence number among unpartitioned
 // surviving data files. Per the Iceberg v2 reader predicate (see
@@ -76,16 +77,15 @@ func (s *SurvivorSurvey) AddSurvivor(partition map[int]any, seq int64) {
 		seq = 0
 	}
 	if len(partition) == 0 {
-		if seq < s.EmptyPartMinSeq {
-			s.EmptyPartMinSeq = seq
-		}
+		s.EmptyPartMinSeq = min(seq, s.EmptyPartMinSeq)
 
 		return
 	}
 	key := partitionMatchKey(partition)
-	if cur, ok := s.PartMinSeq[key]; !ok || seq < cur {
-		s.PartMinSeq[key] = seq
+	if cur, ok := s.PartMinSeq[key]; ok {
+		seq = min(seq, cur)
 	}
+	s.PartMinSeq[key] = seq
 }
 
 // applicableMinSeq returns the smallest surviving-D seq number that
@@ -95,21 +95,17 @@ func (s *SurvivorSurvey) AddSurvivor(partition map[int]any, seq int64) {
 // applies to every surviving D (so we min across every PartMinSeq).
 func (s *SurvivorSurvey) applicableMinSeq(eqPartition map[int]any) int64 {
 	if len(eqPartition) == 0 {
-		min := s.EmptyPartMinSeq
-		for _, v := range s.PartMinSeq {
-			if v < min {
-				min = v
-			}
+		if len(s.PartMinSeq) == 0 {
+			return s.EmptyPartMinSeq
 		}
 
-		return min
+		return min(s.EmptyPartMinSeq, slices.Min(slices.Collect(maps.Values(s.PartMinSeq))))
 	}
-	min := s.EmptyPartMinSeq
-	if v, ok := s.PartMinSeq[partitionMatchKey(eqPartition)]; ok && v < min {
-		min = v
+	if v, ok := s.PartMinSeq[partitionMatchKey(eqPartition)]; ok {
+		return min(s.EmptyPartMinSeq, v)
 	}
 
-	return min
+	return s.EmptyPartMinSeq
 }
 
 // DecideDeadEqualityDeletes is the pure spec-correctness predicate for
@@ -142,10 +138,7 @@ func (s *SurvivorSurvey) applicableMinSeq(eqPartition map[int]any) int64 {
 // Dedup by file path: the same eq-delete file may appear in multiple
 // manifest entries after manifest merging.
 func DecideDeadEqualityDeletes(survey *SurvivorSurvey, candidates []iceberg.ManifestEntry) []iceberg.DataFile {
-	if survey == nil {
-		return nil
-	}
-	if len(candidates) == 0 {
+	if survey == nil || len(candidates) == 0 {
 		return nil
 	}
 

--- a/table/compaction/eq_delete_decision.go
+++ b/table/compaction/eq_delete_decision.go
@@ -1,0 +1,214 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction
+
+import (
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/apache/iceberg-go"
+)
+
+// SurvivorSurvey describes the surviving data files in a snapshot
+// AFTER a planned rewrite has logically removed its rewrite set. It
+// is the input to DecideDeadEqualityDeletes.
+//
+// EmptyPartMinSeq is the smallest sequence number among unpartitioned
+// surviving data files. Per the Iceberg v2 reader predicate (see
+// table/scanner.go matchEqualityDeletesToData), an unpartitioned data
+// file applies to every equality delete — so it is always part of an
+// eq-delete's "applicable survivors" minimum.
+//
+// PartMinSeq maps the partition tuple (encoded via partitionMatchKey)
+// to the smallest sequence number among surviving partitioned data
+// files in that tuple. The key intentionally does NOT include
+// SpecID — the reader's predicate ignores SpecID, so the writer-side
+// cleanup must too.
+//
+// Sentinel "no survivor in this bucket" is math.MaxInt64.
+type SurvivorSurvey struct {
+	EmptyPartMinSeq int64
+	PartMinSeq      map[string]int64
+}
+
+// NewSurvivorSurvey returns a survey initialized with the no-survivor
+// sentinel for the empty-partition bucket and an empty per-partition
+// map. Callers populate via AddSurvivor.
+func NewSurvivorSurvey() *SurvivorSurvey {
+	return &SurvivorSurvey{
+		EmptyPartMinSeq: math.MaxInt64,
+		PartMinSeq:      make(map[string]int64),
+	}
+}
+
+// AddSurvivor records a surviving data file's (partition, seq) into
+// the survey. partition is the data file's partition tuple from
+// iceberg.DataFile.Partition() (nil/empty for unpartitioned tables);
+// seq is the data file's sequence number from the manifest entry.
+//
+// Defensive: if seq < 0 (sentinel for "unset"), the file is recorded
+// with seq=0 (smallest real value), which keeps it permanently alive
+// against every eq-delete. Better to preserve uncertain state than to
+// drop deletes that may still apply.
+//
+// Pointer receiver: EmptyPartMinSeq is int64 (value type) and we need
+// updates to persist. Callers must hold the survey by value or pointer
+// consistently — typical pattern is `survey := NewSurvivorSurvey()`
+// followed by `survey.AddSurvivor(...)` which Go auto-addresses.
+func (s *SurvivorSurvey) AddSurvivor(partition map[int]any, seq int64) {
+	if seq < 0 {
+		seq = 0
+	}
+	if len(partition) == 0 {
+		if seq < s.EmptyPartMinSeq {
+			s.EmptyPartMinSeq = seq
+		}
+
+		return
+	}
+	key := partitionMatchKey(partition)
+	if cur, ok := s.PartMinSeq[key]; !ok || seq < cur {
+		s.PartMinSeq[key] = seq
+	}
+}
+
+// applicableMinSeq returns the smallest surviving-D seq number that
+// the eq-delete with the given partition could apply to. Mirrors the
+// scanner's predicate: an unpartitioned surviving D applies to every
+// E (so EmptyPartMinSeq is always in the min); an unpartitioned E
+// applies to every surviving D (so we min across every PartMinSeq).
+func (s *SurvivorSurvey) applicableMinSeq(eqPartition map[int]any) int64 {
+	if len(eqPartition) == 0 {
+		min := s.EmptyPartMinSeq
+		for _, v := range s.PartMinSeq {
+			if v < min {
+				min = v
+			}
+		}
+
+		return min
+	}
+	min := s.EmptyPartMinSeq
+	if v, ok := s.PartMinSeq[partitionMatchKey(eqPartition)]; ok && v < min {
+		min = v
+	}
+
+	return min
+}
+
+// DecideDeadEqualityDeletes is the pure spec-correctness predicate for
+// equality-delete cleanup during compaction. Given a survey of
+// surviving data file seqs (already excluding the rewrite set) and a
+// list of equality-delete manifest entries, it returns the eq-delete
+// files that no surviving data file could ever apply to.
+//
+// The rule is identical to scanner.matchEqualityDeletesToData (the
+// reader-side filter):
+//
+//	E applies to D iff E.seq > D.seq AND (
+//	    len(E.partition) == 0 ||
+//	    len(D.partition) == 0 ||
+//	    partitionsMatch(E.partition, D.partition)
+//	)
+//
+// E is dead iff no applicable surviving D has D.seq < E.seq —
+// equivalently, the applicable min-seq is >= E.seq.
+//
+// SpecID is intentionally NOT part of the predicate. The Iceberg-go
+// reader does not consult it; if the executor used a stricter
+// predicate it could drop eq-deletes the reader still applies, causing
+// silent data loss under partition-spec evolution.
+//
+// Defensive: candidates with sequence number < 0 (sentinel for unset)
+// are skipped — preserved rather than risk dropping an unidentifiable
+// file.
+//
+// Dedup by file path: the same eq-delete file may appear in multiple
+// manifest entries after manifest merging.
+func DecideDeadEqualityDeletes(survey *SurvivorSurvey, candidates []iceberg.ManifestEntry) []iceberg.DataFile {
+	if survey == nil {
+		return nil
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	dead := make([]iceberg.DataFile, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, e := range candidates {
+		df := e.DataFile()
+		path := df.FilePath()
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		if e.SequenceNum() < 0 {
+			continue
+		}
+		if survey.applicableMinSeq(df.Partition()) >= e.SequenceNum() {
+			seen[path] = struct{}{}
+			dead = append(dead, df)
+		}
+	}
+
+	return dead
+}
+
+// partitionBucketKey returns a deterministic string key for a
+// (specID, partition) tuple. Used by the planner to group tasks for
+// bin-packing — different specs must NOT mix because a compacted
+// output file inherits a single spec.
+func partitionBucketKey(specID int32, part map[int]any) string {
+	if len(part) == 0 {
+		return fmt.Sprintf("%d:_", specID)
+	}
+
+	return string(appendPartitionTuple(fmt.Appendf(nil, "%d:", specID), part))
+}
+
+// partitionMatchKey returns a deterministic string key for a
+// partition tuple alone (no spec id). Used by the eq-delete cleanup
+// to bucket survivors and candidates by the same key the reader uses
+// for applicability matching.
+//
+// Empty / nil partition → empty string sentinel. Callers must
+// special-case empty partitions per the global-applicability rule;
+// this helper does NOT collapse empty partitions into a fake
+// per-spec bucket because that would break the reader-equivalence.
+func partitionMatchKey(part map[int]any) string {
+	if len(part) == 0 {
+		return ""
+	}
+
+	return string(appendPartitionTuple(nil, part))
+}
+
+// appendPartitionTuple emits the sorted "id=value;" tuple into dst.
+// Caller is responsible for any leading prefix (e.g. specID).
+func appendPartitionTuple(dst []byte, part map[int]any) []byte {
+	ids := make([]int, 0, len(part))
+	for id := range part {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		dst = fmt.Appendf(dst, "%d=%v;", id, part[id])
+	}
+
+	return dst
+}

--- a/table/compaction/eq_delete_decision_test.go
+++ b/table/compaction/eq_delete_decision_test.go
@@ -1,0 +1,249 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table/compaction"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecideDeadEqualityDeletes_PredicateMatchesScanner exercises the
+// pure decision logic against the scenarios that earlier code reviews
+// flagged as silent-data-loss risks. The scanner predicate
+// (table/scanner.go matchEqualityDeletesToData) is:
+//
+//	E applies to D iff E.seq > D.seq AND (
+//	    len(E.partition) == 0 ||
+//	    len(D.partition) == 0 ||
+//	    partitionsMatch(E.partition, D.partition)
+//	)
+//
+// Critically: SpecID is NOT part of the predicate, and either-side
+// empty-partition makes it apply globally. The cleanup must agree.
+func TestDecideDeadEqualityDeletes_PredicateMatchesScanner(t *testing.T) {
+	type tc struct {
+		name        string
+		survivors   []survivor
+		eqPart      map[int]any
+		eqSeq       int64
+		expectsDead bool
+	}
+
+	cases := []tc{
+		{
+			name:        "fully-rewritten-bucket: empty survey ⇒ dead",
+			survivors:   nil,
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: true,
+		},
+		{
+			name: "partition match, surviving D has lower seq ⇒ alive",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "us"}, seq: 3},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: false,
+		},
+		{
+			name: "partition match, surviving D has higher seq ⇒ dead",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "us"}, seq: 9},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: true,
+		},
+		{
+			name: "untouched partition does NOT protect us-eq-delete",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "eu"}, seq: 1},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: true,
+		},
+		{
+			name: "unpartitioned survivor protects partitioned eq-delete (cross-spec / global rule)",
+			survivors: []survivor{
+				{partition: nil, seq: 1},
+				{partition: map[int]any{1000: "us"}, seq: 999},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: false, // empty-part D with seq=1 < 5 keeps E alive
+		},
+		{
+			name: "unpartitioned eq-delete: any partitioned survivor with low seq keeps it alive",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "eu"}, seq: 2},
+			},
+			eqPart:      nil, // unpartitioned eq-delete
+			eqSeq:       5,
+			expectsDead: false,
+		},
+		{
+			name: "unpartitioned eq-delete: every survivor has higher seq ⇒ dead",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "us"}, seq: 7},
+				{partition: map[int]any{1000: "eu"}, seq: 8},
+			},
+			eqPart:      nil,
+			eqSeq:       5,
+			expectsDead: true,
+		},
+		{
+			name: "boundary: D.seq == E.seq ⇒ dead (strict-greater rule from scanner)",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "us"}, seq: 5},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       5,
+			expectsDead: true,
+		},
+		{
+			name: "defensive: candidate with seq < 0 is preserved (sentinel for unset)",
+			survivors: []survivor{
+				{partition: map[int]any{1000: "us"}, seq: 100},
+			},
+			eqPart:      map[int]any{1000: "us"},
+			eqSeq:       -1,
+			expectsDead: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			survey := compaction.NewSurvivorSurvey()
+			for _, s := range c.survivors {
+				survey.AddSurvivor(s.partition, s.seq)
+			}
+			candidate := makeEqDeleteEntry(t, c.eqPart, c.eqSeq, "/path/eq.parquet")
+
+			got := compaction.DecideDeadEqualityDeletes(survey, []iceberg.ManifestEntry{candidate})
+
+			if c.expectsDead {
+				assert.Len(t, got, 1, "expected eq-delete to be classified dead")
+			} else {
+				assert.Empty(t, got, "expected eq-delete to be preserved (alive)")
+			}
+		})
+	}
+}
+
+// TestDecideDeadEqualityDeletes_DedupesByPath verifies the executor
+// only emits each dead eq-delete file once even if the same path
+// appears in multiple manifest entries (post manifest-merging this
+// can happen).
+func TestDecideDeadEqualityDeletes_DedupesByPath(t *testing.T) {
+	survey := compaction.NewSurvivorSurvey()
+
+	a1 := makeEqDeleteEntry(t, nil, 5, "/eq-a.parquet")
+	a2 := makeEqDeleteEntry(t, nil, 5, "/eq-a.parquet")
+	b := makeEqDeleteEntry(t, nil, 5, "/eq-b.parquet")
+
+	got := compaction.DecideDeadEqualityDeletes(survey, []iceberg.ManifestEntry{a1, a2, b})
+	require.Len(t, got, 2)
+
+	paths := []string{got[0].FilePath(), got[1].FilePath()}
+	assert.Contains(t, paths, "/eq-a.parquet")
+	assert.Contains(t, paths, "/eq-b.parquet")
+}
+
+// TestSurvivorSurvey_AddSurvivor_DefensiveSeq asserts that a survivor
+// with sequence number < 0 is recorded as if seq=0 — guaranteeing it
+// stays "alive" against every eq-delete.
+func TestSurvivorSurvey_AddSurvivor_DefensiveSeq(t *testing.T) {
+	survey := compaction.NewSurvivorSurvey()
+	survey.AddSurvivor(nil, -1) // unset seq sentinel
+
+	// An eq-delete with seq=1 should still be considered alive against
+	// the seq=0-effective survivor.
+	candidate := makeEqDeleteEntry(t, nil, 1, "/eq.parquet")
+	got := compaction.DecideDeadEqualityDeletes(survey, []iceberg.ManifestEntry{candidate})
+	assert.Empty(t, got, "negative-seq survivor must keep eq-delete alive")
+}
+
+type survivor struct {
+	partition map[int]any
+	seq       int64
+}
+
+// makeEqDeleteEntry constructs a real iceberg.ManifestEntry containing
+// a real DataFile (built via NewDataFileBuilder). The pure predicate
+// reads only path, partition, content type, and seq, so a minimal
+// builder configuration is enough.
+func makeEqDeleteEntry(t *testing.T, part map[int]any, seq int64, path string) iceberg.ManifestEntry {
+	t.Helper()
+
+	// Build a partition spec that matches the partition map's keys so
+	// NewDataFileBuilder accepts the partition data. Partition values
+	// are passed through to DataFile.Partition() unchanged.
+	fields := make([]iceberg.PartitionField, 0, len(part))
+	for id := range part {
+		fields = append(fields, iceberg.PartitionField{
+			SourceIDs: []int{id},
+			FieldID:   id,
+			Name:      "p" + intToStr(id),
+			Transform: iceberg.IdentityTransform{},
+		})
+	}
+	var spec iceberg.PartitionSpec
+	if len(fields) == 0 {
+		spec = *iceberg.UnpartitionedSpec
+	} else {
+		spec = iceberg.NewPartitionSpec(fields...)
+	}
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentEqDeletes, path, iceberg.ParquetFile,
+		part, nil, nil /* records */, 1 /* fileSize */, 128,
+	)
+	require.NoError(t, err)
+	df := builder.Build()
+
+	entryBuilder := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, nil, df)
+	entryBuilder.SequenceNum(seq)
+
+	return entryBuilder.Build()
+}
+
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+
+	return string(digits)
+}

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -40,10 +40,9 @@ type RewriteResult struct {
 	RemovedPositionDeleteFiles int
 
 	// RemovedEqualityDeleteFiles is the count of equality delete files
-	// removed via RewriteDataFilesOptions.ExtraDeleteFilesToRemove. The
-	// caller computes which eq-deletes are dead — typically via
-	// table/compaction.CollectDeadEqualityDeletes — and passes the list
-	// in.
+	// removed via [RewriteDataFilesOptions.ExtraDeleteFilesToRemove].
+	// The caller computes which eq-deletes are dead — typically via
+	// [compaction.CollectDeadEqualityDeletes] — and passes the list in.
 	RemovedEqualityDeleteFiles int
 
 	// BytesBefore is the total size of input data files (from the compaction plan).
@@ -58,8 +57,8 @@ type RewriteResult struct {
 // (table/compaction package) and the executor, avoiding a circular
 // import between table and table/compaction.
 //
-// Use compaction.Config.PlanCompaction() to produce groups, then convert
-// compaction.Group → CompactionTaskGroup to call RewriteDataFiles.
+// Use [compaction.Config.PlanCompaction] to produce groups, then convert
+// [compaction.Group] → [CompactionTaskGroup] to call [Transaction.RewriteDataFiles].
 type CompactionTaskGroup struct {
 	// PartitionKey is an opaque grouping key for display/logging.
 	PartitionKey string
@@ -94,10 +93,10 @@ type RewriteDataFilesOptions struct {
 	// passes them through to ReplaceFiles unchanged. Honored only
 	// when PartialProgress is false.
 	//
-	// Use table/compaction.CollectDeadEqualityDeletes to compute this
-	// list from the current snapshot. Position delete files that are
-	// fully applied are removed automatically and do NOT need to be
-	// passed in here.
+	// Use [compaction.CollectDeadEqualityDeletes] to compute this list
+	// from the current snapshot. Position delete files that are fully
+	// applied are removed automatically and do NOT need to be passed
+	// in here.
 	ExtraDeleteFilesToRemove []iceberg.DataFile
 }
 
@@ -108,15 +107,15 @@ type RewriteDataFilesOptions struct {
 // removed automatically.
 //
 // Equality-delete cleanup is the caller's responsibility: compute the
-// dead set with table/compaction.CollectDeadEqualityDeletes (against
-// the same snapshot the rewrite is staged on) and pass it via
-// opts.ExtraDeleteFilesToRemove. The executor only orchestrates the
-// commit; it does not impose a cleanup policy. This split keeps the
-// pure spec predicate in table/compaction and the unexported snapshot
-// machinery in table.
+// dead set with [compaction.CollectDeadEqualityDeletes] (against the
+// same snapshot the rewrite is staged on) and pass it via
+// [RewriteDataFilesOptions.ExtraDeleteFilesToRemove]. The executor
+// only orchestrates the commit; it does not impose a cleanup policy.
+// This split keeps the pure spec predicate in table/compaction and
+// the unexported snapshot machinery in table.
 //
-// Use table/compaction.Config.PlanCompaction() to produce the groups,
-// then convert compaction.Group → CompactionTaskGroup and pass them
+// Use [compaction.Config.PlanCompaction] to produce the groups, then
+// convert [compaction.Group] → [CompactionTaskGroup] and pass them
 // here.
 func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
 	if len(groups) == 0 {
@@ -211,7 +210,7 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 
 	if !opts.PartialProgress {
 		// Caller-supplied dead eq-deletes (typically from
-		// compaction.CollectDeadEqualityDeletes). The caller is
+		// [compaction.CollectDeadEqualityDeletes]). The caller is
 		// responsible for computing these against the same snapshot
 		// this transaction is staged on.
 		if len(opts.ExtraDeleteFilesToRemove) > 0 {
@@ -251,7 +250,7 @@ func rewriteValidator(rewrittenPaths []string) conflictValidatorFunc {
 // the new output files will not contain the deleted rows.
 //
 // Only position deletes (EntryContentPosDeletes) are considered.
-// Equality deletes are decided by table/compaction.DecideDeadEqualityDeletes
+// Equality deletes are decided by [compaction.DecideDeadEqualityDeletes]
 // (which needs partition-wide visibility, not just the task scope).
 // Deletion vectors will be handled when DV read support lands.
 func collectSafePositionDeletes(tasks []FileScanTask) []iceberg.DataFile {

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -35,8 +35,16 @@ type RewriteResult struct {
 	// RemovedDataFiles is the total number of old data files replaced.
 	RemovedDataFiles int
 
-	// RemovedDeleteFiles is the total number of delete files cleaned up.
-	RemovedDeleteFiles int
+	// RemovedPositionDeleteFiles is the count of position delete files
+	// removed because their referenced data file was rewritten.
+	RemovedPositionDeleteFiles int
+
+	// RemovedEqualityDeleteFiles is the count of equality delete files
+	// removed via RewriteDataFilesOptions.ExtraDeleteFilesToRemove. The
+	// caller computes which eq-deletes are dead — typically via
+	// table/compaction.CollectDeadEqualityDeletes — and passes the list
+	// in.
+	RemovedEqualityDeleteFiles int
 
 	// BytesBefore is the total size of input data files (from the compaction plan).
 	BytesBefore int64
@@ -63,24 +71,54 @@ type CompactionTaskGroup struct {
 	TotalSizeBytes int64
 }
 
-// RewriteDataFiles compacts the given groups by reading data with deletes
-// applied, writing new consolidated files, and atomically replacing the
-// old files. Position delete files that are fully applied are removed.
+// RewriteDataFilesOptions bundles the per-rewrite knobs for
+// Transaction.RewriteDataFiles.
+type RewriteDataFilesOptions struct {
+	// PartialProgress, when true, stages each group via ReplaceFiles
+	// inside the loop so work survives a mid-loop write failure. When
+	// false (the default), all groups are committed in a single atomic
+	// snapshot.
+	//
+	// In both modes the final catalog commit happens once at
+	// Transaction.Commit() time. True per-group durability (matching
+	// Java's behavior) requires committing separate transactions per
+	// group, which is left to the caller.
+	PartialProgress bool
+
+	// SnapshotProps are added to the rewrite snapshot's summary.
+	SnapshotProps iceberg.Properties
+
+	// ExtraDeleteFilesToRemove are delete files (typically equality
+	// deletes that are dead after the rewrite) that the caller wants
+	// expunged in the same snapshot as the rewrite. The executor
+	// passes them through to ReplaceFiles unchanged. Honored only
+	// when PartialProgress is false.
+	//
+	// Use table/compaction.CollectDeadEqualityDeletes to compute this
+	// list from the current snapshot. Position delete files that are
+	// fully applied are removed automatically and do NOT need to be
+	// passed in here.
+	ExtraDeleteFilesToRemove []iceberg.DataFile
+}
+
+// RewriteDataFiles compacts the given groups by reading data with
+// deletes applied, writing new consolidated files, and atomically
+// replacing the old files. Position delete files that are fully
+// applied (every referenced data file is in the rewrite set) are
+// removed automatically.
+//
+// Equality-delete cleanup is the caller's responsibility: compute the
+// dead set with table/compaction.CollectDeadEqualityDeletes (against
+// the same snapshot the rewrite is staged on) and pass it via
+// opts.ExtraDeleteFilesToRemove. The executor only orchestrates the
+// commit; it does not impose a cleanup policy. This split keeps the
+// pure spec predicate in table/compaction and the unexported snapshot
+// machinery in table.
 //
 // Use table/compaction.Config.PlanCompaction() to produce the groups,
-// then convert compaction.Group → CompactionTaskGroup and pass them here.
-//
-// Note: partialProgress accumulates all group commits within this
-// transaction. True per-group durability (matching Java's behavior)
-// requires committing separate transactions per group, which is left
-// to the caller. When partialProgress is false, all groups are committed
-// in a single atomic snapshot.
-//
-// Equality delete files are intentionally preserved — they may apply to
-// data files outside the compaction scope. Removal of equality deletes
-// requires verifying that ALL data files in the partition are being
-// rewritten, which is tracked as a follow-up.
-func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, partialProgress bool, snapshotProps iceberg.Properties) (*RewriteResult, error) {
+// then convert compaction.Group → CompactionTaskGroup and pass them
+// here.
+func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
 	if len(groups) == 0 {
 		return &RewriteResult{}, nil
 	}
@@ -138,7 +176,7 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 		result.RewrittenGroups++
 		result.AddedDataFiles += len(newFiles)
 		result.RemovedDataFiles += len(oldDataFiles)
-		result.RemovedDeleteFiles += len(safeDeletes)
+		result.RemovedPositionDeleteFiles += len(safeDeletes)
 		result.BytesBefore += group.TotalSizeBytes
 		result.BytesAfter += bytesAfter
 
@@ -150,26 +188,17 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 		allNewData = append(allNewData, newFiles...)
 		allOldDeletes = append(allOldDeletes, safeDeletes...)
 
-		if partialProgress {
-			if err := t.ReplaceFiles(ctx, oldDataFiles, newFiles, safeDeletes, snapshotProps, withRewriteSemantics()); err != nil {
+		if opts.PartialProgress {
+			if err := t.ReplaceFiles(ctx, oldDataFiles, newFiles, safeDeletes, opts.SnapshotProps, withRewriteSemantics()); err != nil {
 				return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
 			}
 		}
 	}
 
-	if !partialProgress {
-		if err := t.ReplaceFiles(ctx, allOldData, allNewData, allOldDeletes, snapshotProps, withRewriteSemantics()); err != nil {
-			return result, fmt.Errorf("commit compaction: %w", err)
-		}
-	}
-
-	// Register a single rewrite-specific conflict validator covering
-	// every rewritten data file across every group. t.ReplaceFiles
-	// only stages updates on the transaction (no per-group catalog
-	// commit); the validator list is drained once at
-	// Transaction.Commit() → doCommit, so one registration with the
-	// union of rewritten paths is what actually fires. This runs
-	// alongside the overwrite producer's suppressed validator (via
+	// Register the rewrite-specific conflict validator covering every
+	// rewritten data file across every group. The validator list is
+	// drained at Transaction.Commit() → doCommit. Runs alongside the
+	// overwrite producer's suppressed validator (via
 	// withRewriteSemantics) so concurrent pos/eq-deletes targeting a
 	// rewritten file are caught pre-flight.
 	if len(allOldData) > 0 {
@@ -178,6 +207,21 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 			rewritten = append(rewritten, f.FilePath())
 		}
 		t.validators = append(t.validators, rewriteValidator(rewritten))
+	}
+
+	if !opts.PartialProgress {
+		// Caller-supplied dead eq-deletes (typically from
+		// compaction.CollectDeadEqualityDeletes). The caller is
+		// responsible for computing these against the same snapshot
+		// this transaction is staged on.
+		if len(opts.ExtraDeleteFilesToRemove) > 0 {
+			allOldDeletes = append(allOldDeletes, opts.ExtraDeleteFilesToRemove...)
+			result.RemovedEqualityDeleteFiles += len(opts.ExtraDeleteFilesToRemove)
+		}
+
+		if err := t.ReplaceFiles(ctx, allOldData, allNewData, allOldDeletes, opts.SnapshotProps, withRewriteSemantics()); err != nil {
+			return result, fmt.Errorf("commit compaction: %w", err)
+		}
 	}
 
 	return result, nil
@@ -207,11 +251,9 @@ func rewriteValidator(rewrittenPaths []string) conflictValidatorFunc {
 // the new output files will not contain the deleted rows.
 //
 // Only position deletes (EntryContentPosDeletes) are considered.
-// Equality deletes and deletion vectors are intentionally excluded:
-//   - Equality deletes may apply to data files outside the compaction
-//     scope. Removing them requires verifying the entire partition is
-//     being rewritten.
-//   - Deletion vectors will be handled when DV read support lands.
+// Equality deletes are decided by table/compaction.DecideDeadEqualityDeletes
+// (which needs partition-wide visibility, not just the task scope).
+// Deletion vectors will be handled when DV read support lands.
 func collectSafePositionDeletes(tasks []FileScanTask) []iceberg.DataFile {
 	seen := make(map[string]bool)
 	var safe []iceberg.DataFile

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -76,6 +76,40 @@ func toTaskGroups(groups []compaction.Group) []table.CompactionTaskGroup {
 	return out
 }
 
+// runRewriteWithCleanup is the test-side orchestration: compute dead
+// eq-deletes against the current snapshot, then invoke the executor.
+// Mirrors what cmd/iceberg/compact.go does.
+func runRewriteWithCleanup(t *testing.T, tbl *table.Table, groups []table.CompactionTaskGroup, partialProgress bool) (*table.RewriteResult, *table.Table) {
+	t.Helper()
+
+	tx := tbl.NewTransaction()
+
+	rewriteOpts := table.RewriteDataFilesOptions{PartialProgress: partialProgress}
+	if !partialProgress {
+		snap := tbl.CurrentSnapshot()
+		if snap != nil {
+			rewrittenSet := make(map[string]struct{})
+			for _, g := range groups {
+				for _, task := range g.Tasks {
+					rewrittenSet[task.File.FilePath()] = struct{}{}
+				}
+			}
+			deadEqDeletes, err := compaction.CollectDeadEqualityDeletes(
+				t.Context(), iceio.LocalFS{}, snap, rewrittenSet)
+			require.NoError(t, err)
+			rewriteOpts.ExtraDeleteFilesToRemove = deadEqDeletes
+		}
+	}
+
+	result, err := tx.RewriteDataFiles(t.Context(), groups, rewriteOpts)
+	require.NoError(t, err)
+
+	out, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	return result, out
+}
+
 var defaultTestCompactionCfg = compaction.Config{
 	TargetFileSizeBytes: 10 * 1024 * 1024,
 	MinFileSizeBytes:    5 * 1024 * 1024,
@@ -115,12 +149,7 @@ func TestRewriteDataFiles_SmallFiles(t *testing.T) {
 	require.NotEmpty(t, plan.Groups)
 
 	// Execute compaction.
-	tx := tbl.NewTransaction()
-	result, err := tx.RewriteDataFiles(t.Context(), toTaskGroups(plan.Groups), false, nil)
-	require.NoError(t, err)
-
-	tbl, err = tx.Commit(t.Context())
-	require.NoError(t, err)
+	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), false)
 
 	// Verify: same rows, fewer files.
 	assertRowCount(t, tbl, 5)
@@ -187,16 +216,11 @@ func TestRewriteDataFiles_WithPositionDeletes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, plan.Groups)
 
-	tx2 := tbl.NewTransaction()
-	result, err := tx2.RewriteDataFiles(t.Context(), toTaskGroups(plan.Groups), false, nil)
-	require.NoError(t, err)
-
-	tbl, err = tx2.Commit(t.Context())
-	require.NoError(t, err)
+	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), false)
 
 	// After compaction: delete is applied, 5 rows remain, delete file removed.
 	assertRowCount(t, tbl, 5)
-	assert.Greater(t, result.RemovedDeleteFiles, 0)
+	assert.Greater(t, result.RemovedPositionDeleteFiles, 0)
 
 	// Verify no delete files remain.
 	newTasks, err := tbl.Scan().PlanFiles(t.Context())
@@ -210,7 +234,7 @@ func TestRewriteDataFiles_EmptyPlan(t *testing.T) {
 	tbl := newRewriteTestTable(t)
 
 	tx := tbl.NewTransaction()
-	result, err := tx.RewriteDataFiles(t.Context(), nil, false, nil)
+	result, err := tx.RewriteDataFiles(t.Context(), nil, table.RewriteDataFilesOptions{})
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.RewrittenGroups)
@@ -227,7 +251,7 @@ func TestRewriteDataFiles_EmptyGroupSkipped(t *testing.T) {
 	}
 
 	tx := tbl.NewTransaction()
-	result, err := tx.RewriteDataFiles(t.Context(), groups, false, nil)
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{})
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.RewrittenGroups)
@@ -257,12 +281,7 @@ func TestRewriteDataFiles_PartialProgress(t *testing.T) {
 	plan, err := defaultTestCompactionCfg.PlanCompaction(tasks)
 	require.NoError(t, err)
 
-	tx := tbl.NewTransaction()
-	result, err := tx.RewriteDataFiles(t.Context(), toTaskGroups(plan.Groups), true, nil)
-	require.NoError(t, err)
-
-	tbl, err = tx.Commit(t.Context())
-	require.NoError(t, err)
+	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), true)
 
 	assertRowCount(t, tbl, 6)
 	assert.Greater(t, result.RewrittenGroups, 0)
@@ -299,11 +318,15 @@ func TestRewriteDataFiles_ContextCancellation(t *testing.T) {
 	cancel()
 
 	tx := tbl.NewTransaction()
-	_, err = tx.RewriteDataFiles(ctx, toTaskGroups(plan.Groups), false, nil)
+	_, err = tx.RewriteDataFiles(ctx, toTaskGroups(plan.Groups), table.RewriteDataFilesOptions{})
 	require.Error(t, err)
 }
 
-func TestRewriteDataFiles_EqualityDeletesSurviveCompaction(t *testing.T) {
+// TestRewriteDataFiles_DeadEqualityDeletesDropped covers the common
+// CDC case: every data file in the (sole) partition is being rewritten,
+// so every equality delete in that partition is provably dead and must
+// be expunged from the new snapshot's manifests.
+func TestRewriteDataFiles_DeadEqualityDeletesDropped(t *testing.T) {
 	tbl := newRewriteTestTable(t)
 
 	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
@@ -324,32 +347,7 @@ func TestRewriteDataFiles_EqualityDeletesSurviveCompaction(t *testing.T) {
 	assertRowCount(t, tbl, 6)
 
 	// Add an equality delete that removes id=2.
-	delSchema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
-	)
-	delArrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
-	require.NoError(t, err)
-
-	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, delArrowSc,
-		strings.NewReader(`[{"id": 2}]`))
-	require.NoError(t, err)
-
-	records := func(yield func(arrow.RecordBatch, error) bool) {
-		yield(rec, nil)
-	}
-
-	tx := tbl.NewTransaction()
-	deleteFiles, err := tx.WriteEqualityDeletes(t.Context(), []int{1}, records)
-	require.NoError(t, err)
-	rec.Release()
-
-	rd := tx.NewRowDelta(nil)
-	for _, df := range deleteFiles {
-		rd.AddDeletes(df)
-	}
-	require.NoError(t, rd.Commit(t.Context()))
-	tbl, err = tx.Commit(t.Context())
-	require.NoError(t, err)
+	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 2}]`)
 
 	assertRowCount(t, tbl, 5) // id=2 deleted
 
@@ -364,22 +362,15 @@ func TestRewriteDataFiles_EqualityDeletesSurviveCompaction(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, plan.Groups)
 
-	tx2 := tbl.NewTransaction()
-	result, err := tx2.RewriteDataFiles(t.Context(), toTaskGroups(plan.Groups), false, nil)
-	require.NoError(t, err)
+	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), false)
 
-	tbl, err = tx2.Commit(t.Context())
-	require.NoError(t, err)
-
-	// Equality deletes are applied during the read phase of compaction,
-	// so compacted files don't contain the deleted row. The equality
-	// delete file is NOT removed by collectSafePositionDeletes (which
-	// only handles position deletes). It remains in the manifest but
-	// no longer matches the new data files (higher sequence number).
+	// The eq-delete is dead after compaction — every preexisting data
+	// file it could have applied to has been rewritten, so it must be
+	// dropped from the new snapshot.
 	assertRowCount(t, tbl, 5)
-	assert.Equal(t, 0, result.RemovedDeleteFiles,
-		"equality delete files should NOT be removed by compaction")
-	assert.Greater(t, result.RemovedDataFiles, 0, "compaction should have rewritten data files")
+	assert.Equal(t, 1, result.RemovedEqualityDeleteFiles,
+		"dead equality delete file should be removed by compaction")
+	assert.Greater(t, result.RemovedDataFiles, 0)
 
 	// The deleted row (id=2) must not reappear after compaction.
 	_, itr, err := tbl.Scan(table.WithSelectedFields("id")).ToArrowRecords(t.Context())
@@ -396,4 +387,335 @@ func TestRewriteDataFiles_EqualityDeletesSurviveCompaction(t *testing.T) {
 	}
 
 	assert.NotContains(t, ids, int64(2), "deleted row id=2 must not reappear after compaction")
+
+	// New scan tasks must carry no eq-delete files.
+	newTasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	for _, task := range newTasks {
+		assert.Empty(t, task.EqualityDeleteFiles, "no equality deletes should remain after compaction")
+	}
+}
+
+// TestRewriteDataFiles_PartialRewritePreservesEqDelete covers the case
+// where compaction rewrites some but not all data files in a partition.
+// An eq-delete whose seq is greater than a surviving (non-rewritten)
+// data file's seq must be preserved — it still applies to that file.
+//
+// Layout: commits land in this order to engineer a survivor with
+// seq < eq-delete.seq, then a high-seq file we'll rewrite alone.
+//
+//	commit 1: small-0.parquet      (data, will survive — low seq)
+//	commit 2: small-1.parquet      (data, will survive — low seq)
+//	commit 3: eq-delete (id=99)    (eq-delete; seq > both small files)
+//	commit 4: preserve.parquet     (data, will be rewritten — high seq)
+//
+// The post-rewrite check: eq-delete must remain because small-0/1
+// (which have lower seq) are still alive and applicable.
+func TestRewriteDataFiles_PartialRewritePreservesEqDelete(t *testing.T) {
+	tbl := newRewriteTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	// commit 1, 2: small data files.
+	for i := range 2 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/small-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc, fmt.Sprintf(
+			`[{"id": %d, "data": "a"}]`, i+1))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	// commit 3: eq-delete.
+	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 99}]`)
+
+	// commit 4: preserve.parquet — the high-seq file we'll compact alone.
+	preserveDataPath := tbl.Location() + "/data/preserve.parquet"
+	writeParquetFile(t, preserveDataPath, arrowSc, `[{"id": 50, "data": "preserved"}]`)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{preserveDataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(tasks), 3)
+
+	// Defensive: verify the seq-num invariant the test relies on
+	// (eq-delete.seq is greater than at least one small-* file's seq).
+	// If this ever drifts, fail loudly with a useful message.
+	eqDeleteSeq, smallMinSeq, preserveSeq := readKeySeqNums(t, tbl)
+	require.Greater(t, eqDeleteSeq, smallMinSeq,
+		"test setup expects eq-delete.seq > min(small-*.seq)")
+	require.Greater(t, preserveSeq, eqDeleteSeq,
+		"test setup expects preserve.seq > eq-delete.seq")
+	var preserveTask table.FileScanTask
+	for _, task := range tasks {
+		if strings.HasSuffix(task.File.FilePath(), "/preserve.parquet") {
+			preserveTask = task
+
+			break
+		}
+	}
+	require.NotEmpty(t, preserveTask.File.FilePath())
+
+	// Build a single-task group manually (bypass the planner so we can
+	// force a partial-partition rewrite).
+	groups := []table.CompactionTaskGroup{
+		{
+			PartitionKey:   "force-partial",
+			Tasks:          []table.FileScanTask{preserveTask},
+			TotalSizeBytes: preserveTask.File.FileSizeBytes(),
+		},
+	}
+
+	result, tbl := runRewriteWithCleanup(t, tbl, groups, false)
+
+	// The eq-delete must still be present — it applies to the unrewritten
+	// small-0 / small-1 files (seq 1 and 2), and eq-delete.seq=3 > 2.
+	assert.Equal(t, 0, result.RemovedEqualityDeleteFiles,
+		"eq-delete must be preserved when an unrewritten low-seq data file remains in its partition")
+
+	// Sanity: the eq-delete is still attached to the surviving data
+	// files in scan tasks.
+	postTasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	hasEqDelete := false
+	for _, task := range postTasks {
+		if len(task.EqualityDeleteFiles) > 0 {
+			hasEqDelete = true
+
+			break
+		}
+	}
+	assert.True(t, hasEqDelete, "at least one surviving data file should still see the eq-delete")
+}
+
+// TestRewriteDataFiles_PreserveDeadEqualityDeletesOptOut verifies that
+// passing WithPreserveDeadEqualityDeletes(true) leaves dead
+// eq-deletes in place (legacy / opt-out behavior).
+func TestRewriteDataFiles_PreserveDeadEqualityDeletesOptOut(t *testing.T) {
+	tbl := newRewriteTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/file-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc, fmt.Sprintf(
+			`[{"id": %d, "data": "a"}]`, i+1))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 1}]`)
+
+	// Snapshot the eq-delete file path BEFORE compaction so we can
+	// confirm post-compaction that the manifest still references it.
+	preTasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	preEqDeletePaths := collectEqDeletePaths(preTasks)
+	require.Len(t, preEqDeletePaths, 1, "test setup expects a single eq-delete")
+
+	cfg := defaultTestCompactionCfg
+	cfg.DeleteFileThreshold = 1
+	cfg.PreserveDeadEqualityDeletes = true // opt out of cleanup
+
+	plan, err := cfg.PlanCompaction(preTasks)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Groups)
+
+	// Opt-out path: do NOT compute / pass dead eq-deletes. Mirrors the
+	// CLI behavior when --preserve-dead-equality-deletes is set.
+	tx := tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), toTaskGroups(plan.Groups),
+		table.RewriteDataFilesOptions{PartialProgress: false})
+	require.NoError(t, err)
+
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.RemovedEqualityDeleteFiles,
+		"opt-out: dead eq-deletes must be preserved")
+
+	// The eq-delete file must still exist in the new snapshot's
+	// manifests, even though it no longer matches the new high-seq
+	// compacted files (so scan tasks will not list it).
+	assert.True(t, snapshotContainsDeleteFile(t, tbl, preEqDeletePaths[0]),
+		"opt-out: the eq-delete file %s must remain in the snapshot's manifests",
+		preEqDeletePaths[0])
+}
+
+// snapshotContainsDeleteFile returns true if the table's current
+// snapshot's delete manifests reference the given file path with a
+// non-DELETED status.
+func snapshotContainsDeleteFile(t *testing.T, tbl *table.Table, path string) bool {
+	t.Helper()
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	fs := iceio.LocalFS{}
+	manifests, err := snap.Manifests(fs)
+	require.NoError(t, err)
+
+	for _, m := range manifests {
+		if m.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		entries, err := m.FetchEntries(fs, false)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			if e.DataFile().FilePath() == path {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func collectEqDeletePaths(tasks []table.FileScanTask) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, task := range tasks {
+		for _, df := range task.EqualityDeleteFiles {
+			if _, ok := seen[df.FilePath()]; ok {
+				continue
+			}
+			seen[df.FilePath()] = struct{}{}
+			out = append(out, df.FilePath())
+		}
+	}
+
+	return out
+}
+
+// TestRewriteDataFiles_PartialProgressPreservesEqDeletes verifies that
+// in partial-progress mode, eq-deletes are NOT dropped (the docstring
+// caveat). This protects against a per-group commit dropping an
+// eq-delete that is still alive for a later group's partition.
+func TestRewriteDataFiles_PartialProgressPreservesEqDeletes(t *testing.T) {
+	tbl := newRewriteTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/file-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc, fmt.Sprintf(
+			`[{"id": %d, "data": "a"}]`, i+1))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 1}]`)
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+
+	cfg := defaultTestCompactionCfg
+	cfg.DeleteFileThreshold = 1
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	result, _ := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), true)
+	// runRewriteWithCleanup skips ExtraDeleteFilesToRemove for
+	// partial-progress mode, mirroring the documented limitation:
+	// per-group eq-delete cleanup is a follow-up.
+	assert.Equal(t, 0, result.RemovedEqualityDeleteFiles,
+		"partial-progress mode does not drop eq-deletes (yet)")
+}
+
+// readKeySeqNums walks the table's current snapshot manifests and
+// returns the seq numbers of (a) the equality-delete file, (b) the
+// minimum seq among files prefixed `/data/small-`, and (c) the seq
+// of `/data/preserve.parquet`. Used to assert seq-num invariants
+// without hardcoding values.
+func readKeySeqNums(t *testing.T, tbl *table.Table) (eqDelete, smallMin, preserve int64) {
+	t.Helper()
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	fs := iceio.LocalFS{}
+	manifests, err := snap.Manifests(fs)
+	require.NoError(t, err)
+
+	smallMin = int64(1<<62 - 1)
+	for _, m := range manifests {
+		entries, err := m.FetchEntries(fs, false)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			path := e.DataFile().FilePath()
+			seq := e.SequenceNum()
+			switch {
+			case e.DataFile().ContentType() == iceberg.EntryContentEqDeletes:
+				eqDelete = seq
+			case strings.Contains(path, "/data/small-"):
+				if seq < smallMin {
+					smallMin = seq
+				}
+			case strings.HasSuffix(path, "/data/preserve.parquet"):
+				preserve = seq
+			}
+		}
+	}
+
+	return eqDelete, smallMin, preserve
+}
+
+// appendEqualityDelete is a test helper that writes one equality
+// delete file containing the given JSON records and commits it onto
+// the table. equalityFieldIDs identifies the schema fields used for
+// equality matching.
+func appendEqualityDelete(t *testing.T, tbl *table.Table, equalityFieldIDs []int, recordsJSON string) *table.Table {
+	t.Helper()
+
+	delFields := make([]iceberg.NestedField, 0, len(equalityFieldIDs))
+	for _, id := range equalityFieldIDs {
+		f, ok := tbl.Schema().FindFieldByID(id)
+		require.True(t, ok)
+		delFields = append(delFields, f)
+	}
+	delSchema := iceberg.NewSchema(0, delFields...)
+	delArrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
+	require.NoError(t, err)
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, delArrowSc, strings.NewReader(recordsJSON))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	records := func(yield func(arrow.RecordBatch, error) bool) {
+		yield(rec, nil)
+	}
+
+	tx := tbl.NewTransaction()
+	deleteFiles, err := tx.WriteEqualityDeletes(t.Context(), equalityFieldIDs, records)
+	require.NoError(t, err)
+
+	rd := tx.NewRowDelta(nil)
+	for _, df := range deleteFiles {
+		rd.AddDeletes(df)
+	}
+	require.NoError(t, rd.Commit(t.Context()))
+	out, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	return out
 }


### PR DESCRIPTION
Closes #946.

Sustained CDC workloads (Postgres → Iceberg replication, ~one snapshot per few seconds with one eq-delete per UPDATE/DELETE) accumulate equality-delete files in every snapshot's manifests forever. After compaction, every preexisting eq-delete is provably dead — no surviving applicable data file has seq < eq-delete.seq — but the old RewriteDataFiles only removed position deletes, leaving eq-deletes in place. Manifest fanout grew linearly with the CDC duration.

This change adds three pieces:

1. table/compaction.DecideDeadEqualityDeletes — a pure predicate that exactly matches the v2 reader (table/scanner.go matchEqualityDeletesToData): E applies to D iff E.seq > D.seq AND (either side has empty partition OR partition tuples match). SpecID is intentionally NOT in the predicate — using it would silently drop eq-deletes the reader still applies under partition-spec evolution.

2. table/compaction.CollectDeadEqualityDeletes — walks the snapshot's manifests via the existing public Snapshot.Manifests + FetchEntries APIs, builds a SurvivorSurvey, and returns the dead set. Two-pass design: skip the data-manifest walk if there are no eq-delete candidates.

3. table.RewriteDataFilesOptions.ExtraDeleteFilesToRemove — a new field on the options struct that the executor passes through to ReplaceFiles. The caller (cmd/iceberg/compact.go or any library user) computes dead eq-deletes via CollectDeadEqualityDeletes against the same snapshot and threads them in. The executor itself is policy-free.

The CLI gains a --preserve-dead-equality-deletes flag (default off, i.e., cleanup is on by default — recommended for sustained CDC).

The RewriteDataFiles signature collapses (partialProgress, snapshotProps, opts...) into a single RewriteDataFilesOptions struct. RewriteResult splits RemovedDeleteFiles into RemovedPositionDeleteFiles + RemovedEqualityDeleteFiles for observability.

Tests:
- table/compaction/eq_delete_decision_test.go pins the predicate against the scanner's rule across mixed-partition / cross-spec / boundary cases.
- table/compaction/cdc_stress_test.go runs 80 CDC cycles (81 data files + 80 eq-deletes pre-compaction → 1 data file + 0 eq-deletes post). Skipped under -short.
- table/rewrite_data_files_test.go covers full-rewrite drops, partial-rewrite preserves, partial-progress preserves (per-group cleanup is a follow-up), and the CLI opt-out path.