### PR TITLE
feat(table): clustered partitioned write path

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1454,11 +1454,13 @@ func binPackRecords(itr iter.Seq2[arrow.RecordBatch, error], recordLookback int,
 }
 
 type recordWritingArgs struct {
-	sc        *arrow.Schema
-	itr       iter.Seq2[arrow.RecordBatch, error]
-	fs        iceio.WriteFileIO
-	writeUUID *uuid.UUID
-	counter   iter.Seq[int]
+	sc              *arrow.Schema
+	itr             iter.Seq2[arrow.RecordBatch, error]
+	fs              iceio.WriteFileIO
+	writeUUID       *uuid.UUID
+	counter         iter.Seq[int]
+	maxWriteWorkers int
+	clustered       bool
 }
 
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {
@@ -1497,10 +1499,6 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 		}
 	}
 
-	cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-		return newDataFileWriter(rootLocation, fs, meta, props, opts...)
-	})
-
 	factory, err := newWriterFactory(rootLocation, args, meta, taskSchema, targetFileSize)
 	if err != nil {
 		panic(err)
@@ -1510,8 +1508,19 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 		return unpartitionedWrite(ctx, factory, args.itr)
 	}
 
+	if args.clustered {
+		return clusteredPartitionedWrite(ctx, factory.currentSpec, meta.CurrentSchema(), factory, args.itr)
+	}
+
+	cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
+		return newDataFileWriter(rootLocation, fs, meta, props, opts...)
+	})
+
 	partitionWriter := newPartitionedFanoutWriter(factory.currentSpec, cw, meta.CurrentSchema(), args.itr, factory)
 	workers := config.EnvConfig.MaxWorkers
+	if args.maxWriteWorkers > 0 {
+		workers = args.maxWriteWorkers
+	}
 
 	return partitionWriter.Write(ctx, workers)
 }

--- a/table/clustered_writer.go
+++ b/table/clustered_writer.go
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/iceberg-go"
+)
+
+// clusteredPartitionedWrite writes records to partitioned data files,
+// keeping at most one partition writer open at a time. When the
+// partition changes, the current writer is closed before opening a
+// new one. This is the memory-efficient write path for pre-clustered
+// input (e.g. compaction reads where each source file belongs to a
+// single partition).
+//
+// The input must be strictly clustered by partition: once a partition's
+// writer has been closed, encountering further records for that
+// partition is treated as a violation of the clustering assumption and
+// returns an error. Use the fanout writer if the input is not
+// clustered.
+func clusteredPartitionedWrite(
+	ctx context.Context,
+	spec iceberg.PartitionSpec,
+	schema *iceberg.Schema,
+	factory *writerFactory,
+	records iter.Seq2[arrow.RecordBatch, error],
+) iter.Seq2[iceberg.DataFile, error] {
+	outputCh := make(chan iceberg.DataFile, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(outputCh)
+		defer factory.stopCount()
+
+		var (
+			currentKey          string
+			currentWriter       *RollingDataWriter
+			completedPartitions = make(map[string]struct{})
+		)
+
+		closeCurrentWriter := func() error {
+			if currentWriter == nil {
+				return nil
+			}
+			w := currentWriter
+			currentWriter = nil
+			completedPartitions[currentKey] = struct{}{}
+			close(w.recordCh)
+			w.wg.Wait()
+
+			// stream's deferred close(errorCh) runs before its
+			// deferred wg.Done, so by the time Wait returns the
+			// channel is closed; this read never blocks and yields
+			// either the buffered error or nil.
+			return <-w.errorCh
+		}
+
+		fail := func(err error) {
+			errCh <- errors.Join(err, closeCurrentWriter())
+			close(errCh)
+		}
+
+		takeFn := partitionBatchByKey(ctx)
+
+		for rec, err := range records {
+			if err != nil {
+				fail(err)
+
+				return
+			}
+
+			partitions, err := getRecordPartitions(spec, schema, rec)
+			if err != nil {
+				fail(err)
+
+				return
+			}
+
+			for _, part := range partitions {
+				select {
+				case <-ctx.Done():
+					fail(context.Cause(ctx))
+
+					return
+				default:
+				}
+
+				subBatch, err := takeFn(rec, part.rows)
+				if err != nil {
+					fail(err)
+
+					return
+				}
+
+				partitionPath := spec.PartitionToPath(part.partitionRec, schema)
+				if currentWriter == nil || partitionPath != currentKey {
+					if err := closeCurrentWriter(); err != nil {
+						subBatch.Release()
+						errCh <- err
+						close(errCh)
+
+						return
+					}
+					if _, seen := completedPartitions[partitionPath]; seen {
+						subBatch.Release()
+						fail(fmt.Errorf("clustered write: incoming records violate the clustering assumption; "+
+							"partition %q has records arriving after its writer was already closed", partitionPath))
+
+						return
+					}
+					currentWriter = factory.newRollingDataWriter(
+						ctx, nil, partitionPath, part.partitionValues, outputCh)
+					currentKey = partitionPath
+				}
+
+				addErr := currentWriter.Add(subBatch)
+				subBatch.Release()
+				if addErr != nil {
+					fail(addErr)
+
+					return
+				}
+			}
+		}
+
+		if err := closeCurrentWriter(); err != nil {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	return func(yield func(iceberg.DataFile, error) bool) {
+		defer func() {
+			for range outputCh {
+			}
+		}()
+
+		for df := range outputCh {
+			if !yield(df, nil) {
+				return
+			}
+		}
+
+		if err := <-errCh; err != nil {
+			yield(nil, err)
+		}
+	}
+}

--- a/table/clustered_writer.go
+++ b/table/clustered_writer.go
@@ -18,10 +18,12 @@
 package table
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/iceberg-go"
@@ -34,11 +36,14 @@ import (
 // input (e.g. compaction reads where each source file belongs to a
 // single partition).
 //
-// The input must be strictly clustered by partition: once a partition's
-// writer has been closed, encountering further records for that
-// partition is treated as a violation of the clustering assumption and
-// returns an error. Use the fanout writer if the input is not
-// clustered.
+// The input must be clustered by partition across batches: once a
+// partition's writer has been closed, encountering further records
+// for that partition returns an error. Within a single batch the
+// writer reclusters rows by partition. Use the fanout writer if the
+// input is not clustered across batches.
+//
+// Breaking out of the returned iterator early cancels the producer
+// so it stops opening new writers; in-flight writers finish cleanly.
 func clusteredPartitionedWrite(
 	ctx context.Context,
 	spec iceberg.PartitionSpec,
@@ -46,17 +51,20 @@ func clusteredPartitionedWrite(
 	factory *writerFactory,
 	records iter.Seq2[arrow.RecordBatch, error],
 ) iter.Seq2[iceberg.DataFile, error] {
+	ctx, cancel := context.WithCancel(ctx)
+
 	outputCh := make(chan iceberg.DataFile, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
 		defer close(outputCh)
+		defer close(errCh)
 		defer factory.stopCount()
 
 		var (
-			currentKey          string
+			currentRec          partitionRecord
 			currentWriter       *RollingDataWriter
-			completedPartitions = make(map[string]struct{})
+			completedPartitions = &closedPartitionSet{}
 		)
 
 		closeCurrentWriter := func() error {
@@ -65,7 +73,7 @@ func clusteredPartitionedWrite(
 			}
 			w := currentWriter
 			currentWriter = nil
-			completedPartitions[currentKey] = struct{}{}
+			completedPartitions.add(currentRec)
 			close(w.recordCh)
 			w.wg.Wait()
 
@@ -76,14 +84,34 @@ func clusteredPartitionedWrite(
 			return <-w.errorCh
 		}
 
-		fail := func(err error) {
-			errCh <- errors.Join(err, closeCurrentWriter())
-			close(errCh)
+		sendErr := func(err error) {
+			select {
+			case errCh <- err:
+			default:
+			}
 		}
+
+		fail := func(err error) {
+			sendErr(errors.Join(err, closeCurrentWriter()))
+		}
+
+		// Recover any panic so the consumer is not left blocking on
+		// errCh forever. Declared last so it runs first on goroutine
+		// exit, before the close(errCh) and close(outputCh) defers.
+		defer func() {
+			if r := recover(); r != nil {
+				fail(fmt.Errorf("clustered write panic: %v", r))
+			}
+		}()
 
 		takeFn := partitionBatchByKey(ctx)
 
 		for rec, err := range records {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				fail(context.Cause(ctx))
+
+				return
+			}
 			if err != nil {
 				fail(err)
 
@@ -96,6 +124,13 @@ func clusteredPartitionedWrite(
 
 				return
 			}
+
+			// Process partitions in input row order so the revisit
+			// check is deterministic; getRecordPartitions returns
+			// them in arbitrary (Go map iteration) order.
+			slices.SortFunc(partitions, func(a, b *partitionInfo) int {
+				return cmp.Compare(a.rows[0], b.rows[0])
+			})
 
 			for _, part := range partitions {
 				select {
@@ -113,25 +148,25 @@ func clusteredPartitionedWrite(
 					return
 				}
 
-				partitionPath := spec.PartitionToPath(part.partitionRec, schema)
-				if currentWriter == nil || partitionPath != currentKey {
+				if currentWriter == nil || !slices.Equal(currentRec, part.partitionRec) {
 					if err := closeCurrentWriter(); err != nil {
 						subBatch.Release()
-						errCh <- err
-						close(errCh)
+						sendErr(err)
 
 						return
 					}
-					if _, seen := completedPartitions[partitionPath]; seen {
+					if completedPartitions.contains(part.partitionRec) {
+						partitionPath := spec.PartitionToPath(part.partitionRec, schema)
 						subBatch.Release()
 						fail(fmt.Errorf("clustered write: incoming records violate the clustering assumption; "+
 							"partition %q has records arriving after its writer was already closed", partitionPath))
 
 						return
 					}
+					partitionPath := spec.PartitionToPath(part.partitionRec, schema)
 					currentWriter = factory.newRollingDataWriter(
 						ctx, nil, partitionPath, part.partitionValues, outputCh)
-					currentKey = partitionPath
+					currentRec = part.partitionRec
 				}
 
 				addErr := currentWriter.Add(subBatch)
@@ -145,16 +180,20 @@ func clusteredPartitionedWrite(
 		}
 
 		if err := closeCurrentWriter(); err != nil {
-			errCh <- err
+			sendErr(err)
 		}
-		close(errCh)
 	}()
 
 	return func(yield func(iceberg.DataFile, error) bool) {
+		// LIFO defer order matters: cancel signals the producer first
+		// (synchronous, instant), then the drain pulls outputCh so
+		// any in-flight stream send can complete and the producer's
+		// closeCurrentWriter / wg.Wait paths unblock.
 		defer func() {
 			for range outputCh {
 			}
 		}()
+		defer cancel()
 
 		for df := range outputCh {
 			if !yield(df, nil) {
@@ -166,4 +205,42 @@ func clusteredPartitionedWrite(
 			yield(nil, err)
 		}
 	}
+}
+
+// closedPartitionSet tracks already-closed partitions by walking a
+// tree keyed on each partition field's value, mirroring the layout of
+// partitionMapNode. Go's any-equality at each level distinguishes SQL
+// NULL from the literal string "null" — the same property that
+// PartitionToPath drops via Transform.ToHumanStr — so this is the
+// structural key the revisit check needs.
+type closedPartitionSet struct {
+	children map[any]*closedPartitionSet
+}
+
+func (s *closedPartitionSet) add(rec partitionRecord) {
+	node := s
+	for _, part := range rec {
+		next, ok := node.children[part]
+		if !ok {
+			next = &closedPartitionSet{}
+			if node.children == nil {
+				node.children = map[any]*closedPartitionSet{}
+			}
+			node.children[part] = next
+		}
+		node = next
+	}
+}
+
+func (s *closedPartitionSet) contains(rec partitionRecord) bool {
+	node := s
+	for _, part := range rec {
+		next, ok := node.children[part]
+		if !ok {
+			return false
+		}
+		node = next
+	}
+
+	return true
 }

--- a/table/clustered_writer.go
+++ b/table/clustered_writer.go
@@ -53,7 +53,7 @@ func clusteredPartitionedWrite(
 ) iter.Seq2[iceberg.DataFile, error] {
 	ctx, cancel := context.WithCancel(ctx)
 
-	outputCh := make(chan iceberg.DataFile, 1)
+	outputCh := make(chan iceberg.DataFile, 16)
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -64,7 +64,7 @@ func clusteredPartitionedWrite(
 		var (
 			currentRec          partitionRecord
 			currentWriter       *RollingDataWriter
-			completedPartitions = &closedPartitionSet{}
+			completedPartitions = make(closedPartitionSet)
 		)
 
 		closeCurrentWriter := func() error {
@@ -106,14 +106,40 @@ func clusteredPartitionedWrite(
 
 		takeFn := partitionBatchByKey(ctx)
 
+		processPart := func(rec arrow.RecordBatch, part *partitionInfo) error {
+			subBatch, err := takeFn(rec, part.rows)
+			if err != nil {
+				return err
+			}
+			defer subBatch.Release()
+
+			if currentWriter == nil || !slices.Equal(currentRec, part.partitionRec) {
+				if err := closeCurrentWriter(); err != nil {
+					return err
+				}
+				if completedPartitions.contains(part.partitionRec) {
+					partitionPath := spec.PartitionToPath(part.partitionRec, schema)
+
+					return fmt.Errorf("clustered write: incoming records violate the clustering assumption; "+
+						"partition %q has records arriving after its writer was already closed", partitionPath)
+				}
+				partitionPath := spec.PartitionToPath(part.partitionRec, schema)
+				currentWriter = factory.newRollingDataWriter(
+					ctx, nil, partitionPath, part.partitionValues, outputCh)
+				currentRec = part.partitionRec
+			}
+
+			return currentWriter.Add(subBatch)
+		}
+
 		for rec, err := range records {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				fail(context.Cause(ctx))
+			if err != nil {
+				fail(err)
 
 				return
 			}
-			if err != nil {
-				fail(err)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				fail(context.Cause(ctx))
 
 				return
 			}
@@ -141,38 +167,8 @@ func clusteredPartitionedWrite(
 				default:
 				}
 
-				subBatch, err := takeFn(rec, part.rows)
-				if err != nil {
+				if err := processPart(rec, part); err != nil {
 					fail(err)
-
-					return
-				}
-
-				if currentWriter == nil || !slices.Equal(currentRec, part.partitionRec) {
-					if err := closeCurrentWriter(); err != nil {
-						subBatch.Release()
-						sendErr(err)
-
-						return
-					}
-					if completedPartitions.contains(part.partitionRec) {
-						partitionPath := spec.PartitionToPath(part.partitionRec, schema)
-						subBatch.Release()
-						fail(fmt.Errorf("clustered write: incoming records violate the clustering assumption; "+
-							"partition %q has records arriving after its writer was already closed", partitionPath))
-
-						return
-					}
-					partitionPath := spec.PartitionToPath(part.partitionRec, schema)
-					currentWriter = factory.newRollingDataWriter(
-						ctx, nil, partitionPath, part.partitionValues, outputCh)
-					currentRec = part.partitionRec
-				}
-
-				addErr := currentWriter.Add(subBatch)
-				subBatch.Release()
-				if addErr != nil {
-					fail(addErr)
 
 					return
 				}
@@ -211,31 +207,25 @@ func clusteredPartitionedWrite(
 // tree keyed on each partition field's value, mirroring the layout of
 // partitionMapNode. Go's any-equality at each level distinguishes SQL
 // NULL from the literal string "null" — the same property that
-// PartitionToPath drops via Transform.ToHumanStr — so this is the
-// structural key the revisit check needs.
-type closedPartitionSet struct {
-	children map[any]*closedPartitionSet
-}
+// PartitionToPath drops via Transform.ToHumanStr.
+type closedPartitionSet map[any]closedPartitionSet
 
-func (s *closedPartitionSet) add(rec partitionRecord) {
+func (s closedPartitionSet) add(rec partitionRecord) {
 	node := s
 	for _, part := range rec {
-		next, ok := node.children[part]
+		next, ok := node[part]
 		if !ok {
-			next = &closedPartitionSet{}
-			if node.children == nil {
-				node.children = map[any]*closedPartitionSet{}
-			}
-			node.children[part] = next
+			next = make(closedPartitionSet)
+			node[part] = next
 		}
 		node = next
 	}
 }
 
-func (s *closedPartitionSet) contains(rec partitionRecord) bool {
+func (s closedPartitionSet) contains(rec partitionRecord) bool {
 	node := s
 	for _, part := range rec {
-		next, ok := node.children[part]
+		next, ok := node[part]
 		if !ok {
 			return false
 		}

--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -93,6 +93,22 @@ func (s *ClusteredWriterTestSuite) buildMixedBatch(schema *arrow.Schema, partiti
 	return bldr.NewRecordBatch()
 }
 
+func (s *ClusteredWriterTestSuite) buildNullableBatch(schema *arrow.Schema, partitions []*string) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(s.mem, schema)
+	defer bldr.Release()
+
+	for i, p := range partitions {
+		bldr.Field(0).(*array.Int64Builder).Append(int64(i))
+		if p == nil {
+			bldr.Field(1).(*array.StringBuilder).AppendNull()
+		} else {
+			bldr.Field(1).(*array.StringBuilder).Append(*p)
+		}
+	}
+
+	return bldr.NewRecordBatch()
+}
+
 func (s *ClusteredWriterTestSuite) setupFactory(loc string, arrSchema *arrow.Schema, targetFileSize int64) (*writerFactory, iceberg.PartitionSpec, *iceberg.Schema) {
 	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
 	s.Require().NoError(err)
@@ -274,6 +290,67 @@ func (s *ClusteredWriterTestSuite) TestPartitionRevisitReturnsError() {
 	s.Len(dataFiles, 2, "part_a and part_b should have been flushed before the revisit was rejected")
 }
 
+func (s *ClusteredWriterTestSuite) TestNullVsLiteralStringWithinBatch() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	literalNull := "null"
+	batch := s.buildNullableBatch(arrSchema, []*string{nil, &literalNull, nil})
+	defer batch.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batch))
+
+	s.Require().Len(dataFiles, 2, "SQL NULL and literal string \"null\" must produce two distinct files")
+
+	partType := spec.PartitionType(icebergSchema)
+	rowsByLiteralPartition := map[string]int64{}
+	nilRows := int64(0)
+	for _, df := range dataFiles {
+		rec := GetPartitionRecord(df, partType)
+		val := rec.Get(0)
+		if val == nil {
+			nilRows += df.Count()
+		} else {
+			rowsByLiteralPartition[fmt.Sprintf("%v", val)] += df.Count()
+		}
+	}
+
+	s.Equal(int64(2), nilRows, "SQL NULL partition should contain rows 0 and 2")
+	s.Equal(int64(1), rowsByLiteralPartition["null"], "literal \"null\" partition should contain row 1")
+}
+
+func (s *ClusteredWriterTestSuite) TestNullVsLiteralStringAcrossBatches() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	literalNull := "null"
+	batchNil1 := s.buildNullableBatch(arrSchema, []*string{nil})
+	defer batchNil1.Release()
+	batchLiteral := s.buildNullableBatch(arrSchema, []*string{&literalNull})
+	defer batchLiteral.Release()
+	batchNil2 := s.buildNullableBatch(arrSchema, []*string{nil})
+	defer batchNil2.Release()
+
+	var (
+		dataFiles []iceberg.DataFile
+		writeErr  error
+	)
+	for df, err := range clusteredPartitionedWrite(s.ctx, spec, icebergSchema, factory, s.batchItr(batchNil1, batchLiteral, batchNil2)) {
+		if err != nil {
+			writeErr = err
+
+			break
+		}
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Error(writeErr)
+	s.Contains(writeErr.Error(), "partition_col=null")
+	s.Len(dataFiles, 2, "the SQL NULL and literal-\"null\" partitions should both have flushed before the revisit was rejected")
+}
+
 func (s *ClusteredWriterTestSuite) TestMixedBatchFollowedBySinglePartition() {
 	arrSchema := s.schema()
 	loc := filepath.ToSlash(s.T().TempDir())
@@ -303,6 +380,103 @@ func (s *ClusteredWriterTestSuite) TestMixedBatchFollowedBySinglePartition() {
 	s.Len(partitionRows, 2)
 	s.Equal(int64(25), partitionRows["partition_col=part_a"])
 	s.Equal(int64(55), partitionRows["partition_col=part_b"])
+}
+
+func (s *ClusteredWriterTestSuite) TestWithinBatchInterleaveIsRecluster() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	// A single batch with rows interleaved [a, b, a, b, a, b]. The
+	// clustered writer's contract is batch-granular: within a batch
+	// the rows are reclustered into one writer per partition, so this
+	// is accepted even though the row order is not contiguous.
+	bldr := array.NewRecordBuilder(s.mem, arrSchema)
+	parts := []string{"part_a", "part_b", "part_a", "part_b", "part_a", "part_b"}
+	for i, p := range parts {
+		bldr.Field(0).(*array.Int64Builder).Append(int64(i))
+		bldr.Field(1).(*array.StringBuilder).Append(p)
+	}
+	batch := bldr.NewRecordBatch()
+	bldr.Release()
+	defer batch.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batch))
+
+	partitionRows := make(map[string]int64)
+	for _, df := range dataFiles {
+		rec := GetPartitionRecord(df, spec.PartitionType(icebergSchema))
+		path := spec.PartitionToPath(rec, icebergSchema)
+		partitionRows[path] += df.Count()
+	}
+
+	s.Len(dataFiles, 2, "interleaved rows within a batch should produce one file per partition")
+	s.Equal(int64(3), partitionRows["partition_col=part_a"])
+	s.Equal(int64(3), partitionRows["partition_col=part_b"])
+}
+
+func (s *ClusteredWriterTestSuite) TestEarlyExitDoesNotDeadlock() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	parts := []string{"part_a", "part_b", "part_c", "part_d"}
+	batches := make([]arrow.RecordBatch, len(parts))
+	for i, p := range parts {
+		batches[i] = s.buildBatch(arrSchema, p, 100)
+	}
+	defer func() {
+		for _, b := range batches {
+			b.Release()
+		}
+	}()
+
+	var dataFiles []iceberg.DataFile
+	for df, err := range clusteredPartitionedWrite(s.ctx, spec, icebergSchema, factory, s.batchItr(batches...)) {
+		s.Require().NoError(err)
+		dataFiles = append(dataFiles, df)
+		if len(dataFiles) >= 1 {
+			break
+		}
+	}
+
+	s.GreaterOrEqual(len(dataFiles), 1)
+}
+
+func (s *ClusteredWriterTestSuite) TestPanickyIteratorSurfacesAsError() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	batchA := s.buildBatch(arrSchema, "part_a", 50)
+	defer batchA.Release()
+
+	panickyItr := func(yield func(arrow.RecordBatch, error) bool) {
+		batchA.Retain()
+		if !yield(batchA, nil) {
+			batchA.Release()
+
+			return
+		}
+		batchA.Release()
+		panic("test panic from iterator")
+	}
+
+	var (
+		dataFiles []iceberg.DataFile
+		writeErr  error
+	)
+	for df, err := range clusteredPartitionedWrite(s.ctx, spec, icebergSchema, factory, panickyItr) {
+		if err != nil {
+			writeErr = err
+
+			break
+		}
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Error(writeErr)
+	s.Contains(writeErr.Error(), "panic")
 }
 
 // -- Peak memory and goroutine comparison --

--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -1,0 +1,489 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/config"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// -- Functional tests --
+
+type ClusteredWriterTestSuite struct {
+	suite.Suite
+
+	mem *memory.CheckedAllocator
+	ctx context.Context
+}
+
+func (s *ClusteredWriterTestSuite) SetupTest() {
+	s.mem = memory.NewCheckedAllocator(memory.NewGoAllocator())
+	s.ctx = compute.WithAllocator(context.Background(), s.mem)
+}
+
+func (s *ClusteredWriterTestSuite) TearDownTest() {
+	s.mem.AssertSize(s.T(), 0)
+}
+
+func TestClusteredWriter(t *testing.T) {
+	suite.Run(t, new(ClusteredWriterTestSuite))
+}
+
+func (s *ClusteredWriterTestSuite) schema() *arrow.Schema {
+	return arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "partition_col", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+}
+
+func (s *ClusteredWriterTestSuite) buildBatch(schema *arrow.Schema, partition string, rows int) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(s.mem, schema)
+	defer bldr.Release()
+
+	for i := range rows {
+		bldr.Field(0).(*array.Int64Builder).Append(int64(i))
+		bldr.Field(1).(*array.StringBuilder).Append(partition)
+	}
+
+	return bldr.NewRecordBatch()
+}
+
+func (s *ClusteredWriterTestSuite) buildMixedBatch(schema *arrow.Schema, partitions []string, rowsPerPartition int) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(s.mem, schema)
+	defer bldr.Release()
+
+	row := 0
+	for _, p := range partitions {
+		for range rowsPerPartition {
+			bldr.Field(0).(*array.Int64Builder).Append(int64(row))
+			bldr.Field(1).(*array.StringBuilder).Append(p)
+			row++
+		}
+	}
+
+	return bldr.NewRecordBatch()
+}
+
+func (s *ClusteredWriterTestSuite) setupFactory(loc string, arrSchema *arrow.Schema, targetFileSize int64) (*writerFactory, iceberg.PartitionSpec, *iceberg.Schema) {
+	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
+	s.Require().NoError(err)
+
+	sourceField, ok := icebergSchema.FindFieldByName("partition_col")
+	s.Require().True(ok)
+
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{sourceField.ID},
+		FieldID:   1000,
+		Transform: iceberg.IdentityTransform{},
+		Name:      "partition_col",
+	})
+
+	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	s.Require().NoError(err)
+
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	s.Require().NoError(err)
+
+	writeUUID := uuid.New()
+	args := recordWritingArgs{
+		sc:        arrSchema,
+		fs:        iceio.LocalFS{},
+		writeUUID: &writeUUID,
+		counter: func(yield func(int) bool) {
+			for i := 0; ; i++ {
+				if !yield(i) {
+					break
+				}
+			}
+		},
+	}
+
+	factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, targetFileSize)
+	s.Require().NoError(err)
+
+	return factory, spec, icebergSchema
+}
+
+func (s *ClusteredWriterTestSuite) writeAndCollect(spec iceberg.PartitionSpec, icebergSchema *iceberg.Schema, factory *writerFactory, records func(func(arrow.RecordBatch, error) bool)) []iceberg.DataFile {
+	var dataFiles []iceberg.DataFile
+	for df, err := range clusteredPartitionedWrite(s.ctx, spec, icebergSchema, factory, records) {
+		s.Require().NoError(err)
+		dataFiles = append(dataFiles, df)
+	}
+
+	return dataFiles
+}
+
+func (s *ClusteredWriterTestSuite) batchItr(batches ...arrow.RecordBatch) func(func(arrow.RecordBatch, error) bool) {
+	return func(yield func(arrow.RecordBatch, error) bool) {
+		for _, b := range batches {
+			b.Retain()
+			if !yield(b, nil) {
+				b.Release()
+
+				return
+			}
+			b.Release()
+		}
+	}
+}
+
+func (s *ClusteredWriterTestSuite) TestSinglePartition() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	batch := s.buildBatch(arrSchema, "part_a", 100)
+	defer batch.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batch))
+
+	s.Require().Len(dataFiles, 1)
+	s.Equal(int64(100), dataFiles[0].Count())
+}
+
+func (s *ClusteredWriterTestSuite) TestMultiplePartitionsClustered() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	batchA := s.buildBatch(arrSchema, "part_a", 50)
+	defer batchA.Release()
+	batchB := s.buildBatch(arrSchema, "part_b", 30)
+	defer batchB.Release()
+	batchC := s.buildBatch(arrSchema, "part_c", 20)
+	defer batchC.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batchA, batchB, batchC))
+
+	partitionRows := make(map[string]int64)
+	for _, df := range dataFiles {
+		rec := GetPartitionRecord(df, spec.PartitionType(icebergSchema))
+		path := spec.PartitionToPath(rec, icebergSchema)
+		partitionRows[path] += df.Count()
+	}
+
+	s.Len(partitionRows, 3)
+	s.Equal(int64(50), partitionRows["partition_col=part_a"])
+	s.Equal(int64(30), partitionRows["partition_col=part_b"])
+	s.Equal(int64(20), partitionRows["partition_col=part_c"])
+}
+
+func (s *ClusteredWriterTestSuite) TestMixedBatchSpanningPartitions() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	batch := s.buildMixedBatch(arrSchema, []string{"part_a", "part_b"}, 25)
+	defer batch.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batch))
+
+	var totalRows int64
+	for _, df := range dataFiles {
+		totalRows += df.Count()
+	}
+
+	s.Equal(int64(50), totalRows)
+	s.Len(dataFiles, 2)
+}
+
+func (s *ClusteredWriterTestSuite) TestRollsFilesOnTargetSize() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1) // 1 byte forces rolling
+
+	var batches []arrow.RecordBatch
+	for range 10 {
+		b := s.buildBatch(arrSchema, "part_a", 50)
+		batches = append(batches, b)
+	}
+	defer func() {
+		for _, b := range batches {
+			b.Release()
+		}
+	}()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batches...))
+
+	var totalRows int64
+	for _, df := range dataFiles {
+		totalRows += df.Count()
+	}
+
+	s.Equal(int64(500), totalRows)
+	s.Greater(len(dataFiles), 1, "should produce multiple files with 1-byte target size")
+}
+
+func (s *ClusteredWriterTestSuite) TestPartitionRevisitReturnsError() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	batchA1 := s.buildBatch(arrSchema, "part_a", 10)
+	defer batchA1.Release()
+	batchB := s.buildBatch(arrSchema, "part_b", 20)
+	defer batchB.Release()
+	batchA2 := s.buildBatch(arrSchema, "part_a", 5)
+	defer batchA2.Release()
+
+	var (
+		dataFiles []iceberg.DataFile
+		writeErr  error
+	)
+	for df, err := range clusteredPartitionedWrite(s.ctx, spec, icebergSchema, factory, s.batchItr(batchA1, batchB, batchA2)) {
+		if err != nil {
+			writeErr = err
+
+			break
+		}
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Error(writeErr)
+	s.Contains(writeErr.Error(), "partition_col=part_a")
+	s.Len(dataFiles, 2, "part_a and part_b should have been flushed before the revisit was rejected")
+}
+
+func (s *ClusteredWriterTestSuite) TestMixedBatchFollowedBySinglePartition() {
+	arrSchema := s.schema()
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, spec, icebergSchema := s.setupFactory(loc, arrSchema, 1024*1024)
+
+	// Mixed batch with part_a's rows preceding part_b's, then a follow-up
+	// batch for part_b only. The input is clustered by row order, so the
+	// writer must process partitions within the mixed batch in row order
+	// (part_a then part_b), leaving part_b open for the next batch.
+	// Without that ordering, map iteration could surface part_b first,
+	// close it on the transition to part_a, and then reject the next
+	// batch as a clustering violation.
+	batchMixed := s.buildMixedBatch(arrSchema, []string{"part_a", "part_b"}, 25)
+	defer batchMixed.Release()
+	batchB := s.buildBatch(arrSchema, "part_b", 30)
+	defer batchB.Release()
+
+	dataFiles := s.writeAndCollect(spec, icebergSchema, factory, s.batchItr(batchMixed, batchB))
+
+	partitionRows := make(map[string]int64)
+	for _, df := range dataFiles {
+		rec := GetPartitionRecord(df, spec.PartitionType(icebergSchema))
+		path := spec.PartitionToPath(rec, icebergSchema)
+		partitionRows[path] += df.Count()
+	}
+
+	s.Len(partitionRows, 2)
+	s.Equal(int64(25), partitionRows["partition_col=part_a"])
+	s.Equal(int64(55), partitionRows["partition_col=part_b"])
+}
+
+// -- Peak memory and goroutine comparison --
+
+func buildPartitionedBatch(mem memory.Allocator, schema *arrow.Schema, partition string, rows int) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(mem, schema)
+	defer bldr.Release()
+
+	for i := range rows {
+		bldr.Field(0).(*array.Int64Builder).Append(int64(i))
+		bldr.Field(1).(*array.StringBuilder).Append(partition)
+	}
+
+	return bldr.NewRecordBatch()
+}
+
+type writeResult struct {
+	goroutineDelta int
+	heapInuseAtMid uint64
+}
+
+func writeWithMeasurement(t testing.TB, name string, numPartitions, rowsPerPartition int) writeResult {
+	t.Helper()
+
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "partition_col", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	mem := memory.NewGoAllocator()
+
+	var batches []arrow.RecordBatch
+	for p := range numPartitions {
+		batches = append(batches, buildPartitionedBatch(mem, arrSchema, fmt.Sprintf("p_%04d", p), rowsPerPartition))
+	}
+	defer func() {
+		for _, b := range batches {
+			b.Release()
+		}
+	}()
+
+	var (
+		result      writeResult
+		baselineSet bool
+		baseline    int
+	)
+	halfway := numPartitions / 2
+	count := 0
+
+	itr := func(yield func(arrow.RecordBatch, error) bool) {
+		for _, b := range batches {
+			b.Retain()
+			if !yield(b, nil) {
+				b.Release()
+
+				return
+			}
+			b.Release()
+			count++
+			if count == halfway && baselineSet {
+				runtime.GC()
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				result.heapInuseAtMid = m.HeapInuse
+				result.goroutineDelta = runtime.NumGoroutine() - baseline
+			}
+		}
+	}
+
+	// Captured immediately before the write starts so the delta isolates
+	// goroutines spawned by the writer from anything else running in the
+	// test process.
+	captureBaseline := func() {
+		baseline = runtime.NumGoroutine()
+		baselineSet = true
+	}
+
+	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
+	require.NoError(t, err)
+
+	sourceField, ok := icebergSchema.FindFieldByName("partition_col")
+	require.True(t, ok)
+
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{sourceField.ID},
+		FieldID:   1000,
+		Transform: iceberg.IdentityTransform{},
+		Name:      "partition_col",
+	})
+
+	loc := filepath.ToSlash(t.TempDir())
+	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	require.NoError(t, err)
+
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	writeUUID := uuid.New()
+	args := recordWritingArgs{
+		sc:        arrSchema,
+		itr:       itr,
+		fs:        iceio.LocalFS{},
+		writeUUID: &writeUUID,
+		counter: func(yield func(int) bool) {
+			for i := 0; ; i++ {
+				if !yield(i) {
+					break
+				}
+			}
+		},
+	}
+
+	switch name {
+	case "fanout":
+		cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
+			return newDataFileWriter(rootLocation, fs, meta, props, opts...)
+		})
+		factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, 512*1024*1024)
+		require.NoError(t, err)
+		writer := newPartitionedFanoutWriter(spec, cw, icebergSchema, args.itr, factory)
+		captureBaseline()
+		for df, err := range writer.Write(context.Background(), config.EnvConfig.MaxWorkers) {
+			require.NoError(t, err)
+			_ = df
+		}
+
+	case "clustered":
+		factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, 512*1024*1024)
+		require.NoError(t, err)
+		captureBaseline()
+		for df, err := range clusteredPartitionedWrite(context.Background(), spec, icebergSchema, factory, args.itr) {
+			require.NoError(t, err)
+			_ = df
+		}
+	}
+
+	return result
+}
+
+func TestClusteredWriterPeakMemory(t *testing.T) {
+	const (
+		numPartitions    = 200
+		rowsPerPartition = 2000
+	)
+
+	// Run clustered first so its freed memory doesn't inflate the
+	// fanout measurement.
+	clustered := writeWithMeasurement(t, "clustered", numPartitions, rowsPerPartition)
+	fanout := writeWithMeasurement(t, "fanout", numPartitions, rowsPerPartition)
+
+	t.Logf("fanout    at midpoint: heap %d MB, goroutine delta %d",
+		fanout.heapInuseAtMid/(1024*1024), fanout.goroutineDelta)
+	t.Logf("clustered at midpoint: heap %d MB, goroutine delta %d",
+		clustered.heapInuseAtMid/(1024*1024), clustered.goroutineDelta)
+
+	// The goroutine delta is a proxy for the number of open partition
+	// writers: each RollingDataWriter spawns a stream goroutine that
+	// holds a parquet FileWriter with column buffers and compression
+	// state, so at production scale (wide tables, zstd) the heap
+	// difference scales with this count. Heap is logged but not
+	// asserted because GC timing makes a tight bound flaky.
+	require.Greater(t, fanout.goroutineDelta, clustered.goroutineDelta+50,
+		"fanout should spawn many more concurrent goroutines than clustered (fanout=%d, clustered=%d)",
+		fanout.goroutineDelta, clustered.goroutineDelta)
+}
+
+func BenchmarkPartitionedWrite(b *testing.B) {
+	const (
+		numPartitions    = 200
+		rowsPerPartition = 5000
+	)
+
+	b.Run("fanout", func(b *testing.B) {
+		for b.Loop() {
+			writeWithMeasurement(b, "fanout", numPartitions, rowsPerPartition)
+		}
+	})
+
+	b.Run("clustered", func(b *testing.B) {
+		for b.Loop() {
+			writeWithMeasurement(b, "clustered", numPartitions, rowsPerPartition)
+		}
+	})
+}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -18,10 +18,12 @@
 package table
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -153,11 +155,15 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, record arro
 		partitionPath := p.partitionPath(val.partitionRec)
 		rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, p.concurrentDataFileWriter, partitionPath, val.partitionValues, dataFilesChannel)
 		if err != nil {
+			partitionRecord.Release()
+
 			return err
 		}
 
-		if err = rollingDataWriter.Add(partitionRecord); err != nil {
-			return err
+		addErr := rollingDataWriter.Add(partitionRecord)
+		partitionRecord.Release()
+		if addErr != nil {
+			return addErr
 		}
 	}
 
@@ -201,8 +207,12 @@ func yieldDataFiles(writerFactory *writerFactory, fanoutWorkers *errgroup.Group,
 }
 
 func (p *partitionedFanoutWriter) getPartitions(record arrow.RecordBatch) ([]*partitionInfo, error) {
+	return getRecordPartitions(p.partitionSpec, p.schema, record)
+}
+
+func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, record arrow.RecordBatch) ([]*partitionInfo, error) {
 	partitionMap := newPartitionMapNode()
-	partitionFields := p.partitionSpec.PartitionType(p.schema).FieldList
+	partitionFields := spec.PartitionType(schema).FieldList
 	partitionRec := make(partitionRecord, len(partitionFields))
 
 	partitionColumns := make([]arrow.Array, len(partitionFields))
@@ -212,8 +222,8 @@ func (p *partitionedFanoutWriter) getPartitions(record arrow.RecordBatch) ([]*pa
 	}, len(partitionFields))
 
 	for i := range partitionFields {
-		sourceField := p.partitionSpec.Field(i)
-		colName, _ := p.schema.FindColumnName(sourceField.SourceID())
+		sourceField := spec.Field(i)
+		colName, _ := schema.FindColumnName(sourceField.SourceID())
 		colIdx := record.Schema().FieldIndices(colName)[0]
 		partitionColumns[i] = record.Column(colIdx)
 		partitionFieldsInfo[i] = struct {
@@ -316,17 +326,28 @@ func (n *partitionMapNode) getOrCreate(partitionRec partitionRecord, fieldInfo [
 	return partVal
 }
 
-// collectPartitions recursively collects all partitionInfo into a slice
+// collectPartitions returns every partitionInfo in the tree, ordered by the
+// row at which each partition first appeared in the batch. The ordering makes
+// the clustered writer's revisit check deterministic; without it, Go's
+// randomized map iteration would let unclustered input slip past the check
+// intermittently.
 func (n *partitionMapNode) collectPartitions() []*partitionInfo {
-	result := make([]*partitionInfo, 0, n.leafCount)
+	result := n.flatten()
+	slices.SortFunc(result, func(a, b *partitionInfo) int {
+		return cmp.Compare(a.rows[0], b.rows[0])
+	})
 
+	return result
+}
+
+func (n *partitionMapNode) flatten() []*partitionInfo {
+	result := make([]*partitionInfo, 0, n.leafCount)
 	for _, v := range n.children {
 		switch node := v.(type) {
 		case *partitionInfo:
 			result = append(result, node)
 		case *partitionMapNode:
-			// Recursively collect from child nodes
-			result = append(result, node.collectPartitions()...)
+			result = append(result, node.flatten()...)
 		}
 	}
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -18,12 +18,10 @@
 package table
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
-	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -326,28 +324,18 @@ func (n *partitionMapNode) getOrCreate(partitionRec partitionRecord, fieldInfo [
 	return partVal
 }
 
-// collectPartitions returns every partitionInfo in the tree, ordered by the
-// row at which each partition first appeared in the batch. The ordering makes
-// the clustered writer's revisit check deterministic; without it, Go's
-// randomized map iteration would let unclustered input slip past the check
-// intermittently.
+// collectPartitions returns every partitionInfo in the tree in
+// arbitrary order. Callers that need a deterministic order (such as
+// the clustered writer, whose revisit check would otherwise depend on
+// Go's randomized map iteration) must sort the result themselves.
 func (n *partitionMapNode) collectPartitions() []*partitionInfo {
-	result := n.flatten()
-	slices.SortFunc(result, func(a, b *partitionInfo) int {
-		return cmp.Compare(a.rows[0], b.rows[0])
-	})
-
-	return result
-}
-
-func (n *partitionMapNode) flatten() []*partitionInfo {
 	result := make([]*partitionInfo, 0, n.leafCount)
 	for _, v := range n.children {
 		switch node := v.(type) {
 		case *partitionInfo:
 			result = append(result, node)
 		case *partitionMapNode:
-			result = append(result, node.flatten()...)
+			result = append(result, node.collectPartitions()...)
 		}
 	}
 

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
 	arrowdecimal "github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -42,13 +43,17 @@ import (
 type FanoutWriterTestSuite struct {
 	suite.Suite
 
-	mem memory.Allocator
+	mem *memory.CheckedAllocator
 	ctx context.Context
 }
 
 func (s *FanoutWriterTestSuite) SetupTest() {
-	s.ctx = context.Background()
 	s.mem = memory.NewCheckedAllocator(memory.NewGoAllocator())
+	s.ctx = compute.WithAllocator(context.Background(), s.mem)
+}
+
+func (s *FanoutWriterTestSuite) TearDownTest() {
+	s.mem.AssertSize(s.T(), 0)
 }
 
 func TestFanoutWriter(t *testing.T) {
@@ -114,6 +119,7 @@ func (s *FanoutWriterTestSuite) testTransformPartition(transform iceberg.Transfo
 		itr: func(yield func(arrow.RecordBatch, error) bool) {
 			testRecord.Retain()
 			yield(testRecord, nil)
+			testRecord.Release()
 		},
 		fs: iceio.LocalFS{},
 		writeUUID: func() *uuid.UUID {
@@ -377,12 +383,19 @@ func (s *FanoutWriterTestSuite) createComprehensiveTestRecord() arrow.RecordBatc
 	arrSchema := arrow.NewSchema(fields, nil)
 
 	idB := array.NewInt64Builder(pool)
+	defer idB.Release()
 	decB := array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 10, Scale: 6})
+	defer decB.Release()
 	timeB := array.NewTime64Builder(pool, &arrow.Time64Type{Unit: arrow.Microsecond})
+	defer timeB.Release()
 	tsB := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond})
+	defer tsB.Release()
 	tstzB := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
+	defer tstzB.Release()
 	uuidB := extensions.NewUUIDBuilder(pool)
+	defer uuidB.Release()
 	dateB := array.NewDate32Builder(pool)
+	defer dateB.Release()
 
 	for i := 0; i < 4; i++ {
 		if i%2 == 0 {
@@ -415,8 +428,11 @@ func (s *FanoutWriterTestSuite) createComprehensiveTestRecord() arrow.RecordBatc
 		uuidB.NewArray(),
 		dateB.NewArray(),
 	}
+	defer func() {
+		for _, c := range cols {
+			c.Release()
+		}
+	}()
 
-	record := array.NewRecordBatch(arrSchema, cols, int64(cols[0].Len()))
-
-	return record
+	return array.NewRecordBatch(arrSchema, cols, int64(cols[0].Len()))
 }

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -382,57 +382,26 @@ func (s *FanoutWriterTestSuite) createComprehensiveTestRecord() arrow.RecordBatc
 	}
 	arrSchema := arrow.NewSchema(fields, nil)
 
-	idB := array.NewInt64Builder(pool)
-	defer idB.Release()
-	decB := array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 10, Scale: 6})
-	defer decB.Release()
-	timeB := array.NewTime64Builder(pool, &arrow.Time64Type{Unit: arrow.Microsecond})
-	defer timeB.Release()
-	tsB := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond})
-	defer tsB.Release()
-	tstzB := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
-	defer tstzB.Release()
-	uuidB := extensions.NewUUIDBuilder(pool)
-	defer uuidB.Release()
-	dateB := array.NewDate32Builder(pool)
-	defer dateB.Release()
+	bldr := array.NewRecordBuilder(pool, arrSchema)
+	defer bldr.Release()
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
+		bldr.Field(0).(*array.Int64Builder).Append(int64(i))
 		if i%2 == 0 {
-			idB.Append(int64(i))
 			val := fmt.Sprintf("%d.%06d", 123, i)
 			arrowDec, _ := arrowdecimal.Decimal128FromString(val, 10, 6)
-			decB.Append(arrowDec)
-			timeB.Append(arrow.Time64(time.Duration(i * 1_000_000)))
-			tsB.Append(arrow.Timestamp(1_600_000_000_000_000 + int64(i)*1_000_000))
-			tstzB.Append(arrow.Timestamp(1_600_000_000_000_000 + int64(i)*1_000_000))
-			uuidB.Append(uuid.New())
-			dateB.Append(arrow.Date32(20000 + i))
+			bldr.Field(1).(*array.Decimal128Builder).Append(arrowDec)
+			bldr.Field(2).(*array.Time64Builder).Append(arrow.Time64(time.Duration(i * 1_000_000)))
+			bldr.Field(3).(*array.TimestampBuilder).Append(arrow.Timestamp(1_600_000_000_000_000 + int64(i)*1_000_000))
+			bldr.Field(4).(*array.TimestampBuilder).Append(arrow.Timestamp(1_600_000_000_000_000 + int64(i)*1_000_000))
+			bldr.Field(5).(*extensions.UUIDBuilder).Append(uuid.New())
+			bldr.Field(6).(*array.Date32Builder).Append(arrow.Date32(20000 + i))
 		} else {
-			idB.Append(int64(i))
-			decB.AppendNull()
-			timeB.AppendNull()
-			tsB.AppendNull()
-			tstzB.AppendNull()
-			uuidB.AppendNull()
-			dateB.AppendNull()
+			for j := 1; j <= 6; j++ {
+				bldr.Field(j).AppendNull()
+			}
 		}
 	}
 
-	cols := []arrow.Array{
-		idB.NewArray(),
-		decB.NewArray(),
-		timeB.NewArray(),
-		tsB.NewArray(),
-		tstzB.NewArray(),
-		uuidB.NewArray(),
-		dateB.NewArray(),
-	}
-	defer func() {
-		for _, c := range cols {
-			c.Release()
-		}
-	}()
-
-	return array.NewRecordBatch(arrSchema, cols, int64(cols[0].Len()))
+	return bldr.NewRecordBatch()
 }

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -111,9 +111,10 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 			return result, fmt.Errorf("read tasks for compaction group %q: %w", group.PartitionKey, err)
 		}
 
-		// Write new data files.
+		// Each compaction group is single-partition by construction, so the
+		// read stream is trivially clustered and we can use the clustered writer.
 		var newFiles []iceberg.DataFile
-		for df, err := range WriteRecords(ctx, t.tbl, arrowSchema, records) {
+		for df, err := range WriteRecords(ctx, t.tbl, arrowSchema, records, WithClusteredWrite()) {
 			if err != nil {
 				return result, fmt.Errorf("write compacted files for group %q: %w", group.PartitionKey, err)
 			}

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"strconv"
@@ -123,7 +124,7 @@ func WriteRecords(ctx context.Context, tbl *Table,
 
 	if cfg.clustered && cfg.maxWriteWorkers > 0 {
 		return internal.SingleErrorIter[iceberg.DataFile](
-			fmt.Errorf("WithClusteredWrite and WithMaxWriteWorkers are incompatible: the clustered write path is single-threaded"))
+			errors.New("WithClusteredWrite and WithMaxWriteWorkers are incompatible: the clustered write path is single-threaded"))
 	}
 
 	fs, err := tbl.fsF(ctx)

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -61,7 +61,9 @@ func WithWriteUUID(id uuid.UUID) WriteRecordOption {
 // pages simultaneously, which reduces peak memory. A value of 0
 // (the default) uses [config.EnvConfig.MaxWorkers].
 //
-// This option is ignored when [WithClusteredWrite] is set.
+// Combining this option with [WithClusteredWrite] is rejected by
+// [WriteRecords]: the clustered write path is single-threaded by
+// design, so the two options have no meaningful interaction.
 func WithMaxWriteWorkers(n int) WriteRecordOption {
 	return func(c *writeRecordConfig) {
 		c.maxWriteWorkers = n
@@ -73,12 +75,18 @@ func WithMaxWriteWorkers(n int) WriteRecordOption {
 // open at a time: when a record arrives for a new partition, the
 // current writer is flushed and closed before a new one is opened.
 //
-// The input must be strictly clustered by partition: once a
+// The input must be clustered by partition across batches: once a
 // partition's writer has been closed, encountering further records
-// for that partition returns an error. This is the natural order for
-// compaction, where each source data file typically belongs to a
-// single partition. If the input is not clustered, use the fanout
-// writer (the default) instead.
+// for that partition returns an error. Within a single batch the
+// writer reclusters rows by partition, so interleaved values like
+// [a,b,a,b] are accepted; the strict check fires only across batch
+// boundaries. This is the natural order for compaction, where each
+// source data file typically belongs to a single partition. If the
+// input is not clustered across batches, use the fanout writer (the
+// default) instead.
+//
+// Combining this option with [WithMaxWriteWorkers] is rejected by
+// [WriteRecords]: the clustered path is single-threaded by design.
 func WithClusteredWrite() WriteRecordOption {
 	return func(c *writeRecordConfig) {
 		c.clustered = true
@@ -111,6 +119,11 @@ func WriteRecords(ctx context.Context, tbl *Table,
 	cfg := writeRecordConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	if cfg.clustered && cfg.maxWriteWorkers > 0 {
+		return internal.SingleErrorIter[iceberg.DataFile](
+			fmt.Errorf("WithClusteredWrite and WithMaxWriteWorkers are incompatible: the clustered write path is single-threaded"))
 	}
 
 	fs, err := tbl.fsF(ctx)

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -34,8 +34,10 @@ import (
 type WriteRecordOption func(*writeRecordConfig)
 
 type writeRecordConfig struct {
-	targetFileSize int64
-	writeUUID      *uuid.UUID
+	targetFileSize  int64
+	writeUUID       *uuid.UUID
+	maxWriteWorkers int
+	clustered       bool
 }
 
 // WithTargetFileSize overrides the table's default target file size.
@@ -49,6 +51,37 @@ func WithTargetFileSize(size int64) WriteRecordOption {
 func WithWriteUUID(id uuid.UUID) WriteRecordOption {
 	return func(c *writeRecordConfig) {
 		c.writeUUID = &id
+	}
+}
+
+// WithMaxWriteWorkers overrides the default number of fanout workers
+// used for partitioned writes. Each worker processes record batches,
+// partitions them, and writes to the appropriate partition files.
+// Fewer workers means fewer concurrent parquet writers compressing
+// pages simultaneously, which reduces peak memory. A value of 0
+// (the default) uses [config.EnvConfig.MaxWorkers].
+//
+// This option is ignored when [WithClusteredWrite] is set.
+func WithMaxWriteWorkers(n int) WriteRecordOption {
+	return func(c *writeRecordConfig) {
+		c.maxWriteWorkers = n
+	}
+}
+
+// WithClusteredWrite enables the memory-efficient clustered write
+// path for partitioned tables. It keeps at most one partition writer
+// open at a time: when a record arrives for a new partition, the
+// current writer is flushed and closed before a new one is opened.
+//
+// The input must be strictly clustered by partition: once a
+// partition's writer has been closed, encountering further records
+// for that partition returns an error. This is the natural order for
+// compaction, where each source data file typically belongs to a
+// single partition. If the input is not clustered, use the fanout
+// writer (the default) instead.
+func WithClusteredWrite() WriteRecordOption {
+	return func(c *writeRecordConfig) {
+		c.clustered = true
 	}
 }
 
@@ -119,10 +152,12 @@ func WriteRecords(ctx context.Context, tbl *Table,
 	}
 
 	args := recordWritingArgs{
-		sc:        schema,
-		itr:       releasing,
-		fs:        writeFS,
-		writeUUID: cfg.writeUUID,
+		sc:              schema,
+		itr:             releasing,
+		fs:              writeFS,
+		writeUUID:       cfg.writeUUID,
+		maxWriteWorkers: cfg.maxWriteWorkers,
+		clustered:       cfg.clustered,
 	}
 
 	return recordsToDataFiles(ctx, tbl.Location(), meta, args)

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -157,6 +157,33 @@ func (s *WriteRecordsTestSuite) TestWithWriteUUID() {
 	}
 }
 
+func (s *WriteRecordsTestSuite) TestClusteredWithMaxWriteWorkersIsRejected() {
+	loc := filepath.ToSlash(s.T().TempDir())
+	tbl := s.newTable(loc)
+	schema := s.arrowSchema()
+
+	records := func(yield func(arrow.RecordBatch, error) bool) {}
+
+	var (
+		dataFiles []iceberg.DataFile
+		writeErr  error
+	)
+	for df, err := range table.WriteRecords(s.ctx, tbl, schema, records,
+		table.WithClusteredWrite(), table.WithMaxWriteWorkers(4)) {
+		if err != nil {
+			writeErr = err
+
+			break
+		}
+		dataFiles = append(dataFiles, df)
+	}
+
+	s.Require().Error(writeErr)
+	s.Contains(writeErr.Error(), "WithClusteredWrite")
+	s.Contains(writeErr.Error(), "WithMaxWriteWorkers")
+	s.Empty(dataFiles)
+}
+
 func (s *WriteRecordsTestSuite) TestFSNotWritable() {
 	iceSch := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},


### PR DESCRIPTION
Keeps at most one partition writer open at a time, mirroring iceberg-java's ClusteredWriter. Revisiting a closed partition returns an error.

Wired into RewriteDataFiles since each compaction group is single-partition, drops the fanout writer's per-worker in-flight batches and redundant compute.Take copies.

Also exposes WithMaxWriteWorkers to tune fanout concurrency for the unclustered path.

Sorts partitionMapNode.collectPartitions by first-row index so within-batch processing follows input row order. Required by the clustered writer; the fanout writer is unaffected.

Fixes a pre-existing leak in partitionedFanoutWriter.processRecord where compute.Take sub-records were retained by Add but never released locally.