### PR TITLE
fix(table): include expected vs found snapshot id in AssertRefSnapshotID errors (#940)

### DIFF
--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseRequirementBytes(t *testing.T) {
@@ -143,5 +144,50 @@ func TestParseRequirementList(t *testing.T) {
 		var actual table.Requirements
 		err := json.Unmarshal(jsonData, &actual)
 		assert.Error(t, err)
+	})
+}
+
+func TestAssertRefSnapshotIDValidate(t *testing.T) {
+	meta, err := table.ParseMetadataBytes([]byte(table.ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	t.Run("matching ref passes", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("test", ptr(int64(3051729675574597004)))
+		assert.NoError(t, req.Validate(meta))
+	})
+
+	t.Run("mismatched snapshot id includes expected and found", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("test", ptr(int64(1)))
+		err := req.Validate(meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `ref "test"`)
+		assert.Contains(t, err.Error(), "expected snapshot 1")
+		assert.Contains(t, err.Error(), "found 3051729675574597004")
+	})
+
+	t.Run("nil expected but ref exists includes found snapshot", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("test", nil)
+		err := req.Validate(meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `ref "test"`)
+		assert.Contains(t, err.Error(), "found 3051729675574597004")
+	})
+
+	t.Run("ref missing but expected includes expected snapshot", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("nonexistent", ptr(int64(42)))
+		err := req.Validate(meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `ref "nonexistent"`)
+		assert.Contains(t, err.Error(), "expected snapshot 42")
+	})
+
+	t.Run("nil metadata returns error", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("main", ptr(int64(1)))
+		assert.Error(t, req.Validate(nil))
+	})
+
+	t.Run("nil expected and ref missing passes", func(t *testing.T) {
+		req := table.AssertRefSnapshotID("nonexistent", nil)
+		assert.NoError(t, req.Validate(meta))
 	})
 }

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -160,25 +160,27 @@ func TestAssertRefSnapshotIDValidate(t *testing.T) {
 		req := table.AssertRefSnapshotID("test", ptr(int64(1)))
 		err := req.Validate(meta)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `ref "test"`)
-		assert.Contains(t, err.Error(), "expected snapshot 1")
+		assert.Contains(t, err.Error(), `"test"`)
+		assert.Contains(t, err.Error(), "expected id 1")
 		assert.Contains(t, err.Error(), "found 3051729675574597004")
+		assert.Contains(t, err.Error(), "has changed")
 	})
 
 	t.Run("nil expected but ref exists includes found snapshot", func(t *testing.T) {
 		req := table.AssertRefSnapshotID("test", nil)
 		err := req.Validate(meta)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `ref "test"`)
-		assert.Contains(t, err.Error(), "found 3051729675574597004")
+		assert.Contains(t, err.Error(), `"test"`)
+		assert.Contains(t, err.Error(), "was created concurrently")
 	})
 
 	t.Run("ref missing but expected includes expected snapshot", func(t *testing.T) {
 		req := table.AssertRefSnapshotID("nonexistent", ptr(int64(42)))
 		err := req.Validate(meta)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `ref "nonexistent"`)
-		assert.Contains(t, err.Error(), "expected snapshot 42")
+		assert.Contains(t, err.Error(), `"nonexistent"`)
+		assert.Contains(t, err.Error(), "is missing")
+		assert.Contains(t, err.Error(), "expected 42")
 	})
 
 	t.Run("nil metadata returns error", func(t *testing.T) {

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -180,14 +180,14 @@ func (a *assertRefSnapshotID) Validate(meta Metadata) error {
 
 	if r != nil {
 		if a.SnapshotID == nil {
-			return fmt.Errorf("requirement failed: %s %s was created concurrently", r.SnapshotRefType, a.Ref)
+			return fmt.Errorf("requirement failed: ref %q was created concurrently, found %d", a.Ref, r.SnapshotID)
 		}
 
 		if r.SnapshotID != *a.SnapshotID {
-			return fmt.Errorf("requirement failed: %s %s has changed: expected id %d, found %d", r.SnapshotRefType, a.Ref, a.SnapshotID, r.SnapshotID)
+			return fmt.Errorf("requirement failed: ref %q expected snapshot %d, found %d", a.Ref, *a.SnapshotID, r.SnapshotID)
 		}
 	} else if a.SnapshotID != nil {
-		return fmt.Errorf("requirement failed: branch or tag %s is missing, expected %d", a.Ref, a.SnapshotID)
+		return fmt.Errorf("requirement failed: ref %q expected snapshot %d, ref is missing", a.Ref, *a.SnapshotID)
 	}
 
 	return nil

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -180,14 +180,14 @@ func (a *assertRefSnapshotID) Validate(meta Metadata) error {
 
 	if r != nil {
 		if a.SnapshotID == nil {
-			return fmt.Errorf("requirement failed: ref %q was created concurrently, found %d", a.Ref, r.SnapshotID)
+			return fmt.Errorf("requirement failed: ref \"%s\" was created concurrently, found %d", a.Ref, r.SnapshotID)
 		}
 
 		if r.SnapshotID != *a.SnapshotID {
-			return fmt.Errorf("requirement failed: ref %q expected snapshot %d, found %d", a.Ref, *a.SnapshotID, r.SnapshotID)
+			return fmt.Errorf("requirement failed: ref \"%s\" expected snapshot %d, found %d", a.Ref, *a.SnapshotID, r.SnapshotID)
 		}
 	} else if a.SnapshotID != nil {
-		return fmt.Errorf("requirement failed: ref %q expected snapshot %d, ref is missing", a.Ref, *a.SnapshotID)
+		return fmt.Errorf("requirement failed: ref \"%s\" expected snapshot %d, ref is missing", a.Ref, *a.SnapshotID)
 	}
 
 	return nil

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -180,14 +180,14 @@ func (a *assertRefSnapshotID) Validate(meta Metadata) error {
 
 	if r != nil {
 		if a.SnapshotID == nil {
-			return fmt.Errorf("requirement failed: ref \"%s\" was created concurrently, found %d", a.Ref, r.SnapshotID)
+			return fmt.Errorf("requirement failed: %s %q was created concurrently", r.SnapshotRefType, a.Ref)
 		}
 
 		if r.SnapshotID != *a.SnapshotID {
-			return fmt.Errorf("requirement failed: ref \"%s\" expected snapshot %d, found %d", a.Ref, *a.SnapshotID, r.SnapshotID)
+			return fmt.Errorf("requirement failed: %s %q has changed: expected id %d, found %d", r.SnapshotRefType, a.Ref, *a.SnapshotID, r.SnapshotID)
 		}
 	} else if a.SnapshotID != nil {
-		return fmt.Errorf("requirement failed: ref \"%s\" expected snapshot %d, ref is missing", a.Ref, *a.SnapshotID)
+		return fmt.Errorf("requirement failed: branch or tag %q is missing, expected %d", a.Ref, *a.SnapshotID)
 	}
 
 	return nil


### PR DESCRIPTION
Format ref name, expected snapshot id, and found snapshot id into all three error paths so operators can see what changed during commit conflicts. Also fixes incorrect pointer formatting with %d.

Fixes #940 