### PR TITLE
feat(catalog): add Hadoop catalog scaffold with path helpers

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -48,6 +48,7 @@ const (
 	Glue     Type = "glue"
 	DynamoDB Type = "dynamodb"
 	SQL      Type = "sql"
+	Hadoop   Type = "hadoop"
 )
 
 var (

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hadoop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+)
+
+func init() {
+	catalog.Register(string(catalog.Hadoop), catalog.RegistrarFunc(
+		func(_ context.Context, name string, props iceberg.Properties) (catalog.Catalog, error) {
+			warehouse := props.Get("warehouse", "")
+
+			return NewCatalog(name, warehouse, props)
+		},
+	))
+}
+
+var _ catalog.Catalog = (*Catalog)(nil)
+
+// versionPattern matches Hadoop catalog metadata filenames:
+// v1.metadata.json, v42.metadata.json, v1.gz.metadata.json, etc.
+var versionPattern = regexp.MustCompile(`^v([0-9]+)(?:\.gz)?\.metadata\.json$`)
+
+// Catalog is a filesystem-based Iceberg catalog that requires no external
+// metastore. All state lives on disk as directories and versioned JSON
+// metadata files.
+type Catalog struct {
+	name      string
+	warehouse string
+	props     iceberg.Properties
+}
+
+// NewCatalog creates a new Hadoop catalog rooted at the given warehouse path.
+// The warehouse directory is not created on construction; it is created
+// implicitly by the first CreateNamespace call.
+func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, error) {
+	if warehouse == "" {
+		return nil, errors.New("hadoop catalog requires a warehouse path")
+	}
+
+	warehouse = strings.TrimPrefix(warehouse, "file://")
+	warehouse = strings.TrimPrefix(warehouse, "file:")
+	warehouse = strings.TrimRight(warehouse, "/")
+
+	return &Catalog{
+		name:      name,
+		warehouse: warehouse,
+		props:     props,
+	}, nil
+}
+
+func (c *Catalog) CatalogType() catalog.Type {
+	return catalog.Hadoop
+}
+
+func (c *Catalog) namespaceToPath(ns table.Identifier) string {
+	return filepath.Join(append([]string{c.warehouse}, ns...)...)
+}
+
+func (c *Catalog) tableToPath(ident table.Identifier) string {
+	return filepath.Join(append([]string{c.warehouse}, ident...)...)
+}
+
+func (c *Catalog) metadataDir(ident table.Identifier) string {
+	return filepath.Join(c.tableToPath(ident), "metadata")
+}
+
+func (c *Catalog) metadataFilePath(ident table.Identifier, version int) string {
+	return filepath.Join(c.metadataDir(ident), fmt.Sprintf("v%d.metadata.json", version))
+}
+
+func (c *Catalog) versionHintPath(ident table.Identifier) string {
+	return filepath.Join(c.metadataDir(ident), "version-hint.text")
+}
+
+func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
+	return c.tableToPath(ident)
+}
+
+// isTableDir reports whether path is a table directory by checking for
+// v*.metadata.json files in its metadata/ subdirectory.
+func isTableDir(path string) bool {
+	metaDir := filepath.Join(path, "metadata")
+
+	entries, err := os.ReadDir(metaDir)
+	if err != nil {
+		return false
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() && versionPattern.MatchString(e.Name()) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *Catalog) CreateTable(_ context.Context, _ table.Identifier, _ *iceberg.Schema, _ ...catalog.CreateTableOpt) (*table.Table, error) {
+	return nil, errors.New("hadoop catalog: CreateTable not yet implemented")
+}
+
+func (c *Catalog) CommitTable(_ context.Context, _ table.Identifier, _ []table.Requirement, _ []table.Update) (table.Metadata, string, error) {
+	return nil, "", errors.New("hadoop catalog: CommitTable not yet implemented")
+}
+
+func (c *Catalog) ListTables(_ context.Context, _ table.Identifier) iter.Seq2[table.Identifier, error] {
+	return func(yield func(table.Identifier, error) bool) {
+		yield(nil, errors.New("hadoop catalog: ListTables not yet implemented"))
+	}
+}
+
+func (c *Catalog) LoadTable(_ context.Context, _ table.Identifier) (*table.Table, error) {
+	return nil, errors.New("hadoop catalog: LoadTable not yet implemented")
+}
+
+func (c *Catalog) DropTable(_ context.Context, _ table.Identifier) error {
+	return errors.New("hadoop catalog: DropTable not yet implemented")
+}
+
+func (c *Catalog) RenameTable(_ context.Context, _, _ table.Identifier) (*table.Table, error) {
+	return nil, errors.New("hadoop catalog: RenameTable not yet implemented")
+}
+
+func (c *Catalog) CheckTableExists(_ context.Context, _ table.Identifier) (bool, error) {
+	return false, errors.New("hadoop catalog: CheckTableExists not yet implemented")
+}
+
+func (c *Catalog) ListNamespaces(_ context.Context, _ table.Identifier) ([]table.Identifier, error) {
+	return nil, errors.New("hadoop catalog: ListNamespaces not yet implemented")
+}
+
+func (c *Catalog) CreateNamespace(_ context.Context, _ table.Identifier, _ iceberg.Properties) error {
+	return errors.New("hadoop catalog: CreateNamespace not yet implemented")
+}
+
+func (c *Catalog) DropNamespace(_ context.Context, _ table.Identifier) error {
+	return errors.New("hadoop catalog: DropNamespace not yet implemented")
+}
+
+func (c *Catalog) CheckNamespaceExists(_ context.Context, _ table.Identifier) (bool, error) {
+	return false, errors.New("hadoop catalog: CheckNamespaceExists not yet implemented")
+}
+
+func (c *Catalog) LoadNamespaceProperties(_ context.Context, _ table.Identifier) (iceberg.Properties, error) {
+	return nil, errors.New("hadoop catalog: LoadNamespaceProperties not yet implemented")
+}
+
+func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
+	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
+}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -65,8 +66,21 @@ func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, err
 		return nil, errors.New("hadoop catalog requires a warehouse path")
 	}
 
-	warehouse = strings.TrimPrefix(warehouse, "file://")
-	warehouse = strings.TrimPrefix(warehouse, "file:")
+	u, err := url.Parse(warehouse)
+	if err != nil {
+		return nil, fmt.Errorf("hadoop catalog: invalid warehouse path: %w", err)
+	}
+
+	if u.Scheme != "" && u.Scheme != "file" {
+		return nil, fmt.Errorf("hadoop catalog: unsupported warehouse scheme %q, must be file:// or a local path", u.Scheme)
+	}
+
+	if u.Opaque != "" {
+		warehouse = u.Opaque
+	} else {
+		warehouse = u.Path
+	}
+
 	warehouse = strings.TrimRight(warehouse, "/")
 
 	return &Catalog{

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hadoop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/stretchr/testify/suite"
+)
+
+type HadoopCatalogTestSuite struct {
+	suite.Suite
+	warehouse string
+	cat       *Catalog
+}
+
+func (s *HadoopCatalogTestSuite) SetupTest() {
+	var err error
+	s.warehouse, err = os.MkdirTemp("", "test_hadoop_*")
+	s.Require().NoError(err)
+
+	s.cat, err = NewCatalog("test", s.warehouse, nil)
+	s.Require().NoError(err)
+}
+
+func (s *HadoopCatalogTestSuite) TearDownTest() {
+	s.Require().NoError(os.RemoveAll(s.warehouse))
+}
+
+func TestHadoopCatalogTestSuite(t *testing.T) {
+	suite.Run(t, new(HadoopCatalogTestSuite))
+}
+
+func (s *HadoopCatalogTestSuite) TestCatalogType() {
+	s.Equal(catalog.Hadoop, s.cat.CatalogType())
+}
+
+func (s *HadoopCatalogTestSuite) TestRegistration() {
+	cat, err := catalog.Load(context.Background(), "test", iceberg.Properties{
+		"type":      "hadoop",
+		"warehouse": s.warehouse,
+	})
+	s.Require().NoError(err)
+	s.Equal(catalog.Hadoop, cat.CatalogType())
+}
+
+func (s *HadoopCatalogTestSuite) TestRegistrationMissingWarehouse() {
+	_, err := catalog.Load(context.Background(), "test", iceberg.Properties{
+		"type": "hadoop",
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "warehouse")
+}
+
+func (s *HadoopCatalogTestSuite) TestNewCatalogTrimsTrailingSlash() {
+	cat, err := NewCatalog("test", "/tmp/wh/", nil)
+	s.Require().NoError(err)
+	s.Equal("/tmp/wh", cat.warehouse)
+}
+
+func (s *HadoopCatalogTestSuite) TestNewCatalogStripsFilePrefix() {
+	cat, err := NewCatalog("test", "file:///tmp/wh", nil)
+	s.Require().NoError(err)
+	s.Equal("/tmp/wh", cat.warehouse)
+
+	cat, err = NewCatalog("test", "file:/tmp/wh", nil)
+	s.Require().NoError(err)
+	s.Equal("/tmp/wh", cat.warehouse)
+}
+
+func (s *HadoopCatalogTestSuite) TestNamespaceToPathSingleLevel() {
+	path := s.cat.namespaceToPath([]string{"db"})
+	s.Equal(filepath.Join(s.warehouse, "db"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestNamespaceToPathNested() {
+	path := s.cat.namespaceToPath([]string{"a", "b", "c"})
+	s.Equal(filepath.Join(s.warehouse, "a", "b", "c"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestTableToPathSingleNamespace() {
+	path := s.cat.tableToPath([]string{"ns", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestTableToPathNestedNamespace() {
+	path := s.cat.tableToPath([]string{"a", "b", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "a", "b", "tbl"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestMetadataDir() {
+	path := s.cat.metadataDir([]string{"ns", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl", "metadata"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestMetadataFilePath() {
+	path := s.cat.metadataFilePath([]string{"ns", "tbl"}, 1)
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl", "metadata", "v1.metadata.json"), path)
+
+	path = s.cat.metadataFilePath([]string{"ns", "tbl"}, 42)
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl", "metadata", "v42.metadata.json"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestVersionHintPath() {
+	path := s.cat.versionHintPath([]string{"ns", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl", "metadata", "version-hint.text"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestDefaultTableLocation() {
+	path := s.cat.defaultTableLocation([]string{"ns", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "ns", "tbl"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestDefaultTableLocationNested() {
+	path := s.cat.defaultTableLocation([]string{"a", "b", "tbl"})
+	s.Equal(filepath.Join(s.warehouse, "a", "b", "tbl"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestVersionPatternMatches() {
+	names := []string{
+		"v1.metadata.json",
+		"v42.metadata.json",
+		"v100.metadata.json",
+		"v1.gz.metadata.json",
+		"v42.gz.metadata.json",
+	}
+
+	for _, name := range names {
+		s.True(versionPattern.MatchString(name), "expected %s to match", name)
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestVersionPatternRejects() {
+	tests := []string{
+		"00001-a1b2c3d4.metadata.json",
+		"random.json",
+		"v.metadata.json",
+		"metadata.json",
+		"v1.metadata.json.bak",
+		"v-1.metadata.json",
+	}
+
+	for _, name := range tests {
+		s.False(versionPattern.MatchString(name), "expected %s to not match", name)
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirTrue() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), nil, 0o644))
+
+	s.True(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNoMetadataDir() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.MkdirAll(nsDir, 0o755))
+
+	s.False(isTableDir(nsDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+
+	s.False(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-uuid.metadata.json"), nil, 0o644))
+
+	s.False(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.gz.metadata.json"), nil, 0o644))
+
+	s.True(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirNonExistentPath() {
+	s.False(isTableDir(filepath.Join(s.warehouse, "does", "not", "exist")))
+}

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -88,6 +88,16 @@ func (s *HadoopCatalogTestSuite) TestNewCatalogStripsFilePrefix() {
 	s.Equal("/tmp/wh", cat.warehouse)
 }
 
+func (s *HadoopCatalogTestSuite) TestNewCatalogRejectsNonFileScheme() {
+	_, err := NewCatalog("test", "s3://bucket/path", nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "unsupported warehouse scheme")
+
+	_, err = NewCatalog("test", "hdfs://namenode/warehouse", nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "unsupported warehouse scheme")
+}
+
 func (s *HadoopCatalogTestSuite) TestNamespaceToPathSingleLevel() {
 	path := s.cat.namespaceToPath([]string{"db"})
 	s.Equal(filepath.Join(s.warehouse, "db"), path)


### PR DESCRIPTION
[1: Scaffold + path helpers
](https://github.com/apache/iceberg-go/issues/798#issuecomment-4320784323)
Add the Hadoop type constant and create the catalog/hadoop package with struct, constructor, init() registration, path helpers, version regex, isTableDir, and stubbed interface methods.

Relates to #798
 