### PR TITLE
fix(table): remove double Release() on struct array in ToRequestedSchema

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1096,7 +1096,6 @@ func ToRequestedSchema(ctx context.Context, requested, fileSchema *iceberg.Schem
 	if err != nil {
 		return nil, err
 	}
-	st.Release()
 	out := array.RecordFromStructArray(result.(*array.Struct), nil)
 	result.Release()
 


### PR DESCRIPTION
The defer on line 1085 already handles releasing st. The explicit st.Release() before building the output record caused a double-free on the Struct wrapper.

Fixes #955