### PR TITLE
feat(catalog): add hadoop namespace operations

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"iter"
 	"log"
 	"net/url"
@@ -53,24 +54,36 @@ var _ catalog.Catalog = (*Catalog)(nil)
 var versionPattern = regexp.MustCompile(`^v([0-9]+)(?:\.gz)?\.metadata\.json$`)
 
 // uuidMetadataPattern matches UUID-style metadata filenames produced by
-// Java/PyIceberg catalogs: 00000-<uuid>.metadata.json, etc.
-var uuidMetadataPattern = regexp.MustCompile(`^[0-9]+-[0-9a-fA-F-]+\.metadata\.json$`)
+// Java/PyIceberg catalogs: 00000-<uuid>.metadata.json or
+// 00000-<uuid>.gz.metadata.json. The sequence is a 5-digit zero-padded
+// number and the UUID is in canonical 8-4-4-4-12 hex format.
+var uuidMetadataPattern = regexp.MustCompile(
+	`^[0-9]{5}-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:\.gz)?\.metadata\.json$`,
+)
 
-// validateIdentifier checks that each component of an identifier is safe for
-// use as a path segment. It rejects empty parts, path traversal sequences,
-// and components containing path separators.
+// validateIdentifier checks that an identifier is non-empty and that each
+// component is safe for use as a path segment. It rejects nil/empty
+// identifiers, empty parts, path traversal sequences, and components
+// containing path separators.
+//
+// Note: this is POSIX-best-effort validation — it does not catch NUL bytes
+// or Windows reserved names (NUL, CON, COM1, etc.).
 func validateIdentifier(ident table.Identifier) error {
+	if len(ident) == 0 {
+		return fmt.Errorf("%w: namespace identifier must not be empty", catalog.ErrNoSuchNamespace)
+	}
+
 	for _, part := range ident {
 		if part == "" {
-			return errors.New("hadoop catalog: identifier component must not be empty")
+			return fmt.Errorf("%w: identifier component must not be empty", catalog.ErrNoSuchNamespace)
 		}
 
 		if part == "." || part == ".." {
-			return fmt.Errorf("hadoop catalog: invalid identifier component %q", part)
+			return fmt.Errorf("%w: invalid identifier component %q", catalog.ErrNoSuchNamespace, part)
 		}
 
 		if strings.ContainsAny(part, "/\\") {
-			return fmt.Errorf("hadoop catalog: identifier component must not contain path separators: %q", part)
+			return fmt.Errorf("%w: identifier component must not contain path separators: %q", catalog.ErrNoSuchNamespace, part)
 		}
 	}
 
@@ -109,7 +122,20 @@ func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, err
 		warehouse = u.Path
 	}
 
+	if warehouse == "" || warehouse == "/" {
+		return nil, errors.New("hadoop catalog requires a non-root warehouse path")
+	}
+
 	warehouse = strings.TrimRight(warehouse, "/")
+
+	// Normalize to absolute path so the synthetic "location" property
+	// always produces a valid file:// URI.
+	absWarehouse, err := filepath.Abs(warehouse)
+	if err != nil {
+		return nil, fmt.Errorf("hadoop catalog: failed to resolve absolute warehouse path: %w", err)
+	}
+
+	warehouse = absWarehouse
 
 	return &Catalog{
 		name:      name,
@@ -301,10 +327,6 @@ func (c *Catalog) CheckTableExists(_ context.Context, _ table.Identifier) (bool,
 }
 
 func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props iceberg.Properties) error {
-	if len(ns) == 0 {
-		return errors.New("hadoop catalog: namespace identifier must not be empty")
-	}
-
 	if err := validateIdentifier(ns); err != nil {
 		return err
 	}
@@ -316,8 +338,13 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 	path := c.namespaceToPath(ns)
 
 	if err := os.Mkdir(path, 0o755); err != nil {
-		if os.IsExist(err) {
+		if errors.Is(err, fs.ErrExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+		}
+
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: parent namespace does not exist for %s",
+				catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
 		}
 
 		return fmt.Errorf("hadoop catalog: failed to create namespace: %w", err)
@@ -327,22 +354,18 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 }
 
 func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
-	if len(ns) == 0 {
-		return errors.New("hadoop catalog: namespace identifier must not be empty")
-	}
-
 	if err := validateIdentifier(ns); err != nil {
 		return err
 	}
 
 	path := c.namespaceToPath(ns)
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
-	}
-
 	entries, err := os.ReadDir(path)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
+		}
+
 		return fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err)
 	}
 
@@ -361,7 +384,7 @@ func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (
 	path := c.namespaceToPath(ns)
 
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
 
@@ -387,7 +410,7 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 		path = c.namespaceToPath(parent)
 
 		info, err := os.Stat(path)
-		if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+		if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 			return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(parent, "."))
 		}
 	}
@@ -414,6 +437,9 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 	return result, nil
 }
 
+// LoadNamespaceProperties returns a synthetic "location" property for the
+// namespace. This is a Go-only convenience — the Hadoop catalog does not
+// persist user-defined namespace properties.
 func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier) (iceberg.Properties, error) {
 	if err := validateIdentifier(ns); err != nil {
 		return nil, err
@@ -422,7 +448,7 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 	path := c.namespaceToPath(ns)
 
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
 	}
 
@@ -430,7 +456,9 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 		return nil, fmt.Errorf("hadoop catalog: failed to stat namespace: %w", err)
 	}
 
-	return iceberg.Properties{"location": "file://" + path}, nil
+	loc := (&url.URL{Scheme: "file", Path: path}).String()
+
+	return iceberg.Properties{"location": loc}, nil
 }
 
 func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -52,6 +52,31 @@ var _ catalog.Catalog = (*Catalog)(nil)
 // v1.metadata.json, v42.metadata.json, v1.gz.metadata.json, etc.
 var versionPattern = regexp.MustCompile(`^v([0-9]+)(?:\.gz)?\.metadata\.json$`)
 
+// uuidMetadataPattern matches UUID-style metadata filenames produced by
+// Java/PyIceberg catalogs: 00000-<uuid>.metadata.json, etc.
+var uuidMetadataPattern = regexp.MustCompile(`^[0-9]+-[0-9a-fA-F-]+\.metadata\.json$`)
+
+// validateIdentifier checks that each component of an identifier is safe for
+// use as a path segment. It rejects empty parts, path traversal sequences,
+// and components containing path separators.
+func validateIdentifier(ident table.Identifier) error {
+	for _, part := range ident {
+		if part == "" {
+			return errors.New("hadoop catalog: identifier component must not be empty")
+		}
+
+		if part == "." || part == ".." {
+			return fmt.Errorf("hadoop catalog: invalid identifier component %q", part)
+		}
+
+		if strings.ContainsAny(part, "/\\") {
+			return fmt.Errorf("hadoop catalog: identifier component must not contain path separators: %q", part)
+		}
+	}
+
+	return nil
+}
+
 // Catalog is a filesystem-based Iceberg catalog that requires no external
 // metastore. All state lives on disk as directories and versioned JSON
 // metadata files.
@@ -122,7 +147,10 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 }
 
 // isTableDir reports whether path is a table directory by checking for
-// v*.metadata.json files in its metadata/ subdirectory.
+// metadata files in its metadata/ subdirectory. It recognizes:
+//   - v*.metadata.json (Hadoop catalog format)
+//   - <seq>-<uuid>.metadata.json (Java/PyIceberg format)
+//   - version-hint.text
 func isTableDir(path string) bool {
 	metaDir := filepath.Join(path, "metadata")
 
@@ -132,7 +160,14 @@ func isTableDir(path string) bool {
 	}
 
 	for _, e := range entries {
-		if !e.IsDir() && versionPattern.MatchString(e.Name()) {
+		if e.IsDir() {
+			continue
+		}
+
+		name := e.Name()
+		if versionPattern.MatchString(name) ||
+			uuidMetadataPattern.MatchString(name) ||
+			name == "version-hint.text" {
 			return true
 		}
 	}
@@ -270,22 +305,34 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 		return errors.New("hadoop catalog: namespace identifier must not be empty")
 	}
 
+	if err := validateIdentifier(ns); err != nil {
+		return err
+	}
+
 	if len(props) > 0 {
 		return errors.New("hadoop catalog: namespace properties are not supported")
 	}
 
 	path := c.namespaceToPath(ns)
 
-	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+	if err := os.Mkdir(path, 0o755); err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+		}
+
+		return fmt.Errorf("hadoop catalog: failed to create namespace: %w", err)
 	}
 
-	return os.MkdirAll(path, 0o755)
+	return nil
 }
 
 func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 	if len(ns) == 0 {
 		return errors.New("hadoop catalog: namespace identifier must not be empty")
+	}
+
+	if err := validateIdentifier(ns); err != nil {
+		return err
 	}
 
 	path := c.namespaceToPath(ns)
@@ -307,6 +354,10 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 }
 
 func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (bool, error) {
+	if err := validateIdentifier(ns); err != nil {
+		return false, err
+	}
+
 	path := c.namespaceToPath(ns)
 
 	info, err := os.Stat(path)
@@ -322,6 +373,12 @@ func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (
 }
 
 func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]table.Identifier, error) {
+	if len(parent) > 0 {
+		if err := validateIdentifier(parent); err != nil {
+			return nil, err
+		}
+	}
+
 	var path string
 
 	if len(parent) == 0 {
@@ -358,6 +415,10 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 }
 
 func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier) (iceberg.Properties, error) {
+	if err := validateIdentifier(ns); err != nil {
+		return nil, err
+	}
+
 	path := c.namespaceToPath(ns)
 
 	info, err := os.Stat(path)
@@ -369,9 +430,9 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 		return nil, fmt.Errorf("hadoop catalog: failed to stat namespace: %w", err)
 	}
 
-	return iceberg.Properties{"location": path}, nil
+	return iceberg.Properties{"location": "file://" + path}, nil
 }
 
 func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
-	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
+	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: namespace properties are not supported")
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -265,26 +265,113 @@ func (c *Catalog) CheckTableExists(_ context.Context, _ table.Identifier) (bool,
 	return false, errors.New("hadoop catalog: CheckTableExists not yet implemented")
 }
 
-func (c *Catalog) ListNamespaces(_ context.Context, _ table.Identifier) ([]table.Identifier, error) {
-	return nil, errors.New("hadoop catalog: ListNamespaces not yet implemented")
+func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props iceberg.Properties) error {
+	if len(ns) == 0 {
+		return errors.New("hadoop catalog: namespace identifier must not be empty")
+	}
+
+	if len(props) > 0 {
+		return errors.New("hadoop catalog: namespace properties are not supported")
+	}
+
+	path := c.namespaceToPath(ns)
+
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+	}
+
+	return os.MkdirAll(path, 0o755)
 }
 
-func (c *Catalog) CreateNamespace(_ context.Context, _ table.Identifier, _ iceberg.Properties) error {
-	return errors.New("hadoop catalog: CreateNamespace not yet implemented")
+func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
+	if len(ns) == 0 {
+		return errors.New("hadoop catalog: namespace identifier must not be empty")
+	}
+
+	path := c.namespaceToPath(ns)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err)
+	}
+
+	if len(entries) > 0 {
+		return fmt.Errorf("%w: %s", catalog.ErrNamespaceNotEmpty, strings.Join(ns, "."))
+	}
+
+	return os.Remove(path)
 }
 
-func (c *Catalog) DropNamespace(_ context.Context, _ table.Identifier) error {
-	return errors.New("hadoop catalog: DropNamespace not yet implemented")
+func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (bool, error) {
+	path := c.namespaceToPath(ns)
+
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return info.IsDir(), nil
 }
 
-func (c *Catalog) CheckNamespaceExists(_ context.Context, _ table.Identifier) (bool, error) {
-	return false, errors.New("hadoop catalog: CheckNamespaceExists not yet implemented")
+func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]table.Identifier, error) {
+	var path string
+
+	if len(parent) == 0 {
+		path = c.warehouse
+	} else {
+		path = c.namespaceToPath(parent)
+
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+			return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(parent, "."))
+		}
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("hadoop catalog: failed to read directory: %w", err)
+	}
+
+	result := []table.Identifier{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		child := filepath.Join(path, e.Name())
+		if isTableDir(child) {
+			continue
+		}
+
+		result = append(result, table.Identifier{e.Name()})
+	}
+
+	return result, nil
 }
 
-func (c *Catalog) LoadNamespaceProperties(_ context.Context, _ table.Identifier) (iceberg.Properties, error) {
-	return nil, errors.New("hadoop catalog: LoadNamespaceProperties not yet implemented")
+func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier) (iceberg.Properties, error) {
+	path := c.namespaceToPath(ns)
+
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("hadoop catalog: failed to stat namespace: %w", err)
+	}
+
+	return iceberg.Properties{"location": path}, nil
 }
 
 func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
-	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
+	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: namespace properties are not supported")
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -373,5 +373,5 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 }
 
 func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
-	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: namespace properties are not supported")
+	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
 }

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -386,3 +386,244 @@ func (s *HadoopCatalogTestSuite) TestFindVersionMixedGzipAndPlain() {
 	s.Require().NoError(err)
 	s.Equal(3, ver)
 }
+
+// CreateNamespace tests
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespace() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"ns"}, nil)
+	s.Require().NoError(err)
+
+	info, err := os.Stat(filepath.Join(s.warehouse, "ns"))
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceAlreadyExists() {
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	err := s.cat.CreateNamespace(context.Background(), []string{"ns"}, nil)
+	s.ErrorIs(err, catalog.ErrNamespaceAlreadyExists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceNested() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"a", "b", "c"}, nil)
+	s.Require().NoError(err)
+
+	// Verify leaf and intermediate directories exist
+	for _, p := range []string{
+		filepath.Join(s.warehouse, "a"),
+		filepath.Join(s.warehouse, "a", "b"),
+		filepath.Join(s.warehouse, "a", "b", "c"),
+	} {
+		info, err := os.Stat(p)
+		s.Require().NoError(err)
+		s.True(info.IsDir())
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceWithProperties() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"ns"}, iceberg.Properties{"key": "val"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "properties are not supported")
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceNilProperties() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"ns"}, nil)
+	s.Require().NoError(err)
+
+	info, err := os.Stat(filepath.Join(s.warehouse, "ns"))
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+// DropNamespace tests
+
+func (s *HadoopCatalogTestSuite) TestDropNamespace() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.Mkdir(nsDir, 0o755))
+
+	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
+	s.Require().NoError(err)
+
+	_, err = os.Stat(nsDir)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceNotExists() {
+	err := s.cat.DropNamespace(context.Background(), []string{"nope"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceNotEmptyWithTable() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	metaDir := filepath.Join(nsDir, "tbl", "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), nil, 0o644))
+
+	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
+	s.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceNotEmptyWithChildNamespace() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.MkdirAll(filepath.Join(nsDir, "child_ns"), 0o755))
+
+	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
+	s.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
+}
+
+// CheckNamespaceExists tests
+
+func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsTrue() {
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	exists, err := s.cat.CheckNamespaceExists(context.Background(), []string{"ns"})
+	s.Require().NoError(err)
+	s.True(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsFalse() {
+	exists, err := s.cat.CheckNamespaceExists(context.Background(), []string{"nope"})
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+// ListNamespaces tests
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesRoot() {
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns1"), 0o755))
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns2"), 0o755))
+
+	namespaces, err := s.cat.ListNamespaces(context.Background(), nil)
+	s.Require().NoError(err)
+	s.Len(namespaces, 2)
+	s.Contains(namespaces, table.Identifier{"ns1"})
+	s.Contains(namespaces, table.Identifier{"ns2"})
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesEmpty() {
+	namespaces, err := s.cat.ListNamespaces(context.Background(), nil)
+	s.Require().NoError(err)
+	s.Empty(namespaces)
+	s.NotNil(namespaces)
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesNested() {
+	parentDir := filepath.Join(s.warehouse, "a")
+	s.Require().NoError(os.MkdirAll(filepath.Join(parentDir, "child1"), 0o755))
+	s.Require().NoError(os.MkdirAll(filepath.Join(parentDir, "child2"), 0o755))
+
+	namespaces, err := s.cat.ListNamespaces(context.Background(), []string{"a"})
+	s.Require().NoError(err)
+	s.Len(namespaces, 2)
+	s.Contains(namespaces, table.Identifier{"child1"})
+	s.Contains(namespaces, table.Identifier{"child2"})
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesParentNotExists() {
+	_, err := s.cat.ListNamespaces(context.Background(), []string{"nope"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesParentIsFile() {
+	filePath := filepath.Join(s.warehouse, "a_file")
+	s.Require().NoError(os.WriteFile(filePath, nil, 0o644))
+
+	_, err := s.cat.ListNamespaces(context.Background(), []string{"a_file"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+// LoadNamespaceProperties tests
+
+func (s *HadoopCatalogTestSuite) TestLoadNamespaceProperties() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.Mkdir(nsDir, 0o755))
+
+	props, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"ns"})
+	s.Require().NoError(err)
+	s.Equal(iceberg.Properties{"location": nsDir}, props)
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNotExists() {
+	_, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"nope"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesFileNotDir() {
+	filePath := filepath.Join(s.warehouse, "not_a_ns")
+	s.Require().NoError(os.WriteFile(filePath, nil, 0o644))
+
+	_, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"not_a_ns"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+// UpdateNamespaceProperties test
+
+func (s *HadoopCatalogTestSuite) TestUpdateNamespacePropertiesUnsupported() {
+	_, err := s.cat.UpdateNamespaceProperties(context.Background(), []string{"ns"}, nil, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "properties are not supported")
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceWithRegularFilesOnly() {
+	// A namespace dir containing only regular files (no subdirectories)
+	// should still return ErrNamespaceNotEmpty.
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.Mkdir(nsDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(nsDir, "stray_file.txt"), nil, 0o644))
+
+	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
+	s.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsFileNotDir() {
+	// A file at the namespace path should return false (not a directory).
+	filePath := filepath.Join(s.warehouse, "not_a_dir")
+	s.Require().NoError(os.WriteFile(filePath, nil, 0o644))
+
+	exists, err := s.cat.CheckNamespaceExists(context.Background(), []string{"not_a_dir"})
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceEmptyIdentifier() {
+	err := s.cat.CreateNamespace(context.Background(), []string{}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "must not be empty")
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceEmptyIdentifier() {
+	err := s.cat.DropNamespace(context.Background(), []string{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "must not be empty")
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNested() {
+	// Verify nested namespace returns the correct absolute path.
+	nsDir := filepath.Join(s.warehouse, "a", "b", "c")
+	s.Require().NoError(os.MkdirAll(nsDir, 0o755))
+
+	props, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"a", "b", "c"})
+	s.Require().NoError(err)
+	s.Equal(nsDir, props["location"])
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesMixedContent() {
+	// Directory with tables, namespaces, and regular files.
+	// Only non-table directories should appear.
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "child_ns"), 0o755))
+
+	// Create a table dir
+	tableDir := filepath.Join(s.warehouse, "my_table")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), nil, 0o644))
+
+	// Regular file
+	s.Require().NoError(os.WriteFile(filepath.Join(s.warehouse, "README.txt"), nil, 0o644))
+
+	namespaces, err := s.cat.ListNamespaces(context.Background(), nil)
+	s.Require().NoError(err)
+	s.Len(namespaces, 1)
+	s.Equal(table.Identifier{"child_ns"}, namespaces[0])
+}

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -204,7 +204,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
 	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
-	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4.metadata.json"), nil, 0o644))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"), nil, 0o644))
 
 	s.True(isTableDir(tableDir))
 }
@@ -422,7 +422,7 @@ func (s *HadoopCatalogTestSuite) TestCreateNamespaceNestedParentMissing() {
 	// Creating a nested namespace without parent should fail.
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", "b", "c"}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "failed to create namespace")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceWithProperties() {
@@ -593,13 +593,13 @@ func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsFileNotDir() {
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceEmptyIdentifier() {
 	err := s.cat.CreateNamespace(context.Background(), []string{}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "must not be empty")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceEmptyIdentifier() {
 	err := s.cat.DropNamespace(context.Background(), []string{})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "must not be empty")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNested() {
@@ -637,49 +637,49 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesMixedContent() {
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDotDot() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", ".."}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid identifier component")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDot() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"."}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid identifier component")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsEmptyComponent() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", "", "b"}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "must not be empty")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsPathSeparator() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a/b"}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "path separators")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceRejectsDotDot() {
 	err := s.cat.DropNamespace(context.Background(), []string{".."})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid identifier component")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesRejectsInvalidParent() {
 	_, err := s.cat.ListNamespaces(context.Background(), []string{"a", ".."})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid identifier component")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesRejectsInvalid() {
 	_, err := s.cat.LoadNamespaceProperties(context.Background(), []string{".."})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid identifier component")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsRejectsInvalid() {
 	_, err := s.cat.CheckNamespaceExists(context.Background(), []string{"a/b"})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "path separators")
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 // isTableDir interop tests
@@ -689,6 +689,15 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueVersionHintText() {
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "version-hint.text"), []byte("1"), 0o644))
+
+	s.True(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataGzip() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.gz.metadata.json"), nil, 0o644))
 
 	s.True(isTableDir(tableDir))
 }

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -200,13 +200,13 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
 	s.False(isTableDir(tableDir))
 }
 
-func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
+func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
 	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
-	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-uuid.metadata.json"), nil, 0o644))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4.metadata.json"), nil, 0o644))
 
-	s.False(isTableDir(tableDir))
+	s.True(isTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
@@ -406,19 +406,23 @@ func (s *HadoopCatalogTestSuite) TestCreateNamespaceAlreadyExists() {
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceNested() {
+	// Parent namespaces must exist first with atomic os.Mkdir.
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "a"), 0o755))
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "a", "b"), 0o755))
+
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", "b", "c"}, nil)
 	s.Require().NoError(err)
 
-	// Verify leaf and intermediate directories exist
-	for _, p := range []string{
-		filepath.Join(s.warehouse, "a"),
-		filepath.Join(s.warehouse, "a", "b"),
-		filepath.Join(s.warehouse, "a", "b", "c"),
-	} {
-		info, err := os.Stat(p)
-		s.Require().NoError(err)
-		s.True(info.IsDir())
-	}
+	info, err := os.Stat(filepath.Join(s.warehouse, "a", "b", "c"))
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceNestedParentMissing() {
+	// Creating a nested namespace without parent should fail.
+	err := s.cat.CreateNamespace(context.Background(), []string{"a", "b", "c"}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "failed to create namespace")
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceWithProperties() {
@@ -541,7 +545,7 @@ func (s *HadoopCatalogTestSuite) TestLoadNamespaceProperties() {
 
 	props, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"ns"})
 	s.Require().NoError(err)
-	s.Equal(iceberg.Properties{"location": nsDir}, props)
+	s.Equal(iceberg.Properties{"location": "file://" + nsDir}, props)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNotExists() {
@@ -562,7 +566,7 @@ func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesFileNotDir() {
 func (s *HadoopCatalogTestSuite) TestUpdateNamespacePropertiesUnsupported() {
 	_, err := s.cat.UpdateNamespaceProperties(context.Background(), []string{"ns"}, nil, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "not yet implemented")
+	s.Contains(err.Error(), "not supported")
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceWithRegularFilesOnly() {
@@ -605,7 +609,7 @@ func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNested() {
 
 	props, err := s.cat.LoadNamespaceProperties(context.Background(), []string{"a", "b", "c"})
 	s.Require().NoError(err)
-	s.Equal(nsDir, props["location"])
+	s.Equal("file://"+nsDir, props["location"])
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesMixedContent() {
@@ -626,4 +630,74 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesMixedContent() {
 	s.Require().NoError(err)
 	s.Len(namespaces, 1)
 	s.Equal(table.Identifier{"child_ns"}, namespaces[0])
+}
+
+// Path validation tests
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDotDot() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"a", ".."}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid identifier component")
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDot() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"."}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid identifier component")
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsEmptyComponent() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"a", "", "b"}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "must not be empty")
+}
+
+func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsPathSeparator() {
+	err := s.cat.CreateNamespace(context.Background(), []string{"a/b"}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "path separators")
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceRejectsDotDot() {
+	err := s.cat.DropNamespace(context.Background(), []string{".."})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid identifier component")
+}
+
+func (s *HadoopCatalogTestSuite) TestListNamespacesRejectsInvalidParent() {
+	_, err := s.cat.ListNamespaces(context.Background(), []string{"a", ".."})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid identifier component")
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesRejectsInvalid() {
+	_, err := s.cat.LoadNamespaceProperties(context.Background(), []string{".."})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid identifier component")
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsRejectsInvalid() {
+	_, err := s.cat.CheckNamespaceExists(context.Background(), []string{"a/b"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "path separators")
+}
+
+// isTableDir interop tests
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirTrueVersionHintText() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "version-hint.text"), []byte("1"), 0o644))
+
+	s.True(isTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "random.json"), nil, 0o644))
+
+	s.False(isTableDir(tableDir))
 }

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -562,7 +562,7 @@ func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesFileNotDir() {
 func (s *HadoopCatalogTestSuite) TestUpdateNamespacePropertiesUnsupported() {
 	_, err := s.cat.UpdateNamespaceProperties(context.Background(), []string{"ns"}, nil, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "properties are not supported")
+	s.Contains(err.Error(), "not yet implemented")
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceWithRegularFilesOnly() {


### PR DESCRIPTION
[3: Namespace operations](https://github.com/apache/iceberg-go/issues/798#issuecomment-4320784323)
Implement all six namespace interface methods. CreateNamespace uses os.MkdirAll and errors if the directory already exists or if non-empty properties are passed. DropNamespace checks that there are no tables or child namespaces before calling os.Remove. CheckNamespaceExists uses os.Stat. ListNamespaces reads directory entries and filters out table dirs via isTableDir. LoadNamespaceProperties returns a synthetic {"location": path} (not persisted). UpdateNamespaceProperties returns an unsupported error. Tests cover create, create duplicate, create nested (a.b.c), create with properties (error), drop, drop non-existent, drop non-empty with tables and child namespaces, list empty and mixed entries, check exists, load properties, and update properties error.

Relates to #798

 