### PR TITLE
fix(io): resolve S3 PermanentRedirect for S3 Table Buckets (#974)

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -499,20 +499,22 @@ func toProps(o *options) iceberg.Properties {
 		props[keyRestSigV4] = "true"
 		setIf(keyRestSigV4Region, o.sigv4Region)
 		setIf(keyRestSigV4Service, o.sigv4Service)
+
+		// Best-effort fallback: propagate the SigV4 signing region as
+		// a client region hint so that S3 I/O can determine the correct
+		// regional endpoint when s3.region is not explicitly set.
+		// Only applied for S3/S3Tables services where the signing region
+		// is likely to match the bucket region.
+		if o.sigv4Region != "" && (o.sigv4Service == "s3" || o.sigv4Service == "s3tables") {
+			if _, ok := props[iceio.S3ClientRegion]; !ok {
+				props[iceio.S3ClientRegion] = o.sigv4Region
+			}
+		}
 	}
 
 	setIf(keyPrefix, o.prefix)
 	if o.authUri != nil {
 		setIf(keyAuthUrl, o.authUri.String())
-	}
-
-	// Propagate the SigV4 signing region as a fallback client region so
-	// that S3 I/O can determine the correct regional endpoint when
-	// s3.region is not explicitly set (e.g. S3 Table Buckets).
-	if o.enableSigv4 && o.sigv4Region != "" {
-		if _, ok := props["client.region"]; !ok {
-			props["client.region"] = o.sigv4Region
-		}
 	}
 
 	return props

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -506,6 +506,15 @@ func toProps(o *options) iceberg.Properties {
 		setIf(keyAuthUrl, o.authUri.String())
 	}
 
+	// Propagate the SigV4 signing region as a fallback client region so
+	// that S3 I/O can determine the correct regional endpoint when
+	// s3.region is not explicitly set (e.g. S3 Table Buckets).
+	if o.enableSigv4 && o.sigv4Region != "" {
+		if _, ok := props["client.region"]; !ok {
+			props["client.region"] = o.sigv4Region
+		}
+	}
+
 	return props
 }
 

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -903,3 +903,82 @@ func TestErrorResponse_ErrorFormattingEmpty(t *testing.T) {
 	err := errorResponse{}
 	require.Equal(t, "unknown REST error", err.Error())
 }
+
+func TestToPropsSigv4RegionFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sigv4 region propagated as client.region for s3tables", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			enableSigv4:  true,
+			sigv4Region:  "us-east-1",
+			sigv4Service: "s3tables",
+		}
+		props := toProps(opts)
+		assert.Equal(t, "us-east-1", props["client.region"])
+	})
+
+	t.Run("sigv4 region propagated as client.region for s3", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			enableSigv4:  true,
+			sigv4Region:  "us-west-2",
+			sigv4Service: "s3",
+		}
+		props := toProps(opts)
+		assert.Equal(t, "us-west-2", props["client.region"])
+	})
+
+	t.Run("sigv4 region not propagated for non-s3 service", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			enableSigv4:  true,
+			sigv4Region:  "us-east-1",
+			sigv4Service: "execute-api",
+		}
+		props := toProps(opts)
+		_, ok := props["client.region"]
+		assert.False(t, ok)
+	})
+
+	t.Run("sigv4 region does not overwrite existing client.region", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			enableSigv4:  true,
+			sigv4Region:  "us-east-1",
+			sigv4Service: "s3tables",
+			additionalProps: map[string]string{
+				"client.region": "eu-west-1",
+			},
+		}
+		props := toProps(opts)
+		assert.Equal(t, "eu-west-1", props["client.region"])
+	})
+
+	t.Run("no client.region when sigv4 disabled", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			sigv4Region: "us-east-1",
+		}
+		props := toProps(opts)
+		_, ok := props["client.region"]
+		assert.False(t, ok)
+	})
+
+	t.Run("no client.region when sigv4 region empty", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &options{
+			enableSigv4:  true,
+			sigv4Service: "s3tables",
+		}
+		props := toProps(opts)
+		_, ok := props["client.region"]
+		assert.False(t, ok)
+	})
+}

--- a/io/config.go
+++ b/io/config.go
@@ -29,6 +29,7 @@ const (
 	S3SignerURI              = "s3.signer.uri"
 	S3RemoteSigningEnabled   = "s3.remote-signing-enabled"
 	S3ForceVirtualAddressing = "s3.force-virtual-addressing"
+	S3ClientRegion           = "client.region"
 )
 
 // Constants for GCS configuration options

--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -68,7 +68,7 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 
 	if region, ok := props[io.S3Region]; ok {
 		opts = append(opts, config.WithRegion(region))
-	} else if region, ok := props["client.region"]; ok {
+	} else if region, ok := props[io.S3ClientRegion]; ok {
 		opts = append(opts, config.WithRegion(region))
 	}
 
@@ -102,6 +102,21 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	return awscfg, nil
 }
 
+// resolveUsePathStyle determines whether the S3 client should use
+// path-style addressing. It defaults to virtual-hosted style for
+// standard AWS S3 and path-style for custom endpoints (e.g. MinIO).
+// The s3.force-virtual-addressing property can override either default.
+func resolveUsePathStyle(endpoint string, props map[string]string) bool {
+	usePathStyle := endpoint != ""
+	if forceVirtual, ok := props[io.S3ForceVirtualAddressing]; ok {
+		if cfgForceVirtual, err := strconv.ParseBool(forceVirtual); err == nil {
+			usePathStyle = !cfgForceVirtual
+		}
+	}
+
+	return usePathStyle
+}
+
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	var (
 		awscfg *aws.Config
@@ -121,21 +136,11 @@ func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]strin
 		endpoint = os.Getenv("AWS_S3_ENDPOINT")
 	}
 
-	// Default to virtual-hosted style for standard AWS S3 and path-style
-	// for custom endpoints (e.g. MinIO). The s3.force-virtual-addressing
-	// property can override either default.
-	usePathStyle := endpoint != ""
-	if forceVirtual, ok := props[io.S3ForceVirtualAddressing]; ok {
-		if cfgForceVirtual, err := strconv.ParseBool(forceVirtual); err == nil {
-			usePathStyle = !cfgForceVirtual
-		}
-	}
-
 	client := s3.NewFromConfig(*awscfg, func(o *s3.Options) {
 		if endpoint != "" {
 			o.BaseEndpoint = aws.String(endpoint)
 		}
-		o.UsePathStyle = usePathStyle
+		o.UsePathStyle = resolveUsePathStyle(endpoint, props)
 		o.DisableLogOutputChecksumValidationSkipped = true
 	})
 

--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -121,7 +121,10 @@ func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]strin
 		endpoint = os.Getenv("AWS_S3_ENDPOINT")
 	}
 
-	usePathStyle := true
+	// Default to virtual-hosted style for standard AWS S3 and path-style
+	// for custom endpoints (e.g. MinIO). The s3.force-virtual-addressing
+	// property can override either default.
+	usePathStyle := endpoint != ""
 	if forceVirtual, ok := props[io.S3ForceVirtualAddressing]; ok {
 		if cfgForceVirtual, err := strconv.ParseBool(forceVirtual); err == nil {
 			usePathStyle = !cfgForceVirtual

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -88,3 +88,76 @@ func TestParseAWSConfigUnsupportedProperty(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "unsupported S3 property")
 }
+
+func TestResolveUsePathStyle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		props    map[string]string
+		want     bool
+	}{
+		{
+			name:     "no endpoint defaults to virtual-hosted style",
+			endpoint: "",
+			props:    nil,
+			want:     false,
+		},
+		{
+			name:     "custom endpoint defaults to path-style",
+			endpoint: "http://localhost:9000",
+			props:    nil,
+			want:     true,
+		},
+		{
+			name:     "force virtual-addressing overrides custom endpoint",
+			endpoint: "http://localhost:9000",
+			props: map[string]string{
+				io.S3ForceVirtualAddressing: "true",
+			},
+			want: false,
+		},
+		{
+			name:     "force virtual-addressing=false with no endpoint",
+			endpoint: "",
+			props: map[string]string{
+				io.S3ForceVirtualAddressing: "false",
+			},
+			want: true,
+		},
+		{
+			name:     "force virtual-addressing=true with no endpoint",
+			endpoint: "",
+			props: map[string]string{
+				io.S3ForceVirtualAddressing: "true",
+			},
+			want: false,
+		},
+		{
+			name:     "invalid force-virtual-addressing value ignored, custom endpoint",
+			endpoint: "http://localhost:9000",
+			props: map[string]string{
+				io.S3ForceVirtualAddressing: "not-a-bool",
+			},
+			want: true,
+		},
+		{
+			name:     "invalid force-virtual-addressing value ignored, no endpoint",
+			endpoint: "",
+			props: map[string]string{
+				io.S3ForceVirtualAddressing: "not-a-bool",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveUsePathStyle(tt.endpoint, tt.props)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Two issues caused 301 PermanentRedirect errors when writing data files to S3 Table Buckets:

1. The SigV4 signing region configured on the REST catalog was not propagated to the S3 I/O layer. When s3.region is absent from vended credentials, the S3 client falls back to the SDK default region, which may differ from the bucket's actual region. Fix: toProps() now sets client.region from the SigV4 signing region as a fallback.

2. The S3 client defaulted to path-style addressing, which is deprecated by AWS. Virtual-hosted style is now the default for standard AWS S3, with path-style reserved for custom endpoints.

Fixes #974