### PR TITLE
fix(table): treat empty-base conflict context as fully concurrent

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -192,10 +192,26 @@ func newConflictContext(base, current Metadata, branch string, fs iceio.IO, case
 
 	baseHead := base.SnapshotByName(branch)
 	if baseHead == nil {
-		// Writer has no view of this branch yet (e.g. creating it) —
-		// by definition there are no concurrent commits to validate
-		// against.
-		return &conflictContext{current: current, branch: branch, fs: fs, caseSensitive: caseSensitive}, nil
+		// Writer's base has no view of this branch (empty table or
+		// branch created concurrently). Every snapshot now reachable
+		// from the branch head is concurrent relative to base.
+		// Truncation (missing intermediate, cycle) is treated as
+		// divergent for the same reason AncestorsBetween's
+		// baseFound=false is: an under-counted concurrent list silently
+		// hides conflicts.
+		concurrent, complete := AncestorsOfChecked(currentHead.SnapshotID, current.SnapshotByID)
+		if !complete {
+			return nil, fmt.Errorf("%w: ancestry walk from %d on %s truncated; no base snapshot to bound against",
+				ErrCommitDiverged, currentHead.SnapshotID, branch)
+		}
+
+		return &conflictContext{
+			current:       current,
+			branch:        branch,
+			fs:            fs,
+			caseSensitive: caseSensitive,
+			concurrent:    concurrent,
+		}, nil
 	}
 
 	concurrent, baseFound := AncestorsBetween(currentHead.SnapshotID, baseHead.SnapshotID, current.SnapshotByID)

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -145,6 +145,43 @@ func newConflictTestMetadataWithProps(t *testing.T, branchHead *int64, extraProp
 	return out
 }
 
+// newConflictTestMetadataWithChain builds metadata whose branch head
+// reaches back through ids[0]→ids[1]→...→ids[n-1] via ParentSnapshotID.
+// ids[len-1] becomes the branch head; ids[0] is the chain root.
+func newConflictTestMetadataWithChain(t *testing.T, ids []int64) Metadata {
+	t.Helper()
+	require.NotEmpty(t, ids)
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/conflict-test", props)
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	for i, id := range ids {
+		snap := Snapshot{
+			SnapshotID:     id,
+			SequenceNumber: int64(i + 1),
+			TimestampMs:    meta.LastUpdatedMillis() + int64(i+1),
+			Summary:        &Summary{Operation: OpAppend},
+		}
+		if i > 0 {
+			parent := ids[i-1]
+			snap.ParentSnapshotID = &parent
+		}
+		require.NoError(t, builder.AddSnapshot(&snap))
+	}
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, ids[len(ids)-1], BranchRef))
+	out, err := builder.Build()
+	require.NoError(t, err)
+
+	return out
+}
+
 func TestNewConflictContext_NoConcurrentCommits(t *testing.T) {
 	// base and current point at the same snapshot → zero concurrent
 	// snapshots, no error.
@@ -157,15 +194,35 @@ func TestNewConflictContext_NoConcurrentCommits(t *testing.T) {
 }
 
 func TestNewConflictContext_WriterHasNoBranchView(t *testing.T) {
-	// Writer is creating the branch for the first time (base has no
-	// ref yet) — there is nothing concurrent to validate against.
+	// Writer loaded the table before any snapshot was committed on
+	// the branch (empty base). A snapshot then appeared on the
+	// branch — it must be reported as concurrent so validators that
+	// care about concurrent writes (e.g. RowDelta under
+	// SERIALIZABLE) can inspect its data files.
 	base := newConflictTestMetadata(t, nil)
 	head := int64(7)
 	current := newConflictTestMetadata(t, &head)
 
 	ctx, err := newConflictContext(base, current, MainBranch, nil, true)
 	require.NoError(t, err)
-	assert.Empty(t, ctx.concurrent)
+	require.Len(t, ctx.concurrent, 1)
+	assert.Equal(t, int64(7), ctx.concurrent[0].SnapshotID)
+}
+
+func TestNewConflictContext_EmptyBaseEnumeratesFullAncestry(t *testing.T) {
+	// Empty base, current branch head reaches back through a chain of
+	// three snapshots — all three must surface as concurrent in
+	// reverse-chronological order so validators see the full set the
+	// writer never observed.
+	base := newConflictTestMetadata(t, nil)
+	current := newConflictTestMetadataWithChain(t, []int64{10, 11, 12})
+
+	ctx, err := newConflictContext(base, current, MainBranch, nil, true)
+	require.NoError(t, err)
+	require.Len(t, ctx.concurrent, 3)
+	assert.Equal(t, int64(12), ctx.concurrent[0].SnapshotID)
+	assert.Equal(t, int64(11), ctx.concurrent[1].SnapshotID)
+	assert.Equal(t, int64(10), ctx.concurrent[2].SnapshotID)
 }
 
 func TestNewConflictContext_MissingCurrentBranch(t *testing.T) {

--- a/table/snapshot_ancestry.go
+++ b/table/snapshot_ancestry.go
@@ -33,34 +33,51 @@ type SnapshotLookup func(id int64) *Snapshot
 // The returned slice may be truncated if an intermediate snapshot is
 // missing from the lookup (e.g. expired) or if a cycle is encountered.
 // Callers that need to distinguish a complete walk from a truncated one
-// should use IsAncestorOf against the expected oldest ancestor.
+// should use AncestorsOfChecked instead.
 func AncestorsOf(snapshotID int64, lookup SnapshotLookup) []Snapshot {
+	ancestors, _ := AncestorsOfChecked(snapshotID, lookup)
+
+	return ancestors
+}
+
+// AncestorsOfChecked is AncestorsOf with completeness tracking. The
+// second return value is true when the walk terminated at a snapshot
+// with no parent (a clean root). It is false when the walk was
+// truncated by an unresolvable starting snapshot, a missing intermediate
+// snapshot, or a cycle in malformed metadata.
+//
+// Callers performing conflict detection (where a truncated ancestry
+// equates to under-counting concurrent snapshots) MUST treat
+// complete=false as divergent and refuse the commit, mirroring
+// AncestorsBetween's baseFound=false contract. When complete is false
+// the returned slice is the partial walk before truncation —
+// diagnostic context only, NOT an enumerable ancestry.
+//
+// Snapshots are returned by value in reverse-chronological order.
+// Returns an empty slice and false when snapshotID cannot be resolved.
+func AncestorsOfChecked(snapshotID int64, lookup SnapshotLookup) ([]Snapshot, bool) {
 	var ancestors []Snapshot
 	visited := make(map[int64]struct{})
 
 	id := snapshotID
 	for {
 		if _, seen := visited[id]; seen {
-			// Cycle detection — stop walking. A well-formed metadata will
-			// never hit this, but defensive guard avoids infinite loops.
-			break
+			return ancestors, false
 		}
 		visited[id] = struct{}{}
 
 		snap := lookup(id)
 		if snap == nil {
-			break
+			return ancestors, false
 		}
 
 		ancestors = append(ancestors, *snap)
 
 		if snap.ParentSnapshotID == nil {
-			break
+			return ancestors, true
 		}
 		id = *snap.ParentSnapshotID
 	}
-
-	return ancestors
 }
 
 // AncestorsBetween returns the snapshots from latestID (inclusive) down

--- a/table/snapshot_ancestry_test.go
+++ b/table/snapshot_ancestry_test.go
@@ -101,6 +101,45 @@ func TestAncestorsOf_CycleDefense(t *testing.T) {
 	assert.Equal(t, []int64{1, 2}, snapshotIDs(got))
 }
 
+func TestAncestorsOfChecked_LinearChain(t *testing.T) {
+	got, complete := AncestorsOfChecked(5, buildChain(5))
+
+	assert.True(t, complete, "walk reached the root")
+	assert.Equal(t, []int64{5, 4, 3, 2, 1}, snapshotIDs(got))
+}
+
+func TestAncestorsOfChecked_Unknown(t *testing.T) {
+	got, complete := AncestorsOfChecked(99, buildChain(3))
+
+	assert.False(t, complete, "unresolvable starting snapshot is not a complete walk")
+	assert.Empty(t, got)
+}
+
+func TestAncestorsOfChecked_BrokenChain(t *testing.T) {
+	// Chain 1 ← 2 ← 3 with snapshot 2 missing — the walk stops at 3 and
+	// the missing parent must be reported as truncation.
+	chain := buildChain(3)
+	lookup := func(id int64) *Snapshot {
+		if id == 2 {
+			return nil
+		}
+
+		return chain(id)
+	}
+
+	got, complete := AncestorsOfChecked(3, lookup)
+
+	assert.False(t, complete, "missing intermediate must surface as truncation")
+	assert.Equal(t, []int64{3}, snapshotIDs(got))
+}
+
+func TestAncestorsOfChecked_CycleDefense(t *testing.T) {
+	got, complete := AncestorsOfChecked(1, buildCycle())
+
+	assert.False(t, complete, "cycle must surface as truncation")
+	assert.Equal(t, []int64{1, 2}, snapshotIDs(got))
+}
+
 func TestAncestorsBetween_LinearChain(t *testing.T) {
 	lookup := buildChain(5)
 


### PR DESCRIPTION
newConflictContext returned an empty concurrent list when the writer's base had no snapshot on the branch, silently bypassing RowDelta SERIALIZABLE validation. Walk the branch head's ancestry instead and treat truncation as ErrCommitDiverged.

Fixes #977