### PR TITLE
test(table): add round-trip test for v3 metadata with partition-statistics (#1012)

### DIFF
--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1797,3 +1797,37 @@ func getTestTableMetadata(fileName string) (Metadata, error) {
 
 	return meta, nil
 }
+
+func TestV3PartitionStatisticsRoundTrip(t *testing.T) {
+	const testFile = "TableMetadataV3WithPartitionStatistics.json"
+
+	raw, err := os.ReadFile(path.Join("testdata", testFile))
+	require.NoError(t, err)
+
+	meta, err := ParseMetadataBytes(raw)
+	require.NoError(t, err)
+	require.Equal(t, 3, meta.Version())
+
+	partStats := slices.Collect(meta.PartitionStatistics())
+	require.Len(t, partStats, 2)
+
+	assert.Equal(t, int64(3051729675574597004), partStats[0].SnapshotID)
+	assert.Equal(t, "s3://bucket/test/location/metadata/partition-stats/snap-3051729675574597004.parquet", partStats[0].StatisticsPath)
+	assert.Equal(t, int64(42330), partStats[0].FileSizeInBytes)
+
+	assert.Equal(t, int64(3055729675574597004), partStats[1].SnapshotID)
+	assert.Equal(t, "s3://bucket/test/location/metadata/partition-stats/snap-3055729675574597004.parquet", partStats[1].StatisticsPath)
+	assert.Equal(t, int64(65871), partStats[1].FileSizeInBytes)
+
+	serialized, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	reparsed, err := ParseMetadataBytes(serialized)
+	require.NoError(t, err)
+
+	roundTripStats := slices.Collect(reparsed.PartitionStatistics())
+	require.Len(t, roundTripStats, 2)
+	assert.Equal(t, partStats, roundTripStats)
+
+	assert.JSONEq(t, string(raw), string(serialized))
+}

--- a/table/testdata/TableMetadataV3WithPartitionStatistics.json
+++ b/table/testdata/TableMetadataV3WithPartitionStatistics.json
@@ -1,0 +1,153 @@
+{
+  "format-version": 3,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "next-row-id": 3000,
+  "current-schema-id": 1,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "identifier-field-ids": [],
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "type": "struct",
+      "schema-id": 1,
+      "identifier-field-ids": [1, 2],
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {
+    "read.split.target.size": "134217728"
+  },
+  "current-snapshot-id": 3055729675574597004,
+  "snapshots": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770,
+      "sequence-number": 0,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/1.avro",
+      "first-row-id": 1000
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "parent-snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1555100955770,
+      "sequence-number": 1,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/2.avro",
+      "schema-id": 1,
+      "first-row-id": 2000
+    }
+  ],
+  "snapshot-log": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "timestamp-ms": 1555100955770
+    }
+  ],
+  "metadata-log": [
+    {
+      "metadata-file": "s3://bucket/.../v1.json",
+      "timestamp-ms": 1515100
+    }
+  ],
+  "refs": {
+    "main": {
+      "snapshot-id": 3055729675574597004,
+      "type": "branch"
+    },
+    "test": {
+      "snapshot-id": 3051729675574597004,
+      "type": "tag",
+      "max-ref-age-ms": 10000000
+    }
+  },
+  "partition-statistics": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "statistics-path": "s3://bucket/test/location/metadata/partition-stats/snap-3051729675574597004.parquet",
+      "file-size-in-bytes": 42330
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "statistics-path": "s3://bucket/test/location/metadata/partition-stats/snap-3055729675574597004.parquet",
+      "file-size-in-bytes": 65871
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Java-produced v3 metadata.json fixture with partition-statistics entries and a round-trip test that parses, re-serializes, and asserts no fields are silently dropped.  

Closes: #1012