### PR TITLE
fix(ci): correct labeler action version tag

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,6 +28,6 @@ jobs:
   triage:
     runs-on: ubuntu-slim
     steps:
-    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
       with:
         sync-labels: true


### PR DESCRIPTION
## Summary

The hash `634933edcd8ababfe52f92936142cc22ac488b1b` resolves to tag `v6.0.1`, but the version comment said `# v6`. This caused zizmor's `ref-version-mismatch` audit to fail in CI.

Updates the comment to match the actual tag the hash points to.