### PR TITLE
feat(io): add ManagedIdentityCredential support for Azure

### DIFF
--- a/io/azure.go
+++ b/io/azure.go
@@ -38,12 +38,14 @@ var adlsURIPattern = regexp.MustCompile(`^(abfss?|wasbs?)://([^/?#]+)(.*)?$`)
 
 // Constants for Azure configuration options
 const (
-	AdlsSasTokenPrefix         = "adls.sas-token."
-	AdlsConnectionStringPrefix = "adls.connection-string."
-	AdlsSharedKeyAccountName   = "adls.auth.shared-key.account.name"
-	AdlsSharedKeyAccountKey    = "adls.auth.shared-key.account.key"
-	AdlsEndpoint               = "adls.endpoint"
-	AdlsProtocol               = "adls.protocol"
+	AdlsSasTokenPrefix          = "adls.sas-token."
+	AdlsConnectionStringPrefix  = "adls.connection-string."
+	AdlsSharedKeyAccountName    = "adls.auth.shared-key.account.name"
+	AdlsSharedKeyAccountKey     = "adls.auth.shared-key.account.key"
+	AdlsEndpoint                = "adls.endpoint"
+	AdlsProtocol                = "adls.protocol"
+	AdlsManagedIdentityEnabled  = "adls.auth.managed-identity.enabled"
+	AdlsManagedIdentityClientID = "adls.auth.managed-identity.client-id"
 
 	// Not in use yet
 	// AdlsReadBlockSize          = "adls.read.block-size-bytes"
@@ -169,6 +171,28 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		client, err = container.NewClientFromConnectionString(connectionString, location.containerName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed container.NewClientFromConnectionString: %w", err)
+		}
+	} else if props[AdlsManagedIdentityEnabled] == "true" {
+		containerURL, err := createContainerURL(location.accountName, protocol, endpoint, "", location.containerName)
+		if err != nil {
+			return nil, err
+		}
+
+		var miOpts *azidentity.ManagedIdentityCredentialOptions
+		if clientID := props[AdlsManagedIdentityClientID]; clientID != "" {
+			miOpts = &azidentity.ManagedIdentityCredentialOptions{
+				ID: azidentity.ClientID(clientID),
+			}
+		}
+
+		cred, err := azidentity.NewManagedIdentityCredential(miOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed azidentity.NewManagedIdentityCredential: %w", err)
+		}
+
+		client, err = container.NewClient(containerURL, cred, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed container.NewClient: %w", err)
 		}
 	} else {
 		containerURL, err := createContainerURL(location.accountName, protocol, endpoint, "", location.containerName)

--- a/io/azure_test.go
+++ b/io/azure_test.go
@@ -74,52 +74,25 @@ func TestCreateAzureBucketDefaultCredentialEmptyBucketName(t *testing.T) {
 }
 
 func TestCreateAzureBucketManagedIdentityCredentialCalled(t *testing.T) {
-	ctx := context.Background()
-
 	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
 	assert.NoError(t, err)
 
-	props := map[string]string{
+	bucket, err := createAzureBucket(context.Background(), parsedURL, map[string]string{
 		"adls.auth.managed-identity.enabled": "true",
-	}
-
-	bucket, err := createAzureBucket(ctx, parsedURL, props)
-	if err != nil {
-		assert.NotContains(t, err.Error(), "DefaultAzureCredential",
-			"Expected ManagedIdentityCredential path, not DefaultAzureCredential: %v", err)
-		t.Logf("ManagedIdentityCredential path was taken and failed at creation: %v", err)
-
-		return
-	}
-
+	})
+	assert.NoError(t, err)
 	assert.NotNil(t, bucket)
-	iter := bucket.List(nil)
-	_, err = iter.Next(ctx)
-	assert.Error(t, err)
-	assert.NotContains(t, err.Error(), "DefaultAzureCredential",
-		"Expected ManagedIdentityCredential error, not DefaultAzureCredential: %v", err)
 }
 
 func TestCreateAzureBucketManagedIdentityWithClientID(t *testing.T) {
-	ctx := context.Background()
-
 	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
 	assert.NoError(t, err)
 
-	props := map[string]string{
+	bucket, err := createAzureBucket(context.Background(), parsedURL, map[string]string{
 		"adls.auth.managed-identity.enabled":   "true",
 		"adls.auth.managed-identity.client-id": "00000000-0000-0000-0000-000000000000",
-	}
-
-	bucket, err := createAzureBucket(ctx, parsedURL, props)
-	if err != nil {
-		assert.NotContains(t, err.Error(), "DefaultAzureCredential",
-			"Expected ManagedIdentityCredential path, not DefaultAzureCredential: %v", err)
-		t.Logf("ManagedIdentityCredential (user-assigned) path was taken and failed at creation: %v", err)
-
-		return
-	}
-
+	})
+	assert.NoError(t, err)
 	assert.NotNil(t, bucket)
 }
 

--- a/io/azure_test.go
+++ b/io/azure_test.go
@@ -73,6 +73,56 @@ func TestCreateAzureBucketDefaultCredentialEmptyBucketName(t *testing.T) {
 		"Expected container name error but got: %v", err)
 }
 
+func TestCreateAzureBucketManagedIdentityCredentialCalled(t *testing.T) {
+	ctx := context.Background()
+
+	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
+	assert.NoError(t, err)
+
+	props := map[string]string{
+		"adls.auth.managed-identity.enabled": "true",
+	}
+
+	bucket, err := createAzureBucket(ctx, parsedURL, props)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "DefaultAzureCredential",
+			"Expected ManagedIdentityCredential path, not DefaultAzureCredential: %v", err)
+		t.Logf("ManagedIdentityCredential path was taken and failed at creation: %v", err)
+
+		return
+	}
+
+	assert.NotNil(t, bucket)
+	iter := bucket.List(nil)
+	_, err = iter.Next(ctx)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "DefaultAzureCredential",
+		"Expected ManagedIdentityCredential error, not DefaultAzureCredential: %v", err)
+}
+
+func TestCreateAzureBucketManagedIdentityWithClientID(t *testing.T) {
+	ctx := context.Background()
+
+	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
+	assert.NoError(t, err)
+
+	props := map[string]string{
+		"adls.auth.managed-identity.enabled":   "true",
+		"adls.auth.managed-identity.client-id": "00000000-0000-0000-0000-000000000000",
+	}
+
+	bucket, err := createAzureBucket(ctx, parsedURL, props)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "DefaultAzureCredential",
+			"Expected ManagedIdentityCredential path, not DefaultAzureCredential: %v", err)
+		t.Logf("ManagedIdentityCredential (user-assigned) path was taken and failed at creation: %v", err)
+
+		return
+	}
+
+	assert.NotNil(t, bucket)
+}
+
 func TestCreateAzureBucketSharedKeyMissingAccountKey(t *testing.T) {
 	ctx := context.Background()
 

--- a/io/azure_test.go
+++ b/io/azure_test.go
@@ -74,26 +74,23 @@ func TestCreateAzureBucketDefaultCredentialEmptyBucketName(t *testing.T) {
 }
 
 func TestCreateAzureBucketManagedIdentityCredentialCalled(t *testing.T) {
+	ctx := context.Background()
+
 	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
 	assert.NoError(t, err)
 
-	bucket, err := createAzureBucket(context.Background(), parsedURL, map[string]string{
+	// NewManagedIdentityCredential never fails at construction, so bucket creation always succeeds.
+	bucket, err := createAzureBucket(ctx, parsedURL, map[string]string{
 		"adls.auth.managed-identity.enabled": "true",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, bucket)
-}
 
-func TestCreateAzureBucketManagedIdentityWithClientID(t *testing.T) {
-	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
-	assert.NoError(t, err)
-
-	bucket, err := createAzureBucket(context.Background(), parsedURL, map[string]string{
-		"adls.auth.managed-identity.enabled":   "true",
-		"adls.auth.managed-identity.client-id": "00000000-0000-0000-0000-000000000000",
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, bucket)
+	iter := bucket.List(nil)
+	_, err = iter.Next(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ManagedIdentityCredential",
+		"Expected ManagedIdentityCredential error but got: %v", err)
 }
 
 func TestCreateAzureBucketSharedKeyMissingAccountKey(t *testing.T) {


### PR DESCRIPTION
## Changes
- Add `AdlsManagedIdentityEnabled` (`adls.auth.managed-identity.enabled`) property to opt into `ManagedIdentityCredential` instead of `DefaultAzureCredential`
- Add `AdlsManagedIdentityClientID` (`adls.auth.managed-identity.client-id`) property for user-assigned managed identities

## Motivation
`DefaultAzureCredential` sets a short timeout on its first managed identity attempt to avoid long hangs during local development. In production, this causes "managed identity timed out" errors when the app requests a token before the hosting environment is ready. Using `ManagedIdentityCredential` directly avoids this timeout.