### PR TITLE
feat(io): add ManagedIdentityCredential support for Azure

### DIFF
--- a/io/config.go
+++ b/io/config.go
@@ -43,12 +43,14 @@ const (
 
 // Constants for Azure configuration options
 const (
-	ADLSSasTokenPrefix         = "adls.sas-token."
-	ADLSConnectionStringPrefix = "adls.connection-string."
-	ADLSSharedKeyAccountName   = "adls.auth.shared-key.account.name"
-	ADLSSharedKeyAccountKey    = "adls.auth.shared-key.account.key"
-	ADLSEndpoint               = "adls.endpoint"
-	ADLSProtocol               = "adls.protocol"
+	ADLSSasTokenPrefix          = "adls.sas-token."
+	ADLSConnectionStringPrefix  = "adls.connection-string."
+	ADLSSharedKeyAccountName    = "adls.auth.shared-key.account.name"
+	ADLSSharedKeyAccountKey     = "adls.auth.shared-key.account.key"
+	ADLSEndpoint                = "adls.endpoint"
+	ADLSProtocol                = "adls.protocol"
+	ADLSManagedIdentityEnabled  = "adls.auth.managed-identity.enabled"
+	ADLSManagedIdentityClientID = "adls.auth.managed-identity.client-id"
 
 	// Not in use yet
 	// ADLSReadBlockSize          = "adls.read.block-size-bytes"

--- a/io/config.go
+++ b/io/config.go
@@ -43,14 +43,14 @@ const (
 
 // Constants for Azure configuration options
 const (
-	ADLSSasTokenPrefix          = "adls.sas-token."
-	ADLSConnectionStringPrefix  = "adls.connection-string."
-	ADLSSharedKeyAccountName    = "adls.auth.shared-key.account.name"
-	ADLSSharedKeyAccountKey     = "adls.auth.shared-key.account.key"
-	ADLSEndpoint                = "adls.endpoint"
-	ADLSProtocol                = "adls.protocol"
-	ADLSManagedIdentityEnabled  = "adls.auth.managed-identity.enabled"
-	ADLSManagedIdentityClientID = "adls.auth.managed-identity.client-id"
+	ADLSSasTokenPrefix         = "adls.sas-token."
+	ADLSConnectionStringPrefix = "adls.connection-string."
+	ADLSSharedKeyAccountName   = "adls.auth.shared-key.account.name"
+	ADLSSharedKeyAccountKey    = "adls.auth.shared-key.account.key"
+	ADLSClientID               = "adls.client-id"
+	ADLSEndpoint               = "adls.endpoint"
+	ADLSProtocol               = "adls.protocol"
+	ADLSManagedIdentityEnabled = "adls.auth.managed-identity.enabled"
 
 	// Not in use yet
 	// ADLSReadBlockSize          = "adls.read.block-size-bytes"

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -159,6 +159,28 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		if err != nil {
 			return nil, fmt.Errorf("failed container.NewClientFromConnectionString: %w", err)
 		}
+	} else if props[io.ADLSManagedIdentityEnabled] == "true" {
+		containerURL, err := createContainerURL(location.accountName, protocol, endpoint, "", location.containerName)
+		if err != nil {
+			return nil, err
+		}
+
+		var miOpts *azidentity.ManagedIdentityCredentialOptions
+		if clientID := props[io.ADLSManagedIdentityClientID]; clientID != "" {
+			miOpts = &azidentity.ManagedIdentityCredentialOptions{
+				ID: azidentity.ClientID(clientID),
+			}
+		}
+
+		cred, err := azidentity.NewManagedIdentityCredential(miOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed azidentity.NewManagedIdentityCredential: %w", err)
+		}
+
+		client, err = container.NewClient(containerURL, cred, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed container.NewClient: %w", err)
+		}
 	} else {
 		containerURL, err := createContainerURL(location.accountName, protocol, endpoint, "", location.containerName)
 		if err != nil {

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -166,7 +166,7 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		}
 
 		var miOpts *azidentity.ManagedIdentityCredentialOptions
-		if clientID := props[io.ADLSManagedIdentityClientID]; clientID != "" {
+		if clientID := props[io.ADLSClientID]; clientID != "" {
 			miOpts = &azidentity.ManagedIdentityCredentialOptions{
 				ID: azidentity.ClientID(clientID),
 			}

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -73,6 +73,26 @@ func TestCreateAzureBucketDefaultCredentialEmptyBucketName(t *testing.T) {
 		"Expected container name error but got: %v", err)
 }
 
+func TestCreateAzureBucketManagedIdentityCredentialCalled(t *testing.T) {
+	ctx := context.Background()
+
+	parsedURL, err := url.Parse("abfs://container@testaccount.dfs.core.windows.net/path")
+	assert.NoError(t, err)
+
+	// NewManagedIdentityCredential never fails at construction, so bucket creation always succeeds.
+	bucket, err := createAzureBucket(ctx, parsedURL, map[string]string{
+		"adls.auth.managed-identity.enabled": "true",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, bucket)
+
+	iter := bucket.List(nil)
+	_, err = iter.Next(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ManagedIdentityCredential",
+		"Expected ManagedIdentityCredential error but got: %v", err)
+}
+
 func TestCreateAzureBucketSharedKeyMissingAccountKey(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Changes
- Add `ADLSManagedIdentityEnabled` (`adls.auth.managed-identity.enabled`) property to opt into `ManagedIdentityCredential` instead of `DefaultAzureCredential`
- Add `ADLSManagedIdentityClientID` (`adls.auth.managed-identity.client-id`) property for user-assigned managed identities

## Motivation
`DefaultAzureCredential` sets a short timeout on its first managed identity attempt. In production, this causes frequent "managed identity timed out" errors when the app requests a token. Using `ManagedIdentityCredential` directly avoids this timeout.

Reference: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/TROUBLESHOOTING.md#troubleshoot-defaultazurecredential-authentication-issues