### PR TITLE
feat(cli): add --show-defaults flag to schema command

### DIFF
--- a/cmd/iceberg/schema_defaults.go
+++ b/cmd/iceberg/schema_defaults.go
@@ -18,16 +18,89 @@
 package main
 
 import (
-	"errors"
+	"encoding/json"
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/apache/iceberg-go"
+	"github.com/pterm/pterm"
 )
 
-func runSchemaWithDefaults(output Output, _ *iceberg.Schema) {
-	output.Error(errors.New("schema --show-defaults: not yet implemented"))
-	os.Exit(1)
+func runSchemaWithDefaults(output Output, schema *iceberg.Schema) {
+	output.SchemaWithDefaults(schema)
 }
 
-func (textOutput) SchemaWithDefaults(_ *iceberg.Schema) {}
-func (jsonOutput) SchemaWithDefaults(_ *iceberg.Schema) {}
+func buildSchemaFieldsWithDefaults(schema *iceberg.Schema) []SchemaFieldWithDefaults {
+	fields := schema.Fields()
+	entries := make([]SchemaFieldWithDefaults, 0, len(fields))
+
+	for _, f := range fields {
+		entries = append(entries, SchemaFieldWithDefaults{
+			FieldID:        f.ID,
+			Name:           f.Name,
+			Type:           f.Type.String(),
+			Required:       f.Required,
+			InitialDefault: f.InitialDefault,
+			WriteDefault:   f.WriteDefault,
+		})
+	}
+
+	return entries
+}
+
+func formatDefault(v any) string {
+	if v == nil {
+		return "-"
+	}
+
+	if s, ok := v.(string); ok {
+		return strconv.Quote(s)
+	}
+
+	return fmt.Sprintf("%v", v)
+}
+
+func (t textOutput) SchemaWithDefaults(schema *iceberg.Schema) {
+	entries := buildSchemaFieldsWithDefaults(schema)
+
+	if len(entries) == 0 {
+		pterm.Println("No fields in schema.")
+
+		return
+	}
+
+	data := pterm.TableData{{"FIELD ID", "NAME", "TYPE", "REQUIRED", "INIT DEFAULT", "WRITE DEFAULT"}}
+
+	for _, e := range entries {
+		data = append(data, []string{
+			strconv.Itoa(e.FieldID),
+			e.Name,
+			e.Type,
+			strconv.FormatBool(e.Required),
+			formatDefault(e.InitialDefault),
+			formatDefault(e.WriteDefault),
+		})
+	}
+
+	pterm.DefaultTable.
+		WithHasHeader(true).
+		WithHeaderRowSeparator("-").
+		WithData(data).Render()
+}
+
+func (j jsonOutput) SchemaWithDefaults(schema *iceberg.Schema) {
+	entries := buildSchemaFieldsWithDefaults(schema)
+
+	result := struct {
+		SchemaID int                       `json:"schema_id"`
+		Fields   []SchemaFieldWithDefaults `json:"fields"`
+	}{
+		SchemaID: schema.ID,
+		Fields:   entries,
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		j.Error(err)
+	}
+}

--- a/cmd/iceberg/schema_defaults_test.go
+++ b/cmd/iceberg/schema_defaults_test.go
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/pterm/pterm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSchemaFieldsWithDefaults(t *testing.T) {
+	schema, err := iceberg.NewSchemaFromJsonFields(1, `[
+		{"id": 1, "name": "id", "required": true, "type": "long"},
+		{"id": 2, "name": "name", "required": false, "type": "string", "initial-default": "unknown", "write-default": "N/A"},
+		{"id": 3, "name": "count", "required": false, "type": "int", "initial-default": 0, "write-default": 42}
+	]`)
+	require.NoError(t, err)
+
+	fields := buildSchemaFieldsWithDefaults(schema)
+	require.Len(t, fields, 3)
+
+	assert.Equal(t, 1, fields[0].FieldID)
+	assert.Equal(t, "id", fields[0].Name)
+	assert.Equal(t, "long", fields[0].Type)
+	assert.True(t, fields[0].Required)
+	assert.Nil(t, fields[0].InitialDefault)
+	assert.Nil(t, fields[0].WriteDefault)
+
+	assert.Equal(t, 2, fields[1].FieldID)
+	assert.Equal(t, "name", fields[1].Name)
+	assert.False(t, fields[1].Required)
+	assert.Equal(t, "unknown", fields[1].InitialDefault)
+	assert.Equal(t, "N/A", fields[1].WriteDefault)
+
+	assert.Equal(t, 3, fields[2].FieldID)
+	assert.Equal(t, "count", fields[2].Name)
+}
+
+func TestFormatDefault(t *testing.T) {
+	assert.Equal(t, "-", formatDefault(nil))
+	assert.Equal(t, `"hello"`, formatDefault("hello"))
+	assert.Equal(t, "42", formatDefault(42))
+	assert.Equal(t, "3.14", formatDefault(3.14))
+	assert.Equal(t, "true", formatDefault(true))
+}
+
+func TestTextOutputSchemaWithDefaults(t *testing.T) {
+	var buf bytes.Buffer
+	pterm.SetDefaultOutput(&buf)
+	pterm.DisableColor()
+
+	schema, err := iceberg.NewSchemaFromJsonFields(1, `[
+		{"id": 1, "name": "id", "required": true, "type": "long"},
+		{"id": 2, "name": "name", "required": false, "type": "string", "initial-default": "unknown", "write-default": "N/A"}
+	]`)
+	require.NoError(t, err)
+
+	buf.Reset()
+
+	textOutput{}.SchemaWithDefaults(schema)
+
+	output := buf.String()
+	assert.Contains(t, output, "FIELD ID")
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "TYPE")
+	assert.Contains(t, output, "REQUIRED")
+	assert.Contains(t, output, "INIT DEFAULT")
+	assert.Contains(t, output, "WRITE DEFAULT")
+	assert.Contains(t, output, "id")
+	assert.Contains(t, output, "name")
+	assert.Contains(t, output, `"unknown"`)
+}
+
+func TestJSONOutputSchemaWithDefaults(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	schema, err := iceberg.NewSchemaFromJsonFields(5, `[
+		{"id": 1, "name": "x", "required": true, "type": "long"}
+	]`)
+	require.NoError(t, err)
+
+	jsonOutput{}.SchemaWithDefaults(schema)
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	output := buf.String()
+	assert.Contains(t, output, `"schema_id":5`)
+	assert.Contains(t, output, `"fields":[`)
+	assert.Contains(t, output, `"field_id":1`)
+	assert.Contains(t, output, `"name":"x"`)
+}


### PR DESCRIPTION
Enhance `iceberg schema TABLE_ID --show-defaults` to display initial-default and write-default values alongside field definitions.


Related: #957
Depends On: #1073