### PR TITLE
feat(table): gate v3-only metadata fields on sub-v3 reads (#1006)

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1369,14 +1369,15 @@ type v3FieldCheck struct {
 }
 
 func rejectV3OnlyFields(version int, checks ...v3FieldCheck) error {
+	var errs []error
 	for _, c := range checks {
 		if c.present {
-			return fmt.Errorf("%w: v3-only field '%s' present in v%d metadata",
-				ErrInvalidMetadataFormatVersion, c.name, version)
+			errs = append(errs, fmt.Errorf("%w: v3-only field '%s' present in v%d metadata",
+				ErrInvalidMetadataFormatVersion, c.name, version))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // ParseMetadata parses json metadata provided by the passed in reader,

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1363,15 +1363,17 @@ var (
 	ErrPartitionSpecNotFound        = errors.New("partition spec not found")
 )
 
-func rejectV3OnlyFields(version int, nextRowID *int64, encryptionKeys []EncryptionKey) error {
-	if nextRowID != nil {
-		return fmt.Errorf("%w: v3-only field 'next-row-id' present in v%d metadata",
-			ErrInvalidMetadata, version)
-	}
+type v3FieldCheck struct {
+	name    string
+	present bool
+}
 
-	if len(encryptionKeys) > 0 {
-		return fmt.Errorf("%w: v3-only field 'encryption-keys' present in v%d metadata",
-			ErrInvalidMetadata, version)
+func rejectV3OnlyFields(version int, checks ...v3FieldCheck) error {
+	for _, c := range checks {
+		if c.present {
+			return fmt.Errorf("%w: v3-only field '%s' present in v%d metadata",
+				ErrInvalidMetadataFormatVersion, c.name, version)
+		}
 	}
 
 	return nil
@@ -1920,7 +1922,10 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if err := rejectV3OnlyFields(1, aux.NextRowID, aux.EncryptionKeyList); err != nil {
+	if err := rejectV3OnlyFields(aux.FormatVersion,
+		v3FieldCheck{"next-row-id", aux.NextRowID != nil},
+		v3FieldCheck{"encryption-keys", len(aux.EncryptionKeyList) > 0},
+	); err != nil {
 		return err
 	}
 
@@ -1990,7 +1995,10 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if err := rejectV3OnlyFields(2, aux.NextRowID, aux.EncryptionKeyList); err != nil {
+	if err := rejectV3OnlyFields(aux.FormatVersion,
+		v3FieldCheck{"next-row-id", aux.NextRowID != nil},
+		v3FieldCheck{"encryption-keys", len(aux.EncryptionKeyList) > 0},
+	); err != nil {
 		return err
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1363,6 +1363,20 @@ var (
 	ErrPartitionSpecNotFound        = errors.New("partition spec not found")
 )
 
+func rejectV3OnlyFields(version int, nextRowID *int64, encryptionKeys []EncryptionKey) error {
+	if nextRowID != nil {
+		return fmt.Errorf("%w: v3-only field 'next-row-id' present in v%d metadata",
+			ErrInvalidMetadata, version)
+	}
+
+	if len(encryptionKeys) > 0 {
+		return fmt.Errorf("%w: v3-only field 'encryption-keys' present in v%d metadata",
+			ErrInvalidMetadata, version)
+	}
+
+	return nil
+}
+
 // ParseMetadata parses json metadata provided by the passed in reader,
 // returning an error if one is encountered.
 func ParseMetadata(r io.Reader) (Metadata, error) {
@@ -1906,6 +1920,10 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	if err := rejectV3OnlyFields(1, aux.NextRowID, aux.EncryptionKeyList); err != nil {
+		return err
+	}
+
 	// CurrentSchemaID was optional in v1, it can also be expressed via Schema.
 	if aux.CurrentSchemaID == -1 && aux.Schema != nil {
 		aux.CurrentSchemaID = aux.Schema.ID
@@ -1969,6 +1987,10 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 	aux.LastColumnId = -1
 
 	if err := json.Unmarshal(b, aux); err != nil {
+		return err
+	}
+
+	if err := rejectV3OnlyFields(2, aux.NextRowID, aux.EncryptionKeyList); err != nil {
 		return err
 	}
 

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1925,6 +1925,12 @@ func TestRejectV3OnlyFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "v2 rejects multiple v3 fields at once",
+			json:      v2Base + `, "next-row-id": 42, "encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]}`,
+			wantErr:   true,
+			errSubstr: "next-row-id",
+		},
+		{
 			name: "v3 accepts encryption-keys",
 			json: `{
 				"format-version": 3,
@@ -1958,4 +1964,13 @@ func TestRejectV3OnlyFields(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify multiple v3 fields are all reported in a single error.
+	t.Run("reports all rejected fields", func(t *testing.T) {
+		input := v2Base + `, "next-row-id": 42, "encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]}`
+		_, err := ParseMetadataBytes([]byte(input))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "next-row-id")
+		assert.ErrorContains(t, err, "encryption-keys")
+	})
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1854,3 +1854,91 @@ func TestZstdGoldenFixture(t *testing.T) {
 
 	assert.True(t, expected.Equals(meta))
 }
+
+func TestV1RejectsNextRowID(t *testing.T) {
+	data := `{
+		"format-version": 1,
+		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+		"location": "s3://bucket/test/location",
+		"last-updated-ms": 1602638573874,
+		"last-column-id": 3,
+		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+		"current-schema-id": 0,
+		"partition-specs": [{"spec-id": 0, "fields": []}],
+		"default-spec-id": 0,
+		"sort-orders": [{"order-id": 0, "fields": []}],
+		"default-sort-order-id": 0,
+		"next-row-id": 42
+	}`
+
+	_, err := ParseMetadataBytes([]byte(data))
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "v3-only field 'next-row-id' present in v1 metadata")
+}
+
+func TestV1RejectsEncryptionKeys(t *testing.T) {
+	data := `{
+		"format-version": 1,
+		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+		"location": "s3://bucket/test/location",
+		"last-updated-ms": 1602638573874,
+		"last-column-id": 3,
+		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+		"current-schema-id": 0,
+		"partition-specs": [{"spec-id": 0, "fields": []}],
+		"default-spec-id": 0,
+		"sort-orders": [{"order-id": 0, "fields": []}],
+		"default-sort-order-id": 0,
+		"encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]
+	}`
+
+	_, err := ParseMetadataBytes([]byte(data))
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "v3-only field 'encryption-keys' present in v1 metadata")
+}
+
+func TestV2RejectsNextRowID(t *testing.T) {
+	data := `{
+		"format-version": 2,
+		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+		"location": "s3://bucket/test/location",
+		"last-updated-ms": 1602638573874,
+		"last-column-id": 3,
+		"last-sequence-number": 0,
+		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+		"current-schema-id": 0,
+		"partition-specs": [{"spec-id": 0, "fields": []}],
+		"default-spec-id": 0,
+		"last-partition-id": 1000,
+		"sort-orders": [{"order-id": 0, "fields": []}],
+		"default-sort-order-id": 0,
+		"next-row-id": 42
+	}`
+
+	_, err := ParseMetadataBytes([]byte(data))
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "v3-only field 'next-row-id' present in v2 metadata")
+}
+
+func TestV2RejectsEncryptionKeys(t *testing.T) {
+	data := `{
+		"format-version": 2,
+		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+		"location": "s3://bucket/test/location",
+		"last-updated-ms": 1602638573874,
+		"last-column-id": 3,
+		"last-sequence-number": 0,
+		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+		"current-schema-id": 0,
+		"partition-specs": [{"spec-id": 0, "fields": []}],
+		"default-spec-id": 0,
+		"last-partition-id": 1000,
+		"sort-orders": [{"order-id": 0, "fields": []}],
+		"default-sort-order-id": 0,
+		"encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]
+	}`
+
+	_, err := ParseMetadataBytes([]byte(data))
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "v3-only field 'encryption-keys' present in v2 metadata")
+}

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1855,8 +1855,8 @@ func TestZstdGoldenFixture(t *testing.T) {
 	assert.True(t, expected.Equals(meta))
 }
 
-func TestV1RejectsNextRowID(t *testing.T) {
-	data := `{
+func TestRejectV3OnlyFields(t *testing.T) {
+	v1Base := `{
 		"format-version": 1,
 		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
 		"location": "s3://bucket/test/location",
@@ -1867,38 +1867,9 @@ func TestV1RejectsNextRowID(t *testing.T) {
 		"partition-specs": [{"spec-id": 0, "fields": []}],
 		"default-spec-id": 0,
 		"sort-orders": [{"order-id": 0, "fields": []}],
-		"default-sort-order-id": 0,
-		"next-row-id": 42
-	}`
+		"default-sort-order-id": 0`
 
-	_, err := ParseMetadataBytes([]byte(data))
-	require.ErrorIs(t, err, ErrInvalidMetadata)
-	assert.ErrorContains(t, err, "v3-only field 'next-row-id' present in v1 metadata")
-}
-
-func TestV1RejectsEncryptionKeys(t *testing.T) {
-	data := `{
-		"format-version": 1,
-		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
-		"location": "s3://bucket/test/location",
-		"last-updated-ms": 1602638573874,
-		"last-column-id": 3,
-		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
-		"current-schema-id": 0,
-		"partition-specs": [{"spec-id": 0, "fields": []}],
-		"default-spec-id": 0,
-		"sort-orders": [{"order-id": 0, "fields": []}],
-		"default-sort-order-id": 0,
-		"encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]
-	}`
-
-	_, err := ParseMetadataBytes([]byte(data))
-	require.ErrorIs(t, err, ErrInvalidMetadata)
-	assert.ErrorContains(t, err, "v3-only field 'encryption-keys' present in v1 metadata")
-}
-
-func TestV2RejectsNextRowID(t *testing.T) {
-	data := `{
+	v2Base := `{
 		"format-version": 2,
 		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
 		"location": "s3://bucket/test/location",
@@ -1911,34 +1882,80 @@ func TestV2RejectsNextRowID(t *testing.T) {
 		"default-spec-id": 0,
 		"last-partition-id": 1000,
 		"sort-orders": [{"order-id": 0, "fields": []}],
-		"default-sort-order-id": 0,
-		"next-row-id": 42
-	}`
+		"default-sort-order-id": 0`
 
-	_, err := ParseMetadataBytes([]byte(data))
-	require.ErrorIs(t, err, ErrInvalidMetadata)
-	assert.ErrorContains(t, err, "v3-only field 'next-row-id' present in v2 metadata")
-}
+	tests := []struct {
+		name      string
+		json      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "v1 rejects next-row-id",
+			json:      v1Base + `, "next-row-id": 42}`,
+			wantErr:   true,
+			errSubstr: "v3-only field 'next-row-id' present in v1 metadata",
+		},
+		{
+			name:      "v1 rejects encryption-keys",
+			json:      v1Base + `, "encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]}`,
+			wantErr:   true,
+			errSubstr: "v3-only field 'encryption-keys' present in v1 metadata",
+		},
+		{
+			name:    "v1 accepts empty encryption-keys",
+			json:    v1Base + `, "encryption-keys": []}`,
+			wantErr: false,
+		},
+		{
+			name:      "v2 rejects next-row-id",
+			json:      v2Base + `, "next-row-id": 42}`,
+			wantErr:   true,
+			errSubstr: "v3-only field 'next-row-id' present in v2 metadata",
+		},
+		{
+			name:      "v2 rejects encryption-keys",
+			json:      v2Base + `, "encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]}`,
+			wantErr:   true,
+			errSubstr: "v3-only field 'encryption-keys' present in v2 metadata",
+		},
+		{
+			name:    "v2 accepts empty encryption-keys",
+			json:    v2Base + `, "encryption-keys": []}`,
+			wantErr: false,
+		},
+		{
+			name: "v3 accepts encryption-keys",
+			json: `{
+				"format-version": 3,
+				"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+				"location": "s3://bucket/test/location",
+				"last-updated-ms": 1602638573874,
+				"last-column-id": 3,
+				"last-sequence-number": 0,
+				"next-row-id": 1,
+				"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
+				"current-schema-id": 0,
+				"partition-specs": [{"spec-id": 0, "fields": []}],
+				"default-spec-id": 0,
+				"last-partition-id": 1000,
+				"sort-orders": [{"order-id": 0, "fields": []}],
+				"default-sort-order-id": 0,
+				"encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]
+			}`,
+			wantErr: false,
+		},
+	}
 
-func TestV2RejectsEncryptionKeys(t *testing.T) {
-	data := `{
-		"format-version": 2,
-		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
-		"location": "s3://bucket/test/location",
-		"last-updated-ms": 1602638573874,
-		"last-column-id": 3,
-		"last-sequence-number": 0,
-		"schemas": [{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"x","required":true,"type":"long"}]}],
-		"current-schema-id": 0,
-		"partition-specs": [{"spec-id": 0, "fields": []}],
-		"default-spec-id": 0,
-		"last-partition-id": 1000,
-		"sort-orders": [{"order-id": 0, "fields": []}],
-		"default-sort-order-id": 0,
-		"encryption-keys": [{"key-id": "k1", "encrypted-key-metadata": "abc123"}]
-	}`
-
-	_, err := ParseMetadataBytes([]byte(data))
-	require.ErrorIs(t, err, ErrInvalidMetadata)
-	assert.ErrorContains(t, err, "v3-only field 'encryption-keys' present in v2 metadata")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseMetadataBytes([]byte(tt.json))
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrInvalidMetadataFormatVersion)
+				assert.ErrorContains(t, err, tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Reject next-row-id and encryption-keys during v1/v2 metadata parsing with a descriptive error naming the field and required format version.

Closes: #1006 