### PR TITLE
fix(gocloud): support cross-bucket IO for write.metadata.path

### DIFF
--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -124,6 +124,7 @@ func (bfs *blobFileIO) resolveBucket(path string) (*blob.Bucket, string, error) 
 	if !hasScheme {
 		// No scheme: treat as a key in the primary bucket (legacy behavior).
 		key, err := bfs.keyExtractor(path)
+
 		return bfs.Bucket, key, err
 	}
 
@@ -142,6 +143,7 @@ func (bfs *blobFileIO) resolveBucket(path string) (*blob.Bucket, string, error) 
 		// No opener configured: fall back to primary bucket with legacy key extraction.
 		// This preserves backward compatibility for callers that don't set a BucketOpener.
 		key, err := bfs.keyExtractor(path)
+
 		return bfs.Bucket, key, err
 	}
 
@@ -163,6 +165,7 @@ func (bfs *blobFileIO) resolveBucket(path string) (*blob.Bucket, string, error) 
 	if existing, ok := bfs.buckets[bucketName]; ok {
 		bfs.mu.Unlock()
 		_ = b.Close()
+
 		return existing, key, nil
 	}
 	bfs.buckets[bucketName] = b

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	icebergio "github.com/apache/iceberg-go/io"
 	"gocloud.dev/blob"
@@ -91,8 +92,20 @@ func defaultKeyExtractor(bucketName string) KeyExtractor {
 	}
 }
 
+// BucketOpener creates a new blob.Bucket for the given bucket name.
+// Used to lazily open secondary buckets when a URI references a bucket
+// different from the primary one (e.g. write.metadata.path pointing to
+// a separate metadata bucket).
+type BucketOpener func(ctx context.Context, bucketName string) (*blob.Bucket, error)
+
 type blobFileIO struct {
 	*blob.Bucket
+
+	primaryBucket string
+	bucketOpener  BucketOpener
+
+	mu      sync.RWMutex
+	buckets map[string]*blob.Bucket
 
 	keyExtractor KeyExtractor
 	ctx          context.Context
@@ -102,23 +115,78 @@ type blobFileIO struct {
 	newRangeReader func(ctx context.Context, key string, offset, length int64) (io.ReadCloser, error)
 }
 
+// resolveBucket parses path into a bucket handle and object key. If the URI
+// references the primary bucket (or has no scheme), the primary bucket is
+// returned without any additional allocation. URIs that reference a different
+// bucket are resolved via BucketOpener and cached for reuse.
+func (bfs *blobFileIO) resolveBucket(path string) (*blob.Bucket, string, error) {
+	_, after, hasScheme := strings.Cut(path, "://")
+	if !hasScheme {
+		// No scheme: treat as a key in the primary bucket (legacy behavior).
+		key, err := bfs.keyExtractor(path)
+		return bfs.Bucket, key, err
+	}
+
+	bucketName, key, _ := strings.Cut(after, "/")
+	if key == "" {
+		return nil, "", fmt.Errorf("URI path is empty: %s", path)
+	}
+
+	// Fast path: primary bucket.
+	if bucketName == bfs.primaryBucket {
+		return bfs.Bucket, key, nil
+	}
+
+	// Secondary bucket: check cache first.
+	if bfs.bucketOpener == nil {
+		// No opener configured: fall back to primary bucket with legacy key extraction.
+		// This preserves backward compatibility for callers that don't set a BucketOpener.
+		key, err := bfs.keyExtractor(path)
+		return bfs.Bucket, key, err
+	}
+
+	bfs.mu.RLock()
+	b, ok := bfs.buckets[bucketName]
+	bfs.mu.RUnlock()
+	if ok {
+		return b, key, nil
+	}
+
+	// Open a new bucket handle.
+	b, err := bfs.bucketOpener(bfs.ctx, bucketName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to open bucket %q: %w", bucketName, err)
+	}
+
+	bfs.mu.Lock()
+	// Double-check: another goroutine may have opened it concurrently.
+	if existing, ok := bfs.buckets[bucketName]; ok {
+		bfs.mu.Unlock()
+		_ = b.Close()
+		return existing, key, nil
+	}
+	bfs.buckets[bucketName] = b
+	bfs.mu.Unlock()
+
+	return b, key, nil
+}
+
 func (bfs *blobFileIO) preprocess(path string) (string, error) {
 	return bfs.keyExtractor(path)
 }
 
 func (bfs *blobFileIO) Open(path string) (icebergio.File, error) {
-	var err error
-	path, err = bfs.preprocess(path)
+	bucket, key, err := bfs.resolveBucket(path)
 	if err != nil {
 		return nil, &fs.PathError{Op: "open", Path: path, Err: err}
 	}
-	if !fs.ValidPath(path) {
-		return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrInvalid}
+	if !fs.ValidPath(key) {
+		return nil, &fs.PathError{Op: "open", Path: key, Err: fs.ErrInvalid}
 	}
 
-	key, name := path, filepath.Base(path)
+	name := filepath.Base(key)
 
-	r, err := bfs.NewReader(bfs.ctx, key, nil)
+	r, err := bucket.NewReader(bfs.ctx, key, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +195,12 @@ func (bfs *blobFileIO) Open(path string) (icebergio.File, error) {
 }
 
 func (bfs *blobFileIO) Remove(name string) error {
-	var err error
-	name, err = bfs.preprocess(name)
+	bucket, key, err := bfs.resolveBucket(name)
 	if err != nil {
 		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
 
-	return bfs.Delete(bfs.ctx, name)
+	return bucket.Delete(bfs.ctx, key)
 }
 
 func (bfs *blobFileIO) Create(name string) (icebergio.FileWriter, error) {
@@ -141,13 +208,12 @@ func (bfs *blobFileIO) Create(name string) (icebergio.FileWriter, error) {
 }
 
 func (bfs *blobFileIO) WriteFile(name string, content []byte) error {
-	var err error
-	name, err = bfs.preprocess(name)
+	bucket, key, err := bfs.resolveBucket(name)
 	if err != nil {
 		return &fs.PathError{Op: "write file", Path: name, Err: err}
 	}
 
-	return bfs.WriteAll(bfs.ctx, name, content, nil)
+	return bucket.WriteAll(bfs.ctx, key, content, nil)
 }
 
 // NewWriter returns a Writer that writes to the blob stored at path.
@@ -159,37 +225,53 @@ func (bfs *blobFileIO) WriteFile(name string, content []byte) error {
 // The caller must call Close on the returned Writer, even if the write is
 // aborted.
 func (bfs *blobFileIO) NewWriter(ctx context.Context, path string, overwrite bool, opts *blob.WriterOptions) (w *blobWriteFile, err error) {
-	path, err = bfs.preprocess(path)
+	bucket, key, err := bfs.resolveBucket(path)
 	if err != nil {
 		return nil, &fs.PathError{Op: "new writer", Path: path, Err: err}
 	}
-	if !fs.ValidPath(path) {
-		return nil, &fs.PathError{Op: "new writer", Path: path, Err: fs.ErrInvalid}
+	if !fs.ValidPath(key) {
+		return nil, &fs.PathError{Op: "new writer", Path: key, Err: fs.ErrInvalid}
 	}
 
 	if !overwrite {
-		if exists, err := bfs.Exists(ctx, path); err != nil || exists {
+		if exists, err := bucket.Exists(ctx, key); err != nil || exists {
 			if err != nil {
-				return nil, &fs.PathError{Op: "new writer", Path: path, Err: err}
+				return nil, &fs.PathError{Op: "new writer", Path: key, Err: err}
 			}
 
-			return nil, &fs.PathError{Op: "new writer", Path: path, Err: fs.ErrInvalid}
+			return nil, &fs.PathError{Op: "new writer", Path: key, Err: fs.ErrInvalid}
 		}
 	}
-	bw, err := bfs.Bucket.NewWriter(ctx, path, opts)
+	bw, err := bucket.NewWriter(ctx, key, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	return &blobWriteFile{
 			Writer: bw,
-			name:   path,
+			name:   key,
 		},
 		nil
 }
 
 func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor) icebergio.IO {
-	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, ctx: ctx}
+	return &blobFileIO{
+		Bucket:       bucket,
+		keyExtractor: keyExtractor,
+		ctx:          ctx,
+		buckets:      make(map[string]*blob.Bucket),
+	}
+}
+
+func createMultiBucketBlobFS(ctx context.Context, bucket *blob.Bucket, primaryBucket string, opener BucketOpener) icebergio.IO {
+	return &blobFileIO{
+		Bucket:        bucket,
+		primaryBucket: primaryBucket,
+		bucketOpener:  opener,
+		buckets:       make(map[string]*blob.Bucket),
+		keyExtractor:  defaultKeyExtractor(primaryBucket),
+		ctx:           ctx,
+	}
 }
 
 func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
@@ -220,14 +302,14 @@ func (bfs *blobFileIO) DeleteFiles(ctx context.Context, paths []string) ([]strin
 	var errs error
 
 	for _, p := range paths {
-		key, err := bfs.preprocess(p)
+		bucket, key, err := bfs.resolveBucket(p)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
 
 			continue
 		}
 
-		if err := bfs.Delete(ctx, key); err != nil {
+		if err := bucket.Delete(ctx, key); err != nil {
 			// Missing files are not errors per the interface contract.
 			if gcerrors.Code(err) == gcerrors.NotFound {
 				deleted = append(deleted, p)

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -403,6 +403,7 @@ func TestMultiBucketWriteAndRead(t *testing.T) {
 			if name == "metadata" {
 				return metadataBucket, nil
 			}
+
 			return nil, fmt.Errorf("unknown bucket: %s", name)
 		},
 		buckets:      make(map[string]*blob.Bucket),
@@ -468,6 +469,7 @@ func TestMultiBucketDelete(t *testing.T) {
 			if name == "metadata" {
 				return metadataBucket, nil
 			}
+
 			return nil, fmt.Errorf("unknown bucket: %s", name)
 		},
 		buckets:      make(map[string]*blob.Bucket),
@@ -521,6 +523,7 @@ func TestMultiBucketOpenerCaching(t *testing.T) {
 			if name == "metadata" {
 				return metadataBucket, nil
 			}
+
 			return nil, fmt.Errorf("unknown bucket: %s", name)
 		},
 		buckets:      make(map[string]*blob.Bucket),

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -19,6 +19,7 @@ package gocloud
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	icebergio "github.com/apache/iceberg-go/io"
+	"gocloud.dev/blob"
 	"gocloud.dev/blob/memblob"
 )
 
@@ -93,6 +95,7 @@ func TestNewWriterExistsError(t *testing.T) {
 		Bucket:       bucket,
 		keyExtractor: func(path string) (string, error) { return path, nil },
 		ctx:          ctx,
+		buckets:      make(map[string]*blob.Bucket),
 	}
 	require.NoError(t, bucket.Close())
 
@@ -378,4 +381,190 @@ func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
 	deleted, err := bulk.DeleteFiles(ctx, nil)
 	require.NoError(t, err)
 	assert.Nil(t, deleted)
+}
+
+// TestMultiBucketWriteAndRead verifies that blobFileIO routes reads and writes
+// to the correct bucket when a URI references a bucket different from the
+// primary one. This is the scenario triggered by Iceberg's write.metadata.path
+// table property pointing to a dedicated metadata bucket while data lives in
+// the warehouse bucket.
+func TestMultiBucketWriteAndRead(t *testing.T) {
+	ctx := context.Background()
+
+	warehouseBucket := memblob.OpenBucket(nil)
+	defer warehouseBucket.Close()
+	metadataBucket := memblob.OpenBucket(nil)
+	defer metadataBucket.Close()
+
+	bfs := &blobFileIO{
+		Bucket:        warehouseBucket,
+		primaryBucket: "warehouse",
+		bucketOpener: func(_ context.Context, name string) (*blob.Bucket, error) {
+			if name == "metadata" {
+				return metadataBucket, nil
+			}
+			return nil, fmt.Errorf("unknown bucket: %s", name)
+		},
+		buckets:      make(map[string]*blob.Bucket),
+		keyExtractor: defaultKeyExtractor("warehouse"),
+		ctx:          ctx,
+	}
+
+	// Write a data file to the primary (warehouse) bucket.
+	require.NoError(t, bfs.WriteFile("s3://warehouse/db/table/data/file.parquet", []byte("data-content")))
+
+	// Write a manifest list to the metadata bucket (simulates write.metadata.path).
+	require.NoError(t, bfs.WriteFile("s3://metadata/db/table/snap-123.avro", []byte("manifest-list")))
+
+	// Verify the data file landed in the warehouse bucket, not the metadata bucket.
+	exists, err := warehouseBucket.Exists(ctx, "db/table/data/file.parquet")
+	require.NoError(t, err)
+	assert.True(t, exists, "data file should exist in warehouse bucket")
+
+	exists, err = metadataBucket.Exists(ctx, "db/table/data/file.parquet")
+	require.NoError(t, err)
+	assert.False(t, exists, "data file should NOT exist in metadata bucket")
+
+	// Verify the manifest list landed in the metadata bucket, not the warehouse bucket.
+	exists, err = metadataBucket.Exists(ctx, "db/table/snap-123.avro")
+	require.NoError(t, err)
+	assert.True(t, exists, "manifest list should exist in metadata bucket")
+
+	exists, err = warehouseBucket.Exists(ctx, "db/table/snap-123.avro")
+	require.NoError(t, err)
+	assert.False(t, exists, "manifest list should NOT exist in warehouse bucket")
+
+	// Read back via Open (uses resolveBucket).
+	f, err := bfs.Open("s3://metadata/db/table/snap-123.avro")
+	require.NoError(t, err)
+	defer f.Close()
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, "manifest-list", string(content))
+
+	// Read from the primary bucket.
+	f2, err := bfs.Open("s3://warehouse/db/table/data/file.parquet")
+	require.NoError(t, err)
+	defer f2.Close()
+	content2, err := io.ReadAll(f2)
+	require.NoError(t, err)
+	assert.Equal(t, "data-content", string(content2))
+}
+
+// TestMultiBucketDelete verifies that Remove and DeleteFiles route to the
+// correct bucket based on the URI.
+func TestMultiBucketDelete(t *testing.T) {
+	ctx := context.Background()
+
+	warehouseBucket := memblob.OpenBucket(nil)
+	defer warehouseBucket.Close()
+	metadataBucket := memblob.OpenBucket(nil)
+	defer metadataBucket.Close()
+
+	bfs := &blobFileIO{
+		Bucket:        warehouseBucket,
+		primaryBucket: "warehouse",
+		bucketOpener: func(_ context.Context, name string) (*blob.Bucket, error) {
+			if name == "metadata" {
+				return metadataBucket, nil
+			}
+			return nil, fmt.Errorf("unknown bucket: %s", name)
+		},
+		buckets:      make(map[string]*blob.Bucket),
+		keyExtractor: defaultKeyExtractor("warehouse"),
+		ctx:          ctx,
+	}
+
+	// Seed files in both buckets.
+	require.NoError(t, warehouseBucket.WriteAll(ctx, "data/file.parquet", []byte("d"), nil))
+	require.NoError(t, metadataBucket.WriteAll(ctx, "snap-456.avro", []byte("m"), nil))
+
+	// Remove from metadata bucket.
+	require.NoError(t, bfs.Remove("s3://metadata/snap-456.avro"))
+	exists, err := metadataBucket.Exists(ctx, "snap-456.avro")
+	require.NoError(t, err)
+	assert.False(t, exists, "metadata file should be deleted")
+
+	// Warehouse file should be untouched.
+	exists, err = warehouseBucket.Exists(ctx, "data/file.parquet")
+	require.NoError(t, err)
+	assert.True(t, exists, "warehouse file should still exist")
+
+	// DeleteFiles across both buckets.
+	require.NoError(t, warehouseBucket.WriteAll(ctx, "old-manifest.avro", []byte("x"), nil))
+	require.NoError(t, metadataBucket.WriteAll(ctx, "old-snap.avro", []byte("y"), nil))
+
+	deleted, err := bfs.DeleteFiles(ctx, []string{
+		"s3://warehouse/old-manifest.avro",
+		"s3://metadata/old-snap.avro",
+	})
+	require.NoError(t, err)
+	assert.Len(t, deleted, 2)
+}
+
+// TestMultiBucketOpenerCaching verifies that the bucket opener is called only
+// once per bucket name, and subsequent requests reuse the cached handle.
+func TestMultiBucketOpenerCaching(t *testing.T) {
+	ctx := context.Background()
+
+	warehouseBucket := memblob.OpenBucket(nil)
+	defer warehouseBucket.Close()
+	metadataBucket := memblob.OpenBucket(nil)
+	defer metadataBucket.Close()
+
+	openCount := 0
+	bfs := &blobFileIO{
+		Bucket:        warehouseBucket,
+		primaryBucket: "warehouse",
+		bucketOpener: func(_ context.Context, name string) (*blob.Bucket, error) {
+			openCount++
+			if name == "metadata" {
+				return metadataBucket, nil
+			}
+			return nil, fmt.Errorf("unknown bucket: %s", name)
+		},
+		buckets:      make(map[string]*blob.Bucket),
+		keyExtractor: defaultKeyExtractor("warehouse"),
+		ctx:          ctx,
+	}
+
+	require.NoError(t, metadataBucket.WriteAll(ctx, "file1.avro", []byte("a"), nil))
+	require.NoError(t, metadataBucket.WriteAll(ctx, "file2.avro", []byte("b"), nil))
+
+	// Two reads from the same secondary bucket.
+	f1, err := bfs.Open("s3://metadata/file1.avro")
+	require.NoError(t, err)
+	f1.Close()
+
+	f2, err := bfs.Open("s3://metadata/file2.avro")
+	require.NoError(t, err)
+	f2.Close()
+
+	assert.Equal(t, 1, openCount, "bucket opener should be called exactly once for 'metadata'")
+}
+
+// TestMultiBucketFallbackWithoutOpener verifies backward compatibility: when
+// no BucketOpener is configured, cross-bucket URIs fall back to the primary
+// bucket with the legacy key extractor.
+func TestMultiBucketFallbackWithoutOpener(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	// No bucketOpener set: uses legacy createBlobFS path.
+	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("warehouse"))
+
+	// Write using a URI with a different bucket name. Without an opener,
+	// the key extractor strips "://other-bucket/" and the file ends up
+	// in the primary bucket under a mangled key (legacy behavior).
+	wfs := bfs.(icebergio.WriteFileIO)
+	require.NoError(t, wfs.WriteFile(
+		"s3://other-bucket/path/file.txt", []byte("hello")))
+
+	// The file lands in the primary bucket with the full "other-bucket/path/file.txt" key
+	// because TrimPrefix("other-bucket/...", "warehouse/") is a no-op.
+	exists, err := bucket.Exists(ctx, "other-bucket/path/file.txt")
+	require.NoError(t, err)
+	assert.True(t, exists, "without opener, cross-bucket URI should fall back to primary bucket with mangled key")
 }

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -41,6 +41,7 @@ func registerS3Schemes() {
 
 		opener := func(ctx context.Context, bucketName string) (*blob.Bucket, error) {
 			u := &url.URL{Scheme: parsed.Scheme, Host: bucketName}
+
 			return createS3Bucket(ctx, u, props)
 		}
 

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	icebergio "github.com/apache/iceberg-go/io"
+	"gocloud.dev/blob"
 )
 
 func init() {
@@ -38,7 +39,12 @@ func registerS3Schemes() {
 			return nil, err
 		}
 
-		return createBlobFS(ctx, bucket, defaultKeyExtractor(parsed.Host)), nil
+		opener := func(ctx context.Context, bucketName string) (*blob.Bucket, error) {
+			u := &url.URL{Scheme: parsed.Scheme, Host: bucketName}
+			return createS3Bucket(ctx, u, props)
+		}
+
+		return createMultiBucketBlobFS(ctx, bucket, parsed.Host, opener), nil
 	}
 	icebergio.Register("s3", s3Factory)
 	icebergio.Register("s3a", s3Factory)


### PR DESCRIPTION
## Summary

The blob `FileIO` implementation assumes all file operations target a single S3 bucket (the warehouse bucket opened at init time). When Iceberg's `write.metadata.path` table property points to a different bucket (e.g. a dedicated versioned metadata bucket), `defaultKeyExtractor` strips the wrong bucket prefix and the file lands in the warehouse bucket under a mangled key. Readers following the absolute S3 URI in `metadata.json` get a 404.

**Concrete failure mode**: Setting `write.metadata.path = s3://metadata-bucket/db/table/` causes manifest lists (`snap-*.avro`) and manifest files (`*-m*.avro`) to be written to `s3://warehouse-bucket/metadata-bucket/db/table/snap-*.avro` instead of `s3://metadata-bucket/db/table/snap-*.avro`. The `metadata.json` records the correct URI, but the bytes are in the wrong place.

## Changes

- Add `resolveBucket()` to `blobFileIO` which parses the full S3 URI and routes to the correct bucket
- Primary bucket (warehouse) uses the fast path with no map lookup
- Secondary buckets are opened lazily via a `BucketOpener` callback and cached with `sync.RWMutex`
- Update `Open`, `NewWriter`, `WriteFile`, `Remove`, and `DeleteFiles` to use `resolveBucket`
- Wire S3 scheme registration to pass a `BucketOpener` that reuses the same AWS config
- Backward compatible: callers without a `BucketOpener` get the same legacy behavior

## Test plan

- [x] `TestMultiBucketWriteAndRead` - writes to two memblob buckets via different S3 URIs, verifies files land in the correct bucket and can be read back
- [x] `TestMultiBucketDelete` - verifies `Remove` and `DeleteFiles` route to the correct bucket
- [x] `TestMultiBucketOpenerCaching` - verifies the opener is called once per bucket name
- [x] `TestMultiBucketFallbackWithoutOpener` - verifies backward compatibility when no opener is set
- [x] All existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)