### PR TITLE
feat(table): gate v2-only metadata fields on v1 reads

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1363,17 +1363,18 @@ var (
 	ErrPartitionSpecNotFound        = errors.New("partition spec not found")
 )
 
-type v3FieldCheck struct {
-	name    string
-	present bool
+type versionScopedField struct {
+	name       string
+	introduced int
+	present    bool
 }
 
-func rejectV3OnlyFields(version int, checks ...v3FieldCheck) error {
+func rejectFieldsBeyondVersion(currentVersion int, fields ...versionScopedField) error {
 	var errs []error
-	for _, c := range checks {
-		if c.present {
-			errs = append(errs, fmt.Errorf("%w: v3-only field '%s' present in v%d metadata",
-				ErrInvalidMetadataFormatVersion, c.name, version))
+	for _, f := range fields {
+		if f.present && currentVersion < f.introduced {
+			errs = append(errs, fmt.Errorf("%w: v%d-only field '%s' present in v%d metadata",
+				ErrInvalidMetadataFormatVersion, f.introduced, f.name, currentVersion))
 		}
 	}
 
@@ -1923,9 +1924,11 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if err := rejectV3OnlyFields(aux.FormatVersion,
-		v3FieldCheck{"next-row-id", aux.NextRowID != nil},
-		v3FieldCheck{"encryption-keys", len(aux.EncryptionKeyList) > 0},
+	if err := rejectFieldsBeyondVersion(
+		aux.FormatVersion,
+		versionScopedField{name: "last-sequence-number", introduced: 2, present: aux.LastSequenceNumber != nil},
+		versionScopedField{name: "next-row-id", introduced: 3, present: aux.NextRowID != nil},
+		versionScopedField{name: "encryption-keys", introduced: 3, present: len(aux.EncryptionKeyList) > 0},
 	); err != nil {
 		return err
 	}
@@ -1996,9 +1999,10 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if err := rejectV3OnlyFields(aux.FormatVersion,
-		v3FieldCheck{"next-row-id", aux.NextRowID != nil},
-		v3FieldCheck{"encryption-keys", len(aux.EncryptionKeyList) > 0},
+	if err := rejectFieldsBeyondVersion(
+		aux.FormatVersion,
+		versionScopedField{name: "next-row-id", introduced: 3, present: aux.NextRowID != nil},
+		versionScopedField{name: "encryption-keys", introduced: 3, present: len(aux.EncryptionKeyList) > 0},
 	); err != nil {
 		return err
 	}

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1855,7 +1855,7 @@ func TestZstdGoldenFixture(t *testing.T) {
 	assert.True(t, expected.Equals(meta))
 }
 
-func TestRejectV3OnlyFields(t *testing.T) {
+func TestRejectFieldsBeyondVersion(t *testing.T) {
 	v1Base := `{
 		"format-version": 1,
 		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
@@ -1908,6 +1908,12 @@ func TestRejectV3OnlyFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "v1 rejects last-sequence-number",
+			json:      v1Base + `, "last-sequence-number": 7}`,
+			wantErr:   true,
+			errSubstr: "v2-only field 'last-sequence-number' present in v1 metadata",
+		},
+		{
 			name:      "v2 rejects next-row-id",
 			json:      v2Base + `, "next-row-id": 42}`,
 			wantErr:   true,
@@ -1922,6 +1928,11 @@ func TestRejectV3OnlyFields(t *testing.T) {
 		{
 			name:    "v2 accepts empty encryption-keys",
 			json:    v2Base + `, "encryption-keys": []}`,
+			wantErr: false,
+		},
+		{
+			name:    "v2 accepts last-sequence-number",
+			json:    v2Base + `, "last-sequence-number": 7}`,
 			wantErr: false,
 		},
 		{
@@ -1972,5 +1983,14 @@ func TestRejectV3OnlyFields(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "next-row-id")
 		assert.ErrorContains(t, err, "encryption-keys")
+	})
+
+	// Verify mixed v2-only and v3-only fields in v1 metadata are all reported.
+	t.Run("v1 reports fields from both v2 and v3", func(t *testing.T) {
+		input := v1Base + `, "last-sequence-number": 7, "next-row-id": 42}`
+		_, err := ParseMetadataBytes([]byte(input))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "last-sequence-number")
+		assert.ErrorContains(t, err, "next-row-id")
 	})
 }


### PR DESCRIPTION
Closes #1087.

`#1069` added `rejectV3OnlyFields` to catch v3-only fields in pre-v3 metadata.

This PR applies the same idea to `last-sequence-number`: it’s a v2+ field on the shared `commonMetadata` struct, but today we silently accept it when reading v1 metadata.

To keep the check from becoming one-off, this generalizes the helper to `rejectFieldsBeyondVersion(currentVersion, fields...)`, where each field includes the format version it was introduced in. `last-sequence-number` is then wired into the v1 read path. For v2 reads, `next-row-id` / `encryption-keys` go through the same generalized helper, with no behavior change.

One caveat: this depends on the discussion in `#1086`. If we decide to relax the v3-only gate and silently ignore forward-looking fields for compatibility, then this PR becomes moot and should be revisited together with the strictness introduced in `#1069`.
