### PR TITLE
fix(table): release Arrow chunks on GetRecords error paths

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -51,6 +51,24 @@ type (
 	perFilePosDeletes = map[string]positionDeletes
 )
 
+// releasePerFilePosDeletes releases every Arrow chunk in a positional-delete
+// map. Required on every error return between readAllDeleteFiles and the
+// iterator returned by createIterator — Arrow allocations are not freed by
+// GC, so dropping the map on the floor leaks the chunks. Safe to call on a
+// nil map; the nil-chunk guard is defensive — readDeletes never inserts a
+// nil *arrow.Chunked, but the guard keeps callers safe if that invariant
+// ever changes (e.g. when readAllDeletionVectors lands and starts merging
+// into the same map).
+func releasePerFilePosDeletes(deletesPerFile perFilePosDeletes) {
+	for _, chunks := range deletesPerFile {
+		for _, chunk := range chunks {
+			if chunk != nil {
+				chunk.Release()
+			}
+		}
+	}
+}
+
 func readAllDeleteFiles(ctx context.Context, fs iceio.IO, tasks []FileScanTask, concurrency int) (perFilePosDeletes, error) {
 	var (
 		deletesPerFile = make(perFilePosDeletes)
@@ -751,11 +769,7 @@ func createIterator(ctx context.Context, numWorkers uint, records <-chan enumera
 				}
 			}
 
-			for _, v := range deletesPerFile {
-				for _, chunk := range v {
-					chunk.Release()
-				}
-			}
+			releasePerFilePosDeletes(deletesPerFile)
 		}()
 
 		defer cancel(nil)
@@ -889,12 +903,19 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 
 	deletesPerFile, err := readAllDeleteFiles(ctx, as.fs, tasks, as.concurrency)
 	if err != nil {
+		// readAllDeleteFiles can return a partially-populated map alongside
+		// the error if some goroutines completed before the failure.
+		releasePerFilePosDeletes(deletesPerFile)
+
 		return nil, nil, err
 	}
 
 	eqDeleteSets, err := readAllEqualityDeleteFiles(ctx, as.fs,
 		as.metadata.CurrentSchema(), tasks, as.concurrency)
 	if err != nil {
+		// Positional deletes were fully loaded; release them before aborting.
+		releasePerFilePosDeletes(deletesPerFile)
+
 		return nil, nil, err
 	}
 

--- a/table/arrow_scanner_test.go
+++ b/table/arrow_scanner_test.go
@@ -127,3 +127,67 @@ func mustLoadRecordBatchFromJSON(schema *arrow.Schema, content string) arrow.Rec
 
 	return recordBatch
 }
+
+// chunkedPosDelete allocates a positional-delete *arrow.Chunked against mem so
+// the CheckedAllocator can prove leaks. Returns a chunked that owns one Int64
+// array of `positions` values.
+func chunkedPosDelete(t *testing.T, mem memory.Allocator, positions []int64) *arrow.Chunked {
+	t.Helper()
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(positions, nil)
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	return arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{arr})
+}
+
+// TestReleasePerFilePosDeletes verifies the helper releases every Arrow chunk
+// it holds, leaving the allocator at zero outstanding bytes. Three cases:
+// populated map, nil map (must not panic), and a positionDeletes slice
+// containing a nil chunk (must not panic).
+//
+// This is the regression net for GetRecords' error-return paths: a future
+// change that drops a perFilePosDeletes map on the floor without calling
+// this helper will reintroduce the leak fixed by #1051.
+func TestReleasePerFilePosDeletes(t *testing.T) {
+	t.Run("populated map releases all chunks", func(t *testing.T) {
+		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer mem.AssertSize(t, 0)
+
+		m := perFilePosDeletes{
+			"file://a.parquet": positionDeletes{
+				chunkedPosDelete(t, mem, []int64{0, 1, 2}),
+				chunkedPosDelete(t, mem, []int64{10, 11}),
+			},
+			"file://b.parquet": positionDeletes{
+				chunkedPosDelete(t, mem, []int64{42}),
+			},
+		}
+
+		releasePerFilePosDeletes(m)
+	})
+
+	t.Run("nil map does not panic", func(t *testing.T) {
+		require.NotPanics(t, func() { releasePerFilePosDeletes(nil) })
+	})
+
+	t.Run("nil chunk in slice does not panic", func(t *testing.T) {
+		// Defensive: production code paths never insert a nil *arrow.Chunked
+		// into the map. This subtest pins the guard so a future caller (the
+		// in-flight readAllDeletionVectors merger, or a refactor of readDeletes)
+		// can't silently NPE the cleanup path.
+		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer mem.AssertSize(t, 0)
+
+		m := perFilePosDeletes{
+			"file://a.parquet": positionDeletes{
+				nil,
+				chunkedPosDelete(t, mem, []int64{7}),
+				nil,
+			},
+		}
+
+		require.NotPanics(t, func() { releasePerFilePosDeletes(m) })
+	})
+}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1653,6 +1653,10 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 
 	deletesPerFile, err := readAllDeleteFiles(ctx, fs, tasks, concurrency)
 	if err != nil {
+		// readAllDeleteFiles can return a partially-populated map alongside
+		// the error if some goroutines completed before the failure.
+		releasePerFilePosDeletes(deletesPerFile)
+
 		return nil, err
 	}
 


### PR DESCRIPTION
GetRecords and Transaction.makePositionDeleteRecordsForFilter drop the perFilePosDeletes map on error without releasing its *arrow.Chunked values; extract releasePerFilePosDeletes and call on each error return.

Closes #1051.