### PR TITLE
feat(table): add SerializeDV and DVWriter for deletion vector authoring

### DIFF
--- a/io/mem.go
+++ b/io/mem.go
@@ -60,6 +60,11 @@ type MemFS struct {
 	files map[string][]byte // keyed by full URI
 }
 
+// NewMemFS creates an initialized MemFS ready for use.
+func NewMemFS() *MemFS {
+	return &MemFS{files: make(map[string][]byte)}
+}
+
 func (m *MemFS) Open(name string) (File, error) {
 	m.mu.RLock()
 	data, ok := m.files[name]

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -18,6 +18,7 @@
 package dv
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -99,6 +100,33 @@ func DeserializeDV(data []byte, expectedCardinality int64) (*RoaringPositionBitm
 	}
 
 	return bitmap, nil
+}
+
+// SerializeDV produces the spec-format DV binary envelope from a bitmap:
+//
+//   - Length (4 bytes, big-endian): size of magic + bitmap data, excluding CRC-32
+//   - Magic  (4 bytes, little-endian): DVMagicNumber
+//   - Bitmap (variable): roaring bitmap in Iceberg portable format
+//   - CRC-32 (4 bytes, big-endian): checksum over magic + bitmap
+func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
+	var bitmapBuf bytes.Buffer
+	if err := bitmap.Serialize(&bitmapBuf); err != nil {
+		return nil, fmt.Errorf("serialize roaring bitmap: %w", err)
+	}
+
+	bitmapBytes := bitmapBuf.Bytes()
+	innerLen := dvMagicSize + len(bitmapBytes)
+	totalSize := dvLengthSize + innerLen + dvCRCSize
+	out := make([]byte, totalSize)
+
+	binary.BigEndian.PutUint32(out[0:dvLengthSize], uint32(innerLen))
+	binary.LittleEndian.PutUint32(out[dvLengthSize:dvLengthSize+dvMagicSize], DVMagicNumber)
+	copy(out[dvLengthSize+dvMagicSize:], bitmapBytes)
+
+	crc := crc32.ChecksumIEEE(out[dvLengthSize : totalSize-dvCRCSize])
+	binary.BigEndian.PutUint32(out[totalSize-dvCRCSize:], crc)
+
+	return out, nil
 }
 
 // ReadDV reads a deletion vector from a puffin file using the manifest entry metadata.

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dv
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/puffin"
+)
+
+// DVWriter accumulates deletion positions per data file and flushes them as
+// a single Puffin file containing one deletion-vector-v1 blob per data file.
+// The returned DataFile entries are ready for RowDelta.AddDeletes().
+type DVWriter struct {
+	fs      iceio.WriteFileIO
+	entries map[string]*RoaringPositionBitmap
+	order   []string
+}
+
+// NewDVWriter creates a DVWriter backed by the given writable filesystem.
+func NewDVWriter(fs iceio.WriteFileIO) *DVWriter {
+	return &DVWriter{
+		fs:      fs,
+		entries: make(map[string]*RoaringPositionBitmap),
+	}
+}
+
+// Add accumulates positions to delete for a given data file.
+// Positions are deduplicated via the underlying roaring bitmap.
+func (w *DVWriter) Add(dataFilePath string, positions []int64) {
+	bm, ok := w.entries[dataFilePath]
+	if !ok {
+		bm = NewRoaringPositionBitmap()
+		w.entries[dataFilePath] = bm
+		w.order = append(w.order, dataFilePath)
+	}
+
+	for _, pos := range positions {
+		bm.Set(uint64(pos))
+	}
+}
+
+// Flush writes one Puffin file containing one blob per data file,
+// and returns manifest entries ready for RowDelta.AddDeletes().
+//
+// The location parameter is the full path (including filename) for the
+// Puffin file to create. The caller is responsible for generating a
+// unique path within the table's metadata directory.
+func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile, error) {
+	if len(w.entries) == 0 {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+
+	pw, err := puffin.NewWriter(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("create puffin writer: %w", err)
+	}
+
+	type blobResult struct {
+		dataFilePath string
+		meta         puffin.BlobMetadata
+		cardinality  int64
+	}
+
+	results := make([]blobResult, 0, len(w.order))
+
+	for _, dataFilePath := range w.order {
+		bm := w.entries[dataFilePath]
+		dvBytes, err := SerializeDV(bm)
+		if err != nil {
+			return nil, fmt.Errorf("serialize DV for %s: %w", dataFilePath, err)
+		}
+
+		cardinality := bm.Cardinality()
+		meta, err := pw.AddBlob(puffin.BlobMetadataInput{
+			Type:           puffin.BlobTypeDeletionVector,
+			SnapshotID:     -1,
+			SequenceNumber: -1,
+			Fields:         []int32{},
+			Properties: map[string]string{
+				dvCardinalityProperty:  strconv.FormatInt(cardinality, 10),
+				"referenced-data-file": dataFilePath,
+			},
+		}, dvBytes)
+		if err != nil {
+			return nil, fmt.Errorf("add DV blob for %s: %w", dataFilePath, err)
+		}
+
+		results = append(results, blobResult{
+			dataFilePath: dataFilePath,
+			meta:         meta,
+			cardinality:  cardinality,
+		})
+	}
+
+	if err := pw.Finish(); err != nil {
+		return nil, fmt.Errorf("finish puffin file: %w", err)
+	}
+
+	fileBytes := buf.Bytes()
+	if err := w.fs.WriteFile(location, fileBytes); err != nil {
+		return nil, fmt.Errorf("write DV puffin file: %w", err)
+	}
+
+	fileSize := int64(len(fileBytes))
+
+	dataFiles := make([]iceberg.DataFile, 0, len(results))
+	for _, r := range results {
+		builder, err := iceberg.NewDataFileBuilder(
+			iceberg.PartitionSpec{},
+			iceberg.EntryContentPosDeletes,
+			location,
+			iceberg.PuffinFile,
+			nil, nil, nil,
+			r.cardinality,
+			fileSize,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("build DataFile for %s: %w", r.dataFilePath, err)
+		}
+
+		df := builder.
+			ReferencedDataFile(r.dataFilePath).
+			ContentOffset(r.meta.Offset).
+			ContentSizeInBytes(r.meta.Length).
+			Build()
+
+		dataFiles = append(dataFiles, df)
+	}
+
+	w.entries = make(map[string]*RoaringPositionBitmap)
+	w.order = nil
+
+	return dataFiles, nil
+}

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -1,0 +1,186 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeDVRoundTrip(t *testing.T) {
+	bm := NewRoaringPositionBitmap()
+	bm.Set(1)
+	bm.Set(3)
+	bm.Set(5)
+	bm.Set(7)
+	bm.Set(9)
+
+	data, err := SerializeDV(bm)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	decoded, err := DeserializeDV(data, 5)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(5), decoded.Cardinality())
+	assert.True(t, decoded.Contains(1))
+	assert.True(t, decoded.Contains(3))
+	assert.True(t, decoded.Contains(5))
+	assert.True(t, decoded.Contains(7))
+	assert.True(t, decoded.Contains(9))
+	assert.False(t, decoded.Contains(2))
+	assert.False(t, decoded.Contains(4))
+}
+
+func TestSerializeDVEmpty(t *testing.T) {
+	bm := NewRoaringPositionBitmap()
+
+	data, err := SerializeDV(bm)
+	require.NoError(t, err)
+
+	decoded, err := DeserializeDV(data, 0)
+	require.NoError(t, err)
+	assert.True(t, decoded.IsEmpty())
+}
+
+func TestSerializeDVLargePositions(t *testing.T) {
+	bm := NewRoaringPositionBitmap()
+	bm.Set(100)
+	bm.Set(101)
+	bm.Set(2147483747)
+	bm.Set(2147483748)
+	bm.Set((uint64(1) << 32) | 42)
+
+	data, err := SerializeDV(bm)
+	require.NoError(t, err)
+
+	decoded, err := DeserializeDV(data, 5)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(5), decoded.Cardinality())
+	assert.True(t, decoded.Contains(100))
+	assert.True(t, decoded.Contains(101))
+	assert.True(t, decoded.Contains(2147483747))
+	assert.True(t, decoded.Contains(2147483748))
+	assert.True(t, decoded.Contains((uint64(1)<<32)|42))
+}
+
+func newTestFS() *iceio.MemFS {
+	return iceio.NewMemFS()
+}
+
+func TestDVWriterFlushEmpty(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
+	require.NoError(t, err)
+	assert.Nil(t, dataFiles)
+}
+
+func TestDVWriterSingleDataFile(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	w.Add(dataPath, []int64{1, 3, 5, 7, 9})
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+
+	df := dataFiles[0]
+	assert.Equal(t, iceberg.EntryContentPosDeletes, df.ContentType())
+	assert.Equal(t, "mem://test/dv.puffin", df.FilePath())
+	assert.Equal(t, iceberg.PuffinFile, df.FileFormat())
+	assert.Equal(t, int64(5), df.Count())
+	assert.NotNil(t, df.ReferencedDataFile())
+	assert.Equal(t, dataPath, *df.ReferencedDataFile())
+	assert.NotNil(t, df.ContentOffset())
+	assert.NotNil(t, df.ContentSizeInBytes())
+
+	verifyDVReadBack(t, fs, df)
+}
+
+func TestDVWriterMultipleDataFiles(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	path1 := "s3://bucket/data/file-001.parquet"
+	path2 := "s3://bucket/data/file-002.parquet"
+	w.Add(path1, []int64{0, 10, 20})
+	w.Add(path2, []int64{5, 15, 25, 35})
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-dv.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 2)
+
+	assert.Equal(t, int64(3), dataFiles[0].Count())
+	assert.Equal(t, path1, *dataFiles[0].ReferencedDataFile())
+
+	assert.Equal(t, int64(4), dataFiles[1].Count())
+	assert.Equal(t, path2, *dataFiles[1].ReferencedDataFile())
+
+	for _, df := range dataFiles {
+		assert.Equal(t, "mem://test/multi-dv.puffin", df.FilePath())
+		verifyDVReadBack(t, fs, df)
+	}
+}
+
+func TestDVWriterDeduplicatesPositions(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	w.Add(dataPath, []int64{1, 3, 5})
+	w.Add(dataPath, []int64{3, 5, 7})
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/dedup.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+
+	assert.Equal(t, int64(4), dataFiles[0].Count())
+
+	verifyDVReadBack(t, fs, dataFiles[0])
+}
+
+func TestDVWriterResetsAfterFlush(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3})
+	_, err := w.Flush(context.Background(), "mem://test/first.puffin")
+	require.NoError(t, err)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/second.puffin")
+	require.NoError(t, err)
+	assert.Nil(t, dataFiles)
+}
+
+func verifyDVReadBack(t *testing.T, fs iceio.IO, df iceberg.DataFile) {
+	t.Helper()
+
+	bm, err := ReadDV(fs, df)
+	require.NoError(t, err)
+	assert.Equal(t, df.Count(), bm.Cardinality())
+}


### PR DESCRIPTION
Adds the serialization half of the deletion vector codec (inverse of DeserializeDV) and a DVWriter that accumulates positions per data file and flushes them as a single Puffin file with one blob per data file.

Returned DataFile entries carry ContentOffset, ContentSizeInBytes, and ReferencedDataFile so they can be passed directly to RowDelta.AddDeletes().

Part 1 of #997