### PR TITLE
fix(table): reject reserved metadata IDs before reassignment

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2194,6 +2194,10 @@ func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, 
 		}
 	}
 
+	if err := validateNoReservedMetadataColumnIDs(sc); err != nil {
+		return nil, err
+	}
+
 	reassignedIds, err := reassignIDs(sc, partitions, sortOrder)
 	if err != nil {
 		return nil, err

--- a/table/metadata_schema_compatibility.go
+++ b/table/metadata_schema_compatibility.go
@@ -84,6 +84,10 @@ func checkSchemaCompatibility(sc *iceberg.Schema, formatVersion int) error {
 	const defaultValuesMinFormatVersion = 3
 	problems := make([]IncompatibleField, 0)
 
+	if err := validateNoReservedMetadataColumnIDs(sc); err != nil {
+		return err
+	}
+
 	if err := validateUnknownTypes(sc); err != nil {
 		return fmt.Errorf("failed to validate unknown types: %w", err)
 	}
@@ -107,11 +111,6 @@ func checkSchemaCompatibility(sc *iceberg.Schema, formatVersion int) error {
 		colName, found := sc.FindColumnName(field.ID)
 		if !found {
 			panic("invalid schema: field with id " + strconv.Itoa(field.ID) + " not found, this is a bug, please report.")
-		}
-
-		if iceberg.IsMetadataColumn(field.ID) {
-			return fmt.Errorf("%w: field '%s' uses reserved metadata column ID %d",
-				iceberg.ErrInvalidSchema, colName, field.ID)
 		}
 
 		minFormatVersion := minFormatVersionForType(field.Type)
@@ -145,6 +144,54 @@ func checkSchemaCompatibility(sc *iceberg.Schema, formatVersion int) error {
 
 	if len(problems) != 0 {
 		return ErrIncompatibleSchema{fields: problems, formatVersion: formatVersion}
+	}
+
+	return nil
+}
+
+func validateNoReservedMetadataColumnIDs(sc *iceberg.Schema) error {
+	for _, field := range sc.Fields() {
+		if err := validateNoReservedMetadataColumnID(field, field.Name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNoReservedMetadataColumnID(field iceberg.NestedField, name string) error {
+	if iceberg.IsMetadataColumn(field.ID) {
+		return fmt.Errorf("%w: field '%s' uses reserved metadata column ID %d",
+			iceberg.ErrInvalidSchema, name, field.ID)
+	}
+
+	switch typ := field.Type.(type) {
+	case *iceberg.StructType:
+		if typ == nil {
+			return nil
+		}
+		for _, child := range typ.FieldList {
+			if err := validateNoReservedMetadataColumnID(child, name+"."+child.Name); err != nil {
+				return err
+			}
+		}
+	case *iceberg.ListType:
+		if typ == nil {
+			return nil
+		}
+		if err := validateNoReservedMetadataColumnID(typ.ElementField(), name+".element"); err != nil {
+			return err
+		}
+	case *iceberg.MapType:
+		if typ == nil {
+			return nil
+		}
+		if err := validateNoReservedMetadataColumnID(typ.KeyField(), name+".key"); err != nil {
+			return err
+		}
+		if err := validateNoReservedMetadataColumnID(typ.ValueField(), name+".value"); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/table/metadata_schema_compatibility_test.go
+++ b/table/metadata_schema_compatibility_test.go
@@ -50,3 +50,31 @@ func TestNewMetadata_DuplicateValues(t *testing.T) {
 	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 	assert.Contains(t, err.Error(), "multiple fields for name foo")
 }
+
+func TestNewMetadataRejectsReservedMetadataColumnIDsBeforeReassignment(t *testing.T) {
+	for _, field := range []iceberg.NestedField{
+		iceberg.RowID(),
+		iceberg.LastUpdatedSequenceNumber(),
+	} {
+		t.Run(field.Name, func(t *testing.T) {
+			schema := iceberg.NewSchema(
+				1,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+				field,
+			)
+
+			_, err := NewMetadata(
+				schema,
+				iceberg.UnpartitionedSpec,
+				UnsortedSortOrder,
+				"s3://test-bucket/test_table",
+				iceberg.Properties{PropertyFormatVersion: "3"},
+			)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+			assert.Contains(t, err.Error(), "reserved metadata column ID")
+			assert.Contains(t, err.Error(), field.Name)
+		})
+	}
+}

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -492,10 +492,11 @@ func TestProjectionWithRowLineageRequiresV3(t *testing.T) {
 	assert.ErrorContains(t, err, "row lineage")
 }
 
-// TestProjectionV3SchemaAlreadyHasRowID covers the case where the user schema
-// already declares _row_id (a reserved field id, but legal in v3). The
-// projection helper must be idempotent and not panic on the duplicate ID.
-func TestProjectionV3SchemaAlreadyHasRowID(t *testing.T) {
+// TestAppendMissingLineageFieldsAlreadyHasRowID covers the helper's idempotent
+// behavior when a schema already includes reserved lineage fields. New table
+// metadata rejects user schemas with these IDs, but projections can still
+// contain them after the scanner adds row-lineage columns.
+func TestAppendMissingLineageFieldsAlreadyHasRowID(t *testing.T) {
 	schema := iceberg.NewSchema(
 		1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
@@ -503,34 +504,20 @@ func TestProjectionV3SchemaAlreadyHasRowID(t *testing.T) {
 		iceberg.RowID(),
 	)
 
-	metadata, err := NewMetadata(
-		schema,
-		iceberg.UnpartitionedSpec,
-		UnsortedSortOrder,
-		"s3://test-bucket/test_table",
-		iceberg.Properties{"format-version": "3"},
-	)
-	require.NoError(t, err)
-	assert.Equal(t, 3, metadata.Version(), "sanity: must be v3")
+	proj := appendMissingLineageFields(schema, []iceberg.NestedField{
+		iceberg.RowID(),
+		iceberg.LastUpdatedSequenceNumber(),
+	})
+	require.NotNil(t, proj)
 
-	scan := &Scan{
-		metadata:          metadata,
-		selectedFields:    []string{"*"},
-		caseSensitive:     true,
-		includeRowLineage: true,
+	seen := make(map[int]string, len(proj.Fields()))
+	for _, f := range proj.Fields() {
+		if prev, dup := seen[f.ID]; dup {
+			t.Fatalf("duplicate field id %d: %q and %q", f.ID, prev, f.Name)
+		}
+		seen[f.ID] = f.Name
 	}
 
-	require.NotPanics(t, func() {
-		proj, perr := scan.Projection()
-		require.NoError(t, perr)
-		require.NotNil(t, proj)
-
-		seen := make(map[int]string, len(proj.Fields()))
-		for _, f := range proj.Fields() {
-			if prev, dup := seen[f.ID]; dup {
-				t.Fatalf("duplicate field id %d: %q and %q", f.ID, prev, f.Name)
-			}
-			seen[f.ID] = f.Name
-		}
-	})
+	assert.Equal(t, iceberg.RowIDColumnName, seen[iceberg.RowIDFieldID])
+	assert.Equal(t, iceberg.LastUpdatedSequenceNumberColumnName, seen[iceberg.LastUpdatedSequenceNumberFieldID])
 }


### PR DESCRIPTION
Summary

- reject user schemas that contain reserved metadata column IDs before schema ID reassignment
- validate nested struct, list, and map fields for reserved metadata IDs
- keep lineage projection tests focused on appendMissingLineageFields behavior

Fixes #1107

Testing

- go test ./table -run "TestNewMetadataRejectsReservedMetadataColumnIDsBeforeReassignment|TestAppendMissingLineageFieldsAlreadyHasRowID|TestNewMetadata_DuplicateValues" -count=1
- go test ./table -count=1