### PR TITLE
fix(table): cross-check deletion vector cardinality

### DIFF
--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -132,22 +132,16 @@ func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
 // ReadDV reads a deletion vector from a puffin file using the manifest entry metadata.
 // ContentOffset and ContentSizeInBytes must be set on the DataFile (required by v3 spec).
 //
-// When the puffin blob carries a `cardinality` property (spec-mandated for
-// deletion-vector-v1), its value is parsed and used to validate the decoded
-// bitmap — this catches truncated or partially-overwritten blobs whose CRC
-// still validates over the bytes that are present.
+// ReadDV validates cardinality from both independently available sources:
+// the manifest entry's record_count (when greater than zero) and the Puffin
+// blob's `cardinality` property. Java's BitmapPositionDeleteIndex uses the
+// manifest entry value; Java writers also set the Puffin property to the same
+// value, so a disagreement indicates corrupt or non-conformant metadata.
 //
-// Java's BitmapPositionDeleteIndex validates against the manifest entry's
-// `record_count` field rather than the puffin blob property; the two are
-// always set to the same value by Java's writer, so this PR's behavior agrees
-// with Java for spec-conformant tables. A future change should cross-validate
-// both sources when they're independently available (tracked separately).
-//
-// Blobs missing the spec-required cardinality property are accepted with a
-// slog warning rather than rejected — strict enforcement is deferred until
-// the Go DV writer guarantees the property is always present. The per-byte
-// CRC check in DeserializeDV still applies, so missing-property is degraded
-// integrity, not absent integrity.
+// If neither source carries a usable cardinality, ReadDV logs a warning and
+// falls back to CRC-only validation. The per-byte CRC check in DeserializeDV
+// still applies, so missing cardinality is degraded integrity, not absent
+// integrity.
 func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error) {
 	if dvFile.FileFormat() != iceberg.PuffinFile {
 		return nil, fmt.Errorf("expected PUFFIN format for deletion vector, got %s", dvFile.FileFormat())
@@ -179,21 +173,36 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 		return nil, fmt.Errorf("read DV blob at offset %d: %w", offset, err)
 	}
 
-	cardinality, ok, err := blobCardinality(reader.Blobs(), offset, size)
+	blobCardinality, hasBlobCardinality, err := blobCardinality(reader.Blobs(), offset, size)
 	if err != nil {
 		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
 	}
-	if !ok {
+	manifestCardinality := dvFile.Count()
+	hasManifestCardinality := manifestCardinality > 0
+
+	var expectedCardinality int64
+	switch {
+	case hasManifestCardinality && hasBlobCardinality:
+		if manifestCardinality != blobCardinality {
+			return nil, fmt.Errorf("manifest record_count %d disagrees with puffin cardinality property %d",
+				manifestCardinality, blobCardinality)
+		}
+		expectedCardinality = manifestCardinality
+	case hasManifestCardinality:
+		expectedCardinality = manifestCardinality
+	case hasBlobCardinality:
+		expectedCardinality = blobCardinality
+	default:
 		// Spec deviation: deletion-vector-v1 MUST carry a cardinality
 		// property. We tolerate the absence to keep reading from third-
 		// party writers that emit non-conformant files; flag so operators
 		// can identify affected tables.
 		slog.Warn("DV blob missing spec-required cardinality property; skipping cardinality validation",
 			"dv_file", dvFile.FilePath(), "offset", offset)
-		cardinality = -1
+		expectedCardinality = -1
 	}
 
-	return DeserializeDV(blobData, cardinality)
+	return DeserializeDV(blobData, expectedCardinality)
 }
 
 // blobCardinality returns the cardinality declared by the puffin blob at the

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -413,18 +413,29 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 		assert.Equal(t, int64(5), bm.Cardinality())
 	})
 
-	t.Run("mismatched cardinality is rejected", func(t *testing.T) {
+	t.Run("manifest and puffin cardinality disagreement is rejected", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
 			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-			// Bitmap actually has 5 positions; claim 99.
+			// Manifest record_count below says 5; claim 99 in the Puffin property.
 			"cardinality": "99",
 		})
 		offset, size := meta.Offset, meta.Length
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
 		require.Error(t, err)
-		// Pin the specific error path: DeserializeDV's "cardinality
-		// mismatch", not the helper's "invalid cardinality" parse error.
+		assert.Contains(t, err.Error(), "manifest record_count 5 disagrees with puffin cardinality property 99")
+	})
+
+	t.Run("matching manifest and puffin cardinality still validates bitmap", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
+			"referenced-data-file": "s3://bucket/data/data-001.parquet",
+			// Both metadata sources agree, but the bitmap actually has 5 positions.
+			"cardinality": "99",
+		})
+		offset, size := meta.Offset, meta.Length
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 99, &offset, &size))
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cardinality mismatch")
 	})
 


### PR DESCRIPTION
Summary

- compare deletion vector manifest record_count with the Puffin cardinality property when both are available
- fail fast when manifest and Puffin cardinality metadata disagree
- keep bitmap cardinality validation active when metadata sources agree

Fixes #1058

Testing

- go test ./table/dv -run TestReadDVCardinalityValidation -count=1
- go test ./table/dv -count=1