### PR TITLE
fix(table): validate scan filters before empty planning returns

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -362,6 +362,17 @@ func (scan *Scan) buildPartitionProjection(specID int) (iceberg.BooleanExpressio
 	return buildPartitionProjection(specID, scan.metadata, scan.rowFilter, scan.caseSensitive)
 }
 
+func (scan *Scan) validateRowFilter() error {
+	_, err := newInclusiveMetricsEvaluator(
+		scan.metadata.CurrentSchema(),
+		scan.rowFilter,
+		scan.caseSensitive,
+		scan.options["include_empty_files"] == "true",
+	)
+
+	return err
+}
+
 func buildPartitionProjection(specID int, meta Metadata, rowFilter iceberg.BooleanExpression, caseSensitive bool) (iceberg.BooleanExpression, error) {
 	spec := meta.PartitionSpecByID(specID)
 	if spec == nil {
@@ -657,6 +668,10 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 		scan.snapshotID = &snapshot.SnapshotID
 		scan.asOfTimestamp = nil
 	}
+	if err := scan.validateRowFilter(); err != nil {
+		return nil, err
+	}
+
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifests(ctx)
 	if err != nil || len(manifestList) == 0 {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -234,6 +236,72 @@ func TestBuildPartitionEvaluatorWithInvalidSpecID(t *testing.T) {
 	assert.Nil(t, evaluator)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.ErrorContains(t, err, "id 999")
+}
+
+func newScanValidationMetadata(t *testing.T) Metadata {
+	t.Helper()
+
+	schema := iceberg.NewSchema(
+		1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	metadata, err := NewMetadata(
+		schema,
+		iceberg.UnpartitionedSpec,
+		UnsortedSortOrder,
+		"s3://test-bucket/test_table",
+		iceberg.Properties{},
+	)
+	require.NoError(t, err)
+
+	return metadata
+}
+
+func TestPlanFilesValidatesRowFilterWithoutCurrentSnapshot(t *testing.T) {
+	metadata := newScanValidationMetadata(t)
+
+	scan := &Scan{
+		metadata:      metadata,
+		rowFilter:     iceberg.EqualTo(iceberg.Reference("missing"), int64(1)),
+		caseSensitive: true,
+		options:       iceberg.Properties{},
+	}
+
+	_, err := scan.PlanFiles(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing")
+}
+
+func TestPlanFilesValidatesRowFilterWithEmptyManifestList(t *testing.T) {
+	metadata := newScanValidationMetadata(t)
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+
+	const snapshotID = int64(1)
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: 1,
+		TimestampMs:    metadata.LastUpdatedMillis() + 1,
+		ManifestList:   "",
+		Summary:        &Summary{Operation: OpAppend},
+	}))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+
+	metadata, err = builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, metadata.CurrentSnapshot())
+
+	scan := &Scan{
+		metadata:      metadata,
+		ioF:           func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		rowFilter:     iceberg.EqualTo(iceberg.Reference("missing"), int64(1)),
+		caseSensitive: true,
+		options:       iceberg.Properties{},
+	}
+
+	_, err = scan.PlanFiles(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing")
 }
 
 // TestSynthesizeRowLineageColumns verifies that _row_id and _last_updated_sequence_number


### PR DESCRIPTION
Summary

- validate scan row filters before planning can return early for missing snapshots or empty manifest lists
- add coverage for invalid filters on both empty planning paths

Fixes #1119

Testing

- go test ./table -run "TestPlanFilesValidatesRowFilter|TestBuild.*Evaluator" -count=1
- go test ./table -count=1