### PR TITLE
perf(table): dedupe shared manifest reads in orphan cleanup

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -33,7 +33,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	"golang.org/x/sync/errgroup"
 )
 
 // PrefixMismatchMode defines how to handle cases where candidate files have different
@@ -164,7 +166,7 @@ type OrphanCleanupResult struct {
 	TotalSizeBytes      int64
 }
 
-func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
+func (t *Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
 	cfg := &orphanCleanupConfig{
 		location:           "",             // empty means use table's data location
 		olderThan:          72 * time.Hour, // 3 days ago
@@ -184,7 +186,12 @@ func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOptio
 	return t.executeOrphanCleanup(ctx, cfg)
 }
 
-func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
+type scannedFile struct {
+	path string
+	size int64
+}
+
+func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
 	fs, err := t.fsF(ctx)
 	if err != nil {
 		return OrphanCleanupResult{}, fmt.Errorf("failed to get filesystem: %w", err)
@@ -195,24 +202,60 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 		scanLocation = t.metadata.Location()
 	}
 
-	referencedFiles, err := t.getReferencedFiles(fs, true)
-	if err != nil {
-		return OrphanCleanupResult{}, fmt.Errorf("failed to get referenced files: %w", err)
+	// Run the S3 walk and referenced-file collection concurrently.
+	var referencedFiles map[string]bool
+	var scannedFiles []scannedFile
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		referencedFiles, err = t.getReferencedFiles(gctx, fs, cfg.maxConcurrency, true)
+		return err
+	})
+
+	g.Go(func() error {
+		cutoff := time.Now().Add(-cfg.olderThan)
+
+		return walkDirectory(fs, scanLocation, func(path string, info stdfs.FileInfo) error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			if info.IsDir() || !info.ModTime().Before(cutoff) {
+				return nil
+			}
+			scannedFiles = append(scannedFiles, scannedFile{path: path, size: info.Size()})
+			return nil
+		})
+	})
+
+	if err = g.Wait(); err != nil {
+		return OrphanCleanupResult{}, err
 	}
 
-	allFiles, totalSize, err := t.scanFiles(fs, scanLocation, cfg)
-	if err != nil {
-		return OrphanCleanupResult{}, fmt.Errorf("failed to scan files: %w", err)
+	// Identify orphans.
+	normalizedRef := make(map[string]string, len(referencedFiles))
+	for refPath := range referencedFiles {
+		normalizedPath := normalizeFilePathWithConfig(refPath, cfg)
+		normalizedRef[normalizedPath] = refPath
+		normalizedRef[refPath] = refPath
 	}
 
-	orphanFiles, err := identifyOrphanFiles(allFiles, referencedFiles, cfg)
-	if err != nil {
-		return OrphanCleanupResult{}, fmt.Errorf("failed to identify orphan files: %w", err)
+	var orphanFiles []string
+	var totalOrphanSize int64
+	for _, f := range scannedFiles {
+		isOrphan, err := isFileOrphan(f.path, referencedFiles, normalizedRef, cfg)
+		if err != nil {
+			return OrphanCleanupResult{}, fmt.Errorf("failed to identify orphan %s: %w", f.path, err)
+		}
+		if isOrphan {
+			orphanFiles = append(orphanFiles, f.path)
+			totalOrphanSize += f.size
+		}
 	}
 
 	result := OrphanCleanupResult{
 		OrphanFileLocations: orphanFiles,
-		TotalSizeBytes:      totalSize,
+		TotalSizeBytes:      totalOrphanSize,
 	}
 
 	if cfg.dryRun {
@@ -232,9 +275,17 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 // files, statistics and partition-statistics paths (Puffin, etc.), and all paths reachable
 // from current snapshots (manifest lists, manifests, data files).
 //
+// The collection uses a two-pass approach: first it reads every snapshot's manifest list
+// (small files) to discover the set of unique manifest file paths, then it reads each
+// unique manifest's entries in parallel. Manifests are immutable and shared across
+// snapshots via copy-on-write, so deduplicating avoids redundant I/O that would
+// otherwise grow as O(snapshots × manifests-per-snapshot).
+//
 // If the table has snapshots, fs must not be nil, otherwise an error is returned.
 // All returned paths are normalized using the package-level normalizeFilePath function.
-func (t Table) getReferencedFiles(fs iceio.IO, discardDeleted bool) (map[string]bool, error) {
+// The bool value distinguishes data files (true) from metadata files (false), which
+// is used by PurgeFiles to respect gc.enabled.
+func (t *Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurrency int, discardDeleted bool) (map[string]bool, error) {
 	referenced := make(map[string]bool)
 	metadata := t.metadata
 
@@ -265,6 +316,8 @@ func (t Table) getReferencedFiles(fs iceio.IO, discardDeleted bool) (map[string]
 		return nil, errors.New("fs cannot be nil when table has snapshots")
 	}
 
+	// Pass 1: Read manifest lists (lightweight) to collect unique manifests.
+	uniqueManifests := make(map[string]iceberg.ManifestFile)
 	for _, snapshot := range metadata.Snapshots() {
 		if snapshot.ManifestList != "" {
 			referenced[normalizeFilePath(snapshot.ManifestList)] = false
@@ -276,58 +329,73 @@ func (t Table) getReferencedFiles(fs iceio.IO, discardDeleted bool) (map[string]
 		}
 
 		for _, manifest := range manifestFiles {
-			referenced[normalizeFilePath(manifest.FilePath())] = false
+			path := manifest.FilePath()
+			if _, ok := uniqueManifests[path]; !ok {
+				uniqueManifests[path] = manifest
+				referenced[normalizeFilePath(path)] = false
+			}
+		}
+	}
 
+	if len(uniqueManifests) == 0 {
+		return referenced, nil
+	}
+
+	// Pass 2: Read entries from each unique manifest in parallel.
+	type refEntry struct {
+		path   string
+		isData bool
+	}
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(max(min(maxConcurrency, len(uniqueManifests)), 1))
+	for _, m := range uniqueManifests {
+		g.Go(func() error {
+			var entries []refEntry
 			// discardDeleted=true: skip DELETED-status entries when
 			// computing the reachable file set. A DELETED entry is
 			// not live in this snapshot and should not pin the file
 			// against orphan cleanup once the snapshot that
 			// originally held it live has been expired.
 			// This matches iceberg-java and pyiceberg behavior.
-			for entry, err := range manifest.Entries(fs, discardDeleted) {
+			for entry, err := range m.Entries(fs, discardDeleted) {
 				if err != nil {
-					return nil, fmt.Errorf("failed to read manifest entries: %w", err)
+					return fmt.Errorf("manifest %s: %w", m.FilePath(), err)
+				}
+				if gctx.Err() != nil {
+					return gctx.Err()
 				}
 				// All files tracked within a manifest (data files, equality deletes, position deletes)
 				// are considered "data files" for the purposes of gc.enabled.
-				referenced[normalizeFilePath(entry.DataFile().FilePath())] = true
+				entries = append(entries, refEntry{
+					path:   normalizeFilePath(entry.DataFile().FilePath()),
+					isData: true,
+				})
 				if ref := entry.DataFile().ReferencedDataFile(); ref != nil {
 					// This is a deletion vector entry referencing a data file.
 					// Its FilePath() is the deletion vector (.dv) file itself (added above).
 					// We must also mark the referenced data file as referenced.
-					referenced[normalizeFilePath(*ref)] = true
+					entries = append(entries, refEntry{
+						path:   normalizeFilePath(*ref),
+						isData: true,
+					})
 				}
 			}
-		}
+
+			mu.Lock()
+			for _, e := range entries {
+				referenced[e.path] = e.isData
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to read manifest entries: %w", err)
 	}
 
 	return referenced, nil
-}
-
-func (t Table) scanFiles(fs iceio.IO, location string, cfg *orphanCleanupConfig) ([]string, int64, error) {
-	var allFiles []string
-	var totalSize int64
-
-	err := walkDirectory(fs, location, func(path string, info stdfs.FileInfo) error {
-		if info.IsDir() {
-			return nil
-		}
-
-		cutOffTime := time.Now().Add(-cfg.olderThan)
-		if !info.ModTime().Before(cutOffTime) {
-			return nil // Skip files that are newer than or equal to the threshold
-		}
-
-		allFiles = append(allFiles, path)
-		totalSize += info.Size()
-
-		return nil
-	})
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return allFiles, totalSize, nil
 }
 
 func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
@@ -411,35 +479,13 @@ func makeFileWalkFunc(fn func(path string, info stdfs.FileInfo) error, pathTrans
 	}
 }
 
-func identifyOrphanFiles(allFiles []string, referencedFiles map[string]bool, cfg *orphanCleanupConfig) ([]string, error) {
-	normalizedReferencedFiles := make(map[string]string)
-	for refPath := range referencedFiles {
-		normalizedPath := normalizeFilePathWithConfig(refPath, cfg)
-		normalizedReferencedFiles[normalizedPath] = refPath
-		// Also include the original path for direct lookup
-		normalizedReferencedFiles[refPath] = refPath
-	}
-
-	var orphans []string
-
-	for _, file := range allFiles {
-		isOrphan, err := isFileOrphan(file, referencedFiles, normalizedReferencedFiles, cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine if file %s is orphan: %w", file, err)
-		}
-
-		if isOrphan {
-			orphans = append(orphans, file)
-		}
-	}
-
-	return orphans, nil
-}
-
 func isFileOrphan(file string, referencedFiles map[string]bool, normalizedReferencedFiles map[string]string, cfg *orphanCleanupConfig) (bool, error) {
 	normalizedFile := normalizeFilePathWithConfig(file, cfg)
 
-	if referencedFiles[file] || referencedFiles[normalizedFile] {
+	if _, ok := referencedFiles[file]; ok {
+		return false, nil
+	}
+	if _, ok := referencedFiles[normalizedFile]; ok {
 		return false, nil
 	}
 
@@ -808,7 +854,7 @@ func (t Table) PurgeFiles(ctx context.Context) error {
 	}
 
 	// 2. Union in manifest-referenced and metadata files (which might be outside the table location)
-	referencedFiles, refErr := t.getReferencedFiles(fs, false)
+	referencedFiles, refErr := t.getReferencedFiles(ctx, fs, runtime.GOMAXPROCS(0), false)
 	if refErr != nil {
 		return fmt.Errorf("failed to get referenced files: %w", refErr)
 	}

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -163,10 +163,11 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 type OrphanCleanupResult struct {
 	OrphanFileLocations []string
 	DeletedFiles        []string
-	TotalSizeBytes      int64
+	// TotalSizeBytes is the combined size of orphan files only, not all scanned files.
+	TotalSizeBytes int64
 }
 
-func (t *Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
+func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
 	cfg := &orphanCleanupConfig{
 		location:           "",             // empty means use table's data location
 		olderThan:          72 * time.Hour, // 3 days ago
@@ -191,7 +192,7 @@ type scannedFile struct {
 	size int64
 }
 
-func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
+func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
 	fs, err := t.fsF(ctx)
 	if err != nil {
 		return OrphanCleanupResult{}, fmt.Errorf("failed to get filesystem: %w", err)
@@ -203,6 +204,7 @@ func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConf
 	}
 
 	// Run the S3 walk and referenced-file collection concurrently.
+	// Each goroutine owns its variable exclusively — no shared writes.
 	var referencedFiles map[string]bool
 	var scannedFiles []scannedFile
 
@@ -287,7 +289,7 @@ func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConf
 // All returned paths are normalized using the package-level normalizeFilePath function.
 // The bool value distinguishes data files (true) from metadata files (false), which
 // is used by PurgeFiles to respect gc.enabled.
-func (t *Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurrency int, discardDeleted bool) (map[string]bool, error) {
+func (t Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurrency int, discardDeleted bool) (map[string]bool, error) {
 	referenced := make(map[string]bool)
 	metadata := t.metadata
 
@@ -485,6 +487,8 @@ func makeFileWalkFunc(fn func(path string, info stdfs.FileInfo) error, pathTrans
 func isFileOrphan(file string, referencedFiles map[string]bool, normalizedReferencedFiles map[string]string, cfg *orphanCleanupConfig) (bool, error) {
 	normalizedFile := normalizeFilePathWithConfig(file, cfg)
 
+	// Any presence in referencedFiles means referenced;
+	// the bool distinguishes data vs metadata for gc.enabled, not membership"
 	if _, ok := referencedFiles[file]; ok {
 		return false, nil
 	}

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -210,6 +210,7 @@ func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConf
 	g.Go(func() error {
 		var err error
 		referencedFiles, err = t.getReferencedFiles(gctx, fs, cfg.maxConcurrency, true)
+
 		return err
 	})
 
@@ -224,6 +225,7 @@ func (t *Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConf
 				return nil
 			}
 			scannedFiles = append(scannedFiles, scannedFile{path: path, size: info.Size()})
+
 			return nil
 		})
 	})
@@ -387,6 +389,7 @@ func (t *Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurre
 				referenced[e.path] = e.isData
 			}
 			mu.Unlock()
+
 			return nil
 		})
 	}

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -323,15 +323,21 @@ func TestCheckPrefixMismatch(t *testing.T) {
 }
 
 func TestIsFileOrphan(t *testing.T) {
+	// PrefixMismatchError ensures that metadata files (value=false) found via
+	// normalized lookup don't accidentally fall through to the prefix-mismatch
+	// error path. This would happen if isFileOrphan used a bare map-value check
+	// instead of the existence check (_, ok).
 	cfg := &orphanCleanupConfig{
-		prefixMismatchMode: PrefixMismatchIgnore,
+		prefixMismatchMode: PrefixMismatchError,
 		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
+		equalAuthorities:   map[string]string{"host-a,host-b": "host-a"},
 	}
 
 	referencedFiles := map[string]bool{
-		"s3://bucket/data/file1.parquet":     true,
-		"s3://bucket/metadata/manifest.avro": true,
-		"/local/path/file2.parquet":          true,
+		"s3://bucket/data/file1.parquet":        true,
+		"s3://host-a/metadata/v1.metadata.json": false, // metadata → value=false
+		"s3://host-a/data/file1.parquet":        true,
+		"/local/path/file2.parquet":             true,
 	}
 
 	tests := []struct {
@@ -364,11 +370,27 @@ func TestIsFileOrphan(t *testing.T) {
 			file:         "/local/path/orphan.parquet",
 			expectOrphan: true,
 		},
+		{
+			name:         "metadata_exact_host_match",
+			file:         "s3://host-a/metadata/v1.metadata.json",
+			expectOrphan: false,
+		},
+		{
+			name:         "metadata_equivalent_host",
+			file:         "s3://host-b/metadata/v1.metadata.json",
+			expectOrphan: false,
+		},
+		{
+			name:         "data_equivalent_host",
+			file:         "s3://host-b/data/file1.parquet",
+			expectOrphan: false,
+		},
 	}
 	normalizedReferencedFiles := make(map[string]string)
 	for refPath := range referencedFiles {
 		normalizedPath := normalizeFilePathWithConfig(refPath, cfg)
 		normalizedReferencedFiles[normalizedPath] = refPath
+		normalizedReferencedFiles[refPath] = refPath
 	}
 
 	for _, tt := range tests {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -20,6 +20,8 @@ package table
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -378,34 +380,6 @@ func TestIsFileOrphan(t *testing.T) {
 	}
 }
 
-func TestIdentifyOrphanFiles(t *testing.T) {
-	cfg := &orphanCleanupConfig{
-		prefixMismatchMode: PrefixMismatchIgnore,
-	}
-
-	allFiles := []string{
-		"s3://bucket/data/file1.parquet",
-		"s3://bucket/data/file2.parquet",
-		"s3://bucket/data/orphan1.parquet",
-		"s3://bucket/data/orphan2.parquet",
-	}
-
-	referencedFiles := map[string]bool{
-		"s3://bucket/data/file1.parquet": true,
-		"s3://bucket/data/file2.parquet": true,
-	}
-
-	orphans, err := identifyOrphanFiles(allFiles, referencedFiles, cfg)
-	require.NoError(t, err)
-
-	expectedOrphans := []string{
-		"s3://bucket/data/orphan1.parquet",
-		"s3://bucket/data/orphan2.parquet",
-	}
-
-	assert.ElementsMatch(t, expectedOrphans, orphans)
-}
-
 func TestNormalizeURLPath(t *testing.T) {
 	cfg := &orphanCleanupConfig{
 		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
@@ -529,14 +503,14 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
 	}
 
 	// No snapshots: FileIO is not used; statistics paths must still be referenced.
-	refs, err := tbl.getReferencedFiles(nil, true)
+	refs, err := tbl.getReferencedFiles(context.Background(), nil, 1, true)
 	require.NoError(t, err)
 
 	assert.Contains(t, refs, normalizeFilePath("s3://bucket/stats/table-stats.puffin"))
 	assert.Contains(t, refs, normalizeFilePath("s3://bucket/stats/part-stats.puffin"))
 	assert.Contains(t, refs, normalizeFilePath(tbl.metadataLocation))
-	assert.False(t, refs[normalizeFilePath("s3://bucket/stats/not-referenced.puffin")])
-	assert.False(t, refs[""])
+	assert.NotContains(t, refs, normalizeFilePath("s3://bucket/stats/not-referenced.puffin"))
+	assert.NotContains(t, refs, "")
 }
 
 // mockBulkRemovableIO is a test double that implements BulkRemovableIO.
@@ -716,7 +690,7 @@ func TestGetReferencedFiles_OverwriteThenExpireExcludesTombstones(t *testing.T) 
 
 	// fileA is now referenced only via a DELETED entry in the surviving
 	// snapshot's tombstone manifest. The fix must exclude it.
-	refs, err := tbl.getReferencedFiles(fs, true)
+	refs, err := tbl.getReferencedFiles(ctx, fs, 1, true)
 	require.NoError(t, err)
 
 	assert.Contains(t, refs, normalizeFilePath(fileB),
@@ -748,4 +722,114 @@ func dataFilePathsFromSnapshot(
 	}
 
 	return paths
+}
+
+func TestGetReferencedFiles_SharedManifestReadOnce(t *testing.T) {
+	// A manifest shared by two snapshots must be opened exactly once.
+	// A regression that drops the dedup would open it twice, turning
+	// O(unique_manifests) into O(snapshots × manifests_per_snapshot).
+	const (
+		dataPath      = "s3://bucket/data/file-1.parquet"
+		manifestPath  = "s3://bucket/meta/manifest-shared.avro"
+		manifestList1 = "s3://bucket/meta/snap-1.avro"
+		manifestList2 = "s3://bucket/meta/snap-2.avro"
+	)
+
+	tio := newTrackingCallsIO()
+	mf := writeManifest(t, tio.trackingIO, 1, 1, manifestPath, dataPath)
+	writeManifestList(t, tio.trackingIO, 1, manifestList1, []iceberg.ManifestFile{mf})
+	writeManifestList(t, tio.trackingIO, 2, manifestList2, []iceberg.ManifestFile{mf})
+	tio.files[dataPath] = []byte("data")
+
+	meta, err := ParseMetadataString(buildMetaJSON(metaJSONOpts{
+		snapshots: fmt.Sprintf(
+			`{"snapshot-id":1,"timestamp-ms":1000,"manifest-list":%q},`+
+				`{"snapshot-id":2,"timestamp-ms":2000,"manifest-list":%q}`,
+			manifestList1, manifestList2),
+	}))
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"ns", "tbl"}, meta, "metadata.json", testFSF(tio), nil)
+	refs, err := tbl.getReferencedFiles(context.Background(), tio, 1, true)
+	require.NoError(t, err)
+
+	assert.Contains(t, refs, dataPath)
+	assert.Contains(t, refs, manifestPath)
+	assert.Contains(t, refs, manifestList1)
+	assert.Contains(t, refs, manifestList2)
+
+	assert.Equal(t, 1, tio.openCount[manifestPath],
+		"shared manifest must be opened exactly once across snapshots")
+}
+
+func TestGetReferencedFiles_DisjointManifestsAllRead(t *testing.T) {
+	// Two snapshots with disjoint manifests: both must be read,
+	// and each data file must appear in the referenced set.
+	const (
+		dataPath1     = "s3://bucket/data/file-1.parquet"
+		dataPath2     = "s3://bucket/data/file-2.parquet"
+		manifestPath1 = "s3://bucket/meta/manifest-1.avro"
+		manifestPath2 = "s3://bucket/meta/manifest-2.avro"
+		manifestList1 = "s3://bucket/meta/snap-1.avro"
+		manifestList2 = "s3://bucket/meta/snap-2.avro"
+	)
+
+	tio := newTrackingCallsIO()
+	mf1 := writeManifest(t, tio.trackingIO, 1, 1, manifestPath1, dataPath1)
+	mf2 := writeManifest(t, tio.trackingIO, 2, 2, manifestPath2, dataPath2)
+	writeManifestList(t, tio.trackingIO, 1, manifestList1, []iceberg.ManifestFile{mf1})
+	writeManifestList(t, tio.trackingIO, 2, manifestList2, []iceberg.ManifestFile{mf2})
+
+	meta, err := ParseMetadataString(buildMetaJSON(metaJSONOpts{
+		snapshots: fmt.Sprintf(
+			`{"snapshot-id":1,"timestamp-ms":1000,"manifest-list":%q},`+
+				`{"snapshot-id":2,"timestamp-ms":2000,"manifest-list":%q}`,
+			manifestList1, manifestList2),
+	}))
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"ns", "tbl"}, meta, "metadata.json", testFSF(tio), nil)
+	refs, err := tbl.getReferencedFiles(context.Background(), tio, 1, true)
+	require.NoError(t, err)
+
+	assert.Contains(t, refs, dataPath1)
+	assert.Contains(t, refs, dataPath2)
+	assert.Equal(t, 1, tio.openCount[manifestPath1])
+	assert.Equal(t, 1, tio.openCount[manifestPath2])
+}
+
+func TestGetReferencedFiles_ManySnapshotsShareManifest(t *testing.T) {
+	// Stress the dedup: 10 snapshots all reference the same manifest.
+	// The manifest must be opened exactly once.
+	const (
+		dataPath     = "s3://bucket/data/file-1.parquet"
+		manifestPath = "s3://bucket/meta/manifest-shared.avro"
+	)
+
+	tio := newTrackingCallsIO()
+	mf := writeManifest(t, tio.trackingIO, 1, 1, manifestPath, dataPath)
+
+	numSnapshots := 10
+	var snapJSON []string
+	for i := 1; i <= numSnapshots; i++ {
+		listPath := fmt.Sprintf("s3://bucket/meta/snap-%d.avro", i)
+		writeManifestList(t, tio.trackingIO, int64(i), listPath, []iceberg.ManifestFile{mf})
+		snapJSON = append(snapJSON,
+			fmt.Sprintf(`{"snapshot-id":%d,"timestamp-ms":%d,"manifest-list":%q}`,
+				i, i*1000, listPath))
+	}
+
+	meta, err := ParseMetadataString(buildMetaJSON(metaJSONOpts{
+		snapshots: strings.Join(snapJSON, ","),
+	}))
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"ns", "tbl"}, meta, "metadata.json", testFSF(tio), nil)
+	refs, err := tbl.getReferencedFiles(context.Background(), tio, 4, true)
+	require.NoError(t, err)
+
+	assert.Contains(t, refs, dataPath)
+	assert.Contains(t, refs, manifestPath)
+	assert.Equal(t, 1, tio.openCount[manifestPath],
+		"shared manifest must be opened exactly once even with %d snapshots", numSnapshots)
 }


### PR DESCRIPTION
Fixes [#1132](https://github.com/apache/iceberg-go/issues/1132)

### Summary
- Deduplicate manifest reads in `getReferencedFiles` using a two-pass approach: collect unique manifests from manifest lists (pass 1), then read entries in parallel via `errgroup.SetLimit` (pass 2)
- Run S3 walk and referenced-file collection concurrently via errgroup
- Fix `time.Now()` being evaluated per-file inside walk callback instead of once before the walk

Reduces `getReferencedFiles` I/O from O(snapshots × manifests-per-snapshot) to O(unique manifests).
