### PR TITLE
feat(table/dv): accept partition spec and data on DVWriter.Add

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1671,7 +1671,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 	// follow-up; partitioned v3 writes fall through to the Parquet writer
 	// below and emit the deprecation warning.
 	if latestMetadata.Version() >= 3 && latestMetadata.PartitionSpec().IsUnpartitioned() {
-		return positionDeleteRecordsToDataFilesDV(ctx, rootLocation, args)
+		return positionDeleteRecordsToDataFilesDV(ctx, rootLocation, args, latestMetadata)
 	}
 
 	// V3 and later prefer deletion vectors over Parquet position-delete files;
@@ -1733,11 +1733,13 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 }
 
 // TODO(#1135 PR2): take a partitionContextByFilePath map[string]partitionContext
-// and look up each data file's spec + partitionData per Add, removing the
-// hardcoded UnpartitionedSpec/nil below and the IsUnpartitioned gate upstream.
-func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string, args recordWritingArgs) iter.Seq2[iceberg.DataFile, error] {
+// and look up each data file's specID + partitionData per Add, removing the
+// hardcoded 0/nil below and the IsUnpartitioned gate upstream.
+func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string, args recordWritingArgs, metadata Metadata) iter.Seq2[iceberg.DataFile, error] {
 	return func(yield func(iceberg.DataFile, error) bool) {
-		writer := dv.NewDVWriter(args.fs)
+		writer := dv.NewDVWriter(args.fs, func(id int32) *iceberg.PartitionSpec {
+			return metadata.PartitionSpecByID(int(id))
+		})
 
 		hasEntries := false
 		for batch, err := range args.itr {
@@ -1751,13 +1753,13 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 			positions := batch.Column(1).(*array.Int64)
 
 			for i := range batch.NumRows() {
-				// PR (1) of #1135 wires DVWriter for partitioned tables. This
-				// call site is currently reachable only for unpartitioned v3
-				// (the gate above hard-routes partitioned writes elsewhere),
-				// so we pass UnpartitionedSpec + nil partition data. PR (2)
+				// PR (1) of #1135 reshaped DVWriter.Add to take (specID,
+				// partitionData) so the partitioned path can pass through
+				// partitionContext directly. This site is still
+				// unpartitioned-only (the gate above routes partitioned
+				// writes elsewhere), so specID=0 + nil partition. PR (2)
 				// drops the gate and threads partitionContext through here.
-				writer.Add(filePaths.Value(int(i)), []int64{positions.Value(int(i))},
-					*iceberg.UnpartitionedSpec, nil)
+				writer.Add(filePaths.Value(int(i)), []int64{positions.Value(int(i))}, 0, nil)
 				hasEntries = true
 			}
 		}

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1732,6 +1732,9 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 	return partitionWriter.Write(ctx, workers)
 }
 
+// TODO(#1135 PR2): take a partitionContextByFilePath map[string]partitionContext
+// and look up each data file's spec + partitionData per Add, removing the
+// hardcoded UnpartitionedSpec/nil below and the IsUnpartitioned gate upstream.
 func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string, args recordWritingArgs) iter.Seq2[iceberg.DataFile, error] {
 	return func(yield func(iceberg.DataFile, error) bool) {
 		writer := dv.NewDVWriter(args.fs)
@@ -1748,7 +1751,13 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 			positions := batch.Column(1).(*array.Int64)
 
 			for i := range batch.NumRows() {
-				writer.Add(filePaths.Value(int(i)), []int64{positions.Value(int(i))})
+				// PR (1) of #1135 wires DVWriter for partitioned tables. This
+				// call site is currently reachable only for unpartitioned v3
+				// (the gate above hard-routes partitioned writes elsewhere),
+				// so we pass UnpartitionedSpec + nil partition data. PR (2)
+				// drops the gate and threads partitionContext through here.
+				writer.Add(filePaths.Value(int(i)), []int64{positions.Value(int(i))},
+					*iceberg.UnpartitionedSpec, nil)
 				hasEntries = true
 			}
 		}

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -29,13 +29,17 @@ import (
 	"github.com/apache/iceberg-go/puffin"
 )
 
-// dvEntry holds the per-data-file state a DV manifest entry needs. Each entry
-// is keyed by the referenced data file path; the spec and partition record
-// come from the data file itself and are propagated unchanged onto the output
-// DV manifest entry — matching Java's BaseDVFileWriter.Deletes shape.
+// SpecResolver looks up a PartitionSpec by its id, mirroring
+// Metadata.PartitionSpecByID. Returns nil if the id is not known.
+type SpecResolver func(specID int32) *iceberg.PartitionSpec
+
+// dvEntry holds the per-data-file state a DV manifest entry needs. specID and
+// partitionData come from the data file's own manifest entry; the spec itself
+// is resolved at Flush time via the writer's SpecResolver, matching how the
+// partitioned Parquet writer consults metadata.PartitionSpecByID.
 type dvEntry struct {
 	bitmap        *RoaringPositionBitmap
-	spec          iceberg.PartitionSpec
+	specID        int32
 	partitionData map[int]any
 }
 
@@ -43,47 +47,56 @@ type dvEntry struct {
 // a single Puffin file containing one deletion-vector-v1 blob per data file.
 // The returned DataFile entries are ready for RowDelta.AddDeletes().
 type DVWriter struct {
-	fs      iceio.WriteFileIO
-	entries map[string]*dvEntry
-	order   []string
+	fs       iceio.WriteFileIO
+	specByID SpecResolver
+	entries  map[string]*dvEntry
+	order    []string
 }
 
 // NewDVWriter creates a DVWriter backed by the given writable filesystem.
-func NewDVWriter(fs iceio.WriteFileIO) *DVWriter {
+// specByID resolves PartitionSpec values at Flush time; typically the
+// caller passes Metadata.PartitionSpecByID directly (wrapped to convert
+// int → int32). The unpartitioned path can pass a resolver that returns
+// iceberg.UnpartitionedSpec for id 0.
+func NewDVWriter(fs iceio.WriteFileIO, specByID SpecResolver) *DVWriter {
 	return &DVWriter{
-		fs:      fs,
-		entries: make(map[string]*dvEntry),
+		fs:       fs,
+		specByID: specByID,
+		entries:  make(map[string]*dvEntry),
 	}
 }
 
-// Add accumulates positions to delete for a given data file. The spec and
-// partitionData are the data file's own partition metadata (from its manifest
-// entry) and are propagated to the output DV manifest entry, so partitioned
-// tables produce DV entries with the correct partition record. Positions are
-// deduplicated via the underlying roaring bitmap.
+// Add accumulates positions to delete for a given data file. specID and
+// partitionData come from the data file's own manifest entry (typically
+// partitionContext.specID + partitionContext.partitionData on the caller
+// side) and are propagated to the output DV manifest entry, so partitioned
+// tables produce DV entries with the correct spec id and partition record.
+// Positions are deduplicated via the underlying roaring bitmap.
 //
-// partitionData keys must be partition field IDs (PartitionField.FieldID), not
-// source column IDs. NewDataFileBuilder iterates spec.Fields() and re-keys by
-// field name using these IDs; wrong keys silently produce an empty partition
-// record on the output DataFile.
+// partitionData keys must be partition field IDs (PartitionField.FieldID),
+// not source column IDs. NewDataFileBuilder iterates spec.Fields() and
+// re-keys by field name using these IDs; wrong keys silently produce an
+// empty partition record on the output DataFile.
 //
-// First Add for a given dataFilePath captures spec and partitionData on the
-// entry; later Adds for the same path append positions only and ignore the
-// new spec/partitionData args. This mirrors Java's BaseDVFileWriter, which
-// stores partition metadata via computeIfAbsent on the same key. Callers must
-// not pass conflicting partition values across Adds for the same data file —
-// the writer trusts the first-Add values for the rest of the writer's life.
-func (w *DVWriter) Add(dataFilePath string, positions []int64, spec iceberg.PartitionSpec, partitionData map[int]any) {
+// First Add for a given dataFilePath captures specID and partitionData on
+// the entry; later Adds for the same path append positions only and ignore
+// the new specID/partitionData args. This mirrors Java's BaseDVFileWriter,
+// which stores partition metadata via computeIfAbsent on the same key.
+// Callers must not pass conflicting partition values across Adds for the
+// same data file — the writer trusts the first-Add values for the rest of
+// the writer's life.
+func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, partitionData map[int]any) {
 	entry, ok := w.entries[dataFilePath]
 	if !ok {
-		// Defensive copies on capture so a caller that mutates or reuses
-		// the spec / partition map between Add and Flush can't silently
+		// Defensive copy of partitionData on capture so a caller that
+		// mutates or reuses the map between Add and Flush can't silently
 		// corrupt the entry. Mirrors Java's StructLikeUtil.copy(partition)
-		// in BaseDVFileWriter.Deletes. partitionData=nil round-trips as nil
-		// (maps.Clone returns nil on nil input).
+		// in BaseDVFileWriter.Deletes. partitionData=nil round-trips as
+		// nil (maps.Clone returns nil on nil input). specID is a value
+		// type so no copy is needed.
 		entry = &dvEntry{
 			bitmap:        NewRoaringPositionBitmap(),
-			spec:          copyPartitionSpec(spec),
+			specID:        specID,
 			partitionData: maps.Clone(partitionData),
 		}
 		w.entries[dataFilePath] = entry
@@ -95,28 +108,16 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, spec iceberg.Part
 	}
 }
 
-// copyPartitionSpec returns a fresh PartitionSpec that does not alias the
-// caller's slice and map backing arrays. PartitionSpec carries a `fields`
-// slice and a `sourceIdToFields` map; assigning by value shares both. The
-// reconstructed spec calls initialize() internally, building a private
-// sourceIdToFields map.
-func copyPartitionSpec(spec iceberg.PartitionSpec) iceberg.PartitionSpec {
-	fields := make([]iceberg.PartitionField, 0, spec.NumFields())
-	for _, f := range spec.Fields() {
-		fields = append(fields, f)
-	}
-
-	return iceberg.NewPartitionSpecID(spec.ID(), fields...)
-}
-
 // Flush writes one Puffin file containing one blob per data file, and returns
 // manifest entries ready for RowDelta.AddDeletes(). Each output DataFile
 // carries the partition spec and partition record of the data file it
-// references, so partitioned tables get spec-correct manifest entries.
+// references, with the spec resolved via the writer's SpecResolver at Flush
+// time. A specID with no corresponding spec is a programming error and is
+// surfaced as an error here rather than producing a malformed DataFile.
 //
-// The location parameter is the full path (including filename) for the Puffin
-// file to create. The caller is responsible for generating a unique path
-// within the table's metadata directory.
+// The location parameter is the full path (including filename) for the
+// Puffin file to create. The caller is responsible for generating a unique
+// path within the table's metadata directory.
 func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile, error) {
 	if len(w.entries) == 0 {
 		return nil, nil
@@ -181,8 +182,14 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 
 	dataFiles := make([]iceberg.DataFile, 0, len(results))
 	for _, r := range results {
+		spec := w.specByID(r.entry.specID)
+		if spec == nil {
+			return nil, fmt.Errorf("unknown partition spec id %d for data file %s",
+				r.entry.specID, r.dataFilePath)
+		}
+
 		builder, err := iceberg.NewDataFileBuilder(
-			r.entry.spec,
+			*spec,
 			iceberg.EntryContentPosDeletes,
 			location,
 			iceberg.PuffinFile,

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/apache/iceberg-go"
@@ -28,12 +29,22 @@ import (
 	"github.com/apache/iceberg-go/puffin"
 )
 
+// dvEntry holds the per-data-file state a DV manifest entry needs. Each entry
+// is keyed by the referenced data file path; the spec and partition record
+// come from the data file itself and are propagated unchanged onto the output
+// DV manifest entry — matching Java's BaseDVFileWriter.Deletes shape.
+type dvEntry struct {
+	bitmap        *RoaringPositionBitmap
+	spec          iceberg.PartitionSpec
+	partitionData map[int]any
+}
+
 // DVWriter accumulates deletion positions per data file and flushes them as
 // a single Puffin file containing one deletion-vector-v1 blob per data file.
 // The returned DataFile entries are ready for RowDelta.AddDeletes().
 type DVWriter struct {
 	fs      iceio.WriteFileIO
-	entries map[string]*RoaringPositionBitmap
+	entries map[string]*dvEntry
 	order   []string
 }
 
@@ -41,31 +52,71 @@ type DVWriter struct {
 func NewDVWriter(fs iceio.WriteFileIO) *DVWriter {
 	return &DVWriter{
 		fs:      fs,
-		entries: make(map[string]*RoaringPositionBitmap),
+		entries: make(map[string]*dvEntry),
 	}
 }
 
-// Add accumulates positions to delete for a given data file.
-// Positions are deduplicated via the underlying roaring bitmap.
-func (w *DVWriter) Add(dataFilePath string, positions []int64) {
-	bm, ok := w.entries[dataFilePath]
+// Add accumulates positions to delete for a given data file. The spec and
+// partitionData are the data file's own partition metadata (from its manifest
+// entry) and are propagated to the output DV manifest entry, so partitioned
+// tables produce DV entries with the correct partition record. Positions are
+// deduplicated via the underlying roaring bitmap.
+//
+// partitionData keys must be partition field IDs (PartitionField.FieldID), not
+// source column IDs. NewDataFileBuilder iterates spec.Fields() and re-keys by
+// field name using these IDs; wrong keys silently produce an empty partition
+// record on the output DataFile.
+//
+// First Add for a given dataFilePath captures spec and partitionData on the
+// entry; later Adds for the same path append positions only and ignore the
+// new spec/partitionData args. This mirrors Java's BaseDVFileWriter, which
+// stores partition metadata via computeIfAbsent on the same key. Callers must
+// not pass conflicting partition values across Adds for the same data file —
+// the writer trusts the first-Add values for the rest of the writer's life.
+func (w *DVWriter) Add(dataFilePath string, positions []int64, spec iceberg.PartitionSpec, partitionData map[int]any) {
+	entry, ok := w.entries[dataFilePath]
 	if !ok {
-		bm = NewRoaringPositionBitmap()
-		w.entries[dataFilePath] = bm
+		// Defensive copies on capture so a caller that mutates or reuses
+		// the spec / partition map between Add and Flush can't silently
+		// corrupt the entry. Mirrors Java's StructLikeUtil.copy(partition)
+		// in BaseDVFileWriter.Deletes. partitionData=nil round-trips as nil
+		// (maps.Clone returns nil on nil input).
+		entry = &dvEntry{
+			bitmap:        NewRoaringPositionBitmap(),
+			spec:          copyPartitionSpec(spec),
+			partitionData: maps.Clone(partitionData),
+		}
+		w.entries[dataFilePath] = entry
 		w.order = append(w.order, dataFilePath)
 	}
 
 	for _, pos := range positions {
-		bm.Set(uint64(pos))
+		entry.bitmap.Set(uint64(pos))
 	}
 }
 
-// Flush writes one Puffin file containing one blob per data file,
-// and returns manifest entries ready for RowDelta.AddDeletes().
+// copyPartitionSpec returns a fresh PartitionSpec that does not alias the
+// caller's slice and map backing arrays. PartitionSpec carries a `fields`
+// slice and a `sourceIdToFields` map; assigning by value shares both. The
+// reconstructed spec calls initialize() internally, building a private
+// sourceIdToFields map.
+func copyPartitionSpec(spec iceberg.PartitionSpec) iceberg.PartitionSpec {
+	fields := make([]iceberg.PartitionField, 0, spec.NumFields())
+	for _, f := range spec.Fields() {
+		fields = append(fields, f)
+	}
+
+	return iceberg.NewPartitionSpecID(spec.ID(), fields...)
+}
+
+// Flush writes one Puffin file containing one blob per data file, and returns
+// manifest entries ready for RowDelta.AddDeletes(). Each output DataFile
+// carries the partition spec and partition record of the data file it
+// references, so partitioned tables get spec-correct manifest entries.
 //
-// The location parameter is the full path (including filename) for the
-// Puffin file to create. The caller is responsible for generating a
-// unique path within the table's metadata directory.
+// The location parameter is the full path (including filename) for the Puffin
+// file to create. The caller is responsible for generating a unique path
+// within the table's metadata directory.
 func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile, error) {
 	if len(w.entries) == 0 {
 		return nil, nil
@@ -80,6 +131,7 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 
 	type blobResult struct {
 		dataFilePath string
+		entry        *dvEntry
 		meta         puffin.BlobMetadata
 		cardinality  int64
 	}
@@ -87,13 +139,13 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 	results := make([]blobResult, 0, len(w.order))
 
 	for _, dataFilePath := range w.order {
-		bm := w.entries[dataFilePath]
-		dvBytes, err := SerializeDV(bm)
+		entry := w.entries[dataFilePath]
+		dvBytes, err := SerializeDV(entry.bitmap)
 		if err != nil {
 			return nil, fmt.Errorf("serialize DV for %s: %w", dataFilePath, err)
 		}
 
-		cardinality := bm.Cardinality()
+		cardinality := entry.bitmap.Cardinality()
 		meta, err := pw.AddBlob(puffin.BlobMetadataInput{
 			Type:           puffin.BlobTypeDeletionVector,
 			SnapshotID:     -1,
@@ -110,6 +162,7 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 
 		results = append(results, blobResult{
 			dataFilePath: dataFilePath,
+			entry:        entry,
 			meta:         meta,
 			cardinality:  cardinality,
 		})
@@ -129,11 +182,12 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 	dataFiles := make([]iceberg.DataFile, 0, len(results))
 	for _, r := range results {
 		builder, err := iceberg.NewDataFileBuilder(
-			iceberg.PartitionSpec{},
+			r.entry.spec,
 			iceberg.EntryContentPosDeletes,
 			location,
 			iceberg.PuffinFile,
-			nil, nil, nil,
+			r.entry.partitionData,
+			nil, nil,
 			r.cardinality,
 			fileSize,
 		)
@@ -150,7 +204,7 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 		dataFiles = append(dataFiles, df)
 	}
 
-	w.entries = make(map[string]*RoaringPositionBitmap)
+	w.entries = make(map[string]*dvEntry)
 	w.order = nil
 
 	return dataFiles, nil

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -103,7 +103,7 @@ func TestDVWriterSingleDataFile(t *testing.T) {
 	w := NewDVWriter(fs)
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5, 7, 9})
+	w.Add(dataPath, []int64{1, 3, 5, 7, 9}, *iceberg.UnpartitionedSpec, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
 	require.NoError(t, err)
@@ -118,6 +118,10 @@ func TestDVWriterSingleDataFile(t *testing.T) {
 	assert.Equal(t, dataPath, *df.ReferencedDataFile())
 	assert.NotNil(t, df.ContentOffset())
 	assert.NotNil(t, df.ContentSizeInBytes())
+	assert.Empty(t, df.Partition(),
+		"unpartitioned DV manifest entry carries no partition record")
+	assert.Equal(t, int32(0), df.SpecID(),
+		"unpartitioned spec has id 0")
 
 	verifyDVReadBack(t, fs, df)
 }
@@ -128,8 +132,8 @@ func TestDVWriterMultipleDataFiles(t *testing.T) {
 
 	path1 := "s3://bucket/data/file-001.parquet"
 	path2 := "s3://bucket/data/file-002.parquet"
-	w.Add(path1, []int64{0, 10, 20})
-	w.Add(path2, []int64{5, 15, 25, 35})
+	w.Add(path1, []int64{0, 10, 20}, *iceberg.UnpartitionedSpec, nil)
+	w.Add(path2, []int64{5, 15, 25, 35}, *iceberg.UnpartitionedSpec, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-dv.puffin")
 	require.NoError(t, err)
@@ -152,8 +156,8 @@ func TestDVWriterDeduplicatesPositions(t *testing.T) {
 	w := NewDVWriter(fs)
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5})
-	w.Add(dataPath, []int64{3, 5, 7})
+	w.Add(dataPath, []int64{1, 3, 5}, *iceberg.UnpartitionedSpec, nil)
+	w.Add(dataPath, []int64{3, 5, 7}, *iceberg.UnpartitionedSpec, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dedup.puffin")
 	require.NoError(t, err)
@@ -168,13 +172,219 @@ func TestDVWriterResetsAfterFlush(t *testing.T) {
 	fs := newTestFS()
 	w := NewDVWriter(fs)
 
-	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3})
+	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3},
+		*iceberg.UnpartitionedSpec, nil)
 	_, err := w.Flush(context.Background(), "mem://test/first.puffin")
 	require.NoError(t, err)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/second.puffin")
 	require.NoError(t, err)
 	assert.Nil(t, dataFiles)
+}
+
+// TestDVWriterPartitionedSingleFile verifies that a DV manifest entry for a
+// data file in a partitioned table carries the data file's partition record
+// and spec id. The partition propagation is the load-bearing piece for
+// partitioned-DV write support (#1135 PR 2 lifts the unpartitioned-only gate
+// in arrow_utils.go and starts threading real spec+partition through here).
+func TestDVWriterPartitionedSingleFile(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	spec := iceberg.NewPartitionSpecID(7, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "tenant_id",
+		Transform: iceberg.IdentityTransform{},
+	})
+	partition := map[int]any{1000: int32(42)}
+	dataPath := "s3://bucket/tenant=42/file-001.parquet"
+	w.Add(dataPath, []int64{1, 2, 3}, spec, partition)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/partitioned.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+
+	df := dataFiles[0]
+	assert.Equal(t, iceberg.EntryContentPosDeletes, df.ContentType(),
+		"DV manifest entries must declare position-delete content type")
+	assert.Equal(t, int32(7), df.SpecID(),
+		"DV manifest entry must carry the data file's spec id")
+	assert.Equal(t, map[int]any{1000: int32(42)}, df.Partition(),
+		"DV manifest entry must carry the data file's partition record")
+	assert.Equal(t, dataPath, *df.ReferencedDataFile())
+
+	verifyDVReadBack(t, fs, df)
+}
+
+// TestDVWriterPartitionedMultipleFiles pins per-data-file partition storage:
+// each data file path gets its own DataFile with the partition values from
+// its Add. Two data files in two distinct partitions land in the same Puffin
+// file but produce two manifest entries with distinct partition records and
+// the same spec id.
+func TestDVWriterPartitionedMultipleFiles(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	spec := iceberg.NewPartitionSpecID(3, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	pathEU := "s3://bucket/region=EU/file-eu.parquet"
+	pathUS := "s3://bucket/region=US/file-us.parquet"
+
+	w.Add(pathEU, []int64{1, 2}, spec, map[int]any{1000: "EU"})
+	w.Add(pathUS, []int64{3, 4, 5}, spec, map[int]any{1000: "US"})
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-partition.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 2)
+
+	byRef := make(map[string]iceberg.DataFile, len(dataFiles))
+	for _, df := range dataFiles {
+		require.NotNil(t, df.ReferencedDataFile())
+		byRef[*df.ReferencedDataFile()] = df
+	}
+
+	require.Contains(t, byRef, pathEU)
+	require.Contains(t, byRef, pathUS)
+
+	assert.Equal(t, map[int]any{1000: "EU"}, byRef[pathEU].Partition(),
+		"EU file's DV manifest entry must carry the EU partition record")
+	assert.Equal(t, map[int]any{1000: "US"}, byRef[pathUS].Partition(),
+		"US file's DV manifest entry must carry the US partition record")
+	assert.Equal(t, int32(3), byRef[pathEU].SpecID())
+	assert.Equal(t, int32(3), byRef[pathUS].SpecID())
+	assert.Equal(t, iceberg.EntryContentPosDeletes, byRef[pathEU].ContentType())
+	assert.Equal(t, iceberg.EntryContentPosDeletes, byRef[pathUS].ContentType())
+}
+
+// TestDVWriterPartitionCapturedOnFirstAdd pins the capture invariant: Add
+// captures spec and partition on first call for a given data file path;
+// subsequent Adds contribute positions only. Callers must not pass conflicting
+// partition data on follow-up Adds (one data file has one partition by
+// construction), but if they do, the first-Add capture is the one that lands
+// on the output DataFile. Matches Java's BaseDVFileWriter.deletesByPath
+// computeIfAbsent semantics.
+//
+// Two subtests cover the two dimensions of the captured pair so a future
+// implementation that stops capturing one of them on first Add is detected.
+func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
+	spec0 := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	spec5 := iceberg.NewPartitionSpecID(5, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	dataPath := "s3://bucket/region=EU/file.parquet"
+
+	t.Run("partitionData captured on first Add", func(t *testing.T) {
+		fs := newTestFS()
+		w := NewDVWriter(fs)
+
+		w.Add(dataPath, []int64{1}, spec0, map[int]any{1000: "EU"})
+		// Second Add carries a different partition value; capture is unaffected.
+		w.Add(dataPath, []int64{2}, spec0, map[int]any{1000: "US"})
+
+		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-partition.puffin")
+		require.NoError(t, err)
+		require.Len(t, dataFiles, 1)
+		assert.Equal(t, map[int]any{1000: "EU"}, dataFiles[0].Partition())
+	})
+
+	t.Run("spec captured on first Add", func(t *testing.T) {
+		fs := newTestFS()
+		w := NewDVWriter(fs)
+
+		w.Add(dataPath, []int64{1}, spec0, map[int]any{1000: "EU"})
+		// Second Add carries a different spec id; capture is unaffected.
+		w.Add(dataPath, []int64{2}, spec5, map[int]any{1000: "EU"})
+
+		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-spec.puffin")
+		require.NoError(t, err)
+		require.Len(t, dataFiles, 1)
+		assert.Equal(t, int32(0), dataFiles[0].SpecID(),
+			"spec captured on first Add; later Adds with a different spec id "+
+				"do not overwrite the entry's spec")
+	})
+}
+
+// TestDVWriterAddDefensiveCopies pins that Add takes a defensive copy of the
+// partition data map at capture, so a caller that mutates the map between Add
+// and Flush does not silently corrupt the entry. Matches Java's
+// StructLikeUtil.copy(partition) in BaseDVFileWriter.Deletes.
+func TestDVWriterAddDefensiveCopies(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	partition := map[int]any{1000: "EU"}
+
+	w.Add("s3://bucket/region=EU/file.parquet", []int64{1}, spec, partition)
+	// Mutate the caller's map after Add. A reference-storing writer would
+	// produce a DataFile carrying "MUTATED" on Flush; a defensive-copy
+	// implementation keeps the original captured value.
+	partition[1000] = "MUTATED"
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/defensive-copy.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+	assert.Equal(t, map[int]any{1000: "EU"}, dataFiles[0].Partition(),
+		"Add must defensively copy partitionData so post-Add caller mutations "+
+			"do not corrupt the captured entry")
+}
+
+// TestDVWriterFlushMixedSpecIDs covers the partition-evolution case: two data
+// files in one Flush carry different spec IDs (because their referenced data
+// files were written under different specs). Today the writer accepts this
+// silently and emits one DataFile per entry with each carrying its own spec
+// id. Manifest assembly downstream is expected to group by spec id; this
+// test pins that the writer does not flatten or drop a spec id at this layer.
+func TestDVWriterFlushMixedSpecIDs(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs)
+
+	specOld := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Name: "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	specNew := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1001, Name: "region_bucket",
+		Transform: iceberg.IdentityTransform{},
+	})
+
+	pathOld := "s3://bucket/region=EU/file.parquet"
+	pathNew := "s3://bucket/region_bucket=0/file.parquet"
+
+	w.Add(pathOld, []int64{1}, specOld, map[int]any{1000: "EU"})
+	w.Add(pathNew, []int64{2}, specNew, map[int]any{1001: int32(0)})
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/mixed-spec.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 2)
+
+	byRef := make(map[string]iceberg.DataFile, len(dataFiles))
+	for _, df := range dataFiles {
+		byRef[*df.ReferencedDataFile()] = df
+	}
+
+	assert.Equal(t, int32(0), byRef[pathOld].SpecID(),
+		"each DV DataFile must carry the spec id captured at its Add — "+
+			"flushing a mixed-spec batch must not flatten spec ids")
+	assert.Equal(t, int32(1), byRef[pathNew].SpecID())
 }
 
 func verifyDVReadBack(t *testing.T, fs iceio.IO, df iceberg.DataFile) {

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -89,9 +89,33 @@ func newTestFS() *iceio.MemFS {
 	return iceio.NewMemFS()
 }
 
+// unpartitionedResolver returns the canonical UnpartitionedSpec for id 0 and
+// nil for everything else. Used by tests that exercise only the unpartitioned
+// path; the Flush-side unknown-id error path is covered by a dedicated test.
+func unpartitionedResolver() SpecResolver {
+	return func(id int32) *iceberg.PartitionSpec {
+		if id == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	}
+}
+
+// specMapResolver builds a resolver over a fixed set of specs keyed by id.
+// Used by partitioned tests that exercise multiple specs in one Flush.
+func specMapResolver(specs ...iceberg.PartitionSpec) SpecResolver {
+	m := make(map[int32]*iceberg.PartitionSpec, len(specs))
+	for i := range specs {
+		m[int32(specs[i].ID())] = &specs[i]
+	}
+
+	return func(id int32) *iceberg.PartitionSpec { return m[id] }
+}
+
 func TestDVWriterFlushEmpty(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
+	w := NewDVWriter(fs, unpartitionedResolver())
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
 	require.NoError(t, err)
@@ -100,10 +124,10 @@ func TestDVWriterFlushEmpty(t *testing.T) {
 
 func TestDVWriterSingleDataFile(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
+	w := NewDVWriter(fs, unpartitionedResolver())
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5, 7, 9}, *iceberg.UnpartitionedSpec, nil)
+	w.Add(dataPath, []int64{1, 3, 5, 7, 9}, 0, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
 	require.NoError(t, err)
@@ -128,12 +152,12 @@ func TestDVWriterSingleDataFile(t *testing.T) {
 
 func TestDVWriterMultipleDataFiles(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
+	w := NewDVWriter(fs, unpartitionedResolver())
 
 	path1 := "s3://bucket/data/file-001.parquet"
 	path2 := "s3://bucket/data/file-002.parquet"
-	w.Add(path1, []int64{0, 10, 20}, *iceberg.UnpartitionedSpec, nil)
-	w.Add(path2, []int64{5, 15, 25, 35}, *iceberg.UnpartitionedSpec, nil)
+	w.Add(path1, []int64{0, 10, 20}, 0, nil)
+	w.Add(path2, []int64{5, 15, 25, 35}, 0, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-dv.puffin")
 	require.NoError(t, err)
@@ -153,11 +177,11 @@ func TestDVWriterMultipleDataFiles(t *testing.T) {
 
 func TestDVWriterDeduplicatesPositions(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
+	w := NewDVWriter(fs, unpartitionedResolver())
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5}, *iceberg.UnpartitionedSpec, nil)
-	w.Add(dataPath, []int64{3, 5, 7}, *iceberg.UnpartitionedSpec, nil)
+	w.Add(dataPath, []int64{1, 3, 5}, 0, nil)
+	w.Add(dataPath, []int64{3, 5, 7}, 0, nil)
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dedup.puffin")
 	require.NoError(t, err)
@@ -170,10 +194,9 @@ func TestDVWriterDeduplicatesPositions(t *testing.T) {
 
 func TestDVWriterResetsAfterFlush(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
+	w := NewDVWriter(fs, unpartitionedResolver())
 
-	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3},
-		*iceberg.UnpartitionedSpec, nil)
+	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3}, 0, nil)
 	_, err := w.Flush(context.Background(), "mem://test/first.puffin")
 	require.NoError(t, err)
 
@@ -186,20 +209,19 @@ func TestDVWriterResetsAfterFlush(t *testing.T) {
 // data file in a partitioned table carries the data file's partition record
 // and spec id. The partition propagation is the load-bearing piece for
 // partitioned-DV write support (#1135 PR 2 lifts the unpartitioned-only gate
-// in arrow_utils.go and starts threading real spec+partition through here).
+// in arrow_utils.go and starts threading real specID+partition through here).
 func TestDVWriterPartitionedSingleFile(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
-
 	spec := iceberg.NewPartitionSpecID(7, iceberg.PartitionField{
 		SourceIDs: []int{2},
 		FieldID:   1000,
 		Name:      "tenant_id",
 		Transform: iceberg.IdentityTransform{},
 	})
-	partition := map[int]any{1000: int32(42)}
+	w := NewDVWriter(fs, specMapResolver(spec))
+
 	dataPath := "s3://bucket/tenant=42/file-001.parquet"
-	w.Add(dataPath, []int64{1, 2, 3}, spec, partition)
+	w.Add(dataPath, []int64{1, 2, 3}, 7, map[int]any{1000: int32(42)})
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/partitioned.puffin")
 	require.NoError(t, err)
@@ -224,19 +246,19 @@ func TestDVWriterPartitionedSingleFile(t *testing.T) {
 // the same spec id.
 func TestDVWriterPartitionedMultipleFiles(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
-
 	spec := iceberg.NewPartitionSpecID(3, iceberg.PartitionField{
 		SourceIDs: []int{2},
 		FieldID:   1000,
 		Name:      "region",
 		Transform: iceberg.IdentityTransform{},
 	})
+	w := NewDVWriter(fs, specMapResolver(spec))
+
 	pathEU := "s3://bucket/region=EU/file-eu.parquet"
 	pathUS := "s3://bucket/region=US/file-us.parquet"
 
-	w.Add(pathEU, []int64{1, 2}, spec, map[int]any{1000: "EU"})
-	w.Add(pathUS, []int64{3, 4, 5}, spec, map[int]any{1000: "US"})
+	w.Add(pathEU, []int64{1, 2}, 3, map[int]any{1000: "EU"})
+	w.Add(pathUS, []int64{3, 4, 5}, 3, map[int]any{1000: "US"})
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-partition.puffin")
 	require.NoError(t, err)
@@ -262,7 +284,7 @@ func TestDVWriterPartitionedMultipleFiles(t *testing.T) {
 }
 
 // TestDVWriterPartitionCapturedOnFirstAdd pins the capture invariant: Add
-// captures spec and partition on first call for a given data file path;
+// captures specID and partition on first call for a given data file path;
 // subsequent Adds contribute positions only. Callers must not pass conflicting
 // partition data on follow-up Adds (one data file has one partition by
 // construction), but if they do, the first-Add capture is the one that lands
@@ -288,11 +310,11 @@ func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
 
 	t.Run("partitionData captured on first Add", func(t *testing.T) {
 		fs := newTestFS()
-		w := NewDVWriter(fs)
+		w := NewDVWriter(fs, specMapResolver(spec0))
 
-		w.Add(dataPath, []int64{1}, spec0, map[int]any{1000: "EU"})
+		w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"})
 		// Second Add carries a different partition value; capture is unaffected.
-		w.Add(dataPath, []int64{2}, spec0, map[int]any{1000: "US"})
+		w.Add(dataPath, []int64{2}, 0, map[int]any{1000: "US"})
 
 		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-partition.puffin")
 		require.NoError(t, err)
@@ -300,20 +322,20 @@ func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
 		assert.Equal(t, map[int]any{1000: "EU"}, dataFiles[0].Partition())
 	})
 
-	t.Run("spec captured on first Add", func(t *testing.T) {
+	t.Run("specID captured on first Add", func(t *testing.T) {
 		fs := newTestFS()
-		w := NewDVWriter(fs)
+		w := NewDVWriter(fs, specMapResolver(spec0, spec5))
 
-		w.Add(dataPath, []int64{1}, spec0, map[int]any{1000: "EU"})
+		w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"})
 		// Second Add carries a different spec id; capture is unaffected.
-		w.Add(dataPath, []int64{2}, spec5, map[int]any{1000: "EU"})
+		w.Add(dataPath, []int64{2}, 5, map[int]any{1000: "EU"})
 
 		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-spec.puffin")
 		require.NoError(t, err)
 		require.Len(t, dataFiles, 1)
 		assert.Equal(t, int32(0), dataFiles[0].SpecID(),
-			"spec captured on first Add; later Adds with a different spec id "+
-				"do not overwrite the entry's spec")
+			"spec id captured on first Add; later Adds with a different spec id "+
+				"do not overwrite the entry's specID")
 	})
 }
 
@@ -323,17 +345,16 @@ func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
 // StructLikeUtil.copy(partition) in BaseDVFileWriter.Deletes.
 func TestDVWriterAddDefensiveCopies(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
-
 	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
 		SourceIDs: []int{2},
 		FieldID:   1000,
 		Name:      "region",
 		Transform: iceberg.IdentityTransform{},
 	})
+	w := NewDVWriter(fs, specMapResolver(spec))
 	partition := map[int]any{1000: "EU"}
 
-	w.Add("s3://bucket/region=EU/file.parquet", []int64{1}, spec, partition)
+	w.Add("s3://bucket/region=EU/file.parquet", []int64{1}, 0, partition)
 	// Mutate the caller's map after Add. A reference-storing writer would
 	// produce a DataFile carrying "MUTATED" on Flush; a defensive-copy
 	// implementation keeps the original captured value.
@@ -355,8 +376,6 @@ func TestDVWriterAddDefensiveCopies(t *testing.T) {
 // test pins that the writer does not flatten or drop a spec id at this layer.
 func TestDVWriterFlushMixedSpecIDs(t *testing.T) {
 	fs := newTestFS()
-	w := NewDVWriter(fs)
-
 	specOld := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
 		SourceIDs: []int{2}, FieldID: 1000, Name: "region",
 		Transform: iceberg.IdentityTransform{},
@@ -365,12 +384,13 @@ func TestDVWriterFlushMixedSpecIDs(t *testing.T) {
 		SourceIDs: []int{2}, FieldID: 1001, Name: "region_bucket",
 		Transform: iceberg.IdentityTransform{},
 	})
+	w := NewDVWriter(fs, specMapResolver(specOld, specNew))
 
 	pathOld := "s3://bucket/region=EU/file.parquet"
 	pathNew := "s3://bucket/region_bucket=0/file.parquet"
 
-	w.Add(pathOld, []int64{1}, specOld, map[int]any{1000: "EU"})
-	w.Add(pathNew, []int64{2}, specNew, map[int]any{1001: int32(0)})
+	w.Add(pathOld, []int64{1}, 0, map[int]any{1000: "EU"})
+	w.Add(pathNew, []int64{2}, 1, map[int]any{1001: int32(0)})
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/mixed-spec.puffin")
 	require.NoError(t, err)
@@ -385,6 +405,22 @@ func TestDVWriterFlushMixedSpecIDs(t *testing.T) {
 		"each DV DataFile must carry the spec id captured at its Add — "+
 			"flushing a mixed-spec batch must not flatten spec ids")
 	assert.Equal(t, int32(1), byRef[pathNew].SpecID())
+}
+
+// TestDVWriterFlushUnknownSpecID pins that a specID with no corresponding
+// spec in the resolver is surfaced as a clean error at Flush, not a
+// malformed DataFile. This is the failure mode for a caller bug like
+// passing a stale specID after partition evolution rewrote the metadata.
+func TestDVWriterFlushUnknownSpecID(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs, unpartitionedResolver())
+
+	// specID 99 is not registered with the resolver.
+	w.Add("s3://bucket/file.parquet", []int64{1}, 99, nil)
+
+	_, err := w.Flush(context.Background(), "mem://test/unknown-spec.puffin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown partition spec id 99")
 }
 
 func verifyDVReadBack(t *testing.T, fs iceio.IO, df iceberg.DataFile) {


### PR DESCRIPTION
Part of #1135. Matches Java's BaseDVFileWriter.delete signature so DV manifest entries can carry the data file's partition record and spec id, unblocking the follow-up that lifts the unpartitioned-only gate in positionDeleteRecordsToDataFiles.

First Add for a path captures spec+partition; later Adds append positions only, mirroring Java's computeIfAbsent semantics. Both spec and partitionData are defensively copied on capture (NewPartitionSpecID for spec, maps.Clone for partitionData) so caller mutations between Add and Flush can't silently corrupt the entry, mirroring Java's StructLikeUtil.copy(partition).