### PR TITLE
feat(test): add Spark 4.0 integration test infrastructure

### DIFF
--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -33,6 +33,12 @@ permissions:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        spark:
+          - { version: "3.5", setup: "integration-setup" }
+          - { version: "4.0", setup: "integration-setup-spark4" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,8 +51,8 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Integration setup
-        run: make integration-setup
+      - name: Integration setup (Spark ${{ matrix.spark.version }})
+        run: make ${{ matrix.spark.setup }}
 
       - name: Setup environment variables
         run: |

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 # golangci-lint version (keep in sync with CI and README)
 GOLANGCI_LINT_VERSION := v2.8.0
 
-.PHONY: test test-race lint lint-install integration-setup integration-test integration-scanner integration-io integration-rest integration-spark integration-hadoop integration-down integration-logs docs-gen
+.PHONY: test test-race lint lint-install integration-setup integration-setup-spark4 integration-test integration-scanner integration-io integration-rest integration-spark integration-hadoop integration-down integration-logs docs-gen
 
 test:
 	go test -v ./...
@@ -38,6 +38,12 @@ lint-install:
 integration-setup:
 	mkdir -p /tmp/iceberg-hadoop-warehouse
 	docker compose -f internal/recipe/docker-compose.yml up -d --wait
+	docker compose -f internal/recipe/docker-compose.yml exec -T spark-iceberg ipython ./provision.py
+
+integration-setup-spark4:
+	mkdir -p /tmp/iceberg-hadoop-warehouse
+	SPARK_IMAGE=pyiceberg-spark4 SPARK_DOCKERFILE=Dockerfile.spark4 docker compose -f internal/recipe/docker-compose.yml build spark-iceberg
+	SPARK_IMAGE=pyiceberg-spark4 SPARK_DOCKERFILE=Dockerfile.spark4 docker compose -f internal/recipe/docker-compose.yml up -d --wait
 	docker compose -f internal/recipe/docker-compose.yml exec -T spark-iceberg ipython ./provision.py
 
 integration-down:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ make lint-install
 
    Or run a single suite: `make integration-scanner`, `make integration-io`, `make integration-rest`, `make integration-spark`.
 
+#### Running against Spark 4.0
+
+To validate against Spark 4.0 (used by v3 feature tests), substitute the setup step:
+
+```shell
+make integration-setup-spark4
+```
+
+The exported env vars and `make integration-test` invocation are identical to the Spark 3.5 flow above.
+
 ## Feature Support / Roadmap
 
 ### FileSystem Support

--- a/internal/recipe/Dockerfile.spark4
+++ b/internal/recipe/Dockerfile.spark4
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM apache/spark:4.0.2-python3
+
+USER root
+
+ARG ICEBERG_VERSION=1.10.0
+ARG SCALA_VERSION=2.13
+
+RUN curl --progress-bar -L --retry 3 \
+    "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-4.0_${SCALA_VERSION}/${ICEBERG_VERSION}/iceberg-spark-runtime-4.0_${SCALA_VERSION}-${ICEBERG_VERSION}.jar" \
+    -o "${SPARK_HOME}/jars/iceberg-spark-runtime.jar"
+
+RUN curl --progress-bar -L --retry 3 \
+    "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar" \
+    -o "${SPARK_HOME}/jars/iceberg-aws-bundle.jar"
+
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir pyspark==4.0.0 py4j
+RUN pip3 install --no-cache-dir ipython
+RUN pip3 install --no-cache-dir 'pyiceberg[s3fs,hive]'
+RUN pip3 install --no-cache-dir pyarrow
+
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+
+COPY spark-defaults.conf ${SPARK_HOME}/conf/spark-defaults.conf
+COPY provision.py validation.py hadoop_validation.py /opt/spark/work-dir/
+COPY entrypoint.sh /opt/spark/work-dir/entrypoint.sh
+RUN chmod +x /opt/spark/work-dir/entrypoint.sh
+
+WORKDIR /opt/spark/work-dir
+
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["notebook"]

--- a/internal/recipe/docker-compose.yml
+++ b/internal/recipe/docker-compose.yml
@@ -16,9 +16,11 @@
 # under the License.
 services:
   spark-iceberg:
-    image: pyiceberg-spark
+    image: ${SPARK_IMAGE:-pyiceberg-spark}
     container_name: spark-iceberg
-    build: .
+    build:
+      context: .
+      dockerfile: ${SPARK_DOCKERFILE:-Dockerfile}
     networks:
       iceberg_net:
     depends_on:
@@ -38,7 +40,7 @@ services:
       - 10000:10000
       - 10001:10001
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080 || exit 1"]
+      test: ["CMD-SHELL", "ls $$SPARK_HOME/jars/iceberg-spark-runtime*.jar > /dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/internal/recipe/entrypoint.sh
+++ b/internal/recipe/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+case "$1" in
+  notebook)
+    exec tail -f /dev/null
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac

--- a/internal/recipe/provision.py
+++ b/internal/recipe/provision.py
@@ -38,6 +38,11 @@ catalogs = {
 }
 
 for catalog_name, catalog in catalogs.items():
+    try:
+        catalog.create_namespace("default")
+    except Exception:
+        pass  # namespace already exists
+
     spark.sql(
         f"""
       CREATE DATABASE IF NOT EXISTS default;
@@ -64,32 +69,53 @@ for catalog_name, catalog in catalogs.items():
 
     spark.sql(
         f"""
-      CREATE OR REPLACE TABLE default.test_null_nan
-      USING iceberg
-      AS SELECT
-        1            AS idx,
-        float('NaN') AS col_numeric
-    UNION ALL SELECT
-        2            AS idx,
-        null         AS col_numeric
-    UNION ALL SELECT
-        3            AS idx,
-        1            AS col_numeric;
+      CREATE OR REPLACE TABLE default.test_null_nan (
+        idx         INT,
+        col_numeric FLOAT
+      )
+      USING iceberg;
     """
     )
 
     spark.sql(
         f"""
-      CREATE OR REPLACE TABLE default.test_null_nan_rewritten
-      USING iceberg
-      AS SELECT * FROM default.test_null_nan;
+      INSERT INTO default.test_null_nan VALUES
+        (1, float('NaN')),
+        (2, NULL),
+        (3, 1.0);
     """
     )
 
     spark.sql(
         f"""
-    CREATE OR REPLACE TABLE default.test_limit as
-      SELECT * LATERAL VIEW explode(ARRAY(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) AS idx;
+      CREATE OR REPLACE TABLE default.test_null_nan_rewritten (
+        idx         INT,
+        col_numeric FLOAT
+      )
+      USING iceberg;
+    """
+    )
+
+    spark.sql(
+        f"""
+      INSERT INTO default.test_null_nan_rewritten
+      SELECT * FROM default.test_null_nan;
+    """
+    )
+
+    spark.sql(
+        f"""
+    CREATE OR REPLACE TABLE default.test_limit (
+      idx INT
+    )
+    USING iceberg;
+    """
+    )
+
+    spark.sql(
+        f"""
+    INSERT INTO default.test_limit VALUES
+      (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
     """
     )
 
@@ -209,7 +235,7 @@ for catalog_name, catalog in catalogs.items():
 
     all_types_dataframe.writeTo(f"default.test_all_types").tableProperty("format-version", "2").partitionedBy(
         "intCol"
-    ).createOrReplace()
+    ).create()
 
     for table_name, partition in [
         ("test_partitioned_by_identity", "ts"),

--- a/internal/recipe/provision.py
+++ b/internal/recipe/provision.py
@@ -233,9 +233,23 @@ for catalog_name, catalog in catalogs.items():
         .withColumn("structCol", expr("STRUCT(mapCol, arrayCol)"))
     )
 
-    all_types_dataframe.writeTo(f"default.test_all_types").tableProperty("format-version", "2").partitionedBy(
-        "intCol"
-    ).create()
+    all_types_dataframe.createOrReplaceTempView("_all_types_temp")
+    spark.sql(
+        f"""
+      CREATE OR REPLACE TABLE default.test_all_types (
+        longCol BIGINT, intCol INT, floatCol FLOAT, doubleCol DOUBLE,
+        dateCol DATE, timestampCol TIMESTAMP, stringCol STRING,
+        booleanCol BOOLEAN, binaryCol BINARY, byteCol BYTE,
+        decimalCol DECIMAL(10,2), shortCol SHORT,
+        mapCol MAP<BIGINT, DECIMAL(10,2)>, arrayCol ARRAY<BIGINT>,
+        structCol STRUCT<mapCol: MAP<BIGINT, DECIMAL(10,2)>, arrayCol: ARRAY<BIGINT>>
+      )
+      USING iceberg
+      PARTITIONED BY (intCol)
+      TBLPROPERTIES ('format-version'='2');
+    """
+    )
+    spark.sql("INSERT INTO default.test_all_types SELECT * FROM _all_types_temp")
 
     for table_name, partition in [
         ("test_partitioned_by_identity", "ts"),

--- a/internal/recipe/spark-defaults.conf
+++ b/internal/recipe/spark-defaults.conf
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spark.sql.extensions                                org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
+spark.sql.catalog.spark_catalog.type                 rest
+spark.sql.catalog.spark_catalog.uri                  http://rest:8181
+spark.sql.catalog.spark_catalog.io-impl              org.apache.iceberg.aws.s3.S3FileIO
+spark.sql.catalog.spark_catalog.s3.endpoint          http://minio:9000
+spark.sql.catalog.spark_catalog.s3.path-style-access true
+spark.sql.catalog.spark_catalog.warehouse            s3://warehouse
+spark.sql.defaultCatalog                             spark_catalog
+spark.eventLog.enabled                               false
+spark.sql.ansi.enabled                               false


### PR DESCRIPTION
First part of #1139 

## Summary

Adds Spark 4.0 alongside Spark 3.5 in the integration test matrix so v3 features can be validated cross-engine in CI. 

## What's in

- `Dockerfile.spark4` (apache/spark:4.0.2 + iceberg-spark-runtime-4.0 + aws-bundle), with companion `spark-defaults.conf` and `entrypoint.sh`
- docker-compose parameterized via `SPARK_IMAGE` and `SPARK_DOCKERFILE`; defaults preserve 3.5 behavior
- `make integration-setup-spark4`
- Workflow matrix entry for 4.0 (`fail-fast: false`)
- 3 CTAS statements in `provision.py` rewritten as `CREATE TABLE` + `INSERT INTO` so the same provisioning runs on both versions

## What's not in

No new tests, no cross-engine v3 feature validation. Follow-up PR.

## Validation

Locally ran on both Spark versions:
- `make integration-setup && make integration-test`
- `make integration-setup-spark4 && make integration-test`