### PR TITLE
feat(io/s3): support connect timeout property

### DIFF
--- a/io/config.go
+++ b/io/config.go
@@ -19,12 +19,14 @@ package io
 
 // Constants for S3 configuration options
 const (
-	S3Region                 = "s3.region"
-	S3SessionToken           = "s3.session-token"
-	S3SecretAccessKey        = "s3.secret-access-key"
-	S3AccessKeyID            = "s3.access-key-id"
-	S3EndpointURL            = "s3.endpoint"
-	S3ProxyURI               = "s3.proxy-uri"
+	S3Region          = "s3.region"
+	S3SessionToken    = "s3.session-token"
+	S3SecretAccessKey = "s3.secret-access-key"
+	S3AccessKeyID     = "s3.access-key-id"
+	S3EndpointURL     = "s3.endpoint"
+	S3ProxyURI        = "s3.proxy-uri"
+	// S3ConnectTimeout accepts seconds as a number, such as "60" or "60.0",
+	// or a Go duration string, such as "5s".
 	S3ConnectTimeout         = "s3.connect-timeout"
 	S3SignerURI              = "s3.signer.uri"
 	S3RemoteSigningEnabled   = "s3.remote-signing-enabled"

--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"slices"
 	"strconv"
 	"time"
 
@@ -40,19 +40,8 @@ import (
 	"gocloud.dev/blob/s3blob"
 )
 
-var unsupportedS3Props = []string{
-	io.S3ConnectTimeout,
-}
-
 // ParseAWSConfig parses S3 properties and returns a configuration.
 func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, error) {
-	// If any unsupported properties are set, return an error.
-	for k := range props {
-		if slices.Contains(unsupportedS3Props, k) {
-			return nil, fmt.Errorf("unsupported S3 property %q", k)
-		}
-	}
-
 	// Remote S3 request signing is not implemented yet.
 	if v, ok := props[io.S3RemoteSigningEnabled]; ok {
 		if enabled, err := strconv.ParseBool(v); err == nil && enabled {
@@ -61,6 +50,7 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	}
 
 	opts := []func(*config.LoadOptions) error{}
+	var httpClient *awshttp.BuildableClient
 
 	if tok, ok := props["token"]; ok {
 		opts = append(opts, config.WithBearerAuthTokenProvider(
@@ -83,14 +73,32 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	if proxy, ok := props[io.S3ProxyURI]; ok {
 		proxyURL, err := url.Parse(proxy)
 		if err != nil {
-			return nil, fmt.Errorf("invalid s3 proxy url '%s'", proxy)
+			return nil, fmt.Errorf("invalid s3 proxy url %q: %w", proxy, err)
 		}
 
-		opts = append(opts, config.WithHTTPClient(awshttp.NewBuildableClient().WithTransportOptions(
+		httpClient = awshttp.NewBuildableClient().WithTransportOptions(
 			func(t *http.Transport) {
 				t.Proxy = http.ProxyURL(proxyURL)
 			},
-		)))
+		)
+	}
+
+	if timeout, ok := props[io.S3ConnectTimeout]; ok {
+		duration, err := parseS3ConnectTimeout(timeout)
+		if err != nil {
+			return nil, err
+		}
+
+		if httpClient == nil {
+			httpClient = awshttp.NewBuildableClient()
+		}
+		httpClient = httpClient.WithDialerOptions(func(d *net.Dialer) {
+			d.Timeout = duration
+		})
+	}
+
+	if httpClient != nil {
+		opts = append(opts, config.WithHTTPClient(httpClient))
 	}
 
 	awscfg := new(aws.Config)
@@ -101,6 +109,25 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	}
 
 	return awscfg, nil
+}
+
+func parseS3ConnectTimeout(timeout string) (time.Duration, error) {
+	var duration time.Duration
+	if seconds, err := strconv.ParseFloat(timeout, 64); err == nil {
+		duration = time.Duration(seconds * float64(time.Second))
+	} else {
+		parsedDuration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return 0, fmt.Errorf("invalid s3.connect-timeout %q: must be seconds as a number or a Go duration string", timeout)
+		}
+		duration = parsedDuration
+	}
+
+	if duration <= 0 {
+		return 0, errors.New("s3.connect-timeout must be a positive duration")
+	}
+
+	return duration, nil
 }
 
 // resolveUsePathStyle determines whether the S3 client should use

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -19,9 +19,13 @@ package gocloud
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go/io"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,13 +84,116 @@ func TestParseAWSConfigRemoteSigningEnabled(t *testing.T) {
 	})
 }
 
-func TestParseAWSConfigUnsupportedProperty(t *testing.T) {
+func TestParseAWSConfigInvalidConnectTimeout(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAWSConfig(context.Background(), map[string]string{
-		io.S3ConnectTimeout: "5000",
+		io.S3Region:         "us-east-1",
+		io.S3ConnectTimeout: "not-a-duration",
 	})
-	require.ErrorContains(t, err, "unsupported S3 property")
+	require.ErrorContains(t, err, "invalid s3.connect-timeout")
+}
+
+func TestParseAWSConfigConnectTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{
+			name:    "integer seconds",
+			timeout: "60",
+			want:    60 * time.Second,
+		},
+		{
+			name:    "decimal seconds",
+			timeout: "60.0",
+			want:    60 * time.Second,
+		},
+		{
+			name:    "fractional seconds",
+			timeout: "1.5",
+			want:    1500 * time.Millisecond,
+		},
+		{
+			name:    "go duration",
+			timeout: "5s",
+			want:    5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := ParseAWSConfig(context.Background(), map[string]string{
+				io.S3Region:         "us-east-1",
+				io.S3ConnectTimeout: tt.timeout,
+			})
+			require.NoError(t, err)
+
+			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, client.GetDialer().Timeout)
+		})
+	}
+}
+
+func TestParseAWSConfigConnectTimeoutRejectsNonPositiveDurations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{
+			name:    "zero",
+			timeout: "0",
+		},
+		{
+			name:    "negative",
+			timeout: "-5s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAWSConfig(context.Background(), map[string]string{
+				io.S3Region:         "us-east-1",
+				io.S3ConnectTimeout: tt.timeout,
+			})
+			require.ErrorContains(t, err, "must be a positive duration")
+		})
+	}
+}
+
+func TestParseAWSConfigProxyAndConnectTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseAWSConfig(context.Background(), map[string]string{
+		io.S3Region:         "us-east-1",
+		io.S3ProxyURI:       "http://proxy.example.com:8080",
+		io.S3ConnectTimeout: "5s",
+	})
+	require.NoError(t, err)
+
+	client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Second, client.GetDialer().Timeout)
+
+	proxyFunc := client.GetTransport().Proxy
+	require.NotNil(t, proxyFunc)
+
+	proxyURL, err := proxyFunc(&http.Request{
+		URL: &url.URL{Scheme: "https", Host: "bucket.s3.amazonaws.com"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	assert.Equal(t, "http://proxy.example.com:8080", proxyURL.String())
 }
 
 func TestResolveUsePathStyle(t *testing.T) {


### PR DESCRIPTION
Fixes #941

## Summary
- Support the `s3.connect-timeout` property for S3 clients.
- Accept PyIceberg-compatible numeric seconds such as `60` and `60.0`,  plus Go duration strings such as `5s`.
- Apply the value to the AWS SDK buildable client's dialer timeout.
- Compose connect timeout with `s3.proxy-uri` by sharing the same  buildable HTTP client.
- Reject zero and negative timeout values with a clear error.

Supersedes #950 and addresses all three items from laskoviymishka's review: float-seconds parsing, zero/negative rejection, and proxy+timeout composition test.

## Testing
- `go test ./io/gocloud/...`

## Release note
S3 now supports the `s3.connect-timeout` property, accepting numeric seconds like `60`/`60.0` and Go duration strings like `5s`.