### PR TITLE
fix(manifest): Fix minsequencenumber handling zero value

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1228,10 +1228,6 @@ func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...M
 		return nil, err
 	}
 
-	if w.minSeqNum == initialSequenceNumber {
-		w.minSeqNum = -1
-	}
-
 	partitions, err := constructPartitionSummaries(w.spec, w.schema, w.partitions)
 	if err != nil {
 		return nil, err
@@ -1330,9 +1326,10 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 		dataFile.PartitionData = convertedPartitionData
 	}
 
-	if (entry.Status() == EntryStatusADDED || entry.Status() == EntryStatusEXISTING) &&
-		entry.SequenceNum() > 0 && (w.minSeqNum < 0 || entry.SequenceNum() < w.minSeqNum) {
-		w.minSeqNum = entry.SequenceNum()
+	if entry.Status() == EntryStatusADDED || entry.Status() == EntryStatusEXISTING {
+		if seq := entry.SequenceNum(); seq >= 0 && (w.minSeqNum < 0 || seq < w.minSeqNum) {
+			w.minSeqNum = seq
+		}
 	}
 
 	toEncode, err := w.impl.prepareEntry(entry, w.snapshotID)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2017,6 +2017,47 @@ func (m *ManifestTestSuite) TestV2ManifestListAcceptsV1Manifests() {
 	m.Equal(manifestFileRecordsV1[0].AddedRows(), entry.AddedRows())
 }
 
+// TestManifestWriterPreservesMinSequenceNumberZero verifies that a v2 manifest
+// writer correctly records min_sequence_number=0 when all live ADDED/EXISTING
+// entries carry the v1-inherited sequence number 0. Per spec, 0 is a valid
+// minimum — it must not be treated as "unset" and replaced by the commit's
+// sequence number when the manifest is added to a manifest list.
+func (m *ManifestTestSuite) TestManifestWriterPreservesMinSequenceNumberZero() {
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+
+	seqZero := int64(0)
+	oldSnapshot := int64(999)
+	entries := make([]ManifestEntry, len(manifestEntryV1Records))
+	for i, rec := range manifestEntryV1Records {
+		entries[i] = NewManifestEntry(
+			EntryStatusEXISTING,
+			&oldSnapshot,
+			&seqZero,
+			&seqZero,
+			rec.DataFile(),
+		)
+	}
+
+	var manifestBuf bytes.Buffer
+	mf, err := WriteManifest("carried-forward-v1.avro", &manifestBuf, 2, partitionSpec, testSchema, snapshotID, entries)
+	m.Require().NoError(err)
+	m.Equal(int64(0), mf.MinSequenceNum(), "min_sequence_number must be 0 for v1-inherited live entries")
+	m.Equal(int64(-1), mf.SequenceNum(), "manifest-level sequence_number is assigned by the manifest list writer")
+
+	commitSeq := int64(42)
+	var listBuf bytes.Buffer
+	err = WriteManifestList(2, &listBuf, snapshotID, nil, &commitSeq, 0, []ManifestFile{mf})
+	m.Require().NoError(err)
+
+	list, err := ReadManifestList(&listBuf)
+	m.Require().NoError(err)
+	m.Require().Len(list, 1)
+	m.Equal(int64(0), list[0].MinSequenceNum(), "manifest list must preserve min_sequence_number 0")
+	m.Equal(commitSeq, list[0].SequenceNum(), "manifest list assigns sequence_number from the commit")
+}
+
 // TestV3ManifestListAcceptsV1AndV2Manifests verifies that a v3 manifest list
 // can reference both v1 and v2 manifest files (e.g. after a v1->v3 upgrade)
 // and that first_row_id is assigned to data manifests during the write.


### PR DESCRIPTION
## Summary
Fix `ManifestWriter` mishandling of `min_sequence_number` when live manifest entries carry sequence number `0`. This is the valid inherited value for v1-upgraded tables per the Iceberg spec, but the writer previously skipped seq `0` when computing the minimum and then treated a computed min of `0` as "unset", causing the manifest list writer to substitute the current commit's sequence number instead.
## Problem
When a v2+ table carries forward files from a v1 upgrade (or rewrites manifests containing EXISTING entries with inherited `sequence_number = 0`), two bugs in `ManifestWriter` produced an incorrect `min_sequence_number`:
1. **`addEntry` skipped seq `0`** — min-seq tracking only ran when `entry.SequenceNum() > 0`, so v1-inherited entries at sequence `0` were never counted.
2. **`ToManifestFile` erased a valid min of `0`** — if the computed minimum was `0`, it was converted to `-1` ("unset").
When `MinSeqNumber == -1`, `ManifestListWriter.AddManifests` substitutes the commit's sequence number. That inflates `min_sequence_number` on data manifests that should remain `0`.

## Spec reference
https://github.com/apache/iceberg/blob/7522b02aaf42d51d4b12e211119d159c9dc03552/format/spec.md?plain=1#L1008-L1009


> **`515 sequence_number`** — The sequence number when the manifest was added to the table; **use 0 when reading v1 manifest lists**
>
> **`516 min_sequence_number`** — The minimum data sequence number of all live data or delete files in the manifest; **use 0 when reading v1 manifest lists**


https://github.com/apache/iceberg/blob/7522b02aaf42d51d4b12e211119d159c9dc03552/format/spec.md?plain=1#L1978-L1985

> * Manifest list field `sequence-number` must default to **0**
> * Manifest list field `min-sequence-number` must default to **0**
> * Manifest entry field `sequence_number` must default to **0**
> * Manifest entry field `file_sequence_number` must default to **0**
Sequence number `0` is therefore a **valid, meaningful minimum** — not equivalent to "unset". Only `-1` (internal sentinel) should trigger assignment at commit time.
