### PR TITLE
refactor(table): clean up unused concurrentDataFileWriter in partitioned write paths 

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1686,10 +1686,10 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 	targetFileSize := int64(meta.props.GetInt(WriteTargetFileSizeBytesKey,
 		WriteTargetFileSizeBytesDefault))
 
-	cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-		return newPositionDeleteWriter(rootLocation, fs, meta, props, opts...)
-	}, withSchemaSanitization(false))
 	if latestMetadata.PartitionSpec().IsUnpartitioned() {
+		cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
+			return newPositionDeleteWriter(rootLocation, fs, meta, props, opts...)
+		}, withSchemaSanitization(false))
 		nextCount, stopCount := iter.Pull(args.counter)
 		tasks := func(yield func(WriteTask) bool) {
 			defer stopCount()

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1569,11 +1569,7 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 		return clusteredPartitionedWrite(ctx, factory.currentSpec, meta.CurrentSchema(), factory, args.itr)
 	}
 
-	cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-		return newDataFileWriter(rootLocation, fs, meta, props, opts...)
-	})
-
-	partitionWriter := newPartitionedFanoutWriter(factory.currentSpec, cw, meta.CurrentSchema(), args.itr, factory)
+	partitionWriter := newPartitionedFanoutWriter(factory.currentSpec, meta.CurrentSchema(), args.itr, factory)
 	workers := config.EnvConfig.MaxWorkers
 	if args.maxWriteWorkers > 0 {
 		workers = args.maxWriteWorkers
@@ -1590,7 +1586,7 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 		defer close(outputCh)
 		defer factory.stopCount()
 
-		writer := factory.newRollingDataWriter(ctx, nil, "", nil, outputCh)
+		writer := factory.newRollingDataWriter(ctx, "", nil, outputCh)
 		for rec, err := range records {
 			if err != nil {
 				errCh <- err
@@ -1726,7 +1722,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 		panic(err)
 	}
 
-	partitionWriter := newPositionDeletePartitionedFanoutWriter(latestMetadata, cw, partitionContextByFilePath, args.itr, factory)
+	partitionWriter := newPositionDeletePartitionedFanoutWriter(latestMetadata, partitionContextByFilePath, args.itr, factory)
 	workers := config.EnvConfig.MaxWorkers
 
 	return partitionWriter.Write(ctx, workers)

--- a/table/clustered_writer.go
+++ b/table/clustered_writer.go
@@ -125,7 +125,7 @@ func clusteredPartitionedWrite(
 				}
 				partitionPath := spec.PartitionToPath(part.partitionRec, schema)
 				currentWriter = factory.newRollingDataWriter(
-					ctx, nil, partitionPath, part.partitionValues, outputCh)
+					ctx, partitionPath, part.partitionValues, outputCh)
 				currentRec = part.partitionRec
 			}
 

--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -591,12 +591,9 @@ func writeWithMeasurement(t testing.TB, name string, numPartitions, rowsPerParti
 
 	switch name {
 	case "fanout":
-		cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-			return newDataFileWriter(rootLocation, fs, meta, props, opts...)
-		})
 		factory, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, 512*1024*1024)
 		require.NoError(t, err)
-		writer := newPartitionedFanoutWriter(spec, cw, icebergSchema, args.itr, factory)
+		writer := newPartitionedFanoutWriter(spec, icebergSchema, args.itr, factory)
 		captureBaseline()
 		for df, err := range writer.Write(context.Background(), config.EnvConfig.MaxWorkers) {
 			require.NoError(t, err)

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -158,9 +158,6 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 	targetFileSize := int64(meta.props.GetInt(WriteTargetFileSizeBytesKey,
 		WriteTargetFileSizeBytesDefault))
 
-	cw := newConcurrentDataFileWriter(newEqualityDeleteWriterMaker(deleteSchema, equalityFieldIDs),
-		withSchemaSanitization(false))
-
 	latestMetadata, err := meta.Build()
 	if err != nil {
 		return nil, err
@@ -189,6 +186,9 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 
 		return partitionWriter.Write(ctx, workers), nil
 	}
+
+	cw := newConcurrentDataFileWriter(newEqualityDeleteWriterMaker(deleteSchema, equalityFieldIDs),
+		withSchemaSanitization(false))
 
 	nextCount, stopCount := iter.Pull(args.counter)
 	tasks := func(yield func(WriteTask) bool) {

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -184,7 +184,7 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 		}
 
 		partitionWriter := newPartitionedFanoutWriter(
-			partitionSpec, cw, writeSchema, args.itr, factory)
+			partitionSpec, writeSchema, args.itr, factory)
 		workers := config.EnvConfig.MaxWorkers
 
 		return partitionWriter.Write(ctx, workers), nil

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -40,7 +40,6 @@ type partitionedFanoutWriter struct {
 	schema                   *iceberg.Schema
 	itr                      iter.Seq2[arrow.RecordBatch, error]
 	writerFactory            *writerFactory
-	concurrentDataFileWriter *concurrentDataFileWriter
 }
 
 // PartitionInfo holds the row indices and partition values for a specific partition,
@@ -53,13 +52,12 @@ type partitionInfo struct {
 
 // NewPartitionedFanoutWriter creates a new PartitionedFanoutWriter with the specified
 // partition specification, schema, record iterator, and writerFactory.
-func newPartitionedFanoutWriter(partitionSpec iceberg.PartitionSpec, concurrentWriter *concurrentDataFileWriter, schema *iceberg.Schema, itr iter.Seq2[arrow.RecordBatch, error], writerFactory *writerFactory) *partitionedFanoutWriter {
+func newPartitionedFanoutWriter(partitionSpec iceberg.PartitionSpec, schema *iceberg.Schema, itr iter.Seq2[arrow.RecordBatch, error], writerFactory *writerFactory) *partitionedFanoutWriter {
 	return &partitionedFanoutWriter{
 		partitionSpec:            partitionSpec,
 		schema:                   schema,
 		itr:                      itr,
 		writerFactory:            writerFactory,
-		concurrentDataFileWriter: concurrentWriter,
 	}
 }
 
@@ -151,7 +149,7 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, record arro
 		}
 
 		partitionPath := p.partitionPath(val.partitionRec)
-		rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, p.concurrentDataFileWriter, partitionPath, val.partitionValues, dataFilesChannel)
+		rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, partitionPath, val.partitionValues, dataFilesChannel)
 		if err != nil {
 			partitionRecord.Release()
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -36,10 +36,10 @@ import (
 // a partition specification, writing data to separate files for each partition using
 // a fanout pattern with configurable parallelism.
 type partitionedFanoutWriter struct {
-	partitionSpec            iceberg.PartitionSpec
-	schema                   *iceberg.Schema
-	itr                      iter.Seq2[arrow.RecordBatch, error]
-	writerFactory            *writerFactory
+	partitionSpec iceberg.PartitionSpec
+	schema        *iceberg.Schema
+	itr           iter.Seq2[arrow.RecordBatch, error]
+	writerFactory *writerFactory
 }
 
 // PartitionInfo holds the row indices and partition values for a specific partition,
@@ -54,10 +54,10 @@ type partitionInfo struct {
 // partition specification, schema, record iterator, and writerFactory.
 func newPartitionedFanoutWriter(partitionSpec iceberg.PartitionSpec, schema *iceberg.Schema, itr iter.Seq2[arrow.RecordBatch, error], writerFactory *writerFactory) *partitionedFanoutWriter {
 	return &partitionedFanoutWriter{
-		partitionSpec:            partitionSpec,
-		schema:                   schema,
-		itr:                      itr,
-		writerFactory:            writerFactory,
+		partitionSpec: partitionSpec,
+		schema:        schema,
+		itr:           itr,
+		writerFactory: writerFactory,
 	}
 }
 

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -136,13 +136,10 @@ func (s *FanoutWriterTestSuite) testTransformPartition(transform iceberg.Transfo
 		},
 	}
 
-	cw := newConcurrentDataFileWriter(func(rootLocation string, fs iceio.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-		return newDataFileWriter(rootLocation, fs, meta, props, opts...)
-	})
 	rollingDataWriters, err := newWriterFactory(loc, args, metaBuilder, icebergSchema, 1024*1024)
 	s.Require().NoError(err)
 
-	partitionWriter := newPartitionedFanoutWriter(spec, cw, icebergSchema, args.itr, rollingDataWriters)
+	partitionWriter := newPartitionedFanoutWriter(spec, icebergSchema, args.itr, rollingDataWriters)
 	workers := config.EnvConfig.MaxWorkers
 
 	dataFiles := partitionWriter.Write(s.ctx, workers)

--- a/table/pos_delete_partitioned_fanout_writer.go
+++ b/table/pos_delete_partitioned_fanout_writer.go
@@ -36,18 +36,16 @@ type positionDeletePartitionedFanoutWriter struct {
 	metadata                   Metadata
 	itr                        iter.Seq2[arrow.RecordBatch, error]
 	writerFactory              *writerFactory
-	concurrentDataFileWriter   *concurrentDataFileWriter
 }
 
 // newPositionDeletePartitionedFanoutWriter creates a new PartitionedFanoutWriter with the specified
 // metadata, partition context, and record iterator.
-func newPositionDeletePartitionedFanoutWriter(metadata Metadata, concurrentWriter *concurrentDataFileWriter, partitionContextByFilePath map[string]partitionContext, itr iter.Seq2[arrow.RecordBatch, error], writerFactory *writerFactory) *positionDeletePartitionedFanoutWriter {
+func newPositionDeletePartitionedFanoutWriter(metadata Metadata, partitionContextByFilePath map[string]partitionContext, itr iter.Seq2[arrow.RecordBatch, error], writerFactory *writerFactory) *positionDeletePartitionedFanoutWriter {
 	return &positionDeletePartitionedFanoutWriter{
 		partitionContextByFilePath: partitionContextByFilePath,
 		metadata:                   metadata,
 		itr:                        itr,
 		writerFactory:              writerFactory,
-		concurrentDataFileWriter:   concurrentWriter,
 	}
 }
 
@@ -114,7 +112,7 @@ func (p *positionDeletePartitionedFanoutWriter) processBatch(ctx context.Context
 	if err != nil {
 		return err
 	}
-	rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, p.concurrentDataFileWriter, partitionPath, partitionContext.partitionData, dataFilesChannel)
+	rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, partitionPath, partitionContext.partitionData, dataFilesChannel)
 	if err != nil {
 		return err
 	}

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -128,9 +128,6 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			require.NoError(t, err)
 
 			writeUUID := uuid.New()
-			cw := newConcurrentDataFileWriter(func(rootLocation string, fs io.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-				return newPositionDeleteWriter(rootLocation, fs, meta, props, opts...)
-			})
 			factory, err := newWriterFactory(t.TempDir(), recordWritingArgs{
 				fs:        &io.LocalFS{},
 				sc:        PositionalDeleteArrowSchema,
@@ -140,7 +137,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 				withContentType(iceberg.EntryContentPosDeletes),
 				withFactoryFileSchema(iceberg.PositionalDeleteSchema))
 			require.NoError(t, err)
-			writer := newPositionDeletePartitionedFanoutWriter(latestMeta, cw, tc.pathToPartitionContext, nil, factory)
+			writer := newPositionDeletePartitionedFanoutWriter(latestMeta, tc.pathToPartitionContext, nil, factory)
 
 			dataFileCh := make(chan iceberg.DataFile, 10)
 			err = writer.processBatch(ctx, tc.input, dataFileCh)
@@ -364,9 +361,6 @@ func TestPositionDeletePartitionedFanoutWriterRoutesPartitionsIndependently(t *t
 	}
 
 	writeUUID := uuid.New()
-	cw := newConcurrentDataFileWriter(func(rootLocation string, fs io.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (dataFileWriter, error) {
-		return newPositionDeleteWriter(rootLocation, fs, meta, props, opts...)
-	})
 	factory, err := newWriterFactory(t.TempDir(), recordWritingArgs{
 		fs:        &io.LocalFS{},
 		sc:        PositionalDeleteArrowSchema,
@@ -376,7 +370,7 @@ func TestPositionDeletePartitionedFanoutWriterRoutesPartitionsIndependently(t *t
 		withContentType(iceberg.EntryContentPosDeletes),
 		withFactoryFileSchema(iceberg.PositionalDeleteSchema))
 	require.NoError(t, err)
-	writer := newPositionDeletePartitionedFanoutWriter(latestMeta, cw, pathToCtx, nil, factory)
+	writer := newPositionDeletePartitionedFanoutWriter(latestMeta, pathToCtx, nil, factory)
 
 	dataFileCh := make(chan iceberg.DataFile, 4)
 

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -233,30 +233,30 @@ func (w *writerFactory) partitionLocProvider(partitionPath string) (LocationProv
 // RollingDataWriter writes Arrow records for a specific partition, rolling to
 // new data files when the actual compressed file size reaches the target.
 type RollingDataWriter struct {
-	partitionKey     string
-	partitionID      int
-	fileCount        atomic.Int64
-	recordCh         chan arrow.RecordBatch
-	errorCh          chan error
-	factory          *writerFactory
-	partitionValues  map[int]any
-	ctx              context.Context
-	cancel           context.CancelFunc
-	wg               sync.WaitGroup
+	partitionKey    string
+	partitionID     int
+	fileCount       atomic.Int64
+	recordCh        chan arrow.RecordBatch
+	errorCh         chan error
+	factory         *writerFactory
+	partitionValues map[int]any
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
 }
 
 func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) *RollingDataWriter {
 	ctx, cancel := context.WithCancel(ctx)
 	partitionID := int(w.partitionIDCounter.Add(1) - 1)
 	writer := &RollingDataWriter{
-		partitionKey:     partition,
-		partitionID:      partitionID,
-		recordCh:         make(chan arrow.RecordBatch, 64),
-		errorCh:          make(chan error, 1),
-		factory:          w,
-		partitionValues:  partitionValues,
-		ctx:              ctx,
-		cancel:           cancel,
+		partitionKey:    partition,
+		partitionID:     partitionID,
+		recordCh:        make(chan arrow.RecordBatch, 64),
+		errorCh:         make(chan error, 1),
+		factory:         w,
+		partitionValues: partitionValues,
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 
 	writer.wg.Add(1)

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -243,10 +243,9 @@ type RollingDataWriter struct {
 	ctx              context.Context
 	cancel           context.CancelFunc
 	wg               sync.WaitGroup
-	concurrentWriter *concurrentDataFileWriter
 }
 
-func (w *writerFactory) newRollingDataWriter(ctx context.Context, concurrentWriter *concurrentDataFileWriter, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) *RollingDataWriter {
+func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) *RollingDataWriter {
 	ctx, cancel := context.WithCancel(ctx)
 	partitionID := int(w.partitionIDCounter.Add(1) - 1)
 	writer := &RollingDataWriter{
@@ -257,7 +256,6 @@ func (w *writerFactory) newRollingDataWriter(ctx context.Context, concurrentWrit
 		factory:          w,
 		partitionValues:  partitionValues,
 		ctx:              ctx,
-		concurrentWriter: concurrentWriter,
 		cancel:           cancel,
 	}
 
@@ -267,7 +265,7 @@ func (w *writerFactory) newRollingDataWriter(ctx context.Context, concurrentWrit
 	return writer
 }
 
-func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, concurrentWriter *concurrentDataFileWriter, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) (*RollingDataWriter, error) {
+func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) (*RollingDataWriter, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -279,7 +277,7 @@ func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, concur
 		return nil, fmt.Errorf("invalid writer type for partition: %s", partition)
 	}
 
-	writer := w.newRollingDataWriter(ctx, concurrentWriter, partition, partitionValues, outputDataFilesCh)
+	writer := w.newRollingDataWriter(ctx, partition, partitionValues, outputDataFilesCh)
 	w.writers.Store(partition, writer)
 
 	return writer, nil

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -128,7 +128,7 @@ func (s *RollingDataWriterTestSuite) TestSingleFileUnderTarget() {
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(s.ctx, "", nil, outputCh)
 
 	record := s.buildRecord(arrSchema, 5)
 	defer record.Release()
@@ -157,7 +157,7 @@ func (s *RollingDataWriterTestSuite) TestRollsMultipleFiles() {
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 100)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(s.ctx, "", nil, outputCh)
 
 	totalRows := int64(0)
 	for range 10 {
@@ -296,7 +296,7 @@ func (s *RollingDataWriterTestSuite) TestWriterFactoryPropagatesSortOrderID() {
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(s.ctx, "", nil, outputCh)
 
 	record := s.buildRecord(arrSchema, 5)
 	defer record.Release()
@@ -339,7 +339,7 @@ func (s *RollingDataWriterTestSuite) TestStreamErrorPathUsesAbort() {
 	defer factory.closeAll()
 
 	outputCh := make(chan iceberg.DataFile, 10)
-	writer := factory.newRollingDataWriter(s.ctx, nil, "", nil, outputCh)
+	writer := factory.newRollingDataWriter(s.ctx, "", nil, outputCh)
 
 	// Send a record with an incompatible schema to trigger a
 	// ToRequestedSchema error, exercising the deferred Abort() path.


### PR DESCRIPTION
#### What changed:
This PR removes the  `concurrentDataFileWriter`  parameter from  `PartitionedFanoutWriter`, `PositionDeletePartitionedFanoutWriter` , and  `RollingDataWriter` .
  
#### Why:
The  concurrentDataFileWriter  parameter is currently passed into these partitioned writers but is not used within their implementations. Removing it simplifies the constructor signatures and reduces unnecessary parameter passing.
  
The  concurrentDataFileWriter  struct itself is preserved, as it is still used by unpartitioned delete operations.