### PR TITLE
refactor(catalog/hadoop): Change Hadoop Catalog to Use IO Interface

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -25,7 +25,6 @@ import (
 	"iter"
 	"log"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -98,9 +97,10 @@ func validateIdentifier(ident table.Identifier) error {
 var _ catalog.PurgeableTable = (*Catalog)(nil)
 
 type Catalog struct {
-	name      string
-	warehouse string
-	props     iceberg.Properties
+	name       string
+	warehouse  string
+	filesystem HadoopCatalogFS
+	props      iceberg.Properties
 }
 
 // NewCatalog creates a new Hadoop catalog rooted at the given warehouse path.
@@ -145,7 +145,10 @@ func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, err
 	return &Catalog{
 		name:      name,
 		warehouse: warehouse,
-		props:     props,
+		// for the time being, we default to localfs since there is not yet
+		// support for other filesystems like blob stores
+		filesystem: icebergio.LocalFS{},
+		props:      props,
 	}, nil
 }
 
@@ -182,10 +185,10 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 //   - v*.metadata.json (Hadoop catalog format)
 //   - <seq>-<uuid>.metadata.json (Java/PyIceberg format)
 //   - version-hint.text
-func isTableDir(path string) bool {
+func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 	metaDir := filepath.Join(path, "metadata")
 
-	entries, err := os.ReadDir(metaDir)
+	entries, err := filesystem.ReadDir(metaDir)
 	if err != nil {
 		return false
 	}
@@ -207,7 +210,7 @@ func isTableDir(path string) bool {
 }
 
 func (c *Catalog) readVersionHint(ident table.Identifier) int {
-	data, err := os.ReadFile(c.versionHintPath(ident))
+	data, err := c.filesystem.ReadFile(c.versionHintPath(ident))
 	if err != nil {
 		return 0
 	}
@@ -226,15 +229,15 @@ func (c *Catalog) writeVersionHint(ident table.Identifier, version int) {
 	hintPath := c.versionHintPath(ident)
 
 	content := []byte(strconv.Itoa(version))
-	if err := os.WriteFile(tempPath, content, 0o644); err != nil {
+	if err := c.filesystem.WriteFile(tempPath, content); err != nil {
 		log.Printf("hadoop catalog: failed to write version hint temp file: %v", err)
 
 		return
 	}
 
-	if err := os.Rename(tempPath, hintPath); err != nil {
+	if err := c.filesystem.Rename(tempPath, hintPath); err != nil {
 		log.Printf("hadoop catalog: failed to rename version hint: %v", err)
-		os.Remove(tempPath)
+		_ = c.filesystem.Remove(tempPath)
 	}
 }
 
@@ -244,13 +247,13 @@ func (c *Catalog) metadataVersionExists(ident table.Identifier, version int) boo
 	dir := c.metadataDir(ident)
 	plain := filepath.Join(dir, fmt.Sprintf("v%d.metadata.json", version))
 
-	if _, err := os.Stat(plain); err == nil {
+	if _, err := c.filesystem.Stat(plain); err == nil {
 		return true
 	}
 
 	gz := filepath.Join(dir, fmt.Sprintf("v%d.gz.metadata.json", version))
 
-	_, err := os.Stat(gz)
+	_, err := c.filesystem.Stat(gz)
 
 	return err == nil
 }
@@ -272,7 +275,7 @@ func (c *Catalog) findVersion(ident table.Identifier) (int, error) {
 
 	dir := c.metadataDir(ident)
 
-	entries, err := os.ReadDir(dir)
+	entries, err := c.filesystem.ReadDir(dir)
 	if err != nil {
 		return 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w",
 			strings.Join(ident, "."), catalog.ErrNoSuchTable)
@@ -314,8 +317,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	ns := catalog.NamespaceFromIdent(ident)
 	nsPath := c.namespaceToPath(ns)
 
-	info, err := os.Stat(nsPath)
-	if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+	info, err := c.filesystem.Stat(nsPath)
+	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
 	}
 
@@ -328,7 +331,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, errors.New("hadoop catalog: custom table locations are not supported")
 	}
 
-	if isTableDir(loc) {
+	if isTableDir(c.filesystem, loc) {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrTableAlreadyExists, strings.Join(ident, "."))
 	}
 
@@ -338,7 +341,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	metaDir := c.metadataDir(ident)
-	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 
@@ -354,13 +357,13 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	if err := internal.WriteTableMetadata(metadata, icebergio.LocalFS{}, tempPath, compression); err != nil {
-		os.Remove(tempPath)
+		_ = c.filesystem.Remove(tempPath)
 
 		return nil, fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
-	if err := os.Rename(tempPath, metaPath); err != nil {
-		os.Remove(tempPath)
+	if err := c.filesystem.Rename(tempPath, metaPath); err != nil {
+		_ = c.filesystem.Remove(tempPath)
 
 		return nil, fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
 	}
@@ -398,7 +401,7 @@ func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (b
 		return false, nil
 	}
 
-	return isTableDir(c.tableToPath(ident)), nil
+	return isTableDir(c.filesystem, c.tableToPath(ident)), nil
 }
 
 func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
@@ -464,7 +467,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 	// Step 7: Create metadata directory if needed (create-via-commit).
 	metaDir := c.metadataDir(ident)
-	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, "", fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 
@@ -474,22 +477,22 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 	compression := updated.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
 
 	if err := internal.WriteTableMetadata(updated, icebergio.LocalFS{}, tempPath, compression); err != nil {
-		os.Remove(tempPath)
+		_ = c.filesystem.Remove(tempPath)
 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
 	// Conflict detection: target file must not already exist.
-	if _, err := os.Stat(newMetaPath); err == nil {
-		os.Remove(tempPath)
+	if _, err := c.filesystem.Stat(newMetaPath); err == nil {
+		_ = c.filesystem.Remove(tempPath)
 
 		return nil, "", fmt.Errorf("hadoop catalog: version %d already exists for table %s",
 			newVersion, strings.Join(ident, "."))
 	}
 
 	// Atomic commit via rename.
-	if err := os.Rename(tempPath, newMetaPath); err != nil {
-		os.Remove(tempPath)
+	if err := c.filesystem.Rename(tempPath, newMetaPath); err != nil {
+		_ = c.filesystem.Remove(tempPath)
 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
 	}
@@ -510,8 +513,8 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 
 		nsPath := c.namespaceToPath(ns)
 
-		info, err := os.Stat(nsPath)
-		if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+		info, err := c.filesystem.Stat(nsPath)
+		if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 			yield(nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, ".")))
 
 			return
@@ -523,7 +526,7 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 			return
 		}
 
-		entries, err := os.ReadDir(nsPath)
+		entries, err := c.filesystem.ReadDir(nsPath)
 		if err != nil {
 			yield(nil, fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err))
 
@@ -536,7 +539,7 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 			}
 
 			child := filepath.Join(nsPath, e.Name())
-			if !isTableDir(child) {
+			if !isTableDir(c.filesystem, child) {
 				continue
 			}
 
@@ -556,11 +559,11 @@ func (c *Catalog) DropTable(_ context.Context, ident table.Identifier) error {
 	}
 
 	tablePath := c.tableToPath(ident)
-	if !isTableDir(tablePath) {
+	if !isTableDir(c.filesystem, tablePath) {
 		return fmt.Errorf("%w: %s", catalog.ErrNoSuchTable, strings.Join(ident, "."))
 	}
 
-	return os.RemoveAll(tablePath)
+	return c.filesystem.RemoveAll(tablePath)
 }
 
 func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) error {
@@ -593,7 +596,7 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 
 	path := c.namespaceToPath(ns)
 
-	if err := os.Mkdir(path, 0o755); err != nil {
+	if err := c.filesystem.Mkdir(path); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
 		}
@@ -616,7 +619,7 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 	path := c.namespaceToPath(ns)
 
-	entries, err := os.ReadDir(path)
+	entries, err := c.filesystem.ReadDir(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
@@ -629,7 +632,7 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 		return fmt.Errorf("%w: %s", catalog.ErrNamespaceNotEmpty, strings.Join(ns, "."))
 	}
 
-	return os.Remove(path)
+	return c.filesystem.Remove(path)
 }
 
 func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (bool, error) {
@@ -639,7 +642,7 @@ func (c *Catalog) CheckNamespaceExists(_ context.Context, ns table.Identifier) (
 
 	path := c.namespaceToPath(ns)
 
-	info, err := os.Stat(path)
+	info, err := c.filesystem.Stat(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
@@ -665,13 +668,13 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 	} else {
 		path = c.namespaceToPath(parent)
 
-		info, err := os.Stat(path)
+		info, err := c.filesystem.Stat(path)
 		if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 			return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(parent, "."))
 		}
 	}
 
-	entries, err := os.ReadDir(path)
+	entries, err := c.filesystem.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to read directory: %w", err)
 	}
@@ -683,7 +686,7 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 		}
 
 		child := filepath.Join(path, e.Name())
-		if isTableDir(child) {
+		if isTableDir(c.filesystem, child) {
 			continue
 		}
 
@@ -703,7 +706,7 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 
 	path := c.namespaceToPath(ns)
 
-	info, err := os.Stat(path)
+	info, err := c.filesystem.Stat(path)
 	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
 	}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -356,7 +356,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		}
 	}
 
-	if err := internal.WriteTableMetadata(metadata, icebergio.LocalFS{}, tempPath, compression); err != nil {
+	if err := internal.WriteTableMetadata(metadata, c.filesystem, tempPath, compression); err != nil {
 		_ = c.filesystem.Remove(tempPath)
 
 		return nil, fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -476,7 +476,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 	compression := updated.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
 
-	if err := internal.WriteTableMetadata(updated, icebergio.LocalFS{}, tempPath, compression); err != nil {
+	if err := internal.WriteTableMetadata(updated, c.filesystem, tempPath, compression); err != nil {
 		_ = c.filesystem.Remove(tempPath)
 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -184,14 +184,14 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrue() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(tableDir))
+	s.True(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNoMetadataDir() {
 	nsDir := filepath.Join(s.warehouse, "ns")
 	s.Require().NoError(os.MkdirAll(nsDir, 0o755))
 
-	s.False(isTableDir(nsDir))
+	s.False(isTableDir(s.cat.filesystem, nsDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
@@ -199,7 +199,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 
-	s.False(isTableDir(tableDir))
+	s.False(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
@@ -208,7 +208,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(tableDir))
+	s.True(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
@@ -217,11 +217,11 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.gz.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(tableDir))
+	s.True(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirNonExistentPath() {
-	s.False(isTableDir(filepath.Join(s.warehouse, "does", "not", "exist")))
+	s.False(isTableDir(s.cat.filesystem, filepath.Join(s.warehouse, "does", "not", "exist")))
 }
 
 func (s *HadoopCatalogTestSuite) createMetadataFile(ident table.Identifier, version int) {
@@ -692,7 +692,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueVersionHintText() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "version-hint.text"), []byte("1"), 0o644))
 
-	s.True(isTableDir(tableDir))
+	s.True(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataGzip() {
@@ -701,7 +701,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataGzip() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.gz.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(tableDir))
+	s.True(isTableDir(s.cat.filesystem, tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
@@ -710,7 +710,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "random.json"), nil, 0o644))
 
-	s.False(isTableDir(tableDir))
+	s.False(isTableDir(s.cat.filesystem, tableDir))
 }
 
 // Helper to create a fake table directory with a metadata file.

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -1,0 +1,83 @@
+package hadoop
+
+import (
+	"io/fs"
+
+	icebergio "github.com/apache/iceberg-go/io"
+)
+
+// HadoopCatalogFS represents all the interfaces that a filesystem implementation
+// must satisfy to be used for a Hadoop catalog implementation.
+type HadoopCatalogFS interface {
+	icebergio.ListableIO
+	icebergio.ReadFileIO
+	icebergio.WriteFileIO
+	StatIO
+	RemameIO
+	RemoveAllIO
+	MkdirAllIO
+	MkdirIO
+	ReadDirIO
+}
+
+// Ensure that the LocalFS implements the extensions
+// thus ensuring that the hadoop catalog can use the LocalFS for its
+// IO operations
+var (
+	_ icebergio.IO = (*icebergio.LocalFS)(nil)
+	_ StatIO       = (*icebergio.LocalFS)(nil)
+	_ RemameIO     = (*icebergio.LocalFS)(nil)
+	_ RemoveAllIO  = (*icebergio.LocalFS)(nil)
+	_ MkdirIO      = (*icebergio.LocalFS)(nil)
+	_ MkdirAllIO   = (*icebergio.LocalFS)(nil)
+	_ ReadDirIO    = (*icebergio.LocalFS)(nil)
+)
+
+// StatIO is an extension of IO interface that includes the Stat
+// method for retrieving file information without reading the file
+type StatIO interface {
+	icebergio.IO
+
+	Stat(name string) (fs.FileInfo, error)
+}
+
+// RemameIO is an extension of IO interface that includes the Rename
+// method for renaming (moving) files or directories; this should be atomic
+type RemameIO interface {
+	icebergio.IO
+
+	Rename(oldpath, newpath string) error
+}
+
+// RemoveAllIO is an extension of IO interface that includes the RemoveAll
+// method for removing a file path and any children recursively
+type RemoveAllIO interface {
+	icebergio.IO
+
+	RemoveAll(name string) error
+}
+
+// MkdirIO is an extension of IO interface that includes the Mkdir
+// method for creating a directory
+type MkdirIO interface {
+	icebergio.IO
+
+	Mkdir(path string) error
+}
+
+// MkdirAllIO is an extension of IO interface that includes the MkdirAll
+// method for creating a directory path recursively
+type MkdirAllIO interface {
+	icebergio.IO
+
+	MkdirAll(path string) error
+}
+
+// ReadDirIO is an extension of IO interface that includes the ReadDir
+// method for reading the contents of a directory and returning a slice of
+// DirEntry values
+type ReadDirIO interface {
+	icebergio.IO
+
+	ReadDir(name string) ([]fs.DirEntry, error)
+}

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -13,7 +13,7 @@ type HadoopCatalogFS interface {
 	icebergio.ReadFileIO
 	icebergio.WriteFileIO
 	StatIO
-	RemameIO
+	RenameIO
 	RemoveAllIO
 	MkdirAllIO
 	MkdirIO
@@ -26,7 +26,7 @@ type HadoopCatalogFS interface {
 var (
 	_ icebergio.IO = (*icebergio.LocalFS)(nil)
 	_ StatIO       = (*icebergio.LocalFS)(nil)
-	_ RemameIO     = (*icebergio.LocalFS)(nil)
+	_ RenameIO     = (*icebergio.LocalFS)(nil)
 	_ RemoveAllIO  = (*icebergio.LocalFS)(nil)
 	_ MkdirIO      = (*icebergio.LocalFS)(nil)
 	_ MkdirAllIO   = (*icebergio.LocalFS)(nil)
@@ -41,9 +41,9 @@ type StatIO interface {
 	Stat(name string) (fs.FileInfo, error)
 }
 
-// RemameIO is an extension of IO interface that includes the Rename
+// RenameIO is an extension of IO interface that includes the Rename
 // method for renaming (moving) files or directories; this should be atomic
-type RemameIO interface {
+type RenameIO interface {
 	icebergio.IO
 
 	Rename(oldpath, newpath string) error

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -37,29 +37,21 @@ type HadoopCatalogFS interface {
 	ReadDirIO
 }
 
-// Ensure that the LocalFS implements the extensions
-// thus ensuring that the hadoop catalog can use the LocalFS for its
-// IO operations
-var (
-	_ icebergio.IO = (*icebergio.LocalFS)(nil)
-	_ StatIO       = (*icebergio.LocalFS)(nil)
-	_ RenameIO     = (*icebergio.LocalFS)(nil)
-	_ RemoveAllIO  = (*icebergio.LocalFS)(nil)
-	_ MkdirIO      = (*icebergio.LocalFS)(nil)
-	_ MkdirAllIO   = (*icebergio.LocalFS)(nil)
-	_ ReadDirIO    = (*icebergio.LocalFS)(nil)
-)
+var _ HadoopCatalogFS = (*icebergio.LocalFS)(nil)
 
 // StatIO is an extension of IO interface that includes the Stat
 // method for retrieving file information without reading the file
 type StatIO interface {
 	icebergio.IO
 
+	// The Stat method returns a FileInfo describing the named file, or an error
+	// satisfying errors.Is(err, fs.ErrNotExist) if the file does not exist
 	Stat(name string) (fs.FileInfo, error)
 }
 
 // RenameIO is an extension of IO interface that includes the Rename
-// method for renaming (moving) files or directories; this should be atomic
+// method for renaming (moving) files or directories; this must be
+// atomic and can be used for committing metadata updates
 type RenameIO interface {
 	icebergio.IO
 
@@ -79,6 +71,9 @@ type RemoveAllIO interface {
 type MkdirIO interface {
 	icebergio.IO
 
+	// Mkdir creates a new directory or returns an error
+	// satisfying errors.Is(err, fs.ErrExist) if the directory already exists or
+	// errors.Is(err, fs.ErrNotExist) if it does not create parent directories
 	Mkdir(path string) error
 }
 
@@ -96,5 +91,7 @@ type MkdirAllIO interface {
 type ReadDirIO interface {
 	icebergio.IO
 
+	// ReadDir returns a slice of DirEntry values for the named directory
+	// or an error satisfying errors.Is(err, fs.ErrNotExist) if the directory does not exist
 	ReadDir(name string) ([]fs.DirEntry, error)
 }

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package hadoop
 
 import (

--- a/io/local.go
+++ b/io/local.go
@@ -32,9 +32,13 @@ func (LocalFS) Open(name string) (File, error) {
 	return os.Open(strings.TrimPrefix(name, "file://"))
 }
 
+func (LocalFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(strings.TrimPrefix(name, "file://"))
+}
+
 func (LocalFS) Create(name string) (FileWriter, error) {
 	filename := strings.TrimPrefix(name, "file://")
-	if err := os.MkdirAll(filepath.Dir(filename), 0o777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return nil, err
 	}
 
@@ -42,13 +46,37 @@ func (LocalFS) Create(name string) (FileWriter, error) {
 }
 
 func (LocalFS) WriteFile(name string, content []byte) error {
-	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0o777)
+	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0o755)
 }
 
 func (LocalFS) Remove(name string) error {
 	return os.Remove(strings.TrimPrefix(name, "file://"))
 }
 
+func (LocalFS) RemoveAll(name string) error {
+	return os.RemoveAll(strings.TrimPrefix(name, "file://"))
+}
+
 func (LocalFS) WalkDir(root string, fn fs.WalkDirFunc) error {
 	return filepath.WalkDir(strings.TrimPrefix(root, "file://"), fn)
+}
+
+func (LocalFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(strings.TrimPrefix(name, "file://"))
+}
+
+func (LocalFS) MkdirAll(path string) error {
+	return os.MkdirAll(strings.TrimPrefix(path, "file://"), 0o755)
+}
+
+func (LocalFS) Mkdir(path string) error {
+	return os.Mkdir(strings.TrimPrefix(path, "file://"), 0o755)
+}
+
+func (LocalFS) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(strings.TrimPrefix(name, "file://"))
+}
+
+func (LocalFS) Rename(oldpath, newpath string) error {
+	return os.Rename(strings.TrimPrefix(oldpath, "file://"), strings.TrimPrefix(newpath, "file://"))
 }

--- a/io/local.go
+++ b/io/local.go
@@ -46,7 +46,7 @@ func (LocalFS) Create(name string) (FileWriter, error) {
 }
 
 func (LocalFS) WriteFile(name string, content []byte) error {
-	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0o755)
+	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0o644)
 }
 
 func (LocalFS) Remove(name string) error {


### PR DESCRIPTION
First step of addressing https://github.com/apache/iceberg-go/issues/1096 This just changes the hadoop catalog implementation to support an interface but still requires a local filesystem.

- All `os.` calls have been swapped to using an interface `HadoopCatalogFS`. 
- `HadoopCatalogFS` implements the same exact calls as `os.` 
    - There were a few calls to `os.remove` that didn't handle the `err` value. I made these `_` to explicitly discard the err value.
    - In a follow up PR I can condense the number of methods to reduce interface size. However as a first pass, I wanted to keep the interface and thus the behavior very easy to review.
- The `localfs` struct was extended to support the additional methods. 
    - There were a few places where `mkdir` used `0o777` for a permission. I didn't see any reason to allow for execution by other users so I changed these to `0o755` 