### PR TITLE
fix(table): reject time64[ns] in partition literal extraction (#1115)

### DIFF
--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -392,8 +392,9 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 
 		return iceberg.NewLiteral(iceberg.Date(arr.Value(row))), nil
 	case *array.Time64:
-		if unit := arr.DataType().(*arrow.Time64Type).Unit; unit != arrow.Microsecond {
-			return nil, fmt.Errorf("%w: unsupported arrow type for conversion - time64[%s]", iceberg.ErrInvalidSchema, unit)
+		dt, ok := arr.DataType().(*arrow.Time64Type)
+		if !ok || dt.Unit != arrow.Microsecond {
+			return nil, fmt.Errorf("%w: unsupported arrow type for conversion - %s", iceberg.ErrInvalidSchema, arr.DataType())
 		}
 
 		return iceberg.NewLiteral(iceberg.Time(arr.Value(row))), nil

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -392,6 +392,9 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 
 		return iceberg.NewLiteral(iceberg.Date(arr.Value(row))), nil
 	case *array.Time64:
+		if unit := arr.DataType().(*arrow.Time64Type).Unit; unit != arrow.Microsecond {
+			return nil, fmt.Errorf("%w: unsupported arrow type for conversion - time64[%s]", iceberg.ErrInvalidSchema, unit)
+		}
 
 		return iceberg.NewLiteral(iceberg.Time(arr.Value(row))), nil
 	case *array.Timestamp:

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -597,7 +597,7 @@ func (s *FanoutWriterTestSuite) TestGetArrowValueAsIcebergLiteralTime64() {
 	usArr := usBldr.NewTime64Array()
 	defer usArr.Release()
 
-	lit, err := getArrowValueAsIcebergLiteral(usArr, 0)
+	lit, err := getArrowValueAsIcebergLiteral(usArr, 0, iceberg.PrimitiveTypes.Time)
 	s.Require().NoError(err)
 	s.Equal(iceberg.NewLiteral(iceberg.Time(5_000_000)), lit)
 
@@ -608,7 +608,7 @@ func (s *FanoutWriterTestSuite) TestGetArrowValueAsIcebergLiteralTime64() {
 	nsArr := nsBldr.NewTime64Array()
 	defer nsArr.Release()
 
-	_, err = getArrowValueAsIcebergLiteral(nsArr, 0)
+	_, err = getArrowValueAsIcebergLiteral(nsArr, 0, iceberg.PrimitiveTypes.Time)
 	s.Require().ErrorIs(err, iceberg.ErrInvalidSchema)
 	s.Contains(err.Error(), "time64[ns]")
 }

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -588,3 +588,27 @@ func (s *FanoutWriterTestSuite) createComprehensiveTestRecord() arrow.RecordBatc
 
 	return bldr.NewRecordBatch()
 }
+
+func (s *FanoutWriterTestSuite) TestGetArrowValueAsIcebergLiteralTime64() {
+	// time64[us]: value passes through unchanged.
+	usBldr := array.NewTime64Builder(s.mem, &arrow.Time64Type{Unit: arrow.Microsecond})
+	defer usBldr.Release()
+	usBldr.Append(arrow.Time64(5_000_000))
+	usArr := usBldr.NewTime64Array()
+	defer usArr.Release()
+
+	lit, err := getArrowValueAsIcebergLiteral(usArr, 0)
+	s.Require().NoError(err)
+	s.Equal(iceberg.NewLiteral(iceberg.Time(5_000_000)), lit)
+
+	// time64[ns]: explicitly rejected to avoid silently producing wrong partition keys.
+	nsBldr := array.NewTime64Builder(s.mem, &arrow.Time64Type{Unit: arrow.Nanosecond})
+	defer nsBldr.Release()
+	nsBldr.Append(arrow.Time64(5_000_000_000))
+	nsArr := nsBldr.NewTime64Array()
+	defer nsArr.Release()
+
+	_, err = getArrowValueAsIcebergLiteral(nsArr, 0)
+	s.Require().ErrorIs(err, iceberg.ErrInvalidSchema)
+	s.Contains(err.Error(), "time64[ns]")
+}


### PR DESCRIPTION
`getArrowValueAsIcebergLiteral` previously assumed every `*array.Time64` already held microseconds and ignored the Arrow `Time64Type.Unit`. This is unreachable today because the schema-conversion path in `arrow_utils.go` only accepts `time64[us]`, but the helper was still silently producing wrong partition keys if `time64[ns]` ever reached it.

Inspect `Time64Type.Unit` and return `iceberg.ErrInvalidSchema` for any unit other than microseconds, mirroring the schema-conversion error. Add a focused unit test covering both the success and rejection paths.

Closes https://github.com/apache/iceberg-go/issues/1115