### PR TITLE
fix(io/s3): preserve tuned transport options when configuring HTTP client

### DIFF
--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -76,7 +76,7 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 			return nil, fmt.Errorf("invalid s3 proxy url %q: %w", proxy, err)
 		}
 
-		httpClient = awshttp.NewBuildableClient().WithTransportOptions(
+		httpClient = newS3BuildableClient().WithTransportOptions(
 			func(t *http.Transport) {
 				t.Proxy = http.ProxyURL(proxyURL)
 			},
@@ -90,7 +90,7 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 		}
 
 		if httpClient == nil {
-			httpClient = awshttp.NewBuildableClient()
+			httpClient = newS3BuildableClient()
 		}
 		httpClient = httpClient.WithDialerOptions(func(d *net.Dialer) {
 			d.Timeout = duration
@@ -130,6 +130,28 @@ func parseS3ConnectTimeout(timeout string) (time.Duration, error) {
 	return duration, nil
 }
 
+// S3 transport tuning shared by all S3 BuildableClient paths.
+const (
+	s3MaxIdleConns        = 256
+	s3MaxIdleConnsPerHost = 256
+	s3MaxConnsPerHost     = 2048
+	s3IdleConnTimeout     = 90 * time.Second
+)
+
+// newS3BuildableClient returns an AWS buildable HTTP client with the S3
+// transport tuning applied. Subsequent WithTransportOptions/WithDialerOptions
+// calls preserve this tuning, since the builder clones the transport forward.
+func newS3BuildableClient() *awshttp.BuildableClient {
+	return awshttp.NewBuildableClient().WithTransportOptions(applyS3TransportTuning)
+}
+
+func applyS3TransportTuning(t *http.Transport) {
+	t.MaxIdleConns = s3MaxIdleConns
+	t.MaxIdleConnsPerHost = s3MaxIdleConnsPerHost
+	t.MaxConnsPerHost = s3MaxConnsPerHost
+	t.IdleConnTimeout = s3IdleConnTimeout
+}
+
 // resolveUsePathStyle determines whether the S3 client should use
 // path-style addressing. It defaults to virtual-hosted style for
 // standard AWS S3 and path-style for custom endpoints (e.g. MinIO).
@@ -160,17 +182,10 @@ func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]strin
 	}
 
 	// Default HTTP client when not configured: use the SDK buildable client so
-	// proxy, TLS, dial, and HTTP/2 behavior match the usual AWS defaults, but
-	// raise per-host idle limits (Go's DefaultTransport uses 2 per host).
+	// proxy, TLS, dial, and HTTP/2 behavior match the usual AWS defaults, with
+	// the S3 transport tuning applied (see applyS3TransportTuning).
 	if awscfg.HTTPClient == nil {
-		awscfg.HTTPClient = awshttp.NewBuildableClient().WithTransportOptions(
-			func(t *http.Transport) {
-				t.MaxIdleConns = 256
-				t.MaxIdleConnsPerHost = 256
-				t.MaxConnsPerHost = 256
-				t.IdleConnTimeout = 90 * time.Second
-			},
-		)
+		awscfg.HTTPClient = newS3BuildableClient()
 	}
 
 	endpoint, ok := props[io.S3EndpointURL]

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -137,6 +137,7 @@ func TestParseAWSConfigConnectTimeout(t *testing.T) {
 			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
 			require.True(t, ok)
 			assert.Equal(t, tt.want, client.GetDialer().Timeout)
+			assertS3TransportTuning(t, client.GetTransport())
 		})
 	}
 }
@@ -171,6 +172,21 @@ func TestParseAWSConfigConnectTimeoutRejectsNonPositiveDurations(t *testing.T) {
 	}
 }
 
+func TestParseAWSConfigProxyUsesTunedTransport(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseAWSConfig(context.Background(), map[string]string{
+		io.S3Region:   "us-east-1",
+		io.S3ProxyURI: "http://proxy.example.com:8080",
+	})
+	require.NoError(t, err)
+
+	client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+	require.True(t, ok)
+	assertS3TransportTuning(t, client.GetTransport())
+	assertProxyURL(t, client.GetTransport(), "http://proxy.example.com:8080")
+}
+
 func TestParseAWSConfigProxyAndConnectTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -184,8 +200,15 @@ func TestParseAWSConfigProxyAndConnectTimeout(t *testing.T) {
 	client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
 	require.True(t, ok)
 	assert.Equal(t, 5*time.Second, client.GetDialer().Timeout)
+	assertS3TransportTuning(t, client.GetTransport())
+	assertProxyURL(t, client.GetTransport(), "http://proxy.example.com:8080")
+}
 
-	proxyFunc := client.GetTransport().Proxy
+func assertProxyURL(t *testing.T, transport *http.Transport, want string) {
+	t.Helper()
+
+	require.NotNil(t, transport)
+	proxyFunc := transport.Proxy
 	require.NotNil(t, proxyFunc)
 
 	proxyURL, err := proxyFunc(&http.Request{
@@ -193,7 +216,17 @@ func TestParseAWSConfigProxyAndConnectTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, proxyURL)
-	assert.Equal(t, "http://proxy.example.com:8080", proxyURL.String())
+	assert.Equal(t, want, proxyURL.String())
+}
+
+func assertS3TransportTuning(t *testing.T, transport *http.Transport) {
+	t.Helper()
+
+	require.NotNil(t, transport)
+	assert.Equal(t, 256, transport.MaxIdleConns)
+	assert.Equal(t, 256, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, 2048, transport.MaxConnsPerHost)
+	assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
 }
 
 func TestResolveUsePathStyle(t *testing.T) {


### PR DESCRIPTION
Fixes #1148.

## Summary
- Factor S3 HTTP client transport tuning into a shared helper.
- Use the tuned buildable client when `s3.proxy-uri` configures an HTTP client.
- Use the tuned buildable client when `s3.connect-timeout` configures an HTTP client.
- Preserve the existing S3 transport tuning values for all configured S3 HTTP clients.

## Testing
- `env GOCACHE=/private/tmp/iceberg-go-gocache go test ./io/gocloud -run 'TestParseAWSConfig' -count=1`
- `env GOCACHE=/private/tmp/iceberg-go-gocache go vet ./io/gocloud/...`
- `git diff --check`