### PR TITLE
fix(table): preserve InitialDefault and WriteDefault in AssignFreshSchemaIDs

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1020,11 +1020,13 @@ func (p *pruneColVisitor) Struct(st StructType, fieldResults []Type) Type {
 			sameType = false
 			// type has changed, create a new field with the projected type
 			selected = append(selected, NestedField{
-				ID:       field.ID,
-				Name:     field.Name,
-				Type:     t,
-				Doc:      field.Doc,
-				Required: field.Required,
+				ID:             field.ID,
+				Name:           field.Name,
+				Type:           t,
+				Doc:            field.Doc,
+				Required:       field.Required,
+				InitialDefault: field.InitialDefault,
+				WriteDefault:   field.WriteDefault,
 			})
 		}
 	}
@@ -1318,11 +1320,13 @@ func (s *setFreshIDs) Struct(st StructType, fieldResults []func() Type) Type {
 	newFields := make([]NestedField, len(st.FieldList))
 	for idx, f := range st.FieldList {
 		newFields[idx] = NestedField{
-			ID:       s.getAndInc(f.ID),
-			Name:     f.Name,
-			Type:     fieldResults[idx](),
-			Doc:      f.Doc,
-			Required: f.Required,
+			ID:             s.getAndInc(f.ID),
+			Name:           f.Name,
+			Type:           fieldResults[idx](),
+			Doc:            f.Doc,
+			Required:       f.Required,
+			InitialDefault: f.InitialDefault,
+			WriteDefault:   f.WriteDefault,
 		}
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -761,6 +761,39 @@ func TestAssignFreshSchemaIDs(t *testing.T) {
 	}
 }
 
+func TestAssignFreshSchemaIDsPreservesDefaults(t *testing.T) {
+	src := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:             1,
+			Name:           "with_defaults",
+			Type:           iceberg.PrimitiveTypes.Int64,
+			Required:       true,
+			InitialDefault: int64(42),
+			WriteDefault:   int64(42),
+		},
+		iceberg.NestedField{
+			ID:       2,
+			Name:     "without_defaults",
+			Type:     iceberg.PrimitiveTypes.String,
+			Required: false,
+		},
+	)
+
+	out, err := iceberg.AssignFreshSchemaIDs(src, nil)
+	require.NoError(t, err)
+	require.Len(t, out.Fields(), 2)
+
+	withDefaults := out.Fields()[0]
+	assert.Equal(t, "with_defaults", withDefaults.Name)
+	assert.Equal(t, int64(42), withDefaults.InitialDefault, "InitialDefault must survive AssignFreshSchemaIDs")
+	assert.Equal(t, int64(42), withDefaults.WriteDefault, "WriteDefault must survive AssignFreshSchemaIDs")
+
+	withoutDefaults := out.Fields()[1]
+	assert.Equal(t, "without_defaults", withoutDefaults.Name)
+	assert.Nil(t, withoutDefaults.InitialDefault)
+	assert.Nil(t, withoutDefaults.WriteDefault)
+}
+
 func TestSchemaRoundTrip(t *testing.T) {
 	data, err := json.Marshal(tableSchemaNested)
 	require.NoError(t, err)

--- a/schema_test.go
+++ b/schema_test.go
@@ -777,11 +777,34 @@ func TestAssignFreshSchemaIDsPreservesDefaults(t *testing.T) {
 			Type:     iceberg.PrimitiveTypes.String,
 			Required: false,
 		},
+		iceberg.NestedField{
+			ID:       3,
+			Name:     "nested",
+			Required: true,
+			Type: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{
+						ID:             4,
+						Name:           "nested_with_defaults",
+						Type:           iceberg.PrimitiveTypes.Int64,
+						Required:       true,
+						InitialDefault: int64(7),
+						WriteDefault:   int64(7),
+					},
+					{
+						ID:       5,
+						Name:     "nested_without_defaults",
+						Type:     iceberg.PrimitiveTypes.String,
+						Required: false,
+					},
+				},
+			},
+		},
 	)
 
 	out, err := iceberg.AssignFreshSchemaIDs(src, nil)
 	require.NoError(t, err)
-	require.Len(t, out.Fields(), 2)
+	require.Len(t, out.Fields(), 3)
 
 	withDefaults := out.Fields()[0]
 	assert.Equal(t, "with_defaults", withDefaults.Name)
@@ -792,6 +815,22 @@ func TestAssignFreshSchemaIDsPreservesDefaults(t *testing.T) {
 	assert.Equal(t, "without_defaults", withoutDefaults.Name)
 	assert.Nil(t, withoutDefaults.InitialDefault)
 	assert.Nil(t, withoutDefaults.WriteDefault)
+
+	nested := out.Fields()[2]
+	assert.Equal(t, "nested", nested.Name)
+	nestedStruct, ok := nested.Type.(*iceberg.StructType)
+	require.True(t, ok, "nested field must remain a StructType")
+	require.Len(t, nestedStruct.FieldList, 2)
+
+	nestedWithDefaults := nestedStruct.FieldList[0]
+	assert.Equal(t, "nested_with_defaults", nestedWithDefaults.Name)
+	assert.Equal(t, int64(7), nestedWithDefaults.InitialDefault, "nested InitialDefault must survive AssignFreshSchemaIDs")
+	assert.Equal(t, int64(7), nestedWithDefaults.WriteDefault, "nested WriteDefault must survive AssignFreshSchemaIDs")
+
+	nestedWithoutDefaults := nestedStruct.FieldList[1]
+	assert.Equal(t, "nested_without_defaults", nestedWithoutDefaults.Name)
+	assert.Nil(t, nestedWithoutDefaults.InitialDefault)
+	assert.Nil(t, nestedWithoutDefaults.WriteDefault)
 }
 
 func TestSchemaRoundTrip(t *testing.T) {

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -81,7 +81,15 @@ func TestAddColumn(t *testing.T) {
 				ValueType:     iceberg.PrimitiveTypes.String,
 				ValueRequired: false,
 			}, Required: false, Doc: ""},
-			{ID: 12, Name: "gender", Type: iceberg.PrimitiveTypes.String, Required: false, Doc: ""},
+			{
+				ID:             12,
+				Name:           "gender",
+				Type:           iceberg.PrimitiveTypes.String,
+				Required:       false,
+				Doc:            "",
+				InitialDefault: "male",
+				WriteDefault:   "male",
+			},
 		}, newSchema.Fields())
 	})
 


### PR DESCRIPTION
`AssignFreshSchemaIDs` silently drops `InitialDefault` and `WriteDefault` on every field. This corrupts the behaviour`UpdateSchema.AddColumn(..., defaultValue)`, which constructs the new field with defaults and calls `AssignFreshSchemaIDs`. 