### PR TITLE
refactor(catalog): unify metadata IO operations by passing Table instances directly

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -334,14 +334,16 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 	}
 
 	// Create a staging table with the updates applied
-	staged, err := internal.UpdateAndStageTable(ctx, current, identifier, requirements, updates, c)
+	staged, err := internal.UpdateAndStageTable(ctx, c.props, current, identifier, requirements, updates, c)
 	if err != nil {
 		return nil, "", err
 	}
 	if current != nil && staged.Metadata().Equals(current.Metadata()) {
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+	ioProps := maps.Clone(c.props)
+	maps.Copy(ioProps, staged.Properties())
+	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
 		return nil, "", err
 	}
 

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -255,17 +255,7 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
-	afs, err := staged.FS(ctx)
-	if err != nil {
-		return nil, err
-	}
-	wfs, ok := afs.(io.WriteFileIO)
-	if !ok {
-		return nil, errors.New("loaded filesystem IO does not support writing")
-	}
-
-	compression := staged.Table.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
-	if err := internal.WriteTableMetadata(staged.Metadata(), wfs, staged.MetadataLocation(), compression); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, err
 	}
 
@@ -341,9 +331,7 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 	if current != nil && staged.Metadata().Equals(current.Metadata()) {
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
-	ioProps := maps.Clone(c.props)
-	maps.Copy(ioProps, staged.Properties())
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, "", err
 	}
 

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -483,7 +483,7 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 		}
 	}
 
-	staged, err := internal.UpdateAndStageTable(ctx, current, identifier, requirements, updates, c)
+	staged, err := internal.UpdateAndStageTable(ctx, c.opts.props, current, identifier, requirements, updates, c)
 	if err != nil {
 		return nil, "", err
 	}
@@ -492,7 +492,9 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
 
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+	ioProps := maps.Clone(c.opts.props)
+	maps.Copy(ioProps, staged.Properties())
+	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
 		return nil, "", err
 	}
 

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -178,17 +178,7 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
-	afs, err := staged.FS(ctx)
-	if err != nil {
-		return nil, err
-	}
-	wfs, ok := afs.(io.WriteFileIO)
-	if !ok {
-		return nil, errors.New("loaded filesystem IO does not support writing")
-	}
-
-	compression := staged.Table.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
-	if err := internal.WriteTableMetadata(staged.Metadata(), wfs, staged.MetadataLocation(), compression); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, err
 	}
 
@@ -492,9 +482,7 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
 
-	ioProps := maps.Clone(c.opts.props)
-	maps.Copy(ioProps, staged.Properties())
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, "", err
 	}
 

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -192,7 +192,7 @@ func ParseMetadataVersion(location string) int {
 	return v
 }
 
-func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
+func UpdateAndStageTable(ctx context.Context, catprops iceberg.Properties, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
 	var (
 		baseMeta    table.Metadata
 		metadataLoc string
@@ -231,12 +231,15 @@ func UpdateAndStageTable(ctx context.Context, current *table.Table, ident table.
 		return nil, err
 	}
 
+	ioProps := maps.Clone(catprops)
+	maps.Copy(ioProps, updated.Properties())
+
 	return &table.StagedTable{
 		Table: table.New(
 			ident,
 			updated,
 			newLocation,
-			icebergio.LoadFSFunc(updated.Properties(), newLocation),
+			icebergio.LoadFSFunc(ioProps, newLocation),
 			cat,
 		),
 	}, nil

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -74,8 +74,8 @@ func WriteTableMetadata(metadata table.Metadata, fs icebergio.WriteFileIO, loc s
 	return
 }
 
-func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, props iceberg.Properties) error {
-	fs, err := icebergio.LoadFS(ctx, props, loc)
+func WriteMetadata(ctx context.Context, tbl *table.Table) error {
+	fs, err := tbl.FS(ctx)
 	if err != nil {
 		return err
 	}
@@ -85,9 +85,9 @@ func WriteMetadata(ctx context.Context, metadata table.Metadata, loc string, pro
 		return errors.New("filesystem IO does not support writing")
 	}
 
-	compression := props.Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
+	compression := tbl.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
 
-	return WriteTableMetadata(metadata, wfs, loc, compression)
+	return WriteTableMetadata(tbl.Metadata(), wfs, tbl.MetadataLocation(), compression)
 }
 
 func UpdateTableMetadata(base table.Metadata, updates []table.Update, metadataLoc string) (table.Metadata, error) {
@@ -125,6 +125,9 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 	}
 
 	ioProps := maps.Clone(catprops)
+	if ioProps == nil {
+		ioProps = iceberg.Properties{}
+	}
 	maps.Copy(ioProps, cfg.Properties)
 
 	return table.StagedTable{
@@ -232,6 +235,9 @@ func UpdateAndStageTable(ctx context.Context, catprops iceberg.Properties, curre
 	}
 
 	ioProps := maps.Clone(catprops)
+	if ioProps == nil {
+		ioProps = iceberg.Properties{}
+	}
 	maps.Copy(ioProps, updated.Properties())
 
 	return &table.StagedTable{

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -293,17 +293,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
 	}
 
-	afs, err := staged.FS(ctx)
-	if err != nil {
-		return nil, err
-	}
-	wfs, ok := afs.(io.WriteFileIO)
-	if !ok {
-		return nil, errors.New("loaded filesystem IO does not support writing")
-	}
-
-	compression := staged.Table.Properties().Get(table.MetadataCompressionKey, table.MetadataCompressionDefault)
-	if err := internal.WriteTableMetadata(staged.Metadata(), wfs, staged.MetadataLocation(), compression); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, err
 	}
 
@@ -347,9 +337,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
 
-	ioProps := maps.Clone(c.props)
-	maps.Copy(ioProps, staged.Properties())
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
 		return nil, "", err
 	}
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -337,7 +337,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return nil, "", err
 	}
 
-	staged, err := internal.UpdateAndStageTable(ctx, current, ident, reqs, updates, c)
+	staged, err := internal.UpdateAndStageTable(ctx, c.props, current, ident, reqs, updates, c)
 	if err != nil {
 		return nil, "", err
 	}
@@ -347,7 +347,9 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return current.Metadata(), current.MetadataLocation(), nil
 	}
 
-	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), staged.Properties()); err != nil {
+	ioProps := maps.Clone(c.props)
+	maps.Copy(ioProps, staged.Properties())
+	if err := internal.WriteMetadata(ctx, staged.Metadata(), staged.MetadataLocation(), ioProps); err != nil {
 		return nil, "", err
 	}
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**
This PR fixes an authentication issue when updating tables. 

Currently, `internal.UpdateAndStageTable` and `internal.WriteMetadata` only use table properties. This causes IO failures for remote storage (like S3) because catalog-level credentials (e.g., `s3.access-key-id`) are lost.

**Fix:**
- Updated `UpdateAndStageTable` to accept `catprops` and merge it with table properties before initializing the filesystem.
- Applied the same property merge to `internal.WriteMetadata`.
- Note: This aligns the update logic with how `CreateStagedTable` already works. `nsprops` is intentionally omitted here since table locations are already fixed during updates.

**How was this patch tested?**
- `make test` passes successfully. 
- *No specific unit test was added for this fix, as our mock filesystems do not validate remote credentials, making it hard to test credential merging effectively. Relying on alignment with `CreateStagedTable` instead.* 