### PR TITLE
fix: preserve nested field IDs when filling missing columns

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1051,7 +1051,7 @@ func (a *arrowProjectionVisitor) Struct(st iceberg.StructType, structArr arrow.A
 			fieldArrs[i] = arr
 			fields[i] = a.constructField(field, arr.DataType())
 		} else {
-			dt := retOrPanic(TypeToArrowType(field.Type, false, a.useLargeTypes))
+			dt := retOrPanic(TypeToArrowType(field.Type, a.includeFieldIDs, a.useLargeTypes))
 			alloc := compute.GetAllocator(a.ctx)
 
 			switch {

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -1891,7 +1891,7 @@ func TestToRequestedSchemaMissingNestedFieldID(t *testing.T) {
 	defer rec2.Release()
 
 	fmt.Println("Result Schema:", rec2.Schema().String())
-	
+
 	targetSchema := arrow.NewSchema([]arrow.Field{
 		{
 			Name: "other_field", Type: arrow.PrimitiveTypes.Int32, Nullable: true,

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -1889,8 +1888,6 @@ func TestToRequestedSchemaMissingNestedFieldID(t *testing.T) {
 	rec2, err := table.ToRequestedSchema(context.Background(), reqIcesc, fileIcesc, rec, table.SchemaOptions{IncludeFieldIDs: true})
 	require.NoError(t, err)
 	defer rec2.Release()
-
-	fmt.Println("Result Schema:", rec2.Schema().String())
 
 	targetSchema := arrow.NewSchema([]arrow.Field{
 		{

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1844,4 +1845,66 @@ func TestToRequestedSchemaWriteDefaultJSONRoundTrip(t *testing.T) {
 			tt.check(t, result.Column(1))
 		})
 	}
+}
+
+func TestToRequestedSchemaMissingNestedFieldID(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	// Create an Arrow schema that lacks the nested list completely
+	schemaWithoutMetadata := arrow.NewSchema([]arrow.Field{
+		{
+			Name: "other_field", Type: arrow.PrimitiveTypes.Int32,
+		},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, schemaWithoutMetadata)
+	defer bldr.Release()
+
+	const data = `{"other_field": 1}
+				  {"other_field": 2}`
+
+	s := bufio.NewScanner(strings.NewReader(data))
+	for s.Scan() {
+		require.NoError(t, bldr.UnmarshalJSON(s.Bytes()))
+	}
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	// The file schema lacks the nested_list
+	fileIcesc := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 10, Name: "other_field", Type: iceberg.PrimitiveTypes.Int32, Required: false,
+	})
+
+	// The requested schema has the nested_list
+	reqIcesc := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 10, Name: "other_field", Type: iceberg.PrimitiveTypes.Int32, Required: false,
+	}, iceberg.NestedField{
+		ID: 11, Name: "nested_list", Type: &iceberg.ListType{
+			ElementID: 12, Element: iceberg.PrimitiveTypes.String, ElementRequired: false,
+		}, Required: false,
+	})
+
+	rec2, err := table.ToRequestedSchema(context.Background(), reqIcesc, fileIcesc, rec, table.SchemaOptions{IncludeFieldIDs: true})
+	require.NoError(t, err)
+	defer rec2.Release()
+
+	fmt.Println("Result Schema:", rec2.Schema().String())
+	
+	targetSchema := arrow.NewSchema([]arrow.Field{
+		{
+			Name: "other_field", Type: arrow.PrimitiveTypes.Int32, Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{table.ArrowParquetFieldIDKey: "10"}),
+		},
+		{
+			Name: "nested_list", Type: arrow.ListOfField(arrow.Field{
+				Name: "element", Type: arrow.BinaryTypes.String, Nullable: true,
+				Metadata: arrow.MetadataFrom(map[string]string{table.ArrowParquetFieldIDKey: "12"}),
+			}),
+			Metadata: arrow.MetadataFrom(map[string]string{table.ArrowParquetFieldIDKey: "11"}),
+			Nullable: true,
+		},
+	}, nil)
+	require.True(t, targetSchema.Equal(rec2.Schema()), "Schema is not perfectly equal")
 }


### PR DESCRIPTION
Fixes a bug where generating a null array for a completely missing nested column (e.g., during schema evolution) accidentally drops the inner `PARQUET:field_id` metadata due to a hardcoded `false` flag. This correctly propagates `includeFieldIDs` and resolves the `record schema does not match writer's` error when writing to `pqarrow`.