### PR TITLE
feat(cli): add branch and tag delete commands

### DIFF
--- a/cmd/iceberg/branch_tag.go
+++ b/cmd/iceberg/branch_tag.go
@@ -33,6 +33,8 @@ func runBranch(ctx context.Context, output Output, cat catalog.Catalog, cmd *Bra
 	switch {
 	case cmd.Create != nil:
 		runBranchCreate(ctx, output, cat, cmd.Create)
+	case cmd.Delete != nil:
+		runBranchDelete(ctx, output, cat, cmd.Delete)
 	}
 }
 
@@ -40,6 +42,8 @@ func runTag(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagCmd
 	switch {
 	case cmd.Create != nil:
 		runTagCreate(ctx, output, cat, cmd.Create)
+	case cmd.Delete != nil:
+		runTagDelete(ctx, output, cat, cmd.Delete)
 	}
 }
 
@@ -47,11 +51,11 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()
 
-	for name := range meta.Refs() {
-		if name == cmd.BranchName {
-			output.Error(fmt.Errorf("ref %q already exists", cmd.BranchName))
-			os.Exit(1)
-		}
+	if _, found := findSnapshotRef(meta, cmd.BranchName); found {
+		output.Error(fmt.Errorf("ref %q already exists", cmd.BranchName))
+		osExit(1)
+
+		return
 	}
 
 	snapshotID := resolveSnapshotID(output, tbl, cmd.SnapshotID)
@@ -61,7 +65,9 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 		cmd.Yes,
 	); err != nil {
 		output.Error(err)
-		os.Exit(1)
+		osExit(1)
+
+		return
 	}
 
 	var maxRefAgeMs int64
@@ -69,7 +75,9 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 		d, err := parseDuration(cmd.MaxRefAge)
 		if err != nil {
 			output.Error(fmt.Errorf("invalid --max-ref-age: %w", err))
-			os.Exit(1)
+			osExit(1)
+
+			return
 		}
 
 		maxRefAgeMs = d.Milliseconds()
@@ -80,7 +88,9 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 		d, err := parseDuration(cmd.MaxSnapshotAge)
 		if err != nil {
 			output.Error(fmt.Errorf("invalid --max-snapshot-age: %w", err))
-			os.Exit(1)
+			osExit(1)
+
+			return
 		}
 
 		maxSnapshotAgeMs = d.Milliseconds()
@@ -100,7 +110,9 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 
 	if _, _, err := cat.CommitTable(ctx, tbl.Identifier(), reqs, []table.Update{update}); err != nil {
 		output.Error(fmt.Errorf("failed to create branch: %w", err))
-		os.Exit(1)
+		osExit(1)
+
+		return
 	}
 
 	result := RefCreatedResult{
@@ -126,11 +138,11 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()
 
-	for name := range meta.Refs() {
-		if name == cmd.TagName {
-			output.Error(fmt.Errorf("ref %q already exists", cmd.TagName))
-			os.Exit(1)
-		}
+	if _, found := findSnapshotRef(meta, cmd.TagName); found {
+		output.Error(fmt.Errorf("ref %q already exists", cmd.TagName))
+		osExit(1)
+
+		return
 	}
 
 	snapshotID := resolveSnapshotID(output, tbl, cmd.SnapshotID)
@@ -140,7 +152,9 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 		cmd.Yes,
 	); err != nil {
 		output.Error(err)
-		os.Exit(1)
+		osExit(1)
+
+		return
 	}
 
 	var maxRefAgeMs int64
@@ -148,7 +162,9 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 		d, err := parseDuration(cmd.MaxRefAge)
 		if err != nil {
 			output.Error(fmt.Errorf("invalid --max-ref-age: %w", err))
-			os.Exit(1)
+			osExit(1)
+
+			return
 		}
 
 		maxRefAgeMs = d.Milliseconds()
@@ -163,7 +179,9 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 
 	if _, _, err := cat.CommitTable(ctx, tbl.Identifier(), reqs, []table.Update{update}); err != nil {
 		output.Error(fmt.Errorf("failed to create tag: %w", err))
-		os.Exit(1)
+		osExit(1)
+
+		return
 	}
 
 	result := RefCreatedResult{
@@ -179,11 +197,92 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 	output.RefCreated(result)
 }
 
+func runBranchDelete(ctx context.Context, output Output, cat catalog.Catalog, cmd *BranchDeleteCmd) {
+	if cmd.BranchName == table.MainBranch {
+		output.Error(errors.New(`cannot delete the "main" branch`))
+		osExit(1)
+
+		return
+	}
+
+	runRefDelete(ctx, output, cat, cmd.TableID, cmd.BranchName, table.BranchRef, cmd.Yes)
+}
+
+func runTagDelete(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagDeleteCmd) {
+	runRefDelete(ctx, output, cat, cmd.TableID, cmd.TagName, table.TagRef, cmd.Yes)
+}
+
+func runRefDelete(ctx context.Context, output Output, cat catalog.Catalog, tableID, refName string, refType table.RefType, yes bool) {
+	tbl := loadTable(ctx, output, cat, tableID)
+	meta := tbl.Metadata()
+
+	ref, found := findSnapshotRef(meta, refName)
+	if !found {
+		output.Error(fmt.Errorf("%s %q does not exist", refType, refName))
+		osExit(1)
+
+		return
+	}
+
+	if ref.SnapshotRefType != refType {
+		output.Error(fmt.Errorf("ref %q is a %s, not a %s", refName, ref.SnapshotRefType, refType))
+		osExit(1)
+
+		return
+	}
+
+	if err := confirmAction(
+		fmt.Sprintf("Delete %s %q from %s at snapshot %d?", refType, refName, tableIDString(tbl), ref.SnapshotID),
+		yes,
+	); err != nil {
+		output.Error(err)
+		osExit(1)
+
+		return
+	}
+
+	update := table.NewRemoveSnapshotRefUpdate(refName)
+	// Pin the ref to the snapshot we observed so a concurrent move or delete of
+	// the ref between load and commit fails the requirement instead of silently
+	// removing a different ref state.
+	snapshotID := ref.SnapshotID
+	reqs := []table.Requirement{
+		table.AssertTableUUID(meta.TableUUID()),
+		table.AssertRefSnapshotID(refName, &snapshotID),
+	}
+
+	if _, _, err := cat.CommitTable(ctx, tbl.Identifier(), reqs, []table.Update{update}); err != nil {
+		output.Error(fmt.Errorf("failed to delete %s: %w", refType, err))
+		osExit(1)
+
+		return
+	}
+
+	output.RefDeleted(RefDeletedResult{
+		Table:      tableIDString(tbl),
+		RefName:    refName,
+		RefType:    string(refType),
+		SnapshotID: snapshotID,
+	})
+}
+
+func findSnapshotRef(meta table.Metadata, name string) (table.SnapshotRef, bool) {
+	for refName, ref := range meta.Refs() {
+		if refName == name {
+			return ref, true
+		}
+	}
+
+	return table.SnapshotRef{}, false
+}
+
 func resolveSnapshotID(output Output, tbl *table.Table, explicit *int64) int64 {
 	if explicit != nil {
 		if tbl.Metadata().SnapshotByID(*explicit) == nil {
 			output.Error(fmt.Errorf("snapshot %d not found", *explicit))
-			os.Exit(1)
+			osExit(1)
+
+			return 0
 		}
 
 		return *explicit
@@ -192,7 +291,9 @@ func resolveSnapshotID(output Output, tbl *table.Table, explicit *int64) int64 {
 	snap := tbl.Metadata().CurrentSnapshot()
 	if snap == nil {
 		output.Error(errors.New("table has no current snapshot; specify --snapshot-id explicitly"))
-		os.Exit(1)
+		osExit(1)
+
+		return 0
 	}
 
 	return snap.SnapshotID
@@ -204,6 +305,17 @@ func (t textOutput) RefCreated(result RefCreatedResult) {
 }
 
 func (j jsonOutput) RefCreated(result RefCreatedResult) {
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		j.Error(err)
+	}
+}
+
+func (t textOutput) RefDeleted(result RefDeletedResult) {
+	pterm.Printfln("Deleted %s %q from %s at snapshot %d.",
+		result.RefType, result.RefName, result.Table, result.SnapshotID)
+}
+
+func (j jsonOutput) RefDeleted(result RefDeletedResult) {
 	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
 		j.Error(err)
 	}

--- a/cmd/iceberg/branch_tag.go
+++ b/cmd/iceberg/branch_tag.go
@@ -242,9 +242,11 @@ func runRefDelete(ctx context.Context, output Output, cat catalog.Catalog, table
 	}
 
 	update := table.NewRemoveSnapshotRefUpdate(refName)
-	// Pin the ref to the snapshot we observed so a concurrent move or delete of
-	// the ref between load and commit fails the requirement instead of silently
-	// removing a different ref state.
+	// Pin the ref to the snapshot we observed so the delete only succeeds while
+	// the ref is unchanged: any concurrent head change, including a move, delete,
+	// or append that advances it, trips the requirement, and the user re-runs
+	// against the latest state. This is safe-by-default for a destructive
+	// operation and matches the create path's optimistic-concurrency style.
 	snapshotID := ref.SnapshotID
 	reqs := []table.Requirement{
 		table.AssertTableUUID(meta.TableUUID()),

--- a/cmd/iceberg/branch_tag_test.go
+++ b/cmd/iceberg/branch_tag_test.go
@@ -19,9 +19,13 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/table"
 	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +55,11 @@ const branchTagTestMetadata = `{
     ],
     "snapshot-log": [],
     "metadata-log": [],
-    "refs": {"main": {"snapshot-id": 5000, "type": "branch"}}
+    "refs": {
+        "main": {"snapshot-id": 5000, "type": "branch"},
+        "feature-branch": {"snapshot-id": 5000, "type": "branch"},
+        "v1.0": {"snapshot-id": 5000, "type": "tag"}
+    }
 }`
 
 func TestResolveSnapshotIDExplicit(t *testing.T) {
@@ -195,3 +203,331 @@ func TestJSONOutputRefCreatedWithRetention(t *testing.T) {
 	assert.Contains(t, output, `"max_snapshot_age_ms":86400000`)
 	assert.Contains(t, output, `"min_snapshots_to_keep":5`)
 }
+
+func TestTextOutputRefDeleted(t *testing.T) {
+	var buf bytes.Buffer
+	pterm.SetDefaultOutput(&buf)
+	pterm.DisableColor()
+	t.Cleanup(func() {
+		pterm.SetDefaultOutput(os.Stderr)
+		pterm.EnableColor()
+	})
+
+	result := RefDeletedResult{
+		Table:      "db.events",
+		RefName:    "feature-branch",
+		RefType:    "branch",
+		SnapshotID: 5000,
+	}
+
+	textOutput{}.RefDeleted(result)
+
+	output := buf.String()
+	assert.Contains(t, output, "Deleted branch")
+	assert.Contains(t, output, "feature-branch")
+	assert.Contains(t, output, "db.events")
+	assert.Contains(t, output, "5000")
+}
+
+func TestJSONOutputRefDeleted(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	oldStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() {
+		w.Close()
+		os.Stdout = oldStdout
+	})
+
+	result := RefDeletedResult{
+		Table:      "db.events",
+		RefName:    "feature-branch",
+		RefType:    "branch",
+		SnapshotID: 5000,
+	}
+
+	jsonOutput{}.RefDeleted(result)
+
+	w.Close()
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	output := buf.String()
+	assert.Contains(t, output, `"table":"db.events"`)
+	assert.Contains(t, output, `"ref_name":"feature-branch"`)
+	assert.Contains(t, output, `"ref_type":"branch"`)
+	assert.Contains(t, output, `"snapshot_id":5000`)
+}
+
+func TestRunBranchDeleteCommitsRemoveRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	runBranchDelete(context.Background(), out, cat, &BranchDeleteCmd{
+		TableID:    "db.events",
+		BranchName: "feature-branch",
+		Yes:        true,
+	})
+
+	require.NoError(t, out.lastErr)
+	require.NotNil(t, out.deleted)
+	assert.Equal(t, RefDeletedResult{
+		Table:      "db.events",
+		RefName:    "feature-branch",
+		RefType:    string(table.BranchRef),
+		SnapshotID: 5000,
+	}, *out.deleted)
+	assertDeleteRequirements(t, cat.requirements, "feature-branch", 5000)
+	require.Len(t, cat.updates, 1)
+	assertRemoveSnapshotRefUpdate(t, cat.updates[0], "feature-branch")
+	_, found := findSnapshotRef(cat.committed, "feature-branch")
+	assert.False(t, found)
+}
+
+func TestRunTagDeleteCommitsRemoveRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	runTagDelete(context.Background(), out, cat, &TagDeleteCmd{
+		TableID: "db.events",
+		TagName: "v1.0",
+		Yes:     true,
+	})
+
+	require.NoError(t, out.lastErr)
+	require.NotNil(t, out.deleted)
+	assert.Equal(t, RefDeletedResult{
+		Table:      "db.events",
+		RefName:    "v1.0",
+		RefType:    string(table.TagRef),
+		SnapshotID: 5000,
+	}, *out.deleted)
+	assertDeleteRequirements(t, cat.requirements, "v1.0", 5000)
+	require.Len(t, cat.updates, 1)
+	assertRemoveSnapshotRefUpdate(t, cat.updates[0], "v1.0")
+	_, found := findSnapshotRef(cat.committed, "v1.0")
+	assert.False(t, found)
+}
+
+func TestRunBranchDeleteRejectsMain(t *testing.T) {
+	out := &refDeleteCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runBranchDelete(context.Background(), out, nil, &BranchDeleteCmd{
+			TableID:    "db.events",
+			BranchName: "main",
+			Yes:        true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "cannot delete")
+	assert.Contains(t, out.lastErr.Error(), "main")
+}
+
+func TestRunBranchDeleteRejectsMissingRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runBranchDelete(context.Background(), out, cat, &BranchDeleteCmd{
+			TableID:    "db.events",
+			BranchName: "missing",
+			Yes:        true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), `branch "missing" does not exist`)
+	assert.Empty(t, cat.updates)
+}
+
+func TestRunTagDeleteRejectsMissingRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runTagDelete(context.Background(), out, cat, &TagDeleteCmd{
+			TableID: "db.events",
+			TagName: "missing",
+			Yes:     true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), `tag "missing" does not exist`)
+	assert.Empty(t, cat.updates)
+}
+
+func TestRunBranchDeleteRejectsTagRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runBranchDelete(context.Background(), out, cat, &BranchDeleteCmd{
+			TableID:    "db.events",
+			BranchName: "v1.0",
+			Yes:        true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), `ref "v1.0" is a tag, not a branch`)
+	assert.Empty(t, cat.updates)
+}
+
+func TestRunTagDeleteRejectsBranchRef(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refDeleteCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runTagDelete(context.Background(), out, cat, &TagDeleteCmd{
+			TableID: "db.events",
+			TagName: "feature-branch",
+			Yes:     true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), `ref "feature-branch" is a branch, not a tag`)
+	assert.Empty(t, cat.updates)
+}
+
+func branchTagTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	meta, err := table.ParseMetadataBytes([]byte(branchTagTestMetadata))
+	require.NoError(t, err)
+
+	return table.New([]string{"db", "events"}, meta, "", nil, nil)
+}
+
+type branchTagCommitCatalog struct {
+	catalog.Catalog
+	requirements []table.Requirement
+	updates      []table.Update
+	committed    table.Metadata
+	tbl          *table.Table
+}
+
+func (c *branchTagCommitCatalog) LoadTable(_ context.Context, _ table.Identifier) (*table.Table, error) {
+	return c.tbl, nil
+}
+
+func (c *branchTagCommitCatalog) CommitTable(
+	_ context.Context,
+	_ table.Identifier,
+	requirements []table.Requirement,
+	updates []table.Update,
+) (table.Metadata, string, error) {
+	c.requirements = requirements
+	c.updates = updates
+
+	base := c.tbl.Metadata()
+	for _, req := range requirements {
+		if err := req.Validate(base); err != nil {
+			return nil, "", err
+		}
+	}
+
+	builder, err := table.MetadataBuilderFromBase(base, c.tbl.MetadataLocation())
+	if err != nil {
+		return nil, "", err
+	}
+
+	for _, update := range updates {
+		if err := update.Apply(builder); err != nil {
+			return nil, "", err
+		}
+	}
+
+	meta, err := builder.Build()
+	if err != nil {
+		return nil, "", err
+	}
+
+	c.committed = meta
+	c.tbl = table.New(c.tbl.Identifier(), meta, c.tbl.MetadataLocation(), nil, nil)
+
+	return meta, "", nil
+}
+
+func assertDeleteRequirements(t *testing.T, requirements []table.Requirement, refName string, snapshotID int64) {
+	t.Helper()
+
+	require.Len(t, requirements, 2)
+	expected, err := json.Marshal(table.AssertRefSnapshotID(refName, &snapshotID))
+	require.NoError(t, err)
+
+	var found bool
+	for _, requirement := range requirements {
+		actual, err := json.Marshal(requirement)
+		require.NoError(t, err)
+		if bytes.Equal(actual, expected) {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "expected AssertRefSnapshotID(%q, %d)", refName, snapshotID)
+}
+
+func assertRemoveSnapshotRefUpdate(t *testing.T, update table.Update, refName string) {
+	t.Helper()
+
+	actual, err := json.Marshal(update)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"action":"remove-snapshot-ref","ref-name":`+strconv.Quote(refName)+`}`, string(actual))
+}
+
+type refDeleteCapture struct {
+	textOutput
+	deleted *RefDeletedResult
+	lastErr error
+}
+
+func (r *refDeleteCapture) RefDeleted(result RefDeletedResult) {
+	r.deleted = &result
+}
+
+func (r *refDeleteCapture) Error(err error) {
+	r.lastErr = err
+}
+
+func captureBranchTagExit(f func()) (exitCode int) {
+	origExit := osExit
+	defer func() { osExit = origExit }()
+
+	osExit = func(code int) {
+		exitCode = code
+		panic(branchTagExitSentinel{})
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(branchTagExitSentinel); !ok {
+				panic(r)
+			}
+		}
+	}()
+
+	f()
+
+	return 0
+}
+
+type branchTagExitSentinel struct{}

--- a/cmd/iceberg/exit.go
+++ b/cmd/iceberg/exit.go
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import "os"
+
+// osExit is an indirection over os.Exit so command handlers can be exercised in
+// tests by swapping it for a func that records the exit code and unwinds.
+var osExit = os.Exit

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -254,10 +254,10 @@ func main() {
 	case args.Compact != nil && args.Compact.Analyze == nil && args.Compact.Run == nil:
 		_ = parser.WriteHelpForSubcommand(os.Stderr, "compact")
 		os.Exit(1)
-	case args.Branch != nil && args.Branch.Create == nil:
+	case args.Branch != nil && args.Branch.Create == nil && args.Branch.Delete == nil:
 		_ = parser.WriteHelpForSubcommand(os.Stderr, "branch")
 		os.Exit(1)
-	case args.Tag != nil && args.Tag.Create == nil:
+	case args.Tag != nil && args.Tag.Create == nil && args.Tag.Delete == nil:
 		_ = parser.WriteHelpForSubcommand(os.Stderr, "tag")
 		os.Exit(1)
 	}

--- a/cmd/iceberg/maintenance.go
+++ b/cmd/iceberg/maintenance.go
@@ -89,8 +89,15 @@ type BranchCreateCmd struct {
 	Yes                bool   `arg:"--yes" help:"skip confirmation prompt"`
 }
 
+type BranchDeleteCmd struct {
+	TableID    string `arg:"positional,required" help:"full path to a table"`
+	BranchName string `arg:"positional,required" help:"branch name"`
+	Yes        bool   `arg:"--yes" help:"skip confirmation prompt"`
+}
+
 type BranchCmd struct {
 	Create *BranchCreateCmd `arg:"subcommand:create" help:"create a branch"`
+	Delete *BranchDeleteCmd `arg:"subcommand:delete" help:"delete a branch"`
 }
 
 type TagCreateCmd struct {
@@ -101,8 +108,15 @@ type TagCreateCmd struct {
 	Yes        bool   `arg:"--yes" help:"skip confirmation prompt"`
 }
 
+type TagDeleteCmd struct {
+	TableID string `arg:"positional,required" help:"full path to a table"`
+	TagName string `arg:"positional,required" help:"tag name"`
+	Yes     bool   `arg:"--yes" help:"skip confirmation prompt"`
+}
+
 type TagCmd struct {
 	Create *TagCreateCmd `arg:"subcommand:create" help:"create a tag"`
+	Delete *TagDeleteCmd `arg:"subcommand:delete" help:"delete a tag"`
 }
 
 // Result types
@@ -182,6 +196,13 @@ type RefCreatedResult struct {
 	MaxRefAgeMs        *int64 `json:"max_ref_age_ms,omitempty"`
 	MaxSnapshotAgeMs   *int64 `json:"max_snapshot_age_ms,omitempty"`
 	MinSnapshotsToKeep *int   `json:"min_snapshots_to_keep,omitempty"`
+}
+
+type RefDeletedResult struct {
+	Table      string `json:"table"`
+	RefName    string `json:"ref_name"`
+	RefType    string `json:"ref_type"`
+	SnapshotID int64  `json:"snapshot_id"`
 }
 
 // Shared helpers

--- a/cmd/iceberg/output.go
+++ b/cmd/iceberg/output.go
@@ -49,6 +49,7 @@ type Output interface {
 	UpgradeResult(result UpgradeResult)
 	RollbackResult(result RollbackResult)
 	RefCreated(result RefCreatedResult)
+	RefDeleted(result RefDeletedResult)
 	Text(string)
 	Schema(*iceberg.Schema)
 	Spec(iceberg.PartitionSpec)

--- a/cmd/iceberg/upgrade_rollback.go
+++ b/cmd/iceberg/upgrade_rollback.go
@@ -29,8 +29,6 @@ import (
 	"github.com/pterm/pterm"
 )
 
-var osExit = os.Exit
-
 func runUpgrade(ctx context.Context, output Output, cat catalog.Catalog, cmd *UpgradeCmd) {
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()


### PR DESCRIPTION
Fixes #1165.

## Summary
- Add `iceberg branch delete <table-id> <branch-name> [--yes]`.
- Add `iceberg tag delete <table-id> <tag-name> [--yes]`.
- Reject deletion of the `main` branch before any catalog commit, so the table can't be left headless (`RemoveSnapshotRef` clears `currentSnapshotID` for `main`).
- Validate that the requested ref exists and matches the expected ref type (`branch delete` refuses a tag, `tag delete` refuses a branch).
- Commit a `RemoveSnapshotRef` update guarded by `AssertTableUUID` + `AssertRefSnapshotID(ref, observedSnapshot)`. Pinning the observed snapshot is intentional: a concurrent move/delete of the ref between load and commit fails the requirement instead of silently removing a different ref state.
- Add structured delete output (`RefDeletedResult`) for both text and JSON modes, so `--output json` keeps working.

## Implementation notes
- The delete handlers mirror the existing `branch create` / `tag create` paths in `cmd/iceberg/branch_tag.go`, sharing `loadTable`, `confirmAction`, and the `Output` interface.
- The shared `osExit` test hook moved from `upgrade_rollback.go` into a dedicated `cmd/iceberg/exit.go`, and the create handlers were migrated onto it so the whole file uses one exit convention and the error paths are testable.

## Testing
- `env GOCACHE=/private/tmp/iceberg-go-gocache go test ./cmd/iceberg -count=1`
- `env GOCACHE=/private/tmp/iceberg-go-gocache go vet ./cmd/iceberg`
- `gofmt -l cmd/iceberg`
- `git diff --check`