### PR TITLE
feat(cli): support rollback by timestamp

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -211,6 +211,28 @@ func TestArgsParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "rollback with snapshot id",
+			args: []string{"rollback", "prod.db.events", "--snapshot-id", "123", "--yes"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.Rollback)
+				assert.Equal(t, "prod.db.events", a.Rollback.TableID)
+				require.NotNil(t, a.Rollback.SnapshotID)
+				assert.Equal(t, int64(123), *a.Rollback.SnapshotID)
+				assert.Equal(t, "", a.Rollback.Timestamp)
+				assert.True(t, a.Rollback.Yes)
+			},
+		},
+		{
+			name: "rollback with timestamp",
+			args: []string{"rollback", "prod.db.events", "--timestamp", "2026-01-15T03:00:00Z"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.Rollback)
+				assert.Equal(t, "prod.db.events", a.Rollback.TableID)
+				assert.Nil(t, a.Rollback.SnapshotID)
+				assert.Equal(t, "2026-01-15T03:00:00Z", a.Rollback.Timestamp)
+			},
+		},
+		{
 			name:    "describe without identifier errors",
 			args:    []string{"describe"},
 			wantErr: true,

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -272,6 +272,15 @@ func main() {
 		log.Fatal("unimplemented output type")
 	}
 
+	// Validate the rollback selector before catalog init so invalid flags fail
+	// fast with a clear message instead of a catalog connection error.
+	if args.Rollback != nil {
+		if err := validateRollbackSelector(args.Rollback); err != nil {
+			output.Error(err)
+			os.Exit(1)
+		}
+	}
+
 	cat := initCatalog(ctx, args)
 
 	switch {

--- a/cmd/iceberg/maintenance.go
+++ b/cmd/iceberg/maintenance.go
@@ -76,7 +76,7 @@ type UpgradeCmd struct {
 type RollbackCmd struct {
 	TableID    string `arg:"positional,required" help:"full path to a table"`
 	SnapshotID *int64 `arg:"--snapshot-id" help:"snapshot ID to roll back to (mutually exclusive with --timestamp)"`
-	Timestamp  string `arg:"--timestamp" help:"RFC3339 timestamp to roll back to (mutually exclusive with --snapshot-id)"`
+	Timestamp  string `arg:"--timestamp" help:"RFC3339 timestamp to roll back to; fractional seconds accepted (mutually exclusive with --snapshot-id)"`
 	Yes        bool   `arg:"--yes" help:"skip confirmation prompt"`
 }
 

--- a/cmd/iceberg/maintenance.go
+++ b/cmd/iceberg/maintenance.go
@@ -75,7 +75,8 @@ type UpgradeCmd struct {
 
 type RollbackCmd struct {
 	TableID    string `arg:"positional,required" help:"full path to a table"`
-	SnapshotID int64  `arg:"--snapshot-id,required" help:"snapshot ID to roll back to"`
+	SnapshotID *int64 `arg:"--snapshot-id" help:"snapshot ID to roll back to (mutually exclusive with --timestamp)"`
+	Timestamp  string `arg:"--timestamp" help:"RFC3339 timestamp to roll back to (mutually exclusive with --snapshot-id)"`
 	Yes        bool   `arg:"--yes" help:"skip confirmation prompt"`
 }
 

--- a/cmd/iceberg/upgrade_rollback.go
+++ b/cmd/iceberg/upgrade_rollback.go
@@ -20,9 +20,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/table"
@@ -86,20 +88,27 @@ func runUpgrade(ctx context.Context, output Output, cat catalog.Catalog, cmd *Up
 }
 
 func runRollback(ctx context.Context, output Output, cat catalog.Catalog, cmd *RollbackCmd) {
+	if err := validateRollbackSelector(cmd); err != nil {
+		output.Error(err)
+		osExit(1)
+
+		return
+	}
+
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()
 
-	snap := meta.SnapshotByID(cmd.SnapshotID)
-	if snap == nil {
-		output.Error(fmt.Errorf("snapshot %d not found in table %s", cmd.SnapshotID, tableIDString(tbl)))
+	snapshotID, err := resolveRollbackSnapshotID(tbl, cmd)
+	if err != nil {
+		output.Error(err)
 		osExit(1)
 
 		return
 	}
 
 	if cs := meta.CurrentSnapshot(); cs != nil {
-		if !table.IsAncestorOf(cs.SnapshotID, cmd.SnapshotID, meta.SnapshotByID) {
-			output.Error(fmt.Errorf("snapshot %d is not an ancestor of current snapshot %d", cmd.SnapshotID, cs.SnapshotID))
+		if !table.IsAncestorOf(cs.SnapshotID, snapshotID, meta.SnapshotByID) {
+			output.Error(fmt.Errorf("snapshot %d is not an ancestor of current snapshot %d", snapshotID, cs.SnapshotID))
 			osExit(1)
 
 			return
@@ -112,7 +121,7 @@ func runRollback(ctx context.Context, output Output, cat catalog.Catalog, cmd *R
 		previousSnapshotID = &id
 	}
 
-	prompt := fmt.Sprintf("Roll back %s to snapshot %d?", tableIDString(tbl), cmd.SnapshotID)
+	prompt := fmt.Sprintf("Roll back %s to snapshot %d?", tableIDString(tbl), snapshotID)
 	if err := confirmAction(prompt, cmd.Yes); err != nil {
 		output.Error(err)
 		osExit(1)
@@ -121,7 +130,7 @@ func runRollback(ctx context.Context, output Output, cat catalog.Catalog, cmd *R
 	}
 
 	tx := tbl.NewTransaction()
-	if err := tx.RollbackToSnapshot(cmd.SnapshotID); err != nil {
+	if err := tx.RollbackToSnapshot(snapshotID); err != nil {
 		output.Error(fmt.Errorf("rollback failed: %w", err))
 		osExit(1)
 
@@ -138,10 +147,59 @@ func runRollback(ctx context.Context, output Output, cat catalog.Catalog, cmd *R
 	result := RollbackResult{
 		Table:                  tableIDString(tbl),
 		PreviousSnapshotID:     previousSnapshotID,
-		RolledBackToSnapshotID: cmd.SnapshotID,
+		RolledBackToSnapshotID: snapshotID,
 	}
 
 	output.RollbackResult(result)
+}
+
+// resolveRollbackSnapshotID maps the rollback selector to a concrete snapshot
+// ID. It assumes the caller has already run validateRollbackSelector, so exactly
+// one of cmd.SnapshotID / cmd.Timestamp is set.
+func resolveRollbackSnapshotID(tbl *table.Table, cmd *RollbackCmd) (int64, error) {
+	if cmd.SnapshotID != nil {
+		snapshotID := *cmd.SnapshotID
+		if tbl.Metadata().SnapshotByID(snapshotID) == nil {
+			return 0, fmt.Errorf("snapshot %d not found in table %s", snapshotID, tableIDString(tbl))
+		}
+
+		return snapshotID, nil
+	}
+
+	timestamp, err := parseRollbackTimestamp(cmd.Timestamp)
+	if err != nil {
+		return 0, err
+	}
+
+	if snap := tbl.SnapshotAsOf(timestamp.UnixMilli(), true); snap != nil {
+		return snap.SnapshotID, nil
+	}
+
+	return 0, fmt.Errorf("no snapshot found at or before timestamp %q in table %s", cmd.Timestamp, tableIDString(tbl))
+}
+
+func validateRollbackSelector(cmd *RollbackCmd) error {
+	hasSnapshotID := cmd.SnapshotID != nil
+	hasTimestamp := cmd.Timestamp != ""
+
+	switch {
+	case hasSnapshotID && hasTimestamp:
+		return errors.New("--snapshot-id and --timestamp are mutually exclusive")
+	case !hasSnapshotID && !hasTimestamp:
+		return errors.New("exactly one of --snapshot-id or --timestamp is required")
+	default:
+		return nil
+	}
+}
+
+func parseRollbackTimestamp(value string) (time.Time, error) {
+	timestamp, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid --timestamp %q: expected RFC3339 timestamp like %q: %w",
+			value, "2026-01-15T03:00:00Z", err)
+	}
+
+	return timestamp, nil
 }
 
 func specURL(version int) string {

--- a/cmd/iceberg/upgrade_rollback_test.go
+++ b/cmd/iceberg/upgrade_rollback_test.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"iter"
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
@@ -220,6 +222,188 @@ const upgradeRollbackTestMetadata = `{
     ]
 }`
 
+func TestResolveRollbackSnapshotIDExplicit(t *testing.T) {
+	tbl := upgradeRollbackTestTable(t)
+
+	got, err := resolveRollbackSnapshotID(tbl, &RollbackCmd{
+		TableID:    "db.events",
+		SnapshotID: int64Ptr(100),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), got)
+}
+
+func TestResolveRollbackSnapshotIDTimestamp(t *testing.T) {
+	tbl := upgradeRollbackTestTable(t)
+
+	tests := []struct {
+		name      string
+		timestamp int64
+		want      int64
+	}{
+		{
+			name:      "exact first snapshot",
+			timestamp: 1515100955770,
+			want:      100,
+		},
+		{
+			name:      "between snapshots",
+			timestamp: 1555100955769,
+			want:      100,
+		},
+		{
+			name:      "exact second snapshot",
+			timestamp: 1555100955770,
+			want:      200,
+		},
+		{
+			name:      "after latest snapshot",
+			timestamp: 1555100955771,
+			want:      200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRollbackSnapshotID(tbl, &RollbackCmd{
+				TableID:   "db.events",
+				Timestamp: time.UnixMilli(tt.timestamp).UTC().Format(time.RFC3339Nano),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// unsortedSnapshotsMetadata stores its snapshots array in descending timestamp
+// order while the snapshot-log stays chronological. Timestamp resolution must
+// follow the log, so a naive backward scan of the snapshots array (which would
+// return 100 here) is provably wrong.
+const unsortedSnapshotsMetadata = `{
+    "format-version": 1,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "s3://bucket/test/location",
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 3,
+    "schemas": [
+        {"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "x", "required": true, "type": "long"}]}
+    ],
+    "current-schema-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "default-spec-id": 0,
+    "last-partition-id": 999,
+    "sort-orders": [{"order-id": 0, "fields": []}],
+    "default-sort-order-id": 0,
+    "current-snapshot-id": 200,
+    "snapshots": [
+        {"snapshot-id": 200, "parent-snapshot-id": 100, "timestamp-ms": 1555100955770, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/2.avro"},
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/1.avro"}
+    ],
+    "snapshot-log": [
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770},
+        {"snapshot-id": 200, "timestamp-ms": 1555100955770}
+    ]
+}`
+
+func TestResolveRollbackSnapshotIDTimestampIgnoresSnapshotArrayOrder(t *testing.T) {
+	meta, err := table.ParseMetadataBytes([]byte(unsortedSnapshotsMetadata))
+	require.NoError(t, err)
+	tbl := table.New([]string{"db", "events"}, meta, "", nil, nil)
+
+	// A timestamp after the latest snapshot must resolve to the most recent one
+	// (200) per the chronological log, not the trailing element of the snapshots
+	// array (100).
+	got, err := resolveRollbackSnapshotID(tbl, &RollbackCmd{
+		TableID:   "db.events",
+		Timestamp: time.UnixMilli(1565100955770).UTC().Format(time.RFC3339Nano),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(200), got)
+}
+
+func TestValidateRollbackSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     RollbackCmd
+		wantErr string
+	}{
+		{
+			name:    "snapshot id only",
+			cmd:     RollbackCmd{SnapshotID: int64Ptr(100)},
+			wantErr: "",
+		},
+		{
+			name:    "timestamp only",
+			cmd:     RollbackCmd{Timestamp: "2026-01-15T03:00:00Z"},
+			wantErr: "",
+		},
+		{
+			name:    "both selectors",
+			cmd:     RollbackCmd{SnapshotID: int64Ptr(100), Timestamp: "2026-01-15T03:00:00Z"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "no selector",
+			cmd:     RollbackCmd{},
+			wantErr: "exactly one",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRollbackSelector(&tt.cmd)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestResolveRollbackSnapshotIDErrors covers resolution failures on already
+// validated single-selector input (validateRollbackSelector is the caller's job).
+func TestResolveRollbackSnapshotIDErrors(t *testing.T) {
+	tbl := upgradeRollbackTestTable(t)
+
+	tests := []struct {
+		name    string
+		cmd     RollbackCmd
+		wantErr string
+	}{
+		{
+			name:    "invalid timestamp",
+			cmd:     RollbackCmd{TableID: "db.events", Timestamp: "not-a-time"},
+			wantErr: "invalid --timestamp",
+		},
+		{
+			name:    "timestamp before first snapshot",
+			cmd:     RollbackCmd{TableID: "db.events", Timestamp: time.UnixMilli(1515100955769).UTC().Format(time.RFC3339Nano)},
+			wantErr: "no snapshot found",
+		},
+		{
+			name:    "missing snapshot id",
+			cmd:     RollbackCmd{TableID: "db.events", SnapshotID: int64Ptr(999)},
+			wantErr: "snapshot 999 not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveRollbackSnapshotID(tbl, &tt.cmd)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 type panicCatalog struct {
 	tbl *table.Table
 }
@@ -367,13 +551,164 @@ func TestRunRollbackRejectsNonAncestor(t *testing.T) {
 	exitCode := captureExit(func() {
 		runRollback(context.Background(), &errOut, cat, &RollbackCmd{
 			TableID:    "db.events",
-			SnapshotID: 300,
+			SnapshotID: int64Ptr(300),
 			Yes:        true,
 		})
 	})
 
 	assert.Equal(t, 1, exitCode)
 	assert.Contains(t, errOut.lastErr.Error(), "not an ancestor")
+}
+
+func TestRunRollbackRejectsInvalidSelectorsBeforeLoad(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     RollbackCmd
+		wantErr string
+	}{
+		{
+			name:    "no selector",
+			cmd:     RollbackCmd{TableID: "db.events"},
+			wantErr: "exactly one",
+		},
+		{
+			name: "snapshot id and timestamp",
+			cmd: RollbackCmd{
+				TableID:    "db.events",
+				SnapshotID: int64Ptr(100),
+				Timestamp:  time.UnixMilli(1515100955770).UTC().Format(time.RFC3339),
+			},
+			wantErr: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var errOut errCapture
+			exitCode := captureExit(func() {
+				runRollback(context.Background(), &errOut, nil, &tt.cmd)
+			})
+
+			assert.Equal(t, 1, exitCode)
+			require.Error(t, errOut.lastErr)
+			assert.Contains(t, errOut.lastErr.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestResolveRollbackSnapshotIDTimestampIgnoresOffLineageSnapshot(t *testing.T) {
+	const metaWithBranch = `{
+    "format-version": 2,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "s3://bucket/test/location",
+    "last-sequence-number": 2,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 1,
+    "schemas": [{"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "x", "required": true, "type": "long"}]}],
+    "current-schema-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "default-spec-id": 0,
+    "last-partition-id": 999,
+    "sort-orders": [{"order-id": 0, "fields": []}],
+    "default-sort-order-id": 0,
+    "current-snapshot-id": 200,
+    "snapshots": [
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770, "sequence-number": 0, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/1.avro"},
+        {"snapshot-id": 200, "parent-snapshot-id": 100, "timestamp-ms": 1555100955770, "sequence-number": 1, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/2.avro"},
+        {"snapshot-id": 300, "timestamp-ms": 1565100955770, "sequence-number": 2, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/3.avro"}
+    ],
+    "snapshot-log": [
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770},
+        {"snapshot-id": 200, "timestamp-ms": 1555100955770}
+    ],
+    "refs": {"main": {"snapshot-id": 200, "type": "branch"}}
+}`
+
+	meta, err := table.ParseMetadataBytes([]byte(metaWithBranch))
+	require.NoError(t, err)
+
+	tbl := table.New([]string{"db", "events"}, meta, "", nil, nil)
+
+	// Snapshot 300 exists in the snapshots array with the latest timestamp but is
+	// absent from the snapshot-log: it is off the main lineage. Timestamp
+	// resolution follows the log, so a timestamp equal to 300's must still resolve
+	// to the latest in-lineage snapshot (200), never the off-lineage 300.
+	got, err := resolveRollbackSnapshotID(tbl, &RollbackCmd{
+		TableID:   "db.events",
+		Timestamp: time.UnixMilli(1565100955770).UTC().Format(time.RFC3339Nano),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(200), got)
+}
+
+// TestRunRollbackByTimestampUsesResolvedSnapshotID drives the full runRollback
+// path with a --timestamp selector and asserts the snapshot resolved from the
+// log (200) — not the current snapshot or the raw flag — is what flows into the
+// rollback decision. The fixture's main lineage diverges (100 -> 200 -> back to
+// 100), so a timestamp that resolves to 200 is no longer an ancestor of the
+// current snapshot (100); runRollback must surface 200 in that error, proving
+// the resolved ID is threaded through. The actual commit is exercised by the
+// table package, since it requires a real filesystem to rebuild manifest lists.
+func TestRunRollbackByTimestampUsesResolvedSnapshotID(t *testing.T) {
+	const divergentLogMetadata = `{
+    "format-version": 2,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "s3://bucket/test/location",
+    "last-sequence-number": 2,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 1,
+    "schemas": [{"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "x", "required": true, "type": "long"}]}],
+    "current-schema-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "default-spec-id": 0,
+    "last-partition-id": 999,
+    "sort-orders": [{"order-id": 0, "fields": []}],
+    "default-sort-order-id": 0,
+    "current-snapshot-id": 100,
+    "snapshots": [
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770, "sequence-number": 0, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/1.avro"},
+        {"snapshot-id": 200, "parent-snapshot-id": 100, "timestamp-ms": 1555100955770, "sequence-number": 1, "summary": {"operation": "append"}, "manifest-list": "s3://a/b/2.avro"}
+    ],
+    "snapshot-log": [
+        {"snapshot-id": 100, "timestamp-ms": 1515100955770},
+        {"snapshot-id": 200, "timestamp-ms": 1555100955770},
+        {"snapshot-id": 100, "timestamp-ms": 1565100955770}
+    ],
+    "refs": {"main": {"snapshot-id": 100, "type": "branch"}}
+}`
+
+	meta, err := table.ParseMetadataBytes([]byte(divergentLogMetadata))
+	require.NoError(t, err)
+
+	tbl := table.New([]string{"db", "events"}, meta, "", nil, nil)
+	cat := &panicCatalog{tbl: tbl}
+
+	var errOut errCapture
+	exitCode := captureExit(func() {
+		runRollback(context.Background(), &errOut, cat, &RollbackCmd{
+			TableID:   "db.events",
+			Timestamp: time.UnixMilli(1555100955770).UTC().Format(time.RFC3339Nano),
+			Yes:       true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, errOut.lastErr)
+	assert.Contains(t, errOut.lastErr.Error(), "snapshot 200 is not an ancestor of current snapshot 100")
+}
+
+func upgradeRollbackTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	meta, err := table.ParseMetadataBytes([]byte(upgradeRollbackTestMetadata))
+	require.NoError(t, err)
+
+	return table.New([]string{"db", "events"}, meta, "", nil, nil)
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
 }
 
 type errCapture struct {
@@ -408,3 +743,62 @@ func captureExit(f func()) (exitCode int) {
 }
 
 type exitSentinel struct{}
+
+// TestMain is the entry point for every test in this package. When the binary
+// is re-exec'd with icebergCLISubprocessEnv set, it runs the real CLI main()
+// instead of the test suite, letting tests assert end-to-end behavior such as
+// argument-validation ordering relative to catalog initialization. In the normal
+// (non-subprocess) case it just runs the tests.
+func TestMain(m *testing.M) {
+	if os.Getenv(icebergCLISubprocessEnv) == "1" {
+		main()
+
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+const icebergCLISubprocessEnv = "ICEBERG_CLI_TEST_SUBPROCESS"
+
+// TestRollbackSelectorValidatedBeforeCatalogInit drives the real main() entry
+// point. An invalid selector must fail with the validation message and never
+// reach initCatalog (which would surface a catalog connection error instead).
+func TestRollbackSelectorValidatedBeforeCatalogInit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a subprocess")
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no selector",
+			args:    []string{"rollback", "db.events"},
+			wantErr: "exactly one of --snapshot-id or --timestamp is required",
+		},
+		{
+			name:    "both selectors",
+			args:    []string{"rollback", "db.events", "--snapshot-id", "100", "--timestamp", "2026-01-15T03:00:00Z"},
+			wantErr: "--snapshot-id and --timestamp are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], tt.args...)
+			cmd.Env = append(os.Environ(), icebergCLISubprocessEnv+"=1")
+
+			out, err := cmd.CombinedOutput()
+
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr, "expected non-zero exit; output: %s", out)
+			assert.Equal(t, 1, exitErr.ExitCode())
+			// If validation did not run before initCatalog, the subprocess would
+			// fail with a catalog connection error and never print this message.
+			assert.Contains(t, string(out), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1166.

## Summary
- Add `iceberg rollback <table-id> --timestamp <RFC3339>` to roll back to the snapshot current as of a given time.
- Make `--snapshot-id` and `--timestamp` mutually exclusive, exactly one required(`--snapshot-id` goes from required to optional; existing usage is unchanged).
- Resolve the timestamp via the existing `Table.SnapshotAsOf(timestampMs, true)` and feed the resolved ID into the existing rollback flow, preserving the ancestor check, `AssertRefSnapshotID` guard, and confirmation prompt.
- Validate the selector before catalog init, so invalid usage returns a clear message instead of a catalog connection error.

Timestamp resolution follows the snapshot **log** (main lineage), matching PyIceberg/Spark semantics, so a snapshot never on the main lineage isn't selectable by timestamp (intentional), and no snapshot at/before `t` errors clearly rather than rolling back to nothing.

## Testing
- `env GOCACHE=/private/tmp/iceberg-go-gocache go test ./cmd/iceberg -count=1`
- `env GOCACHE=/private/tmp/iceberg-go-gocache go vet ./cmd/iceberg`
- `gofmt -l cmd/iceberg`
- `git diff --check`