### PR TITLE
fix(table): propagate manifest evaluator errors during scan planning

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -556,14 +556,19 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 
 	// Build per-spec manifest evaluators and filter out irrelevant manifests.
 	manifestEvaluators := newKeyDefaultMapWrapErr(scan.buildManifestEvaluator)
-	manifestList = slices.DeleteFunc(manifestList, func(mf iceberg.ManifestFile) bool {
+	filtered := make([]iceberg.ManifestFile, 0, len(manifestList))
+	for _, mf := range manifestList {
 		eval := manifestEvaluators.Get(int(mf.PartitionSpecID()))
 		use, err := eval(mf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate manifest %s: %w", mf.FilePath(), err)
+		}
+		if use {
+			filtered = append(filtered, mf)
+		}
+	}
 
-		return !use || err != nil
-	})
-
-	return manifestList, nil
+	return filtered, nil
 }
 
 // collectManifestEntries concurrently opens manifests, applies partition and metrics

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -18,6 +18,8 @@
 package table
 
 import (
+	"bytes"
+	"context"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -28,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -170,6 +173,52 @@ func TestBuildPartitionProjectionWithInvalidSpecID(t *testing.T) {
 	assert.Nil(t, expr)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.ErrorContains(t, err, "id 999")
+}
+
+func TestFetchPartitionSpecFilteredManifests_PropagatesEvalError(t *testing.T) {
+	spec := partitionedSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+
+	const (
+		snapshotID       = int64(1)
+		manifestListPath = "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	)
+
+	// Invalid int32 bounds trigger a LiteralFromBytes error during manifest eval.
+	badBounds := []byte{0x00, 0x01}
+	mf := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/manifest.avro", 100, int32(spec.ID()), snapshotID).
+		Partitions([]iceberg.FieldSummary{
+			{LowerBound: &badBounds, UpperBound: &badBounds, ContainsNull: false},
+		}).Build()
+
+	var listBuf bytes.Buffer
+	seqNum := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &seqNum, 0, []iceberg.ManifestFile{mf}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: seqNum,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json", func(context.Context) (iceio.IO, error) {
+		return memIO, nil
+	}, nil)
+
+	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), int32(5))))
+
+	_, err = scan.fetchPartitionSpecFilteredManifests(context.Background())
+	require.Error(t, err, "manifest eval errors must propagate instead of silently dropping manifests")
+	require.ErrorContains(t, err, "manifest")
+
+	_, err = scan.PlanFiles(context.Background())
+	require.Error(t, err, "PlanFiles must fail when manifest filtering errors")
 }
 
 func TestBuildManifestEvaluatorWithInvalidSpecID(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix `fetchPartitionSpecFilteredManifests` so manifest partition evaluator failures propagate as errors instead of silently dropping manifests. Adds a regression test ensuring PlanFiles fails when manifest filtering errors occur.

## Issue
During scan planning, fetchPartitionSpecFilteredManifests used slices.DeleteFunc with:
https://github.com/apache/iceberg-go/blob/e5f4a11744004f5a0a86549bbe8f6e6dd5f2a272/table/scanner.go#L559-L567

When eval(mf) returned an error (e.g. corrupt or incompatible partition summary bounds), the manifest was treated as excluded and removed from the scan. The function still returned nil error, so PlanFiles could return incomplete file tasks with no indication anything went wrong — potentially hiding data that should have been read.

`classifyFilesForFilteredDeletions` in transaction.go already propagates this class of error correctly; scan planning did not.
https://github.com/apache/iceberg-go/blob/e5f4a11744004f5a0a86549bbe8f6e6dd5f2a272/table/transaction.go#L1420