### PR TITLE
feat(cli): expose REST catalog page size as --page-size flag

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -49,6 +49,23 @@ func TestArgsParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "list with page-size",
+			args: []string{"list", "prod.db", "--page-size", "100"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.List)
+				assert.Equal(t, "prod.db", a.List.Parent)
+				assert.Equal(t, 100, a.List.PageSize)
+			},
+		},
+		{
+			name: "list defaults page-size to zero",
+			args: []string{"list"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.List)
+				assert.Equal(t, 0, a.List.PageSize)
+			},
+		},
+		{
 			name: "describe direct identifier",
 			args: []string{"describe", "prod.db.events"},
 			check: func(t *testing.T, a Args) {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -46,7 +46,8 @@ import (
 // Subcommand structs
 
 type ListCmd struct {
-	Parent string `arg:"positional" help:"catalog parent namespace"`
+	Parent   string `arg:"positional" help:"catalog parent namespace"`
+	PageSize int    `arg:"--page-size" help:"page size for paginated list requests (REST catalog only); 0 uses the catalog default"`
 }
 
 type DescribeCmd struct {
@@ -285,7 +286,7 @@ func main() {
 
 	switch {
 	case args.List != nil:
-		list(ctx, output, cat, args.List.Parent)
+		list(ctx, output, cat, args.List.Parent, args.List.PageSize)
 	case args.Describe != nil:
 		runDescribe(ctx, output, cat, args.Describe)
 	case args.Schema != nil:
@@ -691,8 +692,19 @@ func runCompact(ctx context.Context, output Output, cat catalog.Catalog, cmd *Co
 	}
 }
 
-func list(ctx context.Context, output Output, cat catalog.Catalog, parent string) {
+func list(ctx context.Context, output Output, cat catalog.Catalog, parent string, pageSize int) {
 	prnt := catalog.ToIdentifier(parent)
+
+	if pageSize < 0 {
+		output.Error(fmt.Errorf("--page-size must be non-negative, got %d", pageSize))
+		os.Exit(1)
+	}
+
+	if pageSize > 0 {
+		if rc, ok := cat.(*rest.Catalog); ok {
+			ctx = rc.SetPageSize(ctx, pageSize)
+		}
+	}
 
 	var ids []table.Identifier
 


### PR DESCRIPTION
Adds --page-size to the list subcommand. When the catalog is REST and the value is > 0, applies it via Catalog.SetPageSize on the request context. Other catalog types ignore the flag.

Closes #665