### PR TITLE
feat(catalog/rest): endpoint negotiation

### DIFF
--- a/catalog/rest/endpoints.go
+++ b/catalog/rest/endpoints.go
@@ -18,25 +18,21 @@
 package rest
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 )
 
-// ErrEndpointNotSupported indicates the server did not advertise a REST endpoint
-// required by the requested operation. It wraps [ErrRESTError].
-var ErrEndpointNotSupported = fmt.Errorf("%w: endpoint not supported by server", ErrRESTError)
+// ErrEndpointNotSupported means the server did not advertise an endpoint the
+// operation needs.
+var ErrEndpointNotSupported = errors.New("endpoint not supported by server")
 
-// pathPrefix is the part of every endpoint template already encoded in the base
-// URI (API version plus optional catalog prefix); reqPath strips it.
 const pathPrefix = "/v1/{prefix}"
 
-// endpoint identifies a REST catalog operation by HTTP method and path template
-// (e.g. "GET /v1/{prefix}/namespaces"). Servers advertise the endpoints they
-// support in the config response so the client can negotiate capabilities.
-//
-// Each endpoint both gates capability and builds the request path (see
-// [endpoint.reqPath]), making it the single source of truth for its operation.
+// endpoint identifies a REST catalog operation by method and path template. It
+// both gates capability and builds the request path.
 type endpoint struct {
 	method string
 	path   string
@@ -44,9 +40,26 @@ type endpoint struct {
 
 func (e endpoint) String() string { return e.method + " " + e.path }
 
-// reqPath renders the request path relative to the base URI, substituting params
-// in order for the "{...}" placeholders that follow [pathPrefix].
-func (e endpoint) reqPath(params ...string) []string {
+// nparams is the number of "{...}" placeholders reqPath expects.
+func (e endpoint) nparams() int {
+	n := 0
+	for _, s := range strings.Split(strings.TrimPrefix(e.path, pathPrefix+"/"), "/") {
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			n++
+		}
+	}
+
+	return n
+}
+
+// reqPath fills the "{...}" placeholders with params in order, returning the
+// path relative to the base URI. It errors on a param count mismatch.
+func (e endpoint) reqPath(params ...string) ([]string, error) {
+	if n := e.nparams(); len(params) != n {
+		return nil, fmt.Errorf("%w: endpoint %s expects %d path parameter(s), got %d",
+			ErrRESTError, e, n, len(params))
+	}
+
 	segs := strings.Split(strings.TrimPrefix(e.path, pathPrefix+"/"), "/")
 
 	out := make([]string, len(segs))
@@ -59,11 +72,10 @@ func (e endpoint) reqPath(params ...string) []string {
 		}
 	}
 
-	return out
+	return out, nil
 }
 
-// endpointFromString parses an endpoint from its "METHOD PATH" wire form,
-// erroring unless the string is exactly two whitespace-separated tokens.
+// endpointFromString parses an endpoint from its "METHOD PATH" wire form.
 func endpointFromString(s string) (endpoint, error) {
 	fields := strings.Fields(s)
 	if len(fields) != 2 {
@@ -104,32 +116,39 @@ var (
 	endpointRegisterView = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/register-view"}
 )
 
-// fallbackEndpoints is assumed when a server advertises no "endpoints" list. It
-// covers every operation the client can invoke, for compatibility with servers
-// that predate endpoint negotiation.
-var fallbackEndpoints = []endpoint{
-	// namespace and table operations
+// defaultEndpoints is the spec default set, assumed when the server advertises
+// no endpoints. The HEAD existence endpoints are excluded on purpose: their
+// absence is what makes Check*Exists fall back to GET.
+var defaultEndpoints = []endpoint{
 	endpointListNamespaces, endpointLoadNamespace, endpointCreateNamespace,
 	endpointUpdateNamespace, endpointDeleteNamespace,
 	endpointListTables, endpointLoadTable, endpointCreateTable,
 	endpointUpdateTable, endpointDeleteTable, endpointRenameTable,
 	endpointRegisterTable, endpointReportMetrics, endpointCommitTransaction,
+}
 
-	// view operations
+// viewEndpoints is added to the default set only when view-endpoints-supported
+// is set.
+var viewEndpoints = []endpoint{
 	endpointListViews, endpointLoadView, endpointCreateView,
 	endpointUpdateView, endpointDeleteView, endpointRenameView,
+}
 
-	// Existence checks and view registration are included for parity with past
-	// behavior. When an advertised set omits a HEAD endpoint, Check*Exists still
-	// degrades to a GET.
-	endpointNamespaceExists, endpointTableExists, endpointViewExists,
-	endpointRegisterView,
+// allEndpoints lists every endpoint constant, for tests that validate templates.
+var allEndpoints = []endpoint{
+	endpointListNamespaces, endpointLoadNamespace, endpointNamespaceExists,
+	endpointCreateNamespace, endpointUpdateNamespace, endpointDeleteNamespace,
+	endpointCommitTransaction,
+	endpointListTables, endpointLoadTable, endpointTableExists, endpointCreateTable,
+	endpointUpdateTable, endpointDeleteTable, endpointRenameTable, endpointRegisterTable,
+	endpointReportMetrics, endpointTableCredentials,
+	endpointListViews, endpointLoadView, endpointViewExists, endpointCreateView,
+	endpointUpdateView, endpointDeleteView, endpointRenameView, endpointRegisterView,
 }
 
 // endpointSet is the set of endpoints a catalog server supports.
 type endpointSet map[endpoint]struct{}
 
-// newEndpointSet builds a set from a list of endpoints.
 func newEndpointSet(eps []endpoint) endpointSet {
 	s := endpointSet{}
 	for _, e := range eps {
@@ -145,28 +164,44 @@ func (s endpointSet) contains(e endpoint) bool {
 	return ok
 }
 
-// check returns [ErrEndpointNotSupported] if the endpoint is not in the set. A
-// nil set (capabilities never negotiated) permits every endpoint.
+// allowed reports whether an endpoint may be called. A nil set (never
+// negotiated) permits everything.
+func (s endpointSet) allowed(e endpoint) bool {
+	return s == nil || s.contains(e)
+}
+
+// check returns ErrEndpointNotSupported if the endpoint is not allowed.
 func (s endpointSet) check(e endpoint) error {
-	if s == nil || s.contains(e) {
+	if s.allowed(e) {
 		return nil
 	}
 
 	return fmt.Errorf("%w: %s", ErrEndpointNotSupported, e)
 }
 
-// resolveEndpoints builds the effective endpoint set from the advertised list.
-func resolveEndpoints(advertised []string) endpointSet {
+// resolveEndpoints builds the effective set from what the server advertised. A
+// non-empty list is authoritative; unparseable entries are dropped with a
+// warning. An empty list falls back to defaultEndpoints, plus viewEndpoints when
+// viewEndpointsSupported is set.
+func resolveEndpoints(advertised []string, viewEndpointsSupported bool) endpointSet {
+	if len(advertised) == 0 {
+		eps := defaultEndpoints
+		if viewEndpointsSupported {
+			eps = append(append([]endpoint{}, defaultEndpoints...), viewEndpoints...)
+		}
+
+		return newEndpointSet(eps)
+	}
+
 	s := endpointSet{}
 	for _, raw := range advertised {
-		if e, err := endpointFromString(raw); err == nil {
-			s[e] = struct{}{}
+		e, err := endpointFromString(raw)
+		if err != nil {
+			slog.Warn("dropping unparseable advertised REST endpoint", "endpoint", raw, "error", err)
+
+			continue
 		}
-	}
-	// A server that advertises nothing (or only unparseable values) gets the
-	// backward-compatibility fallback set.
-	if len(s) == 0 {
-		return newEndpointSet(fallbackEndpoints)
+		s[e] = struct{}{}
 	}
 
 	return s

--- a/catalog/rest/endpoints.go
+++ b/catalog/rest/endpoints.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ErrEndpointNotSupported indicates the server did not advertise a REST endpoint
+// required by the requested operation. It wraps [ErrRESTError].
+var ErrEndpointNotSupported = fmt.Errorf("%w: endpoint not supported by server", ErrRESTError)
+
+// pathPrefix is the part of every endpoint template already encoded in the base
+// URI (API version plus optional catalog prefix); reqPath strips it.
+const pathPrefix = "/v1/{prefix}"
+
+// endpoint identifies a REST catalog operation by HTTP method and path template
+// (e.g. "GET /v1/{prefix}/namespaces"). Servers advertise the endpoints they
+// support in the config response so the client can negotiate capabilities.
+//
+// Each endpoint both gates capability and builds the request path (see
+// [endpoint.reqPath]), making it the single source of truth for its operation.
+type endpoint struct {
+	method string
+	path   string
+}
+
+func (e endpoint) String() string { return e.method + " " + e.path }
+
+// reqPath renders the request path relative to the base URI, substituting params
+// in order for the "{...}" placeholders that follow [pathPrefix].
+func (e endpoint) reqPath(params ...string) []string {
+	segs := strings.Split(strings.TrimPrefix(e.path, pathPrefix+"/"), "/")
+
+	out := make([]string, len(segs))
+	p := 0
+	for i, s := range segs {
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			out[i], p = params[p], p+1
+		} else {
+			out[i] = s
+		}
+	}
+
+	return out
+}
+
+// endpointFromString parses an endpoint from its "METHOD PATH" wire form,
+// erroring unless the string is exactly two whitespace-separated tokens.
+func endpointFromString(s string) (endpoint, error) {
+	fields := strings.Fields(s)
+	if len(fields) != 2 {
+		return endpoint{}, fmt.Errorf("%w: invalid endpoint %q (expected \"METHOD PATH\")", ErrRESTError, s)
+	}
+
+	return endpoint{method: fields[0], path: fields[1]}, nil
+}
+
+// Well-known REST catalog endpoints, keyed by advertised method and path template.
+var (
+	endpointListNamespaces    = endpoint{http.MethodGet, "/v1/{prefix}/namespaces"}
+	endpointLoadNamespace     = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}"}
+	endpointNamespaceExists   = endpoint{http.MethodHead, "/v1/{prefix}/namespaces/{namespace}"}
+	endpointCreateNamespace   = endpoint{http.MethodPost, "/v1/{prefix}/namespaces"}
+	endpointUpdateNamespace   = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/properties"}
+	endpointDeleteNamespace   = endpoint{http.MethodDelete, "/v1/{prefix}/namespaces/{namespace}"}
+	endpointCommitTransaction = endpoint{http.MethodPost, "/v1/{prefix}/transactions/commit"}
+
+	endpointListTables       = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/tables"}
+	endpointLoadTable        = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/tables/{table}"}
+	endpointTableExists      = endpoint{http.MethodHead, "/v1/{prefix}/namespaces/{namespace}/tables/{table}"}
+	endpointCreateTable      = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/tables"}
+	endpointUpdateTable      = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/tables/{table}"}
+	endpointDeleteTable      = endpoint{http.MethodDelete, "/v1/{prefix}/namespaces/{namespace}/tables/{table}"}
+	endpointRenameTable      = endpoint{http.MethodPost, "/v1/{prefix}/tables/rename"}
+	endpointRegisterTable    = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/register"}
+	endpointReportMetrics    = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics"}
+	endpointTableCredentials = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials"}
+
+	endpointListViews    = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/views"}
+	endpointLoadView     = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/views/{view}"}
+	endpointViewExists   = endpoint{http.MethodHead, "/v1/{prefix}/namespaces/{namespace}/views/{view}"}
+	endpointCreateView   = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/views"}
+	endpointUpdateView   = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/views/{view}"}
+	endpointDeleteView   = endpoint{http.MethodDelete, "/v1/{prefix}/namespaces/{namespace}/views/{view}"}
+	endpointRenameView   = endpoint{http.MethodPost, "/v1/{prefix}/views/rename"}
+	endpointRegisterView = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/register-view"}
+)
+
+// fallbackEndpoints is assumed when a server advertises no "endpoints" list. It
+// covers every operation the client can invoke, for compatibility with servers
+// that predate endpoint negotiation.
+var fallbackEndpoints = []endpoint{
+	// namespace and table operations
+	endpointListNamespaces, endpointLoadNamespace, endpointCreateNamespace,
+	endpointUpdateNamespace, endpointDeleteNamespace,
+	endpointListTables, endpointLoadTable, endpointCreateTable,
+	endpointUpdateTable, endpointDeleteTable, endpointRenameTable,
+	endpointRegisterTable, endpointReportMetrics, endpointCommitTransaction,
+
+	// view operations
+	endpointListViews, endpointLoadView, endpointCreateView,
+	endpointUpdateView, endpointDeleteView, endpointRenameView,
+
+	// Existence checks and view registration are included for parity with past
+	// behavior. When an advertised set omits a HEAD endpoint, Check*Exists still
+	// degrades to a GET.
+	endpointNamespaceExists, endpointTableExists, endpointViewExists,
+	endpointRegisterView,
+}
+
+// endpointSet is the set of endpoints a catalog server supports.
+type endpointSet map[endpoint]struct{}
+
+// newEndpointSet builds a set from a list of endpoints.
+func newEndpointSet(eps []endpoint) endpointSet {
+	s := endpointSet{}
+	for _, e := range eps {
+		s[e] = struct{}{}
+	}
+
+	return s
+}
+
+func (s endpointSet) contains(e endpoint) bool {
+	_, ok := s[e]
+
+	return ok
+}
+
+// check returns [ErrEndpointNotSupported] if the endpoint is not in the set. A
+// nil set (capabilities never negotiated) permits every endpoint.
+func (s endpointSet) check(e endpoint) error {
+	if s == nil || s.contains(e) {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", ErrEndpointNotSupported, e)
+}
+
+// resolveEndpoints builds the effective endpoint set from the advertised list.
+func resolveEndpoints(advertised []string) endpointSet {
+	s := endpointSet{}
+	for _, raw := range advertised {
+		if e, err := endpointFromString(raw); err == nil {
+			s[e] = struct{}{}
+		}
+	}
+	// A server that advertises nothing (or only unparseable values) gets the
+	// backward-compatibility fallback set.
+	if len(s) == 0 {
+		return newEndpointSet(fallbackEndpoints)
+	}
+
+	return s
+}

--- a/catalog/rest/endpoints.go
+++ b/catalog/rest/endpoints.go
@@ -180,8 +180,9 @@ func (s endpointSet) check(e endpoint) error {
 }
 
 // resolveEndpoints builds the effective set from what the server advertised. A
-// non-empty list is authoritative; unparseable entries are dropped with a
-// warning. An empty list falls back to defaultEndpoints, plus viewEndpoints when
+// non-empty list is authoritative: unparseable entries are dropped with a
+// warning, so a bad entry narrows capability instead of falling back. An empty
+// list falls back to defaultEndpoints, plus viewEndpoints when
 // viewEndpointsSupported is set.
 func resolveEndpoints(advertised []string, viewEndpointsSupported bool) endpointSet {
 	if len(advertised) == 0 {

--- a/catalog/rest/endpoints_integration_test.go
+++ b/catalog/rest/endpoints_integration_test.go
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package rest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointNegotiation(t *testing.T) {
+	// Loading the catalog reads /v1/config and negotiates the endpoint set the
+	// fixture advertises. The live server uses the same wire format as our
+	// endpoint constants, so the negotiated set must contain the core
+	// operations; a format mismatch would surface here as a missing entry
+	// rather than as a silent fallback.
+	cat, err := NewCatalog(context.Background(), "rest", "http://localhost:8181")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, cat.endpoints, "fixture should advertise an endpoints list")
+	for _, want := range []endpoint{
+		endpointListNamespaces, endpointCreateNamespace,
+		endpointListTables, endpointCreateTable, endpointLoadTable,
+		endpointDeleteTable, endpointCommitTransaction,
+	} {
+		assert.Truef(t, cat.endpoints.contains(want), "negotiated set should contain %s", want)
+	}
+}

--- a/catalog/rest/endpoints_integration_test.go
+++ b/catalog/rest/endpoints_integration_test.go
@@ -36,7 +36,9 @@ func TestEndpointNegotiation(t *testing.T) {
 	cat, err := NewCatalog(context.Background(), "rest", "http://localhost:8181")
 	require.NoError(t, err)
 
-	require.NotEmpty(t, cat.endpoints, "fixture should advertise an endpoints list")
+	// Not in the fallback defaults, so its presence means we read the wire list.
+	require.Truef(t, cat.endpoints.contains(endpointTableExists),
+		"negotiated set must contain advertised %s, not just the fallback defaults", endpointTableExists)
 	for _, want := range []endpoint{
 		endpointListNamespaces, endpointCreateNamespace,
 		endpointListTables, endpointCreateTable, endpointLoadTable,

--- a/catalog/rest/endpoints_test.go
+++ b/catalog/rest/endpoints_test.go
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointFromString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in      string
+		want    endpoint
+		wantErr bool
+	}{
+		{in: "GET /v1/{prefix}/namespaces", want: endpoint{http.MethodGet, "/v1/{prefix}/namespaces"}},
+		{in: "POST /v1/{prefix}/transactions/commit", want: endpoint{http.MethodPost, "/v1/{prefix}/transactions/commit"}},
+		{in: "HEAD /v1/{prefix}/namespaces/{namespace}", want: endpoint{http.MethodHead, "/v1/{prefix}/namespaces/{namespace}"}},
+		// Extra surrounding/internal whitespace is tolerated.
+		{in: "  DELETE   /v1/{prefix}/namespaces/{namespace}  ", want: endpoint{http.MethodDelete, "/v1/{prefix}/namespaces/{namespace}"}},
+		{in: "", wantErr: true},
+		{in: "GET", wantErr: true},
+		{in: "GET /a /b", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		got, err := endpointFromString(tc.in)
+		if tc.wantErr {
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrRESTError)
+
+			continue
+		}
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func TestEndpointRoundTripString(t *testing.T) {
+	t.Parallel()
+
+	for _, e := range fallbackEndpoints {
+		got, err := endpointFromString(e.String())
+		require.NoError(t, err)
+		assert.Equal(t, e, got)
+	}
+}
+
+func TestEndpointSetCheck(t *testing.T) {
+	t.Parallel()
+
+	s := newEndpointSet([]endpoint{endpointLoadTable})
+	require.NoError(t, s.check(endpointLoadTable))
+
+	err := s.check(endpointCreateTable)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEndpointNotSupported)
+	assert.ErrorIs(t, err, ErrRESTError)
+	assert.Contains(t, err.Error(), endpointCreateTable.String())
+
+	// A nil set means capabilities were never negotiated: everything is allowed.
+	var nilSet endpointSet
+	require.NoError(t, nilSet.check(endpointCreateTable))
+}
+
+func TestResolveEndpointsFallback(t *testing.T) {
+	t.Parallel()
+
+	// When the server advertises nothing, the backward-compatible fallback set
+	// is used: the full set of operations iceberg-go knows how to invoke.
+	for _, advertised := range [][]string{nil, {}, {"garbage", "alsobad"}} {
+		s := resolveEndpoints(advertised)
+		for _, e := range fallbackEndpoints {
+			assert.Truef(t, s.contains(e), "fallback should contain %s", e)
+		}
+	}
+}
+
+func TestResolveEndpointsAdvertised(t *testing.T) {
+	t.Parallel()
+
+	// When the server advertises a set, only those endpoints are honored;
+	// unparseable entries are ignored.
+	s := resolveEndpoints([]string{
+		endpointLoadTable.String(),
+		endpointListNamespaces.String(),
+		"not-an-endpoint",
+	})
+
+	assert.True(t, s.contains(endpointLoadTable))
+	assert.True(t, s.contains(endpointListNamespaces))
+	assert.False(t, s.contains(endpointCreateTable))
+	assert.False(t, s.contains(endpointLoadView))
+	assert.Len(t, s, 2)
+}

--- a/catalog/rest/endpoints_test.go
+++ b/catalog/rest/endpoints_test.go
@@ -19,6 +19,7 @@ package rest
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,10 +60,54 @@ func TestEndpointFromString(t *testing.T) {
 func TestEndpointRoundTripString(t *testing.T) {
 	t.Parallel()
 
-	for _, e := range fallbackEndpoints {
+	all := append(append([]endpoint{}, defaultEndpoints...), viewEndpoints...)
+	for _, e := range all {
 		got, err := endpointFromString(e.String())
 		require.NoError(t, err)
 		assert.Equal(t, e, got)
+	}
+}
+
+func TestReqPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		ep      endpoint
+		params  []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "no params", ep: endpointCommitTransaction, want: []string{"transactions", "commit"}},
+		{name: "one param", ep: endpointCreateTable, params: []string{"ns"}, want: []string{"namespaces", "ns", "tables"}},
+		{name: "two params", ep: endpointLoadTable, params: []string{"ns", "tbl"}, want: []string{"namespaces", "ns", "tables", "tbl"}},
+		{name: "too few", ep: endpointLoadTable, params: []string{"ns"}, wantErr: true},
+		{name: "too many", ep: endpointCommitTransaction, params: []string{"extra"}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.ep.reqPath(tc.params...)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrRESTError)
+
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEndpointConstantsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	for _, e := range allEndpoints {
+		assert.Truef(t, strings.HasPrefix(e.path, pathPrefix+"/"),
+			"%s: path must start with %q", e, pathPrefix)
+		_, err := e.reqPath(make([]string, e.nparams())...)
+		assert.NoErrorf(t, err, "%s: should render with %d params", e, e.nparams())
 	}
 }
 
@@ -75,7 +120,8 @@ func TestEndpointSetCheck(t *testing.T) {
 	err := s.check(endpointCreateTable)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrEndpointNotSupported)
-	assert.ErrorIs(t, err, ErrRESTError)
+	// A capability error is distinct from a transport error.
+	assert.NotErrorIs(t, err, ErrRESTError)
 	assert.Contains(t, err.Error(), endpointCreateTable.String())
 
 	// A nil set means capabilities were never negotiated: everything is allowed.
@@ -86,26 +132,34 @@ func TestEndpointSetCheck(t *testing.T) {
 func TestResolveEndpointsFallback(t *testing.T) {
 	t.Parallel()
 
-	// When the server advertises nothing, the backward-compatible fallback set
-	// is used: the full set of operations iceberg-go knows how to invoke.
-	for _, advertised := range [][]string{nil, {}, {"garbage", "alsobad"}} {
-		s := resolveEndpoints(advertised)
-		for _, e := range fallbackEndpoints {
+	// No advertised endpoints falls back to the spec default set, without views.
+	for _, advertised := range [][]string{nil, {}} {
+		s := resolveEndpoints(advertised, false)
+		for _, e := range defaultEndpoints {
 			assert.Truef(t, s.contains(e), "fallback should contain %s", e)
 		}
+		assert.False(t, s.contains(endpointListViews))
+		// HEAD existence endpoints are excluded so Check*Exists degrades to GET.
+		assert.False(t, s.contains(endpointTableExists))
+	}
+
+	// View endpoints are merged in only when view-endpoints-supported is set.
+	s := resolveEndpoints(nil, true)
+	for _, e := range viewEndpoints {
+		assert.Truef(t, s.contains(e), "view fallback should contain %s", e)
 	}
 }
 
 func TestResolveEndpointsAdvertised(t *testing.T) {
 	t.Parallel()
 
-	// When the server advertises a set, only those endpoints are honored;
-	// unparseable entries are ignored.
+	// A non-empty advertised list is authoritative; unparseable entries are
+	// dropped and nothing else is assumed.
 	s := resolveEndpoints([]string{
 		endpointLoadTable.String(),
 		endpointListNamespaces.String(),
 		"not-an-endpoint",
-	})
+	}, false)
 
 	assert.True(t, s.contains(endpointLoadTable))
 	assert.True(t, s.contains(endpointListNamespaces))

--- a/catalog/rest/endpoints_test.go
+++ b/catalog/rest/endpoints_test.go
@@ -26,6 +26,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// AllEndpointStrings is the wire form of every endpoint, so external tests can
+// advertise a fully-capable server without a second list to keep in sync.
+var AllEndpointStrings = func() []string {
+	s := make([]string, len(allEndpoints))
+	for i, e := range allEndpoints {
+		s[i] = e.String()
+	}
+
+	return s
+}()
+
 func TestEndpointFromString(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -80,6 +80,8 @@ const (
 	keyRestSigV4Service = "rest.signing-name"
 	keyAuthUrl          = "rest.authorization-url"
 	keyTlsSkipVerify    = "rest.tls.skip-verify"
+
+	keyViewEndpointsSupported = "view-endpoints-supported"
 )
 
 var (
@@ -734,16 +736,16 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*http.Client,
 		return nil, nil, err
 	}
 
-	// Negotiate capabilities from the endpoints the server advertises, falling
-	// back to a backward-compatible default set when none are provided.
-	r.endpoints = resolveEndpoints(rsp.Endpoints)
-
 	cfg := rsp.Defaults
 	if cfg == nil {
 		cfg = iceberg.Properties{}
 	}
 	maps.Copy(cfg, toProps(opts))
 	maps.Copy(cfg, rsp.Overrides)
+
+	// Negotiate capabilities from the endpoints the server advertises, falling
+	// back to a backward-compatible default set when none are provided.
+	r.endpoints = resolveEndpoints(rsp.Endpoints, cfg.GetBool(keyViewEndpointsSupported, false))
 
 	o := *opts
 	fromProps(cfg, &o)
@@ -797,12 +799,21 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 }
 
 func (r *Catalog) fetchTableCreds(ctx context.Context, ident []string, location string) (iceberg.Properties, error) {
+	if err := r.endpoints.check(endpointTableCredentials); err != nil {
+		return nil, err
+	}
+
 	ns, tbl, err := splitIdentForPath(ident)
 	if err != nil {
 		return nil, err
 	}
 
-	ret, err := doGet[loadCredentialsResponse](ctx, r.baseURI, endpointTableCredentials.reqPath(ns, tbl),
+	path, err := endpointTableCredentials.reqPath(ns, tbl)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doGet[loadCredentialsResponse](ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		return nil, err
@@ -811,6 +822,8 @@ func (r *Catalog) fetchTableCreds(ctx context.Context, ident []string, location 
 	return resolveStorageCredentials(ret.StorageCredentials, location), nil
 }
 
+// ListTables lists the tables in a namespace. If the server does not advertise
+// the list-tables endpoint, it yields no tables rather than an error.
 func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
@@ -841,11 +854,15 @@ func (r *Catalog) listTablesPage(ctx context.Context, namespace table.Identifier
 		return nil, "", err
 	}
 	// Unsupported listing yields an empty result rather than an error.
-	if r.endpoints != nil && !r.endpoints.contains(endpointListTables) {
+	if !r.endpoints.allowed(endpointListTables) {
 		return nil, "", nil
 	}
 	ns := strings.Join(namespace, namespaceSeparator)
-	uri := r.baseURI.JoinPath(endpointListTables.reqPath(ns)...)
+	path, err := endpointListTables.reqPath(ns)
+	if err != nil {
+		return nil, "", err
+	}
+	uri := r.baseURI.JoinPath(path...)
 
 	v := url.Values{}
 	if pageSize > 0 {
@@ -912,7 +929,12 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		Props:         cfg.Properties,
 	}
 
-	ret, err := doPost[createTableRequest, loadTableResponse](ctx, r.baseURI, endpointCreateTable.reqPath(ns), payload,
+	path, err := endpointCreateTable.reqPath(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doPost[createTableRequest, loadTableResponse](ctx, r.baseURI, path, payload,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrTableAlreadyExists})
 	if err != nil {
 		return nil, err
@@ -1008,7 +1030,12 @@ func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requi
 		Updates      []table.Update      `json:"updates"`
 	}
 
-	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, endpointUpdateTable.reqPath(ns, tblName),
+	path, err := endpointUpdateTable.reqPath(ns, tblName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, path,
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1075,8 +1102,13 @@ func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 		}
 	}
 
-	_, err := doPostAllowNoContent[payload, struct{}](
-		ctx, r.baseURI, endpointCommitTransaction.reqPath(),
+	path, err := endpointCommitTransaction.reqPath()
+	if err != nil {
+		return err
+	}
+
+	_, err = doPostAllowNoContent[payload, struct{}](
+		ctx, r.baseURI, path,
 		payload{TableChanges: changes}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1107,7 +1139,12 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		MetadataLoc string `json:"metadata-location"`
 	}
 
-	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, endpointRegisterTable.reqPath(ns),
+	path, err := endpointRegisterTable.reqPath(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, path,
 		payload{Name: tbl, MetadataLoc: metadataLoc}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrTableAlreadyExists,
 		})
@@ -1134,7 +1171,12 @@ func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 		return nil, err
 	}
 
-	ret, err := doGet[loadTableResponse](ctx, r.baseURI, endpointLoadTable.reqPath(ns, tbl),
+	path, err := endpointLoadTable.reqPath(ns, tbl)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doGet[loadTableResponse](ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		return nil, err
@@ -1168,7 +1210,12 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 		Requirements []table.Requirement `json:"requirements"`
 		Updates      []table.Update      `json:"updates"`
 	}
-	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, endpointUpdateTable.reqPath(ns, tbl),
+	path, err := endpointUpdateTable.reqPath(ns, tbl)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, path,
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1198,7 +1245,12 @@ func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) er
 		return err
 	}
 
-	uri := r.baseURI.JoinPath(endpointDeleteTable.reqPath(ns, tbl)...)
+	path, err := endpointDeleteTable.reqPath(ns, tbl)
+	if err != nil {
+		return err
+	}
+
+	uri := r.baseURI.JoinPath(path...)
 	v := url.Values{}
 	v.Set("purgeRequested", "false")
 	uri.RawQuery = v.Encode()
@@ -1219,7 +1271,12 @@ func (r *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 		return err
 	}
 
-	uri := r.baseURI.JoinPath(endpointDeleteTable.reqPath(ns, tbl)...)
+	path, err := endpointDeleteTable.reqPath(ns, tbl)
+	if err != nil {
+		return err
+	}
+
+	uri := r.baseURI.JoinPath(path...)
 	v := url.Values{}
 	v.Set("purgeRequested", "true")
 	uri.RawQuery = v.Encode()
@@ -1248,7 +1305,12 @@ func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		Name:      catalog.TableNameFromIdent(to),
 	}
 
-	_, err := doPostAllowNoContent[payload, any](ctx, r.baseURI, endpointRenameTable.reqPath(), payload{Source: src, Destination: dst}, r.cl,
+	path, err := endpointRenameTable.reqPath()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = doPostAllowNoContent[payload, any](ctx, r.baseURI, path, payload{Source: src, Destination: dst}, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable}, true)
 	if err != nil {
 		return nil, err
@@ -1266,7 +1328,12 @@ func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
-	_, err := doPost[map[string]any, struct{}](ctx, r.baseURI, endpointCreateNamespace.reqPath(),
+	path, err := endpointCreateNamespace.reqPath()
+	if err != nil {
+		return err
+	}
+
+	_, err = doPost[map[string]any, struct{}](ctx, r.baseURI, path,
 		map[string]any{"namespace": namespace, "properties": props}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrNamespaceAlreadyExists,
 		})
@@ -1283,12 +1350,19 @@ func (r *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
-	_, err := doDelete[struct{}](ctx, r.baseURI, endpointDeleteNamespace.reqPath(strings.Join(namespace, namespaceSeparator)),
+	path, err := endpointDeleteNamespace.reqPath(strings.Join(namespace, namespaceSeparator))
+	if err != nil {
+		return err
+	}
+
+	_, err = doDelete[struct{}](ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 
 	return err
 }
 
+// ListNamespaces lists namespaces under parent. If the server does not advertise
+// the list-namespaces endpoint, it returns an empty slice rather than an error.
 func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) ([]table.Identifier, error) {
 	var allNamespaces []table.Identifier
 	pageSize := r.getPageSize(ctx)
@@ -1311,11 +1385,16 @@ func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 
 func (r *Catalog) listNamespacesPage(ctx context.Context, parent table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
 	// Unsupported listing yields an empty result rather than an error.
-	if r.endpoints != nil && !r.endpoints.contains(endpointListNamespaces) {
+	if !r.endpoints.allowed(endpointListNamespaces) {
 		return nil, "", nil
 	}
 
-	uri := r.baseURI.JoinPath(endpointListNamespaces.reqPath()...)
+	path, err := endpointListNamespaces.reqPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	uri := r.baseURI.JoinPath(path...)
 
 	v := url.Values{}
 	if len(parent) != 0 {
@@ -1358,7 +1437,12 @@ func (r *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 		Props     iceberg.Properties `json:"properties"`
 	}
 
-	rsp, err := doGet[nsresponse](ctx, r.baseURI, endpointLoadNamespace.reqPath(strings.Join(namespace, namespaceSeparator)),
+	path, err := endpointLoadNamespace.reqPath(strings.Join(namespace, namespaceSeparator))
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := doGet[nsresponse](ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 	if err != nil {
 		return nil, err
@@ -1385,7 +1469,12 @@ func (r *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 
 	ns := strings.Join(namespace, namespaceSeparator)
 
-	return doPost[payload, catalog.PropertiesUpdateSummary](ctx, r.baseURI, endpointUpdateNamespace.reqPath(ns),
+	path, err := endpointUpdateNamespace.reqPath(ns)
+	if err != nil {
+		return catalog.PropertiesUpdateSummary{}, err
+	}
+
+	return doPost[payload, catalog.PropertiesUpdateSummary](ctx, r.baseURI, path,
 		payload{Remove: removals, Updates: updates}, r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 }
 
@@ -1394,9 +1483,9 @@ func (r *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Iden
 		return false, err
 	}
 
-	// If the server does not advertise the HEAD existence endpoint, fall back to
-	// a GET (load) for compatibility with servers that predate it.
-	if r.endpoints != nil && !r.endpoints.contains(endpointNamespaceExists) {
+	// No HEAD endpoint: fall back to GET (load). If load is unsupported too, its
+	// ErrEndpointNotSupported surfaces rather than a bogus "not found".
+	if !r.endpoints.contains(endpointNamespaceExists) {
 		_, err := r.LoadNamespaceProperties(ctx, namespace)
 		if err != nil {
 			if errors.Is(err, catalog.ErrNoSuchNamespace) {
@@ -1409,7 +1498,12 @@ func (r *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Iden
 		return true, nil
 	}
 
-	err := doHead(ctx, r.baseURI, endpointNamespaceExists.reqPath(strings.Join(namespace, namespaceSeparator)),
+	path, err := endpointNamespaceExists.reqPath(strings.Join(namespace, namespaceSeparator))
+	if err != nil {
+		return false, err
+	}
+
+	err = doHead(ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchNamespace) {
@@ -1428,9 +1522,9 @@ func (r *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 		return false, err
 	}
 
-	// If the server does not advertise the HEAD existence endpoint, fall back to
-	// a GET (load) for compatibility with servers that predate it.
-	if r.endpoints != nil && !r.endpoints.contains(endpointTableExists) {
+	// No HEAD endpoint: fall back to GET (load). If load is unsupported too, its
+	// ErrEndpointNotSupported surfaces rather than a bogus "not found".
+	if !r.endpoints.contains(endpointTableExists) {
 		_, err := r.LoadTable(ctx, identifier)
 		if err != nil {
 			if errors.Is(err, catalog.ErrNoSuchTable) {
@@ -1443,7 +1537,12 @@ func (r *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 		return true, nil
 	}
 
-	err = doHead(ctx, r.baseURI, endpointTableExists.reqPath(ns, tbl),
+	path, err := endpointTableExists.reqPath(ns, tbl)
+	if err != nil {
+		return false, err
+	}
+
+	err = doHead(ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchTable) {
@@ -1456,6 +1555,8 @@ func (r *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 	return true, nil
 }
 
+// ListViews lists the views in a namespace. If the server does not advertise the
+// list-views endpoint, it yields no views rather than an error.
 func (r *Catalog) ListViews(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
@@ -1486,11 +1587,15 @@ func (r *Catalog) listViewsPage(ctx context.Context, namespace table.Identifier,
 		return nil, "", err
 	}
 	// Unsupported listing yields an empty result rather than an error.
-	if r.endpoints != nil && !r.endpoints.contains(endpointListViews) {
+	if !r.endpoints.allowed(endpointListViews) {
 		return nil, "", nil
 	}
 	ns := strings.Join(namespace, namespaceSeparator)
-	uri := r.baseURI.JoinPath(endpointListViews.reqPath(ns)...)
+	path, err := endpointListViews.reqPath(ns)
+	if err != nil {
+		return nil, "", err
+	}
+	uri := r.baseURI.JoinPath(path...)
 
 	v := url.Values{}
 	if pageSize > 0 {
@@ -1541,7 +1646,12 @@ func (r *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 		return err
 	}
 
-	_, err = doDelete[struct{}](ctx, r.baseURI, endpointDeleteView.reqPath(ns, view), r.cl,
+	path, err := endpointDeleteView.reqPath(ns, view)
+	if err != nil {
+		return err
+	}
+
+	_, err = doDelete[struct{}](ctx, r.baseURI, path, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchView})
 
 	return err
@@ -1553,9 +1663,9 @@ func (r *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 		return false, err
 	}
 
-	// If the server does not advertise the HEAD existence endpoint, fall back to
-	// a GET (load) for compatibility with servers that predate it.
-	if r.endpoints != nil && !r.endpoints.contains(endpointViewExists) {
+	// No HEAD endpoint: fall back to GET (load). If load is unsupported too, its
+	// ErrEndpointNotSupported surfaces rather than a bogus "not found".
+	if !r.endpoints.contains(endpointViewExists) {
 		_, err := r.LoadView(ctx, identifier)
 		if err != nil {
 			if errors.Is(err, catalog.ErrNoSuchView) {
@@ -1568,7 +1678,12 @@ func (r *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 		return true, nil
 	}
 
-	err = doHead(ctx, r.baseURI, endpointViewExists.reqPath(ns, view),
+	path, err := endpointViewExists.reqPath(ns, view)
+	if err != nil {
+		return false, err
+	}
+
+	err = doHead(ctx, r.baseURI, path,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchView})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchView) {
@@ -1651,7 +1766,12 @@ func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 		ViewVersion: version,
 	}
 
-	ret, err := doPost[createViewRequest, viewResponse](ctx, r.baseURI, endpointCreateView.reqPath(ns), payload,
+	path, err := endpointCreateView.reqPath(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doPost[createViewRequest, viewResponse](ctx, r.baseURI, path, payload,
 		r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace,
 			http.StatusConflict: catalog.ErrViewAlreadyExists,
@@ -1683,7 +1803,12 @@ func (r *Catalog) UpdateView(ctx context.Context, ident table.Identifier, requir
 		Requirements []view.Requirement `json:"requirements"`
 		Updates      []view.Update      `json:"updates"`
 	}
-	ret, err := doPost[payload, viewResponse](ctx, r.baseURI, endpointUpdateView.reqPath(ns, viewName),
+	path, err := endpointUpdateView.reqPath(ns, viewName)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := doPost[payload, viewResponse](ctx, r.baseURI, path,
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchView, http.StatusConflict: ErrCommitFailed})
 	if err != nil {
@@ -1719,7 +1844,12 @@ func (r *Catalog) RegisterView(ctx context.Context, identifier table.Identifier,
 		MetadataLoc string `json:"metadata-location"`
 	}
 
-	rsp, err := doPost[payload, loadViewResponse](ctx, r.baseURI, endpointRegisterView.reqPath(ns),
+	path, err := endpointRegisterView.reqPath(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := doPost[payload, loadViewResponse](ctx, r.baseURI, path,
 		payload{Name: v, MetadataLoc: metadataLoc}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrViewAlreadyExists,
 		})
@@ -1746,7 +1876,12 @@ func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 		return nil, err
 	}
 
-	rsp, err := doGet[loadViewResponse](ctx, r.baseURI, endpointLoadView.reqPath(ns, v),
+	path, err := endpointLoadView.reqPath(ns, v)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := doGet[loadViewResponse](ctx, r.baseURI, path,
 		r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchView,
 		})

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -197,6 +197,7 @@ type createTableRequest struct {
 type configResponse struct {
 	Defaults  iceberg.Properties `json:"defaults"`
 	Overrides iceberg.Properties `json:"overrides"`
+	Endpoints []string           `json:"endpoints,omitempty"`
 }
 
 type sessionTransport struct {
@@ -526,8 +527,9 @@ type Catalog struct {
 	baseURI *url.URL
 	cl      *http.Client
 
-	name  string
-	props iceberg.Properties
+	name      string
+	props     iceberg.Properties
+	endpoints endpointSet
 }
 
 func newCatalogFromProps(ctx context.Context, name string, uri string, p iceberg.Properties) (*Catalog, error) {
@@ -732,6 +734,10 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*http.Client,
 		return nil, nil, err
 	}
 
+	// Negotiate capabilities from the endpoints the server advertises, falling
+	// back to a backward-compatible default set when none are provided.
+	r.endpoints = resolveEndpoints(rsp.Endpoints)
+
 	cfg := rsp.Defaults
 	if cfg == nil {
 		cfg = iceberg.Properties{}
@@ -796,7 +802,7 @@ func (r *Catalog) fetchTableCreds(ctx context.Context, ident []string, location 
 		return nil, err
 	}
 
-	ret, err := doGet[loadCredentialsResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl, "credentials"},
+	ret, err := doGet[loadCredentialsResponse](ctx, r.baseURI, endpointTableCredentials.reqPath(ns, tbl),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		return nil, err
@@ -834,8 +840,12 @@ func (r *Catalog) listTablesPage(ctx context.Context, namespace table.Identifier
 	if err := checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}
+	// Unsupported listing yields an empty result rather than an error.
+	if r.endpoints != nil && !r.endpoints.contains(endpointListTables) {
+		return nil, "", nil
+	}
 	ns := strings.Join(namespace, namespaceSeparator)
-	uri := r.baseURI.JoinPath("namespaces", ns, "tables")
+	uri := r.baseURI.JoinPath(endpointListTables.reqPath(ns)...)
 
 	v := url.Values{}
 	if pageSize > 0 {
@@ -872,6 +882,10 @@ func splitIdentForPath(ident table.Identifier) (string, string, error) {
 }
 
 func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	if err := r.endpoints.check(endpointCreateTable); err != nil {
+		return nil, err
+	}
+
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
@@ -898,7 +912,7 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		Props:         cfg.Properties,
 	}
 
-	ret, err := doPost[createTableRequest, loadTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables"}, payload,
+	ret, err := doPost[createTableRequest, loadTableResponse](ctx, r.baseURI, endpointCreateTable.reqPath(ns), payload,
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrTableAlreadyExists})
 	if err != nil {
 		return nil, err
@@ -974,6 +988,10 @@ func (r *Catalog) commitStagedCreate(ctx context.Context, identifier table.Ident
 }
 
 func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requirements []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	if err := r.endpoints.check(endpointUpdateTable); err != nil {
+		return nil, "", err
+	}
+
 	ns, tblName, err := splitIdentForPath(ident)
 	if err != nil {
 		return nil, "", err
@@ -990,7 +1008,7 @@ func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requi
 		Updates      []table.Update      `json:"updates"`
 	}
 
-	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables", tblName},
+	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, endpointUpdateTable.reqPath(ns, tblName),
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1016,6 +1034,10 @@ func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requi
 func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCommit) error {
 	if len(commits) == 0 {
 		return catalog.ErrEmptyCommitList
+	}
+
+	if err := r.endpoints.check(endpointCommitTransaction); err != nil {
+		return err
 	}
 
 	type tableChange struct {
@@ -1054,7 +1076,7 @@ func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 	}
 
 	_, err := doPostAllowNoContent[payload, struct{}](
-		ctx, r.baseURI, []string{"transactions", "commit"},
+		ctx, r.baseURI, endpointCommitTransaction.reqPath(),
 		payload{TableChanges: changes}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1071,6 +1093,10 @@ func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 }
 
 func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier, metadataLoc string) (*table.Table, error) {
+	if err := r.endpoints.check(endpointRegisterTable); err != nil {
+		return nil, err
+	}
+
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
@@ -1081,7 +1107,7 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		MetadataLoc string `json:"metadata-location"`
 	}
 
-	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "register"},
+	ret, err := doPost[payload, loadTableResponse](ctx, r.baseURI, endpointRegisterTable.reqPath(ns),
 		payload{Name: tbl, MetadataLoc: metadataLoc}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrTableAlreadyExists,
 		})
@@ -1099,12 +1125,16 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 }
 
 func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
+	if err := r.endpoints.check(endpointLoadTable); err != nil {
+		return nil, err
+	}
+
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
 	}
 
-	ret, err := doGet[loadTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl},
+	ret, err := doGet[loadTableResponse](ctx, r.baseURI, endpointLoadTable.reqPath(ns, tbl),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		return nil, err
@@ -1120,6 +1150,10 @@ func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 }
 
 func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requirements []table.Requirement, updates []table.Update) (*table.Table, error) {
+	if err := r.endpoints.check(endpointUpdateTable); err != nil {
+		return nil, err
+	}
+
 	ns, tbl, err := splitIdentForPath(ident)
 	if err != nil {
 		return nil, err
@@ -1134,7 +1168,7 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 		Requirements []table.Requirement `json:"requirements"`
 		Updates      []table.Update      `json:"updates"`
 	}
-	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl},
+	ret, err := doPost[payload, commitTableResponse](ctx, r.baseURI, endpointUpdateTable.reqPath(ns, tbl),
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{
 			http.StatusNotFound:            catalog.ErrNoSuchTable,
@@ -1155,12 +1189,16 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 }
 
 func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {
+	if err := r.endpoints.check(endpointDeleteTable); err != nil {
+		return err
+	}
+
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return err
 	}
 
-	uri := r.baseURI.JoinPath("namespaces", ns, "tables", tbl)
+	uri := r.baseURI.JoinPath(endpointDeleteTable.reqPath(ns, tbl)...)
 	v := url.Values{}
 	v.Set("purgeRequested", "false")
 	uri.RawQuery = v.Encode()
@@ -1172,12 +1210,16 @@ func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) er
 }
 
 func (r *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) error {
+	if err := r.endpoints.check(endpointDeleteTable); err != nil {
+		return err
+	}
+
 	ns, tbl, err := splitIdentForPath(identifier)
 	if err != nil {
 		return err
 	}
 
-	uri := r.baseURI.JoinPath("namespaces", ns, "tables", tbl)
+	uri := r.baseURI.JoinPath(endpointDeleteTable.reqPath(ns, tbl)...)
 	v := url.Values{}
 	v.Set("purgeRequested", "true")
 	uri.RawQuery = v.Encode()
@@ -1189,6 +1231,10 @@ func (r *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 }
 
 func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error) {
+	if err := r.endpoints.check(endpointRenameTable); err != nil {
+		return nil, err
+	}
+
 	type payload struct {
 		Source      identifier `json:"source"`
 		Destination identifier `json:"destination"`
@@ -1202,7 +1248,7 @@ func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		Name:      catalog.TableNameFromIdent(to),
 	}
 
-	_, err := doPostAllowNoContent[payload, any](ctx, r.baseURI, []string{"tables", "rename"}, payload{Source: src, Destination: dst}, r.cl,
+	_, err := doPostAllowNoContent[payload, any](ctx, r.baseURI, endpointRenameTable.reqPath(), payload{Source: src, Destination: dst}, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable}, true)
 	if err != nil {
 		return nil, err
@@ -1212,11 +1258,15 @@ func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 }
 
 func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
+	if err := r.endpoints.check(endpointCreateNamespace); err != nil {
+		return err
+	}
+
 	if err := checkValidNamespace(namespace); err != nil {
 		return err
 	}
 
-	_, err := doPost[map[string]any, struct{}](ctx, r.baseURI, []string{"namespaces"},
+	_, err := doPost[map[string]any, struct{}](ctx, r.baseURI, endpointCreateNamespace.reqPath(),
 		map[string]any{"namespace": namespace, "properties": props}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrNamespaceAlreadyExists,
 		})
@@ -1225,11 +1275,15 @@ func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 }
 
 func (r *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier) error {
+	if err := r.endpoints.check(endpointDeleteNamespace); err != nil {
+		return err
+	}
+
 	if err := checkValidNamespace(namespace); err != nil {
 		return err
 	}
 
-	_, err := doDelete[struct{}](ctx, r.baseURI, []string{"namespaces", strings.Join(namespace, namespaceSeparator)},
+	_, err := doDelete[struct{}](ctx, r.baseURI, endpointDeleteNamespace.reqPath(strings.Join(namespace, namespaceSeparator)),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 
 	return err
@@ -1256,7 +1310,12 @@ func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 }
 
 func (r *Catalog) listNamespacesPage(ctx context.Context, parent table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
-	uri := r.baseURI.JoinPath("namespaces")
+	// Unsupported listing yields an empty result rather than an error.
+	if r.endpoints != nil && !r.endpoints.contains(endpointListNamespaces) {
+		return nil, "", nil
+	}
+
+	uri := r.baseURI.JoinPath(endpointListNamespaces.reqPath()...)
 
 	v := url.Values{}
 	if len(parent) != 0 {
@@ -1286,6 +1345,10 @@ func (r *Catalog) listNamespacesPage(ctx context.Context, parent table.Identifie
 }
 
 func (r *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.Identifier) (iceberg.Properties, error) {
+	if err := r.endpoints.check(endpointLoadNamespace); err != nil {
+		return nil, err
+	}
+
 	if err := checkValidNamespace(namespace); err != nil {
 		return nil, err
 	}
@@ -1295,7 +1358,7 @@ func (r *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 		Props     iceberg.Properties `json:"properties"`
 	}
 
-	rsp, err := doGet[nsresponse](ctx, r.baseURI, []string{"namespaces", strings.Join(namespace, namespaceSeparator)},
+	rsp, err := doGet[nsresponse](ctx, r.baseURI, endpointLoadNamespace.reqPath(strings.Join(namespace, namespaceSeparator)),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 	if err != nil {
 		return nil, err
@@ -1307,6 +1370,10 @@ func (r *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 func (r *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table.Identifier,
 	removals []string, updates iceberg.Properties,
 ) (catalog.PropertiesUpdateSummary, error) {
+	if err := r.endpoints.check(endpointUpdateNamespace); err != nil {
+		return catalog.PropertiesUpdateSummary{}, err
+	}
+
 	if err := checkValidNamespace(namespace); err != nil {
 		return catalog.PropertiesUpdateSummary{}, err
 	}
@@ -1318,7 +1385,7 @@ func (r *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 
 	ns := strings.Join(namespace, namespaceSeparator)
 
-	return doPost[payload, catalog.PropertiesUpdateSummary](ctx, r.baseURI, []string{"namespaces", ns, "properties"},
+	return doPost[payload, catalog.PropertiesUpdateSummary](ctx, r.baseURI, endpointUpdateNamespace.reqPath(ns),
 		payload{Remove: removals, Updates: updates}, r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 }
 
@@ -1327,7 +1394,22 @@ func (r *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Iden
 		return false, err
 	}
 
-	err := doHead(ctx, r.baseURI, []string{"namespaces", strings.Join(namespace, namespaceSeparator)},
+	// If the server does not advertise the HEAD existence endpoint, fall back to
+	// a GET (load) for compatibility with servers that predate it.
+	if r.endpoints != nil && !r.endpoints.contains(endpointNamespaceExists) {
+		_, err := r.LoadNamespaceProperties(ctx, namespace)
+		if err != nil {
+			if errors.Is(err, catalog.ErrNoSuchNamespace) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	err := doHead(ctx, r.baseURI, endpointNamespaceExists.reqPath(strings.Join(namespace, namespaceSeparator)),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchNamespace) {
@@ -1345,7 +1427,23 @@ func (r *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 	if err != nil {
 		return false, err
 	}
-	err = doHead(ctx, r.baseURI, []string{"namespaces", ns, "tables", tbl},
+
+	// If the server does not advertise the HEAD existence endpoint, fall back to
+	// a GET (load) for compatibility with servers that predate it.
+	if r.endpoints != nil && !r.endpoints.contains(endpointTableExists) {
+		_, err := r.LoadTable(ctx, identifier)
+		if err != nil {
+			if errors.Is(err, catalog.ErrNoSuchTable) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	err = doHead(ctx, r.baseURI, endpointTableExists.reqPath(ns, tbl),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchTable})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchTable) {
@@ -1387,8 +1485,12 @@ func (r *Catalog) listViewsPage(ctx context.Context, namespace table.Identifier,
 	if err := checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}
+	// Unsupported listing yields an empty result rather than an error.
+	if r.endpoints != nil && !r.endpoints.contains(endpointListViews) {
+		return nil, "", nil
+	}
 	ns := strings.Join(namespace, namespaceSeparator)
-	uri := r.baseURI.JoinPath("namespaces", ns, "views")
+	uri := r.baseURI.JoinPath(endpointListViews.reqPath(ns)...)
 
 	v := url.Values{}
 	if pageSize > 0 {
@@ -1430,12 +1532,16 @@ func (r *Catalog) SetPageSize(ctx context.Context, sz int) context.Context {
 }
 
 func (r *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {
+	if err := r.endpoints.check(endpointDeleteView); err != nil {
+		return err
+	}
+
 	ns, view, err := splitIdentForPath(identifier)
 	if err != nil {
 		return err
 	}
 
-	_, err = doDelete[struct{}](ctx, r.baseURI, []string{"namespaces", ns, "views", view}, r.cl,
+	_, err = doDelete[struct{}](ctx, r.baseURI, endpointDeleteView.reqPath(ns, view), r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchView})
 
 	return err
@@ -1447,7 +1553,22 @@ func (r *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 		return false, err
 	}
 
-	err = doHead(ctx, r.baseURI, []string{"namespaces", ns, "views", view},
+	// If the server does not advertise the HEAD existence endpoint, fall back to
+	// a GET (load) for compatibility with servers that predate it.
+	if r.endpoints != nil && !r.endpoints.contains(endpointViewExists) {
+		_, err := r.LoadView(ctx, identifier)
+		if err != nil {
+			if errors.Is(err, catalog.ErrNoSuchView) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	err = doHead(ctx, r.baseURI, endpointViewExists.reqPath(ns, view),
 		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchView})
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchView) {
@@ -1488,6 +1609,10 @@ func (v *viewResponse) UnmarshalJSON(b []byte) (err error) {
 
 // CreateView creates a new view in the catalog.
 func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, version *view.Version, schema *iceberg.Schema, opts ...catalog.CreateViewOpt) (*view.View, error) {
+	if err := r.endpoints.check(endpointCreateView); err != nil {
+		return nil, err
+	}
+
 	ns, viewName, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
@@ -1526,7 +1651,7 @@ func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 		ViewVersion: version,
 	}
 
-	ret, err := doPost[createViewRequest, viewResponse](ctx, r.baseURI, []string{"namespaces", ns, "views"}, payload,
+	ret, err := doPost[createViewRequest, viewResponse](ctx, r.baseURI, endpointCreateView.reqPath(ns), payload,
 		r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace,
 			http.StatusConflict: catalog.ErrViewAlreadyExists,
@@ -1540,6 +1665,10 @@ func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 
 // UpdateView updates a view in the catalog.
 func (r *Catalog) UpdateView(ctx context.Context, ident table.Identifier, requirements []view.Requirement, updates []view.Update) (*view.View, error) {
+	if err := r.endpoints.check(endpointUpdateView); err != nil {
+		return nil, err
+	}
+
 	ns, viewName, err := splitIdentForPath(ident)
 	if err != nil {
 		return nil, err
@@ -1554,7 +1683,7 @@ func (r *Catalog) UpdateView(ctx context.Context, ident table.Identifier, requir
 		Requirements []view.Requirement `json:"requirements"`
 		Updates      []view.Update      `json:"updates"`
 	}
-	ret, err := doPost[payload, viewResponse](ctx, r.baseURI, []string{"namespaces", ns, "views", viewName},
+	ret, err := doPost[payload, viewResponse](ctx, r.baseURI, endpointUpdateView.reqPath(ns, viewName),
 		payload{Identifier: restIdentifier, Requirements: requirements, Updates: updates}, r.cl,
 		map[int]error{http.StatusNotFound: catalog.ErrNoSuchView, http.StatusConflict: ErrCommitFailed})
 	if err != nil {
@@ -1576,6 +1705,10 @@ type loadViewResponse struct {
 // of RegisterTable, using the REST endpoint POST /namespaces/{ns}/register-view defined in
 // the Iceberg REST catalog specification.
 func (r *Catalog) RegisterView(ctx context.Context, identifier table.Identifier, metadataLoc string) (*view.View, error) {
+	if err := r.endpoints.check(endpointRegisterView); err != nil {
+		return nil, err
+	}
+
 	ns, v, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
@@ -1586,7 +1719,7 @@ func (r *Catalog) RegisterView(ctx context.Context, identifier table.Identifier,
 		MetadataLoc string `json:"metadata-location"`
 	}
 
-	rsp, err := doPost[payload, loadViewResponse](ctx, r.baseURI, []string{"namespaces", ns, "register-view"},
+	rsp, err := doPost[payload, loadViewResponse](ctx, r.baseURI, endpointRegisterView.reqPath(ns),
 		payload{Name: v, MetadataLoc: metadataLoc}, r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchNamespace, http.StatusConflict: catalog.ErrViewAlreadyExists,
 		})
@@ -1604,12 +1737,16 @@ func (r *Catalog) RegisterView(ctx context.Context, identifier table.Identifier,
 
 // LoadView loads a view from the catalog.
 func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*view.View, error) {
+	if err := r.endpoints.check(endpointLoadView); err != nil {
+		return nil, err
+	}
+
 	ns, v, err := splitIdentForPath(identifier)
 	if err != nil {
 		return nil, err
 	}
 
-	rsp, err := doGet[loadViewResponse](ctx, r.baseURI, []string{"namespaces", ns, "views", v},
+	rsp, err := doGet[loadViewResponse](ctx, r.baseURI, endpointLoadView.reqPath(ns, v),
 		r.cl, map[int]error{
 			http.StatusNotFound: catalog.ErrNoSuchView,
 		})

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -43,6 +45,36 @@ const (
 	TestToken       = "some_jwt_token"
 	defaultPageSize = 20
 )
+
+// allEndpointStrings advertises every operation the client knows, so the test
+// server behaves like a fully-capable catalog.
+var allEndpointStrings = []string{
+	"GET /v1/{prefix}/namespaces",
+	"GET /v1/{prefix}/namespaces/{namespace}",
+	"HEAD /v1/{prefix}/namespaces/{namespace}",
+	"POST /v1/{prefix}/namespaces",
+	"POST /v1/{prefix}/namespaces/{namespace}/properties",
+	"DELETE /v1/{prefix}/namespaces/{namespace}",
+	"POST /v1/{prefix}/transactions/commit",
+	"GET /v1/{prefix}/namespaces/{namespace}/tables",
+	"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}",
+	"HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}",
+	"POST /v1/{prefix}/namespaces/{namespace}/tables",
+	"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}",
+	"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}",
+	"POST /v1/{prefix}/tables/rename",
+	"POST /v1/{prefix}/namespaces/{namespace}/register",
+	"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics",
+	"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials",
+	"GET /v1/{prefix}/namespaces/{namespace}/views",
+	"GET /v1/{prefix}/namespaces/{namespace}/views/{view}",
+	"HEAD /v1/{prefix}/namespaces/{namespace}/views/{view}",
+	"POST /v1/{prefix}/namespaces/{namespace}/views",
+	"POST /v1/{prefix}/namespaces/{namespace}/views/{view}",
+	"DELETE /v1/{prefix}/namespaces/{namespace}/views/{view}",
+	"POST /v1/{prefix}/views/rename",
+	"POST /v1/{prefix}/namespaces/{namespace}/register-view",
+}
 
 var (
 	TestHeaders = http.Header{
@@ -74,6 +106,7 @@ func (r *RestCatalogSuite) SetupTest() {
 		json.NewEncoder(w).Encode(map[string]any{
 			"defaults":  map[string]any{},
 			"overrides": map[string]any{},
+			"endpoints": allEndpointStrings,
 		})
 	})
 
@@ -2271,6 +2304,7 @@ func (r *RestTLSCatalogSuite) SetupTest() {
 		json.NewEncoder(w).Encode(map[string]any{
 			"defaults":  map[string]any{},
 			"overrides": map[string]any{},
+			"endpoints": allEndpointStrings,
 		})
 	})
 
@@ -3211,4 +3245,52 @@ func (r *RestCatalogSuite) TestCommitTransactionErrCommitStateUnknown() {
 				"%d should return ErrCommitStateUnknown, got: %v", code, err)
 		})
 	}
+}
+
+// TestEndpointNegotiation drives a catalog against a server that advertises only
+// a subset of endpoints, exercising the negotiation path end to end.
+func TestEndpointNegotiation(t *testing.T) {
+	var listNamespacesHit, tablesHit bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, req *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{},
+			// Advertise list-namespaces only: create-table and list-tables are
+			// deliberately absent.
+			"endpoints": []string{"GET /v1/{prefix}/namespaces"},
+		})
+	})
+	mux.HandleFunc("/v1/namespaces", func(w http.ResponseWriter, req *http.Request) {
+		listNamespacesHit = true
+		json.NewEncoder(w).Encode(map[string]any{"namespaces": []any{}})
+	})
+	mux.HandleFunc("/v1/namespaces/", func(w http.ResponseWriter, req *http.Request) {
+		tablesHit = true
+		http.Error(w, "unexpected request to unsupported endpoint", http.StatusInternalServerError)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
+	require.NoError(t, err)
+
+	// An unsupported op fails with the capability sentinel, not a transport error.
+	_, err = cat.CreateTable(context.Background(), table.Identifier{"ns", "tbl"}, tableSchemaSimple)
+	assert.ErrorIs(t, err, rest.ErrEndpointNotSupported)
+	assert.NotErrorIs(t, err, rest.ErrRESTError)
+
+	// An advertised op works.
+	nss, err := cat.ListNamespaces(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, nss)
+	assert.True(t, listNamespacesHit)
+
+	// An unsupported list op yields empty without erroring or calling the server.
+	for _, err := range cat.ListTables(context.Background(), table.Identifier{"ns"}) {
+		require.NoError(t, err)
+	}
+	assert.False(t, tablesHit)
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -46,36 +46,6 @@ const (
 	defaultPageSize = 20
 )
 
-// allEndpointStrings advertises every operation the client knows, so the test
-// server behaves like a fully-capable catalog.
-var allEndpointStrings = []string{
-	"GET /v1/{prefix}/namespaces",
-	"GET /v1/{prefix}/namespaces/{namespace}",
-	"HEAD /v1/{prefix}/namespaces/{namespace}",
-	"POST /v1/{prefix}/namespaces",
-	"POST /v1/{prefix}/namespaces/{namespace}/properties",
-	"DELETE /v1/{prefix}/namespaces/{namespace}",
-	"POST /v1/{prefix}/transactions/commit",
-	"GET /v1/{prefix}/namespaces/{namespace}/tables",
-	"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}",
-	"HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}",
-	"POST /v1/{prefix}/namespaces/{namespace}/tables",
-	"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}",
-	"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}",
-	"POST /v1/{prefix}/tables/rename",
-	"POST /v1/{prefix}/namespaces/{namespace}/register",
-	"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics",
-	"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials",
-	"GET /v1/{prefix}/namespaces/{namespace}/views",
-	"GET /v1/{prefix}/namespaces/{namespace}/views/{view}",
-	"HEAD /v1/{prefix}/namespaces/{namespace}/views/{view}",
-	"POST /v1/{prefix}/namespaces/{namespace}/views",
-	"POST /v1/{prefix}/namespaces/{namespace}/views/{view}",
-	"DELETE /v1/{prefix}/namespaces/{namespace}/views/{view}",
-	"POST /v1/{prefix}/views/rename",
-	"POST /v1/{prefix}/namespaces/{namespace}/register-view",
-}
-
 var (
 	TestHeaders = http.Header{
 		"X-Client-Version": {"0.14.1"},
@@ -106,7 +76,7 @@ func (r *RestCatalogSuite) SetupTest() {
 		json.NewEncoder(w).Encode(map[string]any{
 			"defaults":  map[string]any{},
 			"overrides": map[string]any{},
-			"endpoints": allEndpointStrings,
+			"endpoints": rest.AllEndpointStrings,
 		})
 	})
 
@@ -2304,7 +2274,7 @@ func (r *RestTLSCatalogSuite) SetupTest() {
 		json.NewEncoder(w).Encode(map[string]any{
 			"defaults":  map[string]any{},
 			"overrides": map[string]any{},
-			"endpoints": allEndpointStrings,
+			"endpoints": rest.AllEndpointStrings,
 		})
 	})
 


### PR DESCRIPTION
The REST Catalog sends out a list of supported endpoints via `/v1/config`. This is important for features like views + server-side planning, where the client has to understand if the catalog supports certain features.

I've created a list of endpoints and a mechanism for iceberg-go to error out if a particular method isn't supported by the server. 

Note: This was created with the help of GenAI, since creating all of the endpoint objects is really duplicative work.