### PR TITLE
feat(compaction): add MaxFilesToRewrite option

### DIFF
--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -56,6 +56,12 @@ type Config struct {
 	// of memory. Default: DefaultPackingLookback.
 	PackingLookback uint
 
+	// MaxFilesToRewrite caps the total number of input files selected
+	// across all compaction groups. Groups are included in order; the
+	// last group is truncated to fit within the budget. 0 means
+	// unlimited.
+	MaxFilesToRewrite int
+
 	// PreserveDeadEqualityDeletes, when true, retains equality delete
 	// files that are provably dead after the rewrite. The cleanup
 	// predicate matches the v2 reader (see scanner.go
@@ -122,6 +128,9 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.DeleteFileThreshold < 1 {
 		return fmt.Errorf("delete file threshold must be >= 1, got %d", cfg.DeleteFileThreshold)
+	}
+	if cfg.MaxFilesToRewrite < 0 {
+		return fmt.Errorf("max files to rewrite must be non-negative, got %d", cfg.MaxFilesToRewrite)
 	}
 
 	return nil
@@ -253,7 +262,49 @@ func (cfg Config) PlanCompaction(tasks []table.FileScanTask) (Plan, error) {
 		}
 	}
 
+	if cfg.MaxFilesToRewrite > 0 {
+		budget := cfg.MaxFilesToRewrite
+		trimmed := make([]Group, 0, len(plan.Groups))
+		for _, g := range plan.Groups {
+			if budget <= 0 {
+				plan.SkippedFiles += len(g.Tasks)
+				plan.EstOutputFiles -= max(1, int((g.TotalSizeBytes+cfg.TargetFileSizeBytes-1)/cfg.TargetFileSizeBytes))
+				plan.EstOutputBytes -= g.TotalSizeBytes
+
+				continue
+			}
+			if len(g.Tasks) <= budget {
+				trimmed = append(trimmed, g)
+				budget -= len(g.Tasks)
+			} else {
+				// Truncate the last group to the remaining budget.
+				truncated := buildGroup(g.PartitionKey, g.Tasks[:budget])
+				dropped := g.Tasks[budget:]
+				for _, t := range dropped {
+					plan.SkippedFiles++
+					plan.EstOutputBytes -= t.File.FileSizeBytes()
+				}
+				estDrop := max(1, int((g.TotalSizeBytes+cfg.TargetFileSizeBytes-1)/cfg.TargetFileSizeBytes))
+				estKeep := max(1, int((truncated.TotalSizeBytes+cfg.TargetFileSizeBytes-1)/cfg.TargetFileSizeBytes))
+				plan.EstOutputFiles -= estDrop - estKeep
+				trimmed = append(trimmed, truncated)
+				budget = 0
+			}
+		}
+		plan.Groups = trimmed
+	}
+
 	return plan, nil
+}
+
+func buildGroup(partitionKey string, tasks []table.FileScanTask) Group {
+	g := Group{PartitionKey: partitionKey, Tasks: tasks}
+	for _, t := range tasks {
+		g.TotalSizeBytes += t.File.FileSizeBytes()
+		g.DeleteFileCount += len(t.DeleteFiles) + len(t.EqualityDeleteFiles)
+	}
+
+	return g
 }
 
 // isCandidate returns true if a file should be considered for compaction.

--- a/table/compaction/compaction_test.go
+++ b/table/compaction/compaction_test.go
@@ -148,6 +148,11 @@ func TestConfig_Validate(t *testing.T) {
 			err:  "delete file threshold must be >= 1",
 		},
 		{
+			name: "negative max files to rewrite",
+			cfg:  compaction.Config{TargetFileSizeBytes: 100, MinFileSizeBytes: 10, MaxFileSizeBytes: 200, MinInputFiles: 1, DeleteFileThreshold: 1, MaxFilesToRewrite: -1},
+			err:  "max files to rewrite must be non-negative",
+		},
+		{
 			name: "valid",
 			cfg:  compaction.DefaultConfig(),
 		},
@@ -508,4 +513,120 @@ func TestPlanCompaction_InvalidConfig(t *testing.T) {
 	_, err := cfg.PlanCompaction(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid compaction config")
+}
+
+func TestPlanCompaction_MaxFilesToRewriteUnlimited(t *testing.T) {
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 100 * 1024 * 1024,
+		MinFileSizeBytes:    75 * 1024 * 1024,
+		MaxFileSizeBytes:    180 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 5,
+		PackingLookback:     compaction.DefaultPackingLookback,
+		MaxFilesToRewrite:   0,
+	}
+
+	var tasks []table.FileScanTask
+	for i := range 10 {
+		tasks = append(tasks, makeTask(newDataFile(fmt.Sprintf("file-%d.parquet", i), 10), 0, 0))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	total := 0
+	for _, g := range plan.Groups {
+		total += len(g.Tasks)
+	}
+	assert.Equal(t, 10, total)
+}
+
+func TestPlanCompaction_MaxFilesToRewriteExactLimit(t *testing.T) {
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 100 * 1024 * 1024,
+		MinFileSizeBytes:    75 * 1024 * 1024,
+		MaxFileSizeBytes:    180 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 5,
+		PackingLookback:     compaction.DefaultPackingLookback,
+		MaxFilesToRewrite:   10,
+	}
+
+	var tasks []table.FileScanTask
+	for i := range 10 {
+		tasks = append(tasks, makeTask(newDataFile(fmt.Sprintf("file-%d.parquet", i), 10), 0, 0))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	total := 0
+	for _, g := range plan.Groups {
+		total += len(g.Tasks)
+	}
+	assert.Equal(t, 10, total)
+	assert.Equal(t, 0, plan.SkippedFiles)
+}
+
+func TestPlanCompaction_MaxFilesToRewriteTruncatesGroup(t *testing.T) {
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 100 * 1024 * 1024,
+		MinFileSizeBytes:    75 * 1024 * 1024,
+		MaxFileSizeBytes:    180 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 5,
+		PackingLookback:     compaction.DefaultPackingLookback,
+		MaxFilesToRewrite:   3,
+	}
+
+	var tasks []table.FileScanTask
+	for i := range 10 {
+		tasks = append(tasks, makeTask(newDataFile(fmt.Sprintf("file-%d.parquet", i), 10), 0, 0))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	total := 0
+	for _, g := range plan.Groups {
+		total += len(g.Tasks)
+	}
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 7, plan.SkippedFiles)
+}
+
+func TestPlanCompaction_MaxFilesToRewriteDropsWholeGroups(t *testing.T) {
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 100 * 1024 * 1024,
+		MinFileSizeBytes:    75 * 1024 * 1024,
+		MaxFileSizeBytes:    180 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 5,
+		PackingLookback:     compaction.DefaultPackingLookback,
+		MaxFilesToRewrite:   5,
+	}
+
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		tasks = append(tasks, makeTask(
+			newPartitionedDataFile(fmt.Sprintf("a-%d.parquet", i), 10, map[int]any{1000: "p1"}),
+			0, 0,
+		))
+	}
+	for i := range 5 {
+		tasks = append(tasks, makeTask(
+			newPartitionedDataFile(fmt.Sprintf("b-%d.parquet", i), 10, map[int]any{1000: "p2"}),
+			0, 0,
+		))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	total := 0
+	for _, g := range plan.Groups {
+		total += len(g.Tasks)
+	}
+	assert.Equal(t, 5, total)
+	assert.Equal(t, 5, plan.SkippedFiles)
 }


### PR DESCRIPTION
## Summary

- Adds `MaxFilesToRewrite int` to `compaction.Config`, matching Java's `max-files-to-rewrite` option (apache/iceberg#12824)
- Applied as a post-planning cap: groups are included in order, and the last group is truncated to fit the remaining budget
- `0` means unlimited (default behavior unchanged)

## Motivation

When rewriting data files, users may want to limit the number of files processed in a single run to reduce file I/O operations. This option truncates the planned file tasks until the specified count is reached. If the table has fewer candidate files than the limit, all files are processed normally.