### PR TITLE
Core: Handle nil logical partition values in manifests

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1848,6 +1848,10 @@ func (d *dataFile) initColumnStatsData() {
 }
 
 func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
+	if v == nil {
+		return nil
+	}
+
 	if logicalType, ok := d.fieldIDToLogicalType[fieldID]; ok {
 		// twmb/avro returns rich Go types (time.Time, time.Duration,
 		// *big.Rat, [16]byte) when the file schema includes a logicalType,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -32,7 +32,6 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/avro"
-	"github.com/twmb/avro/atype"
 	"github.com/twmb/avro/ocf"
 )
 
@@ -1801,24 +1800,68 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 	m.Equal("[]", string(md["partition-spec"]))
 }
 
-func TestDataFileInitializeMapDataHandlesNilLogicalPartitionValue(t *testing.T) {
-	df := &dataFile{
-		PartitionData: map[string]any{
-			"dt": nil,
-		},
-		fieldNameToID: map[string]int{
-			"dt": 1000,
-		},
-		fieldIDToLogicalType: map[int]string{
-			1000: atype.Date,
-		},
+func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing.T) {
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "dt", Type: PrimitiveTypes.Date},
+	)
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "dt", Transform: IdentityTransform{}},
+	)
+
+	dataFileBuilder, err := NewDataFileBuilder(
+		partitionSpec,
+		EntryContentEqDeletes,
+		"s3://bucket/ns/table/data/eq-delete.parquet",
+		ParquetFile,
+		map[int]any{1000: nil},
+		nil,
+		nil,
+		1,
+		1024,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataFileBuilder.EqualityFieldIDs([]int{1})
+
+	snapshotID := int64(1234)
+	seqNum := int64(1)
+	entry := NewManifestEntry(
+		EntryStatusADDED,
+		&snapshotID,
+		&seqNum,
+		&seqNum,
+		dataFileBuilder.Build(),
+	)
+
+	var buf bytes.Buffer
+	cnt := &internal.CountingWriter{W: &buf}
+	writer, err := NewManifestWriter(2, cnt, partitionSpec, schema, snapshotID,
+		WithManifestWriterContent(ManifestContentDeletes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Add(entry); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	file, err := writer.ToManifestFile("s3://bucket/ns/table/metadata/eq-delete-manifest.avro", cnt.Count,
+		WithManifestFileContent(ManifestContentDeletes))
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if got := df.ValueCounts(); len(got) != 0 {
-		t.Fatalf("ValueCounts() = %v, want empty map", got)
+	entries, err := ReadManifest(file, bytes.NewReader(buf.Bytes()), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ReadManifest returned %d entries, want 1", len(entries))
 	}
 
-	if got := df.Partition()[1000]; got != nil {
+	if got := entries[0].DataFile().Partition()[1000]; got != nil {
 		t.Fatalf("Partition()[1000] = %v, want nil", got)
 	}
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -32,6 +32,7 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/avro"
+	"github.com/twmb/avro/atype"
 	"github.com/twmb/avro/ocf"
 )
 
@@ -1798,6 +1799,28 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 	m.Require().NoError(err)
 	m.NotEqual("null", string(md["partition-spec"]))
 	m.Equal("[]", string(md["partition-spec"]))
+}
+
+func TestDataFileInitializeMapDataHandlesNilLogicalPartitionValue(t *testing.T) {
+	df := &dataFile{
+		PartitionData: map[string]any{
+			"dt": nil,
+		},
+		fieldNameToID: map[string]int{
+			"dt": 1000,
+		},
+		fieldIDToLogicalType: map[int]string{
+			1000: atype.Date,
+		},
+	}
+
+	if got := df.ValueCounts(); len(got) != 0 {
+		t.Fatalf("ValueCounts() = %v, want empty map", got)
+	}
+
+	if got := df.Partition()[1000]; got != nil {
+		t.Fatalf("Partition()[1000] = %v, want nil", got)
+	}
 }
 
 func TestManifests(t *testing.T) {

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -539,7 +539,14 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 				return nil, fmt.Errorf("source field ID %d (partition field %q) not found in schema", pf.SourceID(), pf.Name)
 			}
 
-			lit, err := anyToLiteral(p[partFieldID])
+			value := p[partFieldID]
+			if value == nil {
+				conjuncts = append(conjuncts, iceberg.IsNull(iceberg.Reference(sourceField.Name)))
+
+				continue
+			}
+
+			lit, err := anyToLiteral(value)
 			if err != nil {
 				return nil, fmt.Errorf("partition field %q: %w", sourceField.Name, err)
 			}

--- a/table/partition_conflict_test.go
+++ b/table/partition_conflict_test.go
@@ -342,6 +342,42 @@ func TestRowDeltaValidate_SamePartitionRejected(t *testing.T) {
 	assert.ErrorIs(t, err, ErrConflictingDataFiles)
 }
 
+func TestRowDeltaValidate_NullIdentityPartitionRejected(t *testing.T) {
+	dir := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "dt", Type: iceberg.PrimitiveTypes.Date},
+	)
+
+	writerBaseID := int64(249)
+	baseMeta := partitionedConflictMeta(t, schema, 2, &writerBaseID)
+	concSnapshotID := int64(250)
+
+	spec := baseMeta.PartitionSpec()
+
+	nullPartition := map[int]any{}
+	for _, pf := range spec.Fields() {
+		nullPartition[pf.FieldID] = nil
+	}
+	mf := writeTestManifest(t, dir, spec, schema, concSnapshotID, nullPartition, dir+"/null-dt-data.parquet")
+	listPath := writeTestManifestList(t, dir, concSnapshotID, []iceberg.ManifestFile{mf})
+
+	ctx := buildPartitionedContext(t, baseMeta, listPath, writerBaseID, concSnapshotID)
+	require.Len(t, ctx.concurrent, 1)
+
+	eqDf, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentEqDeletes,
+		dir+"/null-dt-eq-del.parquet", iceberg.ParquetFile,
+		nullPartition, nil, nil, 1, 1024,
+	)
+	require.NoError(t, err)
+
+	err = validateNoConflictingDataFilesInPartitions(ctx, []iceberg.DataFile{eqDf.Build()}, IsolationSerializable)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConflictingDataFiles)
+}
+
 // ---------------------------------------------------------------------------
 // UUID partition column: same UUID rejected, different UUID allowed
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Fixes a panic when reading manifest partition data where avro returns a nil value for a logical partition field.

Previously, `convertAvroValueToIcebergType` could reach the `atype.Date` branch with a nil value and panic with:

interface conversion: interface {} is nil, not in32

This change return nil immediately when the Avro partition value is nil.

### Testing

Added a regresion test that builds a data file with a nil `dt` partition value mapped to field ID 1000 using Avro logical type `date` then calls `ValueCounts()` to exercise the same inilization path.

Verified with:

go test -run TestDataFileInitializeMapDataHandlesNilLogicalPartitionValue . 
go test ./... 
git diff --check