### PR TITLE
fix(table): do not claim sort_order_id on files the writer did not fully sort

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1483,9 +1483,8 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 	return dataFiles, nil
 }
 
-// fileToDataFile builds a DataFile for a pre-existing file (AddFiles and
-// ReplaceDataFiles take bare paths). The API gives the caller no way to
-// convey the file's sort layout, so no sort_order_id is claimed.
+// fileToDataFile builds a DataFile for a pre-existing file. The caller cannot
+// convey its sort layout, so no sort_order_id is claimed.
 func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties) iceberg.DataFile {
 	format := tblutils.FormatFromFileName(filePath)
 	rdr := must(format.Open(ctx, fileIO, filePath))

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1470,7 +1470,7 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 				}
 			}()
 
-			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.defaultSortOrderID, meta.props)
+			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.props)
 
 			return nil
 		})
@@ -1483,7 +1483,10 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 	return dataFiles, nil
 }
 
-func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, sortOrderID int, props iceberg.Properties) iceberg.DataFile {
+// fileToDataFile builds a DataFile for a pre-existing file (AddFiles and
+// ReplaceDataFiles take bare paths). The API gives the caller no way to
+// convey the file's sort layout, so no sort_order_id is claimed.
+func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties) iceberg.DataFile {
 	format := tblutils.FormatFromFileName(filePath)
 	rdr := must(format.Open(ctx, fileIO, filePath))
 	defer rdr.Close()
@@ -1526,7 +1529,6 @@ func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, curre
 		Content:         iceberg.EntryContentData,
 		FileSize:        rdr.SourceFileSize(),
 		PartitionValues: partitionValues,
-		SortOrderID:     sortOrderID,
 	})
 }
 
@@ -1749,7 +1751,6 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 					FileCount:   fileCount,
 					Schema:      iceberg.PositionalDeleteSchema,
 					Batches:     batch,
-					SortOrderID: meta.defaultSortOrderID,
 				}
 				if !yield(t) {
 					return

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -205,7 +205,6 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 				FileCount:   fileCount,
 				Schema:      deleteSchema,
 				Batches:     batch,
-				SortOrderID: meta.defaultSortOrderID,
 			}
 			if !yield(t) {
 				return

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -344,33 +344,6 @@ func TestMetricsPrimitiveTypes(t *testing.T) {
 	})
 }
 
-// TestToDataFilePanicsOnPosDeleteSortOrderClaim pins the spec invariant that
-// position delete files never carry a sort order id: a non-zero claim is a
-// caller bug and must be surfaced rather than silently dropped.
-func TestToDataFilePanicsOnPosDeleteSortOrderClaim(t *testing.T) {
-	format := internal.GetFileFormat(iceberg.ParquetFile)
-
-	meta, tblMeta := constructTestTablePrimitiveTypes(t)
-	require.NotNil(t, tblMeta)
-	require.NotNil(t, meta)
-
-	mapping, err := format.PathToIDMapping(tblMeta.CurrentSchema())
-	require.NoError(t, err)
-
-	stats := format.DataFileStatsFromMeta(internal.Metadata(meta), getCollector(), mapping, nil)
-	require.Panics(t, func() {
-		stats.ToDataFile(internal.DataFileOpts{
-			Schema:      tblMeta.CurrentSchema(),
-			Spec:        tblMeta.PartitionSpec(),
-			Path:        "fake-path.parquet",
-			Format:      iceberg.ParquetFile,
-			Content:     iceberg.EntryContentPosDeletes,
-			FileSize:    meta.GetSourceFileSize(),
-			SortOrderID: 7,
-		})
-	})
-}
-
 // TestNanosecondTimestampMetrics tests that nanosecond timestamp types (v3)
 // are correctly handled for Parquet stats collection and physical type mapping.
 func TestNanosecondTimestampMetrics(t *testing.T) {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -344,6 +344,33 @@ func TestMetricsPrimitiveTypes(t *testing.T) {
 	})
 }
 
+// TestToDataFilePanicsOnPosDeleteSortOrderClaim pins the spec invariant that
+// position delete files never carry a sort order id: a non-zero claim is a
+// caller bug and must be surfaced rather than silently dropped.
+func TestToDataFilePanicsOnPosDeleteSortOrderClaim(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	meta, tblMeta := constructTestTablePrimitiveTypes(t)
+	require.NotNil(t, tblMeta)
+	require.NotNil(t, meta)
+
+	mapping, err := format.PathToIDMapping(tblMeta.CurrentSchema())
+	require.NoError(t, err)
+
+	stats := format.DataFileStatsFromMeta(internal.Metadata(meta), getCollector(), mapping, nil)
+	require.Panics(t, func() {
+		stats.ToDataFile(internal.DataFileOpts{
+			Schema:      tblMeta.CurrentSchema(),
+			Spec:        tblMeta.PartitionSpec(),
+			Path:        "fake-path.parquet",
+			Format:      iceberg.ParquetFile,
+			Content:     iceberg.EntryContentPosDeletes,
+			FileSize:    meta.GetSourceFileSize(),
+			SortOrderID: 7,
+		})
+	})
+}
+
 // TestNanosecondTimestampMetrics tests that nanosecond timestamp types (v3)
 // are correctly handled for Parquet stats collection and physical type mapping.
 func TestNanosecondTimestampMetrics(t *testing.T) {

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -248,8 +248,15 @@ type DataFileOpts struct {
 	Content         iceberg.ManifestEntryContent
 	FileSize        int64
 	PartitionValues map[int]any
-	SortOrderID     int
+	// SortOrderID is a per-file claim that the file's rows are fully sorted
+	// by that order. Zero (the unsorted order) makes no claim and leaves the
+	// manifest field absent.
+	SortOrderID int
 }
+
+// unsortedSortOrderID mirrors table.UnsortedSortOrderID (order id 0 is
+// reserved for the unsorted order by the spec).
+const unsortedSortOrderID = 0
 
 func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 	var fieldIDToPartitionData map[int]any
@@ -330,7 +337,11 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 		bldr.EqualityFieldIDs(d.EqualityFieldIDs)
 	}
 
-	bldr.SortOrderID(opts.SortOrderID)
+	// Position deletes are ordered by (file_path, pos), never by a table sort
+	// order; the spec requires their sort order id to stay null.
+	if opts.SortOrderID != unsortedSortOrderID && opts.Content != iceberg.EntryContentPosDeletes {
+		bldr.SortOrderID(opts.SortOrderID)
+	}
 
 	return bldr.Build()
 }

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -248,14 +248,12 @@ type DataFileOpts struct {
 	Content         iceberg.ManifestEntryContent
 	FileSize        int64
 	PartitionValues map[int]any
-	// SortOrderID is a per-file claim that the file's rows are fully sorted
-	// by that order. Zero (the unsorted order) makes no claim and leaves the
-	// manifest field absent.
+	// SortOrderID claims the file's rows are fully sorted by that order; zero
+	// makes no claim and leaves the field absent.
 	SortOrderID int
 }
 
-// unsortedSortOrderID mirrors table.UnsortedSortOrderID (order id 0 is
-// reserved for the unsorted order by the spec).
+// unsortedSortOrderID mirrors table.UnsortedSortOrderID.
 const unsortedSortOrderID = 0
 
 func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
@@ -337,15 +335,7 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 		bldr.EqualityFieldIDs(d.EqualityFieldIDs)
 	}
 
-	// Position deletes are ordered by (file_path, pos), never by a table sort
-	// order; the spec requires their sort order id to stay null. This is an
-	// internal invariant, not user-input validation: no exported API accepts
-	// a WriteTask or reaches this package, and the pos-delete producers never
-	// set a claim — a non-zero value here is a library bug.
-	if opts.Content == iceberg.EntryContentPosDeletes && opts.SortOrderID != unsortedSortOrderID {
-		panic(fmt.Errorf("position delete file %q claims sort order id %d; the spec requires a null sort order id for position deletes",
-			opts.Path, opts.SortOrderID))
-	}
+	// Claim invariants are enforced upstream in defaultDataFileWriter.writeFile.
 	if opts.SortOrderID != unsortedSortOrderID {
 		bldr.SortOrderID(opts.SortOrderID)
 	}

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -338,8 +338,15 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 	}
 
 	// Position deletes are ordered by (file_path, pos), never by a table sort
-	// order; the spec requires their sort order id to stay null.
-	if opts.SortOrderID != unsortedSortOrderID && opts.Content != iceberg.EntryContentPosDeletes {
+	// order; the spec requires their sort order id to stay null. This is an
+	// internal invariant, not user-input validation: no exported API accepts
+	// a WriteTask or reaches this package, and the pos-delete producers never
+	// set a claim — a non-zero value here is a library bug.
+	if opts.Content == iceberg.EntryContentPosDeletes && opts.SortOrderID != unsortedSortOrderID {
+		panic(fmt.Errorf("position delete file %q claims sort order id %d; the spec requires a null sort order id for position deletes",
+			opts.Path, opts.SortOrderID))
+	}
+	if opts.SortOrderID != unsortedSortOrderID {
 		bldr.SortOrderID(opts.SortOrderID)
 	}
 

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -665,10 +665,8 @@ var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatch
 // ptr-helpers previously sprinkled across the internal package tests.
 func ptr[T any](v T) *T { return &v }
 
-// TestPositionDeleteUnpartitionedSortOrderID covers the unpartitioned branch
-// of positionDeleteRecordsToDataFiles: position deletes are ordered by
-// (file_path, pos), never by a table sort order, so the spec requires their
-// sort order id to stay null even when the table has a default sort order.
+// Position deletes are ordered by (file_path, pos), never by a table sort
+// order, so their sort order id stays null.
 func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
 	t.Parallel()
 
@@ -718,9 +716,8 @@ func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
 	}
 }
 
-// TestEqualityDeleteUnpartitionedSortOrderID covers the unpartitioned branch
-// of equalityDeleteRecordsToDataFiles: the writer does not order delete rows
-// by the table sort order, so the resulting DataFiles must not claim it.
+// The eq-delete writer does not order rows by the table sort order, so the
+// DataFiles must not claim it.
 func TestEqualityDeleteUnpartitionedSortOrderID(t *testing.T) {
 	t.Parallel()
 

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -74,7 +74,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "success",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 86, 2147483546: 172}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: ptr(1)},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 86, 2147483546: 172}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 1, specid: 0, contentType: iceberg.EntryContentPosDeletes},
 		},
 		// This test case illustrates how the positionDeletePartitionedFanoutWriter does not validate that all records
 		// in a batch have the same file path. Doing so would be prohibitive in the current implementation and
@@ -84,7 +84,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			name:                   "batch with records having different file paths",
 			pathToPartitionContext: map[string]partitionContext{"file://namespace/age_bucket=1/test.parquet": {partitionData: map[int]any{iceberg.PartitionDataIDStart: 1}, specID: 0}},
 			input:                  mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://namespace/age_bucket=1/test.parquet", "pos": 100}, {"file_path": "file://namespace/age_bucket=0/test.parquet", "pos": 10}]`),
-			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 94, 2147483546: 185}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes, sortOrderID: ptr(1)},
+			expectedDataFile:       &mockDataFile{columnSizes: map[int]int64{2147483545: 94, 2147483546: 185}, format: iceberg.ParquetFile, partition: map[int]any{iceberg.PartitionDataIDStart: 1}, count: 2, specid: 0, contentType: iceberg.EntryContentPosDeletes},
 		},
 	}
 
@@ -666,8 +666,9 @@ var defaultPositionDeleteMatching = []dataFileMatcherOption{withContentTypeMatch
 func ptr[T any](v T) *T { return &v }
 
 // TestPositionDeleteUnpartitionedSortOrderID covers the unpartitioned branch
-// of positionDeleteRecordsToDataFiles: the resulting DataFiles must carry
-// the table's default sort order id exactly like the partitioned branch does.
+// of positionDeleteRecordsToDataFiles: position deletes are ordered by
+// (file_path, pos), never by a table sort order, so the spec requires their
+// sort order id to stay null even when the table has a default sort order.
 func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
 	t.Parallel()
 
@@ -690,8 +691,7 @@ func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
 
 	built, err := metadataBuilder.Build()
 	require.NoError(t, err)
-	expectedID := built.DefaultSortOrder()
-	require.NotZero(t, expectedID, "sanity: sort order id should be non-zero")
+	require.NotZero(t, built.DefaultSortOrder(), "sanity: sort order id should be non-zero")
 
 	writeUUID := uuid.New()
 	rb := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, `[{"file_path": "file://unpartitioned/test.parquet", "pos": 0}]`)
@@ -714,14 +714,13 @@ func TestPositionDeleteUnpartitionedSortOrderID(t *testing.T) {
 	}
 	require.NotEmpty(t, files, "expected at least one data file")
 	for _, df := range files {
-		require.NotNil(t, df.SortOrderID(), "unpartitioned pos-delete DataFile must carry sort order id")
-		assert.Equal(t, expectedID, *df.SortOrderID())
+		assert.Nil(t, df.SortOrderID(), "pos-delete DataFile must have a null sort order id per spec")
 	}
 }
 
 // TestEqualityDeleteUnpartitionedSortOrderID covers the unpartitioned branch
-// of equalityDeleteRecordsToDataFiles: the resulting DataFiles must carry
-// the table's default sort order id.
+// of equalityDeleteRecordsToDataFiles: the writer does not order delete rows
+// by the table sort order, so the resulting DataFiles must not claim it.
 func TestEqualityDeleteUnpartitionedSortOrderID(t *testing.T) {
 	t.Parallel()
 
@@ -749,8 +748,7 @@ func TestEqualityDeleteUnpartitionedSortOrderID(t *testing.T) {
 
 	built, err := metadataBuilder.Build()
 	require.NoError(t, err)
-	expectedID := built.DefaultSortOrder()
-	require.NotZero(t, expectedID, "sanity: sort order id should be non-zero")
+	require.NotZero(t, built.DefaultSortOrder(), "sanity: sort order id should be non-zero")
 
 	delArrowSc, err := SchemaToArrowSchema(delSchema, nil, true, false)
 	require.NoError(t, err)
@@ -777,8 +775,7 @@ func TestEqualityDeleteUnpartitionedSortOrderID(t *testing.T) {
 	}
 	require.NotEmpty(t, files, "expected at least one data file")
 	for _, df := range files {
-		require.NotNil(t, df.SortOrderID(), "unpartitioned eq-delete DataFile must carry sort order id")
-		assert.Equal(t, expectedID, *df.SortOrderID())
+		assert.Nil(t, df.SortOrderID(), "eq-delete DataFile must not claim a sort order it was not written in")
 	}
 }
 

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -57,7 +57,6 @@ type writerFactory struct {
 	format           tblutils.FileFormat
 	content          iceberg.ManifestEntryContent
 	equalityFieldIDs []int
-	sortOrderID      int
 	sortKeys         []compute.SortKey
 
 	writers               sync.Map
@@ -165,7 +164,6 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		format:         format,
 		nextCount:      nextCount,
 		stopCount:      stopCount,
-		sortOrderID:    meta.defaultSortOrderID,
 	}
 	for _, apply := range opts {
 		apply(f)
@@ -178,8 +176,8 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		return nil, err
 	}
 
-	if f.content == iceberg.EntryContentData && f.sortOrderID != UnsortedSortOrderID {
-		sortOrder, err := meta.GetSortOrderByID(f.sortOrderID)
+	if f.content == iceberg.EntryContentData && meta.defaultSortOrderID != UnsortedSortOrderID {
+		sortOrder, err := meta.GetSortOrderByID(meta.defaultSortOrderID)
 		if err != nil {
 			stopCount()
 
@@ -221,6 +219,9 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		filePath = w.locProvider.NewDataLocation(fileName)
 	}
 
+	// SortOrderID is intentionally left unset: batches are only sorted
+	// individually (see resolveSortKeys), which does not satisfy the spec's
+	// per-file sort_order_id contract.
 	return w.format.NewFileWriter(ctx, w.fs, partitionValues, tblutils.WriteFileInfo{
 		FileSchema:       w.fileSchema,
 		FileName:         filePath,
@@ -229,7 +230,6 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		Spec:             w.currentSpec,
 		Content:          w.content,
 		EqualityFieldIDs: w.equalityFieldIDs,
-		SortOrderID:      w.sortOrderID,
 	}, w.arrowSchema)
 }
 

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -201,12 +201,9 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 	cnt, _ := w.nextCount()
 	w.countMu.Unlock()
 
-	fileName := WriteTask{
-		Uuid:        *w.writeUUID,
-		ID:          cnt,
-		PartitionID: partitionID,
-		FileCount:   fileCount,
-	}.GenerateDataFileName(strings.ToLower(string(w.fileFormat)))
+	// Names files directly, not via WriteTask: it has no per-task sort claim.
+	fileName := dataFileName(*w.writeUUID, cnt, partitionID, fileCount,
+		strings.ToLower(string(w.fileFormat)))
 
 	var filePath string
 	if partitionPath != "" {
@@ -219,9 +216,7 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		filePath = w.locProvider.NewDataLocation(fileName)
 	}
 
-	// SortOrderID is intentionally left unset: batches are only sorted
-	// individually (see resolveSortKeys), which does not satisfy the spec's
-	// per-file sort_order_id contract.
+	// No SortOrderID: batches are sorted only individually (see resolveSortKeys).
 	return w.format.NewFileWriter(ctx, w.fs, partitionValues, tblutils.WriteFileInfo{
 		FileSchema:       w.fileSchema,
 		FileName:         filePath,

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -243,11 +243,11 @@ func (s *RollingDataWriterTestSuite) TestBytesWrittenNoDoubleCountAcrossRowGroup
 		"DataFile.FileSizeBytes should match actual file size on disk")
 }
 
-// TestWriterFactoryPropagatesSortOrderID covers the standard data write path:
-// the rolling data writer must stamp each emitted DataFile with the table's
-// default sort order id, mirroring how the partitioned fanout writer uses
-// writerFactory under the hood.
-func (s *RollingDataWriterTestSuite) TestWriterFactoryPropagatesSortOrderID() {
+// TestWriterFactoryDoesNotStampSortOrderID covers the standard data write
+// path: the rolling data writer sorts only per batch, so the emitted DataFile
+// must NOT claim the table's default sort order id — the spec's per-file
+// sort_order_id asserts the whole file is sorted by that order.
+func (s *RollingDataWriterTestSuite) TestWriterFactoryDoesNotStampSortOrderID() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
@@ -276,8 +276,8 @@ func (s *RollingDataWriterTestSuite) TestWriterFactoryPropagatesSortOrderID() {
 	s.Require().NoError(metaBuilder.SetDefaultSortOrderID(-1))
 	builtMeta, err := metaBuilder.Build()
 	s.Require().NoError(err)
-	expectedSortOrderID := builtMeta.DefaultSortOrder()
-	s.Require().NotEqual(UnsortedSortOrderID, expectedSortOrderID, "sanity: sort order id should be non-zero")
+	s.Require().NotEqual(UnsortedSortOrderID, builtMeta.DefaultSortOrder(),
+		"sanity: sort order id should be non-zero")
 
 	writeUUID := uuid.New()
 	args := recordWritingArgs{
@@ -313,8 +313,8 @@ func (s *RollingDataWriterTestSuite) TestWriterFactoryPropagatesSortOrderID() {
 	}
 
 	s.Require().Len(dataFiles, 1)
-	s.Require().NotNil(dataFiles[0].SortOrderID(), "SortOrderID must be set on the emitted DataFile")
-	s.Equal(expectedSortOrderID, *dataFiles[0].SortOrderID())
+	s.Nil(dataFiles[0].SortOrderID(),
+		"emitted DataFile must not claim a sort order id: batches are only sorted individually")
 }
 
 func (s *RollingDataWriterTestSuite) TestAbortWithZeroRowsWritten() {

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -243,10 +243,8 @@ func (s *RollingDataWriterTestSuite) TestBytesWrittenNoDoubleCountAcrossRowGroup
 		"DataFile.FileSizeBytes should match actual file size on disk")
 }
 
-// TestWriterFactoryDoesNotStampSortOrderID covers the standard data write
-// path: the rolling data writer sorts only per batch, so the emitted DataFile
-// must NOT claim the table's default sort order id — the spec's per-file
-// sort_order_id asserts the whole file is sorted by that order.
+// The rolling path sorts per batch but takes no per-task claim, so the emitted
+// DataFile must not claim the table's sort order even when one is set.
 func (s *RollingDataWriterTestSuite) TestWriterFactoryDoesNotStampSortOrderID() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/sort_keys.go
+++ b/table/sort_keys.go
@@ -34,13 +34,9 @@ import (
 //
 // Limitations:
 //
-//   - Per-batch, not per-file: the resolved keys are applied to each record
-//     batch independently as it is flushed; rows are not merged into a single
-//     globally sorted run across batches within a file. Because of this the
-//     written files do not record a sort_order_id — the spec's per-file field
-//     asserts the whole file is sorted by that order. The per-batch sort is
-//     purely a layout optimization (tighter page statistics, better
-//     encodings).
+//   - Per-batch, not per-file: keys are applied to each batch independently,
+//     not merged into a globally sorted run across batches. Files therefore
+//     record no sort_order_id, which asserts the whole file is sorted.
 //   - Bucket transform falls back to source-column order, since the hash
 //     bucket is not order-preserving.
 //   - Multi-argument transform sort fields use only the first source column.

--- a/table/sort_keys.go
+++ b/table/sort_keys.go
@@ -32,14 +32,17 @@ import (
 // Returns nil keys for an unsorted SortOrder. Returns an error when a sort
 // field's source id is not a top-level column of fileSchema.
 //
-// Limitations (these match PyIceberg's current behavior):
+// Limitations:
 //
 //   - Per-batch, not per-file: the resolved keys are applied to each record
 //     batch independently as it is flushed; rows are not merged into a single
-//     globally sorted run across batches within a file.
+//     globally sorted run across batches within a file. Because of this the
+//     written files do not record a sort_order_id — the spec's per-file field
+//     asserts the whole file is sorted by that order. The per-batch sort is
+//     purely a layout optimization (tighter page statistics, better
+//     encodings).
 //   - Bucket transform falls back to source-column order, since the hash
-//     bucket is not order-preserving. The manifest entry still records the
-//     table's sort_order_id verbatim.
+//     bucket is not order-preserving.
 //   - Multi-argument transform sort fields use only the first source column.
 //   - Nested-field sort sources are not supported: a source id that is not a
 //     top-level column of fileSchema is rejected with an error.

--- a/table/write_records_sort_test.go
+++ b/table/write_records_sort_test.go
@@ -138,8 +138,7 @@ func (s *WriteRecordsSortTestSuite) TestPartitionedTableSortedPerFile() {
 	}
 
 	for _, df := range dataFiles {
-		// The writer only sorts per batch, so it never claims the table sort
-		// order on the file (the spec's sort_order_id is a per-file claim).
+		// Per-batch sorting only, so no per-file sort order claim.
 		s.Nil(df.SortOrderID(), "data file must not claim a sort order id")
 
 		ids, cats := readIDsAndCategories(s.T(), df.FilePath())
@@ -196,8 +195,9 @@ func (s *WriteRecordsSortTestSuite) TestUnpartitionedTableMultipleBatchesEachSor
 		return rec
 	}
 
-	batch1 := makeBatch([]int32{3, 1, 2})
-	batch2 := makeBatch([]int32{6, 4, 5})
+	// Interleaved ranges, so per-batch and global sort give different results.
+	batch1 := makeBatch([]int32{5, 3, 1})
+	batch2 := makeBatch([]int32{4, 2, 0})
 	records := func(yield func(arrow.RecordBatch, error) bool) {
 		if !yield(batch1, nil) {
 			return
@@ -213,10 +213,9 @@ func (s *WriteRecordsSortTestSuite) TestUnpartitionedTableMultipleBatchesEachSor
 	s.Require().Len(dataFiles, 1)
 
 	ids, _ := readIDsAndCategories(s.T(), dataFiles[0].FilePath())
-	// Two locally-sorted runs concatenated: [1,2,3] then [4,5,6]. The
-	// boundary between them isn't a global sort, but each run is sorted.
-	s.Equal([]int32{1, 2, 3, 4, 5, 6}, ids,
-		"each batch is sorted independently and emitted in arrival order")
+	// Runs concatenated in arrival order; a global sort would give [0..5].
+	s.Equal([]int32{1, 3, 5, 0, 2, 4}, ids,
+		"batches are sorted independently and emitted in arrival order, not merged")
 }
 
 func readIDsAndCategories(t *testing.T, path string) ([]int32, []string) {

--- a/table/write_records_sort_test.go
+++ b/table/write_records_sort_test.go
@@ -138,8 +138,9 @@ func (s *WriteRecordsSortTestSuite) TestPartitionedTableSortedPerFile() {
 	}
 
 	for _, df := range dataFiles {
-		s.NotNil(df.SortOrderID(), "data file must carry the sort order id")
-		s.Equal(meta.DefaultSortOrder(), *df.SortOrderID())
+		// The writer only sorts per batch, so it never claims the table sort
+		// order on the file (the spec's sort_order_id is a per-file claim).
+		s.Nil(df.SortOrderID(), "data file must not claim a sort order id")
 
 		ids, cats := readIDsAndCategories(s.T(), df.FilePath())
 		s.Require().NotEmpty(cats, "file should have at least one row")

--- a/table/writer.go
+++ b/table/writer.go
@@ -40,7 +40,11 @@ type WriteTask struct {
 	Batches     []arrow.RecordBatch
 	// SortOrderID, when non-zero, is recorded on the resulting file as its
 	// sort order. Set it only when Batches are fully sorted by that order —
-	// the writer does not verify or enforce the claim.
+	// the writer does not verify or enforce the claim. Only the bin-packed
+	// task path (defaultDataFileWriter.writeFile) honors it; the rolling
+	// data writer builds its own file info and ignores it, and position
+	// delete content must leave it zero (the spec requires a null sort
+	// order id there).
 	SortOrderID int
 }
 

--- a/table/writer.go
+++ b/table/writer.go
@@ -31,6 +31,8 @@ import (
 	"github.com/google/uuid"
 )
 
+// WriteTask writes all its Batches into one file. The rolling writer bypasses
+// it, naming files via dataFileName directly.
 type WriteTask struct {
 	Uuid        uuid.UUID
 	ID          int
@@ -38,21 +40,20 @@ type WriteTask struct {
 	FileCount   int // FileCount is a sequential counter for files written by this task.
 	Schema      *iceberg.Schema
 	Batches     []arrow.RecordBatch
-	// SortOrderID, when non-zero, is recorded on the resulting file as its
-	// sort order. Set it only when Batches are fully sorted by that order —
-	// the writer does not verify or enforce the claim. Only the bin-packed
-	// task path (defaultDataFileWriter.writeFile) honors it; the rolling
-	// data writer builds its own file info and ignores it, and position
-	// delete content must leave it zero (the spec requires a null sort
-	// order id there).
+	// SortOrderID claims Batches are globally sorted by that order; writeFile
+	// records it unverified. Must stay zero for position deletes.
 	SortOrderID int
 }
 
 func (w WriteTask) GenerateDataFileName(extension string) string {
-	// Mimics the behavior in the Java API:
-	// https://github.com/apache/iceberg/blob/03ed4ba9af4e47d32bdb22b7e3d033eb2a4b2c83/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java#L93
-	// Format: {partitionId:05d}-{taskId}-{operationId}-{fileCount:05d}.{extension}
-	return fmt.Sprintf("%05d-%d-%s-%05d.%s", w.PartitionID, w.ID, w.Uuid, w.FileCount, extension)
+	return dataFileName(w.Uuid, w.ID, w.PartitionID, w.FileCount, extension)
+}
+
+// dataFileName builds a data file name, mirroring the Java API:
+// https://github.com/apache/iceberg/blob/03ed4ba9af4e47d32bdb22b7e3d033eb2a4b2c83/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java#L93
+// Format: {partitionId:05d}-{taskId}-{operationId}-{fileCount:05d}.{extension}
+func dataFileName(writeUUID uuid.UUID, taskID, partitionID, fileCount int, extension string) string {
+	return fmt.Sprintf("%05d-%d-%s-%05d.%s", partitionID, taskID, writeUUID, fileCount, extension)
 }
 
 type defaultDataFileWriter struct {
@@ -128,6 +129,12 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 			b.Release()
 		}
 	}()
+
+	// Reject here on the caller's goroutine, not deep in the writer's Close().
+	if task.SortOrderID != UnsortedSortOrderID && w.content == iceberg.EntryContentPosDeletes {
+		return nil, fmt.Errorf("position delete file claims sort order id %d; the spec requires a null sort order id for position deletes",
+			task.SortOrderID)
+	}
 
 	batches := make([]arrow.RecordBatch, len(task.Batches))
 	for i, b := range task.Batches {

--- a/table/writer.go
+++ b/table/writer.go
@@ -38,6 +38,9 @@ type WriteTask struct {
 	FileCount   int // FileCount is a sequential counter for files written by this task.
 	Schema      *iceberg.Schema
 	Batches     []arrow.RecordBatch
+	// SortOrderID, when non-zero, is recorded on the resulting file as its
+	// sort order. Set it only when Batches are fully sorted by that order —
+	// the writer does not verify or enforce the claim.
 	SortOrderID int
 }
 

--- a/table/writer_test.go
+++ b/table/writer_test.go
@@ -169,10 +169,8 @@ func TestGenerateDataFileNameUniqueness(t *testing.T) {
 	}
 }
 
-// TestWriteFileHonorsExplicitSortOrderID covers the one path where
-// WriteTask.SortOrderID is load-bearing: defaultDataFileWriter.writeFile must
-// record a caller's non-zero claim on the resulting DataFile, and must record
-// nothing when the task makes no claim.
+// writeFile records a non-zero WriteTask.SortOrderID on the DataFile, nothing
+// when the task makes no claim.
 func TestWriteFileHonorsExplicitSortOrderID(t *testing.T) {
 	t.Parallel()
 
@@ -233,4 +231,37 @@ func TestWriteFileHonorsExplicitSortOrderID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, df.SortOrderID())
 	})
+}
+
+// A sort order claim on position delete content is rejected with an error, not
+// a panic deep in the file writer's Close().
+func TestWriteFileRejectsPosDeleteSortOrderClaim(t *testing.T) {
+	t.Parallel()
+
+	metadataBuilder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSchema(iceberg.PositionalDeleteSchema))
+	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
+	unpartitioned := *iceberg.UnpartitionedSpec
+	require.NoError(t, metadataBuilder.AddPartitionSpec(&unpartitioned, true))
+	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
+
+	writer, err := newPositionDeleteWriter(t.TempDir(), &io.LocalFS{}, metadataBuilder, iceberg.Properties{})
+	require.NoError(t, err)
+
+	rb := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema,
+		`[{"file_path": "file://t/data.parquet", "pos": 0}]`)
+	task := WriteTask{
+		Uuid:        uuid.New(),
+		ID:          0,
+		FileCount:   1,
+		Schema:      iceberg.PositionalDeleteSchema,
+		Batches:     []arrow.RecordBatch{rb},
+		SortOrderID: 1,
+	}
+
+	df, err := writer.writeFile(t.Context(), nil, task)
+	require.Error(t, err, "a sort order claim on position delete content must be rejected")
+	assert.Nil(t, df)
+	assert.Contains(t, err.Error(), "position delete")
 }

--- a/table/writer_test.go
+++ b/table/writer_test.go
@@ -20,6 +20,9 @@ package table
 import (
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,4 +167,70 @@ func TestGenerateDataFileNameUniqueness(t *testing.T) {
 		assert.False(t, seen[f], "filename %s should be unique", f)
 		seen[f] = true
 	}
+}
+
+// TestWriteFileHonorsExplicitSortOrderID covers the one path where
+// WriteTask.SortOrderID is load-bearing: defaultDataFileWriter.writeFile must
+// record a caller's non-zero claim on the resulting DataFile, and must record
+// nothing when the task makes no claim.
+func TestWriteFileHonorsExplicitSortOrderID(t *testing.T) {
+	t.Parallel()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	metadataBuilder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSchema(schema))
+	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
+	unpartitioned := *iceberg.UnpartitionedSpec
+	require.NoError(t, metadataBuilder.AddPartitionSpec(&unpartitioned, true))
+	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
+	sortOrder, err := NewSortOrder(1, []SortField{{
+		SourceIDs: []int{1},
+		Direction: SortASC,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: NullsFirst,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSortOrder(&sortOrder))
+	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(-1))
+
+	built, err := metadataBuilder.Build()
+	require.NoError(t, err)
+	claimedID := built.DefaultSortOrder()
+	require.NotZero(t, claimedID, "sanity: sort order id should be non-zero")
+
+	arrowSc, err := SchemaToArrowSchema(schema, nil, true, false)
+	require.NoError(t, err)
+
+	writer, err := newDataFileWriter(t.TempDir(), &io.LocalFS{}, metadataBuilder, iceberg.Properties{})
+	require.NoError(t, err)
+
+	writeTask := func(id, sortOrderID int) WriteTask {
+		rb := mustLoadRecordBatchFromJSON(arrowSc, `[{"id": 2}, {"id": 1}]`)
+
+		return WriteTask{
+			Uuid:        uuid.New(),
+			ID:          id,
+			FileCount:   1,
+			Schema:      schema,
+			Batches:     []arrow.RecordBatch{rb},
+			SortOrderID: sortOrderID,
+		}
+	}
+
+	t.Run("non-zero claim lands on the data file", func(t *testing.T) {
+		df, err := writer.writeFile(t.Context(), nil, writeTask(0, claimedID))
+		require.NoError(t, err)
+		require.NotNil(t, df.SortOrderID(), "explicit claim must be recorded on the DataFile")
+		assert.Equal(t, claimedID, *df.SortOrderID())
+	})
+
+	t.Run("zero claim leaves the field absent", func(t *testing.T) {
+		df, err := writer.writeFile(t.Context(), nil, writeTask(1, UnsortedSortOrderID))
+		require.NoError(t, err)
+		assert.Nil(t, df.SortOrderID())
+	})
 }


### PR DESCRIPTION
The per-file sort_order_id declares that a file's rows are *fully* sorted by that order; a missing id means unsorted (https://iceberg.apache.org/spec/#sorting). Since #875 every writer stamped the table's default sort order id unconditionally, but #1157's sort-on-write only sorts each record batch individually, so the claim was false for any multi-batch file. Position delete files were stamped too, which the spec forbids outright, their order is (file_path, pos) and writers must set the field to null (https://iceberg.apache.org/spec/#data-file-fields). This contradicts the community consensus: Spark stamps the id *only* when its distribution+ordering globally sorted the whole task input, never inferring it from the table default (https://github.com/apache/iceberg/pull/15150).

This change makes writers claim nothing by default: data files, eq-delete files, pos-delete files, and registered files (add_files) leave sort_order_id absent, matching PyIceberg and iceberg-rust. The per-batch sort is kept as a pure layout optimization (tighter page statistics, better encodings). WriteTask.SortOrderID remains as an explicit caller claim for producers that guarantee fully sorted batches, mirroring how Java/Spark stamps the id only when the engine enforced the ordering. Leaving the field absent is fully spec-compliant, it was always advisory and never assumed applied to all files (https://github.com/apache/iceberg/issues/317). The only incorrect behavior is stamping a claim that isn't true, which a reader could trust to wrongly skip a re-sort.

References: https://github.com/apache/iceberg/issues/13634, https://github.com/apache/iceberg/pull/15150, https://github.com/apache/iceberg/issues/317, https://iceberg.apache.org/spec/#sorting