### PR TITLE
refactor(catalog): Minimize functions in interface for Hadoop catalog

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -793,5 +793,6 @@ func (c *Catalog) CheckedMkdirAll(id table.Identifier) error {
 		// it means that it must already exist
 		return fs.ErrExist
 	}
+
 	return c.filesystem.MkdirAll(path)
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -363,11 +363,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	metaDir := c.metadataDir(ident)
-	if err := c.validSubpaths(ident, false); err != nil {
-		return nil, err
-	}
-
-	if err := c.filesystem.MkdirAll(metaDir); err != nil {
+	if err := c.CheckedMkdirAll(ident, false); err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 
@@ -493,10 +489,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 	// Step 7: Create metadata directory if needed (create-via-commit).
 	metaDir := c.metadataDir(ident)
-	if err := c.validSubpaths(ident, false); err != nil {
-		return nil, "", err
-	}
-	if err := c.filesystem.MkdirAll(metaDir); err != nil {
+	if err := c.CheckedMkdirAll(ident, false); err != nil {
 		return nil, "", fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 
@@ -631,16 +624,20 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 		return errors.New("hadoop catalog: namespace properties are not supported")
 	}
 
-	path := c.namespaceToPath(ns)
-
 	// Raise an error if the namespace already exists
-	if err := c.validSubpaths(ns, true); err != nil {
-		return err
-	}
+	if err := c.CheckedMkdirAll(ns, true); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+		}
 
-	if err := c.filesystem.MkdirAll(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: parent namespace does not exist for %s",
+				catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
+		}
+
 		return fmt.Errorf("hadoop catalog: failed to create namespace: %w", err)
 	}
+
 	return nil
 }
 
@@ -776,28 +773,23 @@ func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifie
 	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
 }
 
-// Helper function for checking that all subpaths in a path exist and that the
-// final path does not already exist.
-// this means that all parent namespaces must already exist, and the target namespace
-// itself must not already exist; this should be used before calls like MkdirAll
-// which don't raise errors if the target already exists.
-func (c *Catalog) validSubpaths(ns table.Identifier, errorIfExists bool) error {
-	path := c.namespaceToPath(ns)
-	for pathIndex := range ns {
-		subPath := ns[:pathIndex]
+// CheckedMkdirAll is a helper function that checkes
+// all subdirectories of a given identifier path exist before creting the full path.
+// If errIfExists is true, it also checks that the full path does not already exist before creating it.
+func (c *Catalog) CheckedMkdirAll(id table.Identifier, errIfExists bool) error {
+	path := c.namespaceToPath(id)
+	for pathIndex := range id {
+		subPath := id[:pathIndex]
 		parentPath := c.namespaceToPath(subPath)
-		_, err := c.filesystem.Stat(parentPath)
-		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("%w: parent namespace does not exist for %s", catalog.ErrNoSuchNamespace, strings.Join(subPath, "."))
-		}
-		if err != nil {
-			return fmt.Errorf("hadoop catalog: failed to stat parent namespace: %w", err)
+		if _, err := c.filesystem.Stat(parentPath); err != nil {
+			return err
 		}
 	}
-	if errorIfExists {
+	if errIfExists {
 		if _, err := c.filesystem.Stat(path); err == nil {
-			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+			return err
 		}
 	}
-	return nil
+	return c.filesystem.MkdirAll(path)
+
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -215,7 +215,6 @@ func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 
 		return nil
 	})
-
 	if err != nil {
 		return false
 	}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -188,7 +188,7 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 	metaDir := filepath.Join(path, "metadata")
 
-	found_metadata := false
+	foundMetadata := false
 	err := filesystem.WalkDir(metaDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -208,7 +208,7 @@ func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 		if versionPattern.MatchString(name) ||
 			uuidMetadataPattern.MatchString(name) ||
 			name == "version-hint.text" {
-			found_metadata = true
+			foundMetadata = true
 
 			return fs.SkipAll
 		}
@@ -216,11 +216,11 @@ func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 		return nil
 	})
 
-	if err != nil && err != fs.SkipAll {
+	if err != nil {
 		return false
 	}
 
-	return found_metadata
+	return foundMetadata
 }
 
 func (c *Catalog) readVersionHint(ident table.Identifier) int {
@@ -566,13 +566,13 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 
 			// Skip anything that is not a table directory.
 			if !isTableDir(c.filesystem, path) {
-				return nil
+				return fs.SkipDir
 			}
 			ident := make(table.Identifier, len(ns)+1)
 			copy(ident, ns)
 			ident[len(ns)] = d.Name()
 			if !yield(ident, nil) {
-				return nil
+				return fs.SkipAll
 			}
 
 			return nil
@@ -627,7 +627,7 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 	}
 
 	// Raise an error if the namespace already exists
-	if err := c.CheckedMkdirAll(ns, true); err != nil {
+	if err := c.CheckedMkdirAll(ns); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
 		}
@@ -774,10 +774,11 @@ func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifie
 	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
 }
 
-// CheckedMkdirAll is a helper function that checkes
-// all subdirectories of a given identifier path exist before creting the full path.
-// If errIfExists is true, it also checks that the full path does not already exist before creating it.
-func (c *Catalog) CheckedMkdirAll(id table.Identifier, errIfExists bool) error {
+// CheckedMkdirAll is a helper function that checks
+// all subdirectories of a given identifier path exist before creating the full path.
+// This function is not atomic and may not return ErrNamespaceAlreadyExists if
+// called concurrently with other calls that change the same identifier
+func (c *Catalog) CheckedMkdirAll(id table.Identifier) error {
 	path := c.namespaceToPath(id)
 	for pathIndex := range id {
 		subPath := id[:pathIndex]
@@ -786,13 +787,11 @@ func (c *Catalog) CheckedMkdirAll(id table.Identifier, errIfExists bool) error {
 			return err
 		}
 	}
-	if errIfExists {
-		if _, err := c.filesystem.Stat(path); err == nil {
-			// If there is no error and stat returns successfully,
-			// it means that it must already exist
-			return fs.ErrExist
-		}
+	// Check the final element in the path
+	if _, err := c.filesystem.Stat(path); err == nil {
+		// If there is no error and stat returns successfully,
+		// it means that it must already exist
+		return fs.ErrExist
 	}
-
 	return c.filesystem.MkdirAll(path)
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -363,7 +363,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	metaDir := c.metadataDir(ident)
-	if err := c.CheckedMkdirAll(ident, false); err != nil {
+	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 
@@ -489,7 +489,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 	// Step 7: Create metadata directory if needed (create-via-commit).
 	metaDir := c.metadataDir(ident)
-	if err := c.CheckedMkdirAll(ident, false); err != nil {
+	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, "", fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
 

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -788,7 +788,9 @@ func (c *Catalog) CheckedMkdirAll(id table.Identifier, errIfExists bool) error {
 	}
 	if errIfExists {
 		if _, err := c.filesystem.Stat(path); err == nil {
-			return err
+			// If there is no error and stat returns successfully,
+			// it means that it must already exist
+			return fs.ErrExist
 		}
 	}
 

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -188,25 +188,38 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 	metaDir := filepath.Join(path, "metadata")
 
-	entries, err := filesystem.ReadDir(metaDir)
-	if err != nil {
-		return false
-	}
-
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	found_metadata := false
+	err := filesystem.WalkDir(metaDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
 
-		name := e.Name()
+		// Skip the root itself.
+		if path == metaDir {
+			return nil
+		}
+
+		// Don't descend into subdirectories.
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+
+		name := d.Name()
 		if versionPattern.MatchString(name) ||
 			uuidMetadataPattern.MatchString(name) ||
 			name == "version-hint.text" {
-			return true
+			found_metadata = true
+			return fs.SkipAll
 		}
+
+		return nil
+	})
+
+	if err != nil && err != fs.SkipAll {
+		return false
 	}
 
-	return false
+	return found_metadata
 }
 
 func (c *Catalog) readVersionHint(ident table.Identifier) int {
@@ -275,25 +288,34 @@ func (c *Catalog) findVersion(ident table.Identifier) (int, error) {
 
 	dir := c.metadataDir(ident)
 
-	entries, err := c.filesystem.ReadDir(dir)
-	if err != nil {
-		return 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w",
-			strings.Join(ident, "."), catalog.ErrNoSuchTable)
-	}
-
 	maxVer := 0
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	// Walk just one directory level to find metadata files,
+	// ignoring any subdirectories that may exist
+	err := c.filesystem.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == dir {
+			return nil
+		}
+		if d.IsDir() {
+			return fs.SkipDir
 		}
 
-		matches := versionPattern.FindStringSubmatch(e.Name())
+		name := d.Name()
+		matches := versionPattern.FindStringSubmatch(name)
 		if len(matches) == 2 {
 			v, _ := strconv.Atoi(matches[1])
 			if v > maxVer {
 				maxVer = v
 			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w",
+			strings.Join(ident, "."), catalog.ErrNoSuchTable)
 	}
 
 	if maxVer == 0 {
@@ -341,6 +363,10 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	metaDir := c.metadataDir(ident)
+	if err := c.validSubpaths(ident, false); err != nil {
+		return nil, err
+	}
+
 	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
@@ -467,6 +493,9 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 	// Step 7: Create metadata directory if needed (create-via-commit).
 	metaDir := c.metadataDir(ident)
+	if err := c.validSubpaths(ident, false); err != nil {
+		return nil, "", err
+	}
 	if err := c.filesystem.MkdirAll(metaDir); err != nil {
 		return nil, "", fmt.Errorf("hadoop catalog: failed to create metadata directory: %w", err)
 	}
@@ -526,29 +555,37 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 			return
 		}
 
-		entries, err := c.filesystem.ReadDir(nsPath)
-		if err != nil {
-			yield(nil, fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err))
-
-			return
-		}
-
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
+		err = c.filesystem.WalkDir(nsPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
 
-			child := filepath.Join(nsPath, e.Name())
-			if !isTableDir(c.filesystem, child) {
-				continue
+			// Anything that is a file is not a namespace or table, so skip it.
+			if !d.IsDir() {
+				return nil
 			}
 
+			// Skip the namespace directory itself.
+			if path == nsPath {
+				return nil
+			}
+
+			// Skip anything that is not a table directory.
+			if !isTableDir(c.filesystem, path) {
+				return nil
+			}
 			ident := make(table.Identifier, len(ns)+1)
 			copy(ident, ns)
-			ident[len(ns)] = e.Name()
+			ident[len(ns)] = d.Name()
 			if !yield(ident, nil) {
-				return
+				return nil
 			}
+
+			return nil
+		})
+		if err != nil {
+			yield(nil, fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err))
+			return
 		}
 	}
 }
@@ -596,19 +633,14 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 
 	path := c.namespaceToPath(ns)
 
-	if err := c.filesystem.Mkdir(path); err != nil {
-		if errors.Is(err, fs.ErrExist) {
-			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
-		}
-
-		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("%w: parent namespace does not exist for %s",
-				catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
-		}
-
-		return fmt.Errorf("hadoop catalog: failed to create namespace: %w", err)
+	// Raise an error if the namespace already exists
+	if err := c.validSubpaths(ns, true); err != nil {
+		return err
 	}
 
+	if err := c.filesystem.MkdirAll(path); err != nil {
+		return fmt.Errorf("hadoop catalog: failed to create namespace: %w", err)
+	}
 	return nil
 }
 
@@ -619,7 +651,21 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 	path := c.namespaceToPath(ns)
 
-	entries, err := c.filesystem.ReadDir(path)
+	foundEntries := false
+	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if p == path {
+			return nil
+		}
+
+		foundEntries = true
+
+		return fs.SkipAll
+	})
+
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
@@ -628,7 +674,7 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 		return fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err)
 	}
 
-	if len(entries) > 0 {
+	if foundEntries {
 		return fmt.Errorf("%w: %s", catalog.ErrNamespaceNotEmpty, strings.Join(ns, "."))
 	}
 
@@ -674,23 +720,29 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 		}
 	}
 
-	entries, err := c.filesystem.ReadDir(path)
+	result := []table.Identifier{}
+	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == path {
+			return nil
+		}
+
+		if !d.IsDir() {
+			// skip plain files
+			return nil
+		}
+		if isTableDir(c.filesystem, p) {
+			// if a table, not a namespace, don't descend
+			return fs.SkipDir
+		}
+		result = append(result, table.Identifier{d.Name()})
+		// found a namespace dir, don't recurse into it
+		return fs.SkipDir
+	})
 	if err != nil {
 		return nil, fmt.Errorf("hadoop catalog: failed to read directory: %w", err)
-	}
-
-	result := []table.Identifier{}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-
-		child := filepath.Join(path, e.Name())
-		if isTableDir(c.filesystem, child) {
-			continue
-		}
-
-		result = append(result, table.Identifier{e.Name()})
 	}
 
 	return result, nil
@@ -722,4 +774,30 @@ func (c *Catalog) LoadNamespaceProperties(_ context.Context, ns table.Identifier
 
 func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifier, _ []string, _ iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
 	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
+}
+
+// Helper function for checking that all subpaths in a path exist and that the
+// final path does not already exist.
+// this means that all parent namespaces must already exist, and the target namespace
+// itself must not already exist; this should be used before calls like MkdirAll
+// which don't raise errors if the target already exists.
+func (c *Catalog) validSubpaths(ns table.Identifier, errorIfExists bool) error {
+	path := c.namespaceToPath(ns)
+	for pathIndex := range ns {
+		subPath := ns[:pathIndex]
+		parentPath := c.namespaceToPath(subPath)
+		_, err := c.filesystem.Stat(parentPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: parent namespace does not exist for %s", catalog.ErrNoSuchNamespace, strings.Join(subPath, "."))
+		}
+		if err != nil {
+			return fmt.Errorf("hadoop catalog: failed to stat parent namespace: %w", err)
+		}
+	}
+	if errorIfExists {
+		if _, err := c.filesystem.Stat(path); err == nil {
+			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
+		}
+	}
+	return nil
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -209,6 +209,7 @@ func isTableDir(filesystem HadoopCatalogFS, path string) bool {
 			uuidMetadataPattern.MatchString(name) ||
 			name == "version-hint.text" {
 			found_metadata = true
+
 			return fs.SkipAll
 		}
 
@@ -578,6 +579,7 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 		})
 		if err != nil {
 			yield(nil, fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err))
+
 			return
 		}
 	}
@@ -662,7 +664,6 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 		return fs.SkipAll
 	})
-
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
@@ -790,6 +791,6 @@ func (c *Catalog) CheckedMkdirAll(id table.Identifier, errIfExists bool) error {
 			return err
 		}
 	}
-	return c.filesystem.MkdirAll(path)
 
+	return c.filesystem.MkdirAll(path)
 }

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -573,8 +573,9 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 			if !yield(ident, nil) {
 				return fs.SkipAll
 			}
-
-			return nil
+			// If a table has been found, then that directory
+			// doesn't need to be walked further
+			return fs.SkipDir
 		})
 		if err != nil {
 			yield(nil, fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err))
@@ -649,8 +650,16 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 	path := c.namespaceToPath(ns)
 
+	info, err := c.filesystem.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
+		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
+	}
+	if err != nil {
+		return fmt.Errorf("hadoop catalog: failed to stat namespace directory: %w", err)
+	}
+
 	foundEntries := false
-	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+	err = c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -626,7 +626,7 @@ func (c *Catalog) CreateNamespace(_ context.Context, ns table.Identifier, props 
 	}
 
 	// Raise an error if the namespace already exists
-	if err := c.CheckedMkdirAll(ns); err != nil {
+	if err := c.checkedMkdirAll(ns); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(ns, "."))
 		}
@@ -773,13 +773,14 @@ func (c *Catalog) UpdateNamespaceProperties(_ context.Context, _ table.Identifie
 	return catalog.PropertiesUpdateSummary{}, errors.New("hadoop catalog: UpdateNamespaceProperties not yet implemented")
 }
 
-// CheckedMkdirAll is a helper function that checks
+// checkedMkdirAll is a helper function that checks
 // all subdirectories of a given identifier path exist before creating the full path.
 // This function is not atomic and may not return ErrNamespaceAlreadyExists if
 // called concurrently with other calls that change the same identifier
-func (c *Catalog) CheckedMkdirAll(id table.Identifier) error {
+func (c *Catalog) checkedMkdirAll(id table.Identifier) error {
 	path := c.namespaceToPath(id)
-	for pathIndex := range id {
+	// Start at index 1 to skip the root warehouse directory
+	for pathIndex := 1; pathIndex < len(id); pathIndex++ {
 		subPath := id[:pathIndex]
 		parentPath := c.namespaceToPath(subPath)
 		if _, err := c.filesystem.Stat(parentPath); err != nil {

--- a/catalog/hadoop/hadoop_integration_test.go
+++ b/catalog/hadoop/hadoop_integration_test.go
@@ -92,7 +92,8 @@ func (s *HadoopIntegrationSuite) createFakeTable(ident table.Identifier) {
 	metaDir := filepath.Join(tablePath, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(
-		filepath.Join(metaDir, "v1.metadata.json"), []byte("{}"), 0o644))
+		filepath.Join(metaDir, "v1.metadata.json"), []byte("{}"), 0o644,
+	))
 }
 
 // TestListTablesSparkCreated creates tables in Spark and verifies that
@@ -240,7 +241,8 @@ func (s *HadoopIntegrationSuite) TestGoCreateSparkDescribe() {
 	err := s.cat.CreateNamespace(s.ctx, []string{"describe_ns"}, nil)
 	s.Require().NoError(err)
 
-	schema := iceberg.NewSchema(1,
+	schema := iceberg.NewSchema(
+		1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
@@ -281,7 +283,8 @@ func (s *HadoopIntegrationSuite) TestGoCreateSparkSelect() {
 	err := s.cat.CreateNamespace(s.ctx, []string{"select_ns"}, nil)
 	s.Require().NoError(err)
 
-	schema := iceberg.NewSchema(1,
+	schema := iceberg.NewSchema(
+		1,
 		iceberg.NestedField{ID: 1, Name: "value", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 	)
 

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -478,6 +478,16 @@ func (s *HadoopCatalogTestSuite) TestDropNamespaceNotEmptyWithChildNamespace() {
 	s.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
 }
 
+func (s *HadoopCatalogTestSuite) TestDropNameSpaceFileInsteadofDir() {
+	filePath := filepath.Join(s.warehouse, "not_a_dir")
+	s.Require().NoError(os.WriteFile(filePath, nil, 0o644))
+	err := s.cat.DropNamespace(context.Background(), []string{"not_a_dir"})
+	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	info, err := os.Stat(filePath)
+	s.NoError(err)
+	s.False(info.IsDir())
+}
+
 // CheckNamespaceExists tests
 
 func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsTrue() {
@@ -809,6 +819,25 @@ func (s *HadoopCatalogTestSuite) TestListTablesNestedNamespace() {
 
 	s.Len(tables, 1)
 	s.Equal(table.Identifier{"a", "b", "tbl1"}, tables[0])
+}
+
+func (s *HadoopCatalogTestSuite) TestListTablesDoesNotYieldTablesInChildNamespace() {
+	// When a namespace is passed into ListTables, only tables in that direct
+	// namespace should be yielded. Not the additionaltables in the children namespaces.
+	ctx := context.Background()
+	err := s.cat.CreateNamespace(ctx, []string{"ns"}, nil)
+	s.Require().NoError(err)
+	s.createFakeTable([]string{"ns", "tbl1"})
+	err = s.cat.CreateNamespace(ctx, []string{"ns", "child_ns"}, nil)
+	s.Require().NoError(err)
+	s.createFakeTable([]string{"ns", "child_ns", "tbl2"})
+	var tables []table.Identifier
+	for ident, err := range s.cat.ListTables(ctx, []string{"ns"}) {
+		s.Require().NoError(err)
+		tables = append(tables, ident)
+	}
+	s.Len(tables, 1)
+	s.Equal(table.Identifier{"ns", "tbl1"}, tables[0])
 }
 
 // DropTable tests

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -857,7 +857,8 @@ func (s *HadoopCatalogTestSuite) TestDropTableShortIdentifier() {
 // CreateTable tests
 
 func (s *HadoopCatalogTestSuite) testSchema() *iceberg.Schema {
-	return iceberg.NewSchema(1,
+	return iceberg.NewSchema(
+		1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
@@ -1150,7 +1151,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableSingleUpdate() {
 	ctx := context.Background()
 	tbl := s.createTestTable("ns", "tbl")
 
-	meta, metaLoc, err := s.cat.CommitTable(ctx, []string{"ns", "tbl"},
+	meta, metaLoc, err := s.cat.CommitTable(
+		ctx, []string{"ns", "tbl"},
 		[]table.Requirement{
 			table.AssertTableUUID(tbl.Metadata().TableUUID()),
 		},
@@ -1177,7 +1179,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableMultipleSequential() {
 		loaded, err := s.cat.LoadTable(ctx, ident)
 		s.Require().NoError(err)
 
-		_, metaLoc, err := s.cat.CommitTable(ctx, ident,
+		_, metaLoc, err := s.cat.CommitTable(
+			ctx, ident,
 			[]table.Requirement{
 				table.AssertTableUUID(loaded.Metadata().TableUUID()),
 			},
@@ -1207,7 +1210,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableNoChanges() {
 	ctx := context.Background()
 	tbl := s.createTestTable("ns", "tbl")
 
-	meta, metaLoc, err := s.cat.CommitTable(ctx, []string{"ns", "tbl"},
+	meta, metaLoc, err := s.cat.CommitTable(
+		ctx, []string{"ns", "tbl"},
 		[]table.Requirement{
 			table.AssertTableUUID(tbl.Metadata().TableUUID()),
 		},
@@ -1233,7 +1237,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetection() {
 	ident := []string{"ns", "tbl"}
 
 	for i := 2; i <= 5; i++ {
-		_, metaLoc, err := s.cat.CommitTable(ctx, ident,
+		_, metaLoc, err := s.cat.CommitTable(
+			ctx, ident,
 			nil,
 			[]table.Update{
 				table.NewSetPropertiesUpdate(iceberg.Properties{
@@ -1252,7 +1257,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableRequirementFailure() {
 	s.createTestTable("ns", "tbl")
 
 	wrongUUID := uuid.New()
-	_, _, err := s.cat.CommitTable(ctx, []string{"ns", "tbl"},
+	_, _, err := s.cat.CommitTable(
+		ctx, []string{"ns", "tbl"},
 		[]table.Requirement{
 			table.AssertTableUUID(wrongUUID),
 		},
@@ -1268,7 +1274,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableLocationChange() {
 	ctx := context.Background()
 	s.createTestTable("ns", "tbl")
 
-	_, _, err := s.cat.CommitTable(ctx, []string{"ns", "tbl"},
+	_, _, err := s.cat.CommitTable(
+		ctx, []string{"ns", "tbl"},
 		nil,
 		[]table.Update{
 			table.NewSetLocationUpdate("/some/other/location"),
@@ -1282,7 +1289,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableWriteMetadataLocation() {
 	ctx := context.Background()
 	s.createTestTable("ns", "tbl")
 
-	_, _, err := s.cat.CommitTable(ctx, []string{"ns", "tbl"},
+	_, _, err := s.cat.CommitTable(
+		ctx, []string{"ns", "tbl"},
 		nil,
 		[]table.Update{
 			table.NewSetPropertiesUpdate(iceberg.Properties{
@@ -1301,7 +1309,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableNoOrphanedTempFiles() {
 
 	// Do several commits and verify no temp files are left behind.
 	for i := 0; i < 3; i++ {
-		_, _, err := s.cat.CommitTable(ctx, ident,
+		_, _, err := s.cat.CommitTable(
+			ctx, ident,
 			nil,
 			[]table.Update{
 				table.NewSetPropertiesUpdate(iceberg.Properties{
@@ -1328,7 +1337,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableVersionHintUpdated() {
 	s.createTestTable("ns", "tbl")
 	ident := []string{"ns", "tbl"}
 
-	_, _, err := s.cat.CommitTable(ctx, ident,
+	_, _, err := s.cat.CommitTable(
+		ctx, ident,
 		nil,
 		[]table.Update{
 			table.NewSetPropertiesUpdate(iceberg.Properties{"k": "v"}),
@@ -1345,7 +1355,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableCreateViaCommit() {
 	ident := []string{"ns", "tbl"}
 
 	loc := s.cat.defaultTableLocation(ident)
-	meta, metaLoc, err := s.cat.CommitTable(ctx, ident,
+	meta, metaLoc, err := s.cat.CommitTable(
+		ctx, ident,
 		[]table.Requirement{
 			table.AssertCreate(),
 		},

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -69,5 +69,8 @@ type RemoveAllIO interface {
 type MkdirAllIO interface {
 	icebergio.IO
 
+	// MkdirAll should not raise an error if the directory already exists,
+	// and should create any parent directories in the path if they
+	// do not already exist.
 	MkdirAll(path string) error
 }

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -33,20 +33,18 @@ type HadoopCatalogFS interface {
 	RenameIO
 	RemoveAllIO
 	MkdirAllIO
-	MkdirIO
-	ReadDirIO
 }
 
 var _ HadoopCatalogFS = (*icebergio.LocalFS)(nil)
 
 // StatIO is an extension of IO interface that includes the Stat
-// method for retrieving file information without reading the file
+// method for retrieving file or directory information
 type StatIO interface {
 	icebergio.IO
 
-	// The Stat method returns a FileInfo describing the named file, or an error
-	// satisfying errors.Is(err, fs.ErrNotExist) if the file does not exist
-	Stat(name string) (fs.FileInfo, error)
+	// The Stat method returns a FileInfo describing the named file or directory,
+	// or an error satisfying errors.Is(err, fs.ErrNotExist) if the file does not exist
+	Stat(path string) (fs.FileInfo, error)
 }
 
 // RenameIO is an extension of IO interface that includes the Rename
@@ -66,32 +64,10 @@ type RemoveAllIO interface {
 	RemoveAll(name string) error
 }
 
-// MkdirIO is an extension of IO interface that includes the Mkdir
-// method for creating a directory
-type MkdirIO interface {
-	icebergio.IO
-
-	// Mkdir creates a new directory or returns an error
-	// satisfying errors.Is(err, fs.ErrExist) if the directory already exists or
-	// errors.Is(err, fs.ErrNotExist) if it does not create parent directories
-	Mkdir(path string) error
-}
-
 // MkdirAllIO is an extension of IO interface that includes the MkdirAll
 // method for creating a directory path recursively
 type MkdirAllIO interface {
 	icebergio.IO
 
 	MkdirAll(path string) error
-}
-
-// ReadDirIO is an extension of IO interface that includes the ReadDir
-// method for reading the contents of a directory and returning a slice of
-// DirEntry values
-type ReadDirIO interface {
-	icebergio.IO
-
-	// ReadDir returns a slice of DirEntry values for the named directory
-	// or an error satisfying errors.Is(err, fs.ErrNotExist) if the directory does not exist
-	ReadDir(name string) ([]fs.DirEntry, error)
 }


### PR DESCRIPTION
Addresses https://github.com/apache/iceberg-go/issues/1096 (as the next step; blob storage support is out of scope for this PR and would be present in a follow up)

- Removes interfaces for `MkdirIO` and `ReadDirIO` to prepare for hadoop cloud storage backends.
- Refactors hadoop catalog to use `MkdirAll` and `WalkDir` in their place.
    - Cleans up the comments for those interfaces to reflect current usage. 
- Adds on new helper function `CheckedMkdirAll`, which before calling `MkdirAll`, walks the directory and ensures that each subdirectory of the full path exists. 
    - Currently this is only used once since only one previous `Mkdir` call checked for errors if the directory already existed. That being said, I think it helps to abstract logic a bit and I'm thinking that it likely may be used in other parts of the Hadoop catalog. 