### PR TITLE
fix: incorrect pruning for NOT STARTS WITH over truncated string partitions

### DIFF
--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -966,6 +966,9 @@ func (p *ProjectionTestSuite) TestStringTruncateProjection() {
 		{iceberg.NotEqualTo(ref, "aaa"), iceberg.AlwaysTrue{}},
 		{iceberg.IsIn(ref, "aaa", "aab"), iceberg.EqualTo(truncStr, "aa")},
 		{iceberg.NotIn(ref, "aaa", "aab"), iceberg.AlwaysTrue{}},
+		{iceberg.NotStartsWith(ref, "a"), iceberg.NotStartsWith(truncStr, "a")},
+		{iceberg.NotStartsWith(ref, "aa"), iceberg.NotEqualTo(truncStr, "aa")},
+		{iceberg.NotStartsWith(ref, "aaa"), iceberg.AlwaysTrue{}},
 	}
 
 	project := newInclusiveProjection(schema, spec, true)

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -981,6 +981,52 @@ func (p *ProjectionTestSuite) TestStringTruncateProjection() {
 	}
 }
 
+func (p *ProjectionTestSuite) TestBinaryTruncateProjection() {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "data", Type: iceberg.PrimitiveTypes.Binary},
+	)
+	spec := iceberg.NewPartitionSpec(
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: iceberg.TruncateTransform{Width: 2}, Name: "data_trunc",
+		},
+	)
+
+	ref, truncBin := iceberg.Reference("data"), iceberg.Reference("data_trunc")
+	notStartsWith := func(t iceberg.UnboundTerm, v string) iceberg.BooleanExpression {
+		return iceberg.LiteralPredicate(iceberg.OpNotStartsWith, t, iceberg.NewLiteral([]byte(v)))
+	}
+	tests := []struct {
+		pred, expected iceberg.BooleanExpression
+	}{
+		{iceberg.NotNull(ref), iceberg.NotNull(truncBin)},
+		{iceberg.IsNull(ref), iceberg.IsNull(truncBin)},
+		{iceberg.LessThan(ref, []byte("aaa")), iceberg.LessThanEqual(truncBin, []byte("aa"))},
+		{iceberg.LessThanEqual(ref, []byte("aaa")), iceberg.LessThanEqual(truncBin, []byte("aa"))},
+		{iceberg.GreaterThan(ref, []byte("aaa")), iceberg.GreaterThanEqual(truncBin, []byte("aa"))},
+		{iceberg.GreaterThanEqual(ref, []byte("aaa")), iceberg.GreaterThanEqual(truncBin, []byte("aa"))},
+		{iceberg.EqualTo(ref, []byte("aaa")), iceberg.EqualTo(truncBin, []byte("aa"))},
+		{iceberg.NotEqualTo(ref, []byte("aaa")), iceberg.AlwaysTrue{}},
+		{iceberg.IsIn(ref, []byte("aaa"), []byte("aab")), iceberg.EqualTo(truncBin, []byte("aa"))},
+		{iceberg.NotIn(ref, []byte("aaa"), []byte("aab")), iceberg.AlwaysTrue{}},
+		// prefix shorter than width: keep NOT STARTS WITH on the truncated field.
+		{notStartsWith(ref, "a"), notStartsWith(truncBin, "a")},
+		// prefix exactly the width: equivalent to != on the partition value.
+		{notStartsWith(ref, "aa"), iceberg.NotEqualTo(truncBin, []byte("aa"))},
+		// prefix longer than width: not projectable, must not prune.
+		{notStartsWith(ref, "aaa"), iceberg.AlwaysTrue{}},
+	}
+
+	project := newInclusiveProjection(schema, spec, true)
+	for _, tt := range tests {
+		p.Run(tt.pred.String(), func() {
+			expr, err := project(tt.pred)
+			p.Require().NoError(err)
+			p.Truef(tt.expected.Equals(expr), "expected: %s\ngot: %s", tt.expected, expr)
+		})
+	}
+}
+
 func (p *ProjectionTestSuite) TestIntTruncateProjection() {
 	schema, spec := p.schema(), p.truncateIntSpec()
 

--- a/transforms.go
+++ b/transforms.go
@@ -548,6 +548,24 @@ func (t TruncateTransform) Project(name string, pred BoundPredicate) (UnboundPre
 			return setApplyTransform(name, p, wrapTransformFn[[]byte](transformer)), nil
 		}
 	case BoundLiteralPredicate:
+		// notStartsWith is only projectable when the prefix fits within the
+		// truncation width. If the prefix is longer, the truncated partition
+		// value may itself satisfy the predicate, so projecting the truncated
+		// prefix would incorrectly prune matching files.
+		if p.Op() == OpNotStartsWith {
+			l := literalLen(p.Literal())
+			switch {
+			case l < 0:
+				return nil, nil
+			case l < t.Width:
+				return LiteralPredicate(OpNotStartsWith, Reference(name), p.Literal()), nil
+			case l == t.Width:
+				return LiteralPredicate(OpNEQ, Reference(name), p.Literal()), nil
+			}
+
+			return nil, nil
+		}
+
 		switch fieldType.(type) {
 		case Int32Type:
 			return truncateNumber(name, p, wrapTransformFn[int32](transformer))
@@ -1072,12 +1090,22 @@ func truncateArray[T LiteralType](name string, pred BoundLiteralPredicate, fn fu
 	case OpStartsWith:
 		return LiteralPredicate(OpStartsWith, Reference(name),
 			transformLiteral(fn, boundary)), nil
-	case OpNotStartsWith:
-		return LiteralPredicate(OpNotStartsWith, Reference(name),
-			transformLiteral(fn, boundary)), nil
 	}
 
 	return nil, nil
+}
+
+func literalLen(lit Literal) int {
+	switch l := lit.(type) {
+	case StringLiteral:
+		return len(l)
+	case BinaryLiteral:
+		return len(l)
+	case FixedLiteral:
+		return len(l)
+	}
+
+	return -1
 }
 
 func setApplyTransform[T LiteralType](name string, pred BoundSetPredicate, fn func(any) Optional[T]) UnboundPredicate {


### PR DESCRIPTION
## Description

Closes #1192.

This fixes unsafe inclusive projection for `NOT STARTS WITH` predicates over truncated string/binary partition fields.

Previously, `truncate[N]` projection could truncate the filter prefix and produce a `NOT STARTS WITH` predicate on the partition value even when the original prefix was longer than `N`. That is unsafe because the truncated partition value does not contain enough information to prove that all rows fail the original predicate, and can incorrectly prune files that contain matching rows.

The projection now follows the safe behavior used by other Iceberg implementations:

- prefix shorter than truncate width: keep `NOT STARTS WITH`
- prefix exactly equal to truncate width: project to `!=`
- prefix longer than truncate width: return no projection

Regression coverage was added for all three cases.

## Testing

```sh
go test ./table -run TestProjection/TestStringTruncateProjection -count=1
go test ./...
```