### PR TITLE
fix: runtime.staticuint64s+42100384 is not 2-byte aligned on big-endian

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -60,3 +60,28 @@ jobs:
     # Race detector is opt-in per package/test.
     - name: Run race detector
       run: go test -race -v ./codec/...
+
+  # Guards against big-endian-only failures such as the runtime.staticuint64s
+  # relocation misalignment triggered by boxing scalars in generic code
+  # (golang/go#76744). The fault is a linker error and only s390x's linker
+  # rejects the misaligned relocation, so this must build a main package for
+  # s390x specifically rather than just vet or compile libraries.
+  cross-compile:
+    name: cross-compile linux/s390x
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: '1.26.1'
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Build for big-endian (s390x)
+      env:
+        GOOS: linux
+        GOARCH: s390x
+        CGO_ENABLED: '0'
+      run: go build ./...

--- a/literals.go
+++ b/literals.go
@@ -80,37 +80,43 @@ type NumericLiteral interface {
 	Decrement() Literal
 }
 
-// NewLiteral provides a literal based on the type of T
+// NewLiteral provides a literal based on the type of T.
+//
+// The type switch is performed on &val (a pointer) rather than val itself.
+// Boxing a small scalar such as bool into an interface makes the compiler
+// reference runtime.staticuint64s, which emits a relocation the linker rejects
+// as misaligned on big-endian platforms such as s390x. Switching on a pointer
+// boxes only the pointer, never the scalar, avoiding that reference.
 func NewLiteral[T LiteralType](val T) Literal {
-	switch v := any(val).(type) {
-	case bool:
-		return BoolLiteral(v)
-	case int32:
-		return Int32Literal(v)
-	case int64:
-		return Int64Literal(v)
-	case float32:
-		return Float32Literal(v)
-	case float64:
-		return Float64Literal(v)
-	case Date:
-		return DateLiteral(v)
-	case Time:
-		return TimeLiteral(v)
-	case Timestamp:
-		return TimestampLiteral(v)
-	case TimestampNano:
-		return TimestampNsLiteral(v)
-	case string:
-		return StringLiteral(v)
-	case []byte:
-		return BinaryLiteral(v)
-	case uuid.UUID:
-		return UUIDLiteral(v)
-	case Decimal:
-		return DecimalLiteral(v)
-	case variant.Value:
-		return VariantLiteral(v)
+	switch v := any(&val).(type) {
+	case *bool:
+		return BoolLiteral(*v)
+	case *int32:
+		return Int32Literal(*v)
+	case *int64:
+		return Int64Literal(*v)
+	case *float32:
+		return Float32Literal(*v)
+	case *float64:
+		return Float64Literal(*v)
+	case *Date:
+		return DateLiteral(*v)
+	case *Time:
+		return TimeLiteral(*v)
+	case *Timestamp:
+		return TimestampLiteral(*v)
+	case *TimestampNano:
+		return TimestampNsLiteral(*v)
+	case *string:
+		return StringLiteral(*v)
+	case *[]byte:
+		return BinaryLiteral(*v)
+	case *uuid.UUID:
+		return UUIDLiteral(*v)
+	case *Decimal:
+		return DecimalLiteral(*v)
+	case *variant.Value:
+		return VariantLiteral(*v)
 	}
 	panic("can't happen due to literal type constraint")
 }


### PR DESCRIPTION
https://github.com/minio/warp recently added iceberg-go as a dependency. iceberg-go encounters the following compiler error on s390x architecture (big-endian) during packaging for Alpine Linux:
```
# github.com/minio/warp
github.com/apache/iceberg-go/table/internal.newStatAgg[go.shape.bool]: runtime.staticuint64s+42100384 is not 2-byte aligned
github.com/apache/iceberg-go/table/internal.newStatAgg[go.shape.bool]: runtime.staticuint64s+42100384 is not 2-byte aligned
github.com/apache/iceberg-go.getComparator[go.shape.bool]: runtime.staticuint64s+42100384 is not 2-byte aligned
github.com/apache/iceberg-go.getComparator[go.shape.bool]: runtime.staticuint64s+42100384 is not 2-byte aligned
>>> ERROR: warp-s3: build failed
```
The issue here is instantiating the generic bool comparator on a generic zero value, resulting in an alignment bug on big-endian architecture. This fix replaces the generic zero-value comparator initialization with explicit typed comparators, allowing compilation on s390x.