### PR TITLE
fix(exprs): support nanosecond timestamp predicates

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -443,6 +443,8 @@ func createBoundRef(field NestedField, acc accessor) BoundReference {
 		return &boundRef[Time]{field: field, acc: acc}
 	case TimestampType, TimestampTzType:
 		return &boundRef[Timestamp]{field: field, acc: acc}
+	case TimestampNsType, TimestampTzNsType:
+		return &boundRef[TimestampNano]{field: field, acc: acc}
 	case StringType:
 		return &boundRef[string]{field: field, acc: acc}
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -633,6 +635,8 @@ func createBoundUnaryPredicate(op Operation, term BoundTerm) BoundUnaryPredicate
 		return newBoundUnaryPred[Time](op, term)
 	case TimestampType, TimestampTzType:
 		return newBoundUnaryPred[Timestamp](op, term)
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundUnaryPred[TimestampNano](op, term)
 	case StringType:
 		return newBoundUnaryPred[string](op, term)
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -797,6 +801,8 @@ func createBoundLiteralPredicate(op Operation, term BoundTerm, lit Literal) (Bou
 		return newBoundLiteralPredicate[Time](op, term, finalLit), nil
 	case TimestampType, TimestampTzType:
 		return newBoundLiteralPredicate[Timestamp](op, term, finalLit), nil
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundLiteralPredicate[TimestampNano](op, term, finalLit), nil
 	case StringType:
 		return newBoundLiteralPredicate[string](op, term, finalLit), nil
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -965,6 +971,8 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 		return newBoundSetPredicate[Time](op, term, typedSet), nil
 	case TimestampType, TimestampTzType:
 		return newBoundSetPredicate[Timestamp](op, term, typedSet), nil
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundSetPredicate[TimestampNano](op, term, typedSet), nil
 	case StringType:
 		return newBoundSetPredicate[string](op, term, typedSet), nil
 	case BinaryType, FixedType, GeographyType, GeometryType:

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -216,7 +216,17 @@ func TestRefTypes(t *testing.T) {
 		iceberg.NestedField{ID: 11, Name: "k", Type: iceberg.PrimitiveTypes.Binary},
 		iceberg.NestedField{ID: 12, Name: "l", Type: iceberg.PrimitiveTypes.UUID},
 		iceberg.NestedField{ID: 13, Name: "m", Type: iceberg.FixedTypeOf(5)},
-		iceberg.NestedField{ID: 14, Name: "n", Type: iceberg.VariantType{}})
+		iceberg.NestedField{ID: 14, Name: "n", Type: iceberg.VariantType{}},
+		iceberg.NestedField{ID: 15, Name: "o", Type: iceberg.PrimitiveTypes.TimestampNs},
+		iceberg.NestedField{ID: 16, Name: "p", Type: iceberg.PrimitiveTypes.TimestampTzNs})
+
+	timestampNanoFields := []struct {
+		name string
+		typ  iceberg.Type
+	}{
+		{name: "o", typ: iceberg.PrimitiveTypes.TimestampNs},
+		{name: "p", typ: iceberg.PrimitiveTypes.TimestampTzNs},
+	}
 
 	t.Run("bind term", func(t *testing.T) {
 		for i := 0; i < sc.NumFields(); i++ {
@@ -294,6 +304,20 @@ func TestRefTypes(t *testing.T) {
 			assert.Equal(t, iceberg.OpEQ, uid.Op())
 			assert.True(t, uid.(iceberg.BoundLiteralPredicate).Literal().Type().Equals(iceberg.PrimitiveTypes.UUID))
 		})
+
+		t.Run("timestamp-nanos", func(t *testing.T) {
+			for _, tt := range timestampNanoFields {
+				t.Run(tt.typ.String(), func(t *testing.T) {
+					value := iceberg.TimestampNano(123456789)
+					b, err := iceberg.EqualTo(iceberg.Reference(tt.name), value).Bind(sc, true)
+					require.NoError(t, err)
+
+					assert.Equal(t, iceberg.OpEQ, b.Op())
+					assert.True(t, b.(iceberg.BoundLiteralPredicate).Ref().Type().Equals(tt.typ))
+					assert.Equal(t, value, b.(iceberg.BoundLiteralPredicate).Literal().Any())
+				})
+			}
+		})
 	})
 
 	t.Run("bind set", func(t *testing.T) {
@@ -363,6 +387,28 @@ func TestRefTypes(t *testing.T) {
 			assert.True(t, uid.(iceberg.BoundSetPredicate).Ref().Type().Equals(iceberg.PrimitiveTypes.UUID))
 			for _, v := range uid.(iceberg.BoundSetPredicate).Literals().Members() {
 				assert.True(t, v.Type().Equals(iceberg.PrimitiveTypes.UUID))
+			}
+		})
+
+		t.Run("timestamp-nanos", func(t *testing.T) {
+			for _, tt := range timestampNanoFields {
+				t.Run(tt.typ.String(), func(t *testing.T) {
+					b, err := iceberg.IsIn(
+						iceberg.Reference(tt.name),
+						iceberg.TimestampNano(123456789),
+						iceberg.TimestampNano(987654321),
+					).(iceberg.UnboundPredicate).Bind(sc, true)
+					require.NoError(t, err)
+
+					assert.Equal(t, iceberg.OpIn, b.Op())
+					assert.True(t, b.(iceberg.BoundSetPredicate).Ref().Type().Equals(tt.typ))
+					assert.Equal(t, 2, b.(iceberg.BoundSetPredicate).Literals().Len())
+					assert.True(t, b.(iceberg.BoundSetPredicate).Literals().All(func(lit iceberg.Literal) bool {
+						_, ok := lit.(iceberg.TimestampNsLiteral)
+
+						return ok
+					}))
+				})
 			}
 		})
 	})

--- a/visitors.go
+++ b/visitors.go
@@ -320,6 +320,8 @@ func doCmp(st StructLike, term BoundTerm, lit Literal) int {
 		return typedCmp[Time](st, term, lit)
 	case TimestampType, TimestampTzType:
 		return typedCmp[Timestamp](st, term, lit)
+	case TimestampNsType, TimestampTzNsType:
+		return typedCmp[TimestampNano](st, term, lit)
 	case BinaryType, FixedType, GeographyType, GeometryType:
 		return typedCmp[[]byte](st, term, lit)
 	case StringType:

--- a/visitors_test.go
+++ b/visitors_test.go
@@ -556,14 +556,17 @@ func TestEvaluatorCmpTypes(t *testing.T) {
 		iceberg.NestedField{ID: 10, Name: "j", Type: iceberg.PrimitiveTypes.String},
 		iceberg.NestedField{ID: 11, Name: "k", Type: iceberg.PrimitiveTypes.Binary},
 		iceberg.NestedField{ID: 12, Name: "l", Type: iceberg.PrimitiveTypes.UUID},
-		iceberg.NestedField{ID: 13, Name: "m", Type: iceberg.FixedTypeOf(5)})
+		iceberg.NestedField{ID: 13, Name: "m", Type: iceberg.FixedTypeOf(5)},
+		iceberg.NestedField{ID: 14, Name: "n", Type: iceberg.PrimitiveTypes.TimestampNs},
+		iceberg.NestedField{ID: 15, Name: "o", Type: iceberg.PrimitiveTypes.TimestampTzNs})
 
 	rowData := rowOf(true,
 		5, 5, float32(5.0), float64(5.0),
 		29, 51661919000, 1503066061919234,
 		iceberg.Decimal{Scale: 2, Val: decimal128.FromI64(3456)},
 		"abcdef", []byte{0x01, 0x02, 0x03},
-		uuid.New(), []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x0})
+		uuid.New(), []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x0},
+		iceberg.TimestampNano(123456789), iceberg.TimestampNano(987654321))
 
 	tests := []struct {
 		ref iceberg.BooleanExpression
@@ -593,6 +596,10 @@ func TestEvaluatorCmpTypes(t *testing.T) {
 		{iceberg.EqualTo(iceberg.Reference("l"), rowData[11].(uuid.UUID)), true},
 		{iceberg.EqualTo(iceberg.Reference("m"), []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x1}), false},
 		{iceberg.EqualTo(iceberg.Reference("m"), []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x0}), true},
+		{iceberg.EqualTo(iceberg.Reference("n"), iceberg.TimestampNano(123456789)), true},
+		{iceberg.GreaterThan(iceberg.Reference("n"), iceberg.TimestampNano(1)), true},
+		{iceberg.EqualTo(iceberg.Reference("o"), iceberg.TimestampNano(987654321)), true},
+		{iceberg.GreaterThan(iceberg.Reference("o"), iceberg.TimestampNano(1)), true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- bind `timestamp_ns` and `timestamptz_ns` references as `TimestampNano` in expression factories
- evaluate bound nanosecond timestamp comparisons through `doCmp`
- cover binding, `IS NULL`, `EQ`, multi-value `IN`, and evaluator comparisons for both nanosecond timestamp types

## Why

V3 nanosecond timestamp columns are valid primitive and literal types, but expression binding and comparison evaluation still missed those type cases. Filters against these columns could panic while binding or fail when evaluating bound comparison predicates.

## Testing

- `go test . -run "TestRefTypes|TestEvaluatorCmpTypes" -count=1`
- `go test ./... -count=1`
- `git diff --check`
