### PR TITLE
fix(transforms): support timestamp nanos in year and month

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -1031,6 +1031,8 @@ func transformLiteral[T LiteralType](fn func(any) Optional[T], lit Literal) Lite
 		return NewLiteral(fn(Time(l)).Val)
 	case TimestampLiteral:
 		return NewLiteral(fn(Timestamp(l)).Val)
+	case TimestampNsLiteral:
+		return NewLiteral(fn(TimestampNano(l)).Val)
 	case StringLiteral:
 		return NewLiteral(fn(string(l)).Val)
 	case FixedLiteral:

--- a/transforms.go
+++ b/transforms.go
@@ -650,6 +650,17 @@ func (YearTransform) Transformer(src Type) (func(any) Optional[int32], error) {
 				Val:   int32(v.(Timestamp).ToTime().Year() - epochTM.Year()),
 			}
 		}, nil
+	case TimestampNsType, TimestampTzNsType:
+		return func(v any) Optional[int32] {
+			if v == nil {
+				return Optional[int32]{}
+			}
+
+			return Optional[int32]{
+				Valid: true,
+				Val:   int32(v.(TimestampNano).ToTime().Year() - epochTM.Year()),
+			}
+		}, nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot apply year transform for type %s",
@@ -668,6 +679,9 @@ func (YearTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 	case TimestampLiteral:
 		out.Valid = true
 		out.Val = Int32Literal(Timestamp(v).ToTime().Year() - epochTM.Year())
+	case TimestampNsLiteral:
+		out.Valid = true
+		out.Val = Int32Literal(TimestampNano(v).ToTime().Year() - epochTM.Year())
 	}
 
 	return out
@@ -733,6 +747,19 @@ func (MonthTransform) Transformer(src Type) (func(any) Optional[int32], error) {
 				Val:   int32((d.Year()-epochTM.Year())*12 + (int(d.Month()) - int(epochTM.Month()))),
 			}
 		}, nil
+	case TimestampNsType, TimestampTzNsType:
+		return func(v any) Optional[int32] {
+			if v == nil {
+				return Optional[int32]{}
+			}
+
+			d := v.(TimestampNano).ToTime()
+
+			return Optional[int32]{
+				Valid: true,
+				Val:   int32((d.Year()-epochTM.Year())*12 + (int(d.Month()) - int(epochTM.Month()))),
+			}
+		}, nil
 
 	}
 
@@ -751,6 +778,8 @@ func (MonthTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 		tm = Date(v).ToTime()
 	case TimestampLiteral:
 		tm = Timestamp(v).ToTime()
+	case TimestampNsLiteral:
+		tm = TimestampNano(v).ToTime()
 	default:
 		return out
 	}

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -395,6 +395,45 @@ func TestCanTransform(t *testing.T) {
 	}
 }
 
+func TestYearMonthTransformNanoseconds(t *testing.T) {
+	ts := iceberg.TimestampNano(time.Date(2024, time.February, 3, 4, 5, 6, 789_000_000, time.UTC).UnixNano())
+	lit := iceberg.NewLiteral(ts)
+
+	tests := []struct {
+		name      string
+		transform iceberg.TimeTransform
+		expected  int32
+	}{
+		{name: "year", transform: iceberg.YearTransform{}, expected: 54},
+		{name: "month", transform: iceberg.MonthTransform{}, expected: 649},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/Apply", func(t *testing.T) {
+			result := tt.transform.Apply(iceberg.Optional[iceberg.Literal]{
+				Valid: true,
+				Val:   lit,
+			})
+			require.True(t, result.Valid)
+			assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
+		})
+
+		for _, srcType := range []iceberg.Type{
+			iceberg.PrimitiveTypes.TimestampNs,
+			iceberg.PrimitiveTypes.TimestampTzNs,
+		} {
+			t.Run(tt.name+"/Transformer/"+srcType.String(), func(t *testing.T) {
+				fn, err := tt.transform.Transformer(srcType)
+				require.NoError(t, err)
+
+				result := fn(ts)
+				require.True(t, result.Valid)
+				assert.Equal(t, tt.expected, result.Val)
+			})
+		}
+	}
+}
+
 func TestHourTransformPreEpoch(t *testing.T) {
 	const microsecondsPerHour = int64(time.Hour / time.Microsecond)
 

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -396,39 +396,80 @@ func TestCanTransform(t *testing.T) {
 }
 
 func TestYearMonthTransformNanoseconds(t *testing.T) {
-	ts := iceberg.TimestampNano(time.Date(2024, time.February, 3, 4, 5, 6, 789_000_000, time.UTC).UnixNano())
-	lit := iceberg.NewLiteral(ts)
+	type testCase struct {
+		name  string
+		ts    iceberg.TimestampNano
+		year  int32
+		month int32
+	}
+
+	values := []testCase{
+		{
+			name:  "post-epoch",
+			ts:    iceberg.TimestampNano(time.Date(2024, time.February, 3, 4, 5, 6, 789_000_000, time.UTC).UnixNano()),
+			year:  54,
+			month: 649,
+		},
+		{
+			name:  "pre-epoch",
+			ts:    iceberg.TimestampNano(-1),
+			year:  -1,
+			month: -1,
+		},
+	}
 
 	tests := []struct {
 		name      string
 		transform iceberg.TimeTransform
-		expected  int32
+		expected  func(testCase) int32
 	}{
-		{name: "year", transform: iceberg.YearTransform{}, expected: 54},
-		{name: "month", transform: iceberg.MonthTransform{}, expected: 649},
+		{name: "year", transform: iceberg.YearTransform{}, expected: func(tc testCase) int32 { return tc.year }},
+		{name: "month", transform: iceberg.MonthTransform{}, expected: func(tc testCase) int32 { return tc.month }},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name+"/Apply", func(t *testing.T) {
-			result := tt.transform.Apply(iceberg.Optional[iceberg.Literal]{
-				Valid: true,
-				Val:   lit,
+		for _, tc := range values {
+			t.Run(tt.name+"/"+tc.name+"/Apply", func(t *testing.T) {
+				result := tt.transform.Apply(iceberg.Optional[iceberg.Literal]{
+					Valid: true,
+					Val:   iceberg.NewLiteral(tc.ts),
+				})
+				require.True(t, result.Valid)
+				assert.Equal(t, iceberg.Int32Literal(tt.expected(tc)), result.Val)
 			})
-			require.True(t, result.Valid)
-			assert.Equal(t, iceberg.Int32Literal(tt.expected), result.Val)
-		})
 
-		for _, srcType := range []iceberg.Type{
-			iceberg.PrimitiveTypes.TimestampNs,
-			iceberg.PrimitiveTypes.TimestampTzNs,
-		} {
-			t.Run(tt.name+"/Transformer/"+srcType.String(), func(t *testing.T) {
-				fn, err := tt.transform.Transformer(srcType)
+			for _, srcType := range []iceberg.Type{
+				iceberg.PrimitiveTypes.TimestampNs,
+				iceberg.PrimitiveTypes.TimestampTzNs,
+			} {
+				t.Run(tt.name+"/"+tc.name+"/Transformer/"+srcType.String(), func(t *testing.T) {
+					fn, err := tt.transform.Transformer(srcType)
+					require.NoError(t, err)
+
+					result := fn(tc.ts)
+					require.True(t, result.Valid)
+					assert.Equal(t, tt.expected(tc), result.Val)
+				})
+			}
+
+			t.Run(tt.name+"/"+tc.name+"/Project", func(t *testing.T) {
+				schema := iceberg.NewSchema(1, iceberg.NestedField{
+					ID:   1,
+					Name: "ts",
+					Type: iceberg.PrimitiveTypes.TimestampNs,
+				})
+				bound, err := iceberg.GreaterThanEqual(
+					iceberg.Reference("ts"),
+					tc.ts,
+				).Bind(schema, true)
 				require.NoError(t, err)
 
-				result := fn(ts)
-				require.True(t, result.Valid)
-				assert.Equal(t, tt.expected, result.Val)
+				projected, err := tt.transform.Project("ts_part", bound.(iceberg.BoundPredicate))
+				require.NoError(t, err)
+				assert.True(t, iceberg.GreaterThanEqual(
+					iceberg.Reference("ts_part"),
+					tt.expected(tc),
+				).Equals(projected))
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

- add `timestamp_ns` and `timestamptz_ns` support to `YearTransform.Transformer` and `MonthTransform.Transformer`
- make `YearTransform.Apply` and `MonthTransform.Apply` handle `TimestampNsLiteral`
- make transform projection handle `TimestampNsLiteral` through `transformLiteral`
- add regression coverage for Apply, Transformer, and Project paths, including a pre-epoch ns value

## Why

`YearTransform` and `MonthTransform` already report that they can transform nanosecond timestamp types through `canTransformTime`, but their implementation only handled date and microsecond timestamp values. That meant accepted partition transforms could produce invalid/null transform results for timestamp-ns inputs, and projection needed the same literal support once the transformer path succeeded.

## Testing

- `go test . -run "TestYearMonthTransformNanoseconds|TestCanTransform|TestManifestPartitionVals" -count=1`
- `go test ./... -count=1`
- `git diff --check`
