### PR TITLE
fix(transforms): support timestamp nanos in bucket

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -285,6 +285,8 @@ func (t BucketTransform) Apply(value Optional[Literal]) Optional[Literal] {
 		hash = hashHelperInt[int64](int64(v))
 	case TimestampLiteral:
 		hash = hashHelperInt[int64](int64(v))
+	case TimestampNsLiteral:
+		hash = hashHelperInt[int64](int64(v))
 	default:
 		return Optional[Literal]{}
 	}
@@ -311,6 +313,8 @@ func (t BucketTransform) Transformer(src Type) func(any) Optional[int32] {
 		h = hashHelperInt[Timestamp]
 	case TimestampTzType:
 		h = hashHelperInt[Timestamp]
+	case TimestampNsType, TimestampTzNsType:
+		h = hashHelperInt[TimestampNano]
 	case DecimalType:
 		h = func(v any) uint32 {
 			b, _ := DecimalLiteral(v.(Decimal)).MarshalBinary()

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -475,6 +475,59 @@ func TestYearMonthTransformNanoseconds(t *testing.T) {
 	}
 }
 
+func TestBucketTransformTimestampNanoseconds(t *testing.T) {
+	transform := iceberg.BucketTransform{NumBuckets: 16}
+	values := []struct {
+		name string
+		ts   iceberg.TimestampNano
+	}{
+		{name: "post-epoch", ts: iceberg.TimestampNano(123456789)},
+		{name: "pre-epoch", ts: iceberg.TimestampNano(-1)},
+	}
+
+	for _, srcType := range []iceberg.Type{
+		iceberg.PrimitiveTypes.TimestampNs,
+		iceberg.PrimitiveTypes.TimestampTzNs,
+	} {
+		t.Run(srcType.String(), func(t *testing.T) {
+			require.True(t, transform.CanTransform(srcType))
+
+			fn := transform.Transformer(srcType)
+			for _, tt := range values {
+				t.Run(tt.name, func(t *testing.T) {
+					applied := transform.Apply(iceberg.Optional[iceberg.Literal]{
+						Valid: true,
+						Val:   iceberg.NewLiteral(tt.ts),
+					})
+					require.True(t, applied.Valid)
+
+					var transformed iceberg.Optional[int32]
+					require.NotPanics(t, func() {
+						transformed = fn(tt.ts)
+					})
+					require.True(t, transformed.Valid)
+					assert.Equal(t, applied.Val, iceberg.NewLiteral(transformed.Val))
+
+					schema := iceberg.NewSchema(1, iceberg.NestedField{
+						ID:   1,
+						Name: "ts",
+						Type: srcType,
+					})
+					bound, err := iceberg.EqualTo(iceberg.Reference("ts"), tt.ts).Bind(schema, true)
+					require.NoError(t, err)
+
+					projected, err := transform.Project("ts_bucket", bound.(iceberg.BoundPredicate))
+					require.NoError(t, err)
+					assert.True(t, iceberg.EqualTo(
+						iceberg.Reference("ts_bucket"),
+						transformed.Val,
+					).Equals(projected))
+				})
+			}
+		})
+	}
+}
+
 func TestHourTransformPreEpoch(t *testing.T) {
 	const microsecondsPerHour = int64(time.Hour / time.Microsecond)
 


### PR DESCRIPTION
Summary
- add `timestamp_ns` and `timestamptz_ns` support to `BucketTransform.Apply` and `BucketTransform.Transformer`
- keep bucket hashing on the physical integer timestamp value
- add regression coverage for Apply, Transformer, and Project paths, including a pre-epoch ns value

Why
`BucketTransform.CanTransform` already accepted nanosecond timestamp types, but `Apply` returned an invalid optional for `TimestampNsLiteral` and `Transformer` could return a closure with a nil hash function. That made `bucket(timestamp_ns)` unsafe for partition value generation and predicate projection.

Testing
- `go test . -run "TestBucketTransformTimestampNanoseconds|TestCanTransform|TestManifestPartitionVals" -count=1`
- `go test ./... -count=1`
- `git diff --check`