### PR TITLE
fix(transforms): preserve UTF-8 in string truncate

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
@@ -484,22 +483,23 @@ func (t TruncateTransform) Transformer(src Type) (func(any) any, error) {
 
 			return val - (((val % width) + width) % width)
 		}, nil
-	case StringType, BinaryType:
+	case StringType:
 		return func(v any) any {
-			switch v := v.(type) {
-			case string:
-				byteOff := 0
-				for cp := 0; cp < t.Width && byteOff < len(v); cp++ {
-					_, size := utf8.DecodeRuneInString(v[byteOff:])
-					byteOff += size
-				}
-
-				return v[:byteOff]
-			case []byte:
-				return v[:min(len(v), t.Width)]
-			default:
+			str, ok := v.(string)
+			if !ok {
 				return nil
 			}
+
+			return truncateString(str, t.Width)
+		}, nil
+	case BinaryType:
+		return func(v any) any {
+			b, ok := v.([]byte)
+			if !ok {
+				return nil
+			}
+
+			return b[:min(len(b), t.Width)]
 		}, nil
 	case DecimalType:
 		bigWidth := big.NewInt(int64(t.Width))
@@ -522,6 +522,20 @@ func (t TruncateTransform) Transformer(src Type) (func(any) any, error) {
 
 	return nil, fmt.Errorf("%w: cannot truncate for type %s",
 		ErrInvalidArgument, src)
+}
+
+// Range yields byte indexes at UTF-8 code point boundaries, so slicing on idx
+// truncates by Unicode characters without copying the whole string to []rune.
+func truncateString(s string, width int) string {
+	for idx := range s {
+		if width == 0 {
+			return s[:idx]
+		}
+
+		width--
+	}
+
+	return s
 }
 
 func (t TruncateTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -872,3 +872,41 @@ func TestTruncateTransformStringUnicode(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateStringDoesNotSplitUTF8(t *testing.T) {
+	transform := iceberg.TruncateTransform{Width: 1}
+
+	out := transform.Apply(iceberg.Optional[iceberg.Literal]{
+		Valid: true,
+		Val:   iceberg.StringLiteral("éx"),
+	})
+	require.True(t, out.Valid)
+	got := string(out.Val.(iceberg.StringLiteral))
+	require.True(t, utf8.ValidString(got), "truncate produced invalid UTF-8: %q", got)
+	assert.Equal(t, "é", got)
+
+	fn, err := transform.Transformer(iceberg.PrimitiveTypes.String)
+	require.NoError(t, err)
+	transformed := fn("éx").(string)
+	require.True(t, utf8.ValidString(transformed), "transformer produced invalid UTF-8: %q", transformed)
+	assert.Equal(t, "é", transformed)
+
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   1,
+		Name: "s",
+		Type: iceberg.PrimitiveTypes.String,
+	})
+	bound, err := iceberg.EqualTo(iceberg.Reference("s"), "éx").Bind(schema, true)
+	require.NoError(t, err)
+
+	projected, err := transform.Project("s_trunc", bound.(iceberg.BoundPredicate))
+	require.NoError(t, err)
+	assert.True(t, iceberg.EqualTo(iceberg.Reference("s_trunc"), "é").Equals(projected))
+
+	binary := transform.Apply(iceberg.Optional[iceberg.Literal]{
+		Valid: true,
+		Val:   iceberg.BinaryLiteral([]byte("éx")),
+	})
+	require.True(t, binary.Valid)
+	assert.Equal(t, iceberg.BinaryLiteral([]byte{0xc3}), binary.Val)
+}


### PR DESCRIPTION
Summary
- make `truncate[string]` truncate at UTF-8 rune boundaries instead of byte offsets
- keep `truncate[binary]` byte-based
- add regression coverage for Apply, Transformer, and Project paths

Why
`TruncateTransform.Transformer` handled strings and binary values with the same byte-slicing branch. For non-ASCII strings, a width could split a UTF-8 code point and produce an invalid string partition value.

Testing
- `go test . -run "TestTruncateStringDoesNotSplitUTF8|TestTruncateTransform|TestCanTransform|TestManifestPartitionVals" -count=1`
- `go test ./... -count=1`
- `git diff --check`