### PR TITLE
fix(table): Propagate snapshotbyID error in snapshot summaries

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -809,7 +809,10 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 
 	var previousSnapshot *Snapshot
 	if sp.parentSnapshotID > 0 {
-		previousSnapshot, _ = sp.txn.meta.SnapshotByID(sp.parentSnapshotID)
+		previousSnapshot, err = sp.txn.meta.SnapshotByID(sp.parentSnapshotID)
+		if err != nil {
+			return Summary{}, fmt.Errorf("summary: lookup parent snapshot %d: %w", sp.parentSnapshotID, err)
+		}
 	}
 
 	var previousSummary iceberg.Properties

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -816,7 +816,7 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 	}
 
 	var previousSummary iceberg.Properties
-	if previousSnapshot != nil {
+	if previousSnapshot != nil && previousSnapshot.Summary != nil {
 		previousSummary = previousSnapshot.Summary.Properties
 	}
 

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -923,6 +923,54 @@ func TestComputeOwnManifests_NewTable(t *testing.T) {
 	require.Nil(t, got, "new table: returned manifests must equal input")
 }
 
+// TestSummary_SnapshotByIDError verifies that summary computation fails when
+// the parent snapshot cannot be found, instead of silently treating totals as
+// starting from zero.
+func TestSummary_SnapshotByIDError(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	io := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, io, spec)
+	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
+	sp.parentSnapshotID = 9999 // no such snapshot in metadata
+	sp.appendDataFile(newTestDataFile(t, spec, "file://data.parquet", nil))
+
+	_, err := sp.summary(nil)
+	require.Error(t, err, "unknown parent snapshot ID: summary must return error, not silent fallback")
+	require.ErrorIs(t, err, ErrSnapshotNotFound,
+		"production wraps ErrSnapshotNotFound; pin meaning via errors.Is")
+	require.ErrorContains(t, err, "summary: lookup parent snapshot 9999",
+		"error must identify the summary code path and parent snapshot ID")
+}
+
+// TestSummary_InheritsPreviousSnapshotTotals verifies that incremental totals
+// are computed from the parent snapshot summary when the parent exists.
+func TestSummary_InheritsPreviousSnapshotTotals(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	io := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, io, spec)
+
+	const parentID = int64(42)
+	txn.meta.snapshotList = append(txn.meta.snapshotList, Snapshot{
+		SnapshotID: parentID,
+		Summary: &Summary{
+			Operation: OpAppend,
+			Properties: iceberg.Properties{
+				totalDataFilesKey: "5",
+			},
+		},
+	})
+
+	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
+	sp.parentSnapshotID = parentID
+	sp.appendDataFile(newTestDataFile(t, spec, "file://data.parquet", nil))
+
+	sum, err := sp.summary(nil)
+	require.NoError(t, err)
+	require.Equal(t, "6", sum.Properties[totalDataFilesKey],
+		"total-data-files must inherit parent total (5) plus one added file")
+	require.Equal(t, "1", sum.Properties[addedDataFilesKey])
+}
+
 // TestComputeOwnManifests_SnapshotByIDError verifies that when the parent
 // snapshot cannot be found an error is returned instead of silently claiming
 // all manifests as own.

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -971,6 +971,31 @@ func TestSummary_InheritsPreviousSnapshotTotals(t *testing.T) {
 	require.Equal(t, "1", sum.Properties[addedDataFilesKey])
 }
 
+// TestSummary_ParentSnapshotWithoutSummary verifies that summary computation
+// does not panic when the parent snapshot exists but has no summary (V1 /
+// omitempty). Totals fall back to the zero baseline like a new table.
+func TestSummary_ParentSnapshotWithoutSummary(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	io := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, io, spec)
+
+	const parentID = int64(42)
+	txn.meta.snapshotList = append(txn.meta.snapshotList, Snapshot{
+		SnapshotID: parentID,
+		Summary:    nil,
+	})
+
+	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
+	sp.parentSnapshotID = parentID
+	sp.appendDataFile(newTestDataFile(t, spec, "file://data.parquet", nil))
+
+	sum, err := sp.summary(nil)
+	require.NoError(t, err)
+	require.Equal(t, "1", sum.Properties[totalDataFilesKey],
+		"nil parent summary must use zero baseline, not panic")
+	require.Equal(t, "1", sum.Properties[addedDataFilesKey])
+}
+
 // TestComputeOwnManifests_SnapshotByIDError verifies that when the parent
 // snapshot cannot be found an error is returned instead of silently claiming
 // all manifests as own.


### PR DESCRIPTION
During commit, summary() loads the parent snapshot to inherit its summary properties before calling updateSnapshotSummaries:

https://github.com/apache/iceberg-go/blob/1e4916f7a79462d193ed65d672545ff71fa6f556/table/snapshot_producers.go#L810-L827

If lookup failed, ``previousSnapshot` stayed nil, `previousSummary` was never set, and updateSnapshotSummaries fell back to zero baselines. That produced incorrect incremental snapshot summary properties (total-data-files, total-records, etc.) with no error surfaced to the caller.

The same lookup in `computeOwnManifests` already propagates the error and is covered by `TestComputeOwnManifests_SnapshotByIDError`; the summary path did not.

https://github.com/apache/iceberg-go/blob/1e4916f7a79462d193ed65d672545ff71fa6f556/table/snapshot_producers.go#L833-L842