### PR TITLE
feat(table): reject Variant in IdentityTransform and bound literal predicates

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -811,6 +811,8 @@ func createBoundLiteralPredicate(op Operation, term BoundTerm, lit Literal) (Bou
 		return newBoundLiteralPredicate[Decimal](op, term, finalLit), nil
 	case UUIDType:
 		return newBoundLiteralPredicate[uuid.UUID](op, term, finalLit), nil
+	case VariantType:
+		return nil, fmt.Errorf("%w: ordered predicates are not supported on variant fields", ErrInvalidArgument)
 	}
 
 	return nil, fmt.Errorf("%w: could not create bound literal predicate for term type %s",

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/parquet/variant"
 	"github.com/apache/iceberg-go"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -887,4 +888,21 @@ func TestBindAboveBelowIntMax(t *testing.T) {
 			assert.Equal(t, tt.exp, b)
 		})
 	}
+}
+
+func TestVariantBoundLiteralRejectionMessage(t *testing.T) {
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "payload", Type: iceberg.VariantType{}, Required: false},
+	)
+
+	var b variant.Builder
+	require.NoError(t, b.Append(int64(1)))
+	val, err := b.Build()
+	require.NoError(t, err)
+
+	pred := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("payload"), iceberg.VariantLiteral(val))
+	_, err = iceberg.BindExpr(sc, pred, true)
+	require.Error(t, err)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.ErrorContains(t, err, "ordered predicates are not supported on variant fields")
 }

--- a/transforms.go
+++ b/transforms.go
@@ -114,7 +114,7 @@ func (IdentityTransform) String() string { return "identity" }
 
 func (IdentityTransform) CanTransform(t Type) bool {
 	switch t.(type) {
-	case GeometryType, GeographyType:
+	case GeometryType, GeographyType, VariantType:
 		return false
 	}
 	_, ok := t.(PrimitiveType)


### PR DESCRIPTION
First part of [#1016](https://github.com/apache/iceberg-go/issues/1016). 

## Changes

- Adds `VariantType` to `IdentityTransform`'s deny-list (matches Java's `Identity.UNSUPPORTED_TYPES`), the other transforms already reject via their allow-list defaults. Adds explicit `case VariantType` in `createBoundLiteralPredicate` returning `ErrInvalidArgument` with a clear message.

- Added a test `TestVariantBoundLiteralRejectionMessage`

This is a precursor to adding the `variant_get` expression and stats-based pruning of #1016. Will address those after the shredding fixes.