### PR TITLE
fix(catalog/sql): use catalog name instead of hardcoded "sql"

### DIFF
--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -92,6 +92,8 @@ func init() {
 			}
 		}()
 
+		// Here, name is the loader-supplied catalog name and is persisted as the
+		// catalog_name partition key on every row in the iceberg_tables and iceberg_namespace_properties.
 		return NewCatalog(name, sqldb, SupportedDialect(dialect), p)
 	}))
 }

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -92,7 +92,7 @@ func init() {
 			}
 		}()
 
-		return NewCatalog(p.Get(name, "sql"), sqldb, SupportedDialect(dialect), p)
+		return NewCatalog(name, sqldb, SupportedDialect(dialect), p)
 	}))
 }
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -323,25 +323,42 @@ func (s *SqliteCatalogTestSuite) TestCreationAllTablesExist() {
 }
 
 func (s *SqliteCatalogTestSuite) TestCatalogNameMatchesLoaderArg() {
-	const catalogName = "test_catalog"
-	cat, err := catalog.Load(context.Background(), catalogName, iceberg.Properties{
-		"uri":             ":memory:",
+	ctx := context.Background()
+
+	sharedURI := s.catalogUri()
+	props := iceberg.Properties{
+		"uri":             sharedURI,
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: string(sqlcat.SQLite),
 		"type":            "sql",
 		"warehouse":       "file://" + s.warehouse,
-	})
+	}
+
+	const catalogName = "test_catalog"
+	cat, err := catalog.Load(ctx, catalogName, props)
 	s.Require().NoError(err)
-	sqlCat := cat.(*sqlcat.Catalog)
+	sqlCat, ok := cat.(*sqlcat.Catalog)
+	s.Require().True(ok, "expected *sqlcat.Catalog")
 	s.Equal(catalogName, sqlCat.Name(), "SQL catalog must surface the name passed to catalog.Load")
 
-	ctx := context.Background()
 	ns := table.Identifier{"test"}
 	s.Require().NoError(sqlCat.CreateNamespace(ctx, ns, iceberg.Properties{"created_by": "iceberg-go"}))
 
 	got, err := sqlCat.ListNamespaces(ctx, table.Identifier{})
 	s.Require().NoError(err)
+	s.Len(got, 1, "the loader-named catalog should see exactly the namespace it just created")
 	s.Contains(got, ns, "iceberg-go must list a namespace it just created under its own catalog name")
+
+	otherCat, err := catalog.Load(ctx, "sql", props)
+	s.Require().NoError(err)
+	otherSQLCat, ok := otherCat.(*sqlcat.Catalog)
+	s.Require().True(ok, "expected *sqlcat.Catalog")
+	s.Equal("sql", otherSQLCat.Name())
+
+	otherNS, err := otherSQLCat.ListNamespaces(ctx, table.Identifier{})
+	s.Require().NoError(err)
+	s.NotContains(otherNS, ns,
+		"a catalog loaded under a different name must not see namespaces written under another catalog_name")
 }
 
 func (s *SqliteCatalogTestSuite) TestDropSQLTablesIdempotency() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -322,6 +322,28 @@ func (s *SqliteCatalogTestSuite) TestCreationAllTablesExist() {
 	s.confirmTablesExist(sqldb)
 }
 
+func (s *SqliteCatalogTestSuite) TestCatalogNameMatchesLoaderArg() {
+	const catalogName = "test_catalog"
+	cat, err := catalog.Load(context.Background(), catalogName, iceberg.Properties{
+		"uri":             ":memory:",
+		sqlcat.DriverKey:  sqliteshim.ShimName,
+		sqlcat.DialectKey: string(sqlcat.SQLite),
+		"type":            "sql",
+		"warehouse":       "file://" + s.warehouse,
+	})
+	s.Require().NoError(err)
+	sqlCat := cat.(*sqlcat.Catalog)
+	s.Equal(catalogName, sqlCat.Name(), "SQL catalog must surface the name passed to catalog.Load")
+
+	ctx := context.Background()
+	ns := table.Identifier{"test"}
+	s.Require().NoError(sqlCat.CreateNamespace(ctx, ns, iceberg.Properties{"created_by": "iceberg-go"}))
+
+	got, err := sqlCat.ListNamespaces(ctx, table.Identifier{})
+	s.Require().NoError(err)
+	s.Contains(got, ns, "iceberg-go must list a namespace it just created under its own catalog name")
+}
+
 func (s *SqliteCatalogTestSuite) TestDropSQLTablesIdempotency() {
 	sqldb := s.getDB()
 	s.confirmNoTables(sqldb)


### PR DESCRIPTION
## Problem

Fixes #1210 

The SQL Catalog registrar in `catalog/sql/sql.go` ignores the catalog name passed to `catalog.Load(ctx, name, props)`, and threads it through `Properties.Get(name, "sql")`. 

## Solution
Thread the loader-supplied `name` directly into `NewCatalog`, so it ends up as `c.name` and as the `catalog_name` partition key on every row. A `catalog.Load(ctx, "olake_iceberg", …)` then shares the same row space as Spark loading the same name.

This change aligns with:
- what we have for [REST](https://github.com/apache/iceberg-go/blob/0c5552bfd34937e07bcb22f9bf9a3b5c4e33b27c/catalog/rest/rest.go#L103-L111) and [Hadoop](https://github.com/apache/iceberg-go/blob/0c5552bfd34937e07bcb22f9bf9a3b5c4e33b27c/catalog/hadoop/hadoop.go#L41-L49) as the catalog.
- Iceberg-java's [JdbcCatalog.initialize](https://github.com/apache/iceberg/blob/6ee0a3be308037e280ff17172a5bbd67a2a4131a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java#L130-L132) stores the caller-supplied name.


## Files Changed

| File | Description |
|------|-------------|
| `catalog/sql/sql.go` | Bug fix |
| `catalog/sql/sql_test.go` | Test for it |


## Testing
- Ingested data into the SQL catalog
- Queried through Spark `3.5.5`

## Changelog Note
Prior versions of the SQL Catalog registrar ignored the `name` argument and always wrote rows with catalog_name=`sql`.

**Upgrade:** if you previously loaded under a name other than `"sql"`, re-key existing rows:
```sql
UPDATE iceberg_tables SET catalog_name='<name>' WHERE catalog_name='sql';
UPDATE iceberg_namespace_properties SET catalog_name='<name>' WHERE catalog_name='sql';
```

Warehouse paths and metadata files are unchanged.
