### PR TITLE
feat(exprs): expression parsing for server-side planning

### DIFF
--- a/expr_json.go
+++ b/expr_json.go
@@ -67,6 +67,22 @@ var jsonToOp = func() map[string]Operation {
 	return m
 }()
 
+// Predicate operations grouped by the shape they carry on the wire. Spelled out
+// rather than keyed off iota ranges, so reordering the Operation constants can't
+// silently reclassify a predicate.
+var (
+	unaryOps = map[Operation]bool{
+		OpIsNull: true, OpNotNull: true, OpIsNan: true, OpNotNan: true,
+	}
+	literalOps = map[Operation]bool{
+		OpLT: true, OpLTEQ: true, OpGT: true, OpGTEQ: true,
+		OpEQ: true, OpNEQ: true, OpStartsWith: true, OpNotStartsWith: true,
+	}
+	setOps = map[Operation]bool{
+		OpIn: true, OpNotIn: true,
+	}
+)
+
 // exprNode is the wire form of an expression node. omitempty leaves only the
 // keys relevant to a given node; field order matches Java's output.
 type exprNode struct {
@@ -91,10 +107,21 @@ type transformNode struct {
 // a task's residual filter).
 //
 // With a schema, literals take the referenced field's type (e.g. "2022-08-14"
-// on a date column becomes a DateLiteral). Without one they fall back to the
-// base JSON kind: Int64Literal, Float64Literal, StringLiteral, or BoolLiteral.
+// on a date column becomes a DateLiteral) and field names are resolved
+// case-sensitively, since REST field names are authoritative. Without a schema
+// literals fall back to the base JSON kind: Int64Literal, Float64Literal,
+// StringLiteral, or BoolLiteral. The result is unbound.
+//
+// Transform terms (e.g. {"type":"transform","transform":"bucket[16]","term":"id"})
+// parse into an UnboundTransform. The term resolves its result type against the
+// schema; binding a full predicate over a transform term to the typed bound
+// machinery is not yet supported.
 func ParseExpr(data []byte, schema *Schema) (BooleanExpression, error) {
-	return decodeExpr(json.RawMessage(data), schema)
+	return parseExpr(json.RawMessage(data), schema, true)
+}
+
+func parseExpr(raw json.RawMessage, schema *Schema, caseSensitive bool) (BooleanExpression, error) {
+	return decodeExpr(raw, schema, caseSensitive)
 }
 
 // MarshalJSON emits the REST form, so an expression can be used as a "filter"
@@ -256,6 +283,19 @@ func (b *BoundTransform) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (u *UnboundTransform) MarshalJSON() ([]byte, error) {
+	ref, ok := u.term.(Reference)
+	if !ok {
+		return nil, fmt.Errorf("%w: cannot serialize transform over a non-reference term", ErrInvalidArgument)
+	}
+
+	return json.Marshal(transformNode{
+		Type:      exprKeyTransform,
+		Transform: u.transform.String(),
+		Term:      string(ref),
+	})
+}
+
 // Each literal writes its REST form (Java's SingleValueParser).
 func (l BoolLiteral) MarshalJSON() ([]byte, error)   { return json.Marshal(bool(l)) }
 func (l Int32Literal) MarshalJSON() ([]byte, error)  { return json.Marshal(int32(l)) }
@@ -350,17 +390,22 @@ func (v *literalValue) UnmarshalJSON(b []byte) error {
 // without it for timestamp.
 func marshalTimestamp(tm time.Time, typ Type) ([]byte, error) {
 	switch typ.(type) {
-	case TimestampTzType, TimestampTzNsType:
+	case TimestampTzType:
 		// "-07:00" prints +00:00 for a UTC instant, matching Java.
 		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999-07:00"))
-	case TimestampType, TimestampNsType:
+	case TimestampTzNsType:
+		// Nanosecond precision needs nine fractional digits.
+		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999999-07:00"))
+	case TimestampType:
 		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999"))
+	case TimestampNsType:
+		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999999"))
 	default:
 		return nil, fmt.Errorf("%w: serializing a timestamp filter needs the field type; bind the expression to a schema first", ErrInvalidArgument)
 	}
 }
 
-func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) {
+func decodeExpr(raw json.RawMessage, schema *Schema, caseSensitive bool) (BooleanExpression, error) {
 	// A bare boolean is AlwaysTrue/AlwaysFalse; anything else is a node object.
 	tok, err := firstToken(raw)
 	if err != nil {
@@ -384,6 +429,11 @@ func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) 
 
 	// {"type":"literal","value":<bool>} is an alternate spelling of a constant.
 	if node.Type == "literal" {
+		// A missing or null value would unmarshal to false and silently become
+		// AlwaysFalse, turning a corrupt payload into "filter everything out".
+		if len(node.Value) == 0 || bytes.Equal(node.Value, []byte("null")) {
+			return nil, fmt.Errorf("%w: literal expression is missing a boolean value", ErrInvalidArgument)
+		}
 		var bv bool
 		if err := json.Unmarshal(node.Value, &bv); err != nil {
 			return nil, fmt.Errorf("%w: cannot parse literal expression: %s", ErrInvalidArgument, err)
@@ -402,18 +452,18 @@ func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) 
 
 	switch op {
 	case OpNot:
-		child, err := decodeExpr(node.Child, schema)
+		child, err := decodeExpr(node.Child, schema, caseSensitive)
 		if err != nil {
 			return nil, err
 		}
 
 		return NewNot(child), nil
 	case OpAnd, OpOr:
-		left, err := decodeExpr(node.Left, schema)
+		left, err := decodeExpr(node.Left, schema, caseSensitive)
 		if err != nil {
 			return nil, err
 		}
-		right, err := decodeExpr(node.Right, schema)
+		right, err := decodeExpr(node.Right, schema, caseSensitive)
 		if err != nil {
 			return nil, err
 		}
@@ -424,7 +474,7 @@ func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) 
 		return NewOr(left, right), nil
 	}
 
-	return decodePredicate(op, node, schema)
+	return decodePredicate(op, node, schema, caseSensitive)
 }
 
 // firstToken returns the first JSON token of raw, used to classify a node
@@ -435,7 +485,7 @@ func firstToken(raw json.RawMessage) (json.Token, error) {
 	return dec.Token()
 }
 
-func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpression, error) {
+func decodePredicate(op Operation, node exprNode, schema *Schema, caseSensitive bool) (BooleanExpression, error) {
 	term, err := decodeTerm(node.Term)
 	if err != nil {
 		return nil, err
@@ -444,7 +494,7 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 	// Resolve the field type once; nil means schema-less.
 	var typ Type
 	if schema != nil {
-		bound, err := term.Bind(schema, false)
+		bound, err := term.Bind(schema, caseSensitive)
 		if err != nil {
 			return nil, err
 		}
@@ -452,13 +502,13 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 	}
 
 	switch {
-	case op >= OpIsNull && op <= OpNotNan:
+	case unaryOps[op]:
 		if len(node.Value) != 0 || node.Values != nil {
 			return nil, fmt.Errorf("%w: unary predicate %s must not have a value", ErrInvalidArgument, node.Type)
 		}
 
 		return UnaryPredicate(op, term), nil
-	case op >= OpLT && op <= OpNotStartsWith:
+	case literalOps[op]:
 		if len(node.Value) == 0 {
 			return nil, fmt.Errorf("%w: predicate %s is missing a value", ErrInvalidArgument, node.Type)
 		}
@@ -471,7 +521,7 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 		}
 
 		return LiteralPredicate(op, term, lit), nil
-	case op >= OpIn && op <= OpNotIn:
+	case setOps[op]:
 		if node.Values == nil {
 			return nil, fmt.Errorf("%w: predicate %s is missing values", ErrInvalidArgument, node.Type)
 		}
@@ -517,7 +567,13 @@ func decodeTerm(raw json.RawMessage) (UnboundTerm, error) {
 		// {"type":"reference","term":"name"}
 		return Reference(t.Term), nil
 	case exprKeyTransform:
-		return nil, fmt.Errorf("%w: transform terms are not supported when parsing expressions", ErrNotImplemented)
+		// {"type":"transform","transform":"bucket[16]","term":"id"}
+		tf, err := ParseTransform(t.Transform)
+		if err != nil {
+			return nil, fmt.Errorf("%w: cannot parse transform term: %s", ErrInvalidArgument, err)
+		}
+
+		return NewUnboundTransform(tf, Reference(t.Term)), nil
 	default:
 		return nil, fmt.Errorf("%w: cannot parse term with type %q", ErrInvalidArgument, t.Type)
 	}
@@ -552,7 +608,11 @@ func convertValue(base Literal, typ Type) (Literal, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid hex for %s value: %s", ErrInvalidArgument, typ, err)
 		}
-		if _, ok := typ.(FixedType); ok {
+		if ft, ok := typ.(FixedType); ok {
+			if len(decoded) != ft.Len() {
+				return nil, fmt.Errorf("%w: fixed[%d] value has %d bytes", ErrInvalidArgument, ft.Len(), len(decoded))
+			}
+
 			return FixedLiteral(decoded), nil
 		}
 

--- a/expr_json.go
+++ b/expr_json.go
@@ -30,8 +30,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// JSON serialization for boolean expressions, used for the "filter" field of a
-// REST scan-planning request. Mirrors Java's ExpressionParser.
+// JSON for boolean expressions, used as the "filter" of a REST scan-planning
+// request. Mirrors Java's ExpressionParser.
 
 // exprKeyTransform is the "type" value identifying a transform term.
 const exprKeyTransform = "transform"
@@ -87,24 +87,6 @@ type transformNode struct {
 	Term      string `json:"term"`
 }
 
-// MarshalJSON emits the REST JSON form, so an expression can be used directly
-// as a request's "filter" field. Tag such fields omitempty to drop a nil one.
-func (e AlwaysTrue) MarshalJSON() ([]byte, error)  { return encodeExpr(e) }
-func (e AlwaysFalse) MarshalJSON() ([]byte, error) { return encodeExpr(e) }
-func (e NotExpr) MarshalJSON() ([]byte, error)     { return encodeExpr(e) }
-func (e AndExpr) MarshalJSON() ([]byte, error)     { return encodeExpr(e) }
-func (e OrExpr) MarshalJSON() ([]byte, error)      { return encodeExpr(e) }
-
-func (p *unboundUnaryPredicate) MarshalJSON() ([]byte, error)   { return encodeExpr(p) }
-func (p *unboundLiteralPredicate) MarshalJSON() ([]byte, error) { return encodeExpr(p) }
-func (p *unboundSetPredicate) MarshalJSON() ([]byte, error)     { return encodeExpr(p) }
-
-// Bound predicates delegate to the same encoder; without these, json.Marshal of
-// a bound expression would fall through to {} since their fields are unexported.
-func (p *boundUnaryPredicate[T]) MarshalJSON() ([]byte, error)   { return encodeExpr(p) }
-func (p *boundLiteralPredicate[T]) MarshalJSON() ([]byte, error) { return encodeExpr(p) }
-func (p *boundSetPredicate[T]) MarshalJSON() ([]byte, error)     { return encodeExpr(p) }
-
 // ParseExpr parses an expression from its REST JSON form (a request "filter" or
 // a task's residual filter).
 //
@@ -115,231 +97,288 @@ func ParseExpr(data []byte, schema *Schema) (BooleanExpression, error) {
 	return decodeExpr(json.RawMessage(data), schema)
 }
 
-func encodeExpr(e BooleanExpression) (json.RawMessage, error) {
-	switch v := e.(type) {
-	case AlwaysTrue:
-		return json.RawMessage("true"), nil
-	case AlwaysFalse:
-		return json.RawMessage("false"), nil
-	case NotExpr:
-		child, err := encodeExpr(v.child)
-		if err != nil {
-			return nil, err
-		}
+// MarshalJSON emits the REST form, so an expression can be used as a "filter"
+// field directly. Tag such fields omitempty to drop a nil one.
+func (AlwaysTrue) MarshalJSON() ([]byte, error)  { return []byte("true"), nil }
+func (AlwaysFalse) MarshalJSON() ([]byte, error) { return []byte("false"), nil }
 
-		return json.Marshal(exprNode{Type: opToJSON[OpNot], Child: child})
-	case AndExpr:
-		left, err := encodeExpr(v.left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := encodeExpr(v.right)
-		if err != nil {
-			return nil, err
-		}
-
-		return json.Marshal(exprNode{Type: opToJSON[OpAnd], Left: left, Right: right})
-	case OrExpr:
-		left, err := encodeExpr(v.left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := encodeExpr(v.right)
-		if err != nil {
-			return nil, err
-		}
-
-		return json.Marshal(exprNode{Type: opToJSON[OpOr], Left: left, Right: right})
-	}
-
-	return encodePredicate(e)
-}
-
-func encodePredicate(e BooleanExpression) (json.RawMessage, error) {
-	op := e.Op()
-	js, ok := opToJSON[op]
-	if !ok {
-		return nil, fmt.Errorf("%w: cannot serialize expression with operation %s", ErrInvalidArgument, op)
-	}
-
-	var (
-		term Term
-		err  error
-	)
-	switch p := e.(type) {
-	case UnboundPredicate:
-		term = p.Term()
-	case BoundPredicate:
-		term = p.Term()
-	default:
-		return nil, fmt.Errorf("%w: cannot serialize expression of type %T", ErrInvalidArgument, e)
-	}
-
-	// A bound term carries the field type, which a timestamptz literal needs to
-	// emit its +00:00 offset. Unbound terms leave it nil.
-	var typ Type
-	if bt, ok := term.(BoundTerm); ok {
-		typ = bt.Type()
-	}
-
-	node := exprNode{Type: js}
-	if node.Term, err = encodeTerm(term); err != nil {
+func (n NotExpr) MarshalJSON() ([]byte, error) {
+	child, err := json.Marshal(n.child)
+	if err != nil {
 		return nil, err
 	}
 
-	switch {
-	case op >= OpIsNull && op <= OpNotNan:
-		// unary predicate: no value or values field
-	case op >= OpLT && op <= OpNotStartsWith:
-		lit, err := literalOf(e)
+	return json.Marshal(exprNode{Type: opToJSON[OpNot], Child: child})
+}
+
+func (a AndExpr) MarshalJSON() ([]byte, error) {
+	left, right, err := marshalChildren(a.left, a.right)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(exprNode{Type: opToJSON[OpAnd], Left: left, Right: right})
+}
+
+func (o OrExpr) MarshalJSON() ([]byte, error) {
+	left, right, err := marshalChildren(o.left, o.right)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(exprNode{Type: opToJSON[OpOr], Left: left, Right: right})
+}
+
+func marshalChildren(left, right BooleanExpression) (json.RawMessage, json.RawMessage, error) {
+	l, err := json.Marshal(left)
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := json.Marshal(right)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return l, r, nil
+}
+
+// Bound predicates need their own MarshalJSON too; without it json.Marshal would
+// fall through to {} since their fields are unexported.
+func (up *unboundUnaryPredicate) MarshalJSON() ([]byte, error) {
+	return marshalUnaryPredicate(up.op, up.term)
+}
+
+func (bp *boundUnaryPredicate[T]) MarshalJSON() ([]byte, error) {
+	return marshalUnaryPredicate(bp.op, bp.term)
+}
+
+func (ul *unboundLiteralPredicate) MarshalJSON() ([]byte, error) {
+	return marshalLiteralPredicate(ul.op, ul.term, ul.lit)
+}
+
+func (blp *boundLiteralPredicate[T]) MarshalJSON() ([]byte, error) {
+	return marshalLiteralPredicate(blp.op, blp.term, blp.lit)
+}
+
+func (usp *unboundSetPredicate) MarshalJSON() ([]byte, error) {
+	return marshalSetPredicate(usp.op, usp.term, usp.lits.Members())
+}
+
+func (bsp *boundSetPredicate[T]) MarshalJSON() ([]byte, error) {
+	return marshalSetPredicate(bsp.op, bsp.term, bsp.lits.Members())
+}
+
+// predicateType returns the wire "type" string for a predicate operation.
+func predicateType(op Operation) (string, error) {
+	s, ok := opToJSON[op]
+	if !ok {
+		return "", fmt.Errorf("%w: cannot serialize expression with operation %s", ErrInvalidArgument, op)
+	}
+
+	return s, nil
+}
+
+func marshalUnaryPredicate(op Operation, term Term) ([]byte, error) {
+	js, err := predicateType(op)
+	if err != nil {
+		return nil, err
+	}
+	t, err := json.Marshal(term)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(exprNode{Type: js, Term: t})
+}
+
+func marshalLiteralPredicate(op Operation, term Term, lit Literal) ([]byte, error) {
+	js, err := predicateType(op)
+	if err != nil {
+		return nil, err
+	}
+	t, err := json.Marshal(term)
+	if err != nil {
+		return nil, err
+	}
+	v, err := json.Marshal(literalValue{lit, termType(term)})
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(exprNode{Type: js, Term: t, Value: v})
+}
+
+// termType is the field type of a bound term, or nil for an unbound reference.
+func termType(term Term) Type {
+	if bt, ok := term.(BoundTerm); ok {
+		return bt.Ref().Field().Type
+	}
+
+	return nil
+}
+
+func marshalSetPredicate(op Operation, term Term, lits []Literal) ([]byte, error) {
+	js, err := predicateType(op)
+	if err != nil {
+		return nil, err
+	}
+	t, err := json.Marshal(term)
+	if err != nil {
+		return nil, err
+	}
+
+	typ := termType(term)
+	values := make([]json.RawMessage, 0, len(lits))
+	for _, l := range lits {
+		v, err := json.Marshal(literalValue{l, typ})
 		if err != nil {
 			return nil, err
 		}
-		if node.Value, err = encodeLiteral(lit, typ); err != nil {
-			return nil, err
-		}
-	case op >= OpIn && op <= OpNotIn:
-		lits, err := literalsOf(e)
-		if err != nil {
-			return nil, err
-		}
-		node.Values = make([]json.RawMessage, 0, len(lits))
-		for _, l := range lits {
-			v, err := encodeLiteral(l, typ)
-			if err != nil {
-				return nil, err
-			}
-			node.Values = append(node.Values, v)
-		}
-		// A set has no order; sort the encoded values for deterministic output.
-		sort.Slice(node.Values, func(i, j int) bool {
-			return bytes.Compare(node.Values[i], node.Values[j]) < 0
-		})
-	default:
-		return nil, fmt.Errorf("%w: cannot serialize expression with operation %s", ErrInvalidArgument, op)
+		values = append(values, v)
 	}
+	// A set has no order; sort the encoded values for deterministic output.
+	sort.Slice(values, func(i, j int) bool {
+		return bytes.Compare(values[i], values[j]) < 0
+	})
 
-	return json.Marshal(node)
+	return json.Marshal(exprNode{Type: js, Term: t, Values: values})
 }
 
-func encodeTerm(term Term) (json.RawMessage, error) {
-	switch t := term.(type) {
-	case Reference:
-		return json.Marshal(string(t))
-	case BoundReference:
-		return json.Marshal(t.Field().Name)
-	case *BoundTransform:
-		return json.Marshal(transformNode{
-			Type:      exprKeyTransform,
-			Transform: t.transform.String(),
-			Term:      t.term.Ref().Field().Name,
-		})
-	default:
-		return nil, fmt.Errorf("%w: cannot serialize term of type %T", ErrInvalidArgument, term)
-	}
+func (r Reference) MarshalJSON() ([]byte, error) { return json.Marshal(string(r)) }
+
+func (b *boundRef[T]) MarshalJSON() ([]byte, error) { return json.Marshal(b.field.Name) }
+
+func (b *BoundTransform) MarshalJSON() ([]byte, error) {
+	return json.Marshal(transformNode{
+		Type:      exprKeyTransform,
+		Transform: b.transform.String(),
+		Term:      b.term.Ref().Field().Name,
+	})
 }
 
-// encodeLiteral writes a non-null literal in the JSON form for its Iceberg type
-// (see Java's SingleValueParser). typ is the resolved field type, used to tell a
-// timestamptz literal from a plain timestamp; it may be nil for an unbound term.
-func encodeLiteral(lit Literal, typ Type) (json.RawMessage, error) {
-	switch l := lit.(type) {
-	case BoolLiteral:
-		return json.Marshal(bool(l))
-	case Int32Literal:
-		return json.Marshal(int32(l))
-	case Int64Literal:
-		return json.Marshal(int64(l))
-	case Float32Literal:
-		if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
-			return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
-		}
+// Each literal writes its REST form (Java's SingleValueParser).
+func (l BoolLiteral) MarshalJSON() ([]byte, error)   { return json.Marshal(bool(l)) }
+func (l Int32Literal) MarshalJSON() ([]byte, error)  { return json.Marshal(int32(l)) }
+func (l Int64Literal) MarshalJSON() ([]byte, error)  { return json.Marshal(int64(l)) }
+func (l StringLiteral) MarshalJSON() ([]byte, error) { return json.Marshal(string(l)) }
 
-		return json.Marshal(float32(l))
-	case Float64Literal:
-		if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
-			return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
-		}
+func (l Float32Literal) MarshalJSON() ([]byte, error) {
+	if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
+		return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
+	}
 
-		return json.Marshal(float64(l))
-	case StringLiteral:
-		return json.Marshal(string(l))
-	case DateLiteral:
-		return json.Marshal(Date(l).ToTime().Format("2006-01-02"))
-	case TimeLiteral:
-		// "9"s trim trailing fractional zeros (and the point when zero), as Java does.
-		return json.Marshal(time.UnixMicro(int64(l)).UTC().Format("15:04:05.999999"))
+	return json.Marshal(float32(l))
+}
+
+func (l Float64Literal) MarshalJSON() ([]byte, error) {
+	if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
+		return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
+	}
+
+	return json.Marshal(float64(l))
+}
+
+func (l DateLiteral) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Date(l).ToTime().Format("2006-01-02"))
+}
+
+func (l TimeLiteral) MarshalJSON() ([]byte, error) {
+	// "9"s trim trailing fractional zeros (and the point when zero), as Java does.
+	return json.Marshal(time.UnixMicro(int64(l)).UTC().Format("15:04:05.999999"))
+}
+
+// A bare timestamp literal has no field type, so it can't pick a wire form;
+// serialize through a predicate (see literalValue) instead.
+func (TimestampLiteral) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("%w: serialize a timestamp literal through a predicate so the field type is known", ErrInvalidArgument)
+}
+
+func (TimestampNsLiteral) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("%w: serialize a timestamp literal through a predicate so the field type is known", ErrInvalidArgument)
+}
+
+func (l UUIDLiteral) MarshalJSON() ([]byte, error) {
+	return json.Marshal(uuid.UUID(l).String())
+}
+
+func (l FixedLiteral) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
+}
+
+func (l BinaryLiteral) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
+}
+
+func (l DecimalLiteral) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Decimal(l).String())
+}
+
+// literalValue pairs a literal with its field type, like typeIFace does for
+// types. timestamp and timestamptz share one literal type, so the field type is
+// the only thing that decides the +00:00 offset on the wire.
+type literalValue struct {
+	Literal
+	typ Type
+}
+
+func (v literalValue) MarshalJSON() ([]byte, error) {
+	switch l := v.Literal.(type) {
 	case TimestampLiteral:
-		t := Timestamp(l).ToTime()
-		// timestamptz gets a +00:00 offset ("-07:00" prints it, "Z07:00" wouldn't).
-		if _, ok := typ.(TimestampTzType); ok {
-			return json.Marshal(t.UTC().Format("2006-01-02T15:04:05.999999-07:00"))
-		}
-
-		return json.Marshal(t.Format("2006-01-02T15:04:05.999999"))
+		return marshalTimestamp(Timestamp(l).ToTime(), v.typ)
 	case TimestampNsLiteral:
-		t := TimestampNano(l).ToTime()
-		if _, ok := typ.(TimestampTzNsType); ok {
-			return json.Marshal(t.UTC().Format("2006-01-02T15:04:05.999999999-07:00"))
-		}
-
-		return json.Marshal(t.Format("2006-01-02T15:04:05.999999999"))
-	case UUIDLiteral:
-		return json.Marshal(uuid.UUID(l).String())
-	case FixedLiteral:
-		return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
-	case BinaryLiteral:
-		return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
-	case DecimalLiteral:
-		return json.Marshal(Decimal(l).String())
+		return marshalTimestamp(TimestampNano(l).ToTime(), v.typ)
 	default:
-		return nil, fmt.Errorf("%w: cannot serialize literal of type %s", ErrInvalidArgument, lit.Type())
+		return json.Marshal(v.Literal)
 	}
 }
 
-func literalOf(e BooleanExpression) (Literal, error) {
-	switch p := e.(type) {
-	case *unboundLiteralPredicate:
-		return p.lit, nil
-	case BoundLiteralPredicate:
-		return p.Literal(), nil
-	default:
-		return nil, fmt.Errorf("%w: expected a literal predicate, got %T", ErrInvalidArgument, e)
+func (v *literalValue) UnmarshalJSON(b []byte) error {
+	base, err := asObject(b)
+	if err != nil {
+		return err
 	}
+	lit, err := convertValue(base, v.typ)
+	if err != nil {
+		return err
+	}
+	v.Literal = lit
+
+	return nil
 }
 
-func literalsOf(e BooleanExpression) ([]Literal, error) {
-	switch p := e.(type) {
-	case *unboundSetPredicate:
-		return p.lits.Members(), nil
-	case BoundSetPredicate:
-		return p.Literals().Members(), nil
+// marshalTimestamp emits the REST form: with the UTC offset for timestamptz,
+// without it for timestamp.
+func marshalTimestamp(tm time.Time, typ Type) ([]byte, error) {
+	switch typ.(type) {
+	case TimestampTzType, TimestampTzNsType:
+		// "-07:00" prints +00:00 for a UTC instant, matching Java.
+		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999-07:00"))
+	case TimestampType, TimestampNsType:
+		return json.Marshal(tm.Format("2006-01-02T15:04:05.999999"))
 	default:
-		return nil, fmt.Errorf("%w: expected a set predicate, got %T", ErrInvalidArgument, e)
+		return nil, fmt.Errorf("%w: serializing a timestamp filter needs the field type; bind the expression to a schema first", ErrInvalidArgument)
 	}
 }
 
 func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) {
-	b := bytes.TrimSpace(raw)
-	if len(b) == 0 {
-		return nil, fmt.Errorf("%w: cannot parse expression from empty input", ErrInvalidArgument)
+	// A bare boolean is AlwaysTrue/AlwaysFalse; anything else is a node object.
+	tok, err := firstToken(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
 	}
-
-	// A bare boolean is AlwaysTrue/AlwaysFalse.
-	if b[0] == 't' || b[0] == 'f' {
-		var bv bool
-		if err := json.Unmarshal(b, &bv); err != nil {
-			return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
-		}
-		if bv {
+	if b, ok := tok.(bool); ok {
+		if b {
 			return AlwaysTrue{}, nil
 		}
 
 		return AlwaysFalse{}, nil
 	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("%w: cannot parse expression from %s", ErrInvalidArgument, raw)
+	}
 
 	var node exprNode
-	if err := json.Unmarshal(b, &node); err != nil {
+	if err := json.Unmarshal(raw, &node); err != nil {
 		return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
 	}
 
@@ -386,6 +425,14 @@ func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) 
 	}
 
 	return decodePredicate(op, node, schema)
+}
+
+// firstToken returns the first JSON token of raw, used to classify a node
+// without inspecting bytes by hand.
+func firstToken(raw json.RawMessage) (json.Token, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+
+	return dec.Token()
 }
 
 func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpression, error) {
@@ -447,22 +494,22 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 }
 
 func decodeTerm(raw json.RawMessage) (UnboundTerm, error) {
-	b := bytes.TrimSpace(raw)
-	if len(b) == 0 {
+	if len(raw) == 0 {
 		return nil, fmt.Errorf("%w: predicate is missing a term", ErrInvalidArgument)
 	}
 
-	if b[0] == '"' {
-		var name string
-		if err := json.Unmarshal(b, &name); err != nil {
-			return nil, fmt.Errorf("%w: cannot parse term: %s", ErrInvalidArgument, err)
-		}
+	tok, err := firstToken(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cannot parse term: %s", ErrInvalidArgument, err)
+	}
 
+	// A bare string is a plain reference.
+	if name, ok := tok.(string); ok {
 		return Reference(name), nil
 	}
 
 	var t transformNode
-	if err := json.Unmarshal(b, &t); err != nil {
+	if err := json.Unmarshal(raw, &t); err != nil {
 		return nil, fmt.Errorf("%w: cannot parse term: %s", ErrInvalidArgument, err)
 	}
 	switch t.Type {
@@ -476,14 +523,19 @@ func decodeTerm(raw json.RawMessage) (UnboundTerm, error) {
 	}
 }
 
-// decodeValue parses one literal value. A nil type yields the base literal kind
-// for the JSON token; otherwise the value is converted to that type.
+// decodeValue parses one literal value and converts it to typ.
 func decodeValue(raw json.RawMessage, typ Type) (Literal, error) {
-	base, err := asObject(raw)
-	if err != nil {
+	v := literalValue{typ: typ}
+	if err := json.Unmarshal(raw, &v); err != nil {
 		return nil, err
 	}
 
+	return v.Literal, nil
+}
+
+// convertValue turns a base literal into typ. A nil type yields the base kind for
+// the JSON token, as the reference does without a schema.
+func convertValue(base Literal, typ Type) (Literal, error) {
 	if typ == nil {
 		return base, nil
 	}

--- a/expr_json.go
+++ b/expr_json.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -98,6 +99,12 @@ func (p *unboundUnaryPredicate) MarshalJSON() ([]byte, error)   { return encodeE
 func (p *unboundLiteralPredicate) MarshalJSON() ([]byte, error) { return encodeExpr(p) }
 func (p *unboundSetPredicate) MarshalJSON() ([]byte, error)     { return encodeExpr(p) }
 
+// Bound predicates delegate to the same encoder; without these, json.Marshal of
+// a bound expression would fall through to {} since their fields are unexported.
+func (p *boundUnaryPredicate[T]) MarshalJSON() ([]byte, error)   { return encodeExpr(p) }
+func (p *boundLiteralPredicate[T]) MarshalJSON() ([]byte, error) { return encodeExpr(p) }
+func (p *boundSetPredicate[T]) MarshalJSON() ([]byte, error)     { return encodeExpr(p) }
+
 // ParseExpr parses an expression from its REST JSON form (a request "filter" or
 // a task's residual filter).
 //
@@ -168,6 +175,13 @@ func encodePredicate(e BooleanExpression) (json.RawMessage, error) {
 		return nil, fmt.Errorf("%w: cannot serialize expression of type %T", ErrInvalidArgument, e)
 	}
 
+	// A bound term carries the field type, which a timestamptz literal needs to
+	// emit its +00:00 offset. Unbound terms leave it nil.
+	var typ Type
+	if bt, ok := term.(BoundTerm); ok {
+		typ = bt.Type()
+	}
+
 	node := exprNode{Type: js}
 	if node.Term, err = encodeTerm(term); err != nil {
 		return nil, err
@@ -181,7 +195,7 @@ func encodePredicate(e BooleanExpression) (json.RawMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if node.Value, err = encodeLiteral(lit); err != nil {
+		if node.Value, err = encodeLiteral(lit, typ); err != nil {
 			return nil, err
 		}
 	case op >= OpIn && op <= OpNotIn:
@@ -191,7 +205,7 @@ func encodePredicate(e BooleanExpression) (json.RawMessage, error) {
 		}
 		node.Values = make([]json.RawMessage, 0, len(lits))
 		for _, l := range lits {
-			v, err := encodeLiteral(l)
+			v, err := encodeLiteral(l, typ)
 			if err != nil {
 				return nil, err
 			}
@@ -226,8 +240,9 @@ func encodeTerm(term Term) (json.RawMessage, error) {
 }
 
 // encodeLiteral writes a non-null literal in the JSON form for its Iceberg type
-// (see Java's SingleValueParser).
-func encodeLiteral(lit Literal) (json.RawMessage, error) {
+// (see Java's SingleValueParser). typ is the resolved field type, used to tell a
+// timestamptz literal from a plain timestamp; it may be nil for an unbound term.
+func encodeLiteral(lit Literal, typ Type) (json.RawMessage, error) {
 	switch l := lit.(type) {
 	case BoolLiteral:
 		return json.Marshal(bool(l))
@@ -236,8 +251,16 @@ func encodeLiteral(lit Literal) (json.RawMessage, error) {
 	case Int64Literal:
 		return json.Marshal(int64(l))
 	case Float32Literal:
+		if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
+			return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
+		}
+
 		return json.Marshal(float32(l))
 	case Float64Literal:
+		if f := float64(l); math.IsInf(f, 0) || math.IsNaN(f) {
+			return nil, fmt.Errorf("%w: cannot serialize non-finite float %v", ErrInvalidArgument, f)
+		}
+
 		return json.Marshal(float64(l))
 	case StringLiteral:
 		return json.Marshal(string(l))
@@ -247,9 +270,20 @@ func encodeLiteral(lit Literal) (json.RawMessage, error) {
 		// "9"s trim trailing fractional zeros (and the point when zero), as Java does.
 		return json.Marshal(time.UnixMicro(int64(l)).UTC().Format("15:04:05.999999"))
 	case TimestampLiteral:
-		return json.Marshal(Timestamp(l).ToTime().Format("2006-01-02T15:04:05.999999"))
+		t := Timestamp(l).ToTime()
+		// timestamptz gets a +00:00 offset ("-07:00" prints it, "Z07:00" wouldn't).
+		if _, ok := typ.(TimestampTzType); ok {
+			return json.Marshal(t.UTC().Format("2006-01-02T15:04:05.999999-07:00"))
+		}
+
+		return json.Marshal(t.Format("2006-01-02T15:04:05.999999"))
 	case TimestampNsLiteral:
-		return json.Marshal(TimestampNano(l).ToTime().Format("2006-01-02T15:04:05.999999999"))
+		t := TimestampNano(l).ToTime()
+		if _, ok := typ.(TimestampTzNsType); ok {
+			return json.Marshal(t.UTC().Format("2006-01-02T15:04:05.999999999-07:00"))
+		}
+
+		return json.Marshal(t.Format("2006-01-02T15:04:05.999999999"))
 	case UUIDLiteral:
 		return json.Marshal(uuid.UUID(l).String())
 	case FixedLiteral:
@@ -381,6 +415,9 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 		if len(node.Value) == 0 {
 			return nil, fmt.Errorf("%w: predicate %s is missing a value", ErrInvalidArgument, node.Type)
 		}
+		if node.Values != nil {
+			return nil, fmt.Errorf("%w: predicate %s must not have values", ErrInvalidArgument, node.Type)
+		}
 		lit, err := decodeValue(node.Value, typ)
 		if err != nil {
 			return nil, err
@@ -390,6 +427,9 @@ func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpres
 	case op >= OpIn && op <= OpNotIn:
 		if node.Values == nil {
 			return nil, fmt.Errorf("%w: predicate %s is missing values", ErrInvalidArgument, node.Type)
+		}
+		if len(node.Value) != 0 {
+			return nil, fmt.Errorf("%w: predicate %s must not have a value", ErrInvalidArgument, node.Type)
 		}
 		lits := make([]Literal, 0, len(node.Values))
 		for _, v := range node.Values {

--- a/expr_json.go
+++ b/expr_json.go
@@ -1,0 +1,502 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// JSON serialization for boolean expressions, used for the "filter" field of a
+// REST scan-planning request. Mirrors Java's ExpressionParser.
+
+// exprKeyTransform is the "type" value identifying a transform term.
+const exprKeyTransform = "transform"
+
+// opToJSON maps an Operation to its wire string (OpLTEQ -> "lt-eq"). OpTrue and
+// OpFalse are handled separately: they serialize as bare JSON booleans.
+var opToJSON = map[Operation]string{
+	OpIsNull:        "is-null",
+	OpNotNull:       "not-null",
+	OpIsNan:         "is-nan",
+	OpNotNan:        "not-nan",
+	OpLT:            "lt",
+	OpLTEQ:          "lt-eq",
+	OpGT:            "gt",
+	OpGTEQ:          "gt-eq",
+	OpEQ:            "eq",
+	OpNEQ:           "not-eq",
+	OpStartsWith:    "starts-with",
+	OpNotStartsWith: "not-starts-with",
+	OpIn:            "in",
+	OpNotIn:         "not-in",
+	OpNot:           "not",
+	OpAnd:           "and",
+	OpOr:            "or",
+}
+
+var jsonToOp = func() map[string]Operation {
+	m := make(map[string]Operation, len(opToJSON))
+	for op, s := range opToJSON {
+		m[s] = op
+	}
+
+	return m
+}()
+
+// exprNode is the wire form of an expression node. omitempty leaves only the
+// keys relevant to a given node; field order matches Java's output.
+type exprNode struct {
+	Type   string            `json:"type"`
+	Child  json.RawMessage   `json:"child,omitempty"`
+	Left   json.RawMessage   `json:"left,omitempty"`
+	Right  json.RawMessage   `json:"right,omitempty"`
+	Term   json.RawMessage   `json:"term,omitempty"`
+	Value  json.RawMessage   `json:"value,omitempty"`
+	Values []json.RawMessage `json:"values,omitempty"`
+}
+
+// transformNode is the wire form of a transform term, e.g.
+// {"type":"transform","transform":"bucket[16]","term":"id"}.
+type transformNode struct {
+	Type      string `json:"type"`
+	Transform string `json:"transform"`
+	Term      string `json:"term"`
+}
+
+// MarshalJSON emits the REST JSON form, so an expression can be used directly
+// as a request's "filter" field. Tag such fields omitempty to drop a nil one.
+func (e AlwaysTrue) MarshalJSON() ([]byte, error)  { return encodeExpr(e) }
+func (e AlwaysFalse) MarshalJSON() ([]byte, error) { return encodeExpr(e) }
+func (e NotExpr) MarshalJSON() ([]byte, error)     { return encodeExpr(e) }
+func (e AndExpr) MarshalJSON() ([]byte, error)     { return encodeExpr(e) }
+func (e OrExpr) MarshalJSON() ([]byte, error)      { return encodeExpr(e) }
+
+func (p *unboundUnaryPredicate) MarshalJSON() ([]byte, error)   { return encodeExpr(p) }
+func (p *unboundLiteralPredicate) MarshalJSON() ([]byte, error) { return encodeExpr(p) }
+func (p *unboundSetPredicate) MarshalJSON() ([]byte, error)     { return encodeExpr(p) }
+
+// ParseExpr parses an expression from its REST JSON form (a request "filter" or
+// a task's residual filter).
+//
+// With a schema, literals take the referenced field's type (e.g. "2022-08-14"
+// on a date column becomes a DateLiteral). Without one they fall back to the
+// base JSON kind: Int64Literal, Float64Literal, StringLiteral, or BoolLiteral.
+func ParseExpr(data []byte, schema *Schema) (BooleanExpression, error) {
+	return decodeExpr(json.RawMessage(data), schema)
+}
+
+func encodeExpr(e BooleanExpression) (json.RawMessage, error) {
+	switch v := e.(type) {
+	case AlwaysTrue:
+		return json.RawMessage("true"), nil
+	case AlwaysFalse:
+		return json.RawMessage("false"), nil
+	case NotExpr:
+		child, err := encodeExpr(v.child)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(exprNode{Type: opToJSON[OpNot], Child: child})
+	case AndExpr:
+		left, err := encodeExpr(v.left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := encodeExpr(v.right)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(exprNode{Type: opToJSON[OpAnd], Left: left, Right: right})
+	case OrExpr:
+		left, err := encodeExpr(v.left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := encodeExpr(v.right)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(exprNode{Type: opToJSON[OpOr], Left: left, Right: right})
+	}
+
+	return encodePredicate(e)
+}
+
+func encodePredicate(e BooleanExpression) (json.RawMessage, error) {
+	op := e.Op()
+	js, ok := opToJSON[op]
+	if !ok {
+		return nil, fmt.Errorf("%w: cannot serialize expression with operation %s", ErrInvalidArgument, op)
+	}
+
+	var (
+		term Term
+		err  error
+	)
+	switch p := e.(type) {
+	case UnboundPredicate:
+		term = p.Term()
+	case BoundPredicate:
+		term = p.Term()
+	default:
+		return nil, fmt.Errorf("%w: cannot serialize expression of type %T", ErrInvalidArgument, e)
+	}
+
+	node := exprNode{Type: js}
+	if node.Term, err = encodeTerm(term); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case op >= OpIsNull && op <= OpNotNan:
+		// unary predicate: no value or values field
+	case op >= OpLT && op <= OpNotStartsWith:
+		lit, err := literalOf(e)
+		if err != nil {
+			return nil, err
+		}
+		if node.Value, err = encodeLiteral(lit); err != nil {
+			return nil, err
+		}
+	case op >= OpIn && op <= OpNotIn:
+		lits, err := literalsOf(e)
+		if err != nil {
+			return nil, err
+		}
+		node.Values = make([]json.RawMessage, 0, len(lits))
+		for _, l := range lits {
+			v, err := encodeLiteral(l)
+			if err != nil {
+				return nil, err
+			}
+			node.Values = append(node.Values, v)
+		}
+		// A set has no order; sort the encoded values for deterministic output.
+		sort.Slice(node.Values, func(i, j int) bool {
+			return bytes.Compare(node.Values[i], node.Values[j]) < 0
+		})
+	default:
+		return nil, fmt.Errorf("%w: cannot serialize expression with operation %s", ErrInvalidArgument, op)
+	}
+
+	return json.Marshal(node)
+}
+
+func encodeTerm(term Term) (json.RawMessage, error) {
+	switch t := term.(type) {
+	case Reference:
+		return json.Marshal(string(t))
+	case BoundReference:
+		return json.Marshal(t.Field().Name)
+	case *BoundTransform:
+		return json.Marshal(transformNode{
+			Type:      exprKeyTransform,
+			Transform: t.transform.String(),
+			Term:      t.term.Ref().Field().Name,
+		})
+	default:
+		return nil, fmt.Errorf("%w: cannot serialize term of type %T", ErrInvalidArgument, term)
+	}
+}
+
+// encodeLiteral writes a non-null literal in the JSON form for its Iceberg type
+// (see Java's SingleValueParser).
+func encodeLiteral(lit Literal) (json.RawMessage, error) {
+	switch l := lit.(type) {
+	case BoolLiteral:
+		return json.Marshal(bool(l))
+	case Int32Literal:
+		return json.Marshal(int32(l))
+	case Int64Literal:
+		return json.Marshal(int64(l))
+	case Float32Literal:
+		return json.Marshal(float32(l))
+	case Float64Literal:
+		return json.Marshal(float64(l))
+	case StringLiteral:
+		return json.Marshal(string(l))
+	case DateLiteral:
+		return json.Marshal(Date(l).ToTime().Format("2006-01-02"))
+	case TimeLiteral:
+		// "9"s trim trailing fractional zeros (and the point when zero), as Java does.
+		return json.Marshal(time.UnixMicro(int64(l)).UTC().Format("15:04:05.999999"))
+	case TimestampLiteral:
+		return json.Marshal(Timestamp(l).ToTime().Format("2006-01-02T15:04:05.999999"))
+	case TimestampNsLiteral:
+		return json.Marshal(TimestampNano(l).ToTime().Format("2006-01-02T15:04:05.999999999"))
+	case UUIDLiteral:
+		return json.Marshal(uuid.UUID(l).String())
+	case FixedLiteral:
+		return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
+	case BinaryLiteral:
+		return json.Marshal(strings.ToUpper(hex.EncodeToString([]byte(l))))
+	case DecimalLiteral:
+		return json.Marshal(Decimal(l).String())
+	default:
+		return nil, fmt.Errorf("%w: cannot serialize literal of type %s", ErrInvalidArgument, lit.Type())
+	}
+}
+
+func literalOf(e BooleanExpression) (Literal, error) {
+	switch p := e.(type) {
+	case *unboundLiteralPredicate:
+		return p.lit, nil
+	case BoundLiteralPredicate:
+		return p.Literal(), nil
+	default:
+		return nil, fmt.Errorf("%w: expected a literal predicate, got %T", ErrInvalidArgument, e)
+	}
+}
+
+func literalsOf(e BooleanExpression) ([]Literal, error) {
+	switch p := e.(type) {
+	case *unboundSetPredicate:
+		return p.lits.Members(), nil
+	case BoundSetPredicate:
+		return p.Literals().Members(), nil
+	default:
+		return nil, fmt.Errorf("%w: expected a set predicate, got %T", ErrInvalidArgument, e)
+	}
+}
+
+func decodeExpr(raw json.RawMessage, schema *Schema) (BooleanExpression, error) {
+	b := bytes.TrimSpace(raw)
+	if len(b) == 0 {
+		return nil, fmt.Errorf("%w: cannot parse expression from empty input", ErrInvalidArgument)
+	}
+
+	// A bare boolean is AlwaysTrue/AlwaysFalse.
+	if b[0] == 't' || b[0] == 'f' {
+		var bv bool
+		if err := json.Unmarshal(b, &bv); err != nil {
+			return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
+		}
+		if bv {
+			return AlwaysTrue{}, nil
+		}
+
+		return AlwaysFalse{}, nil
+	}
+
+	var node exprNode
+	if err := json.Unmarshal(b, &node); err != nil {
+		return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
+	}
+
+	// {"type":"literal","value":<bool>} is an alternate spelling of a constant.
+	if node.Type == "literal" {
+		var bv bool
+		if err := json.Unmarshal(node.Value, &bv); err != nil {
+			return nil, fmt.Errorf("%w: cannot parse literal expression: %s", ErrInvalidArgument, err)
+		}
+		if bv {
+			return AlwaysTrue{}, nil
+		}
+
+		return AlwaysFalse{}, nil
+	}
+
+	op, ok := jsonToOp[node.Type]
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown expression type %q", ErrInvalidArgument, node.Type)
+	}
+
+	switch op {
+	case OpNot:
+		child, err := decodeExpr(node.Child, schema)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewNot(child), nil
+	case OpAnd, OpOr:
+		left, err := decodeExpr(node.Left, schema)
+		if err != nil {
+			return nil, err
+		}
+		right, err := decodeExpr(node.Right, schema)
+		if err != nil {
+			return nil, err
+		}
+		if op == OpAnd {
+			return NewAnd(left, right), nil
+		}
+
+		return NewOr(left, right), nil
+	}
+
+	return decodePredicate(op, node, schema)
+}
+
+func decodePredicate(op Operation, node exprNode, schema *Schema) (BooleanExpression, error) {
+	term, err := decodeTerm(node.Term)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the field type once; nil means schema-less.
+	var typ Type
+	if schema != nil {
+		bound, err := term.Bind(schema, false)
+		if err != nil {
+			return nil, err
+		}
+		typ = bound.Type()
+	}
+
+	switch {
+	case op >= OpIsNull && op <= OpNotNan:
+		if len(node.Value) != 0 || node.Values != nil {
+			return nil, fmt.Errorf("%w: unary predicate %s must not have a value", ErrInvalidArgument, node.Type)
+		}
+
+		return UnaryPredicate(op, term), nil
+	case op >= OpLT && op <= OpNotStartsWith:
+		if len(node.Value) == 0 {
+			return nil, fmt.Errorf("%w: predicate %s is missing a value", ErrInvalidArgument, node.Type)
+		}
+		lit, err := decodeValue(node.Value, typ)
+		if err != nil {
+			return nil, err
+		}
+
+		return LiteralPredicate(op, term, lit), nil
+	case op >= OpIn && op <= OpNotIn:
+		if node.Values == nil {
+			return nil, fmt.Errorf("%w: predicate %s is missing values", ErrInvalidArgument, node.Type)
+		}
+		lits := make([]Literal, 0, len(node.Values))
+		for _, v := range node.Values {
+			lit, err := decodeValue(v, typ)
+			if err != nil {
+				return nil, err
+			}
+			lits = append(lits, lit)
+		}
+
+		return SetPredicate(op, term, lits), nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported predicate operation %s", ErrInvalidArgument, op)
+	}
+}
+
+func decodeTerm(raw json.RawMessage) (UnboundTerm, error) {
+	b := bytes.TrimSpace(raw)
+	if len(b) == 0 {
+		return nil, fmt.Errorf("%w: predicate is missing a term", ErrInvalidArgument)
+	}
+
+	if b[0] == '"' {
+		var name string
+		if err := json.Unmarshal(b, &name); err != nil {
+			return nil, fmt.Errorf("%w: cannot parse term: %s", ErrInvalidArgument, err)
+		}
+
+		return Reference(name), nil
+	}
+
+	var t transformNode
+	if err := json.Unmarshal(b, &t); err != nil {
+		return nil, fmt.Errorf("%w: cannot parse term: %s", ErrInvalidArgument, err)
+	}
+	switch t.Type {
+	case "reference":
+		// {"type":"reference","term":"name"}
+		return Reference(t.Term), nil
+	case exprKeyTransform:
+		return nil, fmt.Errorf("%w: transform terms are not supported when parsing expressions", ErrNotImplemented)
+	default:
+		return nil, fmt.Errorf("%w: cannot parse term with type %q", ErrInvalidArgument, t.Type)
+	}
+}
+
+// decodeValue parses one literal value. A nil type yields the base literal kind
+// for the JSON token; otherwise the value is converted to that type.
+func decodeValue(raw json.RawMessage, typ Type) (Literal, error) {
+	base, err := asObject(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if typ == nil {
+		return base, nil
+	}
+
+	// Binary and fixed arrive as hex strings; decode them rather than treating
+	// the string as raw bytes.
+	switch typ.(type) {
+	case BinaryType, FixedType:
+		s, ok := base.(StringLiteral)
+		if !ok {
+			return nil, fmt.Errorf("%w: expected a string for %s value", ErrInvalidArgument, typ)
+		}
+		decoded, err := hex.DecodeString(string(s))
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid hex for %s value: %s", ErrInvalidArgument, typ, err)
+		}
+		if _, ok := typ.(FixedType); ok {
+			return FixedLiteral(decoded), nil
+		}
+
+		return BinaryLiteral(decoded), nil
+	}
+
+	return base.To(typ)
+}
+
+// asObject parses a JSON scalar to its base literal kind (Int64, Float64,
+// String, or Bool), as the reference does without a schema.
+func asObject(raw json.RawMessage) (Literal, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("%w: cannot parse literal value: %s", ErrInvalidArgument, err)
+	}
+
+	switch x := v.(type) {
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return Int64Literal(i), nil
+		}
+		f, err := x.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("%w: cannot parse number literal %q: %s", ErrInvalidArgument, x.String(), err)
+		}
+
+		return Float64Literal(f), nil
+	case string:
+		return StringLiteral(x), nil
+	case bool:
+		return BoolLiteral(x), nil
+	default:
+		return nil, fmt.Errorf("%w: cannot parse literal value from %s", ErrInvalidArgument, raw)
+	}
+}

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -19,6 +19,7 @@ package iceberg_test
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -172,6 +173,52 @@ func TestMarshalExpressionTypedLiterals(t *testing.T) {
 	}
 }
 
+// TestMarshalExpressionTimestampTz checks that a timestamptz value serializes
+// with a +00:00 offset (Java's format), which needs the bound field type to tell
+// it apart from a plain timestamp. It also round-trips back through the schema.
+func TestMarshalExpressionTimestampTz(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTz},
+	)
+	unbound := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("ts"),
+		mustLit(t, "2022-08-14T10:00:00+00:00", iceberg.PrimitiveTypes.TimestampTz))
+
+	bound, err := iceberg.BindExpr(schema, unbound, true)
+	require.NoError(t, err)
+
+	got, err := json.Marshal(bound)
+	require.NoError(t, err)
+	assert.Equal(t, `{"type":"eq","term":"ts","value":"2022-08-14T10:00:00+00:00"}`, string(got))
+
+	parsed, err := iceberg.ParseExpr(got, schema)
+	require.NoError(t, err)
+	assert.Truef(t, unbound.Equals(parsed), "want %s, got %s", unbound, parsed)
+}
+
+// TestMarshalBoundExpression guards against bound expressions falling through to
+// "{}": their MarshalJSON must delegate to the same encoder as the unbound ones.
+func TestMarshalBoundExpression(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "i", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	bound, err := iceberg.BindExpr(schema, iceberg.EqualTo(iceberg.Reference("i"), int32(25)), true)
+	require.NoError(t, err)
+
+	got, err := json.Marshal(bound)
+	require.NoError(t, err)
+	assert.Equal(t, `{"type":"eq","term":"i","value":25}`, string(got))
+}
+
+// TestMarshalExpressionNonFiniteFloat checks that NaN/Inf bounds are rejected
+// rather than producing invalid JSON.
+func TestMarshalExpressionNonFiniteFloat(t *testing.T) {
+	for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		expr := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("f"), iceberg.Float64Literal(v))
+		_, err := json.Marshal(expr)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	}
+}
+
 func mustLit(t *testing.T, s string, typ iceberg.Type) iceberg.Literal {
 	t.Helper()
 	lit, err := iceberg.NewLiteral(s).To(typ)
@@ -274,6 +321,8 @@ func TestUnmarshalExpressionErrors(t *testing.T) {
 		{"literal missing value", `{"type":"eq","term":"a"}`},
 		{"in missing values", `{"type":"in","term":"a"}`},
 		{"missing term", `{"type":"eq","value":1}`},
+		{"literal with stray values", `{"type":"eq","term":"a","value":1,"values":[1,2]}`},
+		{"set with stray value", `{"type":"in","term":"a","values":[1],"value":1}`},
 	}
 
 	for _, tt := range tests {

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -1,0 +1,291 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalExpressionJSON checks that expressions serialize to the exact JSON
+// that Java's ExpressionParser produces.
+func TestMarshalExpressionJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		expr iceberg.BooleanExpression
+		want string
+	}{
+		{
+			name: "always true",
+			expr: iceberg.AlwaysTrue{},
+			want: `true`,
+		},
+		{
+			name: "always false",
+			expr: iceberg.AlwaysFalse{},
+			want: `false`,
+		},
+		{
+			name: "is null",
+			expr: iceberg.IsNull(iceberg.Reference("a")),
+			want: `{"type":"is-null","term":"a"}`,
+		},
+		{
+			name: "not null",
+			expr: iceberg.NotNull(iceberg.Reference("a")),
+			want: `{"type":"not-null","term":"a"}`,
+		},
+		{
+			name: "is nan",
+			expr: iceberg.IsNaN(iceberg.Reference("f")),
+			want: `{"type":"is-nan","term":"f"}`,
+		},
+		{
+			name: "equal int",
+			expr: iceberg.EqualTo(iceberg.Reference("name"), int32(25)),
+			want: `{"type":"eq","term":"name","value":25}`,
+		},
+		{
+			name: "less than or equal long",
+			expr: iceberg.LessThanEqual(iceberg.Reference("c"), int64(50)),
+			want: `{"type":"lt-eq","term":"c","value":50}`,
+		},
+		{
+			name: "greater than double",
+			expr: iceberg.GreaterThan(iceberg.Reference("d"), float64(3.5)),
+			want: `{"type":"gt","term":"d","value":3.5}`,
+		},
+		{
+			name: "not equal string",
+			expr: iceberg.NotEqualTo(iceberg.Reference("s"), "abc"),
+			want: `{"type":"not-eq","term":"s","value":"abc"}`,
+		},
+		{
+			name: "starts with",
+			expr: iceberg.StartsWith(iceberg.Reference("s"), "ab"),
+			want: `{"type":"starts-with","term":"s","value":"ab"}`,
+		},
+		{
+			name: "not starts with",
+			expr: iceberg.NotStartsWith(iceberg.Reference("s"), "ab"),
+			want: `{"type":"not-starts-with","term":"s","value":"ab"}`,
+		},
+		{
+			name: "equal bool",
+			expr: iceberg.EqualTo(iceberg.Reference("b"), true),
+			want: `{"type":"eq","term":"b","value":true}`,
+		},
+		{
+			name: "in ints (sorted)",
+			expr: iceberg.IsIn(iceberg.Reference("c"), int32(52), int32(50), int32(51)),
+			want: `{"type":"in","term":"c","values":[50,51,52]}`,
+		},
+		{
+			name: "not in strings (sorted)",
+			expr: iceberg.NotIn(iceberg.Reference("c"), "two", "one"),
+			want: `{"type":"not-in","term":"c","values":["one","two"]}`,
+		},
+		{
+			name: "not",
+			expr: iceberg.NewNot(iceberg.GreaterThanEqual(iceberg.Reference("c"), int32(50))),
+			want: `{"type":"not","child":{"type":"gt-eq","term":"c","value":50}}`,
+		},
+		{
+			name: "and",
+			expr: iceberg.NewAnd(
+				iceberg.GreaterThanEqual(iceberg.Reference("c1"), int32(50)),
+				iceberg.IsIn(iceberg.Reference("c2"), "one", "two"),
+			),
+			want: `{"type":"and","left":{"type":"gt-eq","term":"c1","value":50},"right":{"type":"in","term":"c2","values":["one","two"]}}`,
+		},
+		{
+			name: "or with nested and",
+			expr: iceberg.NewOr(
+				iceberg.NewAnd(
+					iceberg.IsIn(iceberg.Reference("c1"), int32(50)),
+					iceberg.EqualTo(iceberg.Reference("c2"), "test"),
+				),
+				iceberg.IsNaN(iceberg.Reference("c3")),
+			),
+			// c1 IN (50) folds to c1 == 50
+			want: `{"type":"or","left":{"type":"and","left":{"type":"eq","term":"c1","value":50},"right":{"type":"eq","term":"c2","value":"test"}},"right":{"type":"is-nan","term":"c3"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.expr)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+			// JSONEq is order-insensitive; also assert exact bytes to lock field order.
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// TestMarshalExpressionTypedLiterals checks the wire encoding of the trickier
+// literal types against SingleValueParser's format.
+func TestMarshalExpressionTypedLiterals(t *testing.T) {
+	tests := []struct {
+		name string
+		lit  any
+		want string
+	}{
+		{"date", mustLit(t, "2022-08-14", iceberg.PrimitiveTypes.Date), `{"type":"eq","term":"d","value":"2022-08-14"}`},
+		{"timestamp (no fraction)", mustLit(t, "2022-08-14T10:00:00", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00"}`},
+		{"timestamp (micros)", mustLit(t, "2022-08-14T10:00:00.123456", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00.123456"}`},
+		{"timestamp (trailing zeros trimmed)", mustLit(t, "2022-08-14T10:00:00.500000", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00.5"}`},
+		{"uuid", iceberg.UUIDLiteral(uuid.MustParse("f79c3e09-677c-4bbd-a479-3f349cb785e7")), `{"type":"eq","term":"d","value":"f79c3e09-677c-4bbd-a479-3f349cb785e7"}`},
+		{"binary", iceberg.BinaryLiteral([]byte{0x01, 0x02, 0x03}), `{"type":"eq","term":"d","value":"010203"}`},
+		{"decimal", mustLit(t, "3.14", iceberg.DecimalTypeOf(9, 2)), `{"type":"eq","term":"d","value":"3.14"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lit, ok := tt.lit.(iceberg.Literal)
+			require.True(t, ok)
+			expr := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("d"), lit)
+			got, err := json.Marshal(expr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func mustLit(t *testing.T, s string, typ iceberg.Type) iceberg.Literal {
+	t.Helper()
+	lit, err := iceberg.NewLiteral(s).To(typ)
+	require.NoError(t, err)
+
+	return lit
+}
+
+// TestExpressionRoundTripSchemaless verifies that parsing without a schema
+// normalizes literals to their base JSON kind, as the reference does.
+func TestExpressionRoundTripSchemaless(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want iceberg.BooleanExpression
+	}{
+		{"true", `true`, iceberg.AlwaysTrue{}},
+		{"false", `false`, iceberg.AlwaysFalse{}},
+		{"literal true", `{"type":"literal","value":true}`, iceberg.AlwaysTrue{}},
+		{"is null", `{"type":"is-null","term":"a"}`, iceberg.IsNull(iceberg.Reference("a"))},
+		{"eq long", `{"type":"eq","term":"name","value":25}`, iceberg.EqualTo(iceberg.Reference("name"), int64(25))},
+		{"eq double", `{"type":"eq","term":"d","value":3.5}`, iceberg.EqualTo(iceberg.Reference("d"), float64(3.5))},
+		{"eq string", `{"type":"not-eq","term":"s","value":"abc"}`, iceberg.NotEqualTo(iceberg.Reference("s"), "abc")},
+		{"eq bool", `{"type":"eq","term":"b","value":true}`, iceberg.EqualTo(iceberg.Reference("b"), true)},
+		{"in longs", `{"type":"in","term":"c","values":[50,51]}`, iceberg.IsIn(iceberg.Reference("c"), int64(50), int64(51))},
+		{
+			"and",
+			`{"type":"and","left":{"type":"gt-eq","term":"c1","value":50},"right":{"type":"is-nan","term":"c2"}}`,
+			iceberg.NewAnd(
+				iceberg.GreaterThanEqual(iceberg.Reference("c1"), int64(50)),
+				iceberg.IsNaN(iceberg.Reference("c2")),
+			),
+		},
+		{
+			"reference object term",
+			`{"type":"eq","term":{"type":"reference","term":"name"},"value":25}`,
+			iceberg.EqualTo(iceberg.Reference("name"), int64(25)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := iceberg.ParseExpr([]byte(tt.json), nil)
+			require.NoError(t, err)
+			assert.Truef(t, tt.want.Equals(got), "want %s, got %s", tt.want, got)
+		})
+	}
+}
+
+// TestExpressionRoundTripWithSchema verifies that with a schema, literals are
+// parsed into the referenced field's type, giving an identity round-trip.
+func TestExpressionRoundTripWithSchema(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "i", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 2, Name: "l", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 3, Name: "s", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 4, Name: "b", Type: iceberg.PrimitiveTypes.Bool},
+		iceberg.NestedField{ID: 5, Name: "f", Type: iceberg.PrimitiveTypes.Float64},
+		iceberg.NestedField{ID: 6, Name: "d", Type: iceberg.PrimitiveTypes.Date},
+		iceberg.NestedField{ID: 7, Name: "u", Type: iceberg.PrimitiveTypes.UUID},
+		iceberg.NestedField{ID: 8, Name: "bin", Type: iceberg.PrimitiveTypes.Binary},
+	)
+
+	exprs := []iceberg.BooleanExpression{
+		iceberg.EqualTo(iceberg.Reference("i"), int32(25)),
+		iceberg.LessThan(iceberg.Reference("l"), int64(100)),
+		iceberg.NotEqualTo(iceberg.Reference("s"), "abc"),
+		iceberg.EqualTo(iceberg.Reference("b"), true),
+		iceberg.GreaterThanEqual(iceberg.Reference("f"), float64(1.5)),
+		iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("d"), mustLit(t, "2022-08-14", iceberg.PrimitiveTypes.Date)),
+		iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("u"), iceberg.UUIDLiteral(uuid.MustParse("f79c3e09-677c-4bbd-a479-3f349cb785e7"))),
+		iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("bin"), iceberg.BinaryLiteral([]byte{0x01, 0x02, 0x03})),
+		iceberg.IsIn(iceberg.Reference("i"), int32(1), int32(2), int32(3)),
+		iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("i"), int32(1)),
+			iceberg.NewNot(iceberg.IsNull(iceberg.Reference("s"))),
+		),
+	}
+
+	for _, want := range exprs {
+		t.Run(want.String(), func(t *testing.T) {
+			data, err := json.Marshal(want)
+			require.NoError(t, err)
+
+			got, err := iceberg.ParseExpr(data, schema)
+			require.NoError(t, err)
+			assert.Truef(t, want.Equals(got), "want %s, got %s", want, got)
+		})
+	}
+}
+
+func TestUnmarshalExpressionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"empty", ``},
+		{"unknown type", `{"type":"bogus","term":"a"}`},
+		{"unary with value", `{"type":"is-null","term":"a","value":1}`},
+		{"literal missing value", `{"type":"eq","term":"a"}`},
+		{"in missing values", `{"type":"in","term":"a"}`},
+		{"missing term", `{"type":"eq","value":1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := iceberg.ParseExpr([]byte(tt.json), nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalExpressionTransformTermUnsupported(t *testing.T) {
+	_, err := iceberg.ParseExpr(
+		[]byte(`{"type":"eq","term":{"type":"transform","transform":"bucket[16]","term":"id"},"value":1}`), nil)
+	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+}

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -153,9 +153,6 @@ func TestMarshalExpressionTypedLiterals(t *testing.T) {
 		want string
 	}{
 		{"date", mustLit(t, "2022-08-14", iceberg.PrimitiveTypes.Date), `{"type":"eq","term":"d","value":"2022-08-14"}`},
-		{"timestamp (no fraction)", mustLit(t, "2022-08-14T10:00:00", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00"}`},
-		{"timestamp (micros)", mustLit(t, "2022-08-14T10:00:00.123456", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00.123456"}`},
-		{"timestamp (trailing zeros trimmed)", mustLit(t, "2022-08-14T10:00:00.500000", iceberg.PrimitiveTypes.Timestamp), `{"type":"eq","term":"d","value":"2022-08-14T10:00:00.5"}`},
 		{"uuid", iceberg.UUIDLiteral(uuid.MustParse("f79c3e09-677c-4bbd-a479-3f349cb785e7")), `{"type":"eq","term":"d","value":"f79c3e09-677c-4bbd-a479-3f349cb785e7"}`},
 		{"binary", iceberg.BinaryLiteral([]byte{0x01, 0x02, 0x03}), `{"type":"eq","term":"d","value":"010203"}`},
 		{"decimal", mustLit(t, "3.14", iceberg.DecimalTypeOf(9, 2)), `{"type":"eq","term":"d","value":"3.14"}`},
@@ -173,26 +170,48 @@ func TestMarshalExpressionTypedLiterals(t *testing.T) {
 	}
 }
 
-// TestMarshalExpressionTimestampTz checks that a timestamptz value serializes
-// with a +00:00 offset (Java's format), which needs the bound field type to tell
-// it apart from a plain timestamp. It also round-trips back through the schema.
-func TestMarshalExpressionTimestampTz(t *testing.T) {
+// TestMarshalExpressionTimestamp checks the timestamp and timestamptz wire forms,
+// which differ only by the UTC offset and so depend on the bound field type.
+func TestMarshalExpressionTimestamp(t *testing.T) {
 	schema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTz},
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp},
+		iceberg.NestedField{ID: 2, Name: "tstz", Type: iceberg.PrimitiveTypes.TimestampTz},
 	)
-	unbound := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("ts"),
-		mustLit(t, "2022-08-14T10:00:00+00:00", iceberg.PrimitiveTypes.TimestampTz))
+	lit := mustLit(t, "2022-08-14T10:00:00", iceberg.PrimitiveTypes.Timestamp)
 
-	bound, err := iceberg.BindExpr(schema, unbound, true)
-	require.NoError(t, err)
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{"ts", `{"type":"eq","term":"ts","value":"2022-08-14T10:00:00"}`},
+		{"tstz", `{"type":"eq","term":"tstz","value":"2022-08-14T10:00:00+00:00"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			bound, err := iceberg.BindExpr(schema,
+				iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference(tt.field), lit), true)
+			require.NoError(t, err)
+			got, err := json.Marshal(bound)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
 
-	got, err := json.Marshal(bound)
-	require.NoError(t, err)
-	assert.Equal(t, `{"type":"eq","term":"ts","value":"2022-08-14T10:00:00+00:00"}`, string(got))
+			// Parse back with the schema to resolve the value via the same type.
+			parsed, err := iceberg.ParseExpr(got, schema)
+			require.NoError(t, err)
+			rebound, err := iceberg.BindExpr(schema, parsed, true)
+			require.NoError(t, err)
+			assert.Truef(t, bound.Equals(rebound), "want %s, got %s", bound, rebound)
+		})
+	}
+}
 
-	parsed, err := iceberg.ParseExpr(got, schema)
-	require.NoError(t, err)
-	assert.Truef(t, unbound.Equals(parsed), "want %s, got %s", unbound, parsed)
+// TestMarshalExpressionUnboundTimestamp covers the gap: an unbound timestamp
+// predicate has no field type, so it can't be serialized.
+func TestMarshalExpressionUnboundTimestamp(t *testing.T) {
+	expr := iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference("ts"),
+		mustLit(t, "2022-08-14T10:00:00", iceberg.PrimitiveTypes.Timestamp))
+	_, err := json.Marshal(expr)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 }
 
 // TestMarshalBoundExpression guards against bound expressions falling through to

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -205,6 +205,45 @@ func TestMarshalExpressionTimestamp(t *testing.T) {
 	}
 }
 
+// TestMarshalExpressionTimestampSubsecond guards the sub-second round-trip:
+// fractional seconds must survive marshal+parse, and the nanosecond types must
+// keep all nine digits rather than truncating to microseconds.
+func TestMarshalExpressionTimestampSubsecond(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp},
+		iceberg.NestedField{ID: 2, Name: "tstz", Type: iceberg.PrimitiveTypes.TimestampTz},
+		iceberg.NestedField{ID: 3, Name: "tsns", Type: iceberg.PrimitiveTypes.TimestampNs},
+		iceberg.NestedField{ID: 4, Name: "tstzns", Type: iceberg.PrimitiveTypes.TimestampTzNs},
+	)
+	tests := []struct {
+		field string
+		value string
+		typ   iceberg.Type
+		want  string
+	}{
+		{"ts", "2022-08-14T10:00:00.123456", iceberg.PrimitiveTypes.Timestamp, `{"type":"eq","term":"ts","value":"2022-08-14T10:00:00.123456"}`},
+		{"tstz", "2022-08-14T10:00:00.123456+00:00", iceberg.PrimitiveTypes.TimestampTz, `{"type":"eq","term":"tstz","value":"2022-08-14T10:00:00.123456+00:00"}`},
+		{"tsns", "2007-12-03T10:15:30.123456789", iceberg.PrimitiveTypes.TimestampNs, `{"type":"eq","term":"tsns","value":"2007-12-03T10:15:30.123456789"}`},
+		{"tstzns", "2007-12-03T10:15:30.123456789+00:00", iceberg.PrimitiveTypes.TimestampTzNs, `{"type":"eq","term":"tstzns","value":"2007-12-03T10:15:30.123456789+00:00"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			bound, err := iceberg.BindExpr(schema,
+				iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference(tt.field), mustLit(t, tt.value, tt.typ)), true)
+			require.NoError(t, err)
+			got, err := json.Marshal(bound)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+
+			parsed, err := iceberg.ParseExpr(got, schema)
+			require.NoError(t, err)
+			rebound, err := iceberg.BindExpr(schema, parsed, true)
+			require.NoError(t, err)
+			assert.Truef(t, bound.Equals(rebound), "want %s, got %s", bound, rebound)
+		})
+	}
+}
+
 // TestMarshalExpressionUnboundTimestamp covers the gap: an unbound timestamp
 // predicate has no field type, so it can't be serialized.
 func TestMarshalExpressionUnboundTimestamp(t *testing.T) {
@@ -342,6 +381,8 @@ func TestUnmarshalExpressionErrors(t *testing.T) {
 		{"missing term", `{"type":"eq","value":1}`},
 		{"literal with stray values", `{"type":"eq","term":"a","value":1,"values":[1,2]}`},
 		{"set with stray value", `{"type":"in","term":"a","values":[1],"value":1}`},
+		{"literal null value", `{"type":"literal","value":null}`},
+		{"literal node missing value", `{"type":"literal"}`},
 	}
 
 	for _, tt := range tests {
@@ -352,8 +393,73 @@ func TestUnmarshalExpressionErrors(t *testing.T) {
 	}
 }
 
-func TestUnmarshalExpressionTransformTermUnsupported(t *testing.T) {
-	_, err := iceberg.ParseExpr(
-		[]byte(`{"type":"eq","term":{"type":"transform","transform":"bucket[16]","term":"id"},"value":1}`), nil)
+// TestExpressionTransformTermRoundTrip covers a residual filter whose term is a
+// partition transform, e.g. a Java server's bucket[100](id) <= 50.
+func TestExpressionTransformTermRoundTrip(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	data := []byte(`{"type":"lt-eq","term":{"type":"transform","transform":"bucket[100]","term":"id"},"value":50}`)
+
+	parsed, err := iceberg.ParseExpr(data, schema)
+	require.NoError(t, err)
+
+	// The parsed term resolves the transform's result type against the schema.
+	want := iceberg.LiteralPredicate(iceberg.OpLTEQ,
+		iceberg.NewUnboundTransform(iceberg.BucketTransform{NumBuckets: 100}, iceberg.Reference("id")),
+		iceberg.Int32Literal(50))
+
+	// And serializes back to the same wire form.
+	got, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(data), string(got))
+
+	reparsed, err := iceberg.ParseExpr(got, schema)
+	require.NoError(t, err)
+	assert.Truef(t, parsed.Equals(reparsed), "want %s, got %s", parsed, reparsed)
+
+	// Binding a predicate over a transform term isn't supported yet, but it must
+	// fail cleanly rather than panic.
+	_, err = iceberg.BindExpr(schema, parsed, true)
 	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+}
+
+// TestUnboundTransformBind checks the transform term itself binds to a
+// BoundTransform with the transform's result type.
+func TestUnboundTransformBind(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	term := iceberg.NewUnboundTransform(iceberg.BucketTransform{NumBuckets: 100}, iceberg.Reference("id"))
+	bound, err := term.Bind(schema, true)
+	require.NoError(t, err)
+	assert.True(t, bound.Type().Equals(iceberg.PrimitiveTypes.Int32))
+}
+
+// TestUnmarshalExpressionTransformTermInvalid rejects an unparseable transform
+// string rather than panicking or binding nonsense.
+func TestUnmarshalExpressionTransformTermInvalid(t *testing.T) {
+	_, err := iceberg.ParseExpr(
+		[]byte(`{"type":"eq","term":{"type":"transform","transform":"bogus[16]","term":"id"},"value":1}`), nil)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+// TestUnmarshalExpressionFixedLength rejects a fixed value whose decoded length
+// doesn't match the column's declared length.
+func TestUnmarshalExpressionFixedLength(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "f", Type: iceberg.FixedTypeOf(4)},
+	)
+	_, err := iceberg.ParseExpr([]byte(`{"type":"eq","term":"f","value":"0102"}`), schema)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+// TestUnmarshalExpressionCaseSensitive checks that ParseExpr resolves field
+// names case-sensitively, since REST field names are authoritative.
+func TestUnmarshalExpressionCaseSensitive(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	_, err := iceberg.ParseExpr([]byte(`{"type":"eq","term":"ID","value":1}`), schema)
+	require.Error(t, err)
 }

--- a/exprs.go
+++ b/exprs.go
@@ -443,6 +443,8 @@ func createBoundRef(field NestedField, acc accessor) BoundReference {
 		return &boundRef[Time]{field: field, acc: acc}
 	case TimestampType, TimestampTzType:
 		return &boundRef[Timestamp]{field: field, acc: acc}
+	case TimestampNsType, TimestampTzNsType:
+		return &boundRef[TimestampNano]{field: field, acc: acc}
 	case StringType:
 		return &boundRef[string]{field: field, acc: acc}
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -574,6 +576,9 @@ func (up *unboundUnaryPredicate) Bind(schema *Schema, caseSensitive bool) (Boole
 	if err != nil {
 		return nil, err
 	}
+	if err := rejectTransformTerm(bound); err != nil {
+		return nil, err
+	}
 
 	// fast case optimizations
 	switch up.op {
@@ -633,6 +638,8 @@ func createBoundUnaryPredicate(op Operation, term BoundTerm) BoundUnaryPredicate
 		return newBoundUnaryPred[Time](op, term)
 	case TimestampType, TimestampTzType:
 		return newBoundUnaryPred[Timestamp](op, term)
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundUnaryPred[TimestampNano](op, term)
 	case StringType:
 		return newBoundUnaryPred[string](op, term)
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -726,6 +733,9 @@ func (ul *unboundLiteralPredicate) Bind(schema *Schema, caseSensitive bool) (Boo
 	if err != nil {
 		return nil, err
 	}
+	if err := rejectTransformTerm(bound); err != nil {
+		return nil, err
+	}
 
 	if (ul.op == OpStartsWith || ul.op == OpNotStartsWith) &&
 		(!bound.Type().Equals(PrimitiveTypes.String) && !bound.Type().Equals(PrimitiveTypes.Binary)) {
@@ -797,6 +807,8 @@ func createBoundLiteralPredicate(op Operation, term BoundTerm, lit Literal) (Bou
 		return newBoundLiteralPredicate[Time](op, term, finalLit), nil
 	case TimestampType, TimestampTzType:
 		return newBoundLiteralPredicate[Timestamp](op, term, finalLit), nil
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundLiteralPredicate[TimestampNano](op, term, finalLit), nil
 	case StringType:
 		return newBoundLiteralPredicate[string](op, term, finalLit), nil
 	case FixedType, BinaryType, GeographyType, GeometryType:
@@ -907,6 +919,9 @@ func (usp *unboundSetPredicate) Bind(schema *Schema, caseSensitive bool) (Boolea
 	if err != nil {
 		return nil, err
 	}
+	if err := rejectTransformTerm(bound); err != nil {
+		return nil, err
+	}
 
 	return createBoundSetPredicate(usp.op, bound, usp.lits)
 }
@@ -965,6 +980,8 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 		return newBoundSetPredicate[Time](op, term, typedSet), nil
 	case TimestampType, TimestampTzType:
 		return newBoundSetPredicate[Timestamp](op, term, typedSet), nil
+	case TimestampNsType, TimestampTzNsType:
+		return newBoundSetPredicate[TimestampNano](op, term, typedSet), nil
 	case StringType:
 		return newBoundSetPredicate[string](op, term, typedSet), nil
 	case BinaryType, FixedType, GeographyType, GeometryType:
@@ -1059,4 +1076,57 @@ func (b *BoundTransform) evalToLiteral(st StructLike) Optional[Literal] {
 
 func (b *BoundTransform) evalIsNull(st StructLike) bool {
 	return !b.evalToLiteral(st).Valid
+}
+
+// UnboundTransform is a transform applied to a term, not yet bound to a schema;
+// the unbound counterpart of BoundTransform. It's what a transform term in a
+// REST expression (e.g. bucket[16](id)) parses into.
+type UnboundTransform struct {
+	transform Transform
+	term      UnboundTerm
+}
+
+func NewUnboundTransform(transform Transform, term UnboundTerm) *UnboundTransform {
+	return &UnboundTransform{transform: transform, term: term}
+}
+
+func (*UnboundTransform) isTerm() {}
+func (u *UnboundTransform) String() string {
+	return fmt.Sprintf("UnboundTransform(transform=%s, term=%s)", u.transform, u.term)
+}
+
+// Transform returns the transform applied to the term.
+func (u *UnboundTransform) Transform() Transform { return u.transform }
+
+func (u *UnboundTransform) Equals(other UnboundTerm) bool {
+	rhs, ok := other.(*UnboundTransform)
+	if !ok {
+		return false
+	}
+
+	return u.transform.Equals(rhs.transform) && u.term.Equals(rhs.term)
+}
+
+func (u *UnboundTransform) Bind(schema *Schema, caseSensitive bool) (BoundTerm, error) {
+	bound, err := u.term.Bind(schema, caseSensitive)
+	if err != nil {
+		return nil, err
+	}
+	if !u.transform.CanTransform(bound.Type()) {
+		return nil, fmt.Errorf("%w: transform %s cannot be applied to %s",
+			ErrInvalidArgument, u.transform, bound.Type())
+	}
+
+	return &BoundTransform{transform: u.transform, term: bound}, nil
+}
+
+// rejectTransformTerm guards the typed bound-predicate machinery, which only
+// accepts bound[T] terms (references). Binding a predicate over a transform term
+// isn't supported yet; without this it would panic in newBound*Predicate.
+func rejectTransformTerm(term BoundTerm) error {
+	if _, ok := term.(*BoundTransform); ok {
+		return fmt.Errorf("%w: binding a predicate over a transform term is not supported", ErrNotImplemented)
+	}
+
+	return nil
 }

--- a/literals.go
+++ b/literals.go
@@ -960,8 +960,8 @@ func (s StringLiteral) To(typ Type) (Literal, error) {
 
 		return TimeLiteral(val), nil
 	case TimestampType:
-		// requires RFC3339 with no time zone
-		tm, err := time.Parse("2006-01-02T15:04:05", string(s))
+		// ISO date-time, no zone; fractional seconds optional.
+		tm, err := time.Parse("2006-01-02T15:04:05.999999999", string(s))
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid Timestamp format for casting from string '%s': %s",
 				ErrBadCast, s, err.Error())
@@ -969,14 +969,32 @@ func (s StringLiteral) To(typ Type) (Literal, error) {
 
 		return TimestampLiteral(Timestamp(tm.UTC().UnixMicro())), nil
 	case TimestampTzType:
-		// requires RFC3339 format WITH time zone
-		tm, err := time.Parse(time.RFC3339, string(s))
+		// ISO date-time WITH zone; up to microsecond fractional seconds.
+		tm, err := time.Parse("2006-01-02T15:04:05.999999Z07:00", string(s))
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid TimestampTz format for casting from string '%s': %s",
 				ErrBadCast, s, err.Error())
 		}
 
 		return TimestampLiteral(Timestamp(tm.UTC().UnixMicro())), nil
+	case TimestampNsType:
+		// Same as timestamp but nanosecond precision.
+		tm, err := time.Parse("2006-01-02T15:04:05.999999999", string(s))
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid TimestampNs format for casting from string '%s': %s",
+				ErrBadCast, s, err.Error())
+		}
+
+		return TimestampNsLiteral(TimestampNano(tm.UTC().UnixNano())), nil
+	case TimestampTzNsType:
+		// Same as timestamptz but nanosecond precision.
+		tm, err := time.Parse("2006-01-02T15:04:05.999999999Z07:00", string(s))
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid TimestampTzNs format for casting from string '%s': %s",
+				ErrBadCast, s, err.Error())
+		}
+
+		return TimestampNsLiteral(TimestampNano(tm.UTC().UnixNano())), nil
 	case UUIDType:
 		val, err := uuid.Parse(string(s))
 		if err != nil {


### PR DESCRIPTION
I'm hoping to build out server-side planning support in Go. There's a bunch of prerequisites we need to do before we can implement.

One of them is parsing Iceberg Expressions, which will be sent over the wire. There's work being done to formalize the Expression spec, so it's as good a time as any to have this support in iceberg-go.

Apologies, this is longer than I'd like because the expression spec is lengthy.