### PR TITLE
feat(table,rest): propose public API surface for REST scan planning

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -109,9 +109,10 @@ func init() {
 }
 
 type errorResponse struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-	Code    int    `json:"code"`
+	Message string   `json:"message"`
+	Type    string   `json:"type"`
+	Code    int      `json:"code"`
+	Stack   []string `json:"stack,omitempty"`
 
 	wrapping error
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -156,7 +156,9 @@ func (t *commitTableResponse) UnmarshalJSON(b []byte) (err error) {
 	return err
 }
 
-type storageCredential struct {
+// StorageCredential carries REST-vended storage credentials scoped to matching
+// object-location prefixes.
+type StorageCredential struct {
 	Prefix string             `json:"prefix"`
 	Config iceberg.Properties `json:"config"`
 }
@@ -165,12 +167,12 @@ type loadTableResponse struct {
 	MetadataLoc        string              `json:"metadata-location"`
 	RawMetadata        json.RawMessage     `json:"metadata"`
 	Config             iceberg.Properties  `json:"config"`
-	StorageCredentials []storageCredential `json:"storage-credentials"`
+	StorageCredentials []StorageCredential `json:"storage-credentials"`
 	Metadata           table.Metadata      `json:"-"`
 }
 
 type loadCredentialsResponse struct {
-	StorageCredentials []storageCredential `json:"storage-credentials"`
+	StorageCredentials []StorageCredential `json:"storage-credentials"`
 }
 
 func (t *loadTableResponse) UnmarshalJSON(b []byte) (err error) {

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -99,17 +99,19 @@ func (c *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, re
 	panic("unimplemented: proposed API for #1178")
 }
 
-// WaitForPlan submits and polls a plan to completion using jittered backoff,
-// cancelling the server-side plan if the context is cancelled.
-func (c *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (FetchPlanningResultResponse, error) {
+// WaitForPlan polls a submitted plan to completion using jittered backoff,
+// cancelling the server-side plan if the context is cancelled. It returns an
+// error if the plan is still submitted after the wait, cancelled, failed, or
+// expired.
+func (c *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (CompletedPlanningResult, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // --- Wire types (sketch) ----------------------------------------------------
 //
-// Field-complete request/response decoding (content-file JSON, residuals,
-// storage credentials) lands with the scan-task decoder PR; these sketch the
-// request/response envelopes so the client surface compiles and reads.
+// Content-file, delete-file, and residual decoding lands with the scan-task
+// decoder PR; these sketch the request/response envelopes so the client
+// surface compiles and reads.
 
 // PlanStatus is the status of a server-side plan.
 type PlanStatus string
@@ -121,6 +123,32 @@ const (
 	PlanStatusFailed    PlanStatus = "failed"
 )
 
+// PlanningError is the ErrorModel payload carried by a failed planning result.
+type PlanningError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    int    `json:"code"`
+}
+
+// ScanTasks carries the task payload shared by completed planning responses and
+// fetchScanTasks responses. Task/delete payload decoding lands with the
+// scan-task decoder PR.
+type ScanTasks struct {
+	PlanTasks     []string        `json:"plan-tasks,omitempty"`
+	FileScanTasks json.RawMessage `json:"file-scan-tasks,omitempty"`
+	DeleteFiles   json.RawMessage `json:"delete-files,omitempty"`
+}
+
+// CompletedPlanningResult is the completed arm of the planning-result union.
+// PlanID is populated only by the initial planTableScan response's
+// CompletedPlanningWithIDResult arm.
+type CompletedPlanningResult struct {
+	Status PlanStatus `json:"status"`
+	PlanID *string    `json:"plan-id,omitempty"`
+	ScanTasks
+	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
+}
+
 // PlanTableScanRequest is the POST .../plan request body. Filter is the
 // ExpressionParser-format JSON produced by iceberg.MarshalExpressionJSON.
 type PlanTableScanRequest struct {
@@ -129,21 +157,31 @@ type PlanTableScanRequest struct {
 	EndSnapshotID     *int64          `json:"end-snapshot-id,omitempty"`
 	Select            []string        `json:"select,omitempty"`
 	Filter            json.RawMessage `json:"filter,omitempty"`
+	MinRowsRequested  *int64          `json:"min-rows-requested,omitempty"`
 	CaseSensitive     *bool           `json:"case-sensitive,omitempty"`
 	UseSnapshotSchema *bool           `json:"use-snapshot-schema,omitempty"`
+	StatsFields       []string        `json:"stats-fields,omitempty"`
 }
 
-// PlanTableScanResponse is the POST .../plan response envelope.
+// PlanTableScanResponse is the POST .../plan response. The spec models this as
+// a `status`-discriminated union; the flat struct carries every arm's fields
+// with omitempty so none are discarded. Task/delete RawMessage payloads are
+// decoded by the scan-task decoder PR.
 type PlanTableScanResponse struct {
-	PlanStatus PlanStatus `json:"plan-status"`
-	PlanID     *string    `json:"plan-id,omitempty"`
-	// file-scan-tasks, delete-files, plan-tasks, storage-credentials decoded
-	// by the scan-task decoder PR.
+	Status PlanStatus     `json:"status"`
+	PlanID *string        `json:"plan-id,omitempty"` // status=submitted, or completed from planTableScan
+	Error  *PlanningError `json:"error,omitempty"`
+	ScanTasks
+	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
 }
 
-// FetchPlanningResultResponse is the GET .../plan/{plan-id} response envelope.
+// FetchPlanningResultResponse is the GET .../plan/{plan-id} poll response. Same
+// `status`-discriminated union (completed / submitted / cancelled / failed).
 type FetchPlanningResultResponse struct {
-	PlanStatus PlanStatus `json:"plan-status"`
+	Status PlanStatus     `json:"status"`
+	Error  *PlanningError `json:"error,omitempty"`
+	ScanTasks
+	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
 }
 
 // FetchScanTasksRequest is the POST .../tasks request body.
@@ -151,8 +189,12 @@ type FetchScanTasksRequest struct {
 	PlanTask string `json:"plan-task"`
 }
 
-// FetchScanTasksResponse is the POST .../tasks response envelope.
-type FetchScanTasksResponse struct{}
+// FetchScanTasksResponse is the POST .../tasks response. May itself return more
+// plan-tasks for further fanout. Task/delete payloads decoded by the
+// scan-task decoder PR.
+type FetchScanTasksResponse struct {
+	ScanTasks
+}
 
 // WaitForPlanOptions tunes the polling loop. Defaults should be conservative.
 type WaitForPlanOptions struct {

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -16,8 +16,10 @@
 // under the License.
 
 // This file is a PROPOSED public API surface for REST server-side scan
-// planning (apache/iceberg-go#1178). The bodies are intentionally
-// unimplemented; the file exists so the REST surface can be reviewed as Go.
+// planning (apache/iceberg-go#1178). The method bodies are intentionally
+// unimplemented stubs (returning ErrNotImplemented) so the REST surface can be
+// reviewed as Go — with one exception: PlanTableScanResponse.UnmarshalJSON
+// validates the status/plan-id union (with tests), added per review.
 // Endpoint capability discovery (Endpoint, SupportsEndpoint) lands separately
 // in the Phase 0 PR and is intentionally not redeclared here.
 
@@ -29,6 +31,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
 )
 
@@ -51,13 +54,13 @@ var ErrPlanExpired = fmt.Errorf("%w: scan plan expired", ErrRESTError)
 // SupportsPlanTableScan reports whether the server advertised the synchronous
 // plan endpoint.
 func (r *Catalog) SupportsPlanTableScan() bool {
-	panic("unimplemented: proposed API for #1178")
+	return false
 }
 
 // SupportsFullRemoteScanPlanning reports whether the server advertised all four
 // scan-planning endpoints (plan, fetch-result, cancel, fetch-tasks).
 func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
-	panic("unimplemented: proposed API for #1178")
+	return false
 }
 
 // --- table.ScanPlanner implementation ---------------------------------------
@@ -65,13 +68,13 @@ func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 // SupportsRemoteScanPlanning reports whether this catalog can complete a remote
 // plan end-to-end; backed by the split capability checks above.
 func (r *Catalog) SupportsRemoteScanPlanning() bool {
-	panic("unimplemented: proposed API for #1178")
+	return false
 }
 
 // PlanFiles plans a scan server-side and returns tasks (and, optionally, a
 // plan-scoped FileIO) for the table to read.
 func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
-	panic("unimplemented: proposed API for #1178")
+	return table.ScanPlanningResult{}, fmt.Errorf("%w: REST scan planning", iceberg.ErrNotImplemented)
 }
 
 // --- Low-level client methods -----------------------------------------------
@@ -79,32 +82,32 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 // PlanTableScan submits a scan plan. The result is either completed inline,
 // submitted (returns a plan-id to poll), or failed.
 func (r *Catalog) PlanTableScan(ctx context.Context, ident table.Identifier, req PlanTableScanRequest) (PlanTableScanResponse, error) {
-	panic("unimplemented: proposed API for #1178")
+	return PlanTableScanResponse{}, fmt.Errorf("%w: plan table scan", iceberg.ErrNotImplemented)
 }
 
 // FetchPlanningResult polls a previously submitted plan.
 func (r *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string) (FetchPlanningResultResponse, error) {
-	panic("unimplemented: proposed API for #1178")
+	return FetchPlanningResultResponse{}, fmt.Errorf("%w: fetch planning result", iceberg.ErrNotImplemented)
 }
 
 // CancelPlanning cancels a server-side plan. Callers should cancel on context
 // cancellation using a detached context with a short timeout.
 func (r *Catalog) CancelPlanning(ctx context.Context, ident table.Identifier, planID string) error {
-	panic("unimplemented: proposed API for #1178")
+	return fmt.Errorf("%w: cancel planning", iceberg.ErrNotImplemented)
 }
 
 // FetchScanTasks fetches the scan tasks for a plan-task handle returned by a
 // completed plan.
 func (r *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, req FetchScanTasksRequest) (FetchScanTasksResponse, error) {
-	panic("unimplemented: proposed API for #1178")
+	return FetchScanTasksResponse{}, fmt.Errorf("%w: fetch scan tasks", iceberg.ErrNotImplemented)
 }
 
 // WaitForPlan polls a submitted plan to completion using jittered backoff,
-// cancelling the server-side plan if the context is cancelled. It returns an
-// error if the plan is still submitted after the wait, cancelled, failed, or
-// expired.
+// cancelling the server-side plan if the context is cancelled. The total wait is
+// bounded by the context deadline; it returns an error if the deadline passes
+// while still submitted, or if the plan is cancelled, failed, or expired.
 func (r *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (CompletedPlanningResult, error) {
-	panic("unimplemented: proposed API for #1178")
+	return CompletedPlanningResult{}, fmt.Errorf("%w: wait for plan", iceberg.ErrNotImplemented)
 }
 
 // --- Wire types (sketch) ----------------------------------------------------
@@ -127,38 +130,51 @@ const (
 )
 
 // PlanningError is the ErrorModel payload carried by a failed planning result.
-type PlanningError struct {
-	Message string   `json:"message"`
-	Type    string   `json:"type"`
-	Code    int      `json:"code"`
-	Stack   []string `json:"stack,omitempty"`
-}
+type PlanningError = errorResponse
+
+// RESTFileScanTask is the REST FileScanTask wire payload. The REST prefix
+// avoids confusion with table.FileScanTask, the decoded domain type. The
+// scan-task decoder PR fills in the content-file and residual fields; the named
+// type is committed here so ScanTasks does not expose json.RawMessage.
+type RESTFileScanTask struct{}
+
+// RESTDeleteFile is the REST DeleteFile wire payload. The scan-task decoder PR
+// fills in the position/equality delete-file variants.
+type RESTDeleteFile struct{}
 
 // ScanTasks carries the task payload shared by completed planning responses and
 // fetchScanTasks responses. Task/delete payload decoding lands with the
 // scan-task decoder PR.
 type ScanTasks struct {
-	PlanTasks     []string        `json:"plan-tasks,omitempty"`
-	FileScanTasks json.RawMessage `json:"file-scan-tasks,omitempty"`
-	DeleteFiles   json.RawMessage `json:"delete-files,omitempty"`
+	PlanTasks     []string           `json:"plan-tasks,omitempty"`
+	FileScanTasks []RESTFileScanTask `json:"file-scan-tasks,omitempty"`
+	DeleteFiles   []RESTDeleteFile   `json:"delete-files,omitempty"`
 }
 
 // CompletedPlanningResult is the completed arm of the planning-result union.
-// PlanID is required by the initial planTableScan response's
-// CompletedPlanningWithIDResult arm and omitted by fetchPlanningResult.
+// planTableScan carries the plan-id on PlanTableScanResponse; fetchPlanningResult
+// omits it.
 type CompletedPlanningResult struct {
 	Status PlanStatus `json:"status"`
-	PlanID *string    `json:"plan-id,omitempty"`
 	ScanTasks
 	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
 }
 
 // PlanTableScanRequest is the POST .../plan request body. Filter is the
 // ExpressionParser-format JSON produced by iceberg.MarshalExpressionJSON.
+//
+// Point-in-time only for now: the spec's incremental start-snapshot-id /
+// end-snapshot-id fields are deliberately omitted and land with the incremental
+// phase, together with the matching fields on table.ScanPlanningRequest, so the
+// wire type and the seam stay in agreement.
 type PlanTableScanRequest struct {
+	// IdempotencyKey is sent as the Idempotency-Key header, not in the JSON body.
+	IdempotencyKey *string `json:"-"`
+	// AccessDelegation is sent as the X-Iceberg-Access-Delegation header, not
+	// in the JSON body. Nil uses the catalog default.
+	AccessDelegation *string `json:"-"`
+
 	SnapshotID        *int64          `json:"snapshot-id,omitempty"`
-	StartSnapshotID   *int64          `json:"start-snapshot-id,omitempty"`
-	EndSnapshotID     *int64          `json:"end-snapshot-id,omitempty"`
 	Select            []string        `json:"select,omitempty"`
 	Filter            json.RawMessage `json:"filter,omitempty"`
 	MinRowsRequested  *int64          `json:"min-rows-requested,omitempty"`
@@ -169,17 +185,38 @@ type PlanTableScanRequest struct {
 
 // PlanTableScanResponse is the POST .../plan response. The spec models this as
 // a `status`-discriminated union; the flat struct carries every arm's fields
-// with omitempty so none are discarded. Task/delete RawMessage payloads are
-// decoded by the scan-task decoder PR. PlanID is required for submitted and
-// completed responses from planTableScan; implementations must reject a missing
-// PlanID for either status. A cancelled status is invalid here and must be
-// treated as an error.
+// with omitempty so none are discarded. Task/delete payloads are filled in by
+// the scan-task decoder PR. Per the spec's CompletedPlanningWithIDResult, plan-id
+// is required for both submitted and completed responses here; the wire decoder
+// must validate PlanID != nil at unmarshal (not rely on the omitempty pointer),
+// since the caller needs it to CancelPlanning and release server resources. A
+// cancelled status is invalid for this endpoint and must be treated as an error.
 type PlanTableScanResponse struct {
 	Status PlanStatus     `json:"status"`
 	PlanID *string        `json:"plan-id,omitempty"`
 	Error  *PlanningError `json:"error,omitempty"`
 	ScanTasks
 	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
+}
+
+func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
+	type planTableScanResponse PlanTableScanResponse
+	var resp planTableScanResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	switch resp.Status {
+	case PlanStatusCompleted, PlanStatusSubmitted:
+		if resp.PlanID == nil {
+			return fmt.Errorf("%w: planTableScan response with status %q missing plan-id", ErrRESTError, resp.Status)
+		}
+	case PlanStatusCancelled:
+		return fmt.Errorf("%w: planTableScan response has invalid status %q", ErrRESTError, resp.Status)
+	}
+
+	*r = PlanTableScanResponse(resp)
+	return nil
 }
 
 // FetchPlanningResultResponse is the GET .../plan/{plan-id} poll response. Same
@@ -193,6 +230,9 @@ type FetchPlanningResultResponse struct {
 
 // FetchScanTasksRequest is the POST .../tasks request body.
 type FetchScanTasksRequest struct {
+	// IdempotencyKey is sent as the Idempotency-Key header, not in the JSON body.
+	IdempotencyKey *string `json:"-"`
+
 	PlanTask string `json:"plan-task"`
 }
 
@@ -203,9 +243,11 @@ type FetchScanTasksResponse struct {
 	ScanTasks
 }
 
-// WaitForPlanOptions tunes the polling loop. Defaults should be conservative.
+// WaitForPlanOptions tunes the polling backoff. The total wait is bounded by the
+// caller's context deadline (context.WithTimeout). There is deliberately no
+// Timeout field to avoid duplicating the context and the zero-value footgun.
+// Defaults should be conservative.
 type WaitForPlanOptions struct {
 	MinDelay time.Duration
 	MaxDelay time.Duration
-	Timeout  time.Duration
 }

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -50,13 +50,13 @@ var ErrPlanExpired = fmt.Errorf("%w: scan plan expired", ErrRESTError)
 
 // SupportsPlanTableScan reports whether the server advertised the synchronous
 // plan endpoint.
-func (c *Catalog) SupportsPlanTableScan() bool {
+func (r *Catalog) SupportsPlanTableScan() bool {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // SupportsFullRemoteScanPlanning reports whether the server advertised all four
 // scan-planning endpoints (plan, fetch-result, cancel, fetch-tasks).
-func (c *Catalog) SupportsFullRemoteScanPlanning() bool {
+func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 	panic("unimplemented: proposed API for #1178")
 }
 
@@ -64,13 +64,13 @@ func (c *Catalog) SupportsFullRemoteScanPlanning() bool {
 
 // SupportsRemoteScanPlanning reports whether this catalog can complete a remote
 // plan end-to-end; backed by the split capability checks above.
-func (c *Catalog) SupportsRemoteScanPlanning() bool {
+func (r *Catalog) SupportsRemoteScanPlanning() bool {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // PlanFiles plans a scan server-side and returns tasks (and, optionally, a
 // plan-scoped FileIO) for the table to read.
-func (c *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
+func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
@@ -78,24 +78,24 @@ func (c *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 
 // PlanTableScan submits a scan plan. The result is either completed inline,
 // submitted (returns a plan-id to poll), or failed.
-func (c *Catalog) PlanTableScan(ctx context.Context, ident table.Identifier, req PlanTableScanRequest) (PlanTableScanResponse, error) {
+func (r *Catalog) PlanTableScan(ctx context.Context, ident table.Identifier, req PlanTableScanRequest) (PlanTableScanResponse, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // FetchPlanningResult polls a previously submitted plan.
-func (c *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string) (FetchPlanningResultResponse, error) {
+func (r *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string) (FetchPlanningResultResponse, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // CancelPlanning cancels a server-side plan. Callers should cancel on context
 // cancellation using a detached context with a short timeout.
-func (c *Catalog) CancelPlanning(ctx context.Context, ident table.Identifier, planID string) error {
+func (r *Catalog) CancelPlanning(ctx context.Context, ident table.Identifier, planID string) error {
 	panic("unimplemented: proposed API for #1178")
 }
 
 // FetchScanTasks fetches the scan tasks for a plan-task handle returned by a
 // completed plan.
-func (c *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, req FetchScanTasksRequest) (FetchScanTasksResponse, error) {
+func (r *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, req FetchScanTasksRequest) (FetchScanTasksResponse, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
@@ -103,7 +103,7 @@ func (c *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, re
 // cancelling the server-side plan if the context is cancelled. It returns an
 // error if the plan is still submitted after the wait, cancelled, failed, or
 // expired.
-func (c *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (CompletedPlanningResult, error) {
+func (r *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (CompletedPlanningResult, error) {
 	panic("unimplemented: proposed API for #1178")
 }
 
@@ -119,6 +119,9 @@ type PlanStatus string
 const (
 	PlanStatusCompleted PlanStatus = "completed"
 	PlanStatusSubmitted PlanStatus = "submitted"
+	// PlanStatusCancelled is valid when polling a submitted plan, but invalid
+	// as a planTableScan response. PlanTableScan and WaitForPlan should treat a
+	// cancelled initial planning response as an error.
 	PlanStatusCancelled PlanStatus = "cancelled"
 	PlanStatusFailed    PlanStatus = "failed"
 )
@@ -141,8 +144,8 @@ type ScanTasks struct {
 }
 
 // CompletedPlanningResult is the completed arm of the planning-result union.
-// PlanID is populated only by the initial planTableScan response's
-// CompletedPlanningWithIDResult arm.
+// PlanID is required by the initial planTableScan response's
+// CompletedPlanningWithIDResult arm and omitted by fetchPlanningResult.
 type CompletedPlanningResult struct {
 	Status PlanStatus `json:"status"`
 	PlanID *string    `json:"plan-id,omitempty"`
@@ -167,10 +170,13 @@ type PlanTableScanRequest struct {
 // PlanTableScanResponse is the POST .../plan response. The spec models this as
 // a `status`-discriminated union; the flat struct carries every arm's fields
 // with omitempty so none are discarded. Task/delete RawMessage payloads are
-// decoded by the scan-task decoder PR.
+// decoded by the scan-task decoder PR. PlanID is required for submitted and
+// completed responses from planTableScan; implementations must reject a missing
+// PlanID for either status. A cancelled status is invalid here and must be
+// treated as an error.
 type PlanTableScanResponse struct {
 	Status PlanStatus     `json:"status"`
-	PlanID *string        `json:"plan-id,omitempty"` // status=submitted, or completed from planTableScan
+	PlanID *string        `json:"plan-id,omitempty"`
 	Error  *PlanningError `json:"error,omitempty"`
 	ScanTasks
 	StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -125,9 +125,10 @@ const (
 
 // PlanningError is the ErrorModel payload carried by a failed planning result.
 type PlanningError struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-	Code    int    `json:"code"`
+	Message string   `json:"message"`
+	Type    string   `json:"type"`
+	Code    int      `json:"code"`
+	Stack   []string `json:"stack,omitempty"`
 }
 
 // ScanTasks carries the task payload shared by completed planning responses and

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is a PROPOSED public API surface for REST server-side scan
+// planning (apache/iceberg-go#1178). The bodies are intentionally
+// unimplemented; the file exists so the REST surface can be reviewed as Go.
+// Endpoint capability discovery (Endpoint, SupportsEndpoint) lands separately
+// in the Phase 0 PR and is intentionally not redeclared here.
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/apache/iceberg-go/table"
+)
+
+// Compile-time proof that the REST catalog satisfies the table planner seam.
+var _ table.ScanPlanner = (*Catalog)(nil)
+
+// ErrPlanExpired is returned when polling a plan-id the server no longer knows
+// about (HTTP 404 while polling), distinct from a table-not-found 404.
+var ErrPlanExpired = fmt.Errorf("%w: scan plan expired", ErrRESTError)
+
+// --- Capability gating (Open Question 2) ------------------------------------
+//
+// A single capability check is too coarse: requiring all four endpoints falls
+// back to local against sync-only servers, while requiring only the plan
+// endpoint false-positives, because planTableScan can return `submitted` or
+// `plan-tasks` that need the poll/fetch endpoints. The split below lets `auto`
+// use a sync-only server while reserving the async/fanout path for servers
+// that advertise everything.
+
+// SupportsPlanTableScan reports whether the server advertised the synchronous
+// plan endpoint.
+func (c *Catalog) SupportsPlanTableScan() bool {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// SupportsFullRemoteScanPlanning reports whether the server advertised all four
+// scan-planning endpoints (plan, fetch-result, cancel, fetch-tasks).
+func (c *Catalog) SupportsFullRemoteScanPlanning() bool {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// --- table.ScanPlanner implementation ---------------------------------------
+
+// SupportsRemoteScanPlanning reports whether this catalog can complete a remote
+// plan end-to-end; backed by the split capability checks above.
+func (c *Catalog) SupportsRemoteScanPlanning() bool {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// PlanFiles plans a scan server-side and returns tasks (and, optionally, a
+// plan-scoped FileIO) for the table to read.
+func (c *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// --- Low-level client methods -----------------------------------------------
+
+// PlanTableScan submits a scan plan. The result is either completed inline,
+// submitted (returns a plan-id to poll), or failed.
+func (c *Catalog) PlanTableScan(ctx context.Context, ident table.Identifier, req PlanTableScanRequest) (PlanTableScanResponse, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// FetchPlanningResult polls a previously submitted plan.
+func (c *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string) (FetchPlanningResultResponse, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// CancelPlanning cancels a server-side plan. Callers should cancel on context
+// cancellation using a detached context with a short timeout.
+func (c *Catalog) CancelPlanning(ctx context.Context, ident table.Identifier, planID string) error {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// FetchScanTasks fetches the scan tasks for a plan-task handle returned by a
+// completed plan.
+func (c *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, req FetchScanTasksRequest) (FetchScanTasksResponse, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// WaitForPlan submits and polls a plan to completion using jittered backoff,
+// cancelling the server-side plan if the context is cancelled.
+func (c *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (FetchPlanningResultResponse, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// --- Wire types (sketch) ----------------------------------------------------
+//
+// Field-complete request/response decoding (content-file JSON, residuals,
+// storage credentials) lands with the scan-task decoder PR; these sketch the
+// request/response envelopes so the client surface compiles and reads.
+
+// PlanStatus is the status of a server-side plan.
+type PlanStatus string
+
+const (
+	PlanStatusCompleted PlanStatus = "completed"
+	PlanStatusSubmitted PlanStatus = "submitted"
+	PlanStatusCancelled PlanStatus = "cancelled"
+	PlanStatusFailed    PlanStatus = "failed"
+)
+
+// PlanTableScanRequest is the POST .../plan request body. Filter is the
+// ExpressionParser-format JSON produced by iceberg.MarshalExpressionJSON.
+type PlanTableScanRequest struct {
+	SnapshotID        *int64          `json:"snapshot-id,omitempty"`
+	StartSnapshotID   *int64          `json:"start-snapshot-id,omitempty"`
+	EndSnapshotID     *int64          `json:"end-snapshot-id,omitempty"`
+	Select            []string        `json:"select,omitempty"`
+	Filter            json.RawMessage `json:"filter,omitempty"`
+	CaseSensitive     *bool           `json:"case-sensitive,omitempty"`
+	UseSnapshotSchema *bool           `json:"use-snapshot-schema,omitempty"`
+}
+
+// PlanTableScanResponse is the POST .../plan response envelope.
+type PlanTableScanResponse struct {
+	PlanStatus PlanStatus `json:"plan-status"`
+	PlanID     *string    `json:"plan-id,omitempty"`
+	// file-scan-tasks, delete-files, plan-tasks, storage-credentials decoded
+	// by the scan-task decoder PR.
+}
+
+// FetchPlanningResultResponse is the GET .../plan/{plan-id} response envelope.
+type FetchPlanningResultResponse struct {
+	PlanStatus PlanStatus `json:"plan-status"`
+}
+
+// FetchScanTasksRequest is the POST .../tasks request body.
+type FetchScanTasksRequest struct {
+	PlanTask string `json:"plan-task"`
+}
+
+// FetchScanTasksResponse is the POST .../tasks response envelope.
+type FetchScanTasksResponse struct{}
+
+// WaitForPlanOptions tunes the polling loop. Defaults should be conservative.
+type WaitForPlanOptions struct {
+	MinDelay time.Duration
+	MaxDelay time.Duration
+	Timeout  time.Duration
+}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -85,8 +85,11 @@ func (r *Catalog) PlanTableScan(ctx context.Context, ident table.Identifier, req
 	return PlanTableScanResponse{}, fmt.Errorf("%w: plan table scan", iceberg.ErrNotImplemented)
 }
 
-// FetchPlanningResult polls a previously submitted plan.
-func (r *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string) (FetchPlanningResultResponse, error) {
+// FetchPlanningResult polls a previously submitted plan. opts.AccessDelegation
+// is sent as the X-Iceberg-Access-Delegation header so an async poll can still
+// receive plan-scoped storage credentials: the spec defines data-access on this
+// endpoint, and the completed-async result is where those credentials are vended.
+func (r *Catalog) FetchPlanningResult(ctx context.Context, ident table.Identifier, planID string, opts FetchPlanningResultOptions) (FetchPlanningResultResponse, error) {
 	return FetchPlanningResultResponse{}, fmt.Errorf("%w: fetch planning result", iceberg.ErrNotImplemented)
 }
 
@@ -129,8 +132,16 @@ const (
 	PlanStatusFailed    PlanStatus = "failed"
 )
 
-// PlanningError is the ErrorModel payload carried by a failed planning result.
-type PlanningError = errorResponse
+// PlanningError is the REST ErrorModel payload carried by the error arm of a
+// failed planning result. It mirrors the package's internal error wire shape
+// but is a dedicated exported struct so it renders cleanly in godoc and does
+// not leak an unexported type or its unexported fields into the public API.
+type PlanningError struct {
+	Message string   `json:"message"`
+	Type    string   `json:"type"`
+	Code    int      `json:"code"`
+	Stack   []string `json:"stack,omitempty"`
+}
 
 // RESTFileScanTask is the REST FileScanTask wire payload. The REST prefix
 // avoids confusion with table.FileScanTask, the decoded domain type. The
@@ -169,6 +180,8 @@ type CompletedPlanningResult struct {
 // wire type and the seam stay in agreement.
 type PlanTableScanRequest struct {
 	// IdempotencyKey is sent as the Idempotency-Key header, not in the JSON body.
+	// If set, it must be a UUID string; nil lets the implementation choose a
+	// safe retry key.
 	IdempotencyKey *string `json:"-"`
 	// AccessDelegation is sent as the X-Iceberg-Access-Delegation header, not
 	// in the JSON body. Nil uses the catalog default.
@@ -186,11 +199,12 @@ type PlanTableScanRequest struct {
 // PlanTableScanResponse is the POST .../plan response. The spec models this as
 // a `status`-discriminated union; the flat struct carries every arm's fields
 // with omitempty so none are discarded. Task/delete payloads are filled in by
-// the scan-task decoder PR. Per the spec's CompletedPlanningWithIDResult, plan-id
-// is required for both submitted and completed responses here; the wire decoder
-// must validate PlanID != nil at unmarshal (not rely on the omitempty pointer),
-// since the caller needs it to CancelPlanning and release server resources. A
-// cancelled status is invalid for this endpoint and must be treated as an error.
+// the scan-task decoder PR. Per the spec, plan-id is required for both completed
+// (CompletedPlanningWithIDResult) and submitted (AsyncPlanningResult) responses
+// here; the wire decoder must validate PlanID != nil at unmarshal rather than
+// rely on the omitempty pointer. A cancelled status is invalid for this endpoint
+// and must be treated as an error. A failed status decodes successfully when it
+// carries Error; callers must branch on Status before dereferencing PlanID.
 type PlanTableScanResponse struct {
 	Status PlanStatus     `json:"status"`
 	PlanID *string        `json:"plan-id,omitempty"`
@@ -211,8 +225,14 @@ func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
 		if resp.PlanID == nil {
 			return fmt.Errorf("%w: planTableScan response with status %q missing plan-id", ErrRESTError, resp.Status)
 		}
+	case PlanStatusFailed:
+		if resp.Error == nil {
+			return fmt.Errorf("%w: planTableScan failed response missing error", ErrRESTError)
+		}
 	case PlanStatusCancelled:
 		return fmt.Errorf("%w: planTableScan response has invalid status %q", ErrRESTError, resp.Status)
+	default:
+		return fmt.Errorf("%w: planTableScan response has unknown status %q", ErrRESTError, resp.Status)
 	}
 
 	*r = PlanTableScanResponse(resp)
@@ -232,6 +252,8 @@ type FetchPlanningResultResponse struct {
 // FetchScanTasksRequest is the POST .../tasks request body.
 type FetchScanTasksRequest struct {
 	// IdempotencyKey is sent as the Idempotency-Key header, not in the JSON body.
+	// If set, it must be a UUID string; nil lets the implementation choose a
+	// safe retry key.
 	IdempotencyKey *string `json:"-"`
 
 	PlanTask string `json:"plan-task"`
@@ -244,11 +266,30 @@ type FetchScanTasksResponse struct {
 	ScanTasks
 }
 
+// DefaultWaitForPlanOptions is the conservative polling backoff used when
+// callers pass the zero-value WaitForPlanOptions.
+var DefaultWaitForPlanOptions = WaitForPlanOptions{
+	MinDelay: 100 * time.Millisecond,
+	MaxDelay: 5 * time.Second,
+}
+
 // WaitForPlanOptions tunes the polling backoff. The total wait is bounded by the
 // caller's context deadline (context.WithTimeout). There is deliberately no
 // Timeout field to avoid duplicating the context and the zero-value footgun.
-// Defaults should be conservative.
+// A zero MinDelay/MaxDelay uses DefaultWaitForPlanOptions.
 type WaitForPlanOptions struct {
 	MinDelay time.Duration
 	MaxDelay time.Duration
+	// AccessDelegation is sent as the X-Iceberg-Access-Delegation header on each
+	// poll; nil uses the catalog default. Needed for async plans so the
+	// completed poll can return vended storage credentials.
+	AccessDelegation *string
+}
+
+// FetchPlanningResultOptions carries per-call headers for fetchPlanningResult.
+type FetchPlanningResultOptions struct {
+	// AccessDelegation is sent as the X-Iceberg-Access-Delegation header; nil
+	// uses the catalog default. The spec defines data-access on this endpoint,
+	// so an async poll needs it to receive vended storage credentials.
+	AccessDelegation *string
 }

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -216,6 +216,7 @@ func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
 	}
 
 	*r = PlanTableScanResponse(resp)
+
 	return nil
 }
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -19,31 +19,37 @@ package rest
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlanTableScanResponseRequiresPlanIDForTrackedStatuses(t *testing.T) {
+	t.Parallel()
+
 	for _, status := range []PlanStatus{PlanStatusCompleted, PlanStatusSubmitted} {
 		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+
 			var resp PlanTableScanResponse
 			err := json.Unmarshal([]byte(`{"status":"`+string(status)+`"}`), &resp)
-			if !errors.Is(err, ErrRESTError) {
-				t.Fatalf("expected ErrRESTError, got %v", err)
-			}
+			require.ErrorIs(t, err, ErrRESTError)
 		})
 	}
 }
 
 func TestPlanTableScanResponseRejectsCancelled(t *testing.T) {
+	t.Parallel()
+
 	var resp PlanTableScanResponse
 	err := json.Unmarshal([]byte(`{"status":"cancelled","plan-id":"abc"}`), &resp)
-	if !errors.Is(err, ErrRESTError) {
-		t.Fatalf("expected ErrRESTError, got %v", err)
-	}
+	require.ErrorIs(t, err, ErrRESTError)
 }
 
 func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
+	t.Parallel()
+
 	var resp PlanTableScanResponse
 	err := json.Unmarshal([]byte(`{
 		"status":"completed",
@@ -52,14 +58,39 @@ func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
 		"file-scan-tasks":[{"data-file":{}}],
 		"delete-files":[{"content":"position-deletes"}]
 	}`), &resp)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if resp.PlanID == nil || *resp.PlanID != "abc" {
-		t.Fatalf("expected plan id abc, got %v", resp.PlanID)
-	}
-	if len(resp.PlanTasks) != 1 || len(resp.FileScanTasks) != 1 || len(resp.DeleteFiles) != 1 {
-		t.Fatalf("expected scan task envelope to decode, got %+v", resp.ScanTasks)
-	}
+	require.NotNil(t, resp.PlanID)
+	assert.Equal(t, "abc", *resp.PlanID)
+	assert.Len(t, resp.PlanTasks, 1)
+	// TODO(Phase 2): assert decoded task/delete-file content once the
+	// scan-task decoder fills RESTFileScanTask and RESTDeleteFile.
+	assert.Len(t, resp.FileScanTasks, 1)
+	assert.Len(t, resp.DeleteFiles, 1)
+}
+
+func TestPlanTableScanResponseRejectsFailedWithoutError(t *testing.T) {
+	t.Parallel()
+
+	var resp PlanTableScanResponse
+	err := json.Unmarshal([]byte(`{"status":"failed"}`), &resp)
+	require.ErrorIs(t, err, ErrRESTError)
+}
+
+func TestPlanTableScanResponseAcceptsFailedWithError(t *testing.T) {
+	t.Parallel()
+
+	var resp PlanTableScanResponse
+	err := json.Unmarshal([]byte(`{"status":"failed","error":{"message":"boom","type":"ServerError","code":500}}`), &resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "boom", resp.Error.Message)
+}
+
+func TestPlanTableScanResponseRejectsUnknownStatus(t *testing.T) {
+	t.Parallel()
+
+	var resp PlanTableScanResponse
+	err := json.Unmarshal([]byte(`{"status":"bogus"}`), &resp)
+	require.ErrorIs(t, err, ErrRESTError)
 }

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestPlanTableScanResponseRequiresPlanIDForTrackedStatuses(t *testing.T) {
+	for _, status := range []PlanStatus{PlanStatusCompleted, PlanStatusSubmitted} {
+		t.Run(string(status), func(t *testing.T) {
+			var resp PlanTableScanResponse
+			err := json.Unmarshal([]byte(`{"status":"`+string(status)+`"}`), &resp)
+			if !errors.Is(err, ErrRESTError) {
+				t.Fatalf("expected ErrRESTError, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPlanTableScanResponseRejectsCancelled(t *testing.T) {
+	var resp PlanTableScanResponse
+	err := json.Unmarshal([]byte(`{"status":"cancelled","plan-id":"abc"}`), &resp)
+	if !errors.Is(err, ErrRESTError) {
+		t.Fatalf("expected ErrRESTError, got %v", err)
+	}
+}
+
+func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
+	var resp PlanTableScanResponse
+	err := json.Unmarshal([]byte(`{
+		"status":"completed",
+		"plan-id":"abc",
+		"plan-tasks":["next"],
+		"file-scan-tasks":[{"data-file":{}}],
+		"delete-files":[{"content":"position-deletes"}]
+	}`), &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.PlanID == nil || *resp.PlanID != "abc" {
+		t.Fatalf("expected plan id abc, got %v", resp.PlanID)
+	}
+	if len(resp.PlanTasks) != 1 || len(resp.FileScanTasks) != 1 || len(resp.DeleteFiles) != 1 {
+		t.Fatalf("expected scan task envelope to decode, got %+v", resp.ScanTasks)
+	}
+}

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -40,8 +40,8 @@ const (
 
 // resolveStorageCredentials finds the best-matching credential for the given
 // location using longest-prefix match, mirroring the Java and Python implementations.
-func resolveStorageCredentials(creds []storageCredential, location string) iceberg.Properties {
-	var best *storageCredential
+func resolveStorageCredentials(creds []StorageCredential, location string) iceberg.Properties {
+	var best *StorageCredential
 	for i := range creds {
 		c := &creds[i]
 		if strings.HasPrefix(location, c.Prefix) {

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -330,7 +330,7 @@ func TestResolveStorageCredentials(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		creds    []storageCredential
+		creds    []StorageCredential
 		location string
 		want     iceberg.Properties
 	}{
@@ -342,7 +342,7 @@ func TestResolveStorageCredentials(t *testing.T) {
 		},
 		{
 			name: "matching prefix",
-			creds: []storageCredential{
+			creds: []StorageCredential{
 				{Prefix: "s3://bucket/", Config: s3Creds},
 			},
 			location: "s3://bucket/path/to/file",
@@ -350,7 +350,7 @@ func TestResolveStorageCredentials(t *testing.T) {
 		},
 		{
 			name: "no matching prefix",
-			creds: []storageCredential{
+			creds: []StorageCredential{
 				{Prefix: "s3://other-bucket/", Config: s3Creds},
 			},
 			location: "s3://bucket/path",
@@ -358,7 +358,7 @@ func TestResolveStorageCredentials(t *testing.T) {
 		},
 		{
 			name: "longest prefix wins",
-			creds: []storageCredential{
+			creds: []StorageCredential{
 				{Prefix: "s3://bucket/", Config: s3Creds},
 				{Prefix: "s3://bucket/specific/", Config: specificCreds},
 			},
@@ -367,7 +367,7 @@ func TestResolveStorageCredentials(t *testing.T) {
 		},
 		{
 			name: "longest prefix wins regardless of order",
-			creds: []storageCredential{
+			creds: []StorageCredential{
 				{Prefix: "s3://bucket/specific/", Config: specificCreds},
 				{Prefix: "s3://bucket/", Config: s3Creds},
 			},

--- a/expression_json.go
+++ b/expression_json.go
@@ -25,12 +25,18 @@
 // confirmed against checked-in Java golden fixtures.
 //
 // Design decision: MarshalExpressionJSON emits Java ExpressionParser wire
-// format, including bare JSON booleans for AlwaysTrue/AlwaysFalse (`true` and
-// `false`). The Java REST reference uses the same parser for planTableScan
-// request filters, even though the REST OpenAPI Expression schema also models
-// true/false as objects (`{"type":"true"}` and `{"type":"false"}`).
-// UnmarshalExpressionJSON must accept both forms so clients can read Java-
-// compatible responses and strictly spec-shaped payloads.
+// format. AlwaysTrue/AlwaysFalse are bare JSON booleans (`true`/`false`) — what
+// ExpressionParser.toJson emits and what the Java REST reference accepts on
+// planTableScan request filters (it parses the filter through the same parser).
+//
+// The REST OpenAPI Expression schema documents true/false as objects
+// (`{"type":"true"}` / `{"type":"false"}`), but the Java reference parser does
+// not implement that form: it rejects `{"type":"true"}` and accepts only bare
+// booleans or the literal form `{"type":"literal","value":true}`. That is why
+// marshal emits bare booleans. UnmarshalExpressionJSON stays permissive — it
+// accepts bare booleans and the `{"type":"literal","value":...}` form, and also
+// the OpenAPI object form for a strictly spec-shaped server, even though no
+// known implementation emits it.
 
 package iceberg
 

--- a/expression_json.go
+++ b/expression_json.go
@@ -26,17 +26,20 @@
 //
 // Design decision: MarshalExpressionJSON emits Java ExpressionParser wire
 // format, including bare JSON booleans for AlwaysTrue/AlwaysFalse (`true` and
-// `false`). That intentionally differs from the REST OpenAPI Expression schema,
-// where true/false are represented as objects (`{"type":"true"}` and
-// `{"type":"false"}`). UnmarshalExpressionJSON must accept both forms so
-// clients can read Java-compatible responses and strictly spec-shaped payloads.
+// `false`). The Java REST reference uses the same parser for planTableScan
+// request filters, even though the REST OpenAPI Expression schema also models
+// true/false as objects (`{"type":"true"}` and `{"type":"false"}`).
+// UnmarshalExpressionJSON must accept both forms so clients can read Java-
+// compatible responses and strictly spec-shaped payloads.
 
 package iceberg
+
+import "fmt"
 
 // MarshalExpressionJSON serializes a boolean expression to the JSON format
 // produced by Java's ExpressionParser, for use as a REST scan-planning filter.
 func MarshalExpressionJSON(expr BooleanExpression) ([]byte, error) {
-	panic("unimplemented: proposed API for #1178")
+	return nil, fmt.Errorf("%w: expression JSON marshal", ErrNotImplemented)
 }
 
 // UnmarshalExpressionJSON parses a Java ExpressionParser-format expression,
@@ -44,5 +47,5 @@ func MarshalExpressionJSON(expr BooleanExpression) ([]byte, error) {
 // date/time/decimal/fixed fidelity and to bind residual filters returned by a
 // REST server.
 func UnmarshalExpressionJSON(data []byte, schema *Schema) (BooleanExpression, error) {
-	panic("unimplemented: proposed API for #1178")
+	return nil, fmt.Errorf("%w: expression JSON unmarshal", ErrNotImplemented)
 }

--- a/expression_json.go
+++ b/expression_json.go
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is a PROPOSED public API surface for REST scan-planning
+// expression JSON (apache/iceberg-go#1178). The bodies are intentionally
+// unimplemented; the file exists so the API shape can be reviewed.
+//
+// The codec lives in the root iceberg package because expression internals
+// are defined here and are not exported. Compatibility with Java's
+// ExpressionParser is correctness-critical and every encoding must be
+// confirmed against checked-in Java golden fixtures (e.g. AlwaysTrue/False
+// serialize as the bare JSON booleans `true`/`false`, not objects).
+
+package iceberg
+
+// MarshalExpressionJSON serializes a boolean expression to the JSON format
+// produced by Java's ExpressionParser, for use as a REST scan-planning filter.
+func MarshalExpressionJSON(expr BooleanExpression) ([]byte, error) {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// UnmarshalExpressionJSON parses a Java ExpressionParser-format expression,
+// binding literal terms against schema. schema is required for full
+// date/time/decimal/fixed fidelity and to bind residual filters returned by a
+// REST server.
+func UnmarshalExpressionJSON(data []byte, schema *Schema) (BooleanExpression, error) {
+	panic("unimplemented: proposed API for #1178")
+}

--- a/expression_json.go
+++ b/expression_json.go
@@ -22,8 +22,14 @@
 // The codec lives in the root iceberg package because expression internals
 // are defined here and are not exported. Compatibility with Java's
 // ExpressionParser is correctness-critical and every encoding must be
-// confirmed against checked-in Java golden fixtures (e.g. AlwaysTrue/False
-// serialize as the bare JSON booleans `true`/`false`, not objects).
+// confirmed against checked-in Java golden fixtures.
+//
+// Design decision: MarshalExpressionJSON emits Java ExpressionParser wire
+// format, including bare JSON booleans for AlwaysTrue/AlwaysFalse (`true` and
+// `false`). That intentionally differs from the REST OpenAPI Expression schema,
+// where true/false are represented as objects (`{"type":"true"}` and
+// `{"type":"false"}`). UnmarshalExpressionJSON must accept both forms so
+// clients can read Java-compatible responses and strictly spec-shaped payloads.
 
 package iceberg
 

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -19,8 +19,9 @@
 // planning (apache/iceberg-go#1178). It defines the table-side seam — the
 // option, request/result types, and the ScanPlanner interface (implemented by
 // catalog/rest) — so it can be reviewed as Go rather than prose.
-// WithScanPlanningMode records the requested mode on the Scan, but nothing reads
-// it until scanner delegation lands, so nothing here changes existing behavior.
+// WithScanPlanningMode records the requested mode on the Scan; the delegation
+// skeleton rejects unavailable remote planning so the exported option is not a
+// silent no-op if this surface is released before the full implementation lands.
 
 package table
 
@@ -61,6 +62,25 @@ func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
 	return func(scan *Scan) { scan.planningMode = mode }
 }
 
+// ScanPlanningMetadata is the subset of table.Metadata a ScanPlanner needs:
+// schema binding, snapshot resolution, partition decode, and property-based
+// mode resolution. Narrowing from the full Metadata interface keeps the seam
+// contract honest — planners do not depend on metadata logs, sort orders, or
+// file lists. table.Metadata satisfies it.
+type ScanPlanningMetadata interface {
+	CurrentSchema() *iceberg.Schema
+	Schemas() []*iceberg.Schema
+	PartitionSpec() iceberg.PartitionSpec
+	PartitionSpecByID(int) *iceberg.PartitionSpec
+	CurrentSnapshot() *Snapshot
+	SnapshotByID(int64) *Snapshot
+	Properties() iceberg.Properties
+}
+
+// Compile-time guard that the full Metadata interface still satisfies the
+// narrowed planner view, so callers can pass a table.Metadata directly.
+var _ ScanPlanningMetadata = (Metadata)(nil)
+
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
 // the resolved scan state a planner needs without depending on catalog/rest.
 //
@@ -71,10 +91,9 @@ func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
 // phase; point-in-time SnapshotID lands first.
 type ScanPlanningRequest struct {
 	Identifier Identifier
-	// Metadata is the full table metadata. This likely over-specifies the
-	// contract: a planner needs only schema(s), partition specs, and snapshot
-	// resolution; narrowing to a smaller interface is an open refinement.
-	Metadata         Metadata
+	// Metadata is the narrowed planner view of table metadata (see
+	// ScanPlanningMetadata); MetadataLocation is kept separate.
+	Metadata         ScanPlanningMetadata
 	MetadataLocation string
 	SnapshotID       *int64
 	SelectedFields   []string
@@ -90,11 +109,20 @@ type ScanPlanningRequest struct {
 	UseSnapshotSchema *bool
 }
 
-// PlanIO lazily loads the FileIO that should be used to read a planned scan.
-// Nil means the scan should keep using the table's normal FileIO. Remote
-// planners may return a PlanIO backed by plan-scoped storage credentials.
+// PlanIO lazily loads the FileIO used to read a planned scan and closes any
+// resources it holds (e.g. plan-scoped credentials) once reading is done. Nil
+// means the scan keeps using the table's normal FileIO. Remote planners may
+// return a PlanIO backed by plan-scoped storage credentials.
+//
+// Delivery contract (OQ1): a returned ScanPlanningResult.IO is stored on the
+// Scan that planned it; ReadTasks then loads from it instead of the table's
+// FileIO and closes it after the returned iterator finishes. This ties a
+// plan-scoped scan to the PlanFiles -> ReadTasks sequence on one Scan — tasks
+// from a remote plan must be read by the Scan that produced them, and a Scan
+// carrying plan-scoped IO is not safe for concurrent PlanFiles/ReadTasks.
 type PlanIO interface {
 	Load(context.Context) (icebergio.IO, error)
+	Close() error
 }
 
 // ScanPlanningResult is what a ScanPlanner returns.
@@ -118,7 +146,7 @@ type ScanPlanner interface {
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
 }
 
-// Scan integration, added here as inert fields and completed in the
+// Scan integration, added here as a delegation skeleton and completed in the
 // scanner-delegation phase:
 //
 //	type Scan struct {
@@ -129,10 +157,11 @@ type ScanPlanner interface {
 //
 // table.New sets Table.planner when the supplied CatalogIO also implements
 // ScanPlanner; Table.Scan copies that planner into Scan. This chooses the
-// Catalog -> Table -> Scan wiring now, while keeping (*Scan).PlanFiles on the
-// existing local path until delegation lands.
+// Catalog -> Table -> Scan wiring now.
 //
 // (*Scan).PlanFiles resolves planningMode and, for remote/auto with a capable
-// planner, delegates to planner.PlanFiles; otherwise it runs the existing local
-// path unchanged. The compile-time `var _ table.ScanPlanner = (*Catalog)(nil)`
-// in catalog/rest proves the REST catalog satisfies the planner interface.
+// planner, delegates to planner.PlanFiles and stores any returned PlanIO on the
+// Scan for ReadTasks. Auto without a capable planner runs the existing local
+// path unchanged; remote without one fails loudly instead of silently planning
+// locally. The compile-time `var _ table.ScanPlanner = (*Catalog)(nil)` in
+// catalog/rest proves the REST catalog satisfies the planner interface.

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is a PROPOSED public API surface for REST server-side scan
+// planning (apache/iceberg-go#1178). The bodies are intentionally
+// unimplemented; the file exists so the seam can be reviewed as Go rather
+// than prose. Nothing here changes existing behavior.
+
+package table
+
+import (
+	"context"
+
+	"github.com/apache/iceberg-go"
+)
+
+// ScanPlanningMode selects how (*Scan).PlanFiles plans a scan. Local planning
+// remains the default; remote planning is opt-in via WithScanPlanningMode.
+type ScanPlanningMode string
+
+const (
+	// ScanPlanningLocal always plans locally by reading manifests through the
+	// table's FileIO. This is the default and current behavior.
+	ScanPlanningLocal ScanPlanningMode = "local"
+	// ScanPlanningRemote requires a planner that advertises remote capability
+	// and fails loudly if remote planning is unavailable.
+	ScanPlanningRemote ScanPlanningMode = "remote"
+	// ScanPlanningAuto uses remote planning when available and allowed by the
+	// table config, otherwise falls back to local.
+	ScanPlanningAuto ScanPlanningMode = "auto"
+)
+
+// WithScanPlanningMode sets the scan-planning mode for a scan. The default is
+// ScanPlanningLocal unless the REST table config requires server planning.
+func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
+	panic("unimplemented: proposed API for #1178")
+}
+
+// ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
+// the resolved scan state a planner needs without depending on catalog/rest.
+//
+// Open question (epic OQ4): when the table has evolved, UseSnapshotSchema must
+// pin which schema binds a returned residual and the partition decode — the
+// snapshot's schema (via schema-id), kept separate from each file's partition
+// spec-id. Incremental scans (start/end snapshot) are deferred to a later
+// phase; point-in-time SnapshotID lands first.
+type ScanPlanningRequest struct {
+	Identifier        Identifier
+	Metadata          Metadata
+	MetadataLocation  string
+	SnapshotID        *int64
+	SelectedFields    []string
+	RowFilter         iceberg.BooleanExpression
+	CaseSensitive     bool
+	UseSnapshotSchema bool
+}
+
+// ScanPlanningResult is what a ScanPlanner returns.
+//
+// Open question (OQ1): how plan-scoped FileIO reaches ReadTasks across the
+// PlanFiles -> ReadTasks boundary is unsettled. IO here is one provisional
+// carrier; a live FileIO should not live on FileScanTask (it has a transport
+// codec). Alternatives: a richer planned-result object, an internal plan
+// context on Scan, or a serializable credential handle on FileScanTask.
+type ScanPlanningResult struct {
+	Tasks []FileScanTask
+	IO    FSysF // PROVISIONAL carrier — see OQ1
+}
+
+// ScanPlanner plans scans for a table. rest.Catalog implements it; non-REST
+// catalogs leave it nil and planning stays local.
+//
+// SupportsRemoteScanPlanning reports whether the planner can complete a remote
+// plan end-to-end for the requested scan.
+//
+// Note: FileScanTask is proposed to gain a `Residual iceberg.BooleanExpression`
+// field so remote tasks can carry the server's residual filter. That field is
+// not added here because it would trip the codec/file_scan_task.go drift guard;
+// it lands with the scan-task decoder PR.
+type ScanPlanner interface {
+	SupportsRemoteScanPlanning() bool
+	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
+}

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -26,10 +26,19 @@ import (
 	"context"
 
 	"github.com/apache/iceberg-go"
+	icebergio "github.com/apache/iceberg-go/io"
 )
 
-// ScanPlanningMode selects how (*Scan).PlanFiles plans a scan. Local planning
-// remains the default; remote planning is opt-in via WithScanPlanningMode.
+// ScanPlanningMode is the user-facing scan option: three values
+// (local/remote/auto) selecting how (*Scan).PlanFiles plans a scan. Local
+// planning remains the default; remote is opt-in via WithScanPlanningMode.
+//
+// This is deliberately distinct from the REST table-config key
+// `scan-planning-mode` (values `client`/`server`), which is a server directive
+// resolved separately (OQ4): a `server` table forces remote planning regardless
+// of this option, and an explicit ScanPlanningLocal against such a table is an
+// error. There is intentionally no fourth `server` value here; the directive
+// lives in the table config, not the user option.
 type ScanPlanningMode string
 
 const (
@@ -47,38 +56,49 @@ const (
 // WithScanPlanningMode sets the scan-planning mode for a scan. The default is
 // ScanPlanningLocal unless the REST table config requires server planning.
 func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
-	panic("unimplemented: proposed API for #1178")
+	// The panic is deferred to option application, not construction: an
+	// unimplemented option must not blow up when an options slice is built,
+	// only if it is actually applied to a Scan.
+	return func(*Scan) { panic("unimplemented: proposed API for #1178") }
 }
 
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
 // the resolved scan state a planner needs without depending on catalog/rest.
 //
 // Open question (epic OQ4): when the table has evolved, UseSnapshotSchema must
-// pin which schema binds a returned residual and the partition decode — the
+// pin which schema binds a returned residual and the partition decode: the
 // snapshot's schema (via schema-id), kept separate from each file's partition
 // spec-id. Incremental scans (start/end snapshot) are deferred to a later
 // phase; point-in-time SnapshotID lands first.
 type ScanPlanningRequest struct {
-	Identifier        Identifier
-	Metadata          Metadata
-	MetadataLocation  string
-	SnapshotID        *int64
-	SelectedFields    []string
-	RowFilter         iceberg.BooleanExpression
+	Identifier Identifier
+	// Metadata is the full table metadata. This likely over-specifies the
+	// contract: a planner needs only schema(s), partition specs, and snapshot
+	// resolution; narrowing to a smaller interface is an open refinement.
+	Metadata         Metadata
+	MetadataLocation string
+	SnapshotID       *int64
+	SelectedFields   []string
+	RowFilter        iceberg.BooleanExpression
+	MinRowsRequested *int64
+	StatsFields      []string
+	// CaseSensitive must carry the Scan's value (which defaults to true), not
+	// Go's false zero value, or the wire request would flip the spec default.
 	CaseSensitive     bool
 	UseSnapshotSchema bool
 }
 
+// PlanIO lazily loads the FileIO that should be used to read a planned scan.
+// Nil means the scan should keep using the table's normal FileIO. Remote
+// planners may return a PlanIO backed by plan-scoped storage credentials.
+type PlanIO interface {
+	Load(context.Context) (icebergio.IO, error)
+}
+
 // ScanPlanningResult is what a ScanPlanner returns.
-//
-// Open question (OQ1): how plan-scoped FileIO reaches ReadTasks across the
-// PlanFiles -> ReadTasks boundary is unsettled. IO here is one provisional
-// carrier; a live FileIO should not live on FileScanTask (it has a transport
-// codec). Alternatives: a richer planned-result object, an internal plan
-// context on Scan, or a serializable credential handle on FileScanTask.
 type ScanPlanningResult struct {
 	Tasks []FileScanTask
-	IO    FSysF // PROVISIONAL carrier — see OQ1
+	IO    PlanIO
 }
 
 // ScanPlanner plans scans for a table. rest.Catalog implements it; non-REST
@@ -95,3 +115,19 @@ type ScanPlanner interface {
 	SupportsRemoteScanPlanning() bool
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
 }
+
+// Proposed Scan integration, added in the scanner-delegation phase. Sketched
+// here (not declared) to show how the seam wires into the existing Scan, whose
+// fields live in scanner.go:
+//
+//	type Scan struct {
+//		// ...existing fields...
+//		planningMode ScanPlanningMode // set by WithScanPlanningMode; default ScanPlanningLocal
+//		planner      ScanPlanner      // non-nil only when the catalog supplies one
+//	}
+//
+// (*Scan).PlanFiles resolves planningMode and, for remote/auto with a capable
+// planner, delegates to planner.PlanFiles; otherwise it runs the existing local
+// path unchanged. The compile-time `var _ table.ScanPlanner = (*Catalog)(nil)`
+// in catalog/rest proves the seam is satisfiable, but not this wiring, which
+// arrives with scanner delegation.

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -16,9 +16,11 @@
 // under the License.
 
 // This file is a PROPOSED public API surface for REST server-side scan
-// planning (apache/iceberg-go#1178). The bodies are intentionally
-// unimplemented; the file exists so the seam can be reviewed as Go rather
-// than prose. Nothing here changes existing behavior.
+// planning (apache/iceberg-go#1178). It defines the table-side seam — the
+// option, request/result types, and the ScanPlanner interface (implemented by
+// catalog/rest) — so it can be reviewed as Go rather than prose.
+// WithScanPlanningMode records the requested mode on the Scan, but nothing reads
+// it until scanner delegation lands, so nothing here changes existing behavior.
 
 package table
 
@@ -56,10 +58,7 @@ const (
 // WithScanPlanningMode sets the scan-planning mode for a scan. The default is
 // ScanPlanningLocal unless the REST table config requires server planning.
 func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
-	// The panic is deferred to option application, not construction: an
-	// unimplemented option must not blow up when an options slice is built,
-	// only if it is actually applied to a Scan.
-	return func(*Scan) { panic("unimplemented: proposed API for #1178") }
+	return func(scan *Scan) { scan.planningMode = mode }
 }
 
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
@@ -84,8 +83,11 @@ type ScanPlanningRequest struct {
 	StatsFields      []string
 	// CaseSensitive must carry the Scan's value (which defaults to true), not
 	// Go's false zero value, or the wire request would flip the spec default.
-	CaseSensitive     bool
-	UseSnapshotSchema bool
+	// Nil means use the scan default.
+	CaseSensitive *bool
+	// UseSnapshotSchema is a pointer to distinguish the spec default from an
+	// explicit false when the scanner-delegation phase binds it to table config.
+	UseSnapshotSchema *bool
 }
 
 // PlanIO lazily loads the FileIO that should be used to read a planned scan.
@@ -116,9 +118,8 @@ type ScanPlanner interface {
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
 }
 
-// Proposed Scan integration, added in the scanner-delegation phase. Sketched
-// here (not declared) to show how the seam wires into the existing Scan, whose
-// fields live in scanner.go:
+// Scan integration, added here as inert fields and completed in the
+// scanner-delegation phase:
 //
 //	type Scan struct {
 //		// ...existing fields...
@@ -126,8 +127,12 @@ type ScanPlanner interface {
 //		planner      ScanPlanner      // non-nil only when the catalog supplies one
 //	}
 //
+// table.New sets Table.planner when the supplied CatalogIO also implements
+// ScanPlanner; Table.Scan copies that planner into Scan. This chooses the
+// Catalog -> Table -> Scan wiring now, while keeping (*Scan).PlanFiles on the
+// existing local path until delegation lands.
+//
 // (*Scan).PlanFiles resolves planningMode and, for remote/auto with a capable
 // planner, delegates to planner.PlanFiles; otherwise it runs the existing local
 // path unchanged. The compile-time `var _ table.ScanPlanner = (*Catalog)(nil)`
-// in catalog/rest proves the seam is satisfiable, but not this wiring, which
-// arrives with scanner delegation.
+// in catalog/rest proves the REST catalog satisfies the planner interface.

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -35,9 +35,9 @@ import (
 //
 // This is deliberately distinct from the REST table-config key
 // `scan-planning-mode` (values `client`/`server`), which is a server directive
-// resolved separately (OQ4): a `server` table forces remote planning regardless
-// of this option, and an explicit ScanPlanningLocal against such a table is an
-// error. There is intentionally no fourth `server` value here; the directive
+// resolved separately (OQ4): a `client` table forces local planning, a `server`
+// table forces remote planning, and explicit conflicting scan options fail
+// fast. There is intentionally no fourth `server` value here; the directive
 // lives in the table config, not the user option.
 type ScanPlanningMode string
 

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	icebergio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanPlanningRemoteRequiresPlanner(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{planningMode: ScanPlanningRemote}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestScanPlanningRemoteStoresPlanIO(t *testing.T) {
+	t.Parallel()
+
+	pio := fakePlanIO{}
+	planner := &fakeScanPlanner{
+		result:   ScanPlanningResult{IO: pio},
+		supports: true,
+	}
+	scan := &Scan{
+		planner:      planner,
+		planningMode: ScanPlanningRemote,
+	}
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+	assert.Equal(t, pio, scan.planIO)
+}
+
+func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{
+		planner:      &fakeScanPlanner{supports: false},
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestScanPlanningRemotePropagatesPlannerError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("planner boom")
+	scan := &Scan{
+		planner:      &fakeScanPlanner{supports: true, err: want},
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, want)
+}
+
+func TestScanPlanningAutoUsesCapablePlanner(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{
+		planner:      &fakeScanPlanner{result: ScanPlanningResult{Tasks: []FileScanTask{{}}}, supports: true},
+		planningMode: ScanPlanningAuto,
+	}
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tasks, 1)
+}
+
+func TestScanPlanningUnknownModeErrors(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{planningMode: ScanPlanningMode("bogus")}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+type fakeScanPlanner struct {
+	result   ScanPlanningResult
+	supports bool
+	err      error
+}
+
+func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
+
+func (f *fakeScanPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+	return f.result, f.err
+}
+
+type fakePlanIO struct{}
+
+func (fakePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil }
+func (fakePlanIO) Close() error                               { return nil }

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -186,6 +186,8 @@ func isDeletionVector(df iceberg.DataFile) bool {
 type Scan struct {
 	metadata       Metadata
 	ioF            FSysF
+	planner        ScanPlanner
+	planningMode   ScanPlanningMode
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -184,10 +184,16 @@ func isDeletionVector(df iceberg.DataFile) bool {
 }
 
 type Scan struct {
-	metadata       Metadata
-	ioF            FSysF
-	planner        ScanPlanner
-	planningMode   ScanPlanningMode
+	identifier       Identifier
+	metadata         Metadata
+	metadataLocation string
+	ioF              FSysF
+	planner          ScanPlanner
+	planningMode     ScanPlanningMode
+	// planIO, when non-nil, is a plan-scoped FileIO loader set by remote scan
+	// planning; ReadTasks loads from it instead of ioF and closes it after the
+	// returned iterator finishes. See PlanIO.
+	planIO         PlanIO
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool
@@ -664,6 +670,21 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 		scan.snapshotID = &snapshot.SnapshotID
 		scan.asOfTimestamp = nil
 	}
+
+	switch scan.planningMode {
+	case ScanPlanningRemote:
+		return scan.planFilesRemote(ctx)
+	case ScanPlanningAuto:
+		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() {
+			return scan.planFilesRemote(ctx)
+		}
+	case ScanPlanningLocal:
+	default:
+		return nil, fmt.Errorf("%w: unknown scan planning mode %q", iceberg.ErrInvalidArgument, scan.planningMode)
+	}
+
+	scan.planIO = nil
+
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifests(ctx)
 	if err != nil || len(manifestList) == 0 {
@@ -729,6 +750,30 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	return results, nil
 }
 
+func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
+	if scan.planner == nil || !scan.planner.SupportsRemoteScanPlanning() {
+		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
+	}
+
+	caseSensitive := scan.caseSensitive
+	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
+		Identifier:       scan.identifier,
+		Metadata:         scan.metadata,
+		MetadataLocation: scan.metadataLocation,
+		SnapshotID:       scan.snapshotID,
+		SelectedFields:   scan.selectedFields,
+		RowFilter:        scan.rowFilter,
+		CaseSensitive:    &caseSensitive,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	scan.planIO = result.IO
+
+	return result.Tasks, nil
+}
+
 type FileScanTask struct {
 	File                iceberg.DataFile
 	DeleteFiles         []iceberg.DataFile // positional delete files
@@ -781,12 +826,19 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		return nil, nil, err
 	}
 
-	fs, err := scan.ioF(ctx)
+	// A plan-scoped FileIO (from remote planning) takes precedence over the
+	// table's default FileIO and is closed once the returned iterator finishes.
+	var fs io.IO
+	if scan.planIO != nil {
+		fs, err = scan.planIO.Load(ctx)
+	} else {
+		fs, err = scan.ioF(ctx)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return (&arrowScan{
+	outSchema, records, err := (&arrowScan{
 		metadata:        scan.metadata,
 		fs:              fs,
 		projectedSchema: schema,
@@ -796,6 +848,35 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		options:         scan.options,
 		concurrency:     scan.concurrency,
 	}).GetRecords(ctx, tasks)
+	if err != nil {
+		// No iterator to drive cleanup on a setup error, so close here.
+		if scan.planIO != nil {
+			_ = scan.planIO.Close()
+		}
+
+		return nil, nil, err
+	}
+
+	if scan.planIO != nil {
+		records = closePlanIOAfter(records, scan.planIO)
+	}
+
+	return outSchema, records, nil
+}
+
+// closePlanIOAfter wraps an arrow record iterator so the plan-scoped IO is
+// closed once iteration ends — whether the consumer exhausts the iterator or
+// stops early. A caller that never ranges over the iterator does not trigger
+// the close; that is an accepted edge for an unread result.
+func closePlanIOAfter(seq iter.Seq2[arrow.RecordBatch, error], pio PlanIO) iter.Seq2[arrow.RecordBatch, error] {
+	return func(yield func(arrow.RecordBatch, error) bool) {
+		defer func() { _ = pio.Close() }()
+		for rec, err := range seq {
+			if !yield(rec, err) {
+				return
+			}
+		}
+	}
 }
 
 // ToArrowTable calls ToArrowRecords and then gathers all of the records together

--- a/table/table.go
+++ b/table/table.go
@@ -81,6 +81,7 @@ type Table struct {
 	metadataLocation string
 	cat              CatalogIO
 	fsF              FSysF
+	planner          ScanPlanner
 }
 
 func (t Table) Equals(other Table) bool {
@@ -831,6 +832,8 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
 		metadata:       t.metadata,
 		ioF:            t.fsF,
+		planner:        t.planner,
+		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},
 		caseSensitive:  true,
@@ -847,13 +850,27 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 	return s
 }
 
+// New constructs a Table. If cat implements ScanPlanner — as rest.Catalog does
+// for servers that support remote scan planning — it is wired as the table's
+// planner so (*Scan).PlanFiles can delegate to it; catalogs that do not
+// implement ScanPlanner leave planner nil and planning stays local. This is the
+// concrete Catalog -> Table -> Scan wiring for #1178: no New signature change
+// and no catalog accessor are needed, because the catalog already satisfies
+// ScanPlanner.
 func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, cat CatalogIO) *Table {
+	// A catalog that supports server-side scan planning implements ScanPlanner.
+	var planner ScanPlanner
+	if p, ok := cat.(ScanPlanner); ok {
+		planner = p
+	}
+
 	return &Table{
 		identifier:       ident,
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 		fsF:              fsF,
 		cat:              cat,
+		planner:          planner,
 	}
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -142,6 +142,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.metadata = fresh.metadata
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
+	t.planner = fresh.planner
 
 	return nil
 }
@@ -830,9 +831,12 @@ func WithRowLineage() ScanOption {
 
 func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
-		metadata:       t.metadata,
-		ioF:            t.fsF,
-		planner:        t.planner,
+		identifier:       t.identifier,
+		metadata:         t.metadata,
+		metadataLocation: t.metadataLocation,
+		ioF:              t.fsF,
+		planner:          t.planner,
+		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1866,6 +1866,8 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 	s := &Scan{
 		metadata:       updatedMeta,
 		ioF:            t.tbl.fsF,
+		planner:        t.tbl.planner,
+		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},
 		caseSensitive:  true,

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1864,9 +1864,12 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 	}
 
 	s := &Scan{
-		metadata:       updatedMeta,
-		ioF:            t.tbl.fsF,
-		planner:        t.tbl.planner,
+		identifier:       t.tbl.identifier,
+		metadata:         updatedMeta,
+		metadataLocation: t.tbl.metadataLocation,
+		ioF:              t.tbl.fsF,
+		planner:          t.tbl.planner,
+		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
 		selectedFields: []string{"*"},


### PR DESCRIPTION
# REST scan planning: proposed public API surface (#1178)

> This design is under active development and will keep changing as it's discussed. Feedback on the open decisions especially welcome and appreciated. Thank you.

This is a design proposal, not an implementation. Every body is `panic("unimplemented")`, and there is no behavior change.

Opening this as a "PR with interfaces" so the seam can be reviewed in Go before implementation. Part of #1178.

## Why

Planning large-table scans entirely in a short-lived Go client (Lambda, Cloud Run, small k8s jobs) can be slow or infeasible. The REST spec's scan-planning endpoints let the catalog plan near its metadata and return only the tasks the client needs, with optional plan-scoped credentials and catalog-side governance. **Local planning stays the default; remote is opt-in.**

## Public API surface

**`table` (the seam)**
- `ScanPlanningMode` (`local` / `remote` / `auto`) + `WithScanPlanningMode(...) ScanOption`
- `ScanPlanner`: `SupportsRemoteScanPlanning() bool`, `PlanFiles(ctx, ScanPlanningRequest) (ScanPlanningResult, error)`
- `ScanPlanningRequest` / `ScanPlanningResult`
- Proposed `FileScanTask.Residual iceberg.BooleanExpression`: not added here (would trip the `codec/file_scan_task.go` drift guard), lands with the scan-task decoder PR.

**root `iceberg` (expression codec)**
- `MarshalExpressionJSON` / `UnmarshalExpressionJSON`: Java `ExpressionParser`-compatible. Correctness-critical; every encoding is pinned to checked-in Java golden fixtures (e.g. `AlwaysTrue`/`False` serialize as the bare booleans `true`/`false`).

**`catalog/rest` (client)**
- Capability discovery `Endpoint` + `SupportsEndpoint`: **Phase 0, already implemented in a separate PR** (held pending).
- Split capability: `SupportsPlanTableScan` / `SupportsFullRemoteScanPlanning`
- `PlanTableScan` / `FetchPlanningResult` / `CancelPlanning` / `FetchScanTasks` / `WaitForPlan`
- `ErrPlanExpired` and wire-type envelopes
- `var _ table.ScanPlanner = (*Catalog)(nil)`: compile-time proof the seam fits.

`table` does not import `catalog/rest`; `StorageCredential` stays out of `table`.

## Decisions pending (before this lands)

1. **Plan-scoped FileIO carrier (OQ1).** How does plan-scoped IO reach `ReadTasks` across the `PlanFiles` -> `ReadTasks` boundary? Options: a richer planned-result object, an internal plan context on `Scan`, or a serializable credential handle on `FileScanTask`. A *live* FileIO should not sit on `FileScanTask` because it has a transport codec. No firm recommendation yet.
2. **Capability gating (OQ2).** A single gate is too coarse: requiring all four endpoints falls back to local on sync-only servers; requiring only the plan endpoint can false-positive on `submitted` / `plan-tasks` flows. Proposed split: `SupportsPlanTableScan` vs `SupportsFullRemoteScanPlanning`. I'll confirm what the Java `iceberg-rest-fixture` advertises.
3. **Schema binding across the boundary (OQ4).** A returned residual must bind to the snapshot schema (via schema-id); the ordered-partition decode uses each file's partition spec-id, kept separate. `UseSnapshotSchema` needs a concrete contract.
4. **`scan-planning-mode=server`.** Proposed fail-fast contract: config `server` requires remote planning; an explicit `ScanPlanningLocal` against a `server` table is an error, not a silent local plan.

## Phasing

0. Capability discovery (`endpoints` decode + `SupportsEndpoint`) - separate PR, no behavior change.
1. Expression JSON codec - highest risk; Java golden tests.
2. REST content-file + scan-task JSON; add `FileScanTask.Residual`.
3. Wire types + validation.
4. REST client methods + poller/backoff + cancel-on-context.
5. Table planner seam.
6. Scanner delegation (`WithScanPlanningMode`, local/remote/auto).
7. Fake server + parity tests; gated Java-fixture integration.
8. Docs + hardening.

## Correctness anchor

The acceptance bar is a local-vs-remote parity test. A fake server that plans locally internally proves *plumbing only*; the real oracle is golden request/response fixtures captured from the Java `iceberg-rest-fixture`.
Expression-JSON mismatch and incorrect server residuals are the silent-corruption risks this design guards against.

## Not in this PR

Implementation (bodies panic), a REST server, a distributed worker runtime, incremental/CDC scans (deferred; point-in-time first), and any change to the local planning path.
