### PR TITLE
feat(table): add partition-match predicate for dynamic overwrite

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -53,7 +53,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
-	"github.com/google/uuid"
+	"github.com/apache/iceberg-go/table/internal"
 )
 
 // IsolationLevel controls how strictly a commit rejects concurrent
@@ -546,7 +546,7 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 				continue
 			}
 
-			lit, err := anyToLiteral(value)
+			lit, err := internal.LiteralForPartitionValue(value)
 			if err != nil {
 				return nil, fmt.Errorf("partition field %q: %w", sourceField.Name, err)
 			}
@@ -570,46 +570,6 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 	}
 
 	return iceberg.NewOr(terms[0], terms[1], terms[2:]...), nil
-}
-
-// anyToLiteral converts a dynamically-typed partition value (as
-// stored in iceberg.DataFile.Partition()) to an iceberg.Literal.
-// The supported types mirror the iceberg.LiteralType constraint.
-func anyToLiteral(v any) (iceberg.Literal, error) {
-	switch val := v.(type) {
-	case bool:
-		return iceberg.NewLiteral(val), nil
-	case int32:
-		return iceberg.NewLiteral(val), nil
-	case int64:
-		return iceberg.NewLiteral(val), nil
-	case float32:
-		return iceberg.NewLiteral(val), nil
-	case float64:
-		return iceberg.NewLiteral(val), nil
-	case string:
-		return iceberg.NewLiteral(val), nil
-	case []byte:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.Date:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.Time:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.Timestamp:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.TimestampNano:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.Decimal:
-		return iceberg.NewLiteral(val), nil
-	case iceberg.DecimalLiteral:
-		// convertAvroValueToIcebergType returns the named type DecimalLiteral
-		// (type DecimalLiteral Decimal), not Decimal itself. Handle both.
-		return iceberg.NewLiteral(iceberg.Decimal(val)), nil
-	case uuid.UUID:
-		return iceberg.NewLiteral(val), nil
-	default:
-		return nil, fmt.Errorf("unsupported partition value type %T", v)
-	}
 }
 
 // validateNoNewDeletesForRewrittenFiles rejects the commit if any

--- a/table/internal/partition_predicate.go
+++ b/table/internal/partition_predicate.go
@@ -109,11 +109,6 @@ func BuildPartitionMatchPredicate(spec iceberg.PartitionSpec, schema *iceberg.Sc
 				continue
 			}
 
-			lit, err := literalForPartitionValue(val)
-			if err != nil {
-				return nil, fmt.Errorf("partition field %q: %w", fr.name, err)
-			}
-
 			if isNaN(val) {
 				// x == NaN is never true (IEEE 754), so a NaN partition value must
 				// match via IsNaN. This intentionally diverges from PyIceberg's
@@ -128,6 +123,11 @@ func BuildPartitionMatchPredicate(spec iceberg.PartitionSpec, schema *iceberg.Sc
 				sigParts = append(sigParts, strconv.Itoa(fr.id)+":nan")
 
 				continue
+			}
+
+			lit, err := LiteralForPartitionValue(val)
+			if err != nil {
+				return nil, fmt.Errorf("partition field %q: %w", fr.name, err)
 			}
 
 			clause = iceberg.NewAnd(clause, iceberg.LiteralPredicate(iceberg.OpEQ, ref, lit))
@@ -163,13 +163,13 @@ func isNaN(v any) bool {
 	}
 }
 
-// literalForPartitionValue converts a partition value (as stored on a DataFile)
+// LiteralForPartitionValue converts a partition value (as stored on a DataFile)
 // into a typed Literal so the resulting predicate binds against the source
 // field with the correct type, rather than relying on a string rendering.
 //
 // DataFile.Partition() yields either a Literal (e.g. DecimalLiteral for decimal
 // fields, decoded in manifest.go) or a raw Go value; both are handled.
-func literalForPartitionValue(v any) (iceberg.Literal, error) {
+func LiteralForPartitionValue(v any) (iceberg.Literal, error) {
 	// Decoded partition values are sometimes already Literals (decimal fields).
 	if lit, ok := v.(iceberg.Literal); ok {
 		return lit, nil

--- a/table/internal/partition_predicate.go
+++ b/table/internal/partition_predicate.go
@@ -1,0 +1,215 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+)
+
+// BuildPartitionMatchPredicate constructs a BooleanExpression matching all rows
+// that belong to any of the given partitions. It is the core of dynamic
+// partition overwrite (see https://github.com/apache/iceberg-go/issues/1215):
+// the returned expression selects the existing data to delete before the new
+// data is appended.
+//
+// partitions holds partition tuples as returned by DataFile.Partition(), each
+// keyed by partition-field ID and carrying the field's (transformed) value. The
+// result is an OR across distinct partitions, each clause an AND across the
+// spec's fields:
+//
+//	source == value   when the partition value is present
+//	IsNaN(source)      when the value is a floating-point NaN (x == NaN is never true)
+//	IsNull(source)     when the partition value is absent or nil
+//
+// Duplicate tuples collapse to a single clause, and an empty input yields
+// AlwaysFalse (matching nothing). Callers are expected to pass a partitioned
+// spec; dynamic partition overwrite rejects unpartitioned tables upstream.
+//
+// Because only identity transforms are accepted (see below), the partition
+// value equals the source-column value, so "source == value" selects exactly
+// the rows in that partition. Non-identity transforms (bucket, truncate, the
+// time transforms) cannot be matched by a source-column predicate and need
+// partition-level matching instead; they are rejected here and tracked as a
+// follow-up under issue #1215.
+func BuildPartitionMatchPredicate(spec iceberg.PartitionSpec, schema *iceberg.Schema, partitions []map[int]any) (iceberg.BooleanExpression, error) {
+	type fieldRef struct {
+		id   int
+		name string
+	}
+
+	var fields []fieldRef
+	for _, f := range spec.Fields() {
+		if _, ok := f.Transform.(iceberg.IdentityTransform); !ok {
+			return nil, fmt.Errorf("%w: dynamic partition overwrite supports identity-transform partition fields only, got %s on %q (tracked in https://github.com/apache/iceberg-go/issues/1215)",
+				iceberg.ErrNotImplemented, f.Transform, f.Name)
+		}
+
+		// Identity transforms always have exactly one source column.
+		if len(f.SourceIDs) != 1 {
+			return nil, fmt.Errorf("%w: identity partition field %q must have exactly one source id, got %d",
+				iceberg.ErrInvalidArgument, f.Name, len(f.SourceIDs))
+		}
+
+		src, ok := schema.FindFieldByID(f.SourceIDs[0])
+		if !ok {
+			return nil, fmt.Errorf("%w: partition field %q references unknown source id %d",
+				iceberg.ErrInvalidArgument, f.Name, f.SourceIDs[0])
+		}
+
+		fields = append(fields, fieldRef{id: f.FieldID, name: src.Name})
+	}
+
+	// NewAnd/NewOr fold away the AlwaysTrue/AlwaysFalse seeds, so a single-field,
+	// single-partition input returns the bare leaf predicate rather than a
+	// wrapped tree.
+	var result iceberg.BooleanExpression = iceberg.AlwaysFalse{}
+	seen := make(map[string]struct{}, len(partitions))
+
+	for _, part := range partitions {
+		var clause iceberg.BooleanExpression = iceberg.AlwaysTrue{}
+
+		// sigParts encodes (field id, canonical value bytes) per field so that
+		// distinct tuples can never collide into one dedup key, regardless of
+		// the value's content (e.g. strings containing the separators).
+		sigParts := make([]string, 0, len(fields))
+
+		for _, fr := range fields {
+			ref := iceberg.Reference(fr.name)
+
+			// A missing key (!ok) is treated like an explicit nil. In practice
+			// DataFile.Partition() stores a null partition value as a nil-valued
+			// entry rather than an absent key; !ok is a defensive guard.
+			val, ok := part[fr.id]
+			if !ok || val == nil {
+				clause = iceberg.NewAnd(clause, iceberg.IsNull(ref))
+				sigParts = append(sigParts, strconv.Itoa(fr.id)+":null")
+
+				continue
+			}
+
+			lit, err := literalForPartitionValue(val)
+			if err != nil {
+				return nil, fmt.Errorf("partition field %q: %w", fr.name, err)
+			}
+
+			if isNaN(val) {
+				// x == NaN is never true (IEEE 754), so a NaN partition value must
+				// match via IsNaN. This intentionally diverges from PyIceberg's
+				// _build_partition_predicate, which emits EqualTo for every value:
+				// IsNaN is both correct as a row filter and lets the strict-metrics
+				// evaluator delete NaN-only files outright instead of rewriting them.
+				//
+				// NaN has many valid bit patterns, so the dedup signature uses a
+				// fixed sentinel (not MarshalBinary) to keep duplicate NaN
+				// partitions collapsing to a single clause.
+				clause = iceberg.NewAnd(clause, iceberg.IsNaN(ref))
+				sigParts = append(sigParts, strconv.Itoa(fr.id)+":nan")
+
+				continue
+			}
+
+			clause = iceberg.NewAnd(clause, iceberg.LiteralPredicate(iceberg.OpEQ, ref, lit))
+
+			enc, err := lit.MarshalBinary()
+			if err != nil {
+				return nil, fmt.Errorf("partition field %q: encoding value for dedup: %w", fr.name, err)
+			}
+			sigParts = append(sigParts, strconv.Itoa(fr.id)+":v"+hex.EncodeToString(enc))
+		}
+
+		sig := strings.Join(sigParts, "|")
+		if _, dup := seen[sig]; dup {
+			continue
+		}
+		seen[sig] = struct{}{}
+
+		result = iceberg.NewOr(result, clause)
+	}
+
+	return result, nil
+}
+
+// isNaN reports whether v is a floating-point NaN.
+func isNaN(v any) bool {
+	switch f := v.(type) {
+	case float32:
+		return math.IsNaN(float64(f))
+	case float64:
+		return math.IsNaN(f)
+	default:
+		return false
+	}
+}
+
+// literalForPartitionValue converts a partition value (as stored on a DataFile)
+// into a typed Literal so the resulting predicate binds against the source
+// field with the correct type, rather than relying on a string rendering.
+//
+// DataFile.Partition() yields either a Literal (e.g. DecimalLiteral for decimal
+// fields, decoded in manifest.go) or a raw Go value; both are handled.
+func literalForPartitionValue(v any) (iceberg.Literal, error) {
+	// Decoded partition values are sometimes already Literals (decimal fields).
+	if lit, ok := v.(iceberg.Literal); ok {
+		return lit, nil
+	}
+
+	// The remaining cases cover the raw Go values manifest decoding emits
+	// (int32/int64/float/string/[]byte and the Date/Time/Timestamp aliases).
+	// The int and iceberg.Decimal cases are accepted defensively for
+	// hand-constructed inputs; the decoder itself yields int32/int64 and, for
+	// decimals, a DecimalLiteral caught by the passthrough above.
+	switch val := v.(type) {
+	case bool:
+		return iceberg.NewLiteral(val), nil
+	case int32:
+		return iceberg.NewLiteral(val), nil
+	case int64:
+		return iceberg.NewLiteral(val), nil
+	case int:
+		return iceberg.NewLiteral(int64(val)), nil
+	case float32:
+		return iceberg.NewLiteral(val), nil
+	case float64:
+		return iceberg.NewLiteral(val), nil
+	case string:
+		return iceberg.NewLiteral(val), nil
+	case []byte:
+		return iceberg.NewLiteral(val), nil
+	case iceberg.Date:
+		return iceberg.NewLiteral(val), nil
+	case iceberg.Time:
+		return iceberg.NewLiteral(val), nil
+	case iceberg.Timestamp:
+		return iceberg.NewLiteral(val), nil
+	case iceberg.TimestampNano:
+		return iceberg.NewLiteral(val), nil
+	case uuid.UUID:
+		return iceberg.NewLiteral(val), nil
+	case iceberg.Decimal:
+		return iceberg.NewLiteral(val), nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported partition value type %T", iceberg.ErrInvalidArgument, v)
+	}
+}

--- a/table/internal/partition_predicate_test.go
+++ b/table/internal/partition_predicate_test.go
@@ -1,0 +1,360 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"math"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dynamicOverwriteSchema() *iceberg.Schema {
+	return iceberg.NewSchema(
+		0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 3, Name: "sub", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 4, Name: "score", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+		iceberg.NestedField{ID: 5, Name: "score32", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+	)
+}
+
+func identityField(sourceID, fieldID int, name string) iceberg.PartitionField {
+	return iceberg.PartitionField{SourceIDs: []int{sourceID}, FieldID: fieldID, Name: name, Transform: iceberg.IdentityTransform{}}
+}
+
+func identitySpec(fields ...iceberg.PartitionField) iceberg.PartitionSpec {
+	return iceberg.NewPartitionSpec(fields...)
+}
+
+func TestBuildPartitionMatchPredicate_EmptyInput(t *testing.T) {
+	spec := identitySpec(identityField(1, 1000, "id"))
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), nil)
+	require.NoError(t, err)
+	assert.True(t, expr.Equals(iceberg.AlwaysFalse{}), "empty input should match nothing, got %s", expr)
+}
+
+func TestBuildPartitionMatchPredicate_SingleField(t *testing.T) {
+	spec := identitySpec(identityField(1, 1000, "id"))
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5)},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.EqualTo(iceberg.Reference("id"), int32(5))
+	assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+}
+
+func TestBuildPartitionMatchPredicate_MultipleFields(t *testing.T) {
+	spec := identitySpec(
+		identityField(1, 1000, "id"),
+		identityField(2, 1001, "category"),
+	)
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5), 1001: "books"},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewAnd(
+		iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+		iceberg.EqualTo(iceberg.Reference("category"), "books"),
+	)
+	assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+}
+
+func TestBuildPartitionMatchPredicate_MultiplePartitions(t *testing.T) {
+	spec := identitySpec(identityField(1, 1000, "id"))
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5)},
+		{1000: int32(7)},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewOr(
+		iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+		iceberg.EqualTo(iceberg.Reference("id"), int32(7)),
+	)
+	assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+}
+
+func TestBuildPartitionMatchPredicate_MultipleFieldsAndPartitions(t *testing.T) {
+	spec := identitySpec(
+		identityField(1, 1000, "id"),
+		identityField(2, 1001, "category"),
+	)
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5), 1001: "books"},
+		{1000: int32(7), 1001: "science"},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewOr(
+		iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+			iceberg.EqualTo(iceberg.Reference("category"), "books"),
+		),
+		iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("id"), int32(7)),
+			iceberg.EqualTo(iceberg.Reference("category"), "science"),
+		),
+	)
+	assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+}
+
+func TestBuildPartitionMatchPredicate_NullValue(t *testing.T) {
+	spec := identitySpec(identityField(2, 1001, "category"))
+
+	// Both an explicit nil and a missing key represent a null partition value.
+	cases := []struct {
+		name       string
+		partitions []map[int]any
+	}{
+		{"explicit nil", []map[int]any{{1001: nil}}},
+		{"missing key", []map[int]any{{}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), tc.partitions)
+			require.NoError(t, err)
+
+			want := iceberg.IsNull(iceberg.Reference("category"))
+			assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+		})
+	}
+}
+
+func TestBuildPartitionMatchPredicate_NullAndNonNullInSameTuple(t *testing.T) {
+	spec := identitySpec(
+		identityField(1, 1000, "id"),
+		identityField(2, 1001, "category"),
+	)
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5), 1001: nil},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewAnd(
+		iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+		iceberg.IsNull(iceberg.Reference("category")),
+	)
+	assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+}
+
+func TestBuildPartitionMatchPredicate_NaNValue(t *testing.T) {
+	// x == NaN is never true, so a NaN partition value must become IsNaN, for
+	// both float widths.
+	cases := []struct {
+		name  string
+		field iceberg.PartitionField
+		col   string
+		nan   any
+	}{
+		{"float64", identityField(4, 1003, "score"), "score", math.NaN()},
+		{"float32", identityField(5, 1004, "score32"), "score32", float32(math.NaN())},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := identitySpec(tc.field)
+
+			expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+				{tc.field.FieldID: tc.nan},
+			})
+			require.NoError(t, err)
+
+			want := iceberg.IsNaN(iceberg.Reference(tc.col))
+			assert.True(t, expr.Equals(want), "want %s, got %s", want, expr)
+		})
+	}
+}
+
+func TestBuildPartitionMatchPredicate_NaNDeduplicates(t *testing.T) {
+	spec := identitySpec(identityField(4, 1003, "score"))
+
+	// NaN has many valid bit patterns; distinct payloads must still collapse to a
+	// single IsNaN clause (the dedup key uses a sentinel, not the raw float bits).
+	nan1 := math.Float64frombits(0x7FF8000000000001)
+	nan2 := math.Float64frombits(0x7FF8000000000002)
+	require.True(t, math.IsNaN(nan1) && math.IsNaN(nan2))
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1003: nan1},
+		{1003: nan2},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.IsNaN(iceberg.Reference("score"))
+	assert.True(t, expr.Equals(want), "distinct NaN payloads should collapse to one clause, got %s", expr)
+}
+
+func TestBuildPartitionMatchPredicate_DeduplicatesPartitions(t *testing.T) {
+	spec := identitySpec(identityField(1, 1000, "id"))
+
+	// Many data files land in the same partition; the predicate must not repeat it.
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5)},
+		{1000: int32(5)},
+		{1000: int32(5)},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.EqualTo(iceberg.Reference("id"), int32(5))
+	assert.True(t, expr.Equals(want), "duplicates should collapse to one clause, got %s", expr)
+}
+
+func TestBuildPartitionMatchPredicate_DeduplicatesMultiFieldPartitions(t *testing.T) {
+	spec := identitySpec(
+		identityField(1, 1000, "id"),
+		identityField(2, 1001, "category"),
+	)
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: int32(5), 1001: "books"},
+		{1000: int32(5), 1001: "books"},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewAnd(
+		iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+		iceberg.EqualTo(iceberg.Reference("category"), "books"),
+	)
+	assert.True(t, expr.Equals(want), "identical multi-field tuples should collapse, got %s", expr)
+}
+
+// Distinct tuples whose values contain the dedup separators ('/' and '=') must
+// not collide into a single clause. A naive "%d=%v"-joined signature would map
+// both of these to "1001=5/1002=three/1002=x" and silently drop one partition.
+func TestBuildPartitionMatchPredicate_NoSeparatorCollision(t *testing.T) {
+	spec := identitySpec(
+		identityField(2, 1001, "category"),
+		identityField(3, 1002, "sub"),
+	)
+
+	expr, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1001: "5/1002=three", 1002: "x"},
+		{1001: "5", 1002: "three/1002=x"},
+	})
+	require.NoError(t, err)
+
+	want := iceberg.NewOr(
+		iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("category"), "5/1002=three"),
+			iceberg.EqualTo(iceberg.Reference("sub"), "x"),
+		),
+		iceberg.NewAnd(
+			iceberg.EqualTo(iceberg.Reference("category"), "5"),
+			iceberg.EqualTo(iceberg.Reference("sub"), "three/1002=x"),
+		),
+	)
+	assert.True(t, expr.Equals(want), "distinct tuples must not be deduped, got %s", expr)
+}
+
+func TestBuildPartitionMatchPredicate_NonIdentityTransformRejected(t *testing.T) {
+	cases := []struct {
+		name      string
+		transform iceberg.Transform
+	}{
+		{"bucket", iceberg.BucketTransform{NumBuckets: 4}},
+		{"truncate", iceberg.TruncateTransform{Width: 10}},
+		{"day", iceberg.DayTransform{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := identitySpec(iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: tc.transform})
+
+			_, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{{1000: int32(1)}})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, iceberg.ErrNotImplemented)
+		})
+	}
+}
+
+func TestBuildPartitionMatchPredicate_UnknownSourceID(t *testing.T) {
+	// Partition field points at a source id that is not present in the schema.
+	spec := identitySpec(identityField(999, 1000, "ghost"))
+
+	_, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{{1000: int32(1)}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+func TestBuildPartitionMatchPredicate_UnsupportedValueType(t *testing.T) {
+	spec := identitySpec(identityField(1, 1000, "id"))
+
+	_, err := BuildPartitionMatchPredicate(spec, dynamicOverwriteSchema(), []map[int]any{
+		{1000: struct{}{}},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+func TestLiteralForPartitionValue(t *testing.T) {
+	id := uuid.New()
+
+	cases := []struct {
+		name string
+		in   any
+		want iceberg.Literal
+	}{
+		{"bool", true, iceberg.NewLiteral(true)},
+		{"int32", int32(5), iceberg.NewLiteral(int32(5))},
+		{"int64", int64(5), iceberg.NewLiteral(int64(5))},
+		{"int", 5, iceberg.NewLiteral(int64(5))},
+		{"float32", float32(1.5), iceberg.NewLiteral(float32(1.5))},
+		{"float64", float64(1.5), iceberg.NewLiteral(float64(1.5))},
+		{"string", "books", iceberg.NewLiteral("books")},
+		{"bytes", []byte{1, 2, 3}, iceberg.NewLiteral([]byte{1, 2, 3})},
+		{"date", iceberg.Date(100), iceberg.NewLiteral(iceberg.Date(100))},
+		{"time", iceberg.Time(100), iceberg.NewLiteral(iceberg.Time(100))},
+		{"timestamp", iceberg.Timestamp(100), iceberg.NewLiteral(iceberg.Timestamp(100))},
+		{"timestampNano", iceberg.TimestampNano(100), iceberg.NewLiteral(iceberg.TimestampNano(100))},
+		{"uuid", id, iceberg.NewLiteral(id)},
+		// DataFile.Partition() decodes decimal fields into a DecimalLiteral, which
+		// already satisfies iceberg.Literal and must pass through unchanged.
+		{"decimal literal passthrough", iceberg.DecimalLiteral{Val: decimal128.FromI64(123), Scale: 2}, iceberg.DecimalLiteral{Val: decimal128.FromI64(123), Scale: 2}},
+		// A raw iceberg.Decimal (defensive, hand-constructed) is wrapped via NewLiteral.
+		{"raw decimal", iceberg.Decimal{Val: decimal128.FromI64(123), Scale: 2}, iceberg.NewLiteral(iceberg.Decimal{Val: decimal128.FromI64(123), Scale: 2})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := literalForPartitionValue(tc.in)
+			require.NoError(t, err)
+			assert.True(t, got.Equals(tc.want), "want %s, got %s", tc.want, got)
+		})
+	}
+
+	t.Run("unsupported", func(t *testing.T) {
+		_, err := literalForPartitionValue(struct{}{})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	})
+}

--- a/table/internal/partition_predicate_test.go
+++ b/table/internal/partition_predicate_test.go
@@ -346,14 +346,14 @@ func TestLiteralForPartitionValue(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := literalForPartitionValue(tc.in)
+			got, err := LiteralForPartitionValue(tc.in)
 			require.NoError(t, err)
 			assert.True(t, got.Equals(tc.want), "want %s, got %s", tc.want, got)
 		})
 	}
 
 	t.Run("unsupported", func(t *testing.T) {
-		_, err := literalForPartitionValue(struct{}{})
+		_, err := LiteralForPartitionValue(struct{}{})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	})

--- a/table/partition_conflict_test.go
+++ b/table/partition_conflict_test.go
@@ -175,50 +175,6 @@ func buildPartitionedContext(
 }
 
 // ---------------------------------------------------------------------------
-// anyToLiteral
-// ---------------------------------------------------------------------------
-
-func TestAnyToLiteral_SupportedTypes(t *testing.T) {
-	cases := []struct {
-		name string
-		v    any
-	}{
-		{"bool", true},
-		{"int32", int32(42)},
-		{"int64", int64(42)},
-		{"float32", float32(1.5)},
-		{"float64", float64(1.5)},
-		{"string", "hello"},
-		{"bytes", []byte{0x01}},
-		{"Date", iceberg.Date(100)},
-		{"Time", iceberg.Time(1000)},
-		{"Timestamp", iceberg.Timestamp(9999)},
-		// TimestampNano: arm in anyToLiteral was unreachable from the manifest read path
-		// because convertAvroValueToIcebergType had no timestamp-nanos case; now fixed.
-		{"TimestampNano", iceberg.TimestampNano(9999)},
-		{"UUID", uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")},
-		// DecimalLiteral is the named type returned by convertAvroValueToIcebergType
-		// (type DecimalLiteral Decimal). It must be accepted without falling through
-		// to the default error branch.
-		{"DecimalLiteral", iceberg.DecimalLiteral{Scale: 2}},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			lit, err := anyToLiteral(tc.v)
-			require.NoError(t, err)
-			assert.NotNil(t, lit)
-		})
-	}
-}
-
-func TestAnyToLiteral_UnsupportedType(t *testing.T) {
-	_, err := anyToLiteral(struct{}{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported partition value type")
-}
-
-// ---------------------------------------------------------------------------
 // validateNoConflictingDataFilesInPartitions short-circuit paths
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Phase 1 of #1215: BuildPartitionMatchPredicate (in table/internal) builds the partition-matching filter the upcoming DynamicPartitionOverwrite will use to delete existing data in the partitions touched by incoming data before appending. Identity-only for now; non-identity transforms are rejected and deferred. Refs #1216.