### PR TITLE
fix(manifest): expose day-transform partition values as Date

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -429,6 +429,12 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 // encoding difference. Only day transforms are affected; other plain integer
 // partition values (including hour/month/year transforms) are left untouched.
 //
+// The Iceberg spec gives the day transform result type "date" and requires
+// readers to also accept the plain-int encoding, interpreting each integer as
+// the number of days since 1970-01-01 (see the transform table and note [1] in
+// apache/iceberg#16446). Accepting both encodings is therefore spec-mandated,
+// not merely cross-engine convention.
+//
 // Absent or malformed partition-spec metadata is ignored: the reader simply
 // falls back to the logical types declared in the Avro schema.
 func applyDayTransformDates(specJSON []byte, fieldIDToType map[int]string) {
@@ -1894,6 +1900,12 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 				return Date(val)
 			}
 
+			// Unreachable with twmb/avro: an int+date logical type decodes
+			// to time.Time and a plain int to int32, so v is always one of
+			// the two cases above. Returning v rather than panicking keeps a
+			// future decoder change from crashing here, but callers that type
+			// assert iceberg.Date would then fail; do not add a guard that
+			// silently coerces other types, which reintroduces #1200.
 			return v
 		case atype.TimeMillis:
 			if val, ok := v.(time.Duration); ok {

--- a/manifest.go
+++ b/manifest.go
@@ -422,6 +422,32 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 	return result, logicalTypes, fixedSizes
 }
 
+// applyDayTransformDates marks every day(...) partition field described by the
+// manifest's partition-spec metadata as a "date" logical type. This normalizes
+// day-transform partition values to iceberg.Date even when they were written as
+// a plain Avro int with no logical type, so callers never observe the Avro
+// encoding difference. Only day transforms are affected; other plain integer
+// partition values (including hour/month/year transforms) are left untouched.
+//
+// Absent or malformed partition-spec metadata is ignored: the reader simply
+// falls back to the logical types declared in the Avro schema.
+func applyDayTransformDates(specJSON []byte, fieldIDToType map[int]string) {
+	if len(specJSON) == 0 {
+		return
+	}
+
+	var fields []PartitionField
+	if err := json.Unmarshal(specJSON, &fields); err != nil {
+		return
+	}
+
+	for _, f := range fields {
+		if _, ok := f.Transform.(DayTransform); ok {
+			fieldIDToType[f.FieldID] = atype.Date
+		}
+	}
+}
+
 type hasFieldToIDMap interface {
 	setFieldNameToIDMap(map[string]int)
 	setFieldIDToLogicalTypeMap(map[int]string)
@@ -667,6 +693,12 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		}
 	}
 	fieldNameToID, fieldIDToType, fieldIDToSize := getFieldIDMap(sc)
+	// day(...) partition values are days since the Unix epoch, but a manifest
+	// may encode them either as an Avro int carrying the "date" logical type or
+	// as a legacy plain Avro int. Overlay the manifest's partition spec so
+	// day-transform fields are always exposed as iceberg.Date, regardless of the
+	// Avro encoding used to write them.
+	applyDayTransformDates(metadata["partition-spec"], fieldIDToType)
 
 	inheritRowIDs := formatVersion >= 3 &&
 		content == ManifestContentData &&
@@ -1858,8 +1890,11 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 			if val, ok := v.(time.Time); ok {
 				return Date(val.Truncate(24*time.Hour).Unix() / int64((time.Hour * 24).Seconds()))
 			}
+			if val, ok := v.(int32); ok {
+				return Date(val)
+			}
 
-			return Date(v.(int32))
+			return v
 		case atype.TimeMillis:
 			if val, ok := v.(time.Duration); ok {
 				return Time(val.Milliseconds())

--- a/manifest_day_partition_test.go
+++ b/manifest_day_partition_test.go
@@ -117,7 +117,9 @@ func writeDayPartitionManifest(t *testing.T, partFieldNode avro.SchemaNode, dayV
 // TestDayPartitionReadsAvroIntAndDate verifies that a day-transform partition
 // value is exposed consistently as iceberg.Date regardless of whether it was
 // written as a plain Avro int or as an Avro int carrying the "date" logical
-// type. Other Iceberg implementations and engines accept both encodings, and
+// type. The Iceberg spec gives the day transform result type "date" and
+// requires readers to also accept the plain-int encoding as days since
+// 1970-01-01 (transform table and note [1] in apache/iceberg#16446), so
 // iceberg-go must not leak that Avro encoding difference to users: both must
 // surface the same iceberg.Date for a day(...) field. See apache/iceberg-go#1200.
 func TestDayPartitionReadsAvroIntAndDate(t *testing.T) {

--- a/manifest_day_partition_test.go
+++ b/manifest_day_partition_test.go
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro"
+	"github.com/twmb/avro/atype"
+	"github.com/twmb/avro/ocf"
+)
+
+// dayPartitionFieldID is the partition field id used by the day-transform tests.
+const dayPartitionFieldID = 1000
+
+// writeDayPartitionManifest encodes a single-entry v2 manifest whose only
+// partition field ("ts_day", produced by a day transform) is serialized using
+// partFieldNode. By varying partFieldNode between a plain Avro int and an Avro
+// int with the "date" logical type, the same day value can be written in either
+// of the two encodings that Iceberg engines produce in the wild. The manifest's
+// partition spec is written to the Avro metadata exactly as a real writer would,
+// so the reader can recognize the day transform.
+func writeDayPartitionManifest(t *testing.T, partFieldNode avro.SchemaNode, dayValue int32) ([]byte, ManifestFile) {
+	t.Helper()
+
+	field := PartitionField{
+		FieldID:   dayPartitionFieldID,
+		SourceIDs: []int{1},
+		Name:      "ts_day",
+		Transform: DayTransform{},
+	}
+	spec := NewPartitionSpecID(0, field)
+
+	builder, err := NewDataFileBuilder(
+		spec,
+		EntryContentData,
+		"s3://bucket/namespace/table/data/00000-0-day.parquet",
+		ParquetFile,
+		map[int]any{dayPartitionFieldID: dayValue},
+		map[int]string{},
+		map[int]int{},
+		100,
+		1024,
+	)
+	require.NoError(t, err)
+
+	snapshotID := int64(42)
+	seqNum := int64(1)
+	entry := NewManifestEntry(EntryStatusADDED, &snapshotID, &seqNum, &seqNum, builder.Build())
+
+	// Build the partition record schema (r102) by hand so the test controls the
+	// on-disk Avro encoding of the partition field, independent of how the
+	// writer would model a day transform's result type.
+	partNode := avro.SchemaNode{
+		Type: atype.Record,
+		Name: "r102",
+		Fields: []avro.SchemaField{
+			{Name: "ts_day", Type: partFieldNode, Props: internal.WithFieldID(dayPartitionFieldID)},
+		},
+	}
+	partSchema, err := partNode.Schema()
+	require.NoError(t, err)
+
+	entrySchema, err := internal.NewManifestEntrySchema(partSchema, 2)
+	require.NoError(t, err)
+
+	// Real manifests carry the partition spec in their metadata; the reader uses
+	// it to normalize day-transform values regardless of their Avro encoding.
+	specFieldsJSON, err := json.Marshal([]PartitionField{field})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	wr, err := ocf.NewWriter(&buf, entrySchema,
+		// WithSchema writes the explicit JSON schema, preserving the field-id
+		// props the manifest reader relies on to map partition values.
+		ocf.WithSchema(entrySchema.String()),
+		ocf.WithMetadata(map[string][]byte{
+			"format-version":    []byte("2"),
+			"content":           []byte("data"),
+			"partition-spec":    specFieldsJSON,
+			"partition-spec-id": []byte("0"),
+		}))
+	require.NoError(t, err)
+	require.NoError(t, wr.Encode(entry))
+	require.NoError(t, wr.Close())
+
+	file := &manifestFile{
+		Path:    "s3://bucket/namespace/table/metadata/00000-day.avro",
+		SpecID:  0,
+		Content: ManifestContentData,
+	}
+	file.setVersion(2)
+
+	return buf.Bytes(), file
+}
+
+// TestDayPartitionReadsAvroIntAndDate verifies that a day-transform partition
+// value is exposed consistently as iceberg.Date regardless of whether it was
+// written as a plain Avro int or as an Avro int carrying the "date" logical
+// type. Other Iceberg implementations and engines accept both encodings, and
+// iceberg-go must not leak that Avro encoding difference to users: both must
+// surface the same iceberg.Date for a day(...) field. See apache/iceberg-go#1200.
+func TestDayPartitionReadsAvroIntAndDate(t *testing.T) {
+	const dayValue = int32(19000) // 2022-01-08
+
+	cases := []struct {
+		name     string
+		partNode avro.SchemaNode
+	}{
+		{
+			name:     "avro int (no logical type)",
+			partNode: internal.NullableNode(internal.IntNode),
+		},
+		{
+			name:     "avro date (date logical type)",
+			partNode: internal.NullableNode(internal.DateNode),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, file := writeDayPartitionManifest(t, tc.partNode, dayValue)
+
+			entries, err := ReadManifest(file, bytes.NewReader(data), false)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+
+			partition := entries[0].DataFile().Partition()
+			got, ok := partition[dayPartitionFieldID]
+			require.True(t, ok, "partition value for field %d must be present", dayPartitionFieldID)
+
+			// Both Avro encodings must be normalized to the same iceberg.Date,
+			// matching the day(...) transform's logical day value.
+			assert.IsType(t, Date(0), got)
+			assert.EqualValues(t, dayValue, got)
+		})
+	}
+}


### PR DESCRIPTION
A day(...) partition value read as iceberg.Date when encoded as an Avro int with the date logical type, but as a plain int32 when encoded as a legacy Avro int, leaking the Avro encoding to users. Use the manifest's partition spec to normalize day-transform fields to iceberg.Date for both encodings; other integer partition values are unaffected.

Closes #1200