### PR TITLE
fix(dv): deletion vectors orphaned by data-file rewrite

### DIFF
--- a/table/dv_rewrite_orphan_test.go
+++ b/table/dv_rewrite_orphan_test.go
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/table/dv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRewriteDataFilesOrphansDeletionVectors demonstrates the open gap that the
+// downstream v3-readiness guard blocks on: compaction rewrites a data file that
+// carries a deletion vector, removes the data file, but leaves the DV manifest
+// entry behind. The DV now references a data file that no longer exists in the
+// table — an orphan.
+//
+// Root cause: every delete-removal path keys by file path, but a DV manifest
+// entry is 1:1 with its referenced data file. ExecuteCompactionGroup only
+// collects pos-delete files from FileScanTask.DeleteFiles (via
+// CollectSafePositionDeletes); DVs ride in FileScanTask.DeletionVectorFiles and
+// are never collected, so the rewrite commit never removes them.
+//
+// The orphan is invisible to scan planning — matchDVToData drops a DV whose
+// referenced data file is gone — so the assertion walks the raw delete
+// manifests of the post-compaction snapshot.
+//
+// This test asserts the correct post-fix behavior (no DV references a rewritten
+// data file) and therefore FAILS on current code, where the DV survives.
+func TestRewriteDataFilesOrphansDeletionVectors(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+	fs := iceio.LocalFS{}
+
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	// Two appends produce two data files so the planner forms a compaction group.
+	for _, rows := range []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	} {
+		tab, err := array.TableFromJSON(mem, arrowSchema, []string{rows})
+		require.NoError(t, err)
+		tbl, err = tbl.Append(ctx, array.NewTableReader(tab, -1), nil)
+		tab.Release()
+		require.NoError(t, err)
+	}
+	assertRowCount(t, tbl, 4)
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	dvTarget := tasks[0].File.FilePath()
+
+	// Author a real DV (puffin) deleting position 0 (id=1) of the first data
+	// file, then commit it as a delete manifest entry.
+	specByID := func(id int32) *iceberg.PartitionSpec {
+		if id == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	}
+	w := dv.NewDVWriter(fs, specByID)
+	w.Add(dvTarget, []int64{0}, 0, nil)
+	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dvTarget), "dv-0001.puffin"))
+	require.NoError(t, err)
+	require.Len(t, dvFiles, 1)
+	require.Equal(t, dvTarget, *dvFiles[0].ReferencedDataFile())
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 3) // id=1 deleted by the DV
+
+	tasks, err = tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+
+	cfg := defaultTestCompactionCfg
+	cfg.DeleteFileThreshold = 1 // force compaction of the DV-bearing file
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Groups)
+
+	rewritten := map[string]struct{}{}
+	for _, g := range plan.Groups {
+		for _, tk := range g.Tasks {
+			rewritten[tk.File.FilePath()] = struct{}{}
+		}
+	}
+	require.Contains(t, rewritten, dvTarget,
+		"the DV's referenced data file must be in the rewrite set for this test to exercise the bug")
+
+	rtx := tbl.NewTransaction()
+	_, err = rtx.RewriteDataFiles(ctx, toTaskGroups(plan.Groups), table.RewriteDataFilesOptions{})
+	require.NoError(t, err)
+	tbl, err = rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	assertRowCount(t, tbl, 3) // DV applied during the rewrite; id=1 stays gone
+
+	orphans := deleteEntriesReferencing(t, tbl, rewritten)
+	assert.Empty(t, orphans,
+		"compaction must remove deletion vectors for rewritten data files; "+
+			"these DV entries still reference files removed by the rewrite: %v", orphans)
+}
+
+// deleteEntriesReferencing walks the current snapshot's delete manifests and
+// returns live entries whose referenced_data_file is in rewritten — i.e.
+// deletion vectors orphaned by a rewrite that removed their data file.
+func deleteEntriesReferencing(t *testing.T, tbl *table.Table, rewritten map[string]struct{}) []string {
+	t.Helper()
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	fs := iceio.LocalFS{}
+	manifests, err := snap.Manifests(fs)
+	require.NoError(t, err)
+
+	var orphans []string
+	for _, m := range manifests {
+		if m.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		for e, err := range m.Entries(fs, false) {
+			require.NoError(t, err)
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			ref := e.DataFile().ReferencedDataFile()
+			if ref == nil {
+				continue
+			}
+			if _, ok := rewritten[*ref]; ok {
+				orphans = append(orphans, e.DataFile().FilePath()+" -> "+*ref)
+			}
+		}
+	}
+
+	return orphans
+}

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -35,7 +35,9 @@ import (
 
 // TestRewriteDataFilesRemovesDeletionVectors guarantees that compacting a data
 // file carrying a deletion vector expunges that DV in the same rewrite snapshot,
-// leaving no manifest entry referencing the removed data file.
+// leaving no manifest entry referencing the removed data file. Both commit
+// paths of [Transaction.RewriteDataFiles] are covered: the single atomic
+// snapshot and the per-group partial-progress path.
 //
 // Background: a DV manifest entry is 1:1 with its referenced data file but rides
 // in FileScanTask.DeletionVectorFiles, separate from the pos-delete files in
@@ -46,87 +48,64 @@ import (
 // referenced data file is gone — so the assertion walks the raw delete manifests
 // of the post-compaction snapshot.
 func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
-	ctx := context.Background()
-	mem := memory.DefaultAllocator
-	fs := iceio.LocalFS{}
-
-	tbl := newV3RowLineageTestTable(t)
-
-	arrowSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
-		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	// Two appends produce two data files so the planner forms a compaction group.
-	for _, rows := range []string{
-		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
-		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
-	} {
-		tab, err := array.TableFromJSON(mem, arrowSchema, []string{rows})
-		require.NoError(t, err)
-		tbl, err = tbl.Append(ctx, array.NewTableReader(tab, -1), nil)
-		tab.Release()
-		require.NoError(t, err)
-	}
-	assertRowCount(t, tbl, 4)
-
-	tasks, err := tbl.Scan().PlanFiles(ctx)
-	require.NoError(t, err)
-	require.Len(t, tasks, 2)
-	dvTarget := tasks[0].File.FilePath()
-
-	// Author a real DV (puffin) deleting position 0 (id=1) of the first data
-	// file, then commit it as a delete manifest entry.
-	specByID := func(id int32) *iceberg.PartitionSpec {
-		if id == 0 {
-			return iceberg.UnpartitionedSpec
+	for _, partialProgress := range []bool{false, true} {
+		name := "atomic"
+		if partialProgress {
+			name = "partial-progress"
 		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			tbl, dvTarget := seedV3TableWithDV(t)
 
-		return nil
+			groups, rewritten := planDVCompaction(t, tbl, dvTarget)
+
+			rtx := tbl.NewTransaction()
+			_, err := rtx.RewriteDataFiles(ctx, groups,
+				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
+			require.NoError(t, err)
+			tbl, err = rtx.Commit(ctx)
+			require.NoError(t, err)
+
+			assertRowCount(t, tbl, 3) // DV applied during the rewrite; id=1 stays gone
+			assert.Empty(t, deleteEntriesReferencing(t, tbl, rewritten),
+				"compaction must remove deletion vectors for rewritten data files")
+		})
 	}
-	w := dv.NewDVWriter(fs, specByID)
-	w.Add(dvTarget, []int64{0}, 0, nil)
-	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dvTarget), "dv-0001.puffin"))
-	require.NoError(t, err)
-	require.Len(t, dvFiles, 1)
-	require.Equal(t, dvTarget, *dvFiles[0].ReferencedDataFile())
+}
+
+// TestRewriteFilesApplyResultRemovesDeletionVectors drives the distributed
+// coordinator path — a worker runs [ExecuteCompactionGroup], then a leader
+// stages the results with [Transaction.NewRewrite] + [RewriteFiles.ApplyResult]
+// + Commit. It locks the ApplyResult→ReplaceFiles coupling that carries
+// SafeDeletionVectors and expunges them by referenced data file.
+func TestRewriteFilesApplyResultRemovesDeletionVectors(t *testing.T) {
+	ctx := context.Background()
+	tbl, dvTarget := seedV3TableWithDV(t)
+
+	groups, rewritten := planDVCompaction(t, tbl, dvTarget)
+
+	var results []table.CompactionGroupResult
+	dvCount := 0
+	for _, g := range groups {
+		gr, err := table.ExecuteCompactionGroup(ctx, tbl, g)
+		require.NoError(t, err)
+		results = append(results, gr)
+		dvCount += len(gr.SafeDeletionVectors)
+	}
+	require.Positive(t, dvCount, "worker must collect the DV for removal")
 
 	tx := tbl.NewTransaction()
-	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
-	tbl, err = tx.Commit(ctx)
-	require.NoError(t, err)
-	assertRowCount(t, tbl, 3) // id=1 deleted by the DV
-
-	tasks, err = tbl.Scan().PlanFiles(ctx)
-	require.NoError(t, err)
-
-	cfg := defaultTestCompactionCfg
-	cfg.DeleteFileThreshold = 1 // force compaction of the DV-bearing file
-	plan, err := cfg.PlanCompaction(tasks)
-	require.NoError(t, err)
-	require.NotEmpty(t, plan.Groups)
-
-	rewritten := map[string]struct{}{}
-	for _, g := range plan.Groups {
-		for _, tk := range g.Tasks {
-			rewritten[tk.File.FilePath()] = struct{}{}
-		}
+	rewrite := tx.NewRewrite(nil)
+	for _, gr := range results {
+		rewrite.ApplyResult(gr)
 	}
-	require.Contains(t, rewritten, dvTarget,
-		"the DV's referenced data file must be in the rewrite set for this test to exercise the bug")
-
-	rtx := tbl.NewTransaction()
-	_, err = rtx.RewriteDataFiles(ctx, toTaskGroups(plan.Groups), table.RewriteDataFilesOptions{})
-	require.NoError(t, err)
-	tbl, err = rtx.Commit(ctx)
+	require.NoError(t, rewrite.Commit(ctx))
+	tbl, err := tx.Commit(ctx)
 	require.NoError(t, err)
 
-	assertRowCount(t, tbl, 3) // DV applied during the rewrite; id=1 stays gone
-
-	orphans := deleteEntriesReferencing(t, tbl, rewritten)
-	assert.Empty(t, orphans,
-		"compaction must remove deletion vectors for rewritten data files; "+
-			"these DV entries still reference files removed by the rewrite: %v", orphans)
+	assertRowCount(t, tbl, 3)
+	assert.Empty(t, deleteEntriesReferencing(t, tbl, rewritten),
+		"coordinator commit must remove deletion vectors for rewritten data files")
 }
 
 // TestRewriteDataFilesPreservesSiblingDeletionVector pins the granularity of DV
@@ -137,26 +116,9 @@ func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 // both and silently resurrect the sibling's deleted rows.
 func TestRewriteDataFilesPreservesSiblingDeletionVector(t *testing.T) {
 	ctx := context.Background()
-	mem := memory.DefaultAllocator
 	fs := iceio.LocalFS{}
 
-	tbl := newV3RowLineageTestTable(t)
-
-	arrowSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
-		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	for _, rows := range []string{
-		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
-		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
-	} {
-		tab, err := array.TableFromJSON(mem, arrowSchema, []string{rows})
-		require.NoError(t, err)
-		tbl, err = tbl.Append(ctx, array.NewTableReader(tab, -1), nil)
-		tab.Release()
-		require.NoError(t, err)
-	}
+	tbl := appendTwoDataFiles(t, newV3RowLineageTestTable(t))
 
 	tasks, err := tbl.Scan().PlanFiles(ctx)
 	require.NoError(t, err)
@@ -164,17 +126,9 @@ func TestRewriteDataFilesPreservesSiblingDeletionVector(t *testing.T) {
 	rewriteTarget := tasks[0].File.FilePath()
 	sibling := tasks[1].File.FilePath()
 
-	specByID := func(id int32) *iceberg.PartitionSpec {
-		if id == 0 {
-			return iceberg.UnpartitionedSpec
-		}
-
-		return nil
-	}
-
 	// One Flush writes a single Puffin holding a DV blob for each data file,
 	// so both manifest entries share the Puffin path. Each deletes id=1 / id=3.
-	w := dv.NewDVWriter(fs, specByID)
+	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
 	w.Add(rewriteTarget, []int64{0}, 0, nil)
 	w.Add(sibling, []int64{0}, 0, nil)
 	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(rewriteTarget), "dv-shared.puffin"))
@@ -217,10 +171,102 @@ func TestRewriteDataFilesPreservesSiblingDeletionVector(t *testing.T) {
 	assertRowCount(t, tbl, 2) // sibling DV still applies: id=3 stays deleted
 }
 
+// seedV3TableWithDV builds a v3 table with two data files ([1,2] and [3,4]) and
+// commits a deletion vector deleting id=1 from the first. Returns the table and
+// the DV's target data-file path.
+func seedV3TableWithDV(t *testing.T) (*table.Table, string) {
+	t.Helper()
+	ctx := context.Background()
+	fs := iceio.LocalFS{}
+
+	tbl := appendTwoDataFiles(t, newV3RowLineageTestTable(t))
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	dvTarget := tasks[0].File.FilePath()
+
+	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
+	w.Add(dvTarget, []int64{0}, 0, nil)
+	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dvTarget), "dv-0001.puffin"))
+	require.NoError(t, err)
+	require.Len(t, dvFiles, 1)
+	require.Equal(t, dvTarget, *dvFiles[0].ReferencedDataFile())
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 3)
+
+	return tbl, dvTarget
+}
+
+// appendTwoDataFiles appends [1,2] and [3,4] as two separate data files. The
+// returned table reflects both commits.
+func appendTwoDataFiles(t *testing.T, tbl *table.Table) *table.Table {
+	t.Helper()
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	for _, rows := range []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	} {
+		tab, err := array.TableFromJSON(mem, arrowSchema, []string{rows})
+		require.NoError(t, err)
+		tbl, err = tbl.Append(ctx, array.NewTableReader(tab, -1), nil)
+		tab.Release()
+		require.NoError(t, err)
+	}
+
+	return tbl
+}
+
+// planDVCompaction plans a compaction forced by the delete threshold and
+// returns the task groups plus the set of data-file paths being rewritten,
+// asserting the DV target is among them.
+func planDVCompaction(t *testing.T, tbl *table.Table, dvTarget string) ([]table.CompactionTaskGroup, map[string]struct{}) {
+	t.Helper()
+
+	tasks, err := tbl.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+
+	cfg := defaultTestCompactionCfg
+	cfg.DeleteFileThreshold = 1
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Groups)
+
+	groups := toTaskGroups(plan.Groups)
+	rewritten := map[string]struct{}{}
+	for _, g := range groups {
+		for _, tk := range g.Tasks {
+			rewritten[tk.File.FilePath()] = struct{}{}
+		}
+	}
+	require.Contains(t, rewritten, dvTarget,
+		"the DV's referenced data file must be in the rewrite set for this test to be meaningful")
+
+	return groups, rewritten
+}
+
+func unpartitionedSpecByID(id int32) *iceberg.PartitionSpec {
+	if id == 0 {
+		return iceberg.UnpartitionedSpec
+	}
+
+	return nil
+}
+
 // deleteEntriesReferencing walks the current snapshot's delete manifests and
-// returns live entries whose referenced_data_file is in rewritten — i.e.
-// deletion vectors orphaned by a rewrite that removed their data file.
-func deleteEntriesReferencing(t *testing.T, tbl *table.Table, rewritten map[string]struct{}) []string {
+// returns live entries whose referenced_data_file is in refs — i.e. deletion
+// vectors still bound to those data files.
+func deleteEntriesReferencing(t *testing.T, tbl *table.Table, refs map[string]struct{}) []string {
 	t.Helper()
 
 	snap := tbl.CurrentSnapshot()
@@ -230,7 +276,7 @@ func deleteEntriesReferencing(t *testing.T, tbl *table.Table, rewritten map[stri
 	manifests, err := snap.Manifests(fs)
 	require.NoError(t, err)
 
-	var orphans []string
+	var found []string
 	for _, m := range manifests {
 		if m.ManifestContent() != iceberg.ManifestContentDeletes {
 			continue
@@ -244,11 +290,11 @@ func deleteEntriesReferencing(t *testing.T, tbl *table.Table, rewritten map[stri
 			if ref == nil {
 				continue
 			}
-			if _, ok := rewritten[*ref]; ok {
-				orphans = append(orphans, e.DataFile().FilePath()+" -> "+*ref)
+			if _, ok := refs[*ref]; ok {
+				found = append(found, e.DataFile().FilePath()+" -> "+*ref)
 			}
 		}
 	}
 
-	return orphans
+	return found
 }

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -33,25 +33,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRewriteDataFilesOrphansDeletionVectors demonstrates the open gap that the
-// downstream v3-readiness guard blocks on: compaction rewrites a data file that
-// carries a deletion vector, removes the data file, but leaves the DV manifest
-// entry behind. The DV now references a data file that no longer exists in the
-// table — an orphan.
+// TestRewriteDataFilesRemovesDeletionVectors guarantees that compacting a data
+// file carrying a deletion vector expunges that DV in the same rewrite snapshot,
+// leaving no manifest entry referencing the removed data file.
 //
-// Root cause: every delete-removal path keys by file path, but a DV manifest
-// entry is 1:1 with its referenced data file. ExecuteCompactionGroup only
-// collects pos-delete files from FileScanTask.DeleteFiles (via
-// CollectSafePositionDeletes); DVs ride in FileScanTask.DeletionVectorFiles and
-// are never collected, so the rewrite commit never removes them.
+// Background: a DV manifest entry is 1:1 with its referenced data file but rides
+// in FileScanTask.DeletionVectorFiles, separate from the pos-delete files in
+// FileScanTask.DeleteFiles. A rewrite that collected only the latter would leave
+// the DV behind, referencing a data file no longer in the table — an orphan.
 //
-// The orphan is invisible to scan planning — matchDVToData drops a DV whose
-// referenced data file is gone — so the assertion walks the raw delete
-// manifests of the post-compaction snapshot.
-//
-// This test asserts the correct post-fix behavior (no DV references a rewritten
-// data file) and therefore FAILS on current code, where the DV survives.
-func TestRewriteDataFilesOrphansDeletionVectors(t *testing.T) {
+// An orphaned DV is invisible to scan planning — matchDVToData drops a DV whose
+// referenced data file is gone — so the assertion walks the raw delete manifests
+// of the post-compaction snapshot.
+func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.DefaultAllocator
 	fs := iceio.LocalFS{}
@@ -133,6 +127,94 @@ func TestRewriteDataFilesOrphansDeletionVectors(t *testing.T) {
 	assert.Empty(t, orphans,
 		"compaction must remove deletion vectors for rewritten data files; "+
 			"these DV entries still reference files removed by the rewrite: %v", orphans)
+}
+
+// TestRewriteDataFilesPreservesSiblingDeletionVector pins the granularity of DV
+// removal: one Puffin file holds DV blobs for two data files (a shared path),
+// but only one of those data files is rewritten. The rewritten file's DV must
+// be expunged while the sibling DV — sharing the same Puffin path — must
+// survive. A removal keyed by path instead of referenced data file would drop
+// both and silently resurrect the sibling's deleted rows.
+func TestRewriteDataFilesPreservesSiblingDeletionVector(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+	fs := iceio.LocalFS{}
+
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	for _, rows := range []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	} {
+		tab, err := array.TableFromJSON(mem, arrowSchema, []string{rows})
+		require.NoError(t, err)
+		tbl, err = tbl.Append(ctx, array.NewTableReader(tab, -1), nil)
+		tab.Release()
+		require.NoError(t, err)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	rewriteTarget := tasks[0].File.FilePath()
+	sibling := tasks[1].File.FilePath()
+
+	specByID := func(id int32) *iceberg.PartitionSpec {
+		if id == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	}
+
+	// One Flush writes a single Puffin holding a DV blob for each data file,
+	// so both manifest entries share the Puffin path. Each deletes id=1 / id=3.
+	w := dv.NewDVWriter(fs, specByID)
+	w.Add(rewriteTarget, []int64{0}, 0, nil)
+	w.Add(sibling, []int64{0}, 0, nil)
+	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(rewriteTarget), "dv-shared.puffin"))
+	require.NoError(t, err)
+	require.Len(t, dvFiles, 2)
+	require.Equal(t, dvFiles[0].FilePath(), dvFiles[1].FilePath(),
+		"both DV blobs must live in one shared Puffin file for this test to be meaningful")
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 2) // id=1 and id=3 deleted
+
+	tasks, err = tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+
+	var group table.CompactionTaskGroup
+	for _, tk := range tasks {
+		if tk.File.FilePath() == rewriteTarget {
+			group = table.CompactionTaskGroup{
+				PartitionKey:   "p",
+				Tasks:          []table.FileScanTask{tk},
+				TotalSizeBytes: tk.File.FileSizeBytes(),
+			}
+		}
+	}
+	require.NotEmpty(t, group.Tasks)
+
+	rtx := tbl.NewTransaction()
+	_, err = rtx.RewriteDataFiles(ctx, []table.CompactionTaskGroup{group}, table.RewriteDataFilesOptions{})
+	require.NoError(t, err)
+	tbl, err = rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Empty(t, deleteEntriesReferencing(t, tbl, map[string]struct{}{rewriteTarget: {}}),
+		"the rewritten file's DV must be expunged")
+	assert.Len(t, deleteEntriesReferencing(t, tbl, map[string]struct{}{sibling: {}}), 1,
+		"the sibling DV in the same Puffin must survive")
+	assertRowCount(t, tbl, 2) // sibling DV still applies: id=3 stays deleted
 }
 
 // deleteEntriesReferencing walks the current snapshot's delete manifests and

--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -68,6 +68,7 @@ func TestIsDeletionVector(t *testing.T) {
 				mockDataFile: mockDataFile{
 					path:        "s3://bucket/data/dv.puffin",
 					contentType: iceberg.EntryContentPosDeletes,
+					format:      iceberg.PuffinFile,
 				},
 				referencedDataFile: strPtr("s3://bucket/data/file.parquet"),
 				contentOffset:      int64Ptr(100),
@@ -117,6 +118,7 @@ func TestManifestEntries_DVClassification(t *testing.T) {
 		mockDataFile: mockDataFile{
 			path:        "s3://bucket/data/dv-001.puffin",
 			contentType: iceberg.EntryContentPosDeletes,
+			format:      iceberg.PuffinFile,
 		},
 		referencedDataFile: strPtr("s3://bucket/data/data-001.parquet"),
 		contentOffset:      int64Ptr(0),
@@ -311,6 +313,7 @@ func TestFileScanTask_DeletionVectorFilesField(t *testing.T) {
 		mockDataFile: mockDataFile{
 			path:        "s3://bucket/data/dv-001.puffin",
 			contentType: iceberg.EntryContentPosDeletes,
+			format:      iceberg.PuffinFile,
 		},
 		referencedDataFile: strPtr("s3://bucket/data/data-001.parquet"),
 		contentOffset:      int64Ptr(0),

--- a/table/replace_files_test.go
+++ b/table/replace_files_test.go
@@ -236,4 +236,52 @@ func TestReplaceFiles_ValidationErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot remove delete files")
 	})
+
+	newDV := func(path, ref string) iceberg.DataFile {
+		b, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+			path, iceberg.PuffinFile, nil, nil, nil, 1, 128)
+		require.NoError(t, err)
+		if ref != "" {
+			b.ReferencedDataFile(ref)
+		}
+
+		return b.Build()
+	}
+
+	t.Run("deletion vector missing referenced_data_file", func(t *testing.T) {
+		tx := tbl.NewTransaction()
+		err := tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{newDV("s3://bucket/dv-0001.puffin", "")},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing referenced_data_file")
+	})
+
+	t.Run("deletion vectors referencing the same data file", func(t *testing.T) {
+		tx := tbl.NewTransaction()
+		err := tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{
+				newDV("s3://bucket/dv-a.puffin", "s3://bucket/data-001.parquet"),
+				newDV("s3://bucket/dv-b.puffin", "s3://bucket/data-001.parquet"),
+			},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "distinct data files")
+	})
+
+	t.Run("deletion vector not in table", func(t *testing.T) {
+		tx := tbl.NewTransaction()
+		err := tx.ReplaceFiles(t.Context(),
+			nil, nil,
+			[]iceberg.DataFile{newDV("s3://bucket/dv-0001.puffin", "s3://bucket/nonexistent-data.parquet")},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot remove deletion vectors that do not belong to the table")
+	})
 }

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 
 	"github.com/apache/iceberg-go"
 )
@@ -46,6 +47,10 @@ type RewriteResult struct {
 	// The caller computes which eq-deletes are dead — typically via
 	// [compaction.CollectDeadEqualityDeletes] — and passes the list in.
 	RemovedEqualityDeleteFiles int
+
+	// RemovedDeletionVectorFiles is the count of deletion vectors removed
+	// because their referenced data file was rewritten.
+	RemovedDeletionVectorFiles int
 
 	// BytesBefore is the total size of input data files (from the compaction plan).
 	BytesBefore int64
@@ -78,7 +83,7 @@ type CompactionTaskGroup struct {
 // the position delete files safe to expunge in the rewrite snapshot.
 //
 // A distributed coordinator aggregates results from N workers and
-// applies them to a [RewriteFiles] builder via [RewriteFiles.Apply]
+// applies them to a [RewriteFiles] builder via [RewriteFiles.ApplyResult]
 // to commit a single atomic snapshot. Each field is plain data
 // ([]iceberg.DataFile values plus scalars) — callers serialize the
 // contained DataFiles across process boundaries themselves; the
@@ -101,6 +106,11 @@ type CompactionGroupResult struct {
 	// via [CollectSafePositionDeletes]. They are safe to expunge in
 	// the rewrite snapshot.
 	SafePosDeletes []iceberg.DataFile
+
+	// SafeDeletionVectors are deletion vectors attached to tasks in this
+	// group, computed via [CollectSafeDeletionVectors]. Each is bound to
+	// a data file being rewritten, so all are safe to expunge.
+	SafeDeletionVectors []iceberg.DataFile
 
 	// BytesBefore is [CompactionTaskGroup.TotalSizeBytes] passed
 	// through, recorded so the coordinator can roll up metrics
@@ -207,7 +217,7 @@ func WithCompactionScanConcurrency(n int) CompactionGroupOption {
 // convert [compaction.Group] → [CompactionTaskGroup] and pass them
 // here. Distributed coordinators stage worker results via
 // [ExecuteCompactionGroup] and commit them via [Transaction.NewRewrite]
-// + [RewriteFiles.Apply] + [RewriteFiles.Commit] instead.
+// + [RewriteFiles.ApplyResult] + [RewriteFiles.Commit] instead.
 func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
 	if len(groups) == 0 {
 		return &RewriteResult{}, nil
@@ -238,7 +248,7 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 			continue
 		}
 
-		rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+		rewrite.ApplyResult(gr)
 		accumulateGroupMetrics(result, gr)
 	}
 
@@ -263,7 +273,7 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 // [WriteRecords], and computes the position-delete files safe to
 // expunge in the rewrite snapshot. It does not commit — the caller
 // hands the result to a coordinator that uses [Transaction.NewRewrite]
-// + [RewriteFiles.Apply] + [RewriteFiles.Commit] to stage the
+// + [RewriteFiles.ApplyResult] + [RewriteFiles.Commit] to stage the
 // atomic commit.
 //
 // Empty groups return a zero [CompactionGroupResult] without doing
@@ -368,12 +378,13 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	}
 
 	return CompactionGroupResult{
-		PartitionKey:   group.PartitionKey,
-		OldDataFiles:   oldFiles,
-		NewDataFiles:   newFiles,
-		SafePosDeletes: CollectSafePositionDeletes(group.Tasks),
-		BytesBefore:    group.TotalSizeBytes,
-		BytesAfter:     bytesAfter,
+		PartitionKey:        group.PartitionKey,
+		OldDataFiles:        oldFiles,
+		NewDataFiles:        newFiles,
+		SafePosDeletes:      CollectSafePositionDeletes(group.Tasks),
+		SafeDeletionVectors: CollectSafeDeletionVectors(group.Tasks),
+		BytesBefore:         group.TotalSizeBytes,
+		BytesAfter:          bytesAfter,
 	}, nil
 }
 
@@ -430,7 +441,8 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 			continue
 		}
 
-		if err := t.ReplaceFiles(ctx, gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes,
+		deletesToRemove := append(slices.Clone(gr.SafePosDeletes), gr.SafeDeletionVectors...)
+		if err := t.ReplaceFiles(ctx, gr.OldDataFiles, gr.NewDataFiles, deletesToRemove,
 			props, withRewriteSemantics()); err != nil {
 			return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
 		}
@@ -453,6 +465,7 @@ func accumulateGroupMetrics(r *RewriteResult, gr CompactionGroupResult) {
 	r.AddedDataFiles += len(gr.NewDataFiles)
 	r.RemovedDataFiles += len(gr.OldDataFiles)
 	r.RemovedPositionDeleteFiles += len(gr.SafePosDeletes)
+	r.RemovedDeletionVectorFiles += len(gr.SafeDeletionVectors)
 	r.BytesBefore += gr.BytesBefore
 	r.BytesAfter += gr.BytesAfter
 }
@@ -519,6 +532,28 @@ func CollectSafePositionDeletes(tasks []FileScanTask) []iceberg.DataFile {
 			}
 			seen[path] = true
 			safe = append(safe, df)
+		}
+	}
+
+	return safe
+}
+
+// CollectSafeDeletionVectors returns the deletion vectors attached to the
+// tasks. A DV is bound 1:1 to the data file it references, and that file is
+// always in the rewrite set (it is the task's own file), so every DV here is
+// safe to expunge. Deduplicated by referenced data file.
+func CollectSafeDeletionVectors(tasks []FileScanTask) []iceberg.DataFile {
+	seen := make(map[string]bool)
+	var safe []iceberg.DataFile
+
+	for _, task := range tasks {
+		for _, dv := range task.DeletionVectorFiles {
+			ref := dv.ReferencedDataFile()
+			if ref == nil || seen[*ref] {
+				continue
+			}
+			seen[*ref] = true
+			safe = append(safe, dv)
 		}
 	}
 

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -539,9 +539,15 @@ func CollectSafePositionDeletes(tasks []FileScanTask) []iceberg.DataFile {
 }
 
 // CollectSafeDeletionVectors returns the deletion vectors attached to the
-// tasks. A DV is bound 1:1 to the data file it references, and that file is
-// always in the rewrite set (it is the task's own file), so every DV here is
-// safe to expunge. Deduplicated by referenced data file.
+// tasks, deduplicated by referenced data file.
+//
+// Safety rests on the scan-planning invariant that a task carries only the DV
+// referencing its own data file (matchDVToData keys on task.File's path), so
+// every DV returned references a file in the rewrite set. A caller that
+// hand-builds a [FileScanTask] with a DV whose ReferencedDataFile is some other
+// live data file would have that DV marked safe to expunge here, silently
+// resurrecting its deleted rows — populate DeletionVectorFiles only from scan
+// planning.
 func CollectSafeDeletionVectors(tasks []FileScanTask) []iceberg.DataFile {
 	seen := make(map[string]bool)
 	var safe []iceberg.DataFile

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -538,27 +538,27 @@ func CollectSafePositionDeletes(tasks []FileScanTask) []iceberg.DataFile {
 	return safe
 }
 
-// CollectSafeDeletionVectors returns the deletion vectors attached to the
-// tasks, deduplicated by referenced data file.
+// CollectSafeDeletionVectors returns the tasks' deletion vectors, deduplicated
+// by referenced data file.
 //
-// Safety rests on the scan-planning invariant that a task carries only the DV
-// referencing its own data file (matchDVToData keys on task.File's path), so
-// every DV returned references a file in the rewrite set. A caller that
-// hand-builds a [FileScanTask] with a DV whose ReferencedDataFile is some other
-// live data file would have that DV marked safe to expunge here, silently
-// resurrecting its deleted rows — populate DeletionVectorFiles only from scan
-// planning.
+// Scan planning attaches to a task only the DV referencing its own data file,
+// so every returned DV references a file in the rewrite set. A hand-built
+// [FileScanTask] carrying a DV for some other live data file would have that DV
+// expunged here — populate DeletionVectorFiles only from scan planning.
 func CollectSafeDeletionVectors(tasks []FileScanTask) []iceberg.DataFile {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var safe []iceberg.DataFile
 
 	for _, task := range tasks {
 		for _, dv := range task.DeletionVectorFiles {
 			ref := dv.ReferencedDataFile()
-			if ref == nil || seen[*ref] {
+			if ref == nil {
 				continue
 			}
-			seen[*ref] = true
+			if _, ok := seen[*ref]; ok {
+				continue
+			}
+			seen[*ref] = struct{}{}
 			safe = append(safe, dv)
 		}
 	}

--- a/table/rewrite_files.go
+++ b/table/rewrite_files.go
@@ -47,7 +47,7 @@ import (
 //     fires.
 //
 // Distributed compaction coordinators construct one [RewriteFiles] on
-// the leader transaction, feed worker outputs in via [RewriteFiles.Apply],
+// the leader transaction, feed worker outputs in via [RewriteFiles.ApplyResult],
 // and commit one snapshot. In-process callers can use
 // [Transaction.RewriteDataFiles] which drives this builder internally.
 //
@@ -152,9 +152,8 @@ func (r *RewriteFiles) AddDataFile(df iceberg.DataFile) *RewriteFiles {
 // [RewriteFiles.DeleteFile] (which routes data vs. delete files by
 // content type), and every entry in adds via [RewriteFiles.AddDataFile].
 //
-// Distributed coordinators should prefer [RewriteFiles.ApplyResult],
-// which takes a [CompactionGroupResult] directly: the three positional
-// same-typed slices here transpose silently under refactor.
+// Coordinators feeding worker outputs must use [RewriteFiles.ApplyResult]; see
+// the warning there.
 func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *RewriteFiles {
 	if r.err != nil {
 		return r
@@ -175,11 +174,12 @@ func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *Rew
 
 // ApplyResult is the typed coordinator entry point: it queues a worker's
 // [CompactionGroupResult] onto this builder by routing OldDataFiles
-// (via DeleteFile), NewDataFiles (via AddDataFile), and SafePosDeletes
-// (via DeleteFile) in one call. Prefer this over [RewriteFiles.Apply]
-// when feeding worker outputs — the field names line up with the
-// builder semantics, so a refactor of CompactionGroupResult cannot
-// silently transpose roles.
+// (via DeleteFile), NewDataFiles (via AddDataFile), SafePosDeletes and
+// SafeDeletionVectors (via DeleteFile) in one call. Use this over
+// [RewriteFiles.Apply] when feeding worker outputs — Apply cannot carry
+// SafeDeletionVectors, and the field names here line up with the builder
+// semantics so a refactor of CompactionGroupResult cannot silently
+// transpose roles.
 //
 // Typical distributed-coordinator pattern:
 //
@@ -189,7 +189,12 @@ func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *Rew
 //	}
 //	if err := rewrite.Commit(ctx); err != nil { ... }
 func (r *RewriteFiles) ApplyResult(gr CompactionGroupResult) *RewriteFiles {
-	return r.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+	r.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+	for _, dv := range gr.SafeDeletionVectors {
+		r.DeleteFile(dv)
+	}
+
+	return r
 }
 
 // Commit stages the rewrite snapshot on the underlying transaction.

--- a/table/rewrite_files.go
+++ b/table/rewrite_files.go
@@ -174,14 +174,10 @@ func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *Rew
 	return r
 }
 
-// ApplyResult is the typed coordinator entry point: it queues a worker's
-// [CompactionGroupResult] onto this builder by routing OldDataFiles
-// (via DeleteFile), NewDataFiles (via AddDataFile), SafePosDeletes and
-// SafeDeletionVectors (via DeleteFile) in one call. Use this over
-// [RewriteFiles.Apply] when feeding worker outputs — Apply cannot carry
-// SafeDeletionVectors, and the field names here line up with the builder
-// semantics so a refactor of CompactionGroupResult cannot silently
-// transpose roles.
+// ApplyResult queues a worker's [CompactionGroupResult] onto this builder,
+// routing OldDataFiles (DeleteFile), NewDataFiles (AddDataFile), SafePosDeletes
+// and SafeDeletionVectors (DeleteFile). Prefer it over [RewriteFiles.Apply],
+// which cannot carry SafeDeletionVectors.
 //
 // Typical distributed-coordinator pattern:
 //
@@ -197,9 +193,8 @@ func (r *RewriteFiles) ApplyResult(gr CompactionGroupResult) *RewriteFiles {
 	for _, df := range gr.NewDataFiles {
 		r.AddDataFile(df)
 	}
-	// Both delete kinds route through DeleteFile: a DV's content type is
-	// EntryContentPosDeletes, so it lands in the removal queue and ReplaceFiles
-	// re-identifies it by referenced data file to expunge the right entry.
+	// DVs route through DeleteFile like any pos-delete; ReplaceFiles then
+	// re-identifies them by referenced data file.
 	for _, df := range gr.SafePosDeletes {
 		r.DeleteFile(df)
 	}

--- a/table/rewrite_files.go
+++ b/table/rewrite_files.go
@@ -152,8 +152,10 @@ func (r *RewriteFiles) AddDataFile(df iceberg.DataFile) *RewriteFiles {
 // [RewriteFiles.DeleteFile] (which routes data vs. delete files by
 // content type), and every entry in adds via [RewriteFiles.AddDataFile].
 //
-// Coordinators feeding worker outputs must use [RewriteFiles.ApplyResult]; see
-// the warning there.
+// Deprecated: use [RewriteFiles.ApplyResult], which also carries
+// SafeDeletionVectors. Apply has no slot for them, so a coordinator wiring
+// worker output through Apply leaves deletion vectors for the rewritten files
+// orphaned.
 func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *RewriteFiles {
 	if r.err != nil {
 		return r
@@ -189,9 +191,20 @@ func (r *RewriteFiles) Apply(deletes, adds, safeDeletes []iceberg.DataFile) *Rew
 //	}
 //	if err := rewrite.Commit(ctx); err != nil { ... }
 func (r *RewriteFiles) ApplyResult(gr CompactionGroupResult) *RewriteFiles {
-	r.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
-	for _, dv := range gr.SafeDeletionVectors {
-		r.DeleteFile(dv)
+	for _, df := range gr.OldDataFiles {
+		r.DeleteFile(df)
+	}
+	for _, df := range gr.NewDataFiles {
+		r.AddDataFile(df)
+	}
+	// Both delete kinds route through DeleteFile: a DV's content type is
+	// EntryContentPosDeletes, so it lands in the removal queue and ReplaceFiles
+	// re-identifies it by referenced data file to expunge the right entry.
+	for _, df := range gr.SafePosDeletes {
+		r.DeleteFile(df)
+	}
+	for _, df := range gr.SafeDeletionVectors {
+		r.DeleteFile(df)
 	}
 
 	return r

--- a/table/rewrite_files_test.go
+++ b/table/rewrite_files_test.go
@@ -227,7 +227,7 @@ func TestRewriteFiles_Commit_SingleShot(t *testing.T) {
 	tx := tbl.NewTransaction()
 	rewrite := tx.NewRewrite(nil)
 	for _, gr := range results {
-		rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+		rewrite.ApplyResult(gr)
 	}
 	require.NoError(t, rewrite.Commit(t.Context()))
 
@@ -424,7 +424,7 @@ func TestRewriteFiles_DistributedEquivalence(t *testing.T) {
 	leaderTxn := tbl.NewTransaction()
 	rewrite := leaderTxn.NewRewrite(nil)
 	for _, gr := range results {
-		rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+		rewrite.ApplyResult(gr)
 	}
 	require.NoError(t, rewrite.Commit(t.Context()))
 
@@ -519,7 +519,7 @@ func TestRewriteFiles_DropsSafePositionDeletes(t *testing.T) {
 	leaderTxn := tbl.NewTransaction()
 	rewrite := leaderTxn.NewRewrite(nil)
 	for _, gr := range results {
-		rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+		rewrite.ApplyResult(gr)
 	}
 	require.NoError(t, rewrite.Commit(t.Context()))
 
@@ -601,7 +601,7 @@ func TestRewriteFiles_RejectsConcurrentEqDelete(t *testing.T) {
 	leaderTxn := tbl.NewTransaction()
 	rewrite := leaderTxn.NewRewrite(nil)
 	for _, gr := range results {
-		rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+		rewrite.ApplyResult(gr)
 	}
 	require.NoError(t, rewrite.Commit(t.Context()),
 		"staging the rewrite must succeed; the conflict surfaces at Commit time")

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -261,7 +261,7 @@ func TestExecuteCompactionGroupPreservesRowID(t *testing.T) {
 
 	tx := tbl.NewTransaction()
 	rewrite := tx.NewRewrite(nil)
-	rewrite.Apply(gr.OldDataFiles, gr.NewDataFiles, gr.SafePosDeletes)
+	rewrite.ApplyResult(gr)
 	require.NoError(t, rewrite.Commit(ctx))
 	tbl, err = tx.Commit(ctx)
 	require.NoError(t, err)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -179,13 +179,14 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 	return out, nil
 }
 
-// isDeletionVector reports whether df is a deletion vector, keyed on the Puffin
-// format to mirror Java's ContentFileUtil.isDV. Format is authoritative: a
-// spec-legal Parquet position-delete file may also set referenced_data_file, so
-// keying on that would misclassify it. Callers that key removal by
-// referenced_data_file guard nil at each site, since a malformed DV may omit it.
+// isDeletionVector reports whether df is a deletion vector: a Puffin file with
+// position-delete content. The content-type guard matters because df is an
+// arbitrary DataFile, so a non-pos-delete Puffin from an external writer must
+// not be misclassified. Keying on format rather than referenced_data_file
+// avoids misclassifying a Parquet pos-delete that legally sets it.
 func isDeletionVector(df iceberg.DataFile) bool {
-	return df.FileFormat() == iceberg.PuffinFile
+	return df.FileFormat() == iceberg.PuffinFile &&
+		df.ContentType() == iceberg.EntryContentPosDeletes
 }
 
 type Scan struct {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -179,8 +179,13 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 	return out, nil
 }
 
+// isDeletionVector reports whether df is a deletion vector, keyed on the Puffin
+// format to mirror Java's ContentFileUtil.isDV. Format is authoritative: a
+// spec-legal Parquet position-delete file may also set referenced_data_file, so
+// keying on that would misclassify it. Callers that key removal by
+// referenced_data_file guard nil at each site, since a malformed DV may omit it.
 func isDeletionVector(df iceberg.DataFile) bool {
-	return df.ReferencedDataFile() != nil
+	return df.FileFormat() == iceberg.PuffinFile
 }
 
 type Scan struct {

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -176,7 +176,7 @@ func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
 			path := entry.DataFile().FilePath()
 			content := entry.DataFile().ContentType()
 			_, isDeletedData := of.base.deletedFiles[path]
-			_, isDeletedDelete := of.base.deletedDeleteFiles[path]
+			isDeletedDelete := of.base.deleteFileRemoved(entry.DataFile())
 
 			isData := content == iceberg.EntryContentData
 			matched := (isDeletedData && isData) || (isDeletedDelete && !isData)
@@ -304,7 +304,7 @@ func (of *overwriteFiles) deletedEntries(ctx context.Context) ([]iceberg.Manifes
 			content := entry.DataFile().ContentType()
 
 			_, isDeletedData := of.base.deletedFiles[path]
-			_, isDeletedDelete := of.base.deletedDeleteFiles[path]
+			isDeletedDelete := of.base.deleteFileRemoved(entry.DataFile())
 
 			if (isDeletedData && content == iceberg.EntryContentData) ||
 				(isDeletedDelete && content != iceberg.EntryContentData) {
@@ -523,6 +523,7 @@ type snapshotProducer struct {
 	manifestCount      atomic.Int32
 	deletedFiles       map[string]iceberg.DataFile
 	deletedDeleteFiles map[string]iceberg.DataFile
+	deletedDVsByRef    map[string]iceberg.DataFile
 	snapshotProps      iceberg.Properties
 }
 
@@ -552,6 +553,7 @@ func createSnapshotProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO
 		addedFiles:         []iceberg.DataFile{},
 		deletedFiles:       make(map[string]iceberg.DataFile),
 		deletedDeleteFiles: make(map[string]iceberg.DataFile),
+		deletedDVsByRef:    make(map[string]iceberg.DataFile),
 		snapshotProps:      snapshotProps,
 	}
 }
@@ -586,6 +588,34 @@ func (sp *snapshotProducer) removeDeleteFile(df iceberg.DataFile) *snapshotProdu
 	sp.deletedDeleteFiles[df.FilePath()] = df
 
 	return sp
+}
+
+func (sp *snapshotProducer) removeDeletionVector(df iceberg.DataFile) *snapshotProducer {
+	sp.deletedDVsByRef[*df.ReferencedDataFile()] = df
+
+	return sp
+}
+
+// deleteFileRemoved reports whether a delete-file entry is being expunged in
+// this snapshot: position/equality deletes match by path, deletion vectors by
+// referenced data file (one Puffin holds blobs for several data files, so a
+// shared path would over-remove live siblings).
+func (sp *snapshotProducer) deleteFileRemoved(df iceberg.DataFile) bool {
+	if _, ok := sp.deletedDeleteFiles[df.FilePath()]; ok {
+		return true
+	}
+	if isDeletionVectorFile(df) {
+		_, ok := sp.deletedDVsByRef[*df.ReferencedDataFile()]
+
+		return ok
+	}
+
+	return false
+}
+
+// isDeletionVectorFile reports whether df is a Puffin deletion vector.
+func isDeletionVectorFile(df iceberg.DataFile) bool {
+	return df.FileFormat() == iceberg.PuffinFile && df.ReferencedDataFile() != nil
 }
 
 func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec, opts ...iceberg.ManifestWriterOption) (_ *iceberg.ManifestWriter, _ string, _ *internal.CountingWriter, _ io.Closer, err error) {
@@ -801,6 +831,15 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 	if len(sp.deletedDeleteFiles) > 0 {
 		specs := sp.txn.meta.specs
 		for _, df := range sp.deletedDeleteFiles {
+			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+				return Summary{}, err
+			}
+		}
+	}
+
+	if len(sp.deletedDVsByRef) > 0 {
+		specs := sp.txn.meta.specs
+		for _, df := range sp.deletedDVsByRef {
 			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
 				return Summary{}, err
 			}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -591,7 +591,11 @@ func (sp *snapshotProducer) removeDeleteFile(df iceberg.DataFile) *snapshotProdu
 }
 
 func (sp *snapshotProducer) removeDeletionVector(df iceberg.DataFile) *snapshotProducer {
-	sp.deletedDVsByRef[*df.ReferencedDataFile()] = df
+	ref := df.ReferencedDataFile()
+	if ref == nil {
+		return sp
+	}
+	sp.deletedDVsByRef[*ref] = df
 
 	return sp
 }
@@ -604,18 +608,13 @@ func (sp *snapshotProducer) deleteFileRemoved(df iceberg.DataFile) bool {
 	if _, ok := sp.deletedDeleteFiles[df.FilePath()]; ok {
 		return true
 	}
-	if isDeletionVectorFile(df) {
-		_, ok := sp.deletedDVsByRef[*df.ReferencedDataFile()]
+	if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
+		_, ok := sp.deletedDVsByRef[*ref]
 
 		return ok
 	}
 
 	return false
-}
-
-// isDeletionVectorFile reports whether df is a Puffin deletion vector.
-func isDeletionVectorFile(df iceberg.DataFile) bool {
-	return df.FileFormat() == iceberg.PuffinFile && df.ReferencedDataFile() != nil
 }
 
 func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec, opts ...iceberg.ManifestWriterOption) (_ *iceberg.ManifestWriter, _ string, _ *internal.CountingWriter, _ io.Closer, err error) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -881,9 +881,19 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 
 	setDeleteFilesToRemove := make(map[string]struct{}, len(deleteFilesToRemove))
+	dvRefsToRemove := make(map[string]struct{}, len(deleteFilesToRemove))
 	for i, df := range deleteFilesToRemove {
 		if df == nil {
 			return fmt.Errorf("nil delete file at index %d for ReplaceFiles", i)
+		}
+		if isDeletionVectorFile(df) {
+			ref := *df.ReferencedDataFile()
+			if _, ok := dvRefsToRemove[ref]; ok {
+				return errors.New("deletion vectors to remove must reference distinct data files for ReplaceFiles")
+			}
+			dvRefsToRemove[ref] = struct{}{}
+
+			continue
 		}
 		path := df.FilePath()
 		if path == "" {
@@ -909,6 +919,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	// that all files to delete/remove actually exist in the table.
 	markedDataForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
 	markedDeleteForRemoval := make([]iceberg.DataFile, 0, len(setDeleteFilesToRemove))
+	markedDVsForRemoval := make([]iceberg.DataFile, 0, len(dvRefsToRemove))
 	for df, err := range s.dataFiles(fs, nil) {
 		if err != nil {
 			return err
@@ -918,8 +929,14 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if _, ok := setToDelete[path]; ok && isData {
 			markedDataForDeletion = append(markedDataForDeletion, df)
 		}
-		if _, ok := setDeleteFilesToRemove[path]; ok && !isData {
-			markedDeleteForRemoval = append(markedDeleteForRemoval, df)
+		if !isData {
+			if _, ok := setDeleteFilesToRemove[path]; ok {
+				markedDeleteForRemoval = append(markedDeleteForRemoval, df)
+			} else if isDeletionVectorFile(df) {
+				if _, ok := dvRefsToRemove[*df.ReferencedDataFile()]; ok {
+					markedDVsForRemoval = append(markedDVsForRemoval, df)
+				}
+			}
 		}
 		if _, ok := setToAdd[path]; ok {
 			return fmt.Errorf("cannot add files that are already referenced by table, files: %s", path)
@@ -931,6 +948,9 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 	if len(markedDeleteForRemoval) != len(setDeleteFilesToRemove) {
 		return errors.New("cannot remove delete files that do not belong to the table")
+	}
+	if len(markedDVsForRemoval) != len(dvRefsToRemove) {
+		return errors.New("cannot remove deletion vectors that do not belong to the table")
 	}
 
 	if !cfg.skipAutoNameMapping {
@@ -959,6 +979,9 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 	for _, df := range markedDeleteForRemoval {
 		updater.removeDeleteFile(df)
+	}
+	for _, df := range markedDVsForRemoval {
+		updater.removeDeletionVector(df)
 	}
 
 	updates, reqs, err := updater.commit(ctx)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -886,6 +886,10 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if df == nil {
 			return fmt.Errorf("nil delete file at index %d for ReplaceFiles", i)
 		}
+		path := df.FilePath()
+		if path == "" {
+			return errors.New("delete file paths must be non-empty for ReplaceFiles")
+		}
 		if isDeletionVector(df) {
 			ref := df.ReferencedDataFile()
 			if ref == nil {
@@ -897,10 +901,6 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 			dvRefsToRemove[*ref] = struct{}{}
 
 			continue
-		}
-		path := df.FilePath()
-		if path == "" {
-			return errors.New("delete file paths must be non-empty for ReplaceFiles")
 		}
 		if _, ok := setDeleteFilesToRemove[path]; ok {
 			return errors.New("delete file paths must be unique for ReplaceFiles")
@@ -922,7 +922,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	// that all files to delete/remove actually exist in the table.
 	markedDataForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
 	markedDeleteForRemoval := make([]iceberg.DataFile, 0, len(setDeleteFilesToRemove))
-	markedDVsForRemoval := make([]iceberg.DataFile, 0, len(dvRefsToRemove))
+	markedDVsForRemoval := make(map[string]iceberg.DataFile, len(dvRefsToRemove))
 	for df, err := range s.dataFiles(fs, nil) {
 		if err != nil {
 			return err
@@ -937,7 +937,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 				markedDeleteForRemoval = append(markedDeleteForRemoval, df)
 			} else if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
 				if _, ok := dvRefsToRemove[*ref]; ok {
-					markedDVsForRemoval = append(markedDVsForRemoval, df)
+					markedDVsForRemoval[*ref] = df
 				}
 			}
 		}
@@ -952,9 +952,8 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	if len(markedDeleteForRemoval) != len(setDeleteFilesToRemove) {
 		return errors.New("cannot remove delete files that do not belong to the table")
 	}
-	// Relies on the spec invariant of at most one DV per referenced data file:
-	// duplicate refs in the table would inflate markedDVsForRemoval past the
-	// deduped map and slip past this check.
+	// Keyed by referenced data file, so duplicate DV entries for one ref collapse
+	// to one slot; equality then means every requested ref exists in the table.
 	if len(markedDVsForRemoval) != len(dvRefsToRemove) {
 		return errors.New("cannot remove deletion vectors that do not belong to the table")
 	}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -886,12 +886,15 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if df == nil {
 			return fmt.Errorf("nil delete file at index %d for ReplaceFiles", i)
 		}
-		if isDeletionVectorFile(df) {
-			ref := *df.ReferencedDataFile()
-			if _, ok := dvRefsToRemove[ref]; ok {
+		if isDeletionVector(df) {
+			ref := df.ReferencedDataFile()
+			if ref == nil {
+				return errors.New("deletion vector to remove is missing referenced_data_file for ReplaceFiles")
+			}
+			if _, ok := dvRefsToRemove[*ref]; ok {
 				return errors.New("deletion vectors to remove must reference distinct data files for ReplaceFiles")
 			}
-			dvRefsToRemove[ref] = struct{}{}
+			dvRefsToRemove[*ref] = struct{}{}
 
 			continue
 		}
@@ -932,8 +935,8 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if !isData {
 			if _, ok := setDeleteFilesToRemove[path]; ok {
 				markedDeleteForRemoval = append(markedDeleteForRemoval, df)
-			} else if isDeletionVectorFile(df) {
-				if _, ok := dvRefsToRemove[*df.ReferencedDataFile()]; ok {
+			} else if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
+				if _, ok := dvRefsToRemove[*ref]; ok {
 					markedDVsForRemoval = append(markedDVsForRemoval, df)
 				}
 			}
@@ -949,6 +952,9 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	if len(markedDeleteForRemoval) != len(setDeleteFilesToRemove) {
 		return errors.New("cannot remove delete files that do not belong to the table")
 	}
+	// Relies on the spec invariant of at most one DV per referenced data file:
+	// duplicate refs in the table would inflate markedDVsForRemoval past the
+	// deduped map and slip past this check.
 	if len(markedDVsForRemoval) != len(dvRefsToRemove) {
 		return errors.New("cannot remove deletion vectors that do not belong to the table")
 	}


### PR DESCRIPTION
Compaction replaces a data file carrying a deletion vector with new compacted files, dropping the old file's manifest entry, but leaves the DV's manifest entry pointing at a data file the table no longer references.

## Cause

DV removal was keyed by path, but a DV entry is 1:1 with its referenced data file and one Puffin can hold DVs for several files. Compaction never collected DVs (they ride in `FileScanTask.DeletionVectorFiles`, not `DeleteFiles`), and a path-keyed removal would have dropped sibling DVs in the same Puffin too.

## Fix

Key DV removal by referenced data file end to end. `CollectSafeDeletionVectors` gathers a group's DVs; `CompactionGroupResult.SafeDeletionVectors` carries them; both commit paths expunge them, dropping the rewritten file's DV while sibling DVs in the same Puffin survive. Use `RewriteFiles.ApplyResult`, not `Apply`, which can't carry them.

## Tests

`TestRewriteDataFilesRemovesDeletionVectors` (no orphan after compaction) and `TestRewriteDataFilesPreservesSiblingDeletionVector` (shared Puffin: rewritten DV expunged, sibling survives).