### PR TITLE
fix(transforms): preserve "+00:00" UTC offset for TimestampTz / TimestampTzNs in IdentityTransform.ToHumanStr

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -552,7 +552,12 @@ func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
 		sb.WriteByte('=')
 
 		// Only escape the value (which changes per row)
-		valueStr := ps.fields[i].Transform.ToHumanStr(data.Get(i))
+		var valueStr string
+		if t, ok := ps.fields[i].Transform.(typedHumanStringer); ok {
+			valueStr = t.ToHumanStrType(partType.FieldList[i].Type, data.Get(i))
+		} else {
+			valueStr = ps.fields[i].Transform.ToHumanStr(data.Get(i))
+		}
 		sb.WriteString(url.QueryEscape(valueStr))
 	}
 

--- a/transforms.go
+++ b/transforms.go
@@ -103,6 +103,10 @@ type Transform interface {
 	ToHumanStr(any) string
 }
 
+type typedHumanStringer interface {
+	ToHumanStrType(typ Type, val any) string
+}
+
 // IdentityTransform uses the identity function, performing no transformation
 // but instead partitioning on the value itself.
 type IdentityTransform struct{}
@@ -151,9 +155,37 @@ func (IdentityTransform) ToHumanStr(val any) string {
 		return v.ToTime().Format("15:04:05.999999")
 	case Timestamp:
 		return v.ToTime().Format("2006-01-02T15:04:05.999999")
+	case TimestampNano:
+		return v.ToTime().Format("2006-01-02T15:04:05.999999999")
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+func (t IdentityTransform) ToHumanStrType(typ Type, val any) string {
+	if val == nil {
+		return "null"
+	}
+	switch typ.(type) {
+	case TimestampType:
+		if v, ok := val.(Timestamp); ok {
+			return v.ToTime().Format("2006-01-02T15:04:05.999999")
+		}
+	case TimestampTzType:
+		if v, ok := val.(Timestamp); ok {
+			return v.ToTime().Format("2006-01-02T15:04:05.999999") + "+00:00"
+		}
+	case TimestampNsType:
+		if v, ok := val.(TimestampNano); ok {
+			return v.ToTime().Format("2006-01-02T15:04:05.999999999")
+		}
+	case TimestampTzNsType:
+		if v, ok := val.(TimestampNano); ok {
+			return v.ToTime().Format("2006-01-02T15:04:05.999999999") + "+00:00"
+		}
+	}
+
+	return t.ToHumanStr(val)
 }
 
 func (t IdentityTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -103,6 +103,8 @@ type Transform interface {
 	ToHumanStr(any) string
 }
 
+// typedHumanStringer is an opt-in extension for transforms whose
+// human-string form depends on the source Iceberg Type
 type typedHumanStringer interface {
 	ToHumanStrType(typ Type, val any) string
 }
@@ -162,6 +164,8 @@ func (IdentityTransform) ToHumanStr(val any) string {
 	}
 }
 
+// ToHumanStrType is the type-aware form invoked by PartitionToPath.
+// It appends "+00:00" for TimestampTz/TimestampTzNs — information the value-only ToHumanStr(any) cannot recover by design
 func (t IdentityTransform) ToHumanStrType(typ Type, val any) string {
 	if val == nil {
 		return "null"

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -152,6 +152,106 @@ func TestToHumanString(t *testing.T) {
 	}
 }
 
+func TestIdentityToHumanStrType_TimestampTz(t *testing.T) {
+	id := iceberg.IdentityTransform{}
+
+	tzMicros := iceberg.Timestamp(1512151975038194)
+	noTzMicros := iceberg.Timestamp(1512123175038194)
+	tzNanos := iceberg.TimestampNano(-1510871468000001001)
+	noTzNanos := iceberg.TimestampNano(1512151975038194001)
+
+	tests := []struct {
+		name     string
+		typ      iceberg.Type
+		val      any
+		expected string
+	}{
+		{
+			name:     "TimestampType formats without UTC offset",
+			typ:      iceberg.PrimitiveTypes.Timestamp,
+			val:      noTzMicros,
+			expected: "2017-12-01T10:12:55.038194",
+		},
+		{
+			name:     "TimestampTzType formats with +00:00 offset",
+			typ:      iceberg.PrimitiveTypes.TimestampTz,
+			val:      tzMicros,
+			expected: "2017-12-01T18:12:55.038194+00:00",
+		},
+		{
+			name:     "TimestampNsType formats nanoseconds without UTC offset",
+			typ:      iceberg.PrimitiveTypes.TimestampNs,
+			val:      noTzNanos,
+			expected: "2017-12-01T18:12:55.038194001",
+		},
+		{
+			name:     "TimestampTzNsType formats nanoseconds with +00:00 offset",
+			typ:      iceberg.PrimitiveTypes.TimestampTzNs,
+			val:      tzNanos,
+			expected: "1922-02-15T01:28:51.999998999+00:00",
+		},
+		{
+			name:     "nil value returns null",
+			typ:      iceberg.PrimitiveTypes.TimestampTz,
+			val:      nil,
+			expected: "null",
+		},
+		{
+			name:     "non-timestamp types fall back to ToHumanStr",
+			typ:      iceberg.PrimitiveTypes.Date,
+			val:      iceberg.Date(17501),
+			expected: "2017-12-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, id.ToHumanStrType(tt.typ, tt.val))
+		})
+	}
+}
+
+func TestPartitionToPath_TimestampTzIdentity(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "created_ts_tz", Type: iceberg.PrimitiveTypes.TimestampTz, Required: true},
+		iceberg.NestedField{ID: 2, Name: "created_ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 3, Name: "created_ts_tz_ns", Type: iceberg.PrimitiveTypes.TimestampTzNs, Required: true},
+		iceberg.NestedField{ID: 4, Name: "created_ts_ns", Type: iceberg.PrimitiveTypes.TimestampNs, Required: true},
+	)
+
+	spec := iceberg.NewPartitionSpecID(3,
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: iceberg.IdentityTransform{}, Name: "created_ts_tz",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{2}, FieldID: 1001,
+			Transform: iceberg.IdentityTransform{}, Name: "created_ts",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{3}, FieldID: 1002,
+			Transform: iceberg.IdentityTransform{}, Name: "created_ts_tz_ns",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{4}, FieldID: 1003,
+			Transform: iceberg.IdentityTransform{}, Name: "created_ts_ns",
+		},
+	)
+
+	tsMicros := iceberg.Timestamp(1705314600000000)
+	tsNanos := iceberg.TimestampNano(1705314600000000001)
+	record := partitionRecord{tsMicros, tsMicros, tsNanos, tsNanos}
+
+	expected := strings.Join([]string{
+		"created_ts_tz=2024-01-15T10%3A30%3A00%2B00%3A00",
+		"created_ts=2024-01-15T10%3A30%3A00",
+		"created_ts_tz_ns=2024-01-15T10%3A30%3A00.000000001%2B00%3A00",
+		"created_ts_ns=2024-01-15T10%3A30%3A00.000000001",
+	}, "/")
+
+	assert.Equal(t, expected, spec.PartitionToPath(record, schema))
+}
+
 func TestManifestPartitionVals(t *testing.T) {
 	// Sanity checks that the source and result types of the transform are
 	// compatible with their use to generate partition data in manifests.

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -152,65 +152,6 @@ func TestToHumanString(t *testing.T) {
 	}
 }
 
-func TestIdentityToHumanStrType_TimestampTz(t *testing.T) {
-	id := iceberg.IdentityTransform{}
-
-	tzMicros := iceberg.Timestamp(1512151975038194)
-	noTzMicros := iceberg.Timestamp(1512123175038194)
-	tzNanos := iceberg.TimestampNano(-1510871468000001001)
-	noTzNanos := iceberg.TimestampNano(1512151975038194001)
-
-	tests := []struct {
-		name     string
-		typ      iceberg.Type
-		val      any
-		expected string
-	}{
-		{
-			name:     "TimestampType formats without UTC offset",
-			typ:      iceberg.PrimitiveTypes.Timestamp,
-			val:      noTzMicros,
-			expected: "2017-12-01T10:12:55.038194",
-		},
-		{
-			name:     "TimestampTzType formats with +00:00 offset",
-			typ:      iceberg.PrimitiveTypes.TimestampTz,
-			val:      tzMicros,
-			expected: "2017-12-01T18:12:55.038194+00:00",
-		},
-		{
-			name:     "TimestampNsType formats nanoseconds without UTC offset",
-			typ:      iceberg.PrimitiveTypes.TimestampNs,
-			val:      noTzNanos,
-			expected: "2017-12-01T18:12:55.038194001",
-		},
-		{
-			name:     "TimestampTzNsType formats nanoseconds with +00:00 offset",
-			typ:      iceberg.PrimitiveTypes.TimestampTzNs,
-			val:      tzNanos,
-			expected: "1922-02-15T01:28:51.999998999+00:00",
-		},
-		{
-			name:     "nil value returns null",
-			typ:      iceberg.PrimitiveTypes.TimestampTz,
-			val:      nil,
-			expected: "null",
-		},
-		{
-			name:     "non-timestamp types fall back to ToHumanStr",
-			typ:      iceberg.PrimitiveTypes.Date,
-			val:      iceberg.Date(17501),
-			expected: "2017-12-01",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, id.ToHumanStrType(tt.typ, tt.val))
-		})
-	}
-}
-
 func TestPartitionToPath_TimestampTzIdentity(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "created_ts_tz", Type: iceberg.PrimitiveTypes.TimestampTz, Required: true},

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -139,6 +139,7 @@ func TestToHumanString(t *testing.T) {
 		{iceberg.IdentityTransform{}, iceberg.Date(17501), "2017-12-01"},
 		{iceberg.IdentityTransform{}, iceberg.Time(36775038194), "10:12:55.038194"},
 		{iceberg.IdentityTransform{}, iceberg.Timestamp(1512151975038194), "2017-12-01T18:12:55.038194"},
+		{iceberg.IdentityTransform{}, iceberg.TimestampNano(1512151975038194001), "2017-12-01T18:12:55.038194001"},
 		{iceberg.IdentityTransform{}, int64(-1234567890000), "-1234567890000"},
 		{iceberg.IdentityTransform{}, "a/b/c=d", "a/b/c=d"},
 		{iceberg.IdentityTransform{}, []byte("foo"), "Zm9v"},


### PR DESCRIPTION
## Problem

In Iceberg-Go, `iceberg.IdentityTransform.ToHumanStr` formats both timezone-bearing (`TimestampTzType`, `TimestampTzNsType`) and zone-naive (`TimestampType`, `TimestampNsType`) timestamps with the same **offset-less** ISO string.

Fixes: #1226 

## Solution

Implement the function to dispatch on Type and appends `+00:00` for `TimestampTzType` / `TimestampTzNsType`. Something similar to what Iceberg Java's [**DateTimeUtil**](https://github.com/apache/iceberg/blob/8924046f7ac5326e454d1cd48a6b30a6d16ba196/api/src/main/java/org/apache/iceberg/util/DateTimeUtil.java)  implements.

## Files changed

| File | Description |
|---|---|
| `partitions.go` | Update PartitionToPath to use a type-aware human-string |
| `transforms.go` | Add type-aware timestamp formatting for IdentityTransform |
| `transforms_test.go` | Regression Test |

## Testing
- Ingested data into a partitioned iceberg table in Glue Catalog