### PR TITLE
fix(catalog/hadoop): validate table identifiers

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -70,21 +70,33 @@ var uuidMetadataPattern = regexp.MustCompile(
 // Note: this is POSIX-best-effort validation — it does not catch NUL bytes
 // or Windows reserved names (NUL, CON, COM1, etc.).
 func validateIdentifier(ident table.Identifier) error {
+	return validateIdentifierParts(ident, catalog.ErrNoSuchNamespace, "namespace identifier", "identifier component")
+}
+
+func validateTableIdentifier(ident table.Identifier) error {
+	if len(ident) < 2 {
+		return fmt.Errorf("%w: table identifier must have at least a namespace and table name", catalog.ErrNoSuchTable)
+	}
+
+	return validateIdentifierParts(ident, catalog.ErrNoSuchTable, "table identifier", "table identifier component")
+}
+
+func validateIdentifierParts(ident table.Identifier, errType error, identifierName, componentName string) error {
 	if len(ident) == 0 {
-		return fmt.Errorf("%w: namespace identifier must not be empty", catalog.ErrNoSuchNamespace)
+		return fmt.Errorf("%w: %s must not be empty", errType, identifierName)
 	}
 
 	for _, part := range ident {
 		if part == "" {
-			return fmt.Errorf("%w: identifier component must not be empty", catalog.ErrNoSuchNamespace)
+			return fmt.Errorf("%w: %s must not be empty", errType, componentName)
 		}
 
 		if part == "." || part == ".." {
-			return fmt.Errorf("%w: invalid identifier component %q", catalog.ErrNoSuchNamespace, part)
+			return fmt.Errorf("%w: invalid %s %q", errType, componentName, part)
 		}
 
 		if strings.ContainsAny(part, "/\\") {
-			return fmt.Errorf("%w: identifier component must not contain path separators: %q", catalog.ErrNoSuchNamespace, part)
+			return fmt.Errorf("%w: %s must not contain path separators: %q", errType, componentName, part)
 		}
 	}
 
@@ -310,8 +322,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		opt(&cfg)
 	}
 
-	if len(ident) < 2 {
-		return nil, errors.New("hadoop catalog: table identifier must have at least a namespace and table name")
+	if err := validateTableIdentifier(ident); err != nil {
+		return nil, err
 	}
 
 	ns := catalog.NamespaceFromIdent(ident)
@@ -382,8 +394,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 }
 
 func (c *Catalog) LoadTable(ctx context.Context, ident table.Identifier) (*table.Table, error) {
-	if len(ident) < 2 {
-		return nil, errors.New("hadoop catalog: table identifier must have at least a namespace and table name")
+	if err := validateTableIdentifier(ident); err != nil {
+		return nil, err
 	}
 
 	ver, err := c.findVersion(ident)
@@ -397,7 +409,7 @@ func (c *Catalog) LoadTable(ctx context.Context, ident table.Identifier) (*table
 }
 
 func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (bool, error) {
-	if len(ident) < 2 {
+	if err := validateTableIdentifier(ident); err != nil {
 		return false, nil
 	}
 
@@ -405,8 +417,8 @@ func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (b
 }
 
 func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
-	if len(ident) < 2 {
-		return nil, "", errors.New("hadoop catalog: table identifier must have at least a namespace and table name")
+	if err := validateTableIdentifier(ident); err != nil {
+		return nil, "", err
 	}
 
 	// Step 1: Load current table (nil for create-via-commit).
@@ -505,8 +517,8 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
-		if len(ns) == 0 {
-			yield(nil, errors.New("hadoop catalog: namespace identifier must not be empty"))
+		if err := validateIdentifier(ns); err != nil {
+			yield(nil, err)
 
 			return
 		}
@@ -554,8 +566,8 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 }
 
 func (c *Catalog) DropTable(_ context.Context, ident table.Identifier) error {
-	if len(ident) < 2 {
-		return errors.New("hadoop catalog: table identifier must have at least a namespace and table name")
+	if err := validateTableIdentifier(ident); err != nil {
+		return err
 	}
 
 	tablePath := c.tableToPath(ident)
@@ -567,6 +579,10 @@ func (c *Catalog) DropTable(_ context.Context, ident table.Identifier) error {
 }
 
 func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) error {
+	if err := validateTableIdentifier(identifier); err != nil {
+		return err
+	}
+
 	tbl, err := c.LoadTable(ctx, identifier)
 	if err != nil {
 		return err

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -684,6 +684,30 @@ func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsRejectsInvalid() {
 	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
+func (s *HadoopCatalogTestSuite) TestListTablesRejectsInvalidIdentifiers() {
+	tests := []struct {
+		name  string
+		ident table.Identifier
+	}{
+		{"empty component", table.Identifier{"a", "", "b"}},
+		{"dot component", table.Identifier{"."}},
+		{"dot dot component", table.Identifier{".."}},
+		{"slash component", table.Identifier{"a/b"}},
+		{"backslash component", table.Identifier{`a\b`}},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			for _, err := range s.cat.ListTables(context.Background(), tt.ident) {
+				s.Require().Error(err)
+				s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+
+				break
+			}
+		})
+	}
+}
+
 // isTableDir interop tests
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrueVersionHintText() {
@@ -851,6 +875,7 @@ func (s *HadoopCatalogTestSuite) TestDropTableVerifyCleanup() {
 func (s *HadoopCatalogTestSuite) TestDropTableShortIdentifier() {
 	err := s.cat.DropTable(context.Background(), []string{"tbl"})
 	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 
@@ -999,7 +1024,111 @@ func (s *HadoopCatalogTestSuite) TestCreateTableShortIdentifier() {
 
 	_, err := s.cat.CreateTable(ctx, []string{"tbl"}, s.testSchema())
 	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
+}
+
+func (s *HadoopCatalogTestSuite) tableIdentifierErrorOperations(ctx context.Context) []struct {
+	name string
+	run  func(table.Identifier) error
+} {
+	return []struct {
+		name string
+		run  func(table.Identifier) error
+	}{
+		{
+			name: "CreateTable",
+			run: func(ident table.Identifier) error {
+				_, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+
+				return err
+			},
+		},
+		{
+			name: "LoadTable",
+			run: func(ident table.Identifier) error {
+				_, err := s.cat.LoadTable(ctx, ident)
+
+				return err
+			},
+		},
+		{
+			name: "CommitTable",
+			run: func(ident table.Identifier) error {
+				_, _, err := s.cat.CommitTable(ctx, ident, nil, nil)
+
+				return err
+			},
+		},
+		{
+			name: "DropTable",
+			run: func(ident table.Identifier) error {
+				return s.cat.DropTable(ctx, ident)
+			},
+		},
+		{
+			name: "PurgeTable",
+			run: func(ident table.Identifier) error {
+				return s.cat.PurgeTable(ctx, ident)
+			},
+		},
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestTableOperationsRejectInvalidIdentifiers() {
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		ident table.Identifier
+	}{
+		{"empty namespace component", table.Identifier{"", "tbl"}},
+		{"empty table name", table.Identifier{"ns", ""}},
+		{"dot namespace component", table.Identifier{".", "tbl"}},
+		{"dot table name", table.Identifier{"ns", "."}},
+		{"dot dot namespace component", table.Identifier{"..", "tbl"}},
+		{"dot dot table name", table.Identifier{"ns", ".."}},
+		{"slash namespace component", table.Identifier{"a/b", "tbl"}},
+		{"slash table name", table.Identifier{"ns", "a/b"}},
+		{"backslash namespace component", table.Identifier{`a\b`, "tbl"}},
+		{"backslash table name", table.Identifier{"ns", `a\b`}},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			for _, op := range s.tableIdentifierErrorOperations(ctx) {
+				s.Run(op.name, func() {
+					err := op.run(tt.ident)
+					s.Require().Error(err)
+					s.ErrorIs(err, catalog.ErrNoSuchTable)
+				})
+			}
+		})
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestTableOperationsRejectParentTraversalIdentifier() {
+	ctx := context.Background()
+	outside, err := os.MkdirTemp(filepath.Dir(s.warehouse), "outside_table_")
+	s.Require().NoError(err)
+	defer os.RemoveAll(outside)
+
+	outsideTable := filepath.Join(outside, "tbl")
+	metaDir := filepath.Join(outsideTable, "metadata")
+	marker := filepath.Join(outsideTable, "sentinel.txt")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), []byte("{}"), 0o644))
+	s.Require().NoError(os.WriteFile(marker, []byte("keep"), 0o644))
+
+	ident := table.Identifier{"..", filepath.Base(outside), "tbl"}
+	for _, op := range s.tableIdentifierErrorOperations(ctx) {
+		s.Run(op.name, func() {
+			err := op.run(ident)
+			s.Require().Error(err)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			s.FileExists(marker)
+			s.DirExists(metaDir)
+		})
+	}
 }
 
 func (s *HadoopCatalogTestSuite) TestDropTableNamespacePreserved() {
@@ -1086,6 +1215,7 @@ func (s *HadoopCatalogTestSuite) TestLoadTableShortIdentifier() {
 
 	_, err := s.cat.LoadTable(ctx, []string{"tbl"})
 	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 
@@ -1107,6 +1237,38 @@ func (s *HadoopCatalogTestSuite) TestCheckTableExistsFalse() {
 	exists, err := s.cat.CheckTableExists(context.Background(), []string{"ns", "tbl"})
 	s.Require().NoError(err)
 	s.False(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckTableExistsShortIdentifier() {
+	exists, err := s.cat.CheckTableExists(context.Background(), []string{"tbl"})
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckTableExistsInvalidIdentifierFalse() {
+	tests := []struct {
+		name  string
+		ident table.Identifier
+	}{
+		{"empty namespace component", table.Identifier{"", "tbl"}},
+		{"empty table name", table.Identifier{"ns", ""}},
+		{"dot namespace component", table.Identifier{".", "tbl"}},
+		{"dot table name", table.Identifier{"ns", "."}},
+		{"dot dot namespace component", table.Identifier{"..", "tbl"}},
+		{"dot dot table name", table.Identifier{"ns", ".."}},
+		{"slash namespace component", table.Identifier{"a/b", "tbl"}},
+		{"slash table name", table.Identifier{"ns", "a/b"}},
+		{"backslash namespace component", table.Identifier{`a\b`, "tbl"}},
+		{"backslash table name", table.Identifier{"ns", `a\b`}},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			exists, err := s.cat.CheckTableExists(context.Background(), tt.ident)
+			s.Require().NoError(err)
+			s.False(exists)
+		})
+	}
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateTableNestedNamespace() {
@@ -1370,5 +1532,6 @@ func (s *HadoopCatalogTestSuite) TestCommitTableCreateViaCommit() {
 func (s *HadoopCatalogTestSuite) TestCommitTableShortIdentifier() {
 	_, _, err := s.cat.CommitTable(context.Background(), []string{"tbl"}, nil, nil)
 	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }


### PR DESCRIPTION
Summary

- validate Hadoop table identifiers before converting them to filesystem paths
- return table-shaped errors for invalid table identifiers in write/load/drop/purge paths
- keep `CheckTableExists` as a pure existence check that returns `false, nil` for invalid identifiers
- return namespace errors for invalid `ListTables` namespaces
- add regression coverage for invalid path components and parent-traversal-style identifiers

Why

Hadoop namespace operations already rejected empty components, dot components, parent traversal, and path separators. Table operations only checked identifier length before building paths with `filepath.Join`, so path-like components could collapse outside the intended table location.

This keeps table operations on the same component-validation invariant as namespace operations while preserving the existing `CheckTableExists` behavior.

Testing

- `git diff --check`
- `go test ./catalog/hadoop -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/hadoop/...`
- `go test ./catalog/... -count=1`
- `go test ./... -count=1`