### PR TITLE
fix(table): handle string file_path layouts in position deletes

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exprs"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
@@ -251,6 +252,153 @@ func sameDVBlob(a, b iceberg.DataFile) bool {
 	return *a.ContentOffset() == *b.ContentOffset()
 }
 
+func filePathValueType(dt arrow.DataType) arrow.DataType {
+	if dictType, ok := dt.(*arrow.DictionaryType); ok {
+		return dictType.ValueType
+	}
+
+	return dt
+}
+
+func filePathValues(values arrow.Array) (arrow.TypedArray[string], error) {
+	switch arr := values.(type) {
+	case *array.Dictionary:
+		wrapped, err := array.NewDictWrapper[string](arr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: file_path column is not string: %w",
+				iceberg.ErrInvalidSchema, err)
+		}
+
+		return wrapped, nil
+	case arrow.TypedArray[string]:
+		return arr, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
+			iceberg.ErrInvalidSchema, values.DataType())
+	}
+}
+
+func validateFilePathValues(values arrow.TypedArray[string], arr arrow.Array) error {
+	var dict arrow.Array
+	var indices *array.Dictionary
+	if dictionary, ok := arr.(*array.Dictionary); ok {
+		indices = dictionary
+		dict = dictionary.Dictionary()
+	}
+
+	for i := 0; i < values.Len(); i++ {
+		if values.IsNull(i) {
+			return fmt.Errorf("%w: null file_path in position delete file",
+				iceberg.ErrInvalidSchema)
+		}
+		if dict != nil && dict.IsNull(indices.GetValueIndex(i)) {
+			return fmt.Errorf("%w: null file_path dictionary value in position delete file",
+				iceberg.ErrInvalidSchema)
+		}
+	}
+
+	return nil
+}
+
+func distinctPosDeleteFilePaths(ctx context.Context, filePathCol *arrow.Chunked) (arrow.Array, error) {
+	if filePathCol.NullN() > 0 {
+		return nil, fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
+	}
+	if filePathValueType(filePathCol.DataType()).ID() == arrow.STRING_VIEW {
+		return nil, fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
+			iceberg.ErrInvalidSchema, filePathCol.DataType())
+	}
+
+	filePaths := compute.NewDatum(filePathCol)
+	unique, err := compute.Unique(ctx, filePaths)
+	filePaths.Release()
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := unique.(*compute.ArrayDatum)
+	if !ok {
+		unique.Release()
+
+		return nil, fmt.Errorf("%w: unique file_path result is %s",
+			iceberg.ErrInvalidSchema, unique.Kind())
+	}
+
+	arr := result.MakeArray()
+	unique.Release()
+
+	return arr, nil
+}
+
+func groupPosDeletesByFilePath(ctx context.Context, filePathCol, posCol *arrow.Chunked) (map[string]*arrow.Chunked, error) {
+	uniquePaths, err := distinctPosDeleteFilePaths(ctx, filePathCol)
+	if err != nil {
+		return nil, err
+	}
+	defer uniquePaths.Release()
+
+	paths, err := filePathValues(uniquePaths)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateFilePathValues(paths, uniquePaths); err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]*arrow.Chunked, uniquePaths.Len())
+	for i := 0; i < uniquePaths.Len(); i++ {
+		sc, err := scalar.GetScalar(uniquePaths, i)
+		if err != nil {
+			releasePosDeletes(results)
+
+			return nil, err
+		}
+		scDatum := compute.NewDatum(sc)
+		if releasable, ok := sc.(scalar.Releasable); ok {
+			releasable.Release()
+		}
+		mask, err := compute.CallFunction(ctx, "equal", nil,
+			compute.NewDatumWithoutOwning(filePathCol), scDatum)
+		scDatum.Release()
+		if err != nil {
+			releasePosDeletes(results)
+
+			return nil, err
+		}
+
+		filtered, err := compute.Filter(ctx, compute.NewDatumWithoutOwning(posCol),
+			mask, *compute.DefaultFilterOptions())
+		mask.Release()
+		if err != nil {
+			releasePosDeletes(results)
+
+			return nil, err
+		}
+
+		filteredChunked, ok := filtered.(*compute.ChunkedDatum)
+		if !ok {
+			filtered.Release()
+			releasePosDeletes(results)
+
+			return nil, fmt.Errorf("%w: filtered position delete result is %s",
+				iceberg.ErrInvalidSchema, filtered.Kind())
+		}
+		filteredChunked.Value.Retain()
+		results[paths.Value(i)] = filteredChunked.Value
+		filtered.Release()
+	}
+
+	return results, nil
+}
+
+func releasePosDeletes(deletes map[string]*arrow.Chunked) {
+	for _, chunk := range deletes {
+		if chunk != nil {
+			chunk.Release()
+		}
+	}
+}
+
 func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_ map[string]*arrow.Chunked, err error) {
 	src, err := internal.GetFile(ctx, fs, dataFile, true)
 	if err != nil {
@@ -277,29 +425,8 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 
 	filePathCol := tbl.Column(tbl.Schema().FieldIndices("file_path")[0]).Data()
 	posCol := tbl.Column(tbl.Schema().FieldIndices("pos")[0]).Data()
-	dict := filePathCol.Chunk(0).(*array.Dictionary).Dictionary().(*array.String)
 
-	results := make(map[string]*arrow.Chunked)
-	for i := 0; i < dict.Len(); i++ {
-		v := dict.Value(i)
-
-		mask, err := compute.CallFunction(ctx, "equal", nil,
-			compute.NewDatumWithoutOwning(filePathCol), compute.NewDatum(v))
-		if err != nil {
-			return nil, err
-		}
-		defer mask.Release()
-
-		filtered, err := compute.Filter(ctx, compute.NewDatumWithoutOwning(posCol),
-			mask, *compute.DefaultFilterOptions())
-		if err != nil {
-			return nil, err
-		}
-
-		results[v] = filtered.(*compute.ChunkedDatum).Value
-	}
-
-	return results, nil
+	return groupPosDeletesByFilePath(ctx, filePathCol, posCol)
 }
 
 type set[T comparable] map[T]struct{}

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -21,11 +21,234 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGroupPosDeletesByFilePathSupportsStringLayouts(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		filePathCol           func(memory.Allocator) (*arrow.Chunked, func())
+		checkComputeAllocator bool
+	}{
+		{
+			name: "string chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				chunkA := stringArray(mem, "file-a.parquet", "file-b.parquet")
+				chunkB := stringArray(mem, "file-a.parquet", "file-c.parquet")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+				}
+			},
+		},
+		{
+			name: "large string chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				chunkA := largeStringArray(mem, "file-a.parquet", "file-b.parquet")
+				chunkB := largeStringArray(mem, "file-a.parquet", "file-c.parquet")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.LargeString, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+				}
+			},
+		},
+		{
+			name:                  "dictionary chunks",
+			checkComputeAllocator: true,
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := stringArray(mem, "file-a.parquet", "file-b.parquet", "file-c.parquet")
+				idxA := int32Array(mem, 0, 1)
+				idxB := int32Array(mem, 0, 2)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.String,
+				}
+				chunkA := array.NewDictionaryArray(dictType, idxA, dict)
+				chunkB := array.NewDictionaryArray(dictType, idxB, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+					dict.Release()
+					idxA.Release()
+					idxB.Release()
+				}
+			},
+		},
+		{
+			name:                  "large string dictionary chunks",
+			checkComputeAllocator: true,
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := largeStringArray(mem, "file-a.parquet", "file-b.parquet", "file-c.parquet")
+				idxA := int32Array(mem, 0, 1)
+				idxB := int32Array(mem, 0, 2)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.LargeString,
+				}
+				chunkA := array.NewDictionaryArray(dictType, idxA, dict)
+				chunkB := array.NewDictionaryArray(dictType, idxB, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+					dict.Release()
+					idxA.Release()
+					idxB.Release()
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.DefaultAllocator
+			ctx := t.Context()
+			if tc.checkComputeAllocator {
+				checked := memory.NewCheckedAllocator(memory.DefaultAllocator)
+				ctx = compute.WithAllocator(ctx, checked)
+				defer checked.AssertSize(t, 0)
+			}
+
+			filePathCol, releaseFilePathCol := tc.filePathCol(mem)
+			defer releaseFilePathCol()
+			posA := int64Array(mem, 1, 2)
+			defer posA.Release()
+			posB := int64Array(mem, 3, 4)
+			defer posB.Release()
+			posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posA, posB})
+			defer posCol.Release()
+
+			got, err := groupPosDeletesByFilePath(ctx, filePathCol, posCol)
+			require.NoError(t, err)
+			defer releasePosDeletes(got)
+
+			assert.Equal(t, []int64{1, 3}, int64Values(got["file-a.parquet"]))
+			assert.Equal(t, []int64{2}, int64Values(got["file-b.parquet"]))
+			assert.Equal(t, []int64{4}, int64Values(got["file-c.parquet"]))
+		})
+	}
+}
+
+func TestGroupPosDeletesByFilePathRejectsUnsupportedFilePathLayout(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		filePathCol func(memory.Allocator) (*arrow.Chunked, func())
+		want        string
+	}{
+		{
+			name: "unsupported primitive",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				arr := int32Array(mem, 1)
+				chunked := arrow.NewChunked(arrow.PrimitiveTypes.Int32, []arrow.Array{arr})
+
+				return chunked, func() {
+					chunked.Release()
+					arr.Release()
+				}
+			},
+			want: "unsupported file_path column type",
+		},
+		{
+			name: "null string",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				arr := nullableStringArray(mem, "file-a.parquet", "")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{arr})
+
+				return chunked, func() {
+					chunked.Release()
+					arr.Release()
+				}
+			},
+			want: "null file_path",
+		},
+		{
+			name: "null dictionary value",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := nullableStringArray(mem, "", "file-a.parquet")
+				idx := int32Array(mem, 0)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.String,
+				}
+				arr := array.NewDictionaryArray(dictType, idx, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{arr})
+
+				return chunked, func() {
+					chunked.Release()
+					arr.Release()
+					dict.Release()
+					idx.Release()
+				}
+			},
+			want: "null file_path dictionary value",
+		},
+		{
+			name: "non-string dictionary",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := int32Array(mem, 1)
+				idx := int32Array(mem, 0)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.PrimitiveTypes.Int32,
+				}
+				arr := array.NewDictionaryArray(dictType, idx, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{arr})
+
+				return chunked, func() {
+					chunked.Release()
+					arr.Release()
+					dict.Release()
+					idx.Release()
+				}
+			},
+			want: "file_path column is not string",
+		},
+		{
+			name: "string view",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				arr := stringViewArray(mem, "file-a.parquet")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.StringView, []arrow.Array{arr})
+
+				return chunked, func() {
+					chunked.Release()
+					arr.Release()
+				}
+			},
+			want: "unsupported file_path column type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			ctx := t.Context()
+			filePathCol, releaseFilePathCol := tc.filePathCol(mem)
+			defer releaseFilePathCol()
+			posArr := int64Array(mem, 1)
+			defer posArr.Release()
+			posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+			defer posCol.Release()
+
+			_, err := groupPosDeletesByFilePath(ctx, filePathCol, posCol)
+			require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
 
 // TestProcessPositionalDeletesAcrossBatches is the regression net for the
 // positional-delete index bug: processPositionalDeletes applies deletes one Arrow
@@ -72,4 +295,67 @@ func TestProcessPositionalDeletesAcrossBatches(t *testing.T) {
 
 		out.Release()
 	}
+}
+
+func stringArray(mem memory.Allocator, values ...string) *array.String {
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewStringArray()
+}
+
+func largeStringArray(mem memory.Allocator, values ...string) *array.LargeString {
+	bldr := array.NewLargeStringBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewLargeStringArray()
+}
+
+func stringViewArray(mem memory.Allocator, values ...string) *array.StringView {
+	bldr := array.NewStringViewBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewStringViewArray()
+}
+
+func nullableStringArray(mem memory.Allocator, values ...string) *array.String {
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+	for _, v := range values {
+		if v == "" {
+			bldr.AppendNull()
+		} else {
+			bldr.Append(v)
+		}
+	}
+
+	return bldr.NewStringArray()
+}
+
+func int32Array(mem memory.Allocator, values ...int32) *array.Int32 {
+	bldr := array.NewInt32Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewInt32Array()
+}
+
+func int64Array(mem memory.Allocator, values ...int64) *array.Int64 {
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewInt64Array()
+}
+
+func int64Values(chunked *arrow.Chunked) []int64 {
+	var out []int64
+	for _, chunk := range chunked.Chunks() {
+		out = append(out, chunk.(*array.Int64).Int64Values()...)
+	}
+
+	return out
 }

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -423,6 +423,19 @@ func TestRowDeltaMultipleCommitsOnSameTransaction(t *testing.T) {
 func writeParquetFile(t testing.TB, path string, sc *arrow.Schema, jsonData string) {
 	t.Helper()
 
+	writeParquetFileWithProperties(t, path, sc, jsonData, 0, nil)
+}
+
+func writeParquetFileWithProperties(
+	t testing.TB,
+	path string,
+	sc *arrow.Schema,
+	jsonData string,
+	rowGroupSize int64,
+	writerProps *parquet.WriterProperties,
+) {
+	t.Helper()
+
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, sc, strings.NewReader(jsonData))
 	require.NoError(t, err)
 	defer rec.Release()
@@ -430,13 +443,19 @@ func writeParquetFile(t testing.TB, path string, sc *arrow.Schema, jsonData stri
 	fs := iceio.LocalFS{}
 	fw, err := fs.Create(path)
 	require.NoError(t, err)
+	defer fw.Close()
 
 	tbl := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
 	defer tbl.Release()
 
-	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
-		parquet.NewWriterProperties(parquet.WithStats(true)),
-		pqarrow.DefaultWriterProps()))
+	if rowGroupSize <= 0 {
+		rowGroupSize = rec.NumRows()
+	}
+	if writerProps == nil {
+		writerProps = parquet.NewWriterProperties(parquet.WithStats(true))
+	}
+
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rowGroupSize, writerProps, pqarrow.DefaultWriterProps()))
 }
 
 func TestRowDeltaIntegrationPosDeleteRoundTrip(t *testing.T) {
@@ -490,10 +509,13 @@ func TestRowDeltaIntegrationPosDeleteRoundTrip(t *testing.T) {
 	// (0-indexed: positions 1 and 3 → "beta" and "delta")
 	posDelArrowSc := table.PositionalDeleteArrowSchema
 	posDelPath := location + "/data/pos-del-001.parquet"
-	writeParquetFile(t, posDelPath, posDelArrowSc, `[
+	writeParquetFileWithProperties(t, posDelPath, posDelArrowSc, `[
 		{"file_path": "`+dataPath+`", "pos": 1},
 		{"file_path": "`+dataPath+`", "pos": 3}
-	]`)
+	]`, 1, parquet.NewWriterProperties(
+		parquet.WithStats(true),
+		parquet.WithDictionaryDefault(false),
+	))
 
 	posDelBuilder, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
@@ -518,16 +540,20 @@ func TestRowDeltaIntegrationPosDeleteRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	var ids []int64
+	var data []string
 	for rec, err := range itr {
 		require.NoError(t, err)
-		col := rec.Column(0).(*array.Int64)
-		for i := 0; i < col.Len(); i++ {
-			ids = append(ids, col.Value(i))
+		idCol := rec.Column(0).(*array.Int64)
+		dataCol := rec.Column(1).(*array.String)
+		for i := 0; i < idCol.Len(); i++ {
+			ids = append(ids, idCol.Value(i))
+			data = append(data, dataCol.Value(i))
 		}
 		rec.Release()
 	}
 
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows at positions 0,2,4 (beta/delta deleted)")
+	assert.Equal(t, []string{"alpha", "gamma", "epsilon"}, data)
 }
 
 func assertRowCount(t *testing.T, tbl *table.Table, expected int64) {


### PR DESCRIPTION
Summary

- collect position-delete `file_path` values from string, large-string, and dictionary Arrow chunks
- return invalid-schema errors for unsupported or null `file_path` layouts instead of panicking
- pass the caller compute context through the `file_path` unique path
- release per-path filter masks immediately after filtering
- keep the existing Arrow filter path for position values

Testing

- `go test ./table -run 'TestGroupPosDeletesByFilePath|TestProcessPositionalDeletesAcrossBatches|TestRowDeltaIntegrationPosDeleteRoundTrip' -count=1`
- `git diff --check`
- `go test ./table -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...`
- `go test ./... -count=1`