### PR TITLE
fix(table): return error instead of panicking on unsupported geo CRS

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -673,7 +673,13 @@ func (c convertToArrow) VisitVariant() arrow.Field {
 }
 
 func (c convertToArrow) VisitGeometry(g iceberg.GeometryType) arrow.Field {
-	meta := icebergCRSToGeoArrowMetadata(g.CRS())
+	meta, err := icebergCRSToGeoArrowMetadata(g.CRS())
+	if err != nil {
+		// Panic to thread the error through iceberg.Visit's recover, matching the
+		// convention used by the other visitor methods.
+		panic(err)
+	}
+
 	if c.useLargeTypes {
 		return arrow.Field{Type: geoarrow.NewWKBType(geoarrow.WKBWithLargeBinaryStorage(), geoarrow.WKBWithMetadata(meta))}
 	}
@@ -682,7 +688,13 @@ func (c convertToArrow) VisitGeometry(g iceberg.GeometryType) arrow.Field {
 }
 
 func (c convertToArrow) VisitGeography(g iceberg.GeographyType) arrow.Field {
-	meta := icebergCRSToGeoArrowMetadata(g.CRS())
+	meta, err := icebergCRSToGeoArrowMetadata(g.CRS())
+	if err != nil {
+		// Panic to thread the error through iceberg.Visit's recover, matching the
+		// convention used by the other visitor methods.
+		panic(err)
+	}
+
 	// Always add an edge to differentiate between Geography and Geometry arrow fields.
 	// Note that the edge convention is a best-effort hint and planar geography from other clients won't round-trip through Arrow alone.
 	meta.Edges = geoarrow.EdgeInterpolation(g.Algorithm())
@@ -1956,13 +1968,13 @@ func geoArrowMetadataToIcebergType(meta geoarrow.Metadata) (iceberg.Type, error)
 
 var authorityCodeCRS = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z0-9_.-]+$`)
 
-func icebergCRSToGeoArrowMetadata(crs string) geoarrow.Metadata {
+func icebergCRSToGeoArrowMetadata(crs string) (geoarrow.Metadata, error) {
 	lowerCRS := strings.ToLower(crs)
 	if strings.HasPrefix(lowerCRS, "srid:") {
 		id := crs[len("srid:"):]
 
 		if id == "0" {
-			return geoarrow.NewMetadata() // srid:0 maps to omitted GeoArrow CRS
+			return geoarrow.NewMetadata(), nil // srid:0 maps to omitted GeoArrow CRS
 		}
 
 		raw, _ := json.Marshal(id) //nolint:errcheck // Marshalling a string can't fail
@@ -1970,11 +1982,11 @@ func icebergCRSToGeoArrowMetadata(crs string) geoarrow.Metadata {
 		return geoarrow.Metadata{
 			CRS:     raw,
 			CRSType: geoarrow.CRSTypeSRID,
-		}
+		}, nil
 	}
 
 	if strings.HasPrefix(lowerCRS, "projjson:") {
-		panic(fmt.Errorf("%w: projjson CRS not supported yet", iceberg.ErrInvalidSchema))
+		return geoarrow.Metadata{}, fmt.Errorf("%w: projjson CRS not supported yet", iceberg.ErrInvalidSchema)
 	}
 
 	var raw []byte
@@ -1991,5 +2003,5 @@ func icebergCRSToGeoArrowMetadata(crs string) geoarrow.Metadata {
 		meta.CRSType = geoarrow.CRSTypeAuthorityCode
 	}
 
-	return meta
+	return meta, nil
 }

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table/internal"
+	"github.com/geoarrow/geoarrow-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -452,4 +453,41 @@ func TestStatsTypes(t *testing.T) {
 		iceberg.PrimitiveTypes.String,
 		iceberg.PrimitiveTypes.Int32,
 	}, actual)
+}
+
+func TestIcebergCRSToGeoArrowMetadata(t *testing.T) {
+	// Calling the converter directly (outside the schema visitor) must not panic:
+	// an unsupported CRS comes back as an error, symmetric with the read path.
+	t.Run("projjson returns an error instead of panicking", func(t *testing.T) {
+		_, err := icebergCRSToGeoArrowMetadata("projjson:my-custom-crs")
+		require.Error(t, err)
+		require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+		require.ErrorContains(t, err, "projjson CRS not supported yet")
+	})
+
+	t.Run("supported CRS values map to the expected CRSType", func(t *testing.T) {
+		cases := []struct {
+			crs         string
+			wantCRSType geoarrow.CRSType
+		}{
+			{"srid:4326", geoarrow.CRSTypeSRID},
+			{"OGC:CRS84", geoarrow.CRSTypeAuthorityCode},
+			{"EPSG:4326", geoarrow.CRSTypeAuthorityCode},
+			{"EPSG:4267", geoarrow.CRSTypeAuthorityCode},
+		}
+		for _, tc := range cases {
+			t.Run(tc.crs, func(t *testing.T) {
+				meta, err := icebergCRSToGeoArrowMetadata(tc.crs)
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantCRSType, meta.CRSType)
+			})
+		}
+	})
+
+	t.Run("srid:0 maps to an omitted CRS", func(t *testing.T) {
+		meta, err := icebergCRSToGeoArrowMetadata("srid:0")
+		require.NoError(t, err)
+		assert.Empty(t, meta.CRS)
+		assert.Empty(t, meta.CRSType)
+	})
 }

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -789,6 +789,17 @@ func TestIcebergGeoTypesToArrowSchema(t *testing.T) {
 
 		_, err = table.TypeToArrowType(geom, true, false)
 		require.Error(t, err)
+		require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+		require.ErrorContains(t, err, "projjson CRS not supported yet")
+
+		// Geography goes through VisitGeography; assert the projjson rejection
+		// surfaces symmetrically through the visitor recover.
+		geog, err := iceberg.GeographyTypeOf("projjson:my-custom-crs", "spherical")
+		require.NoError(t, err)
+
+		_, err = table.TypeToArrowType(geog, true, false)
+		require.Error(t, err)
+		require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 		require.ErrorContains(t, err, "projjson CRS not supported yet")
 
 		arrowType, err := geoarrow.NewWKBType().Deserialize(arrow.BinaryTypes.Binary,


### PR DESCRIPTION
icebergCRSToGeoArrowMetadata panicked on a projjson CRS while the read-side geoArrowCRSToIcebergCRS returned a clean error; it only worked because iceberg.Visit's recover caught the panic. Give it a (geoarrow.Metadata, error) signature; VisitGeometry/VisitGeography re-panic to thread the error through the visitor recover (the file's existing idiom). Public API behavior unchanged. Adds direct + end-to-end Geometry/Geography projjson coverage.

Fixes #1232.