### PR TITLE
fix(v3): _row_id renumbering when rows are dropped in a scan

### DIFF
--- a/metadata_columns.go
+++ b/metadata_columns.go
@@ -63,22 +63,17 @@ func IsMetadataColumn(fieldID int) bool {
 	return fieldID == RowIDFieldID || fieldID == LastUpdatedSequenceNumberFieldID
 }
 
-// SchemaWithRowLineage returns a new schema with both row-lineage metadata columns
-// (_row_id, _last_updated_sequence_number) appended to the given schema's fields.
-// Used when reading source files during a CoW rewrite or compaction so that row
-// identity and per-row update sequence are preserved in the output.
+// SchemaWithRowLineage appends both row-lineage metadata columns (_row_id,
+// _last_updated_sequence_number) so a CoW rewrite or compaction preserves them.
 func SchemaWithRowLineage(s *Schema) *Schema {
 	return SchemaWithRowLineageColumns(s, true, true)
 }
 
-// SchemaWithRowLineageColumns returns a new schema with the requested row-lineage
-// metadata columns appended: _row_id when rowID is set, _last_updated_sequence_number
-// when lastUpdatedSeq is set. Callers that synthesize these columns conditionally must
-// request exactly the ones they will materialize so the read schema stays aligned with
-// the produced batch.
+// SchemaWithRowLineageColumns appends the requested row-lineage columns: _row_id
+// when rowID, _last_updated_sequence_number when lastUpdatedSeq. Request exactly
+// the columns you will materialize so the read schema matches the produced batch.
 //
-// Idempotent: a column already present (by reserved field ID) is not appended again.
-// Always allocates a fresh field slice so it cannot alias the input schema's backing array.
+// Idempotent by reserved field ID; always clones the field slice (no aliasing).
 func SchemaWithRowLineageColumns(s *Schema, rowID, lastUpdatedSeq bool) *Schema {
 	if s == nil {
 		return nil

--- a/metadata_columns.go
+++ b/metadata_columns.go
@@ -63,21 +63,26 @@ func IsMetadataColumn(fieldID int) bool {
 	return fieldID == RowIDFieldID || fieldID == LastUpdatedSequenceNumberFieldID
 }
 
-// SchemaWithRowLineage returns a new schema with the row-lineage metadata columns
+// SchemaWithRowLineage returns a new schema with both row-lineage metadata columns
 // (_row_id, _last_updated_sequence_number) appended to the given schema's fields.
 // Used when reading source files during a CoW rewrite or compaction so that row
 // identity and per-row update sequence are preserved in the output.
-//
-// Idempotent: if a row-lineage column is already present (by reserved field ID),
-// it is not appended again. The returned schema always allocates a fresh field
-// slice so it cannot alias the input schema's backing array.
 func SchemaWithRowLineage(s *Schema) *Schema {
+	return SchemaWithRowLineageColumns(s, true, true)
+}
+
+// SchemaWithRowLineageColumns returns a new schema with the requested row-lineage
+// metadata columns appended: _row_id when rowID is set, _last_updated_sequence_number
+// when lastUpdatedSeq is set. Callers that synthesize these columns conditionally must
+// request exactly the ones they will materialize so the read schema stays aligned with
+// the produced batch.
+//
+// Idempotent: a column already present (by reserved field ID) is not appended again.
+// Always allocates a fresh field slice so it cannot alias the input schema's backing array.
+func SchemaWithRowLineageColumns(s *Schema, rowID, lastUpdatedSeq bool) *Schema {
 	if s == nil {
 		return nil
 	}
-	// Clone the field slice up front so we never share a backing array with the
-	// caller's schema — append-with-spare-capacity could otherwise mutate the
-	// source schema's fields when the caller next mutates either side.
 	fields := slices.Clone(s.Fields())
 
 	hasRowID := false
@@ -91,10 +96,10 @@ func SchemaWithRowLineage(s *Schema) *Schema {
 		}
 	}
 
-	if !hasRowID {
+	if rowID && !hasRowID {
 		fields = append(fields, RowID())
 	}
-	if !hasSeqNum {
+	if lastUpdatedSeq && !hasSeqNum {
 		fields = append(fields, LastUpdatedSequenceNumber())
 	}
 

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -579,12 +579,16 @@ func (as *arrowScan) getRecordFilter(ctx context.Context, fileSchema *iceberg.Sc
 	return nil, false, nil
 }
 
-// synthesizeRowLineageColumns fills _row_id and _last_updated_sequence_number from task constants
-// when those columns are present in the batch (e.g. from ToRequestedSchema). Per the Iceberg v3
-// row lineage spec: if the value is null in the file, it is inherited (synthesized) from the file's
-// first_row_id and data_sequence_number; otherwise the value from the file is kept.
-// rowOffset is the 0-based row index within the current file and is updated so _row_id stays
-// correct across multiple batches from the same file (first_row_id + row_position).
+// synthesizeRowLineageColumns fills _row_id and _last_updated_sequence_number from task constants.
+// Per the Iceberg v3 row lineage spec: if the value is null in the file, it is inherited
+// (synthesized) from the file's first_row_id and data_sequence_number; otherwise the value from
+// the file is kept. When a lineage column is absent from the batch it is appended.
+//
+// This MUST run before any row-dropping pipeline step (positional/equality deletes, deletion
+// vectors, the row filter): _row_id is first_row_id + the row's ORIGINAL position in the file, so
+// rowOffset (advanced by the full unfiltered batch size) only stays correct if no rows have been
+// dropped yet. A later filter then drops rows carrying their already-correct _row_id, and
+// ToRequestedSchema resolves the columns by reserved field id via a lineage-extended read schema.
 func synthesizeRowLineageColumns(
 	ctx context.Context,
 	rowOffset *int64,
@@ -595,69 +599,69 @@ func synthesizeRowLineageColumns(
 	schema := batch.Schema()
 	nrows := batch.NumRows()
 
-	// Start from the existing columns; we'll replace the row lineage columns in-place
-	// when we need to synthesize values.
+	fields := append([]arrow.Field(nil), schema.Fields()...)
 	newCols := append([]arrow.Array(nil), batch.Columns()...)
-
-	// Resolve column indices by name; -1 if not present.
-	rowIDIndices := schema.FieldIndices(iceberg.RowIDColumnName)
-	seqNumIndices := schema.FieldIndices(iceberg.LastUpdatedSequenceNumberColumnName)
-	rowIDColIdx := -1
-	if len(rowIDIndices) > 0 {
-		rowIDColIdx = rowIDIndices[0]
-	}
-	seqNumColIdx := -1
-	if len(seqNumIndices) > 0 {
-		seqNumColIdx = seqNumIndices[0]
-	}
-
-	bldr := array.NewInt64Builder(alloc)
-	defer bldr.Release()
-
-	// _row_id: inherit first_row_id + row_position when null; else keep value from file.
-	if rowIDColIdx >= 0 && task.FirstRowID != nil {
-		if col, ok := newCols[rowIDColIdx].(*array.Int64); ok {
-			bldr.Reserve(int(nrows))
-			first := *task.FirstRowID
-			for k := range nrows {
-				if col.IsNull(int(k)) {
-					bldr.Append(first + *rowOffset + int64(k))
-				} else {
-					bldr.Append(col.Value(int(k)))
-				}
-			}
-
-			arr := bldr.NewArray()
-			newCols[rowIDColIdx] = arr
-			defer arr.Release()
+	var built []arrow.Array
+	defer func() {
+		for _, a := range built {
+			a.Release()
 		}
+	}()
+
+	synth := func(name string, fieldID int, value func(k int64) int64) {
+		idx := -1
+		if ids := schema.FieldIndices(name); len(ids) > 0 {
+			idx = ids[0]
+		}
+		var existing *array.Int64
+		if idx >= 0 {
+			existing, _ = newCols[idx].(*array.Int64)
+		}
+
+		bldr := array.NewInt64Builder(alloc)
+		defer bldr.Release()
+		bldr.Reserve(int(nrows))
+		for k := range nrows {
+			if existing != nil && !existing.IsNull(int(k)) {
+				bldr.Append(existing.Value(int(k)))
+			} else {
+				bldr.Append(value(k))
+			}
+		}
+		arr := bldr.NewArray()
+		built = append(built, arr)
+
+		if idx >= 0 {
+			newCols[idx] = arr
+
+			return
+		}
+		fields = append(fields, arrow.Field{
+			Name:     name,
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: true,
+			Metadata: arrow.NewMetadata([]string{ArrowParquetFieldIDKey}, []string{strconv.Itoa(fieldID)}),
+		})
+		newCols = append(newCols, arr)
 	}
 
-	// _last_updated_sequence_number: inherit file's data_sequence_number when null; else keep value from file.
-	if seqNumColIdx >= 0 && task.DataSequenceNumber != nil {
-		if col, ok := newCols[seqNumColIdx].(*array.Int64); ok {
-			bldr.Reserve(int(nrows))
-			seq := *task.DataSequenceNumber
-			for k := range nrows {
-				if col.IsNull(int(k)) {
-					bldr.Append(seq)
-				} else {
-					bldr.Append(col.Value(int(k)))
-				}
-			}
-
-			arr := bldr.NewArray()
-			newCols[seqNumColIdx] = arr
-			defer arr.Release()
-		}
+	if task.FirstRowID != nil {
+		first := *task.FirstRowID
+		synth(iceberg.RowIDColumnName, iceberg.RowIDFieldID, func(k int64) int64 {
+			return first + *rowOffset + k
+		})
+	}
+	if task.DataSequenceNumber != nil {
+		seq := *task.DataSequenceNumber
+		synth(iceberg.LastUpdatedSequenceNumberColumnName, iceberg.LastUpdatedSequenceNumberFieldID, func(int64) int64 {
+			return seq
+		})
 	}
 
 	// Advance so the next batch from this file uses the correct row position for _row_id.
 	*rowOffset += nrows
 
-	rec := array.NewRecordBatch(schema, newCols, nrows)
-
-	return rec, nil
+	return array.NewRecordBatch(arrow.NewSchema(fields, nil), newCols, nrows), nil
 }
 
 func (as *arrowScan) processRecords(
@@ -756,7 +760,36 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	}
 	defer iceinternal.CheckedClose(rdr, &err)
 
-	pipeline := make([]recProcessFn, 0, 3)
+	pipeline := make([]recProcessFn, 0, 4)
+
+	// Row lineage: synthesize _row_id / _last_updated_sequence_number from the
+	// source file's ORIGINAL positions before any row-dropping step below, so a
+	// deletion vector or positional delete cannot renumber the surviving rows.
+	// readSchema carries the reserved field ids so ToRequestedSchema resolves the
+	// enriched columns. Gated on the projection actually requesting lineage so
+	// non-lineage scans keep their original, allocation-free path.
+	readSchema := iceSchema
+	rowLineageEnabled, lerr := strconv.ParseBool(as.options.Get(ScanOptionRowLineageEnabled, "true"))
+	if lerr != nil {
+		rowLineageEnabled = true
+	}
+	_, wantRowID := as.projectedSchema.FindFieldByID(iceberg.RowIDFieldID)
+	_, wantSeqNum := as.projectedSchema.FindFieldByID(iceberg.LastUpdatedSequenceNumberFieldID)
+	haveRowID := task.Value.FirstRowID != nil
+	haveSeqNum := task.Value.DataSequenceNumber != nil
+	if rowLineageEnabled && (wantRowID || wantSeqNum) && (haveRowID || haveSeqNum) {
+		// Mirror exactly the columns synthesizeRowLineageColumns will append so
+		// ToRequestedSchema never resolves a lineage field absent from the batch.
+		readSchema = iceberg.SchemaWithRowLineageColumns(iceSchema, haveRowID, haveSeqNum)
+		var rowOffset int64
+		taskVal := task.Value
+		pipeline = append(pipeline, func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
+			defer r.Release()
+
+			return synthesizeRowLineageColumns(ctx, &rowOffset, taskVal, r)
+		})
+	}
+
 	if len(positionalDeletes) > 0 {
 		deletes := set[int64]{}
 		for _, chunk := range positionalDeletes {
@@ -812,24 +845,8 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	pipeline = append(pipeline, func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
 		defer r.Release()
 
-		return ToRequestedSchema(ctx, as.projectedSchema, iceSchema, r, SchemaOptions{UseLargeTypes: as.useLargeTypes})
+		return ToRequestedSchema(ctx, as.projectedSchema, readSchema, r, SchemaOptions{UseLargeTypes: as.useLargeTypes})
 	})
-
-	// Row lineage: optionally fill _row_id and _last_updated_sequence_number from task
-	// constants when in projection.
-	rowLineageEnabled, err := strconv.ParseBool(as.options.Get(ScanOptionRowLineageEnabled, "true"))
-	if err != nil {
-		rowLineageEnabled = true
-	}
-	if rowLineageEnabled && (task.Value.FirstRowID != nil || task.Value.DataSequenceNumber != nil) {
-		var rowOffset int64
-		taskVal := task.Value
-		pipeline = append(pipeline, func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
-			defer r.Release()
-
-			return synthesizeRowLineageColumns(ctx, &rowOffset, taskVal, r)
-		})
-	}
 
 	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, out)
 

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -579,9 +579,26 @@ func (as *arrowScan) getRecordFilter(ctx context.Context, fileSchema *iceberg.Sc
 	return nil, false, nil
 }
 
-// synthesizeRowLineageColumns fills _row_id and _last_updated_sequence_number from
-// task constants: per the v3 spec a null value inherits first_row_id + position /
-// data_sequence_number, a non-null value is kept. Absent columns are appended.
+// fieldIndexByID returns the index of the field carrying fieldID in its Arrow
+// metadata, or -1. Resolving by reserved id (not name) matches how
+// SchemaWithRowLineageColumns and projection identify lineage columns.
+func fieldIndexByID(schema *arrow.Schema, fieldID int) int {
+	for i, f := range schema.Fields() {
+		if v, ok := f.Metadata.GetValue(ArrowParquetFieldIDKey); ok {
+			if id, err := strconv.Atoi(v); err == nil && id == fieldID {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+// synthesizeRowLineageColumns fills the requested row-lineage columns from task
+// constants: per the v3 spec a null value inherits first_row_id + position /
+// data_sequence_number, a non-null value is kept. A column absent from the batch
+// is appended. The caller sets synthesizeRowID/synthesizeSeq only when the
+// matching task constant is present.
 //
 // MUST run before any row-dropping step: _row_id is first_row_id + the row's ORIGINAL
 // position, so rowOffset (advanced by the full batch) is only correct before rows are
@@ -591,6 +608,7 @@ func synthesizeRowLineageColumns(
 	rowOffset *int64,
 	task FileScanTask,
 	batch arrow.RecordBatch,
+	synthesizeRowID, synthesizeSeq bool,
 ) (arrow.RecordBatch, error) {
 	alloc := compute.GetAllocator(ctx)
 	schema := batch.Schema()
@@ -605,14 +623,14 @@ func synthesizeRowLineageColumns(
 		}
 	}()
 
-	synth := func(name string, fieldID int, value func(k int64) int64) {
-		idx := -1
-		if ids := schema.FieldIndices(name); len(ids) > 0 {
-			idx = ids[0]
-		}
+	synth := func(name string, fieldID int, value func(k int64) int64) error {
+		idx := fieldIndexByID(schema, fieldID)
 		var existing *array.Int64
 		if idx >= 0 {
-			existing, _ = newCols[idx].(*array.Int64)
+			var ok bool
+			if existing, ok = newCols[idx].(*array.Int64); !ok {
+				return fmt.Errorf("row-lineage column %s is %s, want int64", name, newCols[idx].DataType())
+			}
 		}
 
 		bldr := array.NewInt64Builder(alloc)
@@ -631,7 +649,7 @@ func synthesizeRowLineageColumns(
 		if idx >= 0 {
 			newCols[idx] = arr
 
-			return
+			return nil
 		}
 		fields = append(fields, arrow.Field{
 			Name:     name,
@@ -640,19 +658,25 @@ func synthesizeRowLineageColumns(
 			Metadata: arrow.NewMetadata([]string{ArrowParquetFieldIDKey}, []string{strconv.Itoa(fieldID)}),
 		})
 		newCols = append(newCols, arr)
+
+		return nil
 	}
 
-	if task.FirstRowID != nil {
+	if synthesizeRowID {
 		first := *task.FirstRowID
-		synth(iceberg.RowIDColumnName, iceberg.RowIDFieldID, func(k int64) int64 {
+		if err := synth(iceberg.RowIDColumnName, iceberg.RowIDFieldID, func(k int64) int64 {
 			return first + *rowOffset + k
-		})
+		}); err != nil {
+			return nil, err
+		}
 	}
-	if task.DataSequenceNumber != nil {
+	if synthesizeSeq {
 		seq := *task.DataSequenceNumber
-		synth(iceberg.LastUpdatedSequenceNumberColumnName, iceberg.LastUpdatedSequenceNumberFieldID, func(int64) int64 {
+		if err := synth(iceberg.LastUpdatedSequenceNumberColumnName, iceberg.LastUpdatedSequenceNumberFieldID, func(int64) int64 {
 			return seq
-		})
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	// Advance so the next batch from this file uses the correct row position for _row_id.
@@ -775,19 +799,20 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	}
 	_, wantRowID := as.projectedSchema.FindFieldByID(iceberg.RowIDFieldID)
 	_, wantSeqNum := as.projectedSchema.FindFieldByID(iceberg.LastUpdatedSequenceNumberFieldID)
-	haveRowID := task.Value.FirstRowID != nil
-	haveSeqNum := task.Value.DataSequenceNumber != nil
-	synthesizingLineage := rowLineageEnabled && (wantRowID || wantSeqNum) && (haveRowID || haveSeqNum)
-	if synthesizingLineage {
+	synthesizeRowID := rowLineageEnabled && wantRowID && task.Value.FirstRowID != nil
+	synthesizeSeq := rowLineageEnabled && wantSeqNum && task.Value.DataSequenceNumber != nil
+	// Only _row_id depends on position, so only it forces contiguous reads.
+	needsOriginalPositions := synthesizeRowID
+	if synthesizeRowID || synthesizeSeq {
 		// Mirror the columns synthesize will append so ToRequestedSchema never
 		// resolves a lineage field missing from the batch.
-		readSchema = iceberg.SchemaWithRowLineageColumns(iceSchema, haveRowID, haveSeqNum)
+		readSchema = iceberg.SchemaWithRowLineageColumns(iceSchema, synthesizeRowID, synthesizeSeq)
 		var rowOffset int64
 		taskVal := task.Value
 		pipeline = append(pipeline, func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
 			defer r.Release()
 
-			return synthesizeRowLineageColumns(ctx, &rowOffset, taskVal, r)
+			return synthesizeRowLineageColumns(ctx, &rowOffset, taskVal, r, synthesizeRowID, synthesizeSeq)
 		})
 	}
 
@@ -849,7 +874,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 		return ToRequestedSchema(ctx, as.projectedSchema, readSchema, r, SchemaOptions{UseLargeTypes: as.useLargeTypes})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, synthesizingLineage, out)
+	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, needsOriginalPositions, out)
 
 	return err
 }

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -579,16 +579,13 @@ func (as *arrowScan) getRecordFilter(ctx context.Context, fileSchema *iceberg.Sc
 	return nil, false, nil
 }
 
-// synthesizeRowLineageColumns fills _row_id and _last_updated_sequence_number from task constants.
-// Per the Iceberg v3 row lineage spec: if the value is null in the file, it is inherited
-// (synthesized) from the file's first_row_id and data_sequence_number; otherwise the value from
-// the file is kept. When a lineage column is absent from the batch it is appended.
+// synthesizeRowLineageColumns fills _row_id and _last_updated_sequence_number from
+// task constants: per the v3 spec a null value inherits first_row_id + position /
+// data_sequence_number, a non-null value is kept. Absent columns are appended.
 //
-// This MUST run before any row-dropping pipeline step (positional/equality deletes, deletion
-// vectors, the row filter): _row_id is first_row_id + the row's ORIGINAL position in the file, so
-// rowOffset (advanced by the full unfiltered batch size) only stays correct if no rows have been
-// dropped yet. A later filter then drops rows carrying their already-correct _row_id, and
-// ToRequestedSchema resolves the columns by reserved field id via a lineage-extended read schema.
+// MUST run before any row-dropping step: _row_id is first_row_id + the row's ORIGINAL
+// position, so rowOffset (advanced by the full batch) is only correct before rows are
+// dropped. ToRequestedSchema then resolves the columns by reserved field id.
 func synthesizeRowLineageColumns(
 	ctx context.Context,
 	rowOffset *int64,
@@ -661,7 +658,9 @@ func synthesizeRowLineageColumns(
 	// Advance so the next batch from this file uses the correct row position for _row_id.
 	*rowOffset += nrows
 
-	return array.NewRecordBatch(arrow.NewSchema(fields, nil), newCols, nrows), nil
+	meta := schema.Metadata()
+
+	return array.NewRecordBatch(arrow.NewSchema(fields, &meta), newCols, nrows), nil
 }
 
 func (as *arrowScan) processRecords(
@@ -671,6 +670,7 @@ func (as *arrowScan) processRecords(
 	rdr internal.FileReader,
 	columns []int,
 	pipeline []recProcessFn,
+	skipRowGroupPruning bool,
 	out chan<- enumeratedRecord,
 ) (err error) {
 	var (
@@ -678,8 +678,11 @@ func (as *arrowScan) processRecords(
 		recRdr        array.RecordReader
 	)
 
-	switch task.Value.File.FileFormat() {
-	case iceberg.ParquetFile:
+	// Row-group pruning skips whole groups, so emitted positions stop being
+	// contiguous. Position-keyed steps (row-lineage _row_id) need every group
+	// read; the per-row filter still enforces the predicate.
+	switch {
+	case task.Value.File.FileFormat() == iceberg.ParquetFile && !skipRowGroupPruning:
 		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, as.boundRowFilter, false)
 		if err != nil {
 			return err
@@ -762,12 +765,9 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 
 	pipeline := make([]recProcessFn, 0, 4)
 
-	// Row lineage: synthesize _row_id / _last_updated_sequence_number from the
-	// source file's ORIGINAL positions before any row-dropping step below, so a
-	// deletion vector or positional delete cannot renumber the surviving rows.
-	// readSchema carries the reserved field ids so ToRequestedSchema resolves the
-	// enriched columns. Gated on the projection actually requesting lineage so
-	// non-lineage scans keep their original, allocation-free path.
+	// Synthesize lineage before any row-dropping step so deletes/filters can't
+	// renumber survivors' _row_id; readSchema carries the field ids for
+	// ToRequestedSchema. Gated so non-lineage scans keep the allocation-free path.
 	readSchema := iceSchema
 	rowLineageEnabled, lerr := strconv.ParseBool(as.options.Get(ScanOptionRowLineageEnabled, "true"))
 	if lerr != nil {
@@ -777,9 +777,10 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	_, wantSeqNum := as.projectedSchema.FindFieldByID(iceberg.LastUpdatedSequenceNumberFieldID)
 	haveRowID := task.Value.FirstRowID != nil
 	haveSeqNum := task.Value.DataSequenceNumber != nil
-	if rowLineageEnabled && (wantRowID || wantSeqNum) && (haveRowID || haveSeqNum) {
-		// Mirror exactly the columns synthesizeRowLineageColumns will append so
-		// ToRequestedSchema never resolves a lineage field absent from the batch.
+	synthesizingLineage := rowLineageEnabled && (wantRowID || wantSeqNum) && (haveRowID || haveSeqNum)
+	if synthesizingLineage {
+		// Mirror the columns synthesize will append so ToRequestedSchema never
+		// resolves a lineage field missing from the batch.
 		readSchema = iceberg.SchemaWithRowLineageColumns(iceSchema, haveRowID, haveSeqNum)
 		var rowOffset int64
 		taskVal := task.Value
@@ -848,7 +849,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 		return ToRequestedSchema(ctx, as.projectedSchema, readSchema, r, SchemaOptions{UseLargeTypes: as.useLargeTypes})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, out)
+	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, synthesizingLineage, out)
 
 	return err
 }
@@ -920,7 +921,7 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task interna
 		return ToRequestedSchema(ctx, iceberg.PositionalDeleteSchema, enrichedIcebergSchema, r, SchemaOptions{IncludeFieldIDs: true, UseLargeTypes: as.useLargeTypes})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, out)
+	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, false, out)
 
 	return err
 }

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -73,6 +73,58 @@ func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 	}
 }
 
+// TestRewriteDataFilesPreservesRowIDThroughDeletionVector guarantees that
+// applying a deletion vector during compaction does not renumber the surviving
+// rows' _row_id. The v3 spec requires _row_id = first_row_id + the row's
+// ORIGINAL position in its source file; a rewrite copies survivors and must
+// carry those ids unchanged. The regression this guards: synthesizing lineage
+// after the DV filter dropped rows yields a dense 0..N renumbering instead.
+func TestRewriteDataFilesPreservesRowIDThroughDeletionVector(t *testing.T) {
+	ctx := context.Background()
+	tbl, dvTarget := seedV3TableWithDV(t)
+
+	// Survivors after the DV deletes id=1: id=2 (_row_id 1, first file), id=3
+	// (_row_id 2) and id=4 (_row_id 3, second file).
+	before := rowIDByID(t, tbl)
+	require.Equal(t, map[int64]int64{2: 1, 3: 2, 4: 3}, before)
+
+	groups, _ := planDVCompaction(t, tbl, dvTarget)
+	rtx := tbl.NewTransaction()
+	_, err := rtx.RewriteDataFiles(ctx, groups, table.RewriteDataFilesOptions{})
+	require.NoError(t, err)
+	tbl, err = rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, before, rowIDByID(t, tbl),
+		"_row_id must be preserved for survivors when a deletion vector is applied during compaction")
+}
+
+// rowIDByID scans the table with row lineage and returns a map of id -> _row_id.
+func rowIDByID(t *testing.T, tbl *table.Table) map[int64]int64 {
+	t.Helper()
+
+	_, itr, err := tbl.Scan(table.WithRowLineage()).ToArrowRecords(context.Background())
+	require.NoError(t, err)
+
+	out := map[int64]int64{}
+	for rec, err := range itr {
+		require.NoError(t, err)
+		idIdx := rec.Schema().FieldIndices("id")
+		require.NotEmpty(t, idIdx)
+		rowIDIdx := rec.Schema().FieldIndices(iceberg.RowIDColumnName)
+		require.NotEmpty(t, rowIDIdx, "_row_id must be in the row-lineage scan projection")
+		idCol := rec.Column(idIdx[0]).(*array.Int64)
+		rowIDCol := rec.Column(rowIDIdx[0]).(*array.Int64)
+		for i := 0; i < int(rec.NumRows()); i++ {
+			require.False(t, rowIDCol.IsNull(i), "_row_id must not be null for id=%d", idCol.Value(i))
+			out[idCol.Value(i)] = rowIDCol.Value(i)
+		}
+		rec.Release()
+	}
+
+	return out
+}
+
 // TestRewriteFilesApplyResultRemovesDeletionVectors drives the distributed
 // coordinator path — a worker runs [ExecuteCompactionGroup], then a leader
 // stages the results with [Transaction.NewRewrite] + [RewriteFiles.ApplyResult]

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -143,6 +143,9 @@ func TestRewriteFilesApplyResultRemovesDeletionVectors(t *testing.T) {
 	ctx := context.Background()
 	tbl, dvTarget := seedV3TableWithDV(t)
 
+	before := rowIDByID(t, tbl)
+	require.Equal(t, map[int64]int64{2: 1, 3: 2, 4: 3}, before)
+
 	groups, rewritten := planDVCompaction(t, tbl, dvTarget)
 
 	var results []table.CompactionGroupResult
@@ -167,6 +170,8 @@ func TestRewriteFilesApplyResultRemovesDeletionVectors(t *testing.T) {
 	assertRowCount(t, tbl, 3)
 	assert.Empty(t, deleteEntriesReferencing(t, tbl, rewritten),
 		"coordinator commit must remove deletion vectors for rewritten data files")
+	assert.Equal(t, before, rowIDByID(t, tbl),
+		"the coordinator path must preserve survivors' _row_id")
 }
 
 // TestRewriteDataFilesPreservesSiblingDeletionVector pins the granularity of DV

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -73,37 +73,46 @@ func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 	}
 }
 
-// TestRewriteDataFilesPreservesRowIDThroughDeletionVector guarantees that
-// applying a deletion vector during compaction does not renumber the surviving
-// rows' _row_id. The v3 spec requires _row_id = first_row_id + the row's
-// ORIGINAL position in its source file; a rewrite copies survivors and must
-// carry those ids unchanged. The regression this guards: synthesizing lineage
-// after the DV filter dropped rows yields a dense 0..N renumbering instead.
+// TestRewriteDataFilesPreservesRowIDThroughDeletionVector: applying a DV during
+// compaction must not renumber survivors' _row_id (= first_row_id + ORIGINAL
+// position). Regression guard against synthesizing lineage after the DV filter
+// drops rows, which yields a dense 0..N renumbering.
 func TestRewriteDataFilesPreservesRowIDThroughDeletionVector(t *testing.T) {
-	ctx := context.Background()
-	tbl, dvTarget := seedV3TableWithDV(t)
+	for _, partialProgress := range []bool{false, true} {
+		name := "atomic"
+		if partialProgress {
+			name = "partial-progress"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			tbl, dvTarget := seedV3TableWithDV(t)
 
-	// Survivors after the DV deletes id=1: id=2 (_row_id 1, first file), id=3
-	// (_row_id 2) and id=4 (_row_id 3, second file).
-	before := rowIDByID(t, tbl)
-	require.Equal(t, map[int64]int64{2: 1, 3: 2, 4: 3}, before)
+			// Survivors after the DV deletes id=1: id=2 (_row_id 1, first file),
+			// id=3 (_row_id 2) and id=4 (_row_id 3, second file).
+			before := rowIDByID(t, tbl)
+			require.Equal(t, map[int64]int64{2: 1, 3: 2, 4: 3}, before)
 
-	groups, _ := planDVCompaction(t, tbl, dvTarget)
-	rtx := tbl.NewTransaction()
-	_, err := rtx.RewriteDataFiles(ctx, groups, table.RewriteDataFilesOptions{})
-	require.NoError(t, err)
-	tbl, err = rtx.Commit(ctx)
-	require.NoError(t, err)
+			groups, _ := planDVCompaction(t, tbl, dvTarget)
+			rtx := tbl.NewTransaction()
+			_, err := rtx.RewriteDataFiles(ctx, groups,
+				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
+			require.NoError(t, err)
+			tbl, err = rtx.Commit(ctx)
+			require.NoError(t, err)
 
-	assert.Equal(t, before, rowIDByID(t, tbl),
-		"_row_id must be preserved for survivors when a deletion vector is applied during compaction")
+			assert.Equal(t, before, rowIDByID(t, tbl),
+				"_row_id must be preserved for survivors when a deletion vector is applied during compaction")
+		})
+	}
 }
 
-// rowIDByID scans the table with row lineage and returns a map of id -> _row_id.
-func rowIDByID(t *testing.T, tbl *table.Table) map[int64]int64 {
+// rowIDByID scans the table with row lineage (plus any extra options) and
+// returns a map of id -> _row_id.
+func rowIDByID(t *testing.T, tbl *table.Table, opts ...table.ScanOption) map[int64]int64 {
 	t.Helper()
 
-	_, itr, err := tbl.Scan(table.WithRowLineage()).ToArrowRecords(context.Background())
+	scanOpts := append([]table.ScanOption{table.WithRowLineage()}, opts...)
+	_, itr, err := tbl.Scan(scanOpts...).ToArrowRecords(context.Background())
 	require.NoError(t, err)
 
 	out := map[int64]int64{}
@@ -115,7 +124,7 @@ func rowIDByID(t *testing.T, tbl *table.Table) map[int64]int64 {
 		require.NotEmpty(t, rowIDIdx, "_row_id must be in the row-lineage scan projection")
 		idCol := rec.Column(idIdx[0]).(*array.Int64)
 		rowIDCol := rec.Column(rowIDIdx[0]).(*array.Int64)
-		for i := 0; i < int(rec.NumRows()); i++ {
+		for i := range int(rec.NumRows()) {
 			require.False(t, rowIDCol.IsNull(i), "_row_id must not be null for id=%d", idCol.Value(i))
 			out[idCol.Value(i)] = rowIDCol.Value(i)
 		}
@@ -236,7 +245,19 @@ func seedV3TableWithDV(t *testing.T) (*table.Table, string) {
 	tasks, err := tbl.Scan().PlanFiles(ctx)
 	require.NoError(t, err)
 	require.Len(t, tasks, 2)
-	dvTarget := tasks[0].File.FilePath()
+
+	// PlanFiles order is not stable, so pick the first-appended file (the one
+	// holding ids 1,2) by its first_row_id. Its row at position 0 is id=1, so
+	// the DV below deterministically deletes id=1.
+	target := tasks[0]
+	for _, tk := range tasks[1:] {
+		if tk.FirstRowID != nil && (target.FirstRowID == nil || *tk.FirstRowID < *target.FirstRowID) {
+			target = tk
+		}
+	}
+	require.NotNil(t, target.FirstRowID)
+	require.Zero(t, *target.FirstRowID, "first-appended file must have first_row_id 0")
+	dvTarget := target.File.FilePath()
 
 	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
 	w.Add(dvTarget, []int64{0}, 0, nil)

--- a/table/row_lineage_scan_test.go
+++ b/table/row_lineage_scan_test.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanRowLineagePreservedAcrossPrunedRowGroups: a filter that prunes a
+// leading row group must not renumber survivors' _row_id (= first_row_id +
+// ORIGINAL position). Two row groups (ids 1..5, 6..10); id > 5 prunes the first
+// via stats, and the unfiltered baseline spans both, exercising multiple batches.
+func TestScanRowLineagePreservedAcrossPrunedRowGroups(t *testing.T) {
+	ctx := context.Background()
+	tbl := newV3RowLineageTestTable(t)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.SetProperties(iceberg.Properties{table.ParquetRowGroupLimitKey: "5"}))
+	tbl, err := tx.Commit(ctx)
+	require.NoError(t, err)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},` +
+			`{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"},` +
+			`{"id":9,"data":"i"},{"id":10,"data":"j"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	full := rowIDByID(t, tbl)
+	require.Equal(t, map[int64]int64{1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 7: 6, 8: 7, 9: 8, 10: 9}, full)
+
+	got := rowIDByID(t, tbl,
+		table.WithRowFilter(iceberg.GreaterThan(iceberg.Reference("id"), int64(5))))
+
+	assert.Equal(t, map[int64]int64{6: 5, 7: 6, 8: 7, 9: 8, 10: 9}, got,
+		"a pruned leading row group must not renumber surviving rows' _row_id")
+}

--- a/table/row_lineage_scan_test.go
+++ b/table/row_lineage_scan_test.go
@@ -19,12 +19,15 @@ package table_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,6 +61,10 @@ func TestScanRowLineagePreservedAcrossPrunedRowGroups(t *testing.T) {
 	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
 	require.NoError(t, err)
 
+	// Without two row groups there is nothing to prune and the test would pass
+	// even with the bug (it was verified to fail without the fix).
+	require.Equal(t, 2, parquetRowGroupCount(t, tbl), "file must have multiple row groups to prune")
+
 	full := rowIDByID(t, tbl)
 	require.Equal(t, map[int64]int64{1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 7: 6, 8: 7, 9: 8, 10: 9}, full)
 
@@ -66,4 +73,115 @@ func TestScanRowLineagePreservedAcrossPrunedRowGroups(t *testing.T) {
 
 	assert.Equal(t, map[int64]int64{6: 5, 7: 6, 8: 7, 9: 8, 10: 9}, got,
 		"a pruned leading row group must not renumber surviving rows' _row_id")
+}
+
+// TestScanRowLineagePreservedThroughEqualityDeletes: equality deletes drop rows
+// during the scan (a distinct pipeline step from DVs), so survivors must keep
+// their original _row_id.
+func TestScanRowLineagePreservedThroughEqualityDeletes(t *testing.T) {
+	ctx := context.Background()
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, map[int64]int64{1: 0, 2: 1, 3: 2, 4: 3, 5: 4}, rowIDByID(t, tbl))
+
+	eqDelPath := tbl.Location() + "/data/eq-del.parquet"
+	delSc, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		nil, true, false)
+	require.NoError(t, err)
+	writeParquetFile(t, eqDelPath, delSc, `[{"id": 2}, {"id": 4}]`)
+
+	b, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		eqDelPath, iceberg.ParquetFile, nil, nil, nil, 2, 256)
+	require.NoError(t, err)
+	b.EqualityFieldIDs([]int{1})
+
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddDeletes(b.Build())
+	require.NoError(t, rd.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[int64]int64{1: 0, 3: 2, 5: 4}, rowIDByID(t, tbl),
+		"equality-deleted rows must not renumber surviving rows' _row_id")
+}
+
+// TestScanRowLineagePreservedThroughPositionalDeletes: a Parquet position-delete
+// file drops rows during the scan; survivors must keep their original _row_id.
+func TestScanRowLineagePreservedThroughPositionalDeletes(t *testing.T) {
+	ctx := context.Background()
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, map[int64]int64{1: 0, 2: 1, 3: 2, 4: 3, 5: 4}, rowIDByID(t, tbl))
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	dataPath := tasks[0].File.FilePath()
+
+	// Delete positions 1 and 3 (id=2, id=4) of the data file.
+	posDelPath := tbl.Location() + "/data/pos-del.parquet"
+	posSc, err := table.SchemaToArrowSchema(iceberg.PositionalDeleteSchema, nil, true, false)
+	require.NoError(t, err)
+	writeParquetFile(t, posDelPath, posSc,
+		fmt.Sprintf(`[{"file_path":%q,"pos":1},{"file_path":%q,"pos":3}]`, dataPath, dataPath))
+
+	b, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		posDelPath, iceberg.ParquetFile, nil, nil, nil, 2, 256)
+	require.NoError(t, err)
+
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddDeletes(b.Build())
+	require.NoError(t, rd.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[int64]int64{1: 0, 3: 2, 5: 4}, rowIDByID(t, tbl),
+		"position-deleted rows must not renumber surviving rows' _row_id")
+}
+
+// parquetRowGroupCount opens the table's single data file and returns its
+// Parquet row-group count.
+func parquetRowGroupCount(t *testing.T, tbl *table.Table) int {
+	t.Helper()
+
+	tasks, err := tbl.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	f, err := iceio.LocalFS{}.Open(tasks[0].File.FilePath())
+	require.NoError(t, err)
+	rdr, err := file.NewParquetReader(f)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	return rdr.NumRowGroups()
 }

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -420,6 +420,52 @@ func TestSynthesizeRowLineageColumnsPreservesExplicit(t *testing.T) {
 	assert.EqualValues(t, 3, rowOffset)
 }
 
+// TestSynthesizeRowLineageColumnsAppendsMissing covers the path where the
+// lineage columns are absent from the batch: they must be appended (in _row_id,
+// _last_updated_sequence_number order) and the input schema's metadata must
+// survive the rebuild.
+func TestSynthesizeRowLineageColumnsAppendsMissing(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	defer mem.AssertSize(t, 0)
+
+	firstRowID := int64(1000)
+	dataSeqNum := int64(5)
+	task := FileScanTask{FirstRowID: &firstRowID, DataSequenceNumber: &dataSeqNum}
+	rowOffset := int64(0)
+
+	md := arrow.NewMetadata([]string{"k"}, []string{"v"})
+	schema := arrow.NewSchema(
+		[]arrow.Field{{Name: "x", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, &md)
+	const nrows = 3
+	xBldr := array.NewInt64Builder(mem)
+	defer xBldr.Release()
+	xBldr.AppendValues([]int64{1, 2, 3}, nil)
+	xArr := xBldr.NewArray()
+	batch := array.NewRecordBatch(schema, []arrow.Array{xArr}, nrows)
+	xArr.Release()
+	defer batch.Release()
+
+	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch)
+	require.NoError(t, err)
+	defer out.Release()
+
+	require.EqualValues(t, 3, out.NumCols())
+	assert.Equal(t, iceberg.RowIDColumnName, out.Schema().Field(1).Name)
+	assert.Equal(t, iceberg.LastUpdatedSequenceNumberColumnName, out.Schema().Field(2).Name)
+
+	rowIDCol := out.Column(1).(*array.Int64)
+	seqCol := out.Column(2).(*array.Int64)
+	for i := range nrows {
+		assert.EqualValues(t, 1000+int64(i), rowIDCol.Value(i), "row %d", i)
+		assert.EqualValues(t, 5, seqCol.Value(i), "row %d", i)
+	}
+
+	got, ok := out.Schema().Metadata().GetValue("k")
+	assert.True(t, ok, "input schema metadata must be preserved")
+	assert.Equal(t, "v", got)
+}
+
 // TestProjectionV3SelectRowLineageColumns verifies that explicitly selecting
 // _row_id (and _last_updated_sequence_number) on a v3 table yields a projection
 // containing those metadata columns, even though they are not declared in the

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"runtime"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -300,8 +301,8 @@ func TestSynthesizeRowLineageColumns(t *testing.T) {
 	schema := arrow.NewSchema(
 		[]arrow.Field{
 			{Name: "x", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-			{Name: iceberg.RowIDColumnName, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-			{Name: iceberg.LastUpdatedSequenceNumberColumnName, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			lineageArrowField(iceberg.RowIDColumnName, iceberg.RowIDFieldID),
+			lineageArrowField(iceberg.LastUpdatedSequenceNumberColumnName, iceberg.LastUpdatedSequenceNumberFieldID),
 		},
 		nil,
 	)
@@ -325,7 +326,7 @@ func TestSynthesizeRowLineageColumns(t *testing.T) {
 	seqArr.Release()
 	defer batch.Release()
 
-	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch)
+	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch, true, true)
 	require.NoError(t, err)
 	defer out.Release()
 
@@ -363,8 +364,8 @@ func TestSynthesizeRowLineageColumnsPreservesExplicit(t *testing.T) {
 	schema := arrow.NewSchema(
 		[]arrow.Field{
 			{Name: "x", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-			{Name: iceberg.RowIDColumnName, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-			{Name: iceberg.LastUpdatedSequenceNumberColumnName, Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			lineageArrowField(iceberg.RowIDColumnName, iceberg.RowIDFieldID),
+			lineageArrowField(iceberg.LastUpdatedSequenceNumberColumnName, iceberg.LastUpdatedSequenceNumberFieldID),
 		},
 		nil,
 	)
@@ -395,7 +396,7 @@ func TestSynthesizeRowLineageColumnsPreservesExplicit(t *testing.T) {
 	seqArr.Release()
 	defer batch.Release()
 
-	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch)
+	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch, true, true)
 	require.NoError(t, err)
 	defer out.Release()
 
@@ -446,7 +447,7 @@ func TestSynthesizeRowLineageColumnsAppendsMissing(t *testing.T) {
 	xArr.Release()
 	defer batch.Release()
 
-	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch)
+	out, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch, true, true)
 	require.NoError(t, err)
 	defer out.Release()
 
@@ -464,6 +465,46 @@ func TestSynthesizeRowLineageColumnsAppendsMissing(t *testing.T) {
 	got, ok := out.Schema().Metadata().GetValue("k")
 	assert.True(t, ok, "input schema metadata must be preserved")
 	assert.Equal(t, "v", got)
+}
+
+// TestSynthesizeRowLineageColumnsRejectsWrongType guards against a panic: an
+// existing _row_id column of the wrong type would otherwise leave the field's
+// declared type and the replacement int64 array inconsistent.
+func TestSynthesizeRowLineageColumnsRejectsWrongType(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	defer mem.AssertSize(t, 0)
+
+	firstRowID := int64(1000)
+	task := FileScanTask{FirstRowID: &firstRowID}
+	rowOffset := int64(0)
+
+	wrongField := lineageArrowField(iceberg.RowIDColumnName, iceberg.RowIDFieldID)
+	wrongField.Type = arrow.BinaryTypes.String
+	schema := arrow.NewSchema([]arrow.Field{wrongField}, nil)
+
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues([]string{"a", "b"}, nil)
+	arr := bldr.NewArray()
+	batch := array.NewRecordBatch(schema, []arrow.Array{arr}, 2)
+	arr.Release()
+	defer batch.Release()
+
+	_, err := synthesizeRowLineageColumns(ctx, &rowOffset, task, batch, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "want int64")
+}
+
+// lineageArrowField builds an Int64 Arrow field tagged with the reserved
+// row-lineage field id, mirroring how the Parquet reader tags columns.
+func lineageArrowField(name string, fieldID int) arrow.Field {
+	return arrow.Field{
+		Name:     name,
+		Type:     arrow.PrimitiveTypes.Int64,
+		Nullable: true,
+		Metadata: arrow.NewMetadata([]string{ArrowParquetFieldIDKey}, []string{strconv.Itoa(fieldID)}),
+	}
 }
 
 // TestProjectionV3SelectRowLineageColumns verifies that explicitly selecting


### PR DESCRIPTION
## Problem

Scanning or compacting a v3 table renumbers surviving rows' `_row_id` whenever rows are dropped — by a deletion vector, positional/equality deletes, or a row filter. The spec requires `_row_id = first_row_id + the row's original position in its file`, so survivors must keep their ids, instead they came out as a dense `0..N` sequence.

## Cause

Row-lineage synthesis runs last in the scan pipeline, after the row-dropping steps, and counts positions over the already-filtered batch. Independently, Parquet row-group pruning skips whole groups before the batch reaches the pipeline, leaving survivor positions non-contiguous.

## Fix

Synthesize `_row_id` / `_last_updated_sequence_number` first, before any row-dropping step, counting over the full unfiltered batch; later filters drop rows already carrying the correct id. Skip row-group pruning while synthesizing lineage so positions stay contiguous — the per-row filter still enforces the predicate.

## Tests

`TestRewriteDataFilesPreservesRowIDThroughDeletionVector` (atomic + partial-progress) and `TestScanRowLineagePreservedAcrossPrunedRowGroups` (a filter prunes a leading row group; survivors keep their ids).