### PR TITLE
fix(table): clean up partial positional deletes on error

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -108,12 +108,12 @@ func readAllDeleteFiles(ctx context.Context, fs iceio.IO, tasks []FileScanTask, 
 				if deletes == nil {
 					return nil
 				}
-				select {
-				case perFileChan <- deletes:
-					return nil
-				case <-gctx.Done():
-					return gctx.Err()
-				}
+				// Safe even after gctx cancellation: the channel buffer equals
+				// g's concurrency limit, so every in-flight worker can send
+				// without blocking while the for-range below drains to close.
+				perFileChan <- deletes
+
+				return nil
 			})
 		}
 		_ = g.Wait()
@@ -126,7 +126,7 @@ func readAllDeleteFiles(ctx context.Context, fs iceio.IO, tasks []FileScanTask, 
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return deletesPerFile, err
 	}
 
 	return deletesPerFile, nil
@@ -1136,6 +1136,8 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 	// no intermediate position set.
 	dvBitmaps, err := readAllDeletionVectors(ctx, as.fs, tasks, as.concurrency)
 	if err != nil {
+		releasePerFilePosDeletes(deletesPerFile)
+
 		return nil, nil, err
 	}
 

--- a/table/arrow_scanner_test.go
+++ b/table/arrow_scanner_test.go
@@ -18,17 +18,79 @@
 package table
 
 import (
+	"errors"
+	iofs "io/fs"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failAfterGoodCloseFS struct {
+	*iceio.MemFS
+
+	goodPath string
+	badPath  string
+
+	goodClosed     chan struct{}
+	goodClosedOnce sync.Once
+}
+
+func (f *failAfterGoodCloseFS) Open(name string) (iceio.File, error) {
+	if name == f.goodPath {
+		file, err := f.MemFS.Open(name)
+		if err != nil {
+			return nil, err
+		}
+
+		return &closeSignalFile{
+			File: file,
+			onClose: func() {
+				f.goodClosedOnce.Do(func() { close(f.goodClosed) })
+			},
+		}, nil
+	}
+
+	if name == f.badPath {
+		select {
+		case <-f.goodClosed:
+		case <-time.After(5 * time.Second):
+			return nil, &iofs.PathError{
+				Op:   "open",
+				Path: name,
+				Err:  errors.New("timed out waiting for good delete file to close"),
+			}
+		}
+
+		return nil, &iofs.PathError{Op: "open", Path: name, Err: iofs.ErrNotExist}
+	}
+
+	return f.MemFS.Open(name)
+}
+
+type closeSignalFile struct {
+	iceio.File
+	onClose func()
+}
+
+func (f *closeSignalFile) Close() error {
+	err := f.File.Close()
+	f.onClose()
+
+	return err
+}
 
 func TestEnrichRecordsWithPosDeleteFields(t *testing.T) {
 	testSchema := arrow.NewSchema([]arrow.Field{
@@ -128,6 +190,35 @@ func mustLoadRecordBatchFromJSON(schema *arrow.Schema, content string) arrow.Rec
 	return recordBatch
 }
 
+func writePosDeleteParquetToMemFS(t *testing.T, memFS *iceio.MemFS, path, content string) {
+	t.Helper()
+
+	rec := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, content)
+	defer rec.Release()
+
+	tbl := array.NewTableFromRecords(PositionalDeleteArrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	fw, err := memFS.Create(path)
+	require.NoError(t, err)
+
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)),
+		pqarrow.DefaultWriterProps()))
+	require.NoError(t, fw.Close())
+}
+
+func newPosDeleteFile(t *testing.T, path string, count, size int64) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, count, size)
+	require.NoError(t, err)
+
+	return builder.Build()
+}
+
 // chunkedPosDelete allocates a positional-delete *arrow.Chunked against mem so
 // the CheckedAllocator can prove leaks. Returns a chunked that owns one Int64
 // array of `positions` values.
@@ -140,6 +231,49 @@ func chunkedPosDelete(t *testing.T, mem memory.Allocator, positions []int64) *ar
 	defer arr.Release()
 
 	return arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{arr})
+}
+
+func TestReadAllDeleteFilesReturnsPartialDeletesOnError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	ctx := compute.WithAllocator(t.Context(), mem)
+	goodDeletePath := "mem://bucket/deletes/good.parquet"
+	badDeletePath := "mem://bucket/deletes/missing.parquet"
+	dataPath := "mem://bucket/data/data.parquet"
+
+	memFS := iceio.NewMemFS()
+	writePosDeleteParquetToMemFS(t, memFS, goodDeletePath, `[
+		{"file_path": "`+dataPath+`", "pos": 1},
+		{"file_path": "`+dataPath+`", "pos": 3}
+	]`)
+	testFS := &failAfterGoodCloseFS{
+		MemFS:      memFS,
+		goodPath:   goodDeletePath,
+		badPath:    badDeletePath,
+		goodClosed: make(chan struct{}),
+	}
+	tasks := []FileScanTask{{
+		DeleteFiles: []iceberg.DataFile{
+			newPosDeleteFile(t, goodDeletePath, 2, 128),
+			newPosDeleteFile(t, badDeletePath, 1, 128),
+		},
+	}}
+
+	// concurrency=2 is enough to observe the partial result deterministically:
+	// the good worker closes first, then the bad worker returns its error.
+	deletesPerFile, err := readAllDeleteFiles(ctx, testFS, tasks, 2)
+	require.Error(t, err)
+	require.NotNil(t, deletesPerFile)
+	require.Contains(t, deletesPerFile, dataPath)
+	require.Len(t, deletesPerFile[dataPath], 1)
+
+	chunks := deletesPerFile[dataPath][0].Chunks()
+	require.Len(t, chunks, 1)
+	pos, ok := chunks[0].(*array.Int64)
+	require.True(t, ok)
+	assert.Equal(t, []int64{1, 3}, pos.Int64Values())
+
+	releasePerFilePosDeletes(deletesPerFile)
+	mem.AssertSize(t, 0)
 }
 
 // TestReleasePerFilePosDeletes verifies the helper releases every Arrow chunk


### PR DESCRIPTION
Summary
- return partially loaded positional-delete chunks when a concurrent delete-file read fails
- keep successfully read chunks on the result channel even if another worker cancels the group
- add checked-allocator regression coverage for partial failure cleanup

Why
If one positional-delete file is loaded and a later delete-file read fails, the scanner callers already try to release any partial result. readAllDeleteFiles was returning nil on error, so those loaded Arrow chunks could be lost instead of released.

Testing
- go test ./table -run 'TestReadAllDeleteFilesReturnsPartialDeletesOnError|TestReleasePerFilePosDeletes' -count=1\n- go test ./table -count=1\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout=10m ./table/...