### PR TITLE
fix: keep generated position deletes correct under row-group pruning

### DIFF
--- a/metadata_columns.go
+++ b/metadata_columns.go
@@ -110,18 +110,5 @@ func SchemaWithRowLineageColumns(s *Schema, rowID, lastUpdatedSeq bool) *Schema 
 //
 // Idempotent on RowIDFieldID; allocates a fresh field slice.
 func SchemaWithRowID(s *Schema) *Schema {
-	if s == nil {
-		return nil
-	}
-	fields := slices.Clone(s.Fields())
-
-	for _, f := range fields {
-		if f.ID == RowIDFieldID {
-			return NewSchemaWithIdentifiers(s.ID, s.IdentifierFieldIDs, fields...)
-		}
-	}
-
-	fields = append(fields, RowID())
-
-	return NewSchemaWithIdentifiers(s.ID, s.IdentifierFieldIDs, fields...)
+	return SchemaWithRowLineageColumns(s, true, false)
 }

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -702,9 +702,11 @@ func (as *arrowScan) processRecords(
 		recRdr        array.RecordReader
 	)
 
-	// Row-group pruning skips whole groups, so emitted positions stop being
-	// contiguous. Position-keyed steps (row-lineage _row_id) need every group
-	// read; the per-row filter still enforces the predicate.
+	// Row-group stats/bloom pruning skips whole groups, so emitted batches no
+	// longer cover contiguous file positions. Steps that key on the original
+	// position (row-lineage _row_id, generated position deletes) need the full
+	// sequence, so the per-row filter alone enforces the predicate while every
+	// group is still read.
 	switch {
 	case task.Value.File.FileFormat() == iceberg.ParquetFile && !skipRowGroupPruning:
 		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, as.boundRowFilter, false)
@@ -946,7 +948,9 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task interna
 		return ToRequestedSchema(ctx, iceberg.PositionalDeleteSchema, enrichedIcebergSchema, r, SchemaOptions{IncludeFieldIDs: true, UseLargeTypes: as.useLargeTypes})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, false, out)
+	// enrichRecordsWithPosDeleteFields stamps positions by counting emitted
+	// rows, so the reader must not prune row groups out from under it.
+	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, true, out)
 
 	return err
 }

--- a/table/mor_delete_pruning_test.go
+++ b/table/mor_delete_pruning_test.go
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeOnReadDeleteAcrossPrunedRowGroups guards the row-group pruning hazard
+// in generated position deletes: a merge-on-read DELETE whose filter prunes a
+// leading row group must still delete the right physical rows. enrichRecords-
+// WithPosDeleteFields stamps each surviving row's position by counting emitted
+// rows, so if the reader skips a pruned row group the positions are off by the
+// pruned group's size and the wrong rows get deleted.
+//
+// The file has two row groups (ids 1..5, then 6..10). Deleting id == 7 matches
+// only the second group, so the first is pruned by stats; a dense position
+// count would target physical position 1 (id=2) instead of 6 (id=7).
+func TestMergeOnReadDeleteAcrossPrunedRowGroups(t *testing.T) {
+	ctx := context.Background()
+	tbl := newMergeOnReadTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},` +
+			`{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"},` +
+			`{"id":9,"data":"i"},{"id":10,"data":"j"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, idsInTable(t, tbl))
+
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(7)), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 2, 3, 4, 5, 6, 8, 9, 10}, idsInTable(t, tbl),
+		"only id=7 must be deleted; a pruned leading row group must not shift positions")
+}
+
+// newMergeOnReadTestTable builds a v2 table that deletes via merge-on-read and
+// caps row groups at 5 rows so a 10-row append spans two of them.
+func newMergeOnReadTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, location,
+		iceberg.Properties{
+			table.PropertyFormatVersion:   "2",
+			table.WriteDeleteModeKey:      table.WriteModeMergeOnRead,
+			table.ParquetRowGroupLimitKey: "5",
+		})
+	require.NoError(t, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+
+	return table.New(table.Identifier{"db", "mor_delete_test"}, meta, metaLoc, fsF, cat)
+}
+
+// idsInTable scans the table and returns the surviving id values, sorted.
+func idsInTable(t *testing.T, tbl *table.Table) []int64 {
+	t.Helper()
+
+	_, itr, err := tbl.Scan().ToArrowRecords(context.Background())
+	require.NoError(t, err)
+
+	var ids []int64
+	for rec, err := range itr {
+		require.NoError(t, err)
+		idIdx := rec.Schema().FieldIndices("id")
+		require.NotEmpty(t, idIdx)
+		col := rec.Column(idIdx[0]).(*array.Int64)
+		for i := range int(rec.NumRows()) {
+			ids = append(ids, col.Value(i))
+		}
+		rec.Release()
+	}
+	slices.Sort(ids)
+
+	return ids
+}


### PR DESCRIPTION
A merge-on-read DELETE binds its filter as the scan's row filter, so row-group stats/bloom pruning is active. enrichRecordsWithPosDeleteFields stamps each surviving row's position by counting emitted rows, so a pruned row group shifts every later position by that group's size and the generated position-delete file targets the wrong rows. Skip row-group pruning in producePosDeletesFromTask; the per-row filter still selects which rows to delete.

Add a v2 merge-on-read regression test deleting a row that lives only in a non-leading row group.

Follow-up to the row-lineage row-group pruning fix (#1237) same root cause in a separate code path.

