### PR TITLE
Truncate projection counts UTF-8 string prefixes in bytes instead of characters

### DIFF
--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -1049,6 +1049,9 @@ func (p *ProjectionTestSuite) TestStringTruncateProjection() {
 		{iceberg.NotStartsWith(ref, "a"), iceberg.NotStartsWith(truncStr, "a")},
 		{iceberg.NotStartsWith(ref, "aa"), iceberg.NotEqualTo(truncStr, "aa")},
 		{iceberg.NotStartsWith(ref, "aaa"), iceberg.AlwaysTrue{}},
+		{iceberg.NotStartsWith(ref, "é"), iceberg.NotStartsWith(truncStr, "é")},
+		{iceberg.NotStartsWith(ref, "éé"), iceberg.NotEqualTo(truncStr, "éé")},
+		{iceberg.NotStartsWith(ref, "ééa"), iceberg.AlwaysTrue{}},
 	}
 
 	project := newInclusiveProjection(schema, spec, true)

--- a/transforms.go
+++ b/transforms.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
@@ -1190,7 +1191,7 @@ func truncateArray[T LiteralType](name string, pred BoundLiteralPredicate, fn fu
 func literalLen(lit Literal) int {
 	switch l := lit.(type) {
 	case StringLiteral:
-		return len(l)
+		return utf8.RuneCountInString(string(l))
 	case BinaryLiteral:
 		return len(l)
 	case FixedLiteral:


### PR DESCRIPTION
## Summary

Closes https://github.com/apache/iceberg-go/issues/1248.

Fixes UTF-8 handling in truncate projection length checks for string `NOT STARTS WITH` predicates.

String `truncate[N]` already truncates by Unicode characters/code points, but the projection helper used `len(StringLiteral)`, which counts bytes. For multibyte UTF-8 prefixes like `"éé"`, that made the projection compare a byte length against a character-based truncate width.

This changes string literal length checks to use `utf8.RuneCountInString`, while keeping binary/fixed literals byte-counted. It also adds regression coverage for Unicode prefixes in string truncate projection.