### PR TITLE
feat(transform): deprecate Transform.ToHumanStr(any) in favor of type-aware ToHumanStrType

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -552,12 +552,7 @@ func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
 		sb.WriteByte('=')
 
 		// Only escape the value (which changes per row)
-		var valueStr string
-		if t, ok := ps.fields[i].Transform.(typedHumanStringer); ok {
-			valueStr = t.ToHumanStrType(partType.FieldList[i].Type, data.Get(i))
-		} else {
-			valueStr = ps.fields[i].Transform.ToHumanStr(data.Get(i))
-		}
+		valueStr := ps.fields[i].Transform.ToHumanStrType(partType.FieldList[i].Type, data.Get(i))
 		sb.WriteString(url.QueryEscape(valueStr))
 	}
 

--- a/transforms.go
+++ b/transforms.go
@@ -99,13 +99,9 @@ type Transform interface {
 	Apply(Optional[Literal]) Optional[Literal]
 	Project(name string, pred BoundPredicate) (UnboundPredicate, error)
 
-	ToHumanStr(any) string
-}
-
-// typedHumanStringer is an opt-in extension for transforms whose
-// human-string form depends on the source Iceberg Type
-type typedHumanStringer interface {
 	ToHumanStrType(typ Type, val any) string
+	// Deprecated: ToHumanStr cannot recover source-type information; use ToHumanStrType instead.
+	ToHumanStr(any) string
 }
 
 // IdentityTransform uses the identity function, performing no transformation
@@ -232,6 +228,8 @@ func (VoidTransform) Apply(value Optional[Literal]) Optional[Literal] {
 }
 
 func (VoidTransform) ToHumanStr(any) string { return "null" }
+
+func (VoidTransform) ToHumanStrType(typ Type, val any) string { return "null" }
 
 func (VoidTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {
 	return nil, nil
@@ -397,6 +395,10 @@ func (BucketTransform) ToHumanStr(val any) string {
 	}
 
 	return fmt.Sprintf("%v", val)
+}
+
+func (t BucketTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
 }
 
 func (t BucketTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
@@ -574,6 +576,10 @@ func (TruncateTransform) ToHumanStr(val any) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+func (t TruncateTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
 }
 
 func (t TruncateTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
@@ -775,6 +781,10 @@ func (YearTransform) ToHumanStr(val any) string {
 	}
 }
 
+func (t YearTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
+}
+
 func (t YearTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
 	return projectTimeTransform(t, name, pred)
 }
@@ -880,6 +890,10 @@ func (t MonthTransform) ToHumanStr(val any) string {
 	}
 }
 
+func (t MonthTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
+}
+
 func (t MonthTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
 	return projectTimeTransform(t, name, pred)
 }
@@ -972,6 +986,10 @@ func (DayTransform) ToHumanStr(val any) string {
 	}
 }
 
+func (t DayTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
+}
+
 func (t DayTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
 	return projectTimeTransform(t, name, pred)
 }
@@ -1062,6 +1080,10 @@ func (HourTransform) ToHumanStr(val any) string {
 	default:
 		return "null"
 	}
+}
+
+func (t HourTransform) ToHumanStrType(_ Type, val any) string {
+	return t.ToHumanStr(val)
 }
 
 func (t HourTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -229,7 +229,7 @@ func (VoidTransform) Apply(value Optional[Literal]) Optional[Literal] {
 
 func (VoidTransform) ToHumanStr(any) string { return "null" }
 
-func (VoidTransform) ToHumanStrType(typ Type, val any) string { return "null" }
+func (VoidTransform) ToHumanStrType(Type, any) string { return "null" }
 
 func (VoidTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {
 	return nil, nil

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -153,6 +153,48 @@ func TestToHumanString(t *testing.T) {
 	}
 }
 
+func TestToHumanStrType(t *testing.T) {
+	decVal, _ := decimal.Decimal128FromString("14.21", 4, 2)
+	tsMicros := iceberg.Timestamp(1705314600000000)
+	tsNanos := iceberg.TimestampNano(1705314600000000001)
+
+	tests := []struct {
+		name      string
+		transform iceberg.Transform
+		typ       iceberg.Type
+		input     any
+		expected  string
+	}{
+		{"identity_tstz_micros", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.TimestampTz, tsMicros, "2024-01-15T10:30:00+00:00"},
+		{"identity_ts_micros", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.Timestamp, tsMicros, "2024-01-15T10:30:00"},
+		{"identity_tstz_nanos", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.TimestampTzNs, tsNanos, "2024-01-15T10:30:00.000000001+00:00"},
+		{"identity_ts_nanos", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.TimestampNs, tsNanos, "2024-01-15T10:30:00.000000001"},
+		{"identity_date", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.Date, iceberg.Date(17501), "2017-12-01"},
+		{"identity_string", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.String, "a/b/c=d", "a/b/c=d"},
+		{"identity_nil", iceberg.IdentityTransform{}, iceberg.PrimitiveTypes.TimestampTz, nil, "null"},
+		{"year", iceberg.YearTransform{}, iceberg.PrimitiveTypes.Date, int32(47), "2017"},
+		{"month", iceberg.MonthTransform{}, iceberg.PrimitiveTypes.Date, int32(575), "2017-12"},
+		{"day", iceberg.DayTransform{}, iceberg.PrimitiveTypes.Date, int32(17501), "2017-12-01"},
+		{"hour", iceberg.HourTransform{}, iceberg.PrimitiveTypes.TimestampTz, int32(420042), "2017-12-01-18"},
+		{"year_nil", iceberg.YearTransform{}, iceberg.PrimitiveTypes.Date, nil, "null"},
+		{"bucket", iceberg.BucketTransform{NumBuckets: 16}, iceberg.PrimitiveTypes.String, int32(7), "7"},
+		{"bucket_nil", iceberg.BucketTransform{NumBuckets: 16}, iceberg.PrimitiveTypes.String, nil, "null"},
+		{"truncate_int32", iceberg.TruncateTransform{Width: 1}, iceberg.PrimitiveTypes.Int32, int32(123), "123"},
+		{"truncate_string", iceberg.TruncateTransform{Width: 1}, iceberg.PrimitiveTypes.String, "foo", "foo"},
+		{"truncate_bytes", iceberg.TruncateTransform{Width: 1}, iceberg.PrimitiveTypes.Binary, []byte{0x00, 0x01, 0x02, 0x03}, "AAECAw=="},
+		{"truncate_decimal", iceberg.TruncateTransform{Width: 1}, iceberg.DecimalTypeOf(4, 2), iceberg.Decimal{Val: decVal, Scale: 2}, "14.21"},
+		{"truncate_nil", iceberg.TruncateTransform{Width: 1}, iceberg.PrimitiveTypes.String, nil, "null"},
+		{"void", iceberg.VoidTransform{}, iceberg.PrimitiveTypes.TimestampTz, tsMicros, "null"},
+		{"void_nil", iceberg.VoidTransform{}, iceberg.PrimitiveTypes.String, nil, "null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.transform.ToHumanStrType(tt.typ, tt.input))
+		})
+	}
+}
+
 func TestPartitionToPath_TimestampTzIdentity(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "created_ts_tz", Type: iceberg.PrimitiveTypes.TimestampTz, Required: true},


### PR DESCRIPTION
## Description

Closes #1251 

In iceberg-go, the public Transform.ToHumanStr(any) string cannot distinguish TimestampType from TimestampTzType (both are iceberg.Timestamp in Go), so formatting that depends on source type cannot be recovered at the call site.

Following up on the [discussion](https://github.com/apache/iceberg-go/pull/1227#issuecomment-4746198642) at PR #1227.

## Changelog Note
This is a **breaking change** for external implementers of the public `Transform` interface; all in-tree implementations are updated. The deprecated `ToHumanStr` remains for the deprecation window.