### PR TITLE
fix(table): read non-dictionary file_path columns in position deletes

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exprs"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
@@ -176,7 +177,8 @@ func readAllDeletionVectors(ctx context.Context, fs iceio.IO, tasks []FileScanTa
 				if !sameDVBlob(existing, d) {
 					return nil, fmt.Errorf(
 						"multiple deletion vectors for data file %s: %s and %s",
-						*ref, existing.FilePath(), d.FilePath())
+						*ref, existing.FilePath(), d.FilePath(),
+					)
 				}
 
 				continue
@@ -251,6 +253,158 @@ func sameDVBlob(a, b iceberg.DataFile) bool {
 	return *a.ContentOffset() == *b.ContentOffset()
 }
 
+type releasableScalar interface {
+	scalar.Scalar
+	scalar.Releasable
+}
+
+func filePathScalar(v string, dt arrow.DataType) releasableScalar {
+	if dictType, ok := dt.(*arrow.DictionaryType); ok {
+		dt = dictType.ValueType
+	}
+
+	if dt.ID() == arrow.LARGE_STRING {
+		return scalar.NewLargeStringScalar(v)
+	}
+
+	return scalar.NewStringScalar(v)
+}
+
+// collectFilePaths appends each row's file_path string from values to dst,
+// skipping paths already in seen so the result stays distinct across chunks.
+// It errors on a null path or any non-string column layout.
+func collectFilePaths(dst []string, seen map[string]struct{}, values arrow.Array) ([]string, error) {
+	add := func(p string) {
+		if _, ok := seen[p]; ok {
+			return
+		}
+
+		seen[p] = struct{}{}
+		dst = append(dst, p)
+	}
+
+	switch arr := values.(type) {
+	case *array.StringView:
+		// STRING_VIEW satisfies array.StringLike, but filePathScalar has no
+		// view scalar and would emit a plain STRING scalar, so the equal
+		// comparison in groupPosDeletesByFilePath could silently produce a
+		// wrong (all-false) mask and drop deletes. Reject it rather than risk
+		// that — no Iceberg writer nor the arrow-go Parquet reader produces a
+		// STRING_VIEW file_path column today.
+		return nil, fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
+			iceberg.ErrInvalidSchema, values.DataType())
+	case array.StringLike:
+		for i := 0; i < arr.Len(); i++ {
+			if arr.IsNull(i) {
+				return nil, fmt.Errorf("%w: null file_path in position delete file",
+					iceberg.ErrInvalidSchema)
+			}
+
+			add(arr.Value(i))
+		}
+	case *array.Dictionary:
+		// wrapped is a borrowed view over arr's dictionary; it holds no
+		// refcount of its own, so there is nothing to release.
+		wrapped, err := array.NewDictWrapper[string](arr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: file_path column is not string: %w",
+				iceberg.ErrInvalidSchema, err)
+		}
+
+		dict := arr.Dictionary()
+		for i := 0; i < arr.Len(); i++ {
+			if arr.IsNull(i) {
+				return nil, fmt.Errorf("%w: null file_path in position delete file",
+					iceberg.ErrInvalidSchema)
+			}
+			if dict.IsNull(arr.GetValueIndex(i)) {
+				return nil, fmt.Errorf("%w: null file_path dictionary value in position delete file",
+					iceberg.ErrInvalidSchema)
+			}
+
+			add(wrapped.Value(i))
+		}
+	default:
+		return nil, fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
+			iceberg.ErrInvalidSchema, values.DataType())
+	}
+
+	return dst, nil
+}
+
+// distinctPosDeleteFilePaths returns the distinct file_path values a position
+// delete file references, in first-seen order. It dedups in Go rather than via
+// compute.Unique: the unique kernel has OutputChunked=false, so a chunked input
+// is concatenated into a scratch array first, and deduping a handful of path
+// strings here is cheaper and avoids that allocation entirely.
+func distinctPosDeleteFilePaths(filePathCol *arrow.Chunked) ([]string, error) {
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, chunk := range filePathCol.Chunks() {
+		var err error
+		paths, err = collectFilePaths(paths, seen, chunk)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return paths, nil
+}
+
+func groupPosDeletesByFilePath(ctx context.Context, filePathCol, posCol *arrow.Chunked) (map[string]*arrow.Chunked, error) {
+	paths, err := distinctPosDeleteFilePaths(filePathCol)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]*arrow.Chunked, len(paths))
+	for _, v := range paths {
+		sc := filePathScalar(v, filePathCol.DataType())
+		scDatum := compute.NewDatum(sc)
+		sc.Release()
+		mask, err := compute.CallFunction(ctx, "equal", nil,
+			compute.NewDatumWithoutOwning(filePathCol), scDatum)
+		scDatum.Release()
+		if err != nil {
+			releasePosDeletes(results)
+
+			return nil, err
+		}
+
+		filtered, err := compute.Filter(ctx, compute.NewDatumWithoutOwning(posCol),
+			mask, *compute.DefaultFilterOptions())
+		mask.Release()
+		if err != nil {
+			releasePosDeletes(results)
+
+			return nil, err
+		}
+
+		chunked, ok := filtered.(*compute.ChunkedDatum)
+		if !ok {
+			filtered.Release()
+			releasePosDeletes(results)
+
+			return nil, fmt.Errorf("%w: filtered pos result is %s",
+				iceberg.ErrInvalidSchema, filtered.Kind())
+		}
+
+		// Ownership of chunked.Value transfers to results; do not release the
+		// datum here or releasePosDeletes would double-release the Chunked.
+		results[v] = chunked.Value
+	}
+
+	return results, nil
+}
+
+func releasePosDeletes(deletes map[string]*arrow.Chunked) {
+	for _, chunk := range deletes {
+		if chunk != nil {
+			chunk.Release()
+		}
+	}
+}
+
 func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_ map[string]*arrow.Chunked, err error) {
 	src, err := internal.GetFile(ctx, fs, dataFile, true)
 	if err != nil {
@@ -277,29 +431,8 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 
 	filePathCol := tbl.Column(tbl.Schema().FieldIndices("file_path")[0]).Data()
 	posCol := tbl.Column(tbl.Schema().FieldIndices("pos")[0]).Data()
-	dict := filePathCol.Chunk(0).(*array.Dictionary).Dictionary().(*array.String)
 
-	results := make(map[string]*arrow.Chunked)
-	for i := 0; i < dict.Len(); i++ {
-		v := dict.Value(i)
-
-		mask, err := compute.CallFunction(ctx, "equal", nil,
-			compute.NewDatumWithoutOwning(filePathCol), compute.NewDatum(v))
-		if err != nil {
-			return nil, err
-		}
-		defer mask.Release()
-
-		filtered, err := compute.Filter(ctx, compute.NewDatumWithoutOwning(posCol),
-			mask, *compute.DefaultFilterOptions())
-		if err != nil {
-			return nil, err
-		}
-
-		results[v] = filtered.(*compute.ChunkedDatum).Value
-	}
-
-	return results, nil
+	return groupPosDeletesByFilePath(ctx, filePathCol, posCol)
 }
 
 type set[T comparable] map[T]struct{}

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -21,11 +21,245 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGroupPosDeletesByFilePathSupportsStringLayouts(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		filePathCol func(memory.Allocator) (*arrow.Chunked, func())
+	}{
+		{
+			name: "string chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				chunkA := stringArray(mem, "file-a.parquet", "file-b.parquet")
+				chunkB := stringArray(mem, "file-a.parquet", "file-c.parquet")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+				}
+			},
+		},
+		{
+			name: "large string chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				chunkA := largeStringArray(mem, "file-a.parquet", "file-b.parquet")
+				chunkB := largeStringArray(mem, "file-a.parquet", "file-c.parquet")
+				chunked := arrow.NewChunked(arrow.BinaryTypes.LargeString, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+				}
+			},
+		},
+		{
+			name: "dictionary chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := stringArray(mem, "file-a.parquet", "file-b.parquet", "file-c.parquet")
+				idxA := int32Array(mem, 0, 1)
+				idxB := int32Array(mem, 0, 2)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.String,
+				}
+				chunkA := array.NewDictionaryArray(dictType, idxA, dict)
+				chunkB := array.NewDictionaryArray(dictType, idxB, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+					dict.Release()
+					idxA.Release()
+					idxB.Release()
+				}
+			},
+		},
+		{
+			name: "large string dictionary chunks",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				dict := largeStringArray(mem, "file-a.parquet", "file-b.parquet", "file-c.parquet")
+				idxA := int32Array(mem, 0, 1)
+				idxB := int32Array(mem, 0, 2)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.LargeString,
+				}
+				chunkA := array.NewDictionaryArray(dictType, idxA, dict)
+				chunkB := array.NewDictionaryArray(dictType, idxB, dict)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+					dict.Release()
+					idxA.Release()
+					idxB.Release()
+				}
+			},
+		},
+		{
+			name: "distinct dictionaries per chunk",
+			filePathCol: func(mem memory.Allocator) (*arrow.Chunked, func()) {
+				// Each chunk carries its own dictionary with a different
+				// vocabulary and order — the shape before UnifyTableDicts runs.
+				// The Go-level dedup must not assume a unified dictionary.
+				dictA := stringArray(mem, "file-a.parquet", "file-b.parquet")
+				dictB := stringArray(mem, "file-c.parquet", "file-a.parquet")
+				idxA := int32Array(mem, 0, 1)
+				idxB := int32Array(mem, 1, 0)
+				dictType := &arrow.DictionaryType{
+					IndexType: arrow.PrimitiveTypes.Int32,
+					ValueType: arrow.BinaryTypes.String,
+				}
+				chunkA := array.NewDictionaryArray(dictType, idxA, dictA)
+				chunkB := array.NewDictionaryArray(dictType, idxB, dictB)
+				chunked := arrow.NewChunked(dictType, []arrow.Array{chunkA, chunkB})
+
+				return chunked, func() {
+					chunked.Release()
+					chunkA.Release()
+					chunkB.Release()
+					dictA.Release()
+					dictB.Release()
+					idxA.Release()
+					idxB.Release()
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A checked allocator turns any leak in groupPosDeletesByFilePath
+			// (e.g. an unreleased equal/filter mask) into a test failure.
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			// Registered first so it runs last (t.Cleanup is LIFO), after every
+			// release below. Releases go through t.Cleanup so a require failure
+			// can't skip them.
+			t.Cleanup(func() { mem.AssertSize(t, 0) })
+			ctx := compute.WithAllocator(t.Context(), mem)
+
+			filePathCol, releaseFilePathCol := tc.filePathCol(mem)
+			t.Cleanup(releaseFilePathCol)
+
+			posA := int64Array(mem, 1, 2)
+			posB := int64Array(mem, 3, 4)
+			posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posA, posB})
+			t.Cleanup(func() {
+				posCol.Release()
+				posA.Release()
+				posB.Release()
+			})
+
+			got, err := groupPosDeletesByFilePath(ctx, filePathCol, posCol)
+			require.NoError(t, err)
+			t.Cleanup(func() { releasePosDeletes(got) })
+
+			assert.Equal(t, []int64{1, 3}, int64Values(got["file-a.parquet"]))
+			assert.Equal(t, []int64{2}, int64Values(got["file-b.parquet"]))
+			assert.Equal(t, []int64{4}, int64Values(got["file-c.parquet"]))
+		})
+	}
+}
+
+func TestGroupPosDeletesByFilePathRejectsUnsupportedFilePathLayout(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	filePathArr := int32Array(mem, 1)
+	filePathCol := arrow.NewChunked(arrow.PrimitiveTypes.Int32, []arrow.Array{filePathArr})
+	t.Cleanup(func() {
+		filePathCol.Release()
+		filePathArr.Release()
+	})
+
+	posArr := int64Array(mem, 1)
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	t.Cleanup(func() {
+		posCol.Release()
+		posArr.Release()
+	})
+
+	_, err := groupPosDeletesByFilePath(t.Context(), filePathCol, posCol)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "unsupported file_path column type")
+}
+
+func TestGroupPosDeletesByFilePathRejectsNullFilePath(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+	bldr.Append("file-a.parquet")
+	bldr.AppendNull()
+	filePathArr := bldr.NewStringArray()
+	filePathCol := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{filePathArr})
+	t.Cleanup(func() {
+		filePathCol.Release()
+		filePathArr.Release()
+	})
+
+	posArr := int64Array(mem, 1, 2)
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	t.Cleanup(func() {
+		posCol.Release()
+		posArr.Release()
+	})
+
+	_, err := groupPosDeletesByFilePath(t.Context(), filePathCol, posCol)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "null file_path")
+}
+
+func TestGroupPosDeletesByFilePathRejectsNullDictionaryValue(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	t.Cleanup(func() { mem.AssertSize(t, 0) })
+
+	// The index array is fully valid, but row 1 points at a null entry in the
+	// dictionary value array. This exercises the dict.IsNull(GetValueIndex(i))
+	// guard, which a plain null-index check would miss.
+	dbldr := array.NewStringBuilder(mem)
+	defer dbldr.Release()
+	dbldr.Append("file-a.parquet")
+	dbldr.AppendNull()
+	dictVals := dbldr.NewStringArray()
+	idx := int32Array(mem, 0, 1)
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int32,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	chunk := array.NewDictionaryArray(dictType, idx, dictVals)
+	filePathCol := arrow.NewChunked(dictType, []arrow.Array{chunk})
+	t.Cleanup(func() {
+		filePathCol.Release()
+		chunk.Release()
+		dictVals.Release()
+		idx.Release()
+	})
+
+	posArr := int64Array(mem, 1, 2)
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	t.Cleanup(func() {
+		posCol.Release()
+		posArr.Release()
+	})
+
+	_, err := groupPosDeletesByFilePath(t.Context(), filePathCol, posCol)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "null file_path dictionary value")
+}
 
 // TestProcessPositionalDeletesAcrossBatches is the regression net for the
 // positional-delete index bug: processPositionalDeletes applies deletes one Arrow
@@ -72,4 +306,45 @@ func TestProcessPositionalDeletesAcrossBatches(t *testing.T) {
 
 		out.Release()
 	}
+}
+
+func stringArray(mem memory.Allocator, values ...string) *array.String {
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewStringArray()
+}
+
+func largeStringArray(mem memory.Allocator, values ...string) *array.LargeString {
+	bldr := array.NewLargeStringBuilder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewLargeStringArray()
+}
+
+func int32Array(mem memory.Allocator, values ...int32) *array.Int32 {
+	bldr := array.NewInt32Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewInt32Array()
+}
+
+func int64Array(mem memory.Allocator, values ...int64) *array.Int64 {
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	return bldr.NewInt64Array()
+}
+
+func int64Values(chunked *arrow.Chunked) []int64 {
+	var out []int64
+	for _, chunk := range chunked.Chunks() {
+		out = append(out, chunk.(*array.Int64).Int64Values()...)
+	}
+
+	return out
 }

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -40,7 +40,8 @@ import (
 func newRowDeltaTestTable(t *testing.T, formatVersion int) *table.Table {
 	t.Helper()
 
-	schema := iceberg.NewSchema(0,
+	schema := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
@@ -66,7 +67,8 @@ func buildDataFile(t *testing.T, path string) iceberg.DataFile {
 
 	b, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
-		path, iceberg.ParquetFile, nil, nil, nil, 10, 1024)
+		path, iceberg.ParquetFile, nil, nil, nil, 10, 1024,
+	)
 	require.NoError(t, err)
 
 	return b.Build()
@@ -77,7 +79,8 @@ func buildPosDeleteFile(t *testing.T, path string) iceberg.DataFile {
 
 	b, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
-		path, iceberg.ParquetFile, nil, nil, nil, 5, 512)
+		path, iceberg.ParquetFile, nil, nil, nil, 5, 512,
+	)
 	require.NoError(t, err)
 
 	return b.Build()
@@ -88,7 +91,8 @@ func buildEqDeleteFile(t *testing.T, path string, fieldIDs []int) iceberg.DataFi
 
 	b, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
-		path, iceberg.ParquetFile, nil, nil, nil, 3, 256)
+		path, iceberg.ParquetFile, nil, nil, nil, 3, 256,
+	)
 	require.NoError(t, err)
 	b.EqualityFieldIDs(fieldIDs)
 
@@ -191,7 +195,8 @@ func TestRowDeltaRejectsEqDeleteWithoutFieldIDs(t *testing.T) {
 	// Build an equality delete file without setting EqualityFieldIDs
 	b, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
-		"s3://bucket/data/eq-del.parquet", iceberg.ParquetFile, nil, nil, nil, 3, 256)
+		"s3://bucket/data/eq-del.parquet", iceberg.ParquetFile, nil, nil, nil, 3, 256,
+	)
 	require.NoError(t, err)
 	df := b.Build()
 
@@ -239,7 +244,8 @@ func newRowDeltaCommitTestTable(t *testing.T) *table.Table {
 
 	location := filepath.ToSlash(t.TempDir())
 
-	schema := iceberg.NewSchema(0,
+	schema := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
@@ -423,6 +429,19 @@ func TestRowDeltaMultipleCommitsOnSameTransaction(t *testing.T) {
 func writeParquetFile(t testing.TB, path string, sc *arrow.Schema, jsonData string) {
 	t.Helper()
 
+	writeParquetFileWithProperties(t, path, sc, jsonData, 0, nil)
+}
+
+func writeParquetFileWithProperties(
+	t testing.TB,
+	path string,
+	sc *arrow.Schema,
+	jsonData string,
+	rowGroupSize int64,
+	writerProps *parquet.WriterProperties,
+) {
+	t.Helper()
+
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, sc, strings.NewReader(jsonData))
 	require.NoError(t, err)
 	defer rec.Release()
@@ -434,16 +453,22 @@ func writeParquetFile(t testing.TB, path string, sc *arrow.Schema, jsonData stri
 	tbl := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
 	defer tbl.Release()
 
-	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
-		parquet.NewWriterProperties(parquet.WithStats(true)),
-		pqarrow.DefaultWriterProps()))
+	if rowGroupSize <= 0 {
+		rowGroupSize = rec.NumRows()
+	}
+	if writerProps == nil {
+		writerProps = parquet.NewWriterProperties(parquet.WithStats(true))
+	}
+
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rowGroupSize, writerProps, pqarrow.DefaultWriterProps()))
 }
 
 func TestRowDeltaIntegrationPosDeleteRoundTrip(t *testing.T) {
 	location := filepath.ToSlash(t.TempDir())
 
 	// Schema: id (int64), data (string)
-	iceSchema := iceberg.NewSchema(0,
+	iceSchema := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
@@ -487,17 +512,27 @@ func TestRowDeltaIntegrationPosDeleteRoundTrip(t *testing.T) {
 	assertRowCount(t, tbl, 5)
 
 	// Step 2: Commit a position delete via RowDelta that removes rows 1 and 3
-	// (0-indexed: positions 1 and 3 → "beta" and "delta")
+	// (0-indexed: positions 1 and 3 → "beta" and "delta").
+	//
+	// WithDictionaryDefault(false) is the load-bearing bit: it writes file_path
+	// as a plain (non-dictionary) string column, exercising the read path that
+	// used to panic on the unchecked *array.Dictionary cast. Row-group size is
+	// left at the default — it controls Parquet physical layout, not the Arrow
+	// chunk structure the reader produces.
 	posDelArrowSc := table.PositionalDeleteArrowSchema
 	posDelPath := location + "/data/pos-del-001.parquet"
-	writeParquetFile(t, posDelPath, posDelArrowSc, `[
+	writeParquetFileWithProperties(t, posDelPath, posDelArrowSc, `[
 		{"file_path": "`+dataPath+`", "pos": 1},
 		{"file_path": "`+dataPath+`", "pos": 3}
-	]`)
+	]`, 0, parquet.NewWriterProperties(
+		parquet.WithStats(true),
+		parquet.WithDictionaryDefault(false),
+	))
 
 	posDelBuilder, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
-		posDelPath, iceberg.ParquetFile, nil, nil, nil, 2, 256)
+		posDelPath, iceberg.ParquetFile, nil, nil, nil, 2, 256,
+	)
 	require.NoError(t, err)
 	posDelFile := posDelBuilder.Build()
 


### PR DESCRIPTION
readDeletes assumed a position delete file's file_path column was always dictionary-encoded with a string value type and cast it straight to *array.Dictionary / *array.String. Files that store file_path as a plain or large string column (PyIceberg, arrow-rs, or any writer with dictionary encoding turned off) made that cast panic on the scan path.

Parse the column by layout instead. Plain string, large string, and dictionary variants of both are supported; any other type is rejected with ErrInvalidSchema. Distinct file paths are gathered in Go rather than through compute.Unique, whose kernel concatenated chunked input into a scratch array that was never released.

Build each per-path position list with an explicit mask release after the filter, a checked assertion on the filter result, and chunk cleanup on every error return.

Tests cover the four string layouts, distinct per-chunk dictionaries, null and unsupported-layout rejection, and the RowDelta round-trip now writes file_path without dictionary encoding. The unit tests run under a checked allocator to pin reference counting.