### PR TITLE
fix(table): reject read-only file io in write paths

### DIFF
--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/config"
 	"github.com/apache/iceberg-go/internal"
-	iceio "github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 )
 
@@ -91,9 +90,9 @@ func (t *Transaction) WriteEqualityDeletes(ctx context.Context, equalityFieldIDs
 		return nil, err
 	}
 
-	wfs, ok := fs.(iceio.WriteFileIO)
-	if !ok {
-		return nil, errors.New("filesystem does not support writing")
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return nil, err
 	}
 
 	arrowSc, err := SchemaToArrowSchema(deleteSchema, nil, true, false)

--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/apache/iceberg-go"
-	iceio "github.com/apache/iceberg-go/io"
 )
 
 // RowDelta encodes a set of row-level changes to a table: new data files
@@ -149,9 +148,9 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 		return err
 	}
 
-	wfs, ok := fs.(iceio.WriteFileIO)
-	if !ok {
-		return errors.New("filesystem does not support writing")
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
 	}
 
 	op := rd.Operation()

--- a/table/table.go
+++ b/table/table.go
@@ -54,12 +54,25 @@ import (
 // issue #830).
 var ErrCommitFailed = errors.New("commit failed, refresh and try again")
 
-// ErrWriteIORequired is returned by doCommit when the table's file system
-// does not implement io.WriteFileIO. Manifest-list rebuild on retry requires
-// write access; failing fast here is preferable to silently skipping the
-// rebuild and reintroducing the stale-parent data-loss bug. Callers that
-// need to detect this condition should use errors.Is(err, ErrWriteIORequired).
-var ErrWriteIORequired = errors.New("commit: file system does not implement WriteFileIO")
+// ErrWriteIORequired is returned by write paths when the table's file system
+// does not implement io.WriteFileIO. Commit retries also fail fast on this
+// condition because manifest-list rebuilds need write access; skipping that
+// rebuild can reintroduce stale-parent data loss. Callers should use
+// errors.Is(err, ErrWriteIORequired) to detect the precise condition, or
+// errors.Is(err, iceberg.ErrNotImplemented) for compatibility with older
+// WriteRecords behavior.
+var ErrWriteIORequired = fmt.Errorf("%w: file system does not implement WriteFileIO", iceberg.ErrNotImplemented)
+
+// requireWriteFileIO should run immediately after resolving the table FS and
+// before mutating transaction state such as automatic name mapping.
+func requireWriteFileIO(fs icebergio.IO) (icebergio.WriteFileIO, error) {
+	wfs, ok := fs.(icebergio.WriteFileIO)
+	if !ok {
+		return nil, ErrWriteIORequired
+	}
+
+	return wfs, nil
+}
 
 // ErrSnapshotNotFound is returned (wrapped) by metadata lookups and by
 // computeOwnManifests when a snapshot ID does not exist in the table's
@@ -392,9 +405,9 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 	// Every real commit-path FS implements WriteFileIO. Failing here is
 	// preferable to silently skipping the manifest-list rebuild inside the
 	// retry loop — a skip reintroduces the original stale-parent data loss.
-	wfs, ok := fs.(icebergio.WriteFileIO)
-	if !ok {
-		return nil, fmt.Errorf("%w: manifest list rebuild requires write access", ErrWriteIORequired)
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: manifest list rebuild requires write access", err)
 	}
 
 	var (

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -154,9 +154,9 @@ func (t *Transaction) addValidator(v conflictValidatorFunc) {
 	t.validators = append(t.validators, v)
 }
 
-func (t *Transaction) appendSnapshotProducer(afs io.IO, props iceberg.Properties) *snapshotProducer {
+func (t *Transaction) appendSnapshotProducer(wfs io.WriteFileIO, props iceberg.Properties) *snapshotProducer {
 	manifestMerge := t.meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault)
-	updateSnapshot := t.updateSnapshot(afs, props, OpAppend)
+	updateSnapshot := t.updateSnapshot(wfs, props, OpAppend)
 	if manifestMerge {
 		return updateSnapshot.mergeAppend()
 	}
@@ -164,10 +164,10 @@ func (t *Transaction) appendSnapshotProducer(afs io.IO, props iceberg.Properties
 	return updateSnapshot.fastAppend()
 }
 
-func (t *Transaction) updateSnapshot(fs io.IO, props iceberg.Properties, operation Operation) snapshotUpdate {
+func (t *Transaction) updateSnapshot(wfs io.WriteFileIO, props iceberg.Properties, operation Operation) snapshotUpdate {
 	return snapshotUpdate{
 		txn:           t,
-		io:            fs.(io.WriteFileIO),
+		io:            wfs,
 		snapshotProps: props,
 		operation:     operation,
 	}
@@ -411,11 +411,15 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 	if err != nil {
 		return err
 	}
-	appendFiles := t.appendSnapshotProducer(fs, snapshotProps)
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
+	appendFiles := t.appendSnapshotProducer(wfs, snapshotProps)
 	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
 		sc:        rdr.Schema(),
 		itr:       array.IterFromReader(rdr),
-		fs:        fs.(io.WriteFileIO),
+		fs:        wfs,
 		writeUUID: &appendFiles.commitUuid,
 	})
 
@@ -479,6 +483,11 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	if err != nil {
 		return err
 	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
+
 	markedForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
 	for df, err := range s.dataFiles(fs, nil) {
 		if err != nil {
@@ -511,7 +520,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID, nil)
+	updater := t.updateSnapshot(wfs, snapshotProps, OpOverwrite).mergeOverwrite(&commitUUID, nil)
 
 	for _, df := range markedForDeletion {
 		updater.deleteDataFile(df)
@@ -715,15 +724,19 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 		return err
 	}
 
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
+
 	if !cfg.skipAutoNameMapping {
 		if err := t.ensureNameMapping(); err != nil {
 			return err
 		}
-	}
-
-	fs, err := t.tbl.fsF(ctx)
-	if err != nil {
-		return err
 	}
 
 	if !cfg.skipDuplicateCheck {
@@ -745,7 +758,7 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 		}
 	}
 
-	appendFiles := t.appendSnapshotProducer(fs, snapshotProps)
+	appendFiles := t.appendSnapshotProducer(wfs, snapshotProps)
 	for _, df := range dataFiles {
 		appendFiles.appendDataFile(df)
 	}
@@ -825,6 +838,10 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	if err != nil {
 		return err
 	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
 
 	markedForDeletion := make([]iceberg.DataFile, 0, len(setToDelete))
 	for df, err := range s.dataFiles(fs, nil) {
@@ -857,7 +874,7 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, op).mergeOverwrite(&commitUUID, nil)
+	updater := t.updateSnapshot(wfs, snapshotProps, op).mergeOverwrite(&commitUUID, nil)
 	if cfg.rewriteSemantics {
 		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
 		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
@@ -951,6 +968,10 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	if err != nil {
 		return err
 	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
 
 	// Scan all entries (data + delete files) in a single pass to validate
 	// that all files to delete/remove actually exist in the table.
@@ -1004,7 +1025,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, op).mergeOverwrite(&commitUUID, nil)
+	updater := t.updateSnapshot(wfs, snapshotProps, op).mergeOverwrite(&commitUUID, nil)
 	if cfg.rewriteSemantics {
 		// mergeOverwrite guarantees an *overwriteFiles producerImpl.
 		updater.producerImpl.(*overwriteFiles).skipDefaultValidator = true
@@ -1063,13 +1084,18 @@ func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshot
 		set[filePath] = struct{}{}
 	}
 
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return err
+	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
+
 	if !ignoreDuplicates {
 		if s := t.meta.currentSnapshot(); s != nil {
 			referenced := make([]string, 0)
-			fs, err := t.tbl.fsF(ctx)
-			if err != nil {
-				return err
-			}
 			for df, err := range s.dataFiles(fs, nil) {
 				if err != nil {
 					return err
@@ -1097,12 +1123,7 @@ func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshot
 		}
 	}
 
-	fs, err := t.tbl.fsF(ctx)
-	if err != nil {
-		return err
-	}
-
-	updater := t.appendSnapshotProducer(fs, snapshotProps)
+	updater := t.appendSnapshotProducer(wfs, snapshotProps)
 
 	dataFiles, err := filesToDataFiles(ctx, fs, t.meta, filePaths, addFilesOp.concurrency)
 	if err != nil {
@@ -1215,19 +1236,15 @@ func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, sna
 		apply(&overwrite)
 	}
 
-	updater, err := t.performCopyOnWriteDeletion(ctx, OpOverwrite, snapshotProps, overwrite.filter, overwrite.caseSensitive, overwrite.concurrency)
+	updater, wfs, err := t.performCopyOnWriteDeletion(ctx, OpOverwrite, snapshotProps, overwrite.filter, overwrite.caseSensitive, overwrite.concurrency)
 	if err != nil {
 		return err
 	}
 
-	fs, err := t.tbl.fsF(ctx)
-	if err != nil {
-		return err
-	}
 	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
 		sc:        rdr.Schema(),
 		itr:       array.IterFromReader(rdr),
-		fs:        fs.(io.WriteFileIO),
+		fs:        wfs,
 		writeUUID: &updater.commitUuid,
 	})
 
@@ -1264,30 +1281,34 @@ func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, sna
 	return t.apply(updates, reqs)
 }
 
-func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation Operation, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, error) {
+func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation Operation, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, io.WriteFileIO, error) {
 	fs, err := t.tbl.fsF(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if t.meta.NameMapping() == nil {
 		nameMapping := t.meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		err = t.SetProperties(iceberg.Properties{DefaultNameMappingKey: string(mappingJson)})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, operation).mergeOverwrite(&commitUUID, filter)
+	updater := t.updateSnapshot(wfs, snapshotProps, operation).mergeOverwrite(&commitUUID, filter)
 
 	filesToDelete, filesToRewrite, fileSeqByPath, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, df := range filesToDelete {
@@ -1296,15 +1317,19 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 
 	if len(filesToRewrite) > 0 {
 		if err := t.rewriteFilesWithFilter(ctx, fs, updater, filesToRewrite, fileSeqByPath, filter, caseSensitive, concurrency); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return updater, nil
+	return updater, wfs, nil
 }
 
 func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, error) {
 	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wfs, err := requireWriteFileIO(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -1322,7 +1347,7 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 	}
 
 	commitUUID := uuid.New()
-	updater := t.updateSnapshot(fs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID, filter)
+	updater := t.updateSnapshot(wfs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID, filter)
 
 	filesToDelete, withPartialDeletions, _, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -1403,7 +1428,7 @@ func (t *Transaction) Delete(ctx context.Context, filter iceberg.BooleanExpressi
 	}
 	switch writeDeleteMode {
 	case WriteModeCopyOnWrite:
-		updater, err = t.performCopyOnWriteDeletion(ctx, OpDelete, snapshotProps, filter, deleteOp.caseSensitive, deleteOp.concurrency)
+		updater, _, err = t.performCopyOnWriteDeletion(ctx, OpDelete, snapshotProps, filter, deleteOp.caseSensitive, deleteOp.concurrency)
 		if err != nil {
 			return err
 		}
@@ -1785,11 +1810,16 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 		}
 	}
 
+	wfs, err := requireWriteFileIO(args.fs)
+	if err != nil {
+		return nil, err
+	}
+
 	var result []iceberg.DataFile
 	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
 		sc:          arrowSchema,
 		itr:         releaseIter,
-		fs:          args.fs.(io.WriteFileIO),
+		fs:          wfs,
 		writeUUID:   &args.commitUUID,
 		factoryOpts: factoryOpts,
 	})
@@ -1810,6 +1840,10 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 	if err != nil {
 		return err
 	}
+	wfs, err := requireWriteFileIO(fs)
+	if err != nil {
+		return err
+	}
 
 	partitionContextByFilePath := make(map[string]partitionContext, len(files))
 	for _, df := range files {
@@ -1820,7 +1854,7 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		sc:        PositionalDeleteArrowSchema,
 		itr:       posDeleteRecIter,
 		writeUUID: &commitUUID,
-		fs:        fs.(io.WriteFileIO),
+		fs:        wfs,
 	})
 
 	for f, err := range posDeleteFiles {

--- a/table/write_file_io_test.go
+++ b/table/write_file_io_test.go
@@ -1,0 +1,196 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+func newReadOnlyWriteTable(t *testing.T, overrides ...iceberg.Properties) *Table {
+	t.Helper()
+
+	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	for _, override := range overrides {
+		for k, v := range override {
+			props[k] = v
+		}
+	}
+
+	schema := simpleSchema()
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "file:///tmp/read-only-write",
+		props)
+	require.NoError(t, err)
+
+	cat := &flakyCatalog{metadata: meta}
+
+	return New(
+		Identifier{"db", "read-only-write"},
+		meta,
+		"file:///tmp/read-only-write/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return readOnlyIO{}, nil },
+		cat,
+	)
+}
+
+func newSingleRowReader(t *testing.T, schema *iceberg.Schema) array.RecordReader {
+	t.Helper()
+
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	require.NoError(t, err)
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[{"id": 1}]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	rdr := array.NewTableReader(tbl, -1)
+	t.Cleanup(func() {
+		rdr.Release()
+		tbl.Release()
+	})
+
+	return rdr
+}
+
+func newWriteIORequiredDataFileWithPath(t *testing.T, path string) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		path,
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+
+	return builder.Build()
+}
+
+func newWriteIORequiredDataFile(t *testing.T) iceberg.DataFile {
+	t.Helper()
+
+	return newWriteIORequiredDataFileWithPath(t, "file:///tmp/read-only-write/data.parquet")
+}
+
+func TestWritePathsReturnErrorForReadOnlyIO(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		props iceberg.Properties
+		run   func(context.Context, *Table) error
+	}{
+		{
+			name: "append",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().Append(ctx, newSingleRowReader(t, tbl.Schema()), nil)
+			},
+		},
+		{
+			name: "overwrite",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().Overwrite(ctx, newSingleRowReader(t, tbl.Schema()), nil)
+			},
+		},
+		{
+			name: "copy-on-write delete",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().Delete(ctx, iceberg.AlwaysTrue{}, nil)
+			},
+		},
+		{
+			name:  "merge-on-read delete",
+			props: iceberg.Properties{WriteDeleteModeKey: WriteModeMergeOnRead},
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().Delete(ctx, iceberg.AlwaysTrue{}, nil)
+			},
+		},
+		{
+			name: "row delta",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().NewRowDelta(nil).
+					AddRows(newWriteIORequiredDataFile(t)).
+					Commit(ctx)
+			},
+		},
+		{
+			name: "add data files",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().AddDataFiles(ctx, []iceberg.DataFile{
+					newWriteIORequiredDataFileWithPath(t, "file:///tmp/read-only-write/add-data-files.parquet"),
+				}, nil)
+			},
+		},
+		{
+			name: "replace data files with data files add-only path",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().ReplaceDataFilesWithDataFiles(ctx, nil, []iceberg.DataFile{
+					newWriteIORequiredDataFileWithPath(t, "file:///tmp/read-only-write/replace-data-files-add.parquet"),
+				}, nil)
+			},
+		},
+		{
+			name: "add files",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().AddFiles(ctx, []string{
+					"file:///tmp/read-only-write/add-files.parquet",
+				}, nil, false)
+			},
+		},
+		{
+			name: "replace files add-only path",
+			run: func(ctx context.Context, tbl *Table) error {
+				return tbl.NewTransaction().ReplaceFiles(ctx, nil, []iceberg.DataFile{
+					newWriteIORequiredDataFileWithPath(t, "file:///tmp/read-only-write/replace-files-add.parquet"),
+				}, nil, nil)
+			},
+		},
+		{
+			name: "write equality deletes",
+			run: func(ctx context.Context, tbl *Table) error {
+				records := func(yield func(arrow.RecordBatch, error) bool) {}
+				_, err := tbl.NewTransaction().WriteEqualityDeletes(ctx, []int{1}, records)
+
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := newReadOnlyWriteTable(t, tc.props)
+			var err error
+			// NotPanics guards against the pre-fix unsafe fs.(io.WriteFileIO) assertions.
+			require.NotPanics(t, func() {
+				err = tc.run(t.Context(), tbl)
+			})
+			require.ErrorIs(t, err, ErrWriteIORequired)
+			require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+		})
+	}
+}

--- a/table/write_records.go
+++ b/table/write_records.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
-	iceio "github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 )
 
@@ -178,9 +177,9 @@ func WriteRecords(ctx context.Context, tbl *Table,
 		return internal.SingleErrorIter[iceberg.DataFile](err)
 	}
 
-	writeFS, ok := fs.(iceio.WriteFileIO)
-	if !ok {
-		return internal.SingleErrorIter[iceberg.DataFile](fmt.Errorf("%w: filesystem does not support writing", iceberg.ErrNotImplemented))
+	writeFS, err := requireWriteFileIO(fs)
+	if err != nil {
+		return internal.SingleErrorIter[iceberg.DataFile](err)
 	}
 
 	meta, err := MetadataBuilderFromBase(tbl.metadata, tbl.metadataLocation)

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -208,6 +208,7 @@ func (s *WriteRecordsTestSuite) TestFSNotWritable() {
 	records := func(yield func(arrow.RecordBatch, error) bool) {}
 
 	for _, err := range table.WriteRecords(s.ctx, tbl, schema, records) {
+		s.Require().ErrorIs(err, table.ErrWriteIORequired)
 		s.Require().ErrorIs(err, iceberg.ErrNotImplemented)
 	}
 }


### PR DESCRIPTION
Summary

- add a shared WriteFileIO requirement helper for table write paths
- replace unchecked transaction WriteFileIO assertions with normal errors
- keep ErrWriteIORequired compatible with the older ErrNotImplemented match from WriteRecords
- run the write-IO guard before automatic name-mapping mutations
- reuse the copy-on-write deletion WriteFileIO in Overwrite instead of resolving the FS twice
- add regression coverage for append, overwrite, copy-on-write delete, merge-on-read delete, row delta, AddDataFiles, AddFiles, replacement add-only paths, WriteEqualityDeletes, and WriteRecords

Why

Custom FileIO implementations can satisfy io.IO without supporting writes. A few table write paths still used direct WriteFileIO assertions, so a read-only implementation could panic instead of returning an error.

Testing

- go test ./table -run 'TestWritePathsReturnErrorForReadOnlyIO|TestWriteRecords/TestFSNotWritable|TestDoCommit_NonWriteFileIOReturnsError' -count=1
- go test ./table -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check