### PR TITLE
fix(table): remove parquet files on abort

### DIFF
--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -133,7 +133,15 @@ func (bfs *blobFileIO) Remove(name string) error {
 		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
 
-	return bfs.Delete(bfs.ctx, name)
+	if err := bfs.Delete(bfs.ctx, name); err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			err = fs.ErrNotExist
+		}
+
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
+	}
+
+	return nil
 }
 
 func (bfs *blobFileIO) Create(name string) (icebergio.FileWriter, error) {

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -367,6 +367,17 @@ func TestBlobFileIODeleteFilesMissingFilesAreNotErrors(t *testing.T) {
 	assert.Equal(t, []string{"s3://test-bucket/data/nonexistent.parquet"}, deleted)
 }
 
+func TestBlobFileIORemoveMissingFileReturnsNotExist(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+
+	err := bfs.Remove("s3://test-bucket/data/nonexistent.parquet")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}
+
 func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -22,8 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"maps"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -336,6 +338,7 @@ type ParquetFileWriter struct {
 	pqWriter   *pqarrow.FileWriter
 	counter    *internal.CountingWriter
 	fileCloser io.Closer
+	fs         iceio.WriteFileIO
 	format     parquetFormat
 	info       WriteFileInfo
 	partition  map[int]any
@@ -376,6 +379,7 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		pqWriter:   writer,
 		counter:    counter,
 		fileCloser: fw,
+		fs:         fs,
 		format:     p,
 		info:       info,
 		partition:  partitionValues,
@@ -423,7 +427,13 @@ func (w *ParquetFileWriter) Close() (_ iceberg.DataFile, err error) {
 }
 
 func (w *ParquetFileWriter) Abort() error {
-	return w.fileCloser.Close()
+	closeErr := w.fileCloser.Close()
+	removeErr := w.fs.Remove(w.info.FileName)
+	if errors.Is(removeErr, fs.ErrNotExist) || os.IsNotExist(removeErr) {
+		removeErr = nil
+	}
+
+	return errors.Join(closeErr, removeErr)
 }
 
 type decAsIntAgg[T int32 | int64] struct {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
+	iofs "io/fs"
 	"math/big"
 	"strings"
 	"testing"
@@ -39,6 +41,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/schema"
 	"github.com/apache/iceberg-go"
 	internal2 "github.com/apache/iceberg-go/internal"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/geoarrow/geoarrow-go"
@@ -46,6 +49,36 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type abortTestFile struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (f *abortTestFile) Close() error {
+	return f.closeErr
+}
+
+func newAbortTestWriter(t *testing.T, fs iceio.WriteFileIO, fileName string) internal.FileWriter {
+	t.Helper()
+
+	fm := internal.GetFileFormat(iceberg.ParquetFile)
+	icebergSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false,
+	})
+	arrowSchema, err := table.SchemaToArrowSchema(icebergSchema, nil, true, false)
+	require.NoError(t, err)
+
+	writer, err := fm.NewFileWriter(context.Background(), fs, nil, internal.WriteFileInfo{
+		FileSchema: icebergSchema,
+		Spec:       *iceberg.UnpartitionedSpec,
+		FileName:   fileName,
+		WriteProps: fm.GetWriteProperties(iceberg.Properties{}),
+	}, arrowSchema)
+	require.NoError(t, err)
+
+	return writer
+}
 
 func constructTestTablePrimitiveTypes(t *testing.T) (*metadata.FileMetaData, table.Metadata) {
 	tableMeta, err := table.ParseMetadataString(`{
@@ -808,6 +841,48 @@ func TestWriteDataFileErrOnClose(t *testing.T) {
 		WriteProps: []parquet.WriterProperty{},
 	}, []arrow.RecordBatch{rec})
 	require.ErrorContains(t, err, "error on close")
+}
+
+func TestParquetFileWriterAbortRemovesFile(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	fileName := "mem://abort-test/data.parquet"
+	writer := newAbortTestWriter(t, memFS, fileName)
+
+	require.NoError(t, writer.Abort())
+
+	_, err := memFS.Open(fileName)
+	require.ErrorIs(t, err, iofs.ErrNotExist)
+}
+
+func TestParquetFileWriterAbortIgnoresRemoveNotExist(t *testing.T) {
+	mockfs := internal2.MockFS{}
+	mockfs.Test(t)
+	mockfs.On("Create", "f").Return(&abortTestFile{}, nil)
+	mockfs.On("Remove", "f").Return(&iofs.PathError{
+		Op:   "remove",
+		Path: "f",
+		Err:  iofs.ErrNotExist,
+	})
+
+	writer := newAbortTestWriter(t, &mockfs, "f")
+	require.NoError(t, writer.Abort())
+	mockfs.AssertExpectations(t)
+}
+
+func TestParquetFileWriterAbortJoinsCloseAndRemoveErrors(t *testing.T) {
+	closeErr := errors.New("close failed")
+	removeErr := errors.New("remove failed")
+
+	mockfs := internal2.MockFS{}
+	mockfs.Test(t)
+	mockfs.On("Create", "f").Return(&abortTestFile{closeErr: closeErr}, nil)
+	mockfs.On("Remove", "f").Return(removeErr)
+
+	writer := newAbortTestWriter(t, &mockfs, "f")
+	err := writer.Abort()
+	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, err, removeErr)
+	mockfs.AssertExpectations(t)
 }
 
 func TestGetWritePropertiesPageVersion(t *testing.T) {

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -322,10 +322,14 @@ func (s *RollingDataWriterTestSuite) TestAbortWithZeroRowsWritten() {
 	}, nil)
 
 	loc := filepath.ToSlash(s.T().TempDir())
-	fw := s.createFileWriter(loc, arrSchema, "test-abort-zero-rows.parquet")
+	fileName := "test-abort-zero-rows.parquet"
+	filePath := filepath.Join(loc, fileName)
+	fw := s.createFileWriter(loc, arrSchema, fileName)
 
 	// Abort without writing any rows must not panic.
 	s.Require().NoError(fw.Abort())
+	_, err := os.Stat(filePath)
+	s.True(os.IsNotExist(err), "abort should remove the incomplete file")
 }
 
 func (s *RollingDataWriterTestSuite) TestStreamErrorPathUsesAbort() {
@@ -355,6 +359,20 @@ func (s *RollingDataWriterTestSuite) TestStreamErrorPathUsesAbort() {
 
 	s.Require().NoError(writer.Add(badRecord))
 	s.Require().Error(writer.closeAndWait())
+
+	var files []string
+	err := filepath.Walk(loc, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+	s.Require().NoError(err)
+	s.Empty(files, "deferred abort should remove the incomplete file")
 }
 
 func (s *RollingDataWriterTestSuite) TestBytesWrittenReflectsCompressedSize() {


### PR DESCRIPTION
Summary
- remove the incomplete Parquet file when ParquetFileWriter.Abort is called
- return both close and remove failures from Abort with errors.Join
- cover direct abort cleanup and the rolling writer deferred-abort path

Why
#1241 switched failed batch writes to Abort instead of Close, but Abort still only closed the handle. On object stores that could leave a footer-less object behind even though the snapshot never commits it.

Testing
- go test ./table/internal -run 'TestParquetFileWriterAbort|TestWriteDataFileBatchesAbortsOnWriteError' -count=1\n- go test ./table -run 'TestRollingDataWriter/TestAbortWithZeroRowsWritten|TestRollingDataWriter/TestStreamErrorPathUsesAbort' -count=1\n- go test ./table/internal -count=1\n- go test ./table -count=1\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout=10m ./table/...\n- git diff --check\n\nCloses #1247