### PR TITLE
fix(io): validate cloud object URI buckets

### DIFF
--- a/io/config.go
+++ b/io/config.go
@@ -17,6 +17,14 @@
 
 package io
 
+// Constants for generic object store configuration options.
+const (
+	// ObjectStoreStrictAuthorityValidation rejects fully-qualified object paths
+	// whose URI authority differs from the bucket or container used to create
+	// the FileIO.
+	ObjectStoreStrictAuthorityValidation = "object-store.strict-authority-validation"
+)
+
 // Constants for S3 configuration options
 const (
 	S3Region          = "s3.region"

--- a/io/config.go
+++ b/io/config.go
@@ -17,15 +17,6 @@
 
 package io
 
-// Constants for generic object store configuration options.
-const (
-	// ObjectStoreStrictAuthorityValidation rejects fully-qualified object paths
-	// whose URI authority differs from the bucket or container used to create
-	// the FileIO. This is honored only by the Go gocloud-backed FileIO and is
-	// ignored by other Iceberg implementations.
-	ObjectStoreStrictAuthorityValidation = "object-store.strict-authority-validation"
-)
-
 // Constants for S3 configuration options
 const (
 	S3Region          = "s3.region"

--- a/io/config.go
+++ b/io/config.go
@@ -21,7 +21,8 @@ package io
 const (
 	// ObjectStoreStrictAuthorityValidation rejects fully-qualified object paths
 	// whose URI authority differs from the bucket or container used to create
-	// the FileIO.
+	// the FileIO. This is honored only by the Go gocloud-backed FileIO and is
+	// ignored by other Iceberg implementations.
 	ObjectStoreStrictAuthorityValidation = "object-store.strict-authority-validation"
 )
 

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -230,6 +230,11 @@ func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption)
 		}
 
 		uriPath := matches[3]
+		if uriPath != "" && !strings.HasPrefix(uriPath, "/") {
+			return objectLocation{}, fmt.Errorf("URI authority %q must be followed by an object path: %s",
+				authority, location)
+		}
+
 		key := strings.TrimPrefix(uriPath, "/")
 
 		parsed := objectLocation{

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -220,7 +220,8 @@ func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 
 		authority := matches[2]
 		if authority != expectedAuthority {
-			return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
+			return objectLocation{}, fmt.Errorf("%w: URI authority %q does not match configured authority %q",
+				ErrUnsupportedObjectAuthority,
 				authority, expectedAuthority)
 		}
 
@@ -233,6 +234,7 @@ func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 		key := strings.TrimPrefix(uriPath, "/")
 
 		parsed := objectLocation{
+			scheme:       matches[1],
 			authority:    authority,
 			key:          key,
 			uriPrefix:    matches[1] + "://" + authority + "/",
@@ -240,7 +242,7 @@ func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 		}
 
 		if key == "" {
-			return parsed, fmt.Errorf("%w: %s", errEmptyObjectKey, location)
+			return parsed, fmt.Errorf("%w: %s", ErrEmptyObjectKey, location)
 		}
 
 		return parsed, nil

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"regexp"
 	"strings"
@@ -210,12 +209,7 @@ func adlsAuthority(parsed *url.URL) string {
 	return parsed.User.String() + "@" + parsed.Host
 }
 
-func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption) objectLocationExtractor {
-	var cfg keyExtractorConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
+func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 	expectedAuthority := adlsAuthority(parsedURL)
 
 	return func(location string) (objectLocation, error) {
@@ -225,14 +219,9 @@ func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption)
 		}
 
 		authority := matches[2]
-		if cfg.strictAuthorityValidation && authority != expectedAuthority {
+		if authority != expectedAuthority {
 			return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
 				authority, expectedAuthority)
-		}
-		if !cfg.strictAuthorityValidation && authority != expectedAuthority {
-			slog.Warn("using cross-authority ADLS URI with configured container",
-				"authority", authority,
-				"configured_authority", expectedAuthority)
 		}
 
 		uriPath := matches[3]
@@ -260,6 +249,6 @@ func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption)
 }
 
 // adlsKeyExtractor creates a key extractor for Azure schemes using the adlsURIPattern pattern.
-func adlsKeyExtractor(parsedURL *url.URL, opts ...keyExtractorOption) KeyExtractor {
-	return keyExtractorFromObjectLocation(adlsObjectLocationExtractor(parsedURL, opts...))
+func adlsKeyExtractor(parsedURL *url.URL) KeyExtractor {
+	return keyExtractorFromObjectLocation(adlsObjectLocationExtractor(parsedURL))
 }

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -203,10 +203,10 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 
 func adlsAuthority(parsed *url.URL) string {
 	if parsed.User == nil {
-		return parsed.Host
+		return parsed.Hostname()
 	}
 
-	return parsed.User.String() + "@" + parsed.Host
+	return parsed.User.Username() + "@" + parsed.Hostname()
 }
 
 func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
@@ -235,7 +235,6 @@ func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 		parsed := objectLocation{
 			authority:    authority,
 			key:          key,
-			uriKey:       key,
 			uriPrefix:    matches[1] + "://" + authority + "/",
 			hasAuthority: true,
 		}
@@ -246,9 +245,4 @@ func adlsObjectLocationExtractor(parsedURL *url.URL) objectLocationExtractor {
 
 		return parsed, nil
 	}
-}
-
-// adlsKeyExtractor creates a key extractor for Azure schemes using the adlsURIPattern pattern.
-func adlsKeyExtractor(parsedURL *url.URL) KeyExtractor {
-	return keyExtractorFromObjectLocation(adlsObjectLocationExtractor(parsedURL))
 }

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -235,6 +235,7 @@ func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption)
 		parsed := objectLocation{
 			authority:    authority,
 			key:          key,
+			uriKey:       key,
 			uriPrefix:    matches[1] + "://" + authority + "/",
 			hasAuthority: true,
 		}

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"strings"
@@ -227,6 +228,11 @@ func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption)
 		if cfg.strictAuthorityValidation && authority != expectedAuthority {
 			return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
 				authority, expectedAuthority)
+		}
+		if !cfg.strictAuthorityValidation && authority != expectedAuthority {
+			slog.Warn("using cross-authority ADLS URI with configured container",
+				"authority", authority,
+				"configured_authority", expectedAuthority)
 		}
 
 		uriPath := matches[3]

--- a/io/gocloud/azure.go
+++ b/io/gocloud/azure.go
@@ -201,21 +201,53 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 	return azureblob.OpenBucket(ctx, client, nil)
 }
 
-// adlsKeyExtractor creates a key extractor for Azure schemes using the adlsURIPattern pattern
-func adlsKeyExtractor() KeyExtractor {
-	return func(location string) (string, error) {
+func adlsAuthority(parsed *url.URL) string {
+	if parsed.User == nil {
+		return parsed.Host
+	}
+
+	return parsed.User.String() + "@" + parsed.Host
+}
+
+func adlsObjectLocationExtractor(parsedURL *url.URL, opts ...keyExtractorOption) objectLocationExtractor {
+	var cfg keyExtractorConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	expectedAuthority := adlsAuthority(parsedURL)
+
+	return func(location string) (objectLocation, error) {
 		matches := adlsURIPattern.FindStringSubmatch(location)
 		if len(matches) < 4 {
-			return "", fmt.Errorf("invalid ADLS location: %s", location)
+			return objectLocation{}, fmt.Errorf("invalid ADLS location: %s", location)
+		}
+
+		authority := matches[2]
+		if cfg.strictAuthorityValidation && authority != expectedAuthority {
+			return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
+				authority, expectedAuthority)
 		}
 
 		uriPath := matches[3]
 		key := strings.TrimPrefix(uriPath, "/")
 
-		if key == "" {
-			return "", fmt.Errorf("URI path is empty: %s", location)
+		parsed := objectLocation{
+			authority:    authority,
+			key:          key,
+			uriPrefix:    matches[1] + "://" + authority + "/",
+			hasAuthority: true,
 		}
 
-		return key, nil
+		if key == "" {
+			return parsed, fmt.Errorf("%w: %s", errEmptyObjectKey, location)
+		}
+
+		return parsed, nil
 	}
+}
+
+// adlsKeyExtractor creates a key extractor for Azure schemes using the adlsURIPattern pattern.
+func adlsKeyExtractor(parsedURL *url.URL, opts ...keyExtractorOption) KeyExtractor {
+	return keyExtractorFromObjectLocation(adlsObjectLocationExtractor(parsedURL, opts...))
 }

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -207,14 +207,14 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			name:        "URI with no path",
 			input:       "abfs://container@account.dfs.core.windows.net",
 			expectedErr: "object key is empty",
-			wantErrIs:   errEmptyObjectKey,
+			wantErrIs:   ErrEmptyObjectKey,
 			shouldError: true,
 		},
 		{
 			name:        "URI with empty path",
 			input:       "abfs://container@account.dfs.core.windows.net/",
 			expectedErr: "object key is empty",
-			wantErrIs:   errEmptyObjectKey,
+			wantErrIs:   ErrEmptyObjectKey,
 			shouldError: true,
 		},
 		{
@@ -227,6 +227,7 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			name:        "URI with different container",
 			input:       "abfs://other@account.dfs.core.windows.net/path/to/file.parquet",
 			expectedErr: "does not match configured authority",
+			wantErrIs:   ErrUnsupportedObjectAuthority,
 			shouldError: true,
 		},
 		{

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -178,6 +178,7 @@ func TestAdlsKeyExtractor(t *testing.T) {
 		input       string
 		expectedKey string
 		expectedErr string
+		wantErrIs   error
 		shouldError bool
 	}{
 		{
@@ -205,11 +206,15 @@ func TestAdlsKeyExtractor(t *testing.T) {
 		{
 			name:        "URI with no path",
 			input:       "abfs://container@account.dfs.core.windows.net",
+			expectedErr: "object key is empty",
+			wantErrIs:   errEmptyObjectKey,
 			shouldError: true,
 		},
 		{
 			name:        "URI with empty path",
 			input:       "abfs://container@account.dfs.core.windows.net/",
+			expectedErr: "object key is empty",
+			wantErrIs:   errEmptyObjectKey,
 			shouldError: true,
 		},
 		{
@@ -221,11 +226,13 @@ func TestAdlsKeyExtractor(t *testing.T) {
 		{
 			name:        "URI with different container",
 			input:       "abfs://other@account.dfs.core.windows.net/path/to/file.parquet",
+			expectedErr: "does not match configured authority",
 			shouldError: true,
 		},
 		{
 			name:        "invalid ADLS location - invalid scheme",
 			input:       "s3://bucket/path/to/file.parquet",
+			expectedErr: "invalid ADLS location",
 			shouldError: true,
 		},
 	}
@@ -239,16 +246,19 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			parsed, err := url.Parse(root)
 			require.NoError(t, err)
 
-			extractor := adlsKeyExtractor(parsed)
+			extractor := keyExtractorFromObjectLocation(adlsObjectLocationExtractor(parsed))
 			key, err := extractor(test.input)
 
 			if test.shouldError {
-				assert.Error(t, err, "Expected error for input: %s", test.input)
+				require.Error(t, err, "Expected error for input: %s", test.input)
 				if test.expectedErr != "" {
 					assert.ErrorContains(t, err, test.expectedErr, "Expected specific error for input: %s", test.input)
 				}
+				if test.wantErrIs != nil {
+					assert.ErrorIs(t, err, test.wantErrIs)
+				}
 			} else {
-				assert.NoError(t, err, "Unexpected error for input: %s", test.input)
+				require.NoError(t, err, "Unexpected error for input: %s", test.input)
 				assert.Equal(t, test.expectedKey, key, "Key mismatch for input: %s", test.input)
 			}
 		})

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateAzureBucketDefaultCredentialCalled(t *testing.T) {
@@ -171,12 +172,17 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 }
 
 func TestAdlsKeyExtractor(t *testing.T) {
-	extractor := adlsKeyExtractor()
+	parsed, err := url.Parse("abfs://container@account.dfs.core.windows.net/")
+	require.NoError(t, err)
+
+	extractor := adlsKeyExtractor(parsed)
+	strictExtractor := adlsKeyExtractor(parsed, withStrictAuthorityValidation())
 
 	tests := []struct {
 		name        string
 		input       string
 		expectedKey string
+		strict      bool
 		shouldError bool
 	}{
 		{
@@ -210,6 +216,12 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			shouldError: true,
 		},
 		{
+			name:        "strict URI with different container",
+			input:       "abfs://other@account.dfs.core.windows.net/path/to/file.parquet",
+			strict:      true,
+			shouldError: true,
+		},
+		{
 			name:        "invalid ADLS location - invalid scheme",
 			input:       "s3://bucket/path/to/file.parquet",
 			shouldError: true,
@@ -218,7 +230,11 @@ func TestAdlsKeyExtractor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			key, err := extractor(test.input)
+			extract := extractor
+			if test.strict {
+				extract = strictExtractor
+			}
+			key, err := extract(test.input)
 
 			if test.shouldError {
 				assert.Error(t, err, "Expected error for input: %s", test.input)

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -182,6 +182,7 @@ func TestAdlsKeyExtractor(t *testing.T) {
 		name        string
 		input       string
 		expectedKey string
+		expectedErr string
 		strict      bool
 		shouldError bool
 	}{
@@ -216,6 +217,12 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			shouldError: true,
 		},
 		{
+			name:        "URI with query but no path",
+			input:       "abfs://container@account.dfs.core.windows.net?prefix=data",
+			expectedErr: "must be followed by an object path",
+			shouldError: true,
+		},
+		{
 			name:        "strict URI with different container",
 			input:       "abfs://other@account.dfs.core.windows.net/path/to/file.parquet",
 			strict:      true,
@@ -238,6 +245,9 @@ func TestAdlsKeyExtractor(t *testing.T) {
 
 			if test.shouldError {
 				assert.Error(t, err, "Expected error for input: %s", test.input)
+				if test.expectedErr != "" {
+					assert.ErrorContains(t, err, test.expectedErr, "Expected specific error for input: %s", test.input)
+				}
 			} else {
 				assert.NoError(t, err, "Unexpected error for input: %s", test.input)
 				assert.Equal(t, test.expectedKey, key, "Key mismatch for input: %s", test.input)

--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -172,18 +172,12 @@ func TestNewAdlsLocationUriParsing(t *testing.T) {
 }
 
 func TestAdlsKeyExtractor(t *testing.T) {
-	parsed, err := url.Parse("abfs://container@account.dfs.core.windows.net/")
-	require.NoError(t, err)
-
-	extractor := adlsKeyExtractor(parsed)
-	strictExtractor := adlsKeyExtractor(parsed, withStrictAuthorityValidation())
-
 	tests := []struct {
 		name        string
+		root        string
 		input       string
 		expectedKey string
 		expectedErr string
-		strict      bool
 		shouldError bool
 	}{
 		{
@@ -198,11 +192,13 @@ func TestAdlsKeyExtractor(t *testing.T) {
 		},
 		{
 			name:        "wasb valid URI",
+			root:        "wasb://container@account.blob.core.windows.net/",
 			input:       "wasb://container@account.blob.core.windows.net/path/to/file.parquet",
 			expectedKey: "path/to/file.parquet",
 		},
 		{
 			name:        "wasbs valid URI",
+			root:        "wasbs://container@account.blob.core.windows.net/",
 			input:       "wasbs://container@account.blob.core.windows.net/path/to/file.parquet",
 			expectedKey: "path/to/file.parquet",
 		},
@@ -223,9 +219,8 @@ func TestAdlsKeyExtractor(t *testing.T) {
 			shouldError: true,
 		},
 		{
-			name:        "strict URI with different container",
+			name:        "URI with different container",
 			input:       "abfs://other@account.dfs.core.windows.net/path/to/file.parquet",
-			strict:      true,
 			shouldError: true,
 		},
 		{
@@ -237,11 +232,15 @@ func TestAdlsKeyExtractor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			extract := extractor
-			if test.strict {
-				extract = strictExtractor
+			root := test.root
+			if root == "" {
+				root = "abfs://container@account.dfs.core.windows.net/"
 			}
-			key, err := extract(test.input)
+			parsed, err := url.Parse(root)
+			require.NoError(t, err)
+
+			extractor := adlsKeyExtractor(parsed)
+			key, err := extractor(test.input)
 
 			if test.shouldError {
 				assert.Error(t, err, "Expected error for input: %s", test.input)

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -69,33 +68,130 @@ func (f *blobOpenFile) Sys() any                   { return f.b }
 func (f *blobOpenFile) IsDir() bool                { return false }
 func (f *blobOpenFile) Stat() (fs.FileInfo, error) { return f, nil }
 
-// KeyExtractor extracts the object key from an input path
+// KeyExtractor extracts the object key from an input path.
 type KeyExtractor func(path string) (string, error)
 
-// defaultKeyExtractor extracts the object key by removing the scheme and bucket name from the URI
-// e.g., s3://bucket/path/file -> path/file
-func defaultKeyExtractor(bucketName string) KeyExtractor {
-	return func(location string) (string, error) {
-		_, after, found := strings.Cut(location, "://")
-		if found {
-			location = after
-		}
+var errEmptyObjectKey = errors.New("object key is empty")
 
-		key := strings.TrimPrefix(location, bucketName+"/")
+type objectLocation struct {
+	authority    string
+	key          string
+	uriPrefix    string
+	hasAuthority bool
+}
 
-		if key == "" {
-			return "", fmt.Errorf("URI path is empty: %s", location)
-		}
-
-		return key, nil
+func splitObjectLocation(location string) (objectLocation, error) {
+	scheme, rest, ok := strings.Cut(location, "://")
+	if !ok {
+		return objectLocation{key: location}, nil
 	}
+
+	authorityEnd := strings.IndexAny(rest, "/?#")
+	if authorityEnd == -1 {
+		authorityEnd = len(rest)
+	}
+
+	authority := rest[:authorityEnd]
+	if authority == "" {
+		return objectLocation{}, fmt.Errorf("URI authority is empty: %s", location)
+	}
+
+	key := ""
+	if authorityEnd < len(rest) {
+		if rest[authorityEnd] != '/' {
+			return objectLocation{}, fmt.Errorf("URI authority %q must be followed by an object path: %s",
+				authority, location)
+		}
+
+		key = strings.TrimPrefix(rest[authorityEnd:], "/")
+	}
+
+	return objectLocation{
+		authority:    authority,
+		key:          key,
+		uriPrefix:    scheme + "://" + authority + "/",
+		hasAuthority: true,
+	}, nil
+}
+
+type keyExtractorConfig struct {
+	strictAuthorityValidation bool
+}
+
+type keyExtractorOption func(*keyExtractorConfig)
+
+func withStrictAuthorityValidation() keyExtractorOption {
+	return func(cfg *keyExtractorConfig) {
+		cfg.strictAuthorityValidation = true
+	}
+}
+
+type objectLocationExtractor func(location string) (objectLocation, error)
+
+func keyExtractorFromObjectLocation(extract objectLocationExtractor) KeyExtractor {
+	return func(location string) (string, error) {
+		parsed, err := extract(location)
+		if err != nil {
+			return "", err
+		}
+
+		return parsed.key, nil
+	}
+}
+
+func legacyAuthorityKey(parsed objectLocation) string {
+	if parsed.key == "" {
+		return parsed.authority + "/"
+	}
+
+	return parsed.authority + "/" + parsed.key
+}
+
+func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOption) objectLocationExtractor {
+	var cfg keyExtractorConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return func(location string) (objectLocation, error) {
+		parsed, err := splitObjectLocation(location)
+		if err != nil {
+			return objectLocation{}, err
+		}
+
+		if parsed.hasAuthority {
+			if parsed.authority != bucketName {
+				if cfg.strictAuthorityValidation {
+					return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
+						parsed.authority, bucketName)
+				}
+
+				parsed.key = legacyAuthorityKey(parsed)
+			}
+		} else {
+			parsed.key = strings.TrimPrefix(location, bucketName+"/")
+		}
+
+		if parsed.key == "" {
+			return parsed, fmt.Errorf("%w: %s", errEmptyObjectKey, location)
+		}
+
+		return parsed, nil
+	}
+}
+
+// defaultKeyExtractor extracts the object key by removing the scheme and bucket name from the URI.
+// e.g., s3://bucket/path/file -> path/file.
+func defaultKeyExtractor(bucketName string, opts ...keyExtractorOption) KeyExtractor {
+	return keyExtractorFromObjectLocation(defaultObjectLocationExtractor(bucketName, opts...))
 }
 
 type blobFileIO struct {
 	*blob.Bucket
 
-	keyExtractor KeyExtractor
-	ctx          context.Context
+	keyExtractor  KeyExtractor
+	extractObject objectLocationExtractor
+	ctx           context.Context
 
 	// newRangeReader is an optional hook for testing.
 	// It allows injecting a mock reader to verify Close calls.
@@ -198,25 +294,52 @@ func (bfs *blobFileIO) NewWriter(ctx context.Context, path string, overwrite boo
 		nil
 }
 
-func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor) icebergio.IO {
-	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, ctx: ctx}
+func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor, extractObject ...objectLocationExtractor) icebergio.IO {
+	var extractor objectLocationExtractor
+	if len(extractObject) > 0 {
+		extractor = extractObject[0]
+	}
+
+	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, extractObject: extractor, ctx: ctx}
+}
+
+func (bfs *blobFileIO) objectLocation(root string) (objectLocation, error) {
+	if bfs.extractObject != nil {
+		return bfs.extractObject(root)
+	}
+
+	location, err := splitObjectLocation(root)
+	if err != nil {
+		return objectLocation{}, err
+	}
+
+	key, err := bfs.preprocess(root)
+	location.key = key
+
+	return location, err
 }
 
 func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
-	parsed, err := url.Parse(root)
+	location, err := bfs.objectLocation(root)
+	walkPath := location.key
 	if err != nil {
-		return fmt.Errorf("invalid URL %s: %w", root, err)
-	}
+		if !errors.Is(err, errEmptyObjectKey) {
+			return &fs.PathError{Op: "walk dir", Path: root, Err: err}
+		}
 
-	walkPath := strings.TrimPrefix(parsed.Path, "/")
-	if walkPath == "" {
 		walkPath = "."
 	}
 
-	parsed.Path = ""
-
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
-		return fn(parsed.JoinPath(path).String(), d, err)
+		if location.hasAuthority {
+			if path == "." {
+				path = location.uriPrefix
+			} else {
+				path = location.uriPrefix + path
+			}
+		}
+
+		return fn(path, d, err)
 	})
 }
 

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -141,6 +141,8 @@ func keyExtractorFromObjectLocation(extract objectLocationExtractor) KeyExtracto
 	}
 }
 
+// Non-strict cross-authority paths still fold into a storage key so existing
+// manifests keep loading until the FileIO can open per-authority buckets.
 func legacyAuthorityKey(parsed objectLocation) string {
 	if parsed.key == "" {
 		return parsed.authority + "/"

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -173,6 +174,10 @@ func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOptio
 				// Preserve the legacy fold-by-authority behavior on the default
 				// path so existing cross-authority manifests keep loading until
 				// the FileIO can open per-authority buckets.
+				slog.Warn("folding cross-authority object URI into configured bucket",
+					"authority", parsed.authority,
+					"configured_authority", bucketName,
+					"key", parsed.key)
 				parsed.key = legacyAuthorityKey(parsed)
 			}
 		} else {
@@ -197,7 +202,6 @@ func defaultKeyExtractor(bucketName string, opts ...keyExtractorOption) KeyExtra
 type blobFileIO struct {
 	*blob.Bucket
 
-	keyExtractor  KeyExtractor
 	extractObject objectLocationExtractor
 	ctx           context.Context
 
@@ -209,7 +213,12 @@ type blobFileIO struct {
 var _ icebergio.ListableIO = (*blobFileIO)(nil)
 
 func (bfs *blobFileIO) preprocess(path string) (string, error) {
-	return bfs.keyExtractor(path)
+	location, err := bfs.objectLocation(path)
+	if err != nil {
+		return "", err
+	}
+
+	return location.key, nil
 }
 
 func (bfs *blobFileIO) Open(path string) (icebergio.File, error) {
@@ -302,8 +311,8 @@ func (bfs *blobFileIO) NewWriter(ctx context.Context, path string, overwrite boo
 		nil
 }
 
-func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor, extractObject objectLocationExtractor) icebergio.IO {
-	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, extractObject: extractObject, ctx: ctx}
+func createBlobFS(ctx context.Context, bucket *blob.Bucket, extractObject objectLocationExtractor) icebergio.IO {
+	return &blobFileIO{Bucket: bucket, extractObject: extractObject, ctx: ctx}
 }
 
 func (bfs *blobFileIO) objectLocation(root string) (objectLocation, error) {
@@ -314,9 +323,9 @@ func (bfs *blobFileIO) objectLocation(root string) (objectLocation, error) {
 	return bfs.extractObject(root)
 }
 
-func walkedURIPath(location objectLocation, walked string) string {
+func walkedURIPath(location objectLocation, walked string) (string, error) {
 	if walked == "." {
-		return location.uriPrefix
+		return location.uriPrefix, nil
 	}
 
 	uriKey := walked
@@ -332,15 +341,17 @@ func walkedURIPath(location objectLocation, walked string) string {
 				} else {
 					uriKey = location.uriKey + "/" + suffix
 				}
+			} else {
+				return "", fmt.Errorf("walked path %q is outside storage root %q", walked, storageRoot)
 			}
 		}
 	}
 
 	if uriKey == "" {
-		return location.uriPrefix
+		return location.uriPrefix, nil
 	}
 
-	return location.uriPrefix + uriKey
+	return location.uriPrefix + uriKey, nil
 }
 
 func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
@@ -356,7 +367,11 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		if location.hasAuthority {
-			path = walkedURIPath(location, path)
+			rewritten, rewriteErr := walkedURIPath(location, path)
+			if rewriteErr != nil {
+				return rewriteErr
+			}
+			path = rewritten
 		}
 
 		return fn(path, d, err)

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -117,18 +116,6 @@ func splitObjectLocation(location string) (objectLocation, error) {
 	}, nil
 }
 
-type keyExtractorConfig struct {
-	strictAuthorityValidation bool
-}
-
-type keyExtractorOption func(*keyExtractorConfig)
-
-func withStrictAuthorityValidation() keyExtractorOption {
-	return func(cfg *keyExtractorConfig) {
-		cfg.strictAuthorityValidation = true
-	}
-}
-
 type objectLocationExtractor func(location string) (objectLocation, error)
 
 func keyExtractorFromObjectLocation(extract objectLocationExtractor) KeyExtractor {
@@ -142,22 +129,7 @@ func keyExtractorFromObjectLocation(extract objectLocationExtractor) KeyExtracto
 	}
 }
 
-// Non-strict cross-authority paths still fold into a storage key so existing
-// manifests keep loading until the FileIO can open per-authority buckets.
-func legacyAuthorityKey(parsed objectLocation) string {
-	if parsed.key == "" {
-		return parsed.authority + "/"
-	}
-
-	return parsed.authority + "/" + parsed.key
-}
-
-func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOption) objectLocationExtractor {
-	var cfg keyExtractorConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
+func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
 	return func(location string) (objectLocation, error) {
 		parsed, err := splitObjectLocation(location)
 		if err != nil {
@@ -166,19 +138,8 @@ func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOptio
 
 		if parsed.hasAuthority {
 			if parsed.authority != bucketName {
-				if cfg.strictAuthorityValidation {
-					return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
-						parsed.authority, bucketName)
-				}
-
-				// Preserve the legacy fold-by-authority behavior on the default
-				// path so existing cross-authority manifests keep loading until
-				// the FileIO can open per-authority buckets.
-				slog.Warn("folding cross-authority object URI into configured bucket",
-					"authority", parsed.authority,
-					"configured_authority", bucketName,
-					"key", parsed.key)
-				parsed.key = legacyAuthorityKey(parsed)
+				return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
+					parsed.authority, bucketName)
 			}
 		} else {
 			parsed.key = strings.TrimPrefix(location, bucketName+"/")
@@ -195,8 +156,8 @@ func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOptio
 
 // defaultKeyExtractor extracts the object key by removing the scheme and bucket name from the URI.
 // e.g., s3://bucket/path/file -> path/file.
-func defaultKeyExtractor(bucketName string, opts ...keyExtractorOption) KeyExtractor {
-	return keyExtractorFromObjectLocation(defaultObjectLocationExtractor(bucketName, opts...))
+func defaultKeyExtractor(bucketName string) KeyExtractor {
+	return keyExtractorFromObjectLocation(defaultObjectLocationExtractor(bucketName))
 }
 
 type blobFileIO struct {

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -76,6 +76,7 @@ var errEmptyObjectKey = errors.New("object key is empty")
 type objectLocation struct {
 	authority    string
 	key          string
+	uriKey       string
 	uriPrefix    string
 	hasAuthority bool
 }
@@ -83,7 +84,7 @@ type objectLocation struct {
 func splitObjectLocation(location string) (objectLocation, error) {
 	scheme, rest, ok := strings.Cut(location, "://")
 	if !ok {
-		return objectLocation{key: location}, nil
+		return objectLocation{key: location, uriKey: location}, nil
 	}
 
 	authorityEnd := strings.IndexAny(rest, "/?#")
@@ -109,6 +110,7 @@ func splitObjectLocation(location string) (objectLocation, error) {
 	return objectLocation{
 		authority:    authority,
 		key:          key,
+		uriKey:       key,
 		uriPrefix:    scheme + "://" + authority + "/",
 		hasAuthority: true,
 	}, nil
@@ -166,10 +168,14 @@ func defaultObjectLocationExtractor(bucketName string, opts ...keyExtractorOptio
 						parsed.authority, bucketName)
 				}
 
+				// Preserve the legacy fold-by-authority behavior on the default
+				// path so existing cross-authority manifests keep loading until
+				// the FileIO can open per-authority buckets.
 				parsed.key = legacyAuthorityKey(parsed)
 			}
 		} else {
 			parsed.key = strings.TrimPrefix(location, bucketName+"/")
+			parsed.uriKey = parsed.key
 		}
 
 		if parsed.key == "" {
@@ -294,29 +300,45 @@ func (bfs *blobFileIO) NewWriter(ctx context.Context, path string, overwrite boo
 		nil
 }
 
-func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor, extractObject ...objectLocationExtractor) icebergio.IO {
-	var extractor objectLocationExtractor
-	if len(extractObject) > 0 {
-		extractor = extractObject[0]
-	}
-
-	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, extractObject: extractor, ctx: ctx}
+func createBlobFS(ctx context.Context, bucket *blob.Bucket, keyExtractor KeyExtractor, extractObject objectLocationExtractor) icebergio.IO {
+	return &blobFileIO{Bucket: bucket, keyExtractor: keyExtractor, extractObject: extractObject, ctx: ctx}
 }
 
 func (bfs *blobFileIO) objectLocation(root string) (objectLocation, error) {
-	if bfs.extractObject != nil {
-		return bfs.extractObject(root)
+	if bfs.extractObject == nil {
+		return objectLocation{}, errors.New("blob file IO missing object location extractor")
 	}
 
-	location, err := splitObjectLocation(root)
-	if err != nil {
-		return objectLocation{}, err
+	return bfs.extractObject(root)
+}
+
+func walkedURIPath(location objectLocation, walked string) string {
+	if walked == "." {
+		return location.uriPrefix
 	}
 
-	key, err := bfs.preprocess(root)
-	location.key = key
+	uriKey := walked
+	if location.key != location.uriKey {
+		storageRoot := strings.TrimSuffix(location.key, "/")
+		if walked == location.key || walked == storageRoot {
+			uriKey = location.uriKey
+		} else {
+			prefix := storageRoot + "/"
+			if suffix, ok := strings.CutPrefix(walked, prefix); ok {
+				if location.uriKey == "" {
+					uriKey = suffix
+				} else {
+					uriKey = location.uriKey + "/" + suffix
+				}
+			}
+		}
+	}
 
-	return location, err
+	if uriKey == "" {
+		return location.uriPrefix
+	}
+
+	return location.uriPrefix + uriKey
 }
 
 func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
@@ -332,11 +354,7 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		if location.hasAuthority {
-			if path == "." {
-				path = location.uriPrefix
-			} else {
-				path = location.uriPrefix + path
-			}
+			path = walkedURIPath(location, path)
 		}
 
 		return fn(path, d, err)

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	icebergio "github.com/apache/iceberg-go/io"
@@ -71,9 +72,17 @@ func (f *blobOpenFile) Stat() (fs.FileInfo, error) { return f, nil }
 // KeyExtractor extracts the object key from an input path.
 type KeyExtractor func(path string) (string, error)
 
-var errEmptyObjectKey = errors.New("object key is empty")
+// ErrEmptyObjectKey is returned by object location extractors when a URI names
+// a bucket or container but no object key within it.
+var ErrEmptyObjectKey = errors.New("object key is empty")
+
+// ErrUnsupportedObjectAuthority is returned when this single-bucket FileIO is
+// asked to access a URI for another bucket or container. Load a FileIO for that
+// URI to access it; this backend does not route across authorities.
+var ErrUnsupportedObjectAuthority = errors.New("object URI authority is not supported by this FileIO")
 
 type objectLocation struct {
+	scheme       string
 	authority    string
 	key          string
 	uriPrefix    string
@@ -109,6 +118,7 @@ func splitObjectLocation(location string) (objectLocation, error) {
 	}
 
 	return objectLocation{
+		scheme:       scheme,
 		authority:    authority,
 		key:          key,
 		uriPrefix:    scheme + "://" + authority + "/",
@@ -129,7 +139,7 @@ func keyExtractorFromObjectLocation(extract objectLocationExtractor) KeyExtracto
 	}
 }
 
-func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
+func defaultObjectLocationExtractor(bucketName string, allowedSchemes ...string) objectLocationExtractor {
 	return func(location string) (objectLocation, error) {
 		parsed, err := splitObjectLocation(location)
 		if err != nil {
@@ -137,8 +147,13 @@ func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
 		}
 
 		if parsed.hasAuthority {
+			if len(allowedSchemes) > 0 && !slices.Contains(allowedSchemes, parsed.scheme) {
+				return objectLocation{}, fmt.Errorf("URI scheme %q is not supported by this FileIO (allowed: %s): %s",
+					parsed.scheme, strings.Join(allowedSchemes, ", "), location)
+			}
 			if parsed.authority != bucketName {
-				return objectLocation{}, fmt.Errorf("URI authority %q does not match configured authority %q",
+				return objectLocation{}, fmt.Errorf("%w: URI authority %q does not match configured authority %q",
+					ErrUnsupportedObjectAuthority,
 					parsed.authority, bucketName)
 			}
 		} else {
@@ -146,7 +161,7 @@ func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
 		}
 
 		if parsed.key == "" {
-			return parsed, fmt.Errorf("%w: %s", errEmptyObjectKey, location)
+			return parsed, fmt.Errorf("%w: %s", ErrEmptyObjectKey, location)
 		}
 
 		return parsed, nil
@@ -155,8 +170,8 @@ func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
 
 // defaultKeyExtractor extracts the object key by removing the scheme and bucket name from the URI.
 // e.g., s3://bucket/path/file -> path/file.
-func defaultKeyExtractor(bucketName string) KeyExtractor {
-	return keyExtractorFromObjectLocation(defaultObjectLocationExtractor(bucketName))
+func defaultKeyExtractor(bucketName string, allowedSchemes ...string) KeyExtractor {
+	return keyExtractorFromObjectLocation(defaultObjectLocationExtractor(bucketName, allowedSchemes...))
 }
 
 type blobFileIO struct {
@@ -299,7 +314,7 @@ func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 	location, err := bfs.objectLocation(root)
 	var walkPath string
 	if err != nil {
-		if !errors.Is(err, errEmptyObjectKey) {
+		if !errors.Is(err, ErrEmptyObjectKey) {
 			return &fs.PathError{Op: "walk dir", Path: root, Err: err}
 		}
 

--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -76,7 +76,6 @@ var errEmptyObjectKey = errors.New("object key is empty")
 type objectLocation struct {
 	authority    string
 	key          string
-	uriKey       string
 	uriPrefix    string
 	hasAuthority bool
 }
@@ -84,7 +83,7 @@ type objectLocation struct {
 func splitObjectLocation(location string) (objectLocation, error) {
 	scheme, rest, ok := strings.Cut(location, "://")
 	if !ok {
-		return objectLocation{key: location, uriKey: location}, nil
+		return objectLocation{key: location}, nil
 	}
 
 	authorityEnd := strings.IndexAny(rest, "/?#")
@@ -104,13 +103,14 @@ func splitObjectLocation(location string) (objectLocation, error) {
 				authority, location)
 		}
 
+		// Keep object keys raw. Cloud object names are opaque strings, so this
+		// intentionally does not URL-unescape literal %, spaces, ? or #.
 		key = strings.TrimPrefix(rest[authorityEnd:], "/")
 	}
 
 	return objectLocation{
 		authority:    authority,
 		key:          key,
-		uriKey:       key,
 		uriPrefix:    scheme + "://" + authority + "/",
 		hasAuthority: true,
 	}, nil
@@ -143,7 +143,6 @@ func defaultObjectLocationExtractor(bucketName string) objectLocationExtractor {
 			}
 		} else {
 			parsed.key = strings.TrimPrefix(location, bucketName+"/")
-			parsed.uriKey = parsed.key
 		}
 
 		if parsed.key == "" {
@@ -284,55 +283,34 @@ func (bfs *blobFileIO) objectLocation(root string) (objectLocation, error) {
 	return bfs.extractObject(root)
 }
 
-func walkedURIPath(location objectLocation, walked string) (string, error) {
+func walkedURIPath(location objectLocation, walked string) string {
 	if walked == "." {
-		return location.uriPrefix, nil
+		return location.uriPrefix
 	}
 
-	uriKey := walked
-	if location.key != location.uriKey {
-		storageRoot := strings.TrimSuffix(location.key, "/")
-		if walked == location.key || walked == storageRoot {
-			uriKey = location.uriKey
-		} else {
-			prefix := storageRoot + "/"
-			if suffix, ok := strings.CutPrefix(walked, prefix); ok {
-				if location.uriKey == "" {
-					uriKey = suffix
-				} else {
-					uriKey = location.uriKey + "/" + suffix
-				}
-			} else {
-				return "", fmt.Errorf("walked path %q is outside storage root %q", walked, storageRoot)
-			}
-		}
+	if walked == "" {
+		return location.uriPrefix
 	}
 
-	if uriKey == "" {
-		return location.uriPrefix, nil
-	}
-
-	return location.uriPrefix + uriKey, nil
+	return location.uriPrefix + walked
 }
 
 func (bfs *blobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 	location, err := bfs.objectLocation(root)
-	walkPath := location.key
+	var walkPath string
 	if err != nil {
 		if !errors.Is(err, errEmptyObjectKey) {
 			return &fs.PathError{Op: "walk dir", Path: root, Err: err}
 		}
 
 		walkPath = "."
+	} else {
+		walkPath = location.key
 	}
 
 	return fs.WalkDir(bfs.Bucket, walkPath, func(path string, d fs.DirEntry, err error) error {
 		if location.hasAuthority {
-			rewritten, rewriteErr := walkedURIPath(location, path)
-			if rewriteErr != nil {
-				return rewriteErr
-			}
-			path = rewritten
+			path = walkedURIPath(location, path)
 		}
 
 		return fn(path, d, err)

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -434,6 +434,35 @@ func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
 	}
 }
 
+func TestBlobFileIOWalkDirKeepsCrossAuthorityPathsStableByDefault(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	require.NoError(t, bucket.WriteAll(ctx, "other-bucket/data/file.parquet", []byte("content"), nil))
+
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
+
+	var walked []string
+	err := bfs.WalkDir("s3://other-bucket/data", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		walked = append(walked, path)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, walked, "s3://other-bucket/data")
+	assert.Contains(t, walked, "s3://other-bucket/data/file.parquet")
+	for _, path := range walked {
+		assert.NotContains(t, path, "s3://other-bucket/other-bucket/")
+	}
+}
+
 func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 	ctx := context.Background()
 
@@ -518,7 +547,8 @@ func TestBlobFileIOImplementsBulkRemovableIO(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := createBlobFS(context.Background(), bucket, defaultKeyExtractor("test-bucket"))
+	extractor := defaultObjectLocationExtractor("test-bucket")
+	bfs := createBlobFS(context.Background(), bucket, keyExtractorFromObjectLocation(extractor), extractor)
 
 	_, ok := bfs.(icebergio.BulkRemovableIO)
 	assert.True(t, ok, "blobFileIO should implement BulkRemovableIO")
@@ -534,7 +564,8 @@ func TestBlobFileIODeleteFiles(t *testing.T) {
 	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("data2"), nil))
 	require.NoError(t, bucket.WriteAll(ctx, "data/file3.parquet", []byte("data3"), nil))
 
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	extractor := defaultObjectLocationExtractor("test-bucket")
+	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	deleted, err := bulk.DeleteFiles(ctx, []string{
@@ -563,7 +594,8 @@ func TestBlobFileIODeleteFilesMissingFilesAreNotErrors(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	extractor := defaultObjectLocationExtractor("test-bucket")
+	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	// Deleting non-existent files should succeed.
@@ -590,7 +622,8 @@ func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	extractor := defaultObjectLocationExtractor("test-bucket")
+	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	deleted, err := bulk.DeleteFiles(ctx, nil)

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -36,6 +36,7 @@ func TestDefaultKeyExtractor(t *testing.T) {
 	tests := []struct {
 		name            string
 		bucketName      string
+		allowedSchemes  []string
 		input           string
 		expectedKey     string
 		wantErrContains string
@@ -96,11 +97,25 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			name:            "s3 URI with different bucket",
 			input:           "s3://other-bucket/path/to/file.parquet",
 			wantErrContains: "does not match configured authority",
+			wantErrIs:       ErrUnsupportedObjectAuthority,
 		},
 		{
 			name:            "gs URI with different bucket",
 			input:           "gs://other-bucket/path/to/file.parquet",
 			wantErrContains: "does not match configured authority",
+			wantErrIs:       ErrUnsupportedObjectAuthority,
+		},
+		{
+			name:            "s3 extractor rejects gs URI with same bucket",
+			allowedSchemes:  s3Schemes,
+			input:           "gs://my-bucket/path/to/file.parquet",
+			wantErrContains: `URI scheme "gs" is not supported`,
+		},
+		{
+			name:            "gcs extractor rejects s3 URI with same bucket",
+			allowedSchemes:  gcsSchemes,
+			input:           "s3://my-bucket/path/to/file.parquet",
+			wantErrContains: `URI scheme "s3" is not supported`,
 		},
 		{
 			name:        "URI with query and fragment",
@@ -111,7 +126,7 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			name:            "URI with empty path",
 			input:           "s3://my-bucket/",
 			wantErrContains: "object key is empty",
-			wantErrIs:       errEmptyObjectKey,
+			wantErrIs:       ErrEmptyObjectKey,
 		},
 		{
 			name:            "URI with empty authority",
@@ -131,7 +146,7 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			if bucketName == "" {
 				bucketName = "my-bucket"
 			}
-			extractor := defaultKeyExtractor(bucketName)
+			extractor := defaultKeyExtractor(bucketName, test.allowedSchemes...)
 			key, err := extractor(test.input)
 
 			if test.wantErrContains != "" {
@@ -147,8 +162,11 @@ func TestDefaultKeyExtractor(t *testing.T) {
 	}
 }
 
-func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket) *blobFileIO {
-	extractor := defaultObjectLocationExtractor(bucketName)
+func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket, allowedSchemes ...string) *blobFileIO {
+	if len(allowedSchemes) == 0 {
+		allowedSchemes = s3Schemes
+	}
+	extractor := defaultObjectLocationExtractor(bucketName, allowedSchemes...)
 
 	return &blobFileIO{
 		Bucket:        bucket,
@@ -176,35 +194,60 @@ func identityObjectLocation(location string) (objectLocation, error) {
 	return objectLocation{key: location}, nil
 }
 
-func TestBlobFileIORejectsWrongBucketObjectPaths(t *testing.T) {
+func TestBlobFileIORejectsUnsupportedObjectPaths(t *testing.T) {
 	ctx := context.Background()
 
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
-
 	for _, tt := range []struct {
-		name   string
-		path   string
-		oldKey string
+		name           string
+		allowedSchemes []string
+		path           string
+		oldKey         string
+		wantErr        error
+		wantErrText    string
 	}{
 		{
-			name:   "s3",
-			path:   "s3://other-bucket/data/file.parquet",
-			oldKey: "other-bucket/data/file.parquet",
+			name:           "s3 different bucket",
+			allowedSchemes: s3Schemes,
+			path:           "s3://other-bucket/data/file.parquet",
+			oldKey:         "other-bucket/data/file.parquet",
+			wantErr:        ErrUnsupportedObjectAuthority,
+			wantErrText:    "does not match configured authority",
 		},
 		{
-			name:   "gcs",
-			path:   "gs://other-bucket/data/file.parquet",
-			oldKey: "other-bucket/data/file.parquet",
+			name:           "gcs different bucket",
+			allowedSchemes: gcsSchemes,
+			path:           "gs://other-bucket/data/file.parquet",
+			oldKey:         "other-bucket/data/file.parquet",
+			wantErr:        ErrUnsupportedObjectAuthority,
+			wantErrText:    "does not match configured authority",
+		},
+		{
+			name:           "s3 rejects gs same bucket",
+			allowedSchemes: s3Schemes,
+			path:           "gs://test-bucket/data/file.parquet",
+			oldKey:         "data/file.parquet",
+			wantErrText:    `URI scheme "gs" is not supported`,
+		},
+		{
+			name:           "gcs rejects s3 same bucket",
+			allowedSchemes: gcsSchemes,
+			path:           "s3://test-bucket/data/file.parquet",
+			oldKey:         "data/file.parquet",
+			wantErrText:    `URI scheme "s3" is not supported`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			bucket := memblob.OpenBucket(nil)
+			defer bucket.Close()
+
+			bfs := testBlobFileIO(ctx, "test-bucket", bucket, tt.allowedSchemes...)
 			require.NoError(t, bucket.WriteAll(ctx, tt.oldKey, []byte("sentinel"), nil))
 
 			err := bfs.WriteFile(tt.path, []byte("content"))
-			require.ErrorContains(t, err, "does not match configured authority")
+			require.ErrorContains(t, err, tt.wantErrText)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			}
 
 			got, err := bucket.ReadAll(ctx, tt.oldKey)
 			require.NoError(t, err)
@@ -399,22 +442,23 @@ func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
 
 	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("content"), nil))
 
-	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
-
 	for _, tt := range []struct {
-		name string
-		root string
+		name           string
+		allowedSchemes []string
+		root           string
 	}{
-		{name: "s3", root: "s3://other-bucket/"},
-		{name: "gcs", root: "gs://other-bucket/data"},
+		{name: "s3", allowedSchemes: s3Schemes, root: "s3://other-bucket/"},
+		{name: "gcs", allowedSchemes: gcsSchemes, root: "gs://other-bucket/data"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			bfs := testBlobFileIO(ctx, "test-bucket", bucket, tt.allowedSchemes...)
 			err := bfs.WalkDir(tt.root, func(string, fs.DirEntry, error) error {
 				t.Fatal("WalkDir callback should not be called")
 
 				return nil
 			})
 			require.ErrorContains(t, err, "does not match configured authority")
+			require.ErrorIs(t, err, ErrUnsupportedObjectAuthority)
 		})
 	}
 }
@@ -433,6 +477,7 @@ func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 		return nil
 	})
 	require.ErrorContains(t, err, "does not match configured authority")
+	require.ErrorIs(t, err, ErrUnsupportedObjectAuthority)
 }
 
 func TestBlobFileIOWalkDirRelativeRootReturnsBareKeys(t *testing.T) {

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -38,7 +38,6 @@ func TestDefaultKeyExtractor(t *testing.T) {
 		bucketName      string
 		input           string
 		expectedKey     string
-		strict          bool
 		wantErrContains string
 		wantErrIs       error
 	}{
@@ -94,25 +93,13 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			expectedKey: "path/to/file.parquet",
 		},
 		{
-			name:        "s3 URI with different bucket keeps legacy key shape by default",
-			input:       "s3://other-bucket/path/to/file.parquet",
-			expectedKey: "other-bucket/path/to/file.parquet",
-		},
-		{
-			name:        "gs URI with different bucket keeps legacy key shape by default",
-			input:       "gs://other-bucket/path/to/file.parquet",
-			expectedKey: "other-bucket/path/to/file.parquet",
-		},
-		{
-			name:            "strict s3 URI with different bucket",
+			name:            "s3 URI with different bucket",
 			input:           "s3://other-bucket/path/to/file.parquet",
-			strict:          true,
 			wantErrContains: "does not match configured authority",
 		},
 		{
-			name:            "strict gs URI with different bucket",
+			name:            "gs URI with different bucket",
 			input:           "gs://other-bucket/path/to/file.parquet",
-			strict:          true,
 			wantErrContains: "does not match configured authority",
 		},
 		{
@@ -144,11 +131,7 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			if bucketName == "" {
 				bucketName = "my-bucket"
 			}
-			var opts []keyExtractorOption
-			if test.strict {
-				opts = append(opts, withStrictAuthorityValidation())
-			}
-			extractor := defaultKeyExtractor(bucketName, opts...)
+			extractor := defaultKeyExtractor(bucketName)
 			key, err := extractor(test.input)
 
 			if test.wantErrContains != "" {
@@ -164,26 +147,8 @@ func TestDefaultKeyExtractor(t *testing.T) {
 	}
 }
 
-func TestKeyExtractorOptionsRejectsInvalidStrictAuthorityValidation(t *testing.T) {
-	opts, err := keyExtractorOptions(map[string]string{
-		icebergio.ObjectStoreStrictAuthorityValidation: "ture",
-	})
-
-	require.ErrorContains(t, err, icebergio.ObjectStoreStrictAuthorityValidation)
-	assert.Nil(t, opts)
-}
-
-func TestKeyExtractorOptionsParsesStrictAuthorityValidation(t *testing.T) {
-	opts, err := keyExtractorOptions(map[string]string{
-		icebergio.ObjectStoreStrictAuthorityValidation: "true",
-	})
-
-	require.NoError(t, err)
-	assert.Len(t, opts, 1)
-}
-
-func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket, opts ...keyExtractorOption) *blobFileIO {
-	extractor := defaultObjectLocationExtractor(bucketName, opts...)
+func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket) *blobFileIO {
+	extractor := defaultObjectLocationExtractor(bucketName)
 
 	return &blobFileIO{
 		Bucket:        bucket,
@@ -192,13 +157,13 @@ func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket,
 	}
 }
 
-func testADLSBlobFileIO(t *testing.T, ctx context.Context, root string, bucket *blob.Bucket, opts ...keyExtractorOption) *blobFileIO {
+func testADLSBlobFileIO(t *testing.T, ctx context.Context, root string, bucket *blob.Bucket) *blobFileIO {
 	t.Helper()
 
 	parsed, err := url.Parse(root)
 	require.NoError(t, err)
 
-	extractor := adlsObjectLocationExtractor(parsed, opts...)
+	extractor := adlsObjectLocationExtractor(parsed)
 
 	return &blobFileIO{
 		Bucket:        bucket,
@@ -217,7 +182,7 @@ func TestBlobFileIORejectsWrongBucketObjectPaths(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := testBlobFileIO(ctx, "test-bucket", bucket, withStrictAuthorityValidation())
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
 
 	for _, tt := range []struct {
 		name   string
@@ -434,7 +399,7 @@ func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
 
 	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("content"), nil))
 
-	bfs := testBlobFileIO(ctx, "test-bucket", bucket, withStrictAuthorityValidation())
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
 
 	for _, tt := range []struct {
 		name string
@@ -451,35 +416,6 @@ func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
 			})
 			require.ErrorContains(t, err, "does not match configured authority")
 		})
-	}
-}
-
-func TestBlobFileIOWalkDirKeepsCrossAuthorityPathsStableByDefault(t *testing.T) {
-	ctx := context.Background()
-
-	bucket := memblob.OpenBucket(nil)
-	defer bucket.Close()
-
-	require.NoError(t, bucket.WriteAll(ctx, "other-bucket/data/file.parquet", []byte("content"), nil))
-
-	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
-
-	var walked []string
-	err := bfs.WalkDir("s3://other-bucket/data", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		walked = append(walked, path)
-
-		return nil
-	})
-	require.NoError(t, err)
-
-	assert.Contains(t, walked, "s3://other-bucket/data")
-	assert.Contains(t, walked, "s3://other-bucket/data/file.parquet")
-	for _, path := range walked {
-		assert.NotContains(t, path, "s3://other-bucket/other-bucket/")
 	}
 }
 
@@ -502,8 +438,7 @@ func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := testADLSBlobFileIO(t, ctx, "abfs://container@account.dfs.core.windows.net/", bucket,
-		withStrictAuthorityValidation())
+	bfs := testADLSBlobFileIO(t, ctx, "abfs://container@account.dfs.core.windows.net/", bucket)
 
 	err := bfs.WalkDir("abfs://other@account.dfs.core.windows.net/data", func(string, fs.DirEntry, error) error {
 		t.Fatal("WalkDir callback should not be called")

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -21,26 +21,56 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	icebergio "github.com/apache/iceberg-go/io"
+	"gocloud.dev/blob"
 	"gocloud.dev/blob/memblob"
 )
 
 func TestDefaultKeyExtractor(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		expectedKey string
-		shouldError bool
+		name            string
+		bucketName      string
+		input           string
+		expectedKey     string
+		strict          bool
+		wantErrContains string
+		wantErrIs       error
 	}{
+		{
+			name:        "relative key",
+			input:       "path/to/file.parquet",
+			expectedKey: "path/to/file.parquet",
+		},
+		{
+			name:        "relative key with raw percent",
+			input:       "data/100%off/file.parquet",
+			expectedKey: "data/100%off/file.parquet",
+		},
+		{
+			name:        "bucket-prefixed relative key",
+			input:       "my-bucket/path/to/file.parquet",
+			expectedKey: "path/to/file.parquet",
+		},
 		{
 			name:        "s3 URI with path",
 			input:       "s3://my-bucket/path/to/file.parquet",
 			expectedKey: "path/to/file.parquet",
+		},
+		{
+			name:        "s3 URI with raw percent in key",
+			input:       "s3://my-bucket/data/100%off/file.parquet",
+			expectedKey: "data/100%off/file.parquet",
+		},
+		{
+			name:        "s3 URI with raw space in key",
+			input:       "s3://my-bucket/data/city=New York/file.parquet",
+			expectedKey: "data/city=New York/file.parquet",
 		},
 		{
 			name:        "s3a URI with path",
@@ -58,28 +88,142 @@ func TestDefaultKeyExtractor(t *testing.T) {
 			expectedKey: "path/to/file.parquet",
 		},
 		{
+			name:        "azure URI with path",
+			bucketName:  "container@account.dfs.core.windows.net",
+			input:       "abfs://container@account.dfs.core.windows.net/path/to/file.parquet",
+			expectedKey: "path/to/file.parquet",
+		},
+		{
+			name:        "s3 URI with different bucket keeps legacy key shape by default",
+			input:       "s3://other-bucket/path/to/file.parquet",
+			expectedKey: "other-bucket/path/to/file.parquet",
+		},
+		{
+			name:        "gs URI with different bucket keeps legacy key shape by default",
+			input:       "gs://other-bucket/path/to/file.parquet",
+			expectedKey: "other-bucket/path/to/file.parquet",
+		},
+		{
+			name:            "strict s3 URI with different bucket",
+			input:           "s3://other-bucket/path/to/file.parquet",
+			strict:          true,
+			wantErrContains: "does not match configured authority",
+		},
+		{
+			name:            "strict gs URI with different bucket",
+			input:           "gs://other-bucket/path/to/file.parquet",
+			strict:          true,
+			wantErrContains: "does not match configured authority",
+		},
+		{
 			name:        "URI with query and fragment",
 			input:       "s3://my-bucket/path/to/file.parquet?param=value#fragment",
 			expectedKey: "path/to/file.parquet?param=value#fragment",
 		},
 		{
-			name:        "URI with empty path",
-			input:       "s3://my-bucket/",
-			shouldError: true,
+			name:            "URI with empty path",
+			input:           "s3://my-bucket/",
+			wantErrContains: "object key is empty",
+			wantErrIs:       errEmptyObjectKey,
+		},
+		{
+			name:            "URI with empty authority",
+			input:           "s3:///path/to/file.parquet",
+			wantErrContains: "URI authority is empty",
+		},
+		{
+			name:            "URI authority followed by query",
+			input:           "s3://my-bucket?prefix=data",
+			wantErrContains: "must be followed by an object path",
 		},
 	}
 
-	extractor := defaultKeyExtractor("my-bucket")
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			bucketName := test.bucketName
+			if bucketName == "" {
+				bucketName = "my-bucket"
+			}
+			var opts []keyExtractorOption
+			if test.strict {
+				opts = append(opts, withStrictAuthorityValidation())
+			}
+			extractor := defaultKeyExtractor(bucketName, opts...)
 			key, err := extractor(test.input)
 
-			if test.shouldError {
-				assert.Error(t, err, "Expected error for input: %s", test.input)
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains, "Expected error for input: %s", test.input)
+				if test.wantErrIs != nil {
+					require.ErrorIs(t, err, test.wantErrIs)
+				}
 			} else {
-				assert.NoError(t, err, "Unexpected error for input: %s", test.input)
+				require.NoError(t, err, "Unexpected error for input: %s", test.input)
 				assert.Equal(t, test.expectedKey, key, "Key mismatch for input: %s", test.input)
 			}
+		})
+	}
+}
+
+func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket, opts ...keyExtractorOption) *blobFileIO {
+	extractor := defaultObjectLocationExtractor(bucketName, opts...)
+
+	return &blobFileIO{
+		Bucket:        bucket,
+		keyExtractor:  keyExtractorFromObjectLocation(extractor),
+		extractObject: extractor,
+		ctx:           ctx,
+	}
+}
+
+func testADLSBlobFileIO(t *testing.T, ctx context.Context, root string, bucket *blob.Bucket, opts ...keyExtractorOption) *blobFileIO {
+	t.Helper()
+
+	parsed, err := url.Parse(root)
+	require.NoError(t, err)
+
+	extractor := adlsObjectLocationExtractor(parsed, opts...)
+
+	return &blobFileIO{
+		Bucket:        bucket,
+		keyExtractor:  keyExtractorFromObjectLocation(extractor),
+		extractObject: extractor,
+		ctx:           ctx,
+	}
+}
+
+func TestBlobFileIORejectsWrongBucketObjectPaths(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket, withStrictAuthorityValidation())
+
+	for _, tt := range []struct {
+		name   string
+		path   string
+		oldKey string
+	}{
+		{
+			name:   "s3",
+			path:   "s3://other-bucket/data/file.parquet",
+			oldKey: "other-bucket/data/file.parquet",
+		},
+		{
+			name:   "gcs",
+			path:   "gs://other-bucket/data/file.parquet",
+			oldKey: "other-bucket/data/file.parquet",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, bucket.WriteAll(ctx, tt.oldKey, []byte("sentinel"), nil))
+
+			err := bfs.WriteFile(tt.path, []byte("content"))
+			require.ErrorContains(t, err, "does not match configured authority")
+
+			got, err := bucket.ReadAll(ctx, tt.oldKey)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("sentinel"), got)
 		})
 	}
 }
@@ -202,22 +346,25 @@ func TestBlobFileIOWalkDir(t *testing.T) {
 	files := []string{
 		"data/file1.parquet",
 		"data/file2.parquet",
+		"data/100%off/file.parquet",
+		"data/city=New York/file.parquet",
 		"metadata/snap-123.avro",
 	}
 	for _, f := range files {
 		require.NoError(t, bucket.WriteAll(ctx, f, []byte("content"), nil))
 	}
 
-	bfs := &blobFileIO{
-		Bucket:       bucket,
-		keyExtractor: defaultKeyExtractor("test-bucket"),
-		ctx:          ctx,
-	}
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
 
 	var walked []string
+	var sawRoot bool
 	err := bfs.WalkDir("s3://test-bucket/", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if d.IsDir() && path == "s3://test-bucket/" {
+			sawRoot = true
 		}
 
 		if !d.IsDir() {
@@ -229,11 +376,79 @@ func TestBlobFileIOWalkDir(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
+		"s3://test-bucket/data/100%off/file.parquet",
+		"s3://test-bucket/data/city=New York/file.parquet",
 		"s3://test-bucket/data/file1.parquet",
 		"s3://test-bucket/data/file2.parquet",
 		"s3://test-bucket/metadata/snap-123.avro",
 	}
 	assert.ElementsMatch(t, expected, walked)
+	assert.True(t, sawRoot)
+}
+
+func TestBlobFileIOWalkDirRejectsMalformedAuthorityURI(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
+
+	err := bfs.WalkDir("s3://test-bucket?prefix=data", func(string, fs.DirEntry, error) error {
+		t.Fatal("WalkDir callback should not be called")
+
+		return nil
+	})
+	require.ErrorContains(t, err, "must be followed by an object path")
+
+	var pathErr *fs.PathError
+	require.ErrorAs(t, err, &pathErr)
+	assert.Equal(t, "walk dir", pathErr.Op)
+}
+
+func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("content"), nil))
+
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket, withStrictAuthorityValidation())
+
+	for _, tt := range []struct {
+		name string
+		root string
+	}{
+		{name: "s3", root: "s3://other-bucket/"},
+		{name: "gcs", root: "gs://other-bucket/data"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := bfs.WalkDir(tt.root, func(string, fs.DirEntry, error) error {
+				t.Fatal("WalkDir callback should not be called")
+
+				return nil
+			})
+			require.ErrorContains(t, err, "does not match configured authority")
+		})
+	}
+}
+
+func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := testADLSBlobFileIO(t, ctx, "abfs://container@account.dfs.core.windows.net/", bucket,
+		withStrictAuthorityValidation())
+
+	err := bfs.WalkDir("abfs://other@account.dfs.core.windows.net/data", func(string, fs.DirEntry, error) error {
+		t.Fatal("WalkDir callback should not be called")
+
+		return nil
+	})
+	require.ErrorContains(t, err, "does not match configured authority")
 }
 
 func TestBlobFileIOWalkDirSubPath(t *testing.T) {
@@ -246,11 +461,7 @@ func TestBlobFileIOWalkDirSubPath(t *testing.T) {
 	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("b"), nil))
 	require.NoError(t, bucket.WriteAll(ctx, "metadata/v1.json", []byte("c"), nil))
 
-	bfs := &blobFileIO{
-		Bucket:       bucket,
-		keyExtractor: defaultKeyExtractor("mybucket"),
-		ctx:          ctx,
-	}
+	bfs := testBlobFileIO(ctx, "mybucket", bucket)
 
 	var walked []string
 	err := bfs.WalkDir("s3://mybucket/data", func(path string, d fs.DirEntry, err error) error {
@@ -281,11 +492,7 @@ func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
 
 	require.NoError(t, bucket.WriteAll(ctx, "path/to/file.parquet", []byte("data"), nil))
 
-	bfs := &blobFileIO{
-		Bucket:       bucket,
-		keyExtractor: defaultKeyExtractor("container@account.dfs.core.windows.net"),
-		ctx:          ctx,
-	}
+	bfs := testADLSBlobFileIO(t, ctx, "abfs://container@account.dfs.core.windows.net/", bucket)
 
 	var walked []string
 	err := bfs.WalkDir("abfs://container@account.dfs.core.windows.net/path", func(path string, d fs.DirEntry, err error) error {

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -173,7 +173,7 @@ func testADLSBlobFileIO(t *testing.T, ctx context.Context, root string, bucket *
 }
 
 func identityObjectLocation(location string) (objectLocation, error) {
-	return objectLocation{key: location, uriKey: location}, nil
+	return objectLocation{key: location}, nil
 }
 
 func TestBlobFileIORejectsWrongBucketObjectPaths(t *testing.T) {
@@ -419,19 +419,6 @@ func TestBlobFileIOWalkDirRejectsWrongBucket(t *testing.T) {
 	}
 }
 
-func TestWalkedURIPathRejectsPathOutsideStorageRoot(t *testing.T) {
-	location := objectLocation{
-		authority:    "other-bucket",
-		key:          "other-bucket/data",
-		uriKey:       "data",
-		uriPrefix:    "s3://other-bucket/",
-		hasAuthority: true,
-	}
-
-	_, err := walkedURIPath(location, "unrelated/data/file.parquet")
-	require.ErrorContains(t, err, "outside storage root")
-}
-
 func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 	ctx := context.Background()
 
@@ -446,6 +433,36 @@ func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 		return nil
 	})
 	require.ErrorContains(t, err, "does not match configured authority")
+}
+
+func TestBlobFileIOWalkDirRelativeRootReturnsBareKeys(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	require.NoError(t, bucket.WriteAll(ctx, "data/file1.parquet", []byte("a"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, "data/file2.parquet", []byte("b"), nil))
+
+	bfs := testBlobFileIO(ctx, "mybucket", bucket)
+
+	var walked []string
+	err := bfs.WalkDir("data", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			walked = append(walked, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"data/file1.parquet",
+		"data/file2.parquet",
+	}, walked)
 }
 
 func TestBlobFileIOWalkDirSubPath(t *testing.T) {
@@ -487,7 +504,14 @@ func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	require.NoError(t, bucket.WriteAll(ctx, "path/to/file.parquet", []byte("data"), nil))
+	files := []string{
+		"path/100%off/file.parquet",
+		"path/city=New York/file.parquet",
+		"path/to/file.parquet",
+	}
+	for _, f := range files {
+		require.NoError(t, bucket.WriteAll(ctx, f, []byte("data"), nil))
+	}
 
 	bfs := testADLSBlobFileIO(t, ctx, "abfs://container@account.dfs.core.windows.net/", bucket)
 
@@ -506,9 +530,31 @@ func TestBlobFileIOWalkDirAzureURI(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
+		"abfs://container@account.dfs.core.windows.net/path/100%off/file.parquet",
+		"abfs://container@account.dfs.core.windows.net/path/city=New York/file.parquet",
 		"abfs://container@account.dfs.core.windows.net/path/to/file.parquet",
 	}
-	assert.Equal(t, expected, walked)
+	assert.ElementsMatch(t, expected, walked)
+}
+
+func TestBlobFileIORawQueryFragmentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	bfs := testBlobFileIO(ctx, "test-bucket", bucket)
+	location := "s3://test-bucket/path/to/file.parquet?param=value#fragment"
+	content := []byte("data")
+	require.NoError(t, bfs.WriteFile(location, content))
+
+	file, err := bfs.Open(location)
+	require.NoError(t, err)
+	defer file.Close()
+
+	got, err := io.ReadAll(file)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
 }
 
 func TestBlobFileIOImplementsBulkRemovableIO(t *testing.T) {

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -164,12 +164,29 @@ func TestDefaultKeyExtractor(t *testing.T) {
 	}
 }
 
+func TestKeyExtractorOptionsRejectsInvalidStrictAuthorityValidation(t *testing.T) {
+	opts, err := keyExtractorOptions(map[string]string{
+		icebergio.ObjectStoreStrictAuthorityValidation: "ture",
+	})
+
+	require.ErrorContains(t, err, icebergio.ObjectStoreStrictAuthorityValidation)
+	assert.Nil(t, opts)
+}
+
+func TestKeyExtractorOptionsParsesStrictAuthorityValidation(t *testing.T) {
+	opts, err := keyExtractorOptions(map[string]string{
+		icebergio.ObjectStoreStrictAuthorityValidation: "true",
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, opts, 1)
+}
+
 func testBlobFileIO(ctx context.Context, bucketName string, bucket *blob.Bucket, opts ...keyExtractorOption) *blobFileIO {
 	extractor := defaultObjectLocationExtractor(bucketName, opts...)
 
 	return &blobFileIO{
 		Bucket:        bucket,
-		keyExtractor:  keyExtractorFromObjectLocation(extractor),
 		extractObject: extractor,
 		ctx:           ctx,
 	}
@@ -185,10 +202,13 @@ func testADLSBlobFileIO(t *testing.T, ctx context.Context, root string, bucket *
 
 	return &blobFileIO{
 		Bucket:        bucket,
-		keyExtractor:  keyExtractorFromObjectLocation(extractor),
 		extractObject: extractor,
 		ctx:           ctx,
 	}
+}
+
+func identityObjectLocation(location string) (objectLocation, error) {
+	return objectLocation{key: location, uriKey: location}, nil
 }
 
 func TestBlobFileIORejectsWrongBucketObjectPaths(t *testing.T) {
@@ -234,9 +254,9 @@ func TestNewWriterExistsError(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 
 	bfs := &blobFileIO{
-		Bucket:       bucket,
-		keyExtractor: func(path string) (string, error) { return path, nil },
-		ctx:          ctx,
+		Bucket:        bucket,
+		extractObject: identityObjectLocation,
+		ctx:           ctx,
 	}
 	require.NoError(t, bucket.Close())
 
@@ -302,9 +322,9 @@ func TestReadAtResourceCleanup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var lastReaderClosed bool
 			bfs := &blobFileIO{
-				Bucket:       bucket,
-				keyExtractor: func(path string) (string, error) { return path, nil },
-				ctx:          ctx,
+				Bucket:        bucket,
+				extractObject: identityObjectLocation,
+				ctx:           ctx,
 				newRangeReader: func(ctx context.Context, key string, offset, length int64) (io.ReadCloser, error) {
 					r, err := bucket.NewRangeReader(ctx, key, offset, length, nil)
 					if err != nil {
@@ -463,6 +483,19 @@ func TestBlobFileIOWalkDirKeepsCrossAuthorityPathsStableByDefault(t *testing.T) 
 	}
 }
 
+func TestWalkedURIPathRejectsPathOutsideStorageRoot(t *testing.T) {
+	location := objectLocation{
+		authority:    "other-bucket",
+		key:          "other-bucket/data",
+		uriKey:       "data",
+		uriPrefix:    "s3://other-bucket/",
+		hasAuthority: true,
+	}
+
+	_, err := walkedURIPath(location, "unrelated/data/file.parquet")
+	require.ErrorContains(t, err, "outside storage root")
+}
+
 func TestBlobFileIOWalkDirRejectsWrongAzureAuthority(t *testing.T) {
 	ctx := context.Background()
 
@@ -548,7 +581,7 @@ func TestBlobFileIOImplementsBulkRemovableIO(t *testing.T) {
 	defer bucket.Close()
 
 	extractor := defaultObjectLocationExtractor("test-bucket")
-	bfs := createBlobFS(context.Background(), bucket, keyExtractorFromObjectLocation(extractor), extractor)
+	bfs := createBlobFS(context.Background(), bucket, extractor)
 
 	_, ok := bfs.(icebergio.BulkRemovableIO)
 	assert.True(t, ok, "blobFileIO should implement BulkRemovableIO")
@@ -565,7 +598,7 @@ func TestBlobFileIODeleteFiles(t *testing.T) {
 	require.NoError(t, bucket.WriteAll(ctx, "data/file3.parquet", []byte("data3"), nil))
 
 	extractor := defaultObjectLocationExtractor("test-bucket")
-	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
+	bfs := createBlobFS(ctx, bucket, extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	deleted, err := bulk.DeleteFiles(ctx, []string{
@@ -595,7 +628,7 @@ func TestBlobFileIODeleteFilesMissingFilesAreNotErrors(t *testing.T) {
 	defer bucket.Close()
 
 	extractor := defaultObjectLocationExtractor("test-bucket")
-	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
+	bfs := createBlobFS(ctx, bucket, extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	// Deleting non-existent files should succeed.
@@ -612,7 +645,7 @@ func TestBlobFileIORemoveMissingFileReturnsNotExist(t *testing.T) {
 	defer bucket.Close()
 
 	extractor := defaultObjectLocationExtractor("test-bucket")
-	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
+	bfs := createBlobFS(ctx, bucket, extractor)
 
 	err := bfs.Remove("s3://test-bucket/data/nonexistent.parquet")
 	require.ErrorIs(t, err, fs.ErrNotExist)
@@ -624,7 +657,7 @@ func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
 	defer bucket.Close()
 
 	extractor := defaultObjectLocationExtractor("test-bucket")
-	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
+	bfs := createBlobFS(ctx, bucket, extractor)
 	bulk := bfs.(icebergio.BulkRemovableIO)
 
 	deleted, err := bulk.DeleteFiles(ctx, nil)

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -611,7 +611,8 @@ func TestBlobFileIORemoveMissingFileReturnsNotExist(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
-	bfs := createBlobFS(ctx, bucket, defaultKeyExtractor("test-bucket"))
+	extractor := defaultObjectLocationExtractor("test-bucket")
+	bfs := createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor)
 
 	err := bfs.Remove("s3://test-bucket/data/nonexistent.parquet")
 	require.ErrorIs(t, err, fs.ErrNotExist)

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -30,6 +30,11 @@ func init() {
 	registerAzureSchemes()
 }
 
+var (
+	s3Schemes  = []string{"s3", "s3a", "s3n", "oss"}
+	gcsSchemes = []string{"gs"}
+)
+
 // registerS3Schemes registers S3-compatible storage schemes (s3, s3a, s3n).
 func registerS3Schemes() {
 	s3Factory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
@@ -38,7 +43,7 @@ func registerS3Schemes() {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host)
+		extractor := defaultObjectLocationExtractor(parsed.Host, s3Schemes...)
 
 		return createBlobFS(ctx, bucket, extractor), nil
 	}
@@ -56,7 +61,7 @@ func registerGCSScheme() {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host)
+		extractor := defaultObjectLocationExtractor(parsed.Host, gcsSchemes...)
 
 		return createBlobFS(ctx, bucket, extractor), nil
 	})

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -19,6 +19,7 @@ package gocloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -31,25 +32,41 @@ func init() {
 	registerAzureSchemes()
 }
 
-func keyExtractorOptions(props map[string]string) []keyExtractorOption {
-	if enabled, err := strconv.ParseBool(props[icebergio.ObjectStoreStrictAuthorityValidation]); err == nil && enabled {
-		return []keyExtractorOption{withStrictAuthorityValidation()}
+func keyExtractorOptions(props map[string]string) ([]keyExtractorOption, error) {
+	value, ok := props[icebergio.ObjectStoreStrictAuthorityValidation]
+	if !ok {
+		return nil, nil
 	}
 
-	return nil
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s value %q: %w",
+			icebergio.ObjectStoreStrictAuthorityValidation, value, err)
+	}
+
+	if enabled {
+		return []keyExtractorOption{withStrictAuthorityValidation()}, nil
+	}
+
+	return nil, nil
 }
 
 // registerS3Schemes registers S3-compatible storage schemes (s3, s3a, s3n).
 func registerS3Schemes() {
 	s3Factory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
+		opts, err := keyExtractorOptions(props)
+		if err != nil {
+			return nil, err
+		}
+
 		bucket, err := createS3Bucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host, keyExtractorOptions(props)...)
+		extractor := defaultObjectLocationExtractor(parsed.Host, opts...)
 
-		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
+		return createBlobFS(ctx, bucket, extractor), nil
 	}
 	icebergio.Register("s3", s3Factory)
 	icebergio.Register("s3a", s3Factory)
@@ -60,28 +77,38 @@ func registerS3Schemes() {
 // registerGCSScheme registers the Google Cloud Storage scheme (gs).
 func registerGCSScheme() {
 	icebergio.Register("gs", func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
+		opts, err := keyExtractorOptions(props)
+		if err != nil {
+			return nil, err
+		}
+
 		bucket, err := createGCSBucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host, keyExtractorOptions(props)...)
+		extractor := defaultObjectLocationExtractor(parsed.Host, opts...)
 
-		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
+		return createBlobFS(ctx, bucket, extractor), nil
 	})
 }
 
 // registerAzureSchemes registers Azure Data Lake Storage schemes (abfs, abfss, wasb, wasbs).
 func registerAzureSchemes() {
 	azureFactory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
+		opts, err := keyExtractorOptions(props)
+		if err != nil {
+			return nil, err
+		}
+
 		bucket, err := createAzureBucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := adlsObjectLocationExtractor(parsed, keyExtractorOptions(props)...)
+		extractor := adlsObjectLocationExtractor(parsed, opts...)
 
-		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
+		return createBlobFS(ctx, bucket, extractor), nil
 	}
 	icebergio.Register("abfs", azureFactory)
 	icebergio.Register("abfss", azureFactory)

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -20,6 +20,7 @@ package gocloud
 import (
 	"context"
 	"net/url"
+	"strconv"
 
 	icebergio "github.com/apache/iceberg-go/io"
 )
@@ -30,6 +31,14 @@ func init() {
 	registerAzureSchemes()
 }
 
+func keyExtractorOptions(props map[string]string) []keyExtractorOption {
+	if enabled, err := strconv.ParseBool(props[icebergio.ObjectStoreStrictAuthorityValidation]); err == nil && enabled {
+		return []keyExtractorOption{withStrictAuthorityValidation()}
+	}
+
+	return nil
+}
+
 // registerS3Schemes registers S3-compatible storage schemes (s3, s3a, s3n).
 func registerS3Schemes() {
 	s3Factory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
@@ -38,7 +47,9 @@ func registerS3Schemes() {
 			return nil, err
 		}
 
-		return createBlobFS(ctx, bucket, defaultKeyExtractor(parsed.Host)), nil
+		extractor := defaultObjectLocationExtractor(parsed.Host, keyExtractorOptions(props)...)
+
+		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
 	}
 	icebergio.Register("s3", s3Factory)
 	icebergio.Register("s3a", s3Factory)
@@ -54,7 +65,9 @@ func registerGCSScheme() {
 			return nil, err
 		}
 
-		return createBlobFS(ctx, bucket, defaultKeyExtractor(parsed.Host)), nil
+		extractor := defaultObjectLocationExtractor(parsed.Host, keyExtractorOptions(props)...)
+
+		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
 	})
 }
 
@@ -66,7 +79,9 @@ func registerAzureSchemes() {
 			return nil, err
 		}
 
-		return createBlobFS(ctx, bucket, adlsKeyExtractor()), nil
+		extractor := adlsObjectLocationExtractor(parsed, keyExtractorOptions(props)...)
+
+		return createBlobFS(ctx, bucket, keyExtractorFromObjectLocation(extractor), extractor), nil
 	}
 	icebergio.Register("abfs", azureFactory)
 	icebergio.Register("abfss", azureFactory)

--- a/io/gocloud/register.go
+++ b/io/gocloud/register.go
@@ -19,9 +19,7 @@ package gocloud
 
 import (
 	"context"
-	"fmt"
 	"net/url"
-	"strconv"
 
 	icebergio "github.com/apache/iceberg-go/io"
 )
@@ -32,39 +30,15 @@ func init() {
 	registerAzureSchemes()
 }
 
-func keyExtractorOptions(props map[string]string) ([]keyExtractorOption, error) {
-	value, ok := props[icebergio.ObjectStoreStrictAuthorityValidation]
-	if !ok {
-		return nil, nil
-	}
-
-	enabled, err := strconv.ParseBool(value)
-	if err != nil {
-		return nil, fmt.Errorf("invalid %s value %q: %w",
-			icebergio.ObjectStoreStrictAuthorityValidation, value, err)
-	}
-
-	if enabled {
-		return []keyExtractorOption{withStrictAuthorityValidation()}, nil
-	}
-
-	return nil, nil
-}
-
 // registerS3Schemes registers S3-compatible storage schemes (s3, s3a, s3n).
 func registerS3Schemes() {
 	s3Factory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
-		opts, err := keyExtractorOptions(props)
-		if err != nil {
-			return nil, err
-		}
-
 		bucket, err := createS3Bucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host, opts...)
+		extractor := defaultObjectLocationExtractor(parsed.Host)
 
 		return createBlobFS(ctx, bucket, extractor), nil
 	}
@@ -77,17 +51,12 @@ func registerS3Schemes() {
 // registerGCSScheme registers the Google Cloud Storage scheme (gs).
 func registerGCSScheme() {
 	icebergio.Register("gs", func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
-		opts, err := keyExtractorOptions(props)
-		if err != nil {
-			return nil, err
-		}
-
 		bucket, err := createGCSBucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := defaultObjectLocationExtractor(parsed.Host, opts...)
+		extractor := defaultObjectLocationExtractor(parsed.Host)
 
 		return createBlobFS(ctx, bucket, extractor), nil
 	})
@@ -96,17 +65,12 @@ func registerGCSScheme() {
 // registerAzureSchemes registers Azure Data Lake Storage schemes (abfs, abfss, wasb, wasbs).
 func registerAzureSchemes() {
 	azureFactory := func(ctx context.Context, parsed *url.URL, props map[string]string) (icebergio.IO, error) {
-		opts, err := keyExtractorOptions(props)
-		if err != nil {
-			return nil, err
-		}
-
 		bucket, err := createAzureBucket(ctx, parsed, props)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor := adlsObjectLocationExtractor(parsed, opts...)
+		extractor := adlsObjectLocationExtractor(parsed)
 
 		return createBlobFS(ctx, bucket, extractor), nil
 	}


### PR DESCRIPTION
Summary

- parse cloud object locations without URL-unescaping, so raw `%` and spaces in keys keep working
- reject fully-qualified object paths whose authority differs from the opened bucket or container
- apply the same authority check through S3/GCS/OSS and ADLS
- use the parsed object location for WalkDir path reconstruction, keep the root trailing slash, and reject malformed authority-only roots instead of walking the whole bucket
- add regression coverage for raw key characters, cross-authority rejection, ADLS authority checks, WalkDir roots, and malformed roots

Why

The current gocloud FileIO is bucket/container-bound. Silently folding `s3://other-bucket/...` into the opened bucket can read, write, or delete the wrong object, so this now fails loudly when a manifest path points at a different authority. If iceberg-go should support cross-authority metadata and data paths, that should be handled with explicit per-authority routing in a follow-up instead of pretending the current bucket-bound FileIO can safely serve both.

Testing

- go test ./io/gocloud -run 'TestDefaultKeyExtractor|TestBlobFileIORejectsWrongBucketObjectPaths|TestBlobFileIOWalkDirRejectsWrongBucket|TestBlobFileIOWalkDirRejectsWrongAzureAuthority|TestAdlsKeyExtractor' -count=1
- go test ./io/gocloud -count=1
- go test ./io -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./io/gocloud ./io
- git diff --check