### PR TITLE
ci: key go and lint caches by version and gate saves to main

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -34,6 +34,14 @@ jobs:
   lint-and-test:
     name: ${{ matrix.os }} go${{ matrix.go }}
     runs-on: ubuntu-latest
+    # Cache dirs are pinned to dot-prefixed paths under the workspace so they are
+    # identical across Linux/Windows/macOS (no per-OS path branching) and are
+    # excluded from `go`/golangci-lint `./...` expansion (leading-dot dirs are
+    # ignored). Go and golangci-lint honor these env vars for their cache dirs.
+    env:
+      GOMODCACHE: ${{ github.workspace }}/.gocache/mod
+      GOCACHE: ${{ github.workspace }}/.gocache/build
+      GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.gocache/golangci
     strategy:
       max-parallel: 15
       fail-fast: false
@@ -48,18 +56,53 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go }}
-        cache: true
-        cache-dependency-path: go.sum
+        # Caching is managed explicitly below so saves can be gated to main and
+        # the golangci-lint cache can be keyed by Go version.
+        cache: false
+    # Restore is unconditional (PRs read main's caches); save is gated to main.
+    - name: Restore Go module and build cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ github.workspace }}/.gocache/mod
+          ${{ github.workspace }}/.gocache/build
+        key: go-${{ matrix.os }}-go${{ matrix.go }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-${{ matrix.os }}-go${{ matrix.go }}-
+    - name: Restore golangci-lint cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.gocache/golangci
+        key: golangci-${{ matrix.os }}-go${{ matrix.go }}-${{ hashFiles('go.sum', '.golangci.yml') }}
+        restore-keys: |
+          golangci-${{ matrix.os }}-go${{ matrix.go }}-
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
       with:
         version: v2.11.4
         args: --timeout=10m
+        # The action's own cache key omits the Go version, so all matrix cells
+        # collide on one entry; we manage the cache explicitly above instead.
+        skip-cache: true
     - name: Run tests
       run: go test -v ./...
     # Race detector is opt-in per package/test.
     - name: Run race detector
       run: go test -race -v ./codec/...
+    - name: Save Go module and build cache
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ github.workspace }}/.gocache/mod
+          ${{ github.workspace }}/.gocache/build
+        key: go-${{ matrix.os }}-go${{ matrix.go }}-${{ hashFiles('go.sum') }}
+    - name: Save golangci-lint cache
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.gocache/golangci
+        key: golangci-${{ matrix.os }}-go${{ matrix.go }}-${{ hashFiles('go.sum', '.golangci.yml') }}
 
   # Guards against big-endian-only failures such as the runtime.staticuint64s
   # relocation misalignment triggered by boxing scalars in generic code
@@ -69,6 +112,9 @@ jobs:
   cross-compile:
     name: cross-compile linux/s390x
     runs-on: ubuntu-latest
+    env:
+      GOMODCACHE: ${{ github.workspace }}/.gocache/mod
+      GOCACHE: ${{ github.workspace }}/.gocache/build
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -77,11 +123,27 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26.1'
-        cache: true
-        cache-dependency-path: go.sum
+        cache: false
+    - name: Restore Go module and build cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ github.workspace }}/.gocache/mod
+          ${{ github.workspace }}/.gocache/build
+        key: go-cross-s390x-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-cross-s390x-
     - name: Build for big-endian (s390x)
       env:
         GOOS: linux
         GOARCH: s390x
         CGO_ENABLED: '0'
       run: go build ./...
+    - name: Save Go module and build cache
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ github.workspace }}/.gocache/mod
+          ${{ github.workspace }}/.gocache/build
+        key: go-cross-s390x-${{ hashFiles('go.sum') }}

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -33,6 +33,10 @@ permissions:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    # Cache dirs pinned under the workspace; saves are gated to main below.
+    env:
+      GOMODCACHE: ${{ github.workspace }}/.gocache/mod
+      GOCACHE: ${{ github.workspace }}/.gocache/build
     strategy:
       fail-fast: false
       matrix:
@@ -48,8 +52,18 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25
-          cache: true
-          cache-dependency-path: go.sum
+          # Caching managed explicitly below so saves can be gated to main.
+          cache: false
+
+      - name: Restore Go module and build cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ github.workspace }}/.gocache/mod
+            ${{ github.workspace }}/.gocache/build
+          key: go-integration-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-integration-
 
       - name: Integration setup (Spark ${{ matrix.spark.version }})
         run: make ${{ matrix.spark.setup }}
@@ -72,3 +86,12 @@ jobs:
       - name: Show debug logs
         if: ${{ failure() }}
         run: docker compose -f internal/recipe/docker-compose.yml logs
+
+      - name: Save Go module and build cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ github.workspace }}/.gocache/mod
+            ${{ github.workspace }}/.gocache/build
+          key: go-integration-${{ hashFiles('go.sum') }}


### PR DESCRIPTION
Closes #1260

## What
Stop using the golangci-lint action's built-in cache and manage caching with `actions/cache` instead. The Go module/build cache and the golangci-lint cache are now keyed by os + Go version + lockfile, restored on every run, and saved only on `main`. Cache dirs are pinned under the workspace via `env:` so the same paths work on every runner, and `setup-go`'s own caching is turned off. The cross-compile job and the integration workflow get the same restore-always, save-on-main treatment.

## Why
The golangci-lint action builds its cache key from `{os}-{workdir}-{interval}-{go.mod hash}`, with no Go version and no input to add one, so both Go versions in the matrix share one immutable entry. Whichever version loses the weekly save-race restores a cache built by the other compiler, throws it out, and re-lints from cold. That's roughly 25s vs 203s on the lint step for the same inputs (about 1m42s vs 6m15s per cell). Adding the Go version to the key gives each version its own cache. Gating saves to `main` stops PR branches from overwriting the cache that `main` builds.

## Validation
Tested in a fork: warm runs restored the per-version caches and the previously-slow lint step dropped back to ~25s, and PR runs restored without saving.
