### PR TITLE
ci: run lint-and-test on the real os matrix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,7 @@
 # shell scripts with many flags. Unfortunately, directories themselves
 # won't recursively ignore, so we need the top level directories
 # as well as their files.
+
+# Force LF for Go sources so gofmt passes when checked out on Windows
+# (Windows runners would otherwise convert LF to CRLF and fail the gofmt linter).
+*.go text eol=lf

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   lint-and-test:
     name: ${{ matrix.os }} go${{ matrix.go }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     # Cache dirs are pinned to dot-prefixed paths under the workspace so they are
     # identical across Linux/Windows/macOS (no per-OS path branching) and are
     # excluded from `go`/golangci-lint `./...` expansion (leading-dot dirs are
@@ -47,7 +47,11 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.25.8', '1.26.1' ]
-        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        os:
+          - 'ubuntu-latest'
+          - 'macos-latest'
+          # - 'windows-latest'  # blocked on Windows path support, see #1262
+
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:


### PR DESCRIPTION
Closes #1261

## What
Set `runs-on: ${{ matrix.os }}` so the matrix actually selects runners, and turn on macOS alongside Linux. `windows-latest` stays commented out until the path issues in #1262 are sorted. Also add `*.go text eol=lf` to `.gitattributes` so gofmt passes when Go files are checked out on a non-Linux runner.

## Why
`runs-on:` was hardcoded to `ubuntu-latest` while `name:` used `${{ matrix.os }}`, so the `os` axis had no effect and every job ran on Linux. macOS was listed but never actually tested. Making the matrix real gets macOS covered now. Windows needs filesystem-path fixes first (#1262), so it stays off for the moment. The `.gitattributes` rule keeps the gofmt linter from failing if a runner checks out Go sources with CRLF.

## Validation
Tested in a fork: the macOS cells ran lint, tests, and the race job green.
