### PR TITLE
fix(catalog/glue): case-insensitive type match in convertGlueToIceberg

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -700,7 +700,8 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 		return nil, fmt.Errorf("missing parameters for table %s", tableName)
 	}
 
-	if glueTable.Parameters[tableParamTableType] != glueTypeIceberg {
+	// Keep this case-insensitive check consistent with getTable and filterTableListByType.
+	if !strings.EqualFold(glueTable.Parameters[tableParamTableType], glueTypeIceberg) {
 		return nil, fmt.Errorf("table %s.%s is not an iceberg table", database, tableName)
 	}
 

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -250,6 +251,60 @@ func TestGlueGetTableCaseInsensitive(t *testing.T) {
 			} else {
 				assert.NoError(err)
 				assert.Equal("s3://test-bucket/test_table/metadata/abc123-123.metadata.json", tbl.Parameters[tableParamMetadataLocation])
+			}
+		})
+	}
+}
+
+func TestGlueConvertGlueToIcebergCaseInsensitive(t *testing.T) {
+	// Minimal valid v2 table metadata so NewFromLocation can succeed on the
+	// iceberg cases. Mirrors table/testdata/TableMetadataV2ValidMinimal.json.
+	const metadataJSON = `{"current-schema-id":0,"current-snapshot-id":-1,"default-sort-order-id":0,"default-spec-id":0,"format-version":2,"last-column-id":3,"last-partition-id":999,"last-sequence-number":0,"last-updated-ms":1602638573590,"location":"s3://bucket/test/location","metadata-log":[],"partition-specs":[{"fields":[],"spec-id":0}],"properties":{},"refs":{},"schemas":[{"fields":[{"id":1,"name":"x","required":true,"type":"long"},{"doc":"comment","id":2,"name":"y","required":true,"type":"long"},{"id":3,"name":"z","required":true,"type":"long"}],"schema-id":0,"type":"struct"}],"snapshot-log":[],"snapshots":[],"sort-orders":[{"fields":[],"order-id":0}],"statistics":[],"table-uuid":"9c12d441-03fe-4693-9a96-a0705ddf69c1"}`
+
+	metaPath := filepath.Join(t.TempDir(), "metadata.json")
+	require.NoError(t, os.WriteFile(metaPath, []byte(metadataJSON), 0o644))
+	metadataLocation := "file://" + metaPath
+
+	testCases := []struct {
+		name      string
+		tableType string
+		omitType  bool
+		shouldErr bool
+	}{
+		{"uppercase", "ICEBERG", false, false},
+		{"lowercase", "iceberg", false, false},
+		{"mixed case", "IcEbErG", false, false},
+		{"non-iceberg", "HIVE", false, true},
+		{"empty", "", false, true},
+		{"absent", "", true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			params := map[string]string{
+				tableParamMetadataLocation: metadataLocation,
+			}
+			if !tc.omitType {
+				params[tableParamTableType] = tc.tableType
+			}
+			glueTable := &types.Table{
+				Name:         aws.String("test_table"),
+				DatabaseName: aws.String("test_database"),
+				Parameters:   params,
+			}
+
+			glueCatalog := &Catalog{}
+
+			tbl, err := glueCatalog.convertGlueToIceberg(context.TODO(), glueTable)
+			if tc.shouldErr {
+				assert.Error(err)
+				assert.Contains(err.Error(), "is not an iceberg table")
+			} else {
+				assert.NoError(err)
+				assert.NotNil(tbl)
+				assert.Equal([]string{"test_database", "test_table"}, tbl.Identifier())
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1267 (related: #479, regressed by #537).

### Summary

`convertGlueToIceberg` is the only remaining case-sensitive `table_type` check in `catalog/glue/glue.go` — the other two sites (`getTable`, `filterTableListByType`) already use `strings.EqualFold` since #480. This brings the third site in line so `LoadTable` accepts Glue tables written by PyIceberg or via the AWS Glue Iceberg REST endpoint (both emit lowercase `iceberg`), matching the case-insensitive semantics of the PyIceberg and Java Glue implementations.

### Why

`LoadTable` → `getTable` now passes case-insensitively but the subsequent `convertGlueToIceberg` rejects the same table, reproducing the symptom from #479 (`table X.Y is not an iceberg table` on a valid Iceberg table). Originally flagged by @tommika in a comment on #479.

### Change

- One-line fix at `catalog/glue/glue.go:703`: `!=` → `!strings.EqualFold(...)`.
- New unit test `TestGlueConvertGlueToIcebergCaseInsensitive` mirroring the existing `TestGlueGetTableCaseInsensitive`, covering `ICEBERG`, `iceberg`, `IcEbErG`, and a non-Iceberg negative case. Verified by reverting the fix and confirming the new test fails.

### Test plan

- [x] `go test ./catalog/glue/` passes
- [x] `golangci-lint run ./catalog/glue/...` clean
- [x] New test fails without the fix, passes with it
