### PR TITLE
fix(table): guard nil sequence number in matchDVToData

### DIFF
--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -302,6 +302,60 @@ func TestMatchDVToData_SequenceNumberGuard(t *testing.T) {
 	}
 }
 
+// TestMatchDVToData_NilDVSequenceNumber covers indeterminate sequence
+// numbers, for which ManifestEntry.SequenceNum reports the -1 sentinel. An
+// unset sequence number on either side must be treated as "applies": before
+// the guard, a real (>= 0) data sequence number compared against an unset
+// DV sequence (-1) was always false, silently dropping the DV and
+// resurfacing deleted rows. A known sequence of 0 is a real value, not
+// "unset", so the < 0 guard must stay tight.
+func TestMatchDVToData_NilDVSequenceNumber(t *testing.T) {
+	dataFilePath := "s3://bucket/data/data-001.parquet"
+	snapshotID := int64(1)
+
+	tests := []struct {
+		name     string
+		dvSeq    *int64 // nil → unset, SequenceNum reports -1
+		dataSeq  *int64 // nil → unset
+		expectDV bool
+	}{
+		{"unset DV seq, real data seq — applies (regression)", nil, int64Ptr(7), true},
+		{"unset DV seq and unset data seq — applies", nil, nil, true},
+		{"known DV seq 0, newer data — skipped (guard stays tight)", int64Ptr(0), int64Ptr(5), false},
+		{"known DV seq 0, same data seq 0 — applies", int64Ptr(0), int64Ptr(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dvFile := &dvMockDataFile{
+				mockDataFile: mockDataFile{
+					path:        "s3://bucket/data/dv-001.puffin",
+					contentType: iceberg.EntryContentPosDeletes,
+				},
+				referencedDataFile: strPtr(dataFilePath),
+				contentOffset:      int64Ptr(0),
+				contentSizeInBytes: int64Ptr(128),
+			}
+			dvEntries := []iceberg.ManifestEntry{
+				iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, tt.dvSeq, nil, dvFile),
+			}
+			dvIndex, err := buildDVIndex(dvEntries)
+			assert.NoError(t, err)
+
+			dataEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, tt.dataSeq, nil,
+				&mockDataFile{path: dataFilePath, contentType: iceberg.EntryContentData})
+
+			matched := matchDVToData(dataEntry, dvIndex)
+			if tt.expectDV {
+				assert.Len(t, matched, 1)
+				assert.Equal(t, dvFile.path, matched[0].FilePath())
+			} else {
+				assert.Empty(t, matched)
+			}
+		})
+	}
+}
+
 func TestFileScanTask_DeletionVectorFilesField(t *testing.T) {
 	dataFile := &mockDataFile{
 		path:        "s3://bucket/data/data-001.parquet",

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -528,14 +528,25 @@ func buildDVIndex(dvEntries []iceberg.ManifestEntry) (map[string]iceberg.Manifes
 }
 
 // matchDVToData returns the deletion vector that applies to the given data
-// entry, if any. A DV applies only when the data file's sequence number is
-// less than or equal to the DV's sequence number.
+// entry, if any. A DV applies when the data file's sequence number is less
+// than or equal to the DV's sequence number.
+//
+// SequenceNum reports the -1 sentinel when an entry's sequence number is
+// unset (see manifest.go). Entries arrive here already inherited, so a
+// committed ADDED entry always carries a real (>= 0) sequence number; an
+// unset value comes from an EXISTING/DELETED entry missing its required
+// explicit sequence number, or a not-yet-committed manifest. Such an
+// indeterminate sequence number — on either side — is treated as "applies":
+// comparing a real data sequence number against an unset DV sequence (-1)
+// would never satisfy dataSeq <= -1 and would silently drop the DV,
+// resurfacing deleted rows; an unset data sequence likewise satisfies
+// -1 <= dvSeq for any known DV sequence.
 func matchDVToData(dataEntry iceberg.ManifestEntry, dvIndex map[string]iceberg.ManifestEntry) []iceberg.DataFile {
 	dvEntry, ok := dvIndex[dataEntry.DataFile().FilePath()]
 	if !ok {
 		return nil
 	}
-	if dataEntry.SequenceNum() <= dvEntry.SequenceNum() {
+	if dvSeq := dvEntry.SequenceNum(); dvSeq < 0 || dataEntry.SequenceNum() <= dvSeq {
 		return []iceberg.DataFile{dvEntry.DataFile()}
 	}
 


### PR DESCRIPTION
matchDVToData decided DV applicability with
`dataEntry.SequenceNum() <= dvEntry.SequenceNum()`. A deletion-vector ManifestEntry can reach this point with an unset sequence number, for which SequenceNum() reports the -1 sentinel — so for any real (>= 0) data sequence number the comparison dataSeq <= -1 was always false and the DV was silently skipped, resurfacing rows it should have deleted.

Entries arrive here already inherited, so a committed ADDED entry always carries a real sequence number; an unset value comes from an EXISTING/DELETED entry missing its required explicit sequence number, or a not-yet-committed manifest. Treat an indeterminate (negative) sequence number as applicable — mirroring the existing seq >= 0 sentinel guard in the scan task builder — so an unknown sequence never drops a DV.