### PR TITLE
fix(table): recover panics in RollingDataWriter.stream

### DIFF
--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -322,7 +322,23 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 	defer close(r.errorCh)
 
 	var currentWriter tblutils.FileWriter
+	// Cleanup defer: recover a panic in the write path and abort any
+	// in-progress file. stream runs in its own goroutine with no caller to
+	// recover it, and FileWriter.Close can panic (stats.ToDataFile panics when
+	// NewDataFileBuilder fails); convert that into an error on errorCh instead
+	// of crashing the process, mirroring the recover in
+	// equalityDeleteRecordsToDataFiles. Registered after close(r.errorCh) so it
+	// runs first (LIFO) and can still send on the open channel before it is
+	// closed.
 	defer func() {
+		if rec := recover(); rec != nil {
+			switch e := rec.(type) {
+			case error:
+				r.sendError(fmt.Errorf("panic during rolling data file writing: %w", e))
+			default:
+				r.sendError(fmt.Errorf("panic during rolling data file writing: %v", e))
+			}
+		}
 		if currentWriter != nil {
 			_ = currentWriter.Abort()
 		}

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -648,4 +649,78 @@ func (s *RollingDataWriterTestSuite) TestUnsortedOrderIsNoOp() {
 		}
 	}
 	s.Equal([]int32{3, 1, 2}, ids, "unsorted order must preserve arrival order")
+}
+
+// panicOnCloseFormat wraps a real FileFormat but hands out writers whose Close
+// panics, mimicking stats.ToDataFile panicking when NewDataFileBuilder fails.
+// bytesWritten is reported by every writer it creates: a value >= the target
+// file size makes stream roll (and Close) mid-loop, 0 defers Close to the end
+// of the stream.
+type panicOnCloseFormat struct {
+	tblutils.FileFormat
+	bytesWritten int64
+}
+
+func (f panicOnCloseFormat) NewFileWriter(_ context.Context, _ iceio.WriteFileIO, _ map[int]any, _ tblutils.WriteFileInfo, _ *arrow.Schema) (tblutils.FileWriter, error) {
+	return panicOnCloseWriter{bytesWritten: f.bytesWritten}, nil
+}
+
+// panicOnCloseWriter is a FileWriter whose Close panics with an error, like the
+// real stats.ToDataFile -> NewDataFileBuilder failure path.
+type panicOnCloseWriter struct {
+	bytesWritten int64
+}
+
+func (panicOnCloseWriter) Write(arrow.RecordBatch) error { return nil }
+func (w panicOnCloseWriter) BytesWritten() int64         { return w.bytesWritten }
+func (panicOnCloseWriter) Close() (iceberg.DataFile, error) {
+	panic(errors.New("simulated NewDataFileBuilder failure"))
+}
+func (panicOnCloseWriter) Abort() error { return nil }
+
+// TestStreamRecoversWriterClosePanic drives the rolling writer so the file
+// writer's Close panics inside the stream goroutine, and asserts the panic is
+// recovered and surfaced as an error on errorCh rather than crashing the
+// process. Both Close call sites are covered: the mid-loop roll (the common
+// production path) and the end-of-stream close.
+func (s *RollingDataWriterTestSuite) TestStreamRecoversWriterClosePanic() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	const targetFileSize = 1024 * 1024
+	tests := []struct {
+		name         string
+		bytesWritten int64
+	}{
+		{"end-of-stream close", 0},
+		{"mid-stream file roll", targetFileSize}, // >= target rolls (and closes) mid-loop
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			loc := filepath.ToSlash(s.T().TempDir())
+			factory, _ := s.createWriterFactory(loc, arrSchema, targetFileSize)
+			defer factory.closeAll()
+
+			// Hand out a writer whose Close panics. Assigned before
+			// newRollingDataWriter so it happens-before the stream goroutine
+			// reads factory.format. Before the recover in stream, this panic
+			// escaped the goroutine and crashed the process.
+			factory.format = panicOnCloseFormat{FileFormat: factory.format, bytesWritten: tt.bytesWritten}
+
+			outputCh := make(chan iceberg.DataFile, 1)
+			writer := factory.newRollingDataWriter(s.ctx, "", nil, outputCh)
+
+			record := s.buildRecord(arrSchema, 5)
+			defer record.Release()
+			s.Require().NoError(writer.Add(record))
+
+			err := writer.closeAndWait()
+			s.Require().Error(err)
+			s.Contains(err.Error(), "panic during rolling data file writing")
+			s.Contains(err.Error(), "simulated NewDataFileBuilder failure")
+		})
+	}
 }


### PR DESCRIPTION
stream runs in its own goroutine (spawned by newRollingDataWriter) and has no caller able to recover a panic. Inside, closeWriter -> FileWriter.Close -> stats.ToDataFile panics when NewDataFileBuilder fails, so that panic escaped the goroutine and crashed the whole process instead of failing the write.

Add a recover at the top of stream that converts a panic into an error delivered on errorCh, mirroring the recover already present in equalityDeleteRecordsToDataFiles. The defer is declared after the close(r.errorCh) defer so it runs first (LIFO) and sends while errorCh is still open; the existing Abort defer still cleans up the half-written file.