### PR TITLE
fix: keep ExpireSnapshots retention defaults at int64 on 32-bit builds

### DIFF
--- a/table/properties.go
+++ b/table/properties.go
@@ -95,10 +95,10 @@ const (
 	MinSnapshotsToKeepDefault = math.MaxInt
 
 	MaxSnapshotAgeMsKey     = "max-snapshot-age-ms"
-	MaxSnapshotAgeMsDefault = math.MaxInt
+	MaxSnapshotAgeMsDefault = int64(math.MaxInt64)
 
 	MaxRefAgeMsKey     = "max-ref-age-ms"
-	MaxRefAgeMsDefault = math.MaxInt
+	MaxRefAgeMsDefault = int64(math.MaxInt64)
 
 	// CommitNumRetriesKey is the number of commit retry attempts before
 	// giving up on ErrCommitFailed from the catalog.

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -312,11 +312,11 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	// Read table-level retention properties as the last-resort defaults,
 	// mirroring the Java implementation. When neither the ref nor the
 	// caller provides a value, fall back to the table property; when the
-	// table property is also absent use the constant default (math.MaxInt,
+	// table property is also absent use the constant default (math.MaxInt64,
 	// meaning "keep everything").
-	propMaxRefAgeMs := int64(t.meta.props.GetInt(MaxRefAgeMsKey, MaxRefAgeMsDefault))
+	propMaxRefAgeMs := t.meta.props.GetInt64(MaxRefAgeMsKey, MaxRefAgeMsDefault)
 	propMinSnapshotsToKeep := t.meta.props.GetInt(MinSnapshotsToKeepKey, MinSnapshotsToKeepDefault)
-	propMaxSnapshotAgeMs := int64(t.meta.props.GetInt(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault))
+	propMaxSnapshotAgeMs := t.meta.props.GetInt64(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault)
 
 	for refName, ref := range t.meta.refs {
 		// Assert that this ref's snapshot ID hasn't changed concurrently.

--- a/types.go
+++ b/types.go
@@ -75,6 +75,23 @@ func (p Properties) GetInt(key string, defVal int) int {
 	return defVal
 }
 
+// GetInt64 reads a 64-bit integer property by key. A missing key or an
+// unparseable value returns defVal. Unlike GetInt, this avoids truncating
+// large int64 sentinel values (such as math.MaxInt64) on 32-bit platforms
+// where int is only 32 bits wide.
+func (p Properties) GetInt64(key string, defVal int64) int64 {
+	if v, ok := p[key]; ok {
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return defVal
+		}
+
+		return i
+	}
+
+	return defVal
+}
+
 // PropUInt reads an unsigned-integer property by key. A missing key,
 // an unparseable value, or a negative value returns defVal — PropUInt
 // uses strconv.ParseUint, which rejects negatives rather than silently

--- a/types_test.go
+++ b/types_test.go
@@ -576,10 +576,10 @@ func TestPropUInt(t *testing.T) {
 
 func TestGetInt64(t *testing.T) {
 	props := iceberg.Properties{
-		"n":         "42",
-		"maxint64":  "9223372036854775807",
-		"neg":       "-7",
-		"garbage":   "not-a-number",
+		"n":        "42",
+		"maxint64": "9223372036854775807",
+		"neg":      "-7",
+		"garbage":  "not-a-number",
 	}
 
 	assert.Equal(t, int64(42), props.GetInt64("n", 0))

--- a/types_test.go
+++ b/types_test.go
@@ -19,6 +19,7 @@ package iceberg_test
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -571,6 +572,27 @@ func TestPropUInt(t *testing.T) {
 		"negative string must fall back, not wrap to a huge positive")
 	assert.Equal(t, uint(77), iceberg.PropUInt(props, "garbage", 77), "falls back on parse error")
 	assert.Equal(t, uint(5), iceberg.PropUInt(props, "missing", 5), "falls back on missing key")
+}
+
+func TestGetInt64(t *testing.T) {
+	props := iceberg.Properties{
+		"n":         "42",
+		"maxint64":  "9223372036854775807",
+		"neg":       "-7",
+		"garbage":   "not-a-number",
+	}
+
+	assert.Equal(t, int64(42), props.GetInt64("n", 0))
+	assert.Equal(t, int64(math.MaxInt64), props.GetInt64("maxint64", 0),
+		"must preserve full int64 MaxInt64 value")
+	assert.Equal(t, int64(-7), props.GetInt64("neg", 0))
+	assert.Equal(t, int64(99), props.GetInt64("garbage", 99), "falls back on parse error")
+	assert.Equal(t, int64(5), props.GetInt64("missing", 5), "falls back on missing key")
+
+	// Verify the default itself survives round-trip without truncation on 32-bit.
+	def := int64(math.MaxInt64)
+	assert.Equal(t, def, props.GetInt64("missing", def),
+		"default int64(math.MaxInt64) must not be truncated")
 }
 
 func TestGeometryType(t *testing.T) {


### PR DESCRIPTION
`Properties.GetInt` parses with `strconv.ParseInt(v, 10, 64)` then narrows to platform-width `int`. On 32-bit targets `math.MaxInt` is `MaxInt32` (~25 days in ms), so the "keep everything" sentinel for `MaxSnapshotAgeMsDefault` and `MaxRefAgeMsDefault` collapses before the `int64()` widening in `ExpireSnapshots` — snapshots or refs older than ~25 days get expired even when no retention was configured.

**Fix:** Add `Properties.GetInt64(key string, defVal int64) int64` that returns the full `int64` without platform truncation, retype the two age defaults to `int64(math.MaxInt64)`, and update `ExpireSnapshots` to use `GetInt64` for those properties.

`MinSnapshotsToKeepDefault` remains `math.MaxInt` with `GetInt` because its downstream type is `int`, not `int64`.

Closes #1278
