### PR TITLE
feat(cli): RewriteManifests Maintenance Task

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -219,6 +219,25 @@ func TestArgsParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "rewrite-manifests with flags",
+			args: []string{"rewrite-manifests", "prod.db.events", "--target-manifest-size", "8388608", "--spec-id", "2"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.RewriteManifests)
+				assert.Equal(t, "prod.db.events", a.RewriteManifests.TableID)
+				assert.Equal(t, int64(8388608), a.RewriteManifests.TargetManifestSize)
+				assert.Equal(t, 2, a.RewriteManifests.SpecID)
+			},
+		},
+		{
+			name: "rewrite-manifests defaults",
+			args: []string{"rewrite-manifests", "prod.db.events"},
+			check: func(t *testing.T, a Args) {
+				require.NotNil(t, a.RewriteManifests)
+				assert.Equal(t, int64(0), a.RewriteManifests.TargetManifestSize)
+				assert.Equal(t, -1, a.RewriteManifests.SpecID)
+			},
+		},
+		{
 			name: "global flags",
 			args: []string{"--catalog", "glue", "--output", "json", "--warehouse", "s3://wh", "list"},
 			check: func(t *testing.T, a Args) {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -167,31 +167,38 @@ type CompactCmd struct {
 	Run     *CompactRunCmd     `arg:"subcommand:run" help:"run bin-pack compaction"`
 }
 
+type RewriteManifestsCmd struct {
+	TableID            string `arg:"positional,required" help:"full path to a table"`
+	TargetManifestSize int64  `arg:"--target-manifest-size" default:"0" help:"target manifest size in bytes (default: table property)"`
+	SpecID             int    `arg:"--spec-id" default:"-1" help:"only rewrite manifests of this partition spec id"`
+}
+
 // Top-level args
 
 type Args struct {
-	List         *ListCmd             `arg:"subcommand:list" help:"list tables or namespaces"`
-	Describe     *DescribeCmd         `arg:"subcommand:describe" help:"describe a namespace or table"`
-	Schema       *SchemaCmd           `arg:"subcommand:schema" help:"get the schema of a table"`
-	Spec         *SpecCmd             `arg:"subcommand:spec" help:"return the partition spec of a table"`
-	Uuid         *UuidCmd             `arg:"subcommand:uuid" help:"return the UUID of a table"`
-	Location     *LocationCmd         `arg:"subcommand:location" help:"return the location of a table"`
-	Create       *CreateCmd           `arg:"subcommand:create" help:"create a namespace or table"`
-	Drop         *DropCmd             `arg:"subcommand:drop" help:"drop a namespace or table"`
-	Files        *FilesCmd            `arg:"subcommand:files" help:"list all files of a table"`
-	Rename       *RenameCmd           `arg:"subcommand:rename" help:"rename a table"`
-	Properties   *PropertiesCmd       `arg:"subcommand:properties" help:"manage properties on tables/namespaces"`
-	Compact      *CompactCmd          `arg:"subcommand:compact" help:"analyze or run bin-pack compaction"`
-	Info         *InfoCmd             `arg:"subcommand:info" help:"show single-screen table summary"`
-	Snapshots    *SnapshotsCmd        `arg:"subcommand:snapshots" help:"list table snapshots"`
-	Refs         *RefsCmd             `arg:"subcommand:refs" help:"list snapshot refs"`
-	PartStats    *PartitionStatsCmd   `arg:"subcommand:partition-stats" help:"list partition statistics files"`
-	Branch       *BranchCmd           `arg:"subcommand:branch" help:"manage table branches"`
-	Tag          *TagCmd              `arg:"subcommand:tag" help:"manage table tags"`
-	ExpireSnaps  *ExpireSnapshotsCmd  `arg:"subcommand:expire-snapshots" help:"expire old snapshots"`
-	CleanOrphans *CleanOrphanFilesCmd `arg:"subcommand:clean-orphan-files" help:"remove orphan files"`
-	Upgrade      *UpgradeCmd          `arg:"subcommand:upgrade" help:"upgrade table format version"`
-	Rollback     *RollbackCmd         `arg:"subcommand:rollback" help:"roll back to a previous snapshot"`
+	List             *ListCmd             `arg:"subcommand:list" help:"list tables or namespaces"`
+	Describe         *DescribeCmd         `arg:"subcommand:describe" help:"describe a namespace or table"`
+	Schema           *SchemaCmd           `arg:"subcommand:schema" help:"get the schema of a table"`
+	Spec             *SpecCmd             `arg:"subcommand:spec" help:"return the partition spec of a table"`
+	Uuid             *UuidCmd             `arg:"subcommand:uuid" help:"return the UUID of a table"`
+	Location         *LocationCmd         `arg:"subcommand:location" help:"return the location of a table"`
+	Create           *CreateCmd           `arg:"subcommand:create" help:"create a namespace or table"`
+	Drop             *DropCmd             `arg:"subcommand:drop" help:"drop a namespace or table"`
+	Files            *FilesCmd            `arg:"subcommand:files" help:"list all files of a table"`
+	Rename           *RenameCmd           `arg:"subcommand:rename" help:"rename a table"`
+	Properties       *PropertiesCmd       `arg:"subcommand:properties" help:"manage properties on tables/namespaces"`
+	Compact          *CompactCmd          `arg:"subcommand:compact" help:"analyze or run bin-pack compaction"`
+	RewriteManifests *RewriteManifestsCmd `arg:"subcommand:rewrite-manifests" help:"rewrite (compact) table manifests"`
+	Info             *InfoCmd             `arg:"subcommand:info" help:"show single-screen table summary"`
+	Snapshots        *SnapshotsCmd        `arg:"subcommand:snapshots" help:"list table snapshots"`
+	Refs             *RefsCmd             `arg:"subcommand:refs" help:"list snapshot refs"`
+	PartStats        *PartitionStatsCmd   `arg:"subcommand:partition-stats" help:"list partition statistics files"`
+	Branch           *BranchCmd           `arg:"subcommand:branch" help:"manage table branches"`
+	Tag              *TagCmd              `arg:"subcommand:tag" help:"manage table tags"`
+	ExpireSnaps      *ExpireSnapshotsCmd  `arg:"subcommand:expire-snapshots" help:"expire old snapshots"`
+	CleanOrphans     *CleanOrphanFilesCmd `arg:"subcommand:clean-orphan-files" help:"remove orphan files"`
+	Upgrade          *UpgradeCmd          `arg:"subcommand:upgrade" help:"upgrade table format version"`
+	Rollback         *RollbackCmd         `arg:"subcommand:rollback" help:"roll back to a previous snapshot"`
 
 	Catalog     string `arg:"--catalog" default:"rest" help:"catalog type"`
 	CatalogName string `arg:"--catalog-name" default:"default" help:"catalog name from config"`
@@ -324,6 +331,8 @@ func main() {
 		runProperties(ctx, output, cat, args.Properties)
 	case args.Compact != nil:
 		runCompact(ctx, output, cat, args.Compact)
+	case args.RewriteManifests != nil:
+		runRewriteManifests(ctx, output, cat, args.RewriteManifests)
 	case args.Info != nil:
 		tbl := loadTable(ctx, output, cat, args.Info.TableID)
 		output.Info(tbl)

--- a/cmd/iceberg/rewrite_manifests.go
+++ b/cmd/iceberg/rewrite_manifests.go
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+)
+
+func runRewriteManifests(ctx context.Context, output Output, cat catalog.Catalog, cmd *RewriteManifestsCmd) {
+	tbl := loadTable(ctx, output, cat, cmd.TableID)
+
+	var opts []table.RewriteManifestsOpt
+	if cmd.TargetManifestSize > 0 {
+		opts = append(opts, table.WithManifestTargetSize(cmd.TargetManifestSize))
+	}
+	if cmd.SpecID >= 0 {
+		opts = append(opts, table.WithRewriteSpecID(cmd.SpecID))
+	}
+
+	tx := tbl.NewTransaction()
+	res, err := tx.RewriteManifests(ctx, opts...)
+	if err != nil {
+		output.Error(fmt.Errorf("rewrite manifests failed: %w", err))
+		osExit(1)
+	}
+
+	// No-op — nothing was written or staged, so there is no commit to make. The
+	// reason distinguishes an empty table from an already-optimal layout.
+	if res.IsNoOp() {
+		if res.NoOpReason == table.NoOpNoSnapshot {
+			output.Text("Table has no current snapshot; nothing to rewrite.")
+		} else {
+			output.Text("Manifests already optimal; nothing to rewrite.")
+		}
+
+		return
+	}
+
+	if _, err := tx.Commit(ctx); err != nil {
+		output.Error(fmt.Errorf("commit failed: %w", err))
+		osExit(1)
+	}
+
+	output.Text(fmt.Sprintf("Rewrote %d manifests into %d.",
+		len(res.RewrittenManifests), len(res.AddedManifests)))
+}

--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -1,0 +1,423 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"slices"
+	"strconv"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// Snapshot summary keys for a manifest rewrite.
+const (
+	manifestsCreatedKey  = "manifests-created"  // new manifests the merge wrote
+	manifestsReplacedKey = "manifests-replaced" // input manifests the merge consumed
+	manifestsKeptKey     = "manifests-kept"     // manifests left untouched, delete manifests included
+	entriesProcessedKey  = "entries-processed"  // data-file entries, not rows
+)
+
+// NoOpReason explains why a rewrite changed nothing. It lets callers tell a
+// table with no current snapshot apart from one whose manifests are already
+// optimal, which would otherwise both surface as an empty result.
+type NoOpReason int
+
+const (
+	// NoOpNone means the rewrite produced changes (not a no-op).
+	NoOpNone NoOpReason = iota
+	// NoOpNoSnapshot means the table had no current snapshot to rewrite.
+	NoOpNoSnapshot
+	// NoOpAlreadyOptimal means the eligible manifests were already optimal.
+	NoOpAlreadyOptimal
+)
+
+func (r NoOpReason) String() string {
+	switch r {
+	case NoOpNoSnapshot:
+		return "no current snapshot"
+	case NoOpAlreadyOptimal:
+		return "manifests already optimal"
+	default:
+		return "none"
+	}
+}
+
+// RewriteManifestsResult reports the manifests changed by a rewrite.
+type RewriteManifestsResult struct {
+	// RewrittenManifests are the old manifests that were replaced.
+	RewrittenManifests []iceberg.ManifestFile
+	// AddedManifests are the new manifests written in their place.
+	AddedManifests []iceberg.ManifestFile
+	// NoOpReason is set when the rewrite changed nothing, distinguishing a
+	// missing snapshot from an already-optimal layout. NoOpNone otherwise.
+	NoOpReason NoOpReason
+}
+
+// IsNoOp reports whether the rewrite changed nothing. Callers should skip the
+// commit in that case rather than staging an empty REPLACE snapshot. NoOpReason
+// is the single source of truth.
+func (r *RewriteManifestsResult) IsNoOp() bool {
+	return r.NoOpReason != NoOpNone
+}
+
+type rewriteManifestsCfg struct {
+	targetSizeBytes int64
+	specID          *int
+	predicate       func(iceberg.ManifestFile) bool
+}
+
+// RewriteManifestsOpt configures [Transaction.RewriteManifests].
+type RewriteManifestsOpt func(*rewriteManifestsCfg)
+
+// WithManifestTargetSize overrides the target manifest size in bytes. A
+// non-positive size is ignored, leaving the default from the
+// commit.manifest.target-size-bytes property.
+func WithManifestTargetSize(size int64) RewriteManifestsOpt {
+	return func(c *rewriteManifestsCfg) {
+		if size > 0 {
+			c.targetSizeBytes = size
+		}
+	}
+}
+
+// WithRewriteSpecID restricts the rewrite to manifests of one partition spec.
+func WithRewriteSpecID(id int) RewriteManifestsOpt {
+	return func(c *rewriteManifestsCfg) { c.specID = &id }
+}
+
+// WithRewriteManifestPredicate only rewrites manifests for which pred is true.
+// Manifests that don't match are left untouched.
+func WithRewriteManifestPredicate(pred func(iceberg.ManifestFile) bool) RewriteManifestsOpt {
+	return func(c *rewriteManifestsCfg) { c.predicate = pred }
+}
+
+// rewriteManifests is a producer that merges small data manifests into
+// fewer, target-sized ones, committed as a metadata-only REPLACE snapshot.
+type rewriteManifests struct {
+	base *snapshotProducer
+	cfg  rewriteManifestsCfg
+
+	rewritten []iceberg.ManifestFile
+	added     []iceberg.ManifestFile
+
+	// superseded accumulates merged manifest files written by a rebuild on a
+	// prior OCC attempt that a later attempt replaced. doCommit removes them
+	// after a successful commit so retries don't leak orphaned manifests.
+	superseded []string
+
+	// result is the value returned to the caller. record() rewrites its
+	// fields on every pass, including OCC retries, so the pointer the caller
+	// holds reflects the manifests actually committed, not attempt 0's.
+	result *RewriteManifestsResult
+}
+
+func newRewriteManifestsProducer(txn *Transaction, fs iceio.WriteFileIO, props iceberg.Properties, cfg rewriteManifestsCfg) *snapshotProducer {
+	prod := createSnapshotProducer(OpReplace, txn, fs, nil, props)
+	prod.producerImpl = &rewriteManifests{base: prod, cfg: cfg, result: &RewriteManifestsResult{}}
+
+	return prod
+}
+
+// supersededManifests returns the merged manifests orphaned across OCC retries,
+// safe to delete once the commit resolves. When the commit never landed
+// (committed is false) the final attempt's manifests are orphaned too — a
+// snapshot that never committed references nothing — so they are appended.
+func (r *rewriteManifests) supersededManifests(committed bool) []string {
+	if committed {
+		return r.superseded
+	}
+
+	paths := slices.Clone(r.superseded)
+	for _, m := range r.added {
+		paths = append(paths, m.FilePath())
+	}
+
+	return paths
+}
+
+func (r *rewriteManifests) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
+	if parent == nil {
+		return nil, nil
+	}
+
+	return parent.Manifests(r.base.io)
+}
+
+func (r *rewriteManifests) deletedEntries(context.Context, *Snapshot) ([]iceberg.ManifestEntry, error) {
+	return nil, nil
+}
+
+func (r *rewriteManifests) processManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	var toRewrite, kept []iceberg.ManifestFile
+	for _, m := range manifests {
+		if r.eligible(m) {
+			toRewrite = append(toRewrite, m)
+		} else {
+			kept = append(kept, m)
+		}
+	}
+
+	mgr := manifestMergeManager{
+		targetSizeBytes: r.cfg.targetSizeBytes,
+		minCountToMerge: 1,    // force a merge regardless of count
+		mergeEnabled:    true, // explicit op ignores commit.manifest-merge.enabled
+		snap:            r.base,
+	}
+	merged, err := mgr.mergeManifests(toRewrite)
+	if err != nil {
+		return nil, err
+	}
+
+	// mergeManifests already wrote the new .avro files. If this pass fails
+	// before record() takes ownership, nothing will reference them, so delete
+	// them here rather than leak orphans that no commit/retry cleanup can reach.
+	owned := false
+	defer func() {
+		if !owned {
+			r.deleteWritten(toRewrite, merged)
+		}
+	}()
+
+	// Record on every pass, not just the first. An OCC retry re-runs this
+	// against the fresh parent and writes a different merged set; the last
+	// pass is the one that commits, so its counts are the ones that must win.
+	// record also runs the file-count guard, so an error here leaves the
+	// merged files to the defer above for cleanup.
+	if err := r.record(toRewrite, merged, kept); err != nil {
+		return nil, err
+	}
+	owned = true
+
+	return slices.Concat(merged, kept), nil
+}
+
+// eligible reports whether m is a data manifest selected for rewrite.
+func (r *rewriteManifests) eligible(m iceberg.ManifestFile) bool {
+	if m.ManifestContent() != iceberg.ManifestContentData {
+		return false
+	}
+	if r.cfg.specID != nil && int(m.PartitionSpecID()) != *r.cfg.specID {
+		return false
+	}
+	if r.cfg.predicate != nil && !r.cfg.predicate(m) {
+		return false
+	}
+
+	return true
+}
+
+// deleteWritten removes the manifests mergeManifests newly wrote for this pass.
+// Single-manifest bins pass through with their input path and are left alone;
+// only the merged files (in the output but not the input) are deleted.
+func (r *rewriteManifests) deleteWritten(input, merged []iceberg.ManifestFile) {
+	inPaths := make(map[string]struct{}, len(input))
+	for _, m := range input {
+		inPaths[m.FilePath()] = struct{}{}
+	}
+	for _, m := range merged {
+		if _, ok := inPaths[m.FilePath()]; ok {
+			continue
+		}
+		if err := r.base.io.Remove(m.FilePath()); err != nil {
+			log.Printf("Warning: failed to delete orphaned merged manifest %s: %v", m.FilePath(), err)
+		}
+	}
+}
+
+func (r *rewriteManifests) record(toRewrite, merged, kept []iceberg.ManifestFile) error {
+	// A prior pass (a superseded OCC attempt) wrote its own merged manifests
+	// that the catalog never referenced. Carry their paths into the
+	// producer's superseded set so commit() can delete them on success;
+	// otherwise every retry leaks a full set of merged .avro files.
+	for _, m := range r.added {
+		r.superseded = append(r.superseded, m.FilePath())
+	}
+	r.added, r.rewritten = nil, nil
+
+	inPaths := make(map[string]struct{}, len(toRewrite))
+	for _, m := range toRewrite {
+		inPaths[m.FilePath()] = struct{}{}
+	}
+	outPaths := make(map[string]struct{}, len(merged))
+	for _, m := range merged {
+		outPaths[m.FilePath()] = struct{}{}
+	}
+
+	// Bins of a single manifest pass through unchanged; only the manifests
+	// that actually appear on one side and not the other are added/replaced.
+	// This drives the returned RewriteManifestsResult.
+	for _, m := range merged {
+		if _, ok := inPaths[m.FilePath()]; !ok {
+			r.added = append(r.added, m)
+		}
+	}
+	for _, m := range toRewrite {
+		if _, ok := outPaths[m.FilePath()]; !ok {
+			r.rewritten = append(r.rewritten, m)
+		}
+	}
+
+	// Guard against a merge dropping or duplicating data files: the rewritten
+	// manifests must hold the same active files as the ones written in their
+	// place. Pass-through bins appear on both sides and cancel, so comparing the
+	// rewritten/added diff is equivalent to comparing the full input/output and
+	// avoids re-walking the pass-throughs. The processed count doubles as the
+	// entries-processed summary value.
+	processed, err := manifestActiveFiles(r.base.io, r.rewritten)
+	if err != nil {
+		return err
+	}
+	written, err := manifestActiveFiles(r.base.io, r.added)
+	if err != nil {
+		return err
+	}
+	if processed != written {
+		return fmt.Errorf("rewrite manifests changed active file count: %d before, %d after", processed, written)
+	}
+
+	// Publish into the shared result the caller holds so a retry's counts win.
+	r.result.RewrittenManifests = r.rewritten
+	r.result.AddedManifests = r.added
+
+	// The summary follows Java's Appendix-F accounting, which counts only the
+	// manifests a merge actually wrote and consumed — not single-manifest bins
+	// that pass through untouched — so a Go-written snapshot reads the same as a
+	// Java one.
+	r.base.snapshotProps[manifestsCreatedKey] = strconv.Itoa(len(r.added))
+	r.base.snapshotProps[manifestsReplacedKey] = strconv.Itoa(len(r.rewritten))
+	r.base.snapshotProps[manifestsKeptKey] = strconv.Itoa(len(kept))
+	r.base.snapshotProps[entriesProcessedKey] = strconv.FormatInt(processed, 10)
+
+	return nil
+}
+
+func (r *rewriteManifests) validate(*conflictContext) error { return nil }
+func (r *rewriteManifests) needsValidation() bool           { return false }
+
+// manifestActiveFiles sums the active (added + existing) data files across
+// manifests. It uses the manifest header counts when present and falls back to
+// reading and counting the live entries when a count is absent — V1 manifests
+// don't populate the count fields, so without the fallback the count guard
+// would silently not run on exactly the tables that most need it.
+func manifestActiveFiles(fs iceio.IO, manifests []iceberg.ManifestFile) (int64, error) {
+	var total int64
+	for _, m := range manifests {
+		added, existing := m.AddedDataFiles(), m.ExistingDataFiles()
+		if added < 0 || existing < 0 {
+			// discardDeleted drops DELETED entries, leaving added + existing.
+			for _, err := range m.Entries(fs, true) {
+				if err != nil {
+					return 0, fmt.Errorf("count active files in manifest %s: %w", m.FilePath(), err)
+				}
+				total++
+			}
+
+			continue
+		}
+		total += int64(added) + int64(existing)
+	}
+
+	return total, nil
+}
+
+// RewriteManifests merges small data manifests in the current snapshot into
+// fewer, target-sized ones and stages the result as a REPLACE snapshot. It
+// rewrites metadata only; no data files are read or written. Delete manifests
+// are left untouched.
+//
+// Manifests are clustered by size only (bin-packed toward the target size);
+// clustering by partition or sort key, which Java exposes via clusterBy, is a
+// future extension.
+//
+// On a V3 table each rewrite advances next-row-id by the eligible manifests'
+// row count even though no rows are written, so running it on a cadence
+// steadily consumes row-ID space.
+//
+// A no-op result (IsNoOp) means there was nothing to do — either the table has
+// no current snapshot (NoOpNoSnapshot) or the eligible manifests are already
+// optimal (NoOpAlreadyOptimal). A no-op writes no manifest list and stages
+// nothing on the transaction, so a following Commit is a true no-op; callers
+// can skip it either way.
+func (t *Transaction) RewriteManifests(ctx context.Context, opts ...RewriteManifestsOpt) (*RewriteManifestsResult, error) {
+	if t.meta.currentSnapshot() == nil {
+		return &RewriteManifestsResult{NoOpReason: NoOpNoSnapshot}, nil
+	}
+
+	cfg := rewriteManifestsCfg{
+		targetSizeBytes: int64(t.meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault)),
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	if cfg.specID != nil {
+		if _, err := t.meta.GetSpecByID(*cfg.specID); err != nil {
+			return nil, fmt.Errorf("cannot rewrite manifests: unknown partition spec id %d: %w", *cfg.specID, err)
+		}
+	}
+
+	fs, err := t.tbl.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wfs, ok := fs.(iceio.WriteFileIO)
+	if !ok {
+		return nil, ErrWriteIORequired
+	}
+
+	prod := newRewriteManifestsProducer(t, wfs, iceberg.Properties{}, cfg)
+	impl, ok := prod.producerImpl.(*rewriteManifests)
+	if !ok {
+		return nil, fmt.Errorf("internal error: unexpected producer type %T", prod.producerImpl)
+	}
+
+	parent, err := prod.parentSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	// Plan the merge first (this writes merged manifests only when a real merge
+	// happens) so a no-op is detected before commit writes the manifest list or
+	// apply stages an empty REPLACE. A single-manifest bin passes through and
+	// writes nothing, so an empty diff means nothing was written.
+	newManifests, addedContent, err := prod.buildManifests(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	if len(impl.result.AddedManifests) == 0 && len(impl.result.RewrittenManifests) == 0 {
+		impl.result.NoOpReason = NoOpAlreadyOptimal
+
+		return impl.result, nil
+	}
+
+	updates, reqs, err := prod.commitManifests(newManifests, addedContent)
+	if err != nil {
+		return nil, err
+	}
+	if err := t.apply(updates, reqs); err != nil {
+		return nil, err
+	}
+
+	// impl.result aliases the struct record() updates on every pass, so it
+	// reflects the winning attempt after the caller commits the transaction.
+	return impl.result, nil
+}

--- a/table/rewrite_manifests_internal_test.go
+++ b/table/rewrite_manifests_internal_test.go
@@ -1,0 +1,208 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+// writeManifestWithEntries writes a real data manifest holding n added entries
+// to dir and returns its on-disk path and length.
+func writeManifestWithEntries(t *testing.T, fs iceio.WriteFileIO, dir string, n int) (string, int64) {
+	t.Helper()
+
+	sc := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+
+	var entries []iceberg.ManifestEntry
+	snapID := int64(1)
+	for i := range n {
+		df, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+			dir+"/data/file-"+string(rune('a'+i))+".parquet", iceberg.ParquetFile,
+			nil, nil, nil, 1, 100,
+		)
+		require.NoError(t, err)
+		entries = append(entries,
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, df.Build()))
+	}
+
+	path := dir + "/metadata/m-v1.avro"
+	out, err := fs.Create(path)
+	require.NoError(t, err)
+	mf, err := iceberg.WriteManifest(path, out, 2, *iceberg.UnpartitionedSpec, sc, snapID, entries)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	return path, mf.Length()
+}
+
+// TestManifestActiveFilesCountsEntriesWhenHeaderCountsAbsent covers the V1
+// fallback: when a manifest's header counts are absent (reported as -1, as Java
+// V1 manifests are), manifestActiveFiles reads the live entries and counts them
+// directly instead of silently skipping the guard.
+func TestManifestActiveFilesCountsEntriesWhenHeaderCountsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	const n = 3
+	path, length := writeManifestWithEntries(t, fs, dir, n)
+
+	// A manifest reporting unknown (-1) added/existing counts, as a manifest
+	// written without the count fields would (V1's toFile maps absent counts to
+	// -1), but pointing at the real file so the fallback has entries to read.
+	unknown := iceberg.NewManifestFile(2, path, length, 0, 1).
+		AddedFiles(-1).ExistingFiles(-1).DeletedFiles(-1).Build()
+	require.EqualValues(t, -1, unknown.AddedDataFiles(), "precondition: counts must read as unknown")
+
+	got, err := manifestActiveFiles(fs, []iceberg.ManifestFile{unknown})
+	require.NoError(t, err)
+	require.EqualValues(t, n, got, "fallback must count the live entries, not skip the manifest")
+
+	// And the header-count path still wins when the counts are present.
+	known := iceberg.NewManifestFile(2, path, length, 0, 1).
+		AddedFiles(n).ExistingFiles(0).DeletedFiles(0).Build()
+	got, err = manifestActiveFiles(fs, []iceberg.ManifestFile{known})
+	require.NoError(t, err)
+	require.EqualValues(t, n, got)
+}
+
+// memKeys snapshots the set of paths a memIO currently holds.
+func memKeys(m *memIO) map[string]struct{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]struct{}, len(m.files))
+	for k := range m.files {
+		out[k] = struct{}{}
+	}
+
+	return out
+}
+
+// TestRewriteManifestsCleansOrphanOnValidationError asserts that when the
+// file-count guard rejects a merge, the merged manifest already written to
+// storage is deleted rather than leaked as an orphan.
+func TestRewriteManifestsCleansOrphanOnValidationError(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<20, errLimitedWrite) // large limit: every write succeeds
+	txn := createTestTransaction(t, mem, spec)
+
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{targetSizeBytes: 8 << 20})
+	r := prod.producerImpl.(*rewriteManifests)
+
+	// Two real manifests, each holding one entry. A two-manifest bin forces a
+	// real merge; a one-manifest bin would pass through untouched.
+	inputs := make([]iceberg.ManifestFile, 2)
+	for i := range inputs {
+		df := newTestDataFile(t, spec, "file://data-"+string(rune('a'+i))+".parquet", nil)
+		entries := []iceberg.ManifestEntry{
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, nil, nil, df),
+		}
+		path := "table-location/metadata/input-" + string(rune('a'+i)) + ".avro"
+		var buf bytes.Buffer
+		_, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, prod.snapshotID, entries)
+		require.NoError(t, err)
+		require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+
+		// A header count that lies: the merge re-counts the one real entry and
+		// disagrees, tripping the file-count guard after the merged file is
+		// already on disk.
+		inputs[i] = iceberg.NewManifestFile(2, path, int64(buf.Len()), int32(spec.ID()), prod.snapshotID).
+			AddedFiles(99).Content(iceberg.ManifestContentData).Build()
+	}
+
+	before := memKeys(mem)
+	_, err := r.processManifests(inputs)
+	require.Error(t, err, "lying header counts must trip the file-count guard")
+
+	for path := range memKeys(mem) {
+		_, preexisting := before[path]
+		require.Truef(t, preexisting, "merged manifest %s written before validation must be cleaned up", path)
+	}
+}
+
+// failSecondCreateIO fails every Create after the first, so a concurrent merge
+// has one bin write and persist its manifest while a sibling bin fails.
+type failSecondCreateIO struct {
+	*memIO
+	mu    sync.Mutex
+	count int
+}
+
+func (f *failSecondCreateIO) Create(name string) (iceio.FileWriter, error) {
+	f.mu.Lock()
+	first := f.count == 0
+	f.count++
+	f.mu.Unlock()
+	if first {
+		return f.memIO.Create(name)
+	}
+
+	return &limitedWriteCloser{limit: 0, err: errLimitedWrite}, nil
+}
+
+// TestRewriteManifestsCleansOrphansOnMergeFailure covers zeroshade's mid-merge
+// leak: mergeManifests writes bins concurrently, so when one bin fails the ones
+// that already wrote their .avro files must be deleted, not orphaned.
+func TestRewriteManifestsCleansOrphansOnMergeFailure(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	mem := &failSecondCreateIO{memIO: newMemIO(1<<20, errLimitedWrite)}
+	txn := createTestTransaction(t, mem, spec)
+
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{})
+	r := prod.producerImpl.(*rewriteManifests)
+
+	// Four one-entry manifests. A small target size packs them into two bins of
+	// two, each a real merge, so the merge issues two concurrent Create calls.
+	inputs := make([]iceberg.ManifestFile, 4)
+	var maxLen int64
+	for i := range inputs {
+		df := newTestDataFile(t, spec, "file://data-"+string(rune('a'+i))+".parquet", nil)
+		entries := []iceberg.ManifestEntry{
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, nil, nil, df),
+		}
+		path := "table-location/metadata/input-" + string(rune('a'+i)) + ".avro"
+		var buf bytes.Buffer
+		_, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, prod.snapshotID, entries)
+		require.NoError(t, err)
+		require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+
+		inputs[i] = iceberg.NewManifestFile(2, path, int64(buf.Len()), int32(spec.ID()), prod.snapshotID).
+			AddedFiles(1).Content(iceberg.ManifestContentData).Build()
+		maxLen = max(maxLen, int64(buf.Len()))
+	}
+	r.cfg.targetSizeBytes = 2 * maxLen
+
+	before := memKeys(mem.memIO)
+	_, err := r.processManifests(inputs)
+	require.ErrorIs(t, err, errLimitedWrite, "a failing bin must surface the write error")
+
+	for path := range memKeys(mem.memIO) {
+		_, preexisting := before[path]
+		require.Truef(t, preexisting, "merged manifest %s from the bin that succeeded must be cleaned up", path)
+	}
+}

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -1,0 +1,881 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// activeFiles sums the added + existing data files across manifests. It mirrors
+// the production accounting in manifestActiveFiles: a manifest that reports a
+// negative (unknown) count fails the test rather than being silently folded in,
+// so a count we can't trust never masquerades as a valid total.
+func activeFiles(t *testing.T, manifests []iceberg.ManifestFile) int {
+	t.Helper()
+	var n int
+	for _, m := range manifests {
+		added, existing := m.AddedDataFiles(), m.ExistingDataFiles()
+		require.False(t, added < 0 || existing < 0,
+			"manifest %s reports an unknown data-file count", m.FilePath())
+		n += int(added) + int(existing)
+	}
+
+	return n
+}
+
+// rewriteArrowSchema is the single-column schema used by the rewrite tests.
+var rewriteArrowSchema = arrow.NewSchema([]arrow.Field{
+	{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+}, nil)
+
+// writeOneRowParquet writes a one-row Parquet file at path.
+func writeOneRowParquet(t *testing.T, fs iceio.WriteFileIO, path string) {
+	t.Helper()
+
+	bldr := array.NewInt32Builder(memory.DefaultAllocator)
+	defer bldr.Release()
+
+	bldr.AppendValues([]int32{1}, nil)
+	col := bldr.NewArray()
+	defer col.Release()
+
+	rec := array.NewRecordBatch(rewriteArrowSchema, []arrow.Array{col}, 1)
+	defer rec.Release()
+
+	arrTbl := array.NewTableFromRecords(rewriteArrowSchema, []arrow.RecordBatch{rec})
+	defer arrTbl.Release()
+
+	fo, err := fs.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(arrTbl, fo, arrTbl.NumRows(),
+		nil, pqarrow.DefaultWriterProps()))
+}
+
+func rewriteSchema() *iceberg.Schema {
+	return iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+}
+
+// appendSeparateManifests performs n single-row appends, each in its own
+// commit, leaving n separate data manifests behind (merge must be disabled on
+// the table). It returns the table after the final commit.
+func appendSeparateManifests(t *testing.T, ctx context.Context, tbl *table.Table, fs iceio.WriteFileIO, dir, prefix string, n int) *table.Table {
+	t.Helper()
+	var err error
+	for i := range n {
+		filePath := fmt.Sprintf("%s/%s-%d.parquet", dir, prefix, i)
+		writeOneRowParquet(t, fs, filePath)
+
+		txn := tbl.NewTransaction()
+		require.NoError(t, txn.AddFiles(ctx, []string{filePath}, nil, false))
+		tbl, err = txn.Commit(ctx)
+		require.NoError(t, err)
+	}
+
+	return tbl
+}
+
+// TestRewriteManifests merges several small data manifests into one without
+// changing the data files they reference.
+func TestRewriteManifests(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	// Merge disabled, so each append leaves its own manifest behind.
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	ident := table.Identifier{"default", "test_rewrite_manifests"}
+	tbl := table.New(ident, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil },
+		cat,
+	)
+
+	const numCommits = 3
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numCommits)
+
+	before, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, before, numCommits, "each append should leave its own manifest")
+	wantFiles := activeFiles(t, before)
+	require.Equal(t, numCommits, wantFiles)
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 1)
+	assert.Len(t, res.RewrittenManifests, numCommits)
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, table.OpReplace, snap.Summary.Operation)
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, strconv.Itoa(numCommits), snap.Summary.Properties["manifests-replaced"])
+	// All eligible: nothing is kept, and every input file is accounted for.
+	assert.Equal(t, "0", snap.Summary.Properties["manifests-kept"])
+	assert.Equal(t, strconv.Itoa(numCommits), snap.Summary.Properties["entries-processed"])
+
+	after, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	assert.Len(t, after, 1, "manifests should be merged into one")
+	assert.Equal(t, wantFiles, activeFiles(t, after), "rewrite must preserve the data file count")
+}
+
+// TestRewriteManifestsMultipleBins forces a small target size so the merge emits
+// more than one output manifest — the manifests-created > 1 path the default
+// target size (far larger than any test manifest) never exercises.
+func TestRewriteManifestsMultipleBins(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "bins"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	const numData = 4
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numData)
+
+	before, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, before, numData)
+
+	// Target just large enough for two manifests per bin: any two fit
+	// (2*max ≥ a+b), a third never does (3*min > 2*max for near-equal sizes), so
+	// four inputs pack into two bins of two.
+	var maxLen int64
+	for _, m := range before {
+		maxLen = max(maxLen, m.Length())
+	}
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx, table.WithManifestTargetSize(2*maxLen))
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 2, "four inputs pack into two output manifests")
+	assert.Len(t, res.RewrittenManifests, numData)
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "2", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, strconv.Itoa(numData), snap.Summary.Properties["manifests-replaced"])
+
+	after, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	assert.Len(t, after, 2, "all data merges into two manifests")
+	assert.Equal(t, numData, activeFiles(t, after), "rewrite must preserve the data file count")
+}
+
+// TestRewriteManifestsNoSnapshot is a no-op (empty result, no error) when the
+// table has no current snapshot, so callers can skip staging an empty REPLACE.
+func TestRewriteManifestsNoSnapshot(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, nil)
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "empty"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Empty(t, res.AddedManifests)
+	assert.Empty(t, res.RewrittenManifests)
+	assert.True(t, res.IsNoOp())
+	assert.Equal(t, table.NoOpNoSnapshot, res.NoOpReason,
+		"a missing snapshot must be distinguishable from an already-optimal layout")
+}
+
+// TestRewriteManifestsAlreadyOptimal is a no-op when a single data manifest
+// already holds everything: there is nothing to merge, so the rewrite writes no
+// manifest list, stages nothing, and a following Commit leaves the snapshot
+// untouched.
+func TestRewriteManifestsAlreadyOptimal(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	// Merge enabled so the single append leaves exactly one manifest.
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, nil)
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "optimal"}, meta, dir+"/metadata/00000.json", fsF, cat)
+
+	tbl = appendSeparateManifests(t, ctx, tbl, track, dir, "data", 1)
+
+	before, err := tbl.CurrentSnapshot().Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	beforeSnapshotID := tbl.CurrentSnapshot().SnapshotID
+
+	preExisting := track.snapshotCreated()
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, res.AddedManifests, "a single manifest is already optimal")
+	assert.Empty(t, res.RewrittenManifests)
+	assert.True(t, res.IsNoOp())
+	assert.Equal(t, table.NoOpAlreadyOptimal, res.NoOpReason)
+
+	// The no-op must not have written a new manifest list before the empty
+	// result was returned.
+	for p := range track.snapshotCreated() {
+		if _, ok := preExisting[p]; ok {
+			continue
+		}
+		assert.Falsef(t, strings.HasPrefix(filepath.Base(p), "snap-"),
+			"no-op rewrite wrote an unreferenced manifest list %s", p)
+	}
+
+	// Nothing was staged, so committing the transaction is a true no-op: the
+	// current snapshot is unchanged, not an empty REPLACE.
+	committed, err := txn.Commit(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, committed.CurrentSnapshot())
+	assert.Equal(t, beforeSnapshotID, committed.CurrentSnapshot().SnapshotID,
+		"a no-op rewrite must not stage an empty REPLACE snapshot")
+}
+
+// TestRewriteManifestsUnknownSpecID errors when the requested partition spec id
+// does not exist on the table.
+func TestRewriteManifestsUnknownSpecID(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "spec"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	// Need a current snapshot, otherwise the no-op short-circuit fires first.
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", 1)
+
+	txn := tbl.NewTransaction()
+	_, err = txn.RewriteManifests(ctx, table.WithRewriteSpecID(999))
+	require.Error(t, err)
+	// The underlying sentinel must survive wrapping so callers can branch on it.
+	assert.ErrorIs(t, err, table.ErrPartitionSpecNotFound)
+	assert.Contains(t, err.Error(), "unknown partition spec id 999")
+}
+
+// TestRewriteManifestsPredicate rewrites only the manifests the predicate
+// selects and leaves the rest untouched.
+func TestRewriteManifestsPredicate(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "pred"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	const numCommits = 3
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numCommits)
+
+	before, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, before, numCommits)
+
+	// Select two of the three manifests by path; the third must be left alone.
+	selected := map[string]struct{}{
+		before[0].FilePath(): {},
+		before[1].FilePath(): {},
+	}
+	pred := func(m iceberg.ManifestFile) bool {
+		_, ok := selected[m.FilePath()]
+
+		return ok
+	}
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx, table.WithRewriteManifestPredicate(pred))
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 1, "the two selected manifests merge into one")
+	assert.Len(t, res.RewrittenManifests, 2)
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"])
+
+	after, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	assert.Len(t, after, 2, "one merged manifest plus the untouched one")
+	assert.Equal(t, numCommits, activeFiles(t, after), "no data file may be dropped")
+
+	// The untouched manifest must survive verbatim.
+	var keptPaths []string
+	for _, m := range after {
+		keptPaths = append(keptPaths, m.FilePath())
+	}
+	assert.Contains(t, keptPaths, before[2].FilePath(), "unselected manifest must be kept as-is")
+}
+
+// TestRewriteManifestsSpecIDFilter rewrites only the manifests of the requested
+// partition spec and leaves manifests written under another spec untouched.
+func TestRewriteManifestsSpecIDFilter(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "specfilter"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	// Two manifests under the original unpartitioned spec (id 0).
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "spec0", 2)
+
+	// Evolve the spec, then add a file so it lands in a manifest of the new spec.
+	txn := tbl.NewTransaction()
+	require.NoError(t, table.NewUpdateSpec(txn, false).
+		AddField("id", iceberg.IdentityTransform{}, "id_part").Commit())
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	specOneFile := dir + "/spec1-0.parquet"
+	writeOneRowParquet(t, fs, specOneFile)
+	txn = tbl.NewTransaction()
+	require.NoError(t, txn.AddFiles(ctx, []string{specOneFile}, nil, false))
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	before, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, before, 3, "two spec-0 manifests plus one spec-1 manifest")
+
+	// Find the lone spec-1 manifest so we can prove it survives verbatim.
+	var specOnePath string
+	specCount := map[int]int{}
+	for _, m := range before {
+		specCount[int(m.PartitionSpecID())]++
+		if int(m.PartitionSpecID()) == 1 {
+			specOnePath = m.FilePath()
+		}
+	}
+	require.Equal(t, 2, specCount[0], "setup must leave two spec-0 manifests")
+	require.Equal(t, 1, specCount[1], "setup must leave one spec-1 manifest")
+
+	txn = tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx, table.WithRewriteSpecID(0))
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 1, "the two spec-0 manifests merge into one")
+	assert.Len(t, res.RewrittenManifests, 2)
+	for _, m := range res.RewrittenManifests {
+		assert.EqualValues(t, 0, m.PartitionSpecID(), "only spec-0 manifests may be rewritten")
+	}
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"], "the spec-1 manifest is kept")
+
+	after, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	assert.Len(t, after, 2, "one merged spec-0 manifest plus the untouched spec-1 manifest")
+	assert.Equal(t, 3, activeFiles(t, after), "no data file may be dropped")
+
+	var keptPaths []string
+	for _, m := range after {
+		keptPaths = append(keptPaths, m.FilePath())
+	}
+	assert.Contains(t, keptPaths, specOnePath, "spec-1 manifest must be kept as-is")
+}
+
+// classifyManifests counts data vs delete manifests and returns the path of the
+// (single) delete manifest, if any.
+func classifyManifests(t *testing.T, manifests []iceberg.ManifestFile) (data, delete int, deletePath string) {
+	t.Helper()
+	for _, m := range manifests {
+		if m.ManifestContent() == iceberg.ManifestContentData {
+			data++
+		} else {
+			delete++
+			deletePath = m.FilePath()
+		}
+	}
+
+	return data, delete, deletePath
+}
+
+// TestRewriteManifestsLeavesDeleteManifests verifies that a rewrite merges only
+// data manifests and leaves delete manifests untouched.
+func TestRewriteManifestsLeavesDeleteManifests(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	// Delete files require format version >= 2.
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.PropertyFormatVersion:   "2",
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "del"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+	const numData = 2
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numData)
+
+	// Add a positional-delete file. RowDelta only records its metadata, so the
+	// referenced path need not exist on disk. This leaves a delete manifest the
+	// rewrite must not touch.
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.NewRowDelta(nil).
+		AddDeletes(buildPosDeleteFile(t, dir+"/data/pos-del.parquet")).
+		Commit(ctx))
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	before, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	dataN, delN, beforeDeletePath := classifyManifests(t, before)
+	require.Equal(t, numData, dataN)
+	require.Equal(t, 1, delN, "setup must leave one delete manifest")
+
+	txn = tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 1)
+	assert.Len(t, res.RewrittenManifests, numData, "only data manifests are rewritten")
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, strconv.Itoa(numData), snap.Summary.Properties["manifests-replaced"])
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"], "the delete manifest is kept")
+
+	after, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	afterData, afterDel, afterDeletePath := classifyManifests(t, after)
+	assert.Equal(t, 1, afterData, "data manifests merged into one")
+	assert.Equal(t, 1, afterDel, "delete manifest preserved")
+	assert.Equal(t, beforeDeletePath, afterDeletePath, "delete manifest must survive verbatim")
+}
+
+// trackingFS wraps LocalFS and records the paths it creates and removes so a
+// test can assert that orphaned manifests are cleaned up after a commit.
+type trackingFS struct {
+	iceio.LocalFS
+	mu      sync.Mutex
+	created []string
+	removed []string
+}
+
+func (f *trackingFS) Create(name string) (iceio.FileWriter, error) {
+	f.mu.Lock()
+	f.created = append(f.created, name)
+	f.mu.Unlock()
+
+	return f.LocalFS.Create(name)
+}
+
+func (f *trackingFS) Remove(name string) error {
+	f.mu.Lock()
+	f.removed = append(f.removed, name)
+	f.mu.Unlock()
+
+	return f.LocalFS.Remove(name)
+}
+
+func (f *trackingFS) snapshotCreated() map[string]struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]struct{}, len(f.created))
+	for _, p := range f.created {
+		out[p] = struct{}{}
+	}
+
+	return out
+}
+
+func (f *trackingFS) wasRemoved(path string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, p := range f.removed {
+		if p == path {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mergedManifestsCreated returns the data-manifest .avro files (those whose
+// basename is not a "snap-" manifest list) the rewrite wrote after preExisting
+// was captured.
+func mergedManifestsCreated(track *trackingFS, preExisting map[string]struct{}) []string {
+	var out []string
+	for p := range track.snapshotCreated() {
+		if _, ok := preExisting[p]; ok {
+			continue
+		}
+		if !strings.HasSuffix(p, ".avro") || strings.HasPrefix(filepath.Base(p), "snap-") {
+			continue
+		}
+		out = append(out, p)
+	}
+
+	return out
+}
+
+// stagedHeadCatalog simulates a string of concurrent writers: each retry's
+// LoadTable advances the head to the next pre-built metadata, so the rewrite
+// must rebuild — and supersede the previous attempt's merged manifest — on
+// every retry, not just the first (which a static head would not exercise). It
+// returns ErrCommitFailed for the first `failures` CommitTable calls.
+type stagedHeadCatalog struct {
+	current          table.Metadata
+	heads            []table.Metadata
+	headIdx          int
+	failures         int
+	commitTableCalls atomic.Int32
+	location         string
+	fsF              func(context.Context) (iceio.IO, error)
+}
+
+func (c *stagedHeadCatalog) LoadTable(_ context.Context, _ table.Identifier) (*table.Table, error) {
+	if c.headIdx < len(c.heads) {
+		c.current = c.heads[c.headIdx]
+		c.headIdx++
+	}
+
+	return table.New(table.Identifier{"default", "staged"}, c.current,
+		c.location+"/metadata/current.json", c.fsF, c), nil
+}
+
+func (c *stagedHeadCatalog) CommitTable(_ context.Context, _ table.Identifier, _ []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	n := c.commitTableCalls.Add(1)
+	if int(n) <= c.failures {
+		return nil, "", fmt.Errorf("%w: simulated 409 conflict", table.ErrCommitFailed)
+	}
+
+	meta, err := table.UpdateTableMetadata(c.current, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.current = meta
+
+	return meta, c.location + "/metadata/final.json", nil
+}
+
+// appendOne commits a single new data file onto tbl and returns the new table.
+func appendOne(t *testing.T, ctx context.Context, tbl *table.Table, fs iceio.WriteFileIO, dir, name string) *table.Table {
+	t.Helper()
+	path := fmt.Sprintf("%s/%s.parquet", dir, name)
+	writeOneRowParquet(t, fs, path)
+
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.AddFiles(ctx, []string{path}, nil, false))
+	out, err := txn.Commit(ctx)
+	require.NoError(t, err)
+
+	return out
+}
+
+// stagedRewriteHeads builds the stale base plus two successive concurrent heads
+// (each adds one data manifest the rewrite must inherit) and returns them. The
+// metadata carries fast-retry properties so the rewrite's commit retries
+// quickly. numRetries sets commit.retry.num-retries.
+func stagedRewriteHeads(t *testing.T, ctx context.Context, dir, numRetries string, fsF func(context.Context) (iceio.IO, error), track iceio.WriteFileIO) (h0, h1, h2 table.Metadata) {
+	t.Helper()
+	props := iceberg.Properties{
+		table.PropertyFormatVersion:        "2",
+		table.ManifestMergeEnabledKey:      "false",
+		table.CommitMinRetryWaitMsKey:      "0",
+		table.CommitMaxRetryWaitMsKey:      "0",
+		table.CommitTotalRetryTimeoutMsKey: "60000",
+		table.CommitNumRetriesKey:          numRetries,
+	}
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, props)
+	require.NoError(t, err)
+
+	setup := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "staged"}, meta, dir+"/metadata/00000.json", fsF, setup)
+	tbl = appendSeparateManifests(t, ctx, tbl, track, dir, "stale", 3)
+	h0 = tbl.Metadata()
+	tbl = appendOne(t, ctx, tbl, track, dir, "concurrent-1")
+	h1 = tbl.Metadata()
+	tbl = appendOne(t, ctx, tbl, track, dir, "concurrent-2")
+	h2 = tbl.Metadata()
+
+	return h0, h1, h2
+}
+
+// TestRewriteManifestsCleansEverySupersededGeneration forces two conflicts, each
+// against a freshly-advanced head, so the rewrite rebuilds twice and accumulates
+// two generations of superseded manifests. It asserts every superseded
+// generation is cleaned up — not just the most recent one.
+func TestRewriteManifestsCleansEverySupersededGeneration(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	h0, h1, h2 := stagedRewriteHeads(t, ctx, dir, "2", fsF, track)
+
+	// Two conflicts then success: attempts 0 and 1 are superseded, attempt 2 wins.
+	cat := &stagedHeadCatalog{current: h0, heads: []table.Metadata{h1, h2}, failures: 2, location: dir, fsF: fsF}
+	tbl := table.New(table.Identifier{"default", "staged"}, h0, dir+"/metadata/00000.json", fsF, cat)
+
+	preExisting := track.snapshotCreated()
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	committed, err := txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 3, cat.commitTableCalls.Load(),
+		"expected two conflicts followed by one successful commit")
+
+	snap := committed.CurrentSnapshot()
+	require.NotNil(t, snap)
+	after, err := snap.Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "all inherited manifests merge into one")
+	assert.Len(t, res.AddedManifests, 1)
+	// The winner merged the fully-advanced head: 3 stale + 2 concurrent.
+	assert.Len(t, res.RewrittenManifests, 5)
+
+	merged := mergedManifestsCreated(track, preExisting)
+	require.Len(t, merged, 3, "each of the three attempts writes one merged manifest")
+
+	referenced := map[string]struct{}{}
+	for _, m := range after {
+		referenced[m.FilePath()] = struct{}{}
+	}
+	var removed int
+	for _, p := range merged {
+		if _, ok := referenced[p]; ok {
+			continue
+		}
+		assert.Truef(t, track.wasRemoved(p),
+			"superseded manifest %s was leaked across retries", p)
+		removed++
+	}
+	assert.Equal(t, 2, removed, "both superseded generations must be cleaned up")
+}
+
+// TestRewriteManifestsCleansSupersededOnExhaustedRetries asserts that when every
+// commit attempt fails with ErrCommitFailed, every merged manifest written —
+// the superseded attempts and the final one — is cleaned up rather than leaked.
+func TestRewriteManifestsCleansSupersededOnExhaustedRetries(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	h0, h1, h2 := stagedRewriteHeads(t, ctx, dir, "2", fsF, track) // 3 attempts
+
+	// Never succeed: every attempt conflicts, exhausting the retry budget.
+	cat := &stagedHeadCatalog{current: h0, heads: []table.Metadata{h1, h2}, failures: 99, location: dir, fsF: fsF}
+	tbl := table.New(table.Identifier{"default", "staged"}, h0, dir+"/metadata/00000.json", fsF, cat)
+
+	preExisting := track.snapshotCreated()
+
+	txn := tbl.NewTransaction()
+	_, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	_, err = txn.Commit(ctx)
+	require.Error(t, err, "commit must fail once retries are exhausted")
+	require.ErrorIs(t, err, table.ErrCommitFailed)
+
+	// Three attempts wrote three merged manifests. None is referenced (no commit
+	// succeeded), so all three — the superseded ones and the final attempt's —
+	// must be cleaned on the exhausted-failure path.
+	merged := mergedManifestsCreated(track, preExisting)
+	require.Len(t, merged, 3, "three attempts each write one merged manifest")
+
+	for _, p := range merged {
+		assert.Truef(t, track.wasRemoved(p), "orphaned manifest %s must be cleaned on the failure path", p)
+	}
+}
+
+// TestRewriteManifestsStaleCountsAfterOCCRetry forces a commit conflict and
+// asserts that the RewriteManifestsResult and the committed summary reflect the
+// winning attempt — the one rebuilt against the fresh parent — not the stale
+// attempt 0. It also asserts that the manifests written by the superseded
+// attempt are deleted rather than leaked.
+func TestRewriteManifestsStaleCountsAfterOCCRetry(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	props := iceberg.Properties{
+		table.PropertyFormatVersion:        "2",
+		table.ManifestMergeEnabledKey:      "false",
+		table.CommitMinRetryWaitMsKey:      "0",
+		table.CommitMaxRetryWaitMsKey:      "0",
+		table.CommitTotalRetryTimeoutMsKey: "60000",
+		table.CommitNumRetriesKey:          "2",
+	}
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, props)
+	require.NoError(t, err)
+
+	cat := &occScenarioCatalog{current: meta, conflictsLeft: 0, location: dir}
+	ident := table.Identifier{"default", "occ_rewrite"}
+	tbl := table.New(ident, meta, dir+"/metadata/00000.json", fsF, cat)
+
+	// Writer A's stale view: three separate data manifests.
+	const staleCount = 3
+	tbl = appendSeparateManifests(t, ctx, tbl, track, dir, "stale", staleCount)
+	staleTbl := tbl // metadata frozen at three manifests
+
+	// A concurrent writer adds a fourth manifest the catalog now knows about
+	// but Writer A does not. The rewrite, on retry, must re-merge all four.
+	const freshCount = staleCount + 1
+	_ = appendSeparateManifests(t, ctx, tbl, track, dir, "fresh", 1)
+	freshSnap := cat.current.CurrentSnapshot()
+	require.NotNil(t, freshSnap)
+	freshManifests, err := freshSnap.Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, freshManifests, freshCount, "catalog should now hold four manifests")
+
+	// Force exactly one conflict so Writer A retries against the fresh parent.
+	cat.conflictsLeft = 1
+	cat.commitTableCalls.Store(0) // ignore the setup commits
+
+	preExisting := track.snapshotCreated()
+
+	txn := staleTbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	committed, err := txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 2, cat.commitTableCalls.Load(),
+		"expected one conflict followed by one successful commit")
+
+	// The result must reflect the winning attempt: four manifests replaced,
+	// not the three Writer A saw at attempt 0.
+	assert.Len(t, res.RewrittenManifests, freshCount,
+		"result must report the fresh parent's manifests, not attempt 0's")
+	assert.Len(t, res.AddedManifests, 1)
+
+	snap := committed.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+	assert.Equal(t, strconv.Itoa(freshCount), snap.Summary.Properties["manifests-replaced"],
+		"summary must reflect the winning attempt's counts")
+	assert.Equal(t, strconv.Itoa(freshCount), snap.Summary.Properties["entries-processed"])
+
+	after, err := snap.Manifests(track)
+	require.NoError(t, err)
+	assert.Len(t, after, 1, "all four manifests merge into one")
+	assert.Equal(t, freshCount, activeFiles(t, after))
+
+	// No orphan leak: every .avro file written during the rewrite that the
+	// committed snapshot does not reference must have been removed. The
+	// pre-existing data manifests (written before the rewrite) are exempt.
+	referenced := map[string]struct{}{snap.ManifestList: {}}
+	for _, m := range after {
+		referenced[m.FilePath()] = struct{}{}
+	}
+	for p := range track.snapshotCreated() {
+		if !strings.HasSuffix(p, ".avro") {
+			continue
+		}
+		if _, ok := preExisting[p]; ok {
+			continue
+		}
+		if _, ok := referenced[p]; ok {
+			continue
+		}
+		assert.Truef(t, track.wasRemoved(p),
+			"manifest %s written by the superseded attempt was leaked, not cleaned up", p)
+	}
+}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log"
 	"maps"
 	"runtime"
 	"slices"
@@ -67,6 +68,15 @@ type producerImpl interface {
 	// unconditionally a no-op; commit() skips validator registration
 	// entirely when this returns false, so validate will never run.
 	needsValidation() bool
+}
+
+// supersededAccumulator marks a producer that writes merged manifests OCC
+// retries orphan. Only rewrite implements it.
+type supersededAccumulator interface {
+	// supersededManifests returns paths of merged manifests to delete once the
+	// commit resolves. When committed is false the commit never landed, so the
+	// final attempt's manifests are orphaned too and are included.
+	supersededManifests(committed bool) []string
 }
 
 func newManifestFileName(num int, commit uuid.UUID) string {
@@ -333,7 +343,7 @@ func (of *overwriteFiles) deletedEntries(ctx context.Context, parent *Snapshot) 
 func (of *overwriteFiles) needsValidation() bool { return true }
 
 type manifestMergeManager struct {
-	targetSizeBytes  int
+	targetSizeBytes  int64
 	minCountToMerge  int
 	mergeEnabled     bool
 	mergeConcurrency int
@@ -401,7 +411,7 @@ func (m *manifestMergeManager) createManifest(specID int, bin []iceberg.Manifest
 
 func (m *manifestMergeManager) mergeGroup(firstManifest iceberg.ManifestFile, specID int, manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
 	packer := internal.SlicePacker[iceberg.ManifestFile]{
-		TargetWeight:    int64(m.targetSizeBytes),
+		TargetWeight:    m.targetSizeBytes,
 		Lookback:        1,
 		LargestBinFirst: false,
 	}
@@ -444,10 +454,30 @@ func (m *manifestMergeManager) mergeGroup(firstManifest iceberg.ManifestFile, sp
 	}
 
 	if err := g.Wait(); err != nil {
+		// Delete bins that finished before this one failed.
+		m.removeOrphans(manifests, slices.Concat(binResults...))
+
 		return nil, err
 	}
 
 	return slices.Concat(binResults...), nil
+}
+
+// removeOrphans deletes merged manifests a failed merge left behind. Pass-through
+// bins reuse an input path and are kept; only outputs not in input are removed.
+func (m *manifestMergeManager) removeOrphans(input, output []iceberg.ManifestFile) {
+	inPaths := make(map[string]struct{}, len(input))
+	for _, mf := range input {
+		inPaths[mf.FilePath()] = struct{}{}
+	}
+	for _, mf := range output {
+		if _, ok := inPaths[mf.FilePath()]; ok {
+			continue
+		}
+		if err := m.snap.io.Remove(mf.FilePath()); err != nil {
+			log.Printf("Warning: failed to delete orphaned merged manifest %s: %v", mf.FilePath(), err)
+		}
+	}
 }
 
 func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
@@ -460,12 +490,15 @@ func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) 
 
 	merged := make([]iceberg.ManifestFile, 0, len(groups))
 	for _, specID := range slices.Backward(slices.Sorted(maps.Keys(groups))) {
-		manifests, err := m.mergeGroup(first, specID, groups[specID])
+		groupMerged, err := m.mergeGroup(first, specID, groups[specID])
 		if err != nil {
+			// This group cleaned up its own writes; drop earlier groups' too.
+			m.removeOrphans(manifests, merged)
+
 			return nil, err
 		}
 
-		merged = append(merged, manifests...)
+		merged = append(merged, groupMerged...)
 	}
 
 	return merged, nil
@@ -474,7 +507,7 @@ func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) 
 type mergeAppendFiles struct {
 	fastAppendFiles
 
-	targetSizeBytes  int
+	targetSizeBytes  int64
 	minCountToMerge  int
 	mergeEnabled     bool
 	mergeConcurrency int
@@ -484,7 +517,7 @@ func newMergeAppendFilesProducer(op Operation, txn *Transaction, fs iceio.WriteF
 	prod := createSnapshotProducer(op, txn, fs, commitUUID, snapshotProps)
 	prod.producerImpl = &mergeAppendFiles{
 		fastAppendFiles: fastAppendFiles{base: prod},
-		targetSizeBytes: txn.meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault),
+		targetSizeBytes: int64(txn.meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault)),
 		minCountToMerge: txn.meta.props.GetInt(ManifestMinMergeCountKey, ManifestMinMergeCountDefault),
 		mergeEnabled:    txn.meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault),
 		mergeConcurrency: manifestMergeConcurrencyLimit(
@@ -940,6 +973,9 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 	var ssc SnapshotSummaryCollector
 	partitionSummaryLimit := sp.txn.meta.props.
 		GetInt(WritePartitionSummaryLimitKey, WritePartitionSummaryLimitDefault)
+	if _, ok := sp.producerImpl.(*rewriteManifests); ok {
+		partitionSummaryLimit = 0
+	}
 	ssc.setPartitionSummaryLimit(partitionSummaryLimit)
 
 	currentSchema := sp.txn.meta.CurrentSchema()
@@ -1114,6 +1150,14 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 		return nil, nil, err
 	}
 
+	return sp.commitManifests(newManifests, addedContent)
+}
+
+// commitManifests stages the snapshot for an already-built manifest set.
+// It is split out of commit so callers that must inspect the planned manifests
+// before anything is written (RewriteManifests detecting a no-op) can build the
+// manifests themselves and only then decide to write the manifest list.
+func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg.ManifestFile) (_ []Update, _ []Requirement, err error) {
 	nextSequence := sp.txn.meta.nextSequenceNumber()
 	summary, err := sp.summary(sp.snapshotProps)
 	if err != nil {
@@ -1313,6 +1357,11 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	addSnap := NewAddSnapshotUpdate(&snapshot)
 	addSnap.ownManifests = addedContent
 	addSnap.rebuildManifestList = rebuildFn
+	// Hold the producer so doCommit can read the manifests orphaned by OCC
+	// retries and clean them up. Only rewrite producers implement this.
+	if acc, ok := sp.producerImpl.(supersededAccumulator); ok {
+		addSnap.supersededSource = acc
+	}
 
 	return []Update{
 			addSnap,

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -857,7 +857,7 @@ func TestManifestMergeGroupLimitsConcurrentBins(t *testing.T) {
 	}
 
 	mgr := manifestMergeManager{
-		targetSizeBytes:  int(manifests[0].Length() * 2),
+		targetSizeBytes:  manifests[0].Length() * 2,
 		minCountToMerge:  1,
 		mergeEnabled:     true,
 		mergeConcurrency: mergeConcurrency,

--- a/table/table.go
+++ b/table/table.go
@@ -582,6 +582,21 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		}
 	}
 
+	// Inner data manifests written by superseded retry attempts (a rewrite
+	// re-merges everything on each retry) are orphaned objects. On a safe
+	// exhausted-ErrCommitFailed failure (err != nil here) nothing committed, so
+	// the accumulator also folds in the final attempt's manifests. On success
+	// the committed snapshot references those, so they are excluded. The defer
+	// skips cleanup only on the unsafe non-ErrCommitFailed path, which returned
+	// above with cleanupOrphans = false.
+	for _, u := range updates {
+		su, ok := u.(*addSnapshotUpdate)
+		if !ok || su.supersededSource == nil {
+			continue
+		}
+		orphanedManifests = append(orphanedManifests, su.supersededSource.supersededManifests(err == nil)...)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -680,6 +695,7 @@ func rebuildSnapshotUpdates(ctx context.Context, updates []Update, freshMeta Met
 			Snapshot:            newSnap,
 			ownManifests:        su.ownManifests,
 			rebuildManifestList: su.rebuildManifestList,
+			supersededSource:    su.supersededSource,
 		}
 
 		// The old manifest list is now an orphaned object in object storage.

--- a/table/updates.go
+++ b/table/updates.go
@@ -329,6 +329,13 @@ type addSnapshotUpdate struct {
 	// each retry snapshot correctly inherits all files committed by
 	// concurrent writers since the original build.
 	rebuildManifestList func(ctx context.Context, freshMeta Metadata, freshParent *Snapshot, fio io.WriteFileIO, attempt int) (*Snapshot, error)
+
+	// supersededSource, when non-nil, is the producer whose merged manifests a
+	// rebuild on a prior attempt wrote and a later attempt replaced. doCommit
+	// reads its accumulated paths and removes them once the commit resolves.
+	// Distinct from the manifest-LIST orphans rebuildSnapshotUpdates returns:
+	// these are the inner data manifests a rewrite re-merges on every retry.
+	supersededSource supersededAccumulator
 }
 
 // NewAddSnapshotUpdate creates a new update that adds the given snapshot to the table metadata.


### PR DESCRIPTION
Maintenance tasks are awesome! This introduces support for RewriteManifests and the associated CLI command.

The goal of RewriteManifests is to "rewrite" manifests by combining them together into larger manifests.

Note: I had to introduce a new parameter to the SnapshotProducer impl called `rebuildFromInheritedOnly`. I tried to match the others. Let me know if there's a better way to express this.