### PR TITLE
test: cover Glue and Hive purge table

### DIFF
--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -488,7 +488,20 @@ func TestGluePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 	assert := require.New(t)
 	ctx := context.Background()
 	const scheme = "gluepurgefail"
-	failingFS := failRemoveIO{MemFS: iceio.NewMemFS(), err: errGluePurgeRemove}
+	dropCalled := false
+	removeBeforeDrop := false
+	removeCalls := 0
+	failingFS := failRemoveIO{
+		MemFS: iceio.NewMemFS(),
+		err:   errGluePurgeRemove,
+		onRemove: func() {
+			removeCalls++
+			if !dropCalled {
+				removeBeforeDrop = true
+			}
+		},
+	}
+	iceio.Unregister(scheme)
 	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
 		return failingFS, nil
 	})
@@ -497,8 +510,51 @@ func TestGluePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 	tableLocation := scheme + "://bucket/test_database/test_table"
 	metadataLocation := tableLocation + "/metadata/v1.metadata.json"
 	dataFile := tableLocation + "/data/file.parquet"
-	writeGluePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation)
-	require.NoError(t, failingFS.WriteFile(dataFile, []byte("data")))
+	writeGluePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation, nil)
+	assert.NoError(failingFS.WriteFile(dataFile, []byte("data")))
+	glueTable := gluePurgeTable(metadataLocation)
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &glueTable}, nil).Twice()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Run(func(mock.Arguments) {
+		dropCalled = true
+	}).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	var logs bytes.Buffer
+	originalLogOutput := log.Writer()
+	// This test redirects the process-global logger, so keep it non-parallel.
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+
+	assert.NoError(glueCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.True(dropCalled)
+	assert.Positive(removeCalls)
+	assert.False(removeBeforeDrop, "PurgeTable should drop the catalog entry before removing files")
+	assert.Contains(logs.String(), "WARNING: dropped table")
+	assert.Contains(logs.String(), "test_database")
+	assert.Contains(logs.String(), "test_table")
+	assert.Contains(logs.String(), errGluePurgeRemove.Error())
+	file, err := failingFS.Open(dataFile)
+	assert.NoError(err, "data file should remain when FileIO remove fails")
+	assert.NotNil(file)
+	assert.NoError(file.Close())
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGluePurgeTableWithGCDisabled(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "warehouse", "test_database", "test_table")
+	metadataLocation, dataFile := writeGluePurgeTableFilesWithProperties(
+		t, tableLocation, iceberg.Properties{"gc.enabled": "false"})
 	glueTable := gluePurgeTable(metadataLocation)
 
 	mockGlueSvc := &mockGlueClient{}
@@ -511,28 +567,25 @@ func TestGluePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 		Name:         aws.String("test_table"),
 	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
 
-	var logs bytes.Buffer
-	originalLogOutput := log.Writer()
-	log.SetOutput(&logs)
-	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
-
 	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
 
 	assert.NoError(glueCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
-	assert.Contains(logs.String(), "failed to purge files")
-	assert.Contains(logs.String(), errGluePurgeRemove.Error())
-	file, err := failingFS.Open(dataFile)
-	assert.NoError(err, "data file should remain when FileIO remove fails")
-	assert.NoError(file.Close())
+	assert.NoFileExists(metadataLocation)
+	assert.FileExists(dataFile)
 	mockGlueSvc.AssertExpectations(t)
 }
 
 type failRemoveIO struct {
 	*iceio.MemFS
-	err error
+	err      error
+	onRemove func()
 }
 
 func (f failRemoveIO) Remove(string) error {
+	if f.onRemove != nil {
+		f.onRemove()
+	}
+
 	return f.err
 }
 
@@ -549,22 +602,36 @@ func gluePurgeTable(metadataLocation string) types.Table {
 }
 
 func writeGluePurgeTableFiles(t *testing.T, tableLocation string) (metadataLocation, dataFile string) {
+	return writeGluePurgeTableFilesWithProperties(t, tableLocation, nil)
+}
+
+func writeGluePurgeTableFilesWithProperties(
+	t *testing.T,
+	tableLocation string,
+	props iceberg.Properties,
+) (metadataLocation, dataFile string) {
 	t.Helper()
 	metadataLocation = filepath.Join(tableLocation, "metadata", "v1.metadata.json")
 	dataFile = filepath.Join(tableLocation, "data", "file.parquet")
-	writeGluePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation)
+	writeGluePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation, props)
 	require.NoError(t, os.MkdirAll(filepath.Dir(dataFile), 0o755))
 	require.NoError(t, os.WriteFile(dataFile, []byte("data"), 0o644))
 
 	return metadataLocation, dataFile
 }
 
-func writeGluePurgeTableMetadata(t *testing.T, fs iceio.WriteFileIO, tableLocation, metadataLocation string) {
+func writeGluePurgeTableMetadata(
+	t *testing.T,
+	fs iceio.WriteFileIO,
+	tableLocation,
+	metadataLocation string,
+	props iceberg.Properties,
+) {
 	t.Helper()
 	schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: true,
 	})
-	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, nil)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, props)
 	require.NoError(t, err)
 	require.NoError(t, cataloginternal.WriteTableMetadata(meta, fs, metadataLocation, table.MetadataCompressionCodecNone))
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -18,13 +18,11 @@
 package glue
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -526,22 +524,12 @@ func TestGluePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 		dropCalled = true
 	}).Return(&glue.DeleteTableOutput{}, nil).Once()
 
-	var logs bytes.Buffer
-	originalLogOutput := log.Writer()
-	// This test redirects the process-global logger, so keep it non-parallel.
-	log.SetOutput(&logs)
-	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
-
 	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
 
 	assert.NoError(glueCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
 	assert.True(dropCalled)
 	assert.Positive(removeCalls)
 	assert.False(removeBeforeDrop, "PurgeTable should drop the catalog entry before removing files")
-	assert.Contains(logs.String(), "WARNING: dropped table")
-	assert.Contains(logs.String(), "test_database")
-	assert.Contains(logs.String(), "test_table")
-	assert.Contains(logs.String(), errGluePurgeRemove.Error())
 	file, err := failingFS.Open(dataFile)
 	assert.NoError(err, "data file should remain when FileIO remove fails")
 	assert.NotNil(file)

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -18,12 +18,16 @@
 package glue
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -31,6 +35,8 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	cataloginternal "github.com/apache/iceberg-go/catalog/internal"
+	iceio "github.com/apache/iceberg-go/io"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	"github.com/apache/iceberg-go/table"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -42,6 +48,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var errGluePurgeRemove = errors.New("glue purge remove failed")
 
 type mockGlueClient struct {
 	mock.Mock
@@ -449,6 +457,116 @@ func TestGlueDropTable(t *testing.T) {
 
 	err := glueCatalog.DropTable(context.TODO(), TableIdentifier("test_database", "test_table"))
 	assert.NoError(err)
+}
+
+func TestGluePurgeTable(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "warehouse", "test_database", "test_table")
+	metadataLocation, dataFile := writeGluePurgeTableFiles(t, tableLocation)
+	glueTable := gluePurgeTable(metadataLocation)
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &glueTable}, nil).Twice()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+
+	assert.NoError(glueCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.NoFileExists(metadataLocation)
+	assert.NoFileExists(dataFile)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGluePurgeTableSwallowsPurgeFilesError(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	const scheme = "gluepurgefail"
+	failingFS := failRemoveIO{MemFS: iceio.NewMemFS(), err: errGluePurgeRemove}
+	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		return failingFS, nil
+	})
+	t.Cleanup(func() { iceio.Unregister(scheme) })
+
+	tableLocation := scheme + "://bucket/test_database/test_table"
+	metadataLocation := tableLocation + "/metadata/v1.metadata.json"
+	dataFile := tableLocation + "/data/file.parquet"
+	writeGluePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation)
+	require.NoError(t, failingFS.WriteFile(dataFile, []byte("data")))
+	glueTable := gluePurgeTable(metadataLocation)
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &glueTable}, nil).Twice()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	var logs bytes.Buffer
+	originalLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+
+	assert.NoError(glueCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.Contains(logs.String(), "failed to purge files")
+	assert.Contains(logs.String(), errGluePurgeRemove.Error())
+	file, err := failingFS.Open(dataFile)
+	assert.NoError(err, "data file should remain when FileIO remove fails")
+	assert.NoError(file.Close())
+	mockGlueSvc.AssertExpectations(t)
+}
+
+type failRemoveIO struct {
+	*iceio.MemFS
+	err error
+}
+
+func (f failRemoveIO) Remove(string) error {
+	return f.err
+}
+
+func gluePurgeTable(metadataLocation string) types.Table {
+	return types.Table{
+		Name:         aws.String("test_table"),
+		DatabaseName: aws.String("test_database"),
+		TableType:    aws.String("EXTERNAL_TABLE"),
+		Parameters: map[string]string{
+			tableParamTableType:        glueTypeIceberg,
+			tableParamMetadataLocation: metadataLocation,
+		},
+	}
+}
+
+func writeGluePurgeTableFiles(t *testing.T, tableLocation string) (metadataLocation, dataFile string) {
+	t.Helper()
+	metadataLocation = filepath.Join(tableLocation, "metadata", "v1.metadata.json")
+	dataFile = filepath.Join(tableLocation, "data", "file.parquet")
+	writeGluePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dataFile), 0o755))
+	require.NoError(t, os.WriteFile(dataFile, []byte("data"), 0o644))
+
+	return metadataLocation, dataFile
+}
+
+func writeGluePurgeTableMetadata(t *testing.T, fs iceio.WriteFileIO, tableLocation, metadataLocation string) {
+	t.Helper()
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: true,
+	})
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, nil)
+	require.NoError(t, err)
+	require.NoError(t, cataloginternal.WriteTableMetadata(meta, fs, metadataLocation, table.MetadataCompressionCodecNone))
 }
 
 func TestGlueCreateNamespace(t *testing.T) {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -18,20 +18,27 @@
 package hive
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	cataloginternal "github.com/apache/iceberg-go/catalog/internal"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/beltran/gohive/hive_metastore"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var errHivePurgeRemove = errors.New("hive purge remove failed")
 
 type mockHiveClient struct {
 	mock.Mock
@@ -521,6 +528,114 @@ func TestHiveDropTable(t *testing.T) {
 	assert.NoError(err)
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestHivePurgeTable(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "warehouse", "test_database", "test_table")
+	metadataLocation, dataFile := writeHivePurgeTableFiles(t, tableLocation)
+	hiveTable := hivePurgeTable(metadataLocation, tableLocation)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(hiveTable, nil).Twice()
+	mockClient.On("DropTable", mock.Anything, "test_database", "test_table", false).
+		Return(nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	assert.NoError(hiveCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.NoFileExists(metadataLocation)
+	assert.NoFileExists(dataFile)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHivePurgeTableSwallowsPurgeFilesError(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	const scheme = "hivepurgefail"
+	failingFS := failRemoveIO{MemFS: iceio.NewMemFS(), err: errHivePurgeRemove}
+	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		return failingFS, nil
+	})
+	t.Cleanup(func() { iceio.Unregister(scheme) })
+
+	tableLocation := scheme + "://bucket/test_database/test_table"
+	metadataLocation := tableLocation + "/metadata/v1.metadata.json"
+	dataFile := tableLocation + "/data/file.parquet"
+	writeHivePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation)
+	require.NoError(t, failingFS.WriteFile(dataFile, []byte("data")))
+	hiveTable := hivePurgeTable(metadataLocation, tableLocation)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(hiveTable, nil).Twice()
+	mockClient.On("DropTable", mock.Anything, "test_database", "test_table", false).
+		Return(nil).Once()
+
+	var logs bytes.Buffer
+	originalLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	assert.NoError(hiveCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.Contains(logs.String(), "failed to purge files")
+	assert.Contains(logs.String(), errHivePurgeRemove.Error())
+	file, err := failingFS.Open(dataFile)
+	assert.NoError(err, "data file should remain when FileIO remove fails")
+	assert.NoError(file.Close())
+	mockClient.AssertExpectations(t)
+}
+
+type failRemoveIO struct {
+	*iceio.MemFS
+	err error
+}
+
+func (f failRemoveIO) Remove(string) error {
+	return f.err
+}
+
+func hivePurgeTable(metadataLocation, tableLocation string) *hive_metastore.Table {
+	return &hive_metastore.Table{
+		TableName: "test_table",
+		DbName:    "test_database",
+		TableType: TableTypeExternalTable,
+		Parameters: map[string]string{
+			TableTypeKey:        TableTypeIceberg,
+			MetadataLocationKey: metadataLocation,
+		},
+		Sd: &hive_metastore.StorageDescriptor{
+			Location: tableLocation,
+		},
+	}
+}
+
+func writeHivePurgeTableFiles(t *testing.T, tableLocation string) (metadataLocation, dataFile string) {
+	t.Helper()
+	metadataLocation = filepath.Join(tableLocation, "metadata", "v1.metadata.json")
+	dataFile = filepath.Join(tableLocation, "data", "file.parquet")
+	writeHivePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation)
+	writer, err := iceio.LocalFS{}.Create(dataFile)
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return metadataLocation, dataFile
+}
+
+func writeHivePurgeTableMetadata(t *testing.T, fs iceio.WriteFileIO, tableLocation, metadataLocation string) {
+	t.Helper()
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: true,
+	})
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, nil)
+	require.NoError(t, err)
+	require.NoError(t, cataloginternal.WriteTableMetadata(meta, fs, metadataLocation, table.MetadataCompressionCodecNone))
 }
 
 func TestHiveDropTableNotExists(t *testing.T) {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -18,10 +18,8 @@
 package hive
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -589,22 +587,12 @@ func TestHivePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 			dropCalled = true
 		}).Return(nil).Once()
 
-	var logs bytes.Buffer
-	originalLogOutput := log.Writer()
-	// This test redirects the process-global logger, so keep it non-parallel.
-	log.SetOutput(&logs)
-	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
-
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
 	assert.NoError(hiveCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
 	assert.True(dropCalled)
 	assert.Positive(removeCalls)
 	assert.False(removeBeforeDrop, "PurgeTable should drop the catalog entry before removing files")
-	assert.Contains(logs.String(), "WARNING: dropped table")
-	assert.Contains(logs.String(), "test_database")
-	assert.Contains(logs.String(), "test_table")
-	assert.Contains(logs.String(), errHivePurgeRemove.Error())
 	file, err := failingFS.Open(dataFile)
 	assert.NoError(err, "data file should remain when FileIO remove fails")
 	assert.NotNil(file)

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -555,7 +555,20 @@ func TestHivePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 	assert := require.New(t)
 	ctx := context.Background()
 	const scheme = "hivepurgefail"
-	failingFS := failRemoveIO{MemFS: iceio.NewMemFS(), err: errHivePurgeRemove}
+	dropCalled := false
+	removeBeforeDrop := false
+	removeCalls := 0
+	failingFS := failRemoveIO{
+		MemFS: iceio.NewMemFS(),
+		err:   errHivePurgeRemove,
+		onRemove: func() {
+			removeCalls++
+			if !dropCalled {
+				removeBeforeDrop = true
+			}
+		},
+	}
+	iceio.Unregister(scheme)
 	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
 		return failingFS, nil
 	})
@@ -564,8 +577,47 @@ func TestHivePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 	tableLocation := scheme + "://bucket/test_database/test_table"
 	metadataLocation := tableLocation + "/metadata/v1.metadata.json"
 	dataFile := tableLocation + "/data/file.parquet"
-	writeHivePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation)
-	require.NoError(t, failingFS.WriteFile(dataFile, []byte("data")))
+	writeHivePurgeTableMetadata(t, failingFS, tableLocation, metadataLocation, nil)
+	assert.NoError(failingFS.WriteFile(dataFile, []byte("data")))
+	hiveTable := hivePurgeTable(metadataLocation, tableLocation)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(hiveTable, nil).Twice()
+	mockClient.On("DropTable", mock.Anything, "test_database", "test_table", false).
+		Run(func(mock.Arguments) {
+			dropCalled = true
+		}).Return(nil).Once()
+
+	var logs bytes.Buffer
+	originalLogOutput := log.Writer()
+	// This test redirects the process-global logger, so keep it non-parallel.
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	assert.NoError(hiveCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
+	assert.True(dropCalled)
+	assert.Positive(removeCalls)
+	assert.False(removeBeforeDrop, "PurgeTable should drop the catalog entry before removing files")
+	assert.Contains(logs.String(), "WARNING: dropped table")
+	assert.Contains(logs.String(), "test_database")
+	assert.Contains(logs.String(), "test_table")
+	assert.Contains(logs.String(), errHivePurgeRemove.Error())
+	file, err := failingFS.Open(dataFile)
+	assert.NoError(err, "data file should remain when FileIO remove fails")
+	assert.NotNil(file)
+	assert.NoError(file.Close())
+	mockClient.AssertExpectations(t)
+}
+
+func TestHivePurgeTableWithGCDisabled(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "warehouse", "test_database", "test_table")
+	metadataLocation, dataFile := writeHivePurgeTableFilesWithProperties(
+		t, tableLocation, iceberg.Properties{"gc.enabled": "false"})
 	hiveTable := hivePurgeTable(metadataLocation, tableLocation)
 
 	mockClient := &mockHiveClient{}
@@ -574,28 +626,25 @@ func TestHivePurgeTableSwallowsPurgeFilesError(t *testing.T) {
 	mockClient.On("DropTable", mock.Anything, "test_database", "test_table", false).
 		Return(nil).Once()
 
-	var logs bytes.Buffer
-	originalLogOutput := log.Writer()
-	log.SetOutput(&logs)
-	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
-
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
 	assert.NoError(hiveCatalog.PurgeTable(ctx, TableIdentifier("test_database", "test_table")))
-	assert.Contains(logs.String(), "failed to purge files")
-	assert.Contains(logs.String(), errHivePurgeRemove.Error())
-	file, err := failingFS.Open(dataFile)
-	assert.NoError(err, "data file should remain when FileIO remove fails")
-	assert.NoError(file.Close())
+	assert.NoFileExists(metadataLocation)
+	assert.FileExists(dataFile)
 	mockClient.AssertExpectations(t)
 }
 
 type failRemoveIO struct {
 	*iceio.MemFS
-	err error
+	err      error
+	onRemove func()
 }
 
 func (f failRemoveIO) Remove(string) error {
+	if f.onRemove != nil {
+		f.onRemove()
+	}
+
 	return f.err
 }
 
@@ -607,6 +656,8 @@ func hivePurgeTable(metadataLocation, tableLocation string) *hive_metastore.Tabl
 		Parameters: map[string]string{
 			TableTypeKey:        TableTypeIceberg,
 			MetadataLocationKey: metadataLocation,
+			ExternalKey:         "TRUE",
+			"storage_handler":   "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler",
 		},
 		Sd: &hive_metastore.StorageDescriptor{
 			Location: tableLocation,
@@ -615,10 +666,18 @@ func hivePurgeTable(metadataLocation, tableLocation string) *hive_metastore.Tabl
 }
 
 func writeHivePurgeTableFiles(t *testing.T, tableLocation string) (metadataLocation, dataFile string) {
+	return writeHivePurgeTableFilesWithProperties(t, tableLocation, nil)
+}
+
+func writeHivePurgeTableFilesWithProperties(
+	t *testing.T,
+	tableLocation string,
+	props iceberg.Properties,
+) (metadataLocation, dataFile string) {
 	t.Helper()
 	metadataLocation = filepath.Join(tableLocation, "metadata", "v1.metadata.json")
 	dataFile = filepath.Join(tableLocation, "data", "file.parquet")
-	writeHivePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation)
+	writeHivePurgeTableMetadata(t, iceio.LocalFS{}, tableLocation, metadataLocation, props)
 	writer, err := iceio.LocalFS{}.Create(dataFile)
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("data"))
@@ -628,12 +687,18 @@ func writeHivePurgeTableFiles(t *testing.T, tableLocation string) (metadataLocat
 	return metadataLocation, dataFile
 }
 
-func writeHivePurgeTableMetadata(t *testing.T, fs iceio.WriteFileIO, tableLocation, metadataLocation string) {
+func writeHivePurgeTableMetadata(
+	t *testing.T,
+	fs iceio.WriteFileIO,
+	tableLocation,
+	metadataLocation string,
+	props iceberg.Properties,
+) {
 	t.Helper()
 	schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: true,
 	})
-	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, nil)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, tableLocation, props)
 	require.NoError(t, err)
 	require.NoError(t, cataloginternal.WriteTableMetadata(meta, fs, metadataLocation, table.MetadataCompressionCodecNone))
 }


### PR DESCRIPTION
## Summary

Adds unit coverage for `PurgeTable` in the Glue and Hive catalogs.

The new tests verify that:

- `PurgeTable` loads the table and drops the catalog entry
- local table metadata/data files are physically deleted
- `PurgeFiles` failures are swallowed after the drop
- the warning path is logged when file purge fails

## Why

`glue.PurgeTable` and `hive.PurgeTable` already call `DropTable` followed by best-effort `tbl.PurgeFiles`, but only `DropTable` had test coverage. These tests lock in the intended purge behavior and the existing swallow-and-log error handling.

Fixes #1272.

## Testing

```sh
go test ./catalog/glue ./catalog/hive
go test ./...