### PR TITLE
refactor: require ListableIO for orphan cleanup walk

### DIFF
--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -102,6 +102,8 @@ type blobFileIO struct {
 	newRangeReader func(ctx context.Context, key string, offset, length int64) (io.ReadCloser, error)
 }
 
+var _ icebergio.ListableIO = (*blobFileIO)(nil)
+
 func (bfs *blobFileIO) preprocess(path string) (string, error) {
 	return bfs.keyExtractor(path)
 }

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -166,6 +166,11 @@ type OrphanCleanupResult struct {
 	TotalSizeBytes int64
 }
 
+// DeleteOrphanFiles identifies files under a table location that are no longer
+// referenced by table metadata and deletes them unless dry-run is enabled.
+//
+// The table filesystem must implement iceio.ListableIO so orphan cleanup can
+// fully enumerate candidate files before deciding what is safe to delete.
 func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
 	cfg := &orphanCleanupConfig{
 		location:           "",             // empty means use table's data location
@@ -422,7 +427,7 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 		})
 	}
 
-	return fmt.Errorf("filesystem %T does not implement io.ListableIO", fsys)
+	return fmt.Errorf("filesystem %T does not implement iceio.ListableIO", fsys)
 }
 
 func isFileOrphan(file string, referencedFiles map[string]bool, normalizedReferencedFiles map[string]string, cfg *orphanCleanupConfig) (bool, error) {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -404,7 +403,6 @@ func (t Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurren
 }
 
 func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.FileInfo) error) error {
-	// Prefer ListableIO when available.
 	if listable, ok := fsys.(iceio.ListableIO); ok {
 		return listable.WalkDir(root, func(path string, d stdfs.DirEntry, err error) error {
 			if err != nil {
@@ -424,64 +422,7 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 		})
 	}
 
-	// Fallback to original implementation for IO types that don't
-	// implement ListableIO yet.
-	switch v := fsys.(type) {
-	case iceio.LocalFS:
-		cleanRoot := strings.TrimPrefix(root, "file://")
-		if cleanRoot == "" {
-			cleanRoot = "."
-		}
-
-		return filepath.WalkDir(cleanRoot, makeFileWalkFunc(fn, func(path string) string {
-			return path
-		}))
-
-	default:
-		// For blob storage: direct field access since we know the structure.
-		bucket := getBucketName(v)
-
-		parsed, err := url.Parse(root)
-		if err != nil {
-			return fmt.Errorf("invalid URL %s: %w", root, err)
-		}
-
-		walkPath := strings.TrimPrefix(parsed.Path, "/")
-		if walkPath == "" {
-			walkPath = "."
-		}
-
-		return stdfs.WalkDir(bucket, walkPath, makeFileWalkFunc(fn, func(path string) string {
-			return parsed.Scheme + "://" + parsed.Host + "/" + path
-		}))
-	}
-}
-
-// getBucketName gets the Bucket field from blob storage - absolute minimal approach.
-func getBucketName(fsys iceio.IO) stdfs.FS {
-	v := reflect.ValueOf(fsys).Elem()
-
-	return v.FieldByName("Bucket").Interface().(stdfs.FS)
-}
-
-// makeFileWalkFunc creates a WalkDirFunc that processes only files with path transformation.
-func makeFileWalkFunc(fn func(path string, info stdfs.FileInfo) error, pathTransform func(string) string) stdfs.WalkDirFunc {
-	return func(path string, d stdfs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		return fn(pathTransform(path), info)
-	}
+	return fmt.Errorf("filesystem %T does not implement io.ListableIO", fsys)
 }
 
 func isFileOrphan(file string, referencedFiles map[string]bool, normalizedReferencedFiles map[string]string, cfg *orphanCleanupConfig) (bool, error) {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -611,6 +611,41 @@ func (m *mockPlainIO) Remove(name string) error {
 	return nil
 }
 
+type mockListableIO struct {
+	mockPlainIO
+	root    string
+	entries []mockWalkEntry
+}
+
+type mockWalkEntry struct {
+	path string
+	info mockFileInfo
+}
+
+func (m *mockListableIO) WalkDir(root string, fn stdfs.WalkDirFunc) error {
+	m.root = root
+	for _, entry := range m.entries {
+		if err := fn(entry.path, stdfs.FileInfoToDirEntry(entry.info), nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type mockFileInfo struct {
+	name string
+	size int64
+	mode stdfs.FileMode
+}
+
+func (m mockFileInfo) Name() string         { return m.name }
+func (m mockFileInfo) Size() int64          { return m.size }
+func (m mockFileInfo) Mode() stdfs.FileMode { return m.mode }
+func (m mockFileInfo) ModTime() time.Time   { return time.Time{} }
+func (m mockFileInfo) IsDir() bool          { return m.mode.IsDir() }
+func (m mockFileInfo) Sys() any             { return nil }
+
 func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
 	mock := &mockPlainIO{}
 	orphans := []string{"s3://bucket/data/orphan1.parquet", "s3://bucket/data/orphan2.parquet"}
@@ -622,6 +657,37 @@ func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
 	assert.ElementsMatch(t, orphans, deleted)
 }
 
+func TestWalkDirectoryUsesListableIO(t *testing.T) {
+	mock := &mockListableIO{
+		entries: []mockWalkEntry{
+			{path: "s3://bucket/data", info: mockFileInfo{name: "data", mode: stdfs.ModeDir}},
+			{path: "s3://bucket/data/a.parquet", info: mockFileInfo{name: "a.parquet", size: 3}},
+			{path: "s3://bucket/data/nested", info: mockFileInfo{name: "nested", mode: stdfs.ModeDir}},
+			{path: "s3://bucket/data/nested/b.parquet", info: mockFileInfo{name: "b.parquet", size: 4}},
+		},
+	}
+	var walked []string
+	sizes := make(map[string]int64)
+
+	err := walkDirectory(mock, "s3://bucket/data", func(path string, info stdfs.FileInfo) error {
+		walked = append(walked, path)
+		sizes[path] = info.Size()
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "s3://bucket/data", mock.root)
+	assert.Equal(t, []string{
+		"s3://bucket/data/a.parquet",
+		"s3://bucket/data/nested/b.parquet",
+	}, walked)
+	assert.Equal(t, map[string]int64{
+		"s3://bucket/data/a.parquet":        3,
+		"s3://bucket/data/nested/b.parquet": 4,
+	}, sizes)
+}
+
 func TestWalkDirectoryRequiresListableIO(t *testing.T) {
 	err := walkDirectory(&mockPlainIO{}, "s3://bucket/data", func(string, stdfs.FileInfo) error {
 		require.Fail(t, "walk callback should not run for non-listable IO")
@@ -629,7 +695,7 @@ func TestWalkDirectoryRequiresListableIO(t *testing.T) {
 		return nil
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not implement io.ListableIO")
+	assert.Contains(t, err.Error(), "does not implement iceio.ListableIO")
 }
 
 type inMemoryCatalog struct {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	stdfs "io/fs"
 	"strings"
 	"testing"
 	"time"
@@ -595,7 +596,7 @@ func TestDeleteFilesEmpty(t *testing.T) {
 	assert.Nil(t, deleted)
 }
 
-// mockPlainIO implements only IO (no BulkRemovableIO) to verify fallback behavior.
+// mockPlainIO implements only IO, without optional delete or listing capabilities.
 type mockPlainIO struct {
 	removed []string
 }
@@ -619,6 +620,16 @@ func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, orphans, mock.removed)
 	assert.ElementsMatch(t, orphans, deleted)
+}
+
+func TestWalkDirectoryRequiresListableIO(t *testing.T) {
+	err := walkDirectory(&mockPlainIO{}, "s3://bucket/data", func(string, stdfs.FileInfo) error {
+		require.Fail(t, "walk callback should not run for non-listable IO")
+
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not implement io.ListableIO")
 }
 
 type inMemoryCatalog struct {


### PR DESCRIPTION
Fixes #1276.

## Summary

Removes the dead fallback path in orphan-cleanup directory walking.

`walkDirectory` now requires the table `FileIO` to implement `ListableIO` and returns a clear error if it does not. This also removes the old reflection-based `getBucketName` helper and the unused `reflect` import.

## Why

All concrete IO implementations used here now implement `WalkDir` / `ListableIO`, so the old post-`ListableIO` fallback was unreachable. Removing it gets rid of brittle reflection against blob internals.


## Testing

```sh
go test ./table
go test ./...