### PR TITLE
fix(codec): validate primary data file spec id in EncodeFileScanTask

### DIFF
--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -32,31 +32,36 @@ import (
 // is given on the receiver.
 //
 // All carried DataFiles (data, positional deletes, equality deletes,
-// and deletion vectors) must share the supplied spec.ID(): each delete
-// file's SpecID is validated and a mismatch returns an error. After
-// partition evolution, delete files may have been written under a
-// different partition spec than the data file; the caller is
-// responsible for partitioning the FileScanTask by per-file specID and
-// calling EncodeFileScanTask once per group.
+// and deletion vectors) must share the supplied spec.ID(): every file's
+// SpecID is validated and a mismatch returns an error. After partition
+// evolution, delete files may have been written under a different
+// partition spec than the data file; the caller is responsible for
+// partitioning the FileScanTask by per-file specID and calling
+// EncodeFileScanTask once per group.
 func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, schema *iceberg.Schema, version int) ([]byte, error) {
 	if version < 1 || version > 3 {
 		return nil, fmt.Errorf("codec: EncodeFileScanTask: unsupported format version %d", version)
 	}
+	// Validate the primary data file's spec, like encodeDataFileSlice does for
+	// every delete/equality/DV file.
+	if err := checkDataFileSpecID(task.File, spec); err != nil {
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: %w", err)
+	}
 	fileBytes, err := EncodeDataFile(task.File, spec, schema, version)
 	if err != nil {
-		return nil, fmt.Errorf("file: %w", err)
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: file: %w", err)
 	}
 	del, err := encodeDataFileSlice(task.DeleteFiles, spec, schema, version)
 	if err != nil {
-		return nil, fmt.Errorf("delete files: %w", err)
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: delete files: %w", err)
 	}
 	eq, err := encodeDataFileSlice(task.EqualityDeleteFiles, spec, schema, version)
 	if err != nil {
-		return nil, fmt.Errorf("equality delete files: %w", err)
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: equality delete files: %w", err)
 	}
 	dv, err := encodeDataFileSlice(task.DeletionVectorFiles, spec, schema, version)
 	if err != nil {
-		return nil, fmt.Errorf("deletion vector files: %w", err)
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: deletion vector files: %w", err)
 	}
 	envelope := fileScanTaskEnvelope{
 		File:                fileBytes,
@@ -80,23 +85,23 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	}
 	var envelope fileScanTaskEnvelope
 	if _, err := fileScanTaskSchema.Decode(data, &envelope); err != nil {
-		return table.FileScanTask{}, fmt.Errorf("decode: %w", err)
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: decode: %w", err)
 	}
 	file, err := DecodeDataFile(envelope.File, spec, schema, version)
 	if err != nil {
-		return table.FileScanTask{}, fmt.Errorf("file: %w", err)
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: file: %w", err)
 	}
 	del, err := decodeDataFileSlice(envelope.DeleteFiles, spec, schema, version)
 	if err != nil {
-		return table.FileScanTask{}, fmt.Errorf("delete files: %w", err)
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: delete files: %w", err)
 	}
 	eq, err := decodeDataFileSlice(envelope.EqualityDeleteFiles, spec, schema, version)
 	if err != nil {
-		return table.FileScanTask{}, fmt.Errorf("equality delete files: %w", err)
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: equality delete files: %w", err)
 	}
 	dv, err := decodeDataFileSlice(envelope.DeletionVectorFiles, spec, schema, version)
 	if err != nil {
-		return table.FileScanTask{}, fmt.Errorf("deletion vector files: %w", err)
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: deletion vector files: %w", err)
 	}
 
 	return table.FileScanTask{
@@ -172,14 +177,26 @@ func init() {
 	fileScanTaskSchema = s
 }
 
+// checkDataFileSpecID verifies a data file's SpecID matches the codec spec.
+// EncodeDataFile encodes partition data against the passed-in spec, so a file
+// carrying a different spec would silently mis-map or drop partition values and
+// still succeed. Every file in a FileScanTask must therefore share spec.ID().
+func checkDataFileSpecID(f iceberg.DataFile, spec iceberg.PartitionSpec) error {
+	if int(f.SpecID()) != spec.ID() {
+		return fmt.Errorf("data file spec id %d does not match codec spec id %d (partition evolution requires per-spec grouping)", f.SpecID(), spec.ID())
+	}
+
+	return nil
+}
+
 func encodeDataFileSlice(files []iceberg.DataFile, spec iceberg.PartitionSpec, schema *iceberg.Schema, version int) ([][]byte, error) {
 	if len(files) == 0 {
 		return nil, nil
 	}
 	out := make([][]byte, 0, len(files))
 	for i, f := range files {
-		if int(f.SpecID()) != spec.ID() {
-			return nil, fmt.Errorf("entry %d: data file spec id %d does not match codec spec id %d (partition evolution requires per-spec grouping)", i, f.SpecID(), spec.ID())
+		if err := checkDataFileSpecID(f, spec); err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
 		}
 		b, err := EncodeDataFile(f, spec, schema, version)
 		if err != nil {

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package codec
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeFileScanTaskInnerErrorCarriesMarker covers an inner decode path:
+// the outer Avro envelope decodes fine, but the framed primary-file blob is not
+// a valid DataFile encoding. The wrapped error must still carry the
+// "codec: DecodeFileScanTask: file:" marker. Building the malformed envelope
+// needs the unexported fileScanTaskEnvelope/fileScanTaskSchema, so this lives
+// in an internal test rather than the codec_test package.
+func TestDecodeFileScanTaskInnerErrorCarriesMarker(t *testing.T) {
+	env := fileScanTaskEnvelope{File: []byte("not a valid data file blob")}
+	data, err := fileScanTaskSchema.Encode(&env)
+	require.NoError(t, err)
+
+	spec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+	)
+	schema := iceberg.NewSchema(123,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+	)
+
+	_, err = DecodeFileScanTask(data, spec, schema, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "codec: DecodeFileScanTask: file:",
+		"an inner (primary-file) decode error must carry the function + sub-path marker")
+}

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -95,12 +95,58 @@ func TestEncodeFileScanTaskRejectsMismatchedDeleteFileSpec(t *testing.T) {
 	}
 	_, err := codec.EncodeFileScanTask(task, specMain, schema, 2)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "codec: EncodeFileScanTask:",
+		"propagated error must carry the codec function marker")
 	require.Contains(t, err.Error(), "spec id",
 		"error must call out the spec-id mismatch")
-	require.Contains(t, err.Error(), "99",
+	require.Contains(t, err.Error(), "data file spec id 99",
 		"error must include the offending delete file's spec id")
-	require.Contains(t, err.Error(), "7",
+	require.Contains(t, err.Error(), "codec spec id 7",
 		"error must include the codec's spec id")
+}
+
+func TestEncodeFileScanTaskRejectsMismatchedPrimaryDataFileSpec(t *testing.T) {
+	schema := iceberg.NewSchema(123,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+	)
+	specMain := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+	)
+	specOther := iceberg.NewPartitionSpecID(99,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+	)
+
+	// Primary data file written under a different spec than the codec spec.
+	// Without the guard, EncodeDataFile would encode its partition data against
+	// the wrong spec and silently return a corrupt blob.
+	mismatchedMain := newScanTaskDataFile(t, specOther, "s3://bucket/main.parquet",
+		iceberg.EntryContentData, iceberg.ParquetFile, "", 2)
+
+	task := table.FileScanTask{File: mismatchedMain}
+	_, err := codec.EncodeFileScanTask(task, specMain, schema, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "codec: EncodeFileScanTask:",
+		"error must carry the codec function marker")
+	require.Contains(t, err.Error(), "spec id",
+		"error must call out the spec-id mismatch")
+	require.Contains(t, err.Error(), "data file spec id 99",
+		"error must include the offending data file's spec id")
+	require.Contains(t, err.Error(), "codec spec id 7",
+		"error must include the codec's spec id")
+}
+
+func TestDecodeFileScanTaskErrorCarriesMarker(t *testing.T) {
+	schema := iceberg.NewSchema(123,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+	)
+	spec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+	)
+
+	_, err := codec.DecodeFileScanTask([]byte("not a valid envelope"), spec, schema, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "codec: DecodeFileScanTask:",
+		"decode error must carry the codec function marker")
 }
 
 func TestEncodeFileScanTaskEmptyDeleteLists(t *testing.T) {

--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -256,8 +256,9 @@ func mustNewSchemaCache(size int) *lru.Cache[dataFileSchemaCacheKey, *dataFileSc
 // active partition specs; long-running consumers with larger working
 // sets (e.g. a compaction service touching many tables) should raise
 // it. Existing entries are preserved on grow; on shrink, least-recently
-// used entries are evicted down to the new size. Not safe to call
-// concurrently with codec operations.
+// used entries are evicted down to the new size. Safe to call concurrently
+// with codec operations: the underlying golang-lru/v2 cache serializes Resize
+// against Get/Add through the same mutex.
 func SetSchemaCacheSize(size int) error {
 	if size <= 0 {
 		return fmt.Errorf("iceberg: SetSchemaCacheSize: size must be positive, got %d", size)


### PR DESCRIPTION
Three related codec cleanups:

- EncodeFileScanTask validated the SpecID of every delete/equality/DV file (via encodeDataFileSlice) but not the primary task.File. EncodeDataFile encodes partition data against the passed-in spec, so a transposed (spec, task) pair silently mis-mapped or dropped partition values and still returned success. Guard the primary file the same way the delete files are guarded, and update the doc comment to say every file is checked.

- Tag the Encode/DecodeFileScanTask propagation-path errors with the "codec: EncodeFileScanTask:" / "codec: DecodeFileScanTask:" markers, matching the convention EncodeDataFile/DecodeDataFile already use (and that data_file_test.go asserts).

- Fix the SetSchemaCacheSize doc: it claimed "not safe to call concurrently", but the underlying golang-lru/v2 cache serializes Resize against Get/Add through the same mutex, so it is safe.