### PR TITLE
fix(catalog): avoid mutating load properties

### DIFF
--- a/catalog/registry.go
+++ b/catalog/registry.go
@@ -141,6 +141,7 @@ func Load(ctx context.Context, name string, props iceberg.Properties) (Catalog, 
 			"warehouse":  conf.Warehouse,
 		}
 	} else {
+		props = maps.Clone(props)
 		props["uri"] = props.Get("uri", conf.URI)
 		props["credential"] = props.Get("credential", conf.Credential)
 		props["warehouse"] = props.Get("warehouse", conf.Warehouse)

--- a/catalog/registry_test.go
+++ b/catalog/registry_test.go
@@ -133,6 +133,40 @@ func TestCatalogWithEmptyName(t *testing.T) {
 	catalog.Unregister("mock")
 }
 
+func TestCatalogLoadDoesNotMutateProps(t *testing.T) {
+	ctx := context.Background()
+	defer func(cats map[string]config.CatalogConfig) {
+		config.EnvConfig.Catalogs = cats
+	}(config.EnvConfig.Catalogs)
+	defer catalog.Unregister("mock")
+
+	config.EnvConfig.Catalogs = map[string]config.CatalogConfig{
+		"mock": {
+			URI:         "http://localhost:8181/",
+			Credential:  "default-credential",
+			Warehouse:   "/default/warehouse",
+			CatalogType: "mock",
+		},
+	}
+
+	catalog.Register("mock", catalog.RegistrarFunc(func(ctx context.Context, name string, props iceberg.Properties) (catalog.Catalog, error) {
+		assert.Equal(t, "mock", name)
+		assert.Equal(t, "mock", props.Get("type", ""))
+		assert.Equal(t, "http://localhost:8181/", props.Get("uri", ""))
+		assert.Equal(t, "default-credential", props.Get("credential", ""))
+		assert.Equal(t, "/default/warehouse", props.Get("warehouse", ""))
+
+		return nil, nil
+	}))
+
+	props := iceberg.Properties{"type": "mock"}
+	c, err := catalog.Load(ctx, "mock", props)
+
+	assert.Nil(t, c)
+	assert.NoError(t, err)
+	assert.Equal(t, iceberg.Properties{"type": "mock"}, props)
+}
+
 func TestCatalogLoadInvalidURI(t *testing.T) {
 	ctx := context.Background()
 	config.EnvConfig.DefaultCatalog = "default"


### PR DESCRIPTION
Summary

Clone caller-provided properties in `catalog.Load` before filling defaults from the configured catalog. The merged copy is still passed to the catalog registrar, but the caller-owned map is left alone.

This avoids surprising side effects when callers reuse a config map across loads, or share one between goroutines.

Testing

- `go test ./catalog -run '^TestCatalogLoadDoesNotMutateProps$' -count=1`
- `go test ./catalog -count=1`
- `git diff --check`