### PR TITLE
fix(catalog/hadoop): load discovered metadata files

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -60,8 +60,70 @@ var versionPattern = regexp.MustCompile(`^v([0-9]+)(?:\.gz)?\.metadata\.json$`)
 // 00000-<uuid>.gz.metadata.json. The sequence is a 5-digit zero-padded
 // number and the UUID is in canonical 8-4-4-4-12 hex format.
 var uuidMetadataPattern = regexp.MustCompile(
-	`^[0-9]{5}-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:\.gz)?\.metadata\.json$`,
+	`^([0-9]{5})-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:\.gz)?\.metadata\.json$`,
 )
+
+type metadataFile struct {
+	location   string
+	version    int
+	hadoopName bool
+	compressed bool
+}
+
+func metadataFileFromName(path, name string) (metadataFile, bool) {
+	if matches := versionPattern.FindStringSubmatch(name); len(matches) == 2 {
+		version, err := strconv.Atoi(matches[1])
+		if err != nil || version <= 0 {
+			return metadataFile{}, false
+		}
+
+		return metadataFile{
+			location:   path,
+			version:    version,
+			hadoopName: true,
+			compressed: strings.Contains(name, ".gz.metadata.json"),
+		}, true
+	}
+
+	if matches := uuidMetadataPattern.FindStringSubmatch(name); len(matches) == 2 {
+		version, err := strconv.Atoi(matches[1])
+		if err != nil || version < 0 {
+			return metadataFile{}, false
+		}
+
+		return metadataFile{
+			location:   path,
+			version:    version,
+			compressed: strings.Contains(name, ".gz.metadata.json"),
+		}, true
+	}
+
+	return metadataFile{}, false
+}
+
+func (m metadataFile) betterThan(current metadataFile) bool {
+	switch {
+	case current.location == "":
+		return true
+	case m.version != current.version:
+		return m.version > current.version
+	case m.hadoopName != current.hadoopName:
+		// If both naming styles exist for one version, prefer the Hadoop vN
+		// file because this catalog writes and conflict-checks that sequence.
+		return m.hadoopName
+	case m.compressed != current.compressed:
+		return !m.compressed
+	default:
+		// This keeps scans deterministic under map iteration; within one
+		// metadata directory it reduces to a stable filename tie-break.
+		return m.location > current.location
+	}
+}
+
+func shouldSuppressPermissionError(err error) bool {
+	return errors.Is(err, fs.ErrPermission) ||
+		(err != nil && strings.Contains(err.Error(), "AuthorizationPermissionMismatch"))
+}
 
 // validateIdentifier checks that an identifier is non-empty and that each
 // component is safe for use as a path segment. It rejects nil/empty
@@ -237,12 +299,11 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 }
 
 // isTableDir reports whether path is a table directory by checking for
-// metadata files in its metadata/ subdirectory. It recognizes:
+// loadable metadata files in its metadata/ subdirectory. It recognizes:
 //   - v*.metadata.json (Hadoop catalog format)
 //   - <seq>-<uuid>.metadata.json (Java/PyIceberg format)
-//   - version-hint.text
-func isTableDir(filesystem HadoopCatalogFS, isLocal bool, path string) bool {
-	metaDir := joinPath(isLocal, path, "metadata")
+func isTableDir(filesystem HadoopCatalogFS, isLocal bool, tablePath string) (bool, error) {
+	metaDir := joinPath(isLocal, tablePath, "metadata")
 
 	foundMetadata := false
 	err := filesystem.WalkDir(metaDir, func(path string, d fs.DirEntry, err error) error {
@@ -260,10 +321,7 @@ func isTableDir(filesystem HadoopCatalogFS, isLocal bool, path string) bool {
 			return fs.SkipDir
 		}
 
-		name := d.Name()
-		if versionPattern.MatchString(name) ||
-			uuidMetadataPattern.MatchString(name) ||
-			name == "version-hint.text" {
+		if _, ok := metadataFileFromName(path, d.Name()); ok {
 			foundMetadata = true
 
 			return fs.SkipAll
@@ -272,10 +330,25 @@ func isTableDir(filesystem HadoopCatalogFS, isLocal bool, path string) bool {
 		return nil
 	})
 	if err != nil {
-		return false
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
 	}
 
-	return foundMetadata
+	return foundMetadata, nil
+}
+
+func isTableDirForListing(filesystem HadoopCatalogFS, isLocal bool, tablePath string) (bool, error) {
+	isTable, err := isTableDir(filesystem, isLocal, tablePath)
+	if err != nil && shouldSuppressPermissionError(err) {
+		log.Printf("hadoop catalog: unable to inspect metadata directory %s: %v", joinPath(isLocal, tablePath, "metadata"), err)
+
+		return false, nil
+	}
+
+	return isTable, err
 }
 
 func (c *Catalog) readVersionHint(ident table.Identifier) int {
@@ -310,43 +383,11 @@ func (c *Catalog) writeVersionHint(ident table.Identifier, version int) {
 	}
 }
 
-// metadataVersionExists checks whether a metadata file for the given version
-// exists in either plain or gzip-compressed form.
-func (c *Catalog) metadataVersionExists(ident table.Identifier, version int) bool {
+func (c *Catalog) scanMetadataFiles(ident table.Identifier) (map[int]metadataFile, metadataFile, error) {
 	dir := c.metadataDir(ident)
-	plain := joinPath(c.isLocal, dir, fmt.Sprintf("v%d.metadata.json", version))
+	byVersion := map[int]metadataFile{}
+	var latest metadataFile
 
-	if _, err := c.filesystem.Stat(plain); err == nil {
-		return true
-	}
-
-	gz := joinPath(c.isLocal, dir, fmt.Sprintf("v%d.gz.metadata.json", version))
-
-	_, err := c.filesystem.Stat(gz)
-
-	return err == nil
-}
-
-func (c *Catalog) scanForward(ident table.Identifier, start int) int {
-	ver := start
-	for c.metadataVersionExists(ident, ver+1) {
-		ver++
-	}
-
-	return ver
-}
-
-func (c *Catalog) findVersion(ident table.Identifier) (int, error) {
-	hint := c.readVersionHint(ident)
-	if hint > 0 && c.metadataVersionExists(ident, hint) {
-		return c.scanForward(ident, hint), nil
-	}
-
-	dir := c.metadataDir(ident)
-
-	maxVer := 0
-	// Walk just one directory level to find metadata files,
-	// ignoring any subdirectories that may exist
 	err := c.filesystem.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -358,28 +399,84 @@ func (c *Catalog) findVersion(ident table.Identifier) (int, error) {
 			return fs.SkipDir
 		}
 
-		name := d.Name()
-		matches := versionPattern.FindStringSubmatch(name)
-		if len(matches) == 2 {
-			v, _ := strconv.Atoi(matches[1])
-			if v > maxVer {
-				maxVer = v
-			}
+		file, ok := metadataFileFromName(path, d.Name())
+		if !ok {
+			return nil
+		}
+
+		if file.betterThan(byVersion[file.version]) {
+			byVersion[file.version] = file
+		}
+		if file.betterThan(latest) {
+			latest = file
 		}
 
 		return nil
 	})
+
+	return byVersion, latest, err
+}
+
+func (c *Catalog) metadataVersionExists(ident table.Identifier, version int) (bool, error) {
+	dir := c.metadataDir(ident)
+	found := false
+
+	// This intentionally scans: UUID metadata filenames contain an
+	// unpredictable UUID, so Stat checks cannot cover every same-version race.
+	err := c.filesystem.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == dir {
+			return nil
+		}
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+
+		file, ok := metadataFileFromName(path, d.Name())
+		if !ok || file.version != version {
+			return nil
+		}
+
+		found = true
+
+		return fs.SkipAll
+	})
 	if err != nil {
-		return 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w",
+		return false, err
+	}
+
+	return found, nil
+}
+
+func (c *Catalog) findMetadataLocation(ident table.Identifier) (string, int, error) {
+	_, latest, err := c.scanMetadataFiles(ident)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w: %w",
+				strings.Join(ident, "."), catalog.ErrNoSuchTable, err)
+		}
+
+		return "", 0, fmt.Errorf("hadoop catalog: cannot read metadata directory for %s: %w",
+			strings.Join(ident, "."), err)
+	}
+
+	if latest.location == "" {
+		return "", 0, fmt.Errorf("hadoop catalog: no metadata files found for table %s: %w",
 			strings.Join(ident, "."), catalog.ErrNoSuchTable)
 	}
 
-	if maxVer == 0 {
-		return 0, fmt.Errorf("hadoop catalog: no metadata files found for table %s: %w",
-			strings.Join(ident, "."), catalog.ErrNoSuchTable)
+	return latest.location, latest.version, nil
+}
+
+func (c *Catalog) findVersion(ident table.Identifier) (int, error) {
+	_, version, err := c.findMetadataLocation(ident)
+	if err != nil {
+		return 0, err
 	}
 
-	return c.scanForward(ident, maxVer), nil
+	return version, nil
 }
 
 func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
@@ -409,7 +506,11 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, errors.New("hadoop catalog: custom table locations are not supported")
 	}
 
-	if isTableDir(c.filesystem, c.isLocal, loc) {
+	exists, err := isTableDir(c.filesystem, c.isLocal, loc)
+	if err != nil {
+		return nil, fmt.Errorf("hadoop catalog: failed to inspect table directory: %w", err)
+	}
+	if exists {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrTableAlreadyExists, strings.Join(ident, "."))
 	}
 
@@ -457,19 +558,28 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	return tbl, nil
 }
 
-func (c *Catalog) LoadTable(ctx context.Context, ident table.Identifier) (*table.Table, error) {
+func (c *Catalog) loadTable(ctx context.Context, ident table.Identifier) (*table.Table, int, error) {
 	if err := validateTableIdentifier(ident); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	ver, err := c.findVersion(ident)
+	metaPath, version, err := c.findMetadataLocation(ident)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	metaPath := c.metadataFilePath(ident, ver)
+	tbl, err := table.NewFromLocation(ctx, ident, metaPath, io.LoadFSFunc(c.props, metaPath), c)
+	if err != nil {
+		return nil, 0, err
+	}
 
-	return table.NewFromLocation(ctx, ident, metaPath, io.LoadFSFunc(c.props, metaPath), c)
+	return tbl, version, nil
+}
+
+func (c *Catalog) LoadTable(ctx context.Context, ident table.Identifier) (*table.Table, error) {
+	tbl, _, err := c.loadTable(ctx, ident)
+
+	return tbl, err
 }
 
 func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (bool, error) {
@@ -477,7 +587,12 @@ func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (b
 		return false, nil
 	}
 
-	return isTableDir(c.filesystem, c.isLocal, c.tableToPath(ident)), nil
+	exists, err := isTableDir(c.filesystem, c.isLocal, c.tableToPath(ident))
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
 }
 
 func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
@@ -486,7 +601,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 	}
 
 	// Step 1: Load current table (nil for create-via-commit).
-	current, err := c.LoadTable(ctx, ident)
+	current, currentVersion, err := c.loadTable(ctx, ident)
 	if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
 		return nil, "", err
 	}
@@ -530,15 +645,6 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 	}
 
 	// Step 6: Determine next version number.
-	var currentVersion int
-
-	if current != nil {
-		currentVersion, err = c.findVersion(ident)
-		if err != nil {
-			return nil, "", err
-		}
-	}
-
 	newVersion := currentVersion + 1
 
 	// Step 7: Create metadata directory if needed (create-via-commit).
@@ -558,6 +664,19 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
+	exists, err := c.metadataVersionExists(ident, newVersion)
+	if err != nil {
+		_ = c.filesystem.Remove(tempPath)
+
+		return nil, "", fmt.Errorf("hadoop catalog: failed to inspect metadata directory for version %d: %w",
+			newVersion, err)
+	}
+	if exists {
+		_ = c.filesystem.Remove(tempPath)
+
+		return nil, "", fmt.Errorf("hadoop catalog: version %d already exists for table %s",
+			newVersion, strings.Join(ident, "."))
+	}
 	if err := c.commitMetadataFile(ident, tempPath, newMetaPath, table.ErrCommitFailed); err != nil {
 		return nil, "", err
 	}
@@ -608,6 +727,12 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 
 		err = c.filesystem.WalkDir(nsPath, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
+				if path != nsPath && shouldSuppressPermissionError(err) {
+					log.Printf("hadoop catalog: unable to inspect path %s while listing tables: %v", path, err)
+
+					return fs.SkipDir
+				}
+
 				return err
 			}
 
@@ -622,7 +747,11 @@ func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[t
 			}
 
 			// Skip anything that is not a table directory.
-			if !isTableDir(c.filesystem, c.isLocal, path) {
+			isTable, err := isTableDirForListing(c.filesystem, c.isLocal, path)
+			if err != nil {
+				return err
+			}
+			if !isTable {
 				return fs.SkipDir
 			}
 			ident := make(table.Identifier, len(ns)+1)
@@ -649,7 +778,11 @@ func (c *Catalog) DropTable(_ context.Context, ident table.Identifier) error {
 	}
 
 	tablePath := c.tableToPath(ident)
-	if !isTableDir(c.filesystem, c.isLocal, tablePath) {
+	isTable, err := isTableDir(c.filesystem, c.isLocal, tablePath)
+	if err != nil {
+		return fmt.Errorf("hadoop catalog: failed to inspect table directory: %w", err)
+	}
+	if !isTable {
 		return fmt.Errorf("%w: %s", catalog.ErrNoSuchTable, strings.Join(ident, "."))
 	}
 
@@ -792,6 +925,12 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 	result := []table.Identifier{}
 	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if p != path && shouldSuppressPermissionError(err) {
+				log.Printf("hadoop catalog: unable to inspect path %s while listing namespaces: %v", p, err)
+
+				return fs.SkipDir
+			}
+
 			return err
 		}
 		if p == path {
@@ -802,7 +941,11 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 			// skip plain files
 			return nil
 		}
-		if isTableDir(c.filesystem, c.isLocal, p) {
+		isTable, err := isTableDirForListing(c.filesystem, c.isLocal, p)
+		if err != nil {
+			return err
+		}
+		if isTable {
 			// if a table, not a namespace, don't descend
 			return fs.SkipDir
 		}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -587,6 +587,8 @@ func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (b
 		return false, nil
 	}
 
+	// Direct existence checks surface metadata directory read errors; listing
+	// paths use isTableDirForListing to skip unreadable entries.
 	exists, err := isTableDir(c.filesystem, c.isLocal, c.tableToPath(ident))
 	if err != nil {
 		return false, err

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -18,6 +18,8 @@
 package hadoop
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -34,6 +36,7 @@ import (
 	icebergio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -126,6 +129,197 @@ func (s *HadoopCatalogTestSuite) registerScheme(factory icebergio.SchemeFactory)
 	})
 
 	return scheme
+}
+
+func (s *HadoopCatalogTestSuite) requireIsTableDir(path string) bool {
+	isTable, err := isTableDir(s.cat.filesystem, s.cat.isLocal, path)
+	s.Require().NoError(err)
+
+	return isTable
+}
+
+func TestMetadataFileBetterThan(t *testing.T) {
+	tests := []struct {
+		name    string
+		next    metadataFile
+		current metadataFile
+		want    bool
+	}{
+		{
+			name: "empty current loses",
+			next: metadataFile{
+				location: "v1.metadata.json",
+				version:  1,
+			},
+			want: true,
+		},
+		{
+			name: "higher version wins",
+			next: metadataFile{
+				location: "v2.metadata.json",
+				version:  2,
+			},
+			current: metadataFile{
+				location: "v1.metadata.json",
+				version:  1,
+			},
+			want: true,
+		},
+		{
+			name: "lower version loses",
+			next: metadataFile{
+				location: "v1.metadata.json",
+				version:  1,
+			},
+			current: metadataFile{
+				location: "v2.metadata.json",
+				version:  2,
+			},
+			want: false,
+		},
+		{
+			name: "hadoop name wins same version",
+			next: metadataFile{
+				location:   "v1.metadata.json",
+				version:    1,
+				hadoopName: true,
+			},
+			current: metadataFile{
+				location: "00001-11111111-1111-1111-1111-111111111111.metadata.json",
+				version:  1,
+			},
+			want: true,
+		},
+		{
+			name: "uuid name loses same version against hadoop name",
+			next: metadataFile{
+				location: "00001-11111111-1111-1111-1111-111111111111.metadata.json",
+				version:  1,
+			},
+			current: metadataFile{
+				location:   "v1.metadata.json",
+				version:    1,
+				hadoopName: true,
+			},
+			want: false,
+		},
+		{
+			name: "uncompressed wins same version and style",
+			next: metadataFile{
+				location:   "v1.metadata.json",
+				version:    1,
+				hadoopName: true,
+			},
+			current: metadataFile{
+				location:   "v1.gz.metadata.json",
+				version:    1,
+				hadoopName: true,
+				compressed: true,
+			},
+			want: true,
+		},
+		{
+			name: "same file does not beat itself",
+			next: metadataFile{
+				location:   "v1.metadata.json",
+				version:    1,
+				hadoopName: true,
+			},
+			current: metadataFile{
+				location:   "v1.metadata.json",
+				version:    1,
+				hadoopName: true,
+			},
+			want: false,
+		},
+		{
+			name: "naming style wins before compression",
+			next: metadataFile{
+				location:   "v1.gz.metadata.json",
+				version:    1,
+				hadoopName: true,
+				compressed: true,
+			},
+			current: metadataFile{
+				location:   "00001-11111111-1111-1111-1111-111111111111.metadata.json",
+				version:    1,
+				compressed: false,
+			},
+			want: true,
+		},
+		{
+			name: "lexicographic fallback",
+			next: metadataFile{
+				location: "b.metadata.json",
+				version:  1,
+			},
+			current: metadataFile{
+				location: "a.metadata.json",
+				version:  1,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.next.betterThan(tt.current))
+		})
+	}
+}
+
+type failingWalkFS struct {
+	HadoopCatalogFS
+	err error
+}
+
+func (f failingWalkFS) WalkDir(string, fs.WalkDirFunc) error {
+	return f.err
+}
+
+type stagedWalkDirFS struct {
+	HadoopCatalogFS
+	targetPath string
+	stage      func() error
+
+	mu     sync.Mutex
+	calls  int
+	staged bool
+}
+
+func (f *stagedWalkDirFS) WalkDir(path string, fn fs.WalkDirFunc) error {
+	if path == f.targetPath {
+		stageNow := false
+		f.mu.Lock()
+		f.calls++
+		if f.calls == 2 && !f.staged {
+			f.staged = true
+			stageNow = true
+		}
+		f.mu.Unlock()
+
+		if stageNow {
+			if err := f.stage(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return f.HadoopCatalogFS.WalkDir(path, fn)
+}
+
+type selectiveFailingWalkFS struct {
+	HadoopCatalogFS
+	failPath string
+	err      error
+}
+
+func (f selectiveFailingWalkFS) WalkDir(path string, fn fs.WalkDirFunc) error {
+	if path == f.failPath {
+		return f.err
+	}
+
+	return f.HadoopCatalogFS.WalkDir(path, fn)
 }
 
 func (s *HadoopCatalogTestSuite) TestCatalogType() {
@@ -301,20 +495,38 @@ func (s *HadoopCatalogTestSuite) TestVersionPatternRejects() {
 	}
 }
 
+func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameAcceptsZeroUUIDVersion() {
+	file, ok := metadataFileFromName(
+		"/tmp/00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json",
+		"00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json",
+	)
+	s.True(ok)
+	s.Equal(0, file.version)
+	s.Equal("/tmp/00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", file.location)
+}
+
+func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameRejectsOverflowVersion() {
+	_, ok := metadataFileFromName(
+		"/tmp/v99999999999999999999.metadata.json",
+		"v99999999999999999999.metadata.json",
+	)
+	s.False(ok)
+}
+
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrue() {
 	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.True(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNoMetadataDir() {
 	nsDir := filepath.Join(s.warehouse, "ns")
 	s.Require().NoError(os.MkdirAll(nsDir, 0o755))
 
-	s.False(isTableDir(s.cat.filesystem, s.cat.isLocal, nsDir))
+	s.False(s.requireIsTableDir(nsDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
@@ -322,7 +534,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirFalseEmptyMetadataDir() {
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 
-	s.False(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.False(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
@@ -331,7 +543,16 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadata() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.True(s.requireIsTableDir(tableDir))
+}
+
+func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataVersionZero() {
+	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
+	metaDir := filepath.Join(tableDir, "metadata")
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"), nil, 0o644))
+
+	s.True(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
@@ -340,17 +561,50 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirWithGzipMetadata() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "v1.gz.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.True(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirNonExistentPath() {
-	s.False(isTableDir(s.cat.filesystem, s.cat.isLocal, filepath.Join(s.warehouse, "does", "not", "exist")))
+	s.False(s.requireIsTableDir(filepath.Join(s.warehouse, "does", "not", "exist")))
 }
 
 func (s *HadoopCatalogTestSuite) createMetadataFile(ident table.Identifier, version int) {
 	path := s.cat.metadataFilePath(ident, version)
 	s.Require().NoError(os.MkdirAll(filepath.Dir(path), 0o755))
 	s.Require().NoError(os.WriteFile(path, nil, 0o644))
+}
+
+func (s *HadoopCatalogTestSuite) replaceMetadataWithGzip(ident table.Identifier, version int) string {
+	plainPath := s.cat.metadataFilePath(ident, version)
+	data, err := os.ReadFile(plainPath)
+	s.Require().NoError(err)
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err = zw.Write(data)
+	s.Require().NoError(err)
+	s.Require().NoError(zw.Close())
+
+	gzPath := filepath.Join(s.cat.metadataDir(ident), fmt.Sprintf("v%d.gz.metadata.json", version))
+	s.Require().NoError(os.WriteFile(gzPath, buf.Bytes(), 0o644))
+	s.Require().NoError(os.Remove(plainPath))
+
+	return gzPath
+}
+
+func (s *HadoopCatalogTestSuite) replaceMetadataWithUUIDName(ident table.Identifier, version int) string {
+	return s.replaceMetadataWithUUIDSequence(ident, version, version)
+}
+
+func (s *HadoopCatalogTestSuite) replaceMetadataWithUUIDSequence(ident table.Identifier, version, sequence int) string {
+	plainPath := s.cat.metadataFilePath(ident, version)
+	uuidPath := filepath.Join(
+		s.cat.metadataDir(ident),
+		fmt.Sprintf("%05d-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", sequence),
+	)
+	s.Require().NoError(os.Rename(plainPath, uuidPath))
+
+	return uuidPath
 }
 
 func (s *HadoopCatalogTestSuite) TestReadWriteVersionHint() {
@@ -421,6 +675,19 @@ func (s *HadoopCatalogTestSuite) TestFindVersionScanForward() {
 	s.Equal(5, ver)
 }
 
+func (s *HadoopCatalogTestSuite) TestFindMetadataLocationHintGapKeepsLatest() {
+	ident := []string{"ns", "tbl"}
+	for _, version := range []int{1, 2, 5} {
+		s.createMetadataFile(ident, version)
+	}
+
+	s.cat.writeVersionHint(ident, 1)
+	location, version, err := s.cat.findMetadataLocation(ident)
+	s.Require().NoError(err)
+	s.Equal(5, version)
+	s.Equal(s.cat.metadataFilePath(ident, 5), location)
+}
+
 func (s *HadoopCatalogTestSuite) TestFindVersionNoMetadataDir() {
 	_, err := s.cat.findVersion([]string{"ns", "tbl"})
 	s.Require().Error(err)
@@ -481,8 +748,8 @@ func (s *HadoopCatalogTestSuite) TestFindVersionIgnoresTempFiles() {
 }
 
 func (s *HadoopCatalogTestSuite) TestFindVersionGzipOnlyWithHint() {
-	// Table has only gzip metadata. Hint validation and scanForward
-	// should recognize gzip-compressed metadata files.
+	// Table has only gzip metadata. Discovery should recognize
+	// gzip-compressed metadata files.
 	ident := []string{"ns", "tbl"}
 	dir := s.cat.metadataDir(ident)
 	s.Require().NoError(os.MkdirAll(dir, 0o755))
@@ -492,13 +759,12 @@ func (s *HadoopCatalogTestSuite) TestFindVersionGzipOnlyWithHint() {
 
 	ver, err := s.cat.findVersion(ident)
 	s.Require().NoError(err)
-	// Hint=1 validated via gzip path, scanForward finds v2.gz → returns 2
 	s.Equal(2, ver)
 }
 
 func (s *HadoopCatalogTestSuite) TestFindVersionMixedGzipAndPlain() {
-	// v1 and v2 are plain, v3 is gzip-compressed. scanForward must
-	// check both formats to avoid returning a stale version.
+	// v1 and v2 are plain, v3 is gzip-compressed. Discovery should choose
+	// the latest recognized metadata file across both formats.
 	ident := []string{"ns", "tbl"}
 	dir := s.cat.metadataDir(ident)
 	s.Require().NoError(os.MkdirAll(dir, 0o755))
@@ -873,13 +1139,13 @@ func (s *HadoopCatalogTestSuite) TestListTablesRejectsInvalidIdentifiers() {
 
 // isTableDir interop tests
 
-func (s *HadoopCatalogTestSuite) TestIsTableDirTrueVersionHintText() {
+func (s *HadoopCatalogTestSuite) TestIsTableDirFalseVersionHintOnly() {
 	tableDir := filepath.Join(s.warehouse, "ns", "tbl")
 	metaDir := filepath.Join(tableDir, "metadata")
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "version-hint.text"), []byte("1"), 0o644))
 
-	s.True(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.False(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataGzip() {
@@ -888,7 +1154,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirTrueUUIDMetadataGzip() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.gz.metadata.json"), nil, 0o644))
 
-	s.True(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.True(s.requireIsTableDir(tableDir))
 }
 
 func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
@@ -897,7 +1163,7 @@ func (s *HadoopCatalogTestSuite) TestIsTableDirFalseNonMatchingFiles() {
 	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
 	s.Require().NoError(os.WriteFile(filepath.Join(metaDir, "random.json"), nil, 0o644))
 
-	s.False(isTableDir(s.cat.filesystem, s.cat.isLocal, tableDir))
+	s.False(s.requireIsTableDir(tableDir))
 }
 
 // Helper to create a fake table directory with a metadata file.
@@ -980,6 +1246,32 @@ func (s *HadoopCatalogTestSuite) TestListTablesMixedContent() {
 
 	s.Len(tables, 1)
 	s.Equal(table.Identifier{"ns", "tbl1"}, tables[0])
+}
+
+func (s *HadoopCatalogTestSuite) TestListTablesSkipsUnreadableMetadataDir() {
+	ctx := context.Background()
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	s.createFakeTable([]string{"ns", "visible"})
+	s.createFakeTable([]string{"ns", "hidden"})
+
+	originalFS := s.cat.filesystem
+	s.cat.filesystem = selectiveFailingWalkFS{
+		HadoopCatalogFS: originalFS,
+		failPath:        s.cat.metadataDir([]string{"ns", "hidden"}),
+		err:             fs.ErrPermission,
+	}
+	defer func() {
+		s.cat.filesystem = originalFS
+	}()
+
+	var tables []table.Identifier
+	for ident, err := range s.cat.ListTables(ctx, []string{"ns"}) {
+		s.Require().NoError(err)
+		tables = append(tables, ident)
+	}
+
+	s.Equal([]table.Identifier{{"ns", "visible"}}, tables)
 }
 
 func (s *HadoopCatalogTestSuite) TestListTablesNestedNamespace() {
@@ -1425,6 +1717,21 @@ func (s *HadoopCatalogTestSuite) TestLoadTableNotExists() {
 	s.ErrorIs(err, catalog.ErrNoSuchTable)
 }
 
+func (s *HadoopCatalogTestSuite) TestLoadTablePropagatesMetadataReadError() {
+	ctx := context.Background()
+	walkErr := errors.New("metadata walk failed")
+	originalFS := s.cat.filesystem
+	s.cat.filesystem = failingWalkFS{HadoopCatalogFS: originalFS, err: walkErr}
+	defer func() {
+		s.cat.filesystem = originalFS
+	}()
+
+	_, err := s.cat.LoadTable(ctx, []string{"ns", "tbl"})
+	s.Require().Error(err)
+	s.ErrorIs(err, walkErr)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
+}
+
 func (s *HadoopCatalogTestSuite) TestLoadTableStaleHint() {
 	ctx := context.Background()
 	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
@@ -1441,6 +1748,86 @@ func (s *HadoopCatalogTestSuite) TestLoadTableStaleHint() {
 	tbl, err := s.cat.LoadTable(ctx, ident)
 	s.Require().NoError(err)
 	s.NotNil(tbl)
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadTableGzipMetadata() {
+	ctx := context.Background()
+	ident := []string{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	created, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+	gzPath := s.replaceMetadataWithGzip(ident, 1)
+
+	loaded, err := s.cat.LoadTable(ctx, ident)
+	s.Require().NoError(err)
+	s.Equal(created.Metadata().TableUUID(), loaded.Metadata().TableUUID())
+	s.Equal(gzPath, loaded.MetadataLocation())
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.True(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadTableUUIDMetadata() {
+	ctx := context.Background()
+	ident := []string{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	created, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+	uuidPath := s.replaceMetadataWithUUIDName(ident, 1)
+
+	loaded, err := s.cat.LoadTable(ctx, ident)
+	s.Require().NoError(err)
+	s.Equal(created.Metadata().TableUUID(), loaded.Metadata().TableUUID())
+	s.Equal(uuidPath, loaded.MetadataLocation())
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.True(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestLoadTableUUIDMetadataVersionZero() {
+	ctx := context.Background()
+	ident := []string{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	created, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+	uuidPath := s.replaceMetadataWithUUIDSequence(ident, 1, 0)
+
+	loaded, err := s.cat.LoadTable(ctx, ident)
+	s.Require().NoError(err)
+	s.Equal(created.Metadata().TableUUID(), loaded.Metadata().TableUUID())
+	s.Equal(uuidPath, loaded.MetadataLocation())
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.True(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestVersionHintWithoutMetadataIsNotLoadableTable() {
+	ctx := context.Background()
+	ident := []string{"ns", "tbl"}
+	metaDir := s.cat.metadataDir(ident)
+	s.Require().NoError(os.MkdirAll(metaDir, 0o755))
+	s.cat.writeVersionHint(ident, 1)
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.False(exists)
+
+	var listed []table.Identifier
+	for tblIdent, err := range s.cat.ListTables(ctx, []string{"ns"}) {
+		s.Require().NoError(err)
+		listed = append(listed, tblIdent)
+	}
+	s.Empty(listed)
+
+	_, err = s.cat.LoadTable(ctx, ident)
+	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrNoSuchTable)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadTableShortIdentifier() {
@@ -1470,6 +1857,21 @@ func (s *HadoopCatalogTestSuite) TestCheckTableExistsFalse() {
 	exists, err := s.cat.CheckTableExists(context.Background(), []string{"ns", "tbl"})
 	s.Require().NoError(err)
 	s.False(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestCheckTableExistsPropagatesMetadataReadError() {
+	walkErr := errors.New("metadata walk failed")
+	originalFS := s.cat.filesystem
+	s.cat.filesystem = failingWalkFS{HadoopCatalogFS: originalFS, err: walkErr}
+	defer func() {
+		s.cat.filesystem = originalFS
+	}()
+
+	exists, err := s.cat.CheckTableExists(context.Background(), []string{"ns", "tbl"})
+	s.False(exists)
+	s.Require().Error(err)
+	s.ErrorIs(err, walkErr)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 }
 
 func (s *HadoopCatalogTestSuite) TestCheckTableExistsShortIdentifier() {
@@ -1693,6 +2095,62 @@ func (s *HadoopCatalogTestSuite) TestCommitTableConcurrentMetadataPublishConflic
 	s.Equal(1, conflicts)
 	s.FileExists(s.cat.metadataFilePath(ident, 2))
 	s.Equal(2, s.cat.readVersionHint(ident))
+}
+
+func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetectionRecognizesConcurrentNextVersionMetadata() {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		table    string
+		filename string
+	}{
+		{
+			name:     "uuid metadata",
+			table:    "uuid_conflict",
+			filename: "00002-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json",
+		},
+		{
+			name:     "gzip metadata",
+			table:    "gzip_conflict",
+			filename: "v2.gz.metadata.json",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.createTestTable("ns", tt.table)
+			ident := []string{"ns", tt.table}
+			metaDir := s.cat.metadataDir(ident)
+			conflictPath := filepath.Join(metaDir, tt.filename)
+
+			originalFS := s.cat.filesystem
+			s.cat.filesystem = &stagedWalkDirFS{
+				HadoopCatalogFS: originalFS,
+				targetPath:      metaDir,
+				stage: func() error {
+					return os.WriteFile(conflictPath, nil, 0o644)
+				},
+			}
+			defer func() {
+				s.cat.filesystem = originalFS
+			}()
+
+			_, _, err := s.cat.CommitTable(
+				ctx, ident,
+				nil,
+				[]table.Update{
+					table.NewSetPropertiesUpdate(iceberg.Properties{
+						"writer": tt.name,
+					}),
+				},
+			)
+			s.Require().Error(err)
+			s.Contains(err.Error(), "version 2 already exists")
+			s.FileExists(conflictPath)
+			s.NoFileExists(s.cat.metadataFilePath(ident, 2))
+		})
+	}
 }
 
 func (s *HadoopCatalogTestSuite) TestCommitTableRequirementFailure() {


### PR DESCRIPTION
Summary

Make the Hadoop catalog load the actual metadata file it discovers instead of reconstructing vN.metadata.json after finding a version. This keeps gzip metadata and UUID-style metadata names consistent across LoadTable, CheckTableExists, and ListTables.

This also stops a lone version-hint.text from making a directory look like a table when there is no loadable metadata file.

Follow-up changes from review:

- propagate metadata directory read errors instead of flattening them into ErrNoSuchTable
- keep CheckTableExists on the fast metadata-file existence path
- reuse the metadata version found by LoadTable during CommitTable
- reject UUID metadata sequence 00000 and use 00001 in the UUID fixture
- pin metadata tie-break ordering with focused tests

Testing

- go test ./catalog/hadoop -run 'TestMetadataFileBetterThan|TestHadoopCatalogTestSuite/(TestLoadTablePropagatesMetadataReadError|TestCheckTableExistsPropagatesMetadataReadError|TestLoadTableGzipMetadata|TestLoadTableUUIDMetadata|TestVersionHintWithoutMetadataIsNotLoadableTable|TestIsTableDirFalseVersionHintOnly|TestFindVersionGzipOnlyWithHint|TestFindVersionMixedGzipAndPlain|TestMetadataFileFromNameRejectsZeroUUIDVersion)' -count=1
- go test ./catalog/hadoop -count=1
- go test ./catalog/... -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/hadoop/...
- git diff --check