### PR TITLE
fix: drop redundant hadoop namespace stat

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -670,21 +670,18 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 	path := c.namespaceToPath(ns)
 
-	info, err := c.filesystem.Stat(path)
-	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
-		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
-	}
-	if err != nil {
-		return fmt.Errorf("hadoop catalog: failed to stat namespace directory: %w", err)
-	}
-
+	// Walk the namespace directory directly so existence and type checks use the
+	// same filesystem view. The root entry preserves file-at-namespace handling.
+	rootNotDir := false
 	foundEntries := false
-	err = c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		if p == path {
+			rootNotDir = !d.IsDir()
+
 			return nil
 		}
 
@@ -698,6 +695,10 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 		}
 
 		return fmt.Errorf("hadoop catalog: failed to read namespace directory: %w", err)
+	}
+
+	if rootNotDir {
+		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
 	}
 
 	if foundEntries {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -19,13 +19,16 @@ package hadoop
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
@@ -450,6 +453,36 @@ func (s *HadoopCatalogTestSuite) TestDropNamespace() {
 
 	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
 	s.Require().NoError(err)
+
+	_, err = os.Stat(nsDir)
+	s.True(os.IsNotExist(err))
+}
+
+// statFailingFS guards against reintroducing a pre-walk Stat in DropNamespace
+// (see issue #1273). It embeds LocalFS so every other operation behaves
+// normally, but fails and counts any Stat call so the test can assert that
+// DropNamespace never stats the namespace before walking it.
+type statFailingFS struct {
+	icebergio.LocalFS
+	statCalls int
+}
+
+func (f *statFailingFS) Stat(string) (fs.FileInfo, error) {
+	f.statCalls++
+
+	return nil, errors.New("stat should not be called")
+}
+
+func (s *HadoopCatalogTestSuite) TestDropNamespaceDoesNotPreStat() {
+	nsDir := filepath.Join(s.warehouse, "ns")
+	s.Require().NoError(os.Mkdir(nsDir, 0o755))
+
+	fsys := &statFailingFS{}
+	s.cat.filesystem = fsys
+
+	err := s.cat.DropNamespace(context.Background(), []string{"ns"})
+	s.Require().NoError(err)
+	s.Zero(fsys.statCalls)
 
 	_, err = os.Stat(nsDir)
 	s.True(os.IsNotExist(err))


### PR DESCRIPTION
Fixes #1273.

## Summary

Drops the redundant pre-`Stat` call from Hadoop catalog `DropNamespace` and relies on `WalkDir` to surface missing namespace paths. The root `WalkDir` entry still preserves the existing behavior for a file at the namespace path by returning `ErrNoSuchNamespace`.

## Testing

- `go test ./catalog/hadoop`
- `go test ./...`
- `git diff --check`