### PR TITLE
fix(catalog): avoid redundant hadoop namespace stat

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -670,21 +670,17 @@ func (c *Catalog) DropNamespace(_ context.Context, ns table.Identifier) error {
 
 	path := c.namespaceToPath(ns)
 
-	info, err := c.filesystem.Stat(path)
-	if errors.Is(err, fs.ErrNotExist) || (err == nil && !info.IsDir()) {
-		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(ns, "."))
-	}
-	if err != nil {
-		return fmt.Errorf("hadoop catalog: failed to stat namespace directory: %w", err)
-	}
-
 	foundEntries := false
-	err = c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+	err := c.filesystem.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		if p == path {
+			if !d.IsDir() {
+				return fs.ErrNotExist
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
Remove the standalone `Stat` call before `WalkDir` in the Hadoop catalog's `DropNamespace` path.

`WalkDir` already reports a missing root path, so the separate pre-check widens a check-to-use race window where another caller can delete or recreate the namespace between the two filesystem calls.

## Changes
- Rely on `WalkDir` for missing namespace detection
- Preserve existing behavior for a namespace path that is a file, not a directory, by checking the root `WalkDir` entry and returning `ErrNoSuchNamespace`
- Keep existing `WalkDir` error handling for missing namespaces and non-empty namespaces

## Verification
- `go test -v ./catalog/hadoop` — pass
- `golangci-lint run --timeout=10m ./catalog/hadoop/...` — 0 issues
- `git diff --check` — clean

Fixes #1273