### PR TITLE
feat(compaction): force compaction on file-scoped delete dead space

### DIFF
--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -19,9 +19,10 @@
 package compaction
 
 import (
+	"bytes"
 	"fmt"
 
-	iceberg "github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
 )
@@ -53,10 +54,11 @@ type Config struct {
 	DeleteFileThreshold int
 
 	// DeleteRatioThreshold forces a data file into compaction when the fraction
-	// of its rows shadowed by a deletion vector reaches this value, regardless
-	// of file size. Deletion vectors are 1:1 with their data file and carry an
+	// of its rows shadowed by file-scoped deletes (deletion vectors and
+	// path-scoped positional deletes) reaches this value, regardless of file
+	// size. File-scoped deletes apply to exactly one data file and carry an
 	// exact deleted-row count, so size-based selection alone never reclaims a
-	// right-sized file's DV dead space; this rule does. Range [0,1]; 0 disables
+	// right-sized file's dead space; this rule does. Range [0,1]; 0 disables
 	// it. Default: DefaultDeleteRatioThreshold.
 	DeleteRatioThreshold float64
 
@@ -96,8 +98,9 @@ const (
 	DefaultPackingLookback uint = 128
 
 	// DefaultDeleteRatioThreshold mirrors Java's delete-ratio default: a file
-	// whose deletion vector shadows at least 30% of its rows is rewritten.
-	DefaultDeleteRatioThreshold = 0.3
+	// whose file-scoped deletes (deletion vectors and path-scoped positional
+	// deletes) shadow at least 30% of its rows is rewritten.
+	DefaultDeleteRatioThreshold float64 = 0.3
 )
 
 // DefaultConfig returns a Config with production defaults.
@@ -138,7 +141,7 @@ func (cfg Config) Validate() error {
 		return fmt.Errorf("delete file threshold must be >= 1, got %d", cfg.DeleteFileThreshold)
 	}
 	if cfg.DeleteRatioThreshold < 0 || cfg.DeleteRatioThreshold > 1 {
-		return fmt.Errorf("delete ratio threshold must be in [0,1], got %v", cfg.DeleteRatioThreshold)
+		return fmt.Errorf("delete ratio threshold must be in [0,1], got %g", cfg.DeleteRatioThreshold)
 	}
 
 	return nil
@@ -276,6 +279,13 @@ func (cfg Config) PlanCompaction(tasks []table.FileScanTask) (Plan, error) {
 // isCandidate returns true if a file should be considered for compaction.
 func (cfg Config) isCandidate(t table.FileScanTask) bool {
 	size := t.File.FileSizeBytes()
+
+	// Deletion vectors are counted here alongside positional and equality
+	// delete files, matching Java's unified task.deletes() count. A data file
+	// has at most one DV, so at the minimum DeleteFileThreshold of 1 a single
+	// DV trips this rule before the ratio rule below runs; at the default of 5
+	// it does not. The ratio rule still owns right-sized DV-backed files at any
+	// threshold above 1.
 	deleteCount := len(t.DeleteFiles) + len(t.EqualityDeleteFiles) + len(t.DeletionVectorFiles)
 
 	// Too many delete files — always compact regardless of size.
@@ -286,16 +296,13 @@ func (cfg Config) isCandidate(t table.FileScanTask) bool {
 	// Enough rows shadowed by file-scoped deletes — compact to reclaim the dead
 	// space. Mirrors Java BinPackRewriteFilePlanner.tooHighDeleteRatio: sum the
 	// record counts of file-scoped deletes (deletion vectors and path-scoped
-	// positional deletes — those carrying a referenced data file), cap at the
-	// data file's record count, and compare the ratio. Equality deletes and
-	// partition-scoped positional deletes are not file-scoped (their counts
-	// cannot be attributed to one data file) and are left to the count rule.
+	// positional deletes — see isFileScoped), cap at the data file's record
+	// count, and compare the ratio. Equality deletes and partition-scoped
+	// positional deletes are not file-scoped (their counts cannot be attributed
+	// to one data file) and are left to the count rule.
 	if cfg.DeleteRatioThreshold > 0 {
 		if records := t.File.Count(); records > 0 {
-			deleted := fileScopedDeletedRows(t)
-			if deleted > records {
-				deleted = records
-			}
+			deleted := min(fileScopedDeletedRows(t), records)
 			if float64(deleted)/float64(records) >= cfg.DeleteRatioThreshold {
 				return true
 			}
@@ -337,9 +344,29 @@ func fileScopedDeletedRows(t table.FileScanTask) int64 {
 }
 
 // isFileScoped reports whether a delete file applies to exactly one data file.
-// Mirrors Java ContentFileUtil.isFileScoped: deletion vectors and path-scoped
-// positional deletes carry a referenced data file; partition-scoped positional
-// deletes and equality deletes do not.
+// Mirrors Java ContentFileUtil.isFileScoped/referencedDataFile: a deletion
+// vector or path-scoped positional delete carries a referenced data file
+// either explicitly or, when referenced_data_file is absent (it is optional in
+// V2 and our own scan planning never sets it — see matchDeletesToData), through
+// equal file_path lower/upper bounds. Equality deletes and partition-scoped
+// positional deletes are not file-scoped.
 func isFileScoped(d iceberg.DataFile) bool {
-	return d.ReferencedDataFile() != nil
+	if d.ContentType() == iceberg.EntryContentEqDeletes {
+		return false
+	}
+	if d.ReferencedDataFile() != nil {
+		return true
+	}
+	lower := d.LowerBoundValues()[filePathFieldID]
+	upper := d.UpperBoundValues()[filePathFieldID]
+
+	return len(lower) > 0 && bytes.Equal(lower, upper)
 }
+
+// filePathFieldID is the reserved field ID of the file_path column in a
+// positional delete file, sourced from the canonical delete schema.
+var filePathFieldID = func() int {
+	f, _ := iceberg.PositionalDeleteSchema.FindFieldByName("file_path")
+
+	return f.ID
+}()

--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -21,6 +21,7 @@ package compaction
 import (
 	"fmt"
 
+	iceberg "github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
 )
@@ -50,6 +51,14 @@ type Config struct {
 	// a data file to force it into compaction regardless of file size.
 	// Default: 5.
 	DeleteFileThreshold int
+
+	// DeleteRatioThreshold forces a data file into compaction when the fraction
+	// of its rows shadowed by a deletion vector reaches this value, regardless
+	// of file size. Deletion vectors are 1:1 with their data file and carry an
+	// exact deleted-row count, so size-based selection alone never reclaims a
+	// right-sized file's DV dead space; this rule does. Range [0,1]; 0 disables
+	// it. Default: DefaultDeleteRatioThreshold.
+	DeleteRatioThreshold float64
 
 	// PackingLookback controls how many open bins the packer considers
 	// before evicting. Higher values produce better packing at the cost
@@ -85,6 +94,10 @@ const (
 
 	// DefaultPackingLookback is the default packing lookback.
 	DefaultPackingLookback uint = 128
+
+	// DefaultDeleteRatioThreshold mirrors Java's delete-ratio default: a file
+	// whose deletion vector shadows at least 30% of its rows is rewritten.
+	DefaultDeleteRatioThreshold = 0.3
 )
 
 // DefaultConfig returns a Config with production defaults.
@@ -92,12 +105,13 @@ func DefaultConfig() Config {
 	target := int64(table.WriteTargetFileSizeBytesDefault)
 
 	return Config{
-		TargetFileSizeBytes: target,
-		MinFileSizeBytes:    target * 3 / 4, // 75%
-		MaxFileSizeBytes:    target * 9 / 5, // 180%
-		MinInputFiles:       DefaultMinInputFiles,
-		DeleteFileThreshold: 5,
-		PackingLookback:     DefaultPackingLookback,
+		TargetFileSizeBytes:  target,
+		MinFileSizeBytes:     target * 3 / 4, // 75%
+		MaxFileSizeBytes:     target * 9 / 5, // 180%
+		MinInputFiles:        DefaultMinInputFiles,
+		DeleteFileThreshold:  5,
+		DeleteRatioThreshold: DefaultDeleteRatioThreshold,
+		PackingLookback:      DefaultPackingLookback,
 	}
 }
 
@@ -122,6 +136,9 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.DeleteFileThreshold < 1 {
 		return fmt.Errorf("delete file threshold must be >= 1, got %d", cfg.DeleteFileThreshold)
+	}
+	if cfg.DeleteRatioThreshold < 0 || cfg.DeleteRatioThreshold > 1 {
+		return fmt.Errorf("delete ratio threshold must be in [0,1], got %v", cfg.DeleteRatioThreshold)
 	}
 
 	return nil
@@ -242,7 +259,7 @@ func (cfg Config) PlanCompaction(tasks []table.FileScanTask) (Plan, error) {
 			}
 			for _, t := range bin {
 				group.TotalSizeBytes += t.File.FileSizeBytes()
-				group.DeleteFileCount += len(t.DeleteFiles) + len(t.EqualityDeleteFiles)
+				group.DeleteFileCount += len(t.DeleteFiles) + len(t.EqualityDeleteFiles) + len(t.DeletionVectorFiles)
 			}
 
 			estFiles := max(1, int((group.TotalSizeBytes+cfg.TargetFileSizeBytes-1)/cfg.TargetFileSizeBytes))
@@ -259,11 +276,30 @@ func (cfg Config) PlanCompaction(tasks []table.FileScanTask) (Plan, error) {
 // isCandidate returns true if a file should be considered for compaction.
 func (cfg Config) isCandidate(t table.FileScanTask) bool {
 	size := t.File.FileSizeBytes()
-	deleteCount := len(t.DeleteFiles) + len(t.EqualityDeleteFiles)
+	deleteCount := len(t.DeleteFiles) + len(t.EqualityDeleteFiles) + len(t.DeletionVectorFiles)
 
-	// Too many deletes — always compact regardless of size.
+	// Too many delete files — always compact regardless of size.
 	if deleteCount >= cfg.DeleteFileThreshold {
 		return true
+	}
+
+	// Enough rows shadowed by file-scoped deletes — compact to reclaim the dead
+	// space. Mirrors Java BinPackRewriteFilePlanner.tooHighDeleteRatio: sum the
+	// record counts of file-scoped deletes (deletion vectors and path-scoped
+	// positional deletes — those carrying a referenced data file), cap at the
+	// data file's record count, and compare the ratio. Equality deletes and
+	// partition-scoped positional deletes are not file-scoped (their counts
+	// cannot be attributed to one data file) and are left to the count rule.
+	if cfg.DeleteRatioThreshold > 0 {
+		if records := t.File.Count(); records > 0 {
+			deleted := fileScopedDeletedRows(t)
+			if deleted > records {
+				deleted = records
+			}
+			if float64(deleted)/float64(records) >= cfg.DeleteRatioThreshold {
+				return true
+			}
+		}
 	}
 
 	// Oversized with few deletes — skip.
@@ -278,4 +314,32 @@ func (cfg Config) isCandidate(t table.FileScanTask) bool {
 
 	// Undersized — candidate.
 	return true
+}
+
+// fileScopedDeletedRows sums the record counts of the task's file-scoped
+// deletes — deletion vectors and path-scoped positional deletes. These apply
+// to exactly one data file, so their counts are attributable to it. The sum is
+// not capped here; callers cap at the data file's record count.
+func fileScopedDeletedRows(t table.FileScanTask) int64 {
+	var deleted int64
+	for _, d := range t.DeletionVectorFiles {
+		if isFileScoped(d) {
+			deleted += d.Count()
+		}
+	}
+	for _, d := range t.DeleteFiles {
+		if isFileScoped(d) {
+			deleted += d.Count()
+		}
+	}
+
+	return deleted
+}
+
+// isFileScoped reports whether a delete file applies to exactly one data file.
+// Mirrors Java ContentFileUtil.isFileScoped: deletion vectors and path-scoped
+// positional deletes carry a referenced data file; partition-scoped positional
+// deletes and equality deletes do not.
+func isFileScoped(d iceberg.DataFile) bool {
+	return d.ReferencedDataFile() != nil
 }

--- a/table/compaction/compaction_test.go
+++ b/table/compaction/compaction_test.go
@@ -31,18 +31,20 @@ import (
 
 // testDataFile implements iceberg.DataFile for testing.
 type testDataFile struct {
-	path      string
-	size      int64
-	partition map[int]any
-	specID    int32
-	content   iceberg.ManifestEntryContent
+	path       string
+	size       int64
+	records    int64
+	partition  map[int]any
+	specID     int32
+	content    iceberg.ManifestEntryContent
+	referenced *string
 }
 
 func (f *testDataFile) ContentType() iceberg.ManifestEntryContent { return f.content }
 func (f *testDataFile) FilePath() string                          { return f.path }
 func (f *testDataFile) FileFormat() iceberg.FileFormat            { return iceberg.ParquetFile }
 func (f *testDataFile) Partition() map[int]any                    { return f.partition }
-func (f *testDataFile) Count() int64                              { return 100 }
+func (f *testDataFile) Count() int64                              { return f.records }
 func (f *testDataFile) FileSizeBytes() int64                      { return f.size }
 func (f *testDataFile) ColumnSizes() map[int]int64                { return nil }
 func (f *testDataFile) ValueCounts() map[int]int64                { return nil }
@@ -59,12 +61,13 @@ func (f *testDataFile) SpecID() int32                             { return f.spe
 func (f *testDataFile) FirstRowID() *int64                        { return nil }
 func (f *testDataFile) ContentOffset() *int64                     { return nil }
 func (f *testDataFile) ContentSizeInBytes() *int64                { return nil }
-func (f *testDataFile) ReferencedDataFile() *string               { return nil }
+func (f *testDataFile) ReferencedDataFile() *string               { return f.referenced }
 
 func newDataFile(path string, sizeMB int64) *testDataFile {
 	return &testDataFile{
 		path:    path,
 		size:    sizeMB * 1024 * 1024,
+		records: 100,
 		content: iceberg.EntryContentData,
 	}
 }
@@ -73,6 +76,7 @@ func newPartitionedDataFile(path string, sizeMB int64, partition map[int]any) *t
 	return &testDataFile{
 		path:      path,
 		size:      sizeMB * 1024 * 1024,
+		records:   100,
 		partition: partition,
 		content:   iceberg.EntryContentData,
 	}
@@ -83,6 +87,43 @@ func newDeleteFile(path string) *testDataFile {
 		path:    path,
 		size:    1024,
 		content: iceberg.EntryContentPosDeletes,
+	}
+}
+
+// newScopedDeleteFile builds a file-scoped positional delete / deletion vector:
+// content is position-deletes, record count is the number of shadowed rows, and
+// it carries a referenced data file (what makes it file-scoped).
+func newScopedDeleteFile(path, referenced string, deletedRows int64) *testDataFile {
+	ref := referenced
+
+	return &testDataFile{
+		path:       path,
+		size:       1024,
+		records:    deletedRows,
+		content:    iceberg.EntryContentPosDeletes,
+		referenced: &ref,
+	}
+}
+
+// makeTaskWithDV builds a scan task for a data file shadowed by a single
+// deletion vector deleting dvDeletedRows of its rows.
+func makeTaskWithDV(file *testDataFile, dvDeletedRows int64) table.FileScanTask {
+	return table.FileScanTask{
+		File:                file,
+		Start:               0,
+		Length:              file.size,
+		DeletionVectorFiles: []iceberg.DataFile{newScopedDeleteFile(file.path+".dv", file.path, dvDeletedRows)},
+	}
+}
+
+// makeTaskWithScopedPosDelete builds a scan task whose data file is shadowed by
+// a single path-scoped positional delete file (not a DV) deleting deletedRows.
+func makeTaskWithScopedPosDelete(file *testDataFile, deletedRows int64) table.FileScanTask {
+	return table.FileScanTask{
+		File:        file,
+		Start:       0,
+		Length:      file.size,
+		DeleteFiles: []iceberg.DataFile{newScopedDeleteFile(file.path+".pos", file.path, deletedRows)},
 	}
 }
 
@@ -113,6 +154,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, cfg.TargetFileSizeBytes*9/5, cfg.MaxFileSizeBytes)
 	assert.Equal(t, compaction.DefaultMinInputFiles, cfg.MinInputFiles)
 	assert.Equal(t, 5, cfg.DeleteFileThreshold)
+	assert.Equal(t, compaction.DefaultDeleteRatioThreshold, cfg.DeleteRatioThreshold)
 	assert.NoError(t, cfg.Validate())
 }
 
@@ -146,6 +188,11 @@ func TestConfig_Validate(t *testing.T) {
 			name: "zero delete threshold",
 			cfg:  compaction.Config{TargetFileSizeBytes: 100, MinFileSizeBytes: 10, MaxFileSizeBytes: 200, MinInputFiles: 1, DeleteFileThreshold: 0},
 			err:  "delete file threshold must be >= 1",
+		},
+		{
+			name: "delete ratio above 1",
+			cfg:  compaction.Config{TargetFileSizeBytes: 100, MinFileSizeBytes: 10, MaxFileSizeBytes: 200, MinInputFiles: 1, DeleteFileThreshold: 1, DeleteRatioThreshold: 1.5},
+			err:  "delete ratio threshold must be in [0,1]",
 		},
 		{
 			name: "valid",
@@ -259,6 +306,109 @@ func TestPlanCompaction_DeleteFilesForcesCompaction(t *testing.T) {
 	}
 	assert.Equal(t, 5, totalInGroups)
 	assert.Equal(t, 25, totalDeletes)
+}
+
+// dvRatioConfig sizes files (500 MB) well under target (2600 MB) so candidates
+// co-pack into one bin, while keeping each file right-sized (>= 384 MB min) so
+// size-based selection alone would skip it — isolating the deletion-vector
+// ratio as the only thing that can force compaction.
+func dvRatioConfig() compaction.Config {
+	return compaction.Config{
+		TargetFileSizeBytes:  2600 * 1024 * 1024,
+		MinFileSizeBytes:     384 * 1024 * 1024,
+		MaxFileSizeBytes:     3000 * 1024 * 1024,
+		MinInputFiles:        2,
+		DeleteFileThreshold:  5,
+		DeleteRatioThreshold: 0.3,
+		PackingLookback:      compaction.DefaultPackingLookback,
+	}
+}
+
+func TestPlanCompaction_DeletionVectorRatioForcesCompaction(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	// Right-sized files that size-based selection would skip — but each carries
+	// a deletion vector shadowing 40 of 100 rows (40% >= 30%), so the ratio rule
+	// forces them into compaction.
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+		tasks = append(tasks, makeTaskWithDV(f, 40))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, plan.SkippedFiles, "DV-heavy right-sized files must not be skipped")
+	totalInGroups := 0
+	totalDeletes := 0
+	for _, g := range plan.Groups {
+		totalInGroups += len(g.Tasks)
+		totalDeletes += g.DeleteFileCount
+	}
+	assert.Equal(t, 5, totalInGroups)
+	assert.Equal(t, 5, totalDeletes, "each task contributes its one deletion vector to the delete-file count")
+}
+
+func TestPlanCompaction_DeletionVectorBelowRatioSkipped(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	// Same right-sized files, but each deletion vector shadows only 10 of 100
+	// rows (10% < 30%): below the ratio, so they stay optimal and are skipped.
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+		tasks = append(tasks, makeTaskWithDV(f, 10))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, plan.SkippedFiles)
+	assert.Empty(t, plan.Groups, "DVs below the ratio must not trigger a rewrite")
+}
+
+func TestPlanCompaction_ScopedPositionalDeleteRatioForcesCompaction(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	// Path-scoped positional deletes (not DVs) are also file-scoped, so they
+	// count toward the ratio exactly like deletion vectors — mirroring Java.
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+		tasks = append(tasks, makeTaskWithScopedPosDelete(f, 40))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, plan.SkippedFiles)
+	totalInGroups := 0
+	for _, g := range plan.Groups {
+		totalInGroups += len(g.Tasks)
+	}
+	assert.Equal(t, 5, totalInGroups)
+}
+
+func TestPlanCompaction_UnscopedDeletesIgnoredByRatio(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	// Deletes without a referenced data file (equality deletes and
+	// partition-scoped positional deletes) are not file-scoped: their counts
+	// cannot be attributed to one data file, so the ratio ignores them. With
+	// one such delete per file (below DeleteFileThreshold) and right-sized
+	// files, nothing is rewritten.
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+		tasks = append(tasks, makeTask(f, 1, 0))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, plan.SkippedFiles)
+	assert.Empty(t, plan.Groups, "non-file-scoped deletes must not trigger the ratio rule")
 }
 
 func TestPlanCompaction_OversizedFilesSkipped(t *testing.T) {

--- a/table/compaction/compaction_test.go
+++ b/table/compaction/compaction_test.go
@@ -31,13 +31,15 @@ import (
 
 // testDataFile implements iceberg.DataFile for testing.
 type testDataFile struct {
-	path       string
-	size       int64
-	records    int64
-	partition  map[int]any
-	specID     int32
-	content    iceberg.ManifestEntryContent
-	referenced *string
+	path        string
+	size        int64
+	records     int64
+	partition   map[int]any
+	specID      int32
+	content     iceberg.ManifestEntryContent
+	referenced  *string
+	lowerBounds map[int][]byte
+	upperBounds map[int][]byte
 }
 
 func (f *testDataFile) ContentType() iceberg.ManifestEntryContent { return f.content }
@@ -51,8 +53,8 @@ func (f *testDataFile) ValueCounts() map[int]int64                { return nil }
 func (f *testDataFile) NullValueCounts() map[int]int64            { return nil }
 func (f *testDataFile) NaNValueCounts() map[int]int64             { return nil }
 func (f *testDataFile) DistinctValueCounts() map[int]int64        { return nil }
-func (f *testDataFile) LowerBoundValues() map[int][]byte          { return nil }
-func (f *testDataFile) UpperBoundValues() map[int][]byte          { return nil }
+func (f *testDataFile) LowerBoundValues() map[int][]byte          { return f.lowerBounds }
+func (f *testDataFile) UpperBoundValues() map[int][]byte          { return f.upperBounds }
 func (f *testDataFile) KeyMetadata() []byte                       { return nil }
 func (f *testDataFile) SplitOffsets() []int64                     { return nil }
 func (f *testDataFile) EqualityFieldIDs() []int                   { return nil }
@@ -127,6 +129,36 @@ func makeTaskWithScopedPosDelete(file *testDataFile, deletedRows int64) table.Fi
 	}
 }
 
+// newBoundsScopedDeleteFile builds a path-scoped positional delete that signals
+// file-scope only through equal file_path lower/upper bounds, with no
+// referenced_data_file — mirroring what scan planning (matchDeletesToData)
+// actually produces.
+func newBoundsScopedDeleteFile(path, referenced string, deletedRows int64) *testDataFile {
+	fp, _ := iceberg.PositionalDeleteSchema.FindFieldByName("file_path")
+	bound := []byte(referenced)
+
+	return &testDataFile{
+		path:        path,
+		size:        1024,
+		records:     deletedRows,
+		content:     iceberg.EntryContentPosDeletes,
+		lowerBounds: map[int][]byte{fp.ID: bound},
+		upperBounds: map[int][]byte{fp.ID: bound},
+	}
+}
+
+// makeTaskWithBoundsScopedPosDelete builds a scan task whose data file is
+// shadowed by a positional delete that is file-scoped only via its file_path
+// bounds (referenced_data_file absent).
+func makeTaskWithBoundsScopedPosDelete(file *testDataFile, deletedRows int64) table.FileScanTask {
+	return table.FileScanTask{
+		File:        file,
+		Start:       0,
+		Length:      file.size,
+		DeleteFiles: []iceberg.DataFile{newBoundsScopedDeleteFile(file.path+".pos", file.path, deletedRows)},
+	}
+}
+
 func makeTask(file *testDataFile, numPosDeletes, numEqDeletes int) table.FileScanTask {
 	task := table.FileScanTask{
 		File:   file,
@@ -192,6 +224,11 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "delete ratio above 1",
 			cfg:  compaction.Config{TargetFileSizeBytes: 100, MinFileSizeBytes: 10, MaxFileSizeBytes: 200, MinInputFiles: 1, DeleteFileThreshold: 1, DeleteRatioThreshold: 1.5},
+			err:  "delete ratio threshold must be in [0,1]",
+		},
+		{
+			name: "negative delete ratio",
+			cfg:  compaction.Config{TargetFileSizeBytes: 100, MinFileSizeBytes: 10, MaxFileSizeBytes: 200, MinInputFiles: 1, DeleteFileThreshold: 1, DeleteRatioThreshold: -0.1},
 			err:  "delete ratio threshold must be in [0,1]",
 		},
 		{
@@ -319,7 +356,7 @@ func dvRatioConfig() compaction.Config {
 		MaxFileSizeBytes:     3000 * 1024 * 1024,
 		MinInputFiles:        2,
 		DeleteFileThreshold:  5,
-		DeleteRatioThreshold: 0.3,
+		DeleteRatioThreshold: compaction.DefaultDeleteRatioThreshold,
 		PackingLookback:      compaction.DefaultPackingLookback,
 	}
 }
@@ -377,6 +414,62 @@ func TestPlanCompaction_ScopedPositionalDeleteRatioForcesCompaction(t *testing.T
 	for i := range 5 {
 		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
 		tasks = append(tasks, makeTaskWithScopedPosDelete(f, 40))
+	}
+
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, plan.SkippedFiles)
+	totalInGroups := 0
+	for _, g := range plan.Groups {
+		totalInGroups += len(g.Tasks)
+	}
+	assert.Equal(t, 5, totalInGroups)
+}
+
+func TestPlanCompaction_DeletionVectorAtRatioBoundary(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	t.Run("exactly at threshold forces compaction", func(t *testing.T) {
+		// 30 of 100 rows is the default 0.30 ratio exactly: the >= comparison
+		// must treat the boundary as triggering (guards > vs >=).
+		var tasks []table.FileScanTask
+		for i := range 5 {
+			f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+			tasks = append(tasks, makeTaskWithDV(f, 30))
+		}
+
+		plan, err := cfg.PlanCompaction(tasks)
+		require.NoError(t, err)
+		assert.Equal(t, 0, plan.SkippedFiles)
+		assert.NotEmpty(t, plan.Groups)
+	})
+
+	t.Run("just below threshold is skipped", func(t *testing.T) {
+		// 29 of 100 rows is 0.29 < 0.30: must not trigger.
+		var tasks []table.FileScanTask
+		for i := range 5 {
+			f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+			tasks = append(tasks, makeTaskWithDV(f, 29))
+		}
+
+		plan, err := cfg.PlanCompaction(tasks)
+		require.NoError(t, err)
+		assert.Equal(t, 5, plan.SkippedFiles)
+		assert.Empty(t, plan.Groups)
+	})
+}
+
+func TestPlanCompaction_BoundsScopedPositionalDeleteRatioForcesCompaction(t *testing.T) {
+	cfg := dvRatioConfig()
+
+	// Positional deletes that signal file-scope only through equal file_path
+	// bounds (no referenced_data_file) — what scan planning actually emits —
+	// must still count toward the ratio via the bounds fallback in isFileScoped.
+	var tasks []table.FileScanTask
+	for i := range 5 {
+		f := newDataFile(fmt.Sprintf("rs-%d.parquet", i), 500)
+		tasks = append(tasks, makeTaskWithBoundsScopedPosDelete(f, 40))
 	}
 
 	plan, err := cfg.PlanCompaction(tasks)


### PR DESCRIPTION
The candidate planner only counted positional and equality delete files toward delete pressure, so a right-sized data file accumulating file-scoped deletes (a deletion vector, or a path-scoped positional delete) was never rewritten — its dead rows persisted as read amplification indefinitely.

Add a DeleteRatioThreshold (default 0.3, mirroring Java's delete-ratio-threshold). A file is forced into compaction when its file-scoped deletes shadow at least that fraction of its rows. Following Java's BinPackRewriteFilePlanner.tooHighDeleteRatio, the deleted-row count sums the record counts of file-scoped deletes only — deletion vectors and path-scoped positional deletes (those carrying a referenced data file), identified by isFileScoped (= referenced data file present, matching ContentFileUtil.isFileScoped) — capped at the data file's record count. Equality deletes and partition-scoped positional deletes are not file-scoped and stay under the existing count rule, to which deletion vectors are now also added.

Unlike Java, a threshold of 0 disables the rule so a zero-valued Config stays valid; the default remains 0.3.