### PR TITLE
test: distinguish the managed-identity branch from the DefaultAzureCredential fallback

### DIFF
--- a/io/gocloud/azure_test.go
+++ b/io/gocloud/azure_test.go
@@ -88,6 +88,8 @@ func TestCreateAzureBucketManagedIdentityCredentialCalled(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ManagedIdentityCredential",
 		"Expected ManagedIdentityCredential error but got: %v", err)
+	assert.NotContains(t, err.Error(), "DefaultAzureCredential",
+		"managed-identity path should not fall back to DefaultAzureCredential: %v", err)
 }
 
 func TestCreateAzureBucketSharedKeyMissingAccountKey(t *testing.T) {


### PR DESCRIPTION
## What

Hardens `TestCreateAzureBucketManagedIdentityCredentialCalled` (`io/gocloud/azure_test.go`) so it actually distinguishes the managed-identity path from the `DefaultAzureCredential` fallback, as requested in #1277.

The existing assertion only checks that the error contains `"ManagedIdentityCredential"`. But `DefaultAzureCredential` includes `ManagedIdentityCredential` in its chain and aggregates each source's error, so a regression that fell back to `DefaultAzureCredential` would still satisfy that assertion and pass unnoticed.

This adds `assert.NotContains(err.Error(), "DefaultAzureCredential")`, which passes on the current managed-identity-only path and would fail if the code regressed to `DefaultAzureCredential`.

No production code changes; test-only.

Closes #1277
