### PR TITLE
fix(table): detect concurrently-removed data files in row-level deletes

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -266,11 +266,19 @@ func (c *conflictContext) forEachAddedEntry(content iceberg.ManifestContent, vis
 }
 
 // validateDataFilesExist verifies that every file path in
-// referencedPaths is still reachable from the current branch head.
+// referencedPaths is still a live data file on the current branch head.
 // This is the check a position-delete commit performs to prove the
 // files it references have not been removed by a concurrent commit
 // (at which point the pos-delete would apply to rewritten data and
 // produce incorrect results).
+//
+// A file counts as present only if the head carries a non-deleted entry
+// (ADDED or EXISTING) for it. A DELETED entry — left behind by a
+// concurrent compaction or overwrite that rewrote the file — does NOT
+// satisfy existence: the rows moved to a new file, so the pos-delete is
+// orphaned and the commit must be rejected. This mirrors Java's
+// MergingSnapshotProducer, which treats a concurrently-deleted entry for
+// a referenced path as a conflict.
 //
 // Returns ErrDataFilesMissing listing the first few missing paths.
 // The committer should treat this as unrecoverable for the current
@@ -294,12 +302,19 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 		return fmt.Errorf("%w: branch %q missing on current metadata", ErrCommitDiverged, ctx.branch)
 	}
 
-	for df, err := range head.dataFiles(ctx.fs, nil) {
+	for entry, err := range head.entries(ctx.fs, iceberg.ManifestContentData) {
 		if err != nil {
 			return fmt.Errorf("iterating data files for current head %d: %w", head.SnapshotID, err)
 		}
-		if _, ok := needed[df.FilePath()]; ok {
-			delete(needed, df.FilePath())
+		// A DELETED entry means the file was removed (e.g. rewritten by a
+		// concurrent compaction); it is no longer live data a pos-delete can
+		// apply to, so it does not satisfy existence.
+		if entry.Status() == iceberg.EntryStatusDELETED {
+			continue
+		}
+		path := entry.DataFile().FilePath()
+		if _, ok := needed[path]; ok {
+			delete(needed, path)
 			if len(needed) == 0 {
 				return nil
 			}

--- a/table/mor_delete_conflict_test.go
+++ b/table/mor_delete_conflict_test.go
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+// newV3MoRConflictTestTable builds a v3 table that deletes via merge-on-read
+// (so position deletes are written as Puffin deletion vectors that record their
+// referenced data file) and never retries commits, so a single conflict surfaces
+// terminally.
+func newV3MoRConflictTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, location,
+		iceberg.Properties{
+			table.PropertyFormatVersion:        "3",
+			table.WriteDeleteModeKey:           table.WriteModeMergeOnRead,
+			table.CommitNumRetriesKey:          "2",
+			table.CommitMinRetryWaitMsKey:      "1",
+			table.CommitMaxRetryWaitMsKey:      "2",
+			table.CommitTotalRetryTimeoutMsKey: "1000",
+		})
+	require.NoError(t, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+
+	return table.New(table.Identifier{"db", "mor_delete_conflict"}, meta, metaLoc, fsF, cat)
+}
+
+func appendTenRows(t *testing.T, tbl *table.Table) *table.Table {
+	t.Helper()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},` +
+			`{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"},` +
+			`{"id":9,"data":"i"},{"id":10,"data":"j"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(context.Background(), array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	return tbl
+}
+
+// TestMergeOnReadDeleteConflict_ReferencedDataFileRemoved proves a merge-on-read
+// DELETE is rejected when a concurrent commit removes the data file its freshly
+// written position deletes reference. Without the existence check wired into the
+// MoR delete path, the deletes would be silently orphaned against the
+// rewritten data.
+func TestMergeOnReadDeleteConflict_ReferencedDataFileRemoved(t *testing.T) {
+	ctx := context.Background()
+	tbl := appendTenRows(t, newV3MoRConflictTestTable(t))
+
+	// Capture the single data file before any deletes so the concurrent commit
+	// can rewrite it away.
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	dataFile := tasks[0].File
+
+	// Stage a partial delete (id==7) but do not commit it yet: this writes a
+	// deletion vector that references the single data file.
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(7)), nil))
+
+	// A concurrent compaction rewrites that data file away (its manifest entry
+	// becomes a DELETED tombstone), standing in for any commit that removes it.
+	rtx := tbl.NewTransaction()
+	require.NoError(t, rtx.NewRewrite(nil).DeleteFile(dataFile).Commit(ctx))
+	_, err = rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Committing the staged MoR delete must now detect the removed referenced
+	// data file rather than orphan its deletion vector.
+	_, err = txn.Commit(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, table.ErrDataFilesMissing)
+}
+
+// TestMergeOnReadDeleteConflict_NoConflictCommits is the control: a MoR delete
+// with no concurrent removal commits cleanly and deletes only the targeted row.
+func TestMergeOnReadDeleteConflict_NoConflictCommits(t *testing.T) {
+	ctx := context.Background()
+	tbl := appendTenRows(t, newV3MoRConflictTestTable(t))
+
+	tbl, err := tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(7)), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []int64{1, 2, 3, 4, 5, 6, 8, 9, 10}, idsInTable(t, tbl))
+}

--- a/table/mor_delete_validator_internal_test.go
+++ b/table/mor_delete_validator_internal_test.go
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+// buildV3TableWithRows builds a v3 table backed by a counting catalog and
+// appends a single data file containing rowsJSON.
+func buildV3TableWithRows(t *testing.T, rowsJSON string) *Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, location,
+		iceberg.Properties{PropertyFormatVersion: "3"})
+	require.NoError(t, err)
+
+	cat := &countingCatalog{metadata: meta}
+	tbl := New(Identifier{"db", "vdfe"}, meta, location+"/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{rowsJSON})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(context.Background(), array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	return tbl
+}
+
+// TestValidateDataFilesExist_TreatsConcurrentlyRemovedFileAsMissing pins the
+// status-aware existence check shared by the RowDelta and merge-on-read delete
+// conflict validators: a data file that a concurrent commit rewrote away leaves
+// a DELETED tombstone on the head, which must NOT satisfy existence (the rows
+// moved to a new file, orphaning any position delete that referenced it). Only
+// a live (ADDED/EXISTING) entry counts as present.
+func TestValidateDataFilesExist_TreatsConcurrentlyRemovedFileAsMissing(t *testing.T) {
+	ctx := context.Background()
+	tbl := buildV3TableWithRows(t, `[{"id":1,"data":"a"},{"id":2,"data":"b"}]`)
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	dataFile := tasks[0].File
+
+	fs := iceio.LocalFS{}
+
+	// Control: while the file is live on the head, it satisfies existence.
+	ccLive := &conflictContext{current: tbl.metadata, branch: MainBranch, fs: fs}
+	require.NoError(t, validateDataFilesExist(ccLive, []string{dataFile.FilePath()}))
+
+	// A compaction rewrites the file away, leaving a DELETED tombstone on the
+	// head's data manifests.
+	rtx := tbl.NewTransaction()
+	require.NoError(t, rtx.NewRewrite(nil).DeleteFile(dataFile).Commit(ctx))
+	tbl2, err := rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	// The tombstone must not be mistaken for a live file: existence fails.
+	ccRemoved := &conflictContext{current: tbl2.metadata, branch: MainBranch, fs: fs}
+	err = validateDataFilesExist(ccRemoved, []string{dataFile.FilePath()})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDataFilesMissing)
+}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1334,8 +1334,22 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 	}
 
 	if len(withPartialDeletions) > 0 {
-		if err := t.writePositionDeletesForFiles(ctx, fs, updater, withPartialDeletions, filter, caseSensitive, concurrency, commitUUID); err != nil {
+		referenced, err := t.writePositionDeletesForFiles(ctx, fs, updater, withPartialDeletions, filter, caseSensitive, concurrency, commitUUID)
+		if err != nil {
 			return nil, err
+		}
+
+		// Verify the data files these position deletes target still exist on
+		// the branch head at commit time. The overwriteFiles producer only
+		// validates partition-filter overlap; without this check a concurrent
+		// commit that removed a referenced data file would silently orphan the
+		// deletes (they would apply to rewritten data or dangle). Mirrors
+		// RowDelta.validate: collect referenced data-file paths and run
+		// validateDataFilesExist unconditionally (no isolation gating).
+		if len(referenced) > 0 {
+			t.addValidator(func(cc *conflictContext) error {
+				return validateDataFilesExist(cc, referenced)
+			})
 		}
 	}
 
@@ -1804,11 +1818,15 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 	return result, nil
 }
 
-// writePositionDeletesForFiles rewrites data files by preserving only rows that do NOT match the filter
-func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO, updater *snapshotProducer, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int, commitUUID uuid.UUID) error {
+// writePositionDeletesForFiles writes position-delete files for the rows in
+// files that match filter, appends them to updater, and returns the distinct
+// data-file paths those deletes reference. A position-delete that does not
+// record its referenced data file is omitted from the returned paths (it
+// cannot be existence-checked), matching RowDelta.validate and Java.
+func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO, updater *snapshotProducer, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int, commitUUID uuid.UUID) ([]string, error) {
 	posDeleteRecIter, err := t.makePositionDeleteRecordsForFilter(ctx, fs, files, filter, caseSensitive, concurrency)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	partitionContextByFilePath := make(map[string]partitionContext, len(files))
@@ -1823,14 +1841,22 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		fs:        fs.(io.WriteFileIO),
 	})
 
+	var referenced []string
+	seen := make(map[string]struct{})
 	for f, err := range posDeleteFiles {
 		if err != nil {
-			return err
+			return nil, err
 		}
 		updater.appendDeleteFile(f)
+		if ref := f.ReferencedDataFile(); ref != nil && *ref != "" {
+			if _, ok := seen[*ref]; !ok {
+				seen[*ref] = struct{}{}
+				referenced = append(referenced, *ref)
+			}
+		}
 	}
 
-	return nil
+	return referenced, nil
 }
 
 func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs io.IO, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (seq2 iter.Seq2[arrow.RecordBatch, error], err error) {


### PR DESCRIPTION
Two related fixes for optimistic-concurrency validation of position deletes.

1. validateDataFilesExist counted a referenced data file as present whenever any manifest entry for its path existed on the branch head, because it iterated head.dataFiles (discardDeleted=false). A concurrent compaction or overwrite that rewrote the file leaves a DELETED tombstone, so the check passed and the orphaned position delete (its rows had moved to a new file) was committed silently. Iterate data-manifest entries and treat a DELETED entry as absent — only a live ADDED/EXISTING entry satisfies existence, mirroring Java's MergingSnapshotProducer. This corrects the check for every caller, including RowDelta.

2. performMergeOnReadDeletion never ran that check at all: it builds an overwriteFiles producer whose only validator checks partition-filter overlap, and appended its position deletes without registering validateDataFilesExist (wired only into RowDelta.validate). So a merge-on-read delete whose referenced data file was concurrently removed went undetected. writePositionDeletesForFiles now returns the referenced data-file paths of the position deletes it appends, and performMergeOnReadDeletion registers a validateDataFilesExist validator over them, mirroring RowDelta.validate: unconditional (no isolation gating) and additive to the producer's partition-filter validator. A position delete that does not record its referenced data file is skipped, matching RowDelta and Java.

Tests: TestValidateDataFilesExist_TreatsConcurrentlyRemovedFileAsMissing pins the status-aware check (a compacted-away file is missing; a live file is present); TestMergeOnReadDeleteConflict_ReferencedDataFileRemoved drives a merge-on-read delete whose referenced file a concurrent compaction removes and asserts the commit fails with ErrDataFilesMissing; the no-conflict control still commits.