### PR TITLE
fix(table): honor useLargeTypes when projecting list arrays

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1155,7 +1155,26 @@ func (a *arrowProjectionVisitor) List(listType iceberg.ListType, listArr arrow.A
 		[]arrow.ArrayData{valArr.Data()}, arr.NullN(), arr.Data().Offset())
 	defer data.Release()
 
-	return array.MakeFromData(data)
+	out := array.MakeFromData(data)
+
+	// The Parquet reader may return large_list offsets even when the schema
+	// returned alongside the records (built with useLargeTypes) asks for small
+	// list, or vice versa; coerce the offset width to match so the writer does
+	// not reject the batch. A plain relabel would misread int64 offsets as int32.
+	switch out.DataType().ID() {
+	case arrow.LIST, arrow.LARGE_LIST:
+		var want arrow.DataType = arrow.ListOfField(elemField)
+		if a.useLargeTypes {
+			want = arrow.LargeListOfField(elemField)
+		}
+		if !arrow.TypeEqual(out.DataType(), want) {
+			defer out.Release()
+
+			return retOrPanic(compute.CastArray(a.ctx, out, compute.SafeCastOptions(want)))
+		}
+	}
+
+	return out
 }
 
 func (a *arrowProjectionVisitor) Map(m iceberg.MapType, mapArray, keyResult, valResult arrow.Array) arrow.Array {

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -1258,6 +1258,52 @@ func TestToRequestedSchema(t *testing.T) {
 	assert.True(t, array.RecordEqual(rec, rec2))
 }
 
+// TestToRequestedSchemaListLargeTypeCoercion guards against the writer
+// rejecting compacted batches: the projected list variant must follow
+// UseLargeTypes, not the offset width the reader happened to hand back.
+func TestToRequestedSchemaListLargeTypeCoercion(t *testing.T) {
+	elem := arrow.Field{
+		Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false,
+		Metadata: arrow.NewMetadata([]string{table.ArrowParquetFieldIDKey}, []string{"2"}),
+	}
+
+	build := func(t *testing.T, listType arrow.DataType) (arrow.RecordBatch, *iceberg.Schema) {
+		t.Helper()
+		schema := arrow.NewSchema([]arrow.Field{{
+			Name: "nested", Type: listType,
+			Metadata: arrow.NewMetadata([]string{table.ArrowParquetFieldIDKey}, []string{"1"}),
+		}}, nil)
+		bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+		defer bldr.Release()
+		require.NoError(t, bldr.UnmarshalJSON([]byte(`{"nested": [1, 2, 3]}`)))
+		rec := bldr.NewRecordBatch()
+		icesc, err := table.ArrowSchemaToIceberg(schema, false, nil)
+		require.NoError(t, err)
+
+		return rec, icesc
+	}
+
+	t.Run("large_list downcast to list", func(t *testing.T) {
+		rec, icesc := build(t, arrow.LargeListOfField(elem))
+		defer rec.Release()
+
+		out, err := table.ToRequestedSchema(context.Background(), icesc, icesc, rec, table.SchemaOptions{IncludeFieldIDs: true})
+		require.NoError(t, err)
+		defer out.Release()
+		assert.Equal(t, arrow.LIST, out.Column(0).DataType().ID())
+	})
+
+	t.Run("list upcast to large_list", func(t *testing.T) {
+		rec, icesc := build(t, arrow.ListOfField(elem))
+		defer rec.Release()
+
+		out, err := table.ToRequestedSchema(context.Background(), icesc, icesc, rec, table.SchemaOptions{IncludeFieldIDs: true, UseLargeTypes: true})
+		require.NoError(t, err)
+		defer out.Release()
+		assert.Equal(t, arrow.LARGE_LIST, out.Column(0).DataType().ID())
+	})
+}
+
 func TestToRequestedSchemaWriteDefaults(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())


### PR DESCRIPTION
compacting a pyiceberg created table fails because of this

Summary
- coerce LIST/LARGE_LIST records to the variant useLargeTypes requests in arrowProjectionVisitor.List, converting offsets rather than relabeling
- add a regression covering large_list->list downcast and list->large_list

Why
ReadTasks returns a writer schema built with useLargeTypes (small list by default), but the visitor copied the reader's list variant verbatim. The arrow-go bump in #1238 taught getNestedFactory to reconstruct a parquet file's embedded ARROW:schema, so list columns from pyiceberg-written files (which declare large_list) now read back as large_list instead of list. The projected records no longer match the small-list writer schema, so the parquet file writer rejects every batch with "record schema does not match writer's" -- surfacing in compaction as a group that writes no files and a table that never gets its replace snapshot. Primitives dodge this because castIfNeeded already downcasts large_string/large_binary.

Testing
- go test ./table -run TestToRequestedSchema -count=1
- go test ./table -count=1