### PR TITLE
fix(catalog/hadoop): publish metadata without replacement

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -400,10 +400,8 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
-	if err := c.filesystem.Rename(tempPath, metaPath); err != nil {
-		_ = c.filesystem.Remove(tempPath)
-
-		return nil, fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
+	if err := c.commitMetadataFile(ident, tempPath, metaPath, catalog.ErrTableAlreadyExists); err != nil {
+		return nil, err
 	}
 
 	c.writeVersionHint(ident, version)
@@ -520,25 +518,29 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
-	// Conflict detection: target file must not already exist.
-	if _, err := c.filesystem.Stat(newMetaPath); err == nil {
-		_ = c.filesystem.Remove(tempPath)
-
-		return nil, "", fmt.Errorf("hadoop catalog: version %d already exists for table %s",
-			newVersion, strings.Join(ident, "."))
-	}
-
-	// Atomic commit via rename.
-	if err := c.filesystem.Rename(tempPath, newMetaPath); err != nil {
-		_ = c.filesystem.Remove(tempPath)
-
-		return nil, "", fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
+	if err := c.commitMetadataFile(ident, tempPath, newMetaPath, table.ErrCommitFailed); err != nil {
+		return nil, "", err
 	}
 
 	// Step 8: Best-effort version hint update.
 	c.writeVersionHint(ident, newVersion)
 
 	return updated, newMetaPath, nil
+}
+
+func (c *Catalog) commitMetadataFile(ident table.Identifier, tempPath, metaPath string, conflictErr error) error {
+	if err := c.filesystem.RenameNoReplace(tempPath, metaPath); err != nil {
+		_ = c.filesystem.Remove(tempPath)
+
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("%w: metadata file already exists for table %s: %s",
+				conflictErr, strings.Join(ident, "."), metaPath)
+		}
+
+		return fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Catalog) ListTables(_ context.Context, ns table.Identifier) iter.Seq2[table.Identifier, error] {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -24,7 +24,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
@@ -33,6 +35,45 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
+
+type barrierRenameNoReplaceFS struct {
+	icebergio.LocalFS
+
+	targetName string
+	release    chan struct{}
+
+	mu    sync.Mutex
+	calls int
+}
+
+func newBarrierRenameNoReplaceFS(targetName string) *barrierRenameNoReplaceFS {
+	return &barrierRenameNoReplaceFS{
+		targetName: targetName,
+		release:    make(chan struct{}),
+	}
+}
+
+func (f *barrierRenameNoReplaceFS) RenameNoReplace(oldpath, newpath string) error {
+	if filepath.Base(newpath) != f.targetName {
+		return f.LocalFS.RenameNoReplace(oldpath, newpath)
+	}
+
+	f.mu.Lock()
+	f.calls++
+	if f.calls == 2 {
+		close(f.release)
+	}
+	release := f.release
+	f.mu.Unlock()
+
+	select {
+	case <-release:
+	case <-time.After(5 * time.Second):
+		return errors.New("timed out waiting for concurrent metadata publish")
+	}
+
+	return f.LocalFS.RenameNoReplace(oldpath, newpath)
+}
 
 type HadoopCatalogTestSuite struct {
 	suite.Suite
@@ -1029,6 +1070,56 @@ func (s *HadoopCatalogTestSuite) TestCreateTableAlreadyExists() {
 	s.ErrorIs(err, catalog.ErrTableAlreadyExists)
 }
 
+func (s *HadoopCatalogTestSuite) TestCreateTableConcurrentMetadataPublishConflict() {
+	ctx := context.Background()
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+	s.cat.filesystem = newBarrierRenameNoReplaceFS("v1.metadata.json")
+
+	type createResult struct {
+		metaLoc string
+		err     error
+	}
+
+	results := make(chan createResult, 2)
+	var wg sync.WaitGroup
+
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			tbl, err := s.cat.CreateTable(ctx, []string{"ns", "tbl"}, s.testSchema())
+			result := createResult{err: err}
+			if err == nil {
+				result.metaLoc = tbl.MetadataLocation()
+			}
+
+			results <- result
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	conflicts := 0
+	for result := range results {
+		if result.err == nil {
+			successes++
+			s.Contains(result.metaLoc, "v1.metadata.json")
+
+			continue
+		}
+
+		conflicts++
+		s.ErrorIs(result.err, catalog.ErrTableAlreadyExists)
+	}
+
+	s.Equal(1, successes)
+	s.Equal(1, conflicts)
+	s.FileExists(s.cat.metadataFilePath([]string{"ns", "tbl"}, 1))
+}
+
 func (s *HadoopCatalogTestSuite) TestCreateTableWithPartitionSpec() {
 	ctx := context.Background()
 	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
@@ -1450,12 +1541,6 @@ func (s *HadoopCatalogTestSuite) TestCommitTableNoChanges() {
 }
 
 func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetection() {
-	// Conflict detection relies on os.Stat checking whether the target
-	// v{N+1}.metadata.json already exists before the atomic rename.
-	// In a single-threaded test we cannot trigger the TOCTOU race
-	// between findVersion and os.Stat. Instead, we verify that after
-	// multiple sequential commits, the version sequence is contiguous
-	// and no versions are skipped or duplicated.
 	ctx := context.Background()
 	s.createTestTable("ns", "tbl")
 	ident := []string{"ns", "tbl"}
@@ -1474,6 +1559,61 @@ func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetection() {
 		s.Contains(metaLoc, fmt.Sprintf("v%d.metadata.json", i))
 		s.FileExists(s.cat.metadataFilePath(ident, i))
 	}
+}
+
+func (s *HadoopCatalogTestSuite) TestCommitTableConcurrentMetadataPublishConflict() {
+	ctx := context.Background()
+	s.createTestTable("ns", "tbl")
+	s.cat.filesystem = newBarrierRenameNoReplaceFS("v2.metadata.json")
+	ident := []string{"ns", "tbl"}
+
+	type commitResult struct {
+		metaLoc string
+		err     error
+	}
+
+	results := make(chan commitResult, 2)
+	var wg sync.WaitGroup
+
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			_, metaLoc, err := s.cat.CommitTable(
+				ctx, ident,
+				nil,
+				[]table.Update{
+					table.NewSetPropertiesUpdate(iceberg.Properties{
+						fmt.Sprintf("writer.%d", i): "committed",
+					}),
+				},
+			)
+			results <- commitResult{metaLoc: metaLoc, err: err}
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	conflicts := 0
+	for result := range results {
+		if result.err == nil {
+			successes++
+			s.Contains(result.metaLoc, "v2.metadata.json")
+
+			continue
+		}
+
+		conflicts++
+		s.ErrorIs(result.err, table.ErrCommitFailed)
+	}
+
+	s.Equal(1, successes)
+	s.Equal(1, conflicts)
+	s.FileExists(s.cat.metadataFilePath(ident, 2))
+	s.Equal(2, s.cat.readVersionHint(ident))
 }
 
 func (s *HadoopCatalogTestSuite) TestCommitTableRequirementFailure() {

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -31,6 +31,7 @@ type HadoopCatalogFS interface {
 	icebergio.WriteFileIO
 	StatIO
 	RenameIO
+	RenameNoReplaceIO
 	RemoveAllIO
 	MkdirAllIO
 }
@@ -54,6 +55,16 @@ type RenameIO interface {
 	icebergio.IO
 
 	Rename(oldpath, newpath string) error
+}
+
+// RenameNoReplaceIO is an extension of IO interface that includes the
+// RenameNoReplace method for atomically moving files only when the destination
+// path does not already exist. Implementations may require oldpath and newpath
+// to live on the same filesystem.
+type RenameNoReplaceIO interface {
+	icebergio.IO
+
+	RenameNoReplace(oldpath, newpath string) error
 }
 
 // RemoveAllIO is an extension of IO interface that includes the RemoveAll

--- a/io/local.go
+++ b/io/local.go
@@ -80,3 +80,18 @@ func (LocalFS) Stat(name string) (fs.FileInfo, error) {
 func (LocalFS) Rename(oldpath, newpath string) error {
 	return os.Rename(strings.TrimPrefix(oldpath, "file://"), strings.TrimPrefix(newpath, "file://"))
 }
+
+func (LocalFS) RenameNoReplace(oldpath, newpath string) error {
+	oldpath = strings.TrimPrefix(oldpath, "file://")
+	newpath = strings.TrimPrefix(newpath, "file://")
+
+	if err := os.Link(oldpath, newpath); err != nil {
+		return err
+	}
+
+	// Publishing already succeeded once the hard link exists. Removing the
+	// source temp file is best-effort cleanup.
+	_ = os.Remove(oldpath)
+
+	return nil
+}

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -90,3 +90,24 @@ func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }
+
+func TestLocalFSRenameNoReplaceDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	require.NoError(t, os.WriteFile(src, []byte("new"), 0o644))
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0o644))
+
+	err := LocalFS{}.RenameNoReplace(src, dst)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrExist)
+
+	data, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(data))
+
+	data, err = os.ReadFile(src)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(data))
+}


### PR DESCRIPTION
Summary

- add a no-replace rename path for Hadoop metadata publishes
- use it when creating `v1.metadata.json` and when committing the next table metadata version
- return `ErrTableAlreadyExists` for create races and `table.ErrCommitFailed` for commit races
- add deterministic concurrent create/commit coverage where two writers publish the same metadata version

Why

Hadoop commits wrote metadata to a temp file, checked whether the final path existed, then used `Rename` to publish it. On local filesystems `os.Rename` replaces the destination, so another writer could win between the existence check and rename and then be overwritten by the later commit.

The metadata file publish now fails if the final path already exists. `version-hint.text` stays best-effort after the metadata file is committed.

Testing

- go test ./catalog/hadoop -run 'TestHadoopCatalogTestSuite/(TestCreateTableConcurrentMetadataPublishConflict|TestCommitTableConcurrentMetadataPublishConflict|TestCommitTableConflictDetection)' -count=1
- go test ./io -run '^TestLocalFSRenameNoReplaceDoesNotOverwrite$' -count=1
- go test ./catalog/hadoop -count=1
- go test ./catalog/... -count=1
- go test ./io -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/hadoop/...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./io
- git diff --check
