### PR TITLE
fix(table): write added manifests with file spec

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -754,46 +754,46 @@ func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.Manifest
 
 func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, files []iceberg.DataFile, output *[]iceberg.ManifestFile) func() (err error) {
 	return func() (err error) {
-		out, path, err := sp.newManifestOutput()
-		if err != nil {
-			return err
-		}
-		defer internal.CheckedClose(out, &err)
-
-		counter := &internal.CountingWriter{W: out}
-		currentSpec, err := sp.txn.meta.CurrentSpec()
-		if err != nil || currentSpec == nil {
-			return fmt.Errorf("could not get current partition spec: %w", err)
-		}
-		wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter,
-			*currentSpec, sp.txn.meta.CurrentSchema(),
-			sp.snapshotID, iceberg.WithManifestWriterContent(content))
-		if err != nil {
-			return err
-		}
-		defer internal.CheckedClose(wr, &err)
-
+		groups := make(map[int][]iceberg.DataFile)
 		for _, df := range files {
-			err := wr.Add(iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &sp.snapshotID,
-				nil, nil, df))
+			specID := int(df.SpecID())
+			groups[specID] = append(groups[specID], df)
+		}
+
+		for specID, files := range groups {
+			mf, err := sp.writeAddedManifest(content, specID, files)
 			if err != nil {
 				return err
 			}
+			*output = append(*output, mf)
 		}
-
-		// close the writer to force a flush and ensure counter.Count is accurate
-		if err := wr.Close(); err != nil {
-			return err
-		}
-
-		mf, err := wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(content))
-		if err != nil {
-			return err
-		}
-		*output = []iceberg.ManifestFile{mf}
 
 		return nil
 	}
+}
+
+func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, specID int, files []iceberg.DataFile) (_ iceberg.ManifestFile, retErr error) {
+	wr, path, counter, out, err := sp.newManifestWriter(sp.spec(specID), iceberg.WithManifestWriterContent(content))
+	if err != nil {
+		return nil, err
+	}
+	defer internal.CheckedClose(out, &retErr)
+	defer internal.CheckedClose(wr, &retErr)
+
+	for _, df := range files {
+		err := wr.Add(iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &sp.snapshotID,
+			nil, nil, df))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// close the writer to force a flush and ensure counter.Count is accurate
+	if err := wr.Close(); err != nil {
+		return nil, err
+	}
+
+	return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(content))
 }
 
 func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
@@ -802,18 +802,19 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 		GetInt(WritePartitionSummaryLimitKey, WritePartitionSummaryLimitDefault)
 	ssc.setPartitionSummaryLimit(partitionSummaryLimit)
 
+	var err error
 	currentSchema := sp.txn.meta.CurrentSchema()
 	partitionSpec, err := sp.txn.meta.CurrentSpec()
 	if err != nil || partitionSpec == nil {
 		return Summary{}, fmt.Errorf("could not get current partition spec: %w", err)
 	}
 	for _, df := range sp.addedFiles {
-		if err = ssc.addFile(df, currentSchema, *partitionSpec); err != nil {
+		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
 			return Summary{}, err
 		}
 	}
 	for _, df := range sp.addedDeleteFiles {
-		if err = ssc.addFile(df, currentSchema, *partitionSpec); err != nil {
+		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
 			return Summary{}, err
 		}
 	}

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -164,6 +164,31 @@ func newTestDataFile(t *testing.T, spec iceberg.PartitionSpec, path string, part
 	return newTestDataFileWithCount(t, spec, path, partition, 1)
 }
 
+func newTestPosDeleteFileForSpec(
+	t *testing.T,
+	spec iceberg.PartitionSpec,
+	path string,
+	partition map[int]any,
+	referencedDataFile string,
+) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentPosDeletes,
+		path,
+		iceberg.ParquetFile,
+		partition,
+		nil,
+		nil,
+		1,
+		1,
+	)
+	require.NoError(t, err, "new position delete file builder")
+
+	return builder.ReferencedDataFile(referencedDataFile).Build()
+}
+
 func newTestDataFileWithCount(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any, count int64) iceberg.DataFile {
 	t.Helper()
 
@@ -632,6 +657,55 @@ func TestManifestWriterClosesUnderlyingFile(t *testing.T) {
 
 	unclosed := trackIO.GetUnclosedWriters()
 	require.Empty(t, unclosed, "all file writerFactory should be closed, but these are still open: %v", unclosed)
+}
+
+func TestAddedDeleteManifestsUseDeleteFileSpecID(t *testing.T) {
+	oldSpec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, oldSpec)
+
+	newSpec := partitionedSpec()
+	require.NoError(t, txn.meta.AddPartitionSpec(&newSpec, false))
+	require.NoError(t, txn.meta.SetDefaultSpecID(-1))
+	currentSpec, err := txn.meta.CurrentSpec()
+	require.NoError(t, err)
+	require.NotNil(t, currentSpec)
+	require.Equal(t, 1, currentSpec.ID(), "test setup should evolve the current spec")
+
+	sp := newFastAppendFilesProducer(OpDelete, txn, wfs, nil, nil)
+	oldSpecDelete := newTestPosDeleteFileForSpec(
+		t,
+		oldSpec,
+		"mem://default/table-location/delete/old-spec-pos-delete.parquet",
+		nil,
+		"mem://default/table-location/data/old-spec-data.parquet",
+	)
+	currentSpecDelete := newTestPosDeleteFileForSpec(
+		t,
+		*currentSpec,
+		"mem://default/table-location/delete/current-spec-pos-delete.parquet",
+		map[int]any{1000: int32(7)},
+		"mem://default/table-location/data/current-spec-data.parquet",
+	)
+	sp.appendDeleteFile(oldSpecDelete)
+	sp.appendDeleteFile(currentSpecDelete)
+
+	manifests, err := sp.manifests(context.Background())
+	require.NoError(t, err)
+
+	deleteManifestSpecIDs := make([]int32, 0, len(manifests))
+	for _, manifest := range manifests {
+		if manifest.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+
+		deleteManifestSpecIDs = append(deleteManifestSpecIDs, manifest.PartitionSpecID())
+		for entry, err := range manifest.Entries(wfs, false) {
+			require.NoError(t, err)
+			require.Equal(t, manifest.PartitionSpecID(), entry.DataFile().SpecID())
+		}
+	}
+
+	require.ElementsMatch(t, []int32{0, 1}, deleteManifestSpecIDs)
 }
 
 // TestCreateManifestClosesUnderlyingFile tests that createManifest properly


### PR DESCRIPTION
Summary

- group newly added manifest entries by the added file's partition spec ID
- write each added-file manifest with that matching partition spec
- use the added file's own spec when collecting snapshot summary partition metrics
- add a regression with added position deletes from old and current specs after spec evolution

Why

Position delete files can inherit their partition data and spec ID from the data file they reference. After partition spec evolution, a row-level delete can add a delete file whose spec ID is not the table's current spec ID.

The added-file manifest path wrote every new data/delete file using the current spec. That could put an added delete file into a manifest whose `partition_spec_id` did not match the delete file's own spec. Deleted entries already group by spec ID before writing manifests; this applies the same rule to added files.

Testing

- go test ./table -run '^TestAddedDeleteManifestsUseDeleteFileSpecID$' -count=1
- go test ./table -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check
