### PR TITLE
fix(io): keep MemFS WalkDir within root

### DIFF
--- a/io/mem.go
+++ b/io/mem.go
@@ -104,8 +104,9 @@ func (m *MemFS) WalkDir(root string, fn fs.WalkDirFunc) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	root = strings.TrimRight(root, "/")
 	for key, data := range m.files {
-		if !strings.HasPrefix(key, root) {
+		if !memPathInRoot(key, root) {
 			continue
 		}
 		info := &memFileInfo{name: filepath.Base(key), size: int64(len(data))}
@@ -115,6 +116,10 @@ func (m *MemFS) WalkDir(root string, fn fs.WalkDirFunc) error {
 	}
 
 	return nil
+}
+
+func memPathInRoot(path, root string) bool {
+	return root == "" || path == root || strings.HasPrefix(path, root+"/")
 }
 
 type memFile struct {

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -159,3 +159,36 @@ func TestMemIO_WalkDir(t *testing.T) {
 		"mem://walkdir-bucket/a/2.txt",
 	}, walked)
 }
+
+func TestMemIO_WalkDirDoesNotIncludeSiblingPrefixes(t *testing.T) {
+	ctx := context.Background()
+
+	memIO, err := icebergio.LoadFS(ctx, map[string]string{}, "mem://walkdir-boundary-bucket/")
+	require.NoError(t, err)
+
+	listable := memIO.(icebergio.ListableIO)
+	writeIO := memIO.(icebergio.WriteFileIO)
+
+	require.NoError(t, writeIO.WriteFile("mem://walkdir-boundary-bucket/table/data.parquet", []byte("table")))
+	require.NoError(t, writeIO.WriteFile("mem://walkdir-boundary-bucket/table2/data.parquet", []byte("table2")))
+	require.NoError(t, writeIO.WriteFile("mem://walkdir-boundary-bucket/table_backup/data.parquet", []byte("backup")))
+
+	for _, root := range []string{
+		"mem://walkdir-boundary-bucket/table",
+		"mem://walkdir-boundary-bucket/table/",
+	} {
+		t.Run(root, func(t *testing.T) {
+			var walked []string
+			err := listable.WalkDir(root, func(path string, _ fs.DirEntry, err error) error {
+				require.NoError(t, err)
+				walked = append(walked, path)
+
+				return nil
+			})
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{
+				"mem://walkdir-boundary-bucket/table/data.parquet",
+			}, walked)
+		})
+	}
+}


### PR DESCRIPTION
Summary

- make MemFS.WalkDir match roots on path boundaries instead of raw string prefixes
- normalize trailing slashes on the walk root
- add regression coverage for sibling prefixes like `table2` and `table_backup`

Why

MemFS stored full keys and filtered them with `strings.HasPrefix(key, root)`. Walking `mem://bucket/table` could therefore include `mem://bucket/table2/...` or `mem://bucket/table_backup/...`, which is surprising for tests and in-memory cleanup flows.

Testing

- go test ./io -run 'TestMemIO_WalkDir' -count=1
- go test ./io -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./io
- git diff --check
