### PR TITLE
fix(table): reject empty equality delete keys

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -65,6 +65,10 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 				continue
 			}
 
+			if len(d.EqualityFieldIDs()) == 0 {
+				return nil, fmt.Errorf("%w: equality delete file %s", ErrEmptyEqualityFieldIDs, d.FilePath())
+			}
+
 			hasAny = true
 			if _, ok := uniqueDeletes[d.FilePath()]; !ok {
 				uniqueDeletes[d.FilePath()] = deleteFileInfo{

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		"mem://default/table/delete/empty-equality-fields.parquet",
+		iceberg.ParquetFile, nil, nil, nil, 1, 128,
+	)
+	require.NoError(t, err)
+	deleteFile := builder.EqualityFieldIDs(nil).Build()
+
+	_, err = readAllEqualityDeleteFiles(
+		t.Context(),
+		iceio.NewMemFS(),
+		schema,
+		[]FileScanTask{{EqualityDeleteFiles: []iceberg.DataFile{deleteFile}}},
+		1,
+	)
+	require.ErrorIs(t, err, ErrEmptyEqualityFieldIDs)
+	require.ErrorContains(t, err, "empty-equality-fields.parquet")
+}


### PR DESCRIPTION
Summary

- reject equality delete files with no equality field IDs while loading scan deletes
- add reader-level regression coverage for malformed delete metadata before any delete file is read

Why

Equality delete keys are built from the file's equality field IDs. If that list is empty, the reader can build an empty key, and every data row also encodes to that same empty key. A malformed equality delete file could therefore filter every row from an applicable scan.

Writers already reject empty equality field IDs; this adds the same guard to the reader path for externally-written or malformed delete files.

Testing

- go test ./table -run '^TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs$' -count=1
- go test ./table -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check