### PR TITLE
fix(table): return error when rolling writer is closed

### DIFF
--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -34,6 +35,10 @@ import (
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
 )
+
+// ErrWriterClosed is returned when records are added to a writer after its
+// streaming goroutine has already stopped.
+var ErrWriterClosed = errors.New("writer is closed")
 
 // writerFactory manages the creation and lifecycle of RollingDataWriter instances
 // for different partitions, providing shared configuration and coordination
@@ -306,8 +311,11 @@ func (r *RollingDataWriter) Add(record arrow.RecordBatch) error {
 	select {
 	case r.recordCh <- record:
 		return nil
-	case err := <-r.errorCh:
+	case err, ok := <-r.errorCh:
 		record.Release()
+		if !ok {
+			return ErrWriterClosed
+		}
 
 		return err
 	case <-r.ctx.Done():
@@ -320,6 +328,7 @@ func (r *RollingDataWriter) Add(record arrow.RecordBatch) error {
 func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 	defer r.wg.Done()
 	defer close(r.errorCh)
+	defer r.factory.writers.CompareAndDelete(r.partitionKey, r)
 
 	var currentWriter tblutils.FileWriter
 	defer func() {

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -375,6 +375,61 @@ func (s *RollingDataWriterTestSuite) TestStreamErrorPathUsesAbort() {
 	s.Empty(files, "deferred abort should remove the incomplete file")
 }
 
+func (s *RollingDataWriterTestSuite) TestAddReturnsErrorAfterStreamStopsCleanly() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	record := s.buildRecord(arrSchema, 1)
+	defer record.Release()
+
+	errorCh := make(chan error)
+	close(errorCh)
+
+	writer := &RollingDataWriter{
+		recordCh: make(chan arrow.RecordBatch),
+		errorCh:  errorCh,
+		ctx:      s.ctx,
+	}
+
+	s.ErrorIs(writer.Add(record), ErrWriterClosed)
+}
+
+func (s *RollingDataWriterTestSuite) TestStreamErrorRemovesWriterFromFactory() {
+	writerSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactory(loc, writerSchema, 1024*1024)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writer, err := factory.getOrCreateRollingDataWriter(s.ctx, "", nil, outputCh)
+	s.Require().NoError(err)
+
+	badSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "x", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+	}, nil)
+	bldr := array.NewRecordBuilder(s.mem, badSchema)
+	bldr.Field(0).(*array.Float64Builder).Append(1.0)
+	badRecord := bldr.NewRecordBatch()
+	bldr.Release()
+	defer badRecord.Release()
+
+	s.Require().NoError(writer.Add(badRecord))
+	writer.wg.Wait()
+
+	_, ok := factory.writers.Load("")
+	s.False(ok, "failed writer should be removed from partition writer cache")
+
+	err, ok = <-writer.errorCh
+	s.True(ok)
+	s.Error(err)
+}
+
 func (s *RollingDataWriterTestSuite) TestBytesWrittenReflectsCompressedSize() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},


### PR DESCRIPTION
Summary

- return ErrWriterClosed when RollingDataWriter.Add observes a closed error channel
- remove stopped rolling writers from the partition writer cache
- add regression coverage for the closed-channel Add path and stale writer cache cleanup

Why

RollingDataWriter.Add was reading errorCh with a single-value receive. Once the stream goroutine closed that channel, Add could receive the zero error value, release the caller's record, and return nil. That makes a stopped writer look like it accepted a batch.

The stream now also removes itself from the factory cache when it exits, so later partition writes do not keep reusing a dead writer.

Testing

- go test ./table -run 'TestRollingDataWriter/Test(AddReturnsErrorAfterStreamStopsCleanly|StreamErrorRemovesWriterFromFactory|StreamErrorPathUsesAbort)' -count=1
- go test ./table -count=1
- go test ./table/... -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check