### PR TITLE
fix: reject invalid parameterized transforms

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -36,51 +37,44 @@ import (
 	"github.com/twmb/murmur3"
 )
 
+var (
+	bucketTransformRegex   = regexp.MustCompile(`^bucket\[(\d+)\]$`)
+	truncateTransformRegex = regexp.MustCompile(`^truncate\[(\d+)\]$`)
+)
+
 // ParseTransform takes the string representation of a transform as
 // defined in the iceberg spec, and produces the appropriate Transform
 // object or an error if the string is not a valid transform string.
 func ParseTransform(s string) (Transform, error) {
 	s = strings.ToLower(s)
-	switch {
-	case strings.HasPrefix(s, "bucket"):
-		matches := regexFromBrackets.FindStringSubmatch(s)
-		if len(matches) != 2 {
-			break
-		}
 
+	if matches := bucketTransformRegex.FindStringSubmatch(s); len(matches) == 2 {
 		n, err := strconv.Atoi(matches[1])
-		if err != nil || n <= 0 || n > math.MaxInt32 {
-			break
+		if err == nil && n > 0 && n <= math.MaxInt32 {
+			return BucketTransform{NumBuckets: n}, nil
 		}
+	}
 
-		return BucketTransform{NumBuckets: n}, nil
-	case strings.HasPrefix(s, "truncate"):
-		matches := regexFromBrackets.FindStringSubmatch(s)
-		if len(matches) != 2 {
-			break
-		}
-
+	if matches := truncateTransformRegex.FindStringSubmatch(s); len(matches) == 2 {
 		n, err := strconv.Atoi(matches[1])
-		if err != nil || n <= 0 || n > math.MaxInt32 {
-			break
+		if err == nil && n > 0 && n <= math.MaxInt32 {
+			return TruncateTransform{Width: n}, nil
 		}
+	}
 
-		return TruncateTransform{Width: n}, nil
-	default:
-		switch s {
-		case "identity":
-			return IdentityTransform{}, nil
-		case "void":
-			return VoidTransform{}, nil
-		case "year":
-			return YearTransform{}, nil
-		case "month":
-			return MonthTransform{}, nil
-		case "day":
-			return DayTransform{}, nil
-		case "hour":
-			return HourTransform{}, nil
-		}
+	switch s {
+	case "identity":
+		return IdentityTransform{}, nil
+	case "void":
+		return VoidTransform{}, nil
+	case "year":
+		return YearTransform{}, nil
+	case "month":
+		return MonthTransform{}, nil
+	case "day":
+		return DayTransform{}, nil
+	case "hour":
+		return HourTransform{}, nil
 	}
 
 	return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -89,6 +89,10 @@ func TestParseTransform(t *testing.T) {
 		{"truncate atoi overflow", "truncate[999999999999999999999999999999999999999]"},
 		{"bucket int32 overflow", "bucket[4294967296]"},
 		{"truncate int32 overflow", "truncate[4294967296]"},
+		{"bucket extra suffix", "bucketx[5]"},
+		{"bucket extra token", "bucket_extra[5]"},
+		{"truncate extra suffix", "truncatefoo[10]"},
+		{"truncate extra token", "truncate_garbage[4]"},
 	}
 
 	for _, tt := range errorTests {


### PR DESCRIPTION
Summary

- parse bucket and truncate transforms with exact syntax checks
- reject bogus transform names like bucketx[5] and truncatefoo[10]
- add negative parser coverage for invalid bucket/truncate prefixes

Why

ParseTransform used prefix checks for bucket and truncate before applying a generic bracket parser. That let strings with extra transform-name text parse as valid parameterized transforms.

The parser now only accepts the Iceberg transform forms bucket[N] and truncate[N].

Testing

- go test . -run '^TestParseTransform$' -count=1
- go test . -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m .
- git diff --check