### PR TITLE
fix(io): create parent dirs in LocalFS WriteFile

### DIFF
--- a/io/local.go
+++ b/io/local.go
@@ -46,7 +46,12 @@ func (LocalFS) Create(name string) (FileWriter, error) {
 }
 
 func (LocalFS) WriteFile(name string, content []byte) error {
-	return os.WriteFile(strings.TrimPrefix(name, "file://"), content, 0o644)
+	filename := strings.TrimPrefix(name, "file://")
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(filename, content, 0o644)
 }
 
 func (LocalFS) Remove(name string) error {

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,33 @@ func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{filepath.Join(dir, "test.txt")}, files)
+}
+
+func TestLocalFSWriteFileCreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("content")
+
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{
+			name: "plain path",
+			path: filepath.Join(dir, "plain", "nested", "file.txt"),
+		},
+		{
+			name: "file scheme",
+			path: "file://" + filepath.Join(dir, "scheme", "nested", "file.txt"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, LocalFS{}.WriteFile(tt.path, content))
+
+			got, err := os.ReadFile(strings.TrimPrefix(tt.path, "file://"))
+			require.NoError(t, err)
+			assert.Equal(t, content, got)
+		})
+	}
 }
 
 func TestLocalFSImplementsListableIO(t *testing.T) {


### PR DESCRIPTION
Summary

- create missing parent directories in LocalFS.WriteFile before writing
- cover nested plain paths and file:// paths

Why

LocalFS.Create already creates parent directories, but WriteFile called os.WriteFile directly. Code paths that write generated nested locations through WriteFile could fail locally even though the matching Create path succeeds.

Testing

- go test ./io -run '^TestLocalFSWriteFileCreatesParentDirectories$' -count=1
- go test ./io -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./io
- git diff --check