### PR TITLE
fix(table): track actual metadata removals

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1194,8 +1194,8 @@ func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 		return fmt.Errorf("%w: can't remove default partition spec with id %d", iceberg.ErrInvalidArgument, b.defaultSpecID)
 	}
 
-	newSpecs := make([]iceberg.PartitionSpec, 0, len(b.specs)-len(ints))
-	removed := make([]int, len(ints))
+	newSpecs := make([]iceberg.PartitionSpec, 0, len(b.specs))
+	removed := make([]int, 0, len(ints))
 	for _, spec := range b.specs {
 		if slices.Contains(ints, spec.ID()) {
 			removed = append(removed, spec.ID())
@@ -1208,7 +1208,7 @@ func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 	b.specs = newSpecs
 
 	if len(removed) != 0 {
-		b.updates = append(b.updates, NewRemoveSpecUpdate(ints))
+		b.updates = append(b.updates, NewRemoveSpecUpdate(removed))
 	}
 
 	return nil
@@ -1223,7 +1223,7 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 		return fmt.Errorf("%w: can't remove current schema with id %d", iceberg.ErrInvalidArgument, b.currentSchemaID)
 	}
 
-	removed := make([]int, len(ints))
+	removed := make([]int, 0, len(ints))
 	b.schemaList = slices.DeleteFunc(b.schemaList, func(s *iceberg.Schema) bool {
 		if slices.Contains(ints, s.ID) {
 			removed = append(removed, s.ID)
@@ -1235,7 +1235,7 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 	})
 
 	if len(removed) != 0 {
-		b.updates = append(b.updates, NewRemoveSchemasUpdate(ints))
+		b.updates = append(b.updates, NewRemoveSchemasUpdate(removed))
 	}
 
 	return nil

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1190,6 +1190,10 @@ func (b *MetadataBuilder) reuseOrCreateNewSchemaID(newSchema *iceberg.Schema) in
 }
 
 func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
+	if len(ints) == 0 {
+		return nil
+	}
+
 	if slices.Contains(ints, b.defaultSpecID) {
 		return fmt.Errorf("%w: can't remove default partition spec with id %d", iceberg.ErrInvalidArgument, b.defaultSpecID)
 	}

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -306,15 +306,24 @@ func TestAddRemovePartitionSpec(t *testing.T) {
 	newBuilder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
 	// Remove the spec
-	require.NoError(t, newBuilder.RemovePartitionSpecs([]int{1}))
+	require.NoError(t, newBuilder.RemovePartitionSpecs([]int{1, 99}))
 	newBuild, err := newBuilder.Build()
 	require.NoError(t, err)
 	require.NotNil(t, newBuild)
 	require.Len(t, newBuilder.updates, 1)
+	require.Equal(t, []int{1}, newBuilder.updates[0].(*removeSpecUpdate).SpecIds)
 	require.Len(t, newBuild.PartitionSpecs(), 1)
 	_, err = newBuilder.GetSpecByID(1)
 	require.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	require.ErrorContains(t, err, "id 1")
+}
+
+func TestRemovePartitionSpecsNoMatchDoesNotUpdate(t *testing.T) {
+	builder := builderWithoutChanges(2)
+
+	require.NoError(t, builder.RemovePartitionSpecs([]int{99, 100}))
+	require.Empty(t, builder.updates)
+	require.Len(t, builder.specs, 1)
 }
 
 func TestSetDefaultPartitionSpec(t *testing.T) {
@@ -1060,7 +1069,7 @@ func TestRemoveSchemas(t *testing.T) {
 	require.Len(t, meta.Schemas(), 2, "expected 2 schemas in the metadata")
 	builder, err := MetadataBuilderFromBase(meta, "")
 	require.NoError(t, err)
-	err = builder.RemoveSchemas([]int{0})
+	err = builder.RemoveSchemas([]int{0, 99})
 	require.NoError(t, err, "expected to remove schema with ID 1")
 	newMeta, err := builder.Build()
 	require.NoError(t, err)
@@ -1070,6 +1079,17 @@ func TestRemoveSchemas(t *testing.T) {
 	require.Len(t, builder.updates, 1, "expected one update for schema removal")
 	require.Equal(t, builder.updates[0].Action(), UpdateRemoveSchemas)
 	require.Equal(t, builder.updates[0].(*removeSchemasUpdate).SchemaIDs, []int{0}, "expected schema ID 0 to be removed")
+}
+
+func TestRemoveSchemasNoMatchDoesNotUpdate(t *testing.T) {
+	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.RemoveSchemas([]int{99, 100}))
+	require.Empty(t, builder.updates)
+	require.Len(t, builder.schemaList, 2)
 }
 
 // Java: TestTableMetadata.testUpdateSchema

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -326,6 +326,14 @@ func TestRemovePartitionSpecsNoMatchDoesNotUpdate(t *testing.T) {
 	require.Len(t, builder.specs, 1)
 }
 
+func TestRemovePartitionSpecsEmptyDoesNotUpdate(t *testing.T) {
+	builder := builderWithoutChanges(2)
+
+	require.NoError(t, builder.RemovePartitionSpecs(nil))
+	require.Empty(t, builder.updates)
+	require.Len(t, builder.specs, 1)
+}
+
 func TestSetDefaultPartitionSpec(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	curSchema, err := builder.GetSchemaByID(builder.currentSchemaID)


### PR DESCRIPTION
Summary

- record only partition spec and schema IDs that were actually removed
- avoid emitting remove updates when no requested IDs match existing metadata
- make partition spec removal capacity safe when callers pass more IDs than existing specs

Why

RemovePartitionSpecs and RemoveSchemas preallocated the removed ID slice with length instead of capacity. That made any non-empty request look like a successful removal, and the emitted update used the requested IDs rather than the IDs that were actually removed.

Testing

- go test ./table -run 'Test(AddRemovePartitionSpec|RemovePartitionSpecsNoMatchDoesNotUpdate|RemoveSchemas|RemoveSchemasNoMatchDoesNotUpdate)$' -count=1
- go test ./table -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check