### PR TITLE
fix: use transform equality for partition compatibility

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -371,7 +371,7 @@ func (ps *PartitionSpec) CompatibleWith(other *PartitionSpec) bool {
 
 	return slices.EqualFunc(ps.fields, other.fields, func(left, right PartitionField) bool {
 		return slices.Equal(left.SourceIDs, right.SourceIDs) && left.Name == right.Name &&
-			left.Transform == right.Transform
+			left.Transform.Equals(right.Transform)
 	})
 }
 

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -19,12 +19,24 @@ package iceberg_test
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type nonComparableTransform struct {
+	iceberg.IdentityTransform
+	values []int
+}
+
+func (t nonComparableTransform) Equals(other iceberg.Transform) bool {
+	o, ok := other.(nonComparableTransform)
+
+	return ok && slices.Equal(t.values, o.values)
+}
 
 func TestPartitionSpec(t *testing.T) {
 	assert.Equal(t, 999, iceberg.UnpartitionedSpec.LastAssignedFieldID())
@@ -59,6 +71,32 @@ func TestPartitionSpec(t *testing.T) {
 	spec3 := iceberg.NewPartitionSpec(idField1, idField2)
 	assert.False(t, spec1.CompatibleWith(&spec3))
 	assert.Equal(t, 1002, spec3.LastAssignedFieldID())
+}
+
+func TestPartitionSpecCompatibleWithUsesTransformEquals(t *testing.T) {
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1001, Name: "id",
+		Transform: nonComparableTransform{values: []int{1, 2}},
+	})
+	sameTransformSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1002, Name: "id",
+		Transform: nonComparableTransform{values: []int{1, 2}},
+	})
+	differentTransformSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1003, Name: "id",
+		Transform: nonComparableTransform{values: []int{2, 3}},
+	})
+
+	var compatible bool
+	require.NotPanics(t, func() {
+		compatible = spec.CompatibleWith(&sameTransformSpec)
+	})
+	assert.True(t, compatible)
+
+	require.NotPanics(t, func() {
+		compatible = spec.CompatibleWith(&differentTransformSpec)
+	})
+	assert.False(t, compatible)
 }
 
 func TestUnpartitionedWithVoidField(t *testing.T) {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -97,6 +97,51 @@ func TestPartitionSpecCompatibleWithUsesTransformEquals(t *testing.T) {
 		compatible = spec.CompatibleWith(&differentTransformSpec)
 	})
 	assert.False(t, compatible)
+
+	tests := []struct {
+		name       string
+		left       iceberg.Transform
+		right      iceberg.Transform
+		compatible bool
+	}{
+		{
+			name:       "identical bucket transforms are compatible",
+			left:       iceberg.BucketTransform{NumBuckets: 16},
+			right:      iceberg.BucketTransform{NumBuckets: 16},
+			compatible: true,
+		},
+		{
+			name:       "different bucket transforms are incompatible",
+			left:       iceberg.BucketTransform{NumBuckets: 16},
+			right:      iceberg.BucketTransform{NumBuckets: 32},
+			compatible: false,
+		},
+		{
+			name:       "identical truncate transforms are compatible",
+			left:       iceberg.TruncateTransform{Width: 4},
+			right:      iceberg.TruncateTransform{Width: 4},
+			compatible: true,
+		},
+		{
+			name:       "different truncate transforms are incompatible",
+			left:       iceberg.TruncateTransform{Width: 4},
+			right:      iceberg.TruncateTransform{Width: 8},
+			compatible: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left := iceberg.NewPartitionSpec(iceberg.PartitionField{
+				SourceIDs: []int{1}, FieldID: 1001, Name: "id", Transform: tt.left,
+			})
+			right := iceberg.NewPartitionSpec(iceberg.PartitionField{
+				SourceIDs: []int{1}, FieldID: 1002, Name: "id", Transform: tt.right,
+			})
+
+			assert.Equal(t, tt.compatible, left.CompatibleWith(&right))
+		})
+	}
 }
 
 func TestUnpartitionedWithVoidField(t *testing.T) {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -29,6 +29,7 @@ import (
 
 type nonComparableTransform struct {
 	iceberg.IdentityTransform
+	// values makes this transform non-comparable, which would have panicked with ==.
 	values []int
 }
 
@@ -87,16 +88,10 @@ func TestPartitionSpecCompatibleWithUsesTransformEquals(t *testing.T) {
 		Transform: nonComparableTransform{values: []int{2, 3}},
 	})
 
-	var compatible bool
 	require.NotPanics(t, func() {
-		compatible = spec.CompatibleWith(&sameTransformSpec)
+		assert.True(t, spec.CompatibleWith(&sameTransformSpec))
+		assert.False(t, spec.CompatibleWith(&differentTransformSpec))
 	})
-	assert.True(t, compatible)
-
-	require.NotPanics(t, func() {
-		compatible = spec.CompatibleWith(&differentTransformSpec)
-	})
-	assert.False(t, compatible)
 
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Summary

- compare partition spec transforms with Transform.Equals in CompatibleWith
- add regression coverage for non-comparable transform implementations

Why

PartitionField.Equals already delegates transform comparison to Transform.Equals, but PartitionSpec.CompatibleWith compared transform interfaces directly. That can panic for non-comparable transform implementations and also bypass transform-specific equality semantics.

Testing

- go test . -run '^TestPartitionSpecCompatibleWithUsesTransformEquals$' -count=1\n- go test . -count=1\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m .\n- git diff --check