### PR TITLE
fix(literals): incorrect comparison result for (false, false) in BoolLiteral.Comparator

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -376,11 +376,10 @@ type BoolLiteral bool
 
 func (BoolLiteral) Comparator() Comparator[bool] {
 	return func(v1, v2 bool) int {
+		if v1 == v2 {
+			return 0
+		}
 		if v1 {
-			if v2 {
-				return 0
-			}
-
 			return 1
 		}
 

--- a/literals_test.go
+++ b/literals_test.go
@@ -736,6 +736,27 @@ func TestInvalidBoolLiteralConversions(t *testing.T) {
 	})
 }
 
+func TestBoolLiteralComparator(t *testing.T) {
+	cmp := iceberg.BoolLiteral(false).Comparator()
+
+	tests := []struct {
+		name     string
+		v1, v2   bool
+		expected int
+	}{
+		{"false_equals_false", false, false, 0},
+		{"true_equals_true", true, true, 0},
+		{"false_less_than_true", false, true, -1},
+		{"true_greater_than_false", true, false, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cmp(tt.v1, tt.v2))
+		})
+	}
+}
+
 func TestInvalidNumericConversions(t *testing.T) {
 	testInvalidLiteralConversions(t, iceberg.NewLiteral(int32(34)), []iceberg.Type{
 		iceberg.PrimitiveTypes.Bool,


### PR DESCRIPTION
## Description 

Fix a **bug** in `BoolLiteral.Comparator()` where comparing two `false` values returned `-1` instead of `0`.

The previous implementation returned `-1` whenever `v1` was `false`, regardless of the value of `v2`, causing the comparator to report: `false < false`.

Fixes #1316 

## Testing

Added a regression test covering all boolean comparison combinations:
- `(false, false)` → `0`
- `(true, true)` → `0`
- `(false, true)` → `-1`
- `(true, false)` → `1`