### PR TITLE
fix(config): seed --catalog-name from default-catalog in config file

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -288,6 +288,27 @@ func TestArgsParsing(t *testing.T) {
 	}
 }
 
+func TestResolveCatalogName(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicitFlags map[string]bool
+		flagValue     string
+		want          string
+	}{
+		// explicit --catalog-name wins and is passed through
+		{"explicit flag wins", map[string]bool{"catalog-name": true}, "prod", "prod"},
+		// no flag: return "" so ParseConfig falls back to default-catalog / "default"
+		{"no flag returns empty string", map[string]bool{}, "default", ""},
+		// other flags set but not catalog-name: still falls back
+		{"other flags set only", map[string]bool{"uri": true}, "default", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveCatalogName(tt.explicitFlags, tt.flagValue))
+		})
+	}
+}
+
 func TestMergeConfAwsProfile(t *testing.T) {
 	fileCfg := &config.CatalogConfig{AwsProfile: "file-profile"}
 

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -237,9 +237,14 @@ func main() {
 		}
 	}
 
-	fileCfg := config.ParseConfig(config.LoadConfig(args.Config), args.CatalogName)
-	if fileCfg != nil {
+	configData := config.LoadConfig(args.Config)
+	fileCfg, err := config.ParseConfig(configData, resolveCatalogName(explicitFlags, args.CatalogName))
+	if err != nil {
+		log.Printf("warning: failed to parse config file: %v", err)
+	} else if fileCfg != nil {
 		mergeConf(fileCfg, &args, explicitFlags)
+	} else if len(configData) > 0 {
+		log.Printf("warning: catalog %q not found in config file", args.CatalogName)
 	}
 
 	// Validate nested subcommands before catalog init.
@@ -789,6 +794,17 @@ func loadTable(ctx context.Context, output Output, cat catalog.Catalog, id strin
 	}
 
 	return tbl
+}
+
+// resolveCatalogName returns the catalog name to pass to ParseConfig.
+// When --catalog-name was given explicitly it wins; otherwise "" is returned
+// so ParseConfig can fall back through default-catalog -> "default".
+func resolveCatalogName(explicitFlags map[string]bool, flagValue string) string {
+	if explicitFlags["catalog-name"] {
+		return flagValue
+	}
+
+	return ""
 }
 
 // mergeConf applies values from the file config into args for any option

--- a/config/config.go
+++ b/config/config.go
@@ -70,18 +70,33 @@ func LoadConfig(configPath string) []byte {
 	return file
 }
 
-func ParseConfig(file []byte, catalogName string) *CatalogConfig {
-	var config Config
-	err := yaml.Unmarshal(file, &config)
-	if err != nil {
-		return nil
+// ParseConfig unmarshals the config file once and resolves the catalog to use.
+// When catalogName is empty, it falls back to the file's default-catalog field and
+// then to the built-in "default" name. It returns the matching CatalogConfig, or
+// nil/nil if no such catalog is defined in the file. A non-nil error means the
+// file could not be parsed and should be surfaced to the user.
+func ParseConfig(file []byte, catalogName string) (*CatalogConfig, error) {
+	if len(file) == 0 {
+		return nil, nil
 	}
-	res, ok := config.Catalogs[catalogName]
-	if !ok {
-		return nil
+	var config Config
+	if err := yaml.Unmarshal(file, &config); err != nil {
+		return nil, err
 	}
 
-	return &res
+	if catalogName == "" {
+		catalogName = config.DefaultCatalog
+	}
+	if catalogName == "" {
+		catalogName = "default"
+	}
+
+	res, ok := config.Catalogs[catalogName]
+	if !ok {
+		return nil, nil
+	}
+
+	return &res, nil
 }
 
 func fromConfigFiles() Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testArgs = []struct {
@@ -28,9 +29,9 @@ var testArgs = []struct {
 	catName  string
 	expected *CatalogConfig
 }{
-	// config file does not exist
-	{nil, "default", nil},
-	// config does not have default catalog
+	// config file does not exist; empty name falls back to built-in "default"
+	{nil, "", nil},
+	// config does not have requested catalog
 	{[]byte(`
 catalog:
   custom-catalog:
@@ -115,12 +116,50 @@ catalog:
 			AwsProfile:  "my-aws-profile",
 		},
 	},
+	// empty name resolves via the file's default-catalog field
+	{
+		[]byte(`
+default-catalog: custom-catalog
+catalog:
+  custom-catalog:
+    type: rest
+    uri: http://localhost:8181/
+    warehouse: my_wh
+`), "",
+		&CatalogConfig{
+			CatalogType: "rest",
+			URI:         "http://localhost:8181/",
+			Warehouse:   "my_wh",
+		},
+	},
+	// explicit name takes precedence over the file's default-catalog
+	{
+		[]byte(`
+default-catalog: custom-catalog
+catalog:
+  custom-catalog:
+    type: rest
+    uri: http://localhost:8181/
+  other:
+    type: rest
+    uri: http://other:8181/
+`), "other",
+		&CatalogConfig{
+			CatalogType: "rest",
+			URI:         "http://other:8181/",
+		},
+	},
 }
 
 func TestParseConfig(t *testing.T) {
 	for _, tt := range testArgs {
-		actual := ParseConfig([]byte(tt.file), tt.catName)
-
+		actual, err := ParseConfig(tt.file, tt.catName)
+		require.NoError(t, err)
 		assert.Equal(t, tt.expected, actual)
 	}
+}
+
+func TestParseConfigMalformed(t *testing.T) {
+	_, err := ParseConfig([]byte(":\t[broken yaml"), "default")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Problem

The CLI `--catalog-name` flag defaults to `"default"`. When a config file used a different name under `default-catalog`, that value was never read ‚ `ParseConfig` was called with the flag's default before the config file had any chance to influence it. The result was a silent fallback to the `rest` catalog type with no URI, producing a confusing error:
```
Get "v1/config": unsupported protocol scheme ""
```

Example config that triggered the bug:

```yaml
default-catalog: my-catalog
catalog:
  my-catalog:
    type: glue
    warehouse: s3://my-bucket
```

Running iceberg list would fail because my-catalog was never found in the catalog map, mergeConf was never called, and the catalog type stayed as rest.

## Fix

- Add config.ParseDefaultCatalog to extract default-catalog from the YAML without requiring a catalog name upfront.
- In main, load the config bytes once, then seed args.CatalogName from default-catalog when `--catalog-name` was not explicitly passed on the command line. The explicit-flag guard ensures CLI flags still take precedence.

## How to test

1. Create ~/.iceberg-go.yaml with a non-"default" catalog name:

```yaml
default-catalog: my-glue
catalog:
  my-glue:
    type: glue
    warehouse: s3://my-bucket
```

2. Run without --catalog-name:
```shell
AWS_PROFILE=my-profile AWS_REGION=my-region iceberg list
```

2. Before: Get "v1/config": unsupported protocol scheme "" 
After: connects to the Glue catalog correctly.

3. Verify explicit flag still wins:
```shell
iceberg --catalog-name other-catalog list
```

4. Should use other-catalog, not my-glue.