### PR TITLE
feat(cmd/config): add aws-profile support for Glue catalog

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/alexflint/go-arg"
+	"github.com/apache/iceberg-go/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -228,6 +229,13 @@ func TestArgsParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "aws-profile flag",
+			args: []string{"--catalog", "glue", "--aws-profile", "my-profile", "list"},
+			check: func(t *testing.T, a Args) {
+				assert.Equal(t, "my-profile", a.AwsProfile)
+			},
+		},
+		{
 			name: "rollback with snapshot id",
 			args: []string{"rollback", "prod.db.events", "--snapshot-id", "123", "--yes"},
 			check: func(t *testing.T, a Args) {
@@ -278,4 +286,20 @@ func TestArgsParsing(t *testing.T) {
 			tt.check(t, a)
 		})
 	}
+}
+
+func TestMergeConfAwsProfile(t *testing.T) {
+	fileCfg := &config.CatalogConfig{AwsProfile: "file-profile"}
+
+	t.Run("file value applied when flag absent", func(t *testing.T) {
+		var a Args
+		mergeConf(fileCfg, &a, map[string]bool{})
+		assert.Equal(t, "file-profile", a.AwsProfile)
+	})
+
+	t.Run("cli value preserved when flag explicit", func(t *testing.T) {
+		a := Args{AwsProfile: "cli-profile"}
+		mergeConf(fileCfg, &a, map[string]bool{"aws-profile": true})
+		assert.Equal(t, "cli-profile", a.AwsProfile)
+	})
 }

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -202,6 +202,7 @@ type Args struct {
 	Warehouse   string `arg:"--warehouse" help:"warehouse to use"`
 	Scope       string `arg:"--scope" default:"catalog" help:"OAuth scope"`
 	Config      string `arg:"--config" help:"path to configuration file"`
+	AwsProfile  string `arg:"--aws-profile" help:"AWS profile to use (Glue catalog)"`
 
 	RestOptions *config.RestOptions `arg:"-"`
 }
@@ -379,7 +380,12 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 			log.Fatal(err)
 		}
 	case catalog.Glue:
-		awscfg, err := awsconfig.LoadDefaultConfig(ctx)
+		var awsLoadOpts []func(*awsconfig.LoadOptions) error
+		if args.AwsProfile != "" {
+			awsLoadOpts = append(awsLoadOpts, awsconfig.WithSharedConfigProfile(args.AwsProfile))
+		}
+
+		awscfg, err := awsconfig.LoadDefaultConfig(ctx, awsLoadOpts...)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -808,6 +814,10 @@ func mergeConf(fileConf *config.CatalogConfig, args *Args, explicitFlags map[str
 
 	if !explicitFlags["warehouse"] && len(fileConf.Warehouse) > 0 {
 		args.Warehouse = fileConf.Warehouse
+	}
+
+	if !explicitFlags["aws-profile"] && len(fileConf.AwsProfile) > 0 {
+		args.AwsProfile = fileConf.AwsProfile
 	}
 
 	if fileConf.RestOptions != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type CatalogConfig struct {
 	Output      string       `yaml:"output"`
 	Credential  string       `yaml:"credential"`
 	Warehouse   string       `yaml:"warehouse"`
+	AwsProfile  string       `yaml:"aws-profile,omitempty"`
 	RestOptions *RestOptions `yaml:"rest,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type CatalogConfig struct {
 	Output      string       `yaml:"output"`
 	Credential  string       `yaml:"credential"`
 	Warehouse   string       `yaml:"warehouse"`
-	AwsProfile  string       `yaml:"aws-profile,omitempty"`
+	AwsProfile  string       `yaml:"aws-profile"`
 	RestOptions *RestOptions `yaml:"rest,omitempty"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -102,6 +102,19 @@ catalog:
 			},
 		},
 	},
+	// glue catalog with aws-profile
+	{
+		[]byte(`
+catalog:
+  default:
+    type: glue
+    aws-profile: my-aws-profile
+`), "default",
+		&CatalogConfig{
+			CatalogType: "glue",
+			AwsProfile:  "my-aws-profile",
+		},
+	},
 }
 
 func TestParseConfig(t *testing.T) {

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -52,6 +52,7 @@ Catalog connection flags are global and apply to every subcommand:
 | `--scope` | OAuth scope (default `catalog`) |
 | `--catalog-name` | Catalog name to load from config file (default `default`) |
 | `--config` | Path to a config file |
+| `--aws-profile` | AWS named profile to use (Glue catalog); overrides `aws-profile` in the config file |
 
 To avoid passing flags every time, define a config file at `~/.iceberg-go.yaml`:
 ```yaml

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -37,6 +37,7 @@ catalog:
     warehouse: s3://my-bucket/warehouse
     credential: <client-id>:<client-secret>
     output: text
+    aws-profile: ""
     rest:
       sigv4-enabled: false
       signing-name: ""
@@ -52,6 +53,7 @@ catalog:
 | `catalog.<name>.warehouse` | Warehouse identifier (REST/Glue) or location (Hive/SQL). |
 | `catalog.<name>.credential` | Credential string passed through to the catalog's auth handler. |
 | `catalog.<name>.output` | CLI output format (e.g. `text`, `json`). |
+| `catalog.<name>.aws-profile` | AWS named profile for the Glue catalog. When unset, the AWS SDK default credential chain is used. |
 | `catalog.<name>.rest.sigv4-enabled` | Enable AWS SigV4 signing for REST. |
 | `catalog.<name>.rest.signing-name` | SigV4 service name. |
 | `catalog.<name>.rest.signing-region` | SigV4 region. |


### PR DESCRIPTION
## Problem

When using the Glue catalog, the CLI always resolves AWS credentials through the SDK default chain.
Users working with multiple AWS accounts or roles had to fall back to environment variables (`AWS_PROFILE`) or profile-switching wrappers instead of expressing the profile in their iceberg-go config (1 catalog = 1 account = 1 profile).

## Fix

Add an `aws-profile` field to `CatalogConfig` in `config/config.go`.
When the Glue catalog is initialised in `initCatalog`, the profile is passed to `awsconfig.LoadDefaultConfig` via `WithSharedConfigProfile`.
A matching `--aws-profile` CLI flag is also wired up and takes precedence over the config file value (following the same merge pattern used by the other catalog flags).

## How to test

Add an entry to `~/.iceberg-go.yaml`:

```yaml
catalog:
  default:
    type: glue
    aws-profile: my-aws-profile
```

Run any Glue command and confirm it authenticates with the named profile:
```
iceberg list
```

Alternatively, supply it on the command line:
```
iceberg --catalog glue --aws-profile my-aws-profile list
```

Unit test:
```
go test ./config/...
```