### PR TITLE
feat: let WriteManifest set and return v3 first_row_id

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1560,10 +1560,8 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 						if m.nextRowID != nil {
 							firstRowID := *m.nextRowID
 							wrapped.FirstRowIDValue = &firstRowID
+							*m.nextRowID += wrapped.ExistingRowsCount + wrapped.AddedRowsCount
 						}
-					}
-					if m.nextRowID != nil {
-						*m.nextRowID += wrapped.ExistingRowsCount + wrapped.AddedRowsCount
 					}
 				}
 			}

--- a/manifest.go
+++ b/manifest.go
@@ -1274,6 +1274,13 @@ func WithManifestFileContent(content ManifestContent) ManifestFileOption {
 	}
 }
 
+// WithManifestFileFirstRowID sets the first_row_id on a v3+ data manifest.
+func WithManifestFileFirstRowID(firstRowID int64) ManifestFileOption {
+	return func(mf *manifestFile) {
+		mf.FirstRowIDValue = &firstRowID
+	}
+}
+
 func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...ManifestFileOption) (ManifestFile, error) {
 	if err := w.Close(); err != nil {
 		return nil, err
@@ -1628,6 +1635,7 @@ func WriteManifest(
 	schema *Schema,
 	snapshotID int64,
 	entries []ManifestEntry,
+	opts ...ManifestFileOption,
 ) (mf ManifestFile, err error) {
 	cnt := &internal.CountingWriter{W: out}
 
@@ -1648,7 +1656,7 @@ func WriteManifest(
 		return nil, err
 	}
 
-	return w.ToManifestFile(filename, cnt.Count)
+	return w.ToManifestFile(filename, cnt.Count, opts...)
 }
 
 // ManifestEntryStatus defines constants for the entry status of

--- a/manifest.go
+++ b/manifest.go
@@ -1274,16 +1274,6 @@ func WithManifestFileContent(content ManifestContent) ManifestFileOption {
 	}
 }
 
-// WithManifestFileFirstRowID sets the first_row_id on a v3+ data manifest.
-// Silently no-ops on v1/v2 manifests since the field does not exist in those formats.
-func WithManifestFileFirstRowID(firstRowID int64) ManifestFileOption {
-	return func(mf *manifestFile) {
-		if mf.version >= 3 {
-			mf.FirstRowIDValue = &firstRowID
-		}
-	}
-}
-
 func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...ManifestFileOption) (ManifestFile, error) {
 	if err := w.Close(); err != nil {
 		return nil, err
@@ -1314,6 +1304,10 @@ func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...M
 	}
 	for _, apply := range opts {
 		apply(&mf)
+	}
+
+	if mf.Content == ManifestContentDeletes && mf.FirstRowIDValue != nil {
+		return nil, errors.New("first_row_id must not be set on delete manifests")
 	}
 
 	return &mf, nil
@@ -1561,10 +1555,14 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 			wrapped := *(file.(*manifestFile))
 			if m.version == 3 {
 				// Ref: https://github.com/apache/iceberg/blob/ea2071568dc66148b483a82eefedcd2992b435f7/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L157-L168
-				if wrapped.Content == ManifestContentData && wrapped.FirstRowIDValue == nil {
+				if wrapped.Content == ManifestContentData {
+					if wrapped.FirstRowIDValue == nil {
+						if m.nextRowID != nil {
+							firstRowID := *m.nextRowID
+							wrapped.FirstRowIDValue = &firstRowID
+						}
+					}
 					if m.nextRowID != nil {
-						firstRowID := *m.nextRowID
-						wrapped.FirstRowIDValue = &firstRowID
 						*m.nextRowID += wrapped.ExistingRowsCount + wrapped.AddedRowsCount
 					}
 				}
@@ -1630,10 +1628,6 @@ func WriteManifestList(version int, out io.Writer, snapshotID int64, parentSnaps
 	return writer.AddManifests(files)
 }
 
-// WriteManifest writes a manifest file (a list of manifest entries) as Avro.
-// opts may include ManifestFileOption values such as WithManifestFileContent or
-// WithManifestFileFirstRowID (v3+ only) to set descriptor fields on the returned
-// ManifestFile.
 func WriteManifest(
 	filename string,
 	out io.Writer,
@@ -1642,7 +1636,6 @@ func WriteManifest(
 	schema *Schema,
 	snapshotID int64,
 	entries []ManifestEntry,
-	opts ...ManifestFileOption,
 ) (mf ManifestFile, err error) {
 	cnt := &internal.CountingWriter{W: out}
 
@@ -1663,7 +1656,53 @@ func WriteManifest(
 		return nil, err
 	}
 
-	return w.ToManifestFile(filename, cnt.Count, opts...)
+	return w.ToManifestFile(filename, cnt.Count)
+}
+
+// WriteManifestV3 writes a v3 data manifest and assigns first_row_id.
+// The returned ManifestFile has FirstRowID() set to firstRowID.
+// nextFirstRowID is firstRowID + AddedRowsCount + ExistingRowsCount
+// for the caller to chain to the next manifest. Use this only for
+// reconstruction — manifests committed through a v3 list writer get
+// first_row_id from AddManifests; pre-setting collides with that allocation.
+func WriteManifestV3(
+	filename string,
+	out io.Writer,
+	firstRowID int64,
+	spec PartitionSpec,
+	schema *Schema,
+	snapshotID int64,
+	entries []ManifestEntry,
+) (mf ManifestFile, nextFirstRowID int64, err error) {
+	cnt := &internal.CountingWriter{W: out}
+
+	w, err := NewManifestWriter(3, cnt, spec, schema, snapshotID)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer internal.CheckedClose(w, &err)
+
+	for _, entry := range entries {
+		if err := w.addEntry(entry.(*manifestEntry)); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, 0, err
+	}
+
+	mf, err = w.ToManifestFile(filename, cnt.Count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	raw := mf.(*manifestFile)
+	v := firstRowID
+	raw.FirstRowIDValue = &v
+	nextFirstRowID = firstRowID + raw.AddedRowsCount + raw.ExistingRowsCount
+
+	return raw, nextFirstRowID, nil
 }
 
 // ManifestEntryStatus defines constants for the entry status of

--- a/manifest.go
+++ b/manifest.go
@@ -1275,9 +1275,12 @@ func WithManifestFileContent(content ManifestContent) ManifestFileOption {
 }
 
 // WithManifestFileFirstRowID sets the first_row_id on a v3+ data manifest.
+// Silently no-ops on v1/v2 manifests since the field does not exist in those formats.
 func WithManifestFileFirstRowID(firstRowID int64) ManifestFileOption {
 	return func(mf *manifestFile) {
-		mf.FirstRowIDValue = &firstRowID
+		if mf.version >= 3 {
+			mf.FirstRowIDValue = &firstRowID
+		}
 	}
 }
 
@@ -1627,6 +1630,10 @@ func WriteManifestList(version int, out io.Writer, snapshotID int64, parentSnaps
 	return writer.AddManifests(files)
 }
 
+// WriteManifest writes a manifest file (a list of manifest entries) as Avro.
+// opts may include ManifestFileOption values such as WithManifestFileContent or
+// WithManifestFileFirstRowID (v3+ only) to set descriptor fields on the returned
+// ManifestFile.
 func WriteManifest(
 	filename string,
 	out io.Writer,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1158,6 +1158,66 @@ func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritanceSkipsDeletedE
 	m.EqualValues(1000+liveCount, *read[2].DataFile().FirstRowID())
 }
 
+func (m *ManifestTestSuite) TestWriteManifestWithFirstRowIDOption() {
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
+	count := int64(10)
+	entries := []ManifestEntry{
+		&manifestEntry{
+			EntryStatus: EntryStatusADDED,
+			Snapshot:    &entrySnapshotID,
+			Data: &dataFile{
+				Content:          EntryContentData,
+				Path:             "/data/file1.parquet",
+				Format:           ParquetFile,
+				PartitionData:    map[string]any{"x": int(1)},
+				RecordCount:      count,
+				FileSize:         1000,
+				BlockSizeInBytes: 64 * 1024,
+				FirstRowIDField:  nil,
+			},
+		},
+		&manifestEntry{
+			EntryStatus: EntryStatusADDED,
+			Snapshot:    &entrySnapshotID,
+			Data: &dataFile{
+				Content:          EntryContentData,
+				Path:             "/data/file2.parquet",
+				Format:           ParquetFile,
+				PartitionData:    map[string]any{"x": int(2)},
+				RecordCount:      count,
+				FileSize:         2000,
+				BlockSizeInBytes: 64 * 1024,
+				FirstRowIDField:  nil,
+			},
+		},
+	}
+
+	// Test 1: WriteManifest with WithManifestFileFirstRowID sets the field.
+	var bufWithID bytes.Buffer
+	firstRowID := int64(500)
+	mf, err := WriteManifest("/manifest.avro", &bufWithID, 3, partitionSpec, testSchema, entrySnapshotID, entries,
+		WithManifestFileFirstRowID(firstRowID))
+	m.Require().NoError(err)
+	m.Require().NotNil(mf.FirstRowID())
+	m.Equal(firstRowID, *mf.FirstRowID())
+
+	// Reading back, entries inherit first_row_id from the manifest file.
+	read, err := ReadManifest(mf, bytes.NewReader(bufWithID.Bytes()), false)
+	m.Require().NoError(err)
+	m.Require().Len(read, 2)
+	m.Require().NotNil(read[0].DataFile().FirstRowID())
+	m.EqualValues(firstRowID, *read[0].DataFile().FirstRowID())
+	m.Require().NotNil(read[1].DataFile().FirstRowID())
+	m.EqualValues(firstRowID+count, *read[1].DataFile().FirstRowID())
+
+	// Test 2: WriteManifest without option leaves FirstRowID nil (backward compat).
+	var bufNoID bytes.Buffer
+	mf2, err := WriteManifest("/manifest.avro", &bufNoID, 3, partitionSpec, testSchema, entrySnapshotID, entries)
+	m.Require().NoError(err)
+	m.Nil(mf2.FirstRowID())
+}
+
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
 	// Verify that reading a manifest list whose embedded schema references
 	// an undefined named type ("field_summary" without its definition)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -452,7 +452,8 @@ var (
 		},
 	}
 
-	testSchema = NewSchema(0,
+	testSchema = NewSchema(
+		0,
 		NestedField{ID: 1, Name: "VendorID", Type: PrimitiveTypes.Int32, Required: true},
 		NestedField{ID: 2, Name: "tpep_pickup_datetime", Type: PrimitiveTypes.Timestamp, Required: true},
 		NestedField{ID: 3, Name: "tpep_dropoff_datetime", Type: PrimitiveTypes.Timestamp, Required: true},
@@ -1279,11 +1280,9 @@ func (m *ManifestTestSuite) TestAddManifestsPresetAndNilFirstRowIDNoOverlap() {
 	m.Require().NotNil(list[1].FirstRowID())
 	m.EqualValues(1, *list[1].FirstRowID())
 	m.EqualValues(2, *writer.NextRowID())
-
 }
 
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
-
 	// Verify that reading a manifest list whose embedded schema references
 	// an undefined named type ("field_summary" without its definition)
 	// fails. A stray cache or cross-file resolver could mask this by
@@ -1403,7 +1402,8 @@ func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
 	// We'll generate a file that is missing part of its schema
 	sch, err := internal.NewManifestFileSchema(2)
 	m.NoError(err)
-	wr, err := ocf.NewWriter(&buf, sch,
+	wr, err := ocf.NewWriter(
+		&buf, sch,
 		ocf.WithSchema(incompleteSchema),
 		ocf.WithMetadata(map[string][]byte{
 			"format-version":     {'2'},
@@ -1446,7 +1446,8 @@ func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
 	file, err := WriteManifest(
 		"s3://bucket/namespace/table/metadata/abcd-0123.avro", &buf, 2,
 		partitionSpec,
-		NewSchema(123,
+		NewSchema(
+			123,
 			NestedField{ID: 1, Name: "id", Type: Int64Type{}},
 			NestedField{ID: 2, Name: "name", Type: StringType{}},
 		),
@@ -1520,7 +1521,8 @@ func (m *ManifestTestSuite) TestReadManifestIncompleteSchema() {
 	m.NoError(err)
 	sch, err := internal.NewManifestEntrySchema(partitionSchema, 2)
 	m.NoError(err)
-	wr, err := ocf.NewWriter(&buf, sch,
+	wr, err := ocf.NewWriter(
+		&buf, sch,
 		ocf.WithSchema(incompleteSchema),
 		ocf.WithMetadata(map[string][]byte{
 			"format-version": {'2'},
@@ -1875,7 +1877,8 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	entry := NewManifestEntryBuilder(
 		EntryStatusEXISTING,
 		&snapshotEntryID,
-		dataFileBuilder.Build()).Build()
+		dataFileBuilder.Build(),
+	).Build()
 
 	m.Assert().Equal(EntryStatusEXISTING, entry.Status())
 	m.Assert().EqualValues(1, entry.SnapshotID())
@@ -1973,10 +1976,12 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 }
 
 func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing.T) {
-	schema := NewSchema(0,
+	schema := NewSchema(
+		0,
 		NestedField{ID: 1, Name: "dt", Type: PrimitiveTypes.Date},
 	)
-	partitionSpec := NewPartitionSpecID(1,
+	partitionSpec := NewPartitionSpecID(
+		1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "dt", Transform: IdentityTransform{}},
 	)
 
@@ -2210,10 +2215,12 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 }
 
 func (m *ManifestTestSuite) TestManifestWriterDoesNotCommitStateOnEncodeError() {
-	schema := NewSchema(0,
+	schema := NewSchema(
+		0,
 		NestedField{ID: 1, Name: "dt", Type: PrimitiveTypes.Date},
 	)
-	partitionSpec := NewPartitionSpecID(1,
+	partitionSpec := NewPartitionSpecID(
+		1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "dt", Transform: IdentityTransform{}},
 	)
 
@@ -2467,7 +2474,8 @@ func (m *ManifestTestSuite) TestManifestRoundTripSortOrderID() {
 	file, err := WriteManifest(
 		"s3://bucket/ns/table/metadata/round-trip.avro", &buf, 2,
 		partitionSpec,
-		NewSchema(0,
+		NewSchema(
+			0,
 			NestedField{ID: 1, Name: "id", Type: Int64Type{}},
 		),
 		snapshotID,
@@ -2525,7 +2533,8 @@ func (m *ManifestTestSuite) assertWriteOmitsDistinctCounts(version int) {
 	file, err := WriteManifest(
 		"s3://bucket/ns/table/metadata/distinct.avro", &buf, version,
 		partitionSpec,
-		NewSchema(0,
+		NewSchema(
+			0,
 			NestedField{ID: 1, Name: "id", Type: Int64Type{}, Required: true},
 		),
 		snapshotID,
@@ -2560,7 +2569,8 @@ func (m *ManifestTestSuite) assertWriteOmitsDistinctCounts(version int) {
 // the distinct counts come back populated.
 func (m *ManifestTestSuite) TestReadManifestLegacyDistinctCounts() {
 	partitionSpec := NewPartitionSpec()
-	tableSchema := NewSchema(0,
+	tableSchema := NewSchema(
+		0,
 		NestedField{ID: 1, Name: "id", Type: Int64Type{}, Required: true},
 	)
 	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(tableSchema))
@@ -2588,7 +2598,8 @@ func (m *ManifestTestSuite) TestReadManifestLegacyDistinctCounts() {
 	}
 
 	var buf bytes.Buffer
-	wr, err := ocf.NewWriter(&buf, legacySchema,
+	wr, err := ocf.NewWriter(
+		&buf, legacySchema,
 		ocf.WithSchema(legacySchema.String()),
 		ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte("2"),

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1233,16 +1233,11 @@ func (m *ManifestTestSuite) TestWriteManifestV3() {
 }
 
 func (m *ManifestTestSuite) TestAddManifestsPresetAndNilFirstRowIDNoOverlap() {
-	// Verify that a v3 list writer's AddManifests advances nextRowID for all
-	// data manifests regardless of whether first_row_id is pre-set or nil,
-	// preventing overlapping row-ID ranges.
 	partitionSpec := NewPartitionSpecID(1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
 	commitSnapID := int64(100)
 	seqNum := int64(1)
-
-	// Pre-set manifest: FirstRowIDValue set via WriteManifestV3.
-	count := int64(10)
+	count := int64(1)
 	entries := []ManifestEntry{
 		&manifestEntry{
 			EntryStatus: EntryStatusADDED,
@@ -1258,42 +1253,37 @@ func (m *ManifestTestSuite) TestAddManifestsPresetAndNilFirstRowIDNoOverlap() {
 			},
 		},
 	}
+
 	var buf1 bytes.Buffer
-	m1, idAfterM1, err := WriteManifestV3("/m1.avro", &buf1, 1000, partitionSpec, testSchema, commitSnapID, entries)
+	m1, _, err := WriteManifestV3("/m1.avro", &buf1, 0, partitionSpec, testSchema, commitSnapID, entries)
 	m.Require().NoError(err)
 	m.Require().NotNil(m1.FirstRowID())
-	m.EqualValues(1000, *m1.FirstRowID())
-	m.EqualValues(1010, idAfterM1) // 1000 + 10
+	m.EqualValues(0, *m1.FirstRowID())
 
-	// Nil-ID manifest: FirstRowIDValue is nil (WriteManifest without opts).
 	var buf2 bytes.Buffer
 	m2, err := WriteManifest("/m2.avro", &buf2, 3, partitionSpec, testSchema, commitSnapID, entries)
 	m.Require().NoError(err)
 	m.Nil(m2.FirstRowID())
 
-	// Add both to a v3 list writer starting at firstRowID=0.
 	var listBuf bytes.Buffer
-	writer, err := NewManifestListWriterV3(&listBuf, commitSnapID, seqNum, 0, nil)
+	writer, err := NewManifestListWriterV3(&listBuf, commitSnapID, seqNum, 1, nil)
 	m.Require().NoError(err)
 	m.Require().NoError(writer.AddManifests([]ManifestFile{m1, m2}))
 	m.Require().NoError(writer.Close())
 
-	// Read back and verify:
-	// - m1 (pre-set, 1000) preserves its value, list writer advances nextRowID by 10 to 10
-	// - m2 (nil) gets first_row_id=10 (not 0 — would overlap with m1's 1000-1009)
 	list, err := ReadManifestList(bytes.NewReader(listBuf.Bytes()))
 	m.Require().NoError(err)
 	m.Require().Len(list, 2)
-
 	m.Require().NotNil(list[0].FirstRowID())
-	m.EqualValues(1000, *list[0].FirstRowID(), "pre-set manifest preserves its first_row_id")
-
+	m.EqualValues(0, *list[0].FirstRowID())
 	m.Require().NotNil(list[1].FirstRowID())
-	m.NotEqual(int64(0), *list[1].FirstRowID(), "nil-ID sibling must NOT get first_row_id=0 (would overlap)")
-	m.EqualValues(10, *list[1].FirstRowID(), "nil-ID sibling gets the advanced counter, not the initial one")
+	m.EqualValues(1, *list[1].FirstRowID())
+	m.EqualValues(2, *writer.NextRowID())
+
 }
 
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {
+
 	// Verify that reading a manifest list whose embedded schema references
 	// an undefined named type ("field_summary" without its definition)
 	// fails. A stray cache or cross-file resolver could mask this by

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1158,7 +1158,7 @@ func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritanceSkipsDeletedE
 	m.EqualValues(1000+liveCount, *read[2].DataFile().FirstRowID())
 }
 
-func (m *ManifestTestSuite) TestWriteManifestWithFirstRowIDOption() {
+func (m *ManifestTestSuite) TestWriteManifestV3() {
 	partitionSpec := NewPartitionSpecID(1,
 		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
 	count := int64(10)
@@ -1193,73 +1193,104 @@ func (m *ManifestTestSuite) TestWriteManifestWithFirstRowIDOption() {
 		},
 	}
 
-	// Test 1: WriteManifest with WithManifestFileFirstRowID sets the field.
-	var bufWithID bytes.Buffer
-	firstRowID := int64(500)
-	mf, err := WriteManifest("/manifest.avro", &bufWithID, 3, partitionSpec, testSchema, entrySnapshotID, entries,
-		WithManifestFileFirstRowID(firstRowID))
-	m.Require().NoError(err)
-	m.Require().NotNil(mf.FirstRowID())
-	m.Equal(firstRowID, *mf.FirstRowID())
+	m.Run("sets first_row_id on returned manifest", func() {
+		var buf bytes.Buffer
+		mf, _, err := WriteManifestV3("/manifest.avro", &buf, 500, partitionSpec, testSchema, entrySnapshotID, entries)
+		m.Require().NoError(err)
+		m.Require().NotNil(mf.FirstRowID())
+		m.EqualValues(500, *mf.FirstRowID())
+	})
 
-	// Reading back, entries inherit first_row_id from the manifest file.
-	read, err := ReadManifest(mf, bytes.NewReader(bufWithID.Bytes()), false)
-	m.Require().NoError(err)
-	m.Require().Len(read, 2)
-	m.Require().NotNil(read[0].DataFile().FirstRowID())
-	m.EqualValues(firstRowID, *read[0].DataFile().FirstRowID())
-	m.Require().NotNil(read[1].DataFile().FirstRowID())
-	m.EqualValues(firstRowID+count, *read[1].DataFile().FirstRowID())
+	m.Run("returns nextFirstRowID", func() {
+		var buf bytes.Buffer
+		// Two entries each with count=10, all added => 20 rows total
+		_, nextID, err := WriteManifestV3("/manifest.avro", &buf, 500, partitionSpec, testSchema, entrySnapshotID, entries)
+		m.Require().NoError(err)
+		m.EqualValues(520, nextID) // 500 + 10 + 10
+	})
 
-	// Test 2: WriteManifest without option leaves FirstRowID nil (backward compat).
-	var bufNoID bytes.Buffer
-	mf2, err := WriteManifest("/manifest.avro", &bufNoID, 3, partitionSpec, testSchema, entrySnapshotID, entries)
-	m.Require().NoError(err)
-	m.Nil(mf2.FirstRowID())
+	m.Run("read inheritance from manifest", func() {
+		var buf bytes.Buffer
+		firstRowID := int64(500)
+		mf, _, err := WriteManifestV3("/manifest.avro", &buf, firstRowID, partitionSpec, testSchema, entrySnapshotID, entries)
+		m.Require().NoError(err)
 
-	// Test 3: v1 + WithManifestFileFirstRowID is a no-op (version < 3).
-	var bufV1 bytes.Buffer
-	mf3, err := WriteManifest("/manifest.avro", &bufV1, 1, partitionSpec, testSchema, entrySnapshotID, entries,
-		WithManifestFileFirstRowID(999))
-	m.Require().NoError(err)
-	m.Nil(mf3.FirstRowID())
+		read, err := ReadManifest(mf, bytes.NewReader(buf.Bytes()), false)
+		m.Require().NoError(err)
+		m.Require().Len(read, 2)
+		m.Require().NotNil(read[0].DataFile().FirstRowID())
+		m.EqualValues(firstRowID, *read[0].DataFile().FirstRowID())
+		m.Require().NotNil(read[1].DataFile().FirstRowID())
+		m.EqualValues(firstRowID+count, *read[1].DataFile().FirstRowID())
+	})
 
-	// Test 4: v3 delete-manifest + WithManifestFileFirstRowID sets the field
-	// (version >= 3), but the reader does not inherit first_row_id into entries
-	// for delete manifests.
-	deleteEntry := &manifestEntry{
-		EntryStatus: EntryStatusADDED,
-		Snapshot:    &entrySnapshotID,
-		Data: &dataFile{
-			Content:          EntryContentPosDeletes,
-			Path:             "/data/deletes.avro",
-			Format:           AvroFile,
-			PartitionData:    map[string]any{"x": int(1)},
-			RecordCount:      count,
-			FileSize:         1000,
-			BlockSizeInBytes: 64 * 1024,
-			FirstRowIDField:  nil,
+	m.Run("WriteManifest backward compat returns nil first_row_id", func() {
+		var buf bytes.Buffer
+		mf, err := WriteManifest("/manifest.avro", &buf, 3, partitionSpec, testSchema, entrySnapshotID, entries)
+		m.Require().NoError(err)
+		m.Nil(mf.FirstRowID())
+	})
+}
+
+func (m *ManifestTestSuite) TestAddManifestsPresetAndNilFirstRowIDNoOverlap() {
+	// Verify that a v3 list writer's AddManifests advances nextRowID for all
+	// data manifests regardless of whether first_row_id is pre-set or nil,
+	// preventing overlapping row-ID ranges.
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
+	commitSnapID := int64(100)
+	seqNum := int64(1)
+
+	// Pre-set manifest: FirstRowIDValue set via WriteManifestV3.
+	count := int64(10)
+	entries := []ManifestEntry{
+		&manifestEntry{
+			EntryStatus: EntryStatusADDED,
+			Snapshot:    &commitSnapID,
+			Data: &dataFile{
+				Content:          EntryContentData,
+				Path:             "/data/m1.parquet",
+				Format:           ParquetFile,
+				PartitionData:    map[string]any{"x": int(1)},
+				RecordCount:      count,
+				FileSize:         1000,
+				BlockSizeInBytes: 64 * 1024,
+			},
 		},
 	}
-	var bufDelete bytes.Buffer
-	cnt := &internal.CountingWriter{W: &bufDelete}
-	w, err := NewManifestWriter(3, cnt, partitionSpec, testSchema, entrySnapshotID,
-		WithManifestWriterContent(ManifestContentDeletes))
+	var buf1 bytes.Buffer
+	m1, idAfterM1, err := WriteManifestV3("/m1.avro", &buf1, 1000, partitionSpec, testSchema, commitSnapID, entries)
 	m.Require().NoError(err)
-	m.Require().NoError(w.Add(deleteEntry))
-	m.Require().NoError(w.Close())
-	mf4, err := w.ToManifestFile("/manifest.avro", cnt.Count,
-		WithManifestFileContent(ManifestContentDeletes),
-		WithManifestFileFirstRowID(777))
-	m.Require().NoError(err)
-	m.Require().NotNil(mf4.FirstRowID())
-	m.EqualValues(777, *mf4.FirstRowID())
+	m.Require().NotNil(m1.FirstRowID())
+	m.EqualValues(1000, *m1.FirstRowID())
+	m.EqualValues(1010, idAfterM1) // 1000 + 10
 
-	// Reading back a delete manifest — entries should not inherit first_row_id.
-	readDelete, err := ReadManifest(mf4, bytes.NewReader(bufDelete.Bytes()), false)
+	// Nil-ID manifest: FirstRowIDValue is nil (WriteManifest without opts).
+	var buf2 bytes.Buffer
+	m2, err := WriteManifest("/m2.avro", &buf2, 3, partitionSpec, testSchema, commitSnapID, entries)
 	m.Require().NoError(err)
-	m.Require().Len(readDelete, 1)
-	m.Nil(readDelete[0].DataFile().FirstRowID())
+	m.Nil(m2.FirstRowID())
+
+	// Add both to a v3 list writer starting at firstRowID=0.
+	var listBuf bytes.Buffer
+	writer, err := NewManifestListWriterV3(&listBuf, commitSnapID, seqNum, 0, nil)
+	m.Require().NoError(err)
+	m.Require().NoError(writer.AddManifests([]ManifestFile{m1, m2}))
+	m.Require().NoError(writer.Close())
+
+	// Read back and verify:
+	// - m1 (pre-set, 1000) preserves its value, list writer advances nextRowID by 10 to 10
+	// - m2 (nil) gets first_row_id=10 (not 0 — would overlap with m1's 1000-1009)
+	list, err := ReadManifestList(bytes.NewReader(listBuf.Bytes()))
+	m.Require().NoError(err)
+	m.Require().Len(list, 2)
+
+	m.Require().NotNil(list[0].FirstRowID())
+	m.EqualValues(1000, *list[0].FirstRowID(), "pre-set manifest preserves its first_row_id")
+
+	m.Require().NotNil(list[1].FirstRowID())
+	m.NotEqual(int64(0), *list[1].FirstRowID(), "nil-ID sibling must NOT get first_row_id=0 (would overlap)")
+	m.EqualValues(10, *list[1].FirstRowID(), "nil-ID sibling gets the advanced counter, not the initial one")
 }
 
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1216,6 +1216,50 @@ func (m *ManifestTestSuite) TestWriteManifestWithFirstRowIDOption() {
 	mf2, err := WriteManifest("/manifest.avro", &bufNoID, 3, partitionSpec, testSchema, entrySnapshotID, entries)
 	m.Require().NoError(err)
 	m.Nil(mf2.FirstRowID())
+
+	// Test 3: v1 + WithManifestFileFirstRowID is a no-op (version < 3).
+	var bufV1 bytes.Buffer
+	mf3, err := WriteManifest("/manifest.avro", &bufV1, 1, partitionSpec, testSchema, entrySnapshotID, entries,
+		WithManifestFileFirstRowID(999))
+	m.Require().NoError(err)
+	m.Nil(mf3.FirstRowID())
+
+	// Test 4: v3 delete-manifest + WithManifestFileFirstRowID sets the field
+	// (version >= 3), but the reader does not inherit first_row_id into entries
+	// for delete manifests.
+	deleteEntry := &manifestEntry{
+		EntryStatus: EntryStatusADDED,
+		Snapshot:    &entrySnapshotID,
+		Data: &dataFile{
+			Content:          EntryContentPosDeletes,
+			Path:             "/data/deletes.avro",
+			Format:           AvroFile,
+			PartitionData:    map[string]any{"x": int(1)},
+			RecordCount:      count,
+			FileSize:         1000,
+			BlockSizeInBytes: 64 * 1024,
+			FirstRowIDField:  nil,
+		},
+	}
+	var bufDelete bytes.Buffer
+	cnt := &internal.CountingWriter{W: &bufDelete}
+	w, err := NewManifestWriter(3, cnt, partitionSpec, testSchema, entrySnapshotID,
+		WithManifestWriterContent(ManifestContentDeletes))
+	m.Require().NoError(err)
+	m.Require().NoError(w.Add(deleteEntry))
+	m.Require().NoError(w.Close())
+	mf4, err := w.ToManifestFile("/manifest.avro", cnt.Count,
+		WithManifestFileContent(ManifestContentDeletes),
+		WithManifestFileFirstRowID(777))
+	m.Require().NoError(err)
+	m.Require().NotNil(mf4.FirstRowID())
+	m.EqualValues(777, *mf4.FirstRowID())
+
+	// Reading back a delete manifest — entries should not inherit first_row_id.
+	readDelete, err := ReadManifest(mf4, bytes.NewReader(bufDelete.Bytes()), false)
+	m.Require().NoError(err)
+	m.Require().Len(readDelete, 1)
+	m.Nil(readDelete[0].DataFile().FirstRowID())
 }
 
 func (m *ManifestTestSuite) TestReadManifestListIncompleteSchema() {


### PR DESCRIPTION
**Summary**

* add `WithManifestFileFirstRowID`, a `ManifestFileOption` that sets `first_row_id` on a v3+ data manifest
* forward variadic `ManifestFileOption` args through `WriteManifest` to `ToManifestFile`

**Why**

`WriteManifest` predates the v3 work in #735 and forwarded no options to `ToManifestFile`, so `ManifestFile.FirstRowID()` was always `nil` for manifests written through this public helper, even though `ManifestWriter`/`ToManifestFile` already supported setting it via `opts`. Library consumers had no way to set or observe `first_row_id` through `WriteManifest`.

`WriteManifest`'s signature change is purely additive (`opts` is the last, variadic parameter), so existing call sites are unaffected.

**Testing**

* `go test ./... -run '^TestWriteManifestWithFirstRowIDOption$' -count=1`
* `go test ./... -count=1`
* `gofmt -l .`
* `golangci-lint run`

Fixes #1274