### PR TITLE
fix(literals): handle non-int64 big-int correctly when casting DecimalLiteral to Int32

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -1268,14 +1268,22 @@ func (d DecimalLiteral) To(t Type) (Literal, error) {
 		return nil, fmt.Errorf("%w: could not convert %v to %s",
 			ErrBadCast, d, t)
 	case Int32Type:
-		v := d.Val.BigInt().Int64()
-		if v > math.MaxInt32 {
+		v := d.Val.BigInt()
+		if !v.IsInt64() {
+			if v.Sign() > 0 {
+				return Int32AboveMaxLiteral(), nil
+			} else if v.Sign() < 0 {
+				return Int32BelowMinLiteral(), nil
+			}
+		}
+		i := v.Int64()
+		if i > math.MaxInt32 {
 			return Int32AboveMaxLiteral(), nil
-		} else if v < math.MinInt32 {
+		} else if i < math.MinInt32 {
 			return Int32BelowMinLiteral(), nil
 		}
 
-		return Int32Literal(int32(v)), nil
+		return Int32Literal(int32(i)), nil
 	case Int64Type:
 		v := d.Val.BigInt()
 		if !v.IsInt64() {

--- a/literals_test.go
+++ b/literals_test.go
@@ -437,6 +437,16 @@ func TestDecimalLiteralConversions(t *testing.T) {
 	assert.Equal(t, iceberg.Int64BelowMinLiteral(), below)
 	assert.Equal(t, iceberg.PrimitiveTypes.Int64, below.Type())
 
+	above, err = iceberg.DecimalLiteral(n4).To(iceberg.PrimitiveTypes.Int32)
+	require.NoError(t, err)
+	assert.Equal(t, iceberg.Int32AboveMaxLiteral(), above)
+	assert.Equal(t, iceberg.PrimitiveTypes.Int32, above.Type())
+
+	below, err = iceberg.DecimalLiteral(n5).To(iceberg.PrimitiveTypes.Int32)
+	require.NoError(t, err)
+	assert.Equal(t, iceberg.Int32BelowMinLiteral(), below)
+	assert.Equal(t, iceberg.PrimitiveTypes.Int32, below.Type())
+
 	v, err := decimal128.FromFloat64(math.MaxFloat32+1e37, 38, -1)
 	require.NoError(t, err)
 	above, err = iceberg.DecimalLiteral(iceberg.Decimal{Val: v, Scale: -1}).

--- a/literals_test.go
+++ b/literals_test.go
@@ -447,6 +447,13 @@ func TestDecimalLiteralConversions(t *testing.T) {
 	assert.Equal(t, iceberg.Int32BelowMinLiteral(), below)
 	assert.Equal(t, iceberg.PrimitiveTypes.Int32, below.Type())
 
+	n6 := iceberg.Decimal{Val: decimal128.FromU64(uint64(math.MaxInt64) + 2).Negate(), Scale: 0}
+
+	below, err = iceberg.DecimalLiteral(n6).To(iceberg.PrimitiveTypes.Int32)
+	require.NoError(t, err)
+	assert.Equal(t, iceberg.Int32BelowMinLiteral(), below)
+	assert.Equal(t, iceberg.PrimitiveTypes.Int32, below.Type())
+
 	v, err := decimal128.FromFloat64(math.MaxFloat32+1e37, 38, -1)
 	require.NoError(t, err)
 	above, err = iceberg.DecimalLiteral(iceberg.Decimal{Val: v, Scale: -1}).


### PR DESCRIPTION
## Description

Fixes #1322, the incorrect overflow direction detection in `DecimalLiteral.To(Int32Type)` for decimal values whose unscaled `big.Int` exceeds the `int64` range.

## Testing
Added regression tests covering:
1. Positive values outside the `int64` range (`n4`).
2. Negative values that previously produced an incorrect in-range `Int32Literal` (`n5`).
3. Negative values outside the `int64` range that previously returned the wrong overflow sentinel (`n6`).