### PR TITLE
fix(hadoop): publish metadata without replacing existing files

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -196,6 +196,22 @@ func (c *Catalog) defaultTableLocation(ident table.Identifier) string {
 	return c.tableToPath(ident)
 }
 
+// publishMetadataFile atomically publishes a staged metadata file without
+// replacing an existing destination file.
+func (c *Catalog) publishMetadataFile(tempPath, finalPath string) error {
+	if err := c.filesystem.Link(tempPath, finalPath); err != nil {
+		_ = c.filesystem.Remove(tempPath)
+
+		return err
+	}
+
+	if err := c.filesystem.Remove(tempPath); err != nil {
+		log.Printf("hadoop catalog: failed to remove staged metadata file %s after publish: %v", tempPath, err)
+	}
+
+	return nil
+}
+
 // isTableDir reports whether path is a table directory by checking for
 // metadata files in its metadata/ subdirectory. It recognizes:
 //   - v*.metadata.json (Hadoop catalog format)
@@ -400,8 +416,10 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
-	if err := c.filesystem.Rename(tempPath, metaPath); err != nil {
-		_ = c.filesystem.Remove(tempPath)
+	if err := c.publishMetadataFile(tempPath, metaPath); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("%w: %s", catalog.ErrTableAlreadyExists, strings.Join(ident, "."))
+		}
 
 		return nil, fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
 	}
@@ -520,17 +538,11 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to write table metadata: %w", err)
 	}
 
-	// Conflict detection: target file must not already exist.
-	if _, err := c.filesystem.Stat(newMetaPath); err == nil {
-		_ = c.filesystem.Remove(tempPath)
-
-		return nil, "", fmt.Errorf("hadoop catalog: version %d already exists for table %s",
-			newVersion, strings.Join(ident, "."))
-	}
-
-	// Atomic commit via rename.
-	if err := c.filesystem.Rename(tempPath, newMetaPath); err != nil {
-		_ = c.filesystem.Remove(tempPath)
+	if err := c.publishMetadataFile(tempPath, newMetaPath); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return nil, "", fmt.Errorf("hadoop catalog: version %d already exists for table %s",
+				newVersion, strings.Join(ident, "."))
+		}
 
 		return nil, "", fmt.Errorf("hadoop catalog: failed to commit metadata file: %w", err)
 	}

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -473,6 +473,26 @@ func (f *statFailingFS) Stat(string) (fs.FileInfo, error) {
 	return nil, errors.New("stat should not be called")
 }
 
+type linkConflictFS struct {
+	icebergio.LocalFS
+	target    string
+	contents  []byte
+	linkCalls int
+}
+
+func (f *linkConflictFS) Link(oldpath, newpath string) error {
+	f.linkCalls++
+	if newpath == f.target {
+		if err := os.WriteFile(newpath, f.contents, 0o644); err != nil {
+			return err
+		}
+
+		return fs.ErrExist
+	}
+
+	return f.LocalFS.Link(oldpath, newpath)
+}
+
 func (s *HadoopCatalogTestSuite) TestDropNamespaceDoesNotPreStat() {
 	nsDir := filepath.Join(s.warehouse, "ns")
 	s.Require().NoError(os.Mkdir(nsDir, 0o755))
@@ -1029,6 +1049,34 @@ func (s *HadoopCatalogTestSuite) TestCreateTableAlreadyExists() {
 	s.ErrorIs(err, catalog.ErrTableAlreadyExists)
 }
 
+func (s *HadoopCatalogTestSuite) TestCreateTableDoesNotOverwriteConcurrentMetadataFile() {
+	ctx := context.Background()
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	ident := []string{"ns", "tbl"}
+	metaPath := s.cat.metadataFilePath(ident, 1)
+	fsys := &linkConflictFS{
+		LocalFS:  icebergio.LocalFS{},
+		target:   metaPath,
+		contents: []byte("existing create winner"),
+	}
+	s.cat.filesystem = fsys
+
+	_, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().Error(err)
+	s.ErrorIs(err, catalog.ErrTableAlreadyExists)
+	s.Equal(1, fsys.linkCalls)
+
+	data, err := os.ReadFile(metaPath)
+	s.Require().NoError(err)
+	s.Equal(fsys.contents, data)
+
+	entries, err := os.ReadDir(s.cat.metadataDir(ident))
+	s.Require().NoError(err)
+	s.Len(entries, 1)
+	s.Equal("v1.metadata.json", entries[0].Name())
+}
+
 func (s *HadoopCatalogTestSuite) TestCreateTableWithPartitionSpec() {
 	ctx := context.Background()
 	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
@@ -1450,12 +1498,11 @@ func (s *HadoopCatalogTestSuite) TestCommitTableNoChanges() {
 }
 
 func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetection() {
-	// Conflict detection relies on os.Stat checking whether the target
-	// v{N+1}.metadata.json already exists before the atomic rename.
-	// In a single-threaded test we cannot trigger the TOCTOU race
-	// between findVersion and os.Stat. Instead, we verify that after
-	// multiple sequential commits, the version sequence is contiguous
-	// and no versions are skipped or duplicated.
+	// In a single-threaded test we cannot trigger the publish race
+	// where another writer wins the same metadata version first.
+	// Instead, we verify that after multiple sequential commits,
+	// the version sequence is contiguous and no versions are skipped
+	// or duplicated.
 	ctx := context.Background()
 	s.createTestTable("ns", "tbl")
 	ident := []string{"ns", "tbl"}
@@ -1474,6 +1521,49 @@ func (s *HadoopCatalogTestSuite) TestCommitTableConflictDetection() {
 		s.Contains(metaLoc, fmt.Sprintf("v%d.metadata.json", i))
 		s.FileExists(s.cat.metadataFilePath(ident, i))
 	}
+}
+
+func (s *HadoopCatalogTestSuite) TestCommitTableDoesNotOverwriteConcurrentMetadataFile() {
+	ctx := context.Background()
+	s.createTestTable("ns", "tbl")
+
+	ident := []string{"ns", "tbl"}
+	metaPath := s.cat.metadataFilePath(ident, 2)
+	fsys := &linkConflictFS{
+		LocalFS:  icebergio.LocalFS{},
+		target:   metaPath,
+		contents: []byte("existing commit winner"),
+	}
+	s.cat.filesystem = fsys
+
+	_, _, err := s.cat.CommitTable(
+		ctx, ident,
+		nil,
+		[]table.Update{
+			table.NewSetPropertiesUpdate(iceberg.Properties{"k": "v"}),
+		},
+	)
+	s.Require().Error(err)
+	s.Equal("hadoop catalog: version 2 already exists for table ns.tbl", err.Error())
+	s.Equal(1, fsys.linkCalls)
+
+	data, readErr := os.ReadFile(metaPath)
+	s.Require().NoError(readErr)
+	s.Equal(fsys.contents, data)
+	s.Equal(1, s.cat.readVersionHint(ident))
+
+	entries, readDirErr := os.ReadDir(s.cat.metadataDir(ident))
+	s.Require().NoError(readDirErr)
+	s.Len(entries, 3)
+
+	names := map[string]bool{}
+	for _, entry := range entries {
+		names[entry.Name()] = true
+	}
+
+	s.True(names["v1.metadata.json"])
+	s.True(names["v2.metadata.json"])
+	s.True(names["version-hint.text"])
 }
 
 func (s *HadoopCatalogTestSuite) TestCommitTableRequirementFailure() {

--- a/catalog/hadoop/io.go
+++ b/catalog/hadoop/io.go
@@ -30,6 +30,7 @@ type HadoopCatalogFS interface {
 	icebergio.ReadFileIO
 	icebergio.WriteFileIO
 	StatIO
+	LinkIO
 	RenameIO
 	RemoveAllIO
 	MkdirAllIO
@@ -54,6 +55,15 @@ type RenameIO interface {
 	icebergio.IO
 
 	Rename(oldpath, newpath string) error
+}
+
+// LinkIO is an extension of IO interface that includes the Link
+// method for atomically publishing a new file without replacing an
+// existing destination.
+type LinkIO interface {
+	icebergio.IO
+
+	Link(oldpath, newpath string) error
 }
 
 // RemoveAllIO is an extension of IO interface that includes the RemoveAll

--- a/io/local.go
+++ b/io/local.go
@@ -85,3 +85,7 @@ func (LocalFS) Stat(name string) (fs.FileInfo, error) {
 func (LocalFS) Rename(oldpath, newpath string) error {
 	return os.Rename(strings.TrimPrefix(oldpath, "file://"), strings.TrimPrefix(newpath, "file://"))
 }
+
+func (LocalFS) Link(oldpath, newpath string) error {
+	return os.Link(strings.TrimPrefix(oldpath, "file://"), strings.TrimPrefix(newpath, "file://"))
+}


### PR DESCRIPTION
Summary

- publish staged metadata by hard-linking into place instead of renaming over the target
- use the same no-replace publish path for both CreateTable and CommitTable
- add regression coverage that a rival metadata file wins without being overwritten

Why

CreateTable and CommitTable currently stage metadata to a temp file and then rename it into place. On POSIX, rename can replace an existing destination, so a concurrent writer that publishes the same metadata version first can still be overwritten by the loser.

Using link(temp, final) keeps the publish step atomic while making an existing destination fail with ErrExist instead of being replaced.

Testing

- go test ./catalog/hadoop -run 'TestHadoopCatalogTestSuite/(TestCreateTableDoesNotOverwriteConcurrentMetadataFile|TestCommitTableDoesNotOverwriteConcurrentMetadataFile|TestCommitTableConflictDetection|TestCommitTableNoOrphanedTempFiles|TestCreateTableAlreadyExists)$' -count=1
- go test ./catalog/hadoop -count=1
- go test ./catalog/... -count=1
- go test ./... -run '^$' -count=1
- go test ./io -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/hadoop/...
- git diff --check