### PR TITLE
fix(table): preserve null equality-delete keys

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -365,6 +365,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Int8Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			buf.WriteByte(byte(vals[row]))
 		}
@@ -372,6 +378,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Int16Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint16(buf, uint16(vals[row]))
 		}
@@ -379,6 +391,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Int32Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint32(buf, uint32(vals[row]))
 		}
@@ -386,6 +404,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Int64Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint64(buf, uint64(vals[row]))
 		}
@@ -393,6 +417,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Float32Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint32(buf, math.Float32bits(vals[row]))
 		}
@@ -400,6 +430,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Float64Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint64(buf, math.Float64bits(vals[row]))
 		}
@@ -407,6 +443,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Date32Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint32(buf, uint32(vals[row]))
 		}
@@ -414,6 +456,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Date64Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint64(buf, uint64(vals[row]))
 		}
@@ -421,6 +469,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Time32Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint32(buf, uint32(vals[row]))
 		}
@@ -428,6 +482,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.Time64Values()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint64(buf, uint64(vals[row]))
 		}
@@ -435,6 +495,12 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 		vals := a.TimestampValues()
 
 		return func(buf *bytes.Buffer, row int) {
+			if a.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+
 			buf.WriteByte(1)
 			bufPutUint64(buf, uint64(vals[row]))
 		}

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -18,8 +18,12 @@
 package table
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/require"
@@ -47,4 +51,153 @@ func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrEmptyEqualityFieldIDs)
 	require.ErrorContains(t, err, "empty-equality-fields.parquet")
+}
+
+func TestMakeColEncoderMatchesGenericEncodingForNullSpecializedTypes(t *testing.T) {
+	mem := memory.DefaultAllocator
+
+	tests := []struct {
+		name  string
+		build func() arrow.Array
+	}{
+		{
+			name: "int8",
+			build: func() arrow.Array {
+				b := array.NewInt8Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(7)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "int16",
+			build: func() arrow.Array {
+				b := array.NewInt16Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(70)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "int32",
+			build: func() arrow.Array {
+				b := array.NewInt32Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(700)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "int64",
+			build: func() arrow.Array {
+				b := array.NewInt64Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(7000)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "float32",
+			build: func() arrow.Array {
+				b := array.NewFloat32Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(3.25)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "float64",
+			build: func() arrow.Array {
+				b := array.NewFloat64Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(6.5)
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "date32",
+			build: func() arrow.Array {
+				b := array.NewDate32Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(arrow.Date32(10))
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "date64",
+			build: func() arrow.Array {
+				b := array.NewDate64Builder(mem)
+				defer b.Release()
+				b.AppendNull()
+				b.Append(arrow.Date64(20))
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "time32",
+			build: func() arrow.Array {
+				b := array.NewTime32Builder(mem, &arrow.Time32Type{Unit: arrow.Millisecond})
+				defer b.Release()
+				b.AppendNull()
+				b.Append(arrow.Time32(30))
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "time64",
+			build: func() arrow.Array {
+				b := array.NewTime64Builder(mem, &arrow.Time64Type{Unit: arrow.Microsecond})
+				defer b.Release()
+				b.AppendNull()
+				b.Append(arrow.Time64(40))
+
+				return b.NewArray()
+			},
+		},
+		{
+			name: "timestamp",
+			build: func() arrow.Array {
+				b := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
+				defer b.Release()
+				b.AppendNull()
+				b.Append(arrow.Timestamp(50))
+
+				return b.NewArray()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arr := tt.build()
+			defer arr.Release()
+
+			enc := makeColEncoder(arr)
+			for _, row := range []int{0, 1} {
+				var got bytes.Buffer
+				enc(&got, row)
+
+				var want bytes.Buffer
+				encodeArrowValue(&want, arr, row)
+
+				require.Equal(t, want.Bytes(), got.Bytes())
+			}
+		})
+	}
 }


### PR DESCRIPTION
Summary

- add null checks to the specialized equality-delete encoders for numeric, date, time, and timestamp Arrow columns
- keep the fast paths, but make their null encoding match the generic encoder exactly
- add focused regression coverage that specialized and generic encoders produce identical bytes for null and non-null rows across the affected types

Why

The optimized equality-delete encoder paths for numeric, date, time, and timestamp columns wrote a non-null tag and raw value without checking IsNull(row). That could make null delete keys collide with zero or default values, or encode differently from the generic path used elsewhere.

This change keeps the optimized encoders but makes their null handling match encodeArrowValue so equality-delete key encoding stays stable and correct.

Testing

- go test ./table -run 'Test(ReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs|MakeColEncoderMatchesGenericEncodingForNullSpecializedTypes)$' -count=1
- go test ./table -count=1
- go test ./... -run '^$' -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check