### PR TITLE
fix(table): dedupe transaction requirements by semantics

### DIFF
--- a/table/transaction.go
+++ b/table/transaction.go
@@ -114,12 +114,23 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 
 	existing := map[string]struct{}{}
 	for _, r := range t.reqs {
-		existing[r.GetType()] = struct{}{}
+		key, err := requirementSemanticKey(r)
+		if err != nil {
+			return err
+		}
+
+		existing[key] = struct{}{}
 	}
 
 	for _, r := range reqs {
-		if _, ok := existing[r.GetType()]; !ok {
+		key, err := requirementSemanticKey(r)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := existing[key]; !ok {
 			t.reqs = append(t.reqs, r)
+			existing[key] = struct{}{}
 		}
 	}
 
@@ -140,6 +151,15 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 	}
 
 	return nil
+}
+
+func requirementSemanticKey(r Requirement) (string, error) {
+	data, err := json.Marshal(r)
+	if err != nil {
+		return "", fmt.Errorf("marshal requirement %q: %w", r.GetType(), err)
+	}
+
+	return string(data), nil
 }
 
 // addValidator appends a conflict validator under t.mx. Producers

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -153,6 +153,8 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 	return nil
 }
 
+// requirementSemanticKey assumes Requirement JSON marshaling is canonical and
+// deterministic for every requirement type that participates in dedupe.
 func requirementSemanticKey(r Requirement) (string, error) {
 	data, err := json.Marshal(r)
 	if err != nil {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -38,8 +38,8 @@ func TestTransactionApplyKeepsDistinctRequirementsOfSameType(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, txn.reqs, 2)
-	requireContainsRequirement(t, txn.reqs, AssertRefSnapshotID(MainBranch, &mainSnapshotID))
-	requireContainsRequirement(t, txn.reqs, AssertRefSnapshotID("feature", &featureSnapshotID))
+	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &mainSnapshotID)
+	requireContainsRefSnapshotRequirement(t, txn.reqs, "feature", &featureSnapshotID)
 }
 
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {
@@ -52,12 +52,12 @@ func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *te
 	err := txn.apply(nil, []Requirement{first, second})
 	require.NoError(t, err)
 	require.Len(t, txn.reqs, 1)
-	requireContainsRequirement(t, txn.reqs, first)
+	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &mainSnapshotID)
 
 	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &mainSnapshotID)})
 	require.NoError(t, err)
 	require.Len(t, txn.reqs, 1)
-	requireContainsRequirement(t, txn.reqs, first)
+	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &mainSnapshotID)
 }
 
 func newTransactionWithSnapshotRefs(t *testing.T) *Transaction {
@@ -89,23 +89,27 @@ func newTransactionWithSnapshotRefs(t *testing.T) *Transaction {
 	return txn
 }
 
-func requireContainsRequirement(t *testing.T, requirements []Requirement, expected Requirement) {
+func requireContainsRefSnapshotRequirement(t *testing.T, requirements []Requirement, ref string, snapshotID *int64) {
 	t.Helper()
 
-	expectedKey, err := requirementSemanticKey(expected)
-	require.NoError(t, err)
-
 	for _, requirement := range requirements {
-		actualKey, keyErr := requirementSemanticKey(requirement)
-		require.NoError(t, keyErr)
-		if actualKey == expectedKey {
+		actual, ok := requirement.(*assertRefSnapshotID)
+		if ok && actual.Ref == ref && transactionTestInt64PtrEqual(actual.SnapshotID, snapshotID) {
 			return
 		}
 	}
 
-	t.Fatalf("expected requirement %s not found", expectedKey)
+	t.Fatalf("expected assertRefSnapshotID requirement for ref %q and snapshot id %v not found", ref, snapshotID)
 }
 
 func transactionTestPtr[T any](v T) *T {
 	return &v
+}
+
+func transactionTestInt64PtrEqual(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+
+	return *left == *right
 }

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionApplyKeepsDistinctRequirementsOfSameType(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+
+	mainSnapshotID := int64(10)
+	featureSnapshotID := int64(20)
+
+	err := txn.apply(nil, []Requirement{
+		AssertRefSnapshotID(MainBranch, &mainSnapshotID),
+		AssertRefSnapshotID("feature", &featureSnapshotID),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, txn.reqs, 2)
+	requireContainsRequirement(t, txn.reqs, AssertRefSnapshotID(MainBranch, &mainSnapshotID))
+	requireContainsRequirement(t, txn.reqs, AssertRefSnapshotID("feature", &featureSnapshotID))
+}
+
+func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+
+	mainSnapshotID := int64(10)
+	first := AssertRefSnapshotID(MainBranch, &mainSnapshotID)
+	second := AssertRefSnapshotID(MainBranch, &mainSnapshotID)
+
+	err := txn.apply(nil, []Requirement{first, second})
+	require.NoError(t, err)
+	require.Len(t, txn.reqs, 1)
+	requireContainsRequirement(t, txn.reqs, first)
+
+	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &mainSnapshotID)})
+	require.NoError(t, err)
+	require.Len(t, txn.reqs, 1)
+	requireContainsRequirement(t, txn.reqs, first)
+}
+
+func newTransactionWithSnapshotRefs(t *testing.T) *Transaction {
+	t.Helper()
+
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	now := time.Now().UnixMilli()
+
+	require.NoError(t, txn.meta.AddSnapshot(&Snapshot{
+		SnapshotID:     10,
+		SequenceNumber: 1,
+		ManifestList:   "mem://default/table-location/metadata/manifest-10.avro",
+		Summary:        &Summary{Operation: OpAppend},
+		TimestampMs:    now,
+	}))
+
+	require.NoError(t, txn.meta.AddSnapshot(&Snapshot{
+		SnapshotID:       20,
+		ParentSnapshotID: transactionTestPtr(int64(10)),
+		SequenceNumber:   2,
+		ManifestList:     "mem://default/table-location/metadata/manifest-20.avro",
+		Summary:          &Summary{Operation: OpAppend},
+		TimestampMs:      now + 1,
+	}))
+
+	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 10, BranchRef))
+	require.NoError(t, txn.meta.SetSnapshotRef("feature", 20, BranchRef))
+
+	return txn
+}
+
+func requireContainsRequirement(t *testing.T, requirements []Requirement, expected Requirement) {
+	t.Helper()
+
+	expectedKey, err := requirementSemanticKey(expected)
+	require.NoError(t, err)
+
+	for _, requirement := range requirements {
+		actualKey, keyErr := requirementSemanticKey(requirement)
+		require.NoError(t, keyErr)
+		if actualKey == expectedKey {
+			return
+		}
+	}
+
+	t.Fatalf("expected requirement %s not found", expectedKey)
+}
+
+func transactionTestPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Summary

- dedupe transaction requirements by their full semantic payload instead of GetType() alone
- preserve distinct requirements of the same type, including multiple AssertRefSnapshotID checks for different refs
- add focused transaction regressions for distinct same-type requirements and repeated identical requirements

Why

Transaction.apply currently dedupes requirements by GetType() only. That drops semantically distinct requirements that share a type, especially AssertRefSnapshotID checks for different refs. Operations such as expiring snapshots can build multiple ref assertions, and collapsing them weakens optimistic concurrency control by letting commits proceed without validating every referenced branch or tag.

Using the full requirement payload as the dedupe key keeps equivalent duplicates collapsed while preserving distinct assertions.

Testing

- go test ./table -run 'TestTransactionApply(KeepsDistinctRequirementsOfSameType|DedupesEquivalentRequirementsWithinAndAcrossCalls)$' -count=1
- go test ./table -count=1
- go test ./... -run '^$' -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check