### PR TITLE
fix(table): reject nil uuid assignment updates

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -904,7 +904,7 @@ func (b *MetadataBuilder) RemoveSnapshotRef(name string) error {
 
 func (b *MetadataBuilder) SetUUID(newUUID uuid.UUID) error {
 	if newUUID == uuid.Nil {
-		return errors.New("cannot set uuid to null")
+		return fmt.Errorf("%w: cannot set uuid to nil", iceberg.ErrInvalidArgument)
 	}
 
 	if b.uuid == newUUID {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -902,13 +902,17 @@ func (b *MetadataBuilder) RemoveSnapshotRef(name string) error {
 	return nil
 }
 
-func (b *MetadataBuilder) SetUUID(uuid uuid.UUID) error {
-	if b.uuid == uuid {
+func (b *MetadataBuilder) SetUUID(newUUID uuid.UUID) error {
+	if newUUID == uuid.Nil {
+		return errors.New("cannot set uuid to null")
+	}
+
+	if b.uuid == newUUID {
 		return nil
 	}
 
-	b.updates = append(b.updates, NewAssignUUIDUpdate(uuid))
-	b.uuid = uuid
+	b.updates = append(b.updates, NewAssignUUIDUpdate(newUUID))
+	b.uuid = newUUID
 
 	return nil
 }

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -2322,13 +2322,23 @@ func TestSetUUIDRejectsNil(t *testing.T) {
 	originalUUID := builder.uuid
 
 	err := builder.SetUUID(uuid.Nil)
-	require.ErrorContains(t, err, "cannot set uuid to null")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	require.False(t, builder.HasChanges())
 	require.Equal(t, originalUUID, builder.uuid)
 
 	meta, err := builder.Build()
 	require.NoError(t, err)
 	require.Equal(t, originalUUID, meta.TableUUID())
+}
+
+func TestNewMetadataWithUUIDGeneratesUUIDForNil(t *testing.T) {
+	tableSchema := schema()
+	partSpec := partitionSpec()
+	order := sortOrder()
+
+	meta, err := NewMetadataWithUUID(&tableSchema, &partSpec, order, "s3://bucket/test/location", nil, uuid.Nil)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, meta.TableUUID())
 }
 
 func TestSetFormatVersionDowngradeNotAllowed(t *testing.T) {

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -2317,6 +2317,20 @@ func TestSetFormatVersionPreservesExistingUUID(t *testing.T) {
 	require.Equal(t, existingUUID, meta.TableUUID())
 }
 
+func TestSetUUIDRejectsNil(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	originalUUID := builder.uuid
+
+	err := builder.SetUUID(uuid.Nil)
+	require.ErrorContains(t, err, "cannot set uuid to null")
+	require.False(t, builder.HasChanges())
+	require.Equal(t, originalUUID, builder.uuid)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	require.Equal(t, originalUUID, meta.TableUUID())
+}
+
 func TestSetFormatVersionDowngradeNotAllowed(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	err := builder.SetFormatVersion(1)

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -571,14 +571,15 @@ func buildFromBase(t *testing.T) *MetadataBuilder {
 
 func TestAssignUUIDUpdate_ApplyRejectsNilUUID(t *testing.T) {
 	b := buildFromBase(t)
+	originalUUID := b.uuid
 
 	err := NewAssignUUIDUpdate(uuid.Nil).Apply(b)
-	require.ErrorContains(t, err, "cannot set uuid to null")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	require.False(t, b.HasChanges())
 
 	meta, err := b.Build()
 	require.NoError(t, err)
-	require.NotEqual(t, uuid.Nil, meta.TableUUID())
+	require.Equal(t, originalUUID, meta.TableUUID())
 }
 
 func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -569,6 +569,18 @@ func buildFromBase(t *testing.T) *MetadataBuilder {
 	return b
 }
 
+func TestAssignUUIDUpdate_ApplyRejectsNilUUID(t *testing.T) {
+	b := buildFromBase(t)
+
+	err := NewAssignUUIDUpdate(uuid.Nil).Apply(b)
+	require.ErrorContains(t, err, "cannot set uuid to null")
+	require.False(t, b.HasChanges())
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, meta.TableUUID())
+}
+
 func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{
 		"action": "set-statistics",


### PR DESCRIPTION
Summary

reject uuid.Nil in the table metadata builder's SetUUID path
add regression coverage for direct builder calls and assign-uuid updates applied through the builder
preserve the existing NewMetadata/NewMetadataWithUUID behavior where uuid.Nil means "generate a fresh table UUID" for brand-new metadata

Why

New table creation already treats uuid.Nil as a sentinel for auto-generation, but the mutable table metadata builder still accepted uuid.Nil later through SetUUID and assign-uuid updates. That made it possible to write the zero UUID into table metadata even though the table UUID is supposed to uniquely identify the table.

Testing

go test ./table -run 'Test(SetUUIDRejectsNil|AssignUUIDUpdate_ApplyRejectsNilUUID|SetFormatVersionV1ToV2AssignsUUID)$' -count=1
go test ./table -count=1
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
git diff --check
