### PR TITLE
fix(rest): honor token property in catalog config

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -451,6 +451,10 @@ func handleNon200(rsp *http.Response, override map[int]error) error {
 func fromProps(props iceberg.Properties, o *options) error {
 	for k, v := range props {
 		switch k {
+		case keyOauthToken:
+			if o.oauthToken == "" {
+				o.oauthToken = v
+			}
 		case keyWarehouseLocation:
 			o.warehouseLocation = v
 		case keyMetadataLocation:
@@ -510,6 +514,7 @@ func toProps(o *options) iceberg.Properties {
 		}
 	}
 
+	setIf(keyOauthToken, o.oauthToken)
 	setIf(keyOauthCredential, o.credential)
 	setIf(keyWarehouseLocation, o.warehouseLocation)
 	setIf(keyMetadataLocation, o.metadataLocation)
@@ -544,7 +549,9 @@ type Catalog struct {
 	baseURI *url.URL
 	cl      *http.Client
 
-	name      string
+	name string
+	// Retained catalog properties are reused for table/view IO and may carry
+	// authentication material such as credential or token.
 	props     iceberg.Properties
 	endpoints endpointSet
 

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1117,6 +1117,73 @@ func TestToPropsSigv4RegionFallback(t *testing.T) {
 	})
 }
 
+func TestToPropsPreservesOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	opts := &options{
+		oauthToken: "static-token",
+	}
+	props := toProps(opts)
+	assert.Equal(t, "static-token", props[keyOauthToken])
+}
+
+func TestFromPropsReadsOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	var opts options
+	err := fromProps(iceberg.Properties{
+		keyOauthToken: "static-token",
+		"custom":      "value",
+	}, &opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "static-token", opts.oauthToken)
+	assert.Equal(t, iceberg.Properties{"custom": "value"}, opts.additionalProps)
+	assert.NotContains(t, opts.additionalProps, keyOauthToken)
+}
+
+func TestFromPropsKeepsExistingOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	opts := options{
+		oauthToken: "caller-token",
+	}
+	err := fromProps(iceberg.Properties{
+		keyOauthToken: "server-token",
+	}, &opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "caller-token", opts.oauthToken)
+}
+
+func TestFetchConfigTokenOverrideKeepsCallerToken(t *testing.T) {
+	t.Parallel()
+
+	var configAuthHeader string
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		configAuthHeader = r.Header.Get(authorizationHeader)
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{},
+			"overrides": map[string]any{
+				keyOauthToken: "server-token",
+			},
+			"endpoints": AllEndpointStrings,
+		})
+	})
+
+	cat, err := newCatalogFromProps(context.Background(), "rest", srv.URL, iceberg.Properties{
+		keyOauthToken: "caller-token",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer caller-token", configAuthHeader)
+	assert.Equal(t, "caller-token", cat.props[keyOauthToken])
+}
+
 func TestEncodeNamespace(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2261,7 +2261,8 @@ type RestTLSCatalogSuite struct {
 	srv *httptest.Server
 	mux *http.ServeMux
 
-	configVals url.Values
+	configVals       url.Values
+	configAuthHeader string
 }
 
 func (r *RestTLSCatalogSuite) SetupTest() {
@@ -2270,6 +2271,7 @@ func (r *RestTLSCatalogSuite) SetupTest() {
 	r.mux.HandleFunc("/v1/config", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodGet, req.Method)
 		r.configVals = req.URL.Query()
+		r.configAuthHeader = req.Header.Get("Authorization")
 
 		json.NewEncoder(w).Encode(map[string]any{
 			"defaults":  map[string]any{},
@@ -2286,6 +2288,7 @@ func (r *RestTLSCatalogSuite) TearDownTest() {
 	r.srv = nil
 	r.mux = nil
 	r.configVals = nil
+	r.configAuthHeader = ""
 }
 
 func (r *RestTLSCatalogSuite) TestSSLFail() {
@@ -2307,6 +2310,7 @@ func (r *RestTLSCatalogSuite) TestSSLLoadRegisteredCatalog() {
 
 	r.NotNil(cat)
 	r.Equal(r.configVals.Get("warehouse"), "s3://some-bucket")
+	r.Equal("Bearer "+TestToken, r.configAuthHeader)
 }
 
 func (r *RestTLSCatalogSuite) TestSSLConfig() {


### PR DESCRIPTION
Summary

parse the REST catalog `token` property into the static OAuth token option
preserve that static token in the catalog's retained properties
add regression coverage for helper parsing/serialization and the `catalog.Load(..., {"token": ...})` auth path

Why

The REST catalog already defines `token` as a first-class property key, and `WithOAuthToken` correctly wires a static bearer token into authentication. But the property path was incomplete: `fromProps` ignored `token`, so `catalog.Load` silently skipped static-token auth, and `toProps` dropped it from the catalog's retained properties.

This made property-driven REST catalog auth behave differently from the explicit option path.

Testing

go test ./catalog/rest -run 'Test(ToPropsSigv4RegionFallback|FromPropsReadsOAuthToken|TokenAuthenticationPriority|RestTLSCatalogSuite)$' -count=1
go test ./catalog/rest -count=1
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/rest/...
git diff --check
