### PR TITLE
fix(table): preserve version hint URIs in orphan cleanup

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -304,7 +304,7 @@ func (t Table) getReferencedFiles(ctx context.Context, fs iceio.IO, maxConcurren
 
 	// Add version hint file (for Hadoop-style tables)
 	// Following Java's ReachableFileUtil.versionHintLocation() logic:
-	versionHintPath := filepath.Join(metadata.Location(), "metadata", "version-hint.text")
+	versionHintPath := versionHintLocation(metadata.Location())
 	referenced[normalizeFilePath(versionHintPath)] = false
 
 	for sf := range metadata.Statistics() {
@@ -595,6 +595,16 @@ func normalizeFilePathWithConfig(path string, cfg *orphanCleanupConfig) string {
 	}
 
 	return normalizeNonURLPath(path)
+}
+
+func versionHintLocation(tableLocation string) string {
+	if strings.Contains(tableLocation, "://") || strings.HasPrefix(tableLocation, "file:") {
+		if joined, err := url.JoinPath(tableLocation, "metadata", "version-hint.text"); err == nil {
+			return joined
+		}
+	}
+
+	return filepath.Join(tableLocation, "metadata", "version-hint.text")
 }
 
 // normalizeURLPath normalizes URL-based file paths with scheme/authority equivalence.

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	stdfs "io/fs"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -153,6 +154,36 @@ func TestNormalizeNonURLPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := normalizeNonURLPath(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestVersionHintLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		expected string
+	}{
+		{
+			name:     "s3_uri",
+			location: "s3://bucket/table",
+			expected: "s3://bucket/table/metadata/version-hint.text",
+		},
+		{
+			name:     "file_uri",
+			location: "file:///tmp/table",
+			expected: "file:///tmp/table/metadata/version-hint.text",
+		},
+		{
+			name:     "local_path",
+			location: filepath.Join("local", "table"),
+			expected: filepath.Join("local", "table", "metadata", "version-hint.text"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, versionHintLocation(tt.location))
 		})
 	}
 }
@@ -532,6 +563,8 @@ func TestGetReferencedFiles_IncludesStatisticsFiles(t *testing.T) {
 	assert.Contains(t, refs, normalizeFilePath("s3://bucket/stats/table-stats.puffin"))
 	assert.Contains(t, refs, normalizeFilePath("s3://bucket/stats/part-stats.puffin"))
 	assert.Contains(t, refs, normalizeFilePath(tbl.metadataLocation))
+	assert.Contains(t, refs, normalizeFilePath("s3://bucket/test/location/metadata/version-hint.text"))
+	assert.NotContains(t, refs, normalizeFilePath("s3:/bucket/test/location/metadata/version-hint.text"))
 	assert.NotContains(t, refs, normalizeFilePath("s3://bucket/stats/not-referenced.puffin"))
 	assert.NotContains(t, refs, "")
 }

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -175,6 +175,11 @@ func TestVersionHintLocation(t *testing.T) {
 			expected: "file:///tmp/table/metadata/version-hint.text",
 		},
 		{
+			name:     "file_uri_opaque",
+			location: "file:/tmp/table",
+			expected: "file:/tmp/table/metadata/version-hint.text",
+		},
+		{
 			name:     "local_path",
 			location: filepath.Join("local", "table"),
 			expected: filepath.Join("local", "table", "metadata", "version-hint.text"),


### PR DESCRIPTION
Summary

build the orphan-cleanup version-hint path with a URI-aware join for URL locations
keep the existing filepath join fallback for plain local filesystem paths
add regression coverage for URI and local-path version-hint construction, plus the referenced-file set

Why

`Table.getReferencedFiles` adds `metadata/version-hint.text` to the referenced set so orphan cleanup will not delete it. That path was being built with `filepath.Join(metadata.Location(), ...)`, which is fine for plain local paths but corrupts object-store URIs like `s3://bucket/table` into `s3:/bucket/table/...`.

Once that malformed path hit orphan cleanup's normalizer, it no longer looked like a URL and could diverge from the real `s3://.../version-hint.text` candidate path. That made the real version-hint file eligible to be treated as an orphan.

Testing

go test ./table -run 'Test(VersionHintLocation|GetReferencedFiles_IncludesStatisticsFiles|.*Orphan.*)$' -count=1
go test ./table -count=1
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
git diff --check
