### PR TITLE
fix(partitions): align paths with compacted partition fields

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -482,20 +482,20 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 	return id
 }
 
-type partitionFieldType struct {
+type activePartitionField struct {
 	field      PartitionField
 	resultType Type
 }
 
-func (ps *PartitionSpec) activePartitionFields(schema *Schema) []partitionFieldType {
-	fields := make([]partitionFieldType, 0, len(ps.fields))
+func (ps *PartitionSpec) activePartitionFields(schema *Schema) []activePartitionField {
+	fields := make([]activePartitionField, 0, len(ps.fields))
 	for _, field := range ps.fields {
 		sourceType, ok := schema.FindTypeByID(field.SourceID())
 		if !ok {
 			continue
 		}
 
-		fields = append(fields, partitionFieldType{
+		fields = append(fields, activePartitionField{
 			field:      field,
 			resultType: field.Transform.ResultType(sourceType),
 		})

--- a/partitions.go
+++ b/partitions.go
@@ -482,6 +482,28 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 	return id
 }
 
+type partitionFieldType struct {
+	field      PartitionField
+	resultType Type
+}
+
+func (ps *PartitionSpec) activePartitionFields(schema *Schema) []partitionFieldType {
+	fields := make([]partitionFieldType, 0, len(ps.fields))
+	for _, field := range ps.fields {
+		sourceType, ok := schema.FindTypeByID(field.SourceID())
+		if !ok {
+			continue
+		}
+
+		fields = append(fields, partitionFieldType{
+			field:      field,
+			resultType: field.Transform.ResultType(sourceType),
+		})
+	}
+
+	return fields
+}
+
 // PartitionType produces a struct of the partition spec.
 //
 // The partition fields should be optional:
@@ -503,17 +525,13 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 // placeholder for dropped sources) for that purpose — see manifestPartitionFields
 // in the table package.
 func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
-	nestedFields := []NestedField{}
-	for _, field := range ps.fields {
-		sourceType, ok := schema.FindTypeByID(field.SourceID())
-		if !ok {
-			continue
-		}
-		resultType := field.Transform.ResultType(sourceType)
+	activeFields := ps.activePartitionFields(schema)
+	nestedFields := make([]NestedField, 0, len(activeFields))
+	for _, field := range activeFields {
 		nestedFields = append(nestedFields, NestedField{
-			ID:       field.FieldID,
-			Name:     field.Name,
-			Type:     resultType,
+			ID:       field.field.FieldID,
+			Name:     field.field.Name,
+			Type:     field.resultType,
 			Required: false,
 		})
 	}
@@ -529,9 +547,9 @@ func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
 // This does not apply the transforms to the data, it is assumed the provided data
 // has already been transformed appropriately.
 func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
-	partType := ps.PartitionType(sc)
+	activeFields := ps.activePartitionFields(sc)
 
-	if len(partType.FieldList) == 0 {
+	if len(activeFields) == 0 {
 		return ""
 	}
 
@@ -539,22 +557,22 @@ func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
 	// Estimate capacity: escaped_name + "=" + escaped_value + "/" per field
 	var sb strings.Builder
 	estimatedSize := 0
-	for i := range partType.Fields() {
-		estimatedSize += len(ps.fields[i].EscapedName()) + 20 // name + "=" + avg value + "/"
+	for i := range activeFields {
+		estimatedSize += len(activeFields[i].field.EscapedName()) + 20 // name + "=" + avg value + "/"
 	}
 	sb.Grow(estimatedSize)
 
-	for i := range partType.Fields() {
+	for i := range activeFields {
 		if i > 0 {
 			sb.WriteByte('/')
 		}
 
 		// Use pre-escaped field name (now guaranteed to be initialized)
-		sb.WriteString(ps.fields[i].EscapedName())
+		sb.WriteString(activeFields[i].field.EscapedName())
 		sb.WriteByte('=')
 
 		// Only escape the value (which changes per row)
-		valueStr := ps.fields[i].Transform.ToHumanStrType(partType.FieldList[i].Type, data.Get(i))
+		valueStr := activeFields[i].field.Transform.ToHumanStrType(activeFields[i].resultType, data.Get(i))
 		sb.WriteString(url.QueryEscape(valueStr))
 	}
 

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -190,6 +190,31 @@ func TestPartitionSpecToPath(t *testing.T) {
 		spec.PartitionToPath(record, schema))
 }
 
+func TestPartitionSpecToPathWithDroppedLeadingSourceColumn(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool},
+	)
+
+	spec := iceberg.NewPartitionSpecID(3,
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: iceberg.IdentityTransform{}, Name: "foo",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{2}, FieldID: 1001,
+			Transform: iceberg.IdentityTransform{}, Name: "bar",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{3}, FieldID: 1002,
+			Transform: iceberg.IdentityTransform{}, Name: "baz",
+		},
+	)
+
+	record := partitionRecord{int32(7), true}
+	assert.Equal(t, "bar=7/baz=true", spec.PartitionToPath(record, schema))
+}
+
 func TestGetPartitionFieldName(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "str", Type: iceberg.PrimitiveTypes.String},

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -221,9 +221,16 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 
 	partitionColumns := make([]arrow.Array, len(partitionFields))
 	partitionFieldsInfo := make([]partitionFieldInfo, len(partitionFields))
+	specFieldsByID := make(map[int]iceberg.PartitionField, spec.NumFields())
+	for _, field := range spec.Fields() {
+		specFieldsByID[field.FieldID] = field
+	}
 
-	for i := range partitionFields {
-		sourceField := spec.Field(i)
+	for i, partitionField := range partitionFields {
+		sourceField, ok := specFieldsByID[partitionField.ID]
+		if !ok {
+			return nil, fmt.Errorf("failed to find partition field ID %d in spec", partitionField.ID)
+		}
 		colName, ok := schema.FindColumnName(sourceField.SourceID())
 		if !ok {
 			return nil, fmt.Errorf("failed to find source field ID %d in schema", sourceField.SourceID())

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -480,6 +480,45 @@ func (s *FanoutWriterTestSuite) TestTimestampPartitionRejectsOverflowWhenScaling
 	s.Require().ErrorContains(err, "overflows int64")
 }
 
+func (s *FanoutWriterTestSuite) TestGetRecordPartitionsWithDroppedLeadingSourceColumn() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "bar", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "baz", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	}, nil)
+
+	testRecord := s.createCustomTestRecord(arrSchema, [][]any{
+		{int32(7), true},
+	})
+	defer testRecord.Release()
+
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 3, Name: "baz", Type: iceberg.PrimitiveTypes.Bool},
+	)
+
+	spec := iceberg.NewPartitionSpecID(3,
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: iceberg.IdentityTransform{}, Name: "foo",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{2}, FieldID: 1001,
+			Transform: iceberg.IdentityTransform{}, Name: "bar",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{3}, FieldID: 1002,
+			Transform: iceberg.IdentityTransform{}, Name: "baz",
+		},
+	)
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, testRecord)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Equal(int32(7), partitions[0].partitionRec.Get(0))
+	s.Equal(true, partitions[0].partitionRec.Get(1))
+	s.Equal("bar=7/baz=true", spec.PartitionToPath(partitions[0].partitionRec, icebergSchema))
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},


### PR DESCRIPTION
Summary

make PartitionToPath walk the same active compacted partition-field sequence as PartitionType
reuse that active-field computation in both code paths to keep them aligned
add a regression test for a spec whose leading partition source column has been dropped from the current schema

Why

`PartitionSpec.PartitionType` explicitly compacts away partition fields whose source columns are no longer present in the current schema. But `PartitionSpec.PartitionToPath` still indexed into `ps.fields` positionally while reading values from that compacted partition record.

When an earlier partition source column had been dropped, the compacted record shifted left while `PartitionToPath` kept using names and transforms from the full spec. That could label values under the wrong partition field names or apply the wrong transform when generating partition paths.

Testing

go test . -run 'Test(PartitionType|PartitionSpecToPath|PartitionSpecToPathWithDroppedLeadingSourceColumn)$' -count=1
go test . -count=1
go test ./table -count=1
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m . ./table/...
git diff --check
