### PR TITLE
fix(table): return scanner memoization errors

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -378,7 +378,7 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 
 			mEval, err := manifestEvals.Get(int(mf.PartitionSpecID()))
 			if err != nil {
-				return fmt.Errorf("building manifest evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+				return fmt.Errorf("failed to build manifest evaluator for spec %d: %w", mf.PartitionSpecID(), err)
 			}
 			keep, err := mEval(mf)
 			if err != nil {
@@ -390,7 +390,7 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 
 			pEval, err := partitionEvals.Get(int(mf.PartitionSpecID()))
 			if err != nil {
-				return fmt.Errorf("building partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
 			}
 			for e, err := range mf.Entries(ctx.fs, false) {
 				if err != nil {

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -376,7 +376,10 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 				continue
 			}
 
-			mEval := manifestEvals.Get(int(mf.PartitionSpecID()))
+			mEval, err := manifestEvals.Get(int(mf.PartitionSpecID()))
+			if err != nil {
+				return fmt.Errorf("building manifest evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+			}
 			keep, err := mEval(mf)
 			if err != nil {
 				return err
@@ -385,7 +388,10 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 				continue
 			}
 
-			pEval := partitionEvals.Get(int(mf.PartitionSpecID()))
+			pEval, err := partitionEvals.Get(int(mf.PartitionSpecID()))
+			if err != nil {
+				return fmt.Errorf("building partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+			}
 			for e, err := range mf.Entries(ctx.fs, false) {
 				if err != nil {
 					return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -43,6 +43,18 @@ type keyDefaultMap[K comparable, V any] struct {
 	mx sync.RWMutex
 }
 
+type keyDefaultMapErr[K comparable, V any] struct {
+	defaultFactory func(K) (V, error)
+	data           map[K]keyDefaultValueErr[V]
+
+	mx sync.RWMutex
+}
+
+type keyDefaultValueErr[V any] struct {
+	value V
+	err   error
+}
+
 func (k *keyDefaultMap[K, V]) Get(key K) V {
 	k.mx.RLock()
 	if v, ok := k.data[key]; ok {
@@ -73,17 +85,33 @@ func newKeyDefaultMap[K comparable, V any](factory func(K) V) *keyDefaultMap[K, 
 	}
 }
 
-func newKeyDefaultMapWrapErr[K comparable, V any](factory func(K) (V, error)) *keyDefaultMap[K, V] {
-	return &keyDefaultMap[K, V]{
-		data: make(map[K]V),
-		defaultFactory: func(k K) V {
-			v, err := factory(k)
-			if err != nil {
-				panic(err)
-			}
+func (k *keyDefaultMapErr[K, V]) Get(key K) (V, error) {
+	k.mx.RLock()
+	if v, ok := k.data[key]; ok {
+		k.mx.RUnlock()
 
-			return v
-		},
+		return v.value, v.err
+	}
+
+	k.mx.RUnlock()
+	k.mx.Lock()
+	defer k.mx.Unlock()
+
+	// race check between RLock and Lock
+	if v, ok := k.data[key]; ok {
+		return v.value, v.err
+	}
+
+	value, err := k.defaultFactory(key)
+	k.data[key] = keyDefaultValueErr[V]{value: value, err: err}
+
+	return value, err
+}
+
+func newKeyDefaultMapWrapErr[K comparable, V any](factory func(K) (V, error)) *keyDefaultMapErr[K, V] {
+	return &keyDefaultMapErr[K, V]{
+		data:           make(map[K]keyDefaultValueErr[V]),
+		defaultFactory: factory,
 	}
 }
 
@@ -210,7 +238,7 @@ type Scan struct {
 
 	includeRowLineage bool
 
-	partitionFilters *keyDefaultMap[int, iceberg.BooleanExpression]
+	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression]
 	concurrency      int
 }
 
@@ -390,21 +418,26 @@ func (scan *Scan) buildManifestEvaluator(specID int) (func(iceberg.ManifestFile)
 	return buildManifestEvaluator(specID, scan.metadata, scan.partitionFilters, scan.caseSensitive)
 }
 
-func buildManifestEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMap[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
+func buildManifestEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
 	spec := metadata.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
 	}
 
+	partitionFilter, err := partitionFilters.Get(specID)
+	if err != nil {
+		return nil, err
+	}
+
 	return newManifestEvaluator(*spec, metadata.CurrentSchema(),
-		partitionFilters.Get(specID), caseSensitive)
+		partitionFilter, caseSensitive)
 }
 
 func (scan *Scan) buildPartitionEvaluator(specID int) (func(iceberg.DataFile) (bool, error), error) {
 	return buildPartitionEvaluator(specID, scan.metadata, scan.partitionFilters, scan.caseSensitive)
 }
 
-func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMap[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {
+func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {
 	spec := metadata.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
@@ -412,7 +445,12 @@ func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *ke
 	partType := spec.PartitionType(metadata.CurrentSchema())
 	partSchema := iceberg.NewSchema(0, partType.FieldList...)
 
-	fn, err := iceberg.ExpressionEvaluator(partSchema, partitionFilters.Get(specID), caseSensitive)
+	partitionFilter, err := partitionFilters.Get(specID)
+	if err != nil {
+		return nil, err
+	}
+
+	fn, err := iceberg.ExpressionEvaluator(partSchema, partitionFilter, caseSensitive)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +621,10 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 	manifestEvaluators := newKeyDefaultMapWrapErr(scan.buildManifestEvaluator)
 	filtered := make([]iceberg.ManifestFile, 0, len(manifestList))
 	for _, mf := range manifestList {
-		eval := manifestEvaluators.Get(int(mf.PartitionSpecID()))
+		eval, err := manifestEvaluators.Get(int(mf.PartitionSpecID()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to build manifest evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+		}
 		use, err := eval(mf)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate manifest %s: %w", mf.FilePath(), err)
@@ -631,7 +672,10 @@ func (scan *Scan) collectManifestEntries(
 			if err != nil {
 				return err
 			}
-			partEval := partitionEvaluators.Get(int(mf.PartitionSpecID()))
+			partEval, err := partitionEvaluators.Get(int(mf.PartitionSpecID()))
+			if err != nil {
+				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
+			}
 			manifestEntries, err := openManifest(fs, mf, partEval, metricsEval)
 			if err != nil {
 				return err

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -78,13 +78,6 @@ func (k *keyDefaultMap[K, V]) Get(key K) V {
 	return v
 }
 
-func newKeyDefaultMap[K comparable, V any](factory func(K) V) *keyDefaultMap[K, V] {
-	return &keyDefaultMap[K, V]{
-		data:           make(map[K]V),
-		defaultFactory: factory,
-	}
-}
-
 func (k *keyDefaultMapErr[K, V]) Get(key K) (V, error) {
 	k.mx.RLock()
 	if v, ok := k.data[key]; ok {
@@ -108,6 +101,15 @@ func (k *keyDefaultMapErr[K, V]) Get(key K) (V, error) {
 	return value, err
 }
 
+func newKeyDefaultMap[K comparable, V any](factory func(K) V) *keyDefaultMap[K, V] {
+	return &keyDefaultMap[K, V]{
+		data:           make(map[K]V),
+		defaultFactory: factory,
+	}
+}
+
+// newKeyDefaultMapWrapErr memoizes both successful values and deterministic
+// factory errors, so the same failing key is not retried on subsequent reads.
 func newKeyDefaultMapWrapErr[K comparable, V any](factory func(K) (V, error)) *keyDefaultMapErr[K, V] {
 	return &keyDefaultMapErr[K, V]{
 		data:           make(map[K]keyDefaultValueErr[V]),

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"runtime"
 	"strconv"
 	"sync"
@@ -186,6 +187,27 @@ func TestKeyDefaultMapRaceCondition(t *testing.T) {
 		"factory should be called exactly once per key, but was called %d times", callCount)
 }
 
+func TestKeyDefaultMapWrapErrCachesError(t *testing.T) {
+	var factoryCallCount atomic.Int64
+	expectedErr := errors.New("boom")
+	kdm := newKeyDefaultMapWrapErr(func(key string) (int, error) {
+		factoryCallCount.Add(1)
+
+		return 0, expectedErr
+	})
+
+	value, err := kdm.Get("same-key")
+	require.ErrorIs(t, err, expectedErr)
+	assert.Zero(t, value)
+
+	value, err = kdm.Get("same-key")
+	require.ErrorIs(t, err, expectedErr)
+	assert.Zero(t, value)
+
+	assert.Equal(t, int64(1), factoryCallCount.Load(),
+		"factory should be called exactly once per key even when it fails")
+}
+
 func TestBuildPartitionProjectionWithInvalidSpecID(t *testing.T) {
 	schema := iceberg.NewSchema(
 		1,
@@ -261,6 +283,49 @@ func TestFetchPartitionSpecFilteredManifests_PropagatesEvalError(t *testing.T) {
 
 	_, err = scan.PlanFiles(context.Background())
 	require.Error(t, err, "PlanFiles must fail when manifest filtering errors")
+}
+
+func TestFetchPartitionSpecFilteredManifests_InvalidSpecIDDoesNotPanic(t *testing.T) {
+	spec := partitionedSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+
+	const (
+		snapshotID       = int64(1)
+		manifestListPath = "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	)
+
+	mf := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/manifest.avro", 100, 999, snapshotID).Build()
+
+	var listBuf bytes.Buffer
+	seqNum := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &seqNum, 0, []iceberg.ManifestFile{mf}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: seqNum,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json", func(context.Context) (iceio.IO, error) {
+		return memIO, nil
+	}, nil)
+
+	scan := tbl.Scan()
+
+	_, err = scan.fetchPartitionSpecFilteredManifests(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	require.ErrorContains(t, err, "999")
+
+	_, err = scan.PlanFiles(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPartitionSpecNotFound)
 }
 
 func TestBuildManifestEvaluatorWithInvalidSpecID(t *testing.T) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1477,7 +1477,7 @@ func (t *Transaction) classifyFilesForDeletions(ctx context.Context, fs io.IO, f
 
 type fileClassificationTask struct {
 	meta             Metadata
-	partitionFilters *keyDefaultMap[int, iceberg.BooleanExpression]
+	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression]
 	caseSensitive    bool
 	rowFilter        iceberg.BooleanExpression
 }
@@ -1542,7 +1542,10 @@ func (t *Transaction) classifyFilesForFilteredDeletions(ctx context.Context, fs 
 	for _, manifest := range manifests {
 		manifest := manifest // capture loop variable
 		g.Go(func() error {
-			manifestEval := manifestEvaluators.Get(int(manifest.PartitionSpecID()))
+			manifestEval, err := manifestEvaluators.Get(int(manifest.PartitionSpecID()))
+			if err != nil {
+				return fmt.Errorf("failed to build manifest evaluator for spec %d: %w", manifest.PartitionSpecID(), err)
+			}
 			if manifestEval != nil {
 				match, err := manifestEval(manifest)
 				if err != nil {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1546,14 +1546,12 @@ func (t *Transaction) classifyFilesForFilteredDeletions(ctx context.Context, fs 
 			if err != nil {
 				return fmt.Errorf("failed to build manifest evaluator for spec %d: %w", manifest.PartitionSpecID(), err)
 			}
-			if manifestEval != nil {
-				match, err := manifestEval(manifest)
-				if err != nil {
-					return fmt.Errorf("failed to evaluate manifest %s: %w", manifest.FilePath(), err)
-				}
-				if !match {
-					return nil
-				}
+			match, err := manifestEval(manifest)
+			if err != nil {
+				return fmt.Errorf("failed to evaluate manifest %s: %w", manifest.FilePath(), err)
+			}
+			if !match {
+				return nil
 			}
 
 			localDelete := make([]iceberg.DataFile, 0)


### PR DESCRIPTION
Summary

replace the panic-wrapping memoized factory helper with an error-carrying cache
propagate cached factory errors through scanner planning, filtered overwrite classification, and conflict validation
add regression coverage for cached factory failures and an invalid-spec manifest path that used to panic

Why

The scanner code memoized several per-spec builders using `newKeyDefaultMapWrapErr`, which converted any factory error into a panic. That meant ordinary failures like unknown partition spec ids or projection/evaluator build errors could crash the process instead of being returned to the caller.

The shared helper is also reused in transaction-side manifest classification and conflict validation, so the same panic behavior leaked there too.

Testing

go test ./table -run 'Test(KeyDefaultMapWrapErrCachesError|FetchPartitionSpecFilteredManifests_InvalidSpecIDDoesNotPanic|BuildPartitionProjectionWithInvalidSpecID|BuildManifestEvaluatorWithInvalidSpecID|BuildPartitionEvaluatorWithInvalidSpecID|FetchPartitionSpecFilteredManifests_PropagatesEvalError)$' -count=1
go test ./table -count=1
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
git diff --check
