### PR TITLE
fix(glue): revalidate source table during rename

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -461,6 +461,9 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		return nil, fmt.Errorf("failed to create the table %s.%s: %w", fromDatabase, fromTable, err)
 	}
 
+	// Revalidate the source table immediately before delete to narrow the
+	// rename race window. Glue does not offer a conditional DeleteTable, so
+	// this cannot eliminate the race if a commit lands after this read.
 	currentFromGlueTable, err := c.getTable(ctx, fromDatabase, fromTable)
 	if err != nil {
 		c.rollbackRenamedTable(ctx, toDatabase, toTable)
@@ -495,7 +498,7 @@ func (c *Catalog) rollbackRenamedTable(ctx context.Context, database, tableName 
 		Name:         aws.String(tableName),
 	})
 	if rollbackErr != nil {
-		fmt.Printf("failed to rollback the new table %s.%s: %v", database, tableName, rollbackErr)
+		log.Printf("failed to rollback the new table %s.%s: %v", database, tableName, rollbackErr)
 	}
 }
 
@@ -867,6 +870,9 @@ func glueTableChangedDuringRename(original, current *types.Table) bool {
 	originalVersionID := aws.ToString(original.VersionId)
 	currentVersionID := aws.ToString(current.VersionId)
 	if originalVersionID != "" || currentVersionID != "" {
+		// Glue returns the same VersionId across consecutive GetTable calls
+		// unless the table was updated, making this a stronger drift check
+		// than comparing metadata_location when both versions are present.
 		return originalVersionID != currentVersionID
 	}
 

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -461,6 +461,18 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		return nil, fmt.Errorf("failed to create the table %s.%s: %w", fromDatabase, fromTable, err)
 	}
 
+	currentFromGlueTable, err := c.getTable(ctx, fromDatabase, fromTable)
+	if err != nil {
+		c.rollbackRenamedTable(ctx, toDatabase, toTable)
+
+		return nil, fmt.Errorf("failed to revalidate the table %s.%s before delete: %w", fromDatabase, fromTable, err)
+	}
+	if glueTableChangedDuringRename(fromGlueTable, currentFromGlueTable) {
+		c.rollbackRenamedTable(ctx, toDatabase, toTable)
+
+		return nil, fmt.Errorf("failed to rename the table %s.%s: source table changed during rename", fromDatabase, fromTable)
+	}
+
 	// Drop the old table.
 	_, err = c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
 		CatalogId:    c.catalogId,
@@ -468,20 +480,23 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		Name:         aws.String(fromTable),
 	})
 	if err != nil {
-		// Best-effort rollback the table creation.
-		_, rollbackErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
-			CatalogId:    c.catalogId,
-			DatabaseName: aws.String(toDatabase),
-			Name:         aws.String(toTable),
-		})
-		if rollbackErr != nil {
-			fmt.Printf("failed to rollback the new table %s.%s: %v", toDatabase, toTable, rollbackErr)
-		}
+		c.rollbackRenamedTable(ctx, toDatabase, toTable)
 
 		return nil, fmt.Errorf("failed to rename the table %s.%s: %w", fromDatabase, fromTable, err)
 	}
 
 	return c.LoadTable(ctx, to)
+}
+
+func (c *Catalog) rollbackRenamedTable(ctx context.Context, database, tableName string) {
+	_, rollbackErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		Name:         aws.String(tableName),
+	})
+	if rollbackErr != nil {
+		fmt.Printf("failed to rollback the new table %s.%s: %v", database, tableName, rollbackErr)
+	}
 }
 
 // CheckTableExists returns if an Iceberg table exists in the Glue catalog.
@@ -842,4 +857,26 @@ func constructDatabaseInput(database string, props iceberg.Properties) *types.Da
 // add an Is method to a type from another package.
 func isConcurrentModificationException(err error) bool {
 	return errors.As(err, new(*types.ConcurrentModificationException))
+}
+
+func glueTableChangedDuringRename(original, current *types.Table) bool {
+	if original == nil || current == nil {
+		return true
+	}
+
+	originalVersionID := aws.ToString(original.VersionId)
+	currentVersionID := aws.ToString(current.VersionId)
+	if originalVersionID != "" || currentVersionID != "" {
+		return originalVersionID != currentVersionID
+	}
+
+	return glueTableMetadataLocation(original) != glueTableMetadataLocation(current)
+}
+
+func glueTableMetadataLocation(tbl *types.Table) string {
+	if tbl == nil || tbl.Parameters == nil {
+		return ""
+	}
+
+	return tbl.Parameters[tableParamMetadataLocation]
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -948,7 +948,7 @@ func TestGlueRenameTable(t *testing.T) {
 			Description:       aws.String("description"),
 			StorageDescriptor: &types.StorageDescriptor{},
 		},
-	}, nil).Once()
+	}, nil).Twice()
 
 	// Mock CreateTable response
 	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
@@ -1051,7 +1051,7 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 			Description:       aws.String("description"),
 			StorageDescriptor: &types.StorageDescriptor{},
 		},
-	}, nil).Once()
+	}, nil).Twice()
 
 	// Mock CreateTable response
 	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
@@ -1085,6 +1085,94 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 	renamedTable, err := glueCatalog.RenameTable(context.TODO(), TableIdentifier("test_database", "test_table"), TableIdentifier("test_database", "new_test_table"))
 	assert.Error(err)
 	assert.Nil(renamedTable)
+	mockGlueSvc.AssertCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("new_test_table"),
+	}, mock.Anything)
+}
+
+func TestGlueRenameTable_SourceTableChangedRollback(t *testing.T) {
+	assert := require.New(t)
+
+	mockGlueSvc := &mockGlueClient{}
+
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(&glue.GetDatabaseOutput{
+		Database: &types.Database{
+			Name: aws.String("test_database"),
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v1"),
+			Parameters: map[string]string{
+				tableParamTableType:        glueTypeIceberg,
+				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v1.metadata.json",
+			},
+			Owner:             aws.String("owner"),
+			Description:       aws.String("description"),
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
+		DatabaseName: aws.String("test_database"),
+		TableInput: &types.TableInput{
+			Name:              aws.String("new_test_table"),
+			TableType:         aws.String("EXTERNAL_TABLE"),
+			Owner:             aws.String("owner"),
+			Description:       aws.String("description"),
+			Parameters:        map[string]string{tableParamTableType: glueTypeIceberg, tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v1.metadata.json"},
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
+
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v2"),
+			Parameters: map[string]string{
+				tableParamTableType:        glueTypeIceberg,
+				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v2.metadata.json",
+			},
+			Owner:             aws.String("owner"),
+			Description:       aws.String("description"),
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("new_test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	glueCatalog := &Catalog{
+		glueSvc: mockGlueSvc,
+	}
+
+	renamedTable, err := glueCatalog.RenameTable(
+		context.TODO(),
+		TableIdentifier("test_database", "test_table"),
+		TableIdentifier("test_database", "new_test_table"),
+	)
+	assert.ErrorContains(err, "source table changed during rename")
+	assert.Nil(renamedTable)
+
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything)
 	mockGlueSvc.AssertCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{
 		DatabaseName: aws.String("test_database"),
 		Name:         aws.String("new_test_table"),


### PR DESCRIPTION
Summary

- re-fetch the source Glue table after creating the rename destination and before deleting the source
- roll back the destination table and fail the rename if the source table's VersionId or metadata location changed during the rename window
- add regression coverage for source-table drift during rename alongside the existing rollback path

Why

Glue RenameTable currently snapshots the source table, creates the destination table from that snapshot, and then deletes the source table. If another writer commits between the initial GetTable and DeleteTable, the destination can point at stale metadata while the source entry holding the newer commit is deleted.

Glue exposes VersionId optimistic locking on UpdateTable, but not on DeleteTable, so this change hardens rename by revalidating the source table immediately before delete and failing closed if it drifted.

Testing

- `go test ./catalog/glue -run 'TestGlueRenameTable|TestGlueRenameTable_DeleteTableFailureRollback|TestGlueRenameTable_SourceTableChangedRollback|TestIsConcurrentModificationException' -count=1`
- `go test ./catalog/glue -count=1`
- `git diff --check`
