### PR TITLE
fix(table): return ([]string, error) from writePositionDeletesForFiles

### DIFF
--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1860,7 +1860,7 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 	}
 	wfs, err := requireWriteFileIO(fs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	partitionContextByFilePath := make(map[string]partitionContext, len(files))


### PR DESCRIPTION
A bare `return err` returned a single value where the function now returns ([]string, error), so the table package — and every package that imports it — failed to compile, turning main red.

Silent semantic merge conflict: #1256 added the requireWriteFileIO guard with `return err` while the function still returned only error; #1298 later widened the signature and converted the returns it could see, but its base predated #1256 so it never saw that one. Each PR compiled alone; only the merge breaks, and with no textual conflict git didn't flag it.