### PR TITLE
feat(metrics): add Reporter contract and built-in reporters (#1236)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 
 # Race detector is opt-in per package/test.
 test-race:
-	go test -race -v ./codec/...
+	go test -race -v ./codec/... ./metrics/...
 
 docs-gen:
 	go run ./website/gen

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -17,27 +17,33 @@
 
 // Package metrics implements Iceberg's Metrics Reporting API for iceberg-go.
 //
-// A [Reporter] is a pluggable sink that receives a [Report] — a ScanReport
-// after scan planning or a CommitReport after a commit — describing what the
-// client did (files and manifests considered, scanned and skipped; bytes read;
-// commit attempts and durations). Reporting gives operators a standard way to
-// aggregate these otherwise-invisible client-side metrics across many clients.
+// A [Reporter] is a pluggable sink that receives a [MetricsReport] — a
+// ScanReport after scan planning or a CommitReport after a commit — describing
+// what the client did (files and manifests considered, scanned and skipped;
+// bytes read; commit attempts and durations). Reporting gives operators a
+// standard way to aggregate these otherwise-invisible client-side metrics
+// across many clients.
 //
 // Reporting is strictly opt-in: with no reporter configured the instrumented
 // code paths do no work. Reporters must never block or fail the scan/commit
 // they observe — see [Reporter] for the contract.
 //
-// This package provides the contract and the built-in reporters ([Nop],
-// [LoggingReporter], [InMemoryReporter], and [Combine]). The concrete report
-// types and the scan/commit instrumentation are layered on top in later work.
+// This package provides the contract and the built-in reporters
+// ([NopReporter], [LoggingReporter], [InMemoryReporter], and [Combine]). The
+// concrete report types and the scan/commit instrumentation are layered on top
+// in later work.
 package metrics
 
 import "context"
 
-// Report is the sealed marker interface implemented by the concrete report
-// types (ScanReport and CommitReport). It is sealed to this package so the set
-// of report types stays under the framework's control.
-type Report interface {
+// MetricsReport is the sealed marker interface implemented by the concrete
+// report types (ScanReport and CommitReport). It is sealed to this package so
+// the set of report types stays under the framework's control.
+//
+// The name mirrors the MetricsReport type in the Java and Python Iceberg
+// implementations, easing ports across the ecosystem and disambiguating the
+// type from the [Reporter.Report] method that consumes it.
+type MetricsReport interface {
 	isMetricsReport()
 }
 
@@ -50,5 +56,5 @@ type Report interface {
 // (logged and swallowed), never propagated back to the caller. Report must be
 // safe for concurrent use by multiple goroutines.
 type Reporter interface {
-	Report(ctx context.Context, report Report)
+	Report(ctx context.Context, report MetricsReport)
 }

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -36,16 +36,20 @@ package metrics
 
 import "context"
 
-// MetricsReport is the sealed marker interface implemented by the concrete
-// report types (ScanReport and CommitReport). It is sealed to this package so
-// the set of report types stays under the framework's control.
+// MetricsReport is the marker interface implemented by the concrete report
+// types (ScanReport and CommitReport). It is intentionally empty, mirroring the
+// open MetricsReport interface in the Java and Python Iceberg implementations,
+// so downstream operators can implement it for their own report wrappers.
+//
+// The set of report types is controlled by this package for now, but that is a
+// convention documented here rather than a structural guarantee — the interface
+// is deliberately not sealed, leaving room for third-party reports without a
+// future breaking change.
 //
 // The name mirrors the MetricsReport type in the Java and Python Iceberg
 // implementations, easing ports across the ecosystem and disambiguating the
 // type from the [Reporter.Report] method that consumes it.
-type MetricsReport interface {
-	isMetricsReport()
-}
+type MetricsReport any
 
 // Reporter is a pluggable sink for metrics reports.
 //

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -29,9 +29,9 @@
 // they observe — see [Reporter] for the contract.
 //
 // This package provides the contract and the built-in reporters
-// ([NopReporter], [LoggingReporter], [InMemoryReporter], and [Combine]). The
-// concrete report types and the scan/commit instrumentation are layered on top
-// in later work.
+// ([NopReporter], [LoggingReporter], [InMemoryReporter], [Combine], and
+// [CombineWithLogger]). The concrete report types and the scan/commit
+// instrumentation are layered on top in later work.
 package metrics
 
 import "context"
@@ -42,9 +42,16 @@ import "context"
 // so downstream operators can implement it for their own report wrappers.
 //
 // The set of report types is controlled by this package for now, but that is a
-// convention documented here rather than a structural guarantee — the interface
-// is deliberately not sealed, leaving room for third-party reports without a
-// future breaking change.
+// convention rather than a structural guarantee: the interface is deliberately
+// not sealed. That openness is the irreversible choice — sealing it later would
+// be the breaking change — so it is worth being precise about what it does and
+// does not buy. Custom report types are honored only by the in-process reporters
+// ([LoggingReporter], [InMemoryReporter], and the [Combine] fan-out). The REST
+// reporter (once it lands) can serialize only the discriminators it knows
+// (scan-report and commit-report), so a third-party MetricsReport carries no
+// discriminator and is silently dropped by that reporter — a spec-compliant
+// catalog would reject it outright. Do not build a custom report expecting it to
+// reach a catalog endpoint.
 //
 // The name mirrors the MetricsReport type in the Java and Python Iceberg
 // implementations, easing ports across the ecosystem and disambiguating the

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package metrics implements Iceberg's Metrics Reporting API for iceberg-go.
+//
+// A [Reporter] is a pluggable sink that receives a [Report] — a ScanReport
+// after scan planning or a CommitReport after a commit — describing what the
+// client did (files and manifests considered, scanned and skipped; bytes read;
+// commit attempts and durations). Reporting gives operators a standard way to
+// aggregate these otherwise-invisible client-side metrics across many clients.
+//
+// Reporting is strictly opt-in: with no reporter configured the instrumented
+// code paths do no work. Reporters must never block or fail the scan/commit
+// they observe — see [Reporter] for the contract.
+//
+// This package provides the contract and the built-in reporters ([Nop],
+// [LoggingReporter], [InMemoryReporter], and [Combine]). The concrete report
+// types and the scan/commit instrumentation are layered on top in later work.
+package metrics
+
+import "context"
+
+// Report is the sealed marker interface implemented by the concrete report
+// types (ScanReport and CommitReport). It is sealed to this package so the set
+// of report types stays under the framework's control.
+type Report interface {
+	isMetricsReport()
+}
+
+// Reporter is a pluggable sink for metrics reports.
+//
+// Report is invoked inline at the scan/commit completion point, so
+// implementations must return promptly and must never block or fail the
+// operation being observed: network-backed reporters should dispatch the
+// actual send on a background worker, and any error must be handled internally
+// (logged and swallowed), never propagated back to the caller. Report must be
+// safe for concurrent use by multiple goroutines.
+type Reporter interface {
+	Report(ctx context.Context, report Report)
+}

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -21,8 +21,26 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
+	"runtime/debug"
 	"sync"
 )
+
+// isNilReport reports whether report carries no value. A plain report == nil
+// catches only an untyped nil interface; once the concrete report types land, a
+// typed nil pointer (e.g. (*ScanReport)(nil)) is a non-nil interface value that
+// would slip past that check, so the reporters below would log or store a nil
+// report — and nil-deref if the concrete type grows an [slog.LogValuer] on a nil
+// receiver. This also treats such typed nils as "no report" so the guards honor
+// the documented "nil reports are ignored" behavior.
+func isNilReport(report MetricsReport) bool {
+	if report == nil {
+		return true
+	}
+	v := reflect.ValueOf(report)
+
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}
 
 // NopReporter is a [Reporter] that discards every report. It is the default
 // when no reporter is configured, so that instrumentation is free unless a user
@@ -51,7 +69,7 @@ func NewLoggingReporter(logger *slog.Logger) *LoggingReporter {
 
 // Report logs report at info level.
 func (r *LoggingReporter) Report(ctx context.Context, report MetricsReport) {
-	if report == nil {
+	if isNilReport(report) {
 		return
 	}
 	logger := r.logger
@@ -72,7 +90,7 @@ var _ Reporter = (*InMemoryReporter)(nil)
 
 // Report appends report to the retained set.
 func (r *InMemoryReporter) Report(_ context.Context, report MetricsReport) {
-	if report == nil {
+	if isNilReport(report) {
 		return
 	}
 	r.mu.Lock()
@@ -149,15 +167,16 @@ func (c *compositeReporter) Report(ctx context.Context, report MetricsReport) {
 			defer func() {
 				if v := recover(); v != nil {
 					// Swallow per the Reporter contract, but surface the
-					// failure (with the offending reporter type) so a broken
-					// reporter is traceable rather than showing up only as
-					// mysteriously-missing metrics.
+					// failure (with the offending reporter type and the stack
+					// at the panic) so a broken reporter is traceable rather
+					// than showing up only as mysteriously-missing metrics.
 					logger := c.logger
 					if logger == nil {
 						logger = slog.Default()
 					}
 					logger.WarnContext(ctx, "iceberg metrics reporter panicked; recovered",
-						"reporter", fmt.Sprintf("%T", r), "panic", v)
+						"reporter", fmt.Sprintf("%T", r), "panic", v,
+						slog.String("stack", string(debug.Stack())))
 				}
 			}()
 			r.Report(ctx, report)

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -19,6 +19,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 )
@@ -36,18 +37,15 @@ func (NopReporter) Report(context.Context, MetricsReport) {}
 // LoggingReporter is a [Reporter] that logs each report via an [slog.Logger]. It
 // is a convenient default for development and debugging.
 type LoggingReporter struct {
-	logger *slog.Logger
+	logger *slog.Logger // nil means resolve slog.Default at call time
 }
 
 var _ Reporter = (*LoggingReporter)(nil)
 
 // NewLoggingReporter returns a [LoggingReporter] that logs to logger. If logger
-// is nil, [slog.Default] is used.
+// is nil, [slog.Default] is resolved at each Report call, so a later
+// [slog.SetDefault] is honored rather than snapshotted at construction.
 func NewLoggingReporter(logger *slog.Logger) *LoggingReporter {
-	if logger == nil {
-		logger = slog.Default()
-	}
-
 	return &LoggingReporter{logger: logger}
 }
 
@@ -56,7 +54,11 @@ func (r *LoggingReporter) Report(ctx context.Context, report MetricsReport) {
 	if report == nil {
 		return
 	}
-	r.logger.InfoContext(ctx, "iceberg metrics report", "report", report)
+	logger := r.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.InfoContext(ctx, "iceberg metrics report", "report", report)
 }
 
 // InMemoryReporter is a [Reporter] that retains every report it receives. It is
@@ -97,14 +99,17 @@ func (r *InMemoryReporter) Reset() {
 // reporters in order. nil reporters are skipped. A panic in one reporter must
 // not prevent the others from receiving the report, so each call is isolated;
 // in keeping with the [Reporter] contract a misbehaving reporter never affects
-// the observed operation. A recovered panic is logged at debug level via
-// [slog.Default] so a broken reporter is not entirely invisible.
+// the observed operation. A recovered panic is logged (with the reporter type)
+// at warn level via [slog.Default] so a broken reporter is not silently
+// swallowed.
 //
-// As a convenience, Combine with no reporters returns [NopReporter], and with a
-// single non-nil reporter returns that reporter directly. The per-reporter
-// panic recovery therefore applies only when two or more reporters are
-// combined: a lone reporter is returned unwrapped and runs exactly as it would
-// if called directly, without the safety net.
+// As a convenience, Combine with no non-nil reporters returns [NopReporter].
+// Otherwise every reporter — even a lone one — is wrapped so it receives the
+// per-reporter panic isolation the contract advertises. Wrapping a single
+// reporter also closes a typed-nil hole: a concrete nil pointer (e.g.
+// (*LoggingReporter)(nil)) is a non-nil interface, so it passes the nil filter;
+// returning it unwrapped would let its eventual Report nil-deref escape with no
+// recover to catch it.
 func Combine(reporters ...Reporter) Reporter {
 	nonNil := make([]Reporter, 0, len(reporters))
 	for _, r := range reporters {
@@ -113,26 +118,37 @@ func Combine(reporters ...Reporter) Reporter {
 		}
 	}
 
-	switch len(nonNil) {
-	case 0:
+	if len(nonNil) == 0 {
 		return NopReporter{}
-	case 1:
-		return nonNil[0]
-	default:
-		return compositeReporter(nonNil)
 	}
+
+	return &compositeReporter{reporters: nonNil}
 }
 
-type compositeReporter []Reporter
+// compositeReporter fans a report out to several reporters, isolating each from
+// the others' panics.
+type compositeReporter struct {
+	reporters []Reporter
+	logger    *slog.Logger // nil means resolve slog.Default at call time
+}
 
-func (c compositeReporter) Report(ctx context.Context, report MetricsReport) {
-	for _, r := range c {
+var _ Reporter = (*compositeReporter)(nil)
+
+func (c *compositeReporter) Report(ctx context.Context, report MetricsReport) {
+	for _, r := range c.reporters {
 		func() {
 			defer func() {
 				if v := recover(); v != nil {
 					// Swallow per the Reporter contract, but surface the
-					// failure at debug level so a broken reporter is traceable.
-					slog.Default().DebugContext(ctx, "iceberg metrics reporter panicked; recovered", "panic", v)
+					// failure (with the offending reporter type) so a broken
+					// reporter is traceable rather than showing up only as
+					// mysteriously-missing metrics.
+					logger := c.logger
+					if logger == nil {
+						logger = slog.Default()
+					}
+					logger.WarnContext(ctx, "iceberg metrics reporter panicked; recovered",
+						"reporter", fmt.Sprintf("%T", r), "panic", v)
 				}
 			}()
 			r.Report(ctx, report)

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -23,15 +23,15 @@ import (
 	"sync"
 )
 
-// Nop is a [Reporter] that discards every report. It is the default when no
-// reporter is configured, so that instrumentation is free unless a user opts
-// in. The zero value is ready to use.
-type Nop struct{}
+// NopReporter is a [Reporter] that discards every report. It is the default
+// when no reporter is configured, so that instrumentation is free unless a user
+// opts in. The zero value is ready to use.
+type NopReporter struct{}
 
-var _ Reporter = Nop{}
+var _ Reporter = NopReporter{}
 
 // Report implements [Reporter] and does nothing.
-func (Nop) Report(context.Context, Report) {}
+func (NopReporter) Report(context.Context, MetricsReport) {}
 
 // LoggingReporter is a [Reporter] that logs each report via an [slog.Logger]. It
 // is a convenient default for development and debugging.
@@ -52,7 +52,7 @@ func NewLoggingReporter(logger *slog.Logger) *LoggingReporter {
 }
 
 // Report logs report at info level.
-func (r *LoggingReporter) Report(ctx context.Context, report Report) {
+func (r *LoggingReporter) Report(ctx context.Context, report MetricsReport) {
 	if report == nil {
 		return
 	}
@@ -63,13 +63,13 @@ func (r *LoggingReporter) Report(ctx context.Context, report Report) {
 // primarily intended for tests and inspection. It is safe for concurrent use.
 type InMemoryReporter struct {
 	mu      sync.Mutex
-	reports []Report
+	reports []MetricsReport
 }
 
 var _ Reporter = (*InMemoryReporter)(nil)
 
 // Report appends report to the retained set.
-func (r *InMemoryReporter) Report(_ context.Context, report Report) {
+func (r *InMemoryReporter) Report(_ context.Context, report MetricsReport) {
 	if report == nil {
 		return
 	}
@@ -79,11 +79,11 @@ func (r *InMemoryReporter) Report(_ context.Context, report Report) {
 }
 
 // Reports returns a copy of the reports received so far, in arrival order.
-func (r *InMemoryReporter) Reports() []Report {
+func (r *InMemoryReporter) Reports() []MetricsReport {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	return append([]Report(nil), r.reports...)
+	return append([]MetricsReport(nil), r.reports...)
 }
 
 // Reset discards all retained reports.
@@ -97,10 +97,14 @@ func (r *InMemoryReporter) Reset() {
 // reporters in order. nil reporters are skipped. A panic in one reporter must
 // not prevent the others from receiving the report, so each call is isolated;
 // in keeping with the [Reporter] contract a misbehaving reporter never affects
-// the observed operation.
+// the observed operation. A recovered panic is logged at debug level via
+// [slog.Default] so a broken reporter is not entirely invisible.
 //
-// As a convenience, Combine with no reporters returns [Nop], and with a single
-// non-nil reporter returns that reporter directly.
+// As a convenience, Combine with no reporters returns [NopReporter], and with a
+// single non-nil reporter returns that reporter directly. The per-reporter
+// panic recovery therefore applies only when two or more reporters are
+// combined: a lone reporter is returned unwrapped and runs exactly as it would
+// if called directly, without the safety net.
 func Combine(reporters ...Reporter) Reporter {
 	nonNil := make([]Reporter, 0, len(reporters))
 	for _, r := range reporters {
@@ -111,7 +115,7 @@ func Combine(reporters ...Reporter) Reporter {
 
 	switch len(nonNil) {
 	case 0:
-		return Nop{}
+		return NopReporter{}
 	case 1:
 		return nonNil[0]
 	default:
@@ -121,10 +125,16 @@ func Combine(reporters ...Reporter) Reporter {
 
 type compositeReporter []Reporter
 
-func (c compositeReporter) Report(ctx context.Context, report Report) {
+func (c compositeReporter) Report(ctx context.Context, report MetricsReport) {
 	for _, r := range c {
 		func() {
-			defer func() { _ = recover() }()
+			defer func() {
+				if v := recover(); v != nil {
+					// Swallow per the Reporter contract, but surface the
+					// failure at debug level so a broken reporter is traceable.
+					slog.Default().DebugContext(ctx, "iceberg metrics reporter panicked; recovered", "panic", v)
+				}
+			}()
 			r.Report(ctx, report)
 		}()
 	}

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Nop is a [Reporter] that discards every report. It is the default when no
+// reporter is configured, so that instrumentation is free unless a user opts
+// in. The zero value is ready to use.
+type Nop struct{}
+
+var _ Reporter = Nop{}
+
+// Report implements [Reporter] and does nothing.
+func (Nop) Report(context.Context, Report) {}
+
+// LoggingReporter is a [Reporter] that logs each report via an [slog.Logger]. It
+// is a convenient default for development and debugging.
+type LoggingReporter struct {
+	logger *slog.Logger
+}
+
+var _ Reporter = (*LoggingReporter)(nil)
+
+// NewLoggingReporter returns a [LoggingReporter] that logs to logger. If logger
+// is nil, [slog.Default] is used.
+func NewLoggingReporter(logger *slog.Logger) *LoggingReporter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &LoggingReporter{logger: logger}
+}
+
+// Report logs report at info level.
+func (r *LoggingReporter) Report(ctx context.Context, report Report) {
+	if report == nil {
+		return
+	}
+	r.logger.InfoContext(ctx, "iceberg metrics report", "report", report)
+}
+
+// InMemoryReporter is a [Reporter] that retains every report it receives. It is
+// primarily intended for tests and inspection. It is safe for concurrent use.
+type InMemoryReporter struct {
+	mu      sync.Mutex
+	reports []Report
+}
+
+var _ Reporter = (*InMemoryReporter)(nil)
+
+// Report appends report to the retained set.
+func (r *InMemoryReporter) Report(_ context.Context, report Report) {
+	if report == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reports = append(r.reports, report)
+}
+
+// Reports returns a copy of the reports received so far, in arrival order.
+func (r *InMemoryReporter) Reports() []Report {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]Report(nil), r.reports...)
+}
+
+// Reset discards all retained reports.
+func (r *InMemoryReporter) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reports = nil
+}
+
+// Combine returns a [Reporter] that forwards each report to all of the given
+// reporters in order. nil reporters are skipped. A panic in one reporter must
+// not prevent the others from receiving the report, so each call is isolated;
+// in keeping with the [Reporter] contract a misbehaving reporter never affects
+// the observed operation.
+//
+// As a convenience, Combine with no reporters returns [Nop], and with a single
+// non-nil reporter returns that reporter directly.
+func Combine(reporters ...Reporter) Reporter {
+	nonNil := make([]Reporter, 0, len(reporters))
+	for _, r := range reporters {
+		if r != nil {
+			nonNil = append(nonNil, r)
+		}
+	}
+
+	switch len(nonNil) {
+	case 0:
+		return Nop{}
+	case 1:
+		return nonNil[0]
+	default:
+		return compositeReporter(nonNil)
+	}
+}
+
+type compositeReporter []Reporter
+
+func (c compositeReporter) Report(ctx context.Context, report Report) {
+	for _, r := range c {
+		func() {
+			defer func() { _ = recover() }()
+			r.Report(ctx, report)
+		}()
+	}
+}

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -101,7 +101,7 @@ func (r *InMemoryReporter) Reset() {
 // in keeping with the [Reporter] contract a misbehaving reporter never affects
 // the observed operation. A recovered panic is logged (with the reporter type)
 // at warn level via [slog.Default] so a broken reporter is not silently
-// swallowed.
+// swallowed; use [CombineWithLogger] to direct that log elsewhere.
 //
 // As a convenience, Combine with no non-nil reporters returns [NopReporter].
 // Otherwise every reporter — even a lone one — is wrapped so it receives the
@@ -111,6 +111,15 @@ func (r *InMemoryReporter) Reset() {
 // returning it unwrapped would let its eventual Report nil-deref escape with no
 // recover to catch it.
 func Combine(reporters ...Reporter) Reporter {
+	return CombineWithLogger(nil, reporters...)
+}
+
+// CombineWithLogger is [Combine] with an explicit logger for recovered reporter
+// panics. A nil logger resolves [slog.Default] at each Report call, matching
+// Combine, so a later [slog.SetDefault] is honored rather than snapshotted at
+// construction. Like Combine, with no non-nil reporters it returns
+// [NopReporter] and the logger is unused.
+func CombineWithLogger(logger *slog.Logger, reporters ...Reporter) Reporter {
 	nonNil := make([]Reporter, 0, len(reporters))
 	for _, r := range reporters {
 		if r != nil {
@@ -122,7 +131,7 @@ func Combine(reporters ...Reporter) Reporter {
 		return NopReporter{}
 	}
 
-	return &compositeReporter{reporters: nonNil}
+	return &compositeReporter{reporters: nonNil, logger: logger}
 }
 
 // compositeReporter fans a report out to several reporters, isolating each from

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testReport is a minimal Report. The marker is unexported (sealed to this
+// package), so report values can only be created from within the package — this
+// white-box test is how we exercise the reporters until the concrete report
+// types land.
+type testReport struct{ name string }
+
+func (testReport) isMetricsReport() {}
+
+// countingReporter records how many reports it received.
+type countingReporter struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (c *countingReporter) Report(context.Context, Report) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.count++
+}
+
+func (c *countingReporter) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.count
+}
+
+// panickingReporter always panics, to verify Combine isolates failures.
+type panickingReporter struct{}
+
+func (panickingReporter) Report(context.Context, Report) { panic("boom") }
+
+func TestNopReporter(t *testing.T) {
+	// Nop must accept anything, including nil, without panicking.
+	assert.NotPanics(t, func() {
+		Nop{}.Report(context.Background(), nil)
+		Nop{}.Report(context.Background(), testReport{})
+	})
+}
+
+func TestInMemoryReporter(t *testing.T) {
+	var r InMemoryReporter
+	require.Empty(t, r.Reports())
+
+	r.Report(context.Background(), nil) // ignored
+	require.Empty(t, r.Reports())
+
+	r.Report(context.Background(), testReport{name: "a"})
+	r.Report(context.Background(), testReport{name: "b"})
+
+	got := r.Reports()
+	require.Len(t, got, 2)
+	assert.Equal(t, testReport{name: "a"}, got[0])
+	assert.Equal(t, testReport{name: "b"}, got[1])
+
+	// Reports returns a copy: mutating it must not affect the reporter.
+	got[0] = nil
+	require.Len(t, r.Reports(), 2)
+
+	r.Reset()
+	require.Empty(t, r.Reports())
+}
+
+func TestLoggingReporterNilLoggerAndReport(t *testing.T) {
+	r := NewLoggingReporter(nil) // must fall back to slog.Default
+	require.NotNil(t, r)
+	assert.NotPanics(t, func() {
+		r.Report(context.Background(), nil)
+		r.Report(context.Background(), testReport{name: "x"})
+	})
+}
+
+func TestCombine(t *testing.T) {
+	t.Run("no reporters returns Nop", func(t *testing.T) {
+		assert.IsType(t, Nop{}, Combine())
+		assert.IsType(t, Nop{}, Combine(nil, nil))
+	})
+
+	t.Run("single reporter returned directly", func(t *testing.T) {
+		c := &countingReporter{}
+		assert.Same(t, c, Combine(c))
+		assert.Same(t, c, Combine(nil, c, nil))
+	})
+
+	t.Run("fans out to all", func(t *testing.T) {
+		a, b := &countingReporter{}, &countingReporter{}
+		Combine(a, b).Report(context.Background(), testReport{})
+		assert.Equal(t, 1, a.calls())
+		assert.Equal(t, 1, b.calls())
+	})
+
+	t.Run("isolates a panicking reporter", func(t *testing.T) {
+		after := &countingReporter{}
+		r := Combine(panickingReporter{}, after)
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), testReport{})
+		})
+		assert.Equal(t, 1, after.calls(), "reporters after a panic still run")
+	})
+}
+
+func TestInMemoryReporterConcurrent(t *testing.T) {
+	var r InMemoryReporter
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			r.Report(context.Background(), testReport{})
+		}()
+	}
+	wg.Wait()
+	assert.Len(t, r.Reports(), n)
+}

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -147,6 +147,24 @@ func TestCombine(t *testing.T) {
 		})
 		assert.Equal(t, 1, after.calls(), "reporters after a panic still run")
 	})
+
+	t.Run("logs a recovered panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		after := &countingReporter{}
+		r := CombineWithLogger(logger, panickingReporter{}, after)
+
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), testReport{})
+		})
+		assert.Equal(t, 1, after.calls(), "reporters after a panic still run")
+
+		out := buf.String()
+		assert.Contains(t, out, "level=WARN")
+		assert.Contains(t, out, "panicked", "the warn path must fire")
+		assert.Contains(t, out, "panickingReporter", "the offending reporter type is logged")
+		assert.Contains(t, out, "boom", "the panic value is logged")
+	})
 }
 
 func TestInMemoryReporterConcurrent(t *testing.T) {

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -18,7 +18,9 @@
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 
@@ -26,13 +28,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testReport is a minimal MetricsReport. The marker is unexported (sealed to
-// this package), so report values can only be created from within the
-// package — this white-box test is how we exercise the reporters until the
-// concrete report types land.
+// testReport is a minimal MetricsReport used to exercise the reporters until
+// the concrete report types (ScanReport, CommitReport) land. MetricsReport is
+// an open marker interface, so any type satisfies it.
 type testReport struct{ name string }
-
-func (testReport) isMetricsReport() {}
 
 // countingReporter records how many reports it received.
 type countingReporter struct {
@@ -90,11 +89,28 @@ func TestInMemoryReporter(t *testing.T) {
 }
 
 func TestLoggingReporterNilLoggerAndReport(t *testing.T) {
-	r := NewLoggingReporter(nil) // must fall back to slog.Default
-	require.NotNil(t, r)
-	assert.NotPanics(t, func() {
+	t.Run("nil logger falls back to default", func(t *testing.T) {
+		r := NewLoggingReporter(nil) // must fall back to slog.Default
+		require.NotNil(t, r)
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), nil)
+			r.Report(context.Background(), testReport{name: "x"})
+		})
+	})
+
+	t.Run("logs the report at info level", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewLoggingReporter(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+		// A nil report is ignored and must produce no output.
 		r.Report(context.Background(), nil)
-		r.Report(context.Background(), testReport{name: "x"})
+		require.Empty(t, buf.String())
+
+		r.Report(context.Background(), testReport{name: "scan-42"})
+		out := buf.String()
+		assert.Contains(t, out, "level=INFO")
+		assert.Contains(t, out, "iceberg metrics report")
+		assert.Contains(t, out, "scan-42", "the report value must be logged")
 	})
 }
 
@@ -104,10 +120,16 @@ func TestCombine(t *testing.T) {
 		assert.IsType(t, NopReporter{}, Combine(nil, nil))
 	})
 
-	t.Run("single reporter returned directly", func(t *testing.T) {
-		c := &countingReporter{}
-		assert.Same(t, c, Combine(c))
-		assert.Same(t, c, Combine(nil, c, nil))
+	t.Run("single reporter is wrapped for isolation", func(t *testing.T) {
+		// Even one reporter is wrapped, so a typed-nil concrete pointer (a
+		// non-nil interface that passes the nil filter) still gets the panic
+		// isolation the contract promises instead of escaping unwrapped.
+		var lr *LoggingReporter // (*LoggingReporter)(nil) as a Reporter is non-nil
+		r := Combine(lr)
+		assert.IsType(t, &compositeReporter{}, r)
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), testReport{name: "x"})
+		})
 	})
 
 	t.Run("fans out to all", func(t *testing.T) {
@@ -129,15 +151,38 @@ func TestCombine(t *testing.T) {
 
 func TestInMemoryReporterConcurrent(t *testing.T) {
 	var r InMemoryReporter
-	const n = 100
+	const writers = 100
+
 	var wg sync.WaitGroup
-	wg.Add(n)
-	for range n {
+	wg.Add(writers)
+	for range writers {
 		go func() {
 			defer wg.Done()
 			r.Report(context.Background(), testReport{})
 		}()
 	}
+
+	// Exercise the read-under-write path: loop on Reports() in the foreground
+	// while the writers run, so -race actually has a concurrent reader to flag
+	// rather than just confirming the goroutines finish.
+	done := make(chan struct{})
+	var reader sync.WaitGroup
+	reader.Add(1)
+	go func() {
+		defer reader.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = r.Reports()
+			}
+		}
+	}()
+
 	wg.Wait()
-	assert.Len(t, r.Reports(), n)
+	close(done)
+	reader.Wait()
+
+	assert.Len(t, r.Reports(), writers)
 }

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -88,6 +88,33 @@ func TestInMemoryReporter(t *testing.T) {
 	require.Empty(t, r.Reports())
 }
 
+// TestReportersIgnoreTypedNil guards the isNilReport helper: once the concrete
+// report types land as pointers, a typed nil (e.g. (*testReport)(nil)) is a
+// non-nil interface that a plain report == nil check would miss. Both reporters
+// must still treat it as "no report".
+func TestReportersIgnoreTypedNil(t *testing.T) {
+	// A typed nil pointer is a non-nil interface at the language level (report
+	// == nil is false), so it slips past a plain nil check; isNilReport must
+	// still classify it as "no report".
+	var typedNil MetricsReport = (*testReport)(nil)
+	t.Run("InMemoryReporter drops it", func(t *testing.T) {
+		var r InMemoryReporter
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), typedNil)
+		})
+		assert.Empty(t, r.Reports(), "a typed-nil report must not be retained")
+	})
+
+	t.Run("LoggingReporter drops it", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewLoggingReporter(slog.New(slog.NewTextHandler(&buf, nil)))
+		assert.NotPanics(t, func() {
+			r.Report(context.Background(), typedNil)
+		})
+		assert.Empty(t, buf.String(), "a typed-nil report must produce no output")
+	})
+}
+
 func TestLoggingReporterNilLoggerAndReport(t *testing.T) {
 	t.Run("nil logger falls back to default", func(t *testing.T) {
 		r := NewLoggingReporter(nil) // must fall back to slog.Default
@@ -164,6 +191,7 @@ func TestCombine(t *testing.T) {
 		assert.Contains(t, out, "panicked", "the warn path must fire")
 		assert.Contains(t, out, "panickingReporter", "the offending reporter type is logged")
 		assert.Contains(t, out, "boom", "the panic value is logged")
+		assert.Contains(t, out, "stack=", "the stack at the panic is logged for locatability")
 	})
 }
 

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testReport is a minimal Report. The marker is unexported (sealed to this
-// package), so report values can only be created from within the package — this
-// white-box test is how we exercise the reporters until the concrete report
-// types land.
+// testReport is a minimal MetricsReport. The marker is unexported (sealed to
+// this package), so report values can only be created from within the
+// package — this white-box test is how we exercise the reporters until the
+// concrete report types land.
 type testReport struct{ name string }
 
 func (testReport) isMetricsReport() {}
@@ -40,7 +40,7 @@ type countingReporter struct {
 	count int
 }
 
-func (c *countingReporter) Report(context.Context, Report) {
+func (c *countingReporter) Report(context.Context, MetricsReport) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.count++
@@ -56,13 +56,13 @@ func (c *countingReporter) calls() int {
 // panickingReporter always panics, to verify Combine isolates failures.
 type panickingReporter struct{}
 
-func (panickingReporter) Report(context.Context, Report) { panic("boom") }
+func (panickingReporter) Report(context.Context, MetricsReport) { panic("boom") }
 
 func TestNopReporter(t *testing.T) {
-	// Nop must accept anything, including nil, without panicking.
+	// NopReporter must accept anything, including nil, without panicking.
 	assert.NotPanics(t, func() {
-		Nop{}.Report(context.Background(), nil)
-		Nop{}.Report(context.Background(), testReport{})
+		NopReporter{}.Report(context.Background(), nil)
+		NopReporter{}.Report(context.Background(), testReport{})
 	})
 }
 
@@ -100,8 +100,8 @@ func TestLoggingReporterNilLoggerAndReport(t *testing.T) {
 
 func TestCombine(t *testing.T) {
 	t.Run("no reporters returns Nop", func(t *testing.T) {
-		assert.IsType(t, Nop{}, Combine())
-		assert.IsType(t, Nop{}, Combine(nil, nil))
+		assert.IsType(t, NopReporter{}, Combine())
+		assert.IsType(t, NopReporter{}, Combine(nil, nil))
 	})
 
 	t.Run("single reporter returned directly", func(t *testing.T) {


### PR DESCRIPTION
First PR of the metrics reporting framework. 
Adds the metrics package with the Reporter interface, the sealed Report marker, and the built-in Nop, Logging, InMemory, and Combine reporters. Reporting is opt-in and must never block or fail the observed scan/commit.

Concrete report types and instrumentation follow in later PRs.

Related: #1236 