### PR TITLE
fix(rest): require absolute auth URL

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -449,6 +449,14 @@ func handleNon200(rsp *http.Response, override map[int]error) error {
 }
 
 func fromProps(props iceberg.Properties, o *options) error {
+	if v, ok := props[keyAuthUrl]; ok {
+		u, err := parseAuthURL(v)
+		if err != nil {
+			return err
+		}
+		o.authUri = u
+	}
+
 	for k, v := range props {
 		switch k {
 		case keyWarehouseLocation:
@@ -462,11 +470,6 @@ func fromProps(props iceberg.Properties, o *options) error {
 		case keyRestSigV4Service:
 			o.sigv4Service = v
 		case keyAuthUrl:
-			u, err := url.Parse(v)
-			if err != nil {
-				return fmt.Errorf("invalid %s %q: %w", keyAuthUrl, v, err)
-			}
-			o.authUri = u
 		case keyOauthCredential:
 			o.credential = v
 		case keyScope:
@@ -498,6 +501,18 @@ func fromProps(props iceberg.Properties, o *options) error {
 	}
 
 	return nil
+}
+
+func parseAuthURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s %q: %w", keyAuthUrl, raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid %s %q: missing scheme or host", keyAuthUrl, raw)
+	}
+
+	return u, nil
 }
 
 func toProps(o *options) iceberg.Properties {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -449,14 +449,6 @@ func handleNon200(rsp *http.Response, override map[int]error) error {
 }
 
 func fromProps(props iceberg.Properties, o *options) error {
-	if v, ok := props[keyAuthUrl]; ok {
-		u, err := parseAuthURL(v)
-		if err != nil {
-			return err
-		}
-		o.authUri = u
-	}
-
 	for k, v := range props {
 		switch k {
 		case keyWarehouseLocation:
@@ -470,6 +462,11 @@ func fromProps(props iceberg.Properties, o *options) error {
 		case keyRestSigV4Service:
 			o.sigv4Service = v
 		case keyAuthUrl:
+			u, err := parseAuthURL(v)
+			if err != nil {
+				return err
+			}
+			o.authUri = u
 		case keyOauthCredential:
 			o.credential = v
 		case keyScope:
@@ -508,8 +505,11 @@ func parseAuthURL(raw string) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid %s %q: %w", keyAuthUrl, raw, err)
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return nil, fmt.Errorf("invalid %s %q: missing scheme or host", keyAuthUrl, raw)
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("invalid %s %q: missing scheme", keyAuthUrl, raw)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("invalid %s %q: missing host", keyAuthUrl, raw)
 	}
 
 	return u, nil

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -67,17 +67,22 @@ func TestLoadRegisteredCatalogRejectsInvalidAuthURL(t *testing.T) {
 		{
 			name:    "missing scheme",
 			authURL: "example.com/auth",
-			wantErr: "missing scheme or host",
+			wantErr: "missing scheme",
 		},
 		{
-			name:    "missing host",
+			name:    "scheme and opaque value with no host",
 			authURL: "localhost:8080",
-			wantErr: "missing scheme or host",
+			wantErr: "missing host",
+		},
+		{
+			name:    "scheme with empty host",
+			authURL: "http:///path",
+			wantErr: "missing host",
 		},
 		{
 			name:    "empty URL",
 			authURL: "",
-			wantErr: "missing scheme or host",
+			wantErr: "missing scheme",
 		},
 	}
 
@@ -94,6 +99,49 @@ func TestLoadRegisteredCatalogRejectsInvalidAuthURL(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestLoadRegisteredCatalogAcceptsValidAuthURL(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var oauthCalled atomic.Bool
+	mux.HandleFunc("/auth-token-url", func(w http.ResponseWriter, req *http.Request) {
+		oauthCalled.Store(true)
+		assert.Equal(t, http.MethodPost, req.Method)
+
+		require.NoError(t, req.ParseForm())
+		assert.Equal(t, "client", req.PostForm.Get("client_id"))
+		assert.Equal(t, "secret", req.PostForm.Get("client_secret"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "some_jwt_token",
+			"token_type":   "Bearer",
+			"expires_in":   86400,
+		})
+	})
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{}, "overrides": map[string]any{},
+		})
+	})
+
+	authURL := srv.URL + "/auth-token-url"
+	cat, err := catalog.Load(context.Background(), "rest", iceberg.Properties{
+		"uri":              srv.URL,
+		keyAuthUrl:         authURL,
+		keyOauthCredential: "client:secret",
+	})
+	require.NoError(t, err)
+	require.True(t, oauthCalled.Load())
+
+	restCat, ok := cat.(*Catalog)
+	require.True(t, ok)
+	assert.Equal(t, authURL, restCat.props[keyAuthUrl])
 }
 
 func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
@@ -115,7 +163,7 @@ func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
 			name:    "scheme-less URL in overrides",
 			section: "overrides",
 			authURL: "example.com/auth",
-			wantErr: "missing scheme or host",
+			wantErr: "missing scheme",
 		},
 	}
 
@@ -149,6 +197,26 @@ func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestNewCatalogAcceptsValidAuthURLFromConfig(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	authURL := "https://auth.example.com/oauth/token"
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{keyAuthUrl: authURL},
+		})
+	})
+
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, authURL, cat.props[keyAuthUrl])
 }
 
 func TestTokenAuthenticationPriority(t *testing.T) {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -54,35 +54,101 @@ import (
 func TestLoadRegisteredCatalogRejectsInvalidAuthURL(t *testing.T) {
 	t.Parallel()
 
-	cat, err := catalog.Load(context.Background(), "rest", iceberg.Properties{
-		"uri":                    "http://example.com",
-		"rest.authorization-url": "http://[::1",
-	})
-	require.Error(t, err)
-	assert.Nil(t, cat)
-	assert.ErrorContains(t, err, "invalid rest.authorization-url")
+	tests := []struct {
+		name    string
+		authURL string
+		wantErr string
+	}{
+		{
+			name:    "malformed URL",
+			authURL: "http://[::1",
+			wantErr: "invalid rest.authorization-url",
+		},
+		{
+			name:    "missing scheme",
+			authURL: "example.com/auth",
+			wantErr: "missing scheme or host",
+		},
+		{
+			name:    "missing host",
+			authURL: "localhost:8080",
+			wantErr: "missing scheme or host",
+		},
+		{
+			name:    "empty URL",
+			authURL: "",
+			wantErr: "missing scheme or host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cat, err := catalog.Load(context.Background(), "rest", iceberg.Properties{
+				"uri":                    "http://example.com",
+				"rest.authorization-url": tt.authURL,
+			})
+			require.Error(t, err)
+			assert.Nil(t, cat)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+	tests := []struct {
+		name    string
+		section string
+		authURL string
+		wantErr string
+	}{
+		{
+			name:    "malformed URL in defaults",
+			section: "defaults",
+			authURL: "http://[::1",
+			wantErr: "invalid rest.authorization-url",
+		},
+		{
+			name:    "scheme-less URL in overrides",
+			section: "overrides",
+			authURL: "example.com/auth",
+			wantErr: "missing scheme or host",
+		},
+	}
 
-	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
-			"defaults": map[string]any{
-				"rest.authorization-url": "http://[::1",
-			},
-			"overrides": map[string]any{},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux := http.NewServeMux()
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			defaults := map[string]any{}
+			overrides := map[string]any{}
+			switch tt.section {
+			case "defaults":
+				defaults[keyAuthUrl] = tt.authURL
+			case "overrides":
+				overrides[keyAuthUrl] = tt.authURL
+			}
+
+			mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(map[string]any{
+					"defaults":  defaults,
+					"overrides": overrides,
+				})
+			})
+
+			cat, err := NewCatalog(context.Background(), "rest", srv.URL)
+			require.Error(t, err)
+			assert.Nil(t, cat)
+			assert.ErrorContains(t, err, tt.wantErr)
 		})
-	})
-
-	cat, err := NewCatalog(context.Background(), "rest", srv.URL)
-	require.Error(t, err)
-	assert.Nil(t, cat)
-	assert.ErrorContains(t, err, "invalid rest.authorization-url")
+	}
 }
 
 func TestTokenAuthenticationPriority(t *testing.T) {


### PR DESCRIPTION
Summary

- follow-up to #1336
- require rest.authorization-url to include a scheme and host after url.Parse succeeds
- extract authorization URL parsing into a testable helper
- extend regression coverage for malformed local props, missing scheme/host, valid local config, and server overrides

Why

#1336 made malformed rest.authorization-url values fail instead of being silently ignored. url.Parse still accepts common typos like example.com/auth, localhost:8080, and the empty string, though. Those values made authUri non-nil, so credential-based auth skipped the default OAuth endpoint and pointed at a bad authorization URL instead of rejecting the config.

Testing

- go test ./catalog/rest -run 'Test(LoadRegisteredCatalogRejectsInvalidAuthURL|LoadRegisteredCatalogAcceptsValidAuthURL|NewCatalogRejectsInvalidAuthURLFromConfig|NewCatalogAcceptsValidAuthURLFromConfig)$' -count=1
- go test ./catalog/rest -count=1
- go test ./catalog/... -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./catalog/rest/...
- git diff --check