### PR TITLE
fix(table): reject float equality delete fields

### DIFF
--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -55,12 +55,15 @@ func validateEqualityFieldIDs(tableSchema *iceberg.Schema, fieldIDs []int) ([]st
 			return nil, fmt.Errorf("%w: field ID %d not found in table schema", iceberg.ErrInvalidSchema, id)
 		}
 
+		// Keep both lookups: FindColumnName returns the dotted path Schema.Select
+		// needs for nested fields, while FindFieldByID exposes the field type.
 		field, ok := tableSchema.FindFieldByID(id)
 		if !ok {
+			// Defensive only: FindColumnName already found this field ID.
 			return nil, fmt.Errorf("%w: field ID %d not found in table schema", iceberg.ErrInvalidSchema, id)
 		}
 		if isFloatingPointType(field.Type) {
-			return nil, fmt.Errorf("%w: equality field ID %d (%s) has unsupported type %s: float and double cannot be used in equality delete field IDs",
+			return nil, fmt.Errorf("%w: equality field ID %d (%s) has unsupported floating-point type %s: floating-point columns cannot be used as equality delete keys",
 				iceberg.ErrInvalidSchema, id, name, field.Type)
 		}
 

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -35,6 +35,15 @@ var ErrEmptyEqualityFieldIDs = errors.New("equality field IDs must not be empty"
 // equalityDeleteSchema projects a table schema to only the fields specified
 // by the given field IDs, using Schema.Select for proper nested field handling.
 func equalityDeleteSchema(tableSchema *iceberg.Schema, fieldIDs []int) (*iceberg.Schema, error) {
+	names, err := validateEqualityFieldIDs(tableSchema, fieldIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return tableSchema.Select(true, names...)
+}
+
+func validateEqualityFieldIDs(tableSchema *iceberg.Schema, fieldIDs []int) ([]string, error) {
 	if len(fieldIDs) == 0 {
 		return nil, ErrEmptyEqualityFieldIDs
 	}
@@ -46,10 +55,28 @@ func equalityDeleteSchema(tableSchema *iceberg.Schema, fieldIDs []int) (*iceberg
 			return nil, fmt.Errorf("%w: field ID %d not found in table schema", iceberg.ErrInvalidSchema, id)
 		}
 
+		field, ok := tableSchema.FindFieldByID(id)
+		if !ok {
+			return nil, fmt.Errorf("%w: field ID %d not found in table schema", iceberg.ErrInvalidSchema, id)
+		}
+		if isFloatingPointType(field.Type) {
+			return nil, fmt.Errorf("%w: equality field ID %d (%s) has unsupported type %s: float and double cannot be used in equality delete field IDs",
+				iceberg.ErrInvalidSchema, id, name, field.Type)
+		}
+
 		names = append(names, name)
 	}
 
-	return tableSchema.Select(true, names...)
+	return names, nil
+}
+
+func isFloatingPointType(typ iceberg.Type) bool {
+	switch typ.(type) {
+	case iceberg.Float32Type, iceberg.Float64Type:
+		return true
+	default:
+		return false
+	}
 }
 
 // WriteEqualityDeletes writes Arrow record batches as equality delete
@@ -219,17 +246,16 @@ func equalityDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 // writer to extract partition values from the records while keeping the delete
 // key as the equality identifier.
 func equalityDeleteWriteSchema(tableSchema *iceberg.Schema, equalityFieldIDs []int, spec iceberg.PartitionSpec) (*iceberg.Schema, error) {
+	names, err := validateEqualityFieldIDs(tableSchema, equalityFieldIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	seen := make(map[int]struct{}, len(equalityFieldIDs))
-	names := make([]string, 0, len(equalityFieldIDs))
 
 	// Equality key columns first (deterministic order).
 	for _, id := range equalityFieldIDs {
-		name, ok := tableSchema.FindColumnName(id)
-		if !ok {
-			return nil, fmt.Errorf("%w: field ID %d not found in table schema", iceberg.ErrInvalidSchema, id)
-		}
 		seen[id] = struct{}{}
-		names = append(names, name)
 	}
 
 	// Partition source columns not already in the equality key.

--- a/table/equality_delete_writer_test.go
+++ b/table/equality_delete_writer_test.go
@@ -226,6 +226,53 @@ func TestWriteEqualityDeleteFilesRejectsInvalidFieldID(t *testing.T) {
 	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 }
 
+func TestWriteEqualityDeleteFilesRejectsFloatAndDoubleFieldIDs(t *testing.T) {
+	location := filepath.ToSlash(t.TempDir())
+
+	iceSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "score", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+		iceberg.NestedField{ID: 3, Name: "ratio", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+	)
+
+	meta, err := table.NewMetadata(iceSchema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	tbl := table.New(
+		table.Identifier{"db", "floating_key_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(ctx context.Context) (iceio.IO, error) {
+			return iceio.LocalFS{}, nil
+		},
+		&rowDeltaCatalog{metadata: meta},
+	)
+
+	records := func(yield func(arrow.RecordBatch, error) bool) {}
+
+	tests := []struct {
+		name      string
+		fieldID   int
+		fieldName string
+		fieldType string
+	}{
+		{name: "float", fieldID: 2, fieldName: "score", fieldType: "float"},
+		{name: "double", fieldID: 3, fieldName: "ratio", fieldType: "double"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := tbl.NewTransaction()
+			_, err := tx.WriteEqualityDeletes(t.Context(), []int{tt.fieldID}, records)
+			require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+			assert.ErrorContains(t, err, "equality field ID")
+			assert.ErrorContains(t, err, tt.fieldName)
+			assert.ErrorContains(t, err, tt.fieldType)
+		})
+	}
+}
+
 func newPartitionedEqDeleteTestTable(t *testing.T) *table.Table {
 	t.Helper()
 

--- a/table/equality_delete_writer_test.go
+++ b/table/equality_delete_writer_test.go
@@ -281,6 +281,8 @@ func newPartitionedEqDeleteTestTable(t *testing.T) *table.Table {
 	iceSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 3, Name: "score", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+		iceberg.NestedField{ID: 4, Name: "price", Type: iceberg.DecimalTypeOf(10, 2), Required: false},
 	)
 
 	partSpec := iceberg.NewPartitionSpec(
@@ -343,6 +345,67 @@ func TestWriteEqualityDeleteFilesPartitionedTable(t *testing.T) {
 			pqSchema := rdr.MetaData().Schema
 			assert.Equal(t, 1, pqSchema.NumColumns(), "parquet file should contain only the equality key column")
 			assert.Equal(t, "id", pqSchema.Column(0).Name())
+		}()
+	}
+}
+
+func TestWriteEqualityDeleteFilesPartitionedTableRejectsFloatFieldID(t *testing.T) {
+	tbl := newPartitionedEqDeleteTestTable(t)
+
+	delSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 3, Name: "score", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	delArrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
+	require.NoError(t, err)
+
+	records, release := makeEqDeleteRecords(t, delArrowSc,
+		`[{"score": 1.5, "category": "books"}]`)
+	defer release()
+
+	tx := tbl.NewTransaction()
+	_, err = tx.WriteEqualityDeletes(t.Context(), []int{3}, records)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "score")
+	assert.ErrorContains(t, err, "float")
+	assert.ErrorContains(t, err, "floating-point columns cannot be used as equality delete keys")
+}
+
+func TestWriteEqualityDeleteFilesPartitionedTableAcceptsDecimalFieldID(t *testing.T) {
+	tbl := newPartitionedEqDeleteTestTable(t)
+
+	delSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 4, Name: "price", Type: iceberg.DecimalTypeOf(10, 2), Required: false},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	delArrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
+	require.NoError(t, err)
+
+	records, release := makeEqDeleteRecords(t, delArrowSc,
+		`[{"price": "12.34", "category": "books"}, {"price": "56.78", "category": "music"}]`)
+	defer release()
+
+	tx := tbl.NewTransaction()
+	files, err := tx.WriteEqualityDeletes(t.Context(), []int{4}, records)
+	require.NoError(t, err)
+	require.Len(t, files, 2, "should produce one file per partition")
+
+	for _, df := range files {
+		assert.Equal(t, iceberg.EntryContentEqDeletes, df.ContentType())
+		assert.Equal(t, []int{4}, df.EqualityFieldIDs())
+
+		func() {
+			f, err := os.Open(df.FilePath())
+			require.NoError(t, err)
+			defer f.Close()
+
+			rdr, err := file.NewParquetReader(f)
+			require.NoError(t, err)
+			defer rdr.Close()
+
+			pqSchema := rdr.MetaData().Schema
+			assert.Equal(t, 1, pqSchema.NumColumns(), "parquet file should contain only the equality key column")
+			assert.Equal(t, "price", pqSchema.Column(0).Name())
 		}()
 	}
 }

--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -134,11 +134,8 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 					f.FilePath())
 			}
 
-			for _, id := range eqIDs {
-				if _, ok := schema.FindFieldByID(id); !ok {
-					return fmt.Errorf("equality field ID %d not found in table schema: %s",
-						id, f.FilePath())
-				}
+			if _, err := validateEqualityFieldIDs(schema, eqIDs); err != nil {
+				return fmt.Errorf("invalid equality delete file %s: %w", f.FilePath(), err)
 			}
 		}
 	}

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -57,6 +57,27 @@ func newRowDeltaTestTable(t *testing.T, formatVersion int) *table.Table {
 	)
 }
 
+func newRowDeltaFloatingPointTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "score", Type: iceberg.PrimitiveTypes.Float32, Required: false},
+		iceberg.NestedField{ID: 3, Name: "ratio", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+	)
+
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, "s3://bucket/test",
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	return table.New(
+		table.Identifier{"db", "floating_key_test"},
+		meta, "s3://bucket/test/metadata/v1.metadata.json",
+		nil, nil,
+	)
+}
+
 func formatVersionStr(v int) string {
 	return string(rune('0' + v))
 }
@@ -212,6 +233,33 @@ func TestRowDeltaRejectsEqDeleteWithInvalidFieldID(t *testing.T) {
 	err := rd.Commit(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found in table schema")
+}
+
+func TestRowDeltaRejectsEqDeleteWithFloatAndDoubleFieldIDs(t *testing.T) {
+	tbl := newRowDeltaFloatingPointTestTable(t)
+
+	tests := []struct {
+		name      string
+		fieldID   int
+		fieldName string
+		fieldType string
+	}{
+		{name: "float", fieldID: 2, fieldName: "score", fieldType: "float"},
+		{name: "double", fieldID: 3, fieldName: "ratio", fieldType: "double"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := tbl.NewTransaction().NewRowDelta(nil)
+			rd.AddDeletes(buildEqDeleteFile(t, "s3://bucket/data/eq-del.parquet", []int{tt.fieldID}))
+
+			err := rd.Commit(t.Context())
+			require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+			assert.ErrorContains(t, err, "eq-del.parquet")
+			assert.ErrorContains(t, err, tt.fieldName)
+			assert.ErrorContains(t, err, tt.fieldType)
+		})
+	}
 }
 
 // rowDeltaCatalog simulates catalog behavior for RowDelta commit tests.


### PR DESCRIPTION
Summary

- reject float and double columns in equality delete field IDs
- share equality-ID schema validation between WriteEqualityDeletes and RowDelta commit
- add writer and RowDelta regression coverage for both float and double fields
- cover the partitioned equality-delete writer path with float rejection and decimal acceptance

Why

Iceberg equality delete keys cannot be float or double. Before this change, WriteEqualityDeletes and manually-built equality delete DataFiles could accept those field IDs, which made iceberg-go appear to support delete shapes other engines reject.

Closes #1288.

Testing

- go test ./table -run 'Test(WriteEqualityDeleteFilesRejectsFloatAndDoubleFieldIDs|WriteEqualityDeleteFilesPartitionedTableRejectsFloatFieldID|WriteEqualityDeleteFilesPartitionedTableAcceptsDecimalFieldID|WriteEqualityDeleteFilesPartitionedTable|WriteEqualityDeleteFilesRejectsInvalidFieldID|WriteEqualityDeleteFilesRejectsEmptyFieldIDs|RowDeltaRejectsEqDeleteWithFloatAndDoubleFieldIDs|RowDeltaRejectsEqDeleteWithInvalidFieldID|RowDeltaRejectsEqDeleteWithoutFieldIDs|RowDeltaCommitWithEqualityDeletes)$' -count=1
- go test ./table -count=1
- go test ./table/... -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check