### PR TITLE
fix(table): clarify v3 next-row-id overflow guard, harden tests

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"iter"
 	"maps"
+	"math"
 	"slices"
 	"strconv"
 	"time"
@@ -504,12 +505,20 @@ func (b *MetadataBuilder) validateAndUpdateRowLineage(snapshot *Snapshot) error 
 			ErrInvalidRowLineage, *snapshot.FirstRowID, nextRowID)
 	}
 
-	newNextRowID := nextRowID + *snapshot.AddedRows
-	if newNextRowID < nextRowID {
-		return fmt.Errorf("%w: next-row-id regressed from %d to %d (added-rows %d)",
-			ErrInvalidRowLineage, nextRowID, newNextRowID, *snapshot.AddedRows)
+	// next-row-id is non-decreasing across snapshots, not strictly increasing:
+	// zero-added-rows snapshots (delete-only or metadata-only commits) are
+	// spec-legal and leave the cursor unchanged, so this accepts a sum equal to
+	// the current cursor rather than requiring it to advance. At this point
+	// AddedRows is non-nil and non-negative (guaranteed by the FirstRowID != nil
+	// check above plus Snapshot.ValidateRowLineage), and nextRowID is
+	// non-negative per spec, so the only thing left to guard is int64 overflow
+	// of the running cursor.
+	if *snapshot.AddedRows > math.MaxInt64-nextRowID {
+		return fmt.Errorf("%w: adding %d rows to next-row-id %d overflows int64",
+			ErrInvalidRowLineage, *snapshot.AddedRows, nextRowID)
 	}
 
+	newNextRowID := nextRowID + *snapshot.AddedRows
 	b.nextRowID = &newNextRowID
 
 	return nil

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 	"testing"
@@ -1702,14 +1703,19 @@ func TestAddSnapshotV3AcceptsFirstRowIDEqualToNextRowID(t *testing.T) {
 	require.Equal(t, int64(100), *builder.nextRowID)
 }
 
-func TestAddSnapshotV3AcceptsPositiveAddedRows(t *testing.T) {
-	// Positive added-rows should advance next-row-id.
+func TestAddSnapshotV3AcceptsZeroAddedRows(t *testing.T) {
+	// Asserts spec-permitted no-op behavior: a zero-added-rows snapshot
+	// (delete-only or metadata-only commit) leaves next-row-id unchanged. The
+	// cursor is first advanced to a non-zero value so the assertion is
+	// falsifiable — a regression that advanced the cursor on every commit would
+	// be caught. This is NOT coverage of the overflow guard — see
+	// TestAddSnapshotV3RejectsNextRowIDOverflow.
 	builder := builderWithoutChanges(3)
 	schemaID := 0
-	firstRowID := int64(0)
-	addedRows := int64(50)
 
-	snapshot := Snapshot{
+	appendFirstRowID := int64(0)
+	appendAddedRows := int64(50)
+	appendSnapshot := Snapshot{
 		SnapshotID:       1,
 		ParentSnapshotID: nil,
 		SequenceNumber:   0,
@@ -1717,21 +1723,69 @@ func TestAddSnapshotV3AcceptsPositiveAddedRows(t *testing.T) {
 		ManifestList:     "/snap-1.avro",
 		Summary:          &Summary{Operation: OpAppend},
 		SchemaID:         &schemaID,
-		FirstRowID:       &firstRowID,
-		AddedRows:        &addedRows,
+		FirstRowID:       &appendFirstRowID,
+		AddedRows:        &appendAddedRows,
 	}
+	require.NoError(t, builder.AddSnapshot(&appendSnapshot))
+	require.Equal(t, int64(50), *builder.nextRowID)
 
-	require.NoError(t, builder.AddSnapshot(&snapshot))
+	deleteFirstRowID := int64(50)
+	deleteAddedRows := int64(0)
+	deleteSnapshot := Snapshot{
+		SnapshotID:       2,
+		ParentSnapshotID: &appendSnapshot.SnapshotID,
+		SequenceNumber:   1,
+		TimestampMs:      builder.base.LastUpdatedMillis() + 2,
+		ManifestList:     "/snap-2.avro",
+		Summary:          &Summary{Operation: OpDelete},
+		SchemaID:         &schemaID,
+		FirstRowID:       &deleteFirstRowID,
+		AddedRows:        &deleteAddedRows,
+	}
+	require.NoError(t, builder.AddSnapshot(&deleteSnapshot))
 	require.Equal(t, int64(50), *builder.nextRowID)
 }
 
-func TestAddSnapshotV3AcceptsZeroAddedRows(t *testing.T) {
-	// Zero added-rows is valid and should leave next-row-id unchanged.
+func TestAddSnapshotV3RejectsNextRowIDOverflow(t *testing.T) {
+	// next-row-id + added-rows must not overflow int64. Seed the cursor near
+	// the maximum so a positive added-rows tips it over. This is the only input
+	// that reaches the guard: negative added-rows is rejected earlier by
+	// Snapshot.ValidateRowLineage.
 	builder := builderWithoutChanges(3)
-	schemaID := 0
-	firstRowID := int64(0)
-	addedRows := int64(0)
+	nearMax := int64(math.MaxInt64 - 10)
+	builder.nextRowID = &nearMax
 
+	schemaID := 0
+	firstRowID := nearMax
+	addedRows := int64(20)
+	snapshot := Snapshot{
+		SnapshotID:       1,
+		ParentSnapshotID: nil,
+		SequenceNumber:   0,
+		TimestampMs:      builder.base.LastUpdatedMillis() + 1,
+		ManifestList:     "/snap-1.avro",
+		Summary:          &Summary{Operation: OpAppend},
+		SchemaID:         &schemaID,
+		FirstRowID:       &firstRowID,
+		AddedRows:        &addedRows,
+	}
+
+	err := builder.AddSnapshot(&snapshot)
+	require.ErrorIs(t, err, ErrInvalidRowLineage)
+	require.ErrorContains(t, err, "overflows int64")
+}
+
+func TestAddSnapshotV3AcceptsMaxInt64NextRowID(t *testing.T) {
+	// Boundary: added-rows that fills the cursor to exactly math.MaxInt64 (sum
+	// == MaxInt64) must be accepted; the guard rejects only a strictly larger
+	// sum. This pins the `>` boundary against an off-by-one to `>=`.
+	builder := builderWithoutChanges(3)
+	nearMax := int64(math.MaxInt64 - 10)
+	builder.nextRowID = &nearMax
+
+	schemaID := 0
+	firstRowID := nearMax
+	addedRows := int64(10)
 	snapshot := Snapshot{
 		SnapshotID:       1,
 		ParentSnapshotID: nil,
@@ -1745,7 +1799,7 @@ func TestAddSnapshotV3AcceptsZeroAddedRows(t *testing.T) {
 	}
 
 	require.NoError(t, builder.AddSnapshot(&snapshot))
-	require.Equal(t, int64(0), *builder.nextRowID)
+	require.Equal(t, int64(math.MaxInt64), *builder.nextRowID)
 }
 
 func generateTypeSchema(typ iceberg.Type) *iceberg.Schema {


### PR DESCRIPTION
Follow-up to #1054. cleanup the next-row-id overflow guard in validateAndUpdateRowLineage to check overflow before computing the wrapped sum (added-rows > MaxInt64 - next-row-id) and reword the error to say what actually happened ("adding N rows to next-row-id M overflows int64") rather than the misleading "regressed". Document the invariants the guard relies on: added-rows is non-nil/non-negative and next-row-id is non-negative at that point.

Tests: drop the redundant positive-advance case (covered by TestAddSnapshotV3UpdatesNextRowID), make the zero-added-rows test falsifiable by seeding a non-zero cursor first, and add the MaxInt64 accept boundary alongside the overflow reject.