### PR TITLE
Preserve reserved Glue and Hive table parameters

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -799,15 +799,18 @@ func constructParameters(staged *table.Table, previousGlueTable *types.Table) ma
 	parameters := make(map[string]string)
 	if previousGlueTable != nil {
 		maps.Copy(parameters, previousGlueTable.Parameters)
-		if previousMetadataLocation, ok := parameters[tableParamMetadataLocation]; ok {
+	}
+
+	maps.Copy(parameters, staged.Properties())
+	delete(parameters, tableParamPreviousMetadataLocation)
+
+	if previousGlueTable != nil {
+		if previousMetadataLocation, ok := previousGlueTable.Parameters[tableParamMetadataLocation]; ok {
 			parameters[tableParamPreviousMetadataLocation] = previousMetadataLocation
 		}
 	}
-
 	parameters[tableParamTableType] = glueTypeIceberg
 	parameters[tableParamMetadataLocation] = staged.MetadataLocation()
-
-	maps.Copy(parameters, staged.Properties())
 
 	return parameters
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -213,6 +213,49 @@ func TestGlueGetTable(t *testing.T) {
 	assert.Equal("s3://test-bucket/test_table/metadata/abc123-123.metadata.json", tbl.Parameters[tableParamMetadataLocation])
 }
 
+func TestGlueConstructParametersPreservesReservedParameters(t *testing.T) {
+	assert := require.New(t)
+
+	metadataLocation := "s3://test-bucket/test_table/metadata/v2.metadata.json"
+	previousMetadataLocation := "s3://test-bucket/test_table/metadata/v1.metadata.json"
+
+	metadata, err := table.NewMetadata(testSchema, nil, table.UnsortedSortOrder, "s3://test-bucket/test_table", iceberg.Properties{
+		tableParamTableType:                "HIVE",
+		tableParamMetadataLocation:         "s3://malicious-bucket/table/metadata.json",
+		tableParamPreviousMetadataLocation: "s3://malicious-bucket/table/previous.metadata.json",
+		"custom":                           "value",
+	})
+	assert.NoError(err)
+
+	staged := table.New(
+		TableIdentifier("test_database", "test_table"),
+		metadata,
+		metadataLocation,
+		nil,
+		nil,
+	)
+
+	params := constructParameters(staged, &types.Table{
+		Parameters: map[string]string{
+			tableParamTableType:                glueTypeIceberg,
+			tableParamMetadataLocation:         previousMetadataLocation,
+			tableParamPreviousMetadataLocation: "s3://test-bucket/test_table/metadata/v0.metadata.json",
+		},
+	})
+
+	assert.Equal(glueTypeIceberg, params[tableParamTableType])
+	assert.Equal(metadataLocation, params[tableParamMetadataLocation])
+	assert.Equal(previousMetadataLocation, params[tableParamPreviousMetadataLocation])
+	assert.Equal("value", params["custom"])
+
+	params = constructParameters(staged, nil)
+
+	assert.Equal(glueTypeIceberg, params[tableParamTableType])
+	assert.Equal(metadataLocation, params[tableParamMetadataLocation])
+	assert.NotContains(params, tableParamPreviousMetadataLocation)
+	assert.Equal("value", params["custom"])
+}
+
 func TestGlueGetTableCaseInsensitive(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -756,6 +756,61 @@ func TestHiveCreateTableConflictsWithView(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestConstructHiveTablePreservesReservedParameters(t *testing.T) {
+	assert := require.New(t)
+
+	metadataLocation := "s3://bucket/test_table/metadata/v2.metadata.json"
+	hiveTbl := constructHiveTable(
+		"test_database",
+		"test_table",
+		"s3://bucket/test_table",
+		metadataLocation,
+		testSchema,
+		map[string]string{
+			TableTypeKey:                 "HIVE",
+			MetadataLocationKey:          "s3://wrong-bucket/metadata.json",
+			PreviousMetadataLocationKey:  "s3://wrong-bucket/previous.metadata.json",
+			ExternalKey:                  "FALSE",
+			"storage_handler":            "wrong.StorageHandler",
+			"write.metadata.compression": "gzip",
+		},
+	)
+
+	assert.Equal(TableTypeExternalTable, hiveTbl.TableType)
+	assert.Equal(TableTypeIceberg, hiveTbl.Parameters[TableTypeKey])
+	assert.Equal(metadataLocation, hiveTbl.Parameters[MetadataLocationKey])
+	assert.NotContains(hiveTbl.Parameters, PreviousMetadataLocationKey)
+	assert.Equal("TRUE", hiveTbl.Parameters[ExternalKey])
+	assert.Equal("org.apache.iceberg.mr.hive.HiveIcebergStorageHandler", hiveTbl.Parameters["storage_handler"])
+	assert.Equal("gzip", hiveTbl.Parameters["write.metadata.compression"])
+}
+
+func TestConstructHiveViewTablePreservesReservedParameters(t *testing.T) {
+	assert := require.New(t)
+
+	metadataLocation := "s3://bucket/test_view/metadata/v2.metadata.json"
+	hiveTbl := constructHiveViewTable(
+		"test_database",
+		"test_view",
+		"s3://bucket/test_view",
+		metadataLocation,
+		testSchema,
+		"SELECT 1 AS col",
+		map[string]string{
+			TableTypeKey:        TableTypeIceberg,
+			MetadataLocationKey: "s3://wrong-bucket/metadata.json",
+			ExternalKey:         "FALSE",
+			"owner":             "alice",
+		},
+	)
+
+	assert.Equal(TableTypeVirtualView, hiveTbl.TableType)
+	assert.Equal(TableTypeIcebergView, hiveTbl.Parameters[TableTypeKey])
+	assert.Equal(metadataLocation, hiveTbl.Parameters[MetadataLocationKey])
+	assert.Equal("TRUE", hiveTbl.Parameters[ExternalKey])
+	assert.Equal("alice", hiveTbl.Parameters["owner"])
+}
+
 func TestHiveRegisterTableNoSuchNamespace(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -797,16 +797,18 @@ func TestConstructHiveViewTablePreservesReservedParameters(t *testing.T) {
 		testSchema,
 		"SELECT 1 AS col",
 		map[string]string{
-			TableTypeKey:        TableTypeIceberg,
-			MetadataLocationKey: "s3://wrong-bucket/metadata.json",
-			ExternalKey:         "FALSE",
-			"owner":             "alice",
+			TableTypeKey:                TableTypeIceberg,
+			MetadataLocationKey:         "s3://wrong-bucket/metadata.json",
+			PreviousMetadataLocationKey: "s3://wrong-bucket/previous.metadata.json",
+			ExternalKey:                 "FALSE",
+			"owner":                     "alice",
 		},
 	)
 
 	assert.Equal(TableTypeVirtualView, hiveTbl.TableType)
 	assert.Equal(TableTypeIcebergView, hiveTbl.Parameters[TableTypeKey])
 	assert.Equal(metadataLocation, hiveTbl.Parameters[MetadataLocationKey])
+	assert.NotContains(hiveTbl.Parameters, PreviousMetadataLocationKey)
 	assert.Equal("TRUE", hiveTbl.Parameters[ExternalKey])
 	assert.Equal("alice", hiveTbl.Parameters["owner"])
 }

--- a/catalog/hive/schema.go
+++ b/catalog/hive/schema.go
@@ -102,6 +102,8 @@ func constructHiveViewTable(dbName, viewName, location, metadataLocation string,
 			parameters[k] = v
 		}
 	}
+	delete(parameters, PreviousMetadataLocationKey)
+
 	parameters[TableTypeKey] = TableTypeIcebergView
 	parameters[MetadataLocationKey] = metadataLocation
 	parameters[ExternalKey] = "TRUE"

--- a/catalog/hive/schema.go
+++ b/catalog/hive/schema.go
@@ -97,14 +97,14 @@ const (
 // are set to viewSQL.
 func constructHiveViewTable(dbName, viewName, location, metadataLocation string, schema *iceberg.Schema, viewSQL string, props map[string]string) *hive_metastore.Table {
 	parameters := make(map[string]string)
-	parameters[TableTypeKey] = TableTypeIcebergView
-	parameters[MetadataLocationKey] = metadataLocation
-	parameters[ExternalKey] = "TRUE"
 	for k, v := range props {
 		if v != "" {
 			parameters[k] = v
 		}
 	}
+	parameters[TableTypeKey] = TableTypeIcebergView
+	parameters[MetadataLocationKey] = metadataLocation
+	parameters[ExternalKey] = "TRUE"
 
 	// Ref: https://github.com/apache/iceberg/blob/11dbe2f091edd4ac492f210c878d22386ec9d605/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveOperationsBase.java#L174-L178
 	tbl := &hive_metastore.Table{
@@ -131,18 +131,15 @@ func constructHiveViewTable(dbName, viewName, location, metadataLocation string,
 func constructHiveTable(dbName, tableName, location, metadataLocation string, schema *iceberg.Schema, props map[string]string) *hive_metastore.Table {
 	parameters := make(map[string]string)
 
-	// Set Iceberg-specific parameters
-	parameters[TableTypeKey] = TableTypeIceberg
-	parameters[MetadataLocationKey] = metadataLocation
-	parameters[ExternalKey] = "TRUE"
-
-	// Set storage handler - required for Hive to query Iceberg tables
-	parameters["storage_handler"] = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler"
-
-	// Copy additional properties
 	for k, v := range props {
 		parameters[k] = v
 	}
+	delete(parameters, PreviousMetadataLocationKey)
+
+	parameters[TableTypeKey] = TableTypeIceberg
+	parameters[MetadataLocationKey] = metadataLocation
+	parameters[ExternalKey] = "TRUE"
+	parameters["storage_handler"] = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler"
 
 	return &hive_metastore.Table{
 		TableName: tableName,


### PR DESCRIPTION
## Summary

Glue and Hive table construction copied user table properties after setting catalog-owned parameters. That allowed properties such as `table_type`, `metadata_location`, `EXTERNAL`, and Hive `storage_handler` to overwrite the values required for Iceberg catalog entries.

This changes the parameter construction order so user properties are copied first and catalog-required parameters are assigned last. Glue also keeps `previous_metadata_location` catalog-owned by deriving it from the previous Glue table during updates and omitting user-provided values during create/register. Hive table creation/register does the same for `previous_metadata_location`, and Hive views now preserve their required reserved parameters as well.

## Testing

- `go test ./catalog/glue ./catalog/hive`
- `go test ./...`