### PR TITLE
Clone metadata builder properties

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -780,11 +780,12 @@ func (b *MetadataBuilder) SetProperties(props iceberg.Properties) error {
 		}
 	}
 
-	b.updates = append(b.updates, NewSetPropertiesUpdate(props))
+	updates := maps.Clone(props)
+	b.updates = append(b.updates, NewSetPropertiesUpdate(updates))
 	if b.props == nil {
-		b.props = props
+		b.props = maps.Clone(updates)
 	} else {
-		maps.Copy(b.props, props)
+		maps.Copy(b.props, updates)
 	}
 
 	return nil

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -1182,6 +1182,31 @@ func TestSetReservedPropertiesFails(t *testing.T) {
 	require.ErrorContains(t, err, "can't set reserved property "+PropertyCurrentSnapshotId)
 }
 
+func TestSetPropertiesClonesProperties(t *testing.T) {
+	builder := builderWithoutChanges(2)
+
+	props := iceberg.Properties{"property": "value"}
+	require.NoError(t, builder.SetProperties(props))
+
+	props["property"] = "mutated"
+	props["added"] = "mutated"
+
+	require.Equal(t, "value", builder.props["property"])
+	require.NotContains(t, builder.props, "added")
+
+	require.Len(t, builder.updates, 1)
+	firstUpdate := builder.updates[0].(*setPropertiesUpdate)
+	require.Equal(t, iceberg.Properties{"property": "value"}, firstUpdate.Updates)
+
+	moreProps := iceberg.Properties{"another-property": "another-value"}
+	require.NoError(t, builder.SetProperties(moreProps))
+	moreProps["another-property"] = "mutated"
+
+	require.Equal(t, iceberg.Properties{"property": "value"}, firstUpdate.Updates)
+	require.Equal(t, "another-value", builder.props["another-property"])
+	require.Equal(t, iceberg.Properties{"another-property": "another-value"}, builder.updates[1].(*setPropertiesUpdate).Updates)
+}
+
 func TestRemoveReservedPropertiesFails(t *testing.T) {
 	builder := builderWithoutChanges(2)
 


### PR DESCRIPTION
## Summary

`MetadataBuilder.SetProperties` kept the caller-provided properties map when the builder had no existing properties. That meant later changes to the caller map could mutate builder state after `SetProperties` returned.

This clones incoming properties before storing them in the builder and before recording the pending set-properties update. The builder aggregate properties and the recorded update now stay independent from caller-owned maps and from later builder property merges.

## Testing

- `go test ./table`
- `go test ./...`