### PR TITLE
fix(rest): validate table and view identifiers

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -214,6 +214,16 @@ func NamespaceFromIdent(ident table.Identifier) table.Identifier {
 	return ident[:len(ident)-1]
 }
 
+// ValidateTableIdentifier checks that an identifier contains at least one namespace level and a table name.
+func ValidateTableIdentifier(ident table.Identifier) error {
+	if len(ident) < 2 {
+		return fmt.Errorf("%w: missing namespace or invalid identifier %v",
+			ErrNoSuchTable, strings.Join(ident, "."))
+	}
+
+	return nil
+}
+
 type CreateTableOpt func(*CreateTableCfg)
 
 func WithLocation(location string) CreateTableOpt {

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -34,6 +34,7 @@ import (
 	"iter"
 	"maps"
 	"strings"
+	"unicode"
 
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
@@ -214,14 +215,37 @@ func NamespaceFromIdent(ident table.Identifier) table.Identifier {
 	return ident[:len(ident)-1]
 }
 
-// ValidateTableIdentifier checks that an identifier contains at least one namespace level and a table name.
-func ValidateTableIdentifier(ident table.Identifier) error {
+func validateTableOrViewIdentifier(ident table.Identifier, notFoundErr error) error {
 	if len(ident) < 2 {
 		return fmt.Errorf("%w: missing namespace or invalid identifier %v",
-			ErrNoSuchTable, strings.Join(ident, "."))
+			notFoundErr, strings.Join(ident, "."))
+	}
+
+	for _, part := range ident {
+		if part == "" || part == "." || part == ".." || strings.Contains(part, "/") {
+			return fmt.Errorf("%w: invalid identifier component %q in %v",
+				notFoundErr, part, strings.Join(ident, "."))
+		}
+
+		for _, r := range part {
+			if unicode.IsControl(r) {
+				return fmt.Errorf("%w: invalid control character in identifier component %q in %v",
+					notFoundErr, part, strings.Join(ident, "."))
+			}
+		}
 	}
 
 	return nil
+}
+
+// ValidateTableIdentifier checks that an identifier contains at least one valid namespace level and a table name.
+func ValidateTableIdentifier(ident table.Identifier) error {
+	return validateTableOrViewIdentifier(ident, ErrNoSuchTable)
+}
+
+// ValidateViewIdentifier checks that an identifier contains at least one valid namespace level and a view name.
+func ValidateViewIdentifier(ident table.Identifier) error {
+	return validateTableOrViewIdentifier(ident, ErrNoSuchView)
 }
 
 type CreateTableOpt func(*CreateTableCfg)

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTableIdentifier(t *testing.T) {
+	require.NoError(t, catalog.ValidateTableIdentifier(table.Identifier{"namespace", "table"}))
+	require.NoError(t, catalog.ValidateTableIdentifier(table.Identifier{"parent", "namespace", "table"}))
+
+	require.ErrorIs(t, catalog.ValidateTableIdentifier(nil), catalog.ErrNoSuchTable)
+	require.ErrorIs(t, catalog.ValidateTableIdentifier(table.Identifier{}), catalog.ErrNoSuchTable)
+	require.ErrorIs(t, catalog.ValidateTableIdentifier(table.Identifier{"table"}), catalog.ErrNoSuchTable)
+}

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -29,7 +29,26 @@ func TestValidateTableIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateTableIdentifier(table.Identifier{"namespace", "table"}))
 	require.NoError(t, catalog.ValidateTableIdentifier(table.Identifier{"parent", "namespace", "table"}))
 
-	require.ErrorIs(t, catalog.ValidateTableIdentifier(nil), catalog.ErrNoSuchTable)
-	require.ErrorIs(t, catalog.ValidateTableIdentifier(table.Identifier{}), catalog.ErrNoSuchTable)
-	require.ErrorIs(t, catalog.ValidateTableIdentifier(table.Identifier{"table"}), catalog.ErrNoSuchTable)
+	for _, ident := range []table.Identifier{
+		nil,
+		{},
+		{"table"},
+		{"namespace", ""},
+		{"namespace", "."},
+		{"namespace", ".."},
+		{"namespace", "table/name"},
+		{"namespace", "table\nname"},
+		{"", "table"},
+		{"namespace/child", "table"},
+	} {
+		require.ErrorIs(t, catalog.ValidateTableIdentifier(ident), catalog.ErrNoSuchTable)
+	}
+}
+
+func TestValidateViewIdentifier(t *testing.T) {
+	require.NoError(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view"}))
+
+	require.ErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"view"}), catalog.ErrNoSuchView)
+	require.ErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchView)
+	require.NotErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchTable)
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -967,9 +967,8 @@ func (r *Catalog) namespaceToQueryParam(namespace table.Identifier) string {
 }
 
 func (r *Catalog) splitIdentForPath(ident table.Identifier) (string, string, error) {
-	if len(ident) < 1 {
-		return "", "", fmt.Errorf("%w: missing namespace or invalid identifier %v",
-			catalog.ErrNoSuchTable, strings.Join(ident, "."))
+	if err := catalog.ValidateTableIdentifier(ident); err != nil {
+		return "", "", err
 	}
 
 	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
@@ -1156,8 +1155,8 @@ func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 
 	changes := make([]tableChange, len(commits))
 	for i, c := range commits {
-		if len(c.Identifier) == 0 {
-			return catalog.ErrMissingIdentifier
+		if err := catalog.ValidateTableIdentifier(c.Identifier); err != nil {
+			return fmt.Errorf("%w: %w", catalog.ErrMissingIdentifier, err)
 		}
 
 		reqs := c.Requirements
@@ -1366,6 +1365,12 @@ func (r *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 
 func (r *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error) {
 	if err := r.endpoints.check(endpointRenameTable); err != nil {
+		return nil, err
+	}
+	if err := catalog.ValidateTableIdentifier(from); err != nil {
+		return nil, err
+	}
+	if err := catalog.ValidateTableIdentifier(to); err != nil {
 		return nil, err
 	}
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -974,6 +974,14 @@ func (r *Catalog) splitIdentForPath(ident table.Identifier) (string, string, err
 	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
 }
 
+func (r *Catalog) splitViewIdentForPath(ident table.Identifier) (string, string, error) {
+	if err := catalog.ValidateViewIdentifier(ident); err != nil {
+		return "", "", err
+	}
+
+	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
+}
+
 func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
 	if err := r.endpoints.check(endpointCreateTable); err != nil {
 		return nil, err
@@ -1155,8 +1163,11 @@ func (r *Catalog) CommitTransaction(ctx context.Context, commits []table.TableCo
 
 	changes := make([]tableChange, len(commits))
 	for i, c := range commits {
+		if len(c.Identifier) == 0 {
+			return catalog.ErrMissingIdentifier
+		}
 		if err := catalog.ValidateTableIdentifier(c.Identifier); err != nil {
-			return fmt.Errorf("%w: %w", catalog.ErrMissingIdentifier, err)
+			return err
 		}
 
 		reqs := c.Requirements
@@ -1723,7 +1734,7 @@ func (r *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 		return err
 	}
 
-	ns, view, err := r.splitIdentForPath(identifier)
+	ns, view, err := r.splitViewIdentForPath(identifier)
 	if err != nil {
 		return err
 	}
@@ -1740,7 +1751,7 @@ func (r *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 }
 
 func (r *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifier) (bool, error) {
-	ns, view, err := r.splitIdentForPath(identifier)
+	ns, view, err := r.splitViewIdentForPath(identifier)
 	if err != nil {
 		return false, err
 	}
@@ -1810,7 +1821,7 @@ func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 		return nil, err
 	}
 
-	ns, viewName, err := r.splitIdentForPath(identifier)
+	ns, viewName, err := r.splitViewIdentForPath(identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -1871,7 +1882,7 @@ func (r *Catalog) UpdateView(ctx context.Context, ident table.Identifier, requir
 		return nil, err
 	}
 
-	ns, viewName, err := r.splitIdentForPath(ident)
+	ns, viewName, err := r.splitViewIdentForPath(ident)
 	if err != nil {
 		return nil, err
 	}
@@ -1916,7 +1927,7 @@ func (r *Catalog) RegisterView(ctx context.Context, identifier table.Identifier,
 		return nil, err
 	}
 
-	ns, v, err := r.splitIdentForPath(identifier)
+	ns, v, err := r.splitViewIdentForPath(identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -1953,7 +1964,7 @@ func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 		return nil, err
 	}
 
-	ns, v, err := r.splitIdentForPath(identifier)
+	ns, v, err := r.splitViewIdentForPath(identifier)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -50,6 +51,26 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
+
+func TestSplitIdentForPathRequiresNamespaceAndName(t *testing.T) {
+	cat := &Catalog{}
+
+	_, _, err := cat.splitIdentForPath(nil)
+	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+
+	_, _, err = cat.splitIdentForPath(table.Identifier{"table"})
+	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+
+	ns, tbl, err := cat.splitIdentForPath(table.Identifier{"namespace", "table"})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace", ns)
+	assert.Equal(t, "table", tbl)
+
+	ns, tbl, err = cat.splitIdentForPath(table.Identifier{"parent", "namespace", "table"})
+	require.NoError(t, err)
+	assert.Equal(t, "parent%1Fnamespace", ns)
+	assert.Equal(t, "table", tbl)
+}
 
 func TestLoadRegisteredCatalogRejectsInvalidAuthURL(t *testing.T) {
 	t.Parallel()

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -55,11 +55,22 @@ import (
 func TestSplitIdentForPathRequiresNamespaceAndName(t *testing.T) {
 	cat := &Catalog{}
 
-	_, _, err := cat.splitIdentForPath(nil)
-	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	for _, ident := range []table.Identifier{
+		nil,
+		{"table"},
+		{"namespace", ""},
+		{"namespace", "."},
+		{"namespace", ".."},
+		{"namespace", "table/name"},
+		{"namespace", "table\nname"},
+	} {
+		_, _, err := cat.splitIdentForPath(ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	}
 
-	_, _, err = cat.splitIdentForPath(table.Identifier{"table"})
-	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	_, _, err := cat.splitViewIdentForPath(table.Identifier{"view"})
+	require.ErrorIs(t, err, catalog.ErrNoSuchView)
+	require.NotErrorIs(t, err, catalog.ErrNoSuchTable)
 
 	ns, tbl, err := cat.splitIdentForPath(table.Identifier{"namespace", "table"})
 	require.NoError(t, err)

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2708,7 +2708,31 @@ func (r *RestCatalogSuite) TestTableAndViewIdentifiersRequireNamespace() {
 	r.ErrorIs(err, catalog.ErrNoSuchTable)
 
 	_, err = cat.LoadView(context.Background(), table.Identifier{"view"})
-	r.ErrorIs(err, catalog.ErrNoSuchTable)
+	r.ErrorIs(err, catalog.ErrNoSuchView)
+	r.NotErrorIs(err, catalog.ErrNoSuchTable)
+
+	for _, ident := range []table.Identifier{
+		{"namespace", ""},
+		{"namespace", "."},
+		{"namespace", ".."},
+		{"namespace", "table/name"},
+		{"namespace", "table\nname"},
+	} {
+		_, err = cat.LoadTable(context.Background(), ident)
+		r.ErrorIs(err, catalog.ErrNoSuchTable)
+	}
+
+	for _, ident := range []table.Identifier{
+		{"namespace", ""},
+		{"namespace", "."},
+		{"namespace", ".."},
+		{"namespace", "view/name"},
+		{"namespace", "view\nname"},
+	} {
+		_, err = cat.LoadView(context.Background(), ident)
+		r.ErrorIs(err, catalog.ErrNoSuchView)
+		r.NotErrorIs(err, catalog.ErrNoSuchTable)
+	}
 
 	_, err = cat.RenameTable(context.Background(), table.Identifier{"source"}, table.Identifier{"namespace", "destination"})
 	r.ErrorIs(err, catalog.ErrNoSuchTable)
@@ -2719,8 +2743,14 @@ func (r *RestCatalogSuite) TestTableAndViewIdentifiersRequireNamespace() {
 	err = cat.CommitTransaction(context.Background(), []table.TableCommit{
 		{Identifier: table.Identifier{"table"}},
 	})
-	r.ErrorIs(err, catalog.ErrMissingIdentifier)
 	r.ErrorIs(err, catalog.ErrNoSuchTable)
+	r.NotErrorIs(err, catalog.ErrMissingIdentifier)
+
+	err = cat.CommitTransaction(context.Background(), []table.TableCommit{
+		{Identifier: table.Identifier{"namespace", "table/name"}},
+	})
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+	r.NotErrorIs(err, catalog.ErrMissingIdentifier)
 
 	r.Len(transport.calls, 1)
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2688,13 +2688,41 @@ func (r *RestCatalogSuite) TestCatalogWithCustomTransport() {
 	r.Equal("/v1/config", transport.calls[0].path)
 
 	// Not expected to succeed
-	tbl, err := cat.LoadTable(context.Background(), table.Identifier{"unknown"})
+	tbl, err := cat.LoadTable(context.Background(), table.Identifier{"namespace", "unknown"})
 	r.Error(err)
 	r.Nil(tbl)
 
 	r.Len(transport.calls, 2)
 	r.Equal("GET", transport.calls[1].method)
-	r.Equal("/v1/namespaces/tables/unknown", transport.calls[1].path)
+	r.Equal("/v1/namespaces/namespace/tables/unknown", transport.calls[1].path)
+}
+
+func (r *RestCatalogSuite) TestTableAndViewIdentifiersRequireNamespace() {
+	var transport mockTransport
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithCustomTransport(&transport))
+	r.Require().NoError(err)
+	r.Require().Len(transport.calls, 1)
+
+	_, err = cat.LoadTable(context.Background(), table.Identifier{"table"})
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	_, err = cat.LoadView(context.Background(), table.Identifier{"view"})
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	_, err = cat.RenameTable(context.Background(), table.Identifier{"source"}, table.Identifier{"namespace", "destination"})
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	_, err = cat.RenameTable(context.Background(), table.Identifier{"namespace", "source"}, table.Identifier{"destination"})
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	err = cat.CommitTransaction(context.Background(), []table.TableCommit{
+		{Identifier: table.Identifier{"table"}},
+	})
+	r.ErrorIs(err, catalog.ErrMissingIdentifier)
+	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	r.Len(transport.calls, 1)
 }
 
 func (r *RestTLSCatalogSuite) TestCatalogWithCustomTransportAndTlsConfig() {


### PR DESCRIPTION
## Summary

REST table and view operations accepted one-part identifiers such as `["table"]`. The path helper treated that as an empty namespace plus table name, which could produce malformed REST paths or JSON identifiers.

This adds a shared `catalog.ValidateTableIdentifier` helper that requires at least one namespace level and a table/view name, then wires REST table and view operations through it. Rename and transaction commits now validate identifiers before constructing REST identifier payloads too.

## Testing

- `go test ./catalog ./catalog/rest`
- `go test ./...`