### PR TITLE
fix(manifest): encode decimal partitions with declared width

### DIFF
--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -143,7 +143,6 @@ func unmarshalAvroDataFileEntry(data []byte, spec PartitionSpec, schema *Schema,
 	df.specID = int32(spec.ID())
 	df.fieldNameToID = maps.nameToID
 	df.fieldIDToLogicalType = maps.idToType
-	df.fieldIDToFixedSize = maps.idToFixedSize
 	df.fieldIDToDecimalScale = maps.idToDecimalScale
 
 	return df, nil
@@ -295,15 +294,10 @@ func manifestEntrySchemaFor(spec PartitionSpec, schema *Schema, version int) (*a
 	if err != nil {
 		return nil, dataFileFieldMaps{}, err
 	}
-	n2i, i2t, i2s, i2sc := getFieldIDMap(fullSchema)
+	fieldMaps := getFieldIDMap(fullSchema)
 	entry := &dataFileSchemaEntry{
 		schema: fullSchema,
-		maps: dataFileFieldMaps{
-			nameToID:         n2i,
-			idToType:         i2t,
-			idToFixedSize:    i2s,
-			idToDecimalScale: i2sc,
-		},
+		maps:   fieldMaps,
 	}
 	dataFileSchemaCache.Add(key, entry)
 

--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -107,7 +107,11 @@ func (d *dataFile) MarshalAvroEntry(spec PartitionSpec, schema *Schema, version 
 		return nil, err
 	}
 	clone := cloneDataFileAvroFields(d)
-	clone.PartitionData = avroEncodePartitionData(d.Partition(), maps.nameToID, maps.idToType)
+	partitionData, err := avroEncodePartitionData(d.Partition(), maps.nameToID, maps.idToType, maps.idToFixedSize)
+	if err != nil {
+		return nil, err
+	}
+	clone.PartitionData = partitionData
 
 	return s.Encode(newEncodeEntry(version, clone))
 }
@@ -140,6 +144,7 @@ func unmarshalAvroDataFileEntry(data []byte, spec PartitionSpec, schema *Schema,
 	df.fieldNameToID = maps.nameToID
 	df.fieldIDToLogicalType = maps.idToType
 	df.fieldIDToFixedSize = maps.idToFixedSize
+	df.fieldIDToDecimalScale = maps.idToDecimalScale
 
 	return df, nil
 }
@@ -205,8 +210,11 @@ func cloneDataFileAvroFields(src *dataFile) *dataFile {
 // iceberg-typed values like Date or Decimal) into the name-keyed
 // avro-friendly map the manifest-entry schema expects. Idempotent:
 // values already in primitive form pass through unchanged.
-func avroEncodePartitionData(idKeyed map[int]any, nameToID map[string]int, logicalTypes map[int]string) map[string]any {
-	converted := avroPartitionData(idKeyed, logicalTypes)
+func avroEncodePartitionData(idKeyed map[int]any, nameToID map[string]int, logicalTypes map[int]string, fixedSizes map[int]int) (map[string]any, error) {
+	converted, err := avroPartitionData(idKeyed, logicalTypes, fixedSizes)
+	if err != nil {
+		return nil, err
+	}
 	out := make(map[string]any, len(converted))
 	for name, id := range nameToID {
 		if v, ok := converted[id]; ok {
@@ -214,13 +222,14 @@ func avroEncodePartitionData(idKeyed map[int]any, nameToID map[string]int, logic
 		}
 	}
 
-	return out
+	return out, nil
 }
 
 type dataFileFieldMaps struct {
-	nameToID      map[string]int
-	idToType      map[int]string
-	idToFixedSize map[int]int
+	nameToID         map[string]int
+	idToType         map[int]string
+	idToFixedSize    map[int]int
+	idToDecimalScale map[int]int
 }
 
 // dataFileSchemaCacheKey identifies a cached avro schema by the
@@ -286,13 +295,14 @@ func manifestEntrySchemaFor(spec PartitionSpec, schema *Schema, version int) (*a
 	if err != nil {
 		return nil, dataFileFieldMaps{}, err
 	}
-	n2i, i2t, i2s := getFieldIDMap(fullSchema)
+	n2i, i2t, i2s, i2sc := getFieldIDMap(fullSchema)
 	entry := &dataFileSchemaEntry{
 		schema: fullSchema,
 		maps: dataFileFieldMaps{
-			nameToID:      n2i,
-			idToType:      i2t,
-			idToFixedSize: i2s,
+			nameToID:         n2i,
+			idToType:         i2t,
+			idToFixedSize:    i2s,
+			idToDecimalScale: i2sc,
 		},
 	}
 	dataFileSchemaCache.Add(key, entry)

--- a/data_file_codec_test.go
+++ b/data_file_codec_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,6 +114,42 @@ func TestMarshalAvroEntryDoesNotMutateAnyAvroField(t *testing.T) {
 	require.Equal(t, before, after,
 		"MarshalAvroEntry must not mutate any avro-tagged field of the source DataFile, "+
 			"including pointer-typed fields whose backing storage is shared with the clone")
+}
+
+func TestMarshalAvroEntryDecimalPartitionRoundTrip(t *testing.T) {
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "price", Type: DecimalTypeOf(10, 2)},
+	)
+	spec := NewPartitionSpecID(1,
+		PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "price", Transform: IdentityTransform{}},
+	)
+	want := Decimal{Val: decimal128.FromI64(-123), Scale: 2}
+	builder, err := NewDataFileBuilder(
+		spec,
+		EntryContentData,
+		"s3://bucket/ns/tbl/data/price=-1.23.parquet",
+		ParquetFile,
+		map[int]any{1000: want},
+		nil,
+		nil,
+		1,
+		1024,
+	)
+	require.NoError(t, err)
+	df := builder.Build()
+
+	// Builder partition values are already Iceberg-typed and are returned
+	// directly; decimal scale reconstruction is only needed after Avro decode.
+	require.Equal(t, want, df.Partition()[1000])
+
+	encoded, err := df.(*dataFile).MarshalAvroEntry(spec, schema, 2)
+	require.NoError(t, err)
+	decoded, err := unmarshalAvroDataFileEntry(encoded, spec, schema, 2)
+	require.NoError(t, err)
+
+	got, ok := decoded.Partition()[1000].(DecimalLiteral)
+	require.True(t, ok)
+	require.True(t, got.Equals(DecimalLiteral(want)))
 }
 
 // snapshotAvroFields returns a deep copy of every avro-tagged field on

--- a/manifest.go
+++ b/manifest.go
@@ -1943,7 +1943,7 @@ func encodeDecimalBytes(dec DecimalLiteral, fixedSize int) ([]byte, error) {
 		return nil, err
 	}
 
-	return padOrTruncateBytes(bytes, fixedSize), nil
+	return fitDecimalBytes(bytes, fixedSize)
 }
 
 func convertUUIDValue(v any) any {
@@ -1954,13 +1954,41 @@ func convertUUIDValue(v any) any {
 	return v
 }
 
-func padOrTruncateBytes(bytes []byte, size int) []byte {
-	if len(bytes) >= size {
-		return bytes[len(bytes)-size:]
+func fitDecimalBytes(bytes []byte, size int) ([]byte, error) {
+	if len(bytes) == 0 {
+		return make([]byte, size), nil
 	}
-	padded := slices.Grow(bytes, size-len(bytes))
 
-	return append(make([]byte, size-len(bytes)), padded...)
+	if len(bytes) == size {
+		return bytes, nil
+	}
+
+	if len(bytes) < size {
+		signByte := byte(0x00)
+		if bytes[0]&0x80 != 0 {
+			signByte = 0xff
+		}
+		padded := make([]byte, size)
+		for i := range padded[:size-len(bytes)] {
+			padded[i] = signByte
+		}
+		copy(padded[size-len(bytes):], bytes)
+
+		return padded, nil
+	}
+
+	retained := bytes[len(bytes)-size:]
+	signByte := byte(0x00)
+	if retained[0]&0x80 != 0 {
+		signByte = 0xff
+	}
+	for _, b := range bytes[:len(bytes)-size] {
+		if b != signByte {
+			return nil, fmt.Errorf("decimal value does not fit fixed size %d", size)
+		}
+	}
+
+	return retained, nil
 }
 
 type dataFile struct {

--- a/manifest.go
+++ b/manifest.go
@@ -432,7 +432,7 @@ func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) (_ []Manif
 	return ReadManifest(m, f, discardDeleted)
 }
 
-func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int, map[int]int) {
+func getFieldIDMap(sc *avro.Schema) dataFileFieldMaps {
 	root := sc.Root()
 	getField := func(node avro.SchemaNode, name string) *avro.SchemaField {
 		for i := range node.Fields {
@@ -477,7 +477,12 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 		}
 	}
 
-	return result, logicalTypes, fixedSizes, decimalScales
+	return dataFileFieldMaps{
+		nameToID:         result,
+		idToType:         logicalTypes,
+		idToFixedSize:    fixedSizes,
+		idToDecimalScale: decimalScales,
+	}
 }
 
 // applyDayTransformDates marks every day(...) partition field described by the
@@ -515,7 +520,6 @@ func applyDayTransformDates(specJSON []byte, fieldIDToType map[int]string) {
 type hasFieldToIDMap interface {
 	setFieldNameToIDMap(map[string]int)
 	setFieldIDToLogicalTypeMap(map[int]string)
-	setFieldIDToFixedSizeMap(map[int]int)
 	setFieldIDToDecimalScaleMap(map[int]int)
 }
 
@@ -679,7 +683,6 @@ type ManifestReader struct {
 	content        ManifestContent
 	fieldNameToID  map[string]int
 	fieldIDToType  map[int]string
-	fieldIDToSize  map[int]int
 	fieldIDToScale map[int]int
 
 	// The rest are lazily populated, on demand. Most readers
@@ -762,13 +765,13 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 			}
 		}
 	}
-	fieldNameToID, fieldIDToType, fieldIDToSize, fieldIDToScale := getFieldIDMap(sc)
+	fieldMaps := getFieldIDMap(sc)
 	// day(...) partition values are days since the Unix epoch, but a manifest
 	// may encode them either as an Avro int carrying the "date" logical type or
 	// as a legacy plain Avro int. Overlay the manifest's partition spec so
 	// day-transform fields are always exposed as iceberg.Date, regardless of the
 	// Avro encoding used to write them.
-	applyDayTransformDates(metadata["partition-spec"], fieldIDToType)
+	applyDayTransformDates(metadata["partition-spec"], fieldMaps.idToType)
 
 	// A non-nil manifest-list first_row_id is the spec's inheritance signal and
 	// is only assigned by a v3+ manifest-list writer, so it — not the manifest
@@ -790,10 +793,9 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		formatVersion:  formatVersion,
 		isFallback:     isFallback,
 		content:        content,
-		fieldNameToID:  fieldNameToID,
-		fieldIDToType:  fieldIDToType,
-		fieldIDToSize:  fieldIDToSize,
-		fieldIDToScale: fieldIDToScale,
+		fieldNameToID:  fieldMaps.nameToID,
+		fieldIDToType:  fieldMaps.idToType,
+		fieldIDToScale: fieldMaps.idToDecimalScale,
 		inheritRowIDs:  inheritRowIDs,
 		nextFirstRowID: nextFirstRowID,
 	}, nil
@@ -908,7 +910,6 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	if fieldToIDMap, ok := tmp.DataFile().(hasFieldToIDMap); ok {
 		fieldToIDMap.setFieldNameToIDMap(c.fieldNameToID)
 		fieldToIDMap.setFieldIDToLogicalTypeMap(c.fieldIDToType)
-		fieldToIDMap.setFieldIDToFixedSizeMap(c.fieldIDToSize)
 		fieldToIDMap.setFieldIDToDecimalScaleMap(c.fieldIDToScale)
 	}
 
@@ -1275,7 +1276,7 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	nameToID, idToType, idToSize, _ := getFieldIDMap(fileSchema)
+	fieldMaps := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
 		impl:              impl,
@@ -1284,9 +1285,9 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		spec:              spec,
 		content:           ManifestContentData,
 		schema:            schema,
-		partFieldNameToID: nameToID,
-		partFieldIDToType: idToType,
-		partFieldIDToSize: idToSize,
+		partFieldNameToID: fieldMaps.nameToID,
+		partFieldIDToType: fieldMaps.idToType,
+		partFieldIDToSize: fieldMaps.idToFixedSize,
 		snapshotID:        snapshotID,
 		minSeqNum:         -1,
 		partitions:        make([]map[int]any, 0),
@@ -1955,8 +1956,8 @@ func convertUUIDValue(v any) any {
 }
 
 func fitDecimalBytes(bytes []byte, size int) ([]byte, error) {
-	if len(bytes) == 0 {
-		return make([]byte, size), nil
+	if size <= 0 {
+		return nil, fmt.Errorf("decimal fixed size must be positive: %d", size)
 	}
 
 	if len(bytes) == size {
@@ -1984,7 +1985,7 @@ func fitDecimalBytes(bytes []byte, size int) ([]byte, error) {
 	}
 	for _, b := range bytes[:len(bytes)-size] {
 		if b != signByte {
-			return nil, fmt.Errorf("decimal value does not fit fixed size %d", size)
+			return nil, fmt.Errorf("decimal value of %d bytes does not fit fixed size %d", len(bytes), size)
 		}
 	}
 
@@ -2027,7 +2028,6 @@ type dataFile struct {
 	fieldNameToID          map[string]int
 	fieldIDToLogicalType   map[int]string
 	fieldIDToPartitionData map[int]any
-	fieldIDToFixedSize     map[int]int
 	fieldIDToDecimalScale  map[int]int
 
 	specID          int32
@@ -2147,7 +2147,7 @@ func (d *dataFile) setFieldNameToIDMap(m map[string]int) { d.fieldNameToID = m }
 func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]string) {
 	d.fieldIDToLogicalType = m
 }
-func (d *dataFile) setFieldIDToFixedSizeMap(m map[int]int) { d.fieldIDToFixedSize = m }
+
 func (d *dataFile) setFieldIDToDecimalScaleMap(m map[int]int) {
 	d.fieldIDToDecimalScale = m
 }
@@ -2371,6 +2371,8 @@ type DataFileBuilder struct {
 // NewDataFileBuilder is passed all of the required fields and then allows
 // all of the optional fields to be set by calling the corresponding methods
 // before calling [DataFileBuilder.Build] to construct the object.
+// The fieldIDToFixedSize argument is retained for source compatibility and is
+// ignored; manifest schemas determine decimal fixed widths during encoding.
 func NewDataFileBuilder(
 	spec PartitionSpec,
 	content ManifestEntryContent,
@@ -2382,6 +2384,7 @@ func NewDataFileBuilder(
 	recordCount int64,
 	fileSize int64,
 ) (*DataFileBuilder, error) {
+	_ = fieldIDToFixedSize
 	if content != EntryContentData && content != EntryContentPosDeletes && content != EntryContentEqDeletes {
 		return nil, fmt.Errorf(
 			"%w: content must be one of %s, %s, or %s",
@@ -2435,7 +2438,6 @@ func NewDataFileBuilder(
 			fieldIDToPartitionData: fieldIDToPartitionData,
 			fieldNameToID:          fieldNameToID,
 			fieldIDToLogicalType:   fieldIDToLogicalType,
-			fieldIDToFixedSize:     fieldIDToFixedSize,
 		},
 	}, nil
 }

--- a/manifest.go
+++ b/manifest.go
@@ -432,7 +432,7 @@ func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) (_ []Manif
 	return ReadManifest(m, f, discardDeleted)
 }
 
-func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int) {
+func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int, map[int]int) {
 	root := sc.Root()
 	getField := func(node avro.SchemaNode, name string) *avro.SchemaField {
 		for i := range node.Fields {
@@ -447,6 +447,7 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 	result := make(map[string]int)
 	logicalTypes := make(map[int]string)
 	fixedSizes := make(map[int]int)
+	decimalScales := make(map[int]int)
 
 	entryField := getField(root, "data_file")
 	partitionField := getField(entryField.Type, "partition")
@@ -470,12 +471,13 @@ func getFieldIDMap(sc *avro.Schema) (map[string]int, map[int]string, map[int]int
 		if typ.LogicalType != "" {
 			logicalTypes[fid] = typ.LogicalType
 			if typ.LogicalType == atype.Decimal {
-				fixedSizes[fid] = typ.Scale
+				fixedSizes[fid] = typ.Size
+				decimalScales[fid] = typ.Scale
 			}
 		}
 	}
 
-	return result, logicalTypes, fixedSizes
+	return result, logicalTypes, fixedSizes, decimalScales
 }
 
 // applyDayTransformDates marks every day(...) partition field described by the
@@ -514,6 +516,7 @@ type hasFieldToIDMap interface {
 	setFieldNameToIDMap(map[string]int)
 	setFieldIDToLogicalTypeMap(map[int]string)
 	setFieldIDToFixedSizeMap(map[int]int)
+	setFieldIDToDecimalScaleMap(map[int]int)
 }
 
 // ManifestFile is the interface which covers both V1 and V2 manifest files.
@@ -669,14 +672,15 @@ func decodeManifests[I interface {
 // This type is not thread-safe; its methods should not be called from
 // multiple goroutines.
 type ManifestReader struct {
-	rd            *ocf.Reader
-	file          ManifestFile
-	formatVersion int
-	isFallback    bool
-	content       ManifestContent
-	fieldNameToID map[string]int
-	fieldIDToType map[int]string
-	fieldIDToSize map[int]int
+	rd             *ocf.Reader
+	file           ManifestFile
+	formatVersion  int
+	isFallback     bool
+	content        ManifestContent
+	fieldNameToID  map[string]int
+	fieldIDToType  map[int]string
+	fieldIDToSize  map[int]int
+	fieldIDToScale map[int]int
 
 	// The rest are lazily populated, on demand. Most readers
 	// will likely only try to load the entries.
@@ -758,7 +762,7 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 			}
 		}
 	}
-	fieldNameToID, fieldIDToType, fieldIDToSize := getFieldIDMap(sc)
+	fieldNameToID, fieldIDToType, fieldIDToSize, fieldIDToScale := getFieldIDMap(sc)
 	// day(...) partition values are days since the Unix epoch, but a manifest
 	// may encode them either as an Avro int carrying the "date" logical type or
 	// as a legacy plain Avro int. Overlay the manifest's partition spec so
@@ -789,6 +793,7 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		fieldNameToID:  fieldNameToID,
 		fieldIDToType:  fieldIDToType,
 		fieldIDToSize:  fieldIDToSize,
+		fieldIDToScale: fieldIDToScale,
 		inheritRowIDs:  inheritRowIDs,
 		nextFirstRowID: nextFirstRowID,
 	}, nil
@@ -904,6 +909,7 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 		fieldToIDMap.setFieldNameToIDMap(c.fieldNameToID)
 		fieldToIDMap.setFieldIDToLogicalTypeMap(c.fieldIDToType)
 		fieldToIDMap.setFieldIDToFixedSizeMap(c.fieldIDToSize)
+		fieldToIDMap.setFieldIDToDecimalScaleMap(c.fieldIDToScale)
 	}
 
 	return tmp, nil
@@ -1222,6 +1228,7 @@ type ManifestWriter struct {
 
 	partFieldNameToID map[string]int
 	partFieldIDToType map[int]string
+	partFieldIDToSize map[int]int
 
 	snapshotID    int64
 	addedFiles    int32
@@ -1268,7 +1275,7 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		return nil, err
 	}
 
-	nameToID, idToType, _ := getFieldIDMap(fileSchema)
+	nameToID, idToType, idToSize, _ := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
 		impl:              impl,
@@ -1279,6 +1286,7 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 		schema:            schema,
 		partFieldNameToID: nameToID,
 		partFieldIDToType: idToType,
+		partFieldIDToSize: idToSize,
 		snapshotID:        snapshotID,
 		minSeqNum:         -1,
 		partitions:        make([]map[int]any, 0),
@@ -1413,7 +1421,11 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	entryToEncode := *entry
 	if dataFile, ok := entry.DataFile().(*dataFile); ok {
 		encodeDataFile := cloneDataFileAvroFields(dataFile)
-		encodeDataFile.PartitionData = avroEncodePartitionData(partition, w.partFieldNameToID, w.partFieldIDToType)
+		encodePartition, err := avroEncodePartitionData(partition, w.partFieldNameToID, w.partFieldIDToType, w.partFieldIDToSize)
+		if err != nil {
+			return err
+		}
+		encodeDataFile.PartitionData = encodePartition
 		entryToEncode.Data = encodeDataFile
 	}
 
@@ -1852,33 +1864,37 @@ func mapToAvroColMap[K comparable, V any](m map[K]V) *[]colMap[K, V] {
 	return &out
 }
 
-func avroPartitionData(input map[int]any, logicalTypes map[int]string) map[int]any {
+func avroPartitionData(input map[int]any, logicalTypes map[int]string, fixedSizes map[int]int) (map[int]any, error) {
 	out := make(map[int]any)
 	for k, v := range input {
 		if logical, ok := logicalTypes[k]; ok {
-			out[k] = convertLogicalTypeValue(v, logical)
+			converted, err := convertLogicalTypeValue(v, logical, fixedSizes[k])
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert partition field %d: %w", k, err)
+			}
+			out[k] = converted
 		} else {
 			out[k] = v
 		}
 	}
 
-	return out
+	return out, nil
 }
 
-func convertLogicalTypeValue(v any, logicalType string) any {
+func convertLogicalTypeValue(v any, logicalType string, fixedSize int) (any, error) {
 	switch logicalType {
 	case atype.Date:
-		return convertDateValue(v)
+		return convertDateValue(v), nil
 	case atype.TimeMicros:
-		return convertTimeMicrosValue(v)
+		return convertTimeMicrosValue(v), nil
 	case atype.TimestampMicros:
-		return convertTimestampMicrosValue(v)
+		return convertTimestampMicrosValue(v), nil
 	case atype.Decimal:
-		return convertDecimalValue(v)
+		return convertDecimalValue(v, fixedSize)
 	case atype.UUID:
-		return convertUUIDValue(v)
+		return convertUUIDValue(v), nil
 	default:
-		return v
+		return v, nil
 	}
 }
 
@@ -1906,18 +1922,28 @@ func convertTimestampMicrosValue(v any) any {
 	return v
 }
 
-func convertDecimalValue(v any) any {
-	if dec, ok := v.(Decimal); ok {
-		fixedSize := internal.DecimalRequiredBytes(len(dec.String()))
-		bytes, err := DecimalLiteral(dec).MarshalBinary()
-		if err != nil {
-			return v
-		}
+func convertDecimalValue(v any, fixedSize int) (any, error) {
+	switch dec := v.(type) {
+	case Decimal:
+		return encodeDecimalBytes(DecimalLiteral(dec), fixedSize)
+	case DecimalLiteral:
+		return encodeDecimalBytes(dec, fixedSize)
+	default:
+		return v, nil
+	}
+}
 
-		return padOrTruncateBytes(bytes, fixedSize)
+func encodeDecimalBytes(dec DecimalLiteral, fixedSize int) ([]byte, error) {
+	if fixedSize <= 0 {
+		return nil, fmt.Errorf("missing decimal fixed size")
 	}
 
-	return v
+	bytes, err := dec.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return padOrTruncateBytes(bytes, fixedSize), nil
 }
 
 func convertUUIDValue(v any) any {
@@ -1974,6 +2000,7 @@ type dataFile struct {
 	fieldIDToLogicalType   map[int]string
 	fieldIDToPartitionData map[int]any
 	fieldIDToFixedSize     map[int]int
+	fieldIDToDecimalScale  map[int]int
 
 	specID          int32
 	initPartition   sync.Once
@@ -2064,7 +2091,7 @@ func (d *dataFile) convertAvroValueToIcebergType(v any, fieldID int) any {
 			return TimestampNano(v.(int64))
 		case atype.Decimal:
 			if r, ok := v.(*big.Rat); ok {
-				scale := d.fieldIDToFixedSize[fieldID]
+				scale := d.fieldIDToDecimalScale[fieldID]
 				scaleFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
 				unscaled := new(big.Int).Mul(r.Num(), scaleFactor)
 				unscaled = unscaled.Div(unscaled, r.Denom())
@@ -2093,6 +2120,9 @@ func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]string) {
 	d.fieldIDToLogicalType = m
 }
 func (d *dataFile) setFieldIDToFixedSizeMap(m map[int]int) { d.fieldIDToFixedSize = m }
+func (d *dataFile) setFieldIDToDecimalScaleMap(m map[int]int) {
+	d.fieldIDToDecimalScale = m
+}
 
 func (d *dataFile) ContentType() ManifestEntryContent { return d.Content }
 func (d *dataFile) FilePath() string                  { return d.Path }

--- a/manifest.go
+++ b/manifest.go
@@ -1935,7 +1935,7 @@ func convertDecimalValue(v any, fixedSize int) (any, error) {
 
 func encodeDecimalBytes(dec DecimalLiteral, fixedSize int) ([]byte, error) {
 	if fixedSize <= 0 {
-		return nil, fmt.Errorf("missing decimal fixed size")
+		return nil, errors.New("missing decimal fixed size")
 	}
 
 	bytes, err := dec.MarshalBinary()

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/fs"
 	"math"
+	"math/big"
 	"strconv"
 	"testing"
 	"time"
@@ -2101,22 +2102,199 @@ func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing
 	}
 }
 
+func TestFitDecimalBytesAllowsOnlyRedundantSignExtension(t *testing.T) {
+	tests := []struct {
+		name    string
+		bytes   []byte
+		size    int
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:  "trims redundant positive sign extension",
+			bytes: []byte{0x00, 0x00, 0x01},
+			size:  2,
+			want:  []byte{0x00, 0x01},
+		},
+		{
+			name:  "trims redundant negative sign extension",
+			bytes: []byte{0xff, 0xff, 0x80},
+			size:  2,
+			want:  []byte{0xff, 0x80},
+		},
+		{
+			name:    "rejects positive sign change",
+			bytes:   []byte{0x00, 0x80},
+			size:    1,
+			wantErr: true,
+		},
+		{
+			name:    "rejects negative sign change",
+			bytes:   []byte{0xff, 0x7f},
+			size:    1,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fitDecimalBytes(tt.bytes, tt.size)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Fatalf("fitDecimalBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAvroEncodePartitionDataUsesDeclaredDecimalFixedSize(t *testing.T) {
 	decimalFieldID := 1000
-	converted, err := avroEncodePartitionData(
-		map[int]any{
-			decimalFieldID: Decimal{Val: decimal128.FromI64(1), Scale: 2},
+	maxPrecision38 := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(10), big.NewInt(38), nil), big.NewInt(1))
+
+	tests := []struct {
+		name      string
+		value     any
+		precision int
+		want      []byte
+		wantErr   bool
+	}{
+		{
+			name:      "pads positive decimal",
+			value:     Decimal{Val: decimal128.FromI64(1), Scale: 2},
+			precision: 10,
+			want:      []byte{0x00, 0x00, 0x00, 0x00, 0x01},
 		},
-		map[string]int{"price": decimalFieldID},
-		map[int]string{decimalFieldID: atype.Decimal},
-		map[int]int{decimalFieldID: internal.DecimalRequiredBytes(10)},
+		{
+			name:      "pads zero decimal",
+			value:     Decimal{Val: decimal128.FromI64(0), Scale: 2},
+			precision: 10,
+			want:      []byte{0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:      "sign extends negative decimal",
+			value:     Decimal{Val: decimal128.FromI64(-1), Scale: 2},
+			precision: 10,
+			want:      []byte{0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:      "keeps max precision decimal",
+			value:     DecimalLiteral{Val: decimal128.FromBigInt(maxPrecision38), Scale: 0},
+			precision: 38,
+			want: []byte{
+				0x4b, 0x3b, 0x4c, 0xa8, 0x5a, 0x86, 0xc4, 0x7a,
+				0x09, 0x8a, 0x22, 0x3f, 0xff, 0xff, 0xff, 0xff,
+			},
+		},
+		{
+			name:      "rejects value changing truncation",
+			value:     Decimal{Val: decimal128.FromI64(128), Scale: 0},
+			precision: 2,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted, err := avroEncodePartitionData(
+				map[int]any{decimalFieldID: tt.value},
+				map[string]int{"price": decimalFieldID},
+				map[int]string{decimalFieldID: atype.Decimal},
+				map[int]int{decimalFieldID: internal.DecimalRequiredBytes(tt.precision)},
+			)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, ok := converted["price"].([]byte)
+			if !ok {
+				t.Fatalf("encoded decimal type = %T, want []byte", converted["price"])
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Fatalf("encoded decimal = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManifestRoundTripDecimalPartitionUsesSignedFixedSize(t *testing.T) {
+	schema := NewSchema(
+		0,
+		NestedField{ID: 1, Name: "price", Type: DecimalTypeOf(10, 2)},
+	)
+	partitionSpec := NewPartitionSpecID(
+		1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "price", Transform: IdentityTransform{}},
+	)
+	partitionValue := Decimal{Val: decimal128.FromI64(-1), Scale: 2}
+	dataFileBuilder, err := NewDataFileBuilder(
+		partitionSpec,
+		EntryContentData,
+		"s3://bucket/ns/table/data/decimal-partition.parquet",
+		ParquetFile,
+		map[int]any{1000: partitionValue},
+		map[int]string{1000: atype.Decimal},
+		map[int]int{1000: internal.DecimalRequiredBytes(10)},
+		1,
+		1024,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if got, want := converted["price"], []byte{0, 0, 0, 0, 1}; !bytes.Equal(got.([]byte), want) {
-		t.Fatalf("encoded decimal = %v, want %v", got, want)
+	snapshotID := int64(1234)
+	seqNum := int64(1)
+	entry := NewManifestEntry(
+		EntryStatusADDED,
+		&snapshotID,
+		&seqNum,
+		&seqNum,
+		dataFileBuilder.Build(),
+	)
+
+	var buf bytes.Buffer
+	file, err := WriteManifest(
+		"s3://bucket/ns/table/metadata/decimal-manifest.avro",
+		&buf,
+		2,
+		partitionSpec,
+		schema,
+		snapshotID,
+		[]ManifestEntry{entry},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ReadManifest(file, bytes.NewReader(buf.Bytes()), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ReadManifest returned %d entries, want 1", len(entries))
+	}
+
+	got, ok := entries[0].DataFile().Partition()[1000].(DecimalLiteral)
+	if !ok {
+		t.Fatalf("Partition()[1000] type = %T, want DecimalLiteral", entries[0].DataFile().Partition()[1000])
+	}
+	if want := DecimalLiteral(partitionValue); !got.Equals(want) {
+		t.Fatalf("Partition()[1000] = %v, want %v", got, want)
 	}
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -29,10 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/avro"
+	"github.com/twmb/avro/atype"
 	"github.com/twmb/avro/ocf"
 )
 
@@ -2096,6 +2098,25 @@ func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing
 
 	if got := entries[0].DataFile().Partition()[1000]; got != nil {
 		t.Fatalf("Partition()[1000] = %v, want nil", got)
+	}
+}
+
+func TestAvroEncodePartitionDataUsesDeclaredDecimalFixedSize(t *testing.T) {
+	decimalFieldID := 1000
+	converted, err := avroEncodePartitionData(
+		map[int]any{
+			decimalFieldID: Decimal{Val: decimal128.FromI64(1), Scale: 2},
+		},
+		map[string]int{"price": decimalFieldID},
+		map[int]string{decimalFieldID: atype.Decimal},
+		map[int]int{decimalFieldID: internal.DecimalRequiredBytes(10)},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := converted["price"], []byte{0, 0, 0, 0, 1}; !bytes.Equal(got.([]byte), want) {
+		t.Fatalf("encoded decimal = %v, want %v", got, want)
 	}
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2111,6 +2111,18 @@ func TestFitDecimalBytesAllowsOnlyRedundantSignExtension(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name:  "pads positive value",
+			bytes: []byte{0x01},
+			size:  3,
+			want:  []byte{0x00, 0x00, 0x01},
+		},
+		{
+			name:  "pads negative value",
+			bytes: []byte{0xff},
+			size:  3,
+			want:  []byte{0xff, 0xff, 0xff},
+		},
+		{
 			name:  "trims redundant positive sign extension",
 			bytes: []byte{0x00, 0x00, 0x01},
 			size:  2,
@@ -2121,6 +2133,12 @@ func TestFitDecimalBytesAllowsOnlyRedundantSignExtension(t *testing.T) {
 			bytes: []byte{0xff, 0xff, 0x80},
 			size:  2,
 			want:  []byte{0xff, 0x80},
+		},
+		{
+			name:    "rejects non-positive size",
+			bytes:   []byte{0x01},
+			size:    0,
+			wantErr: true,
 		},
 		{
 			name:    "rejects positive sign change",
@@ -2168,6 +2186,24 @@ func TestAvroEncodePartitionDataUsesDeclaredDecimalFixedSize(t *testing.T) {
 		wantErr   bool
 	}{
 		{
+			name:      "encodes precision 1 boundary",
+			value:     Decimal{Val: decimal128.FromI64(5), Scale: 0},
+			precision: 1,
+			want:      []byte{0x05},
+		},
+		{
+			name:      "encodes precision 9 boundary",
+			value:     Decimal{Val: decimal128.FromI64(123456789), Scale: 0},
+			precision: 9,
+			want:      []byte{0x07, 0x5b, 0xcd, 0x15},
+		},
+		{
+			name:      "encodes negative precision 18 boundary",
+			value:     Decimal{Val: decimal128.FromI64(-1), Scale: 0},
+			precision: 18,
+			want:      []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
 			name:      "pads positive decimal",
 			value:     Decimal{Val: decimal128.FromI64(1), Scale: 2},
 			precision: 10,
@@ -2189,6 +2225,7 @@ func TestAvroEncodePartitionDataUsesDeclaredDecimalFixedSize(t *testing.T) {
 			name:      "keeps max precision decimal",
 			value:     DecimalLiteral{Val: decimal128.FromBigInt(maxPrecision38), Scale: 0},
 			precision: 38,
+			// Two's-complement big-endian representation of 10^38 - 1.
 			want: []byte{
 				0x4b, 0x3b, 0x4c, 0xa8, 0x5a, 0x86, 0xc4, 0x7a,
 				0x09, 0x8a, 0x22, 0x3f, 0xff, 0xff, 0xff, 0xff,

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -35,7 +35,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
-	iceinternal "github.com/apache/iceberg-go/internal"
 	"github.com/twmb/avro/atype"
 	"golang.org/x/sync/errgroup"
 )
@@ -267,7 +266,6 @@ const unsortedSortOrderID = 0
 func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 	var fieldIDToPartitionData map[int]any
 	fieldIDToLogicalType := make(map[int]string)
-	fieldIDToFixedSize := make(map[int]int)
 
 	if !opts.Spec.Equals(*iceberg.UnpartitionedSpec) {
 		fieldIDToPartitionData = make(map[int]any)
@@ -286,7 +284,7 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 			if sourceField, ok := opts.Schema.FindFieldByID(field.SourceID()); ok {
 				resultType := field.Transform.ResultType(sourceField.Type)
 
-				switch rt := resultType.(type) {
+				switch resultType.(type) {
 				case iceberg.DateType:
 					fieldIDToLogicalType[field.FieldID] = atype.Date
 				case iceberg.TimeType:
@@ -297,7 +295,6 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 					fieldIDToLogicalType[field.FieldID] = atype.TimestampMicros
 				case iceberg.DecimalType:
 					fieldIDToLogicalType[field.FieldID] = atype.Decimal
-					fieldIDToFixedSize[field.FieldID] = iceinternal.DecimalRequiredBytes(rt.Precision())
 				case iceberg.UUIDType:
 					fieldIDToLogicalType[field.FieldID] = atype.UUID
 				}
@@ -306,11 +303,10 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 	}
 
 	bldr, err := iceberg.NewDataFileBuilder(opts.Spec, opts.Content,
-		opts.Path, opts.Format, fieldIDToPartitionData, fieldIDToLogicalType, fieldIDToFixedSize, d.RecordCount, opts.FileSize)
+		opts.Path, opts.Format, fieldIDToPartitionData, fieldIDToLogicalType, nil, d.RecordCount, opts.FileSize)
 	if err != nil {
 		panic(err)
 	}
-
 	lowerBounds := make(map[int][]byte)
 	upperBounds := make(map[int][]byte)
 

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
+	iceinternal "github.com/apache/iceberg-go/internal"
 	"github.com/twmb/avro/atype"
 	"golang.org/x/sync/errgroup"
 )
@@ -296,7 +297,7 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 					fieldIDToLogicalType[field.FieldID] = atype.TimestampMicros
 				case iceberg.DecimalType:
 					fieldIDToLogicalType[field.FieldID] = atype.Decimal
-					fieldIDToFixedSize[field.FieldID] = rt.Scale()
+					fieldIDToFixedSize[field.FieldID] = iceinternal.DecimalRequiredBytes(rt.Precision())
 				case iceberg.UUIDType:
 					fieldIDToLogicalType[field.FieldID] = atype.UUID
 				}

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -18,12 +18,14 @@
 package internal_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/assert"
@@ -344,4 +346,63 @@ func TestToDataFile_ReferencedDataFile(t *testing.T) {
 		assert.Nil(t, df.ReferencedDataFile(),
 			"ToDataFile must ignore ReferencedDataFile for non-position-delete content")
 	})
+}
+
+func TestDataFileStatisticsDecimalPartitionManifestRoundTrip(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   1,
+		Name: "price",
+		Type: iceberg.DecimalTypeOf(10, 2),
+	})
+	spec := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "price",
+		Transform: iceberg.IdentityTransform{},
+	})
+	decimal := iceberg.Decimal{Val: decimal128.FromI64(-123), Scale: 2}
+	lit := iceberg.NewLiteral(decimal)
+	stats := internal.DataFileStatistics{
+		RecordCount: 1,
+		ColAggs: map[int]internal.StatsAgg{
+			1: &mockStatsAgg{min: lit, max: lit},
+		},
+	}
+	dataFile := stats.ToDataFile(internal.DataFileOpts{
+		Schema:          schema,
+		Spec:            spec,
+		Path:            "s3://bucket/table/data/file.parquet",
+		Format:          iceberg.ParquetFile,
+		Content:         iceberg.EntryContentData,
+		FileSize:        1024,
+		PartitionValues: map[int]any{1000: decimal},
+	})
+
+	snapshotID := int64(10)
+	sequenceNumber := int64(1)
+	entry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED,
+		&snapshotID,
+		&sequenceNumber,
+		&sequenceNumber,
+		dataFile,
+	)
+	var buf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(
+		"s3://bucket/table/metadata/manifest.avro",
+		&buf,
+		2,
+		spec,
+		schema,
+		snapshotID,
+		[]iceberg.ManifestEntry{entry},
+	)
+	require.NoError(t, err)
+
+	entries, err := iceberg.ReadManifest(manifest, bytes.NewReader(buf.Bytes()), false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	got, ok := entries[0].DataFile().Partition()[1000].(iceberg.DecimalLiteral)
+	require.True(t, ok)
+	assert.True(t, got.Equals(iceberg.DecimalLiteral(decimal)))
 }


### PR DESCRIPTION
## Summary

Decimal partition values now use the fixed byte width declared by partition-schema precision instead of a width inferred from the formatted value.

- keep decimal read scale separate from fixed encoding width;
- sign-extend negative values to the declared width;
- reject oversized values unless discarded bytes are redundant sign extension;
- apply the declared width in data-file statistics conversion and `MarshalAvroEntry`;
- keep builder-created partition values directly typed; scale reconstruction is only required after Avro decoding.

## Testing

- table-driven positive, zero, negative, boundary, padding, and overflow vectors
- manifest write/read decimal round trips
- `DataFileStatistics.ToDataFile` → manifest round trip
- `MarshalAvroEntry` → decoder round trip
- `go test . ./table/internal`