### PR TITLE
fix(view): join view metadata location

### DIFF
--- a/view/view.go
+++ b/view/view.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 
 	"github.com/apache/iceberg-go"
@@ -142,7 +143,10 @@ func CreateView(
 		return nil, err
 	}
 
-	metadataLocation := loc + "/metadata/view-" + uuid.New().String() + ".metadata.json"
+	metadataLocation, err := url.JoinPath(loc, "metadata", "view-"+uuid.New().String()+".metadata.json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build view metadata location: %w", err)
+	}
 
 	viewMetadataBytes, err := json.Marshal(viewMD)
 	if err != nil {

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -20,6 +20,7 @@ package view
 import (
 	"bytes"
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/apache/iceberg-go/internal"
@@ -83,6 +84,33 @@ func (t *ViewTestSuite) TestNewViewFromReadFile() {
 	t.Require().NotNil(vw2)
 
 	t.True(t.view.Equals(*vw2))
+}
+
+func (t *ViewTestSuite) TestCreateViewJoinsTrailingSlashMetadataLocation() {
+	createdView, err := CreateView(
+		t.T().Context(),
+		"test-catalog",
+		[]string{"ns", "test_view"},
+		newTestSchema(0),
+		"select 1",
+		[]string{"ns"},
+		"mem://view-create-location/test-view/",
+		nil,
+	)
+	t.Require().NoError(err)
+	t.Require().NotNil(createdView)
+
+	metadataLocation := createdView.MetadataLocation()
+	parsedLocation, err := url.Parse(metadataLocation)
+	t.Require().NoError(err)
+	t.NotContains(parsedLocation.Path, "//metadata/")
+	t.Contains(parsedLocation.Path, "/test-view/metadata/view-")
+
+	fs, err := iceio.LoadFS(t.T().Context(), nil, metadataLocation)
+	t.Require().NoError(err)
+	metadataFile, err := fs.Open(metadataLocation)
+	t.Require().NoError(err)
+	t.Require().NoError(metadataFile.Close())
 }
 
 func (t *ViewTestSuite) TestLocation() {


### PR DESCRIPTION
### Summary
- build view metadata paths with `url.JoinPath` instead of raw string concatenation
- add a regression test for trailing slash view locations

### Testing
- `go test ./view`
- `go test ./catalog/sql ./catalog/hive ./catalog/rest`
- `go test ./...`