### PR TITLE
fix(metadata): replace updates on unmarshal

### DIFF
--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -147,6 +147,30 @@ func TestParseRequirementList(t *testing.T) {
 	})
 }
 
+func TestParseRequirementListReplacesExistingSlice(t *testing.T) {
+	var requirements table.Requirements
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type": "assert-create"}
+	]`), &requirements))
+
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type": "assert-default-spec-id", "default-spec-id": 1}
+	]`), &requirements))
+	require.Len(t, requirements, 1)
+	assert.Equal(t, table.AssertDefaultSpecID(1), requirements[0])
+
+	previous := append(table.Requirements(nil), requirements...)
+	err := json.Unmarshal([]byte(`[
+		{"type": "assert-create"},
+		{"type": "assert-foo-bar"}
+	]`), &requirements)
+	require.Error(t, err)
+	assert.Equal(t, previous, requirements)
+
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &requirements))
+	assert.Empty(t, requirements)
+}
+
 func TestAssertRefSnapshotIDValidate(t *testing.T) {
 	meta, err := table.ParseMetadataBytes([]byte(table.ExampleTableMetadataV2))
 	require.NoError(t, err)

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -56,6 +56,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	var requirements Requirements
+	if len(rawRequirements) > 0 {
+		requirements = make(Requirements, 0, len(rawRequirements))
+	}
 	for _, raw := range rawRequirements {
 		var base baseRequirement
 		if err := json.Unmarshal(raw, &base); err != nil {
@@ -87,8 +91,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(raw, req); err != nil {
 			return err
 		}
-		*r = append(*r, req)
+		requirements = append(requirements, req)
 	}
+
+	*r = requirements
 
 	return nil
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -79,6 +79,10 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	var updates Updates
+	if len(rawUpdates) > 0 {
+		updates = make(Updates, 0, len(rawUpdates))
+	}
 	for _, raw := range rawUpdates {
 		var base baseUpdate
 		if err := json.Unmarshal(raw, &base); err != nil {
@@ -140,8 +144,10 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(raw, upd); err != nil {
 			return err
 		}
-		*u = append(*u, upd)
+		updates = append(updates, upd)
 	}
+
+	*u = updates
 
 	return nil
 }

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -540,6 +540,30 @@ func TestUnmarshalUpdates(t *testing.T) {
 	}
 }
 
+func TestUnmarshalUpdatesReplacesExistingSlice(t *testing.T) {
+	var updates Updates
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"action": "set-location", "location": "s3://bucket/old-location"}
+	]`), &updates))
+
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"action": "set-properties", "updates": {"key": "value"}}
+	]`), &updates))
+	require.Len(t, updates, 1)
+	assert.Equal(t, UpdateSetProperties, updates[0].Action())
+
+	previous := append(Updates(nil), updates...)
+	err := json.Unmarshal([]byte(`[
+		{"action": "set-location", "location": "s3://bucket/new-location"},
+		{"action": "unknown-action"}
+	]`), &updates)
+	require.Error(t, err)
+	assert.Equal(t, previous, updates)
+
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &updates))
+	assert.Empty(t, updates)
+}
+
 // baseMetaJSON is a minimal valid V2 metadata document used by the Apply tests below.
 const baseMetaJSON = `{
   "format-version": 2,

--- a/view/requirements.go
+++ b/view/requirements.go
@@ -61,6 +61,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	var requirements Requirements
+	if len(rawRequirements) > 0 {
+		requirements = make(Requirements, 0, len(rawRequirements))
+	}
 	for _, raw := range rawRequirements {
 		var base baseRequirement
 		if err := json.Unmarshal(raw, &base); err != nil {
@@ -75,8 +79,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(raw, req); err != nil {
 			return err
 		}
-		*r = append(*r, req)
+		requirements = append(requirements, req)
 	}
+
+	*r = requirements
 
 	return nil
 }

--- a/view/requirements_test.go
+++ b/view/requirements_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/iceberg-go/view"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseRequirementList(t *testing.T) {
@@ -69,4 +70,28 @@ func TestParseRequirementList(t *testing.T) {
 		err := json.Unmarshal(jsonData, &actual)
 		assert.Error(t, err)
 	})
+}
+
+func TestParseRequirementListReplacesExistingSlice(t *testing.T) {
+	var requirements view.Requirements
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type": "assert-view-uuid", "uuid": "550e8400-e29b-41d4-a716-446655440000"}
+	]`), &requirements))
+
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type": "assert-view-uuid", "uuid": "123e4567-e89b-12d3-a456-426614174000"}
+	]`), &requirements))
+	require.Len(t, requirements, 1)
+	assert.Equal(t, view.AssertViewUUID(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")), requirements[0])
+
+	previous := append(view.Requirements(nil), requirements...)
+	err := json.Unmarshal([]byte(`[
+		{"type": "assert-view-uuid", "uuid": "550e8400-e29b-41d4-a716-446655440000"},
+		{"type": "assert-foo-bar"}
+	]`), &requirements)
+	assert.Error(t, err)
+	assert.Equal(t, previous, requirements)
+
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &requirements))
+	assert.Empty(t, requirements)
 }

--- a/view/updates.go
+++ b/view/updates.go
@@ -84,6 +84,10 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	var updates Updates
+	if len(rawUpdates) > 0 {
+		updates = make(Updates, 0, len(rawUpdates))
+	}
 	for _, raw := range rawUpdates {
 		var base baseUpdate
 		if err := json.Unmarshal(raw, &base); err != nil {
@@ -98,8 +102,10 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(raw, update); err != nil {
 			return err
 		}
-		*u = append(*u, update)
+		updates = append(updates, update)
 	}
+
+	*u = updates
 
 	return nil
 }

--- a/view/updates_test.go
+++ b/view/updates_test.go
@@ -107,3 +107,27 @@ func TestUpdatesUnmarshalJSONInvalidJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonData), &updates)
 	require.Error(t, err)
 }
+
+func TestUpdatesUnmarshalJSONReplacesExistingSlice(t *testing.T) {
+	var updates Updates
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"action": "set-location", "location": "s3://bucket/old-location"}
+	]`), &updates))
+
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"action": "set-properties", "updates": {"key": "value"}}
+	]`), &updates))
+	require.Len(t, updates, 1)
+	assert.Equal(t, UpdateSetProperties, updates[0].Action())
+
+	previous := append(Updates(nil), updates...)
+	err := json.Unmarshal([]byte(`[
+		{"action": "set-location", "location": "s3://bucket/new-location"},
+		{"action": "unknown-action"}
+	]`), &updates)
+	require.Error(t, err)
+	assert.Equal(t, previous, updates)
+
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &updates))
+	assert.Empty(t, updates)
+}


### PR DESCRIPTION
### Summary
- decode table and view updates into fresh slices before assigning to the receiver
- decode table and view requirements the same way, including the matching view requirement path found during inspection
- add receiver-reuse regressions that also confirm failed decodes do not partially mutate prior results

### Testing
- `go test ./table ./view`
- `go test ./...`