### PR TITLE
fix(scan): use snapshot schema for pruning

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -372,13 +372,13 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 	// buildPartitionEvaluator) so there is one code path that pruning
 	// semantics flow through.
 	partitionFilters := newKeyDefaultMapWrapErr(func(specID int) (iceberg.BooleanExpression, error) {
-		return buildPartitionProjection(specID, ctx.current, filter, ctx.caseSensitive)
+		return buildPartitionProjection(specID, ctx.current, ctx.current.CurrentSchema(), filter, ctx.caseSensitive)
 	})
 	manifestEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
-		return buildManifestEvaluator(specID, ctx.current, partitionFilters, ctx.caseSensitive)
+		return buildManifestEvaluator(specID, ctx.current, ctx.current.CurrentSchema(), partitionFilters, ctx.caseSensitive)
 	})
 	partitionEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
-		return buildPartitionEvaluator(specID, ctx.current, partitionFilters, ctx.caseSensitive)
+		return buildPartitionEvaluator(specID, ctx.current, ctx.current.CurrentSchema(), partitionFilters, ctx.caseSensitive)
 	})
 
 	for _, snap := range ctx.concurrent {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -287,24 +287,11 @@ func (scan *Scan) Snapshot() *Snapshot {
 }
 
 func (scan *Scan) Projection() (*iceberg.Schema, error) {
-	curSchema := scan.metadata.CurrentSchema()
-	curVersion := scan.metadata.Version()
-	if scan.snapshotID != nil {
-		snap := scan.metadata.SnapshotByID(*scan.snapshotID)
-		if snap == nil {
-			return nil, fmt.Errorf("%w: snapshot not found: %d", ErrInvalidOperation, *scan.snapshotID)
-		}
-
-		if snap.SchemaID != nil {
-			for _, schema := range scan.metadata.Schemas() {
-				if schema.ID == *snap.SchemaID {
-					curSchema = schema
-
-					break
-				}
-			}
-		}
+	curSchema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
 	}
+	curVersion := scan.metadata.Version()
 
 	if scan.includeRowLineage && curVersion < minFormatVersionRowLineage {
 		return nil, fmt.Errorf("%w: row lineage requires format version %d, table is v%d",
@@ -351,6 +338,39 @@ func (scan *Scan) Projection() (*iceberg.Schema, error) {
 	}
 
 	return schema, nil
+}
+
+func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
+	curSchema := scan.metadata.CurrentSchema()
+	var snap *Snapshot
+	if scan.snapshotID != nil {
+		snap = scan.metadata.SnapshotByID(*scan.snapshotID)
+		if snap == nil {
+			return nil, fmt.Errorf("%w: snapshot not found: %d", ErrInvalidOperation, *scan.snapshotID)
+		}
+	} else if scan.asOfTimestamp != nil {
+		entries := slices.Collect(scan.metadata.SnapshotLogs())
+		for i := len(entries) - 1; i >= 0; i-- {
+			entry := entries[i]
+			if entry.TimestampMs <= *scan.asOfTimestamp {
+				snap = scan.metadata.SnapshotByID(entry.SnapshotID)
+
+				break
+			}
+		}
+	}
+
+	if snap == nil || snap.SchemaID == nil {
+		return curSchema, nil
+	}
+
+	for _, schema := range scan.metadata.Schemas() {
+		if schema.ID == *snap.SchemaID {
+			return schema, nil
+		}
+	}
+
+	return curSchema, nil
 }
 
 // splitLineageMetadataFields partitions selectedFields into user fields and
@@ -403,24 +423,34 @@ func appendMissingLineageFields(s *iceberg.Schema, lineageFields []iceberg.Neste
 }
 
 func (scan *Scan) buildPartitionProjection(specID int) (iceberg.BooleanExpression, error) {
-	return buildPartitionProjection(specID, scan.metadata, scan.rowFilter, scan.caseSensitive)
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	return buildPartitionProjection(specID, scan.metadata, schema, scan.rowFilter, scan.caseSensitive)
 }
 
-func buildPartitionProjection(specID int, meta Metadata, rowFilter iceberg.BooleanExpression, caseSensitive bool) (iceberg.BooleanExpression, error) {
+func buildPartitionProjection(specID int, meta Metadata, schema *iceberg.Schema, rowFilter iceberg.BooleanExpression, caseSensitive bool) (iceberg.BooleanExpression, error) {
 	spec := meta.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
 	}
-	project := newInclusiveProjection(meta.CurrentSchema(), *spec, caseSensitive)
+	project := newInclusiveProjection(schema, *spec, caseSensitive)
 
 	return project(rowFilter)
 }
 
 func (scan *Scan) buildManifestEvaluator(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
-	return buildManifestEvaluator(specID, scan.metadata, scan.partitionFilters, scan.caseSensitive)
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	return buildManifestEvaluator(specID, scan.metadata, schema, scan.partitionFilters, scan.caseSensitive)
 }
 
-func buildManifestEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
+func buildManifestEvaluator(specID int, metadata Metadata, schema *iceberg.Schema, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
 	spec := metadata.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
@@ -431,20 +461,25 @@ func buildManifestEvaluator(specID int, metadata Metadata, partitionFilters *key
 		return nil, err
 	}
 
-	return newManifestEvaluator(*spec, metadata.CurrentSchema(),
+	return newManifestEvaluator(*spec, schema,
 		partitionFilter, caseSensitive)
 }
 
 func (scan *Scan) buildPartitionEvaluator(specID int) (func(iceberg.DataFile) (bool, error), error) {
-	return buildPartitionEvaluator(specID, scan.metadata, scan.partitionFilters, scan.caseSensitive)
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	return buildPartitionEvaluator(specID, scan.metadata, schema, scan.partitionFilters, scan.caseSensitive)
 }
 
-func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {
+func buildPartitionEvaluator(specID int, metadata Metadata, schema *iceberg.Schema, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {
 	spec := metadata.PartitionSpecByID(specID)
 	if spec == nil {
 		return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, specID)
 	}
-	partType := spec.PartitionType(metadata.CurrentSchema())
+	partType := spec.PartitionType(schema)
 	partSchema := iceberg.NewSchema(0, partType.FieldList...)
 
 	partitionFilter, err := partitionFilters.Get(specID)
@@ -460,6 +495,12 @@ func buildPartitionEvaluator(specID int, metadata Metadata, partitionFilters *ke
 	return func(d iceberg.DataFile) (bool, error) {
 		return fn(GetPartitionRecord(d, partType))
 	}, nil
+}
+
+func (scan *Scan) partitionFiltersForSchema(schema *iceberg.Schema) *keyDefaultMapErr[int, iceberg.BooleanExpression] {
+	return newKeyDefaultMapWrapErr(func(specID int) (iceberg.BooleanExpression, error) {
+		return buildPartitionProjection(specID, scan.metadata, schema, scan.rowFilter, scan.caseSensitive)
+	})
 }
 
 func (scan *Scan) checkSequenceNumber(minSeqNum int64, manifest iceberg.ManifestFile) bool {
@@ -604,6 +645,15 @@ func matchDVToData(dataEntry iceberg.ManifestEntry, dvIndex map[string]iceberg.M
 // fetchPartitionSpecFilteredManifests retrieves the table's current snapshot,
 // fetches its manifest files, and applies partition-spec filters to remove irrelevant manifests.
 func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]iceberg.ManifestFile, error) {
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	return scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema)
+}
+
+func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Context, schema *iceberg.Schema) ([]iceberg.ManifestFile, error) {
 	snap := scan.Snapshot()
 	if snap == nil {
 		return nil, nil
@@ -620,7 +670,10 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 	}
 
 	// Build per-spec manifest evaluators and filter out irrelevant manifests.
-	manifestEvaluators := newKeyDefaultMapWrapErr(scan.buildManifestEvaluator)
+	partitionFilters := scan.partitionFiltersForSchema(schema)
+	manifestEvaluators := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
+		return buildManifestEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
+	})
 	filtered := make([]iceberg.ManifestFile, 0, len(manifestList))
 	for _, mf := range manifestList {
 		eval, err := manifestEvaluators.Get(int(mf.PartitionSpecID()))
@@ -645,8 +698,21 @@ func (scan *Scan) collectManifestEntries(
 	ctx context.Context,
 	manifestList []iceberg.ManifestFile,
 ) (*manifestEntries, error) {
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	return scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
+}
+
+func (scan *Scan) collectManifestEntriesWithSchema(
+	ctx context.Context,
+	manifestList []iceberg.ManifestFile,
+	schema *iceberg.Schema,
+) (*manifestEntries, error) {
 	metricsEval, err := newInclusiveMetricsEvaluator(
-		scan.metadata.CurrentSchema(),
+		schema,
 		scan.rowFilter,
 		scan.caseSensitive,
 		scan.options["include_empty_files"] == "true",
@@ -662,7 +728,10 @@ func (scan *Scan) collectManifestEntries(
 	g, _ := errgroup.WithContext(ctx)
 	g.SetLimit(concurrencyLimit)
 
-	partitionEvaluators := newKeyDefaultMapWrapErr(scan.buildPartitionEvaluator)
+	partitionFilters := scan.partitionFiltersForSchema(schema)
+	partitionEvaluators := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
+		return buildPartitionEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
+	})
 
 	for _, mf := range manifestList {
 		if !scan.checkSequenceNumber(minSeqNum, mf) {
@@ -748,14 +817,19 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 
 	scan.planIO = nil
 
+	schema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, err
+	}
+
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
-	manifestList, err := scan.fetchPartitionSpecFilteredManifests(ctx)
+	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema)
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}
 
 	// Step 2: Read manifest entries concurrently, accumulating data and positional deletes.
-	entries, err := scan.collectManifestEntries(ctx, manifestList)
+	entries, err := scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 	if err != nil {
 		return nil, err
 	}
@@ -877,8 +951,13 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		err         error
 	)
 
+	effectiveSchema, err := scan.effectiveSchema()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if scan.rowFilter != nil {
-		boundFilter, err = iceberg.BindExpr(scan.metadata.CurrentSchema(), scan.rowFilter, scan.caseSensitive)
+		boundFilter, err = iceberg.BindExpr(effectiveSchema, scan.rowFilter, scan.caseSensitive)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -240,8 +240,7 @@ type Scan struct {
 
 	includeRowLineage bool
 
-	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression]
-	concurrency      int
+	concurrency int
 }
 
 func (scan *Scan) UseRowLimit(n int64) *Scan {
@@ -260,7 +259,6 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {
 		out := *scan
 		out.snapshotID = &snap.SnapshotID
-		out.partitionFilters = newKeyDefaultMapWrapErr(out.buildPartitionProjection)
 
 		return &out, nil
 	}
@@ -342,6 +340,13 @@ func (scan *Scan) Projection() (*iceberg.Schema, error) {
 
 func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 	curSchema := scan.metadata.CurrentSchema()
+	if scan.snapshotID == nil && scan.asOfTimestamp == nil {
+		// Live scans intentionally use the table's current schema. A schema-only
+		// metadata update can advance CurrentSchema without creating a snapshot,
+		// while explicit snapshot/as-of scans use the snapshot schema below.
+		return curSchema, nil
+	}
+
 	var snap *Snapshot
 	if scan.snapshotID != nil {
 		snap = scan.metadata.SnapshotByID(*scan.snapshotID)
@@ -370,7 +375,8 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 		}
 	}
 
-	return curSchema, nil
+	return nil, fmt.Errorf("%w: snapshot %d references unknown schema id %d",
+		ErrInvalidMetadata, snap.SnapshotID, *snap.SchemaID)
 }
 
 // splitLineageMetadataFields partitions selectedFields into user fields and
@@ -422,15 +428,6 @@ func appendMissingLineageFields(s *iceberg.Schema, lineageFields []iceberg.Neste
 	return iceberg.NewSchemaWithIdentifiers(s.ID, s.IdentifierFieldIDs, fields...)
 }
 
-func (scan *Scan) buildPartitionProjection(specID int) (iceberg.BooleanExpression, error) {
-	schema, err := scan.effectiveSchema()
-	if err != nil {
-		return nil, err
-	}
-
-	return buildPartitionProjection(specID, scan.metadata, schema, scan.rowFilter, scan.caseSensitive)
-}
-
 func buildPartitionProjection(specID int, meta Metadata, schema *iceberg.Schema, rowFilter iceberg.BooleanExpression, caseSensitive bool) (iceberg.BooleanExpression, error) {
 	spec := meta.PartitionSpecByID(specID)
 	if spec == nil {
@@ -439,15 +436,6 @@ func buildPartitionProjection(specID int, meta Metadata, schema *iceberg.Schema,
 	project := newInclusiveProjection(schema, *spec, caseSensitive)
 
 	return project(rowFilter)
-}
-
-func (scan *Scan) buildManifestEvaluator(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
-	schema, err := scan.effectiveSchema()
-	if err != nil {
-		return nil, err
-	}
-
-	return buildManifestEvaluator(specID, scan.metadata, schema, scan.partitionFilters, scan.caseSensitive)
 }
 
 func buildManifestEvaluator(specID int, metadata Metadata, schema *iceberg.Schema, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
@@ -463,15 +451,6 @@ func buildManifestEvaluator(specID int, metadata Metadata, schema *iceberg.Schem
 
 	return newManifestEvaluator(*spec, schema,
 		partitionFilter, caseSensitive)
-}
-
-func (scan *Scan) buildPartitionEvaluator(specID int) (func(iceberg.DataFile) (bool, error), error) {
-	schema, err := scan.effectiveSchema()
-	if err != nil {
-		return nil, err
-	}
-
-	return buildPartitionEvaluator(specID, scan.metadata, schema, scan.partitionFilters, scan.caseSensitive)
 }
 
 func buildPartitionEvaluator(specID int, metadata Metadata, schema *iceberg.Schema, partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression], caseSensitive bool) (func(iceberg.DataFile) (bool, error), error) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"runtime"
 	"strconv"
@@ -390,6 +391,133 @@ func TestBuildPartitionEvaluatorWithInvalidSpecID(t *testing.T) {
 	assert.Nil(t, evaluator)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.ErrorContains(t, err, "id 999")
+}
+
+func TestTimeTravelManifestPruningUsesSnapshotSchema(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "id",
+		Transform: iceberg.IdentityTransform{},
+	})
+	scan, _, snapshotID := newSchemaEvolutionScan(t, &spec, iceio.NewMemFS())
+
+	lower := int32Bound(10)
+	upper := int32Bound(20)
+	manifest := iceberg.NewManifestFile(2, "mem://default/table/metadata/manifest.avro", 100, int32(spec.ID()), snapshotID).
+		Partitions([]iceberg.FieldSummary{{
+			ContainsNull: false,
+			LowerBound:   &lower,
+			UpperBound:   &upper,
+		}}).
+		Build()
+
+	eval, err := scan.buildManifestEvaluator(spec.ID())
+	require.NoError(t, err)
+	use, err := eval(manifest)
+	require.NoError(t, err)
+	assert.False(t, use, "old snapshot partition bounds outside the filter should be pruned")
+}
+
+func TestTimeTravelMetricsPruningUsesSnapshotSchema(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	memIO := iceio.NewMemFS()
+	scan, oldSchema, snapshotID := newSchemaEvolutionScan(t, &spec, memIO)
+
+	lower := int32Bound(10)
+	upper := int32Bound(20)
+	dataFile, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"mem://default/table/data.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		1024,
+	)
+	require.NoError(t, err)
+	entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID,
+		dataFile.LowerBoundValues(map[int][]byte{1: lower}).
+			UpperBoundValues(map[int][]byte{1: upper}).
+			Build(),
+	).SequenceNum(1).Build()
+
+	manifestPath := "mem://default/table/metadata/manifest.avro"
+	var manifestBytes bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBytes, 2, spec, oldSchema, snapshotID, []iceberg.ManifestEntry{entry})
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBytes.Bytes()))
+
+	entries, err := scan.collectManifestEntries(context.Background(), []iceberg.ManifestFile{manifest})
+	require.NoError(t, err)
+	assert.Empty(t, entries.dataEntries, "old snapshot file metrics outside the filter should be pruned")
+}
+
+func newSchemaEvolutionScan(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.IO) (*Scan, *iceberg.Schema, int64) {
+	t.Helper()
+
+	oldSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID:   1,
+		Name: "id",
+		Type: iceberg.PrimitiveTypes.Int32,
+	})
+	currentSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   2,
+		Name: "id",
+		Type: iceberg.PrimitiveTypes.Int32,
+	})
+	meta, err := NewMetadata(
+		oldSchema,
+		spec,
+		UnsortedSortOrder,
+		"mem://default/table",
+		iceberg.Properties{PropertyFormatVersion: "2"},
+	)
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.AddSchema(currentSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(currentSchema.ID))
+
+	snapshotID := int64(7)
+	oldSchemaID := oldSchema.ID
+	snapshot := &Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		Summary:        &Summary{Operation: OpAppend},
+		SchemaID:       &oldSchemaID,
+	}
+	require.NoError(t, builder.AddSnapshot(snapshot))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+
+	built, err := builder.Build()
+	require.NoError(t, err)
+
+	scan := &Scan{
+		metadata:       built,
+		ioF:            func(context.Context) (iceio.IO, error) { return fs, nil },
+		rowFilter:      iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
+		selectedFields: []string{"*"},
+		caseSensitive:  true,
+		snapshotID:     &snapshotID,
+		options:        iceberg.Properties{},
+		limit:          ScanNoLimit,
+		concurrency:    1,
+	}
+	scan.partitionFilters = newKeyDefaultMapWrapErr(scan.buildPartitionProjection)
+
+	return scan, oldSchema, snapshotID
+}
+
+func int32Bound(v int32) []byte {
+	out := make([]byte, 4)
+	binary.LittleEndian.PutUint32(out, uint32(v))
+
+	return out
 }
 
 // TestSynthesizeRowLineageColumns verifies that _row_id and _last_updated_sequence_number

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -227,13 +227,7 @@ func TestBuildPartitionProjectionWithInvalidSpecID(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	scan := &Scan{
-		metadata:      metadata,
-		rowFilter:     iceberg.AlwaysTrue{},
-		caseSensitive: true,
-	}
-
-	expr, err := scan.buildPartitionProjection(999)
+	expr, err := buildPartitionProjection(999, metadata, metadata.CurrentSchema(), iceberg.AlwaysTrue{}, true)
 	require.Error(t, err)
 	assert.Nil(t, expr)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
@@ -347,15 +341,12 @@ func TestBuildManifestEvaluatorWithInvalidSpecID(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	scan := &Scan{
-		metadata:      metadata,
-		rowFilter:     iceberg.AlwaysTrue{},
-		caseSensitive: true,
-	}
+	rowFilter := iceberg.AlwaysTrue{}
+	partitionFilters := newKeyDefaultMapWrapErr(func(specID int) (iceberg.BooleanExpression, error) {
+		return buildPartitionProjection(specID, metadata, metadata.CurrentSchema(), rowFilter, true)
+	})
 
-	scan.partitionFilters = newKeyDefaultMapWrapErr(scan.buildPartitionProjection)
-
-	evaluator, err := scan.buildManifestEvaluator(999)
+	evaluator, err := buildManifestEvaluator(999, metadata, metadata.CurrentSchema(), partitionFilters, true)
 	require.Error(t, err)
 	assert.Nil(t, evaluator)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
@@ -380,13 +371,12 @@ func TestBuildPartitionEvaluatorWithInvalidSpecID(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	scan := &Scan{
-		metadata:      metadata,
-		rowFilter:     iceberg.AlwaysTrue{},
-		caseSensitive: true,
-	}
+	rowFilter := iceberg.AlwaysTrue{}
+	partitionFilters := newKeyDefaultMapWrapErr(func(specID int) (iceberg.BooleanExpression, error) {
+		return buildPartitionProjection(specID, metadata, metadata.CurrentSchema(), rowFilter, true)
+	})
 
-	evaluator, err := scan.buildPartitionEvaluator(999)
+	evaluator, err := buildPartitionEvaluator(999, metadata, metadata.CurrentSchema(), partitionFilters, true)
 	require.Error(t, err)
 	assert.Nil(t, evaluator)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
@@ -400,7 +390,9 @@ func TestTimeTravelManifestPruningUsesSnapshotSchema(t *testing.T) {
 		Name:      "id",
 		Transform: iceberg.IdentityTransform{},
 	})
-	scan, _, snapshotID := newSchemaEvolutionScan(t, &spec, iceio.NewMemFS())
+	memIO := iceio.NewMemFS()
+	manifestListPath := "mem://default/table/metadata/snap-7.avro"
+	scan, _, snapshotID := newSchemaEvolutionScanWithSnapshot(t, &spec, memIO, manifestListPath, nil)
 
 	lower := int32Bound(10)
 	upper := int32Bound(20)
@@ -412,11 +404,15 @@ func TestTimeTravelManifestPruningUsesSnapshotSchema(t *testing.T) {
 		}}).
 		Build()
 
-	eval, err := scan.buildManifestEvaluator(spec.ID())
+	var listBytes bytes.Buffer
+	seqNum := int64(1)
+	err := iceberg.WriteManifestList(2, &listBytes, snapshotID, nil, &seqNum, 0, []iceberg.ManifestFile{manifest})
 	require.NoError(t, err)
-	use, err := eval(manifest)
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBytes.Bytes()))
+
+	tasks, err := scan.PlanFiles(context.Background())
 	require.NoError(t, err)
-	assert.False(t, use, "old snapshot partition bounds outside the filter should be pruned")
+	assert.Empty(t, tasks, "old snapshot manifest bounds outside the filter should be pruned")
 }
 
 func TestTimeTravelMetricsPruningUsesSnapshotSchema(t *testing.T) {
@@ -456,6 +452,10 @@ func TestTimeTravelMetricsPruningUsesSnapshotSchema(t *testing.T) {
 }
 
 func newSchemaEvolutionScan(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.IO) (*Scan, *iceberg.Schema, int64) {
+	return newSchemaEvolutionScanWithSnapshot(t, spec, fs, "", nil)
+}
+
+func newSchemaEvolutionScanWithSnapshot(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.IO, manifestList string, snapshotSchemaID *int) (*Scan, *iceberg.Schema, int64) {
 	t.Helper()
 
 	oldSchema := iceberg.NewSchema(0, iceberg.NestedField{
@@ -484,12 +484,16 @@ func newSchemaEvolutionScan(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.
 
 	snapshotID := int64(7)
 	oldSchemaID := oldSchema.ID
+	if snapshotSchemaID == nil {
+		snapshotSchemaID = &oldSchemaID
+	}
 	snapshot := &Snapshot{
 		SnapshotID:     snapshotID,
 		SequenceNumber: 1,
 		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		ManifestList:   manifestList,
 		Summary:        &Summary{Operation: OpAppend},
-		SchemaID:       &oldSchemaID,
+		SchemaID:       snapshotSchemaID,
 	}
 	require.NoError(t, builder.AddSnapshot(snapshot))
 	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
@@ -500,6 +504,7 @@ func newSchemaEvolutionScan(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.
 	scan := &Scan{
 		metadata:       built,
 		ioF:            func(context.Context) (iceio.IO, error) { return fs, nil },
+		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.EqualTo(iceberg.Reference("id"), int32(5)),
 		selectedFields: []string{"*"},
 		caseSensitive:  true,
@@ -508,9 +513,20 @@ func newSchemaEvolutionScan(t *testing.T, spec *iceberg.PartitionSpec, fs iceio.
 		limit:          ScanNoLimit,
 		concurrency:    1,
 	}
-	scan.partitionFilters = newKeyDefaultMapWrapErr(scan.buildPartitionProjection)
 
 	return scan, oldSchema, snapshotID
+}
+
+func TestTimeTravelUnknownSnapshotSchemaIDErrors(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	missingSchemaID := 999
+	scan, _, snapshotID := newSchemaEvolutionScanWithSnapshot(t, &spec, iceio.NewMemFS(), "", &missingSchemaID)
+
+	_, err := scan.Projection()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, strconv.FormatInt(snapshotID, 10))
+	assert.ErrorContains(t, err, strconv.Itoa(missingSchemaID))
 }
 
 func int32Bound(v int32) []byte {

--- a/table/table.go
+++ b/table/table.go
@@ -869,8 +869,6 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 		opt(s)
 	}
 
-	s.partitionFilters = newKeyDefaultMapWrapErr(s.buildPartitionProjection)
-
 	return s
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1530,11 +1530,11 @@ func newFileClassificationTask(meta Metadata, rowFilter iceberg.BooleanExpressio
 }
 
 func (t *fileClassificationTask) buildManifestEvaluator(specID int) (func(iceberg.ManifestFile) (bool, error), error) {
-	return buildManifestEvaluator(specID, t.meta, t.partitionFilters, t.caseSensitive)
+	return buildManifestEvaluator(specID, t.meta, t.meta.CurrentSchema(), t.partitionFilters, t.caseSensitive)
 }
 
 func (t *fileClassificationTask) buildPartitionProjection(specID int) (iceberg.BooleanExpression, error) {
-	return buildPartitionProjection(specID, t.meta, t.rowFilter, t.caseSensitive)
+	return buildPartitionProjection(specID, t.meta, t.meta.CurrentSchema(), t.rowFilter, t.caseSensitive)
 }
 
 // classifyFilesForFilteredDeletions classifies files for filtered overwrite operations.

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2027,8 +2027,6 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		opt(s)
 	}
 
-	s.partitionFilters = newKeyDefaultMapWrapErr(s.buildPartitionProjection)
-
 	return s, nil
 }
 


### PR DESCRIPTION
### Summary
- resolve the effective scan schema from the selected snapshot before local planning
- pass that schema into partition projection, manifest pruning, partition evaluation, metrics pruning, and read-time row filter binding
- keep transaction conflict validation on the current metadata schema by passing it explicitly
- add schema-evolution regressions for time-travel manifest and metrics pruning

### Testing
- `go test ./table -run TestTimeTravel`
- `go test ./table`
- `go test ./...`