### PR TITLE
fix(table): bound manifest merge concurrency

### DIFF
--- a/table/properties.go
+++ b/table/properties.go
@@ -70,6 +70,9 @@ const (
 	ManifestMinMergeCountKey     = "commit.manifest.min-count-to-merge"
 	ManifestMinMergeCountDefault = 100
 
+	ManifestMergeMaxConcurrencyKey     = "commit.manifest-merge.max-concurrency"
+	ManifestMergeMaxConcurrencyDefault = 0
+
 	WritePartitionSummaryLimitKey     = "write.summary.partition-limit"
 	WritePartitionSummaryLimitDefault = 0
 

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"iter"
 	"maps"
+	"runtime"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -334,10 +335,19 @@ func (of *overwriteFiles) deletedEntries(ctx context.Context) ([]iceberg.Manifes
 func (of *overwriteFiles) needsValidation() bool { return true }
 
 type manifestMergeManager struct {
-	targetSizeBytes int
-	minCountToMerge int
-	mergeEnabled    bool
-	snap            *snapshotProducer
+	targetSizeBytes  int
+	minCountToMerge  int
+	mergeEnabled     bool
+	mergeConcurrency int
+	snap             *snapshotProducer
+}
+
+func manifestMergeConcurrencyLimit(configured int) int {
+	if configured <= 0 {
+		return runtime.GOMAXPROCS(0)
+	}
+
+	return configured
 }
 
 func (m *manifestMergeManager) groupBySpec(manifests []iceberg.ManifestFile) map[int][]iceberg.ManifestFile {
@@ -424,6 +434,7 @@ func (m *manifestMergeManager) mergeGroup(firstManifest iceberg.ManifestFile, sp
 
 	binResults := make([][]iceberg.ManifestFile, len(bins))
 	g := errgroup.Group{}
+	g.SetLimit(manifestMergeConcurrencyLimit(m.mergeConcurrency))
 	for i, bin := range bins {
 		i, bin := i, bin
 		g.Go(func() error {
@@ -465,9 +476,10 @@ func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) 
 type mergeAppendFiles struct {
 	fastAppendFiles
 
-	targetSizeBytes int
-	minCountToMerge int
-	mergeEnabled    bool
+	targetSizeBytes  int
+	minCountToMerge  int
+	mergeEnabled     bool
+	mergeConcurrency int
 }
 
 func newMergeAppendFilesProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO, commitUUID *uuid.UUID, snapshotProps iceberg.Properties) *snapshotProducer {
@@ -477,6 +489,8 @@ func newMergeAppendFilesProducer(op Operation, txn *Transaction, fs iceio.WriteF
 		targetSizeBytes: txn.meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault),
 		minCountToMerge: txn.meta.props.GetInt(ManifestMinMergeCountKey, ManifestMinMergeCountDefault),
 		mergeEnabled:    txn.meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault),
+		mergeConcurrency: manifestMergeConcurrencyLimit(
+			txn.meta.props.GetInt(ManifestMergeMaxConcurrencyKey, ManifestMergeMaxConcurrencyDefault)),
 	}
 
 	return prod
@@ -493,10 +507,11 @@ func (m *mergeAppendFiles) processManifests(manifests []iceberg.ManifestFile) ([
 	}
 
 	dataManifestMergeMgr := manifestMergeManager{
-		targetSizeBytes: m.targetSizeBytes,
-		minCountToMerge: m.minCountToMerge,
-		mergeEnabled:    m.mergeEnabled,
-		snap:            m.base,
+		targetSizeBytes:  m.targetSizeBytes,
+		minCountToMerge:  m.minCountToMerge,
+		mergeEnabled:     m.mergeEnabled,
+		mergeConcurrency: m.mergeConcurrency,
+		snap:             m.base,
 	}
 
 	result, err := dataManifestMergeMgr.mergeManifests(unmergedDataManifests)

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"runtime"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -123,6 +125,60 @@ func (m *memIO) Remove(name string) error {
 	return nil
 }
 
+type blockingCreateIO struct {
+	*memIO
+
+	targetActive int
+	reached      chan struct{}
+	release      chan struct{}
+
+	mu          sync.Mutex
+	active      int
+	maxActive   int
+	once        sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingCreateIO(limit int, err error, targetActive int) *blockingCreateIO {
+	return &blockingCreateIO{
+		memIO:        newMemIO(limit, err),
+		targetActive: targetActive,
+		reached:      make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+}
+
+func (b *blockingCreateIO) Create(name string) (iceio.FileWriter, error) {
+	b.mu.Lock()
+	b.active++
+	if b.active > b.maxActive {
+		b.maxActive = b.active
+	}
+	if b.active == b.targetActive {
+		b.once.Do(func() { close(b.reached) })
+	}
+	b.mu.Unlock()
+
+	<-b.release
+
+	b.mu.Lock()
+	b.active--
+	b.mu.Unlock()
+
+	return b.memIO.Create(name)
+}
+
+func (b *blockingCreateIO) MaxActive() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.maxActive
+}
+
+func (b *blockingCreateIO) Release() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
 // createTestTransactionWithMemIO creates a transaction using the io package's mem blob FS
 // so that Create() output is persisted and can be read back (e.g. for sequential commits).
 func createTestTransactionWithMemIO(t *testing.T, spec iceberg.PartitionSpec) (*Transaction, iceio.WriteFileIO) {
@@ -162,6 +218,30 @@ func manifestSize(t *testing.T, version int, spec iceberg.PartitionSpec, schema 
 
 func newTestDataFile(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any) iceberg.DataFile {
 	return newTestDataFileWithCount(t, spec, path, partition, 1)
+}
+
+func writeTestManifestFile(
+	t *testing.T,
+	fs iceio.WriteFileIO,
+	spec iceberg.PartitionSpec,
+	schema *iceberg.Schema,
+	snapshotID int64,
+	index int,
+) iceberg.ManifestFile {
+	t.Helper()
+
+	df := newTestDataFile(t, spec, "file://data-"+strconv.Itoa(index)+".parquet", nil)
+	entries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, df),
+	}
+
+	path := "table-location/metadata/source-" + strconv.Itoa(index) + ".avro"
+	var buf bytes.Buffer
+	manifestFile, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err, "write manifest")
+	require.NoError(t, fs.WriteFile(path, buf.Bytes()))
+
+	return manifestFile
 }
 
 func newTestPosDeleteFileForSpec(
@@ -736,6 +816,81 @@ func TestCreateManifestClosesUnderlyingFile(t *testing.T) {
 
 	unclosed := trackIO.GetUnclosedWriters()
 	require.Empty(t, unclosed, "all file writerFactory should be closed after createManifest, but these are still open: %v", unclosed)
+}
+
+func TestManifestMergeMaxConcurrencyProperty(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	io := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, io, spec)
+	txn.meta.props[ManifestMergeMaxConcurrencyKey] = "3"
+
+	sp := newMergeAppendFilesProducer(OpAppend, txn, io, nil, nil)
+	merge := sp.producerImpl.(*mergeAppendFiles)
+	require.Equal(t, 3, merge.mergeConcurrency)
+}
+
+func TestManifestMergeMaxConcurrencyDefaultsForNonPositiveValues(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	io := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, io, spec)
+	txn.meta.props[ManifestMergeMaxConcurrencyKey] = "0"
+
+	sp := newMergeAppendFilesProducer(OpAppend, txn, io, nil, nil)
+	merge := sp.producerImpl.(*mergeAppendFiles)
+	require.Equal(t, runtime.GOMAXPROCS(0), merge.mergeConcurrency)
+}
+
+func TestManifestMergeGroupLimitsConcurrentBins(t *testing.T) {
+	const mergeConcurrency = 2
+
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	blockingIO := newBlockingCreateIO(1<<20, nil, mergeConcurrency)
+	defer blockingIO.Release()
+	txn := createTestTransaction(t, blockingIO, spec)
+
+	sp := newFastAppendFilesProducer(OpAppend, txn, blockingIO, nil, nil)
+
+	manifests := make([]iceberg.ManifestFile, 0, 8)
+	for i := 0; i < cap(manifests); i++ {
+		manifests = append(manifests, writeTestManifestFile(t, blockingIO, spec, schema, sp.snapshotID, i))
+	}
+
+	mgr := manifestMergeManager{
+		targetSizeBytes:  int(manifests[0].Length() * 2),
+		minCountToMerge:  1,
+		mergeEnabled:     true,
+		mergeConcurrency: mergeConcurrency,
+		snap:             sp,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := mgr.mergeGroup(manifests[0], spec.ID(), manifests)
+		done <- err
+	}()
+
+	select {
+	case <-blockingIO.reached:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for merge workers")
+	}
+
+	// Give any incorrectly-unbounded workers a chance to enter Create before
+	// releasing the blocked merge outputs.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, mergeConcurrency, blockingIO.MaxActive())
+
+	blockingIO.Release()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for manifest merge")
+	}
+
+	require.LessOrEqual(t, blockingIO.MaxActive(), mergeConcurrency)
 }
 
 // TestOverwriteExistingManifestsClosesUnderlyingFile tests that existingManifests


### PR DESCRIPTION
## Summary

Bound manifest merge bin processing with an errgroup concurrency limit instead of starting one goroutine per packed bin.

The limit defaults to runtime.GOMAXPROCS(0) and can be tuned with the table property commit.manifest-merge.max-concurrency. Non-positive or invalid values fall back to the default.

## Why

Large commits can produce many manifest merge bins. Launching all bin merges at once can spike goroutines, file handles, CPU, and memory during commit even though the work is naturally parallel only up to a reasonable worker limit.

## Testing

- go test ./table -run 'TestManifestMerge(MaxConcurrency|GroupLimits)' -count=1
- go test ./table -count=1
- go test ./... -skip '^TestCreateAzureBucketManagedIdentityCredentialCalled$'
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m ./table/...
- git diff --check