### PR TITLE
fix(sql): return error for unsupported dialect

### DIFF
--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -86,12 +86,6 @@ func init() {
 			return nil, err
 		}
 
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("failed to create SQL catalog: %v", r)
-			}
-		}()
-
 		// Here, name is the loader-supplied catalog name and is persisted as the
 		// catalog_name partition key on every row in the iceberg_tables and iceberg_namespace_properties.
 		return NewCatalog(name, sqldb, SupportedDialect(dialect), p)
@@ -107,33 +101,37 @@ var (
 	dialectMx sync.Mutex
 )
 
-func createDialect(d SupportedDialect) schema.Dialect {
+func createDialect(d SupportedDialect) (schema.Dialect, error) {
 	switch d {
 	case Postgres:
-		return pgdialect.New()
+		return pgdialect.New(), nil
 	case MySQL:
-		return mysqldialect.New()
+		return mysqldialect.New(), nil
 	case SQLite:
-		return sqlitedialect.New()
+		return sqlitedialect.New(), nil
 	case MSSQL:
-		return mssqldialect.New()
+		return mssqldialect.New(), nil
 	case Oracle:
-		return oracledialect.New()
+		return oracledialect.New(), nil
 	default:
-		panic("unsupported sql dialect")
+		return nil, fmt.Errorf("unsupported sql dialect: %q", d)
 	}
 }
 
-func getDialect(d SupportedDialect) schema.Dialect {
+func getDialect(d SupportedDialect) (schema.Dialect, error) {
 	dialectMx.Lock()
 	defer dialectMx.Unlock()
 	ret, ok := dialects[d]
 	if !ok {
-		ret = createDialect(d)
+		var err error
+		ret, err = createDialect(d)
+		if err != nil {
+			return nil, err
+		}
 		dialects[d] = ret
 	}
 
-	return ret
+	return ret, nil
 }
 
 type sqlIcebergTable struct {
@@ -199,7 +197,12 @@ type Catalog struct {
 // All interactions with the db are performed within transactions to ensure atomicity and transactional isolation
 // of catalog changes.
 func NewCatalog(name string, db *sql.DB, dialect SupportedDialect, props iceberg.Properties) (*Catalog, error) {
-	cat := &Catalog{db: bun.NewDB(db, getDialect(dialect)), name: name, props: props}
+	d, err := getDialect(dialect)
+	if err != nil {
+		return nil, err
+	}
+
+	cat := &Catalog{db: bun.NewDB(db, d), name: name, props: props}
 
 	cat.db.AddQueryHook(bundebug.NewQueryHook(
 		bundebug.WithEnabled(false),

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -91,6 +91,7 @@ func init() {
 		cat, err := NewCatalog(name, sqldb, SupportedDialect(dialect), p)
 		if err != nil {
 			_ = sqldb.Close()
+
 			return nil, err
 		}
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -88,7 +88,13 @@ func init() {
 
 		// Here, name is the loader-supplied catalog name and is persisted as the
 		// catalog_name partition key on every row in the iceberg_tables and iceberg_namespace_properties.
-		return NewCatalog(name, sqldb, SupportedDialect(dialect), p)
+		cat, err := NewCatalog(name, sqldb, SupportedDialect(dialect), p)
+		if err != nil {
+			_ = sqldb.Close()
+			return nil, err
+		}
+
+		return cat, nil
 	}))
 }
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -119,6 +119,15 @@ func TestInvalidDialect(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewCatalogInvalidDialect(t *testing.T) {
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	assert.NoError(t, err)
+	defer sqldb.Close()
+
+	_, err = sqlcat.NewCatalog("default", sqldb, "foobar", nil)
+	assert.ErrorContains(t, err, "unsupported sql dialect")
+}
+
 func randomString(n int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	var b strings.Builder

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -116,7 +116,7 @@ func TestInvalidDialect(t *testing.T) {
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: "foobar",
 	})
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, `unsupported sql dialect: "foobar"`)
 }
 
 func TestNewCatalogInvalidDialect(t *testing.T) {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -115,6 +115,7 @@ func TestInvalidDialect(t *testing.T) {
 	_, err := catalog.Load(context.Background(), "sql", iceberg.Properties{
 		sqlcat.DriverKey:  sqliteshim.ShimName,
 		sqlcat.DialectKey: "foobar",
+		"type":            "sql",
 	})
 	assert.ErrorContains(t, err, `unsupported sql dialect: "foobar"`)
 }


### PR DESCRIPTION
## Summary
- Changed SQL catalog dialect resolution to return typed errors instead of panicking for unsupported dialects.
- Updated registry usage to rely on clean error flow from \'sql.NewCatalog\'.
- Added test for direct catalog creation via NewCatalog with unsupported dialect.

## Testing
- go test ./catalog/sql -run 'TestInvalidDialect|TestNewCatalogInvalidDialect' -count=1
- go test ./catalog/sql -count=1