### PR TITLE
fix(dv): reject negative deletion-vector positions in DVWriter.Add

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1867,7 +1867,11 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 
 					return
 				}
-				writer.Add(filePath, []int64{positions.Value(int(i))}, pCtx.specID, pCtx.partitionData)
+				if err := writer.Add(filePath, []int64{positions.Value(int(i))}, pCtx.specID, pCtx.partitionData); err != nil {
+					yield(nil, err)
+
+					return
+				}
 				hasEntries = true
 			}
 		}

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -85,7 +85,21 @@ func NewDVWriter(fs iceio.WriteFileIO, specByID SpecResolver) *DVWriter {
 // Callers must not pass conflicting partition values across Adds for the
 // same data file — the writer trusts the first-Add values for the rest of
 // the writer's life.
-func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, partitionData map[int]any) {
+// Add validates that every position is non-negative; negative positions are
+// rejected and returned as errors to avoid silently writing malformed
+// deletion-vector metadata.
+func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, partitionData map[int]any) error {
+	if len(positions) == 0 {
+		return nil
+	}
+
+	for _, pos := range positions {
+		if pos < 0 {
+			return fmt.Errorf("%w: invalid deletion position %d for %q: positions must be >= 0",
+				iceberg.ErrInvalidArgument, pos, dataFilePath)
+		}
+	}
+
 	entry, ok := w.entries[dataFilePath]
 	if !ok {
 		// Defensive copy of partitionData on capture so a caller that
@@ -106,6 +120,8 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 	for _, pos := range positions {
 		entry.bitmap.Set(uint64(pos))
 	}
+
+	return nil
 }
 
 // Flush writes one Puffin file containing one blob per data file, and returns

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -127,7 +127,7 @@ func TestDVWriterSingleDataFile(t *testing.T) {
 	w := NewDVWriter(fs, unpartitionedResolver())
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5, 7, 9}, 0, nil)
+	require.NoError(t, w.Add(dataPath, []int64{1, 3, 5, 7, 9}, 0, nil))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dv.puffin")
 	require.NoError(t, err)
@@ -156,8 +156,8 @@ func TestDVWriterMultipleDataFiles(t *testing.T) {
 
 	path1 := "s3://bucket/data/file-001.parquet"
 	path2 := "s3://bucket/data/file-002.parquet"
-	w.Add(path1, []int64{0, 10, 20}, 0, nil)
-	w.Add(path2, []int64{5, 15, 25, 35}, 0, nil)
+	require.NoError(t, w.Add(path1, []int64{0, 10, 20}, 0, nil))
+	require.NoError(t, w.Add(path2, []int64{5, 15, 25, 35}, 0, nil))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-dv.puffin")
 	require.NoError(t, err)
@@ -180,8 +180,8 @@ func TestDVWriterDeduplicatesPositions(t *testing.T) {
 	w := NewDVWriter(fs, unpartitionedResolver())
 
 	dataPath := "s3://bucket/data/file-001.parquet"
-	w.Add(dataPath, []int64{1, 3, 5}, 0, nil)
-	w.Add(dataPath, []int64{3, 5, 7}, 0, nil)
+	require.NoError(t, w.Add(dataPath, []int64{1, 3, 5}, 0, nil))
+	require.NoError(t, w.Add(dataPath, []int64{3, 5, 7}, 0, nil))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/dedup.puffin")
 	require.NoError(t, err)
@@ -192,11 +192,49 @@ func TestDVWriterDeduplicatesPositions(t *testing.T) {
 	verifyDVReadBack(t, fs, dataFiles[0])
 }
 
+func TestDVWriterAddRejectsNegativePositions(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs, unpartitionedResolver())
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	require.NoError(t, w.Add(dataPath, []int64{1, 3}, 0, nil))
+
+	err := w.Add(dataPath, []int64{5, -1, 7}, 0, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/negative-pos.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+	assert.Equal(t, int64(2), dataFiles[0].Count(), "negative Add should be rejected without mutating prior valid state")
+
+	bm, err := ReadDV(fs, dataFiles[0])
+	require.NoError(t, err)
+	assert.True(t, bm.Contains(1))
+	assert.True(t, bm.Contains(3))
+	assert.False(t, bm.Contains(5))
+	assert.False(t, bm.Contains(7))
+
+	assert.Equal(t, dataFiles[0].Count(), bm.Cardinality())
+}
+
+func TestDVWriterAddNegativeFirstCreatesNoEntry(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs, unpartitionedResolver())
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	require.ErrorIs(t, w.Add(dataPath, []int64{-1}, 0, nil), iceberg.ErrInvalidArgument)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/negative-first.puffin")
+	require.NoError(t, err)
+	assert.Nil(t, dataFiles)
+}
+
 func TestDVWriterResetsAfterFlush(t *testing.T) {
 	fs := newTestFS()
 	w := NewDVWriter(fs, unpartitionedResolver())
 
-	w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3}, 0, nil)
+	require.NoError(t, w.Add("s3://bucket/data/file-001.parquet", []int64{1, 2, 3}, 0, nil))
 	_, err := w.Flush(context.Background(), "mem://test/first.puffin")
 	require.NoError(t, err)
 
@@ -221,7 +259,7 @@ func TestDVWriterPartitionedSingleFile(t *testing.T) {
 	w := NewDVWriter(fs, specMapResolver(spec))
 
 	dataPath := "s3://bucket/tenant=42/file-001.parquet"
-	w.Add(dataPath, []int64{1, 2, 3}, 7, map[int]any{1000: int32(42)})
+	require.NoError(t, w.Add(dataPath, []int64{1, 2, 3}, 7, map[int]any{1000: int32(42)}))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/partitioned.puffin")
 	require.NoError(t, err)
@@ -257,8 +295,8 @@ func TestDVWriterPartitionedMultipleFiles(t *testing.T) {
 	pathEU := "s3://bucket/region=EU/file-eu.parquet"
 	pathUS := "s3://bucket/region=US/file-us.parquet"
 
-	w.Add(pathEU, []int64{1, 2}, 3, map[int]any{1000: "EU"})
-	w.Add(pathUS, []int64{3, 4, 5}, 3, map[int]any{1000: "US"})
+	require.NoError(t, w.Add(pathEU, []int64{1, 2}, 3, map[int]any{1000: "EU"}))
+	require.NoError(t, w.Add(pathUS, []int64{3, 4, 5}, 3, map[int]any{1000: "US"}))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/multi-partition.puffin")
 	require.NoError(t, err)
@@ -312,9 +350,9 @@ func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
 		fs := newTestFS()
 		w := NewDVWriter(fs, specMapResolver(spec0))
 
-		w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"})
+		require.NoError(t, w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"}))
 		// Second Add carries a different partition value; capture is unaffected.
-		w.Add(dataPath, []int64{2}, 0, map[int]any{1000: "US"})
+		require.NoError(t, w.Add(dataPath, []int64{2}, 0, map[int]any{1000: "US"}))
 
 		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-partition.puffin")
 		require.NoError(t, err)
@@ -326,9 +364,9 @@ func TestDVWriterPartitionCapturedOnFirstAdd(t *testing.T) {
 		fs := newTestFS()
 		w := NewDVWriter(fs, specMapResolver(spec0, spec5))
 
-		w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"})
+		require.NoError(t, w.Add(dataPath, []int64{1}, 0, map[int]any{1000: "EU"}))
 		// Second Add carries a different spec id; capture is unaffected.
-		w.Add(dataPath, []int64{2}, 5, map[int]any{1000: "EU"})
+		require.NoError(t, w.Add(dataPath, []int64{2}, 5, map[int]any{1000: "EU"}))
 
 		dataFiles, err := w.Flush(context.Background(), "mem://test/capture-spec.puffin")
 		require.NoError(t, err)
@@ -354,7 +392,7 @@ func TestDVWriterAddDefensiveCopies(t *testing.T) {
 	w := NewDVWriter(fs, specMapResolver(spec))
 	partition := map[int]any{1000: "EU"}
 
-	w.Add("s3://bucket/region=EU/file.parquet", []int64{1}, 0, partition)
+	require.NoError(t, w.Add("s3://bucket/region=EU/file.parquet", []int64{1}, 0, partition))
 	// Mutate the caller's map after Add. A reference-storing writer would
 	// produce a DataFile carrying "MUTATED" on Flush; a defensive-copy
 	// implementation keeps the original captured value.
@@ -389,8 +427,8 @@ func TestDVWriterFlushMixedSpecIDs(t *testing.T) {
 	pathOld := "s3://bucket/region=EU/file.parquet"
 	pathNew := "s3://bucket/region_bucket=0/file.parquet"
 
-	w.Add(pathOld, []int64{1}, 0, map[int]any{1000: "EU"})
-	w.Add(pathNew, []int64{2}, 1, map[int]any{1001: int32(0)})
+	require.NoError(t, w.Add(pathOld, []int64{1}, 0, map[int]any{1000: "EU"}))
+	require.NoError(t, w.Add(pathNew, []int64{2}, 1, map[int]any{1001: int32(0)}))
 
 	dataFiles, err := w.Flush(context.Background(), "mem://test/mixed-spec.puffin")
 	require.NoError(t, err)
@@ -416,7 +454,7 @@ func TestDVWriterFlushUnknownSpecID(t *testing.T) {
 	w := NewDVWriter(fs, unpartitionedResolver())
 
 	// specID 99 is not registered with the resolver.
-	w.Add("s3://bucket/file.parquet", []int64{1}, 99, nil)
+	require.NoError(t, w.Add("s3://bucket/file.parquet", []int64{1}, 99, nil))
 
 	_, err := w.Flush(context.Background(), "mem://test/unknown-spec.puffin")
 	require.Error(t, err)

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -195,8 +195,8 @@ func TestRewriteDataFilesPreservesSiblingDeletionVector(t *testing.T) {
 	// One Flush writes a single Puffin holding a DV blob for each data file,
 	// so both manifest entries share the Puffin path. Each deletes id=1 / id=3.
 	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
-	w.Add(rewriteTarget, []int64{0}, 0, nil)
-	w.Add(sibling, []int64{0}, 0, nil)
+	require.NoError(t, w.Add(rewriteTarget, []int64{0}, 0, nil))
+	require.NoError(t, w.Add(sibling, []int64{0}, 0, nil))
 	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(rewriteTarget), "dv-shared.puffin"))
 	require.NoError(t, err)
 	require.Len(t, dvFiles, 2)
@@ -265,7 +265,7 @@ func seedV3TableWithDV(t *testing.T) (*table.Table, string) {
 	dvTarget := target.File.FilePath()
 
 	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
-	w.Add(dvTarget, []int64{0}, 0, nil)
+	require.NoError(t, w.Add(dvTarget, []int64{0}, 0, nil))
 	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dvTarget), "dv-0001.puffin"))
 	require.NoError(t, err)
 	require.Len(t, dvFiles, 1)

--- a/table/row_lineage_prune_delete_test.go
+++ b/table/row_lineage_prune_delete_test.go
@@ -93,7 +93,7 @@ func TestScanPruningWithDeletionVector(t *testing.T) {
 	dataPath := tasks[0].File.FilePath()
 
 	w := dv.NewDVWriter(iceio.LocalFS{}, unpartitionedSpecByID)
-	w.Add(dataPath, []int64{6}, 0, nil)
+	require.NoError(t, w.Add(dataPath, []int64{6}, 0, nil))
 	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dataPath), "dv-0001.puffin"))
 	require.NoError(t, err)
 
@@ -160,7 +160,7 @@ func TestReadTaskDeletionVectorSupersedesPositionalDeletes(t *testing.T) {
 
 	// DV deletes pos 0 (id=1); the positional delete targets pos 4 (id=5).
 	w := dv.NewDVWriter(iceio.LocalFS{}, unpartitionedSpecByID)
-	w.Add(dataPath, []int64{0}, 0, nil)
+	require.NoError(t, w.Add(dataPath, []int64{0}, 0, nil))
 	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(dataPath), "dv-0001.puffin"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Validate DVWriter.Add positions are non-negative.
- Change DVWriter.Add to return an error on negative positions.
- Plumb error handling where DVWriter.Add is called.
- Add regression coverage for negative position rejection in dv_writer tests.

## Testing
- go test ./table/dv -run 'TestDVWriter'
- go test ./table -run 'TestScanPruningWithDeletionVector|TestReadTaskDeletionVectorSupersedesPositionalDeletes|TestRewriteDataFilesPreservesSiblingDeletionVector'
- go test ./table ./table/dv