### PR TITLE
fix(transforms): validate BucketTransform NumBuckets

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -257,6 +257,9 @@ func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedFiel
 	if targetName == "" {
 		return errors.New("cannot use empty partition name")
 	}
+	if err := validateTransform(transform); err != nil {
+		return err
+	}
 	for _, existingField := range p.fields {
 		if existingField.Name == targetName {
 			return errors.New("duplicate partition name: " + targetName)
@@ -280,6 +283,17 @@ func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedFiel
 	p.fields = append(p.fields, unboundField)
 
 	return nil
+}
+
+func validateTransform(transform Transform) error {
+	switch t := transform.(type) {
+	case BucketTransform:
+		return t.validateNumBuckets()
+	case *BucketTransform:
+		return t.validateNumBuckets()
+	default:
+		return nil
+	}
 }
 
 func (p *PartitionSpec) checkForRedundantPartitions(sourceID int, transform Transform) error {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -139,6 +139,36 @@ func TestPartitionSpecCompatibleWithUsesTransformEquals(t *testing.T) {
 	}
 }
 
+func TestPartitionSpecRejectsInvalidBucketTransform(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   1,
+		Name: "id",
+		Type: iceberg.PrimitiveTypes.Int32,
+	})
+
+	_, err := iceberg.NewPartitionSpecOpts(
+		iceberg.AddPartitionFieldBySourceID(1, "id_bucket", iceberg.BucketTransform{NumBuckets: 0}, schema, nil),
+	)
+
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "numBuckets > 0")
+}
+
+func TestPartitionSpec_MarshalTextRejectsInvalidBucketTransform(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(3,
+		iceberg.PartitionField{
+			SourceIDs: []int{1},
+			FieldID:   1000,
+			Name:      "bad_bucket",
+			Transform: iceberg.BucketTransform{NumBuckets: 0},
+		},
+	)
+
+	_, err := json.Marshal(spec)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "numBuckets > 0")
+}
+
 func TestUnpartitionedWithVoidField(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 		SourceIDs: []int{3}, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},

--- a/transforms.go
+++ b/transforms.go
@@ -244,6 +244,14 @@ func (t BucketTransform) MarshalText() ([]byte, error) {
 
 func (t BucketTransform) String() string { return fmt.Sprintf("bucket[%d]", t.NumBuckets) }
 
+func (t BucketTransform) validateNumBuckets() error {
+	if t.NumBuckets <= 0 {
+		return fmt.Errorf("%w: bucket transform requires numBuckets > 0", ErrInvalidArgument)
+	}
+
+	return nil
+}
+
 func (BucketTransform) CanTransform(t Type) bool {
 	switch t.(type) {
 	case Int32Type,
@@ -292,6 +300,9 @@ func (t BucketTransform) Apply(value Optional[Literal]) Optional[Literal] {
 	if !value.Valid {
 		return Optional[Literal]{}
 	}
+	if err := t.validateNumBuckets(); err != nil {
+		return Optional[Literal]{}
+	}
 
 	var hash uint32
 	switch v := value.Val.(type) {
@@ -327,6 +338,12 @@ func (t BucketTransform) Apply(value Optional[Literal]) Optional[Literal] {
 }
 
 func (t BucketTransform) Transformer(src Type) func(any) Optional[int32] {
+	if err := t.validateNumBuckets(); err != nil {
+		return func(_ any) Optional[int32] {
+			return Optional[int32]{}
+		}
+	}
+
 	var h func(any) uint32
 
 	switch src.(type) {
@@ -373,7 +390,7 @@ func (t BucketTransform) Transformer(src Type) func(any) Optional[int32] {
 	}
 
 	return func(v any) Optional[int32] {
-		if v == nil {
+		if v == nil || h == nil {
 			return Optional[int32]{}
 		}
 
@@ -397,6 +414,9 @@ func (t BucketTransform) ToHumanStrType(_ Type, val any) string {
 }
 
 func (t BucketTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
+	if err := t.validateNumBuckets(); err != nil {
+		return nil, err
+	}
 	if _, ok := pred.Term().(*BoundTransform); ok {
 		return projectTransformPredicate(t, name, pred)
 	}

--- a/transforms.go
+++ b/transforms.go
@@ -239,6 +239,10 @@ type BucketTransform struct {
 }
 
 func (t BucketTransform) MarshalText() ([]byte, error) {
+	if err := t.validateNumBuckets(); err != nil {
+		return nil, err
+	}
+
 	return []byte(t.String()), nil
 }
 

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -336,6 +336,46 @@ func TestManifestPartitionVals(t *testing.T) {
 	}
 }
 
+func TestBucketTransform_NumBucketsValidation(t *testing.T) {
+	transform := iceberg.BucketTransform{}
+	t.Run("ApplyRejectsInvalidBuckets", func(t *testing.T) {
+		out := transform.Apply(iceberg.Optional[iceberg.Literal]{
+			Valid: true,
+			Val:   iceberg.Int32Literal(123),
+		})
+		require.False(t, out.Valid)
+	})
+
+	t.Run("TransformerRejectsInvalidBuckets", func(t *testing.T) {
+		fn := transform.Transformer(iceberg.PrimitiveTypes.String)
+		out := fn("abc")
+		require.False(t, out.Valid)
+	})
+
+	t.Run("ProjectRejectsInvalidBuckets", func(t *testing.T) {
+		schema := iceberg.NewSchema(1, iceberg.NestedField{
+			ID:   1,
+			Name: "id",
+			Type: iceberg.PrimitiveTypes.Int64,
+		})
+		bound, err := iceberg.EqualTo(iceberg.Reference("id"), int64(42)).Bind(schema, true)
+		require.NoError(t, err)
+
+		_, err = transform.Project("id_bucket", bound.(iceberg.BoundPredicate))
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "numBuckets > 0")
+	})
+}
+
+func TestBucketTransformUnsupportedSourceTypeDoesNotPanic(t *testing.T) {
+	transform := iceberg.BucketTransform{NumBuckets: 16}
+	fn := transform.Transformer(iceberg.PrimitiveTypes.Bool)
+	require.NotPanics(t, func() {
+		result := fn(true)
+		require.False(t, result.Valid)
+	})
+}
+
 func TestCanTransform(t *testing.T) {
 	tests := []struct {
 		transform  iceberg.Transform

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -367,6 +367,24 @@ func TestBucketTransform_NumBucketsValidation(t *testing.T) {
 	})
 }
 
+func TestBucketTransform_MarshalTextRejectsInvalidBuckets(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		_, err := iceberg.BucketTransform{NumBuckets: 0}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "numBuckets > 0")
+	})
+	t.Run("negative", func(t *testing.T) {
+		_, err := iceberg.BucketTransform{NumBuckets: -1}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "numBuckets > 0")
+	})
+	t.Run("valid", func(t *testing.T) {
+		txt, err := iceberg.BucketTransform{NumBuckets: 16}.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, "bucket[16]", string(txt))
+	})
+}
+
 func TestBucketTransformUnsupportedSourceTypeDoesNotPanic(t *testing.T) {
 	transform := iceberg.BucketTransform{NumBuckets: 16}
 	fn := transform.Transformer(iceberg.PrimitiveTypes.Bool)


### PR DESCRIPTION
## Summary
- Make `BucketTransform` validate `NumBuckets` before modulo and path/transform application.
- Guard `Apply`, `Transformer`, and `Project` so invalid values (`NumBuckets <= 0`) return safe, non-panicking outcomes.
- Return invalid `Optional` from `Apply`/`Transformer` and `ErrInvalidArgument` from `Project` when bucket count is invalid.
- Add regression tests covering invalid bucket counts for `Apply`, `Transformer`, and `Project`.
- Harden unsupported source-type handling in `Transformer` to return invalid values instead of panicking.