### PR TITLE
fix(literals): return BinaryLiteral for FixedLiteral→binary cast

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"slices"
 	"strconv"
 	"time"
 	"unsafe"
@@ -1140,7 +1141,7 @@ func (f FixedLiteral) To(typ Type) (Literal, error) {
 		return nil, fmt.Errorf("%w: cannot convert FixedLiteral to %s, different length - %d <> %d",
 			ErrBadCast, typ, len(f), t.len)
 	case BinaryType:
-		return f, nil
+		return BinaryLiteral(slices.Clone(f)), nil
 	}
 
 	return nil, fmt.Errorf("%w: FixedLiteral[%d] to %s",

--- a/literals_test.go
+++ b/literals_test.go
@@ -684,7 +684,13 @@ func TestFixedLiteral(t *testing.T) {
 
 	binlit, err := fixedLit012.To(iceberg.PrimitiveTypes.Binary)
 	require.NoError(t, err)
-	assert.EqualValues(t, fixedLit012, binlit)
+	binaryLit, ok := binlit.(iceberg.BinaryLiteral)
+	require.True(t, ok)
+	assert.EqualValues(t, fixedLit012, binaryLit)
+	assert.True(t, binaryLit.Type().Equals(iceberg.PrimitiveTypes.Binary))
+
+	binaryLit[0] = 0xFF
+	assert.Equal(t, byte(0x00), fixedLit012[0])
 }
 
 func TestBinaryLiteral(t *testing.T) {


### PR DESCRIPTION
## Summary

- FixedLiteral.To(BinaryType) now returns a copied BinaryLiteral value instead of returning FixedLiteral directly.
- Added regression coverage in TestFixedLiteral to verify:
  - cast result type is BinaryLiteral
  - target type is binary
  - conversion returns an independent byte slice from the source fixed bytes

This avoids type mismatch issues during predicate binding/serialization paths when casting fixed literals to binary.