### PR TITLE
fix(table): separate rolling data writer close/abort paths

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1718,9 +1718,7 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 				return
 			}
 		}
-		close(writer.recordCh)
-		writer.wg.Wait()
-		if err := <-writer.errorCh; err != nil {
+		if err := writer.closeAndWait(); err != nil {
 			errCh <- err
 		}
 		close(errCh)

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1706,16 +1706,14 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 			if err != nil {
 				errCh <- err
 				close(errCh)
-				writer.close()
-				writer.wg.Wait()
+				writer.abortAndWait()
 
 				return
 			}
 			if err := writer.Add(rec); err != nil {
 				errCh <- err
 				close(errCh)
-				writer.close()
-				writer.wg.Wait()
+				writer.abortAndWait()
 
 				return
 			}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -80,16 +80,17 @@ func (p *partitionedFanoutWriter) Write(ctx context.Context, workers int) iter.S
 	inputRecordsCh := make(chan arrow.RecordBatch, workers)
 	outputDataFilesCh := make(chan iceberg.DataFile, workers)
 
-	fanoutWorkers, ctx := errgroup.WithContext(ctx)
-	startRecordFeeder(ctx, p.itr, fanoutWorkers, inputRecordsCh)
+	fanoutWorkers, fanoutCtx := errgroup.WithContext(ctx)
+	writerCtx, writerCancel := context.WithCancel(ctx)
+	startRecordFeeder(fanoutCtx, p.itr, fanoutWorkers, inputRecordsCh)
 
 	for range workers {
 		fanoutWorkers.Go(func() error {
-			return p.fanout(ctx, inputRecordsCh, outputDataFilesCh)
+			return p.fanout(fanoutCtx, writerCtx, inputRecordsCh, outputDataFilesCh)
 		})
 	}
 
-	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh)
+	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh, writerCancel)
 }
 
 func startRecordFeeder(ctx context.Context, itr iter.Seq2[arrow.RecordBatch, error], fanoutWorkers *errgroup.Group, inputRecordsCh chan<- arrow.RecordBatch) {
@@ -115,7 +116,7 @@ func startRecordFeeder(ctx context.Context, itr iter.Seq2[arrow.RecordBatch, err
 	})
 }
 
-func (p *partitionedFanoutWriter) fanout(ctx context.Context, inputRecordsCh <-chan arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
+func (p *partitionedFanoutWriter) fanout(ctx context.Context, writerCtx context.Context, inputRecordsCh <-chan arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -126,7 +127,7 @@ func (p *partitionedFanoutWriter) fanout(ctx context.Context, inputRecordsCh <-c
 				return nil
 			}
 
-			if err := p.processRecord(ctx, record, dataFilesChannel); err != nil {
+			if err := p.processRecord(ctx, writerCtx, record, dataFilesChannel); err != nil {
 				return err
 			}
 		}
@@ -136,7 +137,7 @@ func (p *partitionedFanoutWriter) fanout(ctx context.Context, inputRecordsCh <-c
 // processRecord partitions a single record batch and writes sub-batches to
 // the appropriate rolling data writers. The record is released when this
 // function returns, bounding Arrow memory to one batch per fanout worker.
-func (p *partitionedFanoutWriter) processRecord(ctx context.Context, record arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
+func (p *partitionedFanoutWriter) processRecord(ctx context.Context, writerCtx context.Context, record arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
 	defer record.Release()
 
 	partitions, err := p.getPartitions(record)
@@ -157,7 +158,7 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, record arro
 		}
 
 		partitionPath := p.partitionPath(val.partitionRec)
-		rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, partitionPath, val.partitionValues, dataFilesChannel)
+		rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(writerCtx, partitionPath, val.partitionValues, dataFilesChannel)
 		if err != nil {
 			partitionRecord.Release()
 
@@ -174,18 +175,37 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, record arro
 	return nil
 }
 
-func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile) iter.Seq2[iceberg.DataFile, error] {
-	return yieldDataFiles(p.writerFactory, fanoutWorkers, outputDataFilesCh)
+func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+	return yieldDataFiles(
+		p.writerFactory,
+		fanoutWorkers,
+		outputDataFilesCh,
+		p.writerFactory.closeAll,
+		p.writerFactory.abortAll,
+		writerCancel,
+	)
 }
 
-func yieldDataFiles(writerFactory *writerFactory, fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile) iter.Seq2[iceberg.DataFile, error] {
+func yieldDataFiles(
+	writerFactory *writerFactory,
+	fanoutWorkers *errgroup.Group,
+	outputDataFilesCh chan iceberg.DataFile,
+	closeAll func() error,
+	abortAll func(),
+	writerCancel context.CancelFunc,
+) iter.Seq2[iceberg.DataFile, error] {
 	// Use a channel to safely communicate the error from the goroutine
 	// to avoid a data race between writing err in the goroutine and reading it in the iterator.
 	errCh := make(chan error, 1)
 	go func() {
 		defer close(outputDataFilesCh)
+		defer writerCancel()
 		err := fanoutWorkers.Wait()
-		err = errors.Join(err, writerFactory.closeAll())
+		if err != nil {
+			abortAll()
+		} else {
+			err = errors.Join(err, closeAll())
+		}
 		errCh <- err
 		close(errCh)
 	}()

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -175,6 +175,7 @@ func (s *FanoutWriterTestSuite) TestCloseAllFlushesAfterFanoutSuccessContextCanc
 		for dataFile, iterErr := range dataFiles {
 			if iterErr != nil {
 				resultCh <- result{err: iterErr}
+
 				return
 			}
 			total += dataFile.Count()
@@ -182,8 +183,7 @@ func (s *FanoutWriterTestSuite) TestCloseAllFlushesAfterFanoutSuccessContextCanc
 		resultCh <- result{total: total}
 	}()
 
-	var sum result
-	sum = <-resultCh
+	sum := <-resultCh
 	s.Require().NoError(sum.err)
 	s.Equal(int64(totalRows), sum.total)
 }

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +91,101 @@ func (s *FanoutWriterTestSuite) createCustomTestRecord(arrSchema *arrow.Schema, 
 	}
 
 	return bldr.NewRecordBatch()
+}
+
+func (s *FanoutWriterTestSuite) createLargeTestRecord(arrSchema *arrow.Schema, rows int, idOffset int64, payloadSize int) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(s.mem, arrSchema)
+	defer bldr.Release()
+
+	payload := strings.Repeat("p", payloadSize)
+	for i := range rows {
+		bldr.Field(0).(*array.Int64Builder).Append(idOffset + int64(i))
+		bldr.Field(1).(*array.StringBuilder).Append(payload)
+	}
+
+	return bldr.NewRecordBatch()
+}
+
+func (s *FanoutWriterTestSuite) TestCloseAllFlushesAfterFanoutSuccessContextCancel() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "payload", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+
+	icebergSchema, err := ArrowSchemaToIcebergWithFreshIDs(arrSchema, false)
+	s.Require().NoError(err)
+
+	sortOrder, err := NewSortOrder(1, []SortField{{
+		SourceIDs: []int{icebergSchema.Fields()[0].ID},
+		Direction: SortASC,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: NullsFirst,
+	}})
+	s.Require().NoError(err)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{icebergSchema.Fields()[0].ID},
+		FieldID:   1000,
+		Transform: iceberg.BucketTransform{NumBuckets: 1},
+		Name:      "id_bucket",
+	})
+	meta, err := NewMetadata(icebergSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	s.Require().NoError(err)
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	s.Require().NoError(err)
+	s.Require().NoError(metaBuilder.AddSortOrder(&sortOrder))
+	s.Require().NoError(metaBuilder.SetDefaultSortOrderID(-1))
+
+	const totalRows = 10000
+	record := s.createLargeTestRecord(arrSchema, totalRows, 0, 512)
+	defer record.Release()
+
+	itr := func(yield func(arrow.RecordBatch, error) bool) {
+		yield(record, nil)
+	}
+
+	writeUUID := uuid.New()
+	factory, err := newWriterFactory(loc, recordWritingArgs{
+		sc:        arrSchema,
+		itr:       itr,
+		fs:        iceio.LocalFS{},
+		writeUUID: &writeUUID,
+		counter: func(yield func(int) bool) {
+			for i := 0; ; i++ {
+				if !yield(i) {
+					break
+				}
+			}
+		},
+	}, metaBuilder, icebergSchema, 1024*1024*256)
+	s.Require().NoError(err)
+	defer factory.closeAll()
+
+	partitionedWriter := newPartitionedFanoutWriter(spec, icebergSchema, itr, factory)
+
+	dataFiles := partitionedWriter.Write(s.ctx, 1)
+	type result struct {
+		total int64
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		var total int64
+		for dataFile, iterErr := range dataFiles {
+			if iterErr != nil {
+				resultCh <- result{err: iterErr}
+				return
+			}
+			total += dataFile.Count()
+		}
+		resultCh <- result{total: total}
+	}()
+
+	var sum result
+	sum = <-resultCh
+	s.Require().NoError(sum.err)
+	s.Equal(int64(totalRows), sum.total)
 }
 
 func (s *FanoutWriterTestSuite) testTransformPartition(transform iceberg.Transform, sourceFieldName string, transformName string, testRecord arrow.RecordBatch, expectedPartitionCount int) {

--- a/table/pos_delete_partitioned_fanout_writer.go
+++ b/table/pos_delete_partitioned_fanout_writer.go
@@ -56,19 +56,20 @@ func (p *positionDeletePartitionedFanoutWriter) Write(ctx context.Context, worke
 	inputRecordsCh := make(chan arrow.RecordBatch, workers)
 	outputDataFilesCh := make(chan iceberg.DataFile, workers)
 
-	fanoutWorkers, ctx := errgroup.WithContext(ctx)
-	startRecordFeeder(ctx, p.itr, fanoutWorkers, inputRecordsCh)
+	fanoutWorkers, fanoutCtx := errgroup.WithContext(ctx)
+	writerCtx, writerCancel := context.WithCancel(ctx)
+	startRecordFeeder(fanoutCtx, p.itr, fanoutWorkers, inputRecordsCh)
 
 	for range workers {
 		fanoutWorkers.Go(func() error {
-			return p.fanout(ctx, inputRecordsCh, outputDataFilesCh)
+			return p.fanout(fanoutCtx, writerCtx, inputRecordsCh, outputDataFilesCh)
 		})
 	}
 
-	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh)
+	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh, writerCancel)
 }
 
-func (p *positionDeletePartitionedFanoutWriter) fanout(ctx context.Context, inputRecordsCh <-chan arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
+func (p *positionDeletePartitionedFanoutWriter) fanout(ctx context.Context, writerCtx context.Context, inputRecordsCh <-chan arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -79,7 +80,7 @@ func (p *positionDeletePartitionedFanoutWriter) fanout(ctx context.Context, inpu
 				return nil
 			}
 
-			err := p.processBatch(ctx, record, dataFilesChannel)
+			err := p.processBatch(ctx, writerCtx, record, dataFilesChannel)
 			if err != nil {
 				return err
 			}
@@ -87,7 +88,7 @@ func (p *positionDeletePartitionedFanoutWriter) fanout(ctx context.Context, inpu
 	}
 }
 
-func (p *positionDeletePartitionedFanoutWriter) processBatch(ctx context.Context, batch arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) (err error) {
+func (p *positionDeletePartitionedFanoutWriter) processBatch(ctx context.Context, writerCtx context.Context, batch arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) (err error) {
 	defer batch.Release()
 
 	select {
@@ -112,7 +113,7 @@ func (p *positionDeletePartitionedFanoutWriter) processBatch(ctx context.Context
 	if err != nil {
 		return err
 	}
-	rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(ctx, partitionPath, partitionContext.partitionData, dataFilesChannel)
+	rollingDataWriter, err := p.writerFactory.getOrCreateRollingDataWriter(writerCtx, partitionPath, partitionContext.partitionData, dataFilesChannel)
 	if err != nil {
 		return err
 	}
@@ -142,6 +143,13 @@ func (p *positionDeletePartitionedFanoutWriter) partitionPath(partitionContext p
 	return spec.PartitionToPath(data, schema), nil
 }
 
-func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile) iter.Seq2[iceberg.DataFile, error] {
-	return yieldDataFiles(p.writerFactory, fanoutWorkers, outputDataFilesCh)
+func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+	return yieldDataFiles(
+		p.writerFactory,
+		fanoutWorkers,
+		outputDataFilesCh,
+		p.writerFactory.closeAll,
+		p.writerFactory.abortAll,
+		writerCancel,
+	)
 }

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -140,7 +140,7 @@ func TestPositionDeletePartitionedFanoutWriterProcessBatch(t *testing.T) {
 			writer := newPositionDeletePartitionedFanoutWriter(latestMeta, tc.pathToPartitionContext, nil, factory)
 
 			dataFileCh := make(chan iceberg.DataFile, 10)
-			err = writer.processBatch(ctx, tc.input, dataFileCh)
+			err = writer.processBatch(ctx, ctx, tc.input, dataFileCh)
 			if tc.expectedErr != nil {
 				require.ErrorContains(t, err, tc.expectedErr.Error())
 
@@ -379,8 +379,8 @@ func TestPositionDeletePartitionedFanoutWriterRoutesPartitionsIndependently(t *t
 	batchB := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema,
 		fmt.Sprintf(`[{"file_path": %q, "pos": 5}]`, pathB))
 
-	require.NoError(t, writer.processBatch(t.Context(), batchA, dataFileCh))
-	require.NoError(t, writer.processBatch(t.Context(), batchB, dataFileCh))
+	require.NoError(t, writer.processBatch(t.Context(), t.Context(), batchA, dataFileCh))
+	require.NoError(t, writer.processBatch(t.Context(), t.Context(), batchB, dataFileCh))
 	require.NoError(t, factory.closeAll())
 	close(dataFileCh)
 

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -275,6 +275,7 @@ type RollingDataWriter struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
 	wg              sync.WaitGroup
+	closeRecordCh   sync.Once
 }
 
 func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) *RollingDataWriter {
@@ -450,13 +451,22 @@ func (r *RollingDataWriter) sendError(err error) {
 	}
 }
 
-func (r *RollingDataWriter) close() {
+// closeInput gracefully closes the record channel so any queued writes can still be
+// processed while honoring context cancellation checks in the stream.
+func (r *RollingDataWriter) closeInput() {
+	r.closeRecordCh.Do(func() {
+		close(r.recordCh)
+	})
+}
+
+// abort cancels in-flight work and then closes input so the stream can exit.
+func (r *RollingDataWriter) abort() {
 	r.cancel()
-	close(r.recordCh)
+	r.closeInput()
 }
 
 func (r *RollingDataWriter) closeAndWait() error {
-	r.close()
+	r.closeInput()
 	r.factory.writers.Delete(r.partitionKey)
 	r.wg.Wait()
 
@@ -465,6 +475,12 @@ func (r *RollingDataWriter) closeAndWait() error {
 	}
 
 	return nil
+}
+
+func (r *RollingDataWriter) abortAndWait() {
+	r.abort()
+	r.factory.writers.Delete(r.partitionKey)
+	r.wg.Wait()
 }
 
 func (w *writerFactory) closeAll() error {

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -471,8 +471,12 @@ func (r *RollingDataWriter) closeAndWait() error {
 	r.wg.Wait()
 
 	if err := <-r.errorCh; err != nil {
+		r.cancel()
+
 		return fmt.Errorf("error in rolling data writer: %w", err)
 	}
+
+	r.cancel()
 
 	return nil
 }
@@ -485,7 +489,26 @@ func (r *RollingDataWriter) abortAndWait() {
 
 func (w *writerFactory) closeAll() error {
 	defer w.stopCount()
-	var writers []*RollingDataWriter
+	writers := w.writerList()
+	var err error
+	for _, writer := range writers {
+		if closeErr := writer.closeAndWait(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}
+
+	return err
+}
+
+func (w *writerFactory) abortAll() {
+	defer w.stopCount()
+	writers := w.writerList()
+	for _, writer := range writers {
+		writer.abortAndWait()
+	}
+}
+
+func (w *writerFactory) writerList() (writers []*RollingDataWriter) {
 	w.writers.Range(func(key, value any) bool {
 		writer, ok := value.(*RollingDataWriter)
 		if ok {
@@ -495,12 +518,5 @@ func (w *writerFactory) closeAll() error {
 		return true
 	})
 
-	var err error
-	for _, writer := range writers {
-		if closeErr := writer.closeAndWait(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}
-
-	return err
+	return
 }

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -234,6 +234,67 @@ func (s *RollingDataWriterTestSuite) TestNewWriterFactoryReturnsErrorForInvalidF
 	s.ErrorContains(err, "withFactoryFileSchema")
 }
 
+func (s *RollingDataWriterTestSuite) TestCloseAllFinishesQueuedRecordsWithoutCancellingContext() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writerCtx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	writer, err := factory.getOrCreateRollingDataWriter(writerCtx, "", nil, outputCh)
+	s.Require().NoError(err)
+	const totalBatches = 4
+	const rowsPerBatch = 25
+	var expectedRows int64
+	for range totalBatches {
+		record := s.buildRecord(arrSchema, rowsPerBatch)
+		expectedRows += record.NumRows()
+		s.Require().NoError(writer.Add(record))
+		record.Release()
+	}
+
+	s.Require().NoError(factory.closeAll())
+	s.Require().Nil(writerCtx.Err(), "normal close should finish queued writes without aborting context")
+
+	close(outputCh)
+	var actualRows int64
+	for df := range outputCh {
+		actualRows += df.Count()
+	}
+
+	s.Equal(expectedRows, actualRows, "all queued records should be flushed when closeAll is used")
+}
+
+func (s *RollingDataWriterTestSuite) TestAbortAndWaitCancelsContext() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+	defer factory.closeAll()
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	writerCtx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	writer, err := factory.getOrCreateRollingDataWriter(writerCtx, "", nil, outputCh)
+	s.Require().NoError(err)
+	record := s.buildRecord(arrSchema, 5)
+	s.Require().NoError(writer.Add(record))
+	record.Release()
+
+	writer.abortAndWait()
+	s.Require().ErrorIs(writer.ctx.Err(), context.Canceled)
+}
+
 func (s *RollingDataWriterTestSuite) TestBytesWrittenNoDoubleCountAcrossRowGroups() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},


### PR DESCRIPTION
## Summary
- Split rolling-data writer lifecycle into graceful close and abort paths.
- Graceful close now only closes writer input (no context cancellation), while abort cancels context and closes input.
- fanout writers now use a decoupled context for coordination so `errgroup.Wait()` does not cancel post-success draining.
- writerFactory.closeAll uses graceful close so normal completion can flush queued records.
- Unpartitioned write error paths now use abort path; success path now uses `closeAndWait` for consistent lifecycle behavior.
- Added regression tests for normal close flushing, context-cancel fanout regression, and abort cancellation behavior.

## Testing
- `go test ./table -count=1`