### PR TITLE
fix(rest): accept oauth2-server-uri for the OAuth token endpoint

### DIFF
--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -103,6 +103,10 @@ func WithSigV4RegionSvc(region, service string) Option {
 	}
 }
 
+// WithAuthURI sets the OAuth2 token endpoint (oauth2-server-uri). When not set,
+// the client falls back to {catalog}/v1/oauth/tokens. This is the programmatic
+// equivalent of the oauth2-server-uri property (or its rest.authorization-url
+// alias).
 func WithAuthURI(uri *url.URL) Option {
 	return func(o *options) {
 		o.authUri = uri

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -593,11 +593,12 @@ func toProps(o *options) iceberg.Properties {
 
 	setIf(keyPrefix, o.prefix)
 	if o.authUri != nil {
-		// Advertise the endpoint under the portable oauth2-server-uri key while
-		// also retaining the legacy rest.authorization-url alias, so existing
-		// consumers that read the properties back keep working.
+		// Advertise the endpoint only under the portable oauth2-server-uri key.
+		// We canonicalize to this key everywhere else (fromProps precedence,
+		// resolveAuthURLAlias), so emitting the legacy rest.authorization-url
+		// alias too would leave the endpoint under two names in r.props and any
+		// table config cloned from it - two sources of truth that can drift.
 		setIf(keyOAuth2ServerURI, o.authUri.String())
-		setIf(keyAuthUrl, o.authUri.String())
 	}
 
 	return props

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -476,15 +476,15 @@ func fromProps(props iceberg.Properties, o *options) error {
 		case keyRestSigV4Service:
 			o.sigv4Service = v
 		case keyAuthUrl:
-			u, err := parseAuthURL(v)
+			u, err := parseAuthURL(keyAuthUrl, v)
 			if err != nil {
 				return err
 			}
 			authURL = u
 		case keyOAuth2ServerURI:
-			u, err := url.Parse(v)
+			u, err := parseAuthURL(keyOAuth2ServerURI, v)
 			if err != nil {
-				return fmt.Errorf("invalid %s %q: %w", keyOAuth2ServerURI, v, err)
+				return err
 			}
 			oauth2ServerURI = u
 		case keyOauthCredential:
@@ -529,16 +529,16 @@ func fromProps(props iceberg.Properties, o *options) error {
 	return nil
 }
 
-func parseAuthURL(raw string) (*url.URL, error) {
+func parseAuthURL(key, raw string) (*url.URL, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return nil, fmt.Errorf("invalid %s %q: %w", keyAuthUrl, raw, err)
+		return nil, fmt.Errorf("invalid %s %q: %w", key, raw, err)
 	}
 	if u.Scheme == "" {
-		return nil, fmt.Errorf("invalid %s %q: missing scheme", keyAuthUrl, raw)
+		return nil, fmt.Errorf("invalid %s %q: missing scheme", key, raw)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("invalid %s %q: missing host", keyAuthUrl, raw)
+		return nil, fmt.Errorf("invalid %s %q: missing host", key, raw)
 	}
 
 	return u, nil
@@ -577,8 +577,11 @@ func toProps(o *options) iceberg.Properties {
 
 	setIf(keyPrefix, o.prefix)
 	if o.authUri != nil {
-		// Serialize under the portable oauth2-server-uri key.
+		// Advertise the endpoint under the portable oauth2-server-uri key while
+		// also retaining the legacy rest.authorization-url alias, so existing
+		// consumers that read the properties back keep working.
 		setIf(keyOAuth2ServerURI, o.authUri.String())
+		setIf(keyAuthUrl, o.authUri.String())
 	}
 
 	return props

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -529,6 +529,22 @@ func fromProps(props iceberg.Properties, o *options) error {
 	return nil
 }
 
+// resolveAuthURLAlias collapses the oauth2-server-uri / rest.authorization-url
+// alias within a single configuration layer into the canonical
+// oauth2-server-uri key. oauth2-server-uri wins over the rest.authorization-url
+// alias within the same layer. Collapsing per layer before merging keeps
+// defaults -> client -> overrides precedence intact.
+func resolveAuthURLAlias(props iceberg.Properties) {
+	v, ok := props[keyOAuth2ServerURI]
+	if !ok {
+		v, ok = props[keyAuthUrl]
+	}
+	delete(props, keyAuthUrl)
+	if ok {
+		props[keyOAuth2ServerURI] = v
+	}
+}
+
 func parseAuthURL(key, raw string) (*url.URL, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -810,7 +826,17 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*http.Client,
 	if cfg == nil {
 		cfg = iceberg.Properties{}
 	}
-	maps.Copy(cfg, toProps(opts))
+
+	// Collapse the oauth2-server-uri / rest.authorization-url alias within each
+	// layer before merging so the defaults -> client -> overrides precedence is
+	// preserved. Merging first would leave both keys in the map, letting a
+	// client oauth2-server-uri shadow a server rest.authorization-url override.
+	clientProps := toProps(opts)
+	resolveAuthURLAlias(cfg)
+	resolveAuthURLAlias(clientProps)
+	resolveAuthURLAlias(rsp.Overrides)
+
+	maps.Copy(cfg, clientProps)
 	maps.Copy(cfg, rsp.Overrides)
 
 	r.namespaceSeparator = cfg.Get(keyNamespaceSeparator, defaultNamespaceSeparator)

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -81,7 +81,12 @@ const (
 	keyRestSigV4Region  = "rest.signing-region"
 	keyRestSigV4Service = "rest.signing-name"
 	keyAuthUrl          = "rest.authorization-url"
-	keyTlsSkipVerify    = "rest.tls.skip-verify"
+	// keyOAuth2ServerURI is the portable, spec-aligned property for the OAuth2
+	// token endpoint used by Java, PyIceberg and iceberg-rust. It is the
+	// preferred key; keyAuthUrl is retained as a compatibility alias. When both
+	// are set, oauth2-server-uri takes precedence.
+	keyOAuth2ServerURI = "oauth2-server-uri"
+	keyTlsSkipVerify   = "rest.tls.skip-verify"
 
 	keyViewEndpointsSupported = "view-endpoints-supported"
 )
@@ -449,6 +454,11 @@ func handleNon200(rsp *http.Response, override map[int]error) error {
 }
 
 func fromProps(props iceberg.Properties, o *options) error {
+	// The OAuth token endpoint may be configured via either the portable
+	// oauth2-server-uri key or the legacy rest.authorization-url alias. Capture
+	// both and resolve precedence after the loop, since map iteration order is
+	// non-deterministic.
+	var authURL, oauth2ServerURI *url.URL
 	for k, v := range props {
 		switch k {
 		case keyOauthToken:
@@ -470,7 +480,13 @@ func fromProps(props iceberg.Properties, o *options) error {
 			if err != nil {
 				return err
 			}
-			o.authUri = u
+			authURL = u
+		case keyOAuth2ServerURI:
+			u, err := url.Parse(v)
+			if err != nil {
+				return fmt.Errorf("invalid %s %q: %w", keyOAuth2ServerURI, v, err)
+			}
+			oauth2ServerURI = u
 		case keyOauthCredential:
 			o.credential = v
 		case keyScope:
@@ -499,6 +515,15 @@ func fromProps(props iceberg.Properties, o *options) error {
 				o.additionalProps[k] = v
 			}
 		}
+	}
+
+	// oauth2-server-uri is the portable, preferred key and takes precedence over
+	// the rest.authorization-url alias when both are set.
+	switch {
+	case oauth2ServerURI != nil:
+		o.authUri = oauth2ServerURI
+	case authURL != nil:
+		o.authUri = authURL
 	}
 
 	return nil
@@ -552,7 +577,8 @@ func toProps(o *options) iceberg.Properties {
 
 	setIf(keyPrefix, o.prefix)
 	if o.authUri != nil {
-		setIf(keyAuthUrl, o.authUri.String())
+		// Serialize under the portable oauth2-server-uri key.
+		setIf(keyOAuth2ServerURI, o.authUri.String())
 	}
 
 	return props

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1447,6 +1447,43 @@ func TestFetchConfigTokenOverrideKeepsCallerToken(t *testing.T) {
 	assert.Equal(t, "caller-token", cat.props[keyOauthToken])
 }
 
+func TestFetchConfigAuthURLOverridePrecedence(t *testing.T) {
+	t.Parallel()
+
+	const overrideAuthURL = "https://override.example.com/token"
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{},
+			// The server overrides the token endpoint via the legacy alias while
+			// the client supplied oauth2-server-uri; the override must win.
+			"overrides": map[string]any{
+				keyAuthUrl: overrideAuthURL,
+			},
+			"endpoints": AllEndpointStrings,
+		})
+	})
+
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL,
+		WithAuthURI(mustParseURL(t, "https://client.example.com/token")))
+	require.NoError(t, err)
+
+	assert.Equal(t, overrideAuthURL, cat.props[keyOAuth2ServerURI])
+	assert.Equal(t, overrideAuthURL, cat.props[keyAuthUrl])
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
+}
+
 func TestEncodeNamespace(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -251,6 +251,88 @@ func TestNewCatalogAcceptsValidAuthURLFromConfig(t *testing.T) {
 	assert.Equal(t, authURL, cat.props[keyAuthUrl])
 }
 
+func TestOAuthServerURIProps(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serverURI = "https://auth.example.com/oauth/tokens"
+		authURL   = "https://legacy.example.com/v1/oauth/tokens"
+	)
+
+	t.Run("oauth2-server-uri configures the token endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		require.NoError(t, fromProps(iceberg.Properties{keyOAuth2ServerURI: serverURI}, &opts))
+		require.NotNil(t, opts.authUri)
+		assert.Equal(t, serverURI, opts.authUri.String())
+	})
+
+	t.Run("rest.authorization-url still works as an alias", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		require.NoError(t, fromProps(iceberg.Properties{keyAuthUrl: authURL}, &opts))
+		require.NotNil(t, opts.authUri)
+		assert.Equal(t, authURL, opts.authUri.String())
+	})
+
+	t.Run("oauth2-server-uri takes precedence when both are set", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		require.NoError(t, fromProps(iceberg.Properties{
+			keyAuthUrl:         authURL,
+			keyOAuth2ServerURI: serverURI,
+		}, &opts))
+		require.NotNil(t, opts.authUri)
+		assert.Equal(t, serverURI, opts.authUri.String())
+	})
+
+	t.Run("neither key leaves the endpoint unset for fallback", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		require.NoError(t, fromProps(iceberg.Properties{}, &opts))
+		assert.Nil(t, opts.authUri)
+	})
+
+	t.Run("neither key is retained as an additional prop", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		require.NoError(t, fromProps(iceberg.Properties{
+			keyAuthUrl:         authURL,
+			keyOAuth2ServerURI: serverURI,
+		}, &opts))
+		_, hasAuthURL := opts.additionalProps[keyAuthUrl]
+		_, hasServerURI := opts.additionalProps[keyOAuth2ServerURI]
+		assert.False(t, hasAuthURL)
+		assert.False(t, hasServerURI)
+	})
+
+	t.Run("invalid oauth2-server-uri is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		var opts options
+		err := fromProps(iceberg.Properties{keyOAuth2ServerURI: "http://[::1"}, &opts)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid oauth2-server-uri")
+	})
+
+	t.Run("toProps serializes under the portable oauth2-server-uri key", func(t *testing.T) {
+		t.Parallel()
+
+		u, err := url.Parse(serverURI)
+		require.NoError(t, err)
+
+		props := toProps(&options{authUri: u})
+		assert.Equal(t, serverURI, props[keyOAuth2ServerURI])
+		_, hasAuthURL := props[keyAuthUrl]
+		assert.False(t, hasAuthURL)
+	})
+}
+
 func TestTokenAuthenticationPriority(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -189,7 +189,7 @@ func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
 			name:    "malformed URL in defaults",
 			section: "defaults",
 			authURL: "http://[::1",
-			wantErr: "invalid rest.authorization-url",
+			wantErr: "invalid oauth2-server-uri",
 		},
 		{
 			name:    "scheme-less URL in overrides",

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -173,7 +173,7 @@ func TestLoadRegisteredCatalogAcceptsValidAuthURL(t *testing.T) {
 
 	restCat, ok := cat.(*Catalog)
 	require.True(t, ok)
-	assert.Equal(t, authURL, restCat.props[keyAuthUrl])
+	assert.Equal(t, authURL, restCat.props[keyOAuth2ServerURI])
 }
 
 func TestNewCatalogRejectsInvalidAuthURLFromConfig(t *testing.T) {
@@ -248,7 +248,7 @@ func TestNewCatalogAcceptsValidAuthURLFromConfig(t *testing.T) {
 
 	cat, err := NewCatalog(context.Background(), "rest", srv.URL)
 	require.NoError(t, err)
-	assert.Equal(t, authURL, cat.props[keyAuthUrl])
+	assert.Equal(t, authURL, cat.props[keyOAuth2ServerURI])
 }
 
 func TestOAuthServerURIProps(t *testing.T) {
@@ -342,9 +342,10 @@ func TestOAuthServerURIProps(t *testing.T) {
 
 		props := toProps(&options{authUri: u})
 		assert.Equal(t, serverURI, props[keyOAuth2ServerURI])
-		// The legacy rest.authorization-url alias is retained for backward
-		// compatibility with consumers that read the properties back.
-		assert.Equal(t, serverURI, props[keyAuthUrl])
+		// Only the portable key is emitted; the legacy rest.authorization-url
+		// alias is not, to avoid carrying the endpoint under two names.
+		_, hasLegacy := props[keyAuthUrl]
+		assert.False(t, hasLegacy)
 	})
 }
 
@@ -1473,7 +1474,8 @@ func TestFetchConfigAuthURLOverridePrecedence(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, overrideAuthURL, cat.props[keyOAuth2ServerURI])
-	assert.Equal(t, overrideAuthURL, cat.props[keyAuthUrl])
+	_, hasLegacy := cat.props[keyAuthUrl]
+	assert.False(t, hasLegacy)
 }
 
 func mustParseURL(t *testing.T, raw string) *url.URL {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -314,10 +314,24 @@ func TestOAuthServerURIProps(t *testing.T) {
 	t.Run("invalid oauth2-server-uri is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		var opts options
-		err := fromProps(iceberg.Properties{keyOAuth2ServerURI: "http://[::1"}, &opts)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "invalid oauth2-server-uri")
+		for _, tt := range []struct {
+			name    string
+			uri     string
+			wantErr string
+		}{
+			{"malformed URL", "http://[::1", "invalid oauth2-server-uri"},
+			{"missing scheme", "auth.example.com/token", "missing scheme"},
+			{"missing host", "https://", "missing host"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				var opts options
+				err := fromProps(iceberg.Properties{keyOAuth2ServerURI: tt.uri}, &opts)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+			})
+		}
 	})
 
 	t.Run("toProps serializes under the portable oauth2-server-uri key", func(t *testing.T) {
@@ -328,8 +342,9 @@ func TestOAuthServerURIProps(t *testing.T) {
 
 		props := toProps(&options{authUri: u})
 		assert.Equal(t, serverURI, props[keyOAuth2ServerURI])
-		_, hasAuthURL := props[keyAuthUrl]
-		assert.False(t, hasAuthURL)
+		// The legacy rest.authorization-url alias is retained for backward
+		// compatibility with consumers that read the properties back.
+		assert.Equal(t, serverURI, props[keyAuthUrl])
 	})
 }
 


### PR DESCRIPTION
Read the portable oauth2-server-uri property used by Java, PyIceberg and iceberg-rust as the OAuth2 token endpoint, so a catalog config that works in those clients also configures iceberg-go. The existing rest.authorization-url key is kept as a compatibility alias, and oauth2-server-uri takes precedence when both are set. toProps now serializes the endpoint under the portable key.

Closes #1346