### PR TITLE
feat(table): emit geo bounds in manifest DataFile

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -170,7 +170,9 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 		err := v.UnmarshalBinary(data)
 
 		return v, err
-	case BinaryType:
+	case BinaryType, GeometryType, GeographyType:
+		// Geometry and Geography bounds are stored as WKB byte payloads
+		// (single-point bounds), handled as opaque binary on read.
 		var v BinaryLiteral
 		err := v.UnmarshalBinary(data)
 

--- a/literals.go
+++ b/literals.go
@@ -170,9 +170,23 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 		err := v.UnmarshalBinary(data)
 
 		return v, err
-	case BinaryType, GeometryType, GeographyType:
-		// Geometry and Geography bounds are stored as WKB byte payloads
-		// (single-point bounds), handled as opaque binary on read.
+	case BinaryType:
+		var v BinaryLiteral
+		err := v.UnmarshalBinary(data)
+
+		return v, err
+	case GeometryType, GeographyType:
+		// Geometry/Geography single-value bounds use the Iceberg geospatial
+		// serialization (spec Appendix D): little-endian float64 coordinates in
+		// X, Y[, Z][, M] order, i.e. 16, 24, or 32 bytes — not WKB. iceberg-go
+		// has no geo literal for predicate evaluation, so the validated
+		// coordinate bytes are returned as an opaque BinaryLiteral.
+		switch len(data) {
+		case 16, 24, 32:
+		default:
+			return nil, fmt.Errorf("%w: geometry/geography bound must be 16, 24, or 32 bytes, got %d",
+				ErrInvalidBinSerialization, len(data))
+		}
 		var v BinaryLiteral
 		err := v.UnmarshalBinary(data)
 

--- a/literals.go
+++ b/literals.go
@@ -178,21 +178,19 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 	case GeometryType, GeographyType:
 		// Geometry/Geography single-value bounds use the Iceberg geospatial
 		// serialization (spec Appendix D): little-endian float64 coordinates in
-		// X, Y[, Z][, M] order, i.e. 16, 24, or 32 bytes — not WKB. iceberg-go
-		// has no geo literal for predicate evaluation, so the validated
-		// coordinate bytes are returned as an opaque BinaryLiteral. Callers doing
-		// geo pruning must not treat this as a plain binary bound: check the
-		// original type first, as the bytes are coordinates, not comparable binary.
+		// X, Y[, Z][, M] order, i.e. 16, 24, or 32 bytes — not WKB. The
+		// coordinates have no total order, so they are returned as a GeoLiteral
+		// (not a plain BinaryLiteral): it reports the real geo type and is not
+		// comparable, so any attempt to order it errors instead of silently
+		// running bytes.Compare over the coordinate bytes.
 		switch len(data) {
-		case 16, 24, 32: // valid coordinate lengths (XY / XYZ|XYM / XYZM), fall through
+		case 16, 24, 32: // valid coordinate lengths (XY / XYZ|XYM / XYZM)
 		default:
 			return nil, fmt.Errorf("%w: geometry/geography bound must be 16, 24, or 32 bytes, got %d",
 				ErrInvalidBinSerialization, len(data))
 		}
-		var v BinaryLiteral
-		err := v.UnmarshalBinary(data)
 
-		return v, err
+		return GeoLiteral{val: data, typ: typ}, nil
 	case FixedType:
 		if len(data) != t.Len() {
 			// looks like some writers will write a prefix of the fixed length
@@ -1131,6 +1129,51 @@ func (b *BinaryLiteral) UnmarshalBinary(data []byte) error {
 	*b = BinaryLiteral(data)
 
 	return nil
+}
+
+// GeoLiteral is a non-null geometry or geography single-value bound. Iceberg
+// serializes geospatial bounds as the concatenation of little-endian float64
+// coordinates in X, Y[, Z][, M] order (spec Appendix D), not as WKB. Those
+// coordinates have no total order, so - unlike every other literal - GeoLiteral
+// is deliberately not a TypedLiteral: it exposes no Comparator and refuses to be
+// cast to an orderable type. That keeps ordering-based pruning from silently
+// running bytes.Compare over coordinate bytes (which would yield wrong answers)
+// and makes it error instead. Type() reports the concrete GeometryType or
+// GeographyType, so callers that key off the literal's own type - pruning, To,
+// logging - see the truth rather than plain binary.
+type GeoLiteral struct {
+	val []byte
+	typ Type
+}
+
+func (g GeoLiteral) Type() Type    { return g.typ }
+func (g GeoLiteral) Value() []byte { return g.val }
+func (g GeoLiteral) Any() any      { return g.val }
+func (g GeoLiteral) String() string {
+	return fmt.Sprintf("%s(%x)", g.typ, g.val)
+}
+
+func (g GeoLiteral) To(typ Type) (Literal, error) {
+	// Only an identity cast is meaningful. Casting to any orderable type is
+	// rejected so a geo bound can never be smuggled into a comparison.
+	if g.typ.Equals(typ) {
+		return g, nil
+	}
+
+	return nil, fmt.Errorf("%w: GeoLiteral to %s", ErrBadCast, typ)
+}
+
+func (g GeoLiteral) Equals(other Literal) bool {
+	rhs, ok := other.(GeoLiteral)
+	if !ok {
+		return false
+	}
+
+	return g.typ.Equals(rhs.typ) && bytes.Equal(g.val, rhs.val)
+}
+
+func (g GeoLiteral) MarshalBinary() ([]byte, error) {
+	return g.val, nil
 }
 
 type FixedLiteral []byte

--- a/literals.go
+++ b/literals.go
@@ -180,9 +180,11 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 		// serialization (spec Appendix D): little-endian float64 coordinates in
 		// X, Y[, Z][, M] order, i.e. 16, 24, or 32 bytes — not WKB. iceberg-go
 		// has no geo literal for predicate evaluation, so the validated
-		// coordinate bytes are returned as an opaque BinaryLiteral.
+		// coordinate bytes are returned as an opaque BinaryLiteral. Callers doing
+		// geo pruning must not treat this as a plain binary bound: check the
+		// original type first, as the bytes are coordinates, not comparable binary.
 		switch len(data) {
-		case 16, 24, 32:
+		case 16, 24, 32: // valid coordinate lengths (XY / XYZ|XYM / XYZM), fall through
 		default:
 			return nil, fmt.Errorf("%w: geometry/geography bound must be 16, 24, or 32 bytes, got %d",
 				ErrInvalidBinSerialization, len(data))

--- a/literals_test.go
+++ b/literals_test.go
@@ -18,6 +18,7 @@
 package iceberg_test
 
 import (
+	"encoding/binary"
 	"math"
 	"strconv"
 	"testing"
@@ -602,6 +603,92 @@ func TestVariantLiteralFromBytes(t *testing.T) {
 	_, err := iceberg.LiteralFromBytes(iceberg.VariantType{}, []byte{0x01, 0x00, 0x00})
 	assert.ErrorIs(t, err, iceberg.ErrType)
 	assert.ErrorContains(t, err, "variant")
+}
+
+// geoCoords encodes coordinate values as little-endian float64s, matching the
+// Iceberg geospatial single-value bound serialization (spec Appendix D).
+func geoCoords(vals ...float64) []byte {
+	b := make([]byte, 0, len(vals)*8)
+	for _, v := range vals {
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(v))
+		b = append(b, buf[:]...)
+	}
+
+	return b
+}
+
+func TestGeoLiteralFromBytes(t *testing.T) {
+	geom, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+
+	xy := geoCoords(1.5, 2.5)
+	lit, err := iceberg.LiteralFromBytes(geom, xy)
+	require.NoError(t, err)
+
+	// Type() must report the real geo type, not plain binary, so callers that
+	// key off the literal's own type don't misroute it.
+	assert.True(t, geom.Equals(lit.Type()), "got %s", lit.Type())
+	assert.False(t, iceberg.PrimitiveTypes.Binary.Equals(lit.Type()))
+
+	g, ok := lit.(iceberg.GeoLiteral)
+	require.True(t, ok, "expected GeoLiteral, got %T", lit)
+	assert.Equal(t, xy, g.Value())
+
+	// A geo literal is deliberately not orderable: it must not satisfy the
+	// []byte TypedLiteral that the pruning comparators dispatch on.
+	_, isComparable := lit.(iceberg.TypedLiteral[[]byte])
+	assert.False(t, isComparable, "GeoLiteral must not expose a []byte Comparator")
+}
+
+func TestGeoLiteralToRejectsOrdering(t *testing.T) {
+	geom, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+
+	lit, err := iceberg.LiteralFromBytes(geom, geoCoords(1, 2))
+	require.NoError(t, err)
+
+	// Identity cast is allowed; casting to anything orderable must fail so a
+	// geo bound can never be smuggled into a comparison.
+	same, err := lit.To(geom)
+	require.NoError(t, err)
+	assert.True(t, lit.Equals(same))
+
+	_, err = lit.To(iceberg.PrimitiveTypes.Binary)
+	assert.ErrorIs(t, err, iceberg.ErrBadCast)
+}
+
+func TestGeoLiteralFromBytesInvalidLength(t *testing.T) {
+	geom, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+
+	// 8 bytes is a single coordinate; a valid bound needs at least X and Y.
+	_, err = iceberg.LiteralFromBytes(geom, geoCoords(1))
+	assert.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)
+}
+
+func TestGeoLiteralEquals(t *testing.T) {
+	geom, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+	geog, err := iceberg.GeographyTypeOf("srid:4326", "karney")
+	require.NoError(t, err)
+
+	xy := geoCoords(1, 2)
+	a, err := iceberg.LiteralFromBytes(geom, xy)
+	require.NoError(t, err)
+	b, err := iceberg.LiteralFromBytes(geom, xy)
+	require.NoError(t, err)
+	assert.True(t, a.Equals(b))
+
+	// Same coordinate bytes but a different geo type are not equal.
+	c, err := iceberg.LiteralFromBytes(geog, xy)
+	require.NoError(t, err)
+	assert.False(t, a.Equals(c))
+
+	// Different coordinates are not equal.
+	d, err := iceberg.LiteralFromBytes(geom, geoCoords(3, 4))
+	require.NoError(t, err)
+	assert.False(t, a.Equals(d))
 }
 
 func TestVariantLiteralLargeArray(t *testing.T) {

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -306,6 +306,13 @@ func getCmpLiteral(boundary iceberg.Literal) func(iceberg.Literal, iceberg.Liter
 		return getCmp(l)
 	case iceberg.TypedLiteral[iceberg.Decimal]:
 		return getCmp(l)
+	case iceberg.GeoLiteral:
+		// Geometry/Geography bounds are coordinate tuples with no total order,
+		// so they must never reach an ordering comparison. Reject explicitly
+		// instead of falling through to the generic type panic, so the failure
+		// names the real cause if a geo term is ever routed here.
+		panic(fmt.Errorf("%w: geometry/geography has no ordering, cannot compare %s bounds",
+			iceberg.ErrType, boundary.Type()))
 	}
 	panic(iceberg.ErrType)
 }

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -2992,6 +2993,22 @@ func TestEvaluators(t *testing.T) {
 	suite.Run(t, &ProjectionTestSuite{})
 	suite.Run(t, &InclusiveMetricsTestSuite{})
 	suite.Run(t, &StrictMetricsTestSuite{})
+}
+
+func TestGetCmpLiteralRejectsGeo(t *testing.T) {
+	// Little-endian float64 X,Y - a valid geospatial single-value bound that
+	// must never be routed into an ordering comparison.
+	coords := make([]byte, 16)
+	binary.LittleEndian.PutUint64(coords[0:8], math.Float64bits(1))
+	binary.LittleEndian.PutUint64(coords[8:16], math.Float64bits(2))
+
+	lit, err := iceberg.LiteralFromBytes(iceberg.GeometryType{}, coords)
+	require.NoError(t, err)
+
+	// getCmpLiteral must reject geo explicitly rather than silently comparing
+	// coordinate bytes with bytes.Compare.
+	assert.PanicsWithError(t, "type error: geometry/geography has no ordering, cannot compare geometry bounds",
+		func() { getCmpLiteral(lit) })
 }
 
 func TestLiteralToPhysBytes(t *testing.T) {

--- a/table/internal/geo_codec.go
+++ b/table/internal/geo_codec.go
@@ -53,6 +53,17 @@ type geoBoundsAccumulator struct {
 	max [geoNumDims]float64
 	has [geoNumDims]bool
 
+	// geoms counts the leaf geometries that contributed coordinates; zGeoms and
+	// mGeoms count how many of those carried a Z / M dimension. The has[] flags
+	// are sticky across rows, so a column mixing e.g. XYZ and XYM geometries
+	// would set both has[geoDimZ] and has[geoDimM] without any single row having
+	// both. An optional dimension is only safe to emit when every geometry
+	// carried it (count == geoms); otherwise the bound would imply rows that lack
+	// the dimension have a value in range. See layout.
+	geoms  int
+	zGeoms int
+	mGeoms int
+
 	// isGeography marks a column whose edges are geodesics on a sphere, for
 	// which raw vertex min/max is not a safe bounding box (see Bounds).
 	isGeography bool
@@ -94,6 +105,13 @@ func (a *geoBoundsAccumulator) extend(g geom.T) {
 
 	layout := g.Layout()
 	zIdx, mIdx := layout.ZIndex(), layout.MIndex()
+	a.geoms++
+	if zIdx >= 0 {
+		a.zGeoms++
+	}
+	if mIdx >= 0 {
+		a.mGeoms++
+	}
 	for base := 0; base+stride <= len(flat); base += stride {
 		a.update(geoDimX, flat[base])
 		a.update(geoDimY, flat[base+1])
@@ -134,12 +152,20 @@ func (a *geoBoundsAccumulator) layout() (geom.Layout, bool) {
 		return geom.NoLayout, false
 	}
 
+	// An optional dimension is only emitted when every geometry carried it and it
+	// saw a finite value. If Z or M is present in only some geometries (e.g. a
+	// mix of XYZ and XYM rows, or XYZM and XYZ rows), emitting it would imply the
+	// geometries that lack it have a value in range, driving wrong-answer pruning
+	// once a reader wires up geo pruning; drop it to the largest safe layout.
+	hasZ := a.has[geoDimZ] && a.zGeoms == a.geoms
+	hasM := a.has[geoDimM] && a.mGeoms == a.geoms
+
 	switch {
-	case a.has[geoDimZ] && a.has[geoDimM]:
+	case hasZ && hasM:
 		return geom.XYZM, true
-	case a.has[geoDimZ]:
+	case hasZ:
 		return geom.XYZ, true
-	case a.has[geoDimM]:
+	case hasM:
 		return geom.XYM, true
 	default:
 		return geom.XY, true
@@ -229,6 +255,13 @@ func (g *geoStatsAgg) Max() iceberg.Literal {
 	return iceberg.BinaryLiteral(g.upper)
 }
 
+// Update is a no-op. geoStatsAgg carries bounds precomputed from raw WKB during
+// the write (see geoBoundsAccumulator), not min/max folded from Parquet column
+// statistics. It satisfies the StatsAgg interface only so its precomputed bytes
+// can flow through ToDataFile's ColAggs draining (via MinAsBytes/MaxAsBytes).
+// Geo aggregators are injected into ColAggs after DataFileStatsFromMeta has
+// finished folding Parquet stats, so nothing ever calls Update on one; any
+// caller that does would be discarding precomputed bounds, so keep it a no-op.
 func (g *geoStatsAgg) Update(interface{ HasMinMax() bool }) {}
 
 func (g *geoStatsAgg) MinAsBytes() ([]byte, error) { return g.lower, nil }

--- a/table/internal/geo_codec.go
+++ b/table/internal/geo_codec.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"encoding/binary"
 	"math"
 
 	"github.com/apache/iceberg-go"
@@ -37,20 +38,28 @@ const (
 )
 
 // geoBoundsAccumulator computes a geospatial bounding box from a stream of WKB
-// values. Iceberg stores geometry/geography column bounds as the WKB encoding
-// of two points: the lower bound carries the per-dimension minimums and the
-// upper bound carries the maximums. Per the Parquet/Iceberg geospatial spec,
-// null and NaN coordinate values are skipped, and a dimension that never sees a
-// finite value is omitted from the resulting points. If the X or Y dimension is
+// values. Iceberg stores geometry/geography column bounds using the single-value
+// serialization for geospatial types (spec Appendix D): the concatenation of
+// little-endian float64 coordinate values in X, Y[, Z][, M] order. The lower
+// bound carries the per-dimension minimums and the upper bound the maximums.
+// Null and NaN coordinate values are skipped, and a dimension that never sees a
+// finite value is omitted from the resulting bounds. If the X or Y dimension is
 // missing entirely, no bounding box is produced.
+//
+// Bounds are only emitted for geometry (planar edges). Geography bounds are
+// omitted: see Bounds.
 type geoBoundsAccumulator struct {
 	min [geoNumDims]float64
 	max [geoNumDims]float64
 	has [geoNumDims]bool
+
+	// isGeography marks a column whose edges are geodesics on a sphere, for
+	// which raw vertex min/max is not a safe bounding box (see Bounds).
+	isGeography bool
 }
 
-func newGeoBoundsAccumulator() *geoBoundsAccumulator {
-	return &geoBoundsAccumulator{}
+func newGeoBoundsAccumulator(isGeography bool) *geoBoundsAccumulator {
+	return &geoBoundsAccumulator{isGeography: isGeography}
 }
 
 // AddWKB unmarshals a single WKB value and extends the bounding box with its
@@ -137,50 +146,60 @@ func (a *geoBoundsAccumulator) layout() (geom.Layout, bool) {
 	}
 }
 
-func geoPointCoords(vals [geoNumDims]float64, layout geom.Layout) []float64 {
+// encodeGeoBound serializes a bound point using the Iceberg single-value
+// serialization for geospatial types: little-endian float64 coordinates in
+// X, Y[, Z][, M] order. Lengths are XY=16, XYZ=24, XYM=32, XYZM=32 bytes. For
+// XYM the Z slot is written as NaN so a reader can tell XYM (NaN in slot 3)
+// apart from XYZM (finite Z in slot 3).
+func encodeGeoBound(vals [geoNumDims]float64, layout geom.Layout) []byte {
+	var coords []float64
 	switch layout {
 	case geom.XYZ:
-		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ]}
+		coords = []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ]}
 	case geom.XYM:
-		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimM]}
+		coords = []float64{vals[geoDimX], vals[geoDimY], math.NaN(), vals[geoDimM]}
 	case geom.XYZM:
-		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ], vals[geoDimM]}
+		coords = []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ], vals[geoDimM]}
 	default:
-		return []float64{vals[geoDimX], vals[geoDimY]}
+		coords = []float64{vals[geoDimX], vals[geoDimY]}
 	}
+
+	buf := make([]byte, len(coords)*8)
+	for i, c := range coords {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(c))
+	}
+
+	return buf
 }
 
-// Bounds encodes the lower and upper bound points as WKB. Both are nil when no
-// bounding box could be produced (e.g. an all-null column).
-func (a *geoBoundsAccumulator) Bounds() (lower, upper []byte, err error) {
+// Bounds encodes the lower and upper bound points using the Iceberg geospatial
+// single-value serialization (see encodeGeoBound). Both are nil when no bounding
+// box could be produced (e.g. an all-null column).
+//
+// Geography bounds are always omitted. Geography edges are geodesics on a
+// sphere, so a box built from raw vertex min/max is unsafe: a geodesic edge can
+// reach a higher latitude than either endpoint, and the correct longitude
+// interval may wrap across the antimeridian (xmin > xmax). Emitting naive vertex
+// bounds would prune rows that actually fall inside a query region — a
+// silent-wrong-results bug. Missing bounds only disable pruning, which is always
+// safe, so geography is left unbounded until geodesic/antimeridian-aware
+// computation is added.
+func (a *geoBoundsAccumulator) Bounds() (lower, upper []byte) {
 	layout, ok := a.layout()
-	if !ok {
-		return nil, nil, nil
+	if !ok || a.isGeography {
+		return nil, nil
 	}
 
-	lower, err = wkb.Marshal(geom.NewPointFlat(layout, geoPointCoords(a.min, layout)), wkb.NDR)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	upper, err = wkb.Marshal(geom.NewPointFlat(layout, geoPointCoords(a.max, layout)), wkb.NDR)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return lower, upper, nil
+	return encodeGeoBound(a.min, layout), encodeGeoBound(a.max, layout)
 }
 
 // StatsAgg materializes the accumulated bounds into a StatsAgg carrying the
-// precomputed WKB point bounds, or nil when no box was produced. Unlike the
+// precomputed single-point bounds, or nil when no box was produced. Unlike the
 // generic statsAggregator, geo bounds are computed from raw WKB during the write
 // (Parquet byte-array min/max over WKB are meaningless), so the aggregator just
 // replays the precomputed bytes through the existing ToDataFile bounds plumbing.
 func (a *geoBoundsAccumulator) StatsAgg() (StatsAgg, error) {
-	lower, upper, err := a.Bounds()
-	if err != nil {
-		return nil, err
-	}
+	lower, upper := a.Bounds()
 	if lower == nil {
 		return nil, nil
 	}
@@ -188,7 +207,8 @@ func (a *geoBoundsAccumulator) StatsAgg() (StatsAgg, error) {
 	return &geoStatsAgg{lower: lower, upper: upper}, nil
 }
 
-// geoStatsAgg is a StatsAgg holding precomputed WKB single-point bounds.
+// geoStatsAgg is a StatsAgg holding precomputed geo single-point bounds encoded
+// with the Iceberg geospatial single-value serialization (see encodeGeoBound).
 type geoStatsAgg struct {
 	lower, upper []byte
 }

--- a/table/internal/geo_codec.go
+++ b/table/internal/geo_codec.go
@@ -1,0 +1,215 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"math"
+
+	"github.com/apache/iceberg-go"
+	"github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/encoding/wkb"
+)
+
+// Geo bounding box dimension indices. X is longitude/easting, Y is
+// latitude/northing; Z and M are optional. These index the per-dimension
+// min/max/has arrays of geoBoundsAccumulator.
+const (
+	geoDimX = iota
+	geoDimY
+	geoDimZ
+	geoDimM
+	geoNumDims
+)
+
+// geoBoundsAccumulator computes a geospatial bounding box from a stream of WKB
+// values. Iceberg stores geometry/geography column bounds as the WKB encoding
+// of two points: the lower bound carries the per-dimension minimums and the
+// upper bound carries the maximums. Per the Parquet/Iceberg geospatial spec,
+// null and NaN coordinate values are skipped, and a dimension that never sees a
+// finite value is omitted from the resulting points. If the X or Y dimension is
+// missing entirely, no bounding box is produced.
+type geoBoundsAccumulator struct {
+	min [geoNumDims]float64
+	max [geoNumDims]float64
+	has [geoNumDims]bool
+}
+
+func newGeoBoundsAccumulator() *geoBoundsAccumulator {
+	return &geoBoundsAccumulator{}
+}
+
+// AddWKB unmarshals a single WKB value and extends the bounding box with its
+// coordinates.
+func (a *geoBoundsAccumulator) AddWKB(data []byte) error {
+	g, err := wkb.Unmarshal(data)
+	if err != nil {
+		return err
+	}
+
+	a.extend(g)
+
+	return nil
+}
+
+// extend walks every coordinate of g, recursing into geometry collections,
+// which cannot expose flat coordinates directly.
+func (a *geoBoundsAccumulator) extend(g geom.T) {
+	if gc, ok := g.(*geom.GeometryCollection); ok {
+		for _, sub := range gc.Geoms() {
+			a.extend(sub)
+		}
+
+		return
+	}
+
+	stride := g.Stride()
+	flat := g.FlatCoords()
+	if stride < 2 || len(flat) == 0 {
+		return
+	}
+
+	layout := g.Layout()
+	zIdx, mIdx := layout.ZIndex(), layout.MIndex()
+	for base := 0; base+stride <= len(flat); base += stride {
+		a.update(geoDimX, flat[base])
+		a.update(geoDimY, flat[base+1])
+		if zIdx >= 0 {
+			a.update(geoDimZ, flat[base+zIdx])
+		}
+		if mIdx >= 0 {
+			a.update(geoDimM, flat[base+mIdx])
+		}
+	}
+}
+
+func (a *geoBoundsAccumulator) update(dim int, v float64) {
+	if math.IsNaN(v) {
+		return
+	}
+
+	if !a.has[dim] {
+		a.min[dim], a.max[dim] = v, v
+		a.has[dim] = true
+
+		return
+	}
+
+	if v < a.min[dim] {
+		a.min[dim] = v
+	}
+	if v > a.max[dim] {
+		a.max[dim] = v
+	}
+}
+
+// layout selects the point layout for the bound points from the dimensions that
+// saw finite values. The bool is false when the box has no X or Y dimension and
+// therefore should not be emitted.
+func (a *geoBoundsAccumulator) layout() (geom.Layout, bool) {
+	if !a.has[geoDimX] || !a.has[geoDimY] {
+		return geom.NoLayout, false
+	}
+
+	switch {
+	case a.has[geoDimZ] && a.has[geoDimM]:
+		return geom.XYZM, true
+	case a.has[geoDimZ]:
+		return geom.XYZ, true
+	case a.has[geoDimM]:
+		return geom.XYM, true
+	default:
+		return geom.XY, true
+	}
+}
+
+func geoPointCoords(vals [geoNumDims]float64, layout geom.Layout) []float64 {
+	switch layout {
+	case geom.XYZ:
+		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ]}
+	case geom.XYM:
+		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimM]}
+	case geom.XYZM:
+		return []float64{vals[geoDimX], vals[geoDimY], vals[geoDimZ], vals[geoDimM]}
+	default:
+		return []float64{vals[geoDimX], vals[geoDimY]}
+	}
+}
+
+// Bounds encodes the lower and upper bound points as WKB. Both are nil when no
+// bounding box could be produced (e.g. an all-null column).
+func (a *geoBoundsAccumulator) Bounds() (lower, upper []byte, err error) {
+	layout, ok := a.layout()
+	if !ok {
+		return nil, nil, nil
+	}
+
+	lower, err = wkb.Marshal(geom.NewPointFlat(layout, geoPointCoords(a.min, layout)), wkb.NDR)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	upper, err = wkb.Marshal(geom.NewPointFlat(layout, geoPointCoords(a.max, layout)), wkb.NDR)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return lower, upper, nil
+}
+
+// StatsAgg materializes the accumulated bounds into a StatsAgg carrying the
+// precomputed WKB point bounds, or nil when no box was produced. Unlike the
+// generic statsAggregator, geo bounds are computed from raw WKB during the write
+// (Parquet byte-array min/max over WKB are meaningless), so the aggregator just
+// replays the precomputed bytes through the existing ToDataFile bounds plumbing.
+func (a *geoBoundsAccumulator) StatsAgg() (StatsAgg, error) {
+	lower, upper, err := a.Bounds()
+	if err != nil {
+		return nil, err
+	}
+	if lower == nil {
+		return nil, nil
+	}
+
+	return &geoStatsAgg{lower: lower, upper: upper}, nil
+}
+
+// geoStatsAgg is a StatsAgg holding precomputed WKB single-point bounds.
+type geoStatsAgg struct {
+	lower, upper []byte
+}
+
+func (g *geoStatsAgg) Min() iceberg.Literal {
+	if g.lower == nil {
+		return nil
+	}
+
+	return iceberg.BinaryLiteral(g.lower)
+}
+
+func (g *geoStatsAgg) Max() iceberg.Literal {
+	if g.upper == nil {
+		return nil
+	}
+
+	return iceberg.BinaryLiteral(g.upper)
+}
+
+func (g *geoStatsAgg) Update(interface{ HasMinMax() bool }) {}
+
+func (g *geoStatsAgg) MinAsBytes() ([]byte, error) { return g.lower, nil }
+func (g *geoStatsAgg) MaxAsBytes() ([]byte, error) { return g.upper, nil }

--- a/table/internal/geo_codec_internal_test.go
+++ b/table/internal/geo_codec_internal_test.go
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/encoding/wkb"
+	"github.com/twpayne/go-geom/encoding/wkt"
+)
+
+// wkbOf converts a WKT string to little-endian WKB for test input.
+func wkbOf(t *testing.T, s string) []byte {
+	t.Helper()
+	g, err := wkt.Unmarshal(s)
+	require.NoError(t, err)
+	b, err := wkb.Marshal(g, wkb.NDR)
+	require.NoError(t, err)
+
+	return b
+}
+
+// decodePoint decodes a WKB point and returns its layout and flat coordinates.
+func decodePoint(t *testing.T, data []byte) (geom.Layout, []float64) {
+	t.Helper()
+	g, err := wkb.Unmarshal(data)
+	require.NoError(t, err)
+	pt, ok := g.(*geom.Point)
+	require.True(t, ok, "expected *geom.Point, got %T", g)
+
+	return pt.Layout(), pt.FlatCoords()
+}
+
+func TestGeoBoundsAccumulatorXY(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (30 10)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "LINESTRING (5 40, 40 5)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POLYGON ((20 20, 25 35, 35 25, 20 20))")))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+	require.NotNil(t, lower)
+	require.NotNil(t, upper)
+
+	layout, lo := decodePoint(t, lower)
+	assert.Equal(t, geom.XY, layout)
+	assert.Equal(t, []float64{5, 5}, lo)
+
+	layout, hi := decodePoint(t, upper)
+	assert.Equal(t, geom.XY, layout)
+	assert.Equal(t, []float64{40, 40}, hi)
+}
+
+func TestGeoBoundsAccumulatorXYZ(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (1 2 3)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (4 0 -1)")))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+
+	layout, lo := decodePoint(t, lower)
+	assert.Equal(t, geom.XYZ, layout)
+	assert.Equal(t, []float64{1, 0, -1}, lo)
+
+	_, hi := decodePoint(t, upper)
+	assert.Equal(t, []float64{4, 2, 3}, hi)
+}
+
+func TestGeoBoundsAccumulatorXYM(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT M (1 2 100)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT M (4 0 50)")))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+
+	layout, lo := decodePoint(t, lower)
+	assert.Equal(t, geom.XYM, layout)
+	assert.Equal(t, []float64{1, 0, 50}, lo)
+
+	_, hi := decodePoint(t, upper)
+	assert.Equal(t, []float64{4, 2, 100}, hi)
+}
+
+func TestGeoBoundsAccumulatorGeometryCollection(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10))")))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+
+	_, lo := decodePoint(t, lower)
+	assert.Equal(t, []float64{4, 6}, lo)
+	_, hi := decodePoint(t, upper)
+	assert.Equal(t, []float64{7, 10}, hi)
+}
+
+func TestGeoBoundsAccumulatorSkipsNaN(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (10 10)")))
+	// A NaN in Y must be skipped so it doesn't poison the Y bounds, while the
+	// finite X=5 still extends the X bounds (per the spec, POINT(5 NaN)
+	// contributes a value to X but none to Y).
+	acc.extend(geom.NewPointFlat(geom.XY, []float64{5, math.NaN()}))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (20 20)")))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+
+	layout, lo := decodePoint(t, lower)
+	assert.Equal(t, geom.XY, layout)
+	assert.Equal(t, []float64{5, 10}, lo)
+	_, hi := decodePoint(t, upper)
+	assert.Equal(t, []float64{20, 20}, hi)
+}
+
+func TestGeoBoundsAccumulatorMissingDimensionNoBox(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	// Y is always NaN: with no finite Y value, no bounding box is produced.
+	acc.extend(geom.NewPointFlat(geom.XY, []float64{1, math.NaN()}))
+
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+	assert.Nil(t, lower)
+	assert.Nil(t, upper)
+}
+
+func TestGeoBoundsAccumulatorEmpty(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	lower, upper, err := acc.Bounds()
+	require.NoError(t, err)
+	assert.Nil(t, lower)
+	assert.Nil(t, upper)
+
+	agg, err := acc.StatsAgg()
+	require.NoError(t, err)
+	assert.Nil(t, agg)
+}
+
+func TestGeoBoundsAccumulatorStatsAgg(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (30 10)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (5 40)")))
+
+	agg, err := acc.StatsAgg()
+	require.NoError(t, err)
+	require.NotNil(t, agg)
+
+	lowerBytes, err := agg.MinAsBytes()
+	require.NoError(t, err)
+	upperBytes, err := agg.MaxAsBytes()
+	require.NoError(t, err)
+
+	_, lo := decodePoint(t, lowerBytes)
+	assert.Equal(t, []float64{5, 10}, lo)
+	_, hi := decodePoint(t, upperBytes)
+	assert.Equal(t, []float64{30, 40}, hi)
+}
+
+func TestGeoBoundsAccumulatorInvalidWKB(t *testing.T) {
+	acc := newGeoBoundsAccumulator()
+	assert.Error(t, acc.AddWKB([]byte{0x01, 0x02, 0x03}))
+}

--- a/table/internal/geo_codec_internal_test.go
+++ b/table/internal/geo_codec_internal_test.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -39,84 +40,92 @@ func wkbOf(t *testing.T, s string) []byte {
 	return b
 }
 
-// decodePoint decodes a WKB point and returns its layout and flat coordinates.
-func decodePoint(t *testing.T, data []byte) (geom.Layout, []float64) {
+// decodeBound decodes an Iceberg geospatial single-value bound (little-endian
+// float64 coordinates in X, Y[, Z][, M] order) into its coordinate slice.
+func decodeBound(t *testing.T, data []byte) []float64 {
 	t.Helper()
-	g, err := wkb.Unmarshal(data)
-	require.NoError(t, err)
-	pt, ok := g.(*geom.Point)
-	require.True(t, ok, "expected *geom.Point, got %T", g)
+	require.Zero(t, len(data)%8, "bound length %d is not a multiple of 8", len(data))
+	coords := make([]float64, len(data)/8)
+	for i := range coords {
+		coords[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[i*8:]))
+	}
 
-	return pt.Layout(), pt.FlatCoords()
+	return coords
 }
 
 func TestGeoBoundsAccumulatorXY(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (30 10)")))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "LINESTRING (5 40, 40 5)")))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POLYGON ((20 20, 25 35, 35 25, 20 20))")))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
-	require.NotNil(t, lower)
-	require.NotNil(t, upper)
+	lower, upper := acc.Bounds()
+	require.Len(t, lower, 16)
+	require.Len(t, upper, 16)
 
-	layout, lo := decodePoint(t, lower)
-	assert.Equal(t, geom.XY, layout)
-	assert.Equal(t, []float64{5, 5}, lo)
-
-	layout, hi := decodePoint(t, upper)
-	assert.Equal(t, geom.XY, layout)
-	assert.Equal(t, []float64{40, 40}, hi)
+	assert.Equal(t, []float64{5, 5}, decodeBound(t, lower))
+	assert.Equal(t, []float64{40, 40}, decodeBound(t, upper))
 }
 
 func TestGeoBoundsAccumulatorXYZ(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (1 2 3)")))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (4 0 -1)")))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
+	lower, upper := acc.Bounds()
+	require.Len(t, lower, 24)
+	require.Len(t, upper, 24)
 
-	layout, lo := decodePoint(t, lower)
-	assert.Equal(t, geom.XYZ, layout)
-	assert.Equal(t, []float64{1, 0, -1}, lo)
-
-	_, hi := decodePoint(t, upper)
-	assert.Equal(t, []float64{4, 2, 3}, hi)
+	assert.Equal(t, []float64{1, 0, -1}, decodeBound(t, lower))
+	assert.Equal(t, []float64{4, 2, 3}, decodeBound(t, upper))
 }
 
 func TestGeoBoundsAccumulatorXYM(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT M (1 2 100)")))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT M (4 0 50)")))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
+	lower, upper := acc.Bounds()
+	// XYM is 32 bytes with the Z slot written as NaN so readers can tell it
+	// apart from XYZM.
+	require.Len(t, lower, 32)
+	require.Len(t, upper, 32)
 
-	layout, lo := decodePoint(t, lower)
-	assert.Equal(t, geom.XYM, layout)
-	assert.Equal(t, []float64{1, 0, 50}, lo)
+	lo := decodeBound(t, lower)
+	assert.Equal(t, []float64{1, 0}, lo[:2])
+	assert.True(t, math.IsNaN(lo[2]), "XYM lower Z slot must be NaN")
+	assert.Equal(t, float64(50), lo[3])
 
-	_, hi := decodePoint(t, upper)
-	assert.Equal(t, []float64{4, 2, 100}, hi)
+	hi := decodeBound(t, upper)
+	assert.Equal(t, []float64{4, 2}, hi[:2])
+	assert.True(t, math.IsNaN(hi[2]), "XYM upper Z slot must be NaN")
+	assert.Equal(t, float64(100), hi[3])
+}
+
+func TestGeoBoundsAccumulatorXYZM(t *testing.T) {
+	acc := newGeoBoundsAccumulator(false)
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT ZM (1 2 3 100)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT ZM (4 0 -1 50)")))
+
+	lower, upper := acc.Bounds()
+	require.Len(t, lower, 32)
+	require.Len(t, upper, 32)
+
+	assert.Equal(t, []float64{1, 0, -1, 50}, decodeBound(t, lower))
+	assert.Equal(t, []float64{4, 2, 3, 100}, decodeBound(t, upper))
 }
 
 func TestGeoBoundsAccumulatorGeometryCollection(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10))")))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
-
-	_, lo := decodePoint(t, lower)
-	assert.Equal(t, []float64{4, 6}, lo)
-	_, hi := decodePoint(t, upper)
-	assert.Equal(t, []float64{7, 10}, hi)
+	lower, upper := acc.Bounds()
+	assert.Equal(t, []float64{4, 6}, decodeBound(t, lower))
+	assert.Equal(t, []float64{7, 10}, decodeBound(t, upper))
 }
 
 func TestGeoBoundsAccumulatorSkipsNaN(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (10 10)")))
 	// A NaN in Y must be skipped so it doesn't poison the Y bounds, while the
 	// finite X=5 still extends the X bounds (per the spec, POINT(5 NaN)
@@ -124,31 +133,24 @@ func TestGeoBoundsAccumulatorSkipsNaN(t *testing.T) {
 	acc.extend(geom.NewPointFlat(geom.XY, []float64{5, math.NaN()}))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (20 20)")))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
-
-	layout, lo := decodePoint(t, lower)
-	assert.Equal(t, geom.XY, layout)
-	assert.Equal(t, []float64{5, 10}, lo)
-	_, hi := decodePoint(t, upper)
-	assert.Equal(t, []float64{20, 20}, hi)
+	lower, upper := acc.Bounds()
+	assert.Equal(t, []float64{5, 10}, decodeBound(t, lower))
+	assert.Equal(t, []float64{20, 20}, decodeBound(t, upper))
 }
 
 func TestGeoBoundsAccumulatorMissingDimensionNoBox(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	// Y is always NaN: with no finite Y value, no bounding box is produced.
 	acc.extend(geom.NewPointFlat(geom.XY, []float64{1, math.NaN()}))
 
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
+	lower, upper := acc.Bounds()
 	assert.Nil(t, lower)
 	assert.Nil(t, upper)
 }
 
 func TestGeoBoundsAccumulatorEmpty(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
-	lower, upper, err := acc.Bounds()
-	require.NoError(t, err)
+	acc := newGeoBoundsAccumulator(false)
+	lower, upper := acc.Bounds()
 	assert.Nil(t, lower)
 	assert.Nil(t, upper)
 
@@ -157,8 +159,26 @@ func TestGeoBoundsAccumulatorEmpty(t *testing.T) {
 	assert.Nil(t, agg)
 }
 
+// TestGeoBoundsAccumulatorGeographyOmitted verifies that geography columns
+// never emit bounds. Geography edges are geodesics, so vertex min/max is not a
+// safe bounding box (latitude bulge, antimeridian wraparound); omitting bounds
+// keeps pruning safe until geodesic-aware computation exists.
+func TestGeoBoundsAccumulatorGeographyOmitted(t *testing.T) {
+	acc := newGeoBoundsAccumulator(true)
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (170 10)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (-170 40)")))
+
+	lower, upper := acc.Bounds()
+	assert.Nil(t, lower, "geography bounds must be omitted")
+	assert.Nil(t, upper, "geography bounds must be omitted")
+
+	agg, err := acc.StatsAgg()
+	require.NoError(t, err)
+	assert.Nil(t, agg, "geography must produce no stats aggregator")
+}
+
 func TestGeoBoundsAccumulatorStatsAgg(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (30 10)")))
 	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT (5 40)")))
 
@@ -171,13 +191,34 @@ func TestGeoBoundsAccumulatorStatsAgg(t *testing.T) {
 	upperBytes, err := agg.MaxAsBytes()
 	require.NoError(t, err)
 
-	_, lo := decodePoint(t, lowerBytes)
-	assert.Equal(t, []float64{5, 10}, lo)
-	_, hi := decodePoint(t, upperBytes)
-	assert.Equal(t, []float64{30, 40}, hi)
+	assert.Equal(t, []float64{5, 10}, decodeBound(t, lowerBytes))
+	assert.Equal(t, []float64{30, 40}, decodeBound(t, upperBytes))
 }
 
 func TestGeoBoundsAccumulatorInvalidWKB(t *testing.T) {
-	acc := newGeoBoundsAccumulator()
+	acc := newGeoBoundsAccumulator(false)
 	assert.Error(t, acc.AddWKB([]byte{0x01, 0x02, 0x03}))
+}
+
+// TestEncodeGeoBoundRoundTrip pins the exact byte layout of the single-value
+// serialization for each dimensionality.
+func TestEncodeGeoBoundRoundTrip(t *testing.T) {
+	vals := [geoNumDims]float64{}
+	vals[geoDimX], vals[geoDimY], vals[geoDimZ], vals[geoDimM] = 1, 2, 3, 4
+
+	assert.Len(t, encodeGeoBound(vals, geom.XY), 16)
+	assert.Equal(t, []float64{1, 2}, decodeBound(t, encodeGeoBound(vals, geom.XY)))
+
+	assert.Len(t, encodeGeoBound(vals, geom.XYZ), 24)
+	assert.Equal(t, []float64{1, 2, 3}, decodeBound(t, encodeGeoBound(vals, geom.XYZ)))
+
+	xym := encodeGeoBound(vals, geom.XYM)
+	assert.Len(t, xym, 32)
+	dec := decodeBound(t, xym)
+	assert.Equal(t, []float64{1, 2}, dec[:2])
+	assert.True(t, math.IsNaN(dec[2]), "XYM Z slot must be NaN")
+	assert.Equal(t, float64(4), dec[3])
+
+	assert.Len(t, encodeGeoBound(vals, geom.XYZM), 32)
+	assert.Equal(t, []float64{1, 2, 3, 4}, decodeBound(t, encodeGeoBound(vals, geom.XYZM)))
 }

--- a/table/internal/geo_codec_internal_test.go
+++ b/table/internal/geo_codec_internal_test.go
@@ -115,6 +115,42 @@ func TestGeoBoundsAccumulatorXYZM(t *testing.T) {
 	assert.Equal(t, []float64{4, 2, 3, 100}, decodeBound(t, upper))
 }
 
+// TestGeoBoundsAccumulatorMixedZMOmitsToXY verifies the omit-on-ambiguity rule:
+// a column mixing XYZ and XYM geometries (Z and M never co-occur in one row)
+// must not be promoted to XYZM, since no row carries both. Emitting XYZM would
+// imply every row has a valid Z and M in range and drive wrong-answer pruning,
+// so the bounds collapse to a safe XY box.
+func TestGeoBoundsAccumulatorMixedZMOmitsToXY(t *testing.T) {
+	acc := newGeoBoundsAccumulator(false)
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (1 2 3)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT M (4 0 100)")))
+
+	lower, upper := acc.Bounds()
+	require.Len(t, lower, 16, "mixed XYZ/XYM must collapse to an XY box")
+	require.Len(t, upper, 16)
+
+	assert.Equal(t, []float64{1, 0}, decodeBound(t, lower))
+	assert.Equal(t, []float64{4, 2}, decodeBound(t, upper))
+}
+
+// TestGeoBoundsAccumulatorMixedXYZMAndXYZDropsM verifies that an optional
+// dimension present in only some geometries is dropped even when the two dims
+// do co-occur somewhere: an XYZM row followed by an XYZ row keeps Z (carried by
+// every geometry) but drops M (carried by only one), yielding XYZ bounds rather
+// than an XYZM box that would claim the XYZ row has an M in range.
+func TestGeoBoundsAccumulatorMixedXYZMAndXYZDropsM(t *testing.T) {
+	acc := newGeoBoundsAccumulator(false)
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT ZM (1 2 3 100)")))
+	require.NoError(t, acc.AddWKB(wkbOf(t, "POINT Z (4 0 -1)")))
+
+	lower, upper := acc.Bounds()
+	require.Len(t, lower, 24, "M carried by only one row must be dropped, leaving XYZ")
+	require.Len(t, upper, 24)
+
+	assert.Equal(t, []float64{1, 0, -1}, decodeBound(t, lower))
+	assert.Equal(t, []float64{4, 2, 3}, decodeBound(t, upper))
+}
+
 func TestGeoBoundsAccumulatorGeometryCollection(t *testing.T) {
 	acc := newGeoBoundsAccumulator(false)
 	require.NoError(t, acc.AddWKB(wkbOf(t, "GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10))")))

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -357,7 +357,8 @@ type geoColumn struct {
 
 // collectGeoColumns finds top-level WKB-encoded geo columns in the Arrow schema
 // and pairs each with its Iceberg field ID. Geo bounds for columns nested inside
-// structs/lists/maps are not yet computed.
+// structs/lists/maps are not yet computed, which diverges from Java/PyIceberg.
+// TODO(#992): compute geo bounds for geo columns nested in structs/lists/maps.
 func collectGeoColumns(sc *arrow.Schema, colMapping map[string]int) []geoColumn {
 	var result []geoColumn
 	for i, f := range sc.Fields() {
@@ -462,7 +463,10 @@ func (w *ParquetFileWriter) accumulateGeoBounds(batch arrow.RecordBatch) error {
 			continue
 		}
 
-		acc := w.geoAccs[gc.fieldID]
+		acc, ok := w.geoAccs[gc.fieldID]
+		if !ok {
+			continue
+		}
 		for i := range storage.Len() {
 			if storage.IsNull(i) {
 				continue
@@ -529,9 +533,12 @@ func (w *ParquetFileWriter) Abort() error {
 // manifest entry like any other typed bound.
 func (w *ParquetFileWriter) applyGeoBounds(stats *DataFileStatistics) error {
 	for fieldID, acc := range w.geoAccs {
-		// Honor the column's metrics mode: counts/none modes do not record bounds.
-		switch w.info.StatsCols[fieldID].Mode.Typ {
-		case MetricModeNone, MetricModeCounts:
+		// Honor the column's metrics mode: a column the caller never registered
+		// (missing key) or one set to counts/none does not record bounds. Check
+		// presence first — a missing key yields a zero-value mode of "" that would
+		// otherwise fall through and write bounds the caller asked to skip.
+		sc, ok := w.info.StatsCols[fieldID]
+		if !ok || sc.Mode.Typ == MetricModeNone || sc.Mode.Typ == MetricModeCounts {
 			continue
 		}
 

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -44,6 +44,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/geoarrow/geoarrow-go"
 	"github.com/google/uuid"
 )
 
@@ -343,6 +344,34 @@ type ParquetFileWriter struct {
 	info       WriteFileInfo
 	partition  map[int]any
 	colMapping map[string]int
+	geoCols    []geoColumn
+	geoAccs    map[int]*geoBoundsAccumulator
+}
+
+// geoColumn locates a top-level geometry/geography column: its position in the
+// Arrow record batch and the Iceberg field ID its bounds are recorded under.
+type geoColumn struct {
+	colIdx  int
+	fieldID int
+}
+
+// collectGeoColumns finds top-level WKB-encoded geo columns in the Arrow schema
+// and pairs each with its Iceberg field ID. Geo bounds for columns nested inside
+// structs/lists/maps are not yet computed.
+func collectGeoColumns(sc *arrow.Schema, colMapping map[string]int) []geoColumn {
+	var result []geoColumn
+	for i, f := range sc.Fields() {
+		if _, ok := f.Type.(*geoarrow.WKBType); !ok {
+			continue
+		}
+		fieldID, ok := colMapping[f.Name]
+		if !ok {
+			continue
+		}
+		result = append(result, geoColumn{colIdx: i, fieldID: fieldID})
+	}
+
+	return result
 }
 
 // NewFileWriter creates a ParquetFileWriter that writes batches to a single
@@ -375,6 +404,12 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		return nil, err
 	}
 
+	geoCols := collectGeoColumns(arrowSchema, colMapping)
+	geoAccs := make(map[int]*geoBoundsAccumulator, len(geoCols))
+	for _, gc := range geoCols {
+		geoAccs[gc.fieldID] = newGeoBoundsAccumulator()
+	}
+
 	return &ParquetFileWriter{
 		pqWriter:   writer,
 		counter:    counter,
@@ -384,12 +419,55 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		info:       info,
 		partition:  partitionValues,
 		colMapping: colMapping,
+		geoCols:    geoCols,
+		geoAccs:    geoAccs,
 	}, nil
 }
 
 // Write appends a record batch to the Parquet file.
 func (w *ParquetFileWriter) Write(batch arrow.RecordBatch) error {
+	if err := w.accumulateGeoBounds(batch); err != nil {
+		return err
+	}
+
 	return w.pqWriter.WriteBuffered(batch)
+}
+
+// wkbStorage is the subset of the binary Arrow arrays that back a geoarrow WKB
+// column (Binary and LargeBinary both satisfy it).
+type wkbStorage interface {
+	arrow.Array
+	Value(int) []byte
+}
+
+// accumulateGeoBounds extends the per-field bounding boxes with the WKB values
+// in this batch. Null rows are skipped; a malformed WKB value fails the write.
+func (w *ParquetFileWriter) accumulateGeoBounds(batch arrow.RecordBatch) error {
+	for _, gc := range w.geoCols {
+		if gc.colIdx >= int(batch.NumCols()) {
+			continue
+		}
+		ext, ok := batch.Column(gc.colIdx).(array.ExtensionArray)
+		if !ok {
+			continue
+		}
+		storage, ok := ext.Storage().(wkbStorage)
+		if !ok {
+			continue
+		}
+
+		acc := w.geoAccs[gc.fieldID]
+		for i := range storage.Len() {
+			if storage.IsNull(i) {
+				continue
+			}
+			if err := acc.AddWKB(storage.Value(i)); err != nil {
+				return fmt.Errorf("computing geo bounds for field %d: %w", gc.fieldID, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // BytesWritten returns the number of bytes flushed to the output so far.
@@ -414,6 +492,10 @@ func (w *ParquetFileWriter) Close() (_ iceberg.DataFile, err error) {
 	stats := w.format.DataFileStatsFromMeta(filemeta, w.info.StatsCols, w.colMapping, VariantFieldIDsFromSchema(w.info.FileSchema))
 	stats.EqualityFieldIDs = w.info.EqualityFieldIDs
 
+	if err = w.applyGeoBounds(stats); err != nil {
+		return nil, err
+	}
+
 	return stats.ToDataFile(DataFileOpts{
 		Schema:          w.info.FileSchema,
 		Spec:            w.info.Spec,
@@ -434,6 +516,44 @@ func (w *ParquetFileWriter) Abort() error {
 	}
 
 	return errors.Join(closeErr, removeErr)
+}
+
+// applyGeoBounds injects the WKB single-point bounds accumulated during the
+// write into the file statistics, so they flow through ToDataFile into the
+// manifest entry like any other typed bound.
+func (w *ParquetFileWriter) applyGeoBounds(stats *DataFileStatistics) error {
+	for fieldID, acc := range w.geoAccs {
+		// Honor the column's metrics mode: counts/none modes do not record bounds.
+		switch w.info.StatsCols[fieldID].Mode.Typ {
+		case MetricModeNone, MetricModeCounts:
+			continue
+		}
+
+		agg, err := acc.StatsAgg()
+		if err != nil {
+			return fmt.Errorf("encoding geo bounds for field %d: %w", fieldID, err)
+		}
+		if agg == nil {
+			continue
+		}
+		if stats.ColAggs == nil {
+			stats.ColAggs = make(map[int]StatsAgg)
+		}
+		stats.ColAggs[fieldID] = agg
+	}
+
+	return nil
+}
+
+// isGeoType reports whether the Iceberg type is a geometry or geography, whose
+// bounds are computed from raw WKB rather than Parquet byte-array statistics.
+func isGeoType(t iceberg.PrimitiveType) bool {
+	switch t.(type) {
+	case iceberg.GeometryType, iceberg.GeographyType:
+		return true
+	default:
+		return false
+	}
 }
 
 type decAsIntAgg[T int32 | int64] struct {
@@ -667,6 +787,14 @@ func (p parquetFormat) DataFileStatsFromMeta(meta Metadata, statsCols map[int]St
 			}
 
 			if statsCol.Mode.Typ == MetricModeCounts || !stats.HasMinMax() {
+				continue
+			}
+
+			// Geometry/Geography bounds are computed from raw WKB during the
+			// write (Parquet byte-array min/max over WKB are meaningless) and
+			// injected separately, so skip the generic min/max aggregator here
+			// while still keeping the column's counts, sizes, and null counts.
+			if isGeoType(statsCol.IcebergTyp) {
 				continue
 			}
 

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -407,7 +407,13 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 	geoCols := collectGeoColumns(arrowSchema, colMapping)
 	geoAccs := make(map[int]*geoBoundsAccumulator, len(geoCols))
 	for _, gc := range geoCols {
-		geoAccs[gc.fieldID] = newGeoBoundsAccumulator()
+		// The accumulator must know whether the column is geometry or geography
+		// so it can omit unsafe geography bounds (see geoBoundsAccumulator.Bounds).
+		var isGeog bool
+		if t, ok := info.FileSchema.FindTypeByID(gc.fieldID); ok {
+			_, isGeog = t.(iceberg.GeographyType)
+		}
+		geoAccs[gc.fieldID] = newGeoBoundsAccumulator(isGeog)
 	}
 
 	return &ParquetFileWriter{

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	iofs "io/fs"
+	"math"
 	"math/big"
 	"strings"
 	"testing"
@@ -1351,7 +1352,8 @@ func TestShreddedVariantReadRoundTrip(t *testing.T) {
 
 // TestWriteDataFileGeoBounds writes geometry and geography columns through the
 // full ParquetFileWriter path and asserts that the resulting DataFile carries
-// WKB single-point lower/upper bounds in the manifest entry.
+// geometry single-point bounds (Iceberg geospatial single-value serialization)
+// in the manifest entry, while geography bounds are omitted as unsafe.
 func TestWriteDataFileGeoBounds(t *testing.T) {
 	geomType, err := iceberg.GeometryTypeOf("srid:4326")
 	require.NoError(t, err)
@@ -1401,27 +1403,33 @@ func TestWriteDataFileGeoBounds(t *testing.T) {
 
 	lower, upper := df.LowerBoundValues(), df.UpperBoundValues()
 
-	// Geometry bounds span both rows: lower (5, 10), upper (30, 40).
-	assert.Equal(t, []byte(mustWKB(t, "POINT (5 10)")), lower[2])
-	assert.Equal(t, []byte(mustWKB(t, "POINT (30 40)")), upper[2])
+	// Geometry bounds span both rows: lower (5, 10), upper (30, 40), encoded as
+	// two little-endian float64 coordinates (16 bytes), not WKB.
+	require.Len(t, lower[2], 16)
+	require.Len(t, upper[2], 16)
+	assert.Equal(t, geoBoundBytes(5, 10), lower[2])
+	assert.Equal(t, geoBoundBytes(30, 40), upper[2])
 
-	// Geography has a single non-null value, so lower == upper == that point.
-	assert.Equal(t, []byte(mustWKB(t, "POINT (20 5)")), lower[3])
-	assert.Equal(t, []byte(mustWKB(t, "POINT (20 5)")), upper[3])
+	// Geography bounds are unsafe to compute from vertices, so they are omitted.
+	assert.NotContains(t, lower, 3, "geography lower bound must be omitted")
+	assert.NotContains(t, upper, 3, "geography upper bound must be omitted")
 
 	// Bounds round-trip back to literals through LiteralFromBytes.
 	lit, err := iceberg.LiteralFromBytes(geomType, lower[2])
 	require.NoError(t, err)
-	assert.Equal(t, []byte(mustWKB(t, "POINT (5 10)")), lit.(iceberg.TypedLiteral[[]byte]).Value())
+	assert.Equal(t, geoBoundBytes(5, 10), lit.(iceberg.TypedLiteral[[]byte]).Value())
 
 	// Null counts are still recorded for geo columns.
 	assert.Equal(t, int64(1), df.NullValueCounts()[3])
 }
 
-func mustWKB(t *testing.T, s string) geoarrow.WKBBytes {
-	t.Helper()
-	b, err := wktToWKB(s)
-	require.NoError(t, err)
+// geoBoundBytes builds the Iceberg geospatial single-value serialization of a
+// bound point: little-endian float64 coordinates in X, Y[, Z][, M] order.
+func geoBoundBytes(coords ...float64) []byte {
+	buf := make([]byte, len(coords)*8)
+	for i, c := range coords {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(c))
+	}
 
-	return b
+	return buf
 }

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1348,3 +1348,80 @@ func TestShreddedVariantReadRoundTrip(t *testing.T) {
 		assert.EqualValues(t, 2, obj.NumElements(), "row %d should have a + city", i)
 	}
 }
+
+// TestWriteDataFileGeoBounds writes geometry and geography columns through the
+// full ParquetFileWriter path and asserts that the resulting DataFile carries
+// WKB single-point lower/upper bounds in the manifest entry.
+func TestWriteDataFileGeoBounds(t *testing.T) {
+	geomType, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+	geogType, err := iceberg.GeographyTypeOf("srid:4326", "vincenty")
+	require.NoError(t, err)
+
+	iceSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 2, Name: "geom", Type: geomType, Required: false},
+		iceberg.NestedField{ID: 3, Name: "geog", Type: geogType, Required: false},
+	)
+
+	arrowSchema, err := table.SchemaToArrowSchema(iceSchema, nil, true, false)
+	require.NoError(t, err)
+
+	wkbStr := func(s string) string {
+		b, err := wktToWKB(s)
+		require.NoError(t, err)
+
+		return b.String()
+	}
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
+		{"id": 1, "geom": "`+wkbStr("POINT (30 10)")+`", "geog": "`+wkbStr("POINT (20 5)")+`"},
+		{"id": 2, "geom": "`+wkbStr("POINT (5 40)")+`", "geog": null}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	fm := internal.GetFileFormat(iceberg.ParquetFile)
+	statsCols := map[int]internal.StatisticsCollector{
+		1: {FieldID: 1, IcebergTyp: iceberg.PrimitiveTypes.Int32, ColName: "id", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+		2: {FieldID: 2, IcebergTyp: geomType, ColName: "geom", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+		3: {FieldID: 3, IcebergTyp: geogType, ColName: "geog", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+	}
+
+	memFS := iceio.NewMemFS()
+	df, err := fm.WriteDataFile(context.Background(), memFS, nil, internal.WriteFileInfo{
+		FileSchema: iceSchema,
+		Spec:       *iceberg.UnpartitionedSpec,
+		FileName:   "geo.parquet",
+		StatsCols:  statsCols,
+		WriteProps: fm.GetWriteProperties(iceberg.Properties{}),
+		Content:    iceberg.EntryContentData,
+	}, []arrow.RecordBatch{rec})
+	require.NoError(t, err)
+
+	lower, upper := df.LowerBoundValues(), df.UpperBoundValues()
+
+	// Geometry bounds span both rows: lower (5, 10), upper (30, 40).
+	assert.Equal(t, []byte(mustWKB(t, "POINT (5 10)")), lower[2])
+	assert.Equal(t, []byte(mustWKB(t, "POINT (30 40)")), upper[2])
+
+	// Geography has a single non-null value, so lower == upper == that point.
+	assert.Equal(t, []byte(mustWKB(t, "POINT (20 5)")), lower[3])
+	assert.Equal(t, []byte(mustWKB(t, "POINT (20 5)")), upper[3])
+
+	// Bounds round-trip back to literals through LiteralFromBytes.
+	lit, err := iceberg.LiteralFromBytes(geomType, lower[2])
+	require.NoError(t, err)
+	assert.Equal(t, []byte(mustWKB(t, "POINT (5 10)")), lit.(iceberg.TypedLiteral[[]byte]).Value())
+
+	// Null counts are still recorded for geo columns.
+	assert.Equal(t, int64(1), df.NullValueCounts()[3])
+}
+
+func mustWKB(t *testing.T, s string) geoarrow.WKBBytes {
+	t.Helper()
+	b, err := wktToWKB(s)
+	require.NoError(t, err)
+
+	return b
+}

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1354,6 +1354,11 @@ func TestShreddedVariantReadRoundTrip(t *testing.T) {
 // full ParquetFileWriter path and asserts that the resulting DataFile carries
 // geometry single-point bounds (Iceberg geospatial single-value serialization)
 // in the manifest entry, while geography bounds are omitted as unsafe.
+//
+// Running MetricModeFull end-to-end also guards a regression: geometry/geography
+// have no generic Parquet stats aggregator, so before the isGeoType guard in
+// DataFileStatsFromMeta a full-mode geo column panicked in createStatsAgg
+// ("unsupported iceberg type"). This test fails if that guard is removed.
 func TestWriteDataFileGeoBounds(t *testing.T) {
 	geomType, err := iceberg.GeometryTypeOf("srid:4326")
 	require.NoError(t, err)
@@ -1384,43 +1389,72 @@ func TestWriteDataFileGeoBounds(t *testing.T) {
 	defer rec.Release()
 
 	fm := internal.GetFileFormat(iceberg.ParquetFile)
-	statsCols := map[int]internal.StatisticsCollector{
-		1: {FieldID: 1, IcebergTyp: iceberg.PrimitiveTypes.Int32, ColName: "id", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
-		2: {FieldID: 2, IcebergTyp: geomType, ColName: "geom", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
-		3: {FieldID: 3, IcebergTyp: geogType, ColName: "geog", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+
+	// writeWithGeomMode runs the full writer path with the geometry column set to
+	// the given metrics mode and returns the resulting DataFile.
+	writeWithGeomMode := func(t *testing.T, geomMode internal.MetricsMode) iceberg.DataFile {
+		t.Helper()
+
+		statsCols := map[int]internal.StatisticsCollector{
+			1: {FieldID: 1, IcebergTyp: iceberg.PrimitiveTypes.Int32, ColName: "id", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+			2: {FieldID: 2, IcebergTyp: geomType, ColName: "geom", Mode: geomMode},
+			3: {FieldID: 3, IcebergTyp: geogType, ColName: "geog", Mode: internal.MetricsMode{Typ: internal.MetricModeFull}},
+		}
+
+		df, err := fm.WriteDataFile(context.Background(), iceio.NewMemFS(), nil, internal.WriteFileInfo{
+			FileSchema: iceSchema,
+			Spec:       *iceberg.UnpartitionedSpec,
+			FileName:   "geo.parquet",
+			StatsCols:  statsCols,
+			WriteProps: fm.GetWriteProperties(iceberg.Properties{}),
+			Content:    iceberg.EntryContentData,
+		}, []arrow.RecordBatch{rec})
+		require.NoError(t, err)
+
+		return df
 	}
 
-	memFS := iceio.NewMemFS()
-	df, err := fm.WriteDataFile(context.Background(), memFS, nil, internal.WriteFileInfo{
-		FileSchema: iceSchema,
-		Spec:       *iceberg.UnpartitionedSpec,
-		FileName:   "geo.parquet",
-		StatsCols:  statsCols,
-		WriteProps: fm.GetWriteProperties(iceberg.Properties{}),
-		Content:    iceberg.EntryContentData,
-	}, []arrow.RecordBatch{rec})
-	require.NoError(t, err)
+	t.Run("full mode emits geometry bounds, omits geography", func(t *testing.T) {
+		df := writeWithGeomMode(t, internal.MetricsMode{Typ: internal.MetricModeFull})
+		lower, upper := df.LowerBoundValues(), df.UpperBoundValues()
 
-	lower, upper := df.LowerBoundValues(), df.UpperBoundValues()
+		// Geometry bounds span both rows: lower (5, 10), upper (30, 40), encoded as
+		// two little-endian float64 coordinates (16 bytes), not WKB.
+		require.Len(t, lower[2], 16)
+		require.Len(t, upper[2], 16)
+		assert.Equal(t, geoBoundBytes(5, 10), lower[2])
+		assert.Equal(t, geoBoundBytes(30, 40), upper[2])
 
-	// Geometry bounds span both rows: lower (5, 10), upper (30, 40), encoded as
-	// two little-endian float64 coordinates (16 bytes), not WKB.
-	require.Len(t, lower[2], 16)
-	require.Len(t, upper[2], 16)
-	assert.Equal(t, geoBoundBytes(5, 10), lower[2])
-	assert.Equal(t, geoBoundBytes(30, 40), upper[2])
+		// Geography bounds are unsafe to compute from vertices, so they are omitted.
+		assert.NotContains(t, lower, 3, "geography lower bound must be omitted")
+		assert.NotContains(t, upper, 3, "geography upper bound must be omitted")
 
-	// Geography bounds are unsafe to compute from vertices, so they are omitted.
-	assert.NotContains(t, lower, 3, "geography lower bound must be omitted")
-	assert.NotContains(t, upper, 3, "geography upper bound must be omitted")
+		// Bounds round-trip back to literals through LiteralFromBytes.
+		lit, err := iceberg.LiteralFromBytes(geomType, lower[2])
+		require.NoError(t, err)
+		assert.Equal(t, geoBoundBytes(5, 10), lit.(iceberg.TypedLiteral[[]byte]).Value())
 
-	// Bounds round-trip back to literals through LiteralFromBytes.
-	lit, err := iceberg.LiteralFromBytes(geomType, lower[2])
-	require.NoError(t, err)
-	assert.Equal(t, geoBoundBytes(5, 10), lit.(iceberg.TypedLiteral[[]byte]).Value())
+		// Null counts are still recorded for geo columns.
+		assert.Equal(t, int64(1), df.NullValueCounts()[3])
+	})
 
-	// Null counts are still recorded for geo columns.
-	assert.Equal(t, int64(1), df.NullValueCounts()[3])
+	// The counts/none modes must gate geo bounds exactly like any other column:
+	// the geo field ID must not appear in lower/upper. This pins the presence +
+	// mode check in applyGeoBounds (a missing/zero-value mode must not fall
+	// through and write bounds the caller asked to skip).
+	for _, tt := range []struct {
+		name string
+		mode internal.MetricsMode
+	}{
+		{"none mode omits geometry bounds", internal.MetricsMode{Typ: internal.MetricModeNone}},
+		{"counts mode omits geometry bounds", internal.MetricsMode{Typ: internal.MetricModeCounts}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			df := writeWithGeomMode(t, tt.mode)
+			assert.NotContains(t, df.LowerBoundValues(), 2, "geometry lower bound must be omitted for %s", tt.mode.Typ)
+			assert.NotContains(t, df.UpperBoundValues(), 2, "geometry upper bound must be omitted for %s", tt.mode.Typ)
+		})
+	}
 }
 
 // geoBoundBytes builds the Iceberg geospatial single-value serialization of a

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1429,10 +1429,12 @@ func TestWriteDataFileGeoBounds(t *testing.T) {
 		assert.NotContains(t, lower, 3, "geography lower bound must be omitted")
 		assert.NotContains(t, upper, 3, "geography upper bound must be omitted")
 
-		// Bounds round-trip back to literals through LiteralFromBytes.
+		// Bounds round-trip back to a GeoLiteral (not a comparable binary
+		// literal) through LiteralFromBytes.
 		lit, err := iceberg.LiteralFromBytes(geomType, lower[2])
 		require.NoError(t, err)
-		assert.Equal(t, geoBoundBytes(5, 10), lit.(iceberg.TypedLiteral[[]byte]).Value())
+		assert.True(t, geomType.Equals(lit.Type()), "want geo type, got %s", lit.Type())
+		assert.Equal(t, geoBoundBytes(5, 10), lit.(iceberg.GeoLiteral).Value())
 
 		// Null counts are still recorded for geo columns.
 		assert.Equal(t, int64(1), df.NullValueCounts()[3])

--- a/utils.go
+++ b/utils.go
@@ -102,6 +102,9 @@ func (l literalSet) addliteral(v Literal) {
 		l[maphash.Bytes(lzseed, []byte(v))] = struct{ orig Literal }{v}
 	case BinaryLiteral:
 		l[maphash.Bytes(lzseed, []byte(v))] = struct{ orig Literal }{v}
+	case GeoLiteral:
+		// GeoLiteral holds a []byte, so it cannot be used as a map key directly.
+		l[maphash.Bytes(lzseed, v.Value())] = struct{ orig Literal }{v}
 	default:
 		l[v] = struct{ orig Literal }{}
 	}
@@ -124,6 +127,13 @@ func (l literalSet) Contains(lit Literal) bool {
 		return lit.Equals(v.orig)
 	case FixedLiteral:
 		v, ok := l[maphash.Bytes(lzseed, []byte(lit))]
+		if !ok {
+			return false
+		}
+
+		return lit.Equals(v.orig)
+	case GeoLiteral:
+		v, ok := l[maphash.Bytes(lzseed, lit.Value())]
 		if !ok {
 			return false
 		}


### PR DESCRIPTION
Compute geometry/geography bounding boxes from WKB during writes and emit WKB single-point lower/upper bounds into the manifest DataFile, which is what Iceberg pruning consumes. arrow-go cannot emit Parquet column-chunk GeospatialStatistics, so bounds are computed in iceberg-go.

Also fixes a panic when writing geo columns through the stats path, and lets geo bounds round-trip via LiteralFromBytes.

Closes: #992 