### PR TITLE
fix(puffin): guard ClearProperties after Finish

### DIFF
--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -340,12 +340,18 @@ func TestSetCreatedBy(t *testing.T) {
 func TestClearProperties(t *testing.T) {
 	w, buf := newWriter()
 	w.AddProperties(map[string]string{"key": "value"})
-	w.ClearProperties()
+	require.NoError(t, w.ClearProperties())
 	w.Finish()
 
 	r := newReader(t, buf)
 	_, exists := r.Properties()["key"]
 	assert.False(t, exists)
+
+	t.Run("after finish rejected", func(t *testing.T) {
+		w, _ := newWriter()
+		require.NoError(t, w.Finish())
+		assert.ErrorContains(t, w.ClearProperties(), "finalized")
+	})
 }
 
 // TestAddPropertiesAfterFinish verifies AddProperties rejects calls after finish.

--- a/puffin/puffin_writer.go
+++ b/puffin/puffin_writer.go
@@ -97,9 +97,14 @@ func (w *Writer) AddProperties(props map[string]string) error {
 	return nil
 }
 
-// clear properties
-func (w *Writer) ClearProperties() {
+// ClearProperties removes all file-level properties.
+func (w *Writer) ClearProperties() error {
+	if w.done {
+		return errors.New("puffin: cannot clear properties: writer already finalized")
+	}
 	w.props = make(map[string]string)
+
+	return nil
 }
 
 // SetCreatedBy overrides the default "created-by" property written to the footer.


### PR DESCRIPTION
## Problem
`Writer.ClearProperties` in `puffin` could be called after `Finish` and silently mutate state because there was no finalization guard.

That is inconsistent with other mutation methods and weakens writer lifecycle safety.

## Fix
- Change `(*Writer).ClearProperties` signature to return `error`.
- Add a finalization check:
  - when `w.done == true`, return `errors.New("puffin: cannot clear properties: writer already finalized")`
- Keep normal pre-finish behavior unchanged (`w.props` is cleared and call succeeds).
- Update tests to assert:
  - `ClearProperties` returns `nil` before finish
  - `ClearProperties` returns an error after finish
- Note: this is a small API-surface change because callers now handle an error return.

## Validation
- `go test ./puffin -run TestClearProperties -count=1`
- `go test ./puffin -run "Test(SetCreatedBy|ClearProperties|AddPropertiesAfterFinish)" -count=1`

## Scope
No behavior change for active writer usage; only enforces lifecycle consistency after finalization.