### PR TITLE
fix(table): reject nil table in PositionDeltaWriter

### DIFF
--- a/table/position_delta_writer.go
+++ b/table/position_delta_writer.go
@@ -86,6 +86,10 @@ type PositionDeltaWriter struct {
 // those two options; everything else (target file size, worker count,
 // clustered write) flows through.
 func NewPositionDeltaWriter(tbl *Table, opts ...WriteRecordOption) (*PositionDeltaWriter, error) {
+	if tbl == nil {
+		return nil, fmt.Errorf("%w: table is nil", iceberg.ErrInvalidArgument)
+	}
+
 	if tbl.metadata.Version() < 3 {
 		return nil, fmt.Errorf("%w: PositionDeltaWriter requires format version >= 3, got %d",
 			iceberg.ErrInvalidArgument, tbl.metadata.Version())

--- a/table/position_delta_writer_test.go
+++ b/table/position_delta_writer_test.go
@@ -19,6 +19,7 @@ package table_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -213,6 +214,13 @@ func TestPositionDeltaWriter_RequiresV3(t *testing.T) {
 	w, err := table.NewPositionDeltaWriter(tbl)
 	require.NoError(t, err)
 	require.NotNil(t, w)
+}
+
+func TestPositionDeltaWriter_NilTable(t *testing.T) {
+	w, err := table.NewPositionDeltaWriter(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, iceberg.ErrInvalidArgument))
+	require.Nil(t, w)
 }
 
 func TestPositionDeltaWriter_ReinsertRejectsNullRowID(t *testing.T) {


### PR DESCRIPTION
## Problem
`NewPositionDeltaWriter` currently panics when called with a nil `*Table` because it dereferences `tbl.metadata` immediately.

For a public constructor, that turns a bad call site into a runtime crash instead of an actionable error.

## Fix
- Add a nil guard in `NewPositionDeltaWriter`:
  - returns `fmt.Errorf("%w: table is nil", iceberg.ErrInvalidArgument)` when `tbl` is nil
- Keep the existing version check behavior unchanged for non-nil tables.
- Add regression test `TestPositionDeltaWriter_NilTable` asserting:
  - an error is returned
  - error is wrapped by `iceberg.ErrInvalidArgument`
  - returned writer is nil

## Validation
- `go test ./table -run TestPositionDeltaWriter_NilTable -count=1`
- `go test ./table -run "TestPositionDeltaWriter_" -count=1`

## Scope
No user-visible data-path behavior change; this is a targeted API-safety fix for invalid constructor input.