### PR TITLE
fix(table): return errors for invalid writer file schemas

### DIFF
--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -73,28 +73,34 @@ type writerFactory struct {
 	mu                    sync.Mutex
 }
 
-type writerFactoryOption func(*writerFactory)
+type writerFactoryOption func(*writerFactory) error
 
 func withContentType(content iceberg.ManifestEntryContent) writerFactoryOption {
-	return func(w *writerFactory) {
+	return func(w *writerFactory) error {
 		w.content = content
+
+		return nil
 	}
 }
 
 func withFactoryEqualityFieldIDs(ids []int) writerFactoryOption {
-	return func(w *writerFactory) {
+	return func(w *writerFactory) error {
 		w.equalityFieldIDs = ids
+
+		return nil
 	}
 }
 
 func withFactoryFileSchema(schema *iceberg.Schema) writerFactoryOption {
-	return func(w *writerFactory) {
+	return func(w *writerFactory) error {
 		w.fileSchema = schema
 		arrowSc, err := SchemaToArrowSchema(schema, nil, true, false)
 		if err != nil {
-			panic(fmt.Sprintf("withFactoryFileSchema: failed to convert schema: %v", err))
+			return fmt.Errorf("withFactoryFileSchema: failed to convert schema: %w", err)
 		}
 		w.arrowSchema = arrowSc
+
+		return nil
 	}
 }
 
@@ -171,7 +177,11 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		stopCount:      stopCount,
 	}
 	for _, apply := range opts {
-		apply(f)
+		if err := apply(f); err != nil {
+			stopCount()
+
+			return nil, err
+		}
 	}
 
 	f.statsCols, err = computeStatsPlan(f.fileSchema, meta.props)

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -50,6 +50,7 @@ func (unsupportedType) Type() string { return "unsupported" }
 func (unsupportedType) String() string {
 	return "unsupported"
 }
+
 func (unsupportedType) Equals(other iceberg.Type) bool {
 	_, ok := other.(unsupportedType)
 

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
@@ -41,6 +42,18 @@ type RollingDataWriterTestSuite struct {
 
 	mem memory.Allocator
 	ctx context.Context
+}
+
+type unsupportedType struct{}
+
+func (unsupportedType) Type() string { return "unsupported" }
+func (unsupportedType) String() string {
+	return "unsupported"
+}
+func (unsupportedType) Equals(other iceberg.Type) bool {
+	_, ok := other.(unsupportedType)
+
+	return ok
 }
 
 func (s *RollingDataWriterTestSuite) SetupTest() {
@@ -185,6 +198,39 @@ func (s *RollingDataWriterTestSuite) TestRollsMultipleFiles() {
 		actualRows += df.Count()
 	}
 	s.Equal(totalRows, actualRows)
+}
+
+func (s *RollingDataWriterTestSuite) TestNewWriterFactoryReturnsErrorForInvalidFileSchema() {
+	loc := filepath.ToSlash(s.T().TempDir())
+	spec := iceberg.NewPartitionSpec()
+	taskSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	})
+	meta, err := NewMetadata(taskSchema, &spec, UnsortedSortOrder, loc, iceberg.Properties{})
+	s.Require().NoError(err)
+	metaBuilder, err := MetadataBuilderFromBase(meta, "")
+	s.Require().NoError(err)
+
+	args := recordWritingArgs{
+		fs:      iceio.LocalFS{},
+		counter: internal.Counter(0),
+	}
+
+	invalidSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: 1, Name: "bad", Type: unsupportedType{}, Required: true,
+	})
+
+	factory, err := newWriterFactory(
+		loc,
+		args,
+		metaBuilder,
+		taskSchema,
+		1024*1024,
+		withFactoryFileSchema(invalidSchema),
+	)
+	s.Require().Error(err)
+	s.Nil(factory)
+	s.ErrorContains(err, "withFactoryFileSchema")
 }
 
 func (s *RollingDataWriterTestSuite) TestBytesWrittenNoDoubleCountAcrossRowGroups() {


### PR DESCRIPTION
## Summary
- Change writer factory options to return errors so `withFactoryFileSchema` can propagate Arrow schema conversion failures instead of panicking.
- Update `withFactoryFileSchema` to return a construction error when `SchemaToArrowSchema` fails.
- Update `newWriterFactory` to stop option iteration and return the first option error.
- Add regression test: `TestNewWriterFactoryReturnsErrorForInvalidFileSchema` verifies invalid/unsupported file schemas fail with error and no panic.

## Verification
- `go test ./table -run TestRollingDataWriter/TestNewWriterFactoryReturnsErrorForInvalidFileSchema -count=1`
- `go test ./table -run TestRollingDataWriter -count=1`
- `go test ./table -count=1`
