### PR TITLE
fix(partitions): copy partition fields in NewPartitionSpecID

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -351,7 +351,14 @@ func NewPartitionSpec(fields ...PartitionField) PartitionSpec {
 //
 // The fields are not verified against a schema, use NewPartitionSpecOpts if you have to ensure compatibility.
 func NewPartitionSpecID(id int, fields ...PartitionField) PartitionSpec {
-	ret := PartitionSpec{id: id, fields: fields}
+	fieldCopies := make([]PartitionField, len(fields))
+	for i, field := range fields {
+		fieldCopies[i] = field
+		if field.SourceIDs != nil {
+			fieldCopies[i].SourceIDs = slices.Clone(field.SourceIDs)
+		}
+	}
+	ret := PartitionSpec{id: id, fields: fieldCopies}
 	ret.initialize()
 
 	return ret

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -74,6 +74,28 @@ func TestPartitionSpec(t *testing.T) {
 	assert.Equal(t, 1002, spec3.LastAssignedFieldID())
 }
 
+func TestNewPartitionSpecIDCopiesFields(t *testing.T) {
+	sourceIDs := []int{1}
+	fields := make([]iceberg.PartitionField, 1)
+	fields[0] = iceberg.PartitionField{
+		SourceIDs: sourceIDs,
+		FieldID:   1000,
+		Name:      "id",
+		Transform: iceberg.IdentityTransform{},
+	}
+
+	spec := iceberg.NewPartitionSpecID(7, fields...)
+
+	fields[0].FieldID = 2000
+	fields[0].Name = "updated"
+	fields[0].SourceIDs[0] = 2
+
+	restored := spec.Field(0)
+	assert.Equal(t, 1000, restored.FieldID)
+	assert.Equal(t, "id", restored.Name)
+	assert.Equal(t, []int{1}, restored.SourceIDs)
+}
+
 func TestPartitionSpecCompatibleWithUsesTransformEquals(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 		SourceIDs: []int{1}, FieldID: 1001, Name: "id",


### PR DESCRIPTION
## Summary

Fixes mutable aliasing when creating a partition spec.

`NewPartitionSpecID` now copies the variadic field arguments and each field's `SourceIDs` slice before initialization, so callers can safely reuse/mutate their input slice after constructing a spec.

Also added a regression test:
- `TestNewPartitionSpecIDCopiesFields` in `partitions_test.go`

## Validation
- `go test ./... -count=1`
