### PR TITLE
fix(gocloud): parse gcs.usejsonapi as boolean

### DIFF
--- a/io/config.go
+++ b/io/config.go
@@ -40,7 +40,7 @@ const (
 	GCSKeyPath    = "gcs.keypath"
 	GCSJSONKey    = "gcs.jsonkey"
 	GCSCredType   = "gcs.credtype"
-	GCSUseJSONAPI = "gcs.usejsonapi" // set to anything to enable
+	GCSUseJSONAPI = "gcs.usejsonapi"
 )
 
 // Constants for Azure configuration options

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -20,6 +20,7 @@ package gocloud
 import (
 	"context"
 	"net/url"
+	"strconv"
 
 	"cloud.google.com/go/storage"
 
@@ -55,8 +56,10 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	if path := props[io.GCSKeyPath]; path != "" {
 		o = append(o, option.WithAuthCredentialsFile(credType, path))
 	}
-	if _, ok := props[io.GCSUseJSONAPI]; ok {
-		o = append(o, storage.WithJSONReads())
+	if v, ok := props[io.GCSUseJSONAPI]; ok {
+		if parse, err := strconv.ParseBool(v); err == nil && parse {
+			o = append(o, storage.WithJSONReads())
+		}
 	}
 
 	return &gcsblob.Options{

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gocloud
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGCSConfigUseJSONAPI(t *testing.T) {
+	t.Run("defaults to disabled", func(t *testing.T) {
+		cfg := ParseGCSConfig(map[string]string{})
+		assert.Len(t, cfg.ClientOptions, 0)
+	})
+
+	t.Run("enables reads on true", func(t *testing.T) {
+		cfg := ParseGCSConfig(map[string]string{io.GCSUseJSONAPI: "true"})
+		assert.Len(t, cfg.ClientOptions, 1)
+	})
+
+	t.Run("does not enable on false", func(t *testing.T) {
+		cfg := ParseGCSConfig(map[string]string{io.GCSUseJSONAPI: "false"})
+		assert.Len(t, cfg.ClientOptions, 0)
+	})
+
+	t.Run("does not enable on invalid value", func(t *testing.T) {
+		cfg := ParseGCSConfig(map[string]string{io.GCSUseJSONAPI: "not-a-bool"})
+		assert.Len(t, cfg.ClientOptions, 0)
+	})
+}

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -158,7 +158,7 @@ Tuning properties:
 | `gcs.keypath` (`io.GCSKeyPath`) | Path to a JSON service-account key file. |
 | `gcs.jsonkey` (`io.GCSJSONKey`) | JSON key as a string. |
 | `gcs.credtype` (`io.GCSCredType`) | Credential type override. |
-| `gcs.usejsonapi` (`io.GCSUseJSONAPI`) | Set to any value to enable the GCS JSON API for reads. |
+| `gcs.usejsonapi` (`io.GCSUseJSONAPI`) | Set to `"true"` to enable the GCS JSON API for reads. |
 
 ### Azure Data Lake Storage / Blob
 


### PR DESCRIPTION
## Summary

`ParseGCSConfig` used to enable JSON reads on `gcs.usejsonapi` whenever the key existed, so values like `"false"` still switched it on.

This change now parses the property as a boolean using `strconv.ParseBool` and only enables JSON reads when it resolves to `true`.

Also included:
- Unit tests covering `true`, `false`, absent, and invalid values (`not-a-bool`).
- Documentation update in `website/src/configuration.md`.
- Removed outdated comment in `io/config.go` that implied truthy-by-presence behavior.

## Validation

- `go test ./io/gocloud -run TestParseGCSConfigUseJSONAPI -count=1`
