### PR TITLE
fix(table): close parquet input file on reader init failure

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -74,7 +74,7 @@ const (
 
 type parquetFormat struct{}
 
-func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (result FileReader, err error) {
+func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (_ FileReader, err error) {
 	inputfile, err := fs.Open(path)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,9 @@ func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (result
 
 	defer func() {
 		if err != nil {
-			_ = inputfile.Close()
+			if closeErr := inputfile.Close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
 		}
 	}()
 
@@ -97,9 +99,7 @@ func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (result
 		return nil, err
 	}
 
-	result = wrapPqArrowReader{arrRdr}
-
-	return result, nil
+	return wrapPqArrowReader{arrRdr}, nil
 }
 
 func (parquetFormat) PathToIDMapping(sc *iceberg.Schema) (map[string]int, error) {
@@ -930,11 +930,19 @@ func checkRowGroupBloomFilters(
 	return true, nil
 }
 
-func (pfs *ParquetFileSource) GetReader(ctx context.Context) (FileReader, error) {
+func (pfs *ParquetFileSource) GetReader(ctx context.Context) (result FileReader, err error) {
 	pf, err := pfs.fs.Open(pfs.file.FilePath())
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		if err != nil {
+			if closeErr := pf.Close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
+		}
+	}()
 
 	rdr, err := file.NewParquetReader(pf,
 		file.WithReadProps(parquet.NewReaderProperties(pfs.mem)))
@@ -958,7 +966,9 @@ func (pfs *ParquetFileSource) GetReader(ctx context.Context) (FileReader, error)
 		return nil, err
 	}
 
-	return wrapPqArrowReader{fr}, nil
+	result = wrapPqArrowReader{fr}
+
+	return result, nil
 }
 
 type manifestVisitor[T any] interface {

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -74,11 +74,17 @@ const (
 
 type parquetFormat struct{}
 
-func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (FileReader, error) {
+func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (result FileReader, err error) {
 	inputfile, err := fs.Open(path)
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		if err != nil {
+			_ = inputfile.Close()
+		}
+	}()
 
 	rdr, err := file.NewParquetReader(inputfile)
 	if err != nil {
@@ -91,7 +97,8 @@ func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (FileRe
 		return nil, err
 	}
 
-	return wrapPqArrowReader{arrRdr}, nil
+	result = wrapPqArrowReader{arrRdr}
+	return result, nil
 }
 
 func (parquetFormat) PathToIDMapping(sc *iceberg.Schema) (map[string]int, error) {

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -98,6 +98,7 @@ func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (result
 	}
 
 	result = wrapPqArrowReader{arrRdr}
+
 	return result, nil
 }
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -269,6 +269,62 @@ func TestParquetOpenClosesFileOnNewFileReaderFailure(t *testing.T) {
 	assert.True(t, mockFile.closed)
 }
 
+func TestParquetGetReaderClosesFileOnNewParquetReaderFailure(t *testing.T) {
+	data := []byte("not-a-parquet-file")
+	mockFile := &trackingOpenFile{
+		Reader: bytes.NewReader(data),
+	}
+	mockIO := &trackingFileSystem{file: mockFile}
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		"bad.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		int64(len(data)),
+	)
+	require.NoError(t, err)
+
+	fileSource, err := internal.GetFile(context.Background(), mockIO, builder.Build(), false)
+	require.NoError(t, err)
+
+	_, err = fileSource.GetReader(context.Background())
+	require.Error(t, err)
+	assert.True(t, mockFile.closed)
+}
+
+func TestParquetGetReaderClosesFileOnNewFileReaderFailure(t *testing.T) {
+	data := mustParquetBytesWithInvalidArrowSchema(t)
+	mockFile := &trackingOpenFile{
+		Reader: bytes.NewReader(data),
+	}
+	mockIO := &trackingFileSystem{file: mockFile}
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		"bad.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		int64(len(data)),
+	)
+	require.NoError(t, err)
+
+	fileSource, err := internal.GetFile(context.Background(), mockIO, builder.Build(), false)
+	require.NoError(t, err)
+
+	_, err = fileSource.GetReader(context.Background())
+	require.Error(t, err)
+	assert.True(t, mockFile.closed)
+}
+
 func assertBounds[T iceberg.LiteralType](t *testing.T, bound []byte, typ iceberg.Type, expected T) {
 	lit, err := iceberg.LiteralFromBytes(typ, bound)
 	require.NoError(t, err)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	iofs "io/fs"
 	"math/big"
 	"strings"
@@ -59,6 +60,69 @@ type abortTestFile struct {
 
 func (f *abortTestFile) Close() error {
 	return f.closeErr
+}
+
+type trackingOpenFile struct {
+	*bytes.Reader
+	closeErr error
+	closed   bool
+}
+
+func (f *trackingOpenFile) Close() error {
+	f.closed = true
+
+	return f.closeErr
+}
+
+func (f *trackingOpenFile) Stat() (iofs.FileInfo, error) {
+	return nil, nil
+}
+
+func (f *trackingOpenFile) ReadFrom(r io.Reader) (n int64, err error) {
+	return 0, nil
+}
+
+func (f *trackingOpenFile) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+type trackingFileSystem struct {
+	file *trackingOpenFile
+}
+
+func (f *trackingFileSystem) Open(name string) (iceio.File, error) {
+	return f.file, nil
+}
+
+func (f *trackingFileSystem) Remove(name string) error {
+	return nil
+}
+
+func mustParquetBytesWithInvalidArrowSchema(t *testing.T) []byte {
+	t.Helper()
+
+	fields := schema.FieldList{
+		schema.NewInt32Node("id", parquet.Repetitions.Required, 1),
+	}
+	sc, err := schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w := file.NewParquetWriter(&buf, sc)
+	require.NoError(t, w.AppendKeyValueMetadata("ARROW:schema", "not-base64"))
+
+	rowGroup := w.AppendRowGroup()
+	column, err := rowGroup.NextColumn()
+	require.NoError(t, err)
+
+	cw := column.(*file.Int32ColumnChunkWriter)
+	_, err = cw.WriteBatch([]int32{1}, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+	require.NoError(t, rowGroup.Close())
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
 }
 
 func newAbortTestWriter(t *testing.T, fs iceio.WriteFileIO, fileName string) internal.FileWriter {
@@ -177,6 +241,32 @@ func constructTestTablePrimitiveTypes(t *testing.T) (*metadata.FileMetaData, tab
 	defer rdr.Close()
 
 	return rdr.MetaData(), tableMeta
+}
+
+func TestParquetOpenClosesFileOnNewParquetReaderFailure(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	mockFile := &trackingOpenFile{
+		Reader: bytes.NewReader([]byte("not-a-parquet-file")),
+	}
+	mockIO := &trackingFileSystem{file: mockFile}
+
+	_, err := format.Open(context.Background(), mockIO, "bad.parquet")
+	require.Error(t, err)
+	assert.True(t, mockFile.closed)
+}
+
+func TestParquetOpenClosesFileOnNewFileReaderFailure(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	mockFile := &trackingOpenFile{
+		Reader: bytes.NewReader(mustParquetBytesWithInvalidArrowSchema(t)),
+	}
+	mockIO := &trackingFileSystem{file: mockFile}
+
+	_, err := format.Open(context.Background(), mockIO, "bad.parquet")
+	require.Error(t, err)
+	assert.True(t, mockFile.closed)
 }
 
 func assertBounds[T iceberg.LiteralType](t *testing.T, bound []byte, typ iceberg.Type, expected T) {


### PR DESCRIPTION
## What changed
- Fixes a resource leak in table/internal/parquet_files.go where parquetFormat.Open returned without closing the opened file when constructing the parquet/parquet-arrow reader failed.
- Added regression tests covering both failure paths: failing file->parquet reader initialization and failing file->arrow reader initialization.

## Validation
- go test ./table/internal -run TestParquetOpenClosesFileOnNew -count=1
- go test ./table/internal -count=1
