### PR TITLE
fix(cli): resolve partition spec fields by schema name

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -515,7 +515,7 @@ func runCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *Cre
 		}
 
 		if tbl.PartitionSpec != "" {
-			spec, err := parsePartitionSpec(tbl.PartitionSpec)
+			spec, err := parsePartitionSpec(tbl.PartitionSpec, schema)
 			if err != nil {
 				output.Error(fmt.Errorf("failed to parse partition spec: %w", err))
 				os.Exit(1)

--- a/cmd/iceberg/utils.go
+++ b/cmd/iceberg/utils.go
@@ -48,31 +48,33 @@ func parseProperties(propStr string) (iceberg.Properties, error) {
 	return props, nil
 }
 
-func parsePartitionSpec(specStr string) (*iceberg.PartitionSpec, error) {
+func parsePartitionSpec(specStr string, schema *iceberg.Schema) (*iceberg.PartitionSpec, error) {
+	if schema == nil {
+		return nil, fmt.Errorf("schema is required for partition spec parsing")
+	}
+
 	if specStr == "" {
 		return iceberg.UnpartitionedSpec, nil
 	}
 
 	fields := strings.Split(specStr, ",")
-	var partitionFields []iceberg.PartitionField
+	opts := make([]iceberg.PartitionOption, 0)
 
-	for i, field := range fields {
+	for _, field := range fields {
 		field = strings.TrimSpace(field)
 		if field == "" {
 			continue
 		}
 
-		partitionFields = append(partitionFields, iceberg.PartitionField{
-			SourceIDs: []int{i + 1},
-			FieldID:   i + iceberg.PartitionDataIDStart,
-			Name:      field,
-			Transform: iceberg.IdentityTransform{},
-		})
+		opts = append(opts, iceberg.AddPartitionFieldByName(field, field, iceberg.IdentityTransform{}, schema, nil))
 	}
-	if len(partitionFields) == 0 {
+	if len(opts) == 0 {
 		return iceberg.UnpartitionedSpec, nil
 	}
-	spec := iceberg.NewPartitionSpec(partitionFields...)
+	spec, err := iceberg.NewPartitionSpecOpts(opts...)
+	if err != nil {
+		return nil, err
+	}
 
 	return &spec, nil
 }

--- a/cmd/iceberg/utils.go
+++ b/cmd/iceberg/utils.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func parseProperties(propStr string) (iceberg.Properties, error) {
 
 func parsePartitionSpec(specStr string, schema *iceberg.Schema) (*iceberg.PartitionSpec, error) {
 	if schema == nil {
-		return nil, fmt.Errorf("schema is required for partition spec parsing")
+		return nil, errors.New("schema is required for partition spec parsing")
 	}
 
 	if specStr == "" {

--- a/cmd/iceberg/utils.go
+++ b/cmd/iceberg/utils.go
@@ -60,6 +60,7 @@ func parsePartitionSpec(specStr string, schema *iceberg.Schema) (*iceberg.Partit
 
 	fields := strings.Split(specStr, ",")
 	opts := make([]iceberg.PartitionOption, 0)
+	nextFieldID := iceberg.PartitionDataIDStart
 
 	for _, field := range fields {
 		field = strings.TrimSpace(field)
@@ -67,7 +68,9 @@ func parsePartitionSpec(specStr string, schema *iceberg.Schema) (*iceberg.Partit
 			continue
 		}
 
-		opts = append(opts, iceberg.AddPartitionFieldByName(field, field, iceberg.IdentityTransform{}, schema, nil))
+		fieldID := nextFieldID
+		nextFieldID++
+		opts = append(opts, iceberg.AddPartitionFieldByName(field, field, iceberg.IdentityTransform{}, schema, &fieldID))
 	}
 	if len(opts) == 0 {
 		return iceberg.UnpartitionedSpec, nil

--- a/cmd/iceberg/utils_test.go
+++ b/cmd/iceberg/utils_test.go
@@ -18,10 +18,16 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/require"
 )
@@ -100,6 +106,7 @@ func TestParsePartitionSpec(t *testing.T) {
 		name          string
 		input         string
 		wantSourceIDs [][]int
+		wantFieldIDs  []int
 		errContains   string
 		isErr         bool
 	}{
@@ -113,6 +120,7 @@ func TestParsePartitionSpec(t *testing.T) {
 			wantSourceIDs: [][]int{
 				{10},
 			},
+			wantFieldIDs: []int{1000},
 		},
 		{
 			name:  "multiple fields",
@@ -121,6 +129,7 @@ func TestParsePartitionSpec(t *testing.T) {
 				{10},
 				{20},
 			},
+			wantFieldIDs: []int{1000, 1001},
 		},
 		{
 			name:  "with spaces",
@@ -129,6 +138,7 @@ func TestParsePartitionSpec(t *testing.T) {
 				{10},
 				{20},
 			},
+			wantFieldIDs: []int{1000, 1001},
 		},
 		{
 			name:        "unknown field",
@@ -164,6 +174,9 @@ func TestParsePartitionSpec(t *testing.T) {
 			require.Equal(t, len(tt.wantSourceIDs), got.NumFields())
 			for i, wantIDs := range tt.wantSourceIDs {
 				require.Equal(t, wantIDs, got.Field(i).SourceIDs)
+			}
+			for i, wantID := range tt.wantFieldIDs {
+				require.Equal(t, wantID, got.Field(i).FieldID)
 			}
 		})
 	}
@@ -291,4 +304,122 @@ func TestParseSortOrder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParsePartitionSpecSendsFieldIDsInRestCreatePayload(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:       10,
+			Name:     "customer_id",
+			Type:     iceberg.PrimitiveTypes.String,
+			Required: false,
+		},
+		iceberg.NestedField{
+			ID:       20,
+			Name:     "event_time",
+			Type:     iceberg.PrimitiveTypes.TimestampNs,
+			Required: false,
+		},
+	)
+
+	spec, err := parsePartitionSpec("customer_id,event_time", schema)
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+
+	var lastCreateBody map[string]any
+	createCalled := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/config":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"defaults":  map[string]any{},
+				"overrides": map[string]any{},
+				"endpoints": []string{},
+			}))
+
+			return
+		case "/v1/namespaces/db/tables":
+			require.Equal(t, http.MethodPost, req.Method)
+			createCalled = true
+
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&lastCreateBody))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"metadata-location": "s3://warehouse/db/tbl/metadata/v1.json",
+				"metadata": ` + tableMetadataJSON("") + `
+			}`))
+
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL)
+	require.NoError(t, err)
+
+	_, err = cat.CreateTable(context.Background(), table.Identifier{"db", "test_table"}, schema,
+		catalog.WithPartitionSpec(spec))
+	require.NoError(t, err)
+	require.True(t, createCalled, "create endpoint should be called")
+
+	rawPartitionSpec, ok := lastCreateBody["partition-spec"].(map[string]any)
+	require.True(t, ok)
+	fields, ok := rawPartitionSpec["fields"].([]any)
+	require.True(t, ok)
+	require.Len(t, fields, 2)
+
+	field0, ok := fields[0].(map[string]any)
+	require.True(t, ok)
+	field1, ok := fields[1].(map[string]any)
+	require.True(t, ok)
+	require.EqualValues(t, 1000, field0["field-id"])
+	require.EqualValues(t, 1001, field1["field-id"])
+}
+
+func tableMetadataJSON(tableUUID string) string {
+	if tableUUID == "" {
+		tableUUID = "bf289591-dcc0-4234-ad4f-5c3eed811a29"
+	}
+
+	return `{
+		"format-version": 1,
+		"table-uuid": "` + tableUUID + `",
+		"location": "s3://warehouse/db/tbl",
+		"last-updated-ms": 1657810967051,
+		"last-column-id": 20,
+		"schema": {
+			"type": "struct",
+			"schema-id": 0,
+			"fields": [
+				{"id": 10, "name": "customer_id", "required": false, "type": "string"},
+				{"id": 20, "name": "event_time", "required": false, "type": "timestamp_ns"}
+			]
+		},
+		"current-schema-id": 0,
+		"schemas": [{
+			"type": "struct",
+			"schema-id": 0,
+			"fields": [
+				{"id": 10, "name": "customer_id", "required": false, "type": "string"},
+				{"id": 20, "name": "event_time", "required": false, "type": "timestamp_ns"}
+			]
+		}],
+		"partition-spec": [],
+		"default-spec-id": 0,
+		"last-partition-id": 999,
+		"default-sort-order-id": 0,
+		"sort-orders": [{"order-id": 0, "fields": []}],
+		"properties": {},
+		"current-snapshot-id": -1,
+		"refs": {},
+		"snapshots": [],
+		"snapshot-log": [],
+		"metadata-log": []
+	}`
 }

--- a/cmd/iceberg/utils_test.go
+++ b/cmd/iceberg/utils_test.go
@@ -158,6 +158,7 @@ func TestParsePartitionSpec(t *testing.T) {
 			}
 			if len(tt.wantSourceIDs) == 0 {
 				require.Equal(t, iceberg.UnpartitionedSpec, got)
+
 				return
 			}
 			require.Equal(t, len(tt.wantSourceIDs), got.NumFields())

--- a/cmd/iceberg/utils_test.go
+++ b/cmd/iceberg/utils_test.go
@@ -81,39 +81,88 @@ func TestParseProperties(t *testing.T) {
 }
 
 func TestParsePartitionSpec(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:       10,
+			Name:     "customer_id",
+			Type:     iceberg.PrimitiveTypes.String,
+			Required: false,
+		},
+		iceberg.NestedField{
+			ID:       20,
+			Name:     "event_time",
+			Type:     iceberg.PrimitiveTypes.TimestampNs,
+			Required: false,
+		},
+	)
+
 	tests := []struct {
-		name  string
-		input string
-		isErr bool
+		name          string
+		input         string
+		wantSourceIDs [][]int
+		errContains   string
+		isErr         bool
 	}{
 		{
 			name:  "empty string",
-			input: "",
+			input: "", // keeps backward compatibility for no partitioning
 		},
 		{
 			name:  "single field",
-			input: "field1",
+			input: "customer_id",
+			wantSourceIDs: [][]int{
+				{10},
+			},
 		},
 		{
 			name:  "multiple fields",
-			input: "field1,field2,field3",
+			input: "customer_id,event_time",
+			wantSourceIDs: [][]int{
+				{10},
+				{20},
+			},
 		},
 		{
 			name:  "with spaces",
-			input: " field1 , field2 , field3 ",
+			input: " customer_id , event_time ",
+			wantSourceIDs: [][]int{
+				{10},
+				{20},
+			},
+		},
+		{
+			name:        "unknown field",
+			input:       "no_such_field",
+			isErr:       true,
+			errContains: "cannot find source column with name: no_such_field in schema",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePartitionSpec(tt.input)
+			got, err := parsePartitionSpec(tt.input, schema)
 			if (err != nil) != tt.isErr {
 				t.Errorf("parsePartitionSpec() error = %v, isErr %v", err, tt.isErr)
 
 				return
 			}
+			if tt.isErr {
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+
+				return
+			}
 			if !tt.isErr && got == nil {
 				t.Errorf("parsePartitionSpec() returned nil for valid input")
+			}
+			if len(tt.wantSourceIDs) == 0 {
+				require.Equal(t, iceberg.UnpartitionedSpec, got)
+				return
+			}
+			require.Equal(t, len(tt.wantSourceIDs), got.NumFields())
+			for i, wantIDs := range tt.wantSourceIDs {
+				require.Equal(t, wantIDs, got.Field(i).SourceIDs)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Resolve CLI --partition-spec entries against the parsed table schema instead of positional field IDs.
- Update table create path to pass schema into partition spec parser.
- Add regression tests for correct field-id mapping and unknown field rejection.

## Testing
- go test ./cmd/iceberg -run TestParsePartitionSpec -count=1
- go test ./cmd/iceberg -count=1