### PR TITLE
fix(requirements): validate missing last partition spec id

### DIFF
--- a/table/requirements.go
+++ b/table/requirements.go
@@ -264,8 +264,13 @@ func (a *assertLastAssignedPartitionId) Validate(meta Metadata) error {
 		return errors.New("Requirement failed: current table metadata does not exist")
 	}
 
-	if *meta.LastPartitionSpecID() != a.LastAssignedPartitionID {
-		return fmt.Errorf("requirement failed: last assigned partition id has changed: expected %d, found %d", a.LastAssignedPartitionID, *meta.LastPartitionSpecID())
+	lastPartitionSpecID := meta.LastPartitionSpecID()
+	if lastPartitionSpecID == nil {
+		return errors.New("requirement failed: last assigned partition id is missing")
+	}
+
+	if *lastPartitionSpecID != a.LastAssignedPartitionID {
+		return fmt.Errorf("requirement failed: last assigned partition id has changed: expected %d, found %d", a.LastAssignedPartitionID, *lastPartitionSpecID)
 	}
 
 	return nil

--- a/table/requirements_internal_test.go
+++ b/table/requirements_internal_test.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertLastAssignedPartitionIDValidate(t *testing.T) {
+	t.Run("missing last partition id returns requirement failure", func(t *testing.T) {
+		meta := &metadataV1{
+			commonMetadata: commonMetadata{},
+		}
+		req := AssertLastAssignedPartitionID(0)
+
+		err := req.Validate(meta)
+		require.Error(t, err)
+		assert.EqualError(t, err, "requirement failed: last assigned partition id is missing")
+	})
+
+	t.Run("matches metadata last partition id", func(t *testing.T) {
+		meta, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+		require.NoError(t, err)
+		req := AssertLastAssignedPartitionID(*meta.LastPartitionSpecID())
+		assert.NoError(t, req.Validate(meta))
+	})
+
+	t.Run("mismatched last partition id is rejected", func(t *testing.T) {
+		meta, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+		require.NoError(t, err)
+		req := AssertLastAssignedPartitionID(*meta.LastPartitionSpecID() + 1)
+		err = req.Validate(meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "last assigned partition id has changed")
+	})
+}


### PR DESCRIPTION
## Summary

Fix a panic in requirement validation when metadata lacks last partition spec ID (for example v1 or malformed metadata).

The previous implementation directly dereferenced `meta.LastPartitionSpecID()` and could panic. This change now checks for nil and returns a clean requirement failure message:

- `requirement failed: last assigned partition id is missing`

When the field is present, behavior is unchanged and the previous comparison path still validates for mismatches.

## Testing

- `go test ./table -run TestAssertLastAssignedPartitionIDValidate -count=1`
