### PR TITLE
fix(sorting): validate sort source IDs

### DIFF
--- a/table/sorting.go
+++ b/table/sorting.go
@@ -184,8 +184,8 @@ func (s *SortField) UnmarshalJSON(b []byte) error {
 }
 
 func validateSortSourceID(id int) error {
-	if id < 0 {
-		return fmt.Errorf("source ID must be non-negative: %d", id)
+	if id <= 0 {
+		return fmt.Errorf("source ID must be positive: %d", id)
 	}
 
 	return nil

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -88,12 +88,20 @@ func TestNewSortOrderRejectsInvalidSourceIDs(t *testing.T) {
 			sourceIDs: []int{},
 		},
 		{
+			name:      "zero",
+			sourceIDs: []int{0},
+		},
+		{
 			name:      "negative",
 			sourceIDs: []int{-1},
 		},
 		{
 			name:      "multi arg with negative",
 			sourceIDs: []int{1, -1},
+		},
+		{
+			name:      "multi arg with zero",
+			sourceIDs: []int{1, 0},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -107,17 +115,6 @@ func TestNewSortOrderRejectsInvalidSourceIDs(t *testing.T) {
 			assert.ErrorIs(t, err, table.ErrInvalidSortSourceID)
 		})
 	}
-}
-
-func TestNewSortOrderAcceptsZeroSourceID(t *testing.T) {
-	sortOrder, err := table.NewSortOrder(1, []table.SortField{{
-		SourceIDs: []int{0},
-		Transform: iceberg.IdentityTransform{},
-		NullOrder: table.NullsFirst,
-		Direction: table.SortASC,
-	}})
-	require.NoError(t, err)
-	assert.Equal(t, 1, sortOrder.Len())
 }
 
 func TestNewSortOrderAcceptsValidTransform(t *testing.T) {
@@ -138,20 +135,6 @@ func TestSortOrderCheckCompatibilityWithValidTransform(t *testing.T) {
 	)
 	sortOrder, err := table.NewSortOrder(1, []table.SortField{{
 		SourceIDs: []int{19},
-		Transform: iceberg.IdentityTransform{},
-		NullOrder: table.NullsFirst,
-		Direction: table.SortASC,
-	}})
-	require.NoError(t, err)
-	require.NoError(t, sortOrder.CheckCompatibility(schema))
-}
-
-func TestSortOrderCheckCompatibilityAcceptsZeroSourceIDInSchema(t *testing.T) {
-	schema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 0, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
-	)
-	sortOrder, err := table.NewSortOrder(1, []table.SortField{{
-		SourceIDs: []int{0},
 		Transform: iceberg.IdentityTransform{},
 		NullOrder: table.NullsFirst,
 		Direction: table.SortASC,
@@ -185,7 +168,13 @@ func TestSortOrderCheckCompatibilityRejectsInvalidSourceIDs(t *testing.T) {
 		{
 			name:                "negative",
 			jsonData:            `{"order-id": 1, "fields": [{"source-id": -1, "transform": "identity", "direction": "asc", "null-order": "nulls-first"}]}`,
-			wantErr:             "source ID must be non-negative: -1",
+			wantErr:             "source ID must be positive: -1",
+			wantInvalidSourceID: true,
+		},
+		{
+			name:                "zero",
+			jsonData:            `{"order-id": 1, "fields": [{"source-id": 0, "transform": "identity", "direction": "asc", "null-order": "nulls-first"}]}`,
+			wantErr:             "source ID must be positive: 0",
 			wantInvalidSourceID: true,
 		},
 		{


### PR DESCRIPTION
## Summary

This change validates sort order source IDs in `NewSortOrder`:

- sort fields with missing/empty `SourceIDs` are rejected
- any non-positive source ID is rejected

This prevents malformed sort metadata from slipping through (for example zero-value sort fields becoming source-id 0).

## Testing

- `go test ./table -count=1`
