### PR TITLE
fix(table): protect identifier from external mutation

### DIFF
--- a/table/commit.go
+++ b/table/commit.go
@@ -17,7 +17,10 @@
 
 package table
 
-import "errors"
+import (
+	"errors"
+	"slices"
+)
 
 // TableCommit holds the identifier, requirements, and updates for a single
 // table within a multi-table transaction. It is used with
@@ -64,7 +67,7 @@ func (t *Transaction) TableCommit() (TableCommit, error) {
 
 	if len(t.meta.updates) == 0 {
 		return TableCommit{
-			Identifier:   t.tbl.identifier,
+			Identifier:   slices.Clone(t.tbl.identifier),
 			Requirements: []Requirement{},
 			Updates:      []Update{},
 		}, nil
@@ -78,7 +81,7 @@ func (t *Transaction) TableCommit() (TableCommit, error) {
 	copy(updates, t.meta.updates)
 
 	return TableCommit{
-		Identifier:   t.tbl.identifier,
+		Identifier:   slices.Clone(t.tbl.identifier),
 		Requirements: reqs,
 		Updates:      updates,
 	}, nil

--- a/table/commit_refresh_replay_test.go
+++ b/table/commit_refresh_replay_test.go
@@ -53,6 +53,12 @@ type headTrackingCatalog struct {
 	attempts atomic.Int32
 }
 
+type identifierCapturingCatalog struct {
+	metadata         Metadata
+	loadIdentifier   Identifier
+	commitIdentifier Identifier
+}
+
 func (c *headTrackingCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
 	return New(ident, c.metadata, "",
 		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c), nil
@@ -72,6 +78,25 @@ func (c *headTrackingCatalog) CommitTable(_ context.Context, _ Identifier, reqs 
 	c.metadata = meta
 
 	return meta, "", nil
+}
+
+func (c *identifierCapturingCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
+	c.loadIdentifier = ident
+
+	return New(ident, c.metadata, c.metadata.Location(),
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c), nil
+}
+
+func (c *identifierCapturingCatalog) CommitTable(_ context.Context, ident Identifier, _ []Requirement, updates []Update) (Metadata, string, error) {
+	c.commitIdentifier = ident
+
+	updated, err := UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = updated
+
+	return updated, updated.Location(), nil
 }
 
 // graftSnapshotOnto builds a metadata that adds a child snapshot on
@@ -182,6 +207,45 @@ func TestDoCommit_ValidatorRejectsOnRefresh(t *testing.T) {
 	// + validator rejects → terminal exit before any further attempts.
 	assert.Equal(t, int32(1), cat.attempts.Load(),
 		"validator rejection on retry must abort before re-issuing CommitTable")
+}
+
+func TestRefreshPassesIdentifierCopy(t *testing.T) {
+	branchHead := int64(1)
+	meta := newConflictTestMetadataWithProps(t, &branchHead, nil)
+	cat := &identifierCapturingCatalog{metadata: meta}
+	identifier := Identifier{"db", "refresh_copy_test"}
+
+	tbl := New(identifier, meta, "file:///tmp/test-refresh-copy/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	err := tbl.Refresh(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, identifier, tbl.Identifier())
+
+	cat.loadIdentifier[0] = "corrupt"
+	assert.Equal(t, identifier, tbl.Identifier())
+}
+
+func TestDoCommitPassesIdentifierCopy(t *testing.T) {
+	branchHead := int64(1)
+	meta := newConflictTestMetadataWithProps(t, &branchHead, nil)
+	cat := &identifierCapturingCatalog{metadata: meta}
+	identifier := Identifier{"db", "do_commit_copy_test"}
+
+	tbl := New(identifier, meta, "file:///tmp/test-do-commit-copy/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+	tx := tbl.NewTransaction()
+
+	require.NoError(t, tx.SetProperties(map[string]string{"k": "v"}))
+	updated, err := tx.Commit(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, identifier, tbl.Identifier())
+	assert.Equal(t, identifier, updated.Identifier())
+
+	cat.commitIdentifier[0] = "corrupt"
+	assert.Equal(t, identifier, tbl.Identifier())
+	assert.Equal(t, identifier, updated.Identifier())
 }
 
 // TestRewriteRefSnapshotRequirements covers the helper directly:

--- a/table/commit_refresh_replay_test.go
+++ b/table/commit_refresh_replay_test.go
@@ -273,6 +273,8 @@ func TestDoCommitRetryPassesIdentifierCopy(t *testing.T) {
 
 	cat.loadIdentifier[0] = "corrupt"
 	assert.Equal(t, identifier, tbl.Identifier())
+	cat.commitIdentifier[0] = "corrupt"
+	assert.Equal(t, identifier, tbl.Identifier())
 }
 
 // TestRewriteRefSnapshotRequirements covers the helper directly:

--- a/table/commit_refresh_replay_test.go
+++ b/table/commit_refresh_replay_test.go
@@ -57,6 +57,7 @@ type identifierCapturingCatalog struct {
 	metadata         Metadata
 	loadIdentifier   Identifier
 	commitIdentifier Identifier
+	failNextCommit   bool
 }
 
 func (c *headTrackingCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
@@ -89,6 +90,11 @@ func (c *identifierCapturingCatalog) LoadTable(_ context.Context, ident Identifi
 
 func (c *identifierCapturingCatalog) CommitTable(_ context.Context, ident Identifier, _ []Requirement, updates []Update) (Metadata, string, error) {
 	c.commitIdentifier = ident
+	if c.failNextCommit {
+		c.failNextCommit = false
+
+		return nil, "", ErrCommitFailed
+	}
 
 	updated, err := UpdateTableMetadata(c.metadata, updates, "")
 	if err != nil {
@@ -246,6 +252,27 @@ func TestDoCommitPassesIdentifierCopy(t *testing.T) {
 	cat.commitIdentifier[0] = "corrupt"
 	assert.Equal(t, identifier, tbl.Identifier())
 	assert.Equal(t, identifier, updated.Identifier())
+}
+
+func TestDoCommitRetryPassesIdentifierCopy(t *testing.T) {
+	branchHead := int64(1)
+	meta := newConflictTestMetadataWithProps(t, &branchHead, iceberg.Properties{
+		CommitNumRetriesKey:     "1",
+		CommitMinRetryWaitMsKey: "1",
+		CommitMaxRetryWaitMsKey: "2",
+	})
+	cat := &identifierCapturingCatalog{metadata: meta, failNextCommit: true}
+	identifier := Identifier{"db", "do-commit-retry-copy-test"}
+
+	tbl := New(identifier, meta, "file:///tmp/test-do-commit-retry-copy/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	_, err := tbl.doCommit(context.Background(), nil, nil, withCommitBranch(MainBranch))
+	require.NoError(t, err)
+	require.NotNil(t, cat.loadIdentifier)
+
+	cat.loadIdentifier[0] = "corrupt"
+	assert.Equal(t, identifier, tbl.Identifier())
 }
 
 // TestRewriteRefSnapshotRequirements covers the helper directly:

--- a/table/commit_test.go
+++ b/table/commit_test.go
@@ -110,6 +110,7 @@ func TestTableCommitDoesNotMarkTransactionCommitted(t *testing.T) {
 func TestTableCommitReturnsCopies(t *testing.T) {
 	tbl := newCommitTestTable(t)
 	tx := tbl.NewTransaction()
+	original := tbl.Identifier()
 
 	require.NoError(t, tx.SetProperties(map[string]string{"key": "value"}))
 
@@ -123,7 +124,10 @@ func TestTableCommitReturnsCopies(t *testing.T) {
 	if len(tc1.Requirements) > 0 {
 		tc1.Requirements = tc1.Requirements[:0]
 	}
+	tc1.Identifier[0] = "different_db"
 	assert.NotEmpty(t, tc2.Requirements)
+	assert.Equal(t, original, tbl.Identifier())
+	assert.Equal(t, original, tc2.Identifier)
 }
 
 func newV1CommitTestTable(t *testing.T) *table.Table {

--- a/table/commit_test.go
+++ b/table/commit_test.go
@@ -49,11 +49,14 @@ func newCommitTestTable(t *testing.T) *table.Table {
 func TestTableCommitFromEmptyTransaction(t *testing.T) {
 	tbl := newCommitTestTable(t)
 	tx := tbl.NewTransaction()
+	original := tbl.Identifier()
 
 	tc, err := tx.TableCommit()
 	require.NoError(t, err)
 
 	assert.Equal(t, table.Identifier{"db", "test_table"}, tc.Identifier)
+	tc.Identifier[0] = "different_db"
+	assert.Equal(t, original, tbl.Identifier())
 	assert.NotNil(t, tc.Requirements, "Requirements must be non-nil empty slice for JSON serialization")
 	assert.NotNil(t, tc.Updates, "Updates must be non-nil empty slice for JSON serialization")
 	assert.Empty(t, tc.Requirements)

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -116,6 +116,22 @@ func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 	assert.Equal(t, Identifier{"db", "scan-copy-test"}, scan.identifier)
 }
 
+func TestTransactionScanCopiesIdentifier(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	txn.tbl.planner = &fakeScanPlanner{
+		result:   ScanPlanningResult{Tasks: []FileScanTask{{}}},
+		supports: true,
+	}
+
+	scan, err := txn.Scan(WithScanPlanningMode(ScanPlanningAuto))
+	require.NoError(t, err)
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+
+	scan.identifier[0] = "corrupt"
+	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
+}
+
 func TestScanPlanningUnknownModeErrors(t *testing.T) {
 	t.Parallel()
 
@@ -136,8 +152,7 @@ type fakeScanPlanner struct {
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
-	// Capture a defensive copy to verify call-site identifiers are not shared.
-	f.receivedIdentifier = append([]string(nil), req.Identifier...)
+	f.receivedIdentifier = req.Identifier
 
 	return f.result, f.err
 }

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -136,6 +136,7 @@ type fakeScanPlanner struct {
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
+	// Capture a defensive copy to verify call-site identifiers are not shared.
 	f.receivedIdentifier = append([]string(nil), req.Identifier...)
 
 	return f.result, f.err

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -94,6 +94,28 @@ func TestScanPlanningAutoUsesCapablePlanner(t *testing.T) {
 	assert.Len(t, tasks, 1)
 }
 
+func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{
+		planner: &fakeScanPlanner{
+			result:   ScanPlanningResult{Tasks: []FileScanTask{{}}},
+			supports: true,
+		},
+		planningMode:   ScanPlanningAuto,
+		identifier:     Identifier{"db", "scan-copy-test"},
+		selectedFields: []string{"*"},
+	}
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, tasks, 1)
+
+	planReq := scan.planner.(*fakeScanPlanner)
+	planReq.receivedIdentifier[0] = "corrupt"
+	assert.Equal(t, Identifier{"db", "scan-copy-test"}, scan.identifier)
+}
+
 func TestScanPlanningUnknownModeErrors(t *testing.T) {
 	t.Parallel()
 
@@ -107,11 +129,14 @@ type fakeScanPlanner struct {
 	result   ScanPlanningResult
 	supports bool
 	err      error
+	// captured after PlanFiles receives it
+	receivedIdentifier Identifier
 }
 
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
 
-func (f *fakeScanPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
+	f.receivedIdentifier = append([]string(nil), req.Identifier...)
 	return f.result, f.err
 }
 

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -137,6 +137,7 @@ func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports 
 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
 	f.receivedIdentifier = append([]string(nil), req.Identifier...)
+
 	return f.result, f.err
 }
 

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -878,7 +878,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 
 	caseSensitive := scan.caseSensitive
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
-		Identifier:       scan.identifier,
+		Identifier:       slices.Clone(scan.identifier),
 		Metadata:         scan.metadata,
 		MetadataLocation: scan.metadataLocation,
 		SnapshotID:       scan.snapshotID,

--- a/table/table.go
+++ b/table/table.go
@@ -104,9 +104,7 @@ func (t Table) Equals(other Table) bool {
 		t.metadata.Equals(other.metadata)
 }
 
-func (t Table) Identifier() Identifier {
-	return slices.Clone(t.identifier)
-}
+func (t Table) Identifier() Identifier                       { return slices.Clone(t.identifier) }
 func (t Table) Metadata() Metadata                           { return t.metadata }
 func (t Table) MetadataLocation() string                     { return t.metadataLocation }
 func (t Table) FS(ctx context.Context) (icebergio.IO, error) { return t.fsF(ctx) }

--- a/table/table.go
+++ b/table/table.go
@@ -605,7 +605,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
-	return New(slices.Clone(t.identifier), newMeta, newLoc, t.fsF, t.cat), nil
+	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every

--- a/table/table.go
+++ b/table/table.go
@@ -511,7 +511,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 			// the new branch head so re-submission is not rejected
 			// just because a peer advanced the head with a
 			// non-conflicting commit.
-			fresh, refreshErr := t.cat.LoadTable(retryCtx, t.identifier)
+			fresh, refreshErr := t.cat.LoadTable(retryCtx, slices.Clone(t.identifier))
 			if refreshErr != nil {
 				return nil, fmt.Errorf("refresh table for retry: %w", refreshErr)
 			}

--- a/table/table.go
+++ b/table/table.go
@@ -104,7 +104,9 @@ func (t Table) Equals(other Table) bool {
 		t.metadata.Equals(other.metadata)
 }
 
-func (t Table) Identifier() Identifier                       { return t.identifier }
+func (t Table) Identifier() Identifier {
+	return slices.Clone(t.identifier)
+}
 func (t Table) Metadata() Metadata                           { return t.metadata }
 func (t Table) MetadataLocation() string                     { return t.metadataLocation }
 func (t Table) FS(ctx context.Context) (icebergio.IO, error) { return t.fsF(ctx) }
@@ -937,7 +939,7 @@ func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, ca
 	}
 
 	return &Table{
-		identifier:       ident,
+		identifier:       slices.Clone(ident),
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 		fsF:              fsF,

--- a/table/table.go
+++ b/table/table.go
@@ -183,7 +183,7 @@ func (t Table) NewTransactionOnBranchWithError(branch string) (*Transaction, err
 }
 
 func (t *Table) Refresh(ctx context.Context) error {
-	fresh, err := t.cat.LoadTable(ctx, t.identifier)
+	fresh, err := t.cat.LoadTable(ctx, slices.Clone(t.identifier))
 	if err != nil {
 		return err
 	}
@@ -567,7 +567,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 			return nil, context.Cause(retryCtx)
 		}
 
-		newMeta, newLoc, err = t.cat.CommitTable(retryCtx, t.identifier, reqs, updates)
+		newMeta, newLoc, err = t.cat.CommitTable(retryCtx, slices.Clone(t.identifier), reqs, updates)
 		if err == nil {
 			break
 		}
@@ -605,7 +605,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
-	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
+	return New(slices.Clone(t.identifier), newMeta, newLoc, t.fsF, t.cat), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every
@@ -903,7 +903,7 @@ func WithRowLineage() ScanOption {
 
 func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
-		identifier:       t.identifier,
+		identifier:       slices.Clone(t.identifier),
 		metadata:         t.metadata,
 		metadataLocation: t.metadataLocation,
 		ioF:              t.fsF,

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -67,6 +67,21 @@ func TestTable(t *testing.T) {
 	suite.Run(t, new(TableTestSuite))
 }
 
+func TestTableIdentifierIsolation(t *testing.T) {
+	meta, err := table.ParseMetadataBytes([]byte(table.ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	ident := table.Identifier{"db", "my_table"}
+	tbl := table.New(ident, meta, "s3://bucket/test/location/metadata.json", nil, nil)
+
+	ident[0] = "altered_ns"
+	require.Equal(t, table.Identifier{"db", "my_table"}, tbl.Identifier())
+
+	out := tbl.Identifier()
+	out[1] = "altered_table"
+	require.Equal(t, table.Identifier{"db", "my_table"}, tbl.Identifier())
+}
+
 func mustFS(t *testing.T, tbl *table.Table) iceio.IO {
 	r, err := tbl.FS(context.Background())
 	require.NoError(t, err)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -26,6 +26,7 @@ import (
 	"iter"
 	"log/slog"
 	"runtime"
+	"slices"
 	"sync"
 	"time"
 
@@ -2194,7 +2195,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 	}
 
 	s := &Scan{
-		identifier:       t.tbl.identifier,
+		identifier:       slices.Clone(t.tbl.identifier),
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,


### PR DESCRIPTION
## Summary

`Table` stores the caller-provided identifier slice directly, and `Identifier()` returned that same slice. Because `Identifier` is `[]string`, callers could mutate table identity after construction and affect catalog operations.

This patch makes `Table` defensive against aliasing:

- `New(...)` now clones the input identifier before storing it.
- `Identifier()` now returns a cloned identifier.
- Added regression coverage to ensure external identifier mutations cannot affect internal table state.

## Testing

- `go test ./table -run TestTableIdentifierIsolation -count=1`
- `go test ./table -count=1`
