### PR TITLE
fix(types): safe compare defaults in NestedField.Equals

### DIFF
--- a/types.go
+++ b/types.go
@@ -20,6 +20,7 @@ package iceberg
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -300,8 +301,8 @@ func (n *NestedField) Equals(other NestedField) bool {
 		n.Name == other.Name &&
 		n.Required == other.Required &&
 		n.Doc == other.Doc &&
-		n.InitialDefault == other.InitialDefault &&
-		n.WriteDefault == other.WriteDefault &&
+		reflect.DeepEqual(n.InitialDefault, other.InitialDefault) &&
+		reflect.DeepEqual(n.WriteDefault, other.WriteDefault) &&
 		n.Type.Equals(other.Type)
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -265,7 +265,8 @@ func TestUnknownTypeInNestedStructs(t *testing.T) {
 		ValueRequired: false,
 	}
 
-	schema := iceberg.NewSchema(1,
+	schema := iceberg.NewSchema(
+		1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
 		iceberg.NestedField{ID: 2, Name: "top", Type: iceberg.UnknownType{}, Required: false},
 		iceberg.NestedField{ID: 3, Name: "arr", Type: listType, Required: false},
@@ -420,7 +421,8 @@ func TestVariantTypeJSONRoundTrip(t *testing.T) {
 }
 
 func TestVariantInSchema(t *testing.T) {
-	sc := iceberg.NewSchema(0,
+	sc := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.VariantType{}, Required: false},
 	)
@@ -433,7 +435,8 @@ func TestVariantInSchema(t *testing.T) {
 }
 
 func TestVariantInNestedTypes(t *testing.T) {
-	sc := iceberg.NewSchema(0,
+	sc := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "events", Type: &iceberg.ListType{
 			ElementID:       2,
 			Element:         iceberg.VariantType{},
@@ -466,7 +469,8 @@ func TestVariantInNestedTypes(t *testing.T) {
 }
 
 func TestVariantInStructField(t *testing.T) {
-	sc := iceberg.NewSchema(0,
+	sc := iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "nested", Type: &iceberg.StructType{
 			FieldList: []iceberg.NestedField{
@@ -838,4 +842,44 @@ func TestGeographyType(t *testing.T) {
 		err := json.Unmarshal([]byte(data), &n)
 		assert.ErrorIs(t, err, iceberg.ErrInvalidTypeString)
 	})
+}
+
+func TestNestedFieldEqualsWithNonComparableDefaults(t *testing.T) {
+	nonComparableDefault := map[string]any{
+		"meta": []any{"a", "b"},
+		"cfg":  map[string]any{"enabled": true},
+	}
+
+	left := iceberg.NestedField{
+		ID:             1,
+		Name:           "payload",
+		Type:           iceberg.PrimitiveTypes.String,
+		Required:       true,
+		InitialDefault: nonComparableDefault,
+		WriteDefault:   []string{"a", "b"},
+	}
+	right := iceberg.NestedField{
+		ID:       1,
+		Name:     "payload",
+		Type:     iceberg.PrimitiveTypes.String,
+		Required: true,
+		InitialDefault: map[string]any{
+			"meta": []any{"a", "b"},
+			"cfg":  map[string]any{"enabled": true},
+		},
+		WriteDefault: []string{"a", "b"},
+	}
+
+	assert.NotPanics(t, func() {
+		assert.True(t, left.Equals(right))
+	})
+
+	right.WriteDefault = []string{"b", "a"}
+	assert.False(t, left.Equals(right))
+	assert.False(t, left.Equals(iceberg.NestedField{
+		ID:       1,
+		Name:     "payload",
+		Type:     iceberg.PrimitiveTypes.String,
+		Required: true,
+	}))
 }


### PR DESCRIPTION
## Summary

`NestedField.Equals` compared `InitialDefault` and `WriteDefault` with `==`, which can panic when defaults contain non-comparable values (maps/slices/etc).

This changes equality to use `reflect.DeepEqual` for defaults so schema/field comparisons stay safe and correct with nested defaults.

Also adds a regression test that verifies:
- non-comparable defaults no longer panic in `Equals`, and
- equivalent deep structures compare equal while different defaults compare false.

## Testing

- `go test ./... -run 'TestNestedFieldEqualsWithNonComparableDefaults|TestUnknownTypeInNestedStructs|TestTypesBasic' -count=1`
