### PR TITLE
fix(view): validate SQL representations in NewVersion

### DIFF
--- a/view/metadata.go
+++ b/view/metadata.go
@@ -173,6 +173,18 @@ func NewVersion(id int64, schemaID int, representations []Representation, defaul
 		return nil, errors.New("invalid view version: must have at least one representation")
 	}
 
+	seenDialects := make(map[string]struct{})
+	for _, repr := range representations {
+		normalizedDialect, err := validateRepresentation(repr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidViewMetadata, err)
+		}
+		if _, ok := seenDialects[normalizedDialect]; ok {
+			return nil, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, normalizedDialect)
+		}
+		seenDialects[normalizedDialect] = struct{}{}
+	}
+
 	version := &Version{
 		VersionID:        id,
 		SchemaID:         schemaID,
@@ -187,6 +199,23 @@ func NewVersion(id int64, schemaID int, representations []Representation, defaul
 	}
 
 	return version, nil
+}
+
+func validateRepresentation(repr Representation) (string, error) {
+	if repr.Type != "sql" {
+		return "", errors.New("invalid view representation: type should be \"sql\"")
+	}
+
+	if strings.TrimSpace(repr.Sql) == "" {
+		return "", errors.New("invalid view representation: sql is required")
+	}
+
+	dialect := strings.TrimSpace(repr.Dialect)
+	if dialect == "" {
+		return "", errors.New("invalid view representation: dialect is required")
+	}
+
+	return strings.ToLower(dialect), nil
 }
 
 // NewVersionFromSQL creates a new Version with a single representation
@@ -446,10 +475,14 @@ func (m *metadata) checkDialectsUnique() error {
 	for _, version := range m.VersionList {
 		seenDialects := make(map[string]bool)
 		for _, repr := range version.Representations {
-			dialect := strings.ToLower(repr.Dialect)
+			dialect, err := validateRepresentation(repr)
+			if err != nil {
+				return fmt.Errorf("%w: version %d: %s", ErrInvalidViewMetadata, version.VersionID, err)
+			}
+
 			if seenDialects[dialect] {
 				return fmt.Errorf("%w: version %d has duplicate dialect %s",
-					ErrInvalidViewMetadata, version.VersionID, repr.Dialect)
+					ErrInvalidViewMetadata, version.VersionID, dialect)
 			}
 			seenDialects[dialect] = true
 		}

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -252,10 +252,14 @@ func (v *Version) Clone() *Version {
 // sqlDialects returns a set of strings representing the SQL dialects supported in this version.
 // Dialects are deduplicated by trimmed, lowercase comparison.
 func (v *Version) sqlDialects() internal.Set[string] {
-	return internal.ToSet(internal.MapSlice(
-		v.Representations,
-		func(r Representation) string { return strings.ToLower(strings.TrimSpace(r.Dialect)) },
-	))
+	dialects := make([]string, 0, len(v.Representations))
+	for _, repr := range v.Representations {
+		if repr.Type == "sql" {
+			dialects = append(dialects, strings.ToLower(strings.TrimSpace(repr.Dialect)))
+		}
+	}
+
+	return internal.ToSet(dialects)
 }
 
 type VersionLogEntry struct {

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -180,7 +180,7 @@ func NewVersion(id int64, schemaID int, representations []Representation, defaul
 			return nil, fmt.Errorf("%w: %s", ErrInvalidViewMetadata, err)
 		}
 		if _, ok := seenDialects[normalizedDialect]; ok {
-			return nil, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, normalizedDialect)
+			return nil, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, repr.Dialect)
 		}
 		seenDialects[normalizedDialect] = struct{}{}
 	}
@@ -201,6 +201,8 @@ func NewVersion(id int64, schemaID int, representations []Representation, defaul
 	return version, nil
 }
 
+// validateRepresentation validates a SQL representation and returns its
+// normalized dialect for duplicate detection.
 func validateRepresentation(repr Representation) (string, error) {
 	if repr.Type != "sql" {
 		return "", errors.New("invalid view representation: type should be \"sql\"")
@@ -248,11 +250,11 @@ func (v *Version) Clone() *Version {
 }
 
 // sqlDialects returns a set of strings representing the SQL dialects supported in this version.
-// Dialects are deduplicated by lowercase comparison
+// Dialects are deduplicated by trimmed, lowercase comparison.
 func (v *Version) sqlDialects() internal.Set[string] {
 	return internal.ToSet(internal.MapSlice(
 		v.Representations,
-		func(r Representation) string { return strings.ToLower(r.Dialect) },
+		func(r Representation) string { return strings.ToLower(strings.TrimSpace(r.Dialect)) },
 	))
 }
 
@@ -475,6 +477,10 @@ func (m *metadata) checkDialectsUnique() error {
 	for _, version := range m.VersionList {
 		seenDialects := make(map[string]bool)
 		for _, repr := range version.Representations {
+			if repr.Type != "sql" {
+				continue
+			}
+
 			dialect, err := validateRepresentation(repr)
 			if err != nil {
 				return fmt.Errorf("%w: version %d: %s", ErrInvalidViewMetadata, version.VersionID, err)
@@ -482,7 +488,7 @@ func (m *metadata) checkDialectsUnique() error {
 
 			if seenDialects[dialect] {
 				return fmt.Errorf("%w: version %d has duplicate dialect %s",
-					ErrInvalidViewMetadata, version.VersionID, dialect)
+					ErrInvalidViewMetadata, version.VersionID, repr.Dialect)
 			}
 			seenDialects[dialect] = true
 		}

--- a/view/metadata_builder.go
+++ b/view/metadata_builder.go
@@ -186,7 +186,7 @@ func (b *MetadataBuilder) addVersion(newVersion *Version) (int64, error) {
 		}
 
 		if _, ok := dialects[normalizedDialect]; ok {
-			return 0, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, normalizedDialect)
+			return 0, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, repr.Dialect)
 		}
 		dialects[normalizedDialect] = struct{}{}
 	}

--- a/view/metadata_builder.go
+++ b/view/metadata_builder.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -181,7 +180,11 @@ func (b *MetadataBuilder) addVersion(newVersion *Version) (int64, error) {
 	}
 	dialects := make(map[string]struct{})
 	for _, repr := range version.Representations {
-		normalizedDialect := strings.ToLower(repr.Dialect)
+		normalizedDialect, err := validateRepresentation(repr)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %s", ErrInvalidViewMetadata, err)
+		}
+
 		if _, ok := dialects[normalizedDialect]; ok {
 			return 0, fmt.Errorf("%w: Invalid view version: Cannot add multiple queries for dialect %s", ErrInvalidViewMetadata, normalizedDialect)
 		}

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -97,6 +97,84 @@ func TestBuild_NullAndMissingFields(t *testing.T) {
 	assert.ErrorContains(t, err, "cannot set uuid to null")
 }
 
+func TestNewVersion_RepresentationValidation(t *testing.T) {
+	_, err := NewVersion(1, 0,
+		Representations{{Type: "sql", Sql: "SELECT 1", Dialect: "spark"}},
+		table.Identifier{"ns"},
+	)
+	assert.NoError(t, err)
+
+	_, err = NewVersion(1, 0,
+		Representations{{Type: "hive", Sql: "SELECT 1", Dialect: "spark"}},
+		table.Identifier{"ns"},
+	)
+	assert.ErrorContains(t, err, "type should be \"sql\"")
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+
+	_, err = NewVersion(1, 0,
+		Representations{{Type: "sql", Sql: "", Dialect: "spark"}},
+		table.Identifier{"ns"},
+	)
+	assert.ErrorContains(t, err, "sql is required")
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+
+	_, err = NewVersion(1, 0,
+		Representations{{Type: "sql", Sql: "SELECT 1", Dialect: ""}},
+		table.Identifier{"ns"},
+	)
+	assert.ErrorContains(t, err, "dialect is required")
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+
+	_, err = NewVersion(1, 0,
+		Representations{
+			{Type: "sql", Sql: "SELECT 1", Dialect: "SpArK"},
+			{Type: "sql", Sql: "SELECT 2", Dialect: "spark"},
+		},
+		table.Identifier{"ns"},
+	)
+	assert.ErrorContains(t, err, "Cannot add multiple queries for dialect spark")
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+}
+
+func TestAddVersion_InvalidRepresentation_Validation(t *testing.T) {
+	invalidVersion := &Version{
+		VersionID: 1,
+		SchemaID:  0,
+		Representations: []Representation{
+			{Type: "hive", Sql: "SELECT 1", Dialect: "spark"},
+		},
+	}
+
+	_, err := newTestBuilder().
+		SetLoc("location").
+		AddSchema(newTestSchema(0)).
+		AddVersion(invalidVersion).
+		SetCurrentVersionID(1).
+		Build()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+	assert.ErrorContains(t, err, "type should be \"sql\"")
+
+	invalidDuplicateVersion := &Version{
+		VersionID: 2,
+		SchemaID:  0,
+		Representations: []Representation{
+			{Type: "sql", Sql: "SELECT 1", Dialect: "spark"},
+			{Type: "sql", Sql: "SELECT 2", Dialect: "spark "},
+		},
+	}
+
+	_, err = newTestBuilder().
+		SetLoc("location").
+		AddSchema(newTestSchema(0)).
+		AddVersion(invalidDuplicateVersion).
+		SetCurrentVersionID(2).
+		Build()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+	assert.ErrorContains(t, err, "Cannot add multiple queries for dialect spark")
+}
+
 func TestSetFormatVersion_Invalid(t *testing.T) {
 	// Downgrade
 	_, err := newTestBuilder().SetFormatVersion(0).Build()
@@ -459,18 +537,20 @@ func TestViewVersionAndSchemaIDReassignment(t *testing.T) {
 }
 
 func TestAddVersion_MultipleSQLForSameDialect(t *testing.T) {
+	// NewVersion now validates representations, so this test exercises duplicate detection
+	// in the builder path for versions coming from external metadata sources.
+	version := &Version{
+		VersionID: 1,
+		SchemaID:  0,
+		Representations: []Representation{
+			{Type: "sql", Sql: "select * from ns.tbl", Dialect: "spark"},
+			{Type: "sql", Sql: "select * from ns.tbl3", Dialect: "SpArK"},
+		},
+	}
 	_, err := newTestBuilder().
 		SetLoc("location").
 		AddSchema(newTestSchema(0)).
-		AddVersion(
-			stripErr(NewVersion(1, 0,
-				[]Representation{
-					NewRepresentation("select * from ns.tbl", "spark"),
-					NewRepresentation("select * from ns.tbl3", "SpArK"),
-				},
-				table.Identifier{"ns"},
-			)),
-		).
+		AddVersion(version).
 		SetCurrentVersionID(1).
 		Build()
 	assert.ErrorContains(t, err, "Invalid view version: Cannot add multiple queries for dialect spark")

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -98,42 +98,70 @@ func TestBuild_NullAndMissingFields(t *testing.T) {
 }
 
 func TestNewVersion_RepresentationValidation(t *testing.T) {
-	_, err := NewVersion(1, 0,
-		Representations{{Type: "sql", Sql: "SELECT 1", Dialect: "spark"}},
-		table.Identifier{"ns"},
-	)
-	assert.NoError(t, err)
-
-	_, err = NewVersion(1, 0,
-		Representations{{Type: "hive", Sql: "SELECT 1", Dialect: "spark"}},
-		table.Identifier{"ns"},
-	)
-	assert.ErrorContains(t, err, "type should be \"sql\"")
-	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
-
-	_, err = NewVersion(1, 0,
-		Representations{{Type: "sql", Sql: "", Dialect: "spark"}},
-		table.Identifier{"ns"},
-	)
-	assert.ErrorContains(t, err, "sql is required")
-	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
-
-	_, err = NewVersion(1, 0,
-		Representations{{Type: "sql", Sql: "SELECT 1", Dialect: ""}},
-		table.Identifier{"ns"},
-	)
-	assert.ErrorContains(t, err, "dialect is required")
-	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
-
-	_, err = NewVersion(1, 0,
-		Representations{
-			{Type: "sql", Sql: "SELECT 1", Dialect: "SpArK"},
-			{Type: "sql", Sql: "SELECT 2", Dialect: "spark"},
+	tests := []struct {
+		name            string
+		representations Representations
+		wantErr         string
+	}{
+		{
+			name: "valid",
+			representations: Representations{
+				{Type: "sql", Sql: "SELECT 1", Dialect: "spark"},
+			},
 		},
-		table.Identifier{"ns"},
-	)
-	assert.ErrorContains(t, err, "Cannot add multiple queries for dialect spark")
-	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+		{
+			name: "invalid type",
+			representations: Representations{
+				{Type: "hive", Sql: "SELECT 1", Dialect: "spark"},
+			},
+			wantErr: "type should be \"sql\"",
+		},
+		{
+			name: "missing sql",
+			representations: Representations{
+				{Type: "sql", Sql: "", Dialect: "spark"},
+			},
+			wantErr: "sql is required",
+		},
+		{
+			name: "missing dialect",
+			representations: Representations{
+				{Type: "sql", Sql: "SELECT 1", Dialect: ""},
+			},
+			wantErr: "dialect is required",
+		},
+		{
+			name: "duplicate dialect",
+			representations: Representations{
+				{Type: "sql", Sql: "SELECT 1", Dialect: "SpArK"},
+				{Type: "sql", Sql: "SELECT 2", Dialect: " spark "},
+			},
+			wantErr: "Cannot add multiple queries for dialect  spark ",
+		},
+		{
+			name: "valid then invalid type",
+			representations: Representations{
+				{Type: "sql", Sql: "SELECT 1", Dialect: "spark"},
+				{Type: "hive", Sql: "SELECT 2", Dialect: "hive"},
+			},
+			wantErr: "type should be \"sql\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewVersion(1, 0, tc.representations, table.Identifier{"ns"})
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidViewMetadata)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }
 
 func TestAddVersion_InvalidRepresentation_Validation(t *testing.T) {
@@ -172,7 +200,7 @@ func TestAddVersion_InvalidRepresentation_Validation(t *testing.T) {
 		Build()
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidViewMetadata)
-	assert.ErrorContains(t, err, "Cannot add multiple queries for dialect spark")
+	assert.ErrorContains(t, err, "Cannot add multiple queries for dialect spark ")
 }
 
 func TestSetFormatVersion_Invalid(t *testing.T) {
@@ -553,7 +581,7 @@ func TestAddVersion_MultipleSQLForSameDialect(t *testing.T) {
 		AddVersion(version).
 		SetCurrentVersionID(1).
 		Build()
-	assert.ErrorContains(t, err, "Invalid view version: Cannot add multiple queries for dialect spark")
+	assert.ErrorContains(t, err, "Invalid view version: Cannot add multiple queries for dialect SpArK")
 }
 
 func TestSetCurrentVersionID_NoLastAddedSchema(t *testing.T) {

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -669,6 +669,40 @@ func TestDroppingDialectDoesNotFailWhenAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUnknownRepresentationSurvivesBuilderRoundTrip(t *testing.T) {
+	metadataJSON := `{
+		"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+		"format-version": 1,
+		"location": "s3://bucket/warehouse/default.db/event_agg",
+		"current-version-id": 1,
+		"versions": [{"version-id": 1, "schema-id": 0, "timestamp-ms": 1234567890, "representations": [
+			{"type": "hive", "sql": "SELECT 1", "dialect": "hive"},
+			{"type": "sql", "sql": "SELECT 1", "dialect": "spark"}
+		]}],
+		"schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+		"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
+	}`
+
+	metadata, err := ParseMetadataString(metadataJSON)
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(metadata)
+	require.NoError(t, err)
+	nextVersion, err := NewVersion(
+		2,
+		metadata.CurrentSchemaID(),
+		Representations{NewRepresentation("SELECT 2", "spark")},
+		metadata.CurrentVersion().DefaultNamespace,
+	)
+	require.NoError(t, err)
+
+	result, err := builder.SetCurrentVersion(nextVersion, metadata.CurrentSchema()).Build()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Metadata.Versions(), 2)
+	assert.Equal(t, "hive", result.Metadata.Versions()[0].Representations[0].Type)
+}
+
 func TestCurrentViewVersionIsNeverExpired(t *testing.T) {
 	props := iceberg.Properties{VersionHistorySizeKey: "1"}
 	schema := newTestSchema(0)

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -699,8 +699,8 @@ func TestUnknownRepresentationSurvivesBuilderRoundTrip(t *testing.T) {
 	result, err := builder.SetCurrentVersion(nextVersion, metadata.CurrentSchema()).Build()
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Len(t, result.Metadata.Versions(), 2)
-	assert.Equal(t, "hive", result.Metadata.Versions()[0].Representations[0].Type)
+	require.Len(t, result.Versions(), 2)
+	assert.Equal(t, "hive", result.Versions()[0].Representations[0].Type)
 }
 
 func TestCurrentViewVersionIsNeverExpired(t *testing.T) {

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -334,7 +334,7 @@ func TestDuplicateDialects(t *testing.T) {
 			"timestamp-ms": 1234567890,
 			"representations": [
 				{"type": "sql", "sql": "SELECT 1", "dialect": "spark"},
-				{"type": "sql", "sql": "SELECT 2", "dialect": "SPARK"}
+				{"type": "sql", "sql": "SELECT 2", "dialect": " SPARK "}
 			]
 		}],
 		"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
@@ -346,6 +346,62 @@ func TestDuplicateDialects(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrInvalidViewMetadata))
 	assert.Contains(t, err.Error(), "duplicate dialect")
+	assert.Contains(t, err.Error(), "version 1")
+	assert.Contains(t, err.Error(), "spark")
+}
+
+func TestInvalidRepresentationInJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "invalid-type",
+			json: `{
+				"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+				"format-version": 1,
+				"location": "s3://bucket/warehouse/default.db/event_agg",
+				"current-version-id": 1,
+				"versions": [{"version-id": 1, "schema-id": 1, "timestamp-ms": 1234567890, "representations": [{"type": "hive", "sql": "SELECT 1", "dialect": "spark"}]}],
+				"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
+				"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
+			}`,
+		},
+		{
+			name: "missing-sql",
+			json: `{
+				"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+				"format-version": 1,
+				"location": "s3://bucket/warehouse/default.db/event_agg",
+				"current-version-id": 1,
+				"versions": [{"version-id": 1, "schema-id": 1, "timestamp-ms": 1234567890, "representations": [{"type": "sql", "sql": "   ", "dialect": "spark"}]}],
+				"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
+				"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
+			}`,
+		},
+		{
+			name: "missing-dialect",
+			json: `{
+				"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+				"format-version": 1,
+				"location": "s3://bucket/warehouse/default.db/event_agg",
+				"current-version-id": 1,
+				"versions": [{"version-id": 1, "schema-id": 1, "timestamp-ms": 1234567890, "representations": [{"type": "sql", "sql": "SELECT 1", "dialect": ""}]}],
+				"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
+				"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var meta metadata
+			err := json.Unmarshal([]byte(tc.json), &meta)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidViewMetadata))
+			assert.Contains(t, err.Error(), "invalid view representation")
+		})
+	}
 }
 
 func TestNilFieldsInJSON(t *testing.T) {

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -347,7 +347,7 @@ func TestDuplicateDialects(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrInvalidViewMetadata))
 	assert.Contains(t, err.Error(), "duplicate dialect")
 	assert.Contains(t, err.Error(), "version 1")
-	assert.Contains(t, err.Error(), "spark")
+	assert.Contains(t, err.Error(), " SPARK ")
 }
 
 func TestInvalidRepresentationInJSON(t *testing.T) {
@@ -355,18 +355,6 @@ func TestInvalidRepresentationInJSON(t *testing.T) {
 		name string
 		json string
 	}{
-		{
-			name: "invalid-type",
-			json: `{
-				"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
-				"format-version": 1,
-				"location": "s3://bucket/warehouse/default.db/event_agg",
-				"current-version-id": 1,
-				"versions": [{"version-id": 1, "schema-id": 1, "timestamp-ms": 1234567890, "representations": [{"type": "hive", "sql": "SELECT 1", "dialect": "spark"}]}],
-				"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
-				"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
-			}`,
-		},
 		{
 			name: "missing-sql",
 			json: `{
@@ -402,6 +390,27 @@ func TestInvalidRepresentationInJSON(t *testing.T) {
 			assert.Contains(t, err.Error(), "invalid view representation")
 		})
 	}
+}
+
+func TestUnknownRepresentationTypeInJSON(t *testing.T) {
+	validJSON := `{
+		"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+		"format-version": 1,
+		"location": "s3://bucket/warehouse/default.db/event_agg",
+		"current-version-id": 1,
+		"versions": [{"version-id": 1, "schema-id": 1, "timestamp-ms": 1234567890, "representations": [
+			{"type": "hive", "sql": "SELECT 1", "dialect": "spark"},
+			{"type": "sql", "sql": "SELECT 1", "dialect": "spark"}
+		]}],
+		"schemas": [{"schema-id": 1, "type": "struct", "fields": []}],
+		"version-log": [{"timestamp-ms": 1234567890, "version-id": 1}]
+	}`
+
+	var meta metadata
+	require.NoError(t, json.Unmarshal([]byte(validJSON), &meta))
+	require.Len(t, meta.VersionList, 1)
+	require.Len(t, meta.VersionList[0].Representations, 2)
+	assert.Equal(t, "hive", meta.VersionList[0].Representations[0].Type)
 }
 
 func TestNilFieldsInJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add strict validation in `view.NewVersion` for each representation:
  - `Type` must be exactly `"sql"`
  - `Sql` must be non-empty
  - `Dialect` must be non-empty
  - duplicate dialects rejected case-insensitively
- Add regression test coverage for malformed/duplicate representation combinations in `view/metadata_builder_test.go`.
- Keep `NewVersionFromSQL` behavior aligned through delegated constructor validation.

## Testing
- `go test ./view -count=1`