### PR TITLE
fix(table): clone scan options map in WithOptions

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"iter"
 	"log"
+	"maps"
 	"math/rand/v2"
 	"runtime"
 	"slices"
@@ -834,7 +835,7 @@ func WithOptions(opts iceberg.Properties) ScanOption {
 	}
 
 	return func(scan *Scan) {
-		scan.options = opts
+		scan.options = maps.Clone(opts)
 	}
 }
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -893,6 +893,31 @@ func (t *TableWritingTestSuite) TestAddFilesWithLargeAndRegular() {
 	t.Truef(arrowSchemaLarge.Equal(result.Schema()), "expected schema: %s, got: %s", arrowSchemaLarge, result.Schema())
 }
 
+func (t *TableWritingTestSuite) TestScanWithOptionsAliasing() {
+	ident := table.Identifier{"default", "test_scan_with_options_alias_v" + strconv.Itoa(t.formatVersion)}
+	tbl := t.createTable(ident, t.formatVersion, *iceberg.UnpartitionedSpec, t.tableSchema)
+
+	filePath := fmt.Sprintf("%s/scan-with-options-alias-%d/test.parquet", t.location, t.formatVersion)
+	t.writeParquet(mustFS(t.T(), tbl).(iceio.WriteFileIO), filePath, t.arrTbl)
+
+	tx := tbl.NewTransaction()
+	t.Require().NoError(tx.AddFiles(t.ctx, []string{filePath}, nil, false))
+
+	opts := iceberg.Properties{
+		table.ScanOptionArrowUseLargeTypes: "false",
+	}
+	scan, err := tx.Scan(table.WithOptions(opts))
+	t.Require().NoError(err)
+
+	opts[table.ScanOptionArrowUseLargeTypes] = "true"
+
+	result, err := scan.ToArrowTable(context.Background())
+	t.Require().NoError(err)
+	defer result.Release()
+
+	t.True(t.arrSchema.Equal(result.Schema()))
+}
+
 func (t *TableWritingTestSuite) TestAddFilesValidUpcast() {
 	ident := table.Identifier{"default", "test_table_with_valid_upcast_v" + strconv.Itoa(t.formatVersion)}
 	tbl := t.createTable(ident, t.formatVersion, *iceberg.UnpartitionedSpec, t.tableSchemaPromotedTypes)


### PR DESCRIPTION
## Summary

- Fix `table.WithOptions` to copy the caller's map with `maps.Clone` so scan behavior no longer changes if the caller mutates options after scan creation.
- Add regression test `TestScanWithOptionsAliasing` in `table/table_test.go` to verify scan behavior is isolated from later external map mutations.

## Testing
- `go test ./table -run TestTable -count=1`
