### PR TITLE
fix: validate format-version in metadata constructors

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2205,16 +2205,20 @@ func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, 
 	if tableUuid == uuid.Nil {
 		tableUuid = uuid.New()
 	}
+	var inputProps iceberg.Properties
 	var err error
 	formatVersion := DefaultFormatVersion
 	if props != nil {
-		verStr, ok := props[PropertyFormatVersion]
+		inputProps = maps.Clone(props)
+		verStr, ok := inputProps[PropertyFormatVersion]
 		if ok {
 			if formatVersion, err = strconv.Atoi(verStr); err != nil {
-				formatVersion = DefaultFormatVersion
+				return nil, fmt.Errorf("%w: %s", iceberg.ErrInvalidFormatVersion, verStr)
 			}
-			delete(props, PropertyFormatVersion)
+			delete(inputProps, PropertyFormatVersion)
 		}
+	} else {
+		inputProps = props
 	}
 
 	reassignedIds, err := reassignIDs(sc, partitions, sortOrder)
@@ -2259,7 +2263,7 @@ func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, 
 		return nil, err
 	}
 
-	if err = builder.SetProperties(props); err != nil {
+	if err = builder.SetProperties(inputProps); err != nil {
 		return nil, err
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2217,8 +2217,6 @@ func NewMetadataWithUUID(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, 
 			}
 			delete(inputProps, PropertyFormatVersion)
 		}
-	} else {
-		inputProps = props
 	}
 
 	reassignedIds, err := reassignIDs(sc, partitions, sortOrder)

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -780,6 +780,22 @@ func TestNewMetadataWithExplicitV1Format(t *testing.T) {
 	assert.Truef(t, expected.Equals(actual), "expected: %s\ngot: %s", expected, actual)
 }
 
+func TestNewMetadataRejectInvalidFormatVersion(t *testing.T) {
+	props := iceberg.Properties{
+		"format-version": "banana",
+		"foo":            "bar",
+	}
+	schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "x", Type: iceberg.PrimitiveTypes.Int64})
+
+	metadata, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "s3://bucket/path", props)
+	require.Error(t, err)
+	require.ErrorIs(t, err, iceberg.ErrInvalidFormatVersion)
+	assert.Nil(t, metadata)
+	assert.Equal(t, "banana", props["format-version"])
+	assert.Equal(t, "bar", props["foo"])
+	assert.Len(t, props, 2)
+}
+
 func TestNewMetadataV2Format(t *testing.T) {
 	schema := iceberg.NewSchemaWithIdentifiers(10,
 		[]int{22},

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -522,16 +522,20 @@ func NewMetadataWithUUID(version *Version, sc *iceberg.Schema, location string, 
 	formatVersion := DefaultViewFormatVersion
 	if props != nil {
 		inputProps = maps.Clone(props)
-		verStr, ok := inputProps["format-version"]
+		verStr, ok := inputProps[table.PropertyFormatVersion]
 		if ok {
 			var err error
 			if formatVersion, err = strconv.Atoi(verStr); err != nil {
 				return nil, fmt.Errorf("%w: %s", iceberg.ErrInvalidFormatVersion, verStr)
 			}
-			delete(inputProps, "format-version")
+			delete(inputProps, table.PropertyFormatVersion)
 		}
 	} else {
 		inputProps = props
+	}
+
+	if formatVersion != DefaultViewFormatVersion {
+		return nil, fmt.Errorf("%w: %d", iceberg.ErrInvalidFormatVersion, formatVersion)
 	}
 
 	// We assume that this constructor is used for building metadata for a new view.

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -530,11 +530,9 @@ func NewMetadataWithUUID(version *Version, sc *iceberg.Schema, location string, 
 			}
 			delete(inputProps, table.PropertyFormatVersion)
 		}
-	} else {
-		inputProps = props
 	}
 
-	if formatVersion != DefaultViewFormatVersion {
+	if formatVersion > SupportedViewFormatVersion {
 		return nil, fmt.Errorf("%w: %d", iceberg.ErrInvalidFormatVersion, formatVersion)
 	}
 

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -518,16 +518,20 @@ func NewMetadataWithUUID(version *Version, sc *iceberg.Schema, location string, 
 		viewUUID = uuid.New()
 	}
 
+	var inputProps iceberg.Properties
 	formatVersion := DefaultViewFormatVersion
 	if props != nil {
-		verStr, ok := props["format-version"]
+		inputProps = maps.Clone(props)
+		verStr, ok := inputProps["format-version"]
 		if ok {
 			var err error
 			if formatVersion, err = strconv.Atoi(verStr); err != nil {
-				formatVersion = DefaultViewFormatVersion
+				return nil, fmt.Errorf("%w: %s", iceberg.ErrInvalidFormatVersion, verStr)
 			}
-			delete(props, "format-version")
+			delete(inputProps, "format-version")
 		}
+	} else {
+		inputProps = props
 	}
 
 	// We assume that this constructor is used for building metadata for a new view.
@@ -547,7 +551,7 @@ func NewMetadataWithUUID(version *Version, sc *iceberg.Schema, location string, 
 		SetFormatVersion(formatVersion).
 		SetUUID(viewUUID).
 		SetLoc(location).
-		SetProperties(props).
+		SetProperties(inputProps).
 		SetCurrentVersion(version, sc).
 		Build()
 }

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,21 +90,43 @@ func TestNewMetadata(t *testing.T) {
 }
 
 func TestNewMetadataRejectInvalidFormatVersion(t *testing.T) {
-	version := newTestVersion(1, LastAddedID,
-		WithVersionSummary(VersionSummary{"summary-key": "summary-val"}),
-		WithTimestampMS(1000))
-	schema := newTestSchema(0)
-	props := iceberg.Properties{
-		"format-version": "banana",
-		"foo":            "bar",
+	tests := []struct {
+		name         string
+		formatVer    string
+		versionValue string
+	}{
+		{
+			name:         "non-numeric format-version",
+			formatVer:    "banana",
+			versionValue: "banana",
+		},
+		{
+			name:         "unsupported format-version",
+			formatVer:    "2",
+			versionValue: "2",
+		},
 	}
 
-	md, err := NewMetadata(version, schema, "location", props)
-	require.Error(t, err)
-	require.Nil(t, md)
-	assert.Equal(t, "banana", props["format-version"])
-	assert.Equal(t, "bar", props["foo"])
-	assert.Len(t, props, 2)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version := newTestVersion(1, LastAddedID,
+				WithVersionSummary(VersionSummary{"summary-key": "summary-val"}),
+				WithTimestampMS(1000))
+			schema := newTestSchema(0)
+			props := iceberg.Properties{
+				table.PropertyFormatVersion: tc.formatVer,
+				"foo":                       "bar",
+			}
+
+			md, err := NewMetadata(version, schema, "location", props)
+			require.Error(t, err)
+			require.ErrorIs(t, err, iceberg.ErrInvalidFormatVersion)
+			require.Nil(t, md)
+			assert.Equal(t, tc.versionValue, props[table.PropertyFormatVersion])
+			assert.Equal(t, "bar", props["foo"])
+			assert.Len(t, props, 2)
+		})
+	}
 }
 
 func TestUnmarshalViewMetadata(t *testing.T) {

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -91,19 +91,16 @@ func TestNewMetadata(t *testing.T) {
 
 func TestNewMetadataRejectInvalidFormatVersion(t *testing.T) {
 	tests := []struct {
-		name         string
-		formatVer    string
-		versionValue string
+		name      string
+		formatVer string
 	}{
 		{
-			name:         "non-numeric format-version",
-			formatVer:    "banana",
-			versionValue: "banana",
+			name:      "non-numeric format-version",
+			formatVer: "banana",
 		},
 		{
-			name:         "unsupported format-version",
-			formatVer:    "2",
-			versionValue: "2",
+			name:      "unsupported format-version",
+			formatVer: "2",
 		},
 	}
 
@@ -122,7 +119,7 @@ func TestNewMetadataRejectInvalidFormatVersion(t *testing.T) {
 			require.Error(t, err)
 			require.ErrorIs(t, err, iceberg.ErrInvalidFormatVersion)
 			require.Nil(t, md)
-			assert.Equal(t, tc.versionValue, props[table.PropertyFormatVersion])
+			assert.Equal(t, tc.formatVer, props[table.PropertyFormatVersion])
 			assert.Equal(t, "bar", props["foo"])
 			assert.Len(t, props, 2)
 		})

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -88,6 +88,24 @@ func TestNewMetadata(t *testing.T) {
 	assert.Equal(t, []VersionLogEntry{{TimestampMS: 1000, VersionID: 1}}, md.VersionLog())
 }
 
+func TestNewMetadataRejectInvalidFormatVersion(t *testing.T) {
+	version := newTestVersion(1, LastAddedID,
+		WithVersionSummary(VersionSummary{"summary-key": "summary-val"}),
+		WithTimestampMS(1000))
+	schema := newTestSchema(0)
+	props := iceberg.Properties{
+		"format-version": "banana",
+		"foo":            "bar",
+	}
+
+	md, err := NewMetadata(version, schema, "location", props)
+	require.Error(t, err)
+	require.Nil(t, md)
+	assert.Equal(t, "banana", props["format-version"])
+	assert.Equal(t, "bar", props["foo"])
+	assert.Len(t, props, 2)
+}
+
 func TestUnmarshalViewMetadata(t *testing.T) {
 	md, err := ParseMetadataString(exampleViewJSON)
 	require.NoError(t, err)


### PR DESCRIPTION
## Why

Table and view metadata creation accepted invalid `format-version` values silently. A bad property like `format-version: banana` currently fell back to the default version and also mutated the caller's props map, which can hide user mistakes and corrupt input ownership.

## What changed

- table metadata (`table/metadata.go`):
  - In `NewMetadataWithUUID`, `format-version` is now parsed with strict `Atoi` validation.
  - Invalid values now return `iceberg.ErrInvalidFormatVersion` instead of silently defaulting.
  - `format-version` is removed from a **cloned** props map before passing into metadata builder, so caller-provided maps are not mutated.

- view metadata (`view/metadata.go`):
  - Mirrored the same strict validation in view metadata creation.
  - Invalid values now return `iceberg.ErrInvalidFormatVersion`.
  - Uses a cloned props map to avoid external mutation.

## Testing

- `go test ./table -run 'TestNewMetadataRejectInvalidFormatVersion|TestNewMetadataWithExplicitV1Format|TestNewMetadataV2Format' -count=1`
- `go test ./view -run 'TestNewMetadataRejectInvalidFormatVersion|TestNewMetadata|TestUnmarshalViewMetadata' -count=1`

