### PR TITLE
fix(table): surface transaction initialization errors

### DIFF
--- a/table/commit.go
+++ b/table/commit.go
@@ -54,6 +54,10 @@ func (t *Transaction) TableCommit() (TableCommit, error) {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
+	if err := t.ensureInitialized(); err != nil {
+		return TableCommit{}, err
+	}
+
 	if t.committed {
 		return TableCommit{}, errors.New("transaction has already been committed")
 	}

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -105,6 +105,10 @@ func isFloatingPointType(typ iceberg.Type) bool {
 //	rd.AddDeletes(deleteFiles...)
 //	err = rd.Commit(ctx)
 func (t *Transaction) WriteEqualityDeletes(ctx context.Context, equalityFieldIDs []int, records iter.Seq2[arrow.RecordBatch, error]) ([]iceberg.DataFile, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
+
 	if t.meta.formatVersion < 2 {
 		return nil, fmt.Errorf("equality deletes require table format version >= 2, got v%d",
 			t.meta.formatVersion)

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -243,7 +243,11 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 	b.lastUpdatedMS = 0
 	b.lastColumnId = metadata.LastColumnID()
 	b.schemaList = slices.Clone(metadata.Schemas())
-	b.currentSchemaID = metadata.CurrentSchema().ID
+	currentSchema := metadata.CurrentSchema()
+	if currentSchema == nil {
+		return nil, fmt.Errorf("%w: current schema is missing", ErrInvalidMetadata)
+	}
+	b.currentSchemaID = currentSchema.ID
 	b.specs = slices.Clone(metadata.PartitionSpecs())
 	defaultSpecID := metadata.DefaultPartitionSpec()
 	b.defaultSpecID = defaultSpecID

--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -101,6 +101,10 @@ func (rd *RowDelta) AddDeletes(files ...iceberg.DataFile) *RowDelta {
 // commit, if any file has an unexpected content type, or if the table
 // format version does not support delete files.
 func (rd *RowDelta) Commit(ctx context.Context) error {
+	if err := rd.txn.ensureInitialized(); err != nil {
+		return err
+	}
+
 	if len(rd.dataFiles) == 0 && len(rd.delFiles) == 0 {
 		return errors.New("row delta must have at least one data file or delete file")
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -131,20 +131,53 @@ func (t Table) LocationProvider() (LocationProvider, error) {
 }
 
 func (t Table) NewTransaction() *Transaction {
-	return t.NewTransactionOnBranch(MainBranch)
+	txn, err := t.NewTransactionOnBranchWithError(MainBranch)
+	if err != nil {
+		return t.newBrokenTransaction(MainBranch, err)
+	}
+
+	return txn
 }
 
 // NewTransactionOnBranch creates a new transaction that commits to the named
 // branch. Use [NewTransaction] to commit to the default "main" branch.
 func (t Table) NewTransactionOnBranch(branch string) *Transaction {
-	meta, _ := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
+	txn, err := t.NewTransactionOnBranchWithError(branch)
+	if err != nil {
+		return t.newBrokenTransaction(branch, err)
+	}
+
+	return txn
+}
+
+func (t Table) newBrokenTransaction(branch string, err error) *Transaction {
+	return &Transaction{
+		tbl:     &t,
+		initErr: err,
+		branch:  branch,
+		reqs:    []Requirement{},
+	}
+}
+
+// NewTransactionOnBranchWithError creates a new transaction and returns any metadata
+// initialization error that prevents builder construction.
+//
+// This preserves the old non-failing constructor contract while allowing
+// callers to receive the precise initialization error instead of hitting
+// panic/undefined behavior later.
+func (t Table) NewTransactionOnBranchWithError(branch string) (*Transaction, error) {
+	meta, err := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Transaction{
-		tbl:    &t,
-		meta:   meta,
-		branch: branch,
-		reqs:   []Requirement{},
-	}
+		tbl:     &t,
+		meta:    meta,
+		branch:  branch,
+		reqs:    []Requirement{},
+		initErr: nil,
+	}, nil
 }
 
 func (t *Table) Refresh(ctx context.Context) error {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -75,9 +75,10 @@ func (s snapshotUpdate) mergeAppend() *snapshotProducer {
 }
 
 type Transaction struct {
-	tbl    *Table
-	meta   *MetadataBuilder
-	branch string
+	tbl     *Table
+	meta    *MetadataBuilder
+	branch  string
+	initErr error
 
 	reqs []Requirement
 
@@ -94,9 +95,24 @@ type Transaction struct {
 	committed bool
 }
 
+func (t *Transaction) ensureInitialized() error {
+	if t.initErr != nil {
+		return t.initErr
+	}
+	if t.meta == nil {
+		return fmt.Errorf("%w: transaction metadata builder is not initialized", ErrInvalidMetadata)
+	}
+
+	return nil
+}
+
 func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 	t.mx.Lock()
 	defer t.mx.Unlock()
+
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 
 	if t.committed {
 		return errors.New("transaction has already been committed")
@@ -223,6 +239,9 @@ func (t *Transaction) updateSnapshot(wfs io.WriteFileIO, props iceberg.Propertie
 }
 
 func (t *Transaction) SetProperties(props iceberg.Properties) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	if len(props) > 0 {
 		return t.apply([]Update{NewSetPropertiesUpdate(props)}, nil)
 	}
@@ -233,10 +252,17 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 // UpgradeFormatVersion upgrades the table to the given format version. Downgrading
 // is not allowed. If the table is already at the given version, this is a no-op.
 func (t *Transaction) UpgradeFormatVersion(version int) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
+
 	return t.apply([]Update{NewUpgradeFormatVersionUpdate(version)}, nil)
 }
 
 func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	cs := t.meta.currentSnapshot()
 	if cs == nil {
 		return errors.New("cannot rollback: table has no current snapshot")
@@ -346,6 +372,9 @@ func WithPostCommit(postCommit bool) ExpireSnapshotsOpt {
 //
 // The "iceberg expire-snapshots" CLI command wraps the same operation.
 func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	var (
 		cfg         = expireSnapshotsCfg{postCommit: true}
 		updates     []Update
@@ -449,6 +478,9 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 }
 
 func (t *Transaction) AppendTable(ctx context.Context, tbl arrow.Table, batchSize int64, snapshotProps iceberg.Properties) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	rdr := array.NewTableReader(tbl, batchSize)
 	defer rdr.Release()
 
@@ -456,6 +488,9 @@ func (t *Transaction) AppendTable(ctx context.Context, tbl arrow.Table, batchSiz
 }
 
 func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapshotProps iceberg.Properties) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	fs, err := t.tbl.fsF(ctx)
 	if err != nil {
 		return err
@@ -496,6 +531,9 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 //
 // For now, we'll keep using an overwrite operation.
 func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
 			return t.AddFiles(ctx, filesToAdd, snapshotProps, false)
@@ -759,6 +797,9 @@ func (t *Transaction) ensureNameMapping() error {
 // Callers are responsible for ensuring each DataFile is valid and consistent with the table.
 // Supplying incorrect DataFile metadata can produce an invalid snapshot and break reads.
 func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	if len(dataFiles) == 0 {
 		return nil
 	}
@@ -843,6 +884,9 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 //   - Avoiding file scanning improves performance or reliability
 //   - Working with storage systems where immediate file reads may be unreliable
 func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesToDelete, filesToAdd []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	if len(filesToDelete) == 0 {
 		if len(filesToAdd) > 0 {
 			return t.AddDataFiles(ctx, filesToAdd, snapshotProps, opts...)
@@ -950,6 +994,9 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 // are replaced with new (compacted) data files, and delete files that are fully
 // applied are removed.
 func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataFilesToAdd, deleteFilesToRemove []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	// Delegate data file replacement to existing logic.
 	if len(deleteFilesToRemove) == 0 {
 		return t.ReplaceDataFilesWithDataFiles(ctx, dataFilesToDelete, dataFilesToAdd, snapshotProps, opts...)
@@ -1118,6 +1165,9 @@ func WithAddFilesConcurrency(concurrency int) AddFilesOption {
 }
 
 func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshotProps iceberg.Properties, ignoreDuplicates bool, opts ...AddFilesOption) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	addFilesOp := addFilesOperation{
 		concurrency: runtime.GOMAXPROCS(0),
 	}
@@ -1276,6 +1326,9 @@ func WithOverwriteCaseInsensitive() OverwriteOption {
 // can be overridden using the WithOverwriteConcurrency option.
 // If concurrency <= 0, defaults to runtime.GOMAXPROCS(0).
 func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, snapshotProps iceberg.Properties, opts ...OverwriteOption) error {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	overwrite := overwriteOperation{
 		concurrency:   runtime.GOMAXPROCS(0),
 		filter:        iceberg.AlwaysTrue{},
@@ -1331,6 +1384,9 @@ func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, sna
 }
 
 func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation Operation, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, io.WriteFileIO, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, nil, err
+	}
 	fs, err := t.tbl.fsF(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -1374,6 +1430,9 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 }
 
 func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
 	fs, err := t.tbl.fsF(ctx)
 	if err != nil {
 		return nil, err
@@ -1474,6 +1533,9 @@ func WithDeleteCaseInsensitive() DeleteOption {
 // The concurrency parameter controls the level of parallelism for manifest processing and file rewriting and
 // can be overridden using the WithOverwriteConcurrency option. Defaults to runtime.GOMAXPROCS(0).
 func (t *Transaction) Delete(ctx context.Context, filter iceberg.BooleanExpression, snapshotProps iceberg.Properties, opts ...DeleteOption) (err error) {
+	if err := t.ensureInitialized(); err != nil {
+		return err
+	}
 	deleteOp := deleteOperation{
 		concurrency:   runtime.GOMAXPROCS(0),
 		caseSensitive: true,
@@ -2108,6 +2170,9 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 }
 
 func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
 	updatedMeta, err := t.meta.Build()
 	if err != nil {
 		return nil, err
@@ -2136,6 +2201,9 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 }
 
 func (t *Transaction) StagedTable() (*StagedTable, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
 	updatedMeta, err := t.meta.Build()
 	if err != nil {
 		return nil, err
@@ -2155,6 +2223,10 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	t.mx.Lock()
 	defer t.mx.Unlock()
+
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
 
 	if t.committed {
 		return nil, errors.New("transaction has already been committed")

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -96,6 +96,9 @@ type Transaction struct {
 }
 
 func (t *Transaction) ensureInitialized() error {
+	if t == nil {
+		return fmt.Errorf("%w: transaction is nil", ErrInvalidMetadata)
+	}
 	if t.initErr != nil {
 		return t.initErr
 	}

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -18,10 +18,12 @@
 package table
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +60,89 @@ func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *te
 	require.NoError(t, err)
 	require.Len(t, txn.reqs, 1)
 	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &mainSnapshotID)
+}
+
+func TestNewTransactionOnBranchWithErrorReturnsTransactionInitError(t *testing.T) {
+	baseMeta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder, "table-location", nil)
+	require.NoError(t, err, "new metadata")
+
+	txn, err := New(Identifier{"db", "broken"}, brokenMetadata{
+		Metadata: baseMeta,
+	}, "metadata.json", func(context.Context) (iceio.IO, error) {
+		return nil, nil
+	}, nil).NewTransactionOnBranchWithError(MainBranch)
+	require.Error(t, err, "expected metadata builder initialization to fail")
+	require.ErrorContains(t, err, "current schema is missing")
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	require.Nil(t, txn)
+}
+
+func TestNewTransactionOnBranchKeepsLegacySignatureAndFailsOnUse(t *testing.T) {
+	baseMeta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder, "table-location", nil)
+	require.NoError(t, err, "new metadata")
+
+	txn := New(Identifier{"db", "broken"}, brokenMetadata{
+		Metadata: baseMeta,
+	}, "metadata.json", func(context.Context) (iceio.IO, error) {
+		return nil, nil
+	}, nil).NewTransaction()
+
+	t.Run("set properties returns init error", func(t *testing.T) {
+		err := txn.SetProperties(iceberg.Properties{"k": "v"})
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
+	t.Run("update schema no longer panics", func(t *testing.T) {
+		var err error
+		require.NotPanics(t, func() {
+			err = txn.UpdateSchema(true, false).
+				AddColumn([]string{"new_col"}, iceberg.PrimitiveTypes.String, "", false, nil).
+				Commit()
+		})
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
+	t.Run("update spec returns init error", func(t *testing.T) {
+		err := txn.UpdateSpec(true).AddIdentity("id").Commit()
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
+	t.Run("table commit returns init error", func(t *testing.T) {
+		_, err := txn.TableCommit()
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
+	t.Run("write equality deletes returns init error", func(t *testing.T) {
+		_, err := txn.WriteEqualityDeletes(context.Background(), []int{1}, nil)
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
+	t.Run("row delta commit returns init error", func(t *testing.T) {
+		rowFile, dataErr := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec,
+			iceberg.EntryContentData,
+			"file://data.parquet",
+			iceberg.ParquetFile,
+			nil,
+			nil,
+			nil,
+			10,
+			10,
+		)
+		require.NoError(t, dataErr, "new data file builder")
+
+		rd := txn.NewRowDelta(nil).AddRows(rowFile.Build())
+		err := rd.Commit(context.Background())
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+}
+
+type brokenMetadata struct {
+	Metadata
+}
+
+func (m brokenMetadata) CurrentSchema() *iceberg.Schema {
+	return nil
 }
 
 func TestTransactionApplyKeepsMetadataUnchangedOnUpdateFailure(t *testing.T) {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -117,6 +117,12 @@ func TestNewTransactionOnBranchKeepsLegacySignatureAndFailsOnUse(t *testing.T) {
 		require.ErrorContains(t, err, "current schema is missing")
 	})
 
+	t.Run("commit returns init error", func(t *testing.T) {
+		_, err := txn.Commit(context.Background())
+		require.ErrorIs(t, err, ErrInvalidMetadata)
+		require.ErrorContains(t, err, "current schema is missing")
+	})
+
 	t.Run("row delta commit returns init error", func(t *testing.T) {
 		rowFile, dataErr := iceberg.NewDataFileBuilder(
 			*iceberg.UnpartitionedSpec,
@@ -135,6 +141,14 @@ func TestNewTransactionOnBranchKeepsLegacySignatureAndFailsOnUse(t *testing.T) {
 		err := rd.Commit(context.Background())
 		require.ErrorContains(t, err, "current schema is missing")
 	})
+}
+
+func TestTransactionEnsureInitializedNilReceiver(t *testing.T) {
+	var txn *Transaction
+
+	err := txn.ensureInitialized()
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	require.ErrorContains(t, err, "transaction is nil")
 }
 
 type brokenMetadata struct {

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -91,6 +91,7 @@ type UpdateSchema struct {
 	txn          *Transaction
 	schema       *iceberg.Schema
 	lastColumnID int
+	err          error
 
 	deletes map[int]struct{}
 	updates map[int]map[int]iceberg.NestedField
@@ -136,12 +137,6 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 	u := &UpdateSchema{
 		txn:    txn,
 		schema: nil,
-		// Seed from metadata's last-column-id rather than the current schema's
-		// highest field id. Per the Iceberg spec, last-column-id is a monotonic
-		// counter that preserves ids across schema evolution (including
-		// deletions) so that newly-allocated ids never collide with ids still
-		// referenced by historical schemas.
-		lastColumnID: txn.meta.LastColumnID(),
 
 		deletes: make(map[int]struct{}),
 		updates: make(map[int]map[int]iceberg.NestedField),
@@ -158,6 +153,23 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 		ops:                      make([]func() error, 0),
 	}
 
+	if txn == nil {
+		u.err = errors.New("transaction is nil")
+
+		return u
+	}
+	u.err = txn.ensureInitialized()
+	if u.err != nil {
+		return u
+	}
+
+	// Seed from metadata's last-column-id rather than the current schema's
+	// highest field id. Per the Iceberg spec, last-column-id is a monotonic
+	// counter that preserves ids across schema evolution (including
+	// deletions) so that newly-allocated ids never collide with ids still
+	// referenced by historical schemas.
+	u.lastColumnID = txn.meta.LastColumnID()
+
 	for _, opt := range opts {
 		opt(u)
 	}
@@ -166,6 +178,9 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 }
 
 func (u *UpdateSchema) init() error {
+	if u.err != nil {
+		return u.err
+	}
 	if u.txn == nil {
 		return errors.New("transaction is nil")
 	}
@@ -617,6 +632,10 @@ func (u *UpdateSchema) SetIdentifierField(paths [][]string) *UpdateSchema {
 }
 
 func (u *UpdateSchema) BuildUpdates() ([]Update, []Requirement, error) {
+	if u.err != nil {
+		return nil, nil, u.err
+	}
+
 	newSchema, err := u.Apply()
 	if err != nil {
 		return nil, nil, err
@@ -671,6 +690,10 @@ func (u *UpdateSchema) BuildUpdates() ([]Update, []Requirement, error) {
 }
 
 func (u *UpdateSchema) Apply() (*iceberg.Schema, error) {
+	if u.err != nil {
+		return nil, u.err
+	}
+
 	if err := u.init(); err != nil {
 		return nil, err
 	}
@@ -722,6 +745,10 @@ func (u *UpdateSchema) Apply() (*iceberg.Schema, error) {
 }
 
 func (u *UpdateSchema) Commit() error {
+	if u.err != nil {
+		return u.err
+	}
+
 	updates, requirements, err := u.BuildUpdates()
 	if err != nil {
 		return err

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -154,7 +154,7 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 	}
 
 	if txn == nil {
-		u.err = errors.New("transaction is nil")
+		u.err = fmt.Errorf("%w: transaction is nil", ErrInvalidMetadata)
 
 		return u
 	}

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -53,7 +53,8 @@ var testMetadata, _ = NewMetadata(originalSchema, nil, UnsortedSortOrder, "", ni
 
 func TestNewUpdateSchemaWithNilTransactionReturnsError(t *testing.T) {
 	err := NewUpdateSchema(nil, true, false).Commit()
-	assert.EqualError(t, err, "transaction is nil")
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "transaction is nil")
 }
 
 func TestAddColumn(t *testing.T) {

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -51,6 +51,11 @@ var originalSchema = iceberg.NewSchema(1,
 
 var testMetadata, _ = NewMetadata(originalSchema, nil, UnsortedSortOrder, "", nil)
 
+func TestNewUpdateSchemaWithNilTransactionReturnsError(t *testing.T) {
+	err := NewUpdateSchema(nil, true, false).Commit()
+	assert.EqualError(t, err, "transaction is nil")
+}
+
 func TestAddColumn(t *testing.T) {
 	t.Run("test update schema with add primitive type on top level", func(t *testing.T) {
 		table := New([]string{"id"}, testMetadata, "", nil, nil)

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -35,6 +35,7 @@ type UpdateSpec struct {
 	operations []updateSpecOp
 
 	txn                   *Transaction
+	err                   error
 	nameToField           map[string]iceberg.PartitionField
 	nameToAddedField      map[string]iceberg.PartitionField
 	transformToField      map[transformKey]iceberg.PartitionField
@@ -54,6 +55,29 @@ type transformKey struct {
 }
 
 func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
+	us := &UpdateSpec{
+		txn:                   t,
+		nameToField:           make(map[string]iceberg.PartitionField),
+		nameToAddedField:      make(map[string]iceberg.PartitionField),
+		transformToField:      make(map[transformKey]iceberg.PartitionField),
+		transformToAddedField: make(map[transformKey]iceberg.PartitionField),
+		renames:               make(map[string]string),
+		addedTimeFields:       make(map[int]iceberg.PartitionField),
+		caseSensitive:         caseSensitive,
+		adds:                  make([]iceberg.PartitionField, 0),
+		deletes:               make(map[int]bool),
+	}
+
+	if t == nil {
+		us.err = errors.New("transaction is nil")
+
+		return us
+	}
+	us.err = t.ensureInitialized()
+	if us.err != nil {
+		return us
+	}
+
 	transformToField := make(map[transformKey]iceberg.PartitionField)
 	nameToField := make(map[string]iceberg.PartitionField)
 	partitionSpec := t.tbl.Metadata().PartitionSpec()
@@ -70,19 +94,11 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 		lastAssignedFieldId = &v
 	}
 
-	return &UpdateSpec{
-		txn:                   t,
-		nameToField:           nameToField,
-		nameToAddedField:      make(map[string]iceberg.PartitionField),
-		transformToField:      transformToField,
-		transformToAddedField: make(map[transformKey]iceberg.PartitionField),
-		renames:               make(map[string]string),
-		addedTimeFields:       make(map[int]iceberg.PartitionField),
-		caseSensitive:         caseSensitive,
-		adds:                  make([]iceberg.PartitionField, 0),
-		deletes:               make(map[int]bool),
-		lastAssignedFieldId:   *lastAssignedFieldId,
-	}
+	us.nameToField = nameToField
+	us.transformToField = transformToField
+	us.lastAssignedFieldId = *lastAssignedFieldId
+
+	return us
 }
 
 func (us *UpdateSpec) AddField(sourceColName string, transform iceberg.Transform, partitionFieldName string) *UpdateSpec {
@@ -108,6 +124,10 @@ func (us *UpdateSpec) RenameField(name string, newName string) *UpdateSpec {
 }
 
 func (us *UpdateSpec) BuildUpdates() ([]Update, []Requirement, error) {
+	if us.err != nil {
+		return nil, nil, us.err
+	}
+
 	for _, op := range us.operations {
 		if err := op(); err != nil {
 			return nil, nil, err
@@ -136,6 +156,10 @@ func (us *UpdateSpec) BuildUpdates() ([]Update, []Requirement, error) {
 }
 
 func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
+	if us.err != nil {
+		return iceberg.PartitionSpec{}, us.err
+	}
+
 	partitionFields := make([]iceberg.PartitionField, 0)
 	partitionNames := make(map[string]bool)
 	spec := us.txn.tbl.Metadata().PartitionSpec()
@@ -190,6 +214,10 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 }
 
 func (us *UpdateSpec) Commit() error {
+	if us.err != nil {
+		return us.err
+	}
+
 	updates, requirements, err := us.BuildUpdates()
 	if err != nil {
 		return err

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -69,7 +69,7 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 	}
 
 	if t == nil {
-		us.err = errors.New("transaction is nil")
+		us.err = fmt.Errorf("%w: transaction is nil", ErrInvalidMetadata)
 
 		return us
 	}

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -60,6 +60,11 @@ var testNonPartitionedTable = table.New([]string{"non_partitioned"}, testMetadat
 
 var testPartitionedTable = table.New([]string{"partitioned"}, testMetadataPartitioned, "", nil, nil)
 
+func TestNewUpdateSpecWithNilTransactionReturnsError(t *testing.T) {
+	err := table.NewUpdateSpec(nil, false).Commit()
+	assert.EqualError(t, err, "transaction is nil")
+}
+
 func TestUpdateSpecAddField(t *testing.T) {
 	var txn *table.Transaction
 

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testSchema = iceberg.NewSchema(1,
@@ -62,7 +63,8 @@ var testPartitionedTable = table.New([]string{"partitioned"}, testMetadataPartit
 
 func TestNewUpdateSpecWithNilTransactionReturnsError(t *testing.T) {
 	err := table.NewUpdateSpec(nil, false).Commit()
-	assert.EqualError(t, err, "transaction is nil")
+	require.ErrorIs(t, err, table.ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "transaction is nil")
 }
 
 func TestUpdateSpecAddField(t *testing.T) {


### PR DESCRIPTION
## What changed
- Added NewTransactionOnBranchE with explicit metadata builder init error return.
- Preserved old NewTransaction/NewTransactionOnBranch API by storing init error on Transaction.
- Propagated initialization errors through transaction methods (including commit, scan, staged table, append/write/delete paths) and RowDelta commit.
- Added regression tests for broken metadata current-schema handling.

