### PR TITLE
fix(hadoop): return invalid identifier errors from CheckTableExists

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -56,6 +56,7 @@ var (
 	// ErrNoSuchTable is returned when a table does not exist in the catalog.
 	ErrNoSuchTable            = errors.New("table does not exist")
 	ErrNoSuchNamespace        = errors.New("namespace does not exist")
+	ErrInvalidIdentifier      = errors.New("identifier is invalid")
 	ErrNamespaceAlreadyExists = errors.New("namespace already exists")
 	ErrTableAlreadyExists     = errors.New("table already exists")
 	ErrCatalogNotFound        = errors.New("catalog type not registered")

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -133,33 +133,33 @@ func shouldSuppressPermissionError(err error) bool {
 // Note: this is POSIX-best-effort validation — it does not catch NUL bytes
 // or Windows reserved names (NUL, CON, COM1, etc.).
 func validateIdentifier(ident table.Identifier) error {
-	return validateIdentifierParts(ident, catalog.ErrNoSuchNamespace, "namespace identifier", "identifier component")
+	return validateIdentifierParts(ident, "namespace identifier", "identifier component")
 }
 
 func validateTableIdentifier(ident table.Identifier) error {
 	if len(ident) < 2 {
-		return fmt.Errorf("%w: table identifier must have at least a namespace and table name", catalog.ErrNoSuchTable)
+		return fmt.Errorf("%w: table identifier must have at least a namespace and table name", catalog.ErrInvalidIdentifier)
 	}
 
-	return validateIdentifierParts(ident, catalog.ErrNoSuchTable, "table identifier", "table identifier component")
+	return validateIdentifierParts(ident, "table identifier", "table identifier component")
 }
 
-func validateIdentifierParts(ident table.Identifier, errType error, identifierName, componentName string) error {
+func validateIdentifierParts(ident table.Identifier, identifierName, componentName string) error {
 	if len(ident) == 0 {
-		return fmt.Errorf("%w: %s must not be empty", errType, identifierName)
+		return fmt.Errorf("%w: %s must not be empty", catalog.ErrInvalidIdentifier, identifierName)
 	}
 
 	for _, part := range ident {
 		if part == "" {
-			return fmt.Errorf("%w: %s must not be empty", errType, componentName)
+			return fmt.Errorf("%w: %s must not be empty", catalog.ErrInvalidIdentifier, componentName)
 		}
 
 		if part == "." || part == ".." {
-			return fmt.Errorf("%w: invalid %s %q", errType, componentName, part)
+			return fmt.Errorf("%w: invalid %s %q", catalog.ErrInvalidIdentifier, componentName, part)
 		}
 
 		if strings.ContainsAny(part, "/\\") {
-			return fmt.Errorf("%w: %s must not contain path separators: %q", errType, componentName, part)
+			return fmt.Errorf("%w: %s must not contain path separators: %q", catalog.ErrInvalidIdentifier, componentName, part)
 		}
 	}
 
@@ -584,7 +584,7 @@ func (c *Catalog) LoadTable(ctx context.Context, ident table.Identifier) (*table
 
 func (c *Catalog) CheckTableExists(_ context.Context, ident table.Identifier) (bool, error) {
 	if err := validateTableIdentifier(ident); err != nil {
-		return false, nil
+		return false, err
 	}
 
 	// Direct existence checks surface metadata directory read errors; listing

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1024,13 +1024,15 @@ func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsFileNotDir() {
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceEmptyIdentifier() {
 	err := s.cat.CreateNamespace(context.Background(), []string{}, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceEmptyIdentifier() {
 	err := s.cat.DropNamespace(context.Background(), []string{})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesNested() {
@@ -1068,49 +1070,57 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesMixedContent() {
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDotDot() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", ".."}, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsDot() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"."}, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsEmptyComponent() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a", "", "b"}, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateNamespaceRejectsPathSeparator() {
 	err := s.cat.CreateNamespace(context.Background(), []string{"a/b"}, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestDropNamespaceRejectsDotDot() {
 	err := s.cat.DropNamespace(context.Background(), []string{".."})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesRejectsInvalidParent() {
 	_, err := s.cat.ListNamespaces(context.Background(), []string{"a", ".."})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestLoadNamespacePropertiesRejectsInvalid() {
 	_, err := s.cat.LoadNamespaceProperties(context.Background(), []string{".."})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestCheckNamespaceExistsRejectsInvalid() {
 	_, err := s.cat.CheckNamespaceExists(context.Background(), []string{"a/b"})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	s.Require().ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 }
 
 func (s *HadoopCatalogTestSuite) TestListTablesRejectsInvalidIdentifiers() {
@@ -1129,7 +1139,8 @@ func (s *HadoopCatalogTestSuite) TestListTablesRejectsInvalidIdentifiers() {
 		s.Run(tt.name, func() {
 			for _, err := range s.cat.ListTables(context.Background(), tt.ident) {
 				s.Require().Error(err)
-				s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+				s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+				s.NotErrorIs(err, catalog.ErrNoSuchNamespace)
 
 				break
 			}
@@ -1349,7 +1360,8 @@ func (s *HadoopCatalogTestSuite) TestDropTableVerifyCleanup() {
 func (s *HadoopCatalogTestSuite) TestDropTableShortIdentifier() {
 	err := s.cat.DropTable(context.Background(), []string{"tbl"})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchTable)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 
@@ -1549,7 +1561,8 @@ func (s *HadoopCatalogTestSuite) TestCreateTableShortIdentifier() {
 
 	_, err := s.cat.CreateTable(ctx, []string{"tbl"}, s.testSchema())
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchTable)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 
@@ -1624,7 +1637,8 @@ func (s *HadoopCatalogTestSuite) TestTableOperationsRejectInvalidIdentifiers() {
 				s.Run(op.name, func() {
 					err := op.run(tt.ident)
 					s.Require().Error(err)
-					s.ErrorIs(err, catalog.ErrNoSuchTable)
+					s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+					s.NotErrorIs(err, catalog.ErrNoSuchTable)
 				})
 			}
 		})
@@ -1649,7 +1663,8 @@ func (s *HadoopCatalogTestSuite) TestTableOperationsRejectParentTraversalIdentif
 		s.Run(op.name, func() {
 			err := op.run(ident)
 			s.Require().Error(err)
-			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+			s.NotErrorIs(err, catalog.ErrNoSuchTable)
 			s.FileExists(marker)
 			s.DirExists(metaDir)
 		})
@@ -1835,7 +1850,8 @@ func (s *HadoopCatalogTestSuite) TestLoadTableShortIdentifier() {
 
 	_, err := s.cat.LoadTable(ctx, []string{"tbl"})
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchTable)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 
@@ -1876,7 +1892,9 @@ func (s *HadoopCatalogTestSuite) TestCheckTableExistsPropagatesMetadataReadError
 
 func (s *HadoopCatalogTestSuite) TestCheckTableExistsShortIdentifier() {
 	exists, err := s.cat.CheckTableExists(context.Background(), []string{"tbl"})
-	s.Require().NoError(err)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 	s.False(exists)
 }
 
@@ -1900,7 +1918,9 @@ func (s *HadoopCatalogTestSuite) TestCheckTableExistsInvalidIdentifierFalse() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			exists, err := s.cat.CheckTableExists(context.Background(), tt.ident)
-			s.Require().NoError(err)
+			s.Require().Error(err)
+			s.Require().ErrorIs(err, catalog.ErrInvalidIdentifier)
+			s.NotErrorIs(err, catalog.ErrNoSuchTable)
 			s.False(exists)
 		})
 	}
@@ -2282,7 +2302,8 @@ func (s *HadoopCatalogTestSuite) TestCommitTableCreateViaCommit() {
 func (s *HadoopCatalogTestSuite) TestCommitTableShortIdentifier() {
 	_, _, err := s.cat.CommitTable(context.Background(), []string{"tbl"}, nil, nil)
 	s.Require().Error(err)
-	s.ErrorIs(err, catalog.ErrNoSuchTable)
+	s.ErrorIs(err, catalog.ErrInvalidIdentifier)
+	s.NotErrorIs(err, catalog.ErrNoSuchTable)
 	s.Contains(err.Error(), "at least a namespace and table name")
 }
 


### PR DESCRIPTION
## What changed
- `Hadoop` catalog `CheckTableExists` now returns the identifier validation error instead of swallowing malformed identifiers as `(false, nil)`.
- Preserves missing-table behavior for valid identifiers while surfacing malformed identifier inputs as errors.
- Updated `catalog/hadoop` tests to assert short and invalid identifiers return `catalog.ErrNoSuchTable`.

## Testing
- `go test ./catalog/hadoop -count=1`
