### PR TITLE
fix(table): split mixed v3 compaction groups for row-lineage

### DIFF
--- a/cmd/iceberg/output.go
+++ b/cmd/iceberg/output.go
@@ -59,6 +59,14 @@ type Output interface {
 
 type textOutput struct{}
 
+func snapshotSchemaText(schemaID *int) string {
+	if schemaID == nil {
+		return "unknown"
+	}
+
+	return strconv.Itoa(*schemaID)
+}
+
 func (textOutput) Identifiers(idlist []table.Identifier) {
 	data := pterm.TableData{[]string{"IDs"}}
 	for _, ids := range idlist {
@@ -90,8 +98,8 @@ func (t textOutput) DescribeTable(tbl *table.Table) {
 		}
 
 		snapshotList = append(snapshotList, pterm.LeveledListItem{
-			Level: 0, Text: fmt.Sprintf("Snapshot %d, schema %d%s",
-				s.SnapshotID, *s.SchemaID, manifest),
+			Level: 0, Text: fmt.Sprintf("Snapshot %d, schema %s%s",
+				s.SnapshotID, snapshotSchemaText(s.SchemaID), manifest),
 		})
 	}
 
@@ -142,8 +150,8 @@ func (t textOutput) Files(tbl *table.Table, history bool) {
 
 		snapshotTree = append(snapshotTree, pterm.LeveledListItem{
 			Level: 0,
-			Text: fmt.Sprintf("Snapshot %d, schema %d%s",
-				snap.SnapshotID, *snap.SchemaID, manifest),
+			Text: fmt.Sprintf("Snapshot %d, schema %s%s",
+				snap.SnapshotID, snapshotSchemaText(snap.SchemaID), manifest),
 		})
 
 		afs, err := tbl.FS(context.TODO())

--- a/cmd/iceberg/output_test.go
+++ b/cmd/iceberg/output_test.go
@@ -19,9 +19,12 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"strings"
 	"testing"
 
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
@@ -406,4 +409,100 @@ func Test_jsonOutput_DescribeTable(t *testing.T) {
 			assert.JSONEq(t, tt.expected, buf.String())
 		})
 	}
+}
+
+func Test_textOutput_DescribeTableSnapshotWithoutSchemaID(t *testing.T) {
+	meta := `{
+    "format-version": 2,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "mem://default/table",
+    "last-sequence-number": 1,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 1,
+    "current-schema-id": 0,
+    "schemas": [
+        {"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "id", "required": true, "type": "int"}]}
+    ],
+    "default-spec-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "last-partition-id": 1000,
+    "default-sort-order-id": 0,
+    "sort-orders": [
+        {"order-id": 0, "fields": []}
+    ],
+    "properties": {},
+    "current-snapshot-id": 100,
+    "snapshots": [
+        {
+            "snapshot-id": 100,
+            "timestamp-ms": 1602638573590,
+            "sequence-number": 1,
+            "summary": {"operation": "append"}
+        }
+    ],
+    "snapshot-log": [],
+    "refs": {}
+}`
+
+	var buf bytes.Buffer
+	pterm.SetDefaultOutput(&buf)
+	pterm.DisableColor()
+
+	parsed, err := table.ParseMetadataBytes([]byte(meta))
+	assert.NoError(t, err)
+	tbl := table.New([]string{"t"}, parsed, "", nil, nil)
+
+	textOutput{}.DescribeTable(tbl)
+
+	assert.True(t, strings.Contains(buf.String(), "Snapshot 100, schema unknown"))
+}
+
+func Test_textOutput_FilesSnapshotWithoutSchemaID(t *testing.T) {
+	meta := `{
+    "format-version": 2,
+    "table-uuid": "c8e7f6d4-03fe-4693-9a96-a0705ddf69c2",
+    "location": "mem://default/table",
+    "last-sequence-number": 1,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 1,
+    "current-schema-id": 0,
+    "schemas": [
+        {"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "id", "required": true, "type": "int"}]}
+    ],
+    "default-spec-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": []}],
+    "last-partition-id": 1000,
+    "default-sort-order-id": 0,
+    "sort-orders": [
+        {"order-id": 0, "fields": []}
+    ],
+    "properties": {},
+    "current-snapshot-id": 100,
+    "snapshots": [
+        {
+            "snapshot-id": 100,
+            "timestamp-ms": 1602638573590,
+            "sequence-number": 1,
+            "summary": {"operation": "append"}
+        }
+    ],
+    "snapshot-log": [],
+    "refs": {}
+}`
+
+	var buf bytes.Buffer
+	pterm.SetDefaultOutput(&buf)
+	pterm.DisableColor()
+
+	memFS, err := iceio.LoadFS(context.Background(), nil, "mem://default/table")
+	assert.NoError(t, err)
+	parsed, err := table.ParseMetadataBytes([]byte(meta))
+	assert.NoError(t, err)
+	tbl := table.New([]string{"db", "events"}, parsed, "", func(_ context.Context) (iceio.IO, error) {
+		return memFS, nil
+	}, nil)
+
+	textOutput{}.Files(tbl, false)
+
+	assert.True(t, strings.Contains(buf.String(), "Snapshot 100, schema unknown"))
 }

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -300,38 +300,60 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 		scanOpts = append(scanOpts, WitMaxConcurrency(cfg.scanConcurrency))
 	}
 
-	// Preserve row lineage only when every source file in the group carries
-	// it. A mixed group (some files with FirstRowID, some without — e.g.
-	// legacy files on a v3 table) would otherwise produce one output where
-	// post-lineage rows have explicit _row_id values and pre-lineage rows
-	// have nulls, which violates the per-file uniqueness/coverage
-	// invariant the v3 spec requires. Splitting mixed groups into separate
-	// outputs is a larger refactor and is left as a follow-up; for now we
-	// degrade gracefully (the rewrite still succeeds, but lineage is not
-	// preserved for the surviving rows).
-	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
-	if preserveLineage {
-		scanOpts = append(scanOpts, WithRowLineage())
-	} else if tbl.metadata.Version() >= 3 {
-		// Mixed group on a v3 table — at least one source file lacks
-		// FirstRowID so we drop lineage on the surviving rows. This is the
-		// common case during a v1/v2→v3 migration; surface it so operators
-		// can detect silent lineage loss instead of having to diff
-		// metadata before/after.
-		var lineageFiles, legacyFiles int
-		for _, t := range group.Tasks {
-			if t.FirstRowID != nil {
-				lineageFiles++
-			} else {
-				legacyFiles++
-			}
-		}
-		if lineageFiles > 0 {
-			slog.Warn("compaction group has mixed row lineage; dropping _row_id on output",
+	if tbl.metadata.Version() >= 3 {
+		lineageTasks, legacyTasks := splitTasksByLineage(group.Tasks)
+		if len(lineageTasks) > 0 && len(legacyTasks) > 0 {
+			slog.Info("compaction group has mixed row-lineage tasks; splitting to preserve _row_id for lineage-capable files",
 				"partition_key", group.PartitionKey,
-				"lineage_files", lineageFiles,
-				"legacy_files", legacyFiles)
+				"lineage_tasks", len(lineageTasks),
+				"legacy_tasks", len(legacyTasks))
+
+			lineageGroup := CompactionTaskGroup{
+				PartitionKey:   group.PartitionKey,
+				Tasks:          lineageTasks,
+				TotalSizeBytes: sumTaskBytes(lineageTasks),
+			}
+			legacyGroup := CompactionTaskGroup{
+				PartitionKey:   group.PartitionKey,
+				Tasks:          legacyTasks,
+				TotalSizeBytes: sumTaskBytes(legacyTasks),
+			}
+
+			preserve, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, lineageGroup, cfg.targetFileSize, true)
+			if err != nil {
+				return CompactionGroupResult{}, err
+			}
+			legacy, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, legacyGroup, cfg.targetFileSize, false)
+			if err != nil {
+				return CompactionGroupResult{}, err
+			}
+
+			safePosDeletes := mergeTaskFiles(preserve.SafePosDeletes, legacy.SafePosDeletes)
+			safeDeletionVectors := mergeTaskFiles(preserve.SafeDeletionVectors, legacy.SafeDeletionVectors)
+
+			return CompactionGroupResult{
+				PartitionKey:        group.PartitionKey,
+				OldDataFiles:        append(preserve.OldDataFiles, legacy.OldDataFiles...),
+				NewDataFiles:        append(preserve.NewDataFiles, legacy.NewDataFiles...),
+				SafePosDeletes:      safePosDeletes,
+				SafeDeletionVectors: safeDeletionVectors,
+				BytesBefore:         preserve.BytesBefore + legacy.BytesBefore,
+				BytesAfter:          preserve.BytesAfter + legacy.BytesAfter,
+			}, nil
 		}
+	}
+
+	// Preserve row lineage only when every source file in the group carries
+	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
+	return executeCompactionTaskGroup(ctx, tbl, scanOpts, group, cfg.targetFileSize, preserveLineage)
+}
+
+// executeCompactionTaskGroup runs a single compaction path over one task group.
+// It can preserve row lineage by projecting _row_id and _last_updated_sequence_number
+// into the read and write schemas.
+func executeCompactionTaskGroup(ctx context.Context, tbl *Table, scanOpts []ScanOption, group CompactionTaskGroup, targetFileSize int64, preserveLineage bool) (CompactionGroupResult, error) {
+	if preserveLineage {
+		scanOpts = append(slices.Clone(scanOpts), WithRowLineage())
 	}
 
 	arrowSchema, records, err := tbl.Scan(scanOpts...).ReadTasks(ctx, group.Tasks)
@@ -342,8 +364,8 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	// Each compaction group is single-partition by construction, so the
 	// read stream is trivially clustered and we can use the clustered writer.
 	writeOpts := []WriteRecordOption{WithClusteredWrite()}
-	if cfg.targetFileSize > 0 {
-		writeOpts = append(writeOpts, WithTargetFileSize(cfg.targetFileSize))
+	if targetFileSize > 0 {
+		writeOpts = append(writeOpts, WithTargetFileSize(targetFileSize))
 	}
 	if preserveLineage {
 		// Rebuild the arrow schema from the projected iceberg schema so the
@@ -388,11 +410,58 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	}, nil
 }
 
+func sumTaskBytes(tasks []FileScanTask) int64 {
+	total := int64(0)
+	for _, t := range tasks {
+		total += t.File.FileSizeBytes()
+	}
+
+	return total
+}
+
+func splitTasksByLineage(tasks []FileScanTask) (lineageTasks []FileScanTask, legacyTasks []FileScanTask) {
+	for _, task := range tasks {
+		if task.FirstRowID != nil {
+			lineageTasks = append(lineageTasks, task)
+			continue
+		}
+
+		legacyTasks = append(legacyTasks, task)
+	}
+
+	return lineageTasks, legacyTasks
+}
+
+func mergeTaskFiles(a, b []iceberg.DataFile) []iceberg.DataFile {
+	if len(a) == 0 {
+		return slices.Clone(b)
+	}
+	if len(b) == 0 {
+		return slices.Clone(a)
+	}
+
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, df := range a {
+		seen[df.FilePath()] = struct{}{}
+	}
+
+	out := make([]iceberg.DataFile, 0, len(a)+len(b))
+	out = append(out, a...)
+	for _, df := range b {
+		if _, ok := seen[df.FilePath()]; ok {
+			continue
+		}
+		seen[df.FilePath()] = struct{}{}
+		out = append(out, df)
+	}
+
+	return out
+}
+
 // allTasksHaveRowLineage returns true iff every task in the group has a
-// non-nil FirstRowID — i.e. every source file already carries v3 row lineage.
-// Used to gate the preservation path on compaction: mixed groups (some
-// lineage, some legacy) would otherwise produce per-file invariant
-// violations, so the gate is conservative.
+// non-nil FirstRowID — i.e. every source file already carries v3 row
+// lineage. Mixed groups are now split so each subgroup can preserve lineage
+// only where it is available.
 func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	if len(tasks) == 0 {
 		return false

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -434,3 +434,70 @@ func TestExecuteCompactionGroupPreservesRowIDAcrossV2Upgrade(t *testing.T) {
 	assert.Equal(t, pre, post,
 		"compaction across a v2->v3 upgrade must preserve every row's _row_id, including the v2-era rows")
 }
+
+// TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks verifies that
+// mixed-task compaction on a v3 table no longer drops row-lineage columns
+// for all files in the group. Lineage-capable files remain preserved while
+// legacy files without a lineage marker are rewritten in a separate output
+// stream.
+func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	first, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(first.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(first, -1), nil)
+	require.NoError(t, err)
+
+	second, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(second.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(second, -1), nil)
+	require.NoError(t, err)
+
+	pre := readRowIDsByID(t, ctx, tbl)
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	// Simulate a mixed lineage group by forcing one task to look like a legacy
+	// file (no inherited FirstRowID). The mixed-input behavior was previously a
+	// silent drop for all surviving rows.
+	tasks[1].FirstRowID = nil
+
+	group := table.CompactionTaskGroup{
+		PartitionKey:   "single",
+		Tasks:          tasks,
+		TotalSizeBytes: tasks[0].File.FileSizeBytes() + tasks[1].File.FileSizeBytes(),
+	}
+
+	gr, err := table.ExecuteCompactionGroup(ctx, tbl, group)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(gr.OldDataFiles), "both source files should be replaced")
+
+	tx := tbl.NewTransaction()
+	rewrite := tx.NewRewrite(nil)
+	rewrite.ApplyResult(gr)
+	require.NoError(t, rewrite.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	post := readRowIDsByID(t, ctx, tbl)
+	assert.Equal(t, pre[1], post[1], "lineage-capable file rows should keep their original _row_id")
+	assert.Equal(t, pre[2], post[2], "lineage-capable file rows should keep their original _row_id")
+	assert.NotEqual(t, pre[3], post[3], "legacy-task rows should be rewritten without legacy lineage")
+	assert.NotEqual(t, pre[4], post[4], "legacy-task rows should be rewritten without legacy lineage")
+}


### PR DESCRIPTION
## Summary
This fix addresses row-lineage correctness for compaction on v3 tables. Mixed compaction groups (some tasks with FirstRowID, some without) were previously compacted into one output that could silently lose  for all surviving rows.

- Split mixed v3 groups into lineage-capable and legacy subgroups.
- Preserve  only for lineage-capable subgroup via existing lineage-preserving path.
- Rewrite legacy subgroup without lineage when required.
- Merge safe delete vectors/deletion vectors across both subgroups.
- Add regression coverage: .

## Testing
ok  	github.com/apache/iceberg-go/table	0.749s
ok  	github.com/apache/iceberg-go/table	0.739s
ok  	github.com/apache/iceberg-go/table	1.001s
ok  	github.com/apache/iceberg-go/table	4.873s