### PR TITLE
docs(table): clarify mixed-group lineage-drop behavior

### DIFF
--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -329,7 +329,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 			}
 
 			safePosDeletes := mergeTaskFiles(preserve.SafePosDeletes, legacy.SafePosDeletes)
-			safeDeletionVectors := mergeTaskFiles(preserve.SafeDeletionVectors, legacy.SafeDeletionVectors)
+			safeDeletionVectors := mergeTaskFilesByReferencedDataFile(preserve.SafeDeletionVectors, legacy.SafeDeletionVectors)
 
 			return CompactionGroupResult{
 				PartitionKey:        group.PartitionKey,
@@ -343,7 +343,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 		}
 	}
 
-	// Preserve row lineage only when every source file in the group carries
+	// Preserve row lineage only when every source file in the group carries row-lineage metadata.
 	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
 
 	return executeCompactionTaskGroup(ctx, tbl, scanOpts, group, cfg.targetFileSize, preserveLineage)
@@ -458,6 +458,42 @@ func mergeTaskFiles(a, b []iceberg.DataFile) []iceberg.DataFile {
 	}
 
 	return out
+}
+
+func mergeTaskFilesByReferencedDataFile(a, b []iceberg.DataFile) []iceberg.DataFile {
+	if len(a) == 0 {
+		return slices.Clone(b)
+	}
+	if len(b) == 0 {
+		return slices.Clone(a)
+	}
+
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, df := range a {
+		ref := dvReferencedDataFile(df)
+		seen[ref] = struct{}{}
+	}
+
+	out := make([]iceberg.DataFile, 0, len(a)+len(b))
+	out = append(out, a...)
+	for _, df := range b {
+		ref := dvReferencedDataFile(df)
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, df)
+	}
+
+	return out
+}
+
+func dvReferencedDataFile(df iceberg.DataFile) string {
+	if ref := df.ReferencedDataFile(); ref != nil && *ref != "" {
+		return *ref
+	}
+
+	return df.FilePath()
 }
 
 // allTasksHaveRowLineage returns true iff every task in the group has a

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -300,38 +300,60 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 		scanOpts = append(scanOpts, WitMaxConcurrency(cfg.scanConcurrency))
 	}
 
-	// Preserve row lineage only when every source file in the group carries
-	// it. A mixed group (some files with FirstRowID, some without — e.g.
-	// legacy files on a v3 table) would otherwise produce one output where
-	// post-lineage rows have explicit _row_id values and pre-lineage rows
-	// have nulls, which violates the per-file uniqueness/coverage
-	// invariant the v3 spec requires. Splitting mixed groups into separate
-	// outputs is a larger refactor and is left as a follow-up; for now we
-	// degrade gracefully (the rewrite still succeeds, but lineage is not
-	// preserved for the surviving rows).
-	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
-	if preserveLineage {
-		scanOpts = append(scanOpts, WithRowLineage())
-	} else if tbl.metadata.Version() >= 3 {
-		// Mixed group on a v3 table — at least one source file lacks
-		// FirstRowID so we drop lineage on the surviving rows. This is the
-		// common case during a v1/v2→v3 migration; surface it so operators
-		// can detect silent lineage loss instead of having to diff
-		// metadata before/after.
-		var lineageFiles, legacyFiles int
-		for _, t := range group.Tasks {
-			if t.FirstRowID != nil {
-				lineageFiles++
-			} else {
-				legacyFiles++
-			}
-		}
-		if lineageFiles > 0 {
-			slog.Warn("compaction group has mixed row lineage; dropping _row_id on output",
+	if tbl.metadata.Version() >= 3 {
+		lineageTasks, legacyTasks := splitTasksByLineage(group.Tasks)
+		if len(lineageTasks) > 0 && len(legacyTasks) > 0 {
+			slog.Info("compaction group has mixed row-lineage tasks; splitting to preserve _row_id for lineage-capable files",
 				"partition_key", group.PartitionKey,
-				"lineage_files", lineageFiles,
-				"legacy_files", legacyFiles)
+				"lineage_tasks", len(lineageTasks),
+				"legacy_tasks", len(legacyTasks))
+
+			lineageGroup := CompactionTaskGroup{
+				PartitionKey:   group.PartitionKey,
+				Tasks:          lineageTasks,
+				TotalSizeBytes: sumTaskBytes(lineageTasks),
+			}
+			legacyGroup := CompactionTaskGroup{
+				PartitionKey:   group.PartitionKey,
+				Tasks:          legacyTasks,
+				TotalSizeBytes: sumTaskBytes(legacyTasks),
+			}
+
+			preserve, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, lineageGroup, cfg.targetFileSize, true)
+			if err != nil {
+				return CompactionGroupResult{}, err
+			}
+			legacy, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, legacyGroup, cfg.targetFileSize, false)
+			if err != nil {
+				return CompactionGroupResult{}, err
+			}
+
+			safePosDeletes := mergeTaskFiles(preserve.SafePosDeletes, legacy.SafePosDeletes)
+			safeDeletionVectors := mergeTaskFiles(preserve.SafeDeletionVectors, legacy.SafeDeletionVectors)
+
+			return CompactionGroupResult{
+				PartitionKey:        group.PartitionKey,
+				OldDataFiles:        append(preserve.OldDataFiles, legacy.OldDataFiles...),
+				NewDataFiles:        append(preserve.NewDataFiles, legacy.NewDataFiles...),
+				SafePosDeletes:      safePosDeletes,
+				SafeDeletionVectors: safeDeletionVectors,
+				BytesBefore:         preserve.BytesBefore + legacy.BytesBefore,
+				BytesAfter:          preserve.BytesAfter + legacy.BytesAfter,
+			}, nil
 		}
+	}
+
+	// Preserve row lineage only when every source file in the group carries
+	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
+	return executeCompactionTaskGroup(ctx, tbl, scanOpts, group, cfg.targetFileSize, preserveLineage)
+}
+
+// executeCompactionTaskGroup runs a single compaction path over one task group.
+// It can preserve row lineage by projecting _row_id and _last_updated_sequence_number
+// into the read and write schemas.
+func executeCompactionTaskGroup(ctx context.Context, tbl *Table, scanOpts []ScanOption, group CompactionTaskGroup, targetFileSize int64, preserveLineage bool) (CompactionGroupResult, error) {
+	if preserveLineage {
+		scanOpts = append(slices.Clone(scanOpts), WithRowLineage())
 	}
 
 	arrowSchema, records, err := tbl.Scan(scanOpts...).ReadTasks(ctx, group.Tasks)
@@ -342,8 +364,8 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	// Each compaction group is single-partition by construction, so the
 	// read stream is trivially clustered and we can use the clustered writer.
 	writeOpts := []WriteRecordOption{WithClusteredWrite()}
-	if cfg.targetFileSize > 0 {
-		writeOpts = append(writeOpts, WithTargetFileSize(cfg.targetFileSize))
+	if targetFileSize > 0 {
+		writeOpts = append(writeOpts, WithTargetFileSize(targetFileSize))
 	}
 	if preserveLineage {
 		// Rebuild the arrow schema from the projected iceberg schema so the
@@ -388,11 +410,58 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	}, nil
 }
 
+func sumTaskBytes(tasks []FileScanTask) int64 {
+	total := int64(0)
+	for _, t := range tasks {
+		total += t.File.FileSizeBytes()
+	}
+
+	return total
+}
+
+func splitTasksByLineage(tasks []FileScanTask) (lineageTasks []FileScanTask, legacyTasks []FileScanTask) {
+	for _, task := range tasks {
+		if task.FirstRowID != nil {
+			lineageTasks = append(lineageTasks, task)
+			continue
+		}
+
+		legacyTasks = append(legacyTasks, task)
+	}
+
+	return lineageTasks, legacyTasks
+}
+
+func mergeTaskFiles(a, b []iceberg.DataFile) []iceberg.DataFile {
+	if len(a) == 0 {
+		return slices.Clone(b)
+	}
+	if len(b) == 0 {
+		return slices.Clone(a)
+	}
+
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, df := range a {
+		seen[df.FilePath()] = struct{}{}
+	}
+
+	out := make([]iceberg.DataFile, 0, len(a)+len(b))
+	out = append(out, a...)
+	for _, df := range b {
+		if _, ok := seen[df.FilePath()]; ok {
+			continue
+		}
+		seen[df.FilePath()] = struct{}{}
+		out = append(out, df)
+	}
+
+	return out
+}
+
 // allTasksHaveRowLineage returns true iff every task in the group has a
-// non-nil FirstRowID — i.e. every source file already carries v3 row lineage.
-// Used to gate the preservation path on compaction: mixed groups (some
-// lineage, some legacy) would otherwise produce per-file invariant
-// violations, so the gate is conservative.
+// non-nil FirstRowID — i.e. every source file already carries v3 row
+// lineage. Mixed groups are now split so each subgroup can preserve lineage
+// only where it is available.
 func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	if len(tasks) == 0 {
 		return false

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -301,17 +301,21 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	}
 
 	// Preserve row lineage only when every source file in the group carries
-	// it. A mixed group (some files with FirstRowID, some without) would
-	// otherwise produce one output where some rows keep explicit _row_id
-	// values and others do not, which violates the per-file uniqueness and
-	// coverage invariants the v3 spec requires. Spec-compliant v3 planning
-	// should already inherit first_row_id for every task, including files
-	// carried forward across a v2->v3 upgrade, so a mixed group here is
-	// treated conservatively as invalid metadata or caller-constructed input.
+	// it. A mixed group (some files with FirstRowID, some without — e.g.
+	// legacy files on a v3 table) would otherwise produce one output where
+	// post-lineage rows have explicit _row_id values and pre-lineage rows
+	// have nulls, which violates the per-file uniqueness/coverage
+	// invariant the v3 spec requires. Row IDs are assigned lazily during
+	// the first v3 manifest-list write after a v1/v2->v3 upgrade, so mixed
+	// groups are expected during migration; for now we degrade gracefully
+	// and do not preserve lineage for the surviving rows.
 	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
 	if preserveLineage {
 		scanOpts = append(scanOpts, WithRowLineage())
 	} else if tbl.metadata.Version() >= 3 {
+		// Drop lineage for the whole mixed group. Warn only when at least one
+		// source file already carried lineage; all-legacy groups fall through
+		// silently because there is no lineage to lose.
 		var lineageFiles, legacyFiles int
 		for _, t := range group.Tasks {
 			if t.FirstRowID != nil {
@@ -321,7 +325,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 			}
 		}
 		if lineageFiles > 0 {
-			slog.Warn("compaction group has unexpected mixed row lineage on v3 table; dropping _row_id on output",
+			slog.Warn("compaction group has mixed row lineage; dropping _row_id on output",
 				"partition_key", group.PartitionKey,
 				"lineage_files", lineageFiles,
 				"legacy_files", legacyFiles)
@@ -384,9 +388,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 
 // allTasksHaveRowLineage returns true iff every task in the group has a
 // non-nil FirstRowID — i.e. every source file already carries v3 row lineage.
-// Used to gate the preservation path on compaction: mixed groups are treated
-// conservatively because spec-compliant v3 planning should already surface an
-// effective first_row_id for every task.
+// It returns false for an empty task slice.
 func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	if len(tasks) == 0 {
 		return false

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -300,61 +300,32 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 		scanOpts = append(scanOpts, WitMaxConcurrency(cfg.scanConcurrency))
 	}
 
-	if tbl.metadata.Version() >= 3 {
-		lineageTasks, legacyTasks := splitTasksByLineage(group.Tasks)
-		if len(lineageTasks) > 0 && len(legacyTasks) > 0 {
-			slog.Info("compaction group has mixed row-lineage tasks; splitting to preserve _row_id for lineage-capable files",
-				"partition_key", group.PartitionKey,
-				"lineage_tasks", len(lineageTasks),
-				"legacy_tasks", len(legacyTasks))
-
-			lineageGroup := CompactionTaskGroup{
-				PartitionKey:   group.PartitionKey,
-				Tasks:          lineageTasks,
-				TotalSizeBytes: sumTaskBytes(lineageTasks),
-			}
-			legacyGroup := CompactionTaskGroup{
-				PartitionKey:   group.PartitionKey,
-				Tasks:          legacyTasks,
-				TotalSizeBytes: sumTaskBytes(legacyTasks),
-			}
-
-			preserve, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, lineageGroup, cfg.targetFileSize, true)
-			if err != nil {
-				return CompactionGroupResult{}, err
-			}
-			legacy, err := executeCompactionTaskGroup(ctx, tbl, scanOpts, legacyGroup, cfg.targetFileSize, false)
-			if err != nil {
-				return CompactionGroupResult{}, err
-			}
-
-			safePosDeletes := mergeTaskFiles(preserve.SafePosDeletes, legacy.SafePosDeletes)
-			safeDeletionVectors := mergeTaskFilesByReferencedDataFile(preserve.SafeDeletionVectors, legacy.SafeDeletionVectors)
-
-			return CompactionGroupResult{
-				PartitionKey:        group.PartitionKey,
-				OldDataFiles:        append(preserve.OldDataFiles, legacy.OldDataFiles...),
-				NewDataFiles:        append(preserve.NewDataFiles, legacy.NewDataFiles...),
-				SafePosDeletes:      safePosDeletes,
-				SafeDeletionVectors: safeDeletionVectors,
-				BytesBefore:         preserve.BytesBefore + legacy.BytesBefore,
-				BytesAfter:          preserve.BytesAfter + legacy.BytesAfter,
-			}, nil
-		}
-	}
-
-	// Preserve row lineage only when every source file in the group carries row-lineage metadata.
+	// Preserve row lineage only when every source file in the group carries
+	// it. A mixed group (some files with FirstRowID, some without) would
+	// otherwise produce one output where some rows keep explicit _row_id
+	// values and others do not, which violates the per-file uniqueness and
+	// coverage invariants the v3 spec requires. Spec-compliant v3 planning
+	// should already inherit first_row_id for every task, including files
+	// carried forward across a v2->v3 upgrade, so a mixed group here is
+	// treated conservatively as invalid metadata or caller-constructed input.
 	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
-
-	return executeCompactionTaskGroup(ctx, tbl, scanOpts, group, cfg.targetFileSize, preserveLineage)
-}
-
-// executeCompactionTaskGroup runs a single compaction path over one task group.
-// It can preserve row lineage by projecting _row_id and _last_updated_sequence_number
-// into the read and write schemas.
-func executeCompactionTaskGroup(ctx context.Context, tbl *Table, scanOpts []ScanOption, group CompactionTaskGroup, targetFileSize int64, preserveLineage bool) (CompactionGroupResult, error) {
 	if preserveLineage {
-		scanOpts = append(slices.Clone(scanOpts), WithRowLineage())
+		scanOpts = append(scanOpts, WithRowLineage())
+	} else if tbl.metadata.Version() >= 3 {
+		var lineageFiles, legacyFiles int
+		for _, t := range group.Tasks {
+			if t.FirstRowID != nil {
+				lineageFiles++
+			} else {
+				legacyFiles++
+			}
+		}
+		if lineageFiles > 0 {
+			slog.Warn("compaction group has unexpected mixed row lineage on v3 table; dropping _row_id on output",
+				"partition_key", group.PartitionKey,
+				"lineage_files", lineageFiles,
+				"legacy_files", legacyFiles)
+		}
 	}
 
 	arrowSchema, records, err := tbl.Scan(scanOpts...).ReadTasks(ctx, group.Tasks)
@@ -365,8 +336,8 @@ func executeCompactionTaskGroup(ctx context.Context, tbl *Table, scanOpts []Scan
 	// Each compaction group is single-partition by construction, so the
 	// read stream is trivially clustered and we can use the clustered writer.
 	writeOpts := []WriteRecordOption{WithClusteredWrite()}
-	if targetFileSize > 0 {
-		writeOpts = append(writeOpts, WithTargetFileSize(targetFileSize))
+	if cfg.targetFileSize > 0 {
+		writeOpts = append(writeOpts, WithTargetFileSize(cfg.targetFileSize))
 	}
 	if preserveLineage {
 		// Rebuild the arrow schema from the projected iceberg schema so the
@@ -411,95 +382,11 @@ func executeCompactionTaskGroup(ctx context.Context, tbl *Table, scanOpts []Scan
 	}, nil
 }
 
-func sumTaskBytes(tasks []FileScanTask) int64 {
-	total := int64(0)
-	for _, t := range tasks {
-		total += t.File.FileSizeBytes()
-	}
-
-	return total
-}
-
-func splitTasksByLineage(tasks []FileScanTask) (lineageTasks []FileScanTask, legacyTasks []FileScanTask) {
-	for _, task := range tasks {
-		if task.FirstRowID != nil {
-			lineageTasks = append(lineageTasks, task)
-
-			continue
-		}
-
-		legacyTasks = append(legacyTasks, task)
-	}
-
-	return lineageTasks, legacyTasks
-}
-
-func mergeTaskFiles(a, b []iceberg.DataFile) []iceberg.DataFile {
-	if len(a) == 0 {
-		return slices.Clone(b)
-	}
-	if len(b) == 0 {
-		return slices.Clone(a)
-	}
-
-	seen := make(map[string]struct{}, len(a)+len(b))
-	for _, df := range a {
-		seen[df.FilePath()] = struct{}{}
-	}
-
-	out := make([]iceberg.DataFile, 0, len(a)+len(b))
-	out = append(out, a...)
-	for _, df := range b {
-		if _, ok := seen[df.FilePath()]; ok {
-			continue
-		}
-		seen[df.FilePath()] = struct{}{}
-		out = append(out, df)
-	}
-
-	return out
-}
-
-func mergeTaskFilesByReferencedDataFile(a, b []iceberg.DataFile) []iceberg.DataFile {
-	if len(a) == 0 {
-		return slices.Clone(b)
-	}
-	if len(b) == 0 {
-		return slices.Clone(a)
-	}
-
-	seen := make(map[string]struct{}, len(a)+len(b))
-	for _, df := range a {
-		ref := dvReferencedDataFile(df)
-		seen[ref] = struct{}{}
-	}
-
-	out := make([]iceberg.DataFile, 0, len(a)+len(b))
-	out = append(out, a...)
-	for _, df := range b {
-		ref := dvReferencedDataFile(df)
-		if _, ok := seen[ref]; ok {
-			continue
-		}
-		seen[ref] = struct{}{}
-		out = append(out, df)
-	}
-
-	return out
-}
-
-func dvReferencedDataFile(df iceberg.DataFile) string {
-	if ref := df.ReferencedDataFile(); ref != nil && *ref != "" {
-		return *ref
-	}
-
-	return df.FilePath()
-}
-
 // allTasksHaveRowLineage returns true iff every task in the group has a
-// non-nil FirstRowID — i.e. every source file already carries v3 row
-// lineage. Mixed groups are now split so each subgroup can preserve lineage
-// only where it is available.
+// non-nil FirstRowID — i.e. every source file already carries v3 row lineage.
+// Used to gate the preservation path on compaction: mixed groups are treated
+// conservatively because spec-compliant v3 planning should already surface an
+// effective first_row_id for every task.
 func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	if len(tasks) == 0 {
 		return false

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -345,6 +345,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 
 	// Preserve row lineage only when every source file in the group carries
 	preserveLineage := tbl.metadata.Version() >= 3 && allTasksHaveRowLineage(group.Tasks)
+
 	return executeCompactionTaskGroup(ctx, tbl, scanOpts, group, cfg.targetFileSize, preserveLineage)
 }
 
@@ -423,6 +424,7 @@ func splitTasksByLineage(tasks []FileScanTask) (lineageTasks []FileScanTask, leg
 	for _, task := range tasks {
 		if task.FirstRowID != nil {
 			lineageTasks = append(lineageTasks, task)
+
 			continue
 		}
 

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -19,7 +19,6 @@ package table_test
 
 import (
 	"context"
-	"iter"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
-	"github.com/apache/iceberg-go/table/dv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,22 +71,9 @@ func newV2RowLineageTestTable(t *testing.T) *table.Table {
 }
 
 func readRowIDsByID(t *testing.T, ctx context.Context, tbl *table.Table) map[int64]int64 {
-	return readRowIDsByTasks(t, ctx, tbl, nil)
-}
-
-func readRowIDsByTasks(t *testing.T, ctx context.Context, tbl *table.Table, tasks []table.FileScanTask) map[int64]int64 {
 	t.Helper()
 
-	scan := tbl.Scan(table.WithRowLineage())
-	var (
-		itr iter.Seq2[arrow.RecordBatch, error]
-		err error
-	)
-	if tasks == nil {
-		_, itr, err = scan.ToArrowRecords(ctx)
-	} else {
-		_, itr, err = scan.ReadTasks(ctx, tasks)
-	}
+	_, itr, err := tbl.Scan(table.WithRowLineage()).ToArrowRecords(ctx)
 	require.NoError(t, err)
 
 	got := map[int64]int64{}
@@ -448,157 +433,4 @@ func TestExecuteCompactionGroupPreservesRowIDAcrossV2Upgrade(t *testing.T) {
 	post := readRowIDsByID(t, ctx, tbl)
 	assert.Equal(t, pre, post,
 		"compaction across a v2->v3 upgrade must preserve every row's _row_id, including the v2-era rows")
-}
-
-// TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks verifies that
-// mixed-task compaction on a v3 table no longer drops row-lineage columns
-// for all files in the group. Lineage-capable files remain preserved while
-// legacy files without a lineage marker are rewritten in a separate output
-// stream.
-func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) {
-	ctx := context.Background()
-	mem := memory.DefaultAllocator
-
-	tbl := newV3RowLineageTestTable(t)
-
-	arrowSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
-		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	first, err := array.TableFromJSON(mem, arrowSchema, []string{
-		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
-	})
-	require.NoError(t, err)
-	t.Cleanup(first.Release)
-	tbl, err = tbl.Append(ctx, array.NewTableReader(first, -1), nil)
-	require.NoError(t, err)
-
-	second, err := array.TableFromJSON(mem, arrowSchema, []string{
-		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
-	})
-	require.NoError(t, err)
-	t.Cleanup(second.Release)
-	tbl, err = tbl.Append(ctx, array.NewTableReader(second, -1), nil)
-	require.NoError(t, err)
-
-	pre := readRowIDsByID(t, ctx, tbl)
-
-	tasks, err := tbl.Scan().PlanFiles(ctx)
-	require.NoError(t, err)
-	require.Len(t, tasks, 2)
-
-	// Simulate a mixed lineage group by forcing one task to look like a legacy
-	// file (no inherited FirstRowID). The mixed-input behavior was previously a
-	// silent drop for all surviving rows.
-	legacyRows := readRowIDsByTasks(t, ctx, tbl, []table.FileScanTask{tasks[1]})
-	tasks[1].FirstRowID = nil
-
-	group := table.CompactionTaskGroup{
-		PartitionKey:   "single",
-		Tasks:          tasks,
-		TotalSizeBytes: tasks[0].File.FileSizeBytes() + tasks[1].File.FileSizeBytes(),
-	}
-
-	gr, err := table.ExecuteCompactionGroup(ctx, tbl, group)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(gr.OldDataFiles), "both source files should be replaced")
-
-	tx := tbl.NewTransaction()
-	rewrite := tx.NewRewrite(nil)
-	rewrite.ApplyResult(gr)
-	require.NoError(t, rewrite.Commit(ctx))
-	tbl, err = tx.Commit(ctx)
-	require.NoError(t, err)
-
-	post := readRowIDsByID(t, ctx, tbl)
-	for id, before := range pre {
-		if _, ok := legacyRows[id]; ok {
-			assert.NotEqual(t, before, post[id],
-				"legacy-task rows should be rewritten without legacy lineage")
-
-			continue
-		}
-		assert.Equal(t, before, post[id], "lineage-capable file rows should keep their original _row_id")
-	}
-}
-
-// TestExecuteCompactionGroupMixedLineageRetainsSiblingDeletionVectors verifies that
-// mixed-task compaction on a v3 table removes deletion vectors by referenced
-// data file, not by shared deletion-vector container path.
-func TestExecuteCompactionGroupMixedLineageRetainsSiblingDeletionVectors(t *testing.T) {
-	ctx := context.Background()
-	fs := iceio.LocalFS{}
-
-	tbl := newV3RowLineageTestTable(t)
-	mem := memory.DefaultAllocator
-
-	arrowSchema := arrow.NewSchema([]arrow.Field{
-		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
-		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
-	}, nil)
-
-	left, err := array.TableFromJSON(mem, arrowSchema, []string{
-		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
-	})
-	require.NoError(t, err)
-	t.Cleanup(left.Release)
-	tbl, err = tbl.Append(ctx, array.NewTableReader(left, -1), nil)
-	require.NoError(t, err)
-
-	right, err := array.TableFromJSON(mem, arrowSchema, []string{
-		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
-	})
-	require.NoError(t, err)
-	t.Cleanup(right.Release)
-	tbl, err = tbl.Append(ctx, array.NewTableReader(right, -1), nil)
-	require.NoError(t, err)
-
-	tasks, err := tbl.Scan().PlanFiles(ctx)
-	require.NoError(t, err)
-	require.Len(t, tasks, 2)
-
-	rewriteTarget := tasks[0].File.FilePath()
-	siblingTarget := tasks[1].File.FilePath()
-
-	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
-	require.NoError(t, w.Add(rewriteTarget, []int64{0}, 0, nil))
-	require.NoError(t, w.Add(siblingTarget, []int64{0}, 0, nil))
-	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(rewriteTarget), "dv-shared.puffin"))
-	require.NoError(t, err)
-	require.Len(t, dvFiles, 2)
-	require.Equal(t, dvFiles[0].FilePath(), dvFiles[1].FilePath(),
-		"both deletion vectors must share one Puffin file for this regression")
-
-	rdtx := tbl.NewTransaction()
-	require.NoError(t, rdtx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
-	tbl, err = rdtx.Commit(ctx)
-	require.NoError(t, err)
-
-	tasks, err = tbl.Scan().PlanFiles(ctx)
-	require.NoError(t, err)
-	require.Len(t, tasks, 2)
-	tasks[1].FirstRowID = nil
-
-	group := table.CompactionTaskGroup{
-		PartitionKey:   "single",
-		Tasks:          tasks,
-		TotalSizeBytes: tasks[0].File.FileSizeBytes() + tasks[1].File.FileSizeBytes(),
-	}
-	gr, err := table.ExecuteCompactionGroup(ctx, tbl, group)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(gr.OldDataFiles), "both source files should be rewritten")
-	require.Greater(t, len(gr.SafeDeletionVectors), 0, "mixed group should expose deletion vectors for rewrite")
-
-	rtx := tbl.NewTransaction()
-	rewrite := rtx.NewRewrite(nil)
-	rewrite.ApplyResult(gr)
-	require.NoError(t, rewrite.Commit(ctx))
-	tbl, err = rtx.Commit(ctx)
-	require.NoError(t, err)
-
-	assert.Empty(t, deleteEntriesReferencing(t, tbl, map[string]struct{}{
-		rewriteTarget: {},
-		siblingTarget: {},
-	}), "shared-path deletion vectors should be removed per referenced-data-file")
 }

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -515,6 +515,7 @@ func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) 
 		if _, ok := legacyRows[id]; ok {
 			assert.NotEqual(t, before, post[id],
 				"legacy-task rows should be rewritten without legacy lineage")
+
 			continue
 		}
 		assert.Equal(t, before, post[id], "lineage-capable file rows should keep their original _row_id")

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -434,3 +434,70 @@ func TestExecuteCompactionGroupPreservesRowIDAcrossV2Upgrade(t *testing.T) {
 	assert.Equal(t, pre, post,
 		"compaction across a v2->v3 upgrade must preserve every row's _row_id, including the v2-era rows")
 }
+
+// TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks verifies that
+// mixed-task compaction on a v3 table no longer drops row-lineage columns
+// for all files in the group. Lineage-capable files remain preserved while
+// legacy files without a lineage marker are rewritten in a separate output
+// stream.
+func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+
+	tbl := newV3RowLineageTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	first, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(first.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(first, -1), nil)
+	require.NoError(t, err)
+
+	second, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(second.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(second, -1), nil)
+	require.NoError(t, err)
+
+	pre := readRowIDsByID(t, ctx, tbl)
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	// Simulate a mixed lineage group by forcing one task to look like a legacy
+	// file (no inherited FirstRowID). The mixed-input behavior was previously a
+	// silent drop for all surviving rows.
+	tasks[1].FirstRowID = nil
+
+	group := table.CompactionTaskGroup{
+		PartitionKey:   "single",
+		Tasks:          tasks,
+		TotalSizeBytes: tasks[0].File.FileSizeBytes() + tasks[1].File.FileSizeBytes(),
+	}
+
+	gr, err := table.ExecuteCompactionGroup(ctx, tbl, group)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(gr.OldDataFiles), "both source files should be replaced")
+
+	tx := tbl.NewTransaction()
+	rewrite := tx.NewRewrite(nil)
+	rewrite.ApplyResult(gr)
+	require.NoError(t, rewrite.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	post := readRowIDsByID(t, ctx, tbl)
+	assert.Equal(t, pre[1], post[1], "lineage-capable file rows should keep their original _row_id")
+	assert.Equal(t, pre[2], post[2], "lineage-capable file rows should keep their original _row_id")
+	assert.NotEqual(t, pre[3], post[3], "legacy-task rows should be rewritten without legacy lineage")
+	assert.NotEqual(t, pre[4], post[4], "legacy-task rows should be rewritten without legacy lineage")
+}

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -19,6 +19,7 @@ package table_test
 
 import (
 	"context"
+	"iter"
 	"path/filepath"
 	"testing"
 
@@ -71,9 +72,22 @@ func newV2RowLineageTestTable(t *testing.T) *table.Table {
 }
 
 func readRowIDsByID(t *testing.T, ctx context.Context, tbl *table.Table) map[int64]int64 {
+	return readRowIDsByTasks(t, ctx, tbl, nil)
+}
+
+func readRowIDsByTasks(t *testing.T, ctx context.Context, tbl *table.Table, tasks []table.FileScanTask) map[int64]int64 {
 	t.Helper()
 
-	_, itr, err := tbl.Scan(table.WithRowLineage()).ToArrowRecords(ctx)
+	scan := tbl.Scan(table.WithRowLineage())
+	var (
+		itr iter.Seq2[arrow.RecordBatch, error]
+		err error
+	)
+	if tasks == nil {
+		_, itr, err = scan.ToArrowRecords(ctx)
+	} else {
+		_, itr, err = scan.ReadTasks(ctx, tasks)
+	}
 	require.NoError(t, err)
 
 	got := map[int64]int64{}
@@ -476,6 +490,7 @@ func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) 
 	// Simulate a mixed lineage group by forcing one task to look like a legacy
 	// file (no inherited FirstRowID). The mixed-input behavior was previously a
 	// silent drop for all surviving rows.
+	legacyRows := readRowIDsByTasks(t, ctx, tbl, []table.FileScanTask{tasks[1]})
 	tasks[1].FirstRowID = nil
 
 	group := table.CompactionTaskGroup{
@@ -496,8 +511,12 @@ func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) 
 	require.NoError(t, err)
 
 	post := readRowIDsByID(t, ctx, tbl)
-	assert.Equal(t, pre[1], post[1], "lineage-capable file rows should keep their original _row_id")
-	assert.Equal(t, pre[2], post[2], "lineage-capable file rows should keep their original _row_id")
-	assert.NotEqual(t, pre[3], post[3], "legacy-task rows should be rewritten without legacy lineage")
-	assert.NotEqual(t, pre[4], post[4], "legacy-task rows should be rewritten without legacy lineage")
+	for id, before := range pre {
+		if _, ok := legacyRows[id]; ok {
+			assert.NotEqual(t, before, post[id],
+				"legacy-task rows should be rewritten without legacy lineage")
+			continue
+		}
+		assert.Equal(t, before, post[id], "lineage-capable file rows should keep their original _row_id")
+	}
 }

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/table/dv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -520,4 +521,84 @@ func TestExecuteCompactionGroupPreservesLineageSubsetOnMixedTasks(t *testing.T) 
 		}
 		assert.Equal(t, before, post[id], "lineage-capable file rows should keep their original _row_id")
 	}
+}
+
+// TestExecuteCompactionGroupMixedLineageRetainsSiblingDeletionVectors verifies that
+// mixed-task compaction on a v3 table removes deletion vectors by referenced
+// data file, not by shared deletion-vector container path.
+func TestExecuteCompactionGroupMixedLineageRetainsSiblingDeletionVectors(t *testing.T) {
+	ctx := context.Background()
+	fs := iceio.LocalFS{}
+
+	tbl := newV3RowLineageTestTable(t)
+	mem := memory.DefaultAllocator
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	left, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 1, "data": "a"}, {"id": 2, "data": "b"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(left.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(left, -1), nil)
+	require.NoError(t, err)
+
+	right, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id": 3, "data": "c"}, {"id": 4, "data": "d"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(right.Release)
+	tbl, err = tbl.Append(ctx, array.NewTableReader(right, -1), nil)
+	require.NoError(t, err)
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	rewriteTarget := tasks[0].File.FilePath()
+	siblingTarget := tasks[1].File.FilePath()
+
+	w := dv.NewDVWriter(fs, unpartitionedSpecByID)
+	require.NoError(t, w.Add(rewriteTarget, []int64{0}, 0, nil))
+	require.NoError(t, w.Add(siblingTarget, []int64{0}, 0, nil))
+	dvFiles, err := w.Flush(ctx, filepath.Join(filepath.Dir(rewriteTarget), "dv-shared.puffin"))
+	require.NoError(t, err)
+	require.Len(t, dvFiles, 2)
+	require.Equal(t, dvFiles[0].FilePath(), dvFiles[1].FilePath(),
+		"both deletion vectors must share one Puffin file for this regression")
+
+	rdtx := tbl.NewTransaction()
+	require.NoError(t, rdtx.NewRowDelta(nil).AddDeletes(dvFiles...).Commit(ctx))
+	tbl, err = rdtx.Commit(ctx)
+	require.NoError(t, err)
+
+	tasks, err = tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	tasks[1].FirstRowID = nil
+
+	group := table.CompactionTaskGroup{
+		PartitionKey:   "single",
+		Tasks:          tasks,
+		TotalSizeBytes: tasks[0].File.FileSizeBytes() + tasks[1].File.FileSizeBytes(),
+	}
+	gr, err := table.ExecuteCompactionGroup(ctx, tbl, group)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(gr.OldDataFiles), "both source files should be rewritten")
+	require.Greater(t, len(gr.SafeDeletionVectors), 0, "mixed group should expose deletion vectors for rewrite")
+
+	rtx := tbl.NewTransaction()
+	rewrite := rtx.NewRewrite(nil)
+	rewrite.ApplyResult(gr)
+	require.NoError(t, rewrite.Commit(ctx))
+	tbl, err = rtx.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Empty(t, deleteEntriesReferencing(t, tbl, map[string]struct{}{
+		rewriteTarget: {},
+		siblingTarget: {},
+	}), "shared-path deletion vectors should be removed per referenced-data-file")
 }


### PR DESCRIPTION
## Summary
- Clarify the current mixed-group row-lineage fallback in compaction on v3 tables.
- Document that mixed groups can appear during a v1/v2->v3 migration because `first_row_id` is assigned lazily at the next v3 manifest-list write.
- Keep the existing conservative behavior: when a mixed group is compacted, `_row_id` is dropped for the merged output.
- Restore the warning text and helper docs so they describe the current behavior accurately.

## Testing
- `go test ./table -run 'TestExecuteCompactionGroupPreservesRowIDAcrossV2Upgrade|TestExecuteCompactionGroupPreservesRowID|TestCoWRewritePreservesRowID|TestCoWRewriteRowIDNextRowIDAccounting' -count=1`