### PR TITLE
fix(codec): validate FileScanTask scan ranges on decode

### DIFF
--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -87,6 +87,12 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	if _, err := fileScanTaskSchema.Decode(data, &envelope); err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: decode: %w", err)
 	}
+	if envelope.Start < 0 {
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: start must be non-negative: %d", envelope.Start)
+	}
+	if envelope.Length < 0 {
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: length must be non-negative: %d", envelope.Length)
+	}
 	file, err := DecodeDataFile(envelope.File, spec, schema, version)
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: file: %w", err)

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -42,6 +42,12 @@ func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, sch
 	if version < 1 || version > 3 {
 		return nil, fmt.Errorf("codec: EncodeFileScanTask: unsupported format version %d", version)
 	}
+	if task.Start < 0 {
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: start must be non-negative: %d", task.Start)
+	}
+	if task.Length < 0 {
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: length must be non-negative: %d", task.Length)
+	}
 	// Validate the primary data file's spec, like encodeDataFileSlice does for
 	// every delete/equality/DV file.
 	if err := checkDataFileSpecID(task.File, spec); err != nil {

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -47,3 +47,38 @@ func TestDecodeFileScanTaskInnerErrorCarriesMarker(t *testing.T) {
 	require.Contains(t, err.Error(), "codec: DecodeFileScanTask: file:",
 		"an inner (primary-file) decode error must carry the function + sub-path marker")
 }
+
+func TestDecodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+	)
+	schema := iceberg.NewSchema(123,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+	)
+
+	t.Run("start", func(t *testing.T) {
+		data, err := fileScanTaskSchema.Encode(&fileScanTaskEnvelope{
+			Start:  -1,
+			Length: 1,
+		})
+		require.NoError(t, err)
+
+		_, err = DecodeFileScanTask(data, spec, schema, 2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "codec: DecodeFileScanTask:")
+		require.Contains(t, err.Error(), "start must be non-negative")
+	})
+
+	t.Run("length", func(t *testing.T) {
+		data, err := fileScanTaskSchema.Encode(&fileScanTaskEnvelope{
+			Start:  0,
+			Length: -1,
+		})
+		require.NoError(t, err)
+
+		_, err = DecodeFileScanTask(data, spec, schema, 2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "codec: DecodeFileScanTask:")
+		require.Contains(t, err.Error(), "length must be non-negative")
+	})
+}

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -49,6 +49,9 @@ func TestDecodeFileScanTaskInnerErrorCarriesMarker(t *testing.T) {
 }
 
 func TestDecodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
+	// Range checks are intentionally validated before attempting to decode nested
+	// data-file payloads, so malformed start/length are rejected at the
+	// envelope layer without decoding heavy blob fields.
 	spec := iceberg.NewPartitionSpecID(7,
 		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
 	)

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -165,6 +165,27 @@ func TestEncodeFileScanTaskEmptyDeleteLists(t *testing.T) {
 	require.Empty(t, decoded.DeletionVectorFiles)
 }
 
+func TestEncodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
+	spec, _, task := fullyPopulatedFileScanTask(t, 2)
+
+	t.Run("start", func(t *testing.T) {
+		task.Start = -1
+		_, err := codec.EncodeFileScanTask(task, spec, nil, 2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "codec: EncodeFileScanTask:")
+		require.Contains(t, err.Error(), "start must be non-negative")
+	})
+
+	t.Run("length", func(t *testing.T) {
+		task.Length = -1
+		task.Start = 0
+		_, err := codec.EncodeFileScanTask(task, spec, nil, 2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "codec: EncodeFileScanTask:")
+		require.Contains(t, err.Error(), "length must be non-negative")
+	})
+}
+
 func fullyPopulatedFileScanTask(t *testing.T, version int) (iceberg.PartitionSpec, *iceberg.Schema, table.FileScanTask) {
 	t.Helper()
 	schema := iceberg.NewSchema(123,


### PR DESCRIPTION
## Summary
- Reject negative Start/Length scan ranges in DecodeFileScanTask.
- Add regression coverage for malformed envelopes with negative Start and Length.

## Testing
- go test ./codec -run 'DecodeFileScanTask|EncodeDecodeFileScanTask' -count=1
- go test ./codec -count=1