### PR TITLE
fix(io): return not-exist error for missing MemFS removals

### DIFF
--- a/io/mem.go
+++ b/io/mem.go
@@ -80,8 +80,13 @@ func (m *MemFS) Open(name string) (File, error) {
 
 func (m *MemFS) Remove(name string) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.files[name]; !ok {
+		return &fs.PathError{Op: "remove", Path: name, Err: fs.ErrNotExist}
+	}
+
 	delete(m.files, name)
-	m.mu.Unlock()
 
 	return nil
 }

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -132,6 +132,14 @@ func TestMemIO_MultipleFiles(t *testing.T) {
 	file3.Close()
 }
 
+func TestMemIO_RemoveMissingReturnsNotExist(t *testing.T) {
+	ctx := context.Background()
+
+	memIO, err := icebergio.LoadFS(ctx, map[string]string{}, "mem://bucket/")
+	require.NoError(t, err)
+	require.ErrorIs(t, memIO.Remove("does-not-exist.txt"), fs.ErrNotExist)
+}
+
 func TestMemIO_WalkDir(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Make MemFS.Remove return a `*fs.PathError` with `ErrNotExist` when the target file path is absent.
- Add regression coverage in `io/mem_test.go` for removing a missing file path.

## Testing
- `go test ./io -count=1`