### PR TITLE
fix(manifest): protect FileSequenceNum from aliasing

### DIFF
--- a/table/encryption.go
+++ b/table/encryption.go
@@ -17,7 +17,11 @@
 
 package table
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+	"strings"
+)
 
 // EncryptionKey represents an encryption key stored in table metadata (V3+).
 type EncryptionKey struct {
@@ -25,6 +29,18 @@ type EncryptionKey struct {
 	EncryptedKeyMetadata string            `json:"encrypted-key-metadata"`
 	EncryptedByID        *string           `json:"encrypted-by-id,omitempty"`
 	Properties           map[string]string `json:"properties,omitempty"`
+}
+
+func (e EncryptionKey) Validate() error {
+	if strings.TrimSpace(e.KeyID) == "" {
+		return fmt.Errorf("encryption key-id must be non-empty")
+	}
+
+	if strings.TrimSpace(e.EncryptedKeyMetadata) == "" {
+		return fmt.Errorf("encrypted key metadata must be non-empty")
+	}
+
+	return nil
 }
 
 func (e EncryptionKey) Equals(other EncryptionKey) bool {

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -18,7 +18,7 @@
 package table
 
 import (
-	"fmt"
+	"errors"
 	"maps"
 	"strings"
 )
@@ -33,11 +33,11 @@ type EncryptionKey struct {
 
 func (e EncryptionKey) Validate() error {
 	if strings.TrimSpace(e.KeyID) == "" {
-		return fmt.Errorf("encryption key-id must be non-empty")
+		return errors.New("encryption key-id must be non-empty")
 	}
 
 	if strings.TrimSpace(e.EncryptedKeyMetadata) == "" {
-		return fmt.Errorf("encrypted key metadata must be non-empty")
+		return errors.New("encrypted key metadata must be non-empty")
 	}
 
 	return nil

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1338,6 +1338,9 @@ func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
 		return fmt.Errorf("%w: encryption keys are only supported for format version 3 or higher, current version: %d",
 			iceberg.ErrInvalidArgument, b.formatVersion)
 	}
+	if err := key.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
+	}
 
 	replaced := false
 	for i, k := range b.encryptionKeyList {

--- a/table/updates.go
+++ b/table/updates.go
@@ -775,6 +775,7 @@ func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
 	if err := u.EncryptionKey.Validate(); err != nil {
 		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
 	}
+
 	return builder.AddEncryptionKey(u.EncryptionKey)
 }
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -772,6 +772,9 @@ func NewAddEncryptionKeyUpdate(key EncryptionKey) *addEncryptionKeyUpdate {
 }
 
 func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
+	if err := u.EncryptionKey.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
+	}
 	return builder.AddEncryptionKey(u.EncryptionKey)
 }
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -772,10 +772,6 @@ func NewAddEncryptionKeyUpdate(key EncryptionKey) *addEncryptionKeyUpdate {
 }
 
 func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
-	if err := u.EncryptionKey.Validate(); err != nil {
-		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
-	}
-
 	return builder.AddEncryptionKey(u.EncryptionKey)
 }
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -884,6 +884,37 @@ func TestAddEncryptionKeyUpdate_Apply_RejectsV2(t *testing.T) {
 	assert.Contains(t, err.Error(), "format version 3")
 }
 
+func TestAddEncryptionKeyUpdate_Apply_RejectsMissingKeyID(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "", EncryptedKeyMetadata: "dGVzdA=="}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "key-id")
+}
+
+func TestAddEncryptionKeyUpdate_Apply_RejectsMissingEncryptedKeyMetadata(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: ""}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "metadata")
+}
+
+func TestAddEncryptionKeyUpdate_UnmarshalMissingFields_ApplyRejects(t *testing.T) {
+	data := []byte(`[{"action":"add-encryption-key","encryption-key":{"key-id":"my-key"}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	err := updates[0].Apply(buildFromBaseV3(t))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
 func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{"action":"remove-encryption-key","key-id":"key-42"}]`)
 


### PR DESCRIPTION
### What changed
- Return a copied pointer from `ManifestEntry.FileSequenceNum()` to avoid exposing internal `manifestEntry` state.
- Added regression coverage for pointer aliasing; mutating the returned pointer no longer mutates manifest-entry data.
- Added tests in `manifest_test.go` for `FileSequenceNum()` copy behavior.

