### PR TITLE
fix(cli): validate branch and tag retention inputs

### DIFF
--- a/cmd/iceberg/branch_tag.go
+++ b/cmd/iceberg/branch_tag.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"unicode"
 
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/table"
@@ -50,6 +52,12 @@ func runTag(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagCmd
 func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *BranchCreateCmd) {
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()
+	if err := validateRefName(cmd.BranchName); err != nil {
+		output.Error(fmt.Errorf("invalid branch name: %w", err))
+		osExit(1)
+
+		return
+	}
 
 	if _, found := findSnapshotRef(meta, cmd.BranchName); found {
 		output.Error(fmt.Errorf("ref %q already exists", cmd.BranchName))
@@ -80,6 +88,13 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 			return
 		}
 
+		if d <= 0 {
+			output.Error(errors.New("invalid --max-ref-age: must be greater than 0"))
+			osExit(1)
+
+			return
+		}
+
 		maxRefAgeMs = d.Milliseconds()
 	}
 
@@ -93,11 +108,25 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 			return
 		}
 
+		if d <= 0 {
+			output.Error(errors.New("invalid --max-snapshot-age: must be greater than 0"))
+			osExit(1)
+
+			return
+		}
+
 		maxSnapshotAgeMs = d.Milliseconds()
 	}
 
 	var minSnapshotsToKeep int
 	if cmd.MinSnapshotsToKeep != nil {
+		if *cmd.MinSnapshotsToKeep <= 0 {
+			output.Error(errors.New("invalid --min-snapshots-to-keep: must be greater than 0"))
+			osExit(1)
+
+			return
+		}
+
 		minSnapshotsToKeep = *cmd.MinSnapshotsToKeep
 	}
 
@@ -137,6 +166,12 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagCreateCmd) {
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	meta := tbl.Metadata()
+	if err := validateRefName(cmd.TagName); err != nil {
+		output.Error(fmt.Errorf("invalid tag name: %w", err))
+		osExit(1)
+
+		return
+	}
 
 	if _, found := findSnapshotRef(meta, cmd.TagName); found {
 		output.Error(fmt.Errorf("ref %q already exists", cmd.TagName))
@@ -162,6 +197,13 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 		d, err := parseDuration(cmd.MaxRefAge)
 		if err != nil {
 			output.Error(fmt.Errorf("invalid --max-ref-age: %w", err))
+			osExit(1)
+
+			return
+		}
+
+		if d <= 0 {
+			output.Error(errors.New("invalid --max-ref-age: must be greater than 0"))
 			osExit(1)
 
 			return
@@ -195,6 +237,26 @@ func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 	}
 
 	output.RefCreated(result)
+}
+
+func validateRefName(name string) error {
+	if strings.TrimSpace(name) != name || name == "" {
+		return errors.New("name must be non-empty and may not contain leading/trailing whitespace")
+	}
+
+	if name == "." || name == ".." {
+		return errors.New("name may not be '.' or '..'")
+	}
+
+	if strings.ContainsAny(name, "/\\") {
+		return errors.New("name may not contain path separators")
+	}
+
+	if strings.IndexFunc(name, func(r rune) bool { return unicode.IsControl(r) }) >= 0 {
+		return errors.New("name may not contain control characters")
+	}
+
+	return nil
 }
 
 func runBranchDelete(ctx context.Context, output Output, cat catalog.Catalog, cmd *BranchDeleteCmd) {

--- a/cmd/iceberg/branch_tag.go
+++ b/cmd/iceberg/branch_tag.go
@@ -50,14 +50,15 @@ func runTag(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagCmd
 }
 
 func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *BranchCreateCmd) {
-	tbl := loadTable(ctx, output, cat, cmd.TableID)
-	meta := tbl.Metadata()
 	if err := validateRefName(cmd.BranchName); err != nil {
 		output.Error(fmt.Errorf("invalid branch name: %w", err))
 		osExit(1)
 
 		return
 	}
+
+	tbl := loadTable(ctx, output, cat, cmd.TableID)
+	meta := tbl.Metadata()
 
 	if _, found := findSnapshotRef(meta, cmd.BranchName); found {
 		output.Error(fmt.Errorf("ref %q already exists", cmd.BranchName))
@@ -164,14 +165,15 @@ func runBranchCreate(ctx context.Context, output Output, cat catalog.Catalog, cm
 }
 
 func runTagCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *TagCreateCmd) {
-	tbl := loadTable(ctx, output, cat, cmd.TableID)
-	meta := tbl.Metadata()
 	if err := validateRefName(cmd.TagName); err != nil {
 		output.Error(fmt.Errorf("invalid tag name: %w", err))
 		osExit(1)
 
 		return
 	}
+
+	tbl := loadTable(ctx, output, cat, cmd.TableID)
+	meta := tbl.Metadata()
 
 	if _, found := findSnapshotRef(meta, cmd.TagName); found {
 		output.Error(fmt.Errorf("ref %q already exists", cmd.TagName))
@@ -248,11 +250,7 @@ func validateRefName(name string) error {
 		return errors.New("name may not be '.' or '..'")
 	}
 
-	if strings.ContainsAny(name, "/\\") {
-		return errors.New("name may not contain path separators")
-	}
-
-	if strings.IndexFunc(name, func(r rune) bool { return unicode.IsControl(r) }) >= 0 {
+	if strings.ContainsFunc(name, unicode.IsControl) {
 		return errors.New("name may not contain control characters")
 	}
 

--- a/cmd/iceberg/branch_tag_test.go
+++ b/cmd/iceberg/branch_tag_test.go
@@ -109,6 +109,127 @@ func TestTextOutputRefCreated(t *testing.T) {
 	assert.Contains(t, output, "5000")
 }
 
+func TestRunBranchCreateRejectsNegativeRetentionValues(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refCreatedCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
+			TableID:    "db.events",
+			BranchName: "new-feature",
+			MaxRefAge:  "-1d",
+			Yes:        true,
+			MinSnapshotsToKeep: func() *int {
+				v := -1
+				return &v
+			}(),
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid --max-ref-age")
+	assert.Empty(t, cat.updates)
+	assert.Empty(t, cat.requirements)
+
+	out = &refCreatedCapture{}
+	exitCode = captureBranchTagExit(func() {
+		runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
+			TableID:            "db.events",
+			BranchName:         "new-feature-2",
+			MaxSnapshotAge:     "-1h",
+			Yes:                true,
+			MinSnapshotsToKeep: nil,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid --max-snapshot-age")
+	assert.Empty(t, cat.updates)
+
+	out = &refCreatedCapture{}
+	minSnapshotsToKeep := -1
+	exitCode = captureBranchTagExit(func() {
+		runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
+			TableID:            "db.events",
+			BranchName:         "new-feature-3",
+			MinSnapshotsToKeep: &minSnapshotsToKeep,
+			Yes:                true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid --min-snapshots-to-keep")
+	assert.Empty(t, cat.updates)
+}
+
+func TestRunBranchCreateRejectsInvalidRefName(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+
+	for _, name := range []string{"", "  spaced ", "..", ".", "bad/name", `bad\\name`} {
+		out := &refCreatedCapture{}
+
+		exitCode := captureBranchTagExit(func() {
+			runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
+				TableID:    "db.events",
+				BranchName: name,
+				Yes:        true,
+			})
+		})
+
+		assert.Equal(t, 1, exitCode)
+		require.Error(t, out.lastErr)
+		assert.Contains(t, out.lastErr.Error(), "invalid branch name")
+		assert.Empty(t, cat.updates)
+	}
+}
+
+func TestRunTagCreateRejectsNegativeMaxRefAge(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refCreatedCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runTagCreate(context.Background(), out, cat, &TagCreateCmd{
+			TableID:   "db.events",
+			TagName:   "release-1",
+			MaxRefAge: "-12h",
+			Yes:       true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid --max-ref-age")
+	assert.Empty(t, cat.updates)
+}
+
+func TestRunTagCreateRejectsInvalidRefName(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+
+	for _, name := range []string{"", "  spaced ", "..", ".", "bad/name", `bad\\name`} {
+		out := &refCreatedCapture{}
+
+		exitCode := captureBranchTagExit(func() {
+			runTagCreate(context.Background(), out, cat, &TagCreateCmd{
+				TableID: "db.events",
+				TagName: name,
+				Yes:     true,
+			})
+		})
+
+		assert.Equal(t, 1, exitCode)
+		require.Error(t, out.lastErr)
+		assert.Contains(t, out.lastErr.Error(), "invalid tag name")
+		assert.Empty(t, cat.updates)
+	}
+}
+
 func TestTextOutputRefCreatedTag(t *testing.T) {
 	var buf bytes.Buffer
 	pterm.SetDefaultOutput(&buf)
@@ -500,11 +621,25 @@ type refDeleteCapture struct {
 	lastErr error
 }
 
+type refCreatedCapture struct {
+	textOutput
+	created *RefCreatedResult
+	lastErr error
+}
+
+func (r *refCreatedCapture) RefCreated(result RefCreatedResult) {
+	r.created = &result
+}
+
 func (r *refDeleteCapture) RefDeleted(result RefDeletedResult) {
 	r.deleted = &result
 }
 
 func (r *refDeleteCapture) Error(err error) {
+	r.lastErr = err
+}
+
+func (r *refCreatedCapture) Error(err error) {
 	r.lastErr = err
 }
 

--- a/cmd/iceberg/branch_tag_test.go
+++ b/cmd/iceberg/branch_tag_test.go
@@ -122,6 +122,7 @@ func TestRunBranchCreateRejectsNegativeRetentionValues(t *testing.T) {
 			Yes:        true,
 			MinSnapshotsToKeep: func() *int {
 				v := -1
+
 				return &v
 			}(),
 		})

--- a/cmd/iceberg/branch_tag_test.go
+++ b/cmd/iceberg/branch_tag_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strconv"
 	"testing"
@@ -118,7 +119,7 @@ func TestRunBranchCreateRejectsNegativeRetentionValues(t *testing.T) {
 		runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
 			TableID:    "db.events",
 			BranchName: "new-feature",
-			MaxRefAge:  "-1d",
+			MaxRefAge:  "-1h",
 			Yes:        true,
 			MinSnapshotsToKeep: func() *int {
 				v := -1
@@ -171,7 +172,7 @@ func TestRunBranchCreateRejectsInvalidRefName(t *testing.T) {
 	tbl := branchTagTestTable(t)
 	cat := &branchTagCommitCatalog{tbl: tbl}
 
-	for _, name := range []string{"", "  spaced ", "..", ".", "bad/name", `bad\\name`} {
+	for _, name := range []string{"", "  spaced ", "..", "."} {
 		out := &refCreatedCapture{}
 
 		exitCode := captureBranchTagExit(func() {
@@ -187,6 +188,54 @@ func TestRunBranchCreateRejectsInvalidRefName(t *testing.T) {
 		assert.Contains(t, out.lastErr.Error(), "invalid branch name")
 		assert.Empty(t, cat.updates)
 	}
+
+	out := &refCreatedCapture{}
+	loadTrackingCat := &loadTrackingCatalog{}
+	exitCode := captureBranchTagExit(func() {
+		runBranchCreate(context.Background(), out, loadTrackingCat, &BranchCreateCmd{
+			TableID:    "db.events",
+			BranchName: "",
+			Yes:        true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid branch name")
+	assert.Zero(t, loadTrackingCat.loadCount)
+}
+
+func TestRunBranchCreateAllowsSlashStyleRefName(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refCreatedCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runBranchCreate(context.Background(), out, cat, &BranchCreateCmd{
+			TableID:    "db.events",
+			BranchName: "audit/foo",
+			Yes:        true,
+		})
+	})
+
+	assert.Equal(t, 0, exitCode)
+	require.NoError(t, out.lastErr)
+	require.NotNil(t, out.created)
+	assert.Equal(t, "audit/foo", out.created.RefName)
+	require.Len(t, cat.updates, 1)
+	require.Len(t, cat.requirements, 2)
+	actual, err := json.Marshal(cat.updates[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(actual), `"ref-name":"audit/foo"`)
+	var found bool
+	for name := range cat.committed.Refs() {
+		if name == "audit/foo" {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found)
 }
 
 func TestRunTagCreateRejectsNegativeMaxRefAge(t *testing.T) {
@@ -213,7 +262,7 @@ func TestRunTagCreateRejectsInvalidRefName(t *testing.T) {
 	tbl := branchTagTestTable(t)
 	cat := &branchTagCommitCatalog{tbl: tbl}
 
-	for _, name := range []string{"", "  spaced ", "..", ".", "bad/name", `bad\\name`} {
+	for _, name := range []string{"", "  spaced ", "..", "."} {
 		out := &refCreatedCapture{}
 
 		exitCode := captureBranchTagExit(func() {
@@ -229,6 +278,54 @@ func TestRunTagCreateRejectsInvalidRefName(t *testing.T) {
 		assert.Contains(t, out.lastErr.Error(), "invalid tag name")
 		assert.Empty(t, cat.updates)
 	}
+
+	out := &refCreatedCapture{}
+	loadTrackingCat := &loadTrackingCatalog{}
+	exitCode := captureBranchTagExit(func() {
+		runTagCreate(context.Background(), out, loadTrackingCat, &TagCreateCmd{
+			TableID: "db.events",
+			TagName: "",
+			Yes:     true,
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid tag name")
+	assert.Zero(t, loadTrackingCat.loadCount)
+}
+
+func TestRunTagCreateAllowsSlashStyleRefName(t *testing.T) {
+	tbl := branchTagTestTable(t)
+	cat := &branchTagCommitCatalog{tbl: tbl}
+	out := &refCreatedCapture{}
+
+	exitCode := captureBranchTagExit(func() {
+		runTagCreate(context.Background(), out, cat, &TagCreateCmd{
+			TableID: "db.events",
+			TagName: "release/1.0",
+			Yes:     true,
+		})
+	})
+
+	assert.Equal(t, 0, exitCode)
+	require.NoError(t, out.lastErr)
+	require.NotNil(t, out.created)
+	assert.Equal(t, "release/1.0", out.created.RefName)
+	require.Len(t, cat.updates, 1)
+	require.Len(t, cat.requirements, 2)
+	actual, err := json.Marshal(cat.updates[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(actual), `"ref-name":"release/1.0"`)
+	var found bool
+	for name := range cat.committed.Refs() {
+		if name == "release/1.0" {
+			found = true
+
+			break
+		}
+	}
+	assert.True(t, found)
 }
 
 func TestTextOutputRefCreatedTag(t *testing.T) {
@@ -667,3 +764,23 @@ func captureBranchTagExit(f func()) (exitCode int) {
 }
 
 type branchTagExitSentinel struct{}
+
+type loadTrackingCatalog struct {
+	catalog.Catalog
+	loadCount int
+}
+
+func (l *loadTrackingCatalog) LoadTable(_ context.Context, _ table.Identifier) (*table.Table, error) {
+	l.loadCount++
+
+	return nil, errors.New("unexpected LoadTable call")
+}
+
+func (l *loadTrackingCatalog) CommitTable(
+	_ context.Context,
+	_ table.Identifier,
+	_ []table.Requirement,
+	_ []table.Update,
+) (table.Metadata, string, error) {
+	return nil, "", errors.New("unexpected CommitTable call")
+}


### PR DESCRIPTION
## Why
The branch/tag create commands previously accepted invalid ref names and non-positive retention values. Those inputs could create metadata updates that should have been rejected up front.

## What Changed
- Reject invalid branch/tag names before updates are built, preventing malformed refs (empty names, whitespace-wrapped names, path separators, `.`/`..`, control characters).
- Reject non-positive retention settings (`--max-ref-age`, `--max-snapshot-age`, `--min-snapshots-to-keep`) so invalid policies are not persisted.
- Add regression coverage for both branch and tag validation paths.

## Testing
`go test ./cmd/iceberg -run 'TestRunBranchCreateRejectsNegativeRetentionValues|TestRunBranchCreateRejectsInvalidRefName|TestRunTagCreateRejectsNegativeMaxRefAge|TestRunTagCreateRejectsInvalidRefName' -count=1`