### PR TITLE
fix(table): validate parquet file writer properties

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -365,7 +365,12 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 
 	counter := &internal.CountingWriter{W: fw}
 	mem := compute.GetAllocator(ctx)
-	writerProps := parquet.NewWriterProperties(info.WriteProps.([]parquet.WriterProperty)...)
+	writerProps, err := getWriteProperties(info.WriteProps)
+	if err != nil {
+		fw.Close()
+
+		return nil, err
+	}
 	arrProps := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithStoreSchema())
 
 	writer, err := pqarrow.NewFileWriter(arrowSchema, counter, writerProps, arrProps)
@@ -385,6 +390,19 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		partition:  partitionValues,
 		colMapping: colMapping,
 	}, nil
+}
+
+func getWriteProperties(writeProps any) (*parquet.WriterProperties, error) {
+	if writeProps == nil {
+		return nil, fmt.Errorf("%w: write properties are required", iceberg.ErrInvalidArgument)
+	}
+
+	writerProperties, ok := writeProps.([]parquet.WriterProperty)
+	if !ok {
+		return nil, fmt.Errorf("%w: invalid write properties type %T", iceberg.ErrInvalidArgument, writeProps)
+	}
+
+	return parquet.NewWriterProperties(writerProperties...), nil
 }
 
 // Write appends a record batch to the Parquet file.

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -392,6 +392,8 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 	}, nil
 }
 
+// getWriteProperties requires explicit write properties so misconfigured writer
+// plumbing fails fast instead of silently defaulting Parquet settings.
 func getWriteProperties(writeProps any) (*parquet.WriterProperties, error) {
 	if writeProps == nil {
 		return nil, fmt.Errorf("%w: write properties are required", iceberg.ErrInvalidArgument)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -890,6 +890,7 @@ func TestNewFileWriterRejectsInvalidWriteProps(t *testing.T) {
 		})
 	}
 }
+
 func TestParquetFileWriterAbortRemovesFile(t *testing.T) {
 	memFS := iceio.NewMemFS()
 	fileName := "mem://abort-test/data.parquet"

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -845,6 +845,51 @@ func TestWriteDataFileErrOnClose(t *testing.T) {
 	require.ErrorContains(t, err, "error on close")
 }
 
+func TestNewFileWriterRejectsInvalidWriteProps(t *testing.T) {
+	fm := internal.GetFileFormat(iceberg.ParquetFile)
+
+	icebergSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID:       1,
+		Name:     "id",
+		Type:     iceberg.PrimitiveTypes.Int32,
+		Required: false,
+	})
+	arrowSchema, err := table.SchemaToArrowSchema(icebergSchema, nil, true, false)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		writeProps any
+		expected   string
+	}{
+		{
+			name:       "nil write props",
+			writeProps: nil,
+			expected:   "write properties are required",
+		},
+		{
+			name:       "wrong write props type",
+			writeProps: "bad",
+			expected:   "invalid write properties type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memfs := iceio.NewMemFS()
+
+			_, err = fm.NewFileWriter(context.Background(), memfs, nil, internal.WriteFileInfo{
+				FileSchema: icebergSchema,
+				FileName:   "f",
+				WriteProps: tt.writeProps,
+				Content:    iceberg.EntryContentData,
+				Spec:       *iceberg.UnpartitionedSpec,
+			}, arrowSchema)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, tt.expected)
+		})
+	}
+}
 func TestParquetFileWriterAbortRemovesFile(t *testing.T) {
 	memFS := iceio.NewMemFS()
 	fileName := "mem://abort-test/data.parquet"


### PR DESCRIPTION
Parquet writer initialization now validates WriteProps type before constructing writer properties so malformed file-info does not panic.

- Adds safe getWriteProperties helper used by NewFileWriter.
- Returns iceberg.ErrInvalidArgument-compatible errors when write properties are nil or the wrong type.
- Adds regression tests for nil and non-slice write properties.