### PR TITLE
fix(manifest): protect FileSequenceNum from aliasing

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -2180,7 +2180,13 @@ func (m *manifestEntry) SequenceNum() int64 {
 }
 
 func (m *manifestEntry) FileSequenceNum() *int64 {
-	return m.FileSeqNum
+	if m.FileSeqNum == nil {
+		return nil
+	}
+
+	fileSeqNum := *m.FileSeqNum
+
+	return &fileSeqNum
 }
 
 func (m *manifestEntry) DataFile() DataFile { return m.Data }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1941,8 +1941,6 @@ func (m *ManifestTestSuite) TestManifestEntryFileSequenceNumReturnsCopy() {
 	current := entry.FileSequenceNum()
 	m.Require().NotNil(current)
 	m.Assert().Equal(int64(10), *current)
-	m.Assert().NotEqual(int64(20), *current)
-	m.Assert().Equal(entryFileSeqNum, *current)
 }
 
 // equalityIDsSchemaIsInt asserts equality_ids uses Avro "int", not "long".

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1925,6 +1925,26 @@ func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	m.Assert().Equal(0, *data.SortOrderID())
 }
 
+func (m *ManifestTestSuite) TestManifestEntryFileSequenceNumReturnsCopy() {
+	entryFileSeqNum := int64(10)
+	entry := &manifestEntry{
+		EntryStatus: EntryStatusADDED,
+		FileSeqNum:  &entryFileSeqNum,
+		Data:        &dataFile{Path: "/data/sample.parquet"},
+	}
+
+	got := entry.FileSequenceNum()
+	m.Require().NotNil(got)
+	m.Assert().Equal(entryFileSeqNum, *got)
+	*got = 20
+
+	current := entry.FileSequenceNum()
+	m.Require().NotNil(current)
+	m.Assert().Equal(int64(10), *current)
+	m.Assert().NotEqual(int64(20), *current)
+	m.Assert().Equal(entryFileSeqNum, *current)
+}
+
 // equalityIDsSchemaIsInt asserts equality_ids uses Avro "int", not "long".
 func (m *ManifestTestSuite) equalityIDsSchemaIsInt(sc *avro.Schema) {
 	m.T().Helper()


### PR DESCRIPTION
## Why
Manifest callers currently can mutate internal `ManifestEntry` state by writing through the pointer returned from `FileSequenceNum()`. That creates subtle state corruption risk during metadata handling and makes aliasing bugs hard to detect.

## What changed
- Return a copied `int64` pointer from `FileSequenceNum()` instead of exposing the internal pointer directly.
- Keep behavior unchanged for nil sequence values.
- Preserve the existing API shape while preventing external mutation of the manifest entry's internal sequence number.
- Add regression coverage that confirms returned pointer mutation no longer impacts the underlying manifest entry.

## Validation
- `go test ./...` for package-level coverage of the updated tests.
- `golangci-lint` clean on this branch.

## Compatibility
This is a source-compatible behavioral safety fix with no external API change.