### PR TITLE
fix(manifest): clone partition and key metadata inputs

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -144,13 +144,48 @@ func (b *ManifestBuilder) DeletedRows(cnt int64) *ManifestBuilder {
 }
 
 func (b *ManifestBuilder) Partitions(p []FieldSummary) *ManifestBuilder {
-	b.m.PartitionList = &p
+	if p == nil {
+		// Preserve the semantic "no partition summaries" state by clearing the
+		// union pointer entirely instead of storing a pointer to a nil slice.
+		b.m.PartitionList = nil
+
+		return b
+	}
+
+	copied := make([]FieldSummary, len(p))
+	for i, partition := range p {
+		copiedPartition := partition
+		if partition.LowerBound != nil {
+			lowerBound := slices.Clone(*partition.LowerBound)
+			copiedPartition.LowerBound = &lowerBound
+		}
+		if partition.UpperBound != nil {
+			upperBound := slices.Clone(*partition.UpperBound)
+			copiedPartition.UpperBound = &upperBound
+		}
+		if partition.ContainsNaN != nil {
+			containsNaN := *partition.ContainsNaN
+			copiedPartition.ContainsNaN = &containsNaN
+		}
+
+		copied[i] = copiedPartition
+	}
+	b.m.PartitionList = &copied
 
 	return b
 }
 
 func (b *ManifestBuilder) KeyMetadata(km []byte) *ManifestBuilder {
-	b.m.Key = &km
+	if km == nil {
+		// Preserve the semantic "no key metadata" state by clearing the union
+		// pointer entirely instead of storing a pointer to a nil slice.
+		b.m.Key = nil
+
+		return b
+	}
+
+	keyMetadata := slices.Clone(km)
+	b.m.Key = &keyMetadata
 
 	return b
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1943,6 +1943,43 @@ func (m *ManifestTestSuite) TestManifestEntryFileSequenceNumReturnsCopy() {
 	m.Assert().Equal(int64(10), *current)
 }
 
+func (m *ManifestTestSuite) TestManifestBuilderPartitionsCopiesInput() {
+	containsNaN := true
+	lowerBound := []byte{0x00, 0x01}
+	upperBound := []byte{0x01, 0x02}
+	partitions := []FieldSummary{{
+		ContainsNull: true,
+		ContainsNaN:  &containsNaN,
+		LowerBound:   &lowerBound,
+		UpperBound:   &upperBound,
+	}}
+
+	manifest := NewManifestFile(2, "file.avro", 1, 1, entrySnapshotID).Partitions(partitions).Build()
+
+	containsNaN = false
+	lowerBound[0] = 0x09
+	upperBound[1] = 0x0a
+	partitions[0].ContainsNull = false
+	partitions[0].ContainsNaN = nil
+
+	manifestPartitions := manifest.Partitions()
+	m.Require().Len(manifestPartitions, 1)
+	m.Assert().True(manifestPartitions[0].ContainsNull)
+	m.Require().NotNil(manifestPartitions[0].ContainsNaN)
+	m.Assert().True(*manifestPartitions[0].ContainsNaN)
+	m.Assert().Equal([]byte{0x00, 0x01}, *manifestPartitions[0].LowerBound)
+	m.Assert().Equal([]byte{0x01, 0x02}, *manifestPartitions[0].UpperBound)
+}
+
+func (m *ManifestTestSuite) TestManifestBuilderKeyMetadataCopiesInput() {
+	keyMetadata := []byte{0x00, 0x01, 0x02}
+	manifest := NewManifestFile(2, "file.avro", 1, 1, entrySnapshotID).KeyMetadata(keyMetadata).Build()
+
+	keyMetadata[1] = 0x09
+
+	m.Assert().Equal([]byte{0x00, 0x01, 0x02}, manifest.KeyMetadata())
+}
+
 // equalityIDsSchemaIsInt asserts equality_ids uses Avro "int", not "long".
 func (m *ManifestTestSuite) equalityIDsSchemaIsInt(sc *avro.Schema) {
 	m.T().Helper()


### PR DESCRIPTION
## Summary

`ManifestBuilder` previously retained caller-owned partition summaries and key-metadata bytes, allowing later caller mutations to change built manifest metadata.

- deep-copy partition summaries, including bounds and `ContainsNaN` pointers;
- clone key-metadata bytes;
- preserve nil inputs;
- add regression tests that mutate every caller-owned input after building.

## Testing

- `go test .`