### PR TITLE
fix(table): clone row delta snapshot properties

### DIFF
--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/apache/iceberg-go"
 )
@@ -74,7 +75,7 @@ type RowDelta struct {
 func (t *Transaction) NewRowDelta(snapshotProps iceberg.Properties) *RowDelta {
 	return &RowDelta{
 		txn:   t,
-		props: snapshotProps,
+		props: maps.Clone(snapshotProps),
 	}
 }
 

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -329,6 +329,27 @@ func TestRowDeltaCommitDataAndDeletes(t *testing.T) {
 	assert.Equal(t, "10", snap.Summary.Properties["added-records"])
 }
 
+func TestNewRowDeltaCopiesSnapshotProperties(t *testing.T) {
+	tbl := newRowDeltaCommitTestTable(t)
+
+	snapshotProps := iceberg.Properties{"custom-prop": "initial"}
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(snapshotProps)
+	snapshotProps["custom-prop"] = "changed"
+	snapshotProps["new-prop"] = "added"
+
+	rd.AddRows(buildDataFile(t, "s3://bucket/data/insert.parquet"))
+	require.NoError(t, rd.Commit(t.Context()))
+
+	result, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+	snap := result.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	assert.Equal(t, "initial", snap.Summary.Properties["custom-prop"])
+	assert.NotContains(t, snap.Summary.Properties, "new-prop")
+}
+
 func TestRowDeltaCommitDataOnly(t *testing.T) {
 	tbl := newRowDeltaCommitTestTable(t)
 


### PR DESCRIPTION
## Why
`Transaction.NewRowDelta` used to store `snapshotProps` by reference. If callers mutated the same map after creating a row delta, those changes leaked into snapshot summary metadata after commit.

## Fix
Clone snapshot properties at construction time so the `RowDelta` snapshot metadata is isolated from caller-owned maps.

- Defensive-copy `snapshotProps` in `NewRowDelta`.
- Add a regression test (`TestNewRowDeltaCopiesSnapshotProperties`) that mutates the original map after `NewRowDelta` and verifies the committed snapshot still uses the original values.

## Testing
go test ./table -run TestNewRowDeltaCopiesSnapshotProperties -count=1