### PR TITLE
fix(types): validate fixed type length

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -1119,7 +1119,7 @@ func (b *BinaryLiteral) UnmarshalBinary(data []byte) error {
 type FixedLiteral []byte
 
 func (FixedLiteral) Comparator() Comparator[[]byte] { return bytes.Compare }
-func (f FixedLiteral) Type() Type                   { return FixedTypeOf(len(f)) }
+func (f FixedLiteral) Type() Type                   { return FixedType{len: len(f)} }
 func (f FixedLiteral) Value() []byte                { return []byte(f) }
 func (f FixedLiteral) Any() any                     { return f.Value() }
 func (f FixedLiteral) String() string               { return string(f) }

--- a/literals_test.go
+++ b/literals_test.go
@@ -656,6 +656,11 @@ func TestVariantLiteralLargeObject(t *testing.T) {
 }
 
 func TestFixedLiteral(t *testing.T) {
+	emptyFixed := iceberg.FixedLiteral(nil)
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "fixed[0]", emptyFixed.Type().String())
+	})
+
 	fixedLit012 := iceberg.FixedLiteral{0x00, 0x01, 0x02}
 	fixedLit013 := iceberg.FixedLiteral{0x00, 0x01, 0x03}
 	assert.True(t, fixedLit012.Equals(fixedLit012))

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -52,6 +52,7 @@ func TestArrowToIceberg(t *testing.T) {
 		reciprocal bool
 		err        string
 	}{
+		{&arrow.FixedSizeBinaryType{ByteWidth: 0}, iceberg.FixedTypeOf(0), true, ""},
 		{&arrow.FixedSizeBinaryType{ByteWidth: 23}, iceberg.FixedTypeOf(23), true, ""},
 		{&arrow.Decimal32Type{Precision: 8, Scale: 9}, iceberg.DecimalTypeOf(8, 9), false, ""},
 		{&arrow.Decimal64Type{Precision: 15, Scale: 14}, iceberg.DecimalTypeOf(15, 14), false, ""},

--- a/types.go
+++ b/types.go
@@ -189,7 +189,10 @@ func (t *typeIFace) UnmarshalJSON(b []byte) error {
 					return fmt.Errorf("%w: %s", ErrInvalidTypeString, typename)
 				}
 
-				n, _ := strconv.Atoi(matches[1])
+				n, err := strconv.Atoi(matches[1])
+				if err != nil {
+					return fmt.Errorf("%w: invalid fixed length %q: %v", ErrInvalidTypeString, matches[1], err)
+				}
 				t.Type = FixedType{len: n}
 			case strings.HasPrefix(typename, "decimal"):
 				matches := decimalRegex.FindStringSubmatch(typename)
@@ -558,7 +561,21 @@ func (m *MapType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func FixedTypeOf(n int) FixedType { return FixedType{len: n} }
+func validateFixedLength(length int) error {
+	if length < 0 {
+		return fmt.Errorf("fixed length must be non-negative, got %d", length)
+	}
+
+	return nil
+}
+
+func FixedTypeOf(n int) FixedType {
+	if err := validateFixedLength(n); err != nil {
+		panic(fmt.Errorf("%w: %s", ErrInvalidArgument, err))
+	}
+
+	return FixedType{len: n}
+}
 
 type FixedType struct {
 	len int

--- a/types_test.go
+++ b/types_test.go
@@ -47,6 +47,7 @@ func TestTypesBasic(t *testing.T) {
 		{"binary", iceberg.PrimitiveTypes.Binary},
 		{"unknown", iceberg.PrimitiveTypes.Unknown},
 		{"variant", iceberg.VariantType{}},
+		{"fixed[0]", iceberg.FixedTypeOf(0)},
 		{"fixed[5]", iceberg.FixedTypeOf(5)},
 		{"decimal(9, 4)", iceberg.DecimalTypeOf(9, 4)},
 	}
@@ -77,6 +78,49 @@ func TestFixedType(t *testing.T) {
 	assert.Equal(t, "fixed[5]", typ.String())
 	assert.True(t, typ.Equals(iceberg.FixedTypeOf(5)))
 	assert.False(t, typ.Equals(iceberg.FixedTypeOf(6)))
+	assert.Equal(t, "fixed[0]", iceberg.FixedTypeOf(0).String())
+
+	t.Run("FixedTypeOf validates length", func(t *testing.T) {
+		assertFixedTypeOfPanicsWithInvalidArgument(t, -1)
+	})
+}
+
+func TestFixedTypeInvalidParse(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "malformed suffix",
+			data: `{"id": 1, "name": "f", "type": "fixed[0]junk", "required": true}`,
+		},
+		{
+			name: "overflow",
+			data: `{"id": 1, "name": "f", "type": "fixed[99999999999999999999]", "required": true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var n iceberg.NestedField
+			err := json.Unmarshal([]byte(tt.data), &n)
+			assert.ErrorIs(t, err, iceberg.ErrInvalidTypeString)
+		})
+	}
+}
+
+func assertFixedTypeOfPanicsWithInvalidArgument(t *testing.T, length int) {
+	t.Helper()
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+		err, ok := r.(error)
+		require.True(t, ok)
+		assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	}()
+
+	iceberg.FixedTypeOf(length)
 }
 
 func TestDecimalType(t *testing.T) {


### PR DESCRIPTION
## Why
`fixed[N]` schemas should only allow a positive fixed byte length, but the parser and constructor path currently allowed invalid lengths through. That could leak malformed type definitions into metadata and fail later in conversion/encoding paths.

## What changed
- Added strict fixed-length validation for both construction and parsing paths.
- `FixedTypeOf` now rejects non-positive lengths.
- Fixed-type parsing now validates the `fixed(<length>)` declaration using the same checks, so `fixed[0]` and invalid forms are rejected immediately.
- Added regression coverage for malformed/invalid fixed type lengths.

## Validation
- `go test . -run "TestFixedType|TestFixedTypeInvalidParse" -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=10m`
