### PR TITLE
fix(table): validate encryption-key metadata fields

### DIFF
--- a/table/encryption.go
+++ b/table/encryption.go
@@ -18,7 +18,9 @@
 package table
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"maps"
 	"strings"
 )
@@ -31,13 +33,20 @@ type EncryptionKey struct {
 	Properties           map[string]string `json:"properties,omitempty"`
 }
 
-func (e EncryptionKey) Validate() error {
-	if strings.TrimSpace(e.KeyID) == "" {
+func (e EncryptionKey) validate() error {
+	trimmedKeyID := strings.TrimSpace(e.KeyID)
+	if trimmedKeyID == "" {
 		return errors.New("encryption key-id must be non-empty")
 	}
+	if trimmedKeyID != e.KeyID {
+		return errors.New("encryption key-id must not have leading or trailing whitespace")
+	}
 
-	if strings.TrimSpace(e.EncryptedKeyMetadata) == "" {
+	if e.EncryptedKeyMetadata == "" {
 		return errors.New("encrypted key metadata must be non-empty")
+	}
+	if _, err := base64.StdEncoding.DecodeString(e.EncryptedKeyMetadata); err != nil {
+		return fmt.Errorf("encrypted key metadata must be valid base64: %w", err)
 	}
 
 	return nil

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -17,7 +17,11 @@
 
 package table
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+	"strings"
+)
 
 // EncryptionKey represents an encryption key stored in table metadata (V3+).
 type EncryptionKey struct {
@@ -25,6 +29,18 @@ type EncryptionKey struct {
 	EncryptedKeyMetadata string            `json:"encrypted-key-metadata"`
 	EncryptedByID        *string           `json:"encrypted-by-id,omitempty"`
 	Properties           map[string]string `json:"properties,omitempty"`
+}
+
+func (e EncryptionKey) Validate() error {
+	if strings.TrimSpace(e.KeyID) == "" {
+		return fmt.Errorf("encryption key-id must be non-empty")
+	}
+
+	if strings.TrimSpace(e.EncryptedKeyMetadata) == "" {
+		return fmt.Errorf("encrypted key metadata must be non-empty")
+	}
+
+	return nil
 }
 
 func (e EncryptionKey) Equals(other EncryptionKey) bool {

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -42,11 +42,12 @@ func (e EncryptionKey) validate() error {
 		return errors.New("encryption key-id must not have leading or trailing whitespace")
 	}
 
-	if e.EncryptedKeyMetadata == "" {
-		return errors.New("encrypted key metadata must be non-empty")
-	}
-	if _, err := base64.StdEncoding.DecodeString(e.EncryptedKeyMetadata); err != nil {
+	decodedMetadata, err := base64.StdEncoding.DecodeString(e.EncryptedKeyMetadata)
+	if err != nil {
 		return fmt.Errorf("encrypted key metadata must be valid base64: %w", err)
+	}
+	if len(decodedMetadata) == 0 {
+		return errors.New("encrypted key metadata must be non-empty")
 	}
 
 	return nil

--- a/table/encryption.go
+++ b/table/encryption.go
@@ -18,7 +18,7 @@
 package table
 
 import (
-	"fmt"
+	"errors"
 	"maps"
 	"strings"
 )
@@ -33,11 +33,11 @@ type EncryptionKey struct {
 
 func (e EncryptionKey) Validate() error {
 	if strings.TrimSpace(e.KeyID) == "" {
-		return fmt.Errorf("encryption key-id must be non-empty")
+		return errors.New("encryption key-id must be non-empty")
 	}
 
 	if strings.TrimSpace(e.EncryptedKeyMetadata) == "" {
-		return fmt.Errorf("encrypted key metadata must be non-empty")
+		return errors.New("encrypted key metadata must be non-empty")
 	}
 
 	return nil

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1338,8 +1338,8 @@ func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
 		return fmt.Errorf("%w: encryption keys are only supported for format version 3 or higher, current version: %d",
 			iceberg.ErrInvalidArgument, b.formatVersion)
 	}
-	if err := key.Validate(); err != nil {
-		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
+	if err := key.validate(); err != nil {
+		return fmt.Errorf("%w: %v", iceberg.ErrInvalidArgument, err)
 	}
 
 	replaced := false

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1338,6 +1338,9 @@ func (b *MetadataBuilder) AddEncryptionKey(key EncryptionKey) error {
 		return fmt.Errorf("%w: encryption keys are only supported for format version 3 or higher, current version: %d",
 			iceberg.ErrInvalidArgument, b.formatVersion)
 	}
+	if err := key.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
+	}
 
 	replaced := false
 	for i, k := range b.encryptionKeyList {

--- a/table/updates.go
+++ b/table/updates.go
@@ -772,9 +772,6 @@ func NewAddEncryptionKeyUpdate(key EncryptionKey) *addEncryptionKeyUpdate {
 }
 
 func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
-	if err := u.EncryptionKey.Validate(); err != nil {
-		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
-	}
 	return builder.AddEncryptionKey(u.EncryptionKey)
 }
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -772,6 +772,9 @@ func NewAddEncryptionKeyUpdate(key EncryptionKey) *addEncryptionKeyUpdate {
 }
 
 func (u *addEncryptionKeyUpdate) Apply(builder *MetadataBuilder) error {
+	if err := u.EncryptionKey.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", iceberg.ErrInvalidArgument, err)
+	}
 	return builder.AddEncryptionKey(u.EncryptionKey)
 }
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -904,6 +904,15 @@ func TestAddEncryptionKeyUpdate_Apply_RejectsMissingEncryptedKeyMetadata(t *test
 	assert.Contains(t, err.Error(), "metadata")
 }
 
+func TestAddEncryptionKeyUpdate_Apply_RejectsWhitespaceOnlyEncryptedKeyMetadata(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: "\n"}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "metadata must be non-empty")
+}
+
 func TestMetadataBuilderAddEncryptionKeyRejectsMissingKeyID(t *testing.T) {
 	b := buildFromBaseV3(t)
 	err := b.AddEncryptionKey(EncryptionKey{EncryptedKeyMetadata: "dGVzdA=="})

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -884,6 +884,37 @@ func TestAddEncryptionKeyUpdate_Apply_RejectsV2(t *testing.T) {
 	assert.Contains(t, err.Error(), "format version 3")
 }
 
+func TestAddEncryptionKeyUpdate_Apply_RejectsMissingKeyID(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "", EncryptedKeyMetadata: "dGVzdA=="}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "key-id")
+}
+
+func TestAddEncryptionKeyUpdate_Apply_RejectsMissingEncryptedKeyMetadata(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: ""}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "metadata")
+}
+
+func TestAddEncryptionKeyUpdate_UnmarshalMissingFields_ApplyRejects(t *testing.T) {
+	data := []byte(`[{"action":"add-encryption-key","encryption-key":{"key-id":"my-key"}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	err := updates[0].Apply(buildFromBaseV3(t))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
 func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{"action":"remove-encryption-key","key-id":"key-42"}]`)
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -890,7 +890,7 @@ func TestAddEncryptionKeyUpdate_Apply_RejectsMissingKeyID(t *testing.T) {
 
 	err := NewAddEncryptionKeyUpdate(key).Apply(b)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	assert.Contains(t, err.Error(), "key-id")
 }
 
@@ -900,8 +900,33 @@ func TestAddEncryptionKeyUpdate_Apply_RejectsMissingEncryptedKeyMetadata(t *test
 
 	err := NewAddEncryptionKeyUpdate(key).Apply(b)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	assert.Contains(t, err.Error(), "metadata")
+}
+
+func TestMetadataBuilderAddEncryptionKeyRejectsMissingKeyID(t *testing.T) {
+	b := buildFromBaseV3(t)
+	err := b.AddEncryptionKey(EncryptionKey{EncryptedKeyMetadata: "dGVzdA=="})
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "key-id")
+}
+
+func TestAddEncryptionKeyUpdate_Apply_RejectsInvalidEncryptedKeyMetadata(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: "my-key", EncryptedKeyMetadata: "not-base64"}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "base64")
+}
+
+func TestAddEncryptionKeyUpdate_Apply_RejectsPaddedKeyID(t *testing.T) {
+	b := buildFromBaseV3(t)
+	key := EncryptionKey{KeyID: " my-key ", EncryptedKeyMetadata: "dGVzdA=="}
+
+	err := NewAddEncryptionKeyUpdate(key).Apply(b)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "key-id")
 }
 
 func TestAddEncryptionKeyUpdate_UnmarshalMissingFields_ApplyRejects(t *testing.T) {
@@ -913,6 +938,7 @@ func TestAddEncryptionKeyUpdate_UnmarshalMissingFields_ApplyRejects(t *testing.T
 
 	err := updates[0].Apply(buildFromBaseV3(t))
 	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Contains(t, err.Error(), "metadata")
 }
 
 func TestRemoveEncryptionKeyUpdate_Unmarshal(t *testing.T) {


### PR DESCRIPTION
## Why
`add-encryption-key` updates accepted incomplete key payloads and could persist invalid metadata (empty key-id or empty encrypted metadata).

## What changed
- Validate `EncryptionKey` whenever an encryption-key add update is applied (both through `MetadataBuilder.AddEncryptionKey` and the update object path).
- Return `ErrInvalidArgument` when required encryption key fields are missing or empty.
- Add coverage for empty `key-id`, empty `encrypted-key-metadata`, and malformed update payloads that decode with missing fields.

## Testing
- `go test ./table -run 'TestAddEncryptionKeyUpdate_Apply_RejectsMissingKeyID|TestAddEncryptionKeyUpdate_Apply_RejectsMissingEncryptedKeyMetadata|TestAddEncryptionKeyUpdate_UnmarshalMissingFields_ApplyRejects' -count=1`