### PR TITLE
fix(sql): hide namespace exists sentinel property

### DIFF
--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -225,12 +225,18 @@ func init() {
 
 var _ catalog.Catalog = (*Catalog)(nil)
 
+const namespaceExistsProperty = "exists"
+
 var (
-	minimalNamespaceProps = iceberg.Properties{"exists": "true"}
+	minimalNamespaceProps = iceberg.Properties{namespaceExistsProperty: "true"}
 
 	dialects  = map[SupportedDialect]schema.Dialect{}
 	dialectMx sync.Mutex
 )
+
+func isReservedNamespaceProperty(key string) bool {
+	return key == namespaceExistsProperty
+}
 
 func createDialect(d SupportedDialect) (schema.Dialect, error) {
 	switch d {
@@ -1151,6 +1157,12 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
+	for key := range props {
+		if isReservedNamespaceProperty(key) {
+			return fmt.Errorf("%w: cannot create namespace with reserved namespace property %q", iceberg.ErrInvalidArgument, key)
+		}
+	}
+
 	_, exists, err := c.resolveNamespaceKey(ctx, namespace)
 	if err != nil {
 		return err
@@ -1248,11 +1260,31 @@ func (c *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 
 		result := make(iceberg.Properties)
 		for _, p := range props {
+			if isReservedNamespaceProperty(p.PropertyKey) {
+				continue
+			}
 			result[p.PropertyKey] = p.PropertyValue.String
 		}
 
 		return result, nil
 	})
+}
+
+func validateNamespacePropertyUpdates(removals []string, updates iceberg.Properties) error {
+	for key := range updates {
+		if isReservedNamespaceProperty(key) {
+			return fmt.Errorf("%w: cannot update reserved namespace property %q", iceberg.ErrInvalidArgument, key)
+		}
+	}
+
+	for _, key := range removals {
+		if isReservedNamespaceProperty(key) {
+			// Removing the marker would make a namespace without user properties disappear.
+			return fmt.Errorf("%w: cannot remove reserved namespace property %q", iceberg.ErrInvalidArgument, key)
+		}
+	}
+
+	return nil
 }
 
 func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
@@ -1374,6 +1406,9 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table.Identifier, removals []string, updates iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
 	var summary catalog.PropertiesUpdateSummary
 	if err := checkValidNamespace(namespace); err != nil {
+		return summary, err
+	}
+	if err := validateNamespacePropertyUpdates(removals, updates); err != nil {
 		return summary, err
 	}
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1907,7 +1907,102 @@ func (s *SqliteCatalogTestSuite) TestLoadEmptyNamespaceProperties() {
 		s.Require().NoError(tt.cat.CreateNamespace(ctx, tt.namespace, nil))
 		props, err := tt.cat.LoadNamespaceProperties(ctx, tt.namespace)
 		s.Require().NoError(err)
-		s.Equal(iceberg.Properties{"exists": "true"}, props)
+		s.Empty(props)
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsReservedProperty() {
+	tests := []struct {
+		cat       *sqlcat.Catalog
+		namespace table.Identifier
+	}{
+		{s.getCatalogMemory(), table.Identifier{databaseName()}},
+		{s.getCatalogSqlite(), strings.Split(hiearchicalNamespaceName(), ".")},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		err := tt.cat.CreateNamespace(ctx, tt.namespace, iceberg.Properties{"exists": "false"})
+		s.ErrorIs(err, iceberg.ErrInvalidArgument)
+		s.ErrorContains(err, "cannot create namespace with reserved namespace property")
+		s.ErrorContains(err, `"exists"`)
+
+		_, err = tt.cat.UpdateNamespaceProperties(ctx, tt.namespace, []string{"exists"}, nil)
+		s.ErrorIs(err, iceberg.ErrInvalidArgument)
+
+		_, err = tt.cat.UpdateNamespaceProperties(ctx, tt.namespace, nil, iceberg.Properties{"exists": "false"})
+		s.ErrorIs(err, iceberg.ErrInvalidArgument)
+
+		exists, err := tt.cat.CheckNamespaceExists(ctx, tt.namespace)
+		s.Require().NoError(err)
+		s.False(exists)
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestNamespacePropertiesCannotUpdateSentinel() {
+	tests := []struct {
+		name          string
+		cat           *sqlcat.Catalog
+		namespace     table.Identifier
+		createProps   iceberg.Properties
+		expectedProps iceberg.Properties
+	}{
+		{
+			name:          "memory with user props",
+			cat:           s.getCatalogMemory(),
+			namespace:     table.Identifier{databaseName()},
+			createProps:   iceberg.Properties{"comment": "baseline"},
+			expectedProps: iceberg.Properties{"comment": "baseline"},
+		},
+		{
+			name:          "memory sentinel only",
+			cat:           s.getCatalogMemory(),
+			namespace:     table.Identifier{databaseName()},
+			createProps:   nil,
+			expectedProps: nil,
+		},
+		{
+			name:          "sqlite with user props",
+			cat:           s.getCatalogSqlite(),
+			namespace:     strings.Split(hiearchicalNamespaceName(), "."),
+			createProps:   iceberg.Properties{"comment": "baseline"},
+			expectedProps: iceberg.Properties{"comment": "baseline"},
+		},
+		{
+			name:          "sqlite sentinel only",
+			cat:           s.getCatalogSqlite(),
+			namespace:     strings.Split(hiearchicalNamespaceName(), "."),
+			createProps:   nil,
+			expectedProps: nil,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Require().NoError(tt.cat.CreateNamespace(ctx, tt.namespace, tt.createProps))
+
+			_, err := tt.cat.UpdateNamespaceProperties(ctx, tt.namespace, []string{"exists"}, nil)
+			s.ErrorIs(err, iceberg.ErrInvalidArgument)
+			s.ErrorContains(err, "cannot remove reserved namespace property")
+			s.ErrorContains(err, `"exists"`)
+
+			_, err = tt.cat.UpdateNamespaceProperties(ctx, tt.namespace, nil, iceberg.Properties{"exists": "false"})
+			s.ErrorIs(err, iceberg.ErrInvalidArgument)
+			s.ErrorContains(err, "cannot update reserved namespace property")
+
+			props, err := tt.cat.LoadNamespaceProperties(ctx, tt.namespace)
+			s.Require().NoError(err)
+			if len(tt.expectedProps) == 0 {
+				s.Empty(props)
+			} else {
+				s.Equal(tt.expectedProps, props)
+			}
+
+			exists, err := tt.cat.CheckNamespaceExists(ctx, tt.namespace)
+			s.Require().NoError(err)
+			s.True(exists)
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

SQL catalogs persist an internal `exists=true` row for namespaces that have no user properties. Returning that row leaks an implementation detail through the public namespace-properties API, while allowing callers to mutate it can make a sentinel-only namespace disappear.

## Changes

- hide the internal `exists` sentinel from `LoadNamespaceProperties`
- reject the reserved key during namespace creation, updates, and removals with `iceberg.ErrInvalidArgument`
- preserve the sentinel internally for namespaces created without user properties
- cover sentinel-only and user-property namespaces on the in-memory and SQLite backends

Removal is intentionally rejected rather than treated as a missing-property no-op because deleting the only sentinel row would remove the namespace itself.

## Testing

- `go test ./catalog/sql`
- full CI