### PR TITLE
fix(partitions): reject negative PartitionSpec IDs

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -210,6 +210,9 @@ func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
 
 func WithSpecID(id int) PartitionOption {
 	return func(p *PartitionSpec) error {
+		if id < 0 {
+			return fmt.Errorf("spec id must be non-negative: %d", id)
+		}
 		p.id = id
 
 		return nil

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -176,6 +176,13 @@ func TestPartitionSpecRejectsInvalidBucketTransform(t *testing.T) {
 	require.ErrorContains(t, err, "numBuckets > 0")
 }
 
+func TestPartitionSpecRejectsNegativeSpecID(t *testing.T) {
+	_, err := iceberg.NewPartitionSpecOpts(iceberg.WithSpecID(-1))
+
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	require.ErrorContains(t, err, "spec id must be non-negative: -1")
+}
+
 func TestPartitionSpec_MarshalTextRejectsInvalidBucketTransform(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{


### PR DESCRIPTION
## Summary

- validate `WithSpecID` inputs and reject negative partition spec IDs;
- return `ErrInvalidPartitionSpec` with the invalid value;
- add regression coverage for the negative boundary.

## Testing

- `go test . -run TestPartitionSpecRejectsNegativeSpecID -count=1`