### PR TITLE
fix(schema): prevent AsStruct aliasing

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -257,7 +257,13 @@ func (s *Schema) Type() string { return "struct" }
 
 // AsStruct returns a Struct with the same fields as the schema which can
 // then be used as a Type.
-func (s *Schema) AsStruct() StructType    { return StructType{FieldList: s.fields} }
+func (s *Schema) AsStruct() StructType { return StructType{FieldList: cloneFields(s.fields)} }
+
+// asStructRef returns a read-only view over the schema field slice for
+// internal callers that only traverse fields and must avoid clone-on-read
+// overhead on hot paths.
+func (s *Schema) asStructRef() StructType { return StructType{FieldList: s.fields} }
+
 func (s *Schema) NumFields() int          { return len(s.fields) }
 func (s *Schema) Field(i int) NestedField { return s.fields[i] }
 func (s *Schema) Fields() []NestedField   { return slices.Clone(s.fields) }
@@ -308,6 +314,46 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 		Fields []NestedField `json:"fields"`
 		*Alias
 	}{Type: "struct", Fields: s.fields, Alias: &aliasCopy})
+}
+
+func cloneFields(fields []NestedField) []NestedField {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	cloned := make([]NestedField, len(fields))
+	for i, field := range fields {
+		cloned[i] = field
+		cloned[i].Type = cloneType(field.Type)
+	}
+
+	return cloned
+}
+
+func cloneType(t Type) Type {
+	if t == nil {
+		return nil
+	}
+
+	switch typed := t.(type) {
+	case *StructType:
+		return &StructType{FieldList: cloneFields(typed.FieldList)}
+	case *ListType:
+		cloned := *typed
+		cloned.Element = cloneType(typed.Element)
+
+		return &cloned
+	case *MapType:
+		cloned := *typed
+		cloned.KeyType = cloneType(typed.KeyType)
+		cloned.ValueType = cloneType(typed.ValueType)
+
+		return &cloned
+	default:
+		// Leaf and parameterized non-container types are immutable value objects,
+		// so sharing them between clones is safe.
+		return t
+	}
 }
 
 // FindColumnName returns the name of the column identified by the
@@ -596,7 +642,7 @@ func Visit[T any](sc *Schema, visitor SchemaVisitor[T]) (res T, err error) {
 		}
 	}()
 
-	return visitor.Schema(sc, visitStruct(sc.AsStruct(), visitor)), nil
+	return visitor.Schema(sc, visitStruct(sc.asStructRef(), visitor)), nil
 }
 
 func visitStruct[T any](obj StructType, visitor SchemaVisitor[T]) T {
@@ -767,7 +813,7 @@ func PreOrderVisit[T any](sc *Schema, visitor PreOrderSchemaVisitor[T]) (res T, 
 	}()
 
 	return visitor.Schema(sc, func() T {
-		return visitStructPreOrder(sc.AsStruct(), visitor)
+		return visitStructPreOrder(sc.asStructRef(), visitor)
 	}), nil
 }
 
@@ -1482,7 +1528,7 @@ func VisitSchemaWithPartner[T, P any](sc *Schema, partner P, visitor SchemaWithP
 
 	structPartner := accessor.SchemaPartner(partner)
 
-	return visitor.Schema(sc, partner, visitStructWithPartner(sc.AsStruct(), structPartner, visitor, accessor)), nil
+	return visitor.Schema(sc, partner, visitStructWithPartner(sc.asStructRef(), structPartner, visitor, accessor)), nil
 }
 
 func visitStructWithPartner[T, P any](st StructType, partner P, visitor SchemaWithPartnerVisitor[T, P], accessor PartnerAccessor[P]) T {

--- a/schema_test.go
+++ b/schema_test.go
@@ -219,6 +219,105 @@ func TestNestedFieldToString(t *testing.T) {
 	}
 }
 
+func TestSchemaAsStructClonesTopLevelFieldList(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	structType := schema.AsStruct()
+	structType.FieldList[0].Name = "hijacked"
+
+	assert.Equal(t, "foo", schema.Field(0).Name)
+}
+
+func TestSchemaAsStructClonesNestedTypes(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:   1,
+			Name: "person",
+			Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+			}},
+			Required: true,
+		},
+	)
+
+	structType := schema.AsStruct()
+	personType, ok := structType.FieldList[0].Type.(*iceberg.StructType)
+	require.True(t, ok)
+	personType.FieldList[0].Name = "full_name"
+
+	clonedPersonType, ok := schema.Field(0).Type.(*iceberg.StructType)
+	require.True(t, ok)
+	assert.Equal(t, "name", clonedPersonType.FieldList[0].Name)
+}
+
+func TestSchemaAsStructClonesNestedListTypes(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:   1,
+			Name: "people",
+			Type: &iceberg.ListType{
+				ElementID:       2,
+				ElementRequired: true,
+				Element: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 3, Name: "name", Type: iceberg.PrimitiveTypes.String},
+				}},
+			},
+			Required: true,
+		},
+	)
+
+	structType := schema.AsStruct()
+	listType, ok := structType.FieldList[0].Type.(*iceberg.ListType)
+	require.True(t, ok)
+
+	elementType, ok := listType.Element.(*iceberg.StructType)
+	require.True(t, ok)
+	elementType.FieldList[0].Name = "full_name"
+
+	clonedListType, ok := schema.Field(0).Type.(*iceberg.ListType)
+	require.True(t, ok)
+
+	clonedElementType, ok := clonedListType.Element.(*iceberg.StructType)
+	require.True(t, ok)
+	assert.Equal(t, "name", clonedElementType.FieldList[0].Name)
+}
+
+func TestSchemaAsStructClonesNestedMapTypes(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{
+			ID:   1,
+			Name: "people_by_id",
+			Type: &iceberg.MapType{
+				KeyID:         2,
+				KeyType:       iceberg.PrimitiveTypes.String,
+				ValueID:       3,
+				ValueRequired: true,
+				ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 4, Name: "name", Type: iceberg.PrimitiveTypes.String},
+				}},
+			},
+			Required: true,
+		},
+	)
+
+	structType := schema.AsStruct()
+	mapType, ok := structType.FieldList[0].Type.(*iceberg.MapType)
+	require.True(t, ok)
+
+	valueType, ok := mapType.ValueType.(*iceberg.StructType)
+	require.True(t, ok)
+	valueType.FieldList[0].Name = "full_name"
+
+	clonedMapType, ok := schema.Field(0).Type.(*iceberg.MapType)
+	require.True(t, ok)
+
+	clonedValueType, ok := clonedMapType.ValueType.(*iceberg.StructType)
+	require.True(t, ok)
+	assert.Equal(t, "name", clonedValueType.FieldList[0].Name)
+}
+
 func TestSchemaIndexByIDVisitor(t *testing.T) {
 	index, err := iceberg.IndexByID(tableSchemaNested)
 	require.NoError(t, err)

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -717,7 +717,6 @@ func newInclusiveMetricsEvaluator(s *iceberg.Schema, expr iceberg.BooleanExpress
 	}
 
 	return (&inclusiveMetricsEval{
-		st:                s.AsStruct(),
 		includeEmptyFiles: includeEmptyFiles,
 		expr:              bound,
 	}).Eval, nil
@@ -732,7 +731,6 @@ func newParquetRowGroupStatsEvaluator(fileSchema *iceberg.Schema, expr iceberg.B
 	}
 
 	return (&inclusiveMetricsEval{
-		st:                fileSchema.AsStruct(),
 		includeEmptyFiles: includeEmptyFiles,
 		expr:              rewritten,
 	}).TestRowGroup, nil
@@ -740,8 +738,6 @@ func newParquetRowGroupStatsEvaluator(fileSchema *iceberg.Schema, expr iceberg.B
 
 type inclusiveMetricsEval struct {
 	metricsEvaluator
-
-	st                iceberg.StructType
 	expr              iceberg.BooleanExpression
 	includeEmptyFiles bool
 }
@@ -797,7 +793,6 @@ func (m *inclusiveMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 
 	// avoid race condition while maintaining existing state
 	ev := inclusiveMetricsEval{
-		st:                m.st,
 		includeEmptyFiles: m.includeEmptyFiles,
 		expr:              m.expr,
 	}
@@ -1251,7 +1246,6 @@ func newStrictMetricsEvaluator(s *iceberg.Schema, expr iceberg.BooleanExpression
 	}
 
 	return (&strictMetricsEval{
-		st:                s.AsStruct(),
 		includeEmptyFiles: includeEmptyFiles,
 		expr:              bound,
 	}).Eval, nil
@@ -1259,8 +1253,6 @@ func newStrictMetricsEvaluator(s *iceberg.Schema, expr iceberg.BooleanExpression
 
 type strictMetricsEval struct {
 	metricsEvaluator
-
-	st                iceberg.StructType
 	expr              iceberg.BooleanExpression
 	includeEmptyFiles bool
 }
@@ -1272,7 +1264,6 @@ func (m *strictMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 
 	// avoid race condition while maintaining existing state
 	ev := strictMetricsEval{
-		st:                m.st,
 		includeEmptyFiles: m.includeEmptyFiles,
 		expr:              m.expr,
 	}


### PR DESCRIPTION
## What changed
- Make `Schema.AsStruct()` return a deep-cloned `StructType` field list instead of exposing internal schema state.
- Add deep-copy helpers for nested struct/list/map types to prevent mutable aliasing through returned nested types.
- Add regression tests covering top-level and nested field aliasing.

This ensures callers cannot mutate schema internals through `Schema.AsStruct()`.
