### PR TITLE
Add SQL UDF metadata model package

### DIFF
--- a/udf/metadata.go
+++ b/udf/metadata.go
@@ -520,8 +520,15 @@ func (d *Definition) validate() error {
 	switch d.FunctionType {
 	case FunctionTypeUDF:
 	case FunctionTypeUDTF:
-		if _, ok := d.ReturnType.(StructType); !ok {
+		st, ok := d.ReturnType.(StructType)
+		if !ok {
 			return fmt.Errorf("%w: definition %q is a udtf but its return-type is not a struct",
+				ErrInvalidUDFMetadata, d.DefinitionID)
+		}
+		// The struct describes the output schema; a table without columns
+		// is meaningless.
+		if len(st.Fields) == 0 {
+			return fmt.Errorf("%w: definition %q is a udtf but its return-type struct has no fields",
 				ErrInvalidUDFMetadata, d.DefinitionID)
 		}
 	case "":
@@ -743,6 +750,9 @@ func (m *metadata) DefinitionByID(definitionID string) (*Definition, bool) {
 
 func (m *metadata) Equals(other Metadata) bool {
 	if other == nil {
+		return false
+	}
+	if o, ok := other.(*metadata); ok && o == nil {
 		return false
 	}
 

--- a/udf/metadata.go
+++ b/udf/metadata.go
@@ -1,0 +1,887 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package udf provides the metadata model for Iceberg SQL UDFs as
+// specified by the Iceberg UDF spec.
+// https://iceberg.apache.org/udf-spec/
+package udf
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/apache/iceberg-go"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrInvalidUDFMetadata              = errors.New("invalid UDF metadata")
+	ErrInvalidUDFMetadataFormatVersion = errors.New("invalid or missing format-version in UDF metadata")
+)
+
+const (
+	SupportedUDFFormatVersion = 1
+
+	initialVersionID = 1
+)
+
+// FunctionType indicates whether a definition is a scalar function (udf)
+// or a table function (udtf).
+type FunctionType string
+
+const (
+	FunctionTypeUDF  FunctionType = "udf"
+	FunctionTypeUDTF FunctionType = "udtf"
+)
+
+// OnNullInput defines how a UDF behaves when any input parameter is NULL.
+type OnNullInput string
+
+const (
+	// OnNullInputCall means the function may handle NULLs internally, so
+	// engines must execute it even if some inputs are NULL. This is the
+	// default behavior when on-null-input is absent.
+	OnNullInputCall OnNullInput = "call"
+	// OnNullInputReturnNull means the function always returns NULL if any
+	// input argument is NULL, allowing engines to skip evaluation.
+	OnNullInputReturnNull OnNullInput = "return-null"
+)
+
+// Representation is a single implementation of a definition version. The
+// only representation type defined by the UDF spec is SQL; unrecognized
+// types round-trip through UnknownRepresentation.
+type Representation interface {
+	// RepresentationType returns the representation's type discriminator,
+	// e.g. "sql".
+	RepresentationType() string
+
+	// isRepresentation seals the interface to the implementations in
+	// this package.
+	isRepresentation()
+}
+
+// SQLRepresentation stores the function body as a SQL expression in a
+// specific dialect. The SQL must reference parameters using the names
+// declared in the definition's parameters.
+type SQLRepresentation struct {
+	Dialect string `json:"dialect"`
+	SQL     string `json:"sql"`
+}
+
+// NewSQLRepresentation creates a SQL representation from a dialect
+// identifier (e.g. "spark", "trino") and a SQL expression.
+func NewSQLRepresentation(dialect, sql string) (SQLRepresentation, error) {
+	if dialect == "" {
+		return SQLRepresentation{}, fmt.Errorf("%w: sql representation requires a dialect", ErrInvalidUDFMetadata)
+	}
+	if sql == "" {
+		return SQLRepresentation{}, fmt.Errorf("%w: sql representation requires a sql expression", ErrInvalidUDFMetadata)
+	}
+
+	return SQLRepresentation{Dialect: dialect, SQL: sql}, nil
+}
+
+func (SQLRepresentation) RepresentationType() string { return "sql" }
+func (SQLRepresentation) isRepresentation()          {}
+
+func (r SQLRepresentation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    string `json:"type"`
+		Dialect string `json:"dialect"`
+		SQL     string `json:"sql"`
+	}{Type: "sql", Dialect: r.Dialect, SQL: r.SQL})
+}
+
+// UnknownRepresentation preserves a representation of an unrecognized type
+// so that metadata written by newer or extended writers round-trips intact.
+type UnknownRepresentation struct {
+	TypeName string
+
+	raw json.RawMessage
+}
+
+// Raw returns the representation's original JSON.
+func (r UnknownRepresentation) Raw() json.RawMessage { return r.raw }
+
+func (r UnknownRepresentation) RepresentationType() string { return r.TypeName }
+func (UnknownRepresentation) isRepresentation()            {}
+
+func (r UnknownRepresentation) MarshalJSON() ([]byte, error) {
+	return slices.Clone(r.raw), nil
+}
+
+func representationsEqual(a, b Representation) bool {
+	switch av := a.(type) {
+	case SQLRepresentation:
+		bv, ok := b.(SQLRepresentation)
+
+		return ok && av == bv
+	case UnknownRepresentation:
+		bv, ok := b.(UnknownRepresentation)
+
+		return ok && av.TypeName == bv.TypeName && bytes.Equal(av.raw, bv.raw)
+	default:
+		return false
+	}
+}
+
+func unmarshalRepresentation(b json.RawMessage) (Representation, error) {
+	aux := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return nil, err
+	}
+	if aux.Type == "" {
+		return nil, fmt.Errorf("%w: representation requires a type", ErrInvalidUDFMetadata)
+	}
+
+	if aux.Type == "sql" {
+		var r SQLRepresentation
+		if err := json.Unmarshal(b, &r); err != nil {
+			return nil, err
+		}
+
+		return r, nil
+	}
+
+	// Store the raw JSON compacted so that round-tripped representations
+	// compare equal: encoding/json compacts MarshalJSON output.
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, b); err != nil {
+		return nil, err
+	}
+
+	return UnknownRepresentation{TypeName: aux.Type, raw: compacted.Bytes()}, nil
+}
+
+// Parameter is a single function parameter.
+type Parameter struct {
+	Name string `json:"name"`
+	Type Type   `json:"type"`
+	Doc  string `json:"doc,omitempty"`
+}
+
+func (p *Parameter) UnmarshalJSON(b []byte) error {
+	type Alias Parameter
+	aux := struct {
+		Type json.RawMessage `json:"type"`
+		*Alias
+	}{Alias: (*Alias)(p)}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.Type) == 0 {
+		return fmt.Errorf("%w: parameter %q requires a type", ErrInvalidUDFMetadata, p.Name)
+	}
+
+	typ, err := unmarshalType(aux.Type)
+	if err != nil {
+		return err
+	}
+	p.Type = typ
+
+	return nil
+}
+
+func (p Parameter) equals(other Parameter) bool {
+	return p.Name == other.Name && p.Doc == other.Doc &&
+		p.Type != nil && other.Type != nil && p.Type.Equals(other.Type)
+}
+
+// DefinitionVersion is a specific implementation of a definition at a
+// given point in time. Versions are immutable: changes to a definition
+// introduce a new version.
+type DefinitionVersion struct {
+	// VersionID is a monotonically increasing identifier of the
+	// definition version.
+	VersionID int `json:"version-id"`
+	// Representations lists the UDF implementations of this version.
+	Representations []Representation `json:"representations"`
+	// Deterministic indicates whether the function is deterministic.
+	// Defaults to false.
+	Deterministic bool `json:"deterministic,omitempty"`
+	// OnNullInput defines how the UDF behaves when any input parameter
+	// is NULL. Defaults to OnNullInputCall when empty.
+	OnNullInput OnNullInput `json:"on-null-input,omitempty"`
+	// TimestampMS is the creation timestamp of this version (ms from epoch).
+	TimestampMS int64 `json:"timestamp-ms"`
+}
+
+func (v *DefinitionVersion) UnmarshalJSON(b []byte) error {
+	type Alias DefinitionVersion
+	aux := struct {
+		Representations []json.RawMessage `json:"representations"`
+		*Alias
+	}{Alias: (*Alias)(v)}
+
+	v.VersionID = -1
+	v.TimestampMS = -1
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	v.Representations = make([]Representation, len(aux.Representations))
+	for i, raw := range aux.Representations {
+		repr, err := unmarshalRepresentation(raw)
+		if err != nil {
+			return err
+		}
+		v.Representations[i] = repr
+	}
+
+	return nil
+}
+
+// NullInputBehavior returns the effective on-null-input behavior,
+// applying the spec default (OnNullInputCall) when the field is absent.
+func (v *DefinitionVersion) NullInputBehavior() OnNullInput {
+	if v.OnNullInput == "" {
+		return OnNullInputCall
+	}
+
+	return v.OnNullInput
+}
+
+// Equals compares two versions for semantic equality: the default
+// on-null-input behavior compares equal to an explicit "call".
+func (v *DefinitionVersion) Equals(other *DefinitionVersion) bool {
+	return v.VersionID == other.VersionID &&
+		v.Deterministic == other.Deterministic &&
+		v.NullInputBehavior() == other.NullInputBehavior() &&
+		v.TimestampMS == other.TimestampMS &&
+		slices.EqualFunc(v.Representations, other.Representations, representationsEqual)
+}
+
+func (v *DefinitionVersion) Clone() *DefinitionVersion {
+	if v == nil {
+		return nil
+	}
+
+	cloned := *v
+	cloned.Representations = slices.Clone(v.Representations)
+
+	return &cloned
+}
+
+func (v *DefinitionVersion) validate(definitionID string) error {
+	if v.VersionID == -1 {
+		return fmt.Errorf("%w: definition %q has a version missing version-id",
+			ErrInvalidUDFMetadata, definitionID)
+	}
+	if v.VersionID < 0 {
+		return fmt.Errorf("%w: definition %q has invalid negative version-id %d",
+			ErrInvalidUDFMetadata, definitionID, v.VersionID)
+	}
+
+	if v.TimestampMS == -1 {
+		return fmt.Errorf("%w: definition %q version %d is missing timestamp-ms",
+			ErrInvalidUDFMetadata, definitionID, v.VersionID)
+	}
+	if v.TimestampMS < 0 {
+		return fmt.Errorf("%w: definition %q version %d has invalid negative timestamp-ms %d",
+			ErrInvalidUDFMetadata, definitionID, v.VersionID, v.TimestampMS)
+	}
+
+	if len(v.Representations) == 0 {
+		return fmt.Errorf("%w: definition %q version %d must have at least one representation",
+			ErrInvalidUDFMetadata, definitionID, v.VersionID)
+	}
+
+	switch v.OnNullInput {
+	case "", OnNullInputCall, OnNullInputReturnNull:
+	default:
+		return fmt.Errorf("%w: definition %q version %d has invalid on-null-input %q",
+			ErrInvalidUDFMetadata, definitionID, v.VersionID, v.OnNullInput)
+	}
+
+	seenDialects := make(map[string]bool)
+	for _, repr := range v.Representations {
+		if repr == nil {
+			return fmt.Errorf("%w: definition %q version %d representations must not contain null entries",
+				ErrInvalidUDFMetadata, definitionID, v.VersionID)
+		}
+		if unknown, ok := repr.(UnknownRepresentation); ok && len(unknown.raw) == 0 {
+			return fmt.Errorf("%w: definition %q version %d has an unknown representation without raw JSON; unknown representations must originate from parsed metadata",
+				ErrInvalidUDFMetadata, definitionID, v.VersionID)
+		}
+		sqlRepr, ok := repr.(SQLRepresentation)
+		if !ok {
+			continue
+		}
+		if sqlRepr.Dialect == "" {
+			return fmt.Errorf("%w: definition %q version %d has a sql representation without a dialect",
+				ErrInvalidUDFMetadata, definitionID, v.VersionID)
+		}
+		if sqlRepr.SQL == "" {
+			return fmt.Errorf("%w: definition %q version %d has a sql representation without a sql expression",
+				ErrInvalidUDFMetadata, definitionID, v.VersionID)
+		}
+		dialect := strings.ToLower(sqlRepr.Dialect)
+		if seenDialects[dialect] {
+			return fmt.Errorf("%w: definition %q version %d has duplicate sql dialect %s",
+				ErrInvalidUDFMetadata, definitionID, v.VersionID, sqlRepr.Dialect)
+		}
+		seenDialects[dialect] = true
+	}
+
+	return nil
+}
+
+// Definition represents one function signature (e.g. add_one(int) vs
+// add_one(float)). A definition is uniquely identified by its signature:
+// the ordered list of parameter types, canonicalized as its DefinitionID.
+type Definition struct {
+	// DefinitionID is the canonical string derived from the parameter
+	// types (see CanonicalDefinitionID).
+	DefinitionID string `json:"definition-id"`
+	// SpecificName is an optional user-assignable name for this
+	// definition, unique among all definitions of the function.
+	SpecificName string `json:"specific-name,omitempty"`
+	// Parameters is the ordered list of function parameters. Invocation
+	// order must match this list.
+	Parameters []Parameter `json:"parameters"`
+	// ReturnType is the declared return type. All versions must produce
+	// values of this type.
+	ReturnType Type `json:"return-type"`
+	// ReturnNullable hints whether the return value is nullable.
+	// Defaults to true when absent.
+	ReturnNullable *bool `json:"return-nullable,omitempty"`
+	// Versions lists the versioned implementations of this definition.
+	Versions []*DefinitionVersion `json:"versions"`
+	// CurrentVersionID identifies the current version of this definition.
+	CurrentVersionID int `json:"current-version-id"`
+	// FunctionType is "udf" for scalar functions or "udtf" for table
+	// functions. For "udtf", ReturnType must be a struct describing the
+	// output schema.
+	FunctionType FunctionType `json:"function-type"`
+	// Doc is an optional documentation string.
+	Doc string `json:"doc,omitempty"`
+}
+
+func (d *Definition) UnmarshalJSON(b []byte) error {
+	type Alias Definition
+	// definition-id and parameters are shadowed to distinguish a required
+	// field that is absent from one that is legitimately empty: a
+	// zero-parameter definition has "" as its definition-id and [] as its
+	// parameters.
+	aux := struct {
+		DefinitionID *string         `json:"definition-id"`
+		Parameters   json.RawMessage `json:"parameters"`
+		ReturnType   json.RawMessage `json:"return-type"`
+		*Alias
+	}{Alias: (*Alias)(d)}
+
+	d.CurrentVersionID = -1
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	if aux.DefinitionID == nil {
+		return fmt.Errorf("%w: definition is missing definition-id", ErrInvalidUDFMetadata)
+	}
+	d.DefinitionID = *aux.DefinitionID
+
+	if len(aux.Parameters) == 0 {
+		return fmt.Errorf("%w: definition %q is missing parameters", ErrInvalidUDFMetadata, d.DefinitionID)
+	}
+	if err := json.Unmarshal(aux.Parameters, &d.Parameters); err != nil {
+		return err
+	}
+	if d.Parameters == nil {
+		return fmt.Errorf("%w: definition %q is missing parameters", ErrInvalidUDFMetadata, d.DefinitionID)
+	}
+
+	if len(aux.ReturnType) == 0 {
+		return fmt.Errorf("%w: definition %q requires a return-type", ErrInvalidUDFMetadata, d.DefinitionID)
+	}
+
+	typ, err := unmarshalType(aux.ReturnType)
+	if err != nil {
+		return err
+	}
+	d.ReturnType = typ
+
+	return nil
+}
+
+// ReturnsNullable returns the effective return-nullable hint, applying
+// the spec default (true) when the field is absent.
+func (d *Definition) ReturnsNullable() bool {
+	return d.ReturnNullable == nil || *d.ReturnNullable
+}
+
+// CurrentVersion returns the definition version identified by
+// CurrentVersionID, or nil if no such version exists.
+func (d *Definition) CurrentVersion() *DefinitionVersion {
+	return d.Version(d.CurrentVersionID)
+}
+
+// Version returns the definition version with the given id, or nil if no
+// such version exists.
+func (d *Definition) Version(versionID int) *DefinitionVersion {
+	for _, v := range d.Versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+// Equals compares two definitions for semantic equality: absent optional
+// fields compare equal to their spec defaults.
+func (d *Definition) Equals(other *Definition) bool {
+	return d.DefinitionID == other.DefinitionID &&
+		d.SpecificName == other.SpecificName &&
+		slices.EqualFunc(d.Parameters, other.Parameters, Parameter.equals) &&
+		d.ReturnType != nil && other.ReturnType != nil && d.ReturnType.Equals(other.ReturnType) &&
+		d.ReturnsNullable() == other.ReturnsNullable() &&
+		d.CurrentVersionID == other.CurrentVersionID &&
+		d.FunctionType == other.FunctionType &&
+		d.Doc == other.Doc &&
+		slices.EqualFunc(d.Versions, other.Versions, (*DefinitionVersion).Equals)
+}
+
+func (d *Definition) Clone() *Definition {
+	if d == nil {
+		return nil
+	}
+
+	cloned := *d
+	// Type values are immutable, so sharing them across clones is safe.
+	cloned.Parameters = slices.Clone(d.Parameters)
+	cloned.Versions = cloneSlice(d.Versions)
+	if d.ReturnNullable != nil {
+		nullable := *d.ReturnNullable
+		cloned.ReturnNullable = &nullable
+	}
+
+	return &cloned
+}
+
+func (d *Definition) validate() error {
+	seenNames := make(map[string]bool)
+	for _, p := range d.Parameters {
+		if p.Name == "" {
+			return fmt.Errorf("%w: definition %q has a parameter without a name",
+				ErrInvalidUDFMetadata, d.DefinitionID)
+		}
+		if seenNames[p.Name] {
+			return fmt.Errorf("%w: definition %q has duplicate parameter name %q",
+				ErrInvalidUDFMetadata, d.DefinitionID, p.Name)
+		}
+		seenNames[p.Name] = true
+		if err := validateType(p.Type); err != nil {
+			return fmt.Errorf("%w: definition %q parameter %q: %w",
+				ErrInvalidUDFMetadata, d.DefinitionID, p.Name, err)
+		}
+	}
+
+	canonicalID, err := CanonicalDefinitionID(d.Parameters)
+	if err != nil {
+		return fmt.Errorf("%w: definition %q: %w", ErrInvalidUDFMetadata, d.DefinitionID, err)
+	}
+	if d.DefinitionID != canonicalID {
+		return fmt.Errorf("%w: definition-id %q does not match canonical form %q of its parameters",
+			ErrInvalidUDFMetadata, d.DefinitionID, canonicalID)
+	}
+
+	if err := validateType(d.ReturnType); err != nil {
+		return fmt.Errorf("%w: definition %q return-type: %w", ErrInvalidUDFMetadata, d.DefinitionID, err)
+	}
+
+	switch d.FunctionType {
+	case FunctionTypeUDF:
+	case FunctionTypeUDTF:
+		if _, ok := d.ReturnType.(StructType); !ok {
+			return fmt.Errorf("%w: definition %q is a udtf but its return-type is not a struct",
+				ErrInvalidUDFMetadata, d.DefinitionID)
+		}
+	case "":
+		return fmt.Errorf("%w: definition %q is missing function-type", ErrInvalidUDFMetadata, d.DefinitionID)
+	default:
+		return fmt.Errorf("%w: definition %q has invalid function-type %q (must be %q or %q)",
+			ErrInvalidUDFMetadata, d.DefinitionID, d.FunctionType, FunctionTypeUDF, FunctionTypeUDTF)
+	}
+
+	if len(d.Versions) == 0 {
+		return fmt.Errorf("%w: definition %q must have at least one version", ErrInvalidUDFMetadata, d.DefinitionID)
+	}
+
+	seenVersions := make(map[int]bool)
+	for _, v := range d.Versions {
+		if v == nil {
+			return fmt.Errorf("%w: definition %q versions must not contain null entries",
+				ErrInvalidUDFMetadata, d.DefinitionID)
+		}
+		if err := v.validate(d.DefinitionID); err != nil {
+			return err
+		}
+		if seenVersions[v.VersionID] {
+			return fmt.Errorf("%w: definition %q has duplicate version-id %d",
+				ErrInvalidUDFMetadata, d.DefinitionID, v.VersionID)
+		}
+		seenVersions[v.VersionID] = true
+	}
+
+	if d.CurrentVersionID == -1 {
+		return fmt.Errorf("%w: definition %q is missing current-version-id", ErrInvalidUDFMetadata, d.DefinitionID)
+	}
+	if d.CurrentVersionID < 0 {
+		return fmt.Errorf("%w: definition %q has invalid negative current-version-id %d",
+			ErrInvalidUDFMetadata, d.DefinitionID, d.CurrentVersionID)
+	}
+	if !seenVersions[d.CurrentVersionID] {
+		return fmt.Errorf("%w: definition %q current-version-id %d not found in versions",
+			ErrInvalidUDFMetadata, d.DefinitionID, d.CurrentVersionID)
+	}
+
+	return nil
+}
+
+// DefinitionVersionRef maps a definition to a selected version.
+type DefinitionVersionRef struct {
+	// DefinitionID may be empty: a zero-parameter definition has the
+	// empty string as its definition-id.
+	DefinitionID string `json:"definition-id"`
+	VersionID    int    `json:"version-id"`
+}
+
+func (r *DefinitionVersionRef) UnmarshalJSON(b []byte) error {
+	type Alias DefinitionVersionRef
+	// definition-id is shadowed to distinguish the required field being
+	// absent from the legitimately empty id of a zero-parameter definition.
+	aux := struct {
+		DefinitionID *string `json:"definition-id"`
+		*Alias
+	}{Alias: (*Alias)(r)}
+
+	r.VersionID = -1
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	if aux.DefinitionID == nil {
+		return fmt.Errorf("%w: definition-log reference is missing definition-id", ErrInvalidUDFMetadata)
+	}
+	r.DefinitionID = *aux.DefinitionID
+
+	return nil
+}
+
+// DefinitionLogEntry records the selected version of every definition at
+// the time of a change, enabling rollback without external state.
+type DefinitionLogEntry struct {
+	// TimestampMS is when the function was updated to use these
+	// definition versions (ms from epoch).
+	TimestampMS int64 `json:"timestamp-ms"`
+	// DefinitionVersions maps each definition to its selected version at
+	// this time.
+	DefinitionVersions []DefinitionVersionRef `json:"definition-versions"`
+}
+
+func (e *DefinitionLogEntry) UnmarshalJSON(b []byte) error {
+	type Alias DefinitionLogEntry
+	aux := (*Alias)(e)
+
+	e.TimestampMS = -1
+
+	return json.Unmarshal(b, aux)
+}
+
+func (e DefinitionLogEntry) validate() error {
+	if e.TimestampMS == -1 {
+		return fmt.Errorf("%w: definition-log entry is missing timestamp-ms", ErrInvalidUDFMetadata)
+	}
+	if e.TimestampMS < 0 {
+		return fmt.Errorf("%w: definition-log entry has invalid negative timestamp-ms %d",
+			ErrInvalidUDFMetadata, e.TimestampMS)
+	}
+
+	if len(e.DefinitionVersions) == 0 {
+		return fmt.Errorf("%w: definition-log entry at timestamp %d must have definition-versions",
+			ErrInvalidUDFMetadata, e.TimestampMS)
+	}
+
+	seen := make(map[string]bool)
+	for _, ref := range e.DefinitionVersions {
+		if ref.VersionID == -1 {
+			return fmt.Errorf("%w: definition-log entry at timestamp %d has a reference to definition %q missing version-id",
+				ErrInvalidUDFMetadata, e.TimestampMS, ref.DefinitionID)
+		}
+		if ref.VersionID < 0 {
+			return fmt.Errorf("%w: definition-log entry at timestamp %d has invalid negative version-id %d for definition %q",
+				ErrInvalidUDFMetadata, e.TimestampMS, ref.VersionID, ref.DefinitionID)
+		}
+		if seen[ref.DefinitionID] {
+			return fmt.Errorf("%w: definition-log entry at timestamp %d references definition %q more than once",
+				ErrInvalidUDFMetadata, e.TimestampMS, ref.DefinitionID)
+		}
+		seen[ref.DefinitionID] = true
+	}
+
+	return nil
+}
+
+func (e DefinitionLogEntry) equals(other DefinitionLogEntry) bool {
+	return e.TimestampMS == other.TimestampMS &&
+		slices.Equal(e.DefinitionVersions, other.DefinitionVersions)
+}
+
+// Metadata is the self-contained metadata of an Iceberg SQL UDF as
+// specified by the UDF spec. Metadata files are immutable: any change
+// creates a new file, and catalogs atomically swap the file linked to a
+// catalog identifier. UDF names are not part of the metadata; mapping
+// names to metadata locations is the catalog's responsibility.
+type Metadata interface {
+	// FormatVersion returns the UDF spec format version (1).
+	FormatVersion() int
+	// FunctionUUID returns the UUID identifying this UDF, generated once
+	// at creation.
+	FunctionUUID() uuid.UUID
+	// Location returns the function's base location, used to create
+	// metadata file locations. It may be empty.
+	Location() string
+	// Definitions returns the function's definitions, one per signature.
+	Definitions() []*Definition
+	// DefinitionByID returns the definition with the given definition-id.
+	DefinitionByID(definitionID string) (*Definition, bool)
+	// DefinitionLog returns the history of definition version selections.
+	DefinitionLog() []DefinitionLogEntry
+	// Properties returns the function's properties. Entries are treated
+	// as hints, not strict rules.
+	Properties() iceberg.Properties
+	// Secure reports whether this is a secure function whose sensitive
+	// information engines should not leak to end users.
+	Secure() bool
+	// Doc returns the function's documentation string.
+	Doc() string
+
+	Equals(Metadata) bool
+}
+
+// ParseMetadata parses UDF metadata JSON provided by the passed in
+// reader, returning an error if one is encountered.
+func ParseMetadata(r io.Reader) (Metadata, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseMetadataBytes(data)
+}
+
+// ParseMetadataString is like [ParseMetadata], but for a string rather
+// than an io.Reader.
+func ParseMetadataString(s string) (Metadata, error) {
+	return ParseMetadataBytes([]byte(s))
+}
+
+// ParseMetadataBytes is like [ParseMetadataString] but for a byte slice.
+func ParseMetadataBytes(b []byte) (Metadata, error) {
+	var ret Metadata = &metadata{}
+
+	return ret, json.Unmarshal(b, ret)
+}
+
+type metadata struct {
+	UUID               *uuid.UUID           `json:"function-uuid"`
+	FormatVersionValue int                  `json:"format-version"`
+	DefinitionList     []*Definition        `json:"definitions"`
+	DefinitionLogList  []DefinitionLogEntry `json:"definition-log"`
+	Loc                string               `json:"location,omitempty"`
+	Props              iceberg.Properties   `json:"properties,omitempty"`
+	SecureValue        bool                 `json:"secure,omitempty"`
+	DocValue           string               `json:"doc,omitempty"`
+
+	// cached lookup helpers, must be initialized in init()
+	lazyDefinitionsByID func() map[string]*Definition
+}
+
+func (m *metadata) FormatVersion() int                  { return m.FormatVersionValue }
+func (m *metadata) FunctionUUID() uuid.UUID             { return *m.UUID }
+func (m *metadata) Location() string                    { return m.Loc }
+func (m *metadata) Definitions() []*Definition          { return m.DefinitionList }
+func (m *metadata) DefinitionLog() []DefinitionLogEntry { return m.DefinitionLogList }
+func (m *metadata) Properties() iceberg.Properties      { return m.Props }
+func (m *metadata) Secure() bool                        { return m.SecureValue }
+func (m *metadata) Doc() string                         { return m.DocValue }
+
+func (m *metadata) DefinitionByID(definitionID string) (*Definition, bool) {
+	def, ok := m.lazyDefinitionsByID()[definitionID]
+
+	return def, ok
+}
+
+func (m *metadata) Equals(other Metadata) bool {
+	if other == nil {
+		return false
+	}
+
+	if m == other {
+		return true
+	}
+
+	return *m.UUID == other.FunctionUUID() &&
+		m.FormatVersionValue == other.FormatVersion() &&
+		m.Loc == other.Location() &&
+		m.SecureValue == other.Secure() &&
+		m.DocValue == other.Doc() &&
+		maps.Equal(m.Props, other.Properties()) &&
+		slices.EqualFunc(m.DefinitionList, other.Definitions(), (*Definition).Equals) &&
+		slices.EqualFunc(m.DefinitionLogList, other.DefinitionLog(), DefinitionLogEntry.equals)
+}
+
+func (m *metadata) validate() error {
+	if m.UUID == nil {
+		return fmt.Errorf("%w: function-uuid is required", ErrInvalidUDFMetadata)
+	}
+
+	if m.FormatVersionValue == -1 {
+		return fmt.Errorf("%w: format-version is required", ErrInvalidUDFMetadataFormatVersion)
+	}
+
+	if m.FormatVersionValue != SupportedUDFFormatVersion {
+		return fmt.Errorf("%w: format-version %d (only version %d is supported)",
+			ErrInvalidUDFMetadataFormatVersion, m.FormatVersionValue, SupportedUDFFormatVersion)
+	}
+
+	if len(m.DefinitionList) == 0 {
+		return fmt.Errorf("%w: at least one definition is required", ErrInvalidUDFMetadata)
+	}
+
+	seenIDs := make(map[string]bool)
+	seenSpecificNames := make(map[string]bool)
+	for _, def := range m.DefinitionList {
+		if def == nil {
+			return fmt.Errorf("%w: definitions must not contain null entries", ErrInvalidUDFMetadata)
+		}
+		if err := def.validate(); err != nil {
+			return err
+		}
+		if seenIDs[def.DefinitionID] {
+			return fmt.Errorf("%w: duplicate definition-id %q; there can be only one definition for a given signature",
+				ErrInvalidUDFMetadata, def.DefinitionID)
+		}
+		seenIDs[def.DefinitionID] = true
+		if def.SpecificName != "" {
+			if seenSpecificNames[def.SpecificName] {
+				return fmt.Errorf("%w: duplicate specific-name %q; specific names must be unique among all definitions",
+					ErrInvalidUDFMetadata, def.SpecificName)
+			}
+			seenSpecificNames[def.SpecificName] = true
+		}
+	}
+
+	for _, entry := range m.DefinitionLogList {
+		if err := entry.validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// init performs state initialization for metadata instances, such as
+// constructing the definition index. It should be called on a new
+// metadata instance before returning to a caller.
+func (m *metadata) init() {
+	if m.DefinitionList == nil {
+		m.DefinitionList = []*Definition{}
+	}
+
+	if m.DefinitionLogList == nil {
+		m.DefinitionLogList = []DefinitionLogEntry{}
+	}
+
+	if m.Props == nil {
+		m.Props = iceberg.Properties{}
+	}
+
+	m.lazyDefinitionsByID = sync.OnceValue(func() map[string]*Definition {
+		return indexBy(m.DefinitionList, func(d *Definition) string { return d.DefinitionID })
+	})
+}
+
+func (m *metadata) UnmarshalJSON(b []byte) error {
+	type Alias metadata
+	// definition-log is shadowed to reject the required field being absent
+	// or null, which the default decoding cannot distinguish from empty.
+	aux := struct {
+		DefinitionLog json.RawMessage `json:"definition-log"`
+		*Alias
+	}{Alias: (*Alias)(m)}
+
+	m.FormatVersionValue = -1
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.DefinitionLog) == 0 {
+		return fmt.Errorf("%w: definition-log is required", ErrInvalidUDFMetadata)
+	}
+	if err := json.Unmarshal(aux.DefinitionLog, &m.DefinitionLogList); err != nil {
+		return err
+	}
+	if m.DefinitionLogList == nil {
+		return fmt.Errorf("%w: definition-log is required", ErrInvalidUDFMetadata)
+	}
+
+	m.init()
+
+	return m.validate()
+}
+
+// indexBy indexes a slice into a map, using a provided extractKey function.
+func indexBy[T any, K comparable](s []T, extractKey func(T) K) map[K]T {
+	index := make(map[K]T, len(s))
+	for _, v := range s {
+		index[extractKey(v)] = v
+	}
+
+	return index
+}
+
+// cloner is an interface which implements a Clone method for deep copying itself.
+type cloner[T any] interface {
+	Clone() T
+}
+
+// cloneSlice returns a deep-clone of a slice of elements implementing cloner.
+func cloneSlice[T cloner[T]](val []T) []T {
+	cloned := make([]T, len(val))
+	for i, elem := range val {
+		cloned[i] = elem.Clone()
+	}
+
+	return cloned
+}

--- a/udf/metadata_builder.go
+++ b/udf/metadata_builder.go
@@ -1,0 +1,561 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/apache/iceberg-go"
+
+	"github.com/google/uuid"
+)
+
+// DefinitionOpt configures optional fields of a new Definition.
+type DefinitionOpt func(*Definition)
+
+// WithSpecificName sets the definition's optional specific name, a stable
+// user-assignable handle that must be unique among all definitions.
+func WithSpecificName(name string) DefinitionOpt {
+	return func(d *Definition) {
+		d.SpecificName = name
+	}
+}
+
+// WithDefinitionDoc sets the definition's documentation string.
+func WithDefinitionDoc(doc string) DefinitionOpt {
+	return func(d *Definition) {
+		d.Doc = doc
+	}
+}
+
+// WithReturnNullable sets the definition's return-nullable hint.
+func WithReturnNullable(nullable bool) DefinitionOpt {
+	return func(d *Definition) {
+		d.ReturnNullable = &nullable
+	}
+}
+
+// NewDefinition creates a definition for the given signature, deriving its
+// definition-id from the parameter types. The definition starts with no
+// versions; add them with MetadataBuilder.AddDefinitionVersion.
+func NewDefinition(functionType FunctionType, params []Parameter, returnType Type, opts ...DefinitionOpt) (*Definition, error) {
+	definitionID, err := CanonicalDefinitionID(params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep parameters non-nil so a zero-parameter definition serializes as
+	// the required empty list rather than null.
+	parameters := slices.Clone(params)
+	if parameters == nil {
+		parameters = []Parameter{}
+	}
+
+	def := &Definition{
+		DefinitionID:     definitionID,
+		Parameters:       parameters,
+		ReturnType:       returnType,
+		CurrentVersionID: -1,
+		FunctionType:     functionType,
+	}
+
+	for _, opt := range opts {
+		opt(def)
+	}
+
+	return def, nil
+}
+
+// DefinitionVersionOpt configures optional fields of a new DefinitionVersion.
+type DefinitionVersionOpt func(*DefinitionVersion)
+
+// WithTimestampMS overrides the version's creation timestamp.
+func WithTimestampMS(timestampMS int64) DefinitionVersionOpt {
+	return func(v *DefinitionVersion) {
+		v.TimestampMS = timestampMS
+	}
+}
+
+// WithDeterministic marks whether the function version is deterministic.
+func WithDeterministic(deterministic bool) DefinitionVersionOpt {
+	return func(v *DefinitionVersion) {
+		v.Deterministic = deterministic
+	}
+}
+
+// WithOnNullInput sets the version's behavior for NULL input parameters.
+func WithOnNullInput(behavior OnNullInput) DefinitionVersionOpt {
+	return func(v *DefinitionVersion) {
+		v.OnNullInput = behavior
+	}
+}
+
+// NewDefinitionVersion creates a definition version from the given
+// representations. The version id is assigned when the version is added to
+// a definition via MetadataBuilder.AddDefinitionVersion.
+//
+// NewDefinitionVersion seeds TimestampMS to time.Now().UnixMilli(); use
+// WithTimestampMS to override.
+func NewDefinitionVersion(representations []Representation, opts ...DefinitionVersionOpt) (*DefinitionVersion, error) {
+	if len(representations) == 0 {
+		return nil, fmt.Errorf("%w: a definition version must have at least one representation", ErrInvalidUDFMetadata)
+	}
+	for _, repr := range representations {
+		if repr == nil {
+			return nil, fmt.Errorf("%w: representations must not contain nil entries", ErrInvalidUDFMetadata)
+		}
+	}
+
+	version := &DefinitionVersion{
+		Representations: slices.Clone(representations),
+		TimestampMS:     time.Now().UnixMilli(),
+	}
+
+	for _, opt := range opts {
+		opt(version)
+	}
+
+	return version, nil
+}
+
+// MetadataBuilder builds UDF metadata, either from scratch or on top of an
+// existing metadata instance. Because metadata files are immutable, every
+// change produces a complete new metadata object; when any definition's
+// selected version changes, Build appends a definition-log entry capturing
+// the selected version of every definition.
+type MetadataBuilder struct {
+	base Metadata
+
+	uuid          uuid.UUID
+	loc           string
+	props         iceberg.Properties
+	secure        bool
+	doc           string
+	definitions   []*Definition
+	definitionLog []DefinitionLogEntry
+
+	definitionsByID map[string]*Definition
+
+	logTimestampMS   int64
+	selectionChanged bool
+	hasChanges       bool
+
+	// error tracking for build chaining
+	// if set, subsequent operations become a noop
+	err error
+}
+
+// NewMetadataBuilder creates a builder for a new UDF's metadata.
+func NewMetadataBuilder() (*MetadataBuilder, error) {
+	return &MetadataBuilder{
+		props:           iceberg.Properties{},
+		definitions:     make([]*Definition, 0),
+		definitionLog:   make([]DefinitionLogEntry, 0),
+		definitionsByID: make(map[string]*Definition),
+	}, nil
+}
+
+// MetadataBuilderFromBase creates a builder seeded with the state of an
+// existing metadata instance.
+func MetadataBuilderFromBase(base Metadata) (*MetadataBuilder, error) {
+	if base == nil {
+		return nil, fmt.Errorf("%w: cannot create metadata builder from nil base", ErrInvalidUDFMetadata)
+	}
+
+	b := &MetadataBuilder{
+		base:          base,
+		uuid:          base.FunctionUUID(),
+		loc:           base.Location(),
+		props:         maps.Clone(base.Properties()),
+		secure:        base.Secure(),
+		doc:           base.Doc(),
+		definitions:   cloneSlice(base.Definitions()),
+		definitionLog: cloneDefinitionLog(base.DefinitionLog()),
+	}
+	if b.props == nil {
+		b.props = iceberg.Properties{}
+	}
+	b.definitionsByID = indexBy(b.definitions, func(d *Definition) string { return d.DefinitionID })
+
+	return b, nil
+}
+
+// HasChanges reports whether any builder operation changed the state
+// relative to the base metadata.
+func (b *MetadataBuilder) HasChanges() bool { return b.hasChanges }
+
+// Err returns the first error encountered by builder operations, if any.
+func (b *MetadataBuilder) Err() error { return b.err }
+
+// SetUUID assigns the function's UUID. The UUID is generated once at
+// creation and cannot be reassigned.
+func (b *MetadataBuilder) SetUUID(newUUID uuid.UUID) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	if newUUID == uuid.Nil {
+		b.err = errors.New("cannot set uuid to null")
+
+		return b
+	}
+
+	if b.uuid == newUUID {
+		return b
+	}
+
+	if b.uuid != uuid.Nil {
+		b.err = errors.New("cannot reassign uuid")
+
+		return b
+	}
+
+	b.uuid = newUUID
+	b.hasChanges = true
+
+	return b
+}
+
+// SetLoc sets the function's base location, used to create metadata
+// file locations.
+func (b *MetadataBuilder) SetLoc(loc string) *MetadataBuilder {
+	if b.err != nil || b.loc == loc {
+		return b
+	}
+
+	b.loc = loc
+	b.hasChanges = true
+
+	return b
+}
+
+// SetProperties adds or updates the given properties.
+func (b *MetadataBuilder) SetProperties(props iceberg.Properties) *MetadataBuilder {
+	if b.err != nil || len(props) == 0 {
+		return b
+	}
+
+	maps.Copy(b.props, props)
+	b.hasChanges = true
+
+	return b
+}
+
+// RemoveProperties removes the given property keys.
+func (b *MetadataBuilder) RemoveProperties(keys []string) *MetadataBuilder {
+	if b.err != nil || len(keys) == 0 {
+		return b
+	}
+
+	for _, key := range keys {
+		delete(b.props, key)
+	}
+	b.hasChanges = true
+
+	return b
+}
+
+// SetSecure marks whether this is a secure function.
+func (b *MetadataBuilder) SetSecure(secure bool) *MetadataBuilder {
+	if b.err != nil || b.secure == secure {
+		return b
+	}
+
+	b.secure = secure
+	b.hasChanges = true
+
+	return b
+}
+
+// SetDoc sets the function's documentation string.
+func (b *MetadataBuilder) SetDoc(doc string) *MetadataBuilder {
+	if b.err != nil || b.doc == doc {
+		return b
+	}
+
+	b.doc = doc
+	b.hasChanges = true
+
+	return b
+}
+
+// SetLogTimestampMS overrides the timestamp used for the definition-log
+// entry appended by Build. Writers that need deterministic metadata (or a
+// timestamp consistent with an external commit) should set this; it
+// defaults to time.Now().UnixMilli().
+func (b *MetadataBuilder) SetLogTimestampMS(timestampMS int64) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	b.logTimestampMS = timestampMS
+
+	return b
+}
+
+// AddDefinition adds a definition for a new signature. The definition's
+// definition-id is derived from its parameters; if the definition already
+// carries an id it must match the canonical form. Adding a definition
+// whose signature or specific name already exists fails: there can be
+// only one definition for a given signature.
+func (b *MetadataBuilder) AddDefinition(def *Definition) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	if def == nil {
+		b.err = fmt.Errorf("%w: cannot add nil definition", ErrInvalidUDFMetadata)
+
+		return b
+	}
+
+	canonicalID, err := CanonicalDefinitionID(def.Parameters)
+	if b.setErr(err) {
+		return b
+	}
+
+	if def.DefinitionID != "" && def.DefinitionID != canonicalID {
+		b.err = fmt.Errorf("%w: definition-id %q does not match canonical form %q of its parameters",
+			ErrInvalidUDFMetadata, def.DefinitionID, canonicalID)
+
+		return b
+	}
+
+	if _, ok := b.definitionsByID[canonicalID]; ok {
+		b.err = fmt.Errorf("%w: a definition for signature %q already exists", ErrInvalidUDFMetadata, canonicalID)
+
+		return b
+	}
+
+	if def.SpecificName != "" {
+		for _, existing := range b.definitions {
+			if existing.SpecificName == def.SpecificName {
+				b.err = fmt.Errorf("%w: a definition with specific-name %q already exists",
+					ErrInvalidUDFMetadata, def.SpecificName)
+
+				return b
+			}
+		}
+	}
+
+	added := def.Clone()
+	added.DefinitionID = canonicalID
+	// Keep parameters non-nil so a zero-parameter definition serializes as
+	// the required empty list rather than null.
+	if added.Parameters == nil {
+		added.Parameters = []Parameter{}
+	}
+	b.definitions = append(b.definitions, added)
+	b.definitionsByID[canonicalID] = added
+	b.hasChanges = true
+	b.selectionChanged = true
+
+	return b
+}
+
+// RemoveDefinition removes the definition with the given definition-id.
+func (b *MetadataBuilder) RemoveDefinition(definitionID string) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	if _, ok := b.definitionsByID[definitionID]; !ok {
+		b.err = fmt.Errorf("%w: no definition with definition-id %q", ErrInvalidUDFMetadata, definitionID)
+
+		return b
+	}
+
+	delete(b.definitionsByID, definitionID)
+	b.definitions = slices.DeleteFunc(b.definitions, func(d *Definition) bool {
+		return d.DefinitionID == definitionID
+	})
+	b.hasChanges = true
+	b.selectionChanged = true
+
+	return b
+}
+
+// AddDefinitionVersion adds a version to the definition with the given
+// definition-id and selects it as the definition's current version. A
+// version id of 0 is assigned the next id for the definition; an explicit
+// version id must not already exist. Use SetCurrentVersion to roll back to
+// an earlier version.
+func (b *MetadataBuilder) AddDefinitionVersion(definitionID string, version *DefinitionVersion) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	if version == nil {
+		b.err = fmt.Errorf("%w: cannot add nil definition version", ErrInvalidUDFMetadata)
+
+		return b
+	}
+
+	def, ok := b.definitionsByID[definitionID]
+	if !ok {
+		b.err = fmt.Errorf("%w: no definition with definition-id %q", ErrInvalidUDFMetadata, definitionID)
+
+		return b
+	}
+
+	added := version.Clone()
+	if added.VersionID < 0 {
+		b.err = fmt.Errorf("%w: invalid negative version-id %d", ErrInvalidUDFMetadata, added.VersionID)
+
+		return b
+	}
+	if added.VersionID == 0 {
+		added.VersionID = nextVersionID(def)
+	} else if def.Version(added.VersionID) != nil {
+		b.err = fmt.Errorf("%w: definition %q already has version-id %d",
+			ErrInvalidUDFMetadata, definitionID, added.VersionID)
+
+		return b
+	}
+
+	def.Versions = append(def.Versions, added)
+	def.CurrentVersionID = added.VersionID
+	b.hasChanges = true
+	b.selectionChanged = true
+
+	return b
+}
+
+// SetCurrentVersion sets the definition's current version to an existing
+// version id, e.g. to roll back to an earlier implementation.
+func (b *MetadataBuilder) SetCurrentVersion(definitionID string, versionID int) *MetadataBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	def, ok := b.definitionsByID[definitionID]
+	if !ok {
+		b.err = fmt.Errorf("%w: no definition with definition-id %q", ErrInvalidUDFMetadata, definitionID)
+
+		return b
+	}
+
+	if def.CurrentVersionID == versionID {
+		return b
+	}
+
+	if def.Version(versionID) == nil {
+		b.err = fmt.Errorf("%w: definition %q has no version-id %d", ErrInvalidUDFMetadata, definitionID, versionID)
+
+		return b
+	}
+
+	def.CurrentVersionID = versionID
+	b.hasChanges = true
+	b.selectionChanged = true
+
+	return b
+}
+
+// Build validates and returns the metadata. When any definition's selected
+// version changed, a definition-log entry capturing the current selection
+// of every definition is appended, with entries ordered by definition-id.
+func (b *MetadataBuilder) Build() (Metadata, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	uuid_ := b.uuid
+	if uuid_ == uuid.Nil {
+		uuid_ = uuid.New()
+	}
+
+	definitionLog := cloneDefinitionLog(b.definitionLog)
+	if b.selectionChanged {
+		timestampMS := b.logTimestampMS
+		if timestampMS == 0 {
+			timestampMS = time.Now().UnixMilli()
+		}
+
+		refs := make([]DefinitionVersionRef, len(b.definitions))
+		for i, def := range b.definitions {
+			refs[i] = DefinitionVersionRef{DefinitionID: def.DefinitionID, VersionID: def.CurrentVersionID}
+		}
+		slices.SortFunc(refs, func(a, c DefinitionVersionRef) int {
+			return strings.Compare(a.DefinitionID, c.DefinitionID)
+		})
+
+		definitionLog = append(definitionLog, DefinitionLogEntry{
+			TimestampMS:        timestampMS,
+			DefinitionVersions: refs,
+		})
+	}
+
+	// Clone the mutable state so that further builder operations cannot
+	// alter previously built metadata.
+	md := &metadata{
+		UUID:               &uuid_,
+		FormatVersionValue: SupportedUDFFormatVersion,
+		DefinitionList:     cloneSlice(b.definitions),
+		DefinitionLogList:  definitionLog,
+		Loc:                b.loc,
+		Props:              maps.Clone(b.props),
+		SecureValue:        b.secure,
+		DocValue:           b.doc,
+	}
+	md.init()
+
+	if err := md.validate(); err != nil {
+		return nil, err
+	}
+
+	return md, nil
+}
+
+// setErr is a helper for enforcing build error assignment during
+// operations. It returns true if the error was non-nil and the builder has
+// entered an error state.
+func (b *MetadataBuilder) setErr(err error) (buildHasFailed bool) {
+	if err != nil {
+		b.err = err
+
+		return true
+	}
+
+	return false
+}
+
+func nextVersionID(def *Definition) int {
+	next := initialVersionID
+	for _, v := range def.Versions {
+		if v.VersionID >= next {
+			next = v.VersionID + 1
+		}
+	}
+
+	return next
+}
+
+func cloneDefinitionLog(log []DefinitionLogEntry) []DefinitionLogEntry {
+	cloned := slices.Clone(log)
+	for i := range cloned {
+		cloned[i].DefinitionVersions = slices.Clone(log[i].DefinitionVersions)
+	}
+
+	return cloned
+}

--- a/udf/metadata_builder.go
+++ b/udf/metadata_builder.go
@@ -172,6 +172,7 @@ func NewMetadataBuilder() (*MetadataBuilder, error) {
 		definitions:     make([]*Definition, 0),
 		definitionLog:   make([]DefinitionLogEntry, 0),
 		definitionsByID: make(map[string]*Definition),
+		logTimestampMS:  -1,
 	}, nil
 }
 
@@ -183,14 +184,15 @@ func MetadataBuilderFromBase(base Metadata) (*MetadataBuilder, error) {
 	}
 
 	b := &MetadataBuilder{
-		base:          base,
-		uuid:          base.FunctionUUID(),
-		loc:           base.Location(),
-		props:         maps.Clone(base.Properties()),
-		secure:        base.Secure(),
-		doc:           base.Doc(),
-		definitions:   cloneSlice(base.Definitions()),
-		definitionLog: cloneDefinitionLog(base.DefinitionLog()),
+		base:           base,
+		uuid:           base.FunctionUUID(),
+		loc:            base.Location(),
+		props:          maps.Clone(base.Properties()),
+		secure:         base.Secure(),
+		doc:            base.Doc(),
+		definitions:    cloneSlice(base.Definitions()),
+		definitionLog:  cloneDefinitionLog(base.DefinitionLog()),
+		logTimestampMS: -1,
 	}
 	if b.props == nil {
 		b.props = iceberg.Properties{}
@@ -301,8 +303,8 @@ func (b *MetadataBuilder) SetDoc(doc string) *MetadataBuilder {
 
 // SetLogTimestampMS overrides the timestamp used for the definition-log
 // entry appended by Build. Writers that need deterministic metadata (or a
-// timestamp consistent with an external commit) should set this; it
-// defaults to time.Now().UnixMilli().
+// timestamp consistent with an external commit) should set this; when
+// unset it defaults to time.Now().UnixMilli().
 func (b *MetadataBuilder) SetLogTimestampMS(timestampMS int64) *MetadataBuilder {
 	if b.err != nil {
 		return b
@@ -488,7 +490,7 @@ func (b *MetadataBuilder) Build() (Metadata, error) {
 	definitionLog := cloneDefinitionLog(b.definitionLog)
 	if b.selectionChanged {
 		timestampMS := b.logTimestampMS
-		if timestampMS == 0 {
+		if timestampMS == -1 {
 			timestampMS = time.Now().UnixMilli()
 		}
 

--- a/udf/metadata_builder_test.go
+++ b/udf/metadata_builder_test.go
@@ -487,6 +487,35 @@ func TestBuilderOnNullInput(t *testing.T) {
 	assert.Equal(t, OnNullInputReturnNull, def.CurrentVersion().NullInputBehavior())
 }
 
+// TestBuilderLogTimestampZero pins that epoch-0 is a settable log timestamp:
+// the builder's "unset" sentinel is -1, matching DefinitionVersion.TimestampMS.
+func TestBuilderLogTimestampZero(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	meta, err := builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		SetLogTimestampMS(0).
+		Build()
+	require.NoError(t, err)
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 1)
+	assert.Equal(t, int64(0), log[0].TimestampMS)
+
+	// a negative log timestamp is rejected by validation at Build
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	_, err = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		SetLogTimestampMS(-5).
+		Build()
+	require.ErrorIs(t, err, ErrInvalidUDFMetadata)
+	assert.ErrorContains(t, err, "invalid negative timestamp-ms -5")
+}
+
 func TestBuilderRemoveProperties(t *testing.T) {
 	builder, err := NewMetadataBuilder()
 	require.NoError(t, err)

--- a/udf/metadata_builder_test.go
+++ b/udf/metadata_builder_test.go
@@ -1,0 +1,641 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDefinition(t *testing.T) *Definition {
+	t.Helper()
+	def, err := NewDefinition(FunctionTypeUDF,
+		[]Parameter{{Name: "x", Type: mustPrimitive(t, "int"), Doc: "Input integer"}},
+		mustPrimitive(t, "int"),
+		WithDefinitionDoc("Add one to the input integer"))
+	require.NoError(t, err)
+
+	return def
+}
+
+func newTestVersion(t *testing.T, sql string, timestampMS int64) *DefinitionVersion {
+	t.Helper()
+	repr, err := NewSQLRepresentation("trino", sql)
+	require.NoError(t, err)
+	version, err := NewDefinitionVersion([]Representation{repr},
+		WithTimestampMS(timestampMS), WithDeterministic(true))
+	require.NoError(t, err)
+
+	return version
+}
+
+func TestNewDefinition(t *testing.T) {
+	def := newTestDefinition(t)
+	assert.Equal(t, "int", def.DefinitionID)
+	assert.Equal(t, -1, def.CurrentVersionID)
+	assert.Empty(t, def.Versions)
+
+	multi, err := NewDefinition(FunctionTypeUDF,
+		[]Parameter{
+			{Name: "a", Type: mustPrimitive(t, "int")},
+			{Name: "b", Type: ListType{Element: mustPrimitive(t, "int")}},
+		},
+		mustPrimitive(t, "long"),
+		WithSpecificName("sum_list"), WithReturnNullable(false))
+	require.NoError(t, err)
+	assert.Equal(t, "int,list<int>", multi.DefinitionID)
+	assert.Equal(t, "sum_list", multi.SpecificName)
+	assert.False(t, multi.ReturnsNullable())
+
+	_, err = NewDefinition(FunctionTypeUDF, []Parameter{{Name: "x", Type: nil}}, mustPrimitive(t, "int"))
+	assert.ErrorIs(t, err, ErrInvalidUDFType)
+}
+
+func TestNewDefinitionVersion(t *testing.T) {
+	version := newTestVersion(t, "x + 1", 1000)
+	assert.Equal(t, 0, version.VersionID, "version id is assigned when added to a definition")
+	assert.Equal(t, int64(1000), version.TimestampMS)
+	assert.True(t, version.Deterministic)
+
+	_, err := NewDefinitionVersion(nil)
+	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
+
+	_, err = NewDefinitionVersion([]Representation{nil})
+	assert.ErrorContains(t, err, "representations must not contain nil entries")
+}
+
+// TestBuildRejectsNilRepresentation ensures a hand-built version carrying a
+// nil representation fails validation at Build instead of marshaling null.
+func TestBuildRejectsNilRepresentation(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	_, err = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", &DefinitionVersion{
+			Representations: []Representation{nil},
+			TimestampMS:     1000,
+		}).
+		Build()
+	require.ErrorIs(t, err, ErrInvalidUDFMetadata)
+	assert.ErrorContains(t, err, "representations must not contain null entries")
+}
+
+func TestBuildNewMetadata(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	meta, err := builder.
+		SetLoc("s3://bucket/functions/add_one").
+		SetDoc("Adds one").
+		SetSecure(true).
+		SetProperties(iceberg.Properties{"owner": "iceberg-go"}).
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		SetLogTimestampMS(2000).
+		Build()
+	require.NoError(t, err)
+
+	assert.Equal(t, SupportedUDFFormatVersion, meta.FormatVersion())
+	assert.NotEqual(t, uuid.Nil, meta.FunctionUUID(), "a uuid is generated when none is set")
+	assert.Equal(t, "s3://bucket/functions/add_one", meta.Location())
+	assert.Equal(t, "Adds one", meta.Doc())
+	assert.True(t, meta.Secure())
+	assert.Equal(t, iceberg.Properties{"owner": "iceberg-go"}, meta.Properties())
+
+	def, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, initialVersionID, def.CurrentVersionID)
+	require.Len(t, def.Versions, 1)
+	assert.Equal(t, initialVersionID, def.Versions[0].VersionID)
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 1)
+	assert.Equal(t, int64(2000), log[0].TimestampMS)
+	assert.Equal(t, []DefinitionVersionRef{{DefinitionID: "int", VersionID: 1}}, log[0].DefinitionVersions)
+
+	// built metadata round-trips through JSON
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	again, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	assert.True(t, meta.Equals(again))
+}
+
+func TestBuildSetUUID(t *testing.T) {
+	functionID := uuid.New()
+
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	meta, err := builder.
+		SetUUID(functionID).
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		Build()
+	require.NoError(t, err)
+	assert.Equal(t, functionID, meta.FunctionUUID())
+}
+
+func TestBuildRequiresCompleteDefinition(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	// a definition without any version is incomplete
+	_, err = builder.AddDefinition(newTestDefinition(t)).Build()
+	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	_, err = builder.Build()
+	assert.ErrorContains(t, err, "at least one definition is required")
+}
+
+func TestBuilderFromBase(t *testing.T) {
+	base := parseFixture(t, "udf-metadata-scalar.json")
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+	assert.False(t, builder.HasChanges())
+
+	meta, err := builder.
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1 + 0", 3000)).
+		SetLogTimestampMS(3000).
+		Build()
+	require.NoError(t, err)
+	assert.True(t, builder.HasChanges())
+
+	def, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, 3, def.CurrentVersionID, "new version gets the next id and becomes current")
+	require.Len(t, def.Versions, 3)
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 4, "a definition-log entry is appended for the selection change")
+	assert.Equal(t, DefinitionLogEntry{
+		TimestampMS: 3000,
+		DefinitionVersions: []DefinitionVersionRef{
+			{DefinitionID: "float", VersionID: 1},
+			{DefinitionID: "int", VersionID: 3},
+		},
+	}, log[3], "the appended entry snapshots every definition, ordered by definition-id")
+
+	// the base metadata is not mutated
+	baseDef, ok := base.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, 2, baseDef.CurrentVersionID)
+	assert.Len(t, baseDef.Versions, 2)
+	assert.Len(t, base.DefinitionLog(), 3)
+
+	_, err = MetadataBuilderFromBase(nil)
+	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
+}
+
+func TestBuilderNoChanges(t *testing.T) {
+	base := parseFixture(t, "udf-metadata-scalar.json")
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	assert.False(t, builder.HasChanges())
+	assert.True(t, base.Equals(meta), "building without changes appends no definition-log entry")
+}
+
+func TestBuilderRollback(t *testing.T) {
+	base := parseFixture(t, "udf-metadata-scalar.json")
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+
+	meta, err := builder.
+		SetCurrentVersion("int", 1).
+		SetLogTimestampMS(4000).
+		Build()
+	require.NoError(t, err)
+
+	def, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, 1, def.CurrentVersionID)
+	assert.Len(t, def.Versions, 2, "rollback keeps all versions")
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 4)
+	assert.Equal(t, []DefinitionVersionRef{
+		{DefinitionID: "float", VersionID: 1},
+		{DefinitionID: "int", VersionID: 1},
+	}, log[3].DefinitionVersions)
+}
+
+func TestBuilderRemoveDefinition(t *testing.T) {
+	base := parseFixture(t, "udf-metadata-scalar.json")
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+
+	meta, err := builder.
+		RemoveDefinition("float").
+		SetLogTimestampMS(5000).
+		Build()
+	require.NoError(t, err)
+
+	assert.Len(t, meta.Definitions(), 1)
+	_, ok := meta.DefinitionByID("float")
+	assert.False(t, ok)
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 4)
+	assert.Equal(t, []DefinitionVersionRef{{DefinitionID: "int", VersionID: 2}}, log[3].DefinitionVersions)
+}
+
+func TestBuilderAddDefinitionConflicts(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	builder = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinition(newTestDefinition(t))
+	assert.ErrorContains(t, builder.Err(), "already exists")
+
+	// a mismatched pre-set definition-id is rejected
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	def := newTestDefinition(t)
+	def.DefinitionID = "float"
+	builder = builder.AddDefinition(def)
+	assert.ErrorContains(t, builder.Err(), "does not match canonical form")
+
+	// duplicate specific names are rejected across signatures
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	first, err := NewDefinition(FunctionTypeUDF,
+		[]Parameter{{Name: "x", Type: mustPrimitive(t, "int")}},
+		mustPrimitive(t, "int"), WithSpecificName("add_one"))
+	require.NoError(t, err)
+	second, err := NewDefinition(FunctionTypeUDF,
+		[]Parameter{{Name: "x", Type: mustPrimitive(t, "float")}},
+		mustPrimitive(t, "float"), WithSpecificName("add_one"))
+	require.NoError(t, err)
+	builder = builder.AddDefinition(first).AddDefinition(second)
+	assert.ErrorContains(t, builder.Err(), `specific-name "add_one" already exists`)
+}
+
+func TestBuilderVersionErrors(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000))
+	assert.ErrorContains(t, builder.Err(), `no definition with definition-id "int"`)
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	explicit := newTestVersion(t, "x + 1", 1000)
+	explicit.VersionID = 1
+	duplicate := newTestVersion(t, "x + 2", 2000)
+	duplicate.VersionID = 1
+	builder = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", explicit).
+		AddDefinitionVersion("int", duplicate)
+	assert.ErrorContains(t, builder.Err(), `already has version-id 1`)
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		SetCurrentVersion("int", 7)
+	assert.ErrorContains(t, builder.Err(), "has no version-id 7")
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.RemoveDefinition("int")
+	assert.ErrorContains(t, builder.Err(), `no definition with definition-id "int"`)
+}
+
+func TestBuilderErrorChaining(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	builder = builder.
+		RemoveDefinition("missing").
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000))
+
+	firstErr := builder.Err()
+	require.Error(t, firstErr)
+
+	// operations after an error are noops and Build reports the first error
+	_, err = builder.Build()
+	assert.Equal(t, firstErr, err)
+}
+
+func TestBuilderUUIDReassignment(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	builder = builder.SetUUID(uuid.New()).SetUUID(uuid.New())
+	assert.ErrorContains(t, builder.Err(), "cannot reassign uuid")
+
+	base := parseFixture(t, "udf-metadata-scalar.json")
+	fromBase, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+	fromBase = fromBase.SetUUID(base.FunctionUUID())
+	assert.NoError(t, fromBase.Err(), "setting the same uuid is a noop")
+	fromBase = fromBase.SetUUID(uuid.New())
+	assert.ErrorContains(t, fromBase.Err(), "cannot reassign uuid")
+}
+
+// TestBuilderNormalizesNilParameters ensures a hand-built zero-parameter
+// definition with nil parameters serializes as the required empty list.
+func TestBuilderNormalizesNilParameters(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	meta, err := builder.
+		AddDefinition(&Definition{
+			ReturnType:       mustPrimitive(t, "long"),
+			CurrentVersionID: -1,
+			FunctionType:     FunctionTypeUDF,
+		}).
+		AddDefinitionVersion("", newTestVersion(t, "42", 1000)).
+		SetLogTimestampMS(1000).
+		Build()
+	require.NoError(t, err)
+
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"parameters":[]`)
+
+	again, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	assert.True(t, meta.Equals(again))
+}
+
+func TestBuilderZeroParameterDefinition(t *testing.T) {
+	def, err := NewDefinition(FunctionTypeUDF, nil, mustPrimitive(t, "long"))
+	require.NoError(t, err)
+	assert.Equal(t, "", def.DefinitionID, "a zero-parameter definition has an empty definition-id")
+
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	meta, err := builder.
+		AddDefinition(def).
+		AddDefinitionVersion("", newTestVersion(t, "42", 1000)).
+		SetLogTimestampMS(1000).
+		Build()
+	require.NoError(t, err)
+
+	built, ok := meta.DefinitionByID("")
+	require.True(t, ok)
+	assert.Equal(t, 1, built.CurrentVersionID)
+
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	again, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	assert.True(t, meta.Equals(again))
+}
+
+// TestBuildIsolation ensures further builder operations cannot alter
+// previously built metadata.
+func TestBuildIsolation(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	builder = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		SetLogTimestampMS(1000)
+
+	first, err := builder.Build()
+	require.NoError(t, err)
+
+	builder = builder.
+		AddDefinitionVersion("int", newTestVersion(t, "x + 2", 2000)).
+		SetProperties(iceberg.Properties{"owner": "someone"})
+	_, err = builder.Build()
+	require.NoError(t, err)
+
+	def, ok := first.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, 1, def.CurrentVersionID)
+	assert.Len(t, def.Versions, 1)
+	assert.Empty(t, first.Properties())
+	assert.Len(t, first.DefinitionLog(), 1)
+}
+
+func TestBuilderRejectsHandBuiltUnknownRepresentation(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	version, err := NewDefinitionVersion(
+		[]Representation{UnknownRepresentation{TypeName: "python"}},
+		WithTimestampMS(1000))
+	require.NoError(t, err)
+
+	_, err = builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", version).
+		Build()
+	assert.ErrorContains(t, err, "unknown representation without raw JSON")
+}
+
+func TestBuilderOnNullInput(t *testing.T) {
+	repr, err := NewSQLRepresentation("trino", "coalesce(x, 0)")
+	require.NoError(t, err)
+	version, err := NewDefinitionVersion([]Representation{repr},
+		WithTimestampMS(1000), WithOnNullInput(OnNullInputReturnNull))
+	require.NoError(t, err)
+
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	meta, err := builder.
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", version).
+		SetLogTimestampMS(1000).
+		Build()
+	require.NoError(t, err)
+
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	again, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+
+	def, ok := again.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, OnNullInputReturnNull, def.CurrentVersion().NullInputBehavior())
+}
+
+func TestBuilderRemoveProperties(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	meta, err := builder.
+		SetProperties(iceberg.Properties{"owner": "iceberg-go", "team": "iceberg"}).
+		RemoveProperties([]string{"team", "not-present"}).
+		AddDefinition(newTestDefinition(t)).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		Build()
+	require.NoError(t, err)
+	assert.Equal(t, iceberg.Properties{"owner": "iceberg-go"}, meta.Properties())
+}
+
+// TestBuilderNoopsAndErrorGuards covers the equal-value noop branches and the
+// sticky-error guards of every builder operation.
+func TestBuilderNoopsAndErrorGuards(t *testing.T) {
+	base := parseFixture(t, "udf-metadata-scalar.json")
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+	builder = builder.
+		SetLoc(base.Location()).
+		SetSecure(base.Secure()).
+		SetDoc(base.Doc()).
+		SetProperties(nil).
+		RemoveProperties(nil).
+		SetCurrentVersion("int", 2)
+	require.NoError(t, builder.Err())
+	assert.False(t, builder.HasChanges(), "setting current values must be a noop")
+
+	builder = builder.SetUUID(uuid.Nil)
+	require.ErrorContains(t, builder.Err(), "cannot set uuid to null")
+
+	firstErr := builder.Err()
+	builder = builder.
+		SetLoc("s3://other").
+		SetProperties(iceberg.Properties{"k": "v"}).
+		RemoveProperties([]string{"k"}).
+		SetSecure(true).
+		SetDoc("other").
+		SetLogTimestampMS(1).
+		SetUUID(uuid.New()).
+		AddDefinition(newTestDefinition(t)).
+		RemoveDefinition("int").
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1)).
+		SetCurrentVersion("int", 1)
+	assert.Equal(t, firstErr, builder.Err(), "operations after an error must be noops")
+	_, err = builder.Build()
+	assert.Equal(t, firstErr, err)
+}
+
+func TestBuilderAddDefinitionWithInvalidTypes(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+
+	builder = builder.AddDefinition(&Definition{
+		Parameters:   []Parameter{{Name: "x", Type: nil}},
+		FunctionType: FunctionTypeUDF,
+	})
+	assert.ErrorIs(t, builder.Err(), ErrInvalidUDFType)
+}
+
+func TestBuilderNilArguments(t *testing.T) {
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.AddDefinition(nil)
+	assert.ErrorContains(t, builder.Err(), "cannot add nil definition")
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.AddDefinition(newTestDefinition(t)).AddDefinitionVersion("int", nil)
+	assert.ErrorContains(t, builder.Err(), "cannot add nil definition version")
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	builder = builder.SetCurrentVersion("missing", 1)
+	assert.ErrorContains(t, builder.Err(), `no definition with definition-id "missing"`)
+
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	negative := newTestVersion(t, "x + 1", 1000)
+	negative.VersionID = -2
+	builder = builder.AddDefinition(newTestDefinition(t)).AddDefinitionVersion("int", negative)
+	assert.ErrorContains(t, builder.Err(), "invalid negative version-id -2")
+}
+
+// TestBuildValidatesReturnType ensures Build rejects a definition whose
+// return type was never set: AddDefinition only validates the signature.
+func TestBuildValidatesReturnType(t *testing.T) {
+	intType := mustPrimitive(t, "int")
+
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	_, err = builder.
+		AddDefinition(&Definition{
+			Parameters:   []Parameter{{Name: "x", Type: intType}},
+			FunctionType: FunctionTypeUDF,
+		}).
+		AddDefinitionVersion("int", newTestVersion(t, "x + 1", 1000)).
+		Build()
+	require.ErrorIs(t, err, ErrInvalidUDFMetadata)
+	assert.ErrorContains(t, err, "return-type")
+}
+
+func TestCloneNilAndDeepCopy(t *testing.T) {
+	assert.Nil(t, (*Definition)(nil).Clone())
+	assert.Nil(t, (*DefinitionVersion)(nil).Clone())
+
+	nullable := false
+	def := newTestDefinition(t)
+	def.ReturnNullable = &nullable
+
+	cloned := def.Clone()
+	require.NotNil(t, cloned.ReturnNullable)
+	*def.ReturnNullable = true
+	assert.False(t, *cloned.ReturnNullable, "clone must not share the return-nullable pointer")
+}
+
+func TestBuilderUDTF(t *testing.T) {
+	returnType := StructType{Fields: []StructField{
+		{Name: "name", Type: mustPrimitive(t, "string")},
+		{Name: "color", Type: mustPrimitive(t, "string")},
+	}}
+	def, err := NewDefinition(FunctionTypeUDTF,
+		[]Parameter{{Name: "c", Type: mustPrimitive(t, "string")}}, returnType)
+	require.NoError(t, err)
+
+	builder, err := NewMetadataBuilder()
+	require.NoError(t, err)
+	meta, err := builder.
+		AddDefinition(def).
+		AddDefinitionVersion("string", newTestVersion(t, "SELECT name, color FROM fruits WHERE color = c", 1000)).
+		Build()
+	require.NoError(t, err)
+
+	built, ok := meta.DefinitionByID("string")
+	require.True(t, ok)
+	assert.Equal(t, FunctionTypeUDTF, built.FunctionType)
+
+	// a udtf whose return type is not a struct fails to build
+	invalid, err := NewDefinition(FunctionTypeUDTF,
+		[]Parameter{{Name: "c", Type: mustPrimitive(t, "int")}}, mustPrimitive(t, "int"))
+	require.NoError(t, err)
+	builder, err = NewMetadataBuilder()
+	require.NoError(t, err)
+	_, err = builder.
+		AddDefinition(invalid).
+		AddDefinitionVersion("int", newTestVersion(t, "SELECT 1", 1000)).
+		Build()
+	assert.ErrorContains(t, err, "return-type is not a struct")
+}

--- a/udf/metadata_test.go
+++ b/udf/metadata_test.go
@@ -1,0 +1,715 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseFixture(t *testing.T, name string) Metadata {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	require.NoError(t, err)
+	meta, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+
+	return meta
+}
+
+// TestParseMetadataScalarFixture parses the overloaded scalar function
+// example from Appendix A of the UDF spec.
+func TestParseMetadataScalarFixture(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-scalar.json")
+
+	assert.Equal(t, 1, meta.FormatVersion())
+	assert.Equal(t, uuid.MustParse("42fd3f91-bc10-41c1-8a52-92b57dd0a9b2"), meta.FunctionUUID())
+	assert.Equal(t, "Overloaded scalar UDF for integer and float inputs", meta.Doc())
+	assert.False(t, meta.Secure())
+	assert.Empty(t, meta.Location())
+	assert.Empty(t, meta.Properties())
+
+	require.Len(t, meta.Definitions(), 2)
+
+	intDef, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, "int", intDef.DefinitionID)
+	assert.Equal(t, FunctionTypeUDF, intDef.FunctionType)
+	assert.Equal(t, "Add one to the input integer", intDef.Doc)
+	require.Len(t, intDef.Parameters, 1)
+	assert.Equal(t, "x", intDef.Parameters[0].Name)
+	assert.Equal(t, "int", intDef.Parameters[0].Type.String())
+	assert.Equal(t, "Input integer", intDef.Parameters[0].Doc)
+	assert.Equal(t, "int", intDef.ReturnType.String())
+	assert.True(t, intDef.ReturnsNullable(), "return-nullable defaults to true when absent")
+	assert.Equal(t, 2, intDef.CurrentVersionID)
+	require.Len(t, intDef.Versions, 2)
+
+	v1 := intDef.Version(1)
+	require.NotNil(t, v1)
+	assert.True(t, v1.Deterministic)
+	assert.Equal(t, int64(1734507000123), v1.TimestampMS)
+	assert.Equal(t, OnNullInputCall, v1.NullInputBehavior(), "on-null-input defaults to call when absent")
+	require.Len(t, v1.Representations, 1)
+	assert.Equal(t, SQLRepresentation{Dialect: "trino", SQL: "x + 2"}, v1.Representations[0])
+
+	current := intDef.CurrentVersion()
+	require.NotNil(t, current)
+	assert.Equal(t, 2, current.VersionID)
+	require.Len(t, current.Representations, 2)
+	assert.Equal(t, SQLRepresentation{Dialect: "trino", SQL: "x + 1"}, current.Representations[0])
+	assert.Equal(t, SQLRepresentation{Dialect: "spark", SQL: "x + 1"}, current.Representations[1])
+
+	floatDef, ok := meta.DefinitionByID("float")
+	require.True(t, ok)
+	assert.Equal(t, 1, floatDef.CurrentVersionID)
+
+	_, ok = meta.DefinitionByID("string")
+	assert.False(t, ok)
+
+	log := meta.DefinitionLog()
+	require.Len(t, log, 3)
+	assert.Equal(t, []DefinitionVersionRef{{DefinitionID: "int", VersionID: 1}}, log[0].DefinitionVersions)
+	assert.Equal(t, int64(1734507000123), log[0].TimestampMS)
+	assert.Equal(t, []DefinitionVersionRef{
+		{DefinitionID: "int", VersionID: 2},
+		{DefinitionID: "float", VersionID: 1},
+	}, log[2].DefinitionVersions)
+}
+
+// TestParseMetadataUDTFFixture parses the table function example from
+// Appendix B of the UDF spec.
+func TestParseMetadataUDTFFixture(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-table.json")
+
+	assert.Equal(t, uuid.MustParse("8a7fa39a-6d8f-4a2f-9d8d-3f3a8f3c2a10"), meta.FunctionUUID())
+	require.Len(t, meta.Definitions(), 1)
+
+	def, ok := meta.DefinitionByID("string")
+	require.True(t, ok)
+	assert.Equal(t, FunctionTypeUDTF, def.FunctionType)
+
+	st, ok := def.ReturnType.(StructType)
+	require.True(t, ok, "a udtf's return type must be a struct")
+	require.Len(t, st.Fields, 2)
+	assert.Equal(t, "name", st.Fields[0].Name)
+	assert.Equal(t, "color", st.Fields[1].Name)
+	assert.Equal(t, "struct<name:string,color:string>", def.ReturnType.String())
+
+	require.Len(t, meta.DefinitionLog(), 1)
+}
+
+func TestMetadataRoundTrip(t *testing.T) {
+	for _, fixture := range []string{"udf-metadata-scalar.json", "udf-metadata-table.json"} {
+		t.Run(fixture, func(t *testing.T) {
+			meta := parseFixture(t, fixture)
+
+			data, err := json.Marshal(meta)
+			require.NoError(t, err)
+
+			again, err := ParseMetadataBytes(data)
+			require.NoError(t, err)
+			assert.True(t, meta.Equals(again))
+		})
+	}
+}
+
+func TestParseMetadataReader(t *testing.T) {
+	data, err := os.ReadFile("testdata/udf-metadata-scalar.json")
+	require.NoError(t, err)
+
+	fromReader, err := ParseMetadata(strings.NewReader(string(data)))
+	require.NoError(t, err)
+
+	fromString, err := ParseMetadataString(string(data))
+	require.NoError(t, err)
+	assert.True(t, fromReader.Equals(fromString))
+}
+
+const unknownRepresentationJSON = `{
+  "function-uuid": "42fd3f91-bc10-41c1-8a52-92b57dd0a9b2",
+  "format-version": 1,
+  "definitions": [
+    {
+      "definition-id": "int",
+      "parameters": [{"name": "x", "type": "int"}],
+      "return-type": "int",
+      "function-type": "udf",
+      "versions": [
+        {
+          "version-id": 1,
+          "representations": [
+            {"type": "python", "code": "return x + 1", "runtime": "3.12"},
+            {"type": "sql", "dialect": "trino", "sql": "x + 1"}
+          ],
+          "timestamp-ms": 1734507000123
+        }
+      ],
+      "current-version-id": 1
+    }
+  ],
+  "definition-log": [
+    {"timestamp-ms": 1734507000123, "definition-versions": [{"definition-id": "int", "version-id": 1}]}
+  ]
+}`
+
+// TestUnknownRepresentation ensures representations of unrecognized types
+// round-trip intact for forward compatibility.
+func TestUnknownRepresentation(t *testing.T) {
+	meta, err := ParseMetadataString(unknownRepresentationJSON)
+	require.NoError(t, err)
+
+	def, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	reprs := def.CurrentVersion().Representations
+	require.Len(t, reprs, 2)
+
+	unknown, ok := reprs[0].(UnknownRepresentation)
+	require.True(t, ok)
+	assert.Equal(t, "python", unknown.RepresentationType())
+	assert.Contains(t, string(unknown.Raw()), `"runtime"`)
+
+	sqlRepr, ok := reprs[1].(SQLRepresentation)
+	require.True(t, ok)
+	assert.Equal(t, "sql", sqlRepr.RepresentationType())
+
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"runtime"`)
+
+	again, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	assert.True(t, meta.Equals(again))
+}
+
+func TestReturnNullable(t *testing.T) {
+	metaJSON := strings.Replace(unknownRepresentationJSON,
+		`"return-type": "int",`, `"return-type": "int", "return-nullable": false,`, 1)
+	meta, err := ParseMetadataString(metaJSON)
+	require.NoError(t, err)
+
+	def, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.False(t, def.ReturnsNullable())
+
+	// an explicit false must survive serialization
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"return-nullable":false`)
+
+	// while an absent value (defaulting to true) stays absent
+	meta = parseFixture(t, "udf-metadata-scalar.json")
+	data, err = json.Marshal(meta)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "return-nullable")
+}
+
+func TestMetadataEquals(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-scalar.json")
+	other := parseFixture(t, "udf-metadata-scalar.json")
+
+	assert.True(t, meta.Equals(meta))
+	assert.True(t, meta.Equals(other))
+	assert.False(t, meta.Equals(nil))
+	assert.False(t, meta.Equals(parseFixture(t, "udf-metadata-table.json")))
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+
+func TestParseMetadataReaderError(t *testing.T) {
+	_, err := ParseMetadata(failingReader{})
+	assert.ErrorContains(t, err, "read failed")
+}
+
+func TestRepresentationsEqualCrossType(t *testing.T) {
+	sqlRepr := SQLRepresentation{Dialect: "trino", SQL: "x + 1"}
+	unknown := UnknownRepresentation{TypeName: "python", raw: json.RawMessage(`{"type":"python"}`)}
+	other := UnknownRepresentation{TypeName: "python", raw: json.RawMessage(`{"type":"python","v":2}`)}
+
+	assert.True(t, representationsEqual(sqlRepr, sqlRepr))
+	assert.True(t, representationsEqual(unknown, unknown))
+	assert.False(t, representationsEqual(sqlRepr, unknown))
+	assert.False(t, representationsEqual(unknown, sqlRepr))
+	assert.False(t, representationsEqual(unknown, other))
+	assert.False(t, representationsEqual(nil, sqlRepr))
+}
+
+func TestNewSQLRepresentation(t *testing.T) {
+	repr, err := NewSQLRepresentation("trino", "x + 1")
+	require.NoError(t, err)
+	assert.Equal(t, SQLRepresentation{Dialect: "trino", SQL: "x + 1"}, repr)
+
+	_, err = NewSQLRepresentation("", "x + 1")
+	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
+
+	_, err = NewSQLRepresentation("trino", "")
+	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
+}
+
+// minimalMetadata returns a decoded minimal valid metadata document for
+// mutation-based validation tests.
+func minimalMetadata(t *testing.T) map[string]any {
+	t.Helper()
+	const minimal = `{
+	  "function-uuid": "42fd3f91-bc10-41c1-8a52-92b57dd0a9b2",
+	  "format-version": 1,
+	  "definitions": [
+	    {
+	      "definition-id": "int",
+	      "parameters": [{"name": "x", "type": "int"}],
+	      "return-type": "int",
+	      "function-type": "udf",
+	      "versions": [
+	        {
+	          "version-id": 1,
+	          "representations": [{"type": "sql", "dialect": "trino", "sql": "x + 1"}],
+	          "timestamp-ms": 1734507000123
+	        }
+	      ],
+	      "current-version-id": 1
+	    }
+	  ],
+	  "definition-log": [
+	    {"timestamp-ms": 1734507000123, "definition-versions": [{"definition-id": "int", "version-id": 1}]}
+	  ]
+	}`
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(minimal), &m))
+
+	return m
+}
+
+func definition(t *testing.T, m map[string]any, idx int) map[string]any {
+	t.Helper()
+
+	return m["definitions"].([]any)[idx].(map[string]any)
+}
+
+func version(t *testing.T, m map[string]any, defIdx, verIdx int) map[string]any {
+	t.Helper()
+
+	return definition(t, m, defIdx)["versions"].([]any)[verIdx].(map[string]any)
+}
+
+func TestMetadataValidation(t *testing.T) {
+	t.Run("minimal is valid", func(t *testing.T) {
+		data, err := json.Marshal(minimalMetadata(t))
+		require.NoError(t, err)
+		_, err = ParseMetadataBytes(data)
+		require.NoError(t, err)
+	})
+
+	tests := []struct {
+		name        string
+		mutate      func(t *testing.T, m map[string]any)
+		expectedErr error
+		contains    string
+	}{
+		{
+			"missing function-uuid",
+			func(t *testing.T, m map[string]any) { delete(m, "function-uuid") },
+			ErrInvalidUDFMetadata, "function-uuid is required",
+		},
+		{
+			"missing format-version",
+			func(t *testing.T, m map[string]any) { delete(m, "format-version") },
+			ErrInvalidUDFMetadataFormatVersion, "format-version is required",
+		},
+		{
+			"unsupported format-version",
+			func(t *testing.T, m map[string]any) { m["format-version"] = 2 },
+			ErrInvalidUDFMetadataFormatVersion, "only version 1 is supported",
+		},
+		{
+			"empty definitions",
+			func(t *testing.T, m map[string]any) { m["definitions"] = []any{} },
+			ErrInvalidUDFMetadata, "at least one definition is required",
+		},
+		{
+			"definition-id does not match parameters",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["definition-id"] = "float" },
+			ErrInvalidUDFMetadata, "does not match canonical form",
+		},
+		{
+			"duplicate signature",
+			func(t *testing.T, m map[string]any) {
+				m["definitions"] = append(m["definitions"].([]any), definition(t, m, 0))
+			},
+			ErrInvalidUDFMetadata, "duplicate definition-id",
+		},
+		{
+			"duplicate specific-name",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["specific-name"] = "add_one_int"
+				var second map[string]any
+				data, err := json.Marshal(definition(t, m, 0))
+				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(data, &second))
+				second["definition-id"] = "float"
+				second["parameters"] = []any{map[string]any{"name": "x", "type": "float"}}
+				m["definitions"] = append(m["definitions"].([]any), second)
+			},
+			ErrInvalidUDFMetadata, "duplicate specific-name",
+		},
+		{
+			"missing current-version-id",
+			func(t *testing.T, m map[string]any) { delete(definition(t, m, 0), "current-version-id") },
+			ErrInvalidUDFMetadata, "missing current-version-id",
+		},
+		{
+			"current-version-id not found",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["current-version-id"] = 5 },
+			ErrInvalidUDFMetadata, "current-version-id 5 not found",
+		},
+		{
+			"duplicate version-id",
+			func(t *testing.T, m map[string]any) {
+				def := definition(t, m, 0)
+				def["versions"] = append(def["versions"].([]any), version(t, m, 0, 0))
+			},
+			ErrInvalidUDFMetadata, "duplicate version-id",
+		},
+		{
+			"missing version-id",
+			func(t *testing.T, m map[string]any) { delete(version(t, m, 0, 0), "version-id") },
+			ErrInvalidUDFMetadata, "missing version-id",
+		},
+		{
+			"missing timestamp-ms",
+			func(t *testing.T, m map[string]any) { delete(version(t, m, 0, 0), "timestamp-ms") },
+			ErrInvalidUDFMetadata, "missing timestamp-ms",
+		},
+		{
+			"empty representations",
+			func(t *testing.T, m map[string]any) { version(t, m, 0, 0)["representations"] = []any{} },
+			ErrInvalidUDFMetadata, "at least one representation",
+		},
+		{
+			"representation without type",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["representations"] = []any{map[string]any{"dialect": "trino", "sql": "x + 1"}}
+			},
+			ErrInvalidUDFMetadata, "representation requires a type",
+		},
+		{
+			"sql representation without dialect",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["representations"] = []any{map[string]any{"type": "sql", "sql": "x + 1"}}
+			},
+			ErrInvalidUDFMetadata, "without a dialect",
+		},
+		{
+			"sql representation without sql",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["representations"] = []any{map[string]any{"type": "sql", "dialect": "trino"}}
+			},
+			ErrInvalidUDFMetadata, "without a sql expression",
+		},
+		{
+			"duplicate sql dialect",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["representations"] = []any{
+					map[string]any{"type": "sql", "dialect": "trino", "sql": "x + 1"},
+					map[string]any{"type": "sql", "dialect": "Trino", "sql": "x + 2"},
+				}
+			},
+			ErrInvalidUDFMetadata, "duplicate sql dialect",
+		},
+		{
+			"invalid on-null-input",
+			func(t *testing.T, m map[string]any) { version(t, m, 0, 0)["on-null-input"] = "always" },
+			ErrInvalidUDFMetadata, "invalid on-null-input",
+		},
+		{
+			"udtf with non-struct return type",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["function-type"] = "udtf" },
+			ErrInvalidUDFMetadata, "return-type is not a struct",
+		},
+		{
+			"missing function-type",
+			func(t *testing.T, m map[string]any) { delete(definition(t, m, 0), "function-type") },
+			ErrInvalidUDFMetadata, "missing function-type",
+		},
+		{
+			"invalid function-type",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["function-type"] = "aggregate" },
+			ErrInvalidUDFMetadata, "invalid function-type",
+		},
+		{
+			"parameter without name",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["parameters"] = []any{map[string]any{"name": "", "type": "int"}}
+			},
+			ErrInvalidUDFMetadata, "parameter without a name",
+		},
+		{
+			"duplicate parameter names",
+			func(t *testing.T, m map[string]any) {
+				def := definition(t, m, 0)
+				def["parameters"] = []any{
+					map[string]any{"name": "x", "type": "int"},
+					map[string]any{"name": "x", "type": "string"},
+				}
+				def["definition-id"] = "int,string"
+			},
+			ErrInvalidUDFMetadata, "duplicate parameter name",
+		},
+		{
+			"definition-log entry without definition-versions",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"] = []any{map[string]any{"timestamp-ms": 1, "definition-versions": []any{}}}
+			},
+			ErrInvalidUDFMetadata, "must have definition-versions",
+		},
+		{
+			"missing return-type",
+			func(t *testing.T, m map[string]any) { delete(definition(t, m, 0), "return-type") },
+			ErrInvalidUDFMetadata, "requires a return-type",
+		},
+		{
+			"absent definitions field",
+			func(t *testing.T, m map[string]any) { delete(m, "definitions") },
+			ErrInvalidUDFMetadata, "at least one definition is required",
+		},
+		{
+			"malformed parameter",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["parameters"] = []any{42} },
+			nil, "cannot unmarshal number",
+		},
+		{
+			"malformed representation",
+			func(t *testing.T, m map[string]any) { version(t, m, 0, 0)["representations"] = []any{42} },
+			nil, "cannot unmarshal number",
+		},
+		{
+			"sql representation with non-string dialect",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["representations"] = []any{
+					map[string]any{"type": "sql", "dialect": 5, "sql": "x + 1"},
+				}
+			},
+			nil, "cannot unmarshal number",
+		},
+		{
+			"malformed version",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["versions"] = []any{42} },
+			nil, "cannot unmarshal number",
+		},
+		{
+			"parameter with invalid type",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["parameters"] = []any{map[string]any{"name": "x", "type": "foo"}}
+			},
+			ErrInvalidUDFType, "not a valid Iceberg type string",
+		},
+		{
+			"null definition entry",
+			func(t *testing.T, m map[string]any) { m["definitions"] = []any{nil} },
+			ErrInvalidUDFMetadata, "definitions must not contain null entries",
+		},
+		{
+			// definition-id is required even though a zero-parameter
+			// definition legitimately has the empty string as its id
+			"definition missing definition-id",
+			func(t *testing.T, m map[string]any) {
+				delete(definition(t, m, 0), "definition-id")
+				definition(t, m, 0)["parameters"] = []any{}
+			},
+			ErrInvalidUDFMetadata, "definition is missing definition-id",
+		},
+		{
+			// parameters is required even though a zero-parameter
+			// definition legitimately has an empty list
+			"definition missing parameters",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["definition-id"] = ""
+				delete(definition(t, m, 0), "parameters")
+			},
+			ErrInvalidUDFMetadata, `definition "" is missing parameters`,
+		},
+		{
+			"definition with null parameters",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["definition-id"] = ""
+				definition(t, m, 0)["parameters"] = nil
+			},
+			ErrInvalidUDFMetadata, `definition "" is missing parameters`,
+		},
+		{
+			"definition-log reference missing definition-id",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["definition-versions"] = []any{
+					map[string]any{"version-id": 1},
+				}
+			},
+			ErrInvalidUDFMetadata, "definition-log reference is missing definition-id",
+		},
+		{
+			"malformed definition-log reference",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["definition-versions"] = []any{42}
+			},
+			nil, "cannot unmarshal number",
+		},
+		{
+			"missing definition-log",
+			func(t *testing.T, m map[string]any) { delete(m, "definition-log") },
+			ErrInvalidUDFMetadata, "definition-log is required",
+		},
+		{
+			"null definition-log",
+			func(t *testing.T, m map[string]any) { m["definition-log"] = nil },
+			ErrInvalidUDFMetadata, "definition-log is required",
+		},
+		{
+			"null version entry",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["versions"] = []any{nil} },
+			ErrInvalidUDFMetadata, "versions must not contain null entries",
+		},
+		{
+			"negative version-id",
+			func(t *testing.T, m map[string]any) {
+				version(t, m, 0, 0)["version-id"] = -2
+				definition(t, m, 0)["current-version-id"] = -2
+			},
+			ErrInvalidUDFMetadata, "invalid negative version-id -2",
+		},
+		{
+			"negative current-version-id",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["current-version-id"] = -2 },
+			ErrInvalidUDFMetadata, "invalid negative current-version-id -2",
+		},
+		{
+			"negative version timestamp-ms",
+			func(t *testing.T, m map[string]any) { version(t, m, 0, 0)["timestamp-ms"] = -5 },
+			ErrInvalidUDFMetadata, "invalid negative timestamp-ms -5",
+		},
+		{
+			"definition-log entry missing timestamp-ms",
+			func(t *testing.T, m map[string]any) {
+				delete(m["definition-log"].([]any)[0].(map[string]any), "timestamp-ms")
+			},
+			ErrInvalidUDFMetadata, "definition-log entry is missing timestamp-ms",
+		},
+		{
+			"definition-log entry with negative timestamp-ms",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["timestamp-ms"] = -7
+			},
+			ErrInvalidUDFMetadata, "invalid negative timestamp-ms -7",
+		},
+		{
+			"definition-log reference missing version-id",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["definition-versions"] = []any{
+					map[string]any{"definition-id": "int"},
+				}
+			},
+			ErrInvalidUDFMetadata, `reference to definition "int" missing version-id`,
+		},
+		{
+			"definition-log reference with negative version-id",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["definition-versions"] = []any{
+					map[string]any{"definition-id": "int", "version-id": -3},
+				}
+			},
+			ErrInvalidUDFMetadata, `invalid negative version-id -3 for definition "int"`,
+		},
+		{
+			"definition-log entry with duplicate definition references",
+			func(t *testing.T, m map[string]any) {
+				m["definition-log"].([]any)[0].(map[string]any)["definition-versions"] = []any{
+					map[string]any{"definition-id": "int", "version-id": 1},
+					map[string]any{"definition-id": "int", "version-id": 2},
+				}
+			},
+			ErrInvalidUDFMetadata, `references definition "int" more than once`,
+		},
+		{
+			"invalid return-type",
+			func(t *testing.T, m map[string]any) { definition(t, m, 0)["return-type"] = "foo" },
+			ErrInvalidUDFType, "not a valid Iceberg type string",
+		},
+		{
+			"parameter without type",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["parameters"] = []any{map[string]any{"name": "x"}}
+			},
+			ErrInvalidUDFMetadata, "requires a type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := minimalMetadata(t)
+			tt.mutate(t, m)
+
+			data, err := json.Marshal(m)
+			require.NoError(t, err)
+
+			_, err = ParseMetadataBytes(data)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			}
+			assert.ErrorContains(t, err, tt.contains)
+		})
+	}
+}
+
+// TestParseMetadataWithEmptyDefinitionLog pins the required-field boundary:
+// an absent or null definition-log is rejected, but a present, empty list is
+// structurally accepted — the spec requires the field without stating a
+// non-empty cardinality, and the builder never emits an empty log for built
+// metadata with definitions.
+func TestParseMetadataWithEmptyDefinitionLog(t *testing.T) {
+	m := minimalMetadata(t)
+	m["definition-log"] = []any{}
+
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	meta, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	assert.Empty(t, meta.DefinitionLog())
+}
+
+func TestOnNullInputValues(t *testing.T) {
+	for _, behavior := range []OnNullInput{OnNullInputCall, OnNullInputReturnNull} {
+		m := minimalMetadata(t)
+		version(t, m, 0, 0)["on-null-input"] = string(behavior)
+
+		data, err := json.Marshal(m)
+		require.NoError(t, err)
+
+		meta, err := ParseMetadataBytes(data)
+		require.NoError(t, err)
+		def, _ := meta.DefinitionByID("int")
+		assert.Equal(t, behavior, def.CurrentVersion().NullInputBehavior())
+	}
+}

--- a/udf/metadata_test.go
+++ b/udf/metadata_test.go
@@ -233,7 +233,22 @@ func TestMetadataEquals(t *testing.T) {
 	assert.True(t, meta.Equals(meta))
 	assert.True(t, meta.Equals(other))
 	assert.False(t, meta.Equals(nil))
+	assert.False(t, meta.Equals((*metadata)(nil)), "a typed-nil Metadata must not panic")
 	assert.False(t, meta.Equals(parseFixture(t, "udf-metadata-table.json")))
+}
+
+// TestScalarMayReturnEmptyStruct pins that the udtf non-empty-struct rule is
+// scoped to table functions: a scalar function may still declare an empty
+// struct return type.
+func TestScalarMayReturnEmptyStruct(t *testing.T) {
+	m := minimalMetadata(t)
+	definition(t, m, 0)["return-type"] = map[string]any{"type": "struct", "fields": []any{}}
+
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	_, err = ParseMetadataBytes(data)
+	require.NoError(t, err)
 }
 
 type failingReader struct{}
@@ -449,6 +464,27 @@ func TestMetadataValidation(t *testing.T) {
 			"udtf with non-struct return type",
 			func(t *testing.T, m map[string]any) { definition(t, m, 0)["function-type"] = "udtf" },
 			ErrInvalidUDFMetadata, "return-type is not a struct",
+		},
+		{
+			"udtf with empty struct return type",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["function-type"] = "udtf"
+				definition(t, m, 0)["return-type"] = map[string]any{"type": "struct", "fields": []any{}}
+			},
+			ErrInvalidUDFMetadata, "return-type struct has no fields",
+		},
+		{
+			"parameter struct with duplicate field names",
+			func(t *testing.T, m map[string]any) {
+				definition(t, m, 0)["parameters"] = []any{map[string]any{
+					"name": "x",
+					"type": map[string]any{"type": "struct", "fields": []any{
+						map[string]any{"name": "a", "type": "int"},
+						map[string]any{"name": "a", "type": "string"},
+					}},
+				}}
+			},
+			ErrInvalidUDFType, `duplicate field name "a"`,
 		},
 		{
 			"missing function-type",

--- a/udf/testdata/udf-metadata-scalar.json
+++ b/udf/testdata/udf-metadata-scalar.json
@@ -1,0 +1,83 @@
+{
+  "function-uuid": "42fd3f91-bc10-41c1-8a52-92b57dd0a9b2",
+  "format-version": 1,
+  "definitions": [
+    {
+      "definition-id": "int",
+      "parameters": [
+        {
+          "name": "x", "type": "int", "doc": "Input integer"
+        }
+      ],
+      "return-type": "int",
+      "function-type": "udf",
+      "doc": "Add one to the input integer",
+      "versions": [
+        {
+          "version-id": 1,
+          "deterministic": true,
+          "representations": [
+            { "type": "sql", "dialect": "trino", "sql": "x + 2" }
+          ],
+          "timestamp-ms": 1734507000123
+        },
+        {
+          "version-id": 2,
+          "deterministic": true,
+          "representations": [
+            { "type": "sql", "dialect": "trino", "sql": "x + 1" },
+            { "type": "sql", "dialect": "spark", "sql": "x + 1" }
+          ],
+          "timestamp-ms": 1735507000124
+        }
+      ],
+      "current-version-id": 2
+    },
+    {
+      "definition-id": "float",
+      "parameters": [
+        {
+          "name": "x", "type": "float", "doc": "Input float"
+        }
+      ],
+      "return-type": "float",
+      "function-type": "udf",
+      "doc": "Add one to the input float",
+      "versions": [
+        {
+          "version-id": 1,
+          "deterministic": true,
+          "representations": [
+            { "type": "sql", "dialect": "trino", "sql": "x + 1.0" }
+          ],
+          "timestamp-ms": 1734507001123
+        }
+      ],
+      "current-version-id": 1
+    }
+  ],
+  "definition-log": [
+    {
+      "timestamp-ms": 1734507000123,
+      "definition-versions": [
+        { "definition-id": "int", "version-id": 1 }
+      ]
+    },
+    {
+      "timestamp-ms": 1734507001123,
+      "definition-versions": [
+        { "definition-id": "int", "version-id": 1 },
+        { "definition-id": "float", "version-id": 1 }
+      ]
+    },
+    {
+      "timestamp-ms": 1735507000124,
+      "definition-versions": [
+        { "definition-id": "int", "version-id": 2 },
+        { "definition-id": "float", "version-id": 1 }
+      ]
+    }
+  ],
+  "doc": "Overloaded scalar UDF for integer and float inputs",
+  "secure": false
+}

--- a/udf/testdata/udf-metadata-table.json
+++ b/udf/testdata/udf-metadata-table.json
@@ -1,0 +1,45 @@
+{
+  "function-uuid": "8a7fa39a-6d8f-4a2f-9d8d-3f3a8f3c2a10",
+  "format-version": 1,
+  "definitions": [
+    {
+      "definition-id": "string",
+      "parameters": [
+        {
+          "name": "c", "type": "string", "doc": "Color of fruits"
+        }
+      ],
+      "return-type": {
+        "type": "struct",
+        "fields": [
+          { "name": "name", "type": "string" },
+          { "name": "color", "type": "string" }
+        ]
+      },
+      "function-type": "udtf",
+      "doc": "Return fruits of a specific color from the fruits table",
+      "versions": [
+        {
+          "version-id": 1,
+          "deterministic": true,
+          "representations": [
+            { "type": "sql", "dialect": "trino", "sql": "SELECT name, color FROM fruits WHERE color = c" },
+            { "type": "sql", "dialect": "spark", "sql": "SELECT name, color FROM fruits WHERE color = c" }
+          ],
+          "timestamp-ms": 1734508000123
+        }
+      ],
+      "current-version-id": 1
+    }
+  ],
+  "definition-log": [
+    {
+      "timestamp-ms": 1734508000123,
+      "definition-versions": [
+        { "definition-id": "string", "version-id": 1 }
+      ]
+    }
+  ],
+  "doc": "UDTF returning (name, color) rows filtered by the given color",
+  "secure": false
+}

--- a/udf/types.go
+++ b/udf/types.go
@@ -1,0 +1,360 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/apache/iceberg-go"
+)
+
+// ErrInvalidUDFType is returned when a UDF parameter or return type
+// does not conform to the UDF spec's Types section.
+var ErrInvalidUDFType = errors.New("invalid UDF type")
+
+// Type represents a UDF parameter or return type as defined by the UDF
+// spec. UDF types are Iceberg types without field IDs: primitives are
+// encoded as plain strings (e.g. "int", "decimal(9,2)") and nested types
+// (list, map, struct) as JSON objects carrying only the fields the UDF
+// spec requires.
+//
+// String returns the canonical string representation used to build
+// definition IDs (see CanonicalDefinitionID).
+type Type interface {
+	fmt.Stringer
+
+	Equals(Type) bool
+
+	// canonicalTo writes the canonical string form, sealing the
+	// interface to the implementations in this package.
+	canonicalTo(sb *strings.Builder)
+}
+
+// PrimitiveType is a primitive or semi-structured UDF type, stored as the
+// verbatim type string (e.g. "int", "decimal(9,2)", "variant"). Values are
+// always validated: construct them with PrimitiveTypeOf.
+type PrimitiveType struct {
+	name string
+}
+
+// PrimitiveTypeOf validates s against the Iceberg type system and the UDF
+// spec's rules for type strings (no spaces or quote characters) and returns
+// the corresponding PrimitiveType.
+func PrimitiveTypeOf(s string) (PrimitiveType, error) {
+	if s == "" {
+		return PrimitiveType{}, fmt.Errorf("%w: type string must not be empty", ErrInvalidUDFType)
+	}
+
+	if strings.ContainsFunc(s, unicode.IsSpace) || strings.ContainsAny(s, `"'`) {
+		return PrimitiveType{}, fmt.Errorf("%w: type string %q must not contain spaces or quote characters",
+			ErrInvalidUDFType, s)
+	}
+
+	// Validate through the iceberg type parser so the accepted set of
+	// primitive type strings always matches the rest of the module.
+	// NestedField is the exported entry point to that parser.
+	payload, err := json.Marshal(map[string]any{"id": 1, "name": "f", "required": false, "type": s})
+	if err != nil {
+		return PrimitiveType{}, err
+	}
+	var field iceberg.NestedField
+	if err := json.Unmarshal(payload, &field); err != nil {
+		return PrimitiveType{}, fmt.Errorf("%w: %q is not a valid Iceberg type string: %w", ErrInvalidUDFType, s, err)
+	}
+
+	return PrimitiveType{name: s}, nil
+}
+
+func (p PrimitiveType) String() string { return p.name }
+
+func (p PrimitiveType) Equals(other Type) bool {
+	o, ok := other.(PrimitiveType)
+
+	return ok && p.name == o.name
+}
+
+func (p PrimitiveType) canonicalTo(sb *strings.Builder) { sb.WriteString(p.name) }
+
+func (p PrimitiveType) MarshalJSON() ([]byte, error) { return json.Marshal(p.name) }
+
+// ListType is a UDF list type carrying only its element type.
+type ListType struct {
+	Element Type
+}
+
+func (l ListType) String() string { return canonicalString(l) }
+
+func (l ListType) Equals(other Type) bool {
+	o, ok := other.(ListType)
+
+	return ok && l.Element.Equals(o.Element)
+}
+
+func (l ListType) canonicalTo(sb *strings.Builder) {
+	sb.WriteString("list<")
+	l.Element.canonicalTo(sb)
+	sb.WriteString(">")
+}
+
+func (l ListType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    string `json:"type"`
+		Element Type   `json:"element"`
+	}{Type: "list", Element: l.Element})
+}
+
+// MapType is a UDF map type carrying only its key and value types.
+type MapType struct {
+	Key   Type
+	Value Type
+}
+
+func (m MapType) String() string { return canonicalString(m) }
+
+func (m MapType) Equals(other Type) bool {
+	o, ok := other.(MapType)
+
+	return ok && m.Key.Equals(o.Key) && m.Value.Equals(o.Value)
+}
+
+func (m MapType) canonicalTo(sb *strings.Builder) {
+	sb.WriteString("map<")
+	m.Key.canonicalTo(sb)
+	sb.WriteString(",")
+	m.Value.canonicalTo(sb)
+	sb.WriteString(">")
+}
+
+func (m MapType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  string `json:"type"`
+		Key   Type   `json:"key"`
+		Value Type   `json:"value"`
+	}{Type: "map", Key: m.Key, Value: m.Value})
+}
+
+// StructField is a single field of a UDF struct type, carrying only a name
+// and a type.
+type StructField struct {
+	Name string
+	Type Type
+}
+
+// StructType is a UDF struct type carrying only its fields.
+type StructType struct {
+	Fields []StructField
+}
+
+func (s StructType) String() string { return canonicalString(s) }
+
+func (s StructType) Equals(other Type) bool {
+	o, ok := other.(StructType)
+	if !ok || len(s.Fields) != len(o.Fields) {
+		return false
+	}
+	for i, f := range s.Fields {
+		if f.Name != o.Fields[i].Name || !f.Type.Equals(o.Fields[i].Type) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s StructType) canonicalTo(sb *strings.Builder) {
+	sb.WriteString("struct<")
+	for i, f := range s.Fields {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(f.Name)
+		sb.WriteString(":")
+		f.Type.canonicalTo(sb)
+	}
+	sb.WriteString(">")
+}
+
+func (s StructType) MarshalJSON() ([]byte, error) {
+	fields := make([]struct {
+		Name string `json:"name"`
+		Type Type   `json:"type"`
+	}, len(s.Fields))
+	for i, f := range s.Fields {
+		fields[i].Name, fields[i].Type = f.Name, f.Type
+	}
+
+	return json.Marshal(struct {
+		Type   string `json:"type"`
+		Fields any    `json:"fields"`
+	}{Type: "struct", Fields: fields})
+}
+
+func canonicalString(t Type) string {
+	var sb strings.Builder
+	t.canonicalTo(&sb)
+
+	return sb.String()
+}
+
+// validateType checks that t and all nested types are fully specified.
+// PrimitiveType values are valid by construction; composite types built as
+// literals may carry nil children, which this rejects.
+func validateType(t Type) error {
+	switch v := t.(type) {
+	case nil:
+		return fmt.Errorf("%w: type must not be nil", ErrInvalidUDFType)
+	case PrimitiveType:
+		if v.name == "" {
+			return fmt.Errorf("%w: uninitialized primitive type; use PrimitiveTypeOf", ErrInvalidUDFType)
+		}
+
+		return nil
+	case ListType:
+		return validateType(v.Element)
+	case MapType:
+		if err := validateType(v.Key); err != nil {
+			return err
+		}
+
+		return validateType(v.Value)
+	case StructType:
+		for _, f := range v.Fields {
+			if f.Name == "" {
+				return fmt.Errorf("%w: struct field name must not be empty", ErrInvalidUDFType)
+			}
+			if err := validateType(f.Type); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported type %T", ErrInvalidUDFType, t)
+	}
+}
+
+// unmarshalType parses a UDF type from its JSON form: either a primitive
+// type string or an object for list, map, and struct types. Fields beyond
+// the ones the UDF spec requires are ignored.
+func unmarshalType(b []byte) (Type, error) {
+	var name string
+	if err := json.Unmarshal(b, &name); err == nil {
+		return PrimitiveTypeOf(name)
+	}
+
+	aux := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return nil, fmt.Errorf("%w: type must be a string or an object: %w", ErrInvalidUDFType, err)
+	}
+
+	switch aux.Type {
+	case "list":
+		lst := struct {
+			Element json.RawMessage `json:"element"`
+		}{}
+		if err := json.Unmarshal(b, &lst); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidUDFType, err)
+		}
+		if len(lst.Element) == 0 {
+			return nil, fmt.Errorf("%w: list type requires an element type", ErrInvalidUDFType)
+		}
+		elem, err := unmarshalType(lst.Element)
+		if err != nil {
+			return nil, err
+		}
+
+		return ListType{Element: elem}, nil
+	case "map":
+		mp := struct {
+			Key   json.RawMessage `json:"key"`
+			Value json.RawMessage `json:"value"`
+		}{}
+		if err := json.Unmarshal(b, &mp); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidUDFType, err)
+		}
+		if len(mp.Key) == 0 || len(mp.Value) == 0 {
+			return nil, fmt.Errorf("%w: map type requires key and value types", ErrInvalidUDFType)
+		}
+		key, err := unmarshalType(mp.Key)
+		if err != nil {
+			return nil, err
+		}
+		value, err := unmarshalType(mp.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return MapType{Key: key, Value: value}, nil
+	case "struct":
+		st := struct {
+			Fields []struct {
+				Name string          `json:"name"`
+				Type json.RawMessage `json:"type"`
+			} `json:"fields"`
+		}{}
+		if err := json.Unmarshal(b, &st); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidUDFType, err)
+		}
+		if st.Fields == nil {
+			return nil, fmt.Errorf("%w: struct type requires fields", ErrInvalidUDFType)
+		}
+		fields := make([]StructField, len(st.Fields))
+		for i, f := range st.Fields {
+			if f.Name == "" {
+				return nil, fmt.Errorf("%w: struct field requires a name", ErrInvalidUDFType)
+			}
+			if len(f.Type) == 0 {
+				return nil, fmt.Errorf("%w: struct field %q requires a type", ErrInvalidUDFType, f.Name)
+			}
+			typ, err := unmarshalType(f.Type)
+			if err != nil {
+				return nil, err
+			}
+			fields[i] = StructField{Name: f.Name, Type: typ}
+		}
+
+		return StructType{Fields: fields}, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported type object %q", ErrInvalidUDFType, aux.Type)
+	}
+}
+
+// CanonicalDefinitionID derives the definition-id for a parameter list: the
+// canonical string forms of the parameter types joined by commas with no
+// spaces, e.g. "int,list<int>,struct<id:int,name:string>". A definition
+// with no parameters has the empty string as its definition-id.
+func CanonicalDefinitionID(params []Parameter) (string, error) {
+	var sb strings.Builder
+	for i, p := range params {
+		if err := validateType(p.Type); err != nil {
+			return "", err
+		}
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		p.Type.canonicalTo(&sb)
+	}
+
+	return sb.String(), nil
+}

--- a/udf/types.go
+++ b/udf/types.go
@@ -237,10 +237,15 @@ func validateType(t Type) error {
 
 		return validateType(v.Value)
 	case StructType:
+		seen := make(map[string]bool)
 		for _, f := range v.Fields {
 			if f.Name == "" {
 				return fmt.Errorf("%w: struct field name must not be empty", ErrInvalidUDFType)
 			}
+			if seen[f.Name] {
+				return fmt.Errorf("%w: struct has duplicate field name %q", ErrInvalidUDFType, f.Name)
+			}
+			seen[f.Name] = true
 			if err := validateType(f.Type); err != nil {
 				return err
 			}

--- a/udf/types_test.go
+++ b/udf/types_test.go
@@ -1,0 +1,255 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustPrimitive(t *testing.T, s string) PrimitiveType {
+	t.Helper()
+	p, err := PrimitiveTypeOf(s)
+	require.NoError(t, err)
+
+	return p
+}
+
+func TestPrimitiveTypeOf(t *testing.T) {
+	valid := []string{
+		"boolean", "int", "long", "float", "double", "date", "time",
+		"timestamp", "timestamptz", "string", "uuid", "binary",
+		"decimal(9,2)", "fixed[16]", "variant", "unknown", "geometry",
+	}
+	for _, s := range valid {
+		p, err := PrimitiveTypeOf(s)
+		require.NoError(t, err, s)
+		assert.Equal(t, s, p.String())
+	}
+
+	invalid := []string{
+		"",
+		"decimal(9, 2)", // spaces are not allowed in type strings
+		"int ",
+		" int",
+		"va\"riant",
+		"va'riant",
+		"foo",
+		"struct", // nested types must be JSON objects
+		"list",
+		"map",
+		// canonical definition-id forms are not valid type strings either
+		"list<int>",
+		"map<string,int>",
+		"struct<id:int>",
+	}
+	for _, s := range invalid {
+		_, err := PrimitiveTypeOf(s)
+		assert.ErrorIs(t, err, ErrInvalidUDFType, s)
+	}
+}
+
+func TestTypeCanonicalStrings(t *testing.T) {
+	intType := mustPrimitive(t, "int")
+	stringType := mustPrimitive(t, "string")
+
+	tests := []struct {
+		typ      Type
+		expected string
+	}{
+		{intType, "int"},
+		{mustPrimitive(t, "decimal(9,2)"), "decimal(9,2)"},
+		{ListType{Element: intType}, "list<int>"},
+		{MapType{Key: stringType, Value: intType}, "map<string,int>"},
+		{StructType{Fields: []StructField{
+			{Name: "id", Type: intType},
+			{Name: "name", Type: stringType},
+		}}, "struct<id:int,name:string>"},
+		{ListType{Element: StructType{Fields: []StructField{{Name: "id", Type: intType}}}}, "list<struct<id:int>>"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.typ.String())
+	}
+}
+
+func TestCanonicalDefinitionID(t *testing.T) {
+	intType := mustPrimitive(t, "int")
+	stringType := mustPrimitive(t, "string")
+
+	id, err := CanonicalDefinitionID(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", id)
+
+	id, err = CanonicalDefinitionID([]Parameter{{Name: "x", Type: intType}})
+	require.NoError(t, err)
+	assert.Equal(t, "int", id)
+
+	id, err = CanonicalDefinitionID([]Parameter{{Name: "x", Type: intType}, {Name: "y", Type: stringType}})
+	require.NoError(t, err)
+	assert.Equal(t, "int,string", id)
+
+	// example from the UDF spec's Definition ID section
+	id, err = CanonicalDefinitionID([]Parameter{
+		{Name: "a", Type: intType},
+		{Name: "b", Type: ListType{Element: intType}},
+		{Name: "c", Type: StructType{Fields: []StructField{
+			{Name: "id", Type: intType},
+			{Name: "name", Type: stringType},
+		}}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "int,list<int>,struct<id:int,name:string>", id)
+
+	_, err = CanonicalDefinitionID([]Parameter{{Name: "x", Type: nil}})
+	assert.ErrorIs(t, err, ErrInvalidUDFType)
+
+	_, err = CanonicalDefinitionID([]Parameter{{Name: "x", Type: ListType{}}})
+	assert.ErrorIs(t, err, ErrInvalidUDFType)
+}
+
+func TestTypeEquals(t *testing.T) {
+	intType := mustPrimitive(t, "int")
+	stringType := mustPrimitive(t, "string")
+
+	assert.True(t, intType.Equals(mustPrimitive(t, "int")))
+	assert.False(t, intType.Equals(stringType))
+	assert.True(t, ListType{Element: intType}.Equals(ListType{Element: intType}))
+	assert.False(t, ListType{Element: intType}.Equals(ListType{Element: stringType}))
+	assert.False(t, ListType{Element: intType}.Equals(intType))
+	assert.True(t, MapType{Key: stringType, Value: intType}.Equals(MapType{Key: stringType, Value: intType}))
+	assert.False(t, MapType{Key: stringType, Value: intType}.Equals(MapType{Key: stringType, Value: stringType}))
+
+	s1 := StructType{Fields: []StructField{{Name: "id", Type: intType}}}
+	s2 := StructType{Fields: []StructField{{Name: "id", Type: intType}}}
+	s3 := StructType{Fields: []StructField{{Name: "other", Type: intType}}}
+	assert.True(t, s1.Equals(s2))
+	assert.False(t, s1.Equals(s3))
+	assert.False(t, s1.Equals(StructType{}))
+}
+
+func TestUnmarshalTypeJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{"primitive", `"int"`, "int"},
+		{"decimal", `"decimal(9,2)"`, "decimal(9,2)"},
+		{"list", `{"type": "list", "element": "string"}`, "list<string>"},
+		{"map", `{"type": "map", "key": "string", "value": "int"}`, "map<string,int>"},
+		{
+			"struct",
+			`{"type": "struct", "fields": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]}`,
+			"struct<id:int,name:string>",
+		},
+		{
+			"nested",
+			`{"type": "map", "key": "string", "value": {"type": "list", "element": {"type": "struct", "fields": [{"name": "id", "type": "int"}]}}}`,
+			"map<string,list<struct<id:int>>>",
+		},
+		{
+			// fields beyond the ones the UDF spec requires must be ignored
+			"extra fields ignored",
+			`{"type": "list", "element-id": 3, "element-required": true, "element": "string"}`,
+			"list<string>",
+		},
+		{
+			"extra struct field attrs ignored",
+			`{"type": "struct", "fields": [{"name": "id", "type": "int", "id": 1, "required": true, "doc": "x"}]}`,
+			"struct<id:int>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typ, err := unmarshalType([]byte(tt.json))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, typ.String())
+
+			// round-trip: marshal and re-parse to the same type
+			data, err := json.Marshal(typ)
+			require.NoError(t, err)
+			again, err := unmarshalType(data)
+			require.NoError(t, err)
+			assert.True(t, typ.Equals(again))
+		})
+	}
+}
+
+func TestUnmarshalTypeErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"invalid primitive", `"foo"`},
+		{"primitive with space", `"decimal(9, 2)"`},
+		{"unsupported object", `{"type": "unknown-thing"}`},
+		{"object without type", `{"element": "string"}`},
+		{"list without element", `{"type": "list"}`},
+		{"map without key", `{"type": "map", "value": "int"}`},
+		{"map without value", `{"type": "map", "key": "string"}`},
+		{"struct without fields", `{"type": "struct"}`},
+		{"struct field without name", `{"type": "struct", "fields": [{"type": "int"}]}`},
+		{"struct field without type", `{"type": "struct", "fields": [{"name": "id"}]}`},
+		{"not a string or object", `5`},
+		{"non-string type discriminator", `{"type": 5}`},
+		{"list with invalid element", `{"type": "list", "element": "foo"}`},
+		{"map with invalid key", `{"type": "map", "key": "foo", "value": "int"}`},
+		{"map with invalid value", `{"type": "map", "key": "string", "value": "foo"}`},
+		{"struct field with invalid type", `{"type": "struct", "fields": [{"name": "id", "type": "foo"}]}`},
+		{"struct with malformed fields", `{"type": "struct", "fields": 5}`},
+		{"nested list string", `"list<int>"`},
+		{"nested map string", `"map<string,int>"`},
+		{"nested struct string", `"struct<id:int>"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := unmarshalType([]byte(tt.json))
+			assert.ErrorIs(t, err, ErrInvalidUDFType)
+		})
+	}
+}
+
+// sealedFakeType exercises validateType's guard against Type implementations
+// beyond the ones this package defines.
+type sealedFakeType struct{}
+
+func (sealedFakeType) String() string                  { return "fake" }
+func (sealedFakeType) Equals(Type) bool                { return false }
+func (sealedFakeType) canonicalTo(sb *strings.Builder) {}
+
+func TestValidateType(t *testing.T) {
+	intType := mustPrimitive(t, "int")
+
+	require.NoError(t, validateType(intType))
+	require.NoError(t, validateType(StructType{}))
+
+	assert.ErrorIs(t, validateType(nil), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(PrimitiveType{}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(ListType{}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(MapType{Key: intType}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(MapType{Value: intType}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(StructType{Fields: []StructField{{Name: "", Type: intType}}}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(StructType{Fields: []StructField{{Name: "id", Type: nil}}}), ErrInvalidUDFType)
+	assert.ErrorIs(t, validateType(sealedFakeType{}), ErrInvalidUDFType)
+}

--- a/udf/types_test.go
+++ b/udf/types_test.go
@@ -252,4 +252,12 @@ func TestValidateType(t *testing.T) {
 	assert.ErrorIs(t, validateType(StructType{Fields: []StructField{{Name: "", Type: intType}}}), ErrInvalidUDFType)
 	assert.ErrorIs(t, validateType(StructType{Fields: []StructField{{Name: "id", Type: nil}}}), ErrInvalidUDFType)
 	assert.ErrorIs(t, validateType(sealedFakeType{}), ErrInvalidUDFType)
+
+	duplicated := StructType{Fields: []StructField{
+		{Name: "a", Type: intType},
+		{Name: "a", Type: mustPrimitive(t, "string")},
+	}}
+	err := validateType(duplicated)
+	require.ErrorIs(t, err, ErrInvalidUDFType)
+	assert.ErrorContains(t, err, `duplicate field name "a"`)
 }


### PR DESCRIPTION
## Description

Addressing part 1 from https://github.com/apache/iceberg-go/issues/1360.

This adds a new `udf` package for Apache Iceberg SQL UDF metadata. The package models the UDF metadata JSON format from the Iceberg UDF spec: function UUID, format version, definitions, definition versions, `definition-log`, properties, secure flag, documentation, scalar UDFs and table UDFs. It includes parsing, JSON serialization, validation, semantic equality, cloning and a metadata builder for writers.

Definitions are keyed by the canonical `definition-id` derived from parameter types, including nested list/map/struct signatures such as `int,list<int>,struct<id:int,name:string>`. UDF types are represented separately from schema types because UDF nested type JSON does not require field IDs, while iceberg-go schema parsing expects them. The parser accepts primitive type strings and the spec's nested type JSON objects, ignores extra nested-type fields as required by the spec and rejects nested canonical strings as metadata type encodings.

The implementation validates the important spec invariants: required metadata fields, supported format version, one definition per signature, unique optional `specific-name`, valid function type, UDTF return type as a struct, non-empty definition versions, current version references, required `definition-log`, required representation fields, one SQL representation per dialect, supported `on-null-input` values and invalid nil/null or negative ID/timestamp cases. Unknown representation types are preserved for forward-compatible round-tripping when read from metadata, while writer-created unknown representations without raw JSON are rejected.

This PR is intentionally limited to the metadata model. REST read-side support remains the next step from #1360.

## Tests

- `go test ./udf`
- `go test -race ./udf`
- `go test ./...`
- `go vet ./udf`
