### PR TITLE
fix(table): merge deletion vectors on repeated merge-on-read deletes

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1851,16 +1851,20 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 
 		// Seed the writer with any deletion vector the referenced data file
 		// already carries so its previously deleted positions survive into the
-		// merged DV. The read path that produced args.itr already applied these
-		// existing deletes, so the incoming batches hold only the new positions;
-		// without the seed the replacement DV would silently resurrect rows. The
-		// spec allows at most one DV per data file, so the caller supersedes the
-		// old DV once this merged one is written.
+		// merged DV. The scan that produced args.itr does NOT apply the existing
+		// DVs (makePositionDeleteRecordsForFilter builds its FileScanTasks
+		// without DeleteFiles), so the incoming batches may re-report positions
+		// already in the old DV; re-Setting them on top of the seed is a no-op
+		// because the bitmap is idempotent. The seed is what guarantees the old
+		// positions survive — do not remove it, or a second delete would drop
+		// the earlier deletes and resurrect those rows. The spec allows at most
+		// one DV per data file, so the caller supersedes the old DV once this
+		// merged one is written.
 		hasEntries := false
 		for filePath, bitmap := range args.existingDVs {
 			pCtx, ok := partitionContextByFilePath[filePath]
 			if !ok {
-				yield(nil, fmt.Errorf("unexpected missing partition context for path %s", filePath))
+				yield(nil, fmt.Errorf("unexpected missing partition context for existing deletion vector path %s", filePath))
 
 				return
 			}

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1633,6 +1633,11 @@ type recordWritingArgs struct {
 	maxWriteWorkers int
 	clustered       bool
 	factoryOpts     []writerFactoryOption
+	// existingDVs maps a data file path to the positions already recorded in
+	// its current deletion vector. On the v3 DV write path these are folded
+	// into the newly written DV so a data file that already had a DV ends up
+	// with a single merged vector (the caller removes the superseded one).
+	existingDVs map[string]*dv.RoaringPositionBitmap
 }
 
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {
@@ -1844,7 +1849,25 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 			return metadata.PartitionSpecByID(int(id))
 		})
 
+		// Seed the writer with any deletion vector the referenced data file
+		// already carries so its previously deleted positions survive into the
+		// merged DV. The read path that produced args.itr already applied these
+		// existing deletes, so the incoming batches hold only the new positions;
+		// without the seed the replacement DV would silently resurrect rows. The
+		// spec allows at most one DV per data file, so the caller supersedes the
+		// old DV once this merged one is written.
 		hasEntries := false
+		for filePath, bitmap := range args.existingDVs {
+			pCtx, ok := partitionContextByFilePath[filePath]
+			if !ok {
+				yield(nil, fmt.Errorf("unexpected missing partition context for path %s", filePath))
+
+				return
+			}
+			writer.Load(filePath, bitmap, pCtx.specID, pCtx.partitionData)
+			hasEntries = true
+		}
+
 		for batch, err := range args.itr {
 			if err != nil {
 				yield(nil, err)

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -128,12 +128,20 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 // file so subsequent Add calls merge new positions into it. The spec permits
 // at most one DV per data file per snapshot, so when a data file that already
 // has a DV receives more deletes the old positions must be carried into the
-// replacement DV (and the old DV superseded) rather than dropped. Load must be
-// called before any Add for the same path; specID and partitionData are
-// captured exactly as Add's first call would, and the supplied bitmap is
-// unioned into the entry. A nil bitmap simply registers the entry so it is
-// re-emitted. Callers retain ownership of the passed bitmap; only its set
-// positions are copied.
+// replacement DV (and the old DV superseded) rather than dropped.
+//
+// Load is intended to be called before any Add for the same path: on the first
+// call for a path it captures specID and partitionData exactly as Add would and
+// unions the supplied bitmap into a fresh entry. If an entry already exists
+// (because Add or Load ran first for this path), Load only unions the bitmap in
+// and the earlier specID/partitionData are kept — the later values are ignored,
+// mirroring Add's first-write-wins behavior. Callers must not pass conflicting
+// partition values across calls for the same path.
+//
+// bitmap must be non-nil; its set positions are copied and the caller retains
+// ownership. (A nil bitmap would register a cardinality-0 entry, which is never
+// useful — collectExistingDVs always supplies a non-nil bitmap read from the
+// existing DV.)
 func (w *DVWriter) Load(dataFilePath string, bitmap *RoaringPositionBitmap, specID int32, partitionData map[int]any) {
 	entry, ok := w.entries[dataFilePath]
 	if !ok {

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -124,6 +124,31 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 	return nil
 }
 
+// Load seeds the writer with an already-written deletion vector for a data
+// file so subsequent Add calls merge new positions into it. The spec permits
+// at most one DV per data file per snapshot, so when a data file that already
+// has a DV receives more deletes the old positions must be carried into the
+// replacement DV (and the old DV superseded) rather than dropped. Load must be
+// called before any Add for the same path; specID and partitionData are
+// captured exactly as Add's first call would, and the supplied bitmap is
+// unioned into the entry. A nil bitmap simply registers the entry so it is
+// re-emitted. Callers retain ownership of the passed bitmap; only its set
+// positions are copied.
+func (w *DVWriter) Load(dataFilePath string, bitmap *RoaringPositionBitmap, specID int32, partitionData map[int]any) {
+	entry, ok := w.entries[dataFilePath]
+	if !ok {
+		entry = &dvEntry{
+			bitmap:        NewRoaringPositionBitmap(),
+			specID:        specID,
+			partitionData: maps.Clone(partitionData),
+		}
+		w.entries[dataFilePath] = entry
+		w.order = append(w.order, dataFilePath)
+	}
+
+	entry.bitmap.Or(bitmap)
+}
+
 // Flush writes one Puffin file containing one blob per data file, and returns
 // manifest entries ready for RowDelta.AddDeletes(). Each output DataFile
 // carries the partition spec and partition record of the data file it

--- a/table/dv/roaring_bitmap.go
+++ b/table/dv/roaring_bitmap.go
@@ -64,6 +64,25 @@ func (b *RoaringPositionBitmap) Set(pos uint64) {
 	bm.Add(low)
 }
 
+// Or merges every position set in other into b. Buckets present only in
+// other are cloned so the two bitmaps stay independent after the merge;
+// shared buckets are unioned in place. A nil other is a no-op. Used to fold a
+// previously written deletion vector into a new one when a data file that
+// already has a DV receives more deletes.
+func (b *RoaringPositionBitmap) Or(other *RoaringPositionBitmap) {
+	if other == nil {
+		return
+	}
+	for key, obm := range other.bitmaps {
+		if bm, ok := b.bitmaps[key]; ok {
+			bm.Or(obm)
+
+			continue
+		}
+		b.bitmaps[key] = obm.Clone()
+	}
+}
+
 // Contains checks if a position is set.
 func (b *RoaringPositionBitmap) Contains(pos uint64) bool {
 	key := uint32(pos >> 32)

--- a/table/mor_delete_pruning_test.go
+++ b/table/mor_delete_pruning_test.go
@@ -75,6 +75,14 @@ func TestMergeOnReadDeleteAcrossPrunedRowGroups(t *testing.T) {
 func newMergeOnReadTestTable(t *testing.T) *table.Table {
 	t.Helper()
 
+	return newMergeOnReadTestTableVersion(t, "2")
+}
+
+// newMergeOnReadTestTableVersion builds a merge-on-read table at the given
+// format version, capping row groups at 5 rows so a 10-row append spans two.
+func newMergeOnReadTestTableVersion(t *testing.T, formatVersion string) *table.Table {
+	t.Helper()
+
 	location := filepath.ToSlash(t.TempDir())
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
@@ -82,7 +90,7 @@ func newMergeOnReadTestTable(t *testing.T) *table.Table {
 	)
 	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, location,
 		iceberg.Properties{
-			table.PropertyFormatVersion:   "2",
+			table.PropertyFormatVersion:   formatVersion,
 			table.WriteDeleteModeKey:      table.WriteModeMergeOnRead,
 			table.ParquetRowGroupLimitKey: "5",
 		})
@@ -93,6 +101,79 @@ func newMergeOnReadTestTable(t *testing.T) *table.Table {
 	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
 
 	return table.New(table.Identifier{"db", "mor_delete_test"}, meta, metaLoc, fsF, cat)
+}
+
+// TestV3MergeOnReadDoubleDeleteMergesDeletionVector guards against a second
+// merge-on-read DELETE on a data file that already has a deletion vector
+// writing a second live DV. The spec permits at most one DV per data file, so
+// the new deletes must merge into the existing DV (which is then superseded),
+// not accumulate as a parallel one. A second live DV corrupts the table:
+// buildDVIndex rejects it at scan time with "can't index multiple deletion
+// vectors". See issue #1372.
+func TestV3MergeOnReadDoubleDeleteMergesDeletionVector(t *testing.T) {
+	ctx := context.Background()
+	tbl := newMergeOnReadTestTableVersion(t, "3")
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	// First delete writes DV #1 against the single data file.
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(2)), nil)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 3, 4, 5}, idsInTable(t, tbl))
+	require.Equal(t, 1, liveDVCount(t, tbl), "first delete must write exactly one DV")
+
+	// Second delete on the same data file must merge into DV #1, not add a
+	// second live DV.
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(4)), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, liveDVCount(t, tbl),
+		"the two deletes must collapse into a single merged deletion vector")
+	assert.Equal(t, []int64{1, 3, 5}, idsInTable(t, tbl),
+		"both id=2 and id=4 must be deleted and no previously deleted row may resurrect")
+}
+
+// liveDVCount returns the number of live deletion-vector entries in the table's
+// current snapshot.
+func liveDVCount(t *testing.T, tbl *table.Table) int {
+	t.Helper()
+
+	fs, err := tbl.FS(context.Background())
+	require.NoError(t, err)
+
+	snapshot := tbl.CurrentSnapshot()
+	require.NotNil(t, snapshot)
+	manifests, err := snapshot.Manifests(fs)
+	require.NoError(t, err)
+
+	count := 0
+	for _, m := range manifests {
+		for entry, err := range m.Entries(fs, false) {
+			require.NoError(t, err)
+			if entry.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			df := entry.DataFile()
+			if df.FileFormat() == iceberg.PuffinFile &&
+				df.ContentType() == iceberg.EntryContentPosDeletes &&
+				df.ReferencedDataFile() != nil {
+				count++
+			}
+		}
+	}
+
+	return count
 }
 
 // idsInTable scans the table and returns the surviving id values, sorted.

--- a/table/mor_delete_pruning_test.go
+++ b/table/mor_delete_pruning_test.go
@@ -144,6 +144,123 @@ func TestV3MergeOnReadDoubleDeleteMergesDeletionVector(t *testing.T) {
 		"both id=2 and id=4 must be deleted and no previously deleted row may resurrect")
 }
 
+// TestV3MergeOnReadTripleDeleteMergesDeletionVector extends the double-delete
+// guard to a third delete. The second delete supersedes DV #1, leaving it as a
+// DELETED-status entry in the deleted-files manifest against the same data file.
+// The third delete's collectExistingDVs must skip that ghost entry; otherwise it
+// seeds the merged DV from the stale first bitmap (resurrecting id=4, removed by
+// the second delete) and tries to remove a DV that no longer exists. See #1372.
+func TestV3MergeOnReadTripleDeleteMergesDeletionVector(t *testing.T) {
+	ctx := context.Background()
+	tbl := newMergeOnReadTestTableVersion(t, "3")
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(2)), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, liveDVCount(t, tbl), "first delete must write exactly one DV")
+
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(4)), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, liveDVCount(t, tbl), "second delete must merge into the single DV")
+
+	// Third delete: DV #1 is now a superseded DELETED entry. collectExistingDVs
+	// must ignore it and seed only from the live merged DV.
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(1)), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, liveDVCount(t, tbl),
+		"the three deletes must collapse into a single merged deletion vector")
+	assert.Equal(t, []int64{3, 5}, idsInTable(t, tbl),
+		"id=1, id=2 and id=4 must all be deleted and none may resurrect")
+}
+
+// TestV3MergeOnReadDoubleDeletePartitionedMergesDeletionVectors runs the merge
+// on a partitioned table where a single delete touches two data files that each
+// already carry a DV. It exercises the per-file partition-context capture in the
+// DV seed loop, which the single unpartitioned data file does not.
+func TestV3MergeOnReadDoubleDeletePartitionedMergesDeletionVectors(t *testing.T) {
+	ctx := context.Background()
+	tbl := newPartitionedMergeOnReadTestTable(t)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "category", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+	// Two partitions ("x", "y") produce two data files.
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"category":"x"},{"id":2,"category":"x"},{"id":3,"category":"x"},` +
+			`{"id":4,"category":"y"},{"id":5,"category":"y"},{"id":6,"category":"y"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 3, 4, 5, 6}, idsInTable(t, tbl))
+
+	// Seed a DV on each partition's data file.
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(2)), nil)
+	require.NoError(t, err)
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(5)), nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, liveDVCount(t, tbl), "one live DV per partition data file")
+
+	// A single delete touching both partitions must merge into each existing DV
+	// rather than add parallel ones — seeding both from their own partition ctx.
+	tbl, err = tbl.Delete(ctx, iceberg.NewOr(
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+		iceberg.EqualTo(iceberg.Reference("id"), int64(4)),
+	), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, liveDVCount(t, tbl),
+		"each partition data file must keep exactly one merged DV")
+	assert.Equal(t, []int64{3, 6}, idsInTable(t, tbl),
+		"ids 1,2 (x) and 4,5 (y) must be deleted and none may resurrect")
+}
+
+// newPartitionedMergeOnReadTestTable builds a v3 merge-on-read table partitioned
+// by identity(category) so distinct category values land in distinct data files.
+func newPartitionedMergeOnReadTestTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Transform: iceberg.IdentityTransform{},
+		Name:      "category",
+	})
+	meta, err := table.NewMetadata(schema, &spec, table.UnsortedSortOrder, location,
+		iceberg.Properties{
+			table.PropertyFormatVersion: "3",
+			table.WriteDeleteModeKey:    table.WriteModeMergeOnRead,
+		})
+	require.NoError(t, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+
+	return table.New(table.Identifier{"db", "mor_delete_partitioned_test"}, meta, metaLoc, fsF, cat)
+}
+
 // liveDVCount returns the number of live deletion-vector entries in the table's
 // current snapshot.
 func liveDVCount(t *testing.T, tbl *table.Table) int {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1895,25 +1895,27 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 	// V3 tables store deletes as deletion vectors, and the spec allows at most
 	// one DV per data file. A data file being partially deleted may already
 	// carry a DV from an earlier delete; those existing positions are folded
-	// into the new DV (the scan that produced the records already applied them,
-	// so the new records hold only the incremental deletes) and the superseded
-	// DVs are removed. Without this a second delete on the same file would
-	// write a second live DV, corrupting the table (buildDVIndex rejects it).
-	var existingDVs map[string]iceberg.DataFile
+	// into the new DV (the incremental deletes) and the superseded DVs are
+	// removed. Without this a second delete on the same file would write a
+	// second live DV, corrupting the table (buildDVIndex rejects it).
+	var (
+		existingDVs       map[string]iceberg.DataFile
+		existingDVBitmaps map[string]*dv.RoaringPositionBitmap
+	)
 	if t.meta.formatVersion >= 3 {
 		existingDVs, err = t.collectExistingDVs(fs, files)
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	existingDVBitmaps := make(map[string]*dv.RoaringPositionBitmap, len(existingDVs))
-	for ref, dvFile := range existingDVs {
-		bitmap, err := dv.ReadDV(fs, dvFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read existing deletion vector for %s: %w", ref, err)
+		existingDVBitmaps = make(map[string]*dv.RoaringPositionBitmap, len(existingDVs))
+		for ref, dvFile := range existingDVs {
+			bitmap, err := dv.ReadDV(fs, dvFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read existing deletion vector for %s: %w", ref, err)
+			}
+			existingDVBitmaps[ref] = bitmap
 		}
-		existingDVBitmaps[ref] = bitmap
 	}
 
 	posDeleteFiles := positionDeleteRecordsToDataFiles(ctx, t.tbl.Location(), t.meta, partitionContextByFilePath, recordWritingArgs{
@@ -1964,10 +1966,20 @@ func (t *Transaction) collectExistingDVs(fs io.IO, files []iceberg.DataFile) (ma
 	}
 
 	result := make(map[string]iceberg.DataFile)
-	for df, err := range s.dataFiles(fs, nil) {
+	// Iterate delete manifests only and skip DELETED-status entries: a
+	// superseded DV lingers as a DELETED entry in the deleted-files manifest
+	// against the same referenced data file. Including it here would let the
+	// stale ghost win the last-write into result (manifest concat order places
+	// deleted entries last), seeding the new DV from an outdated bitmap and
+	// resurrecting rows removed by the prior delete. See issue #1372.
+	for entry, err := range s.entries(fs, iceberg.ManifestContentDeletes) {
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scanning existing deletion vectors: %w", err)
 		}
+		if entry.Status() == iceberg.EntryStatusDELETED {
+			continue
+		}
+		df := entry.DataFile()
 		if !isDeletionVector(df) {
 			continue
 		}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute/exprs"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/dv"
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/apache/iceberg-go/table/substrait"
 	"github.com/google/uuid"
@@ -1891,11 +1892,36 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		partitionContextByFilePath[df.FilePath()] = partitionContext{partitionData: df.Partition(), specID: df.SpecID()}
 	}
 
+	// V3 tables store deletes as deletion vectors, and the spec allows at most
+	// one DV per data file. A data file being partially deleted may already
+	// carry a DV from an earlier delete; those existing positions are folded
+	// into the new DV (the scan that produced the records already applied them,
+	// so the new records hold only the incremental deletes) and the superseded
+	// DVs are removed. Without this a second delete on the same file would
+	// write a second live DV, corrupting the table (buildDVIndex rejects it).
+	var existingDVs map[string]iceberg.DataFile
+	if t.meta.formatVersion >= 3 {
+		existingDVs, err = t.collectExistingDVs(fs, files)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	existingDVBitmaps := make(map[string]*dv.RoaringPositionBitmap, len(existingDVs))
+	for ref, dvFile := range existingDVs {
+		bitmap, err := dv.ReadDV(fs, dvFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read existing deletion vector for %s: %w", ref, err)
+		}
+		existingDVBitmaps[ref] = bitmap
+	}
+
 	posDeleteFiles := positionDeleteRecordsToDataFiles(ctx, t.tbl.Location(), t.meta, partitionContextByFilePath, recordWritingArgs{
-		sc:        PositionalDeleteArrowSchema,
-		itr:       posDeleteRecIter,
-		writeUUID: &commitUUID,
-		fs:        wfs,
+		sc:          PositionalDeleteArrowSchema,
+		itr:         posDeleteRecIter,
+		writeUUID:   &commitUUID,
+		fs:          wfs,
+		existingDVs: existingDVBitmaps,
 	})
 
 	var referenced []string
@@ -1913,7 +1939,48 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		}
 	}
 
+	// Supersede the old DVs only after the merged replacements are staged, so a
+	// write failure above leaves the existing DVs untouched.
+	for _, dvFile := range existingDVs {
+		updater.removeDeletionVector(dvFile)
+	}
+
 	return referenced, nil
+}
+
+// collectExistingDVs returns the live deletion vectors that reference any of
+// files, keyed by the referenced data file path. Used by the v3 merge-on-read
+// delete path to fold prior deletes into a new DV and remove the superseded
+// entries, preserving the spec's one-DV-per-data-file invariant.
+func (t *Transaction) collectExistingDVs(fs io.IO, files []iceberg.DataFile) (map[string]iceberg.DataFile, error) {
+	s := t.meta.currentSnapshot()
+	if s == nil {
+		return nil, nil
+	}
+
+	wanted := make(map[string]struct{}, len(files))
+	for _, df := range files {
+		wanted[df.FilePath()] = struct{}{}
+	}
+
+	result := make(map[string]iceberg.DataFile)
+	for df, err := range s.dataFiles(fs, nil) {
+		if err != nil {
+			return nil, err
+		}
+		if !isDeletionVector(df) {
+			continue
+		}
+		ref := df.ReferencedDataFile()
+		if ref == nil {
+			continue
+		}
+		if _, ok := wanted[*ref]; ok {
+			result[*ref] = df
+		}
+	}
+
+	return result, nil
 }
 
 func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs io.IO, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (seq2 iter.Seq2[arrow.RecordBatch, error], err error) {


### PR DESCRIPTION
A second merge-on-read DELETE on a data file that already had a deletion vector wrote a second live DV instead of merging, violating the one-DV-per -data-file invariant and failing subsequent scans.

The v3 delete path now folds the existing DV's positions into the new one and supersedes the old DV, mirroring the compaction/ReplaceFiles path.

Fixes #1372 