### PR TITLE
fix(table): apply optionality updates to list elements and map values in UpdateSchema

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -830,11 +830,13 @@ func (a *applyChanges) Field(field iceberg.NestedField, fieldResult iceberg.Type
 	return fieldResult
 }
 
-// updatedRequired returns the effective Required flag for fieldID.
-//
-// Note: updateColumn seeds each pending update from a copy of the original
+// updateColumn seeds each pending update from a copy of the original
 // NestedField. As a result, updates that only modify other properties
 // still preserve the original Required value here.
+// 
+// Note: If updateColumn is refactored to lazily populate only the
+// touched fields, this helper must gain an explicit "Required was set"
+// signal or it will silently return the zero-value false.
 func (a *applyChanges) updatedRequired(fieldID int, fallback bool) bool {
 	if update, ok := a.updates[fieldID]; ok {
 		return update.Required

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -830,21 +830,29 @@ func (a *applyChanges) Field(field iceberg.NestedField, fieldResult iceberg.Type
 	return fieldResult
 }
 
+// updatedRequired returns the effective Required flag for fieldID.
+//
+// Note: updateColumn seeds each pending update from a copy of the original
+// NestedField. As a result, updates that only modify other properties
+// still preserve the original Required value here.
+func (a *applyChanges) updatedRequired(fieldID int, fallback bool) bool {
+	if update, ok := a.updates[fieldID]; ok {
+		return update.Required
+	}
+
+	return fallback
+}
+
 func (a *applyChanges) List(listType iceberg.ListType, elementResult iceberg.Type) iceberg.Type {
 	elementType := a.Field(listType.ElementField(), elementResult)
 	if elementType == nil {
 		panic(fmt.Sprintf("cannot delete element type from list: %s", elementResult))
 	}
 
-	elementRequired := listType.ElementRequired
-	if update, ok := a.updates[listType.ElementID]; ok {
-		elementRequired = update.Required
-	}
-
 	return &iceberg.ListType{
 		ElementID:       listType.ElementID,
 		Element:         elementType,
-		ElementRequired: elementRequired,
+		ElementRequired: a.updatedRequired(listType.ElementID, listType.ElementRequired),
 	}
 }
 
@@ -873,17 +881,12 @@ func (a *applyChanges) Map(mapType iceberg.MapType, keyResult, valueResult icebe
 		panic(fmt.Errorf("cannot delete value type from map: %s", mapType.String()))
 	}
 
-	valueRequired := mapType.ValueRequired
-	if update, ok := a.updates[mapType.ValueID]; ok {
-		valueRequired = update.Required
-	}
-
 	return &iceberg.MapType{
 		KeyID:         mapType.KeyID,
 		KeyType:       mapType.KeyType,
 		ValueID:       mapType.ValueID,
 		ValueType:     valueType,
-		ValueRequired: valueRequired,
+		ValueRequired: a.updatedRequired(mapType.ValueID, mapType.ValueRequired),
 	}
 }
 

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -836,10 +836,15 @@ func (a *applyChanges) List(listType iceberg.ListType, elementResult iceberg.Typ
 		panic(fmt.Sprintf("cannot delete element type from list: %s", elementResult))
 	}
 
+	elementRequired := listType.ElementRequired
+	if update, ok := a.updates[listType.ElementID]; ok {
+		elementRequired = update.Required
+	}
+
 	return &iceberg.ListType{
 		ElementID:       listType.ElementID,
 		Element:         elementType,
-		ElementRequired: listType.ElementRequired,
+		ElementRequired: elementRequired,
 	}
 }
 
@@ -868,12 +873,17 @@ func (a *applyChanges) Map(mapType iceberg.MapType, keyResult, valueResult icebe
 		panic(fmt.Errorf("cannot delete value type from map: %s", mapType.String()))
 	}
 
+	valueRequired := mapType.ValueRequired
+	if update, ok := a.updates[mapType.ValueID]; ok {
+		valueRequired = update.Required
+	}
+
 	return &iceberg.MapType{
 		KeyID:         mapType.KeyID,
 		KeyType:       mapType.KeyType,
 		ValueID:       mapType.ValueID,
 		ValueType:     valueType,
-		ValueRequired: mapType.ValueRequired,
+		ValueRequired: valueRequired,
 	}
 }
 

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -833,7 +833,7 @@ func (a *applyChanges) Field(field iceberg.NestedField, fieldResult iceberg.Type
 // updateColumn seeds each pending update from a copy of the original
 // NestedField. As a result, updates that only modify other properties
 // still preserve the original Required value here.
-// 
+//
 // Note: If updateColumn is refactored to lazily populate only the
 // touched fields, this helper must gain an explicit "Required was set"
 // signal or it will silently return the zero-value false.

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -1194,8 +1194,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 	})
 
 	t.Run("optionality change composes with type promotion", func(t *testing.T) {
-		// Ensures the fix in applyChanges.Map does not clobber the type
-		// promotion already handled by applyChanges.Field.
 		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
 		assert.NoError(t, err)
 
@@ -1219,8 +1217,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 	})
 
 	t.Run("type promotion alone preserves original ValueRequired", func(t *testing.T) {
-		// Guards against the fix over-applying: when no Required update is
-		// registered, ValueRequired must match the original schema.
 		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
 		assert.NoError(t, err)
 

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -1143,3 +1143,123 @@ func TestAddColumnAfterDropHighestID(t *testing.T) {
 		"new column id must be last-column-id+1 (13), not HighestFieldID+1 (12) — "+
 			"reusing 12 would collide with the dropped column still in historical schemas")
 }
+
+func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
+	baseSchema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 2, Name: "tags", Type: &iceberg.ListType{
+			ElementID:       3,
+			Element:         iceberg.PrimitiveTypes.String,
+			ElementRequired: true,
+		}, Required: false},
+		iceberg.NestedField{ID: 4, Name: "properties", Type: &iceberg.MapType{
+			KeyID:         5,
+			KeyType:       iceberg.PrimitiveTypes.String,
+			ValueID:       6,
+			ValueType:     iceberg.PrimitiveTypes.String,
+			ValueRequired: true,
+		}, Required: false},
+	)
+	baseMeta, err := NewMetadata(baseSchema, nil, UnsortedSortOrder, "", nil)
+	assert.NoError(t, err)
+
+	t.Run("list element required -> optional is applied", func(t *testing.T) {
+		table := New([]string{"id"}, baseMeta, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, false).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: false, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		assert.True(t, ok)
+		listType, ok := tags.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.False(t, listType.ElementRequired,
+			"list element optionality update must be reflected in the applied schema")
+	})
+
+	t.Run("map value required -> optional is applied", func(t *testing.T) {
+		table := New([]string{"id"}, baseMeta, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, false).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: false, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		props, ok := newSchema.FindFieldByName("properties")
+		assert.True(t, ok)
+		mapType, ok := props.Type.(*iceberg.MapType)
+		assert.True(t, ok)
+		assert.False(t, mapType.ValueRequired,
+			"map value optionality update must be reflected in the applied schema")
+	})
+
+	t.Run("list element optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
+		optionalSchema := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 2, Name: "tags", Type: &iceberg.ListType{
+				ElementID:       3,
+				Element:         iceberg.PrimitiveTypes.String,
+				ElementRequired: false,
+			}, Required: false},
+		)
+		meta, err := NewMetadata(optionalSchema, nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: true, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		assert.True(t, ok)
+		listType, ok := tags.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.True(t, listType.ElementRequired)
+	})
+
+	t.Run("combined type promotion and optionality update on list element", func(t *testing.T) {
+		intListSchema := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 2, Name: "vals", Type: &iceberg.ListType{
+				ElementID:       3,
+				Element:         iceberg.PrimitiveTypes.Int32,
+				ElementRequired: true,
+			}, Required: false},
+		)
+		meta, err := NewMetadata(intListSchema, nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, false).
+			UpdateColumn([]string{"vals", "element"}, ColumnUpdate{
+				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
+				Required:  iceberg.Optional[bool]{Val: false, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		vals, ok := newSchema.FindFieldByName("vals")
+		assert.True(t, ok)
+		listType, ok := vals.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(listType.Element),
+			"type promotion should still be applied alongside optionality change")
+		assert.False(t, listType.ElementRequired,
+			"optionality change should be applied alongside type promotion")
+	})
+}

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -1043,107 +1043,6 @@ func TestAddColumnMonotonicFieldIDs(t *testing.T) {
 		"new field id must be allocated above metadata.LastColumnID() (13), not reused from the current schema's highest id (11)")
 }
 
-// TestAddColumnAfterDropHighestID is a regression test for #942.
-// It reproduces the exact scenario from the original bug: a column is added
-// (bumping last-column-id) then dropped (lowering the current schema's
-// HighestFieldID back down). A subsequent AddColumn must allocate an id above
-// last-column-id, not above HighestFieldID. Reverting #936 (i.e. seeding from
-// HighestFieldID instead of LastColumnID) causes the new column to reuse a
-// previously assigned id, which violates the Iceberg spec's monotonic id
-// invariant.
-func TestAddColumnAfterDropHighestID(t *testing.T) {
-	// originalSchema has field ids 1..11.
-	baseMeta, err := NewMetadata(originalSchema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "", nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 11, baseMeta.LastColumnID())
-
-	// Step 1: Add a column via UpdateSchema. This allocates id 12 and bumps
-	// last-column-id to 12.
-	tbl := New([]string{"id"}, baseMeta, "", nil, nil)
-	txn := tbl.NewTransaction()
-
-	withExtra, err := NewUpdateSchema(txn, true, true).
-		AddColumn([]string{"temp_col"}, iceberg.PrimitiveTypes.String, "", false, nil).
-		Apply()
-	assert.NoError(t, err)
-
-	tempCol, ok := withExtra.FindFieldByName("temp_col")
-	assert.True(t, ok)
-	assert.Equal(t, 12, tempCol.ID, "added column should get id 12")
-
-	// Persist the expanded schema into metadata so last-column-id is 12.
-	builder1, err := MetadataBuilderFromBase(baseMeta, "")
-	assert.NoError(t, err)
-	assert.NoError(t, builder1.AddSchema(withExtra))
-	assert.NoError(t, builder1.SetCurrentSchemaID(-1))
-
-	afterAdd, err := builder1.Build()
-	assert.NoError(t, err)
-	assert.Equal(t, 12, afterAdd.LastColumnID())
-	assert.Equal(t, 12, afterAdd.CurrentSchema().HighestFieldID())
-
-	// Step 2: Drop the highest-id column. The new current schema's
-	// HighestFieldID drops back to 11 while last-column-id stays at 12.
-	tbl2 := New([]string{"id"}, afterAdd, "", nil, nil)
-	txn2 := tbl2.NewTransaction()
-
-	afterDrop, err := NewUpdateSchema(txn2, true, true).
-		DeleteColumn([]string{"temp_col"}).
-		Apply()
-	assert.NoError(t, err)
-
-	_, found := afterDrop.FindFieldByName("temp_col")
-	assert.False(t, found, "temp_col should be gone after drop")
-
-	builder2, err := MetadataBuilderFromBase(afterAdd, "")
-	assert.NoError(t, err)
-	assert.NoError(t, builder2.AddSchema(afterDrop))
-	assert.NoError(t, builder2.SetCurrentSchemaID(-1))
-
-	afterDropMeta, err := builder2.Build()
-	assert.NoError(t, err)
-
-	assert.Equal(t, 11, afterDropMeta.CurrentSchema().HighestFieldID(),
-		"precondition: current schema's highest id should be 11 after dropping id-12 column")
-	assert.Equal(t, 12, afterDropMeta.LastColumnID(),
-		"precondition: last-column-id must still be 12 — ids are never reclaimed")
-
-	// Verify schema history still contains the dropped temp_col with id 12.
-	// A partial fix that strips dropped fields from historical schemas could
-	// still pass the id-monotonicity check above but break interop with
-	// Java/PyIceberg/Glue which expect historical schemas to be intact.
-	var foundInHistory bool
-	for _, s := range afterDropMeta.Schemas() {
-		if col, ok := s.FindFieldByID(12); ok {
-			assert.Equal(t, "temp_col", col.Name,
-				"historical schema must retain temp_col at id 12")
-			foundInHistory = true
-
-			break
-		}
-	}
-	assert.True(t, foundInHistory,
-		"dropped column (id 12) must still appear in at least one historical schema")
-
-	// Step 3: Add a new column. Its id must be 13 (last-column-id + 1), not
-	// 12 (HighestFieldID + 1). Using HighestFieldID would re-assign id 12,
-	// colliding with the dropped column still referenced by historical schemas.
-	tbl3 := New([]string{"id"}, afterDropMeta, "", nil, nil)
-	txn3 := tbl3.NewTransaction()
-
-	finalSchema, err := NewUpdateSchema(txn3, true, true).
-		AddColumn([]string{"new_col"}, iceberg.PrimitiveTypes.Int64, "", false, nil).
-		Apply()
-	assert.NoError(t, err)
-	assert.NotNil(t, finalSchema)
-
-	newCol, ok := finalSchema.FindFieldByName("new_col")
-	assert.True(t, ok, "new_col should be present in the final schema")
-	assert.Equal(t, 13, newCol.ID,
-		"new column id must be last-column-id+1 (13), not HighestFieldID+1 (12) — "+
-			"reusing 12 would collide with the dropped column still in historical schemas")
-}
-
 func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
 	baseSchema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
@@ -1262,4 +1161,105 @@ func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
 		assert.False(t, listType.ElementRequired,
 			"optionality change should be applied alongside type promotion")
 	})
+}
+
+// TestAddColumnAfterDropHighestID is a regression test for #942.
+// It reproduces the exact scenario from the original bug: a column is added
+// (bumping last-column-id) then dropped (lowering the current schema's
+// HighestFieldID back down). A subsequent AddColumn must allocate an id above
+// last-column-id, not above HighestFieldID. Reverting #936 (i.e. seeding from
+// HighestFieldID instead of LastColumnID) causes the new column to reuse a
+// previously assigned id, which violates the Iceberg spec's monotonic id
+// invariant.
+func TestAddColumnAfterDropHighestID(t *testing.T) {
+	// originalSchema has field ids 1..11.
+	baseMeta, err := NewMetadata(originalSchema, iceberg.UnpartitionedSpec, UnsortedSortOrder, "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 11, baseMeta.LastColumnID())
+
+	// Step 1: Add a column via UpdateSchema. This allocates id 12 and bumps
+	// last-column-id to 12.
+	tbl := New([]string{"id"}, baseMeta, "", nil, nil)
+	txn := tbl.NewTransaction()
+
+	withExtra, err := NewUpdateSchema(txn, true, true).
+		AddColumn([]string{"temp_col"}, iceberg.PrimitiveTypes.String, "", false, nil).
+		Apply()
+	assert.NoError(t, err)
+
+	tempCol, ok := withExtra.FindFieldByName("temp_col")
+	assert.True(t, ok)
+	assert.Equal(t, 12, tempCol.ID, "added column should get id 12")
+
+	// Persist the expanded schema into metadata so last-column-id is 12.
+	builder1, err := MetadataBuilderFromBase(baseMeta, "")
+	assert.NoError(t, err)
+	assert.NoError(t, builder1.AddSchema(withExtra))
+	assert.NoError(t, builder1.SetCurrentSchemaID(-1))
+
+	afterAdd, err := builder1.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, 12, afterAdd.LastColumnID())
+	assert.Equal(t, 12, afterAdd.CurrentSchema().HighestFieldID())
+
+	// Step 2: Drop the highest-id column. The new current schema's
+	// HighestFieldID drops back to 11 while last-column-id stays at 12.
+	tbl2 := New([]string{"id"}, afterAdd, "", nil, nil)
+	txn2 := tbl2.NewTransaction()
+
+	afterDrop, err := NewUpdateSchema(txn2, true, true).
+		DeleteColumn([]string{"temp_col"}).
+		Apply()
+	assert.NoError(t, err)
+
+	_, found := afterDrop.FindFieldByName("temp_col")
+	assert.False(t, found, "temp_col should be gone after drop")
+
+	builder2, err := MetadataBuilderFromBase(afterAdd, "")
+	assert.NoError(t, err)
+	assert.NoError(t, builder2.AddSchema(afterDrop))
+	assert.NoError(t, builder2.SetCurrentSchemaID(-1))
+
+	afterDropMeta, err := builder2.Build()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 11, afterDropMeta.CurrentSchema().HighestFieldID(),
+		"precondition: current schema's highest id should be 11 after dropping id-12 column")
+	assert.Equal(t, 12, afterDropMeta.LastColumnID(),
+		"precondition: last-column-id must still be 12 — ids are never reclaimed")
+
+	// Verify schema history still contains the dropped temp_col with id 12.
+	// A partial fix that strips dropped fields from historical schemas could
+	// still pass the id-monotonicity check above but break interop with
+	// Java/PyIceberg/Glue which expect historical schemas to be intact.
+	var foundInHistory bool
+	for _, s := range afterDropMeta.Schemas() {
+		if col, ok := s.FindFieldByID(12); ok {
+			assert.Equal(t, "temp_col", col.Name,
+				"historical schema must retain temp_col at id 12")
+			foundInHistory = true
+
+			break
+		}
+	}
+	assert.True(t, foundInHistory,
+		"dropped column (id 12) must still appear in at least one historical schema")
+
+	// Step 3: Add a new column. Its id must be 13 (last-column-id + 1), not
+	// 12 (HighestFieldID + 1). Using HighestFieldID would re-assign id 12,
+	// colliding with the dropped column still referenced by historical schemas.
+	tbl3 := New([]string{"id"}, afterDropMeta, "", nil, nil)
+	txn3 := tbl3.NewTransaction()
+
+	finalSchema, err := NewUpdateSchema(txn3, true, true).
+		AddColumn([]string{"new_col"}, iceberg.PrimitiveTypes.Int64, "", false, nil).
+		Apply()
+	assert.NoError(t, err)
+	assert.NotNil(t, finalSchema)
+
+	newCol, ok := finalSchema.FindFieldByName("new_col")
+	assert.True(t, ok, "new_col should be present in the final schema")
+	assert.Equal(t, 13, newCol.ID,
+		"new column id must be last-column-id+1 (13), not HighestFieldID+1 (12) — "+
+			"reusing 12 would collide with the dropped column still in historical schemas")
 }

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -1043,30 +1043,24 @@ func TestAddColumnMonotonicFieldIDs(t *testing.T) {
 		"new field id must be allocated above metadata.LastColumnID() (13), not reused from the current schema's highest id (11)")
 }
 
-func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
-	baseSchema := iceberg.NewSchema(1,
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 2, Name: "tags", Type: &iceberg.ListType{
-			ElementID:       3,
-			Element:         iceberg.PrimitiveTypes.String,
-			ElementRequired: true,
-		}, Required: false},
-		iceberg.NestedField{ID: 4, Name: "properties", Type: &iceberg.MapType{
-			KeyID:         5,
-			KeyType:       iceberg.PrimitiveTypes.String,
-			ValueID:       6,
-			ValueType:     iceberg.PrimitiveTypes.String,
-			ValueRequired: true,
-		}, Required: false},
-	)
-	baseMeta, err := NewMetadata(baseSchema, nil, UnsortedSortOrder, "", nil)
-	assert.NoError(t, err)
+func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
+	newListSchema := func(elementRequired bool, elementType iceberg.Type) *iceberg.Schema {
+		return iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 2, Name: "tags", Type: &iceberg.ListType{
+				ElementID:       3,
+				Element:         elementType,
+				ElementRequired: elementRequired,
+			}, Required: false},
+		)
+	}
 
-	t.Run("list element required -> optional is applied", func(t *testing.T) {
-		table := New([]string{"id"}, baseMeta, "", nil, nil)
-		txn := table.NewTransaction()
+	t.Run("required -> optional is applied", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
 
-		newSchema, err := NewUpdateSchema(txn, true, false).
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
 			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
 				Required: iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
@@ -1081,11 +1075,90 @@ func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
 			"list element optionality update must be reflected in the applied schema")
 	})
 
-	t.Run("map value required -> optional is applied", func(t *testing.T) {
-		table := New([]string{"id"}, baseMeta, "", nil, nil)
-		txn := table.NewTransaction()
+	t.Run("optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
 
-		newSchema, err := NewUpdateSchema(txn, true, false).
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, true).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: true, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		assert.True(t, ok)
+		listType, ok := tags.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.True(t, listType.ElementRequired,
+			"list element optionality update must be reflected in the applied schema")
+	})
+
+	t.Run("optionality change composes with type promotion", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
+				Required:  iceberg.Optional[bool]{Val: false, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		assert.True(t, ok)
+		listType, ok := tags.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(listType.Element),
+			"type promotion must still be applied alongside optionality change")
+		assert.False(t, listType.ElementRequired,
+			"optionality change must be applied alongside type promotion")
+	})
+
+	t.Run("type promotion alone preserves original ElementRequired", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		assert.True(t, ok)
+		listType, ok := tags.Type.(*iceberg.ListType)
+		assert.True(t, ok)
+		assert.True(t, listType.ElementRequired,
+			"ElementRequired must be preserved from the original schema when no Required update is registered")
+	})
+}
+
+func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
+	newMapSchema := func(valueRequired bool, valueType iceberg.Type) *iceberg.Schema {
+		return iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 2, Name: "properties", Type: &iceberg.MapType{
+				KeyID:         3,
+				KeyType:       iceberg.PrimitiveTypes.String,
+				ValueID:       4,
+				ValueType:     valueType,
+				ValueRequired: valueRequired,
+			}, Required: false},
+		)
+	}
+
+	t.Run("required -> optional is applied", func(t *testing.T) {
+		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
 			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
 				Required: iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
@@ -1100,66 +1173,71 @@ func TestApplyChangesNestedOptionalityUpdates(t *testing.T) {
 			"map value optionality update must be reflected in the applied schema")
 	})
 
-	t.Run("list element optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
-		optionalSchema := iceberg.NewSchema(1,
-			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-			iceberg.NestedField{ID: 2, Name: "tags", Type: &iceberg.ListType{
-				ElementID:       3,
-				Element:         iceberg.PrimitiveTypes.String,
-				ElementRequired: false,
-			}, Required: false},
-		)
-		meta, err := NewMetadata(optionalSchema, nil, UnsortedSortOrder, "", nil)
+	t.Run("optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
+		meta, err := NewMetadata(newMapSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
 		assert.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
-		txn := table.NewTransaction()
-
-		newSchema, err := NewUpdateSchema(txn, true, true).
-			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, true).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
 				Required: iceberg.Optional[bool]{Val: true, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
 		assert.NotNil(t, newSchema)
 
-		tags, ok := newSchema.FindFieldByName("tags")
+		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)
-		listType, ok := tags.Type.(*iceberg.ListType)
+		mapType, ok := props.Type.(*iceberg.MapType)
 		assert.True(t, ok)
-		assert.True(t, listType.ElementRequired)
+		assert.True(t, mapType.ValueRequired,
+			"map value optionality update must be reflected in the applied schema")
 	})
 
-	t.Run("combined type promotion and optionality update on list element", func(t *testing.T) {
-		intListSchema := iceberg.NewSchema(1,
-			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-			iceberg.NestedField{ID: 2, Name: "vals", Type: &iceberg.ListType{
-				ElementID:       3,
-				Element:         iceberg.PrimitiveTypes.Int32,
-				ElementRequired: true,
-			}, Required: false},
-		)
-		meta, err := NewMetadata(intListSchema, nil, UnsortedSortOrder, "", nil)
+	t.Run("optionality change composes with type promotion", func(t *testing.T) {
+		// Ensures the fix in applyChanges.Map does not clobber the type
+		// promotion already handled by applyChanges.Field.
+		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
 		assert.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
-		txn := table.NewTransaction()
-
-		newSchema, err := NewUpdateSchema(txn, true, false).
-			UpdateColumn([]string{"vals", "element"}, ColumnUpdate{
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
 				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
 				Required:  iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
 		assert.NotNil(t, newSchema)
 
-		vals, ok := newSchema.FindFieldByName("vals")
+		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)
-		listType, ok := vals.Type.(*iceberg.ListType)
+		mapType, ok := props.Type.(*iceberg.MapType)
 		assert.True(t, ok)
-		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(listType.Element),
-			"type promotion should still be applied alongside optionality change")
-		assert.False(t, listType.ElementRequired,
-			"optionality change should be applied alongside type promotion")
+		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(mapType.ValueType),
+			"type promotion must still be applied alongside optionality change")
+		assert.False(t, mapType.ValueRequired,
+			"optionality change must be applied alongside type promotion")
+	})
+
+	t.Run("type promotion alone preserves original ValueRequired", func(t *testing.T) {
+		// Guards against the fix over-applying: when no Required update is
+		// registered, ValueRequired must match the original schema.
+		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
+		assert.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
+				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+		assert.NotNil(t, newSchema)
+
+		props, ok := newSchema.FindFieldByName("properties")
+		assert.True(t, ok)
+		mapType, ok := props.Type.(*iceberg.MapType)
+		assert.True(t, ok)
+		assert.True(t, mapType.ValueRequired,
+			"ValueRequired must be preserved from the original schema when no Required update is registered")
 	})
 }
 

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var originalSchema = iceberg.NewSchema(1,
@@ -1057,7 +1058,7 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 
 	t.Run("required -> optional is applied", func(t *testing.T) {
 		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1067,16 +1068,16 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		tags, ok := newSchema.FindFieldByName("tags")
-		assert.True(t, ok)
+		require.True(t, ok, "tags field must be present in the applied schema")
 		listType, ok := tags.Type.(*iceberg.ListType)
-		assert.True(t, ok)
+		require.True(t, ok, "tags must remain a ListType after apply")
 		assert.False(t, listType.ElementRequired,
 			"list element optionality update must be reflected in the applied schema")
 	})
 
 	t.Run("optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
 		meta, err := NewMetadata(newListSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, true).
@@ -1086,16 +1087,29 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		tags, ok := newSchema.FindFieldByName("tags")
-		assert.True(t, ok)
+		require.True(t, ok, "tags field must be present in the applied schema")
 		listType, ok := tags.Type.(*iceberg.ListType)
-		assert.True(t, ok)
+		require.True(t, ok, "tags must remain a ListType after apply")
 		assert.True(t, listType.ElementRequired,
 			"list element optionality update must be reflected in the applied schema")
 	})
 
+	t.Run("optional -> required is rejected without allowIncompatibleChanges", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		require.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		_, err = NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: true, Valid: true},
+			}).Apply()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot change column nullability from optional to required")
+	})
+
 	t.Run("optionality change composes with type promotion", func(t *testing.T) {
 		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1106,9 +1120,9 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		tags, ok := newSchema.FindFieldByName("tags")
-		assert.True(t, ok)
+		require.True(t, ok, "tags field must be present in the applied schema")
 		listType, ok := tags.Type.(*iceberg.ListType)
-		assert.True(t, ok)
+		require.True(t, ok, "tags must remain a ListType after apply")
 		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(listType.Element),
 			"type promotion must still be applied alongside optionality change")
 		assert.False(t, listType.ElementRequired,
@@ -1117,7 +1131,7 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 
 	t.Run("type promotion alone preserves original ElementRequired", func(t *testing.T) {
 		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1127,11 +1141,30 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		tags, ok := newSchema.FindFieldByName("tags")
-		assert.True(t, ok)
+		require.True(t, ok, "tags field must be present in the applied schema")
 		listType, ok := tags.Type.(*iceberg.ListType)
-		assert.True(t, ok)
+		require.True(t, ok, "tags must remain a ListType after apply")
 		assert.True(t, listType.ElementRequired,
 			"ElementRequired must be preserved from the original schema when no Required update is registered")
+	})
+
+	t.Run("doc-only update preserves original ElementRequired", func(t *testing.T) {
+		meta, err := NewMetadata(newListSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		require.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"tags", "element"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Val: "element doc", Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+
+		tags, ok := newSchema.FindFieldByName("tags")
+		require.True(t, ok, "tags field must be present in the applied schema")
+		listType, ok := tags.Type.(*iceberg.ListType)
+		require.True(t, ok, "tags must remain a ListType after apply")
+		assert.True(t, listType.ElementRequired,
+			"ElementRequired must be preserved when the registered update leaves Required unset")
 	})
 }
 
@@ -1151,7 +1184,7 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 
 	t.Run("required -> optional is applied", func(t *testing.T) {
 		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1161,16 +1194,16 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		props, ok := newSchema.FindFieldByName("properties")
-		assert.True(t, ok)
+		require.True(t, ok, "properties field must be present in the applied schema")
 		mapType, ok := props.Type.(*iceberg.MapType)
-		assert.True(t, ok)
+		require.True(t, ok, "properties must remain a MapType after apply")
 		assert.False(t, mapType.ValueRequired,
 			"map value optionality update must be reflected in the applied schema")
 	})
 
 	t.Run("optional -> required is applied with allowIncompatibleChanges", func(t *testing.T) {
 		meta, err := NewMetadata(newMapSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, true).
@@ -1180,16 +1213,29 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		props, ok := newSchema.FindFieldByName("properties")
-		assert.True(t, ok)
+		require.True(t, ok, "properties field must be present in the applied schema")
 		mapType, ok := props.Type.(*iceberg.MapType)
-		assert.True(t, ok)
+		require.True(t, ok, "properties must remain a MapType after apply")
 		assert.True(t, mapType.ValueRequired,
 			"map value optionality update must be reflected in the applied schema")
 	})
 
+	t.Run("optional -> required is rejected without allowIncompatibleChanges", func(t *testing.T) {
+		meta, err := NewMetadata(newMapSchema(false, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		require.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		_, err = NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
+				Required: iceberg.Optional[bool]{Val: true, Valid: true},
+			}).Apply()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot change column nullability from optional to required")
+	})
+
 	t.Run("optionality change composes with type promotion", func(t *testing.T) {
 		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1200,9 +1246,9 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		props, ok := newSchema.FindFieldByName("properties")
-		assert.True(t, ok)
+		require.True(t, ok, "properties field must be present in the applied schema")
 		mapType, ok := props.Type.(*iceberg.MapType)
-		assert.True(t, ok)
+		require.True(t, ok, "properties must remain a MapType after apply")
 		assert.True(t, iceberg.PrimitiveTypes.Int64.Equals(mapType.ValueType),
 			"type promotion must still be applied alongside optionality change")
 		assert.False(t, mapType.ValueRequired,
@@ -1211,7 +1257,7 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 
 	t.Run("type promotion alone preserves original ValueRequired", func(t *testing.T) {
 		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.Int32), nil, UnsortedSortOrder, "", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		table := New([]string{"id"}, meta, "", nil, nil)
 		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
@@ -1221,11 +1267,30 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 		assert.NoError(t, err)
 
 		props, ok := newSchema.FindFieldByName("properties")
-		assert.True(t, ok)
+		require.True(t, ok, "properties field must be present in the applied schema")
 		mapType, ok := props.Type.(*iceberg.MapType)
-		assert.True(t, ok)
+		require.True(t, ok, "properties must remain a MapType after apply")
 		assert.True(t, mapType.ValueRequired,
 			"ValueRequired must be preserved from the original schema when no Required update is registered")
+	})
+
+	t.Run("doc-only update preserves original ValueRequired", func(t *testing.T) {
+		meta, err := NewMetadata(newMapSchema(true, iceberg.PrimitiveTypes.String), nil, UnsortedSortOrder, "", nil)
+		require.NoError(t, err)
+
+		table := New([]string{"id"}, meta, "", nil, nil)
+		newSchema, err := NewUpdateSchema(table.NewTransaction(), true, false).
+			UpdateColumn([]string{"properties", "value"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Val: "value doc", Valid: true},
+			}).Apply()
+		assert.NoError(t, err)
+
+		props, ok := newSchema.FindFieldByName("properties")
+		require.True(t, ok, "properties field must be present in the applied schema")
+		mapType, ok := props.Type.(*iceberg.MapType)
+		require.True(t, ok, "properties must remain a MapType after apply")
+		assert.True(t, mapType.ValueRequired,
+			"ValueRequired must be preserved when the registered update leaves Required unset")
 	})
 }
 

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -1065,7 +1065,6 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 				Required: iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		tags, ok := newSchema.FindFieldByName("tags")
 		assert.True(t, ok)
@@ -1085,7 +1084,6 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 				Required: iceberg.Optional[bool]{Val: true, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		tags, ok := newSchema.FindFieldByName("tags")
 		assert.True(t, ok)
@@ -1106,7 +1104,6 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 				Required:  iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		tags, ok := newSchema.FindFieldByName("tags")
 		assert.True(t, ok)
@@ -1128,7 +1125,6 @@ func TestApplyChangesListElementOptionalityUpdates(t *testing.T) {
 				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		tags, ok := newSchema.FindFieldByName("tags")
 		assert.True(t, ok)
@@ -1163,7 +1159,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 				Required: iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)
@@ -1183,7 +1178,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 				Required: iceberg.Optional[bool]{Val: true, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)
@@ -1204,7 +1198,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 				Required:  iceberg.Optional[bool]{Val: false, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)
@@ -1226,7 +1219,6 @@ func TestApplyChangesMapValueOptionalityUpdates(t *testing.T) {
 				FieldType: iceberg.Optional[iceberg.Type]{Val: iceberg.PrimitiveTypes.Int64, Valid: true},
 			}).Apply()
 		assert.NoError(t, err)
-		assert.NotNil(t, newSchema)
 
 		props, ok := newSchema.FindFieldByName("properties")
 		assert.True(t, ok)


### PR DESCRIPTION
## Description

`applyChanges.List` and `applyChanges.Map` silently dropped _optionality_ updates registered against a list's element or a map's value. 

Fixes #1424 

## Test

Added `TestApplyChangesNestedOptionalityUpdates`