### PR TITLE
fix(table): fix occ rewrite resurrection

### DIFF
--- a/table/occ_scenario_test.go
+++ b/table/occ_scenario_test.go
@@ -451,6 +451,129 @@ func (s *OCCScenarioTestSuite) TestV3MergeAppendRowLineageAfterOCCRetry() {
 	}
 }
 
+// TestReplaceFilesNoResurrectionAfterConflict is a regression test for the OCC
+// retry-replay resurrection bug. When a replace/overwrite commit retries after
+// a conflict, the rebuild must re-apply the file removal against the FRESH
+// parent — not graft attempt-0's stale "own" manifests onto a fresh parent
+// that still lists the removed files. Otherwise the removed files come back
+// alive next to their replacement and their rows are duplicated.
+//
+// Scenario:
+//   - Base: file0 = rows [1,2,3] committed.
+//   - Concurrent peer: appends filePeer = row [4]; catalog head is file0+peer.
+//   - Writer A (stale base = only file0) replaces file0 with a compacted file
+//     holding the same rows [1,2,3]. First attempt conflicts; the retry rebases
+//     onto the fresh head.
+//
+// Correct: live rows = {1,2,3,4} (compacted + peer), file0 dropped → 4 rows.
+// Buggy:   file0 resurrected → rows [1,2,3] duplicated → 7 rows, 3 live files.
+func (s *OCCScenarioTestSuite) TestReplaceFilesNoResurrectionAfterConflict() {
+	props := iceberg.Properties{
+		table.CommitMinRetryWaitMsKey:      "0",
+		table.CommitMaxRetryWaitMsKey:      "0",
+		table.CommitTotalRetryTimeoutMsKey: "60000",
+		table.CommitNumRetriesKey:          "2",
+		// Snapshot isolation lets the replace commit past the concurrent
+		// append the same way compaction's rewrite semantics do; the bug we
+		// are guarding lives in the retry rebuild, not the validator.
+		table.WriteUpdateIsolationLevelKey: string(table.IsolationSnapshot),
+	}
+
+	localFS := func(_ context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+
+	// Step 1: base table with file0 = rows [1,2,3].
+	baseTbl, cat := s.makeTable(0, props)
+	arrowSc, err := table.SchemaToArrowSchema(baseTbl.Schema(), nil, false, false)
+	s.Require().NoError(err)
+
+	file0Path := s.location + "/data/file0.parquet"
+	writeParquetFile(s.T(), file0Path, arrowSc,
+		`[{"id":1,"val":"a"},{"id":2,"val":"b"},{"id":3,"val":"c"}]`)
+
+	tx := baseTbl.NewTransaction()
+	s.Require().NoError(tx.AddFiles(s.ctx, []string{file0Path}, nil, false))
+	_, err = tx.Commit(s.ctx)
+	s.Require().NoError(err)
+	metaBase := cat.current
+
+	// Step 2: a concurrent peer appends filePeer = row [4] onto metaBase.
+	peerCat := &occScenarioCatalog{current: metaBase, location: s.location}
+	peerTbl := table.New(baseTbl.Identifier(), metaBase,
+		s.location+"/metadata/base.metadata.json", localFS, peerCat)
+
+	peerPath := s.location + "/data/file_peer.parquet"
+	writeParquetFile(s.T(), peerPath, arrowSc, `[{"id":4,"val":"d"}]`)
+
+	ptx := peerTbl.NewTransaction()
+	s.Require().NoError(ptx.AddFiles(s.ctx, []string{peerPath}, nil, false))
+	_, err = ptx.Commit(s.ctx)
+	s.Require().NoError(err)
+	metaPeer := peerCat.current
+
+	// Step 3: Writer A replaces file0 -> compacted, starting from the stale
+	// metaBase; its catalog is at metaPeer and returns one 409 before success.
+	catA := &occScenarioCatalog{current: metaPeer, conflictsLeft: 1, location: s.location}
+	writerA := table.New(baseTbl.Identifier(), metaBase,
+		s.location+"/metadata/base.metadata.json", localFS, catA)
+
+	tasks, err := writerA.Scan().PlanFiles(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Len(tasks, 1, "Writer A's stale base must see exactly file0")
+	oldFile := tasks[0].File
+
+	compactedPath := s.location + "/data/compacted.parquet"
+	writeParquetFile(s.T(), compactedPath, arrowSc,
+		`[{"id":1,"val":"a"},{"id":2,"val":"b"},{"id":3,"val":"c"}]`)
+	newBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		compactedPath, iceberg.ParquetFile, nil, nil, nil, 3, 512)
+	s.Require().NoError(err)
+	newFile := newBuilder.Build()
+
+	txA := writerA.NewTransaction()
+	s.Require().NoError(txA.ReplaceFiles(s.ctx,
+		[]iceberg.DataFile{oldFile}, []iceberg.DataFile{newFile}, nil, nil))
+	committedA, err := txA.Commit(s.ctx)
+	s.Require().NoError(err, "Writer A replace must succeed after one conflict retry")
+	s.Equal(int32(2), catA.commitTableCalls.Load(),
+		"expected 2 commit attempts: 1 conflict + 1 success")
+
+	// The replaced file0 must NOT be resurrected: exactly the compacted file
+	// and the peer's file are live.
+	finalSnap := catA.current.CurrentSnapshot()
+	s.Require().NotNil(finalSnap)
+	live := s.liveDataFilePaths(finalSnap)
+	s.NotContains(live, oldFile.FilePath(), "replaced file0 must not be resurrected on retry")
+	s.Len(live, 2, "exactly {compacted, peer} must be live after retry")
+
+	// A full scan must return 4 rows, not 7.
+	assertRowCount(s.T(), committedA, 4)
+}
+
+// liveDataFilePaths returns the paths of all non-deleted data-file entries
+// referenced by snap's manifest list.
+func (s *OCCScenarioTestSuite) liveDataFilePaths(snap *table.Snapshot) []string {
+	fio := iceio.LocalFS{}
+	manifests, err := snap.Manifests(fio)
+	s.Require().NoError(err)
+
+	var paths []string
+	for _, mf := range manifests {
+		if mf.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		for e, err := range mf.Entries(fio, false) {
+			s.Require().NoError(err)
+			if e.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			paths = append(paths, e.DataFile().FilePath())
+		}
+	}
+
+	return paths
+}
+
 func (s *OCCScenarioTestSuite) makeArrowTableN(n int) arrow.Table {
 	mem := memory.DefaultAllocator
 	sc := arrow.NewSchema([]arrow.Field{

--- a/table/occ_scenario_test.go
+++ b/table/occ_scenario_test.go
@@ -53,6 +53,10 @@ type occScenarioCatalog struct {
 	loadTableCalls   atomic.Int32
 	commitTableCalls atomic.Int32
 	location         string
+
+	// onConflict, when set, advances current before each simulated 409 so
+	// successive retries rebase onto a genuinely newer head.
+	onConflict func(current table.Metadata) table.Metadata
 }
 
 func (c *occScenarioCatalog) LoadTable(_ context.Context, _ table.Identifier) (*table.Table, error) {
@@ -77,6 +81,9 @@ func (c *occScenarioCatalog) CommitTable(
 
 	if c.conflictsLeft > 0 {
 		c.conflictsLeft--
+		if c.onConflict != nil {
+			c.current = c.onConflict(c.current)
+		}
 
 		return nil, "", fmt.Errorf("%w: simulated 409 conflict", table.ErrCommitFailed)
 	}
@@ -548,6 +555,101 @@ func (s *OCCScenarioTestSuite) TestReplaceFilesNoResurrectionAfterConflict() {
 
 	// A full scan must return 4 rows, not 7.
 	assertRowCount(s.T(), committedA, 4)
+}
+
+// TestReplaceFilesNoResurrectionAfterTwoConflicts extends the single-retry
+// resurrection guard across two distinct peer commits. The reused
+// added-content manifest must survive two rebuilds and each rebuild must
+// re-apply file0's removal against the freshest head, so the replaced file is
+// never resurrected and both peers' rows are inherited.
+//
+// Scenario:
+//   - Base: file0 = rows [1,2,3].
+//   - Writer A (stale base = only file0) replaces file0 with a compacted file
+//     holding rows [1,2,3]. Its catalog returns two 409s; before each it lets a
+//     distinct peer append a row (peer1 = [4], then peer2 = [5]).
+//
+// Correct: live = {compacted, peer1, peer2}, rows {1,2,3,4,5} = 5, file0 dropped.
+func (s *OCCScenarioTestSuite) TestReplaceFilesNoResurrectionAfterTwoConflicts() {
+	props := iceberg.Properties{
+		table.CommitMinRetryWaitMsKey:      "0",
+		table.CommitMaxRetryWaitMsKey:      "0",
+		table.CommitTotalRetryTimeoutMsKey: "60000",
+		table.CommitNumRetriesKey:          "3",
+		table.WriteUpdateIsolationLevelKey: string(table.IsolationSnapshot),
+	}
+
+	localFS := func(_ context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+
+	baseTbl, cat := s.makeTable(0, props)
+	arrowSc, err := table.SchemaToArrowSchema(baseTbl.Schema(), nil, false, false)
+	s.Require().NoError(err)
+
+	file0Path := s.location + "/data/file0.parquet"
+	writeParquetFile(s.T(), file0Path, arrowSc,
+		`[{"id":1,"val":"a"},{"id":2,"val":"b"},{"id":3,"val":"c"}]`)
+
+	tx := baseTbl.NewTransaction()
+	s.Require().NoError(tx.AddFiles(s.ctx, []string{file0Path}, nil, false))
+	_, err = tx.Commit(s.ctx)
+	s.Require().NoError(err)
+	metaBase := cat.current
+
+	// Each conflict lets a fresh peer append a new row onto the current head.
+	peerRows := []string{`[{"id":4,"val":"d"}]`, `[{"id":5,"val":"e"}]`}
+	peer := 0
+	appendPeer := func(current table.Metadata) table.Metadata {
+		peerCat := &occScenarioCatalog{current: current, location: s.location}
+		peerTbl := table.New(baseTbl.Identifier(), current,
+			s.location+"/metadata/peer.metadata.json", localFS, peerCat)
+
+		peerPath := fmt.Sprintf("%s/data/file_peer%d.parquet", s.location, peer)
+		writeParquetFile(s.T(), peerPath, arrowSc, peerRows[peer])
+		peer++
+
+		ptx := peerTbl.NewTransaction()
+		s.Require().NoError(ptx.AddFiles(s.ctx, []string{peerPath}, nil, false))
+		_, err := ptx.Commit(s.ctx)
+		s.Require().NoError(err)
+
+		return peerCat.current
+	}
+
+	catA := &occScenarioCatalog{
+		current: metaBase, conflictsLeft: 2, location: s.location, onConflict: appendPeer,
+	}
+	writerA := table.New(baseTbl.Identifier(), metaBase,
+		s.location+"/metadata/base.metadata.json", localFS, catA)
+
+	tasks, err := writerA.Scan().PlanFiles(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Len(tasks, 1, "Writer A's stale base must see exactly file0")
+	oldFile := tasks[0].File
+
+	compactedPath := s.location + "/data/compacted.parquet"
+	writeParquetFile(s.T(), compactedPath, arrowSc,
+		`[{"id":1,"val":"a"},{"id":2,"val":"b"},{"id":3,"val":"c"}]`)
+	newBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		compactedPath, iceberg.ParquetFile, nil, nil, nil, 3, 512)
+	s.Require().NoError(err)
+	newFile := newBuilder.Build()
+
+	txA := writerA.NewTransaction()
+	s.Require().NoError(txA.ReplaceFiles(s.ctx,
+		[]iceberg.DataFile{oldFile}, []iceberg.DataFile{newFile}, nil, nil))
+	committedA, err := txA.Commit(s.ctx)
+	s.Require().NoError(err, "Writer A replace must succeed after two conflict retries")
+	s.Equal(int32(3), catA.commitTableCalls.Load(),
+		"expected 3 commit attempts: 2 conflicts + 1 success")
+
+	finalSnap := catA.current.CurrentSnapshot()
+	s.Require().NotNil(finalSnap)
+	live := s.liveDataFilePaths(finalSnap)
+	s.NotContains(live, oldFile.FilePath(), "replaced file0 must not be resurrected across two retries")
+	s.Len(live, 3, "exactly {compacted, peer1, peer2} must be live after two retries")
+
+	assertRowCount(s.T(), committedA, 5)
 }
 
 // liveDataFilePaths returns the paths of all non-deleted data-file entries

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -612,16 +612,18 @@ func (sp *snapshotProducer) removeDeletionVector(df iceberg.DataFile) *snapshotP
 
 // deleteFileRemoved reports whether a delete-file entry is being expunged in
 // this snapshot: position/equality deletes match by path, deletion vectors by
-// referenced data file (one Puffin holds blobs for several data files, so a
-// shared path would over-remove live siblings).
+// (referenced data file, path) pair. Path alone would over-remove live
+// siblings (one Puffin holds blobs for several data files); ref alone would
+// expunge a peer's replacement DV for the same data file on an OCC retry,
+// silently discarding the peer's newer deletes.
 func (sp *snapshotProducer) deleteFileRemoved(df iceberg.DataFile) bool {
 	if _, ok := sp.deletedDeleteFiles[df.FilePath()]; ok {
 		return true
 	}
 	if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
-		_, ok := sp.deletedDVsByRef[*ref]
+		want, ok := sp.deletedDVsByRef[*ref]
 
-		return ok
+		return ok && want.FilePath() == df.FilePath()
 	}
 
 	return false
@@ -994,7 +996,7 @@ func (sp *snapshotProducer) rebaseSummary(delta, previousSummary, props iceberg.
 // removals the parent still counts.
 type removedFilePresence struct {
 	deleteFiles map[string]struct{} // pos/eq delete FilePath()
-	dvRefs      map[string]struct{} // deletion-vector ReferencedDataFile()
+	dvRefs      map[string]struct{} // ReferencedDataFile() of DVs whose exact captured path is still on parent
 }
 
 func (p *removedFilePresence) counts(df iceberg.DataFile) bool {
@@ -1017,7 +1019,9 @@ func (p *removedFilePresence) counts(df iceberg.DataFile) bool {
 // already removed it, so proceeding would leave our replacement beside the
 // concurrent result and duplicate rows (Java's failMissingDeletePaths) — and
 // (2) returns which removed delete files / deletion vectors are still present so
-// the retry summary does not double-subtract a peer's prior removal.
+// the retry summary does not double-subtract a peer's prior removal. A DV
+// superseded by a peer (same referenced data file, new path) counts as absent:
+// the replacement is inherited untouched and our removal is a no-op.
 func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePresence, error) {
 	present := &removedFilePresence{
 		deleteFiles: map[string]struct{}{},
@@ -1058,8 +1062,11 @@ func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePre
 			if isDeletionVector(df) {
 				// A DV without a referenced data file cannot be matched by ref;
 				// skip it rather than misclassifying it as a path-keyed delete file.
+				// The path must match too: a peer may have superseded our DV with
+				// a replacement for the same data file (same ref, new path), and
+				// that replacement must not read as "our DV is still present".
 				if ref := df.ReferencedDataFile(); ref != nil {
-					if _, want := sp.deletedDVsByRef[*ref]; want {
+					if want, ok := sp.deletedDVsByRef[*ref]; ok && want.FilePath() == df.FilePath() {
 						present.dvRefs[*ref] = struct{}{}
 					}
 				}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -26,7 +26,6 @@ import (
 	"maps"
 	"runtime"
 	"slices"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -913,7 +912,7 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 // because a peer may have already dropped it — replaying the captured removal
 // delta on top of a fresh parent that no longer counts the file undercounts
 // total-delete-files. Removed data files are always counted: a successful retry
-// has already asserted they are present (assertRemovedFilesPresent).
+// has already asserted they are present (checkRemovedFiles).
 func (sp *snapshotProducer) summaryOnRetry(props iceberg.Properties, parent *Snapshot, present *removedFilePresence) (Summary, error) {
 	delta, err := sp.accumulateSummaryDelta(present.counts)
 	if err != nil {
@@ -1025,6 +1024,13 @@ func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePre
 		dvRefs:      map[string]struct{}{},
 	}
 
+	// Producers that remove nothing (fast/merge append) skip the parent scan
+	// entirely — otherwise every retry re-reads the full manifest list only to
+	// find there is nothing to check.
+	if len(sp.deletedFiles) == 0 && len(sp.deletedDeleteFiles) == 0 && len(sp.deletedDVsByRef) == 0 {
+		return present, nil
+	}
+
 	missingData := make(map[string]struct{}, len(sp.deletedFiles))
 	for path := range sp.deletedFiles {
 		missingData[path] = struct{}{}
@@ -1049,11 +1055,18 @@ func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePre
 
 				continue
 			}
-			if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
-				if _, want := sp.deletedDVsByRef[*ref]; want {
-					present.dvRefs[*ref] = struct{}{}
+			if isDeletionVector(df) {
+				// A DV without a referenced data file cannot be matched by ref;
+				// skip it rather than misclassifying it as a path-keyed delete file.
+				if ref := df.ReferencedDataFile(); ref != nil {
+					if _, want := sp.deletedDVsByRef[*ref]; want {
+						present.dvRefs[*ref] = struct{}{}
+					}
 				}
-			} else if _, want := sp.deletedDeleteFiles[df.FilePath()]; want {
+
+				continue
+			}
+			if _, want := sp.deletedDeleteFiles[df.FilePath()]; want {
 				present.deleteFiles[df.FilePath()] = struct{}{}
 			}
 		}
@@ -1071,9 +1084,9 @@ func (sp *snapshotProducer) missingDataError(present *removedFilePresence, missi
 	for path := range missingData {
 		missing = append(missing, path)
 	}
-	sort.Strings(missing)
+	slices.Sort(missing)
 
-	return nil, fmt.Errorf("%w: %d data file(s) to rewrite are no longer on the branch head, e.g. %v",
+	return nil, fmt.Errorf("%w: %d data file(s) to rewrite are no longer on the branch head, e.g. %q",
 		ErrCommitDiverged, len(missing), missing[:min(len(missing), 5)])
 }
 
@@ -1277,9 +1290,11 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 		// removal is not subtracted twice, which would undercount
 		// total-delete-files.
 		if freshParent != nil && freshParent.Summary != nil && capturedSnapshot.Summary != nil {
-			if s, sumErr := sp.summaryOnRetry(sp.snapshotProps, freshParent, present); sumErr == nil {
-				rebuilt.Summary = &s
+			s, sumErr := sp.summaryOnRetry(sp.snapshotProps, freshParent, present)
+			if sumErr != nil {
+				return nil, fmt.Errorf("rebuild manifest list: recompute summary: %w", sumErr)
 			}
+			rebuilt.Summary = &s
 		}
 
 		return &rebuilt, nil

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -26,6 +26,7 @@ import (
 	"maps"
 	"runtime"
 	"slices"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -44,11 +45,17 @@ type producerImpl interface {
 	// before writing a manifest list file, using the result of this function
 	// as the final list of manifests to write.
 	processManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error)
-	// perform any processing necessary and return the list of existing
-	// manifests that should be included in the snapshot
-	existingManifests() ([]iceberg.ManifestFile, error)
-	// return the deleted entries for writing delete file manifests
-	deletedEntries(ctx context.Context) ([]iceberg.ManifestEntry, error)
+	// existingManifests returns the manifests inherited from parent that must
+	// be carried into the new snapshot. parent is the snapshot this producer is
+	// layered on (nil means none). Appends return parent's manifests as-is;
+	// overwrites return them with removed data/delete files filtered out. It is
+	// re-evaluated against the fresh parent on every OCC retry, so it must read
+	// parent rather than the transaction's (stale) base snapshot.
+	existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error)
+	// deletedEntries returns the DELETE manifest entries for files this
+	// producer removes from parent (nil means none), re-evaluated against the
+	// fresh parent on every OCC retry.
+	deletedEntries(ctx context.Context, parent *Snapshot) ([]iceberg.ManifestEntry, error)
 	// validate runs producer-specific conflict checks against the
 	// current catalog state. Implementations should return a wrapped
 	// ErrCommit* sentinel on conflict, ErrCommitDiverged on terminal
@@ -88,20 +95,15 @@ func (fa *fastAppendFiles) processManifests(manifests []iceberg.ManifestFile) ([
 	return manifests, nil
 }
 
-func (fa *fastAppendFiles) existingManifests() ([]iceberg.ManifestFile, error) {
-	if fa.base.parentSnapshotID <= 0 {
+func (fa *fastAppendFiles) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
+	if parent == nil {
 		return nil, nil
 	}
 
-	previous, err := fa.base.txn.meta.SnapshotByID(fa.base.parentSnapshotID)
-	if err != nil {
-		return nil, fmt.Errorf("could not find parent snapshot %d: %w", fa.base.parentSnapshotID, err)
-	}
-
-	return previous.Manifests(fa.base.io)
+	return parent.Manifests(fa.base.io)
 }
 
-func (fa *fastAppendFiles) deletedEntries(_ context.Context) ([]iceberg.ManifestEntry, error) {
+func (fa *fastAppendFiles) deletedEntries(_ context.Context, _ *Snapshot) ([]iceberg.ManifestEntry, error) {
 	// for fast appends, there are no deleted entries
 	return nil, nil
 }
@@ -151,16 +153,15 @@ func (of *overwriteFiles) processManifests(manifests []iceberg.ManifestFile) ([]
 	return manifests, nil
 }
 
-func (of *overwriteFiles) existingManifests() ([]iceberg.ManifestFile, error) {
+func (of *overwriteFiles) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
 	// determine if there are any existing manifest files
 	existingFiles := make([]iceberg.ManifestFile, 0)
 
-	snap := of.base.txn.meta.currentSnapshot()
-	if snap == nil {
+	if parent == nil {
 		return existingFiles, nil
 	}
 
-	manifestList, err := snap.Manifests(of.base.io)
+	manifestList, err := parent.Manifests(of.base.io)
 	if err != nil {
 		return existingFiles, err
 	}
@@ -273,19 +274,14 @@ func (of *overwriteFiles) validate(cc *conflictContext) error {
 	return validateAddedDataFilesMatchingFilter(cc, filter)
 }
 
-func (of *overwriteFiles) deletedEntries(ctx context.Context) ([]iceberg.ManifestEntry, error) {
+func (of *overwriteFiles) deletedEntries(ctx context.Context, parent *Snapshot) ([]iceberg.ManifestEntry, error) {
 	// determine if we need to record any deleted entries
 	//
 	// with a full overwrite all the entries are considered deleted
 	// with partial overwrites we have to use the predicate to evaluate
 	// which entries are affected
-	if of.base.parentSnapshotID <= 0 {
+	if parent == nil {
 		return nil, nil
-	}
-
-	parent, err := of.base.txn.meta.SnapshotByID(of.base.parentSnapshotID)
-	if err != nil {
-		return nil, fmt.Errorf("%w: cannot overwrite empty table", err)
 	}
 
 	previousManifests, err := parent.Manifests(of.base.io)
@@ -667,18 +663,60 @@ func (sp *snapshotProducer) iterManifestEntries(m iceberg.ManifestFile, discardD
 	return m.Entries(sp.io, discardDeleted)
 }
 
-func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.ManifestFile, err error) {
-	deleted, err := sp.deletedEntries(ctx)
+// parentSnapshot resolves the snapshot this producer is layered on (the branch
+// head captured when the producer was built), or nil for the first snapshot.
+func (sp *snapshotProducer) parentSnapshot() (*Snapshot, error) {
+	if sp.parentSnapshotID <= 0 {
+		return nil, nil
+	}
+
+	return sp.txn.meta.SnapshotByID(sp.parentSnapshotID)
+}
+
+func (sp *snapshotProducer) manifests(ctx context.Context) ([]iceberg.ManifestFile, error) {
+	parent, err := sp.parentSnapshot()
 	if err != nil {
 		return nil, err
 	}
 
+	all, _, err := sp.buildManifests(ctx, parent)
+
+	return all, err
+}
+
+// buildManifests assembles the new snapshot's full manifest set layered on
+// parent and separately returns the parent-independent added-content manifests
+// so the caller can reuse them across OCC retries. The parent-dependent portion
+// (which evaluates deletedEntries) is built before any added-content writer is
+// created, so a delete-side failure cannot orphan added-content writers.
+func (sp *snapshotProducer) buildManifests(ctx context.Context, parent *Snapshot) (all, addedContent []iceberg.ManifestFile, err error) {
+	dependent, err := sp.parentDependentManifests(ctx, parent)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	addedContent, err = sp.addedContentManifests()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	all, err = sp.processManifests(slices.Concat(addedContent, dependent))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return all, addedContent, nil
+}
+
+// addedContentManifests writes the manifests for this producer's newly added
+// data and delete files. They do not depend on the parent snapshot, so they are
+// written once and reused verbatim across OCC retries (rewriting them would
+// churn manifest paths and orphan object-store files on every attempt).
+func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, error) {
 	var g errgroup.Group
 
 	addedManifests := make([]iceberg.ManifestFile, 0)
 	positionDeleteManifests := make([]iceberg.ManifestFile, 0)
-	var deletedFilesManifests []iceberg.ManifestFile
-	var existingManifests []iceberg.ManifestFile
 
 	if len(sp.addedFiles) > 0 {
 		g.Go(sp.manifestProducer(iceberg.ManifestContentData, sp.addedFiles, &addedManifests))
@@ -687,6 +725,44 @@ func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.Manifest
 	if len(sp.addedDeleteFiles) > 0 {
 		g.Go(sp.manifestProducer(iceberg.ManifestContentDeletes, sp.addedDeleteFiles, &positionDeleteManifests))
 	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return slices.Concat(addedManifests, positionDeleteManifests), nil
+}
+
+// assembleManifests recomputes the parent-dependent manifests against parent and
+// combines them with the already-written added-content manifests, then applies
+// producer-specific post-processing (manifest merging for merge-append, a no-op
+// otherwise). Used on OCC retries, where addedContent was written at attempt 0
+// and is reused verbatim.
+func (sp *snapshotProducer) assembleManifests(ctx context.Context, parent *Snapshot, addedContent []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	dependent, err := sp.parentDependentManifests(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	return sp.processManifests(slices.Concat(addedContent, dependent))
+}
+
+// parentDependentManifests builds the manifests whose contents depend on the
+// parent the new snapshot is layered on: DELETE tombstone manifests for removed
+// files, followed by the inherited/filtered existing manifests. It is recomputed
+// against the fresh parent on every OCC retry so that a concurrent writer's
+// files are inherited and the removed files are actually dropped — grafting the
+// attempt-0 result onto a fresh parent would resurrect the removed files.
+func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent *Snapshot) (_ []iceberg.ManifestFile, err error) {
+	deleted, err := sp.deletedEntries(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	var g errgroup.Group
+
+	var deletedFilesManifests []iceberg.ManifestFile
+	var existingManifests []iceberg.ManifestFile
 
 	if len(deleted) > 0 {
 		g.Go(func() error {
@@ -749,7 +825,7 @@ func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.Manifest
 	}
 
 	g.Go(func() error {
-		m, err := sp.existingManifests()
+		m, err := sp.existingManifests(parent)
 		if err != nil {
 			return err
 		}
@@ -762,9 +838,7 @@ func (sp *snapshotProducer) manifests(ctx context.Context) (_ []iceberg.Manifest
 		return nil, err
 	}
 
-	manifests := slices.Concat(addedManifests, positionDeleteManifests, deletedFilesManifests, existingManifests)
-
-	return sp.processManifests(manifests)
+	return slices.Concat(deletedFilesManifests, existingManifests), nil
 }
 
 func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, files []iceberg.DataFile, output *[]iceberg.ManifestFile) func() (err error) {
@@ -812,53 +886,9 @@ func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, 
 }
 
 func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
-	var ssc SnapshotSummaryCollector
-	partitionSummaryLimit := sp.txn.meta.props.
-		GetInt(WritePartitionSummaryLimitKey, WritePartitionSummaryLimitDefault)
-	ssc.setPartitionSummaryLimit(partitionSummaryLimit)
-
-	var err error
-	currentSchema := sp.txn.meta.CurrentSchema()
-	partitionSpec, err := sp.txn.meta.CurrentSpec()
-	if err != nil || partitionSpec == nil {
-		return Summary{}, fmt.Errorf("could not get current partition spec: %w", err)
-	}
-	for _, df := range sp.addedFiles {
-		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
-			return Summary{}, err
-		}
-	}
-	for _, df := range sp.addedDeleteFiles {
-		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
-			return Summary{}, err
-		}
-	}
-
-	if len(sp.deletedFiles) > 0 {
-		specs := sp.txn.meta.specs
-		for _, df := range sp.deletedFiles {
-			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
-				return Summary{}, err
-			}
-		}
-	}
-
-	if len(sp.deletedDeleteFiles) > 0 {
-		specs := sp.txn.meta.specs
-		for _, df := range sp.deletedDeleteFiles {
-			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
-				return Summary{}, err
-			}
-		}
-	}
-
-	if len(sp.deletedDVsByRef) > 0 {
-		specs := sp.txn.meta.specs
-		for _, df := range sp.deletedDVsByRef {
-			if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
-				return Summary{}, err
-			}
-		}
+	delta, err := sp.accumulateSummaryDelta(nil)
+	if err != nil {
+		return Summary{}, err
 	}
 
 	var previousSnapshot *Snapshot
@@ -874,63 +904,189 @@ func (sp *snapshotProducer) summary(props iceberg.Properties) (Summary, error) {
 		previousSummary = previousSnapshot.Summary.Properties
 	}
 
-	summaryProps := ssc.build()
-	maps.Copy(summaryProps, props)
-
-	return updateSnapshotSummaries(Summary{
-		Operation:  sp.op,
-		Properties: summaryProps,
-	}, previousSummary)
+	return sp.rebaseSummary(delta, previousSummary, props)
 }
 
-// computeOwnManifests returns the subset of allManifests that were written
-// by this producer (i.e. not inherited from the parent snapshot). These are
-// preserved across OCC retry attempts when the manifest list is rebuilt
-// against a fresh parent.
-func (sp *snapshotProducer) computeOwnManifests(allManifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
-	if sp.parentSnapshotID <= 0 {
-		// No parent means all manifests are new — nothing to exclude.
-		return allManifests, nil
-	}
-
-	parent, err := sp.txn.meta.SnapshotByID(sp.parentSnapshotID)
+// summaryOnRetry recomputes the snapshot summary against the fresh parent for an
+// OCC retry. Additions are always counted; a removal of a delete file / deletion
+// vector is counted only when it is still present on parent (present.counts),
+// because a peer may have already dropped it — replaying the captured removal
+// delta on top of a fresh parent that no longer counts the file undercounts
+// total-delete-files. Removed data files are always counted: a successful retry
+// has already asserted they are present (assertRemovedFilesPresent).
+func (sp *snapshotProducer) summaryOnRetry(props iceberg.Properties, parent *Snapshot, present *removedFilePresence) (Summary, error) {
+	delta, err := sp.accumulateSummaryDelta(present.counts)
 	if err != nil {
-		return nil, fmt.Errorf("computeOwnManifests: lookup parent snapshot %d: %w", sp.parentSnapshotID, err)
-	}
-	if parent == nil {
-		return nil, fmt.Errorf("%w: computeOwnManifests parent id %d", ErrSnapshotNotFound, sp.parentSnapshotID)
+		return Summary{}, err
 	}
 
-	parentManifests, err := parent.Manifests(sp.io)
-	if err != nil {
-		return nil, fmt.Errorf("computeOwnManifests: read parent manifests: %w", err)
+	var previousSummary iceberg.Properties
+	if parent != nil && parent.Summary != nil {
+		previousSummary = parent.Summary.Properties
 	}
 
-	inherited := make(map[string]bool, len(parentManifests))
-	for _, m := range parentManifests {
-		inherited[m.FilePath()] = true
-	}
+	return sp.rebaseSummary(delta, previousSummary, props)
+}
 
-	own := make([]iceberg.ManifestFile, 0, len(allManifests))
-	for _, m := range allManifests {
-		if !inherited[m.FilePath()] {
-			own = append(own, m)
+// accumulateSummaryDelta builds the added/removed file delta for this producer.
+// countDeleteRemoval, when non-nil, gates removal of delete files / deletion
+// vectors (returning false skips that removal); data-file removals are always
+// counted. nil counts every removal (the initial commit).
+func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(iceberg.DataFile) bool) (iceberg.Properties, error) {
+	var ssc SnapshotSummaryCollector
+	partitionSummaryLimit := sp.txn.meta.props.
+		GetInt(WritePartitionSummaryLimitKey, WritePartitionSummaryLimitDefault)
+	ssc.setPartitionSummaryLimit(partitionSummaryLimit)
+
+	currentSchema := sp.txn.meta.CurrentSchema()
+	partitionSpec, err := sp.txn.meta.CurrentSpec()
+	if err != nil || partitionSpec == nil {
+		return nil, fmt.Errorf("could not get current partition spec: %w", err)
+	}
+	for _, df := range sp.addedFiles {
+		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+			return nil, err
+		}
+	}
+	for _, df := range sp.addedDeleteFiles {
+		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+			return nil, err
 		}
 	}
 
-	return own, nil
+	specs := sp.txn.meta.specs
+	for _, df := range sp.deletedFiles {
+		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+			return nil, err
+		}
+	}
+	for _, df := range sp.deletedDeleteFiles {
+		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
+			continue
+		}
+		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+			return nil, err
+		}
+	}
+	for _, df := range sp.deletedDVsByRef {
+		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
+			continue
+		}
+		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+			return nil, err
+		}
+	}
+
+	return ssc.build(), nil
+}
+
+func (sp *snapshotProducer) rebaseSummary(delta, previousSummary, props iceberg.Properties) (Summary, error) {
+	maps.Copy(delta, props)
+
+	return updateSnapshotSummaries(Summary{
+		Operation:  sp.op,
+		Properties: delta,
+	}, previousSummary)
+}
+
+// removedFilePresence records which of a producer's to-be-removed delete files
+// and deletion vectors are still live on the retry's fresh parent. counts is the
+// gate passed to accumulateSummaryDelta so the retry summary only subtracts
+// removals the parent still counts.
+type removedFilePresence struct {
+	deleteFiles map[string]struct{} // pos/eq delete FilePath()
+	dvRefs      map[string]struct{} // deletion-vector ReferencedDataFile()
+}
+
+func (p *removedFilePresence) counts(df iceberg.DataFile) bool {
+	if isDeletionVector(df) {
+		ref := df.ReferencedDataFile()
+		if ref == nil {
+			return false
+		}
+		_, ok := p.dvRefs[*ref]
+
+		return ok
+	}
+	_, ok := p.deleteFiles[df.FilePath()]
+
+	return ok
+}
+
+// checkRemovedFiles scans parent once and (1) fails terminally if any data file
+// this producer intends to rewrite is no longer live — a concurrent writer
+// already removed it, so proceeding would leave our replacement beside the
+// concurrent result and duplicate rows (Java's failMissingDeletePaths) — and
+// (2) returns which removed delete files / deletion vectors are still present so
+// the retry summary does not double-subtract a peer's prior removal.
+func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePresence, error) {
+	present := &removedFilePresence{
+		deleteFiles: map[string]struct{}{},
+		dvRefs:      map[string]struct{}{},
+	}
+
+	missingData := make(map[string]struct{}, len(sp.deletedFiles))
+	for path := range sp.deletedFiles {
+		missingData[path] = struct{}{}
+	}
+
+	if parent == nil {
+		return sp.missingDataError(present, missingData)
+	}
+
+	manifests, err := parent.Manifests(sp.io)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range manifests {
+		for entry, err := range sp.iterManifestEntries(m, true) {
+			if err != nil {
+				return nil, err
+			}
+			df := entry.DataFile()
+			if m.ManifestContent() == iceberg.ManifestContentData {
+				delete(missingData, df.FilePath())
+
+				continue
+			}
+			if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
+				if _, want := sp.deletedDVsByRef[*ref]; want {
+					present.dvRefs[*ref] = struct{}{}
+				}
+			} else if _, want := sp.deletedDeleteFiles[df.FilePath()]; want {
+				present.deleteFiles[df.FilePath()] = struct{}{}
+			}
+		}
+	}
+
+	return sp.missingDataError(present, missingData)
+}
+
+func (sp *snapshotProducer) missingDataError(present *removedFilePresence, missingData map[string]struct{}) (*removedFilePresence, error) {
+	if len(missingData) == 0 {
+		return present, nil
+	}
+
+	missing := make([]string, 0, len(missingData))
+	for path := range missingData {
+		missing = append(missing, path)
+	}
+	sort.Strings(missing)
+
+	return nil, fmt.Errorf("%w: %d data file(s) to rewrite are no longer on the branch head, e.g. %v",
+		ErrCommitDiverged, len(missing), missing[:min(len(missing), 5)])
 }
 
 func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Requirement, err error) {
-	newManifests, err := sp.manifests(ctx)
+	parent, err := sp.parentSnapshot()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Separate "own" manifests (those written by this producer) from
-	// manifests inherited from the stale parent. The own manifests are
-	// preserved when the manifest list is rebuilt during OCC retries.
-	ownManifests, err := sp.computeOwnManifests(newManifests)
+	// addedContent is parent-independent: written once here and reused verbatim
+	// on every OCC retry (rebuildManifestList recomputes only the parent-
+	// dependent portion against the fresh parent).
+	newManifests, addedContent, err := sp.buildManifests(ctx, parent)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1030,25 +1186,25 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	snapshotID := sp.snapshotID
 	commitUUID := sp.commitUuid
 	capturedSnapshot := snapshot // copy the value so the closure is self-contained
-	processManifestsFn := func(m []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
-		return sp.processManifests(m)
-	}
 
-	rebuildFn := func(_ context.Context, freshMeta Metadata, freshParent *Snapshot, fio iceio.WriteFileIO, attempt int) (_ *Snapshot, retErr error) {
-		// Load inherited manifests from the fresh parent.
-		var inherited []iceberg.ManifestFile
-		if freshParent != nil {
-			inherited, retErr = freshParent.Manifests(fio)
-			if retErr != nil {
-				return nil, fmt.Errorf("rebuild manifest list: load parent manifests: %w", retErr)
-			}
+	rebuildFn := func(rebuildCtx context.Context, freshMeta Metadata, freshParent *Snapshot, fio iceio.WriteFileIO, attempt int) (_ *Snapshot, retErr error) {
+		// A concurrent writer may have already removed the files this producer
+		// intends to rewrite. Grafting our replacement on top of the fresh
+		// parent would duplicate rows, so abort terminally. The scan also
+		// reports which removed delete files / DVs survive on the fresh parent
+		// so the summary below does not double-subtract a peer's prior removal.
+		present, err := sp.checkRemovedFiles(freshParent)
+		if err != nil {
+			return nil, err
 		}
 
-		// Combine own manifests with inherited ones, applying any
-		// producer-specific processing (no-op for fast/merge-append).
-		combined, procErr := processManifestsFn(slices.Concat(ownManifests, inherited))
+		// Recompute the parent-dependent manifests (inherited/filtered existing
+		// manifests plus DELETE tombstones) against the fresh parent and combine
+		// them with the reused added-content manifests. This drops the removed
+		// files from the fresh parent's manifests rather than resurrecting them.
+		combined, procErr := sp.assembleManifests(rebuildCtx, freshParent, addedContent)
 		if procErr != nil {
-			return nil, fmt.Errorf("rebuild manifest list: process manifests: %w", procErr)
+			return nil, fmt.Errorf("rebuild manifest list: assemble manifests: %w", procErr)
 		}
 
 		// Derive the sequence number from the fresh table-wide last-sequence-number.
@@ -1115,17 +1271,13 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 			rebuilt.AddedRows = &addedRows
 		}
 
-		// Recompute snapshot summary against the fresh parent so that totals
-		// (total-records, total-data-files, total-files-size) are not regressed
-		// to the stale values captured at attempt 0. The per-operation delta
-		// (added-data-files, added-records, etc.) is preserved in
-		// capturedSnapshot.Summary and is replayed on top of the fresh base.
+		// Recompute the snapshot summary against the fresh parent so totals are
+		// not regressed to the stale attempt-0 values. Removals of delete files
+		// / DVs are gated by present (see checkRemovedFiles) so a peer's prior
+		// removal is not subtracted twice, which would undercount
+		// total-delete-files.
 		if freshParent != nil && freshParent.Summary != nil && capturedSnapshot.Summary != nil {
-			deltaSummary := Summary{
-				Operation:  capturedSnapshot.Summary.Operation,
-				Properties: maps.Clone(capturedSnapshot.Summary.Properties),
-			}
-			if s, sumErr := updateSnapshotSummaries(deltaSummary, freshParent.Summary.Properties); sumErr == nil {
+			if s, sumErr := sp.summaryOnRetry(sp.snapshotProps, freshParent, present); sumErr == nil {
 				rebuilt.Summary = &s
 			}
 		}
@@ -1134,7 +1286,7 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	}
 
 	addSnap := NewAddSnapshotUpdate(&snapshot)
-	addSnap.ownManifests = ownManifests
+	addSnap.ownManifests = addedContent
 	addSnap.rebuildManifestList = rebuildFn
 
 	return []Update{

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -1427,6 +1427,189 @@ func TestCheckRemovedFiles_ShortCircuitsWithNothingToRemove(t *testing.T) {
 	require.Empty(t, present.dvRefs)
 }
 
+// TestDeleteFileRemoved_DVMatchesByRefAndPath pins the DV expunge identity:
+// a deletion vector matches a captured removal only when both its referenced
+// data file and its path match. Ref-only matching would drop a peer's
+// replacement DV on an OCC retry; path-only matching would drop Puffin
+// siblings sharing the file.
+func TestDeleteFileRemoved_DVMatchesByRefAndPath(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	dv := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(dv)
+
+	require.True(t, sp.deleteFileRemoved(dv), "exact (ref, path) pair matches")
+
+	replacement := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-new.puffin", dataPath)
+	require.False(t, sp.deleteFileRemoved(replacement),
+		"a peer's replacement DV (same ref, new path) must survive")
+
+	sibling := newTestDeletionVectorForRef(t, spec, dv.FilePath(), "mem://default/table-location/data/other.parquet")
+	require.False(t, sp.deleteFileRemoved(sibling),
+		"a Puffin sibling (same path, other ref) must survive")
+}
+
+// TestCheckRemovedFiles_SupersededDVReadsAsAbsent covers the concurrent DV
+// replacement race: a peer removed the DV this producer intends to expunge and
+// added a new one for the same data file. The replacement must not read as
+// "our DV is still present" — otherwise the retry summary subtracts a removal
+// the fresh parent no longer counts.
+func TestCheckRemovedFiles_SupersededDVReadsAsAbsent(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	staleDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(staleDV)
+
+	peerDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-new.puffin", dataPath)
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 91, "superseded", peerDV)
+
+	present, err := sp.checkRemovedFiles(parent)
+	require.NoError(t, err)
+	require.Empty(t, present.dvRefs,
+		"a superseded DV (same ref, different path) must not read as present")
+
+	s, err := sp.summaryOnRetry(nil, parent, present)
+	require.NoError(t, err)
+	require.Equal(t, "1", s.Properties["total-delete-files"],
+		"the peer's replacement DV stays counted on the retry summary")
+	require.Equal(t, "1", s.Properties["total-position-deletes"],
+		"the peer's position deletes stay counted on the retry summary")
+}
+
+// TestCheckRemovedFiles_ExactDVPresentAndSubtracted is the companion guard:
+// when the exact DV this producer removes is still live on the fresh parent,
+// it must be marked present and the retry summary must subtract it.
+func TestCheckRemovedFiles_ExactDVPresentAndSubtracted(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	staleDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(staleDV)
+
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 92, "exact", staleDV)
+
+	present, err := sp.checkRemovedFiles(parent)
+	require.NoError(t, err)
+	require.Contains(t, present.dvRefs, dataPath, "the exact DV is still live on parent")
+
+	s, err := sp.summaryOnRetry(nil, parent, present)
+	require.NoError(t, err)
+	require.Equal(t, "0", s.Properties["total-delete-files"],
+		"a DV still present on the fresh parent must be subtracted (1→0)")
+}
+
+// TestExistingManifests_SupersededDVSurvivesRetry pins the manifest-filter half
+// of the pair-matching rule: on an OCC retry the fresh parent may carry a
+// peer's replacement DV for the data file whose DV this producer removes. The
+// replacement must be inherited untouched and not tombstoned — ref-only
+// matching would expunge it and resurrect the rows the peer deleted.
+func TestExistingManifests_SupersededDVSurvivesRetry(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	staleDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(staleDV)
+
+	peerDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-new.puffin", dataPath)
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 93, "survives", peerDV)
+
+	parentManifests, err := parent.Manifests(wfs)
+	require.NoError(t, err)
+	require.Len(t, parentManifests, 1)
+
+	got, err := sp.existingManifests(parent)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "the peer's deletes manifest must be inherited")
+	require.Equal(t, parentManifests[0].FilePath(), got[0].FilePath(),
+		"nothing matched, so the manifest is passed through untouched")
+
+	tombstones, err := sp.deletedEntries(context.Background(), parent)
+	require.NoError(t, err)
+	require.Empty(t, tombstones, "no DELETE tombstone for the peer's replacement DV")
+}
+
+// TestExistingManifests_ExactDVStillExpunged is the companion guard: the exact
+// captured DV is still filtered from the inherited manifests and tombstoned.
+func TestExistingManifests_ExactDVStillExpunged(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	staleDV := newTestDeletionVectorForRef(t, spec, "mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(staleDV)
+
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 94, "expunged", staleDV)
+
+	got, err := sp.existingManifests(parent)
+	require.NoError(t, err)
+	require.Empty(t, got, "a manifest whose only entry is the removed DV is dropped")
+
+	tombstones, err := sp.deletedEntries(context.Background(), parent)
+	require.NoError(t, err)
+	require.Len(t, tombstones, 1)
+	require.Equal(t, staleDV.FilePath(), tombstones[0].DataFile().FilePath())
+}
+
+// writeParentSnapshotWithDeletesManifest writes a v3 deletes manifest holding
+// the given delete files plus its manifest list into fs and returns a parent
+// snapshot pointing at it. v3 because referenced_data_file only serializes in
+// the v3 data_file schema. The summary counts one delete file so retry-summary
+// assertions can observe whether a removal was subtracted.
+func writeParentSnapshotWithDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.PartitionSpec, snapshotID int64, tag string, deleteFiles ...iceberg.DataFile) *Snapshot {
+	t.Helper()
+
+	manifestPath := "mem://default/table-location/metadata/deletes-" + tag + ".avro"
+	var buf bytes.Buffer
+	wr, err := iceberg.NewManifestWriter(3, &buf, spec, simpleSchema(), snapshotID,
+		iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+	for _, df := range deleteFiles {
+		require.NoError(t, wr.Add(iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, df)))
+	}
+	require.NoError(t, wr.Close())
+	mf, err := wr.ToManifestFile(manifestPath, int64(buf.Len()),
+		iceberg.WithManifestFileContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+
+	out, err := fs.Create(manifestPath)
+	require.NoError(t, err)
+	_, err = out.Write(buf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	listPath := "mem://default/table-location/metadata/snap-" + tag + ".avro"
+	lout, err := fs.Create(listPath)
+	require.NoError(t, err)
+	seq := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(3, lout, snapshotID, nil, &seq, 0, []iceberg.ManifestFile{mf}))
+	require.NoError(t, lout.Close())
+
+	return &Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: seq,
+		ManifestList:   listPath,
+		Summary: &Summary{Operation: OpAppend, Properties: iceberg.Properties{
+			"total-delete-files":     "1",
+			"total-position-deletes": "1",
+			"total-equality-deletes": "0",
+			"total-data-files":       "1",
+			"total-records":          "1",
+			"total-files-size":       "1",
+		}},
+	}
+}
+
 func TestAddDataFilesV3RejectsWithoutFirstRowID(t *testing.T) {
 	spec := iceberg.NewPartitionSpec()
 	txn, _ := createTestTransactionWithMemIO(t, spec)

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -615,7 +615,7 @@ func TestOverwriteFilesExistingManifestsClosesWriterOnError(t *testing.T) {
 	sp := newOverwriteFilesProducer(OpOverwrite, txn, mem, nil, nil)
 	sp.deleteDataFile(deletedFile)
 
-	_, err = sp.existingManifests()
+	_, err = sp.existingManifests(&snap)
 	require.ErrorIs(t, err, errLimitedWrite)
 }
 
@@ -938,7 +938,7 @@ func TestOverwriteExistingManifestsClosesUnderlyingFile(t *testing.T) {
 
 	trackIO.writers = make(map[string]*trackingWriteCloser)
 
-	_, err = sp.existingManifests()
+	_, err = sp.existingManifests(&snap)
 	require.NoError(t, err, "existingManifests should succeed")
 
 	unclosed := trackIO.GetUnclosedWriters()
@@ -958,11 +958,11 @@ func (e *errorOnDeletedEntries) processManifests(manifests []iceberg.ManifestFil
 	return manifests, nil
 }
 
-func (e *errorOnDeletedEntries) existingManifests() ([]iceberg.ManifestFile, error) {
+func (e *errorOnDeletedEntries) existingManifests(_ *Snapshot) ([]iceberg.ManifestFile, error) {
 	return nil, nil
 }
 
-func (e *errorOnDeletedEntries) deletedEntries(_ context.Context) ([]iceberg.ManifestEntry, error) {
+func (e *errorOnDeletedEntries) deletedEntries(_ context.Context, _ *Snapshot) ([]iceberg.ManifestEntry, error) {
 	if e.waitForWriter != nil {
 		select {
 		case <-e.waitForWriter:
@@ -1138,18 +1138,18 @@ func TestFastAppendInheritsZeroCountManifests(t *testing.T) {
 	require.True(t, newManifestFound, "new snapshot must include a manifest written by snap2")
 }
 
-// TestComputeOwnManifests_NewTable verifies that when there is no parent
-// snapshot (parentSnapshotID == 0) all manifests are returned as-is with no error.
-func TestComputeOwnManifests_NewTable(t *testing.T) {
+// TestParentDependentManifests_NilParent verifies that with no parent snapshot
+// there is nothing to inherit or delete, so the parent-dependent manifest set
+// is empty.
+func TestParentDependentManifests_NilParent(t *testing.T) {
 	spec := iceberg.NewPartitionSpec()
 	io := newMemIO(1<<20, nil)
 	txn := createTestTransaction(t, io, spec)
 	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
-	// parentSnapshotID is 0 by default (new table) — all manifests belong to this producer.
 
-	got, err := sp.computeOwnManifests(nil)
-	require.NoError(t, err, "new table: computeOwnManifests must not error")
-	require.Nil(t, got, "new table: returned manifests must equal input")
+	got, err := sp.parentDependentManifests(context.Background(), nil)
+	require.NoError(t, err, "nil parent: parentDependentManifests must not error")
+	require.Empty(t, got, "nil parent: nothing to inherit or delete")
 }
 
 // TestSummary_SnapshotByIDError verifies that summary computation fails when
@@ -1225,50 +1225,163 @@ func TestSummary_ParentSnapshotWithoutSummary(t *testing.T) {
 	require.Equal(t, "1", sum.Properties[addedDataFilesKey])
 }
 
-// TestComputeOwnManifests_SnapshotByIDError verifies that when the parent
-// snapshot cannot be found an error is returned instead of silently claiming
-// all manifests as own.
-func TestComputeOwnManifests_SnapshotByIDError(t *testing.T) {
+// TestParentSnapshot_SnapshotByIDError verifies that when the parent snapshot
+// cannot be found an error is returned instead of a silent nil parent — which
+// would drop all inherited data from the new snapshot.
+func TestParentSnapshot_SnapshotByIDError(t *testing.T) {
 	spec := iceberg.NewPartitionSpec()
 	io := newMemIO(1<<20, nil)
 	txn := createTestTransaction(t, io, spec)
 	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
 	sp.parentSnapshotID = 9999 // no such snapshot in metadata
 
-	got, err := sp.computeOwnManifests(nil)
+	got, err := sp.parentSnapshot()
 	require.Error(t, err, "unknown parent snapshot ID: must return error, not silent fallback")
 	require.ErrorIs(t, err, ErrSnapshotNotFound,
 		"production wraps ErrSnapshotNotFound; pin meaning via errors.Is so a regression "+
-			"that swallows the lookup error and returns a programming-bug error would fail this test")
-	require.Nil(t, got, "error path must return nil manifest slice")
+			"that swallows the lookup error would fail this test")
+	require.Nil(t, got, "error path must return nil snapshot")
 }
 
-// TestComputeOwnManifests_ParentManifestsIOError verifies that when the parent
-// snapshot exists but its manifest list file cannot be read an error is returned
-// instead of silently claiming all manifests as own (which would cause duplicates
-// in the rebuilt manifest list).
-func TestComputeOwnManifests_ParentManifestsIOError(t *testing.T) {
+// TestParentDependentManifests_IOError verifies that when the parent snapshot's
+// manifest list file cannot be read an error is surfaced instead of a silent
+// empty inherited set (which would drop the parent's data on an OCC retry).
+func TestParentDependentManifests_IOError(t *testing.T) {
 	spec := iceberg.NewPartitionSpec()
 	io := newMemIO(1<<20, nil)
 	txn := createTestTransaction(t, io, spec)
 	sp := newFastAppendFilesProducer(OpAppend, txn, io, nil, nil)
 
-	// Add a snapshot with a manifest list path that does not exist in the IO.
-	// parent.Manifests will fail with fs.ErrNotExist when it tries to open it.
-	parentID := int64(42)
-	txn.meta.snapshotList = append(txn.meta.snapshotList, Snapshot{
-		SnapshotID:   parentID,
+	// A parent whose manifest list path does not exist in the IO: Manifests()
+	// fails with fs.ErrNotExist when it tries to open it.
+	ghostParent := &Snapshot{
+		SnapshotID:   42,
 		ManifestList: "mem://default/table-location/metadata/ghost-manifest-list.avro",
 		Summary:      &Summary{Operation: OpAppend},
-	})
-	sp.parentSnapshotID = parentID
+	}
 
-	got, err := sp.computeOwnManifests(nil)
-	require.Error(t, err, "IO error reading parent manifests: must return error, not silent fallback")
+	got, err := sp.parentDependentManifests(context.Background(), ghostParent)
+	require.Error(t, err, "IO error reading parent manifests: must surface, not silent empty set")
 	require.ErrorIs(t, err, fs.ErrNotExist,
-		"production wraps the underlying IO error; pin meaning via errors.Is so a regression that "+
-			"swallows the IO error and returns a programming-bug error would fail this test")
+		"production propagates the underlying IO error; pin meaning via errors.Is")
 	require.Nil(t, got, "error path must return nil manifest slice")
+}
+
+func newTestDeletionVectorForRef(t *testing.T, spec iceberg.PartitionSpec, path, referencedDataFile string) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes, path, iceberg.PuffinFile,
+		nil, nil, nil, 1, 1)
+	require.NoError(t, err, "new deletion vector builder")
+
+	return builder.ReferencedDataFile(referencedDataFile).Build()
+}
+
+// TestSummaryOnRetry_SkipsAlreadyRemovedDeleteFile is the regression for the
+// retry summary undercount: when a peer already removed the delete file this
+// producer also intends to remove, the fresh parent no longer counts it, so the
+// retry summary must NOT subtract it again (which would drive total-delete-files
+// below the real value).
+func TestSummaryOnRetry_SkipsAlreadyRemovedDeleteFile(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	posDel := newTestPosDeleteFileForSpec(t, spec,
+		"mem://default/table-location/data/pos-del.parquet", nil,
+		"mem://default/table-location/data/data.parquet")
+	sp.removeDeleteFile(posDel)
+
+	// Fresh parent: a peer already dropped the pos-delete. Empty manifest list,
+	// summary counts zero delete files.
+	parentManifestList := "mem://default/table-location/metadata/fresh-parent-skip.avro"
+	out, err := wfs.Create(parentManifestList)
+	require.NoError(t, err)
+	require.NoError(t, iceberg.WriteManifestList(2, out, 77, nil, ptr(int64(0)), 0, nil))
+	require.NoError(t, out.Close())
+
+	freshParent := &Snapshot{
+		SnapshotID:   77,
+		ManifestList: parentManifestList,
+		Summary: &Summary{Operation: OpAppend, Properties: iceberg.Properties{
+			"total-delete-files":     "0",
+			"total-position-deletes": "0",
+			"total-equality-deletes": "0",
+			"total-data-files":       "1",
+			"total-records":          "1",
+			"total-files-size":       "1",
+		}},
+	}
+
+	present, err := sp.checkRemovedFiles(freshParent)
+	require.NoError(t, err)
+	require.NotContains(t, present.deleteFiles, posDel.FilePath(),
+		"a pos-delete absent from the fresh parent must not be marked present")
+
+	s, err := sp.summaryOnRetry(nil, freshParent, present)
+	require.NoError(t, err)
+	require.Equal(t, "0", s.Properties["total-delete-files"],
+		"must not subtract a delete file the peer already removed")
+	require.Equal(t, "0", s.Properties["total-position-deletes"],
+		"must not subtract position deletes for an already-removed file")
+}
+
+// TestSummaryOnRetry_SubtractsPresentDeleteFile is the companion guard: when the
+// delete file the producer removes is still present on the fresh parent, the
+// retry summary MUST subtract it (the gate does not silently disable removals).
+func TestSummaryOnRetry_SubtractsPresentDeleteFile(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	posDel := newTestPosDeleteFileForSpec(t, spec,
+		"mem://default/table-location/data/pos-del.parquet", nil,
+		"mem://default/table-location/data/data.parquet")
+	sp.removeDeleteFile(posDel)
+
+	freshParent := &Snapshot{
+		SnapshotID: 88,
+		Summary: &Summary{Operation: OpAppend, Properties: iceberg.Properties{
+			"total-delete-files":     "1",
+			"total-position-deletes": "1",
+			"total-equality-deletes": "0",
+			"total-data-files":       "1",
+			"total-records":          "1",
+			"total-files-size":       "1",
+		}},
+	}
+
+	// The pos-delete is still live on the fresh parent.
+	present := &removedFilePresence{
+		deleteFiles: map[string]struct{}{posDel.FilePath(): {}},
+		dvRefs:      map[string]struct{}{},
+	}
+
+	s, err := sp.summaryOnRetry(nil, freshParent, present)
+	require.NoError(t, err)
+	require.Equal(t, "0", s.Properties["total-delete-files"],
+		"a delete file still present on the fresh parent must be subtracted (1→0)")
+}
+
+// TestRemovedFilePresenceCounts pins the gate's matching rules: pos/eq deletes
+// match by path, deletion vectors by referenced data file.
+func TestRemovedFilePresenceCounts(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	present := &removedFilePresence{
+		deleteFiles: map[string]struct{}{"file://present-del.parquet": {}},
+		dvRefs:      map[string]struct{}{"file://present-ref.parquet": {}},
+	}
+
+	presentDel := newTestPosDeleteFileForSpec(t, spec, "file://present-del.parquet", nil, "file://x.parquet")
+	absentDel := newTestPosDeleteFileForSpec(t, spec, "file://absent-del.parquet", nil, "file://x.parquet")
+	require.True(t, present.counts(presentDel), "pos-delete present by path")
+	require.False(t, present.counts(absentDel), "pos-delete absent by path")
+
+	presentDV := newTestDeletionVectorForRef(t, spec, "file://dv.puffin", "file://present-ref.parquet")
+	absentDV := newTestDeletionVectorForRef(t, spec, "file://dv.puffin", "file://absent-ref.parquet")
+	require.True(t, present.counts(presentDV), "DV present by referenced data file")
+	require.False(t, present.counts(absentDV), "DV absent by referenced data file")
 }
 
 func TestAddDataFilesV3RejectsWithoutFirstRowID(t *testing.T) {

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -1384,6 +1384,49 @@ func TestRemovedFilePresenceCounts(t *testing.T) {
 	require.False(t, present.counts(absentDV), "DV absent by referenced data file")
 }
 
+// TestCheckRemovedFiles_AbortsWhenRewriteTargetMissing pins the terminal abort:
+// when a data file this producer intends to rewrite is no longer on the fresh
+// parent (a peer already removed it), checkRemovedFiles must fail with
+// ErrCommitDiverged rather than resurrecting our replacement beside the peer's
+// result.
+func TestCheckRemovedFiles_AbortsWhenRewriteTargetMissing(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	target := newTestDataFile(t, spec, "mem://default/table-location/data/gone.parquet", nil)
+	sp.deleteDataFile(target)
+
+	// Fresh parent no longer contains the data file (empty manifest list).
+	parentManifestList := "mem://default/table-location/metadata/fresh-parent-diverged.avro"
+	out, err := wfs.Create(parentManifestList)
+	require.NoError(t, err)
+	require.NoError(t, iceberg.WriteManifestList(2, out, 99, nil, ptr(int64(0)), 0, nil))
+	require.NoError(t, out.Close())
+
+	freshParent := &Snapshot{SnapshotID: 99, ManifestList: parentManifestList}
+
+	present, err := sp.checkRemovedFiles(freshParent)
+	require.ErrorIs(t, err, ErrCommitDiverged)
+	require.ErrorContains(t, err, target.FilePath())
+	require.Nil(t, present, "no presence set is returned on a diverged abort")
+}
+
+// TestCheckRemovedFiles_ShortCircuitsWithNothingToRemove guards the append
+// fast-path: a producer that removes nothing must not scan the parent's
+// manifests at all, so a nil parent is fine and an empty presence set is
+// returned.
+func TestCheckRemovedFiles_ShortCircuitsWithNothingToRemove(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+
+	present, err := sp.checkRemovedFiles(nil)
+	require.NoError(t, err)
+	require.Empty(t, present.deleteFiles)
+	require.Empty(t, present.dvRefs)
+}
+
 func TestAddDataFilesV3RejectsWithoutFirstRowID(t *testing.T) {
 	spec := iceberg.NewPartitionSpec()
 	txn, _ := createTestTransactionWithMemIO(t, spec)

--- a/table/table.go
+++ b/table/table.go
@@ -75,9 +75,9 @@ func requireWriteFileIO(fs icebergio.IO) (icebergio.WriteFileIO, error) {
 	return wfs, nil
 }
 
-// ErrSnapshotNotFound is returned (wrapped) by metadata lookups and by
-// computeOwnManifests when a snapshot ID does not exist in the table's
-// snapshot list. Tests pin meaning via errors.Is(err, ErrSnapshotNotFound).
+// ErrSnapshotNotFound is returned (wrapped) by metadata lookups when a
+// snapshot ID does not exist in the table's snapshot list. Tests pin meaning
+// via errors.Is(err, ErrSnapshotNotFound).
 var ErrSnapshotNotFound = errors.New("snapshot not found")
 
 type FSysF func(ctx context.Context) (icebergio.IO, error)


### PR DESCRIPTION
This fixes manifest-list replay after optimistic-concurrency retries. On retry, snapshot producers now rebuild parent-dependent manifests against the fresh branch head while reusing already-written added-content manifests. That prevents overwrite/replace retries from resurrecting removed data files or dropping concurrently committed files. The rebuild also refreshes sequence numbers, v3 row-lineage fields, and snapshot summary totals from latest metadata. If a file planned for rewrite is no longer live, replay now aborts so callers can re-plan safely. Regression coverage adds an end-to-end replace-after-conflict scenario plus focused retry-rebuild tests.