### PR TITLE
fix(table): match partition-scoped pos-deletes in rewrite conflict validation

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -47,13 +47,18 @@ package table
 // outputs are public.
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
+	"strconv"
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table/internal"
+	"github.com/google/uuid"
 )
 
 // IsolationLevel controls how strictly a commit rejects concurrent
@@ -595,40 +600,65 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 
 // validateNoNewDeletesForRewrittenFiles rejects the commit if any
 // concurrent snapshot added delete files that would be lost when the
-// committer's rewrite replaces a data file.
+// committer's rewrite replaces one of rewrittenFiles.
 //
 // Two cases are flagged:
 //
-//   - A position-delete whose referenced-data-file path is one of
-//     rewrittenPaths — the delete applies to a file the rewrite is
-//     removing, so the delete would be orphaned and its semantics
-//     lost.
+//   - A position-delete that resolves to one of the rewritten paths,
+//     via referencedDataFilePath (explicit referenced_data_file, then
+//     equal file_path lower/upper bounds), or, when no single path can
+//     be resolved, whose (specID, partition) matches a rewritten file
+//     — the delete applies to a file the rewrite is removing, so it
+//     would be orphaned and its semantics lost. This mirrors Java's
+//     DeleteFileIndex, which indexes path-scoped deletes by path and
+//     falls back to indexing partition-scoped deletes by (specId,
+//     partition).
 //
 //   - An equality-delete added by a concurrent snapshot — these apply
-//     by predicate, not by path, so we cannot precisely check
-//     overlap without the rewritten files' partition tuples. The
-//     conservative behavior is to reject any concurrent eq-delete,
-//     which matches Java's approach for RewriteFiles and avoids
-//     silently losing deletes. A follow-up PR will accept optional
-//     partition-overlap hints and narrow this check.
-func validateNoNewDeletesForRewrittenFiles(ctx *conflictContext, rewrittenPaths []string) error {
-	if len(rewrittenPaths) == 0 || len(ctx.concurrent) == 0 {
+//     by predicate, not by path, so we cannot precisely check overlap
+//     without the rewritten files' partition tuples. The conservative
+//     behavior is to reject any concurrent eq-delete, which matches
+//     Java's approach for RewriteFiles and avoids silently losing
+//     deletes. A follow-up PR will accept optional partition-overlap
+//     hints to narrow this check.
+func validateNoNewDeletesForRewrittenFiles(ctx *conflictContext, rewrittenFiles []iceberg.DataFile) error {
+	if len(rewrittenFiles) == 0 || len(ctx.concurrent) == 0 {
 		return nil
 	}
-	rewritten := make(map[string]struct{}, len(rewrittenPaths))
-	for _, p := range rewrittenPaths {
-		rewritten[p] = struct{}{}
+
+	rewrittenPaths := make(map[string]struct{}, len(rewrittenFiles))
+	rewrittenPartitions := make(map[string]struct{}, len(rewrittenFiles))
+	for _, df := range rewrittenFiles {
+		rewrittenPaths[df.FilePath()] = struct{}{}
+		key, err := partitionConflictKey(df.SpecID(), df.Partition())
+		if err != nil {
+			return fmt.Errorf("building partition conflict key for rewritten file %s (spec %d): %w",
+				df.FilePath(), df.SpecID(), err)
+		}
+		rewrittenPartitions[key] = struct{}{}
 	}
 
 	return ctx.forEachAddedEntry(iceberg.ManifestContentDeletes, func(snap Snapshot, e iceberg.ManifestEntry) error {
 		df := e.DataFile()
 		switch df.ContentType() {
 		case iceberg.EntryContentPosDeletes:
-			if ref := df.ReferencedDataFile(); ref != nil {
-				if _, overlap := rewritten[*ref]; overlap {
+			if path := referencedDataFilePath(df); path != "" {
+				if _, overlap := rewrittenPaths[path]; overlap {
 					return fmt.Errorf("%w: snapshot %d added pos-delete %s referencing rewritten file %s",
-						ErrConflictingDeleteFiles, snap.SnapshotID, df.FilePath(), *ref)
+						ErrConflictingDeleteFiles, snap.SnapshotID, df.FilePath(), path)
 				}
+
+				return nil
+			}
+
+			key, err := partitionConflictKey(df.SpecID(), df.Partition())
+			if err != nil {
+				return fmt.Errorf("building partition conflict key for concurrent pos-delete %s (spec %d): %w",
+					df.FilePath(), df.SpecID(), err)
+			}
+			if _, overlap := rewrittenPartitions[key]; overlap {
+				return fmt.Errorf("%w: snapshot %d added partition-scoped pos-delete %s overlapping rewritten partition (spec %d)",
+					ErrConflictingDeleteFiles, snap.SnapshotID, df.FilePath(), df.SpecID())
 			}
 
 			return nil
@@ -644,4 +674,138 @@ func validateNoNewDeletesForRewrittenFiles(ctx *conflictContext, rewrittenPaths 
 
 		return nil
 	})
+}
+
+// referencedDataFilePath resolves the single data file a pos-delete
+// targets, mirroring Java ContentFileUtil.referencedDataFile: explicit
+// referenced_data_file first, then equal file_path lower/upper bounds.
+// Returns "" when the delete is partition-scoped (no single data file
+// can be determined), which callers must treat conservatively via a
+// partition-tuple match rather than skipping the delete.
+func referencedDataFilePath(df iceberg.DataFile) string {
+	if ref := df.ReferencedDataFile(); ref != nil {
+		return *ref
+	}
+
+	lower := df.LowerBoundValues()[filePathFieldID]
+	upper := df.UpperBoundValues()[filePathFieldID]
+	if len(lower) == 0 || !bytes.Equal(lower, upper) {
+		return ""
+	}
+
+	lit, err := iceberg.LiteralFromBytes(iceberg.PrimitiveTypes.String, lower)
+	if err != nil {
+		return ""
+	}
+
+	return lit.(iceberg.TypedLiteral[string]).Value()
+}
+
+// filePathFieldID is the reserved field ID of the file_path column in a
+// positional delete file, sourced from the canonical delete schema.
+var filePathFieldID = func() int {
+	f, _ := iceberg.PositionalDeleteSchema.FindFieldByName("file_path")
+
+	return f.ID
+}()
+
+// partitionConflictKey returns a deterministic, injective string key
+// for a (specID, partition) tuple, used to detect overlap between a
+// partition-scoped delete and a rewritten data file. Partition values
+// are compared post-transform (direct equality), matching Java's
+// DeleteFileIndex — no transform-aware logic is needed because both
+// sides store the same post-transform representation.
+//
+// Values are encoded type-normalized across the known Avro-decode and
+// write-side representations (see appendPartitionConflictValue):
+// integer-backed types are unified per field, so e.g. an int32 and an
+// iceberg.Date carrying the same day match. An unknown value type
+// fails the key build — and thereby the validation — rather than
+// falling back to a lossy formatting that could silently mismatch.
+//
+// Different spec IDs never match, even with identical-looking tuples:
+// Java's DeleteFileIndex keys its PartitionMap by specId, and field IDs
+// are only meaningful within a single spec.
+func partitionConflictKey(specID int32, partition map[int]any) (string, error) {
+	ids := make([]int, 0, len(partition))
+	for id := range partition {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	buf := strconv.AppendInt(nil, int64(specID), 10)
+	buf = append(buf, '|')
+	for _, id := range ids {
+		buf = strconv.AppendInt(buf, int64(id), 10)
+		buf = append(buf, ':')
+		var err error
+		buf, err = appendPartitionConflictValue(buf, partition[id])
+		if err != nil {
+			return "", fmt.Errorf("partition field %d: %w", id, err)
+		}
+		buf = append(buf, ';')
+	}
+
+	return string(buf), nil
+}
+
+// appendPartitionConflictValue encodes one partition value into dst by
+// semantic class, so different Go representations of the same logical
+// value produce the same bytes:
+//
+//   - integer-backed types (int/int32/int64, Date, Time, Timestamp,
+//     TimestampNano) collapse into one class — within a single
+//     (specID, fieldID) the logical type is fixed, so this only
+//     tolerates decoder representation drift, never conflates two
+//     logical values of one field;
+//   - uuid.UUID and []byte collapse into raw-bytes hex;
+//   - Decimal and DecimalLiteral collapse into (scale, unscaled).
+//
+// String values are length-prefixed so keys stay injective for inputs
+// containing the field separators. Unknown types return an error.
+func appendPartitionConflictValue(dst []byte, v any) ([]byte, error) {
+	switch v := v.(type) {
+	case nil:
+		return append(dst, 'z'), nil
+	case bool:
+		return strconv.AppendBool(append(dst, 'b', ':'), v), nil
+	case int:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case int32:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case int64:
+		return strconv.AppendInt(append(dst, 'i', ':'), v, 10), nil
+	case iceberg.Date:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case iceberg.Time:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case iceberg.Timestamp:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case iceberg.TimestampNano:
+		return strconv.AppendInt(append(dst, 'i', ':'), int64(v), 10), nil
+	case float32:
+		return strconv.AppendFloat(append(dst, 'f', ':'), float64(v), 'x', -1, 64), nil
+	case float64:
+		return strconv.AppendFloat(append(dst, 'f', ':'), v, 'x', -1, 64), nil
+	case string:
+		dst = strconv.AppendInt(append(dst, 's', ':'), int64(len(v)), 10)
+
+		return append(append(dst, ':'), v...), nil
+	case []byte:
+		return hex.AppendEncode(append(dst, 'B', ':'), v), nil
+	case uuid.UUID:
+		return hex.AppendEncode(append(dst, 'B', ':'), v[:]), nil
+	case iceberg.Decimal:
+		return appendDecimalConflictValue(dst, v), nil
+	case iceberg.DecimalLiteral:
+		return appendDecimalConflictValue(dst, iceberg.Decimal(v)), nil
+	default:
+		return nil, fmt.Errorf("unsupported partition value type %T in conflict key", v)
+	}
+}
+
+func appendDecimalConflictValue(dst []byte, v iceberg.Decimal) []byte {
+	dst = strconv.AppendInt(append(dst, 'd', ':'), int64(v.Scale), 10)
+
+	return append(append(dst, ':'), v.Val.BigInt().String()...)
 }

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -18,13 +18,113 @@
 package table
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/internal"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// writeTestDeleteManifest writes a single-entry delete-content manifest
+// for delFile and returns its ManifestFile descriptor. Mirrors
+// writeTestManifest in partition_conflict_test.go, but forces
+// ManifestContentDeletes on both the writer and the resulting
+// ManifestFile so forEachAddedEntry's ManifestContentDeletes filter
+// picks the entry up.
+func writeTestDeleteManifest(
+	t *testing.T,
+	dir string,
+	spec iceberg.PartitionSpec,
+	schema *iceberg.Schema,
+	snapshotID int64,
+	delFile iceberg.DataFile,
+) iceberg.ManifestFile {
+	t.Helper()
+
+	entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID, delFile).
+		SequenceNum(1).
+		Build()
+
+	manifestPath := filepath.ToSlash(filepath.Join(dir, fmt.Sprintf("delete-manifest-%d.avro", snapshotID)))
+	var buf bytes.Buffer
+	cnt := &internal.CountingWriter{W: &buf}
+	writer, err := iceberg.NewManifestWriter(2, cnt, spec, schema, snapshotID,
+		iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+	require.NoError(t, writer.Add(entry))
+	require.NoError(t, writer.Close())
+
+	mf, err := writer.ToManifestFile(manifestPath, cnt.Count,
+		iceberg.WithManifestFileContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+
+	fs := iceio.LocalFS{}
+	f, err := fs.Create(manifestPath)
+	require.NoError(t, err)
+	_, err = f.Write(buf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	return mf
+}
+
+// runPosDeleteConflictCheck builds a concurrent snapshot carrying delFile
+// as a single ADDED delete-manifest entry and runs
+// validateNoNewDeletesForRewrittenFiles against rewrittenFiles. Used by
+// the pos-delete and eq-delete matching-behavior tests, which only care
+// about the resulting error, not the surrounding metadata plumbing.
+func runPosDeleteConflictCheck(t *testing.T, rewrittenFiles []iceberg.DataFile, delFile iceberg.DataFile) error {
+	t.Helper()
+	dir := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+	spec := *iceberg.UnpartitionedSpec
+	if len(delFile.Partition()) > 0 {
+		spec = iceberg.NewPartitionSpecID(int(delFile.SpecID()), iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+		})
+	}
+
+	writerBaseID := int64(1)
+	concSnapshotID := int64(2)
+
+	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	baseMeta, err := NewMetadata(schema, &spec, UnsortedSortOrder, dir, props)
+	require.NoError(t, err)
+
+	baseBuilder, err := MetadataBuilderFromBase(baseMeta, "")
+	require.NoError(t, err)
+	baseSnap := Snapshot{
+		SnapshotID:     writerBaseID,
+		SequenceNumber: 1,
+		TimestampMs:    baseMeta.LastUpdatedMillis() + 1,
+		Summary:        &Summary{Operation: OpAppend},
+	}
+	require.NoError(t, baseBuilder.AddSnapshot(&baseSnap))
+	require.NoError(t, baseBuilder.SetSnapshotRef(MainBranch, writerBaseID, BranchRef))
+	writerBaseMeta, err := baseBuilder.Build()
+	require.NoError(t, err)
+
+	mf := writeTestDeleteManifest(t, dir, spec, schema, concSnapshotID, delFile)
+	listPath := writeTestManifestList(t, dir, concSnapshotID, []iceberg.ManifestFile{mf})
+
+	ctx := buildPartitionedContext(t, writerBaseMeta, listPath, writerBaseID, concSnapshotID)
+	require.Len(t, ctx.concurrent, 1)
+
+	return validateNoNewDeletesForRewrittenFiles(ctx, rewrittenFiles)
+}
 
 func TestReadIsolationLevel(t *testing.T) {
 	tests := []struct {
@@ -269,19 +369,335 @@ func TestValidateDataFilesExist_EmptyInput(t *testing.T) {
 }
 
 func TestValidateNoNewDeletesForRewrittenFiles_EmptyInputs(t *testing.T) {
-	// Empty rewrittenPaths OR empty concurrent snapshots must both
+	// Empty rewrittenFiles OR empty concurrent snapshots must both
 	// short-circuit to nil.
 	head := int64(1)
 	meta := newConflictTestMetadata(t, &head)
 	ctx, err := newConflictContext(meta, meta, MainBranch, nil, true)
 	require.NoError(t, err)
 
-	// Empty rewrittenPaths.
+	// Empty rewrittenFiles.
 	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, nil))
-	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []string{}))
+	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []iceberg.DataFile{}))
 
-	// Non-empty rewrittenPaths but no concurrent snapshots.
-	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []string{"a.parquet"}))
+	// Non-empty rewrittenFiles but no concurrent snapshots.
+	rewritten := newTestDataFile(t, *iceberg.UnpartitionedSpec, "a.parquet", nil)
+	require.NoError(t, validateNoNewDeletesForRewrittenFiles(ctx, []iceberg.DataFile{rewritten}))
+}
+
+// posDeleteBoundsFile builds a position-delete DataFile whose file_path
+// lower/upper bounds are both set to path, without ReferencedDataFile —
+// the shape a v2 writer produces when it records bounds but not the
+// referenced_data_file column.
+func posDeleteBoundsFile(t *testing.T, spec iceberg.PartitionSpec, delPath, path string, partition map[int]any) iceberg.DataFile {
+	t.Helper()
+
+	bound, err := iceberg.StringLiteral(path).MarshalBinary()
+	require.NoError(t, err)
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes, delPath, iceberg.ParquetFile,
+		partition, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	return builder.
+		LowerBoundValues(map[int][]byte{filePathFieldID: bound}).
+		UpperBoundValues(map[int][]byte{filePathFieldID: bound}).
+		Build()
+}
+
+// posDeletePartitionScopedFile builds a position-delete DataFile with no
+// ReferencedDataFile and no (or non-degenerate) file_path bounds — the
+// shape Java resolves purely by (specID, partition) overlap.
+func posDeletePartitionScopedFile(t *testing.T, spec iceberg.PartitionSpec, delPath string, partition map[int]any) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes, delPath, iceberg.ParquetFile,
+		partition, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	return builder.Build()
+}
+
+// posDeleteUnequalBoundsFile builds a position-delete DataFile whose
+// file_path lower/upper bounds differ — unresolvable to a single path,
+// so callers must fall back to the partition-scoped rule.
+func posDeleteUnequalBoundsFile(t *testing.T, spec iceberg.PartitionSpec, delPath, lowerPath, upperPath string, partition map[int]any) iceberg.DataFile {
+	t.Helper()
+
+	lower, err := iceberg.StringLiteral(lowerPath).MarshalBinary()
+	require.NoError(t, err)
+	upper, err := iceberg.StringLiteral(upperPath).MarshalBinary()
+	require.NoError(t, err)
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes, delPath, iceberg.ParquetFile,
+		partition, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	return builder.
+		LowerBoundValues(map[int][]byte{filePathFieldID: lower}).
+		UpperBoundValues(map[int][]byte{filePathFieldID: upper}).
+		Build()
+}
+
+func TestReferencedDataFilePath(t *testing.T) {
+	unpart := *iceberg.UnpartitionedSpec
+
+	t.Run("explicit reference wins", func(t *testing.T) {
+		builder, err := iceberg.NewDataFileBuilder(
+			unpart, iceberg.EntryContentPosDeletes, "del.parquet", iceberg.ParquetFile,
+			nil, nil, nil, 1, 1)
+		require.NoError(t, err)
+		df := builder.ReferencedDataFile("data-a.parquet").Build()
+
+		assert.Equal(t, "data-a.parquet", referencedDataFilePath(df))
+	})
+
+	t.Run("equal bounds resolve to the bound path", func(t *testing.T) {
+		df := posDeleteBoundsFile(t, unpart, "del.parquet", "data-b.parquet", nil)
+		assert.Equal(t, "data-b.parquet", referencedDataFilePath(df))
+	})
+
+	t.Run("unequal bounds are unresolvable", func(t *testing.T) {
+		df := posDeleteUnequalBoundsFile(t, unpart, "del.parquet", "data-a.parquet", "data-b.parquet", nil)
+		assert.Empty(t, referencedDataFilePath(df))
+	})
+
+	t.Run("no reference and no bounds are unresolvable", func(t *testing.T) {
+		df := posDeletePartitionScopedFile(t, unpart, "del.parquet", nil)
+		assert.Empty(t, referencedDataFilePath(df))
+	})
+}
+
+// mustPartitionConflictKey unwraps partitionConflictKey for test
+// tuples that only contain supported value types.
+func mustPartitionConflictKey(t *testing.T, specID int32, partition map[int]any) string {
+	t.Helper()
+	key, err := partitionConflictKey(specID, partition)
+	require.NoError(t, err)
+
+	return key
+}
+
+func TestPartitionConflictKey(t *testing.T) {
+	sampleUUID := uuid.MustParse("12345678-9abc-def0-1234-56789abcdef0")
+	dec := iceberg.Decimal{Val: decimal128.FromI64(12345), Scale: 2}
+	decOther := iceberg.Decimal{Val: decimal128.FromI64(12346), Scale: 2}
+	decOtherScale := iceberg.Decimal{Val: decimal128.FromI64(12345), Scale: 3}
+
+	equal := []struct {
+		name string
+		a, b map[int]any
+	}{
+		{"field order is irrelevant", map[int]any{1: int32(1), 2: "x"}, map[int]any{2: "x", 1: int32(1)}},
+		{"nil vs empty tuple", nil, map[int]any{}},
+		{"bool", map[int]any{1: true}, map[int]any{1: true}},
+		{"nil value", map[int]any{1: nil}, map[int]any{1: nil}},
+		{"int widths unify", map[int]any{1: int32(7)}, map[int]any{1: int64(7)}},
+		{"int unifies too", map[int]any{1: int(7)}, map[int]any{1: int64(7)}},
+		{"Date vs raw int32", map[int]any{1: iceberg.Date(19000)}, map[int]any{1: int32(19000)}},
+		{"Time vs raw int64", map[int]any{1: iceberg.Time(123456)}, map[int]any{1: int64(123456)}},
+		{"Timestamp vs raw int64", map[int]any{1: iceberg.Timestamp(99)}, map[int]any{1: int64(99)}},
+		{"TimestampNano vs raw int64", map[int]any{1: iceberg.TimestampNano(99)}, map[int]any{1: int64(99)}},
+		{"float32 vs float64", map[int]any{1: float32(1.5)}, map[int]any{1: float64(1.5)}},
+		{"NaN matches NaN", map[int]any{1: math.NaN()}, map[int]any{1: math.NaN()}},
+		{"string", map[int]any{1: "us-east-1"}, map[int]any{1: "us-east-1"}},
+		{"bytes", map[int]any{1: []byte{0xde, 0xad}}, map[int]any{1: []byte{0xde, 0xad}}},
+		{"uuid vs its raw bytes", map[int]any{1: sampleUUID}, map[int]any{1: sampleUUID[:]}},
+		{"Decimal vs DecimalLiteral", map[int]any{1: dec}, map[int]any{1: iceberg.DecimalLiteral(dec)}},
+	}
+	for _, tt := range equal {
+		t.Run("equal/"+tt.name, func(t *testing.T) {
+			assert.Equal(t,
+				mustPartitionConflictKey(t, 0, tt.a),
+				mustPartitionConflictKey(t, 0, tt.b))
+		})
+	}
+
+	distinct := []struct {
+		name string
+		a, b map[int]any
+	}{
+		{"bool", map[int]any{1: true}, map[int]any{1: false}},
+		{"nil vs zero int", map[int]any{1: nil}, map[int]any{1: int64(0)}},
+		{"int", map[int]any{1: int64(7)}, map[int]any{1: int64(8)}},
+		{"Date", map[int]any{1: iceberg.Date(19000)}, map[int]any{1: iceberg.Date(19001)}},
+		{"float", map[int]any{1: 1.5}, map[int]any{1: 1.25}},
+		{"NaN vs number", map[int]any{1: math.NaN()}, map[int]any{1: 0.0}},
+		{"string", map[int]any{1: "x"}, map[int]any{1: "y"}},
+		{"string vs its bytes", map[int]any{1: "x"}, map[int]any{1: []byte("x")}},
+		{"bytes", map[int]any{1: []byte{0xde}}, map[int]any{1: []byte{0xad}}},
+		{"uuid", map[int]any{1: sampleUUID}, map[int]any{1: uuid.Nil}},
+		{"decimal value", map[int]any{1: dec}, map[int]any{1: decOther}},
+		{"decimal scale", map[int]any{1: dec}, map[int]any{1: decOtherScale}},
+		{"different field ids", map[int]any{1: int64(1)}, map[int]any{2: int64(1)}},
+		{
+			"injectivity: separator inside a string value",
+			map[int]any{1: "a;2:b"},
+			map[int]any{1: "a", 2: "b"},
+		},
+	}
+	for _, tt := range distinct {
+		t.Run("distinct/"+tt.name, func(t *testing.T) {
+			assert.NotEqual(t,
+				mustPartitionConflictKey(t, 0, tt.a),
+				mustPartitionConflictKey(t, 0, tt.b))
+		})
+	}
+
+	t.Run("different spec ids never collide", func(t *testing.T) {
+		tuple := map[int]any{1: int32(1), 2: "x"}
+		assert.NotEqual(t,
+			mustPartitionConflictKey(t, 0, tuple),
+			mustPartitionConflictKey(t, 1, tuple))
+		assert.NotEqual(t,
+			mustPartitionConflictKey(t, 0, nil),
+			mustPartitionConflictKey(t, 1, nil))
+	})
+
+	t.Run("unsupported types fail closed", func(t *testing.T) {
+		for _, v := range []any{struct{}{}, time.Now()} {
+			_, err := partitionConflictKey(0, map[int]any{1: v})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported partition value type")
+		}
+	})
+}
+
+// TestValidateNoNewDeletesForRewrittenFiles_PosDeleteMatching drives the
+// validator through a synthetic concurrent snapshot carrying a single
+// position-delete entry, covering every resolution path documented on
+// referencedDataFilePath and the partition fallback in
+// validateNoNewDeletesForRewrittenFiles.
+func TestValidateNoNewDeletesForRewrittenFiles_PosDeleteMatching(t *testing.T) {
+	unpart := *iceberg.UnpartitionedSpec
+	spec0 := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+	spec1 := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+
+	rewrittenUnpart := newTestDataFile(t, unpart, "data-rewritten.parquet", nil)
+	rewrittenPart := newTestDataFile(t, spec0, "data-part.parquet", map[int]any{1000: int32(7)})
+
+	tests := []struct {
+		name           string
+		rewrittenFiles []iceberg.DataFile
+		delFile        iceberg.DataFile
+		wantConflict   bool
+	}{
+		{
+			name:           "explicit reference matching rewritten path conflicts",
+			rewrittenFiles: []iceberg.DataFile{rewrittenUnpart},
+			delFile: func() iceberg.DataFile {
+				b, err := iceberg.NewDataFileBuilder(unpart, iceberg.EntryContentPosDeletes,
+					"del.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 1)
+				require.NoError(t, err)
+
+				return b.ReferencedDataFile("data-rewritten.parquet").Build()
+			}(),
+			wantConflict: true,
+		},
+		{
+			name:           "equal bounds naming rewritten path conflicts (main bug)",
+			rewrittenFiles: []iceberg.DataFile{rewrittenUnpart},
+			delFile:        posDeleteBoundsFile(t, unpart, "del.parquet", "data-rewritten.parquet", nil),
+			wantConflict:   true,
+		},
+		{
+			name:           "equal bounds naming a non-rewritten path do not conflict",
+			rewrittenFiles: []iceberg.DataFile{rewrittenUnpart},
+			delFile:        posDeleteBoundsFile(t, unpart, "del.parquet", "data-other.parquet", nil),
+			wantConflict:   false,
+		},
+		{
+			name:           "unequal bounds fall back to partition match and conflict",
+			rewrittenFiles: []iceberg.DataFile{rewrittenPart},
+			delFile: posDeleteUnequalBoundsFile(t, spec0, "del.parquet",
+				"data-a.parquet", "data-b.parquet", map[int]any{1000: int32(7)}),
+			wantConflict: true,
+		},
+		{
+			name:           "no reference, no bounds, same spec+partition conflicts",
+			rewrittenFiles: []iceberg.DataFile{rewrittenPart},
+			delFile:        posDeletePartitionScopedFile(t, spec0, "del.parquet", map[int]any{1000: int32(7)}),
+			wantConflict:   true,
+		},
+		{
+			name:           "different partition tuple, same spec does not conflict",
+			rewrittenFiles: []iceberg.DataFile{rewrittenPart},
+			delFile:        posDeletePartitionScopedFile(t, spec0, "del.parquet", map[int]any{1000: int32(9)}),
+			wantConflict:   false,
+		},
+		{
+			name:           "unpartitioned table: partition-scoped delete conflicts with any rewritten file",
+			rewrittenFiles: []iceberg.DataFile{rewrittenUnpart},
+			delFile:        posDeletePartitionScopedFile(t, unpart, "del.parquet", nil),
+			wantConflict:   true,
+		},
+		{
+			name:           "different specID, same-looking tuple does not conflict",
+			rewrittenFiles: []iceberg.DataFile{rewrittenPart},
+			delFile:        posDeletePartitionScopedFile(t, spec1, "del.parquet", map[int]any{1000: int32(7)}),
+			wantConflict:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runPosDeleteConflictCheck(t, tt.rewrittenFiles, tt.delFile)
+			if tt.wantConflict {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrConflictingDeleteFiles)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateNoNewDeletesForRewrittenFiles_EqDeleteAlwaysConflicts pins
+// the pre-existing conservative eq-delete rule: any concurrent eq-delete
+// during a rewrite is a conflict, regardless of partition overlap.
+func TestValidateNoNewDeletesForRewrittenFiles_EqDeleteAlwaysConflicts(t *testing.T) {
+	unpart := *iceberg.UnpartitionedSpec
+	rewritten := newTestDataFile(t, unpart, "data-rewritten.parquet", nil)
+
+	eqBuilder, err := iceberg.NewDataFileBuilder(unpart, iceberg.EntryContentEqDeletes,
+		"eq.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 1)
+	require.NoError(t, err)
+	eqDel := eqBuilder.EqualityFieldIDs([]int{1}).Build()
+
+	err = runPosDeleteConflictCheck(t, []iceberg.DataFile{rewritten}, eqDel)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConflictingDeleteFiles)
+}
+
+// TestValidateNoNewDeletesForRewrittenFiles_UnsupportedPartitionType
+// pins the fail-closed contract: a rewritten file whose partition
+// carries a value type outside partitionConflictKey's closed set must
+// fail the validation loudly instead of silently skipping the file.
+// Only the rewritten side is testable — the delete side is decoded
+// from real Avro manifests whose value domain is exactly the closed
+// set, so an unsupported type cannot reach it.
+func TestValidateNoNewDeletesForRewrittenFiles_UnsupportedPartitionType(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+
+	rewritten := newTestDataFile(t, spec, "data-part.parquet", map[int]any{1000: struct{}{}})
+	delFile := posDeletePartitionScopedFile(t, spec, "del.parquet", map[int]any{1000: int32(7)})
+
+	err := runPosDeleteConflictCheck(t, []iceberg.DataFile{rewritten}, delFile)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrConflictingDeleteFiles,
+		"a key-encoding failure is not a conflict; it must surface as its own error")
+	assert.Contains(t, err.Error(), "unsupported partition value type")
+	assert.Contains(t, err.Error(), "data-part.parquet",
+		"error must identify the offending file")
 }
 
 func TestValidateAddedDataFilesMatchingFilter_NoConcurrent(t *testing.T) {

--- a/table/producer_validate_test.go
+++ b/table/producer_validate_test.go
@@ -226,10 +226,11 @@ func TestRowDelta_ValidateEqDeleteIsolationGates(t *testing.T) {
 func TestRewriteValidator_Smokes(t *testing.T) {
 	cc := newEmptyConflictContext(t)
 
-	// Empty rewrittenPaths short-circuits regardless of cc.
+	// Empty rewrittenFiles short-circuits regardless of cc.
 	require.NoError(t, rewriteValidator(nil)(cc))
 	require.NoError(t, rewriteValidator(nil)(nil))
 
-	// Non-empty paths but zero concurrent snapshots is also nil.
-	require.NoError(t, rewriteValidator([]string{"a.parquet"})(cc))
+	// Non-empty files but zero concurrent snapshots is also nil.
+	rewritten := newTestDataFile(t, *iceberg.UnpartitionedSpec, "a.parquet", nil)
+	require.NoError(t, rewriteValidator([]iceberg.DataFile{rewritten})(cc))
 }

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -421,7 +421,7 @@ func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
 	result := &RewriteResult{}
 	props := maps.Clone(opts.SnapshotProps)
-	var allRewritten []string
+	var allRewritten []iceberg.DataFile
 
 	for _, group := range groups {
 		if err := ctx.Err(); err != nil {
@@ -447,9 +447,7 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 			return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
 		}
 
-		for _, f := range gr.OldDataFiles {
-			allRewritten = append(allRewritten, f.FilePath())
-		}
+		allRewritten = append(allRewritten, gr.OldDataFiles...)
 		accumulateGroupMetrics(result, gr)
 	}
 
@@ -471,17 +469,19 @@ func accumulateGroupMetrics(r *RewriteResult, gr CompactionGroupResult) {
 }
 
 // rewriteValidator builds a conflictValidatorFunc that rejects the
-// commit if a concurrent snapshot added delete files pointing at any
-// of the rewritten data-file paths (or eq-deletes during the rewrite,
-// conservatively). Always runs — no isolation gating, because rewrite
-// is a structural operation, not a user-facing isolation choice.
-func rewriteValidator(rewrittenPaths []string) conflictValidatorFunc {
+// commit if a concurrent snapshot added delete files targeting any of
+// the rewritten data files — by referenced-data-file path, by
+// file_path bounds, by partition overlap for partition-scoped
+// pos-deletes, or (conservatively) any eq-delete during the rewrite.
+// Always runs — no isolation gating, because rewrite is a structural
+// operation, not a user-facing isolation choice.
+func rewriteValidator(rewrittenFiles []iceberg.DataFile) conflictValidatorFunc {
 	return func(cc *conflictContext) error {
 		if cc == nil {
 			return nil
 		}
 
-		return validateNoNewDeletesForRewrittenFiles(cc, rewrittenPaths)
+		return validateNoNewDeletesForRewrittenFiles(cc, rewrittenFiles)
 	}
 }
 

--- a/table/rewrite_files.go
+++ b/table/rewrite_files.go
@@ -38,13 +38,13 @@ import (
 //     is the defining behavior of a rewrite).
 //   - A rewrite-specific conflict validator is registered so concurrent
 //     pos/eq-delete files targeting any rewritten data file are
-//     rejected pre-flight at [Transaction.Commit] time. The pos-delete
-//     branch only fires when the concurrent writer populated the
-//     manifest's referenced_data_file column (field id 143). That
-//     column is V2-optional and V3-required for deletion-vector
-//     deletes; V2 pos-delete writers commonly leave it empty, in
-//     which case only the conservative eq-delete-during-rewrite rule
-//     fires.
+//     rejected pre-flight at [Transaction.Commit] time. A pos-delete
+//     is matched to a rewritten file via its referenced_data_file
+//     column, via equal file_path lower/upper bounds when that column
+//     is unset, or — when neither resolves a single path — via
+//     partition overlap with a rewritten file. Eq-deletes are matched
+//     conservatively: any concurrent eq-delete during the rewrite
+//     conflicts.
 //
 // Distributed compaction coordinators construct one [RewriteFiles] on
 // the leader transaction, feed worker outputs in via [RewriteFiles.ApplyResult],
@@ -242,11 +242,7 @@ func (r *RewriteFiles) Commit(ctx context.Context) error {
 	}
 
 	if len(r.dataFilesToDelete) > 0 {
-		rewritten := make([]string, 0, len(r.dataFilesToDelete))
-		for _, df := range r.dataFilesToDelete {
-			rewritten = append(rewritten, df.FilePath())
-		}
-		r.txn.addValidator(rewriteValidator(rewritten))
+		r.txn.addValidator(rewriteValidator(r.dataFilesToDelete))
 	}
 
 	return nil

--- a/table/rewrite_files_test.go
+++ b/table/rewrite_files_test.go
@@ -31,7 +31,10 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
@@ -633,4 +636,238 @@ func TestRewriteFiles_RejectsConcurrentEqDelete(t *testing.T) {
 	// pre-flight; a delta of ≥2 means the retry reached the catalog.
 	assert.Equal(t, int32(1), cat.attempts.Load()-beforeLeader,
 		"only the stale-assertion attempt landed; the retry never reached CommitTable")
+}
+
+// TestRewriteFiles_RejectsConcurrentPartitionScopedPosDelete covers the
+// gap fixed by validateNoNewDeletesForRewrittenFiles' partition
+// fallback: a concurrent pos-delete with neither ReferencedDataFile nor
+// resolvable file_path bounds set (the shape a v2 MoR writer commonly
+// produces) must still be caught by matching the delete's
+// (specID, partition) against the rewritten files, rather than passing
+// validation and silently losing the delete. Before the fix, this
+// pos-delete had no path to check and the rewrite-specific validator
+// let it through unconditionally.
+func TestRewriteFiles_RejectsConcurrentPartitionScopedPosDelete(t *testing.T) {
+	tbl, cat := newConcurrentRewriteTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/file-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc,
+			fmt.Sprintf(`[{"id": %d, "data": "row-%d"}]`, i+1, i+1))
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+
+	plan, err := defaultTestCompactionCfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Groups)
+
+	groups := toTaskGroups(plan.Groups)
+
+	results := make([]table.CompactionGroupResult, 0, len(groups))
+	for _, g := range groups {
+		gr, err := table.ExecuteCompactionGroup(t.Context(), tbl, g)
+		require.NoError(t, err)
+		require.NotEmpty(t, gr.OldDataFiles)
+		results = append(results, gr)
+	}
+
+	leaderTxn := tbl.NewTransaction()
+	rewrite := leaderTxn.NewRewrite(nil)
+	for _, gr := range results {
+		rewrite.ApplyResult(gr)
+	}
+	require.NoError(t, rewrite.Commit(t.Context()),
+		"staging the rewrite must succeed; the conflict surfaces at Commit time")
+
+	// A pos-delete with no ReferencedDataFile and no bounds: unresolvable
+	// to a single path, so the validator must fall back to matching this
+	// delete's (specID, partition) — the table is unpartitioned, so any
+	// rewritten file of the same spec conflicts.
+	posDelPath := tbl.Location() + "/data/concurrent-partition-scoped-pos-del.parquet"
+	posDelBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		posDelPath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+
+	peerTxn := tbl.NewTransaction()
+	rd := peerTxn.NewRowDelta(nil)
+	rd.AddDeletes(posDelBuilder.Build())
+	require.NoError(t, rd.Commit(t.Context()))
+	_, err = peerTxn.Commit(t.Context())
+	require.NoError(t, err, "peer commit advances the catalog so the leader's first attempt fails")
+
+	beforeLeader := cat.attempts.Load()
+	_, err = leaderTxn.Commit(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, table.ErrConflictingDeleteFiles,
+		"refresh-and-replay must detect the concurrent partition-scoped pos-delete during a rewrite")
+	assert.Equal(t, int32(1), cat.attempts.Load()-beforeLeader,
+		"only the stale-assertion attempt landed; the retry never reached CommitTable")
+}
+
+func newConcurrentPartitionedRewriteTestTable(t *testing.T, schema *iceberg.Schema, spec *iceberg.PartitionSpec) (*table.Table, *concurrentTestCatalog) {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	meta, err := table.NewMetadata(schema, spec, table.UnsortedSortOrder, location,
+		iceberg.Properties{
+			table.PropertyFormatVersion:        "2",
+			table.CommitNumRetriesKey:          "2",
+			table.CommitMinRetryWaitMsKey:      "1",
+			table.CommitMaxRetryWaitMsKey:      "2",
+			table.CommitTotalRetryTimeoutMsKey: "1000",
+		})
+	require.NoError(t, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+
+	return table.New(table.Identifier{"db", "concurrent_partitioned_rewrite"}, meta, metaLoc, fsF, cat), cat
+}
+
+// runConcurrentPartitionScopedPosDeleteRewrite drives the shared
+// partitioned scenario: append rowsJSON (spanning two partitions via
+// the real fanout writer), rewrite the data file whose Avro-decoded
+// partition value equals rewritePartValue, then have a concurrent peer
+// commit a partition-scoped pos-delete (no ReferencedDataFile, no
+// bounds) carrying deletePartValue in its tuple. Both sides of the
+// validator's partition matching therefore come from real Avro
+// manifest decode. Returns the leader's Commit error.
+func runConcurrentPartitionScopedPosDeleteRewrite(
+	t *testing.T,
+	schema *iceberg.Schema,
+	spec *iceberg.PartitionSpec,
+	rowsJSON string,
+	rewritePartValue any,
+	deletePartValue any,
+) error {
+	t.Helper()
+
+	tbl, _ := newConcurrentPartitionedRewriteTestTable(t, schema, spec)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSc, []string{rowsJSON})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(t.Context(), array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	currentSpec := tbl.Metadata().PartitionSpec()
+	require.Equal(t, 1, currentSpec.NumFields(), "scenario assumes a single partition field")
+	var partFieldID int
+	for _, pf := range currentSpec.Fields() {
+		partFieldID = pf.FieldID
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2, "the fanout writer must have split the append into one file per partition")
+
+	var rewriteFile iceberg.DataFile
+	for _, task := range tasks {
+		got := task.File.Partition()[partFieldID]
+		require.IsTypef(t, rewritePartValue, got,
+			"Avro-decoded partition value representation drifted from the expected one")
+		if got == rewritePartValue {
+			rewriteFile = task.File
+		}
+	}
+	require.NotNilf(t, rewriteFile,
+		"no data file decoded with partition value %#v", rewritePartValue)
+
+	leaderTxn := tbl.NewTransaction()
+	require.NoError(t, leaderTxn.NewRewrite(nil).DeleteFile(rewriteFile).Commit(t.Context()),
+		"staging the rewrite must succeed; the conflict surfaces at Commit time")
+
+	posDelPath := tbl.Location() + "/data/concurrent-partition-scoped-pos-del.parquet"
+	posDelBuilder, err := iceberg.NewDataFileBuilder(
+		currentSpec, iceberg.EntryContentPosDeletes,
+		posDelPath, iceberg.ParquetFile,
+		map[int]any{partFieldID: deletePartValue}, nil, nil, 1, 128)
+	require.NoError(t, err)
+
+	peerTxn := tbl.NewTransaction()
+	rd := peerTxn.NewRowDelta(nil)
+	rd.AddDeletes(posDelBuilder.Build())
+	require.NoError(t, rd.Commit(t.Context()))
+	_, err = peerTxn.Commit(t.Context())
+	require.NoError(t, err, "peer commit advances the catalog so the leader's first attempt fails")
+
+	_, err = leaderTxn.Commit(t.Context())
+
+	return err
+}
+
+// TestRewriteFiles_PartitionScopedPosDelete_IdentityIntPartition proves
+// the partition fallback on a genuinely partitioned table where both
+// the rewritten file's tuple and the concurrent delete's tuple flow
+// through real Avro manifest encode/decode: a same-partition
+// partition-scoped pos-delete must conflict, a different-partition one
+// must not (no false positive).
+func TestRewriteFiles_PartitionScopedPosDelete_IdentityIntPartition(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "part", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Name: "part", Transform: iceberg.IdentityTransform{},
+	})
+	rowsJSON := `[{"id":1,"part":1},{"id":2,"part":1},{"id":3,"part":2},{"id":4,"part":2}]`
+
+	t.Run("same partition conflicts", func(t *testing.T) {
+		err := runConcurrentPartitionScopedPosDeleteRewrite(t, schema, &spec, rowsJSON, int64(1), int64(1))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, table.ErrConflictingDeleteFiles)
+	})
+
+	t.Run("different partition does not conflict", func(t *testing.T) {
+		err := runConcurrentPartitionScopedPosDeleteRewrite(t, schema, &spec, rowsJSON, int64(1), int64(2))
+		require.NoError(t, err,
+			"a partition-scoped pos-delete in a different partition must not be rejected")
+	})
+}
+
+// TestRewriteFiles_PartitionScopedPosDelete_IdentityDatePartition is
+// the representation-drift canary for the validator's partition
+// matching: date partition values pass through the Avro date logical
+// type (encoded as int32, decoded via time.Time into iceberg.Date), so
+// if either side ever decoded into a different Go representation for
+// the same logical day, the same-partition case would silently stop
+// conflicting.
+func TestRewriteFiles_PartitionScopedPosDelete_IdentityDatePartition(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "dt", Type: iceberg.PrimitiveTypes.Date, Required: true},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Name: "dt", Transform: iceberg.IdentityTransform{},
+	})
+	rowsJSON := `[{"id":1,"dt":"2024-03-01"},{"id":2,"dt":"2024-03-01"},` +
+		`{"id":3,"dt":"2024-03-02"},{"id":4,"dt":"2024-03-02"}]`
+	dayA := iceberg.Date(time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC).Unix() / 86400)
+	dayB := dayA + 1
+
+	t.Run("same partition conflicts", func(t *testing.T) {
+		err := runConcurrentPartitionScopedPosDeleteRewrite(t, schema, &spec, rowsJSON, dayA, dayA)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, table.ErrConflictingDeleteFiles)
+	})
+
+	t.Run("different partition does not conflict", func(t *testing.T) {
+		err := runConcurrentPartitionScopedPosDeleteRewrite(t, schema, &spec, rowsJSON, dayA, dayB)
+		require.NoError(t, err,
+			"a partition-scoped pos-delete on a different day must not be rejected")
+	})
 }


### PR DESCRIPTION
validateNoNewDeletesForRewrittenFiles only flagged concurrent position deletes whose referenced_data_file column (field 143) was set, a column V2 writers commonly leave empty, so a partition-scoped pos-delete committed during a rewrite passed validation and its deletes were silently lost. Mirror Java's ContentFileUtil.referencedDataFile and DeleteFileIndex: resolve a pos-delete's target via referenced_data_file, then via equal file_path lower/upper bounds, and otherwise match it against the rewritten files by (spec ID, partition tuple). Partition tuples are compared through an injective, type-normalized key that unifies the known Avro-decode and write-side value representations and fails the commit on unknown value types rather than guessing. Covered by unit tests over every resolution path and end-to-end tests on unpartitioned, int-partitioned, and date-partitioned tables where both sides round-trip real Avro manifests.