### PR TITLE
fix(ci): give Trino healthcheck startup grace time

### DIFF
--- a/internal/recipe/docker-compose.yml
+++ b/internal/recipe/docker-compose.yml
@@ -117,6 +117,11 @@ services:
       - CATALOG_MANAGEMENT=dynamic
     ports:
       - 8088:8080
+    healthcheck:
+      # Trino can take ~30s to finish booting in GitHub Actions; without a
+      # startup grace period, docker compose up --wait can mark it unhealthy
+      # just before the server reaches READY.
+      start_period: 45s
 
   fake-gcs-server:
     image: fsouza/fake-gcs-server


### PR DESCRIPTION
## Summary
- give the Trino service a startup grace period in `internal/recipe/docker-compose.yml`
- keep `docker compose up -d --wait` from failing while Trino is still booting in CI

## Why
The Spark 3.5 integration setup has been flaking before any Go tests run because Trino can take around 30 seconds to become ready in GitHub Actions. Without a startup grace period, the container's healthcheck can flip to `unhealthy` just before startup completes, which makes `make integration-setup` fail even though Trino comes up moments later.

This keeps the existing readiness flow in place and just gives the healthcheck enough warm-up time to match observed CI startup behavior.

Closes #1420.

## Testing
- `docker compose -f internal/recipe/docker-compose.yml config`
