### PR TITLE
feat(metrics): wire reporter selection through catalog, table, and scan (#1236)

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -193,6 +193,28 @@ type PurgeableTable interface {
 	PurgeTable(ctx context.Context, identifier table.Identifier) error
 }
 
+// Closer is an optional interface implemented by catalogs that hold releasable
+// resources — currently a metrics reporter, and in future a stateful (e.g.
+// HTTP-backed) one. It is not part of [Catalog] because adding a method to that
+// widely-implemented interface would break every external implementation; a
+// follow-up may promote it. Callers holding a [Catalog] from [Load] should
+// release it via a type assertion:
+//
+//	cat, err := catalog.Load(ctx, name, props)
+//	if err != nil {
+//	    return err
+//	}
+//	if closer, ok := cat.(catalog.Closer); ok {
+//	    defer closer.Close()
+//	}
+//
+// All built-in catalogs (REST, SQL, Glue, Hive, Hadoop) implement Closer. Close
+// releases the catalog's own resources; a catalog built on a caller-owned handle
+// (e.g. the SQL catalog's *sql.DB) does not close that handle.
+type Closer interface {
+	Close() error
+}
+
 func ToIdentifier(ident ...string) table.Identifier {
 	if len(ident) == 1 {
 		if ident[0] == "" {

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -284,18 +284,15 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
-	reporter, err := metrics.FromProperties(c.props)
-	if err != nil {
-		return nil, err
-	}
-	// Read the metadata file
+	// Read the metadata file. The reporter is intentionally not wired here: the
+	// tail c.LoadTable(...) re-resolves it through convertGlueToIceberg, and the
+	// table built below is discarded after constructTableInput.
 	tbl, err := table.NewFromLocation(
 		ctx,
 		[]string{tableName},
 		metadataLocation,
 		io.LoadFSFunc(nil, metadataLocation),
 		c,
-		table.WithMetricsReporter(reporter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read table metadata from %s: %w", metadataLocation, err)
@@ -841,7 +838,7 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 
 	reporter, err := metrics.FromProperties(c.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	icebergTable, err := table.NewFromLocation(

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -150,6 +150,9 @@ type Catalog struct {
 	catalogId *string
 	awsCfg    *aws.Config
 	props     iceberg.Properties
+	// reporter builds and caches the catalog's metrics reporter once, so it is
+	// constructed per-catalog rather than per table load. Released by Close.
+	reporter metrics.CachedReporter
 }
 
 // NewCatalog creates a new instance of glue.Catalog with the given options.
@@ -245,6 +248,12 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.Glue
 }
+
+// Close releases the catalog's metrics reporter. The Glue catalog does not own
+// the lifetime of the AWS clients it was configured with, so only the reporter
+// is released. Callers holding a [catalog.Catalog] can reach this via an
+// io.Closer type assertion.
+func (c *Catalog) Close() error { return c.reporter.Close() }
 
 // CreateTable creates a new Iceberg table in the Glue catalog.
 // This function will create the metadata file in S3 using the catalog and table properties,
@@ -836,7 +845,7 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 		return nil, fmt.Errorf("missing metadata location for table %s", tableName)
 	}
 
-	reporter, err := metrics.FromProperties(c.props)
+	reporter, err := c.reporter.Get(c.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -283,6 +284,10 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
+	reporter, err := metrics.FromProperties(c.props)
+	if err != nil {
+		return nil, err
+	}
 	// Read the metadata file
 	tbl, err := table.NewFromLocation(
 		ctx,
@@ -290,6 +295,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		metadataLocation,
 		io.LoadFSFunc(nil, metadataLocation),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read table metadata from %s: %w", metadataLocation, err)
@@ -833,12 +839,18 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 		return nil, fmt.Errorf("missing metadata location for table %s", tableName)
 	}
 
+	reporter, err := metrics.FromProperties(c.props)
+	if err != nil {
+		return nil, err
+	}
+
 	icebergTable, err := table.NewFromLocation(
 		utils.WithAwsConfig(ctx, c.awsCfg),
 		TableIdentifier(database, tableName),
 		metadataLocation,
 		io.LoadFSFunc(nil, metadataLocation),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create iceberg table from location %s: %w", metadataLocation, err)

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -93,7 +93,7 @@ func init() {
 			return nil, err
 		}
 
-		return NewCatalog(WithAwsConfig(awsConfig), WithAwsProperties(AwsProperties(props))), nil
+		return NewCatalog(WithAwsConfig(awsConfig), WithAwsProperties(AwsProperties(props)))
 	}))
 }
 
@@ -165,9 +165,9 @@ type Catalog struct {
 //     ...other transport options...
 // })
 // awsCfg.HTTPClient = client
-// catalog := glue.NewCatalog(glue.WithAwsConfig(awsCfg))
+// catalog, err := glue.NewCatalog(glue.WithAwsConfig(awsCfg))
 
-func NewCatalog(opts ...Option) *Catalog {
+func NewCatalog(opts ...Option) (*Catalog, error) {
 	glueOps := &options{}
 
 	for _, o := range opts {
@@ -185,12 +185,23 @@ func NewCatalog(opts ...Option) *Catalog {
 		catalogId = nil
 	}
 
-	return &Catalog{
+	cat := &Catalog{
 		glueSvc:   glue.NewFromConfig(glueOps.awsConfig),
 		catalogId: catalogId,
 		awsCfg:    &glueOps.awsConfig,
 		props:     iceberg.Properties(glueOps.awsProperties),
 	}
+
+	// Resolve the metrics reporter once, up front. CachedReporter caches the
+	// first result, so building it here means a bad metrics-reporter-impl fails
+	// construction — rather than surfacing later as a spurious CreateTable error
+	// (after the Glue entry is written, via the trailing convertGlueToIceberg) or
+	// as a cached error that wedges every later table op on this catalog.
+	if _, err := cat.reporter.Get(cat.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
+	return cat, nil
 }
 
 // ListTables returns a list of Iceberg tables in the given Glue database.
@@ -251,23 +262,20 @@ func (c *Catalog) CatalogType() catalog.Type {
 
 // Close releases the catalog's metrics reporter. The Glue catalog does not own
 // the lifetime of the AWS clients it was configured with, so only the reporter
-// is released. Callers holding a [catalog.Catalog] can reach this via an
-// io.Closer type assertion.
+// is released. Callers holding a [catalog.Catalog] can reach this via a
+// [catalog.Closer] type assertion.
 func (c *Catalog) Close() error { return c.reporter.Close() }
+
+var _ catalog.Closer = (*Catalog)(nil)
 
 // CreateTable creates a new Iceberg table in the Glue catalog.
 // This function will create the metadata file in S3 using the catalog and table properties,
 // to determine the bucket and key for the metadata location.
 func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
-	// Resolve the reporter before mutating the catalog: a bad
-	// metrics-reporter-impl must fail before the Glue entry is created, not
-	// after, which would report a failure for a table that was actually created
-	// (and make the retry hit ErrTableAlreadyExists). CachedReporter caches this
-	// first result, so the trailing LoadTable reuses it.
-	if _, err := c.reporter.Get(c.props); err != nil {
-		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
-	}
-
+	// The reporter is resolved once at construction (see NewCatalog), so a bad
+	// metrics-reporter-impl already failed there — no per-op guard is needed
+	// before mutating the catalog, and the trailing LoadTable reuses the cached
+	// reporter.
 	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, opts...)
 	if err != nil {
 		return nil, err
@@ -301,13 +309,6 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		return nil, err
 	}
 
-	// Resolve the reporter before mutating the catalog, for the same reason as
-	// CreateTable: an invalid reporter must not turn a successful registration
-	// into a reported failure. CachedReporter caches this for the trailing
-	// LoadTable.
-	if _, err := c.reporter.Get(c.props); err != nil {
-		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
-	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)
 	// Read the metadata file. The reporter is intentionally not wired here: the

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -259,6 +259,15 @@ func (c *Catalog) Close() error { return c.reporter.Close() }
 // This function will create the metadata file in S3 using the catalog and table properties,
 // to determine the bucket and key for the metadata location.
 func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	// Resolve the reporter before mutating the catalog: a bad
+	// metrics-reporter-impl must fail before the Glue entry is created, not
+	// after, which would report a failure for a table that was actually created
+	// (and make the retry hit ErrTableAlreadyExists). CachedReporter caches this
+	// first result, so the trailing LoadTable reuses it.
+	if _, err := c.reporter.Get(c.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
 	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, opts...)
 	if err != nil {
 		return nil, err
@@ -290,6 +299,14 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	database, tableName, err := identifierToGlueTable(identifier)
 	if err != nil {
 		return nil, err
+	}
+
+	// Resolve the reporter before mutating the catalog, for the same reason as
+	// CreateTable: an invalid reporter must not turn a successful registration
+	// into a reported failure. CachedReporter caches this for the trailing
+	// LoadTable.
+	if _, err := c.reporter.Get(c.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 	// Load the metadata file to get table properties
 	ctx = utils.WithAwsConfig(ctx, c.awsCfg)

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1437,7 +1437,8 @@ func TestGlueListTablesIntegration(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	iter := ctlg.ListTables(context.TODO(), DatabaseIdentifier(os.Getenv("TEST_DATABASE_NAME")))
 
@@ -1469,7 +1470,8 @@ func TestGlueLoadTableIntegration(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	tbl, err := ctlg.LoadTable(context.TODO(), []string{os.Getenv("TEST_DATABASE_NAME"), os.Getenv("TEST_TABLE_NAME")})
 	assert.NoError(err)
@@ -1485,7 +1487,8 @@ func TestGlueListNamespacesIntegration(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	namespaces, err := ctlg.ListNamespaces(context.TODO(), nil)
 	assert.NoError(err)
@@ -1508,7 +1511,8 @@ func TestGlueCreateTableSuccessIntegration(t *testing.T) {
 	metadataLocation := os.Getenv("TEST_TABLE_LOCATION")
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName})
 	assert.NoError(err)
 	assert.Equal([]string{dbName, sourceTableName}, sourceTable.Identifier())
@@ -1538,7 +1542,8 @@ func TestGlueCreateTableInvalidMetadataRollback(t *testing.T) {
 	sourceTableName := os.Getenv("TEST_TABLE_NAME")
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 	sourceTable, err := ctlg.LoadTable(context.TODO(), []string{dbName, sourceTableName})
 	assert.NoError(err)
 	newTableName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), sourceTableName)
@@ -1628,7 +1633,8 @@ func TestRegisterTableIntegration(t *testing.T) {
 
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	// Drop table if it exists
 	_ = ctlg.DropTable(context.TODO(), TableIdentifier(dbName, tableName))
@@ -1663,7 +1669,8 @@ func TestAlterTableIntegration(t *testing.T) {
 
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	// Create a table within the input database and location
 	testProps := iceberg.Properties{
@@ -1759,7 +1766,8 @@ func TestSnapshotManagementIntegration(t *testing.T) {
 
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	// clean up table after test
 	defer cleanupTable(t, ctlg, tbIdent, awsCfg)
@@ -1958,7 +1966,8 @@ func TestCommitTableOptimisticLockingIntegration(t *testing.T) {
 	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRequest|aws.LogResponse))
 	assert.NoError(err)
 
-	ctlg := NewCatalog(WithAwsConfig(awsCfg))
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg))
+	assert.NoError(err)
 
 	createOpts := []catalog.CreateTableOpt{
 		catalog.WithLocation(metadataLocation),

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -552,7 +552,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 
 	reporter, err := metrics.FromProperties(c.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	tbl := table.New(
@@ -579,7 +579,7 @@ func (c *Catalog) loadTable(ctx context.Context, ident table.Identifier) (*table
 
 	reporter, err := metrics.FromProperties(c.props)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	tbl, err := table.NewFromLocation(ctx, ident, metaPath, io.LoadFSFunc(c.props, metaPath), c, table.WithMetricsReporter(reporter))

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -244,14 +244,25 @@ func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, err
 		return nil, fmt.Errorf("hadoop catalog: %T does not implement HadoopCatalogFS", filesystem)
 	}
 
-	return &Catalog{
+	cat := &Catalog{
 		name:      name,
 		warehouse: warehouse,
 		isLocal:   isLocal,
 		// filesystem is resolved dynamically from the IO registry based on the warehouse scheme
 		filesystem: hadoopFs,
 		props:      props,
-	}, nil
+	}
+
+	// Resolve the metrics reporter once, up front. CachedReporter caches the
+	// first result, so building it here means a bad metrics-reporter-impl fails
+	// construction — rather than surfacing later as a spurious CreateTable error
+	// after the table is already on disk, or as a cached error that wedges every
+	// later table op on this catalog.
+	if _, err := cat.reporter.Get(props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
+	return cat, nil
 }
 
 func (c *Catalog) CatalogType() catalog.Type {
@@ -259,8 +270,10 @@ func (c *Catalog) CatalogType() catalog.Type {
 }
 
 // Close releases the catalog's metrics reporter. Callers holding a
-// [catalog.Catalog] can reach this via an io.Closer type assertion.
+// [catalog.Catalog] can reach this via a [catalog.Closer] type assertion.
 func (c *Catalog) Close() error { return c.reporter.Close() }
+
+var _ catalog.Closer = (*Catalog)(nil)
 
 // joinPath is a helper that allows paths to be joined as both local filesystem
 // paths or as remote URIs needed for filesystems like blob stores.

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 )
@@ -549,12 +550,18 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 
 	c.writeVersionHint(ident, version)
 
+	reporter, err := metrics.FromProperties(c.props)
+	if err != nil {
+		return nil, err
+	}
+
 	tbl := table.New(
 		ident,
 		metadata,
 		metaPath,
 		io.LoadFSFunc(c.props, metaPath),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 
 	return tbl, nil
@@ -570,7 +577,12 @@ func (c *Catalog) loadTable(ctx context.Context, ident table.Identifier) (*table
 		return nil, 0, err
 	}
 
-	tbl, err := table.NewFromLocation(ctx, ident, metaPath, io.LoadFSFunc(c.props, metaPath), c)
+	reporter, err := metrics.FromProperties(c.props)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	tbl, err := table.NewFromLocation(ctx, ident, metaPath, io.LoadFSFunc(c.props, metaPath), c, table.WithMetricsReporter(reporter))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -495,6 +495,15 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, err
 	}
 
+	// Resolve the reporter before any catalog mutation: a bad
+	// metrics-reporter-impl must fail here, not after the metadata file and
+	// version hint are written, which would report a failure for a table that
+	// was actually created (and make the retry hit ErrTableAlreadyExists).
+	reporter, err := c.reporter.Get(c.props)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
 	ns := catalog.NamespaceFromIdent(ident)
 	nsPath := c.namespaceToPath(ns)
 
@@ -556,11 +565,6 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 	}
 
 	c.writeVersionHint(ident, version)
-
-	reporter, err := c.reporter.Get(c.props)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
-	}
 
 	tbl := table.New(
 		ident,

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -184,6 +184,9 @@ type Catalog struct {
 	isLocal    bool
 	filesystem HadoopCatalogFS
 	props      iceberg.Properties
+	// reporter builds and caches the catalog's metrics reporter once, so it is
+	// constructed per-catalog rather than per table load. Released by Close.
+	reporter metrics.CachedReporter
 }
 
 // NewCatalog creates a new Hadoop catalog rooted at the given warehouse path.
@@ -254,6 +257,10 @@ func NewCatalog(name, warehouse string, props iceberg.Properties) (*Catalog, err
 func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.Hadoop
 }
+
+// Close releases the catalog's metrics reporter. Callers holding a
+// [catalog.Catalog] can reach this via an io.Closer type assertion.
+func (c *Catalog) Close() error { return c.reporter.Close() }
 
 // joinPath is a helper that allows paths to be joined as both local filesystem
 // paths or as remote URIs needed for filesystems like blob stores.
@@ -550,7 +557,7 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 
 	c.writeVersionHint(ident, version)
 
-	reporter, err := metrics.FromProperties(c.props)
+	reporter, err := c.reporter.Get(c.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
@@ -577,7 +584,7 @@ func (c *Catalog) loadTable(ctx context.Context, ident table.Identifier) (*table
 		return nil, 0, err
 	}
 
-	reporter, err := metrics.FromProperties(c.props)
+	reporter, err := c.reporter.Get(c.props)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1533,27 +1533,19 @@ func (s *HadoopCatalogTestSuite) TestCreateTableAndLoad() {
 }
 
 // TestCreateTableInvalidReporterDoesNotMutate pins that an invalid
-// metrics-reporter-impl fails CreateTable before any table is written to disk,
-// so a bad reporter can't turn a successful create into a reported failure that
-// then leaves the caller unable to retry (ErrTableAlreadyExists).
+// metrics-reporter-impl fails at catalog construction, before any table op runs,
+// so a bad reporter can never turn a successful create into a reported failure
+// (ErrTableAlreadyExists on retry) or leave a cached error that wedges later ops.
 func (s *HadoopCatalogTestSuite) TestCreateTableInvalidReporterDoesNotMutate() {
-	ctx := context.Background()
 	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
 
-	cat, err := NewCatalog("test", s.warehouse, iceberg.Properties{
+	_, err := NewCatalog("test", s.warehouse, iceberg.Properties{
 		metrics.ReporterImplKey: "does-not-exist",
 	})
-	s.Require().NoError(err)
-
-	_, err = cat.CreateTable(ctx, []string{"ns", "tbl"}, s.testSchema())
 	s.Require().Error(err)
 
-	// The table must not have been created, so the failure is a clean no-op and
-	// the caller can retry rather than hit ErrTableAlreadyExists.
+	// No table op ran, so nothing was written to disk.
 	s.NoDirExists(filepath.Join(s.warehouse, "ns", "tbl", "metadata"))
-	exists, err := cat.CheckTableExists(ctx, []string{"ns", "tbl"})
-	s.Require().NoError(err)
-	s.False(exists)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateTableGzipMetadata() {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
 	icebergio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -1529,6 +1530,30 @@ func (s *HadoopCatalogTestSuite) TestCreateTableAndLoad() {
 	s.Equal(created.Metadata().TableUUID(), loaded.Metadata().TableUUID())
 	s.Equal(created.Location(), loaded.Location())
 	s.Equal(len(created.Schema().Fields()), len(loaded.Schema().Fields()))
+}
+
+// TestCreateTableInvalidReporterDoesNotMutate pins that an invalid
+// metrics-reporter-impl fails CreateTable before any table is written to disk,
+// so a bad reporter can't turn a successful create into a reported failure that
+// then leaves the caller unable to retry (ErrTableAlreadyExists).
+func (s *HadoopCatalogTestSuite) TestCreateTableInvalidReporterDoesNotMutate() {
+	ctx := context.Background()
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	cat, err := NewCatalog("test", s.warehouse, iceberg.Properties{
+		metrics.ReporterImplKey: "does-not-exist",
+	})
+	s.Require().NoError(err)
+
+	_, err = cat.CreateTable(ctx, []string{"ns", "tbl"}, s.testSchema())
+	s.Require().Error(err)
+
+	// The table must not have been created, so the failure is a clean no-op and
+	// the caller can retry rather than hit ErrTableAlreadyExists.
+	s.NoDirExists(filepath.Join(s.warehouse, "ns", "tbl", "metadata"))
+	exists, err := cat.CheckTableExists(ctx, []string{"ns", "tbl"})
+	s.Require().NoError(err)
+	s.False(exists)
 }
 
 func (s *HadoopCatalogTestSuite) TestCreateTableGzipMetadata() {

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -247,7 +247,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		table.WithMetricsReporter(reporter),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read table metadata from %s: %s", metadataLocation, err)
+		return nil, fmt.Errorf("failed to read table metadata from %s: %w", metadataLocation, err)
 	}
 
 	hiveTbl := constructHiveTable(database, tableName, tbl.Location(), metadataLocation, tbl.Metadata().CurrentSchema(), maps.Clone(tbl.Metadata().Properties()))

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/beltran/gohive/hive_metastore"
@@ -149,12 +150,18 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 		return nil, fmt.Errorf("failed to get metadata location: %w", err)
 	}
 
+	reporter, err := metrics.FromProperties(c.opts.props)
+	if err != nil {
+		return nil, err
+	}
+
 	return table.NewFromLocation(
 		ctx,
 		identifier,
 		metadataLocation,
 		io.LoadFSFunc(c.opts.props, metadataLocation),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 }
 
@@ -226,12 +233,18 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		return nil, fmt.Errorf("%w: %s.%s", catalog.ErrTableAlreadyExists, database, tableName)
 	}
 
+	reporter, err := metrics.FromProperties(c.opts.props)
+	if err != nil {
+		return nil, err
+	}
+
 	tbl, err := table.NewFromLocation(
 		ctx,
 		identifier,
 		metadataLocation,
 		io.LoadFSFunc(c.opts.props, metadataLocation),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read table metadata from %s: %s", metadataLocation, err)

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -176,6 +176,15 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
+	// Resolve the reporter before any mutation: this method ends in LoadTable,
+	// which is where the reporter is otherwise first built, so a bad
+	// metrics-reporter-impl would only surface after the metastore entry was
+	// created — turning a successful create into a reported failure whose retry
+	// hits ErrTableAlreadyExists. CachedReporter caches this for that LoadTable.
+	if _, err := c.reporter.Get(c.opts.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
 	// Ensure there is no view with the same identifier.
 	viewExists, err := c.CheckViewExists(ctx, identifier)
 	if err != nil {

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -98,11 +98,33 @@ func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.Hive
 }
 
-// Close releases the Hive client and the catalog's metrics reporter, joining
-// any errors so one failing close does not skip the other.
+// Close releases the Hive client and the catalog's metrics reporter. Each close
+// is isolated from the other so one failing does not skip the other and leak its
+// resource — not just when a close returns an error (errors.Join already keeps
+// both), but when it panics: a bare errors.Join(c.client.Close(), c.reporter.Close())
+// would let a panic in the first close abort the second. Recovered panics are
+// converted to errors and joined with any close errors. Callers holding a
+// [catalog.Catalog] can reach this via a [catalog.Closer] type assertion.
 func (c *Catalog) Close() error {
-	return errors.Join(c.client.Close(), c.reporter.Close())
+	return errors.Join(
+		closeIsolated(c.client.Close),
+		closeIsolated(c.reporter.Close),
+	)
 }
+
+// closeIsolated runs a close function, converting a panic into an error so a
+// single misbehaving close cannot abort a sibling close in the same Close call.
+func closeIsolated(closeFn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("hive catalog: panic during close: %v", r)
+		}
+	}()
+
+	return closeFn()
+}
+
+var _ catalog.Closer = (*Catalog)(nil)
 
 // ListTables returns a list of table identifiers in the given namespace.
 func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -152,7 +152,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 
 	reporter, err := metrics.FromProperties(c.opts.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	return table.NewFromLocation(
@@ -235,7 +235,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 
 	reporter, err := metrics.FromProperties(c.opts.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	tbl, err := table.NewFromLocation(

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -56,6 +56,9 @@ var _ catalog.PurgeableTable = (*Catalog)(nil)
 type Catalog struct {
 	client HiveClient
 	opts   *HiveOptions
+	// reporter builds and caches the catalog's metrics reporter once, so it is
+	// constructed per-catalog rather than per table load. Released by Close.
+	reporter metrics.CachedReporter
 }
 
 func NewCatalog(props iceberg.Properties, opts ...Option) (*Catalog, error) {
@@ -95,8 +98,10 @@ func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.Hive
 }
 
+// Close releases the Hive client and the catalog's metrics reporter, joining
+// any errors so one failing close does not skip the other.
 func (c *Catalog) Close() error {
-	return c.client.Close()
+	return errors.Join(c.client.Close(), c.reporter.Close())
 }
 
 // ListTables returns a list of table identifiers in the given namespace.
@@ -150,7 +155,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 		return nil, fmt.Errorf("failed to get metadata location: %w", err)
 	}
 
-	reporter, err := metrics.FromProperties(c.opts.props)
+	reporter, err := c.reporter.Get(c.opts.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
@@ -233,7 +238,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		return nil, fmt.Errorf("%w: %s.%s", catalog.ErrTableAlreadyExists, database, tableName)
 	}
 
-	reporter, err := metrics.FromProperties(c.opts.props)
+	reporter, err := c.reporter.Get(c.opts.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -354,6 +354,7 @@ func TestHiveCreateNamespace(t *testing.T) {
 
 	mockClient.AssertExpectations(t)
 }
+
 func TestHiveCreateNamespaceAlreadyExists(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -331,6 +331,50 @@ func TestHiveCreateTableInvalidReporterDoesNotMutate(t *testing.T) {
 	mockClient.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything)
 }
 
+// panicOnCloseClient is a HiveClient whose Close panics; the embedded interface
+// is nil, so any other method call would panic too, but the Close-isolation test
+// touches only Close.
+type panicOnCloseClient struct{ HiveClient }
+
+func (panicOnCloseClient) Close() error { panic("client close boom") }
+
+// recordingReporter records that Close was called, so a test can assert the
+// reporter was released even when a sibling close panics.
+type recordingReporter struct{ closed *bool }
+
+func (recordingReporter) Report(context.Context, metrics.MetricsReport) {}
+func (r recordingReporter) Close() error {
+	*r.closed = true
+
+	return nil
+}
+
+// TestHiveCloseIsolatesClientPanicFromReporter pins that a panic in the client's
+// Close does not skip the reporter's Close (which would leak the reporter): the
+// panic is recovered and returned as an error, and the reporter is still closed.
+func TestHiveCloseIsolatesClientPanicFromReporter(t *testing.T) {
+	assert := require.New(t)
+
+	var reporterClosed bool
+	metrics.Register("hive-close-panic", func(map[string]string) (metrics.Reporter, error) {
+		return recordingReporter{closed: &reporterClosed}, nil
+	})
+	t.Cleanup(func() { metrics.Deregister("hive-close-panic") })
+
+	cat := NewCatalogWithClient(panicOnCloseClient{}, iceberg.Properties{
+		metrics.ReporterImplKey: "hive-close-panic",
+	})
+	// Force the reporter to be built so Close has something to release.
+	_, err := cat.reporter.Get(cat.opts.props)
+	assert.NoError(err)
+
+	assert.NotPanics(func() {
+		err = cat.Close()
+	})
+	assert.Error(err, "the recovered client-close panic must surface as an error")
+	assert.True(reporterClosed, "a client-close panic must not skip the reporter close")
+}
+
 func TestHiveCreateNamespace(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	cataloginternal "github.com/apache/iceberg-go/catalog/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/beltran/gohive/hive_metastore"
@@ -310,6 +311,26 @@ func TestHiveListNamespacesHierarchicalError(t *testing.T) {
 	assert.Contains(err.Error(), "hierarchical namespace is not supported")
 }
 
+// TestHiveCreateTableInvalidReporterDoesNotMutate pins that an invalid
+// metrics-reporter-impl fails CreateTable before any metastore mutation, so a
+// bad reporter can't turn a successful create into a reported failure. The
+// reporter is resolved at the top of CreateTable, so the client is never
+// touched.
+func TestHiveCreateTableInvalidReporterDoesNotMutate(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{
+		metrics.ReporterImplKey: "does-not-exist",
+	})
+
+	_, err := hiveCatalog.CreateTable(context.TODO(), TableIdentifier("test_database", "test_table"), testSchema)
+	assert.Error(err)
+
+	// The create must fail before any metastore call, so nothing was mutated.
+	mockClient.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything)
+}
+
 func TestHiveCreateNamespace(t *testing.T) {
 	assert := require.New(t)
 
@@ -333,7 +354,6 @@ func TestHiveCreateNamespace(t *testing.T) {
 
 	mockClient.AssertExpectations(t)
 }
-
 func TestHiveCreateNamespaceAlreadyExists(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1280,6 +1280,15 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
+	// Resolve the reporter before the create POST mutates the server: it is
+	// otherwise first built in the trailing tableFromResponse, so a bad
+	// metrics-reporter-impl would turn a table the server already created into a
+	// reported failure whose retry hits ErrTableAlreadyExists. CachedReporter
+	// caches this for that tableFromResponse call.
+	if _, err := r.reporter.Get(r.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
 	cfg := catalog.NewCreateTableCfg()
 	for _, o := range opts {
 		o(&cfg)
@@ -1512,6 +1521,14 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	type payload struct {
 		Name        string `json:"name"`
 		MetadataLoc string `json:"metadata-location"`
+	}
+
+	// Resolve the reporter before the register POST mutates the server, for the
+	// same reason as CreateTable: it is otherwise first built in the trailing
+	// tableFromResponse, so an invalid reporter would turn a successful
+	// registration into a reported failure. CachedReporter caches this.
+	if _, err := r.reporter.Get(r.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	path, err := endpointRegisterTable.reqPath(ns)

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1075,9 +1075,15 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF = iceio.LoadFSFunc(config, loc)
 	}
 
-	reporter, err := metrics.FromProperties(config)
+	// Resolve the reporter from the catalog's own properties, not the merged
+	// config. The merged config folds in table metadata, server-vended
+	// ret.Config, and creds, any of which could otherwise shadow the client's
+	// reporter choice or turn an unknown server-side name into a hard load
+	// error. Server-vended reporter selection, if ever wanted, should be an
+	// explicit decision rather than a side effect of merge order.
+	reporter, err := metrics.FromProperties(r.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	return table.New(

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -774,6 +774,10 @@ type Catalog struct {
 	endpoints endpointSet
 
 	namespaceSeparator string
+
+	// reporter builds and caches the catalog's metrics reporter once, so it is
+	// constructed per-catalog rather than per table load. Released by Close.
+	reporter metrics.CachedReporter
 }
 
 func newCatalogFromProps(ctx context.Context, name string, uri string, p iceberg.Properties) (*Catalog, error) {
@@ -1050,6 +1054,12 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*options, err
 func (r *Catalog) Name() string              { return r.name }
 func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
+// Close releases the catalog's metrics reporter. The REST catalog does not own
+// the lifetime of the HTTP client it was configured with, so only the reporter
+// is released. Callers holding a [catalog.Catalog] can reach this via an
+// io.Closer type assertion.
+func (r *Catalog) Close() error { return r.reporter.Close() }
+
 func checkValidNamespace(ident table.Identifier) error {
 	if len(ident) < 1 {
 		return fmt.Errorf("%w: empty namespace identifier", catalog.ErrNoSuchNamespace)
@@ -1081,7 +1091,7 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 	// reporter choice or turn an unknown server-side name into a hard load
 	// error. Server-vended reporter selection, if ever wanted, should be an
 	// explicit decision rather than a side effect of merge order.
-	reporter, err := metrics.FromProperties(r.props)
+	reporter, err := r.reporter.Get(r.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -778,6 +778,12 @@ type Catalog struct {
 	// reporter builds and caches the catalog's metrics reporter once, so it is
 	// constructed per-catalog rather than per table load. Released by Close.
 	reporter metrics.CachedReporter
+	// reporterProps holds only the client-supplied properties, captured before
+	// the server's /v1/config defaults and overrides are merged into props. The
+	// metrics reporter is resolved from these so a server-vended
+	// metrics-reporter-impl cannot select (or, via an unregistered name, break)
+	// a reporter the client never asked for.
+	reporterProps iceberg.Properties
 }
 
 func newCatalogFromProps(ctx context.Context, name string, uri string, p iceberg.Properties) (*Catalog, error) {
@@ -898,6 +904,12 @@ func (r *Catalog) init(ctx context.Context, ops *options, uri string) error {
 	}
 
 	r.baseURI = baseuri.JoinPath("v1")
+
+	// Capture the client-supplied properties before fetchConfig folds in the
+	// server's /v1/config defaults and overrides, so the metrics reporter is
+	// resolved from the client's choice alone (see the reporterProps field).
+	r.reporterProps = toProps(ops)
+
 	if ops, err = r.fetchConfig(ctx, ops); err != nil {
 		return err
 	}
@@ -1056,9 +1068,11 @@ func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
 // Close releases the catalog's metrics reporter. The REST catalog does not own
 // the lifetime of the HTTP client it was configured with, so only the reporter
-// is released. Callers holding a [catalog.Catalog] can reach this via an
-// io.Closer type assertion.
+// is released. Callers holding a [catalog.Catalog] can reach this via a
+// [catalog.Closer] type assertion.
 func (r *Catalog) Close() error { return r.reporter.Close() }
+
+var _ catalog.Closer = (*Catalog)(nil)
 
 func checkValidNamespace(ident table.Identifier) error {
 	if len(ident) < 1 {
@@ -1085,13 +1099,13 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF = iceio.LoadFSFunc(config, loc)
 	}
 
-	// Resolve the reporter from the catalog's own properties, not the merged
-	// config. The merged config folds in table metadata, server-vended
-	// ret.Config, and creds, any of which could otherwise shadow the client's
-	// reporter choice or turn an unknown server-side name into a hard load
-	// error. Server-vended reporter selection, if ever wanted, should be an
+	// Resolve the reporter from the client-supplied properties only (see the
+	// reporterProps field). r.props folds in server-vended /v1/config and, per
+	// call, table metadata and creds — any of which could otherwise shadow the
+	// client's reporter choice or turn an unknown server-side name into a hard
+	// load error. Server-vended reporter selection, if ever wanted, should be an
 	// explicit decision rather than a side effect of merge order.
-	reporter, err := r.reporter.Get(r.props)
+	reporter, err := r.reporter.Get(r.reporterProps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
@@ -1284,8 +1298,9 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	// otherwise first built in the trailing tableFromResponse, so a bad
 	// metrics-reporter-impl would turn a table the server already created into a
 	// reported failure whose retry hits ErrTableAlreadyExists. CachedReporter
-	// caches this for that tableFromResponse call.
-	if _, err := r.reporter.Get(r.props); err != nil {
+	// caches this for that tableFromResponse call. Resolved from the
+	// client-supplied properties only (see the reporterProps field).
+	if _, err := r.reporter.Get(r.reporterProps); err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
@@ -1526,8 +1541,9 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	// Resolve the reporter before the register POST mutates the server, for the
 	// same reason as CreateTable: it is otherwise first built in the trailing
 	// tableFromResponse, so an invalid reporter would turn a successful
-	// registration into a reported failure. CachedReporter caches this.
-	if _, err := r.reporter.Get(r.props); err != nil {
+	// registration into a reported failure. CachedReporter caches this. Resolved
+	// from the client-supplied properties only (see the reporterProps field).
+	if _, err := r.reporter.Get(r.reporterProps); err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/udf"
 	"github.com/apache/iceberg-go/view"
@@ -1074,12 +1075,18 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF = iceio.LoadFSFunc(config, loc)
 	}
 
+	reporter, err := metrics.FromProperties(config)
+	if err != nil {
+		return nil, err
+	}
+
 	return table.New(
 		identifier,
 		metadata,
 		loc,
 		fsF,
 		r,
+		table.WithMetricsReporter(reporter),
 	), nil
 }
 

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1338,6 +1338,36 @@ func (r *RestCatalogSuite) TestCreateTableInvalidReporterDoesNotHitServer() {
 	r.False(serverHit, "create POST must not be sent when the reporter is invalid")
 }
 
+// TestServerVendedReporterImplIgnored pins that a metrics-reporter-impl vended by
+// the server via /v1/config cannot select — or, with an unregistered name, break
+// — the client's reporter. The client configured none, so the op must succeed and
+// fall back to the nop reporter; selection is resolved from client props only.
+func TestServerVendedReporterImplIgnored(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, req *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults": map[string]any{},
+			// A server-vended reporter impl the Go client does not recognize.
+			"overrides": map[string]any{metrics.ReporterImplKey: "does-not-exist"},
+			"endpoints": rest.AllEndpointStrings,
+		})
+	})
+	mux.HandleFunc("/v1/namespaces/fokko/tables", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(createTableRestExample))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Client does NOT configure a reporter.
+	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
+	require.NoError(t, err)
+
+	tbl, err := cat.CreateTable(context.Background(), catalog.ToIdentifier("fokko", "fokko2"), tableSchemaSimple)
+	require.NoError(t, err, "an unregistered server-vended reporter must not fail the create")
+	assert.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter())
+}
+
 func (r *RestCatalogSuite) TestCheckTableExists204() {
 	r.mux.HandleFunc("/v1/namespaces/fokko/tables/fokko2", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodHead, req.Method)

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1355,6 +1355,7 @@ func (r *RestCatalogSuite) TestCheckTableExists204() {
 	r.Require().NoError(err)
 	r.True(exists)
 }
+
 func (r *RestCatalogSuite) TestCheckTableExists404() {
 	r.mux.HandleFunc("/v1/namespaces/fokko/tables/nonexistent", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodHead, req.Method)

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/rest"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/google/uuid"
@@ -1314,6 +1315,29 @@ func (r *RestCatalogSuite) TestCreateTable409() {
 	r.ErrorIs(err, catalog.ErrTableAlreadyExists)
 }
 
+// TestCreateTableInvalidReporterDoesNotHitServer pins that an invalid
+// metrics-reporter-impl fails CreateTable before the create POST is sent, so a
+// bad reporter can't turn a table the server already created into a reported
+// failure. The reporter is resolved at the top of CreateTable, so the server
+// endpoint is never hit.
+func (r *RestCatalogSuite) TestCreateTableInvalidReporterDoesNotHitServer() {
+	var serverHit bool
+	r.mux.HandleFunc("/v1/namespaces/fokko/tables", func(w http.ResponseWriter, req *http.Request) {
+		serverHit = true
+		w.Write([]byte(createTableRestExample))
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
+		rest.WithOAuthToken(TestToken),
+		rest.WithAdditionalProps(iceberg.Properties{metrics.ReporterImplKey: "does-not-exist"}),
+	)
+	r.Require().NoError(err)
+
+	_, err = cat.CreateTable(context.Background(), catalog.ToIdentifier("fokko", "fokko2"), tableSchemaSimple)
+	r.Require().Error(err)
+	r.False(serverHit, "create POST must not be sent when the reporter is invalid")
+}
+
 func (r *RestCatalogSuite) TestCheckTableExists204() {
 	r.mux.HandleFunc("/v1/namespaces/fokko/tables/fokko2", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodHead, req.Method)
@@ -1331,7 +1355,6 @@ func (r *RestCatalogSuite) TestCheckTableExists204() {
 	r.Require().NoError(err)
 	r.True(exists)
 }
-
 func (r *RestCatalogSuite) TestCheckTableExists404() {
 	r.mux.HandleFunc("/v1/namespaces/fokko/tables/nonexistent", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodHead, req.Method)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -212,6 +212,11 @@ func init() {
 			return nil, err
 		}
 
+		// This registrar opened sqldb itself, so nobody else holds the handle;
+		// Close must release its connection pool. NewCatalog leaves ownsDB false
+		// for caller-supplied handles, which stay owned by the caller.
+		cat.ownsDB = true
+
 		return cat, nil
 	}))
 }
@@ -304,6 +309,10 @@ type Catalog struct {
 	// reporter builds and caches the catalog's metrics reporter once, so it is
 	// constructed per-catalog rather than per table load. Released by Close.
 	reporter metrics.CachedReporter
+	// ownsDB reports whether this catalog opened its own *sql.DB (the registrar
+	// path) and must therefore close it in Close. It stays false for handles
+	// supplied to NewCatalog, which remain owned by the caller.
+	ownsDB bool
 }
 
 // isV0 reports whether the catalog is operating against a legacy V0 schema that
@@ -363,11 +372,21 @@ func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.SQL
 }
 
-// Close releases the catalog's metrics reporter. The SQL catalog is constructed
-// from a caller-owned database handle, so it does not close that handle; only
-// the reporter is released. Callers holding a [catalog.Catalog] can reach this
-// via a [catalog.Closer] type assertion.
-func (c *Catalog) Close() error { return c.reporter.Close() }
+// Close releases the catalog's metrics reporter. When the catalog opened its own
+// database handle (the registry [catalog.Load] path), Close also closes that
+// handle's connection pool; a handle supplied to [NewCatalog] stays owned by the
+// caller and is left open. Callers holding a [catalog.Catalog] can reach this via
+// a [catalog.Closer] type assertion.
+func (c *Catalog) Close() error {
+	err := c.reporter.Close()
+	if c.ownsDB {
+		if dbErr := c.db.Close(); dbErr != nil && err == nil {
+			err = dbErr
+		}
+	}
+
+	return err
+}
 
 var _ catalog.Closer = (*Catalog)(nil)
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -626,6 +626,15 @@ func checkValidNamespace(ident table.Identifier) error {
 }
 
 func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	// Resolve the reporter before any mutation: this method ends in LoadTable,
+	// which is where the reporter is otherwise first built, so a bad
+	// metrics-reporter-impl would only surface after the row was inserted —
+	// turning a successful create into a reported failure whose retry hits
+	// ErrTableAlreadyExists. CachedReporter caches this for that LoadTable.
+	if _, err := c.reporter.Get(c.props); err != nil {
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
+	}
+
 	nsIdent := catalog.NamespaceFromIdent(ident)
 	tblIdent := catalog.TableNameFromIdent(ident)
 	ns, exists, err := c.resolveNamespaceKey(ctx, nsIdent)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -800,7 +800,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 
 	reporter, err := metrics.FromProperties(c.props)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
 
 	return table.NewFromLocation(

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -366,8 +366,10 @@ func (c *Catalog) CatalogType() catalog.Type {
 // Close releases the catalog's metrics reporter. The SQL catalog is constructed
 // from a caller-owned database handle, so it does not close that handle; only
 // the reporter is released. Callers holding a [catalog.Catalog] can reach this
-// via an io.Closer type assertion.
+// via a [catalog.Closer] type assertion.
 func (c *Catalog) Close() error { return c.reporter.Close() }
+
+var _ catalog.Closer = (*Catalog)(nil)
 
 func (c *Catalog) CreateSQLTables(ctx context.Context) error {
 	_, err := c.db.NewCreateTable().Model((*sqlIcebergTable)(nil)).

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -301,6 +301,9 @@ type Catalog struct {
 	name          string
 	props         iceberg.Properties
 	schemaVersion schemaVer
+	// reporter builds and caches the catalog's metrics reporter once, so it is
+	// constructed per-catalog rather than per table load. Released by Close.
+	reporter metrics.CachedReporter
 }
 
 // isV0 reports whether the catalog is operating against a legacy V0 schema that
@@ -359,6 +362,12 @@ func (c *Catalog) Name() string { return c.name }
 func (c *Catalog) CatalogType() catalog.Type {
 	return catalog.SQL
 }
+
+// Close releases the catalog's metrics reporter. The SQL catalog is constructed
+// from a caller-owned database handle, so it does not close that handle; only
+// the reporter is released. Callers holding a [catalog.Catalog] can reach this
+// via an io.Closer type assertion.
+func (c *Catalog) Close() error { return c.reporter.Close() }
 
 func (c *Catalog) CreateSQLTables(ctx context.Context) error {
 	_, err := c.db.NewCreateTable().Model((*sqlIcebergTable)(nil)).
@@ -798,7 +807,7 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 		return nil, fmt.Errorf("%w: %s, metadata location is missing", catalog.ErrNoSuchTable, identifier)
 	}
 
-	reporter, err := metrics.FromProperties(c.props)
+	reporter, err := c.reporter.Get(c.props)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/internal"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/uptrace/bun"
@@ -797,12 +798,18 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 		return nil, fmt.Errorf("%w: %s, metadata location is missing", catalog.ErrNoSuchTable, identifier)
 	}
 
+	reporter, err := metrics.FromProperties(c.props)
+	if err != nil {
+		return nil, err
+	}
+
 	return table.NewFromLocation(
 		ctx,
 		identifier,
 		result.MetadataLocation.String,
 		io.LoadFSFunc(c.props, result.MetadataLocation.String),
 		c,
+		table.WithMetricsReporter(reporter),
 	)
 }
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/iceberg-go/catalog/internal"
 	sqlcat "github.com/apache/iceberg-go/catalog/sql"
 	_ "github.com/apache/iceberg-go/io/gocloud"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -864,6 +865,77 @@ func (s *SqliteCatalogTestSuite) TestCreateTableDefaultSortOrder() {
 		s.Equal(0, tbl.SortOrder().OrderID())
 		s.NoError(tt.cat.DropTable(context.Background(), tt.tblID))
 	}
+}
+
+func (s *SqliteCatalogTestSuite) TestMetricsReporterWiring() {
+	ctx := context.Background()
+
+	newCatMemory := func(extra iceberg.Properties) *sqlcat.Catalog {
+		props := iceberg.Properties{
+			"uri":             ":memory:",
+			sqlcat.DriverKey:  sqliteshim.ShimName,
+			sqlcat.DialectKey: string(sqlcat.SQLite),
+			"type":            "sql",
+			"warehouse":       "file://" + s.warehouse,
+		}
+		maps.Copy(props, extra)
+		cat, err := catalog.Load(ctx, "default", props)
+		s.Require().NoError(err)
+
+		return cat.(*sqlcat.Catalog)
+	}
+
+	createTable := func(cat *sqlcat.Catalog) (*table.Table, table.Identifier) {
+		tblID := s.randomTableIdentifier()
+		s.Require().NoError(cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+		tbl, err := cat.CreateTable(ctx, tblID, tableSchemaNested)
+		s.Require().NoError(err)
+
+		return tbl, tblID
+	}
+
+	s.Run("configured reporter reaches created and loaded table", func() {
+		cat := newCatMemory(iceberg.Properties{metrics.ReporterImplKey: "logging"})
+		created, tblID := createTable(cat)
+		s.IsType(&metrics.LoggingReporter{}, created.MetricsReporter())
+
+		loaded, err := cat.LoadTable(ctx, tblID)
+		s.Require().NoError(err)
+		s.IsType(&metrics.LoggingReporter{}, loaded.MetricsReporter())
+
+		// Scans inherit the table's reporter.
+		s.IsType(&metrics.LoggingReporter{}, loaded.Scan().Reporter())
+	})
+
+	s.Run("default is the no-op reporter", func() {
+		cat := newCatMemory(nil)
+		created, _ := createTable(cat)
+		s.IsType(metrics.NopReporter{}, created.MetricsReporter())
+	})
+
+	s.Run("unknown reporter name fails table load", func() {
+		// Create with a well-configured catalog, then reopen the same
+		// on-disk DB with a bad reporter name so the failure is isolated to
+		// LoadTable rather than the create path.
+		good := s.getCatalogSqlite()
+		tblID := s.randomTableIdentifier()
+		s.Require().NoError(good.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+		_, err := good.CreateTable(ctx, tblID, tableSchemaNested)
+		s.Require().NoError(err)
+
+		bad, err := catalog.Load(ctx, "default", iceberg.Properties{
+			"uri":                   s.catalogUri(),
+			sqlcat.DriverKey:        sqliteshim.ShimName,
+			sqlcat.DialectKey:       string(sqlcat.SQLite),
+			"type":                  "sql",
+			"warehouse":             "file://" + s.warehouse,
+			metrics.ReporterImplKey: "does-not-exist",
+		})
+		s.Require().NoError(err)
+
+		_, err = bad.LoadTable(ctx, tblID)
+		s.Require().Error(err)
+	})
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateV1Table() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -950,6 +950,21 @@ func (s *SqliteCatalogTestSuite) TestMetricsReporterWiring() {
 		_, err = bad.LoadTable(ctx, tblID)
 		s.Require().Error(err)
 	})
+
+	s.Run("invalid reporter fails CreateTable before inserting the row", func() {
+		cat := newCatMemory(iceberg.Properties{metrics.ReporterImplKey: "does-not-exist"})
+		tblID := s.randomTableIdentifier()
+		s.Require().NoError(cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+
+		_, err := cat.CreateTable(ctx, tblID, tableSchemaNested)
+		s.Require().Error(err)
+
+		// The row must not have been inserted, so the failure is a clean no-op
+		// and the caller can retry rather than hit ErrTableAlreadyExists.
+		exists, err := cat.CheckTableExists(ctx, tblID)
+		s.Require().NoError(err)
+		s.False(exists)
+	})
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateV1Table() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -914,23 +914,37 @@ func (s *SqliteCatalogTestSuite) TestMetricsReporterWiring() {
 	})
 
 	s.Run("unknown reporter name fails table load", func() {
-		// Create with a well-configured catalog, then reopen the same
-		// on-disk DB with a bad reporter name so the failure is isolated to
-		// LoadTable rather than the create path.
-		good := s.getCatalogSqlite()
-		tblID := s.randomTableIdentifier()
-		s.Require().NoError(good.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
-		_, err := good.CreateTable(ctx, tblID, tableSchemaNested)
+		// Fully self-contained: provision a dedicated on-disk DB, create a
+		// table with a well-configured catalog, then reopen the same DB with a
+		// bad reporter name so the failure is isolated to LoadTable rather than
+		// leaning on shared suite fixtures.
+		dir, err := os.MkdirTemp(os.TempDir(), "test_sql_reporter_*")
+		s.Require().NoError(err)
+		s.T().Cleanup(func() { s.Require().NoError(os.RemoveAll(dir)) })
+
+		uri := "file://" + filepath.Join(dir, "sql-catalog.db")
+		warehouse := "file://" + dir
+		baseProps := iceberg.Properties{
+			"uri":             uri,
+			sqlcat.DriverKey:  sqliteshim.ShimName,
+			sqlcat.DialectKey: string(sqlcat.SQLite),
+			"type":            "sql",
+			"warehouse":       warehouse,
+		}
+
+		goodProps := maps.Clone(baseProps)
+		goodProps["init_catalog_tables"] = "true"
+		good, err := catalog.Load(ctx, "default", goodProps)
 		s.Require().NoError(err)
 
-		bad, err := catalog.Load(ctx, "default", iceberg.Properties{
-			"uri":                   s.catalogUri(),
-			sqlcat.DriverKey:        sqliteshim.ShimName,
-			sqlcat.DialectKey:       string(sqlcat.SQLite),
-			"type":                  "sql",
-			"warehouse":             "file://" + s.warehouse,
-			metrics.ReporterImplKey: "does-not-exist",
-		})
+		tblID := s.randomTableIdentifier()
+		s.Require().NoError(good.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+		_, err = good.CreateTable(ctx, tblID, tableSchemaNested)
+		s.Require().NoError(err)
+
+		badProps := maps.Clone(baseProps)
+		badProps[metrics.ReporterImplKey] = "does-not-exist"
+		bad, err := catalog.Load(ctx, "default", badProps)
 		s.Require().NoError(err)
 
 		_, err = bad.LoadTable(ctx, tblID)

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -402,7 +402,9 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 		opts := []glue.Option{
 			glue.WithAwsConfig(awscfg),
 		}
-		cat = glue.NewCatalog(opts...)
+		if cat, err = glue.NewCatalog(opts...); err != nil {
+			log.Fatal(err)
+		}
 	case catalog.Hive:
 		props := iceberg.Properties{
 			hive.URI: args.URI,

--- a/metrics/cached_reporter.go
+++ b/metrics/cached_reporter.go
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import "sync"
+
+// CachedReporter builds a [Reporter] from catalog properties once and caches
+// it, so a catalog holds a single reporter for its lifetime — matching Java's
+// per-catalog MetricsReporter — rather than constructing a fresh one on every
+// table load or commit. That per-operation construction is what makes a
+// stateful reporter (an HTTP-backed one holding a shared client or a background
+// dispatch worker) leak: a new one per load with no owner to close it.
+//
+// The zero value is ready to use and safe for concurrent use. Close releases
+// the built reporter, giving a catalog a single place to clean up at shutdown.
+type CachedReporter struct {
+	mu    sync.Mutex
+	built bool
+	rep   Reporter
+	err   error
+}
+
+// Get returns the cached reporter, building it from props on the first call via
+// [FromProperties]. The first call's result — reporter and error — is cached and
+// returned to every later caller; props supplied on subsequent calls is ignored,
+// because a catalog's reporter configuration does not change over its lifetime.
+func (c *CachedReporter) Get(props map[string]string) (Reporter, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.built {
+		c.rep, c.err = FromProperties(props)
+		c.built = true
+	}
+
+	return c.rep, c.err
+}
+
+// Close closes the built reporter, if one was ever built, and is a no-op
+// otherwise (including when Get was never called or returned an error). Close is
+// expected at catalog shutdown, after operations have quiesced; it is safe for
+// concurrent use, but a Get racing a Close has no defined ordering.
+func (c *CachedReporter) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rep != nil {
+		return c.rep.Close()
+	}
+
+	return nil
+}

--- a/metrics/cached_reporter.go
+++ b/metrics/cached_reporter.go
@@ -29,19 +29,27 @@ import "sync"
 // The zero value is ready to use and safe for concurrent use. Close releases
 // the built reporter, giving a catalog a single place to clean up at shutdown.
 type CachedReporter struct {
-	mu    sync.Mutex
-	built bool
-	rep   Reporter
-	err   error
+	mu     sync.Mutex
+	built  bool
+	closed bool
+	rep    Reporter
+	err    error
 }
 
 // Get returns the cached reporter, building it from props on the first call via
 // [FromProperties]. The first call's result — reporter and error — is cached and
 // returned to every later caller; props supplied on subsequent calls is ignored,
 // because a catalog's reporter configuration does not change over its lifetime.
+//
+// After Close, Get returns [NopReporter] with no error: the built reporter has
+// been released, so handing it back would violate the "no Report after Close"
+// contract, and returning nil would force every caller to nil-check.
 func (c *CachedReporter) Get(props map[string]string) (Reporter, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closed {
+		return NopReporter{}, nil
+	}
 	if !c.built {
 		c.rep, c.err = FromProperties(props)
 		c.built = true
@@ -52,13 +60,24 @@ func (c *CachedReporter) Get(props map[string]string) (Reporter, error) {
 
 // Close closes the built reporter, if one was ever built, and is a no-op
 // otherwise (including when Get was never called or returned an error). Close is
-// expected at catalog shutdown, after operations have quiesced; it is safe for
-// concurrent use, but a Get racing a Close has no defined ordering.
+// idempotent: it nils the cached reporter after closing, so a second Close does
+// not re-close an underlying reporter that is not obliged to tolerate it, and a
+// post-Close Get hands back [NopReporter] rather than a released reporter.
+//
+// A factory returning a typed nil (e.g. (*Custom)(nil)) yields a non-nil
+// [Reporter] interface that passes the guard below, so Close still invokes its
+// Close — [Factory] implementations must return a usable reporter or an error,
+// never a typed-nil reporter. Close is expected at catalog shutdown, after
+// operations have quiesced; it is safe for concurrent use, but a Get racing a
+// Close has no defined ordering.
 func (c *CachedReporter) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.rep != nil {
-		return c.rep.Close()
+	c.closed = true
+	rep := c.rep
+	c.rep = nil
+	if rep != nil {
+		return rep.Close()
 	}
 
 	return nil

--- a/metrics/cached_reporter_test.go
+++ b/metrics/cached_reporter_test.go
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachedReporter(t *testing.T) {
+	t.Run("builds once and caches", func(t *testing.T) {
+		var builds int
+		Register("cached-once", func(map[string]string) (Reporter, error) {
+			builds++
+
+			return &countingReporter{}, nil
+		})
+		t.Cleanup(func() { Deregister("cached-once") })
+
+		var c CachedReporter
+		props := map[string]string{ReporterImplKey: "cached-once"}
+		r1, err := c.Get(props)
+		require.NoError(t, err)
+		r2, err := c.Get(props)
+		require.NoError(t, err)
+		assert.Same(t, r1, r2, "Get must return the same cached reporter")
+		assert.Equal(t, 1, builds, "the reporter must be built only once, not per Get")
+	})
+
+	t.Run("Close releases the built reporter", func(t *testing.T) {
+		cr := &countingReporter{}
+		Register("cached-close", func(map[string]string) (Reporter, error) { return cr, nil })
+		t.Cleanup(func() { Deregister("cached-close") })
+
+		var c CachedReporter
+		_, err := c.Get(map[string]string{ReporterImplKey: "cached-close"})
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+		assert.Equal(t, 1, cr.closeCalls(), "Close must close the built reporter")
+	})
+
+	t.Run("Close without a prior Get is a no-op", func(t *testing.T) {
+		var c CachedReporter
+		assert.NoError(t, c.Close())
+	})
+
+	t.Run("a build error is cached and not retried", func(t *testing.T) {
+		var c CachedReporter
+		props := map[string]string{ReporterImplKey: "does-not-exist"}
+		_, err1 := c.Get(props)
+		require.Error(t, err1)
+		_, err2 := c.Get(props)
+		assert.Equal(t, err1, err2, "the cached error must be returned without rebuilding")
+	})
+}

--- a/metrics/cached_reporter_test.go
+++ b/metrics/cached_reporter_test.go
@@ -61,6 +61,35 @@ func TestCachedReporter(t *testing.T) {
 		assert.NoError(t, c.Close())
 	})
 
+	t.Run("Close is idempotent and does not re-close", func(t *testing.T) {
+		cr := &countingReporter{}
+		Register("cached-idempotent", func(map[string]string) (Reporter, error) { return cr, nil })
+		t.Cleanup(func() { Deregister("cached-idempotent") })
+
+		var c CachedReporter
+		_, err := c.Get(map[string]string{ReporterImplKey: "cached-idempotent"})
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+		require.NoError(t, c.Close())
+		assert.Equal(t, 1, cr.closeCalls(), "a second Close must not re-close the reporter")
+	})
+
+	t.Run("Get after Close returns the nop reporter", func(t *testing.T) {
+		cr := &countingReporter{}
+		Register("cached-post-close", func(map[string]string) (Reporter, error) { return cr, nil })
+		t.Cleanup(func() { Deregister("cached-post-close") })
+
+		var c CachedReporter
+		props := map[string]string{ReporterImplKey: "cached-post-close"}
+		_, err := c.Get(props)
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+
+		got, err := c.Get(props)
+		require.NoError(t, err)
+		assert.IsType(t, NopReporter{}, got, "Get after Close must not hand back the released reporter")
+	})
+
 	t.Run("a build error is cached and not retried", func(t *testing.T) {
 		var c CachedReporter
 		props := map[string]string{ReporterImplKey: "does-not-exist"}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -82,6 +82,11 @@ func Deregister(name string) {
 // FromProperties builds the reporter named by props[ReporterImplKey]. An absent
 // or empty name yields [NopReporter] (reporting is opt-in), and an unrecognized name is
 // an error so misconfiguration surfaces rather than silently disabling metrics.
+//
+// This nop default is an intentional divergence from Java, where an absent
+// metrics-reporter-impl defaults to LoggingMetricsReporter. Callers migrating
+// from Java that want scan/commit reports by default must set ReporterImplKey to
+// [ReporterNameLogging] explicitly.
 func FromProperties(props map[string]string) (Reporter, error) {
 	name := props[ReporterImplKey]
 	if name == "" {

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+)
+
+// ReporterImplKey is the catalog/table property that selects a registered
+// reporter by name (e.g. "logging"). It is the Go analogue of Java's
+// metrics-reporter-impl; Go uses a name→factory registry rather than
+// reflection over a class name.
+const ReporterImplKey = "metrics-reporter-impl"
+
+// Built-in reporter names usable as the value of [ReporterImplKey].
+const (
+	reporterNameNop     = "nop"
+	reporterNameLogging = "logging"
+)
+
+// Factory builds a Reporter from configuration properties. The same property
+// map that selected the reporter is passed in, so a factory may read its own
+// configuration keys.
+type Factory func(props map[string]string) (Reporter, error)
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Factory{}
+)
+
+func init() {
+	Register(reporterNameNop, func(map[string]string) (Reporter, error) { return NopReporter{}, nil })
+	Register(reporterNameLogging, func(map[string]string) (Reporter, error) {
+		return NewLoggingReporter(nil), nil
+	})
+}
+
+// Register makes a reporter factory available under name. It panics if name is
+// empty or already registered, mirroring database/sql.Register — registration
+// is expected to happen once, from package init.
+func Register(name string, factory Factory) {
+	if name == "" {
+		panic("metrics: Register called with empty name")
+	}
+	if factory == nil {
+		panic("metrics: Register called with nil factory")
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, dup := registry[name]; dup {
+		panic("metrics: Register called twice for " + name)
+	}
+	registry[name] = factory
+}
+
+// FromProperties builds the reporter named by props[ReporterImplKey]. An absent
+// or empty name yields [NopReporter] (reporting is opt-in), and an unrecognized name is
+// an error so misconfiguration surfaces rather than silently disabling metrics.
+func FromProperties(props map[string]string) (Reporter, error) {
+	name := props[ReporterImplKey]
+	if name == "" {
+		return NopReporter{}, nil
+	}
+
+	registryMu.RLock()
+	factory, ok := registry[name]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("metrics: unknown reporter %q (set via %q)", name, ReporterImplKey)
+	}
+
+	return factory(props)
+}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -37,6 +37,11 @@ const (
 // Factory builds a Reporter from configuration properties. The same property
 // map that selected the reporter is passed in, so a factory may read its own
 // configuration keys.
+//
+// A factory must return either a usable [Reporter] or a non-nil error, never a
+// typed-nil reporter (e.g. (*Custom)(nil)): that is a non-nil interface value,
+// so it passes interface nil checks and its Report/Close would nil-deref where a
+// caller reasonably assumed a nil interface meant "no reporter".
 type Factory func(props map[string]string) (Reporter, error)
 
 var (

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -30,8 +30,8 @@ const ReporterImplKey = "metrics-reporter-impl"
 
 // Built-in reporter names usable as the value of [ReporterImplKey].
 const (
-	reporterNameNop     = "nop"
-	reporterNameLogging = "logging"
+	ReporterNameNop     = "nop"
+	ReporterNameLogging = "logging"
 )
 
 // Factory builds a Reporter from configuration properties. The same property
@@ -45,8 +45,8 @@ var (
 )
 
 func init() {
-	Register(reporterNameNop, func(map[string]string) (Reporter, error) { return NopReporter{}, nil })
-	Register(reporterNameLogging, func(map[string]string) (Reporter, error) {
+	Register(ReporterNameNop, func(map[string]string) (Reporter, error) { return NopReporter{}, nil })
+	Register(ReporterNameLogging, func(map[string]string) (Reporter, error) {
 		return NewLoggingReporter(nil), nil
 	})
 }
@@ -67,6 +67,16 @@ func Register(name string, factory Factory) {
 		panic("metrics: Register called twice for " + name)
 	}
 	registry[name] = factory
+}
+
+// Deregister removes a previously registered reporter factory. It is a no-op if
+// name is not registered. This exists primarily so tests can register a factory
+// and undo it via t.Cleanup, keeping the process-global registry re-runnable
+// under go test -count=N.
+func Deregister(name string) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	delete(registry, name)
 }
 
 // FromProperties builds the reporter named by props[ReporterImplKey]. An absent

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -73,7 +73,15 @@ func Register(name string, factory Factory) {
 // name is not registered. This exists primarily so tests can register a factory
 // and undo it via t.Cleanup, keeping the process-global registry re-runnable
 // under go test -count=N.
+//
+// The built-in "nop" and "logging" factories cannot be removed: since Register
+// panics on a duplicate name, nothing could put them back for the rest of the
+// process, and a stray Deregister("nop") would permanently break
+// metrics-reporter-impl=nop everywhere. Deregister silently ignores those names.
 func Deregister(name string) {
+	if name == ReporterNameNop || name == ReporterNameLogging {
+		return
+	}
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	delete(registry, name)

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -78,3 +78,19 @@ func TestRegister(t *testing.T) {
 		assert.Panics(t, func() { Register("logging", func(map[string]string) (Reporter, error) { return NopReporter{}, nil }) })
 	})
 }
+
+func TestDeregisterProtectsBuiltins(t *testing.T) {
+	// Deregister must not remove the built-in factories: Register panics on a
+	// duplicate, so a removed built-in could never be restored, permanently
+	// breaking metrics-reporter-impl=nop/logging for the rest of the process.
+	Deregister(ReporterNameNop)
+	Deregister(ReporterNameLogging)
+
+	nop, err := FromProperties(map[string]string{ReporterImplKey: ReporterNameNop})
+	require.NoError(t, err)
+	assert.IsType(t, NopReporter{}, nop)
+
+	logging, err := FromProperties(map[string]string{ReporterImplKey: ReporterNameLogging})
+	require.NoError(t, err)
+	assert.IsType(t, &LoggingReporter{}, logging)
+}

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromProperties(t *testing.T) {
+	t.Run("absent name yields NopReporter", func(t *testing.T) {
+		r, err := FromProperties(nil)
+		require.NoError(t, err)
+		assert.IsType(t, NopReporter{}, r)
+	})
+
+	t.Run("empty name yields NopReporter", func(t *testing.T) {
+		r, err := FromProperties(map[string]string{ReporterImplKey: ""})
+		require.NoError(t, err)
+		assert.IsType(t, NopReporter{}, r)
+	})
+
+	t.Run("nop name yields NopReporter", func(t *testing.T) {
+		r, err := FromProperties(map[string]string{ReporterImplKey: "nop"})
+		require.NoError(t, err)
+		assert.IsType(t, NopReporter{}, r)
+	})
+
+	t.Run("logging name yields LoggingReporter", func(t *testing.T) {
+		r, err := FromProperties(map[string]string{ReporterImplKey: "logging"})
+		require.NoError(t, err)
+		assert.IsType(t, &LoggingReporter{}, r)
+	})
+
+	t.Run("unknown name is an error", func(t *testing.T) {
+		_, err := FromProperties(map[string]string{ReporterImplKey: "does-not-exist"})
+		assert.Error(t, err)
+	})
+}
+
+func TestRegister(t *testing.T) {
+	t.Run("factory is selectable via FromProperties", func(t *testing.T) {
+		Register("test-custom", func(props map[string]string) (Reporter, error) {
+			return &InMemoryReporter{}, nil
+		})
+		r, err := FromProperties(map[string]string{ReporterImplKey: "test-custom"})
+		require.NoError(t, err)
+		assert.IsType(t, &InMemoryReporter{}, r)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		assert.Panics(t, func() { Register("", func(map[string]string) (Reporter, error) { return NopReporter{}, nil }) })
+	})
+
+	t.Run("nil factory panics", func(t *testing.T) {
+		assert.Panics(t, func() { Register("test-nil-factory", nil) })
+	})
+
+	t.Run("duplicate name panics", func(t *testing.T) {
+		assert.Panics(t, func() { Register("logging", func(map[string]string) (Reporter, error) { return NopReporter{}, nil }) })
+	})
+}

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -60,6 +60,7 @@ func TestRegister(t *testing.T) {
 		Register("test-custom", func(props map[string]string) (Reporter, error) {
 			return &InMemoryReporter{}, nil
 		})
+		t.Cleanup(func() { Deregister("test-custom") })
 		r, err := FromProperties(map[string]string{ReporterImplKey: "test-custom"})
 		require.NoError(t, err)
 		assert.IsType(t, &InMemoryReporter{}, r)

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -34,7 +34,10 @@
 // instrumentation are layered on top in later work.
 package metrics
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // MetricsReport is the marker interface implemented by the concrete report
 // types (ScanReport and CommitReport). It is intentionally empty, mirroring the
@@ -66,6 +69,15 @@ type MetricsReport any
 // actual send on a background worker, and any error must be handled internally
 // (logged and swallowed), never propagated back to the caller. Report must be
 // safe for concurrent use by multiple goroutines.
+//
+// Reporter embeds [io.Closer] to mirror Java's Closeable MetricsReporter: a
+// stateful reporter (e.g. an HTTP-backed one holding a shared client or a
+// background dispatch worker) releases those resources in Close. Close is
+// called once, by the owner of the reporter, when the reporter is no longer
+// needed; Report must not be called after Close returns. Stateless reporters
+// return nil. Close lives on the interface deliberately — adding it after this
+// surface stabilizes would be a breaking change for external implementers.
 type Reporter interface {
 	Report(ctx context.Context, report MetricsReport)
+	io.Closer
 }

--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -19,6 +19,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -52,6 +53,9 @@ var _ Reporter = NopReporter{}
 // Report implements [Reporter] and does nothing.
 func (NopReporter) Report(context.Context, MetricsReport) {}
 
+// Close implements [Reporter]. NopReporter holds no resources, so it is a no-op.
+func (NopReporter) Close() error { return nil }
+
 // LoggingReporter is a [Reporter] that logs each report via an [slog.Logger]. It
 // is a convenient default for development and debugging.
 type LoggingReporter struct {
@@ -78,6 +82,10 @@ func (r *LoggingReporter) Report(ctx context.Context, report MetricsReport) {
 	}
 	logger.InfoContext(ctx, "iceberg metrics report", "report", report)
 }
+
+// Close implements [Reporter]. A LoggingReporter does not own the logger it
+// writes to, so there is nothing to release; it is a no-op.
+func (r *LoggingReporter) Close() error { return nil }
 
 // InMemoryReporter is a [Reporter] that retains every report it receives. It is
 // primarily intended for tests and inspection. It is safe for concurrent use.
@@ -112,6 +120,11 @@ func (r *InMemoryReporter) Reset() {
 	defer r.mu.Unlock()
 	r.reports = nil
 }
+
+// Close implements [Reporter]. InMemoryReporter retains reports in memory and
+// holds no external resources, so Close is a no-op; retained reports remain
+// readable via Reports.
+func (r *InMemoryReporter) Close() error { return nil }
 
 // Combine returns a [Reporter] that forwards each report to all of the given
 // reporters in order. nil reporters are skipped. A panic in one reporter must
@@ -182,4 +195,29 @@ func (c *compositeReporter) Report(ctx context.Context, report MetricsReport) {
 			r.Report(ctx, report)
 		}()
 	}
+}
+
+// Close closes every wrapped reporter, isolating each from the others so one
+// failing or panicking Close still lets the rest run — mirroring the fan-out
+// panic isolation in Report. It returns the joined non-nil errors (a recovered
+// panic is converted to an error), or nil if all children closed cleanly.
+func (c *compositeReporter) Close() error {
+	var errs []error
+	for _, r := range c.reporters {
+		errs = append(errs, closeIsolated(r))
+	}
+
+	return errors.Join(errs...)
+}
+
+// closeIsolated calls r.Close, converting a panic into an error so a single
+// misbehaving reporter cannot abort closing its peers.
+func closeIsolated(r Reporter) (err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("metrics reporter %T panicked on Close: %v", r, v)
+		}
+	}()
+
+	return r.Close()
 }

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -20,6 +20,7 @@ package metrics
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -35,8 +36,10 @@ type testReport struct{ name string }
 
 // countingReporter records how many reports it received.
 type countingReporter struct {
-	mu    sync.Mutex
-	count int
+	mu       sync.Mutex
+	count    int
+	closes   int
+	closeErr error
 }
 
 func (c *countingReporter) Report(context.Context, MetricsReport) {
@@ -52,10 +55,27 @@ func (c *countingReporter) calls() int {
 	return c.count
 }
 
-// panickingReporter always panics, to verify Combine isolates failures.
+func (c *countingReporter) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closes++
+
+	return c.closeErr
+}
+
+func (c *countingReporter) closeCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.closes
+}
+
+// panickingReporter always panics, to verify Combine isolates failures. It also
+// panics on Close to verify Close isolation.
 type panickingReporter struct{}
 
 func (panickingReporter) Report(context.Context, MetricsReport) { panic("boom") }
+func (panickingReporter) Close() error                          { panic("close boom") }
 
 func TestNopReporter(t *testing.T) {
 	// NopReporter must accept anything, including nil, without panicking.
@@ -231,4 +251,35 @@ func TestInMemoryReporterConcurrent(t *testing.T) {
 	reader.Wait()
 
 	assert.Len(t, r.Reports(), writers)
+}
+
+func TestReporterClose(t *testing.T) {
+	t.Run("built-in reporters close without error", func(t *testing.T) {
+		assert.NoError(t, NopReporter{}.Close())
+		assert.NoError(t, NewLoggingReporter(nil).Close())
+		assert.NoError(t, (&InMemoryReporter{}).Close())
+	})
+
+	t.Run("composite closes every child once", func(t *testing.T) {
+		a, b := &countingReporter{}, &countingReporter{}
+		require.NoError(t, Combine(a, b).Close())
+		assert.Equal(t, 1, a.closeCalls())
+		assert.Equal(t, 1, b.closeCalls())
+	})
+
+	t.Run("composite joins child errors and still closes peers", func(t *testing.T) {
+		boom := errors.New("boom")
+		bad := &countingReporter{closeErr: boom}
+		good := &countingReporter{}
+		err := Combine(bad, good).Close()
+		assert.ErrorIs(t, err, boom)
+		assert.Equal(t, 1, good.closeCalls(), "a failing child must not stop peers from closing")
+	})
+
+	t.Run("composite isolates a panicking Close", func(t *testing.T) {
+		good := &countingReporter{}
+		err := Combine(panickingReporter{}, good).Close()
+		assert.Error(t, err, "a panic on Close is converted to an error")
+		assert.Equal(t, 1, good.closeCalls(), "a panicking child must not stop peers from closing")
+	})
 }

--- a/table/metrics_wiring_test.go
+++ b/table/metrics_wiring_test.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableMetricsReporterDefaultsToNop(t *testing.T) {
+	tbl := New(nil, nil, "", nil, nil)
+	assert.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter())
+}
+
+func TestWithMetricsReporter(t *testing.T) {
+	rep := &metrics.InMemoryReporter{}
+	tbl := New(nil, nil, "", nil, nil, WithMetricsReporter(rep))
+	assert.Same(t, rep, tbl.MetricsReporter())
+
+	// A nil reporter option is ignored; the default no-op reporter is kept.
+	tblNil := New(nil, nil, "", nil, nil, WithMetricsReporter(nil))
+	assert.IsType(t, metrics.NopReporter{}, tblNil.MetricsReporter())
+}
+
+func TestScanInheritsReporterFromTable(t *testing.T) {
+	rep := &metrics.InMemoryReporter{}
+	tbl := New(nil, nil, "", nil, nil, WithMetricsReporter(rep))
+
+	scan := tbl.Scan()
+	assert.Same(t, rep, scan.Reporter())
+}
+
+func TestScanReporterDefaultsToNop(t *testing.T) {
+	tbl := New(nil, nil, "", nil, nil)
+	assert.IsType(t, metrics.NopReporter{}, tbl.Scan().Reporter())
+}
+
+func TestWithReporterOverridesScan(t *testing.T) {
+	tableRep := &metrics.InMemoryReporter{}
+	scanRep := &metrics.InMemoryReporter{}
+	tbl := New(nil, nil, "", nil, nil, WithMetricsReporter(tableRep))
+
+	// Scan-level WithReporter wins over the table's reporter.
+	scan := tbl.Scan(WithReporter(scanRep))
+	assert.Same(t, scanRep, scan.Reporter())
+	require.NotSame(t, tableRep, scan.Reporter())
+
+	// A nil WithReporter is ignored; the inherited reporter is kept.
+	scanNil := tbl.Scan(WithReporter(nil))
+	assert.Same(t, tableRep, scanNil.Reporter())
+}

--- a/table/metrics_wiring_test.go
+++ b/table/metrics_wiring_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/metrics"
 	"github.com/stretchr/testify/assert"
@@ -92,7 +93,28 @@ func (c *reporterStubCatalog) CommitTable(context.Context, Identifier, []Require
 	return nil, "", nil
 }
 
-// TestRefreshKeepsCallerReporter is the invariant the commit retry loop depends
+// TestStagedTableInheritsReporter pins that Transaction.StagedTable() forwards
+// the transaction table's reporter. StagedTable rebuilds the table via New(...),
+// which would otherwise reset the reporter to the construction-time nop default.
+func TestStagedTableInheritsReporter(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://default/staged", iceberg.Properties{PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	rep := &metrics.InMemoryReporter{}
+	tbl := New(Identifier{"default", "staged"}, meta, "",
+		func(context.Context) (iceio.IO, error) { return iceio.NewMemFS(), nil }, nil,
+		WithMetricsReporter(rep))
+
+	staged, err := tbl.NewTransaction().StagedTable()
+	require.NoError(t, err)
+	assert.Same(t, rep, staged.MetricsReporter(),
+		"StagedTable must forward the transaction table's reporter")
+}
+
 // on: a reporter injected via WithMetricsReporter must survive a Refresh even
 // though the catalog's LoadTable hands back the default nop reporter.
 func TestRefreshKeepsCallerReporter(t *testing.T) {
@@ -108,7 +130,23 @@ func TestRefreshKeepsCallerReporter(t *testing.T) {
 		"caller-set reporter must not be reverted to the catalog default on refresh")
 }
 
-// TestRefreshInheritsCatalogReporterWhenUnset covers the other direction: when
+// TestRefreshKeepsExplicitNopOptOut pins the flag-based guard: a caller who
+// explicitly opts out with WithMetricsReporter(NopReporter{}) has still "set" a
+// reporter, so Refresh must not revert it to a catalog-provided logging reporter.
+// A type-based "is it a nop?" guard would silently fail this case.
+func TestRefreshKeepsExplicitNopOptOut(t *testing.T) {
+	fresh := &metrics.InMemoryReporter{}
+	cat := &reporterStubCatalog{reporter: fresh} // LoadTable yields a logging-style reporter
+	tbl := New(Identifier{"db", "reporter-refresh"}, nil, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat,
+		WithMetricsReporter(metrics.NopReporter{}))
+
+	require.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter())
+	require.NoError(t, tbl.Refresh(context.Background()))
+	assert.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter(),
+		"explicit NopReporter opt-out must not be reverted to the catalog reporter on refresh")
+}
+
 // the caller never overrode the reporter, Refresh adopts the fresh table's.
 func TestRefreshInheritsCatalogReporterWhenUnset(t *testing.T) {
 	fresh := &metrics.InMemoryReporter{}

--- a/table/metrics_wiring_test.go
+++ b/table/metrics_wiring_test.go
@@ -18,8 +18,10 @@
 package table
 
 import (
+	"context"
 	"testing"
 
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,4 +68,56 @@ func TestWithReporterOverridesScan(t *testing.T) {
 	// A nil WithReporter is ignored; the inherited reporter is kept.
 	scanNil := tbl.Scan(WithReporter(nil))
 	assert.Same(t, tableRep, scanNil.Reporter())
+}
+
+// reporterStubCatalog is a minimal catalog whose LoadTable returns a table
+// carrying the configured reporter (or the default nop reporter when nil). It
+// lets the Refresh tests control exactly which reporter the "fresh" table
+// arrives with.
+type reporterStubCatalog struct {
+	reporter metrics.Reporter
+}
+
+func (c *reporterStubCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
+	opts := []Option{}
+	if c.reporter != nil {
+		opts = append(opts, WithMetricsReporter(c.reporter))
+	}
+
+	return New(ident, nil, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c, opts...), nil
+}
+
+func (c *reporterStubCatalog) CommitTable(context.Context, Identifier, []Requirement, []Update) (Metadata, string, error) {
+	return nil, "", nil
+}
+
+// TestRefreshKeepsCallerReporter is the invariant the commit retry loop depends
+// on: a reporter injected via WithMetricsReporter must survive a Refresh even
+// though the catalog's LoadTable hands back the default nop reporter.
+func TestRefreshKeepsCallerReporter(t *testing.T) {
+	rep := &metrics.InMemoryReporter{}
+	cat := &reporterStubCatalog{} // LoadTable yields a nop-reporter table
+	tbl := New(Identifier{"db", "reporter-refresh"}, nil, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat,
+		WithMetricsReporter(rep))
+
+	require.Same(t, rep, tbl.MetricsReporter())
+	require.NoError(t, tbl.Refresh(context.Background()))
+	assert.Same(t, rep, tbl.MetricsReporter(),
+		"caller-set reporter must not be reverted to the catalog default on refresh")
+}
+
+// TestRefreshInheritsCatalogReporterWhenUnset covers the other direction: when
+// the caller never overrode the reporter, Refresh adopts the fresh table's.
+func TestRefreshInheritsCatalogReporterWhenUnset(t *testing.T) {
+	fresh := &metrics.InMemoryReporter{}
+	cat := &reporterStubCatalog{reporter: fresh}
+	tbl := New(Identifier{"db", "reporter-refresh"}, nil, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	require.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter())
+	require.NoError(t, tbl.Refresh(context.Background()))
+	assert.Same(t, fresh, tbl.MetricsReporter(),
+		"an unset reporter must inherit the catalog-derived one on refresh")
 }

--- a/table/metrics_wiring_test.go
+++ b/table/metrics_wiring_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -115,8 +116,9 @@ func TestStagedTableInheritsReporter(t *testing.T) {
 		"StagedTable must forward the transaction table's reporter")
 }
 
-// on: a reporter injected via WithMetricsReporter must survive a Refresh even
-// though the catalog's LoadTable hands back the default nop reporter.
+// TestRefreshKeepsCallerReporter pins that a reporter injected via
+// WithMetricsReporter must survive a Refresh even though the catalog's LoadTable
+// hands back the default nop reporter.
 func TestRefreshKeepsCallerReporter(t *testing.T) {
 	rep := &metrics.InMemoryReporter{}
 	cat := &reporterStubCatalog{} // LoadTable yields a nop-reporter table
@@ -147,7 +149,8 @@ func TestRefreshKeepsExplicitNopOptOut(t *testing.T) {
 		"explicit NopReporter opt-out must not be reverted to the catalog reporter on refresh")
 }
 
-// the caller never overrode the reporter, Refresh adopts the fresh table's.
+// TestRefreshInheritsCatalogReporterWhenUnset pins that when the caller never
+// overrode the reporter, Refresh adopts the fresh table's.
 func TestRefreshInheritsCatalogReporterWhenUnset(t *testing.T) {
 	fresh := &metrics.InMemoryReporter{}
 	cat := &reporterStubCatalog{reporter: fresh}
@@ -158,4 +161,68 @@ func TestRefreshInheritsCatalogReporterWhenUnset(t *testing.T) {
 	require.NoError(t, tbl.Refresh(context.Background()))
 	assert.Same(t, fresh, tbl.MetricsReporter(),
 		"an unset reporter must inherit the catalog-derived one on refresh")
+}
+
+// committingReporterCatalog applies updates on CommitTable and hands every
+// LoadTable a table carrying the configured reporter, so a create+Commit+Refresh
+// sequence can be exercised end to end.
+type committingReporterCatalog struct {
+	metadata Metadata
+	reporter metrics.Reporter
+}
+
+func (c *committingReporterCatalog) LoadTable(_ context.Context, ident Identifier) (*Table, error) {
+	opts := []Option{}
+	if c.reporter != nil {
+		opts = append(opts, WithMetricsReporter(c.reporter))
+	}
+
+	return New(ident, c.metadata, "",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, c, opts...), nil
+}
+
+func (c *committingReporterCatalog) CommitTable(_ context.Context, _ Identifier, _ []Requirement, updates []Update) (Metadata, string, error) {
+	meta, err := UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = meta
+
+	return meta, "", nil
+}
+
+// TestCommitPreservesDefaultedReporterInheritance pins that a table riding the
+// catalog default (reporterSet == false) keeps inheriting the catalog reporter
+// on a Refresh that follows a Commit. doCommit rebuilds the table via New(...);
+// carrying the reporter through WithMetricsReporter(MetricsReporter()) would
+// force reporterSet true (that accessor is never nil), freezing the post-commit
+// table to its current reporter — this is the create+Commit+Refresh path the
+// Refresh-only tests do not cover.
+func TestCommitPreservesDefaultedReporterInheritance(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	loc := filepath.ToSlash(t.TempDir())
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, loc,
+		iceberg.Properties{PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	fresh := &metrics.InMemoryReporter{}
+	cat := &committingReporterCatalog{metadata: meta, reporter: fresh}
+
+	// Created without an explicit reporter: reporterSet == false.
+	tbl := New(Identifier{"db", "commit_reporter"}, meta, loc+"/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+	require.IsType(t, metrics.NopReporter{}, tbl.MetricsReporter())
+
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberg.Properties{"k": "v"}))
+	committed, err := txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	// No caller ever set a reporter, so the committed table must still inherit
+	// the catalog-derived one on refresh.
+	require.NoError(t, committed.Refresh(context.Background()))
+	assert.Same(t, fresh, committed.MetricsReporter(),
+		"a defaulted table must keep inheriting the catalog reporter after a commit")
 }

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -241,6 +242,8 @@ type Scan struct {
 	includeRowLineage bool
 
 	concurrency int
+
+	reporter metrics.Reporter
 }
 
 func (scan *Scan) UseRowLimit(n int64) *Scan {
@@ -248,6 +251,16 @@ func (scan *Scan) UseRowLimit(n int64) *Scan {
 	out.limit = n
 
 	return &out
+}
+
+// Reporter returns the metrics reporter for this scan, never nil. The
+// scan-planning instrumentation emits its ScanReport through it.
+func (scan *Scan) Reporter() metrics.Reporter {
+	if scan.reporter == nil {
+		return metrics.NopReporter{}
+	}
+
+	return scan.reporter
 }
 
 func (scan *Scan) UseRef(name string) (*Scan, error) {

--- a/table/table.go
+++ b/table/table.go
@@ -201,7 +201,13 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
 	t.planner = fresh.planner
-	t.reporter = fresh.reporter
+	// Only inherit the catalog-derived reporter when the caller hasn't set one
+	// of their own. Refresh runs inside commit retry loops, so unconditionally
+	// copying fresh.reporter would silently revert a WithMetricsReporter-injected
+	// reporter to the catalog default mid-operation.
+	if _, isNop := t.reporter.(metrics.NopReporter); isNop {
+		t.reporter = fresh.reporter
+	}
 
 	return nil
 }

--- a/table/table.go
+++ b/table/table.go
@@ -628,7 +628,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
-	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat, WithMetricsReporter(t.MetricsReporter())), nil
+	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat, withReporterState(t.reporter, t.reporterSet)), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every
@@ -989,6 +989,20 @@ func WithMetricsReporter(r metrics.Reporter) Option {
 	return func(t *Table) {
 		t.reporter = r
 		t.reporterSet = true
+	}
+}
+
+// withReporterState copies both the reporter and the reporterSet flag verbatim.
+// Unlike WithMetricsReporter it does not force reporterSet true, so a table
+// riding the catalog default (reporterSet == false) stays defaulted across a
+// New(...) rebuild instead of being frozen to its current reporter. Used by
+// doCommit and StagedTable to carry reporter state without breaking the Refresh
+// inheritance invariant — WithMetricsReporter cannot be used there because
+// MetricsReporter() is never nil, so it would always mark the table caller-set.
+func withReporterState(r metrics.Reporter, set bool) Option {
+	return func(t *Table) {
+		t.reporter = r
+		t.reporterSet = set
 	}
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	icebergio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/klauspost/compress/zstd"
 	"golang.org/x/sync/errgroup"
@@ -96,6 +97,7 @@ type Table struct {
 	cat              CatalogIO
 	fsF              FSysF
 	planner          ScanPlanner
+	reporter         metrics.Reporter
 }
 
 func (t Table) Equals(other Table) bool {
@@ -112,11 +114,20 @@ func (t Table) Schema() *iceberg.Schema                      { return t.metadata
 func (t Table) Spec() iceberg.PartitionSpec                  { return t.metadata.PartitionSpec() }
 func (t Table) SortOrder() SortOrder                         { return t.metadata.SortOrder() }
 func (t Table) Properties() iceberg.Properties               { return t.metadata.Properties() }
-func (t Table) NameMapping() iceberg.NameMapping             { return t.metadata.NameMapping() }
-func (t Table) Location() string                             { return t.metadata.Location() }
-func (t Table) CurrentSnapshot() *Snapshot                   { return t.metadata.CurrentSnapshot() }
-func (t Table) SnapshotByID(id int64) *Snapshot              { return t.metadata.SnapshotByID(id) }
-func (t Table) SnapshotByName(name string) *Snapshot         { return t.metadata.SnapshotByName(name) }
+
+// MetricsReporter returns the table's metrics reporter, never nil.
+func (t Table) MetricsReporter() metrics.Reporter {
+	if t.reporter == nil {
+		return metrics.NopReporter{}
+	}
+
+	return t.reporter
+}
+func (t Table) NameMapping() iceberg.NameMapping     { return t.metadata.NameMapping() }
+func (t Table) Location() string                     { return t.metadata.Location() }
+func (t Table) CurrentSnapshot() *Snapshot           { return t.metadata.CurrentSnapshot() }
+func (t Table) SnapshotByID(id int64) *Snapshot      { return t.metadata.SnapshotByID(id) }
+func (t Table) SnapshotByName(name string) *Snapshot { return t.metadata.SnapshotByName(name) }
 func (t Table) Schemas() map[int]*iceberg.Schema {
 	m := make(map[int]*iceberg.Schema)
 	for _, s := range t.metadata.Schemas() {
@@ -190,6 +201,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
 	t.planner = fresh.planner
+	t.reporter = fresh.reporter
 
 	return nil
 }
@@ -896,6 +908,19 @@ func WithOptions(opts iceberg.Properties) ScanOption {
 	}
 }
 
+// WithReporter overrides the metrics reporter for a single scan, taking
+// precedence over the reporter inherited from the table. A nil reporter is
+// ignored.
+func WithReporter(r metrics.Reporter) ScanOption {
+	if r == nil {
+		return noopOption
+	}
+
+	return func(scan *Scan) {
+		scan.reporter = r
+	}
+}
+
 // WithRowLineage projects the row-lineage metadata columns (_row_id and
 // _last_updated_sequence_number) so that row identity and per-row update
 // sequence are preserved through rewrites and compactions. Requires a v3
@@ -921,6 +946,7 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 		caseSensitive:  true,
 		limit:          ScanNoLimit,
 		concurrency:    runtime.GOMAXPROCS(0),
+		reporter:       t.MetricsReporter(),
 	}
 
 	for _, opt := range opts {
@@ -930,28 +956,48 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 	return s
 }
 
+// Option configures a [Table] at construction. Options are applied in order
+// after the core fields are set.
+type Option func(*Table)
+
+// WithMetricsReporter sets the metrics reporter for the table; scans created
+// from the table inherit it. A nil reporter is ignored (the table keeps its
+// default no-op reporter).
+func WithMetricsReporter(r metrics.Reporter) Option {
+	return func(t *Table) {
+		if r != nil {
+			t.reporter = r
+		}
+	}
+}
+
 // New constructs a Table. If cat implements ScanPlanner — as rest.Catalog does
 // for servers that support remote scan planning — it is wired as the table's
 // planner so (*Scan).PlanFiles can delegate to it; catalogs that do not
 // implement ScanPlanner leave planner nil and planning stays local. This is the
-// concrete Catalog -> Table -> Scan wiring for #1178: no New signature change
-// and no catalog accessor are needed, because the catalog already satisfies
-// ScanPlanner.
-func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, cat CatalogIO) *Table {
+// concrete Catalog -> Table -> Scan wiring for #1178: the catalog already
+// satisfies ScanPlanner, so no catalog accessor is needed.
+func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, cat CatalogIO, opts ...Option) *Table {
 	// A catalog that supports server-side scan planning implements ScanPlanner.
 	var planner ScanPlanner
 	if p, ok := cat.(ScanPlanner); ok {
 		planner = p
 	}
 
-	return &Table{
+	t := &Table{
 		identifier:       slices.Clone(ident),
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 		fsF:              fsF,
 		cat:              cat,
 		planner:          planner,
+		reporter:         metrics.NopReporter{},
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
 }
 
 func NewFromLocation(
@@ -960,6 +1006,7 @@ func NewFromLocation(
 	metalocation string,
 	fsysF FSysF,
 	cat CatalogIO,
+	opts ...Option,
 ) (_ *Table, err error) {
 	var meta Metadata
 
@@ -1012,7 +1059,7 @@ func NewFromLocation(
 		}
 	}
 
-	return New(ident, meta, metalocation, fsysF, cat), nil
+	return New(ident, meta, metalocation, fsysF, cat, opts...), nil
 }
 
 func metadataCompressionCodec(location string) string {

--- a/table/table.go
+++ b/table/table.go
@@ -621,7 +621,7 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 
 	deleteOldMetadata(fs, t.metadata, newMeta)
 
-	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat), nil
+	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat, WithMetricsReporter(t.MetricsReporter())), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every

--- a/table/table.go
+++ b/table/table.go
@@ -98,6 +98,11 @@ type Table struct {
 	fsF              FSysF
 	planner          ScanPlanner
 	reporter         metrics.Reporter
+	// reporterSet records whether a caller injected a reporter via
+	// WithMetricsReporter. It distinguishes an explicit reporter (including an
+	// explicit NopReporter opt-out) from the construction-time default, so
+	// Refresh knows whether it may overwrite reporter with the catalog default.
+	reporterSet bool
 }
 
 func (t Table) Equals(other Table) bool {
@@ -204,8 +209,10 @@ func (t *Table) Refresh(ctx context.Context) error {
 	// Only inherit the catalog-derived reporter when the caller hasn't set one
 	// of their own. Refresh runs inside commit retry loops, so unconditionally
 	// copying fresh.reporter would silently revert a WithMetricsReporter-injected
-	// reporter to the catalog default mid-operation.
-	if _, isNop := t.reporter.(metrics.NopReporter); isNop {
+	// reporter to the catalog default mid-operation. reporterSet distinguishes an
+	// explicit reporter — including an explicit NopReporter opt-out — from the
+	// construction-time default.
+	if !t.reporterSet {
 		t.reporter = fresh.reporter
 	}
 
@@ -966,14 +973,22 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 // after the core fields are set.
 type Option func(*Table)
 
+// noopTableOption is the shared no-op [Option], returned when an option has
+// nothing to apply (e.g. WithMetricsReporter(nil)). It mirrors noopOption on
+// the ScanOption side.
+func noopTableOption(*Table) {}
+
 // WithMetricsReporter sets the metrics reporter for the table; scans created
 // from the table inherit it. A nil reporter is ignored (the table keeps its
 // default no-op reporter).
 func WithMetricsReporter(r metrics.Reporter) Option {
+	if r == nil {
+		return noopTableOption
+	}
+
 	return func(t *Table) {
-		if r != nil {
-			t.reporter = r
-		}
+		t.reporter = r
+		t.reporterSet = true
 	}
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2348,6 +2348,7 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 			updatedMeta.Location(),
 			t.tbl.fsF,
 			t.tbl.cat,
+			WithMetricsReporter(t.tbl.MetricsReporter()),
 		),
 	}, nil
 }

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2321,6 +2321,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		caseSensitive:  true,
 		limit:          ScanNoLimit,
 		concurrency:    runtime.GOMAXPROCS(0),
+		reporter:       t.tbl.MetricsReporter(),
 	}
 
 	for _, opt := range opts {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2348,7 +2348,7 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 			updatedMeta.Location(),
 			t.tbl.fsF,
 			t.tbl.cat,
-			WithMetricsReporter(t.tbl.MetricsReporter()),
+			withReporterState(t.tbl.reporter, t.tbl.reporterSet),
 		),
 	}, nil
 }


### PR DESCRIPTION
Third PR of the metrics reporting framework. Adds reporter selection and threads it from catalog to scan:

- metrics: a name->factory registry and FromProperties, selecting a reporter via the metrics-reporter-impl property (the Go analogue of Java's reflection-based loader); built-in nop and logging reporters.
- table: a WithMetricsReporter option on New/NewFromLocation (variadic, backward compatible), a MetricsReporter accessor, and a WithReporter scan option; scans inherit the table's reporter.
- catalog/{rest,sql,glue,hive,hadoop} resolve the reporter from properties when loading or creating a table.

Reporting stays opt-in: the default reporter is no-op, so there is no behavior change for existing users. Report emission is added with the scan and commit instrumentation in later PRs.

Related: #1236