### PR TITLE
feat(udf): add SQL UDF REST catalog read support

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -39,7 +39,6 @@ import (
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
-	"github.com/apache/iceberg-go/udf"
 )
 
 type Type string
@@ -192,30 +191,6 @@ type TransactionalCatalog interface {
 // remains the single source of truth.
 type PurgeableTable interface {
 	PurgeTable(ctx context.Context, identifier table.Identifier) error
-}
-
-// FunctionCatalog is an optional interface implemented by catalogs that
-// support the Iceberg REST function (SQL UDF) endpoints. The function
-// endpoints are not part of the spec's assumed default endpoint set, so
-// servers must advertise them: unsupported loads report an
-// endpoint-not-supported error and unsupported listings yield no results.
-// Callers should check for this capability via a type assertion:
-//
-//	if fc, ok := cat.(catalog.FunctionCatalog); ok {
-//	    fn, err := fc.LoadFunction(ctx, ident)
-//	}
-type FunctionCatalog interface {
-	// ListFunctions returns the function identifiers under a namespace,
-	// with the returned identifiers containing the information required
-	// to load the function via this catalog.
-	ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error]
-	// LoadFunction loads a function from the catalog. All overloaded
-	// definitions are included in the single metadata response.
-	LoadFunction(ctx context.Context, identifier table.Identifier) (*udf.UDF, error)
-	// CheckFunctionExists returns if the function exists. The REST spec
-	// defines no HEAD endpoint for functions, so existence is checked by
-	// loading the function.
-	CheckFunctionExists(ctx context.Context, identifier table.Identifier) (bool, error)
 }
 
 func ToIdentifier(ident ...string) table.Identifier {

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -205,12 +205,18 @@ func ToIdentifier(ident ...string) table.Identifier {
 	return table.Identifier(ident)
 }
 
-func TableNameFromIdent(ident table.Identifier) string {
+// ObjectNameFromIdent returns the name of a catalog object (a table, view,
+// or function), which is the last element of its identifier.
+func ObjectNameFromIdent(ident table.Identifier) string {
 	if len(ident) == 0 {
 		return ""
 	}
 
 	return ident[len(ident)-1]
+}
+
+func TableNameFromIdent(ident table.Identifier) string {
+	return ObjectNameFromIdent(ident)
 }
 
 func NamespaceFromIdent(ident table.Identifier) table.Identifier {

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/udf"
 )
 
 type Type string
@@ -63,6 +64,7 @@ var (
 	ErrNamespaceNotEmpty      = errors.New("namespace is not empty")
 	ErrNoSuchView             = errors.New("view does not exist")
 	ErrViewAlreadyExists      = errors.New("view already exists")
+	ErrNoSuchFunction         = errors.New("function does not exist")
 	ErrEmptyCommitList        = errors.New("commit list must not be empty")
 	ErrMissingIdentifier      = errors.New("every table commit must have a valid identifier")
 )
@@ -192,6 +194,30 @@ type PurgeableTable interface {
 	PurgeTable(ctx context.Context, identifier table.Identifier) error
 }
 
+// FunctionCatalog is an optional interface implemented by catalogs that
+// support the Iceberg REST function (SQL UDF) endpoints. The function
+// endpoints are not part of the spec's assumed default endpoint set, so
+// servers must advertise them: unsupported loads report an
+// endpoint-not-supported error and unsupported listings yield no results.
+// Callers should check for this capability via a type assertion:
+//
+//	if fc, ok := cat.(catalog.FunctionCatalog); ok {
+//	    fn, err := fc.LoadFunction(ctx, ident)
+//	}
+type FunctionCatalog interface {
+	// ListFunctions returns the function identifiers under a namespace,
+	// with the returned identifiers containing the information required
+	// to load the function via this catalog.
+	ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error]
+	// LoadFunction loads a function from the catalog. All overloaded
+	// definitions are included in the single metadata response.
+	LoadFunction(ctx context.Context, identifier table.Identifier) (*udf.UDF, error)
+	// CheckFunctionExists returns if the function exists. The REST spec
+	// defines no HEAD endpoint for functions, so existence is checked by
+	// loading the function.
+	CheckFunctionExists(ctx context.Context, identifier table.Identifier) (bool, error)
+}
+
 func ToIdentifier(ident ...string) table.Identifier {
 	if len(ident) == 1 {
 		if ident[0] == "" {
@@ -216,7 +242,7 @@ func NamespaceFromIdent(ident table.Identifier) table.Identifier {
 	return ident[:len(ident)-1]
 }
 
-func validateTableOrViewIdentifier(ident table.Identifier, notFoundErr error) error {
+func validateIdentifier(ident table.Identifier, notFoundErr error) error {
 	if len(ident) < 2 {
 		return fmt.Errorf("%w: missing namespace or invalid identifier %v",
 			notFoundErr, strings.Join(ident, "."))
@@ -241,12 +267,17 @@ func validateTableOrViewIdentifier(ident table.Identifier, notFoundErr error) er
 
 // ValidateTableIdentifier checks that an identifier contains at least one valid namespace level and a table name.
 func ValidateTableIdentifier(ident table.Identifier) error {
-	return validateTableOrViewIdentifier(ident, ErrNoSuchTable)
+	return validateIdentifier(ident, ErrNoSuchTable)
 }
 
 // ValidateViewIdentifier checks that an identifier contains at least one valid namespace level and a view name.
 func ValidateViewIdentifier(ident table.Identifier) error {
-	return validateTableOrViewIdentifier(ident, ErrNoSuchView)
+	return validateIdentifier(ident, ErrNoSuchView)
+}
+
+// ValidateFunctionIdentifier checks that an identifier contains at least one valid namespace level and a function name.
+func ValidateFunctionIdentifier(ident table.Identifier) error {
+	return validateIdentifier(ident, ErrNoSuchFunction)
 }
 
 type CreateTableOpt func(*CreateTableCfg)

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -60,3 +60,13 @@ func TestValidateFunctionIdentifier(t *testing.T) {
 	require.ErrorIs(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function/name"}), catalog.ErrNoSuchFunction)
 	require.NotErrorIs(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function/name"}), catalog.ErrNoSuchTable)
 }
+
+func TestObjectNameFromIdent(t *testing.T) {
+	require.Equal(t, "object", catalog.ObjectNameFromIdent(table.Identifier{"namespace", "object"}))
+	require.Equal(t, "object", catalog.ObjectNameFromIdent(table.Identifier{"parent", "namespace", "object"}))
+	require.Equal(t, "object", catalog.ObjectNameFromIdent(table.Identifier{"object"}))
+	require.Equal(t, "", catalog.ObjectNameFromIdent(table.Identifier{}))
+
+	// TableNameFromIdent stays as the table-flavored alias of the same rule.
+	require.Equal(t, "object", catalog.TableNameFromIdent(table.Identifier{"namespace", "object"}))
+}

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -52,3 +52,11 @@ func TestValidateViewIdentifier(t *testing.T) {
 	require.ErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchView)
 	require.NotErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchTable)
 }
+
+func TestValidateFunctionIdentifier(t *testing.T) {
+	require.NoError(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function"}))
+
+	require.ErrorIs(t, catalog.ValidateFunctionIdentifier(table.Identifier{"function"}), catalog.ErrNoSuchFunction)
+	require.ErrorIs(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function/name"}), catalog.ErrNoSuchFunction)
+	require.NotErrorIs(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function/name"}), catalog.ErrNoSuchTable)
+}

--- a/catalog/rest/endpoints.go
+++ b/catalog/rest/endpoints.go
@@ -114,6 +114,12 @@ var (
 	endpointDeleteView   = endpoint{http.MethodDelete, "/v1/{prefix}/namespaces/{namespace}/views/{view}"}
 	endpointRenameView   = endpoint{http.MethodPost, "/v1/{prefix}/views/rename"}
 	endpointRegisterView = endpoint{http.MethodPost, "/v1/{prefix}/namespaces/{namespace}/register-view"}
+
+	// Function (SQL UDF) endpoints. The spec keeps these out of the assumed
+	// default endpoint set, so they are only used when the server advertises
+	// them.
+	endpointListFunctions = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/functions"}
+	endpointLoadFunction  = endpoint{http.MethodGet, "/v1/{prefix}/namespaces/{namespace}/functions/{function}"}
 )
 
 // defaultEndpoints is the spec default set, assumed when the server advertises
@@ -144,6 +150,7 @@ var allEndpoints = []endpoint{
 	endpointReportMetrics, endpointTableCredentials,
 	endpointListViews, endpointLoadView, endpointViewExists, endpointCreateView,
 	endpointUpdateView, endpointDeleteView, endpointRenameView, endpointRegisterView,
+	endpointListFunctions, endpointLoadFunction,
 }
 
 // endpointSet is the set of endpoints a catalog server supports.

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1028,7 +1028,7 @@ func (r *Catalog) splitIdentForPath(ident table.Identifier) (string, string, err
 		return "", "", err
 	}
 
-	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
+	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.ObjectNameFromIdent(ident), nil
 }
 
 func (r *Catalog) splitViewIdentForPath(ident table.Identifier) (string, string, error) {
@@ -1036,7 +1036,7 @@ func (r *Catalog) splitViewIdentForPath(ident table.Identifier) (string, string,
 		return "", "", err
 	}
 
-	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
+	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.ObjectNameFromIdent(ident), nil
 }
 
 func (r *Catalog) splitFunctionIdentForPath(ident table.Identifier) (string, string, error) {
@@ -1044,7 +1044,7 @@ func (r *Catalog) splitFunctionIdentForPath(ident table.Identifier) (string, str
 		return "", "", err
 	}
 
-	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
+	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.ObjectNameFromIdent(ident), nil
 }
 
 func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apache/iceberg-go/catalog"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/udf"
 	"github.com/apache/iceberg-go/view"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -1032,6 +1033,14 @@ func (r *Catalog) splitIdentForPath(ident table.Identifier) (string, string, err
 
 func (r *Catalog) splitViewIdentForPath(ident table.Identifier) (string, string, error) {
 	if err := catalog.ValidateViewIdentifier(ident); err != nil {
+		return "", "", err
+	}
+
+	return r.encodeNamespace(catalog.NamespaceFromIdent(ident)), catalog.TableNameFromIdent(ident), nil
+}
+
+func (r *Catalog) splitFunctionIdentForPath(ident table.Identifier) (string, string, error) {
+	if err := catalog.ValidateFunctionIdentifier(ident); err != nil {
 		return "", "", err
 	}
 
@@ -2044,4 +2053,146 @@ func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 	}
 
 	return view.New(identifier, metadata, rsp.MetadataLoc), nil
+}
+
+// Catalog implements the optional function (SQL UDF) read support defined
+// by the REST spec: list and load. The function endpoints are not part of
+// the spec's assumed default endpoint set, so they are only used when the
+// server advertises them.
+var _ catalog.FunctionCatalog = (*Catalog)(nil)
+
+// ListFunctions returns the function (SQL UDF) identifiers under a
+// namespace, with the returned identifiers containing the information
+// required to load the function via this catalog.
+func (r *Catalog) ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
+	return func(yield func(table.Identifier, error) bool) {
+		pageSize := r.getPageSize(ctx)
+		var pageToken string
+
+		for {
+			functions, nextPageToken, err := r.listFunctionsPage(ctx, namespace, pageToken, pageSize)
+			if err != nil {
+				yield(table.Identifier{}, err)
+
+				return
+			}
+			for _, function := range functions {
+				if !yield(function, nil) {
+					return
+				}
+			}
+			if nextPageToken == "" {
+				return
+			}
+			pageToken = nextPageToken
+		}
+	}
+}
+
+func (r *Catalog) listFunctionsPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
+	if err := checkValidNamespace(namespace); err != nil {
+		return nil, "", err
+	}
+	// Unsupported listing yields an empty result rather than an error.
+	if !r.endpoints.allowed(endpointListFunctions) {
+		return nil, "", nil
+	}
+	ns := r.encodeNamespace(namespace)
+	path, err := endpointListFunctions.reqPath(ns)
+	if err != nil {
+		return nil, "", err
+	}
+	uri := r.baseURI.JoinPath(path...)
+
+	v := url.Values{}
+	if pageSize > 0 {
+		v.Set("pageSize", strconv.Itoa(pageSize))
+	}
+	if pageToken != "" {
+		v.Set("pageToken", pageToken)
+	}
+
+	uri.RawQuery = v.Encode()
+	// Function identifiers are CatalogObjectIdentifier values: ordered
+	// hierarchy levels (the namespace levels followed by the function
+	// name), not the {namespace, name} object tables and views use.
+	type resp struct {
+		Identifiers   [][]string `json:"identifiers"`
+		NextPageToken string     `json:"next-page-token,omitempty"`
+	}
+
+	rsp, err := doGet[resp](ctx, uri, []string{}, r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
+	if err != nil {
+		return nil, "", err
+	}
+
+	out := make([]table.Identifier, len(rsp.Identifiers))
+	for i, levels := range rsp.Identifiers {
+		out[i] = table.Identifier(levels)
+	}
+
+	return out, rsp.NextPageToken, nil
+}
+
+// loadFunctionResponse contains the response from loading a function.
+type loadFunctionResponse struct {
+	MetadataLoc string          `json:"metadata-location"`
+	RawMetadata json.RawMessage `json:"metadata"`
+}
+
+// LoadFunction loads a function (SQL UDF) from the catalog. All overloaded
+// definitions are included in the single metadata response.
+func (r *Catalog) LoadFunction(ctx context.Context, identifier table.Identifier) (*udf.UDF, error) {
+	if err := r.endpoints.check(endpointLoadFunction); err != nil {
+		return nil, err
+	}
+
+	ns, fn, err := r.splitFunctionIdentForPath(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := endpointLoadFunction.reqPath(ns, fn)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := doGet[loadFunctionResponse](ctx, r.baseURI, path,
+		r.cl, map[int]error{
+			http.StatusNotFound: catalog.ErrNoSuchFunction,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := udf.ParseMetadataBytes(rsp.RawMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse function metadata: %w", err)
+	}
+
+	return udf.New(identifier, metadata, rsp.MetadataLoc), nil
+}
+
+// CheckFunctionExists returns if the function exists. The REST spec defines
+// no HEAD endpoint for functions, so existence is checked by loading the
+// function; if loading is unsupported, its ErrEndpointNotSupported surfaces
+// rather than a bogus "not found".
+func (r *Catalog) CheckFunctionExists(ctx context.Context, identifier table.Identifier) (bool, error) {
+	// Validate first, as the table and view existence checks do: an invalid
+	// identifier surfaces as an error, so ErrNoSuchFunction below can only
+	// mean a server-reported "not found".
+	if err := catalog.ValidateFunctionIdentifier(identifier); err != nil {
+		return false, err
+	}
+
+	_, err := r.LoadFunction(ctx, identifier)
+	if err != nil {
+		if errors.Is(err, catalog.ErrNoSuchFunction) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -2055,15 +2055,37 @@ func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 	return view.New(identifier, metadata, rsp.MetadataLoc), nil
 }
 
-// Catalog implements the optional function (SQL UDF) read support defined
-// by the REST spec: list and load. The function endpoints are not part of
-// the spec's assumed default endpoint set, so they are only used when the
-// server advertises them.
-var _ catalog.FunctionCatalog = (*Catalog)(nil)
+// FunctionCatalog is an optional interface for catalogs that support the
+// function (SQL UDF) read endpoints defined by the REST spec: list and load.
+// The function endpoints are not part of the spec's assumed default endpoint
+// set, so they are only used when the server advertises them: unsupported
+// loads fail with ErrEndpointNotSupported and unsupported listings yield no
+// results. Callers holding a catalog.Catalog can check for this capability
+// via a type assertion:
+//
+//	if fc, ok := cat.(rest.FunctionCatalog); ok {
+//	    fn, err := fc.LoadFunction(ctx, ident)
+//	}
+type FunctionCatalog interface {
+	// ListFunctions returns the function identifiers under a namespace,
+	// with the returned identifiers containing the information required
+	// to load the function via this catalog.
+	ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error]
+	// LoadFunction loads a function from the catalog. All overloaded
+	// definitions are included in the single metadata response.
+	LoadFunction(ctx context.Context, identifier table.Identifier) (*udf.UDF, error)
+	// CheckFunctionExists returns if the function exists. The REST spec
+	// defines no HEAD endpoint for functions, so existence is checked by
+	// loading the function.
+	CheckFunctionExists(ctx context.Context, identifier table.Identifier) (bool, error)
+}
 
 // ListFunctions returns the function (SQL UDF) identifiers under a
 // namespace, with the returned identifiers containing the information
-// required to load the function via this catalog.
+// required to load the function via this catalog. The function endpoints
+// are not part of the spec's assumed default endpoint set; if the server
+// does not advertise the list-functions endpoint, it yields no functions
+// rather than an error.
 func (r *Catalog) ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
@@ -2141,7 +2163,10 @@ type loadFunctionResponse struct {
 }
 
 // LoadFunction loads a function (SQL UDF) from the catalog. All overloaded
-// definitions are included in the single metadata response.
+// definitions are included in the single metadata response. The function
+// endpoints are not part of the spec's assumed default endpoint set; if the
+// server does not advertise the load-function endpoint, LoadFunction fails
+// with ErrEndpointNotSupported.
 func (r *Catalog) LoadFunction(ctx context.Context, identifier table.Identifier) (*udf.UDF, error) {
 	if err := r.endpoints.check(endpointLoadFunction); err != nil {
 		return nil, err
@@ -2152,6 +2177,12 @@ func (r *Catalog) LoadFunction(ctx context.Context, identifier table.Identifier)
 		return nil, err
 	}
 
+	return r.loadFunction(ctx, identifier, ns, fn)
+}
+
+// loadFunction fetches and parses a function after endpoint negotiation and
+// identifier validation, so its ErrNoSuchFunction is always server-reported.
+func (r *Catalog) loadFunction(ctx context.Context, identifier table.Identifier, ns, fn string) (*udf.UDF, error) {
 	path, err := endpointLoadFunction.reqPath(ns, fn)
 	if err != nil {
 		return nil, err
@@ -2162,7 +2193,23 @@ func (r *Catalog) LoadFunction(ctx context.Context, identifier table.Identifier)
 			http.StatusNotFound: catalog.ErrNoSuchFunction,
 		})
 	if err != nil {
+		// The spec's load 404 covers both a missing namespace and a missing
+		// function; discriminate on the error type so a missing namespace is
+		// not reported as a missing function.
+		var errRsp errorResponse
+		if errors.As(err, &errRsp) && errRsp.Type == "NoSuchNamespaceException" {
+			errRsp.wrapping = catalog.ErrNoSuchNamespace
+
+			return nil, errRsp
+		}
+
 		return nil, err
+	}
+
+	// The spec marks metadata as required; guard so a buggy server yields a
+	// clear error instead of a JSON parsing artifact.
+	if len(rsp.RawMetadata) == 0 {
+		return nil, fmt.Errorf("%w: load function response is missing metadata", ErrRESTError)
 	}
 
 	metadata, err := udf.ParseMetadataBytes(rsp.RawMetadata)
@@ -2175,18 +2222,21 @@ func (r *Catalog) LoadFunction(ctx context.Context, identifier table.Identifier)
 
 // CheckFunctionExists returns if the function exists. The REST spec defines
 // no HEAD endpoint for functions, so existence is checked by loading the
-// function; if loading is unsupported, its ErrEndpointNotSupported surfaces
-// rather than a bogus "not found".
+// function; if loading is unsupported, ErrEndpointNotSupported surfaces
+// rather than a bogus "not found". The identifier is validated once here, so
+// an invalid one surfaces as an error and only a server-reported "not found"
+// becomes (false, nil), matching the table and view existence checks.
 func (r *Catalog) CheckFunctionExists(ctx context.Context, identifier table.Identifier) (bool, error) {
-	// Validate first, as the table and view existence checks do: an invalid
-	// identifier surfaces as an error, so ErrNoSuchFunction below can only
-	// mean a server-reported "not found".
-	if err := catalog.ValidateFunctionIdentifier(identifier); err != nil {
+	if err := r.endpoints.check(endpointLoadFunction); err != nil {
 		return false, err
 	}
 
-	_, err := r.LoadFunction(ctx, identifier)
+	ns, fn, err := r.splitFunctionIdentForPath(identifier)
 	if err != nil {
+		return false, err
+	}
+
+	if _, err := r.loadFunction(ctx, identifier, ns, fn); err != nil {
 		if errors.Is(err, catalog.ErrNoSuchFunction) {
 			return false, nil
 		}

--- a/catalog/rest/rest_functions_test.go
+++ b/catalog/rest/rest_functions_test.go
@@ -1,0 +1,428 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/rest"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFunctionMetadataJSON is minimal valid UDF metadata for add_one(int).
+const testFunctionMetadataJSON = `{
+  "function-uuid": "42fd3f91-bc10-41c1-8a52-92b57dd0a9b2",
+  "format-version": 1,
+  "definitions": [
+    {
+      "definition-id": "int",
+      "parameters": [{"name": "x", "type": "int"}],
+      "return-type": "int",
+      "function-type": "udf",
+      "versions": [
+        {
+          "version-id": 1,
+          "representations": [{"type": "sql", "dialect": "trino", "sql": "x + 1"}],
+          "timestamp-ms": 1000
+        }
+      ],
+      "current-version-id": 1
+    }
+  ],
+  "definition-log": [
+    {"timestamp-ms": 1000, "definition-versions": [{"definition-id": "int", "version-id": 1}]}
+  ]
+}`
+
+func (r *RestCatalogSuite) TestListFunctions200() {
+	customPageSize := 100
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/functions", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		pageToken := req.URL.Query().Get("pageToken")
+		pageSize := req.URL.Query().Get("pageSize")
+		r.Equal("", pageToken)
+		r.Equal(strconv.Itoa(customPageSize), pageSize)
+
+		// Function identifiers are CatalogObjectIdentifier values: flat
+		// arrays of hierarchy levels, not {namespace, name} objects.
+		json.NewEncoder(w).Encode(map[string]any{
+			"identifiers": []any{
+				[]string{"accounting", "tax", "paid"},
+				[]string{"accounting", "tax", "owed"},
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+	// Passing in a custom page size through context
+	ctx := cat.SetPageSize(context.Background(), customPageSize)
+
+	var lastErr error
+	functions := make([]table.Identifier, 0)
+	for function, err := range cat.ListFunctions(ctx, catalog.ToIdentifier(namespace)) {
+		functions = append(functions, function)
+		if err != nil {
+			lastErr = err
+			r.FailNow("unexpected error:", err)
+		}
+	}
+
+	r.Equal([]table.Identifier{
+		{"accounting", "tax", "paid"},
+		{"accounting", "tax", "owed"},
+	}, functions)
+	r.Require().NoError(lastErr)
+}
+
+func (r *RestCatalogSuite) TestListFunctionsPagination() {
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/functions", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		switch req.URL.Query().Get("pageToken") {
+		case "":
+			json.NewEncoder(w).Encode(map[string]any{
+				"identifiers":     []any{[]string{"accounting", "add_one"}},
+				"next-page-token": "token-1",
+			})
+		case "token-1":
+			json.NewEncoder(w).Encode(map[string]any{
+				"identifiers": []any{[]string{"accounting", "add_two"}},
+			})
+		default:
+			r.FailNow("unexpected page token")
+		}
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	functions := make([]table.Identifier, 0)
+	for function, err := range cat.ListFunctions(context.Background(), catalog.ToIdentifier(namespace)) {
+		r.Require().NoError(err)
+		functions = append(functions, function)
+	}
+
+	r.Equal([]table.Identifier{
+		{"accounting", "add_one"},
+		{"accounting", "add_two"},
+	}, functions)
+
+	// Breaking out of the iteration stops paging without error.
+	for function, err := range cat.ListFunctions(context.Background(), catalog.ToIdentifier(namespace)) {
+		r.Require().NoError(err)
+		r.Equal(table.Identifier{"accounting", "add_one"}, function)
+
+		break
+	}
+}
+
+func (r *RestCatalogSuite) TestListFunctionsZeroPageSizeNotSent() {
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/functions", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+		r.Equal("", req.URL.Query().Get("pageSize"), "pageSize must not be sent when set to 0")
+		json.NewEncoder(w).Encode(map[string]any{"identifiers": []any{}})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	ctx := cat.SetPageSize(context.Background(), 0)
+	for _, err := range cat.ListFunctions(ctx, catalog.ToIdentifier(namespace)) {
+		r.Require().NoError(err)
+	}
+}
+
+func (r *RestCatalogSuite) TestListFunctionsPaginationErrorOnSubsequentPage() {
+	namespace := "accounting"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/functions", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		pageToken := req.URL.Query().Get("pageToken")
+
+		// First page succeeds
+		if pageToken == "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"identifiers": []any{
+					[]string{namespace, "paid1"},
+					[]string{namespace, "paid2"},
+				},
+				"next-page-token": "token1",
+			})
+
+			return
+		}
+
+		// Second page fails with an error
+		if pageToken == "token1" {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"message": "Token expired or invalid",
+					"type":    "NoSuchPageTokenException",
+					"code":    404,
+				},
+			})
+
+			return
+		}
+
+		r.FailNow("unexpected page token:", pageToken)
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	functions := make([]table.Identifier, 0)
+	var lastErr error
+	for function, err := range cat.ListFunctions(context.Background(), catalog.ToIdentifier(namespace)) {
+		if err != nil {
+			lastErr = err
+
+			break
+		}
+		functions = append(functions, function)
+	}
+
+	// Check that we got the functions from the first page
+	r.Equal([]table.Identifier{
+		{"accounting", "paid1"},
+		{"accounting", "paid2"},
+	}, functions)
+
+	// Check that we got the error from the second page
+	r.Error(lastErr)
+	r.ErrorContains(lastErr, "Token expired or invalid")
+}
+
+func (r *RestCatalogSuite) TestListFunctions404() {
+	namespace := "nonexistent"
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/functions", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "The given namespace does not exist",
+				"type":    "NoSuchNamespaceException",
+				"code":    404,
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	var lastErr error
+	for _, err := range cat.ListFunctions(context.Background(), catalog.ToIdentifier(namespace)) {
+		if err != nil {
+			lastErr = err
+		}
+	}
+	r.ErrorIs(lastErr, catalog.ErrNoSuchNamespace)
+	r.ErrorContains(lastErr, "The given namespace does not exist")
+}
+
+func (r *RestCatalogSuite) TestLoadFunction200() {
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/add_one", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		w.Write([]byte(`{
+			"metadata-location": "s3://bucket/functions/add_one/metadata/00000-x.metadata.json",
+			"metadata": ` + testFunctionMetadataJSON + `
+		}`))
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	fn, err := cat.LoadFunction(context.Background(), catalog.ToIdentifier("accounting", "add_one"))
+	r.Require().NoError(err)
+
+	r.Equal(table.Identifier{"accounting", "add_one"}, fn.Identifier())
+	r.Equal("s3://bucket/functions/add_one/metadata/00000-x.metadata.json", fn.MetadataLocation())
+	r.Equal("42fd3f91-bc10-41c1-8a52-92b57dd0a9b2", fn.Metadata().FunctionUUID().String())
+
+	def, ok := fn.Metadata().DefinitionByID("int")
+	r.Require().True(ok, "expected the int overload in the loaded metadata")
+	r.Equal(1, def.CurrentVersionID)
+	r.Len(fn.Definitions(), 1)
+}
+
+func (r *RestCatalogSuite) TestLoadFunction404() {
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/missing_fn", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "The requested function does not exist",
+				"type":    "NoSuchFunctionException",
+				"code":    404,
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	_, err = cat.LoadFunction(context.Background(), catalog.ToIdentifier("accounting", "missing_fn"))
+	r.ErrorIs(err, catalog.ErrNoSuchFunction)
+	r.ErrorContains(err, "The requested function does not exist")
+}
+
+func (r *RestCatalogSuite) TestLoadFunctionMalformedMetadata() {
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/broken_fn", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`{"metadata-location": "s3://x", "metadata": {"format-version": 1}}`))
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	_, err = cat.LoadFunction(context.Background(), catalog.ToIdentifier("accounting", "broken_fn"))
+	r.ErrorContains(err, "failed to parse function metadata")
+}
+
+func (r *RestCatalogSuite) TestCheckFunctionExists() {
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/add_one", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method, "existence must be checked via GET: the spec has no HEAD endpoint")
+
+		w.Write([]byte(`{"metadata": ` + testFunctionMetadataJSON + `}`))
+	})
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/missing_fn", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "The requested function does not exist",
+				"type":    "NoSuchFunctionException",
+				"code":    404,
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	exists, err := cat.CheckFunctionExists(context.Background(), catalog.ToIdentifier("accounting", "add_one"))
+	r.Require().NoError(err)
+	r.True(exists)
+
+	exists, err = cat.CheckFunctionExists(context.Background(), catalog.ToIdentifier("accounting", "missing_fn"))
+	r.Require().NoError(err)
+	r.False(exists)
+}
+
+func (r *RestCatalogSuite) TestLoadFunctionInvalidIdentifier() {
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	// An invalid identifier reports the function sentinel, not the table one.
+	_, err = cat.LoadFunction(context.Background(), table.Identifier{})
+	r.ErrorIs(err, catalog.ErrNoSuchFunction)
+	r.NotErrorIs(err, catalog.ErrNoSuchTable)
+	r.ErrorContains(err, "missing namespace or invalid identifier")
+
+	// The existence check surfaces the invalid identifier as an error, as the
+	// table and view existence checks do.
+	exists, err := cat.CheckFunctionExists(context.Background(), table.Identifier{})
+	r.False(exists)
+	r.ErrorIs(err, catalog.ErrNoSuchFunction)
+}
+
+func (r *RestCatalogSuite) TestListFunctionsInvalidNamespace() {
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	var lastErr error
+	for _, err := range cat.ListFunctions(context.Background(), table.Identifier{}) {
+		if err != nil {
+			lastErr = err
+		}
+	}
+	r.Error(lastErr)
+}
+
+// TestFunctionEndpointNegotiation drives the catalog against a server that
+// does not advertise the function endpoints, which the spec keeps out of
+// the assumed default endpoint set.
+func TestFunctionEndpointNegotiation(t *testing.T) {
+	var functionsHit bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, req *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{},
+			// Function endpoints deliberately absent.
+			"endpoints": []string{"GET /v1/{prefix}/namespaces"},
+		})
+	})
+	mux.HandleFunc("/v1/namespaces/", func(w http.ResponseWriter, req *http.Request) {
+		functionsHit = true
+		http.Error(w, "unexpected request to unsupported endpoint", http.StatusInternalServerError)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
+	require.NoError(t, err)
+
+	// An unsupported load fails with the capability sentinel, not a transport error.
+	_, err = cat.LoadFunction(context.Background(), table.Identifier{"ns", "fn"})
+	assert.ErrorIs(t, err, rest.ErrEndpointNotSupported)
+	assert.NotErrorIs(t, err, rest.ErrRESTError)
+
+	// The existence check surfaces the capability error rather than a bogus "not found".
+	_, err = cat.CheckFunctionExists(context.Background(), table.Identifier{"ns", "fn"})
+	assert.ErrorIs(t, err, rest.ErrEndpointNotSupported)
+
+	// An unsupported list yields empty without erroring or calling the server.
+	for _, err := range cat.ListFunctions(context.Background(), table.Identifier{"ns"}) {
+		require.NoError(t, err)
+	}
+	assert.False(t, functionsHit)
+}

--- a/catalog/rest/rest_functions_test.go
+++ b/catalog/rest/rest_functions_test.go
@@ -87,21 +87,16 @@ func (r *RestCatalogSuite) TestListFunctions200() {
 	// Passing in a custom page size through context
 	ctx := cat.SetPageSize(context.Background(), customPageSize)
 
-	var lastErr error
 	functions := make([]table.Identifier, 0)
 	for function, err := range cat.ListFunctions(ctx, catalog.ToIdentifier(namespace)) {
+		r.Require().NoError(err)
 		functions = append(functions, function)
-		if err != nil {
-			lastErr = err
-			r.FailNow("unexpected error:", err)
-		}
 	}
 
 	r.Equal([]table.Identifier{
 		{"accounting", "tax", "paid"},
 		{"accounting", "tax", "owed"},
 	}, functions)
-	r.Require().NoError(lastErr)
 }
 
 func (r *RestCatalogSuite) TestListFunctionsPagination() {
@@ -256,6 +251,8 @@ func (r *RestCatalogSuite) TestListFunctions404() {
 	for _, err := range cat.ListFunctions(context.Background(), catalog.ToIdentifier(namespace)) {
 		if err != nil {
 			lastErr = err
+
+			break
 		}
 	}
 	r.ErrorIs(lastErr, catalog.ErrNoSuchNamespace)
@@ -312,6 +309,50 @@ func (r *RestCatalogSuite) TestLoadFunction404() {
 	_, err = cat.LoadFunction(context.Background(), catalog.ToIdentifier("accounting", "missing_fn"))
 	r.ErrorIs(err, catalog.ErrNoSuchFunction)
 	r.ErrorContains(err, "The requested function does not exist")
+}
+
+func (r *RestCatalogSuite) TestLoadFunction404Namespace() {
+	r.mux.HandleFunc("/v1/namespaces/ghost_ns/functions/some_fn", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "The given namespace does not exist",
+				"type":    "NoSuchNamespaceException",
+				"code":    404,
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	// The load 404 discriminates on the error type: a missing namespace is
+	// not reported as a missing function.
+	_, err = cat.LoadFunction(context.Background(), catalog.ToIdentifier("ghost_ns", "some_fn"))
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	r.NotErrorIs(err, catalog.ErrNoSuchFunction)
+	r.ErrorContains(err, "The given namespace does not exist")
+
+	// The existence check consequently surfaces the namespace error instead
+	// of a bogus (false, nil).
+	exists, err := cat.CheckFunctionExists(context.Background(), catalog.ToIdentifier("ghost_ns", "some_fn"))
+	r.False(exists)
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+}
+
+func (r *RestCatalogSuite) TestLoadFunctionMissingMetadata() {
+	r.mux.HandleFunc("/v1/namespaces/accounting/functions/hollow_fn", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`{"metadata-location": "s3://bucket/functions/hollow_fn/metadata/00000-x.metadata.json"}`))
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	_, err = cat.LoadFunction(context.Background(), catalog.ToIdentifier("accounting", "hollow_fn"))
+	r.ErrorIs(err, rest.ErrRESTError)
+	r.ErrorContains(err, "missing metadata")
 }
 
 func (r *RestCatalogSuite) TestLoadFunctionMalformedMetadata() {
@@ -380,9 +421,11 @@ func (r *RestCatalogSuite) TestListFunctionsInvalidNamespace() {
 	for _, err := range cat.ListFunctions(context.Background(), table.Identifier{}) {
 		if err != nil {
 			lastErr = err
+
+			break
 		}
 	}
-	r.Error(lastErr)
+	r.ErrorIs(lastErr, catalog.ErrNoSuchNamespace)
 }
 
 // TestFunctionEndpointNegotiation drives the catalog against a server that
@@ -410,6 +453,9 @@ func TestFunctionEndpointNegotiation(t *testing.T) {
 
 	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
 	require.NoError(t, err)
+
+	// The catalog satisfies the optional capability interface.
+	var _ rest.FunctionCatalog = cat
 
 	// An unsupported load fails with the capability sentinel, not a transport error.
 	_, err = cat.LoadFunction(context.Background(), table.Identifier{"ns", "fn"})

--- a/udf/metadata_builder_test.go
+++ b/udf/metadata_builder_test.go
@@ -211,6 +211,24 @@ func TestBuilderFromBase(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidUDFMetadata)
 }
 
+// nilPropertiesMetadata simulates a third-party Metadata implementation that
+// returns nil Properties, driving the builder's defensive nil-props guard.
+type nilPropertiesMetadata struct{ Metadata }
+
+func (nilPropertiesMetadata) Properties() iceberg.Properties { return nil }
+
+func TestBuilderFromBaseNilProperties(t *testing.T) {
+	base := nilPropertiesMetadata{parseFixture(t, "udf-metadata-scalar.json")}
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	assert.NotNil(t, meta.Properties())
+	assert.Empty(t, meta.Properties())
+}
+
 func TestBuilderNoChanges(t *testing.T) {
 	base := parseFixture(t, "udf-metadata-scalar.json")
 

--- a/udf/metadata_test.go
+++ b/udf/metadata_test.go
@@ -273,6 +273,20 @@ func TestRepresentationsEqualCrossType(t *testing.T) {
 	assert.False(t, representationsEqual(nil, sqlRepr))
 }
 
+// TestMetadataInitDefaults pins init's nil-guards: a zero-value metadata
+// instance gets non-nil collections and a working definition index.
+func TestMetadataInitDefaults(t *testing.T) {
+	m := &metadata{}
+	m.init()
+
+	assert.NotNil(t, m.DefinitionList)
+	assert.NotNil(t, m.DefinitionLogList)
+	assert.NotNil(t, m.Props)
+
+	_, ok := m.DefinitionByID("missing")
+	assert.False(t, ok)
+}
+
 func TestNewSQLRepresentation(t *testing.T) {
 	repr, err := NewSQLRepresentation("trino", "x + 1")
 	require.NoError(t, err)

--- a/udf/udf.go
+++ b/udf/udf.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"slices"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+)
+
+// UDF is a function (SQL UDF) loaded from a catalog: its catalog identifier,
+// its metadata, and the location the metadata was loaded from.
+type UDF struct {
+	identifier       table.Identifier
+	metadata         Metadata
+	metadataLocation string
+}
+
+// New creates a UDF from its catalog identifier, metadata and metadata
+// location.
+func New(ident table.Identifier, meta Metadata, metadataLocation string) *UDF {
+	return &UDF{
+		identifier:       ident,
+		metadata:         meta,
+		metadataLocation: metadataLocation,
+	}
+}
+
+// Equals reports whether two UDFs have the same identifier, metadata
+// location and metadata.
+func (u UDF) Equals(other UDF) bool {
+	return slices.Equal(u.identifier, other.identifier) &&
+		u.metadataLocation == other.metadataLocation &&
+		u.metadata.Equals(other.metadata)
+}
+
+func (u UDF) Identifier() table.Identifier   { return u.identifier }
+func (u UDF) Metadata() Metadata             { return u.metadata }
+func (u UDF) MetadataLocation() string       { return u.metadataLocation }
+func (u UDF) Definitions() []*Definition     { return u.metadata.Definitions() }
+func (u UDF) Properties() iceberg.Properties { return u.metadata.Properties() }
+func (u UDF) Location() string               { return u.metadata.Location() }

--- a/udf/udf.go
+++ b/udf/udf.go
@@ -43,7 +43,9 @@ func New(ident table.Identifier, meta Metadata, metadataLocation string) *UDF {
 }
 
 // Equals reports whether two UDFs have the same identifier, metadata
-// location and metadata.
+// location and metadata. The value receiver and argument are intentional,
+// matching view.View: a UDF is a cheap value of references, so callers
+// holding the *UDF from New compare with fn.Equals(*other).
 func (u UDF) Equals(other UDF) bool {
 	return slices.Equal(u.identifier, other.identifier) &&
 		u.metadataLocation == other.metadataLocation &&

--- a/udf/udf_test.go
+++ b/udf/udf_test.go
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUDF(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-scalar.json")
+	ident := table.Identifier{"accounting", "add_one"}
+	location := "s3://bucket/functions/add_one/metadata/00001-x.metadata.json"
+
+	fn := New(ident, meta, location)
+
+	assert.Equal(t, ident, fn.Identifier())
+	assert.Equal(t, location, fn.MetadataLocation())
+	assert.True(t, meta.Equals(fn.Metadata()))
+	assert.Len(t, fn.Definitions(), 2)
+	assert.Empty(t, fn.Properties())
+	assert.Empty(t, fn.Location())
+
+	same := New(table.Identifier{"accounting", "add_one"}, parseFixture(t, "udf-metadata-scalar.json"), location)
+	assert.True(t, fn.Equals(*same))
+
+	differentIdent := New(table.Identifier{"accounting", "other"}, meta, location)
+	assert.False(t, fn.Equals(*differentIdent))
+
+	differentLocation := New(ident, meta, "s3://bucket/elsewhere")
+	assert.False(t, fn.Equals(*differentLocation))
+
+	differentMetadata := New(ident, parseFixture(t, "udf-metadata-table.json"), location)
+	assert.False(t, fn.Equals(*differentMetadata))
+
+	require.NotNil(t, fn.Metadata())
+}


### PR DESCRIPTION
## Description

Addressing part 2 from https://github.com/apache/iceberg-go/issues/1360, following the SQL UDF metadata model added in #1418.

This adds read-side SQL UDF support to the REST catalog through a new optional `FunctionCatalog` capability interface. REST catalogs can list functions in a namespace, load a function and check whether a function exists. Loaded functions are represented by a new `udf.UDF` wrapper containing the catalog identifier, parsed UDF metadata and optional metadata location.

The REST implementation supports the two function endpoints currently defined by the Iceberg REST OpenAPI:

- `GET /v1/{prefix}/namespaces/{namespace}/functions`
- `GET /v1/{prefix}/namespaces/{namespace}/functions/{function}`

Function endpoints are not part of the REST spec's assumed default endpoint set, so they are used only when advertised by the server through `ConfigResponse.endpoints`. An unsupported load or existence check returns `ErrEndpointNotSupported`, while an unsupported listing yields no results without issuing a request, matching the existing list behavior for optional endpoints.

`ListFunctions` is a paginated iterator and handles the function-specific `CatalogObjectIdentifier` wire shape: each identifier is a flat array of hierarchy levels, such as `["accounting", "tax", "paid"]`, rather than the `{namespace, name}` object used for tables and views. `LoadFunction` parses the returned metadata using the `udf` package and returns all overloads from the single metadata response. The optional `metadata-location` is preserved when present.

The catalog adds `ErrNoSuchFunction` for `NoSuchFunctionException` responses and validates function identifiers independently from table and view identifiers. `CheckFunctionExists` uses `LoadFunction` because the REST spec does not define a HEAD endpoint for functions; invalid identifiers remain errors, while a server-reported missing function returns `false` without an error.

This PR does not add create, replace or drop operations because standardized REST write endpoints for functions are not currently defined. It also does not resolve overloads or execute UDF SQL bodies; those remain query-engine responsibilities.

The tests cover list and load responses, pagination, early iterator termination, page-size handling, subsequent-page errors, missing namespaces and functions, malformed metadata, identifier validation, GET-based existence checks and endpoint capability negotiation. They also add focused coverage for existing UDF metadata initialization and nil-properties safeguards.

## Tests

- `go test ./...`
- `go test ./catalog/rest -run 'Function|Endpoint' -count=10`
- `go test -race ./catalog ./catalog/rest ./udf -run 'Function|Endpoint|TestUDF|TestBuilderFromBaseNilProperties|TestMetadataInitDefaults' -count=1`
- `go vet ./...`
- `golangci-lint run --timeout=10m`