### PR TITLE
feat(compaction): add CollectDeadPositionDeletes for leader-side expunge

### DIFF
--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -345,6 +345,9 @@ func fileScopedDeletedRows(t table.FileScanTask) int64 {
 
 // isFileScoped reports whether a delete file applies to exactly one data file.
 // Equality deletes and partition-scoped positional deletes are not file-scoped.
+// Mirrors Java ContentFileUtil.isFileScoped. Stricter than a nil check on
+// referenced_data_file: an empty-string ref counts as unset and falls through
+// to the file_path bounds.
 func isFileScoped(d iceberg.DataFile) bool {
 	if d.ContentType() == iceberg.EntryContentEqDeletes {
 		return false

--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -344,23 +344,38 @@ func fileScopedDeletedRows(t table.FileScanTask) int64 {
 }
 
 // isFileScoped reports whether a delete file applies to exactly one data file.
-// Mirrors Java ContentFileUtil.isFileScoped/referencedDataFile: a deletion
-// vector or path-scoped positional delete carries a referenced data file
-// either explicitly or, when referenced_data_file is absent (it is optional in
-// V2 and our own scan planning never sets it — see matchDeletesToData), through
-// equal file_path lower/upper bounds. Equality deletes and partition-scoped
-// positional deletes are not file-scoped.
+// Equality deletes and partition-scoped positional deletes are not file-scoped.
 func isFileScoped(d iceberg.DataFile) bool {
 	if d.ContentType() == iceberg.EntryContentEqDeletes {
 		return false
 	}
-	if d.ReferencedDataFile() != nil {
-		return true
+
+	return referencedDataFilePath(d) != ""
+}
+
+// referencedDataFilePath resolves the single data file a delete targets, or ""
+// when it is partition-scoped (no single target). Mirrors Java
+// ContentFileUtil.referencedDataFile: explicit referenced_data_file first, then
+// equal file_path lower/upper bounds — the bounds fallback matters because
+// referenced_data_file is optional in V2 and our own scan planning never sets
+// it (see matchDeletesToData).
+func referencedDataFilePath(d iceberg.DataFile) string {
+	if ref := d.ReferencedDataFile(); ref != nil && *ref != "" {
+		return *ref
 	}
+
 	lower := d.LowerBoundValues()[filePathFieldID]
 	upper := d.UpperBoundValues()[filePathFieldID]
+	if len(lower) == 0 || !bytes.Equal(lower, upper) {
+		return ""
+	}
 
-	return len(lower) > 0 && bytes.Equal(lower, upper)
+	lit, err := iceberg.LiteralFromBytes(iceberg.PrimitiveTypes.String, lower)
+	if err != nil {
+		return ""
+	}
+
+	return lit.(iceberg.TypedLiteral[string]).Value()
 }
 
 // filePathFieldID is the reserved field ID of the file_path column in a

--- a/table/compaction/compaction.go
+++ b/table/compaction/compaction.go
@@ -374,8 +374,12 @@ func referencedDataFilePath(d iceberg.DataFile) string {
 	if err != nil {
 		return ""
 	}
+	s, ok := lit.(iceberg.TypedLiteral[string])
+	if !ok {
+		return ""
+	}
 
-	return lit.(iceberg.TypedLiteral[string]).Value()
+	return s.Value()
 }
 
 // filePathFieldID is the reserved field ID of the file_path column in a

--- a/table/compaction/pos_delete_collect.go
+++ b/table/compaction/pos_delete_collect.go
@@ -1,0 +1,217 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction
+
+import (
+	"context"
+	"slices"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+)
+
+// CollectDeadPositionDeletes walks the given snapshot's manifests and returns
+// the position-delete files made dead by a rewrite that removes rewrittenPaths.
+// A dead position delete references only data files the rewrite is removing, so
+// after the rewrite it applies to nothing and is safe to expunge in the same
+// commit.
+//
+// Scope resolution mirrors Java ContentFileUtil.referencedDataFile and
+// DeleteFileIndex:
+//
+//   - File-scoped — explicit referenced_data_file, or equal file_path
+//     lower/upper bounds — is dead iff its single target is in rewrittenPaths.
+//   - Partition-scoped — no single target — is dead iff no surviving
+//     (non-rewritten) data file in the same (specID, partition) has a sequence
+//     number <= the delete's. Such a survivor is one the delete still applies
+//     to, so the delete must be retained for a later dangling-delete pass.
+//
+// Deletion vectors (Puffin position deletes) are intentionally excluded: they
+// are 1:1 with their data file and expunged per-group via
+// [table.CompactionGroupResult.SafeDeletionVectors].
+//
+// rewrittenPaths is the union of every old data file path being replaced across
+// all rewrite groups. Like [CollectDeadEqualityDeletes], the returned files are
+// safe to remove in the same commit that stages the rewrite: a concurrent
+// commit cannot resurrect them, because any concurrent delete touching a
+// rewritten file is rejected by the rewrite validator and any concurrent data
+// file gets a sequence number strictly greater than every preexisting delete.
+//
+// Two-pass design: the first pass walks delete manifests to resolve candidates,
+// deciding file-scoped ones immediately; the more expensive data-manifest walk
+// runs only when a partition-scoped candidate needs a survivor check.
+func CollectDeadPositionDeletes(
+	ctx context.Context,
+	fs iceio.IO,
+	snap *table.Snapshot,
+	rewrittenPaths map[string]struct{},
+) ([]iceberg.DataFile, error) {
+	if snap == nil || len(rewrittenPaths) == 0 {
+		return nil, nil
+	}
+
+	manifests, err := snap.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	// First pass: delete manifests, resolving each candidate's expunge scope.
+	candidates, err := collectPositionDeleteCandidates(ctx, fs, manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	// Second pass runs only when a partition-scoped candidate needs a survivor
+	// check; file-scoped ones are decided from rewrittenPaths alone.
+	var minSurvivorSeq map[string]int64
+	if slices.ContainsFunc(candidates, func(c positionDeleteCandidate) bool { return c.fileScopedTarget == "" }) {
+		minSurvivorSeq, err = minSurvivorSeqByPartition(ctx, fs, manifests, rewrittenPaths)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return decideDeadPositionDeletes(candidates, rewrittenPaths, minSurvivorSeq), nil
+}
+
+// positionDeleteCandidate is a classic position-delete file resolved to its
+// expunge scope: fileScopedTarget is the single referenced data file for a
+// file-scoped delete, or "" for a partition-scoped one, which is then keyed by
+// partitionKey and gated by the delete's sequence number seq.
+type positionDeleteCandidate struct {
+	df               iceberg.DataFile
+	fileScopedTarget string
+	partitionKey     string
+	seq              int64
+}
+
+// collectPositionDeleteCandidates walks the delete manifests and returns the
+// classic position-delete files (deletion vectors excluded), deduplicated by
+// path and resolved to their expunge scope.
+func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile) ([]positionDeleteCandidate, error) {
+	var candidates []positionDeleteCandidate
+	seen := make(map[string]struct{})
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		for e, err := range m.Entries(fs, true) {
+			if err != nil {
+				return nil, err
+			}
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentPosDeletes || isDeletionVector(df) {
+				continue
+			}
+			path := df.FilePath()
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+
+			if target := referencedDataFilePath(df); target != "" {
+				candidates = append(candidates, positionDeleteCandidate{df: df, fileScopedTarget: target})
+
+				continue
+			}
+
+			// Partition-scoped. A negative sequence number is the "unset"
+			// sentinel; retain rather than risk expunging a delete whose
+			// applicability cannot be established.
+			if seq := e.SequenceNum(); seq >= 0 {
+				candidates = append(candidates, positionDeleteCandidate{
+					df:           df,
+					partitionKey: partitionBucketKey(df.SpecID(), df.Partition()),
+					seq:          seq,
+				})
+			}
+		}
+	}
+
+	return candidates, nil
+}
+
+// minSurvivorSeqByPartition walks the data manifests and returns, per (specID,
+// partition), the smallest sequence number among surviving (non-rewritten) data
+// files. A missing key means the partition has no survivor.
+func minSurvivorSeqByPartition(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile, rewrittenPaths map[string]struct{}) (map[string]int64, error) {
+	minSeq := make(map[string]int64)
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		for e, err := range m.Entries(fs, true) {
+			if err != nil {
+				return nil, err
+			}
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentData {
+				continue
+			}
+			if _, rewritten := rewrittenPaths[df.FilePath()]; rewritten {
+				continue
+			}
+			seq := max(e.SequenceNum(), 0)
+			key := partitionBucketKey(df.SpecID(), df.Partition())
+			if cur, ok := minSeq[key]; ok {
+				seq = min(seq, cur)
+			}
+			minSeq[key] = seq
+		}
+	}
+
+	return minSeq, nil
+}
+
+// decideDeadPositionDeletes returns the candidates that are dead after the
+// rewrite. A file-scoped delete is dead when its single target is rewritten. A
+// partition-scoped delete is dead when no surviving data file in its partition
+// predates it — position deletes apply when data.seq <= delete.seq, so a
+// survivor with seq <= the delete's seq keeps it alive.
+func decideDeadPositionDeletes(candidates []positionDeleteCandidate, rewrittenPaths map[string]struct{}, minSurvivorSeq map[string]int64) []iceberg.DataFile {
+	dead := make([]iceberg.DataFile, 0, len(candidates))
+	for _, c := range candidates {
+		if c.fileScopedTarget != "" {
+			if _, rewritten := rewrittenPaths[c.fileScopedTarget]; rewritten {
+				dead = append(dead, c.df)
+			}
+
+			continue
+		}
+		if cur, ok := minSurvivorSeq[c.partitionKey]; !ok || cur > c.seq {
+			dead = append(dead, c.df)
+		}
+	}
+
+	return dead
+}
+
+// isDeletionVector reports whether df is a deletion vector: a Puffin file with
+// position-delete content. Mirrors table.isDeletionVector, reimplemented here
+// because that predicate is unexported.
+func isDeletionVector(df iceberg.DataFile) bool {
+	return df.FileFormat() == iceberg.PuffinFile &&
+		df.ContentType() == iceberg.EntryContentPosDeletes
+}

--- a/table/compaction/pos_delete_collect.go
+++ b/table/compaction/pos_delete_collect.go
@@ -47,8 +47,12 @@ import (
 // [table.CompactionGroupResult.SafeDeletionVectors].
 //
 // rewrittenPaths is the union of every old data file path being replaced across
-// all rewrite groups. Like [CollectDeadEqualityDeletes], the returned files are
-// safe to remove in the same commit that stages the rewrite: a concurrent
+// all rewrite groups. This is the whole-rewrite re-check that
+// [table.CollectSafePositionDeletes]'s caller contract requires whenever
+// multiple groups land in one rewrite snapshot; the result feeds
+// [table.RewriteDataFilesOptions].ExtraDeleteFilesToRemove. Like
+// [CollectDeadEqualityDeletes], the returned files are safe to remove in the
+// same commit that stages the rewrite: a concurrent
 // commit cannot resurrect them, because any concurrent delete touching a
 // rewritten file is rejected by the rewrite validator and any concurrent data
 // file gets a sequence number strictly greater than every preexisting delete.

--- a/table/compaction/pos_delete_collect.go
+++ b/table/compaction/pos_delete_collect.go
@@ -19,7 +19,6 @@ package compaction
 
 import (
 	"context"
-	"slices"
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
@@ -76,7 +75,7 @@ func CollectDeadPositionDeletes(
 	}
 
 	// First pass: delete manifests, resolving each candidate's expunge scope.
-	candidates, err := collectPositionDeleteCandidates(ctx, fs, manifests)
+	candidates, hasPartitionScoped, err := collectPositionDeleteCandidates(ctx, fs, manifests)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +83,7 @@ func CollectDeadPositionDeletes(
 	// Second pass runs only when a partition-scoped candidate needs a survivor
 	// check; file-scoped ones are decided from rewrittenPaths alone.
 	var minSurvivorSeq map[string]int64
-	if slices.ContainsFunc(candidates, func(c positionDeleteCandidate) bool { return c.fileScopedTarget == "" }) {
+	if hasPartitionScoped {
 		minSurvivorSeq, err = minSurvivorSeqByPartition(ctx, fs, manifests, rewrittenPaths)
 		if err != nil {
 			return nil, err
@@ -107,23 +106,23 @@ type positionDeleteCandidate struct {
 
 // collectPositionDeleteCandidates walks the delete manifests and returns the
 // classic position-delete files (deletion vectors excluded), deduplicated by
-// path and resolved to their expunge scope.
-func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile) ([]positionDeleteCandidate, error) {
-	var candidates []positionDeleteCandidate
+// path and resolved to their expunge scope. hasPartitionScoped reports whether
+// any candidate needs the data-manifest survivor pass.
+func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile) (candidates []positionDeleteCandidate, hasPartitionScoped bool, err error) {
 	seen := make(map[string]struct{})
 	for _, m := range manifests {
 		if cerr := ctx.Err(); cerr != nil {
-			return nil, cerr
+			return nil, false, cerr
 		}
 		if m.ManifestContent() != iceberg.ManifestContentDeletes {
 			continue
 		}
 		for e, err := range m.Entries(fs, true) {
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			df := e.DataFile()
-			if df.ContentType() != iceberg.EntryContentPosDeletes || isDeletionVector(df) {
+			if df.ContentType() != iceberg.EntryContentPosDeletes || table.IsDeletionVector(df) {
 				continue
 			}
 			path := df.FilePath()
@@ -142,6 +141,7 @@ func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests
 			// sentinel; retain rather than risk expunging a delete whose
 			// applicability cannot be established.
 			if seq := e.SequenceNum(); seq >= 0 {
+				hasPartitionScoped = true
 				candidates = append(candidates, positionDeleteCandidate{
 					df:           df,
 					partitionKey: partitionBucketKey(df.SpecID(), df.Partition()),
@@ -151,7 +151,7 @@ func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests
 		}
 	}
 
-	return candidates, nil
+	return candidates, hasPartitionScoped, nil
 }
 
 // minSurvivorSeqByPartition walks the data manifests and returns, per (specID,
@@ -177,6 +177,10 @@ func minSurvivorSeqByPartition(ctx context.Context, fs iceio.IO, manifests []ice
 			if _, rewritten := rewrittenPaths[df.FilePath()]; rewritten {
 				continue
 			}
+			// The negative "unset" sentinel clamps to 0 here — the opposite
+			// bias from the candidate side, which drops unset deletes: an
+			// unknown survivor is treated as old as possible so it retains
+			// every delete it might predate.
 			seq := max(e.SequenceNum(), 0)
 			key := partitionBucketKey(df.SpecID(), df.Partition())
 			if cur, ok := minSeq[key]; ok {
@@ -210,12 +214,4 @@ func decideDeadPositionDeletes(candidates []positionDeleteCandidate, rewrittenPa
 	}
 
 	return dead
-}
-
-// isDeletionVector reports whether df is a deletion vector: a Puffin file with
-// position-delete content. Mirrors table.isDeletionVector, reimplemented here
-// because that predicate is unexported.
-func isDeletionVector(df iceberg.DataFile) bool {
-	return df.FileFormat() == iceberg.PuffinFile &&
-		df.ContentType() == iceberg.EntryContentPosDeletes
 }

--- a/table/compaction/pos_delete_collect_ext_test.go
+++ b/table/compaction/pos_delete_collect_ext_test.go
@@ -18,7 +18,9 @@
 package compaction_test
 
 import (
+	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -80,6 +82,86 @@ func TestCollectDeadPositionDeletes(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, dead, "a surviving covered data file must keep the partition-scoped delete alive")
 	})
+}
+
+// TestCollectDeadPositionDeletesPartitioned guards the (specID, partition)
+// keying of the survivor check: a partition-scoped delete stays alive only
+// through a same-partition survivor that predates it — survivors in other
+// partitions or with newer sequence numbers must not retain it.
+func TestCollectDeadPositionDeletesPartitioned(t *testing.T) {
+	ctx := t.Context()
+	fs := iceio.LocalFS{}
+	tbl := newPartitionedTable(t)
+	spec := tbl.Spec()
+
+	addDataFile := func(path, part string) {
+		df, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData,
+			path, iceberg.ParquetFile, map[int]any{1000: part}, nil, nil, 1, 128)
+		require.NoError(t, err)
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.NewRowDelta(nil).AddRows(df.Build()).Commit(ctx))
+		tbl, err = tx.Commit(ctx)
+		require.NoError(t, err)
+	}
+
+	aOld := tbl.Location() + "/data/data=a/old.parquet"
+	bOld := tbl.Location() + "/data/data=b/old.parquet"
+	aNew := tbl.Location() + "/data/data=a/new.parquet"
+
+	addDataFile(aOld, "a")
+	addDataFile(bOld, "b")
+
+	// Partition-scoped delete in partition "a": applies to aOld only.
+	delDF, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentPosDeletes,
+		tbl.Location()+"/data/data=a/pos-del.parquet", iceberg.ParquetFile,
+		map[int]any{1000: "a"}, nil, nil, 1, 128)
+	require.NoError(t, err)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(delDF.Build()).Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Same partition, but sequenced after the delete — must not retain it.
+	addDataFile(aNew, "a")
+
+	t.Run("same-partition predating survivor retains", func(t *testing.T) {
+		dead, err := compaction.CollectDeadPositionDeletes(ctx, fs, tbl.CurrentSnapshot(), pathSet(bOld))
+		require.NoError(t, err)
+		require.Empty(t, dead, "a same-partition survivor with seq <= the delete's must keep it alive")
+	})
+
+	t.Run("cross-partition and newer survivors do not retain", func(t *testing.T) {
+		dead, err := compaction.CollectDeadPositionDeletes(ctx, fs, tbl.CurrentSnapshot(), pathSet(aOld))
+		require.NoError(t, err)
+		require.Len(t, dead, 1, "a survivor in another partition or sequenced after the delete must not retain it")
+	})
+}
+
+func newPartitionedTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "data",
+	})
+
+	meta, err := table.NewMetadata(schema, &spec, table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	return table.New(
+		table.Identifier{"db", "pos_delete_collect_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(ctx context.Context) (iceio.IO, error) {
+			return iceio.LocalFS{}, nil
+		},
+		&stubCatalog{metadata: meta},
+	)
 }
 
 func dataFilePaths(t *testing.T, tbl *table.Table) []string {

--- a/table/compaction/pos_delete_collect_ext_test.go
+++ b/table/compaction/pos_delete_collect_ext_test.go
@@ -20,9 +20,12 @@ package compaction_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
@@ -135,6 +138,121 @@ func TestCollectDeadPositionDeletesPartitioned(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, dead, 1, "a survivor in another partition or sequenced after the delete must not retain it")
 	})
+}
+
+// TestDeadPositionDeleteRoundTrip drives the full integration path the
+// collector is documented for: Collect → ExtraDeleteFilesToRemove →
+// RewriteDataFiles → commit → re-scan. It pins that a merge-on-read-deleted
+// row stays deleted after the expunge, that the delete file disappears from
+// scan planning, and that it is removed and counted exactly once even though
+// the per-group staging and the collector both report it.
+func TestDeadPositionDeleteRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	fs := iceio.LocalFS{}
+	tbl := newCDCStressTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	dataPaths := make([]string, 3)
+	for i := range dataPaths {
+		dataPaths[i] = tbl.Location() + fmt.Sprintf("/data/d-%d.parquet", i)
+		writeParquet(t, dataPaths[i], arrowSc, fmt.Sprintf(`[{"id": %d, "data": "r%d"}]`, i+1, i+1))
+	}
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(ctx, dataPaths, nil, false))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// A real partition-scoped position delete (no ref, no bounds) killing the
+	// single row of dataPaths[1] (id 2).
+	delPath := tbl.Location() + "/data/pos-del.parquet"
+	writeParquet(t, delPath, table.PositionalDeleteArrowSchema,
+		fmt.Sprintf(`[{"file_path": %q, "pos": 0}]`, dataPaths[1]))
+	delInfo, err := os.Stat(delPath)
+	require.NoError(t, err)
+	delDF, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		delPath, iceberg.ParquetFile, nil, nil, nil, 1, delInfo.Size())
+	require.NoError(t, err)
+
+	tx = tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(delDF.Build()).Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, []int64{1, 3}, scanIDs(t, tbl), "merge-on-read delete must hide id 2")
+
+	tasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	cfg := compaction.Config{
+		TargetFileSizeBytes: 64 * 1024 * 1024,
+		MinFileSizeBytes:    32 * 1024 * 1024,
+		MaxFileSizeBytes:    128 * 1024 * 1024,
+		MinInputFiles:       2,
+		DeleteFileThreshold: 1,
+		PackingLookback:     compaction.DefaultPackingLookback,
+	}
+	plan, err := cfg.PlanCompaction(tasks)
+	require.NoError(t, err)
+
+	rewritten := make(map[string]struct{})
+	groups := make([]table.CompactionTaskGroup, len(plan.Groups))
+	for i, g := range plan.Groups {
+		groups[i] = table.CompactionTaskGroup{
+			PartitionKey:   g.PartitionKey,
+			Tasks:          g.Tasks,
+			TotalSizeBytes: g.TotalSizeBytes,
+		}
+		for _, task := range g.Tasks {
+			rewritten[task.File.FilePath()] = struct{}{}
+		}
+	}
+	require.Len(t, rewritten, len(dataPaths), "plan must rewrite every data file")
+
+	dead, err := compaction.CollectDeadPositionDeletes(ctx, fs, tbl.CurrentSnapshot(), rewritten)
+	require.NoError(t, err)
+	require.Len(t, dead, 1, "the delete's every covered file is rewritten, so it must be dead")
+
+	tx = tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(ctx, groups, table.RewriteDataFilesOptions{
+		ExtraDeleteFilesToRemove: dead,
+	})
+	require.NoError(t, err)
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, result.RemovedPositionDeleteFiles,
+		"the dead delete must be removed and counted exactly once despite being both group-staged and collected")
+	require.Equal(t, 0, result.RemovedEqualityDeleteFiles,
+		"a dead position delete must not be miscounted as an equality delete")
+
+	require.Equal(t, []int64{1, 3}, scanIDs(t, tbl), "id 2 must stay deleted after the expunge")
+
+	postTasks, err := tbl.Scan().PlanFiles(ctx)
+	require.NoError(t, err)
+	for _, task := range postTasks {
+		require.Empty(t, task.DeleteFiles, "no position delete may survive the rewrite")
+	}
+}
+
+func scanIDs(t *testing.T, tbl *table.Table) []int64 {
+	t.Helper()
+
+	_, itr, err := tbl.Scan(table.WithSelectedFields("id")).ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	var ids []int64
+	for rec, err := range itr {
+		require.NoError(t, err)
+		col := rec.Column(0).(*array.Int64)
+		for i := range int(rec.NumRows()) {
+			ids = append(ids, col.Value(i))
+		}
+	}
+	slices.Sort(ids)
+
+	return ids
 }
 
 func newPartitionedTable(t *testing.T) *table.Table {

--- a/table/compaction/pos_delete_collect_ext_test.go
+++ b/table/compaction/pos_delete_collect_ext_test.go
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/apache/iceberg-go/table/compaction"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectDeadPositionDeletes drives the full manifest walk: a
+// partition-scoped position delete (no referenced_data_file, no file_path
+// bounds — Spark's default granularity) covering three data files is dead only
+// when every file it covers is rewritten, and retained the moment one is not.
+func TestCollectDeadPositionDeletes(t *testing.T) {
+	ctx := t.Context()
+	fs := iceio.LocalFS{}
+	tbl := newCDCStressTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		p := tbl.Location() + fmt.Sprintf("/data/d-%d.parquet", i)
+		writeParquet(t, p, arrowSc, fmt.Sprintf(`[{"id": %d, "data": "r%d"}]`, i+1, i+1))
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(ctx, []string{p}, nil, false))
+		tbl, err = tx.Commit(ctx)
+		require.NoError(t, err)
+	}
+
+	dataPaths := dataFilePaths(t, tbl)
+	require.Len(t, dataPaths, 3)
+
+	// A partition-scoped position delete: unpartitioned spec, no ref, no
+	// bounds. Committed after the data files, so its sequence number exceeds
+	// theirs and it applies to all three.
+	delDF, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		tbl.Location()+"/data/pos-del.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddDeletes(delDF.Build())
+	require.NoError(t, rd.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	t.Run("all covered files rewritten is dead", func(t *testing.T) {
+		rewritten := pathSet(dataPaths...)
+		dead, err := compaction.CollectDeadPositionDeletes(ctx, fs, tbl.CurrentSnapshot(), rewritten)
+		require.NoError(t, err)
+		require.Len(t, dead, 1, "a partition-scoped delete whose every covered file is rewritten must be expunged")
+	})
+
+	t.Run("one covered file surviving is retained", func(t *testing.T) {
+		rewritten := pathSet(dataPaths[0], dataPaths[1])
+		dead, err := compaction.CollectDeadPositionDeletes(ctx, fs, tbl.CurrentSnapshot(), rewritten)
+		require.NoError(t, err)
+		require.Empty(t, dead, "a surviving covered data file must keep the partition-scoped delete alive")
+	})
+}
+
+func dataFilePaths(t *testing.T, tbl *table.Table) []string {
+	t.Helper()
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, task := range tasks {
+		p := task.File.FilePath()
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		paths = append(paths, p)
+	}
+
+	return paths
+}
+
+func pathSet(paths ...string) map[string]struct{} {
+	s := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		s[p] = struct{}{}
+	}
+
+	return s
+}

--- a/table/compaction/pos_delete_collect_test.go
+++ b/table/compaction/pos_delete_collect_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/apache/iceberg-go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,12 +29,12 @@ func TestReferencedDataFilePath(t *testing.T) {
 
 	t.Run("explicit referenced_data_file", func(t *testing.T) {
 		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("data-a.parquet").Build()
-		assert.Equal(t, "data-a.parquet", referencedDataFilePath(df))
+		require.Equal(t, "data-a.parquet", referencedDataFilePath(df))
 	})
 
 	t.Run("empty referenced_data_file falls through to bounds", func(t *testing.T) {
 		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("").Build()
-		assert.Equal(t, "", referencedDataFilePath(df))
+		require.Equal(t, "", referencedDataFilePath(df))
 	})
 
 	t.Run("equal file_path bounds resolve the single target", func(t *testing.T) {
@@ -43,7 +42,7 @@ func TestReferencedDataFilePath(t *testing.T) {
 			LowerBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
 			UpperBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
 			Build()
-		assert.Equal(t, "data-a.parquet", referencedDataFilePath(df))
+		require.Equal(t, "data-a.parquet", referencedDataFilePath(df))
 	})
 
 	t.Run("unequal file_path bounds are partition-scoped", func(t *testing.T) {
@@ -51,12 +50,32 @@ func TestReferencedDataFilePath(t *testing.T) {
 			LowerBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
 			UpperBoundValues(map[int][]byte{filePathID: []byte("data-b.parquet")}).
 			Build()
-		assert.Equal(t, "", referencedDataFilePath(df))
+		require.Equal(t, "", referencedDataFilePath(df))
 	})
 
 	t.Run("no bounds and no ref is partition-scoped", func(t *testing.T) {
 		df := newPosDelete(t, "del-a.parquet").Build()
-		assert.Equal(t, "", referencedDataFilePath(df))
+		require.Equal(t, "", referencedDataFilePath(df))
+	})
+}
+
+func TestIsFileScoped(t *testing.T) {
+	t.Run("non-empty referenced_data_file", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("data-a.parquet").Build()
+		require.True(t, isFileScoped(df))
+	})
+
+	t.Run("empty referenced_data_file without bounds is not file-scoped", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("").Build()
+		require.False(t, isFileScoped(df))
+	})
+
+	t.Run("equality delete is never file-scoped", func(t *testing.T) {
+		b, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+			"eq-del.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 128)
+		require.NoError(t, err)
+		require.False(t, isFileScoped(b.Build()))
 	})
 }
 
@@ -108,7 +127,7 @@ func TestDecideDeadPositionDeletes(t *testing.T) {
 	for _, df := range dead {
 		got[df.FilePath()] = struct{}{}
 	}
-	assert.Equal(t, map[string]struct{}{
+	require.Equal(t, map[string]struct{}{
 		"del-a.parquet":         {},
 		"del-p-covered.parquet": {},
 		"del-p-newer.parquet":   {},

--- a/table/compaction/pos_delete_collect_test.go
+++ b/table/compaction/pos_delete_collect_test.go
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package compaction
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReferencedDataFilePath(t *testing.T) {
+	filePathID := filePathFieldID
+
+	t.Run("explicit referenced_data_file", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("data-a.parquet").Build()
+		assert.Equal(t, "data-a.parquet", referencedDataFilePath(df))
+	})
+
+	t.Run("empty referenced_data_file falls through to bounds", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").ReferencedDataFile("").Build()
+		assert.Equal(t, "", referencedDataFilePath(df))
+	})
+
+	t.Run("equal file_path bounds resolve the single target", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").
+			LowerBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
+			UpperBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
+			Build()
+		assert.Equal(t, "data-a.parquet", referencedDataFilePath(df))
+	})
+
+	t.Run("unequal file_path bounds are partition-scoped", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").
+			LowerBoundValues(map[int][]byte{filePathID: []byte("data-a.parquet")}).
+			UpperBoundValues(map[int][]byte{filePathID: []byte("data-b.parquet")}).
+			Build()
+		assert.Equal(t, "", referencedDataFilePath(df))
+	})
+
+	t.Run("no bounds and no ref is partition-scoped", func(t *testing.T) {
+		df := newPosDelete(t, "del-a.parquet").Build()
+		assert.Equal(t, "", referencedDataFilePath(df))
+	})
+}
+
+func TestDecideDeadPositionDeletes(t *testing.T) {
+	rewritten := map[string]struct{}{"data-a.parquet": {}}
+
+	fileScopedCovered := positionDeleteCandidate{
+		df:               newPosDelete(t, "del-a.parquet").Build(),
+		fileScopedTarget: "data-a.parquet",
+	}
+	fileScopedLive := positionDeleteCandidate{
+		df:               newPosDelete(t, "del-b.parquet").Build(),
+		fileScopedTarget: "data-b.parquet",
+	}
+	partitionCovered := positionDeleteCandidate{
+		df:           newPosDelete(t, "del-p-covered.parquet").Build(),
+		partitionKey: "0:_",
+		seq:          5,
+	}
+	partitionWithOlderSurvivor := positionDeleteCandidate{
+		df:           newPosDelete(t, "del-p-live.parquet").Build(),
+		partitionKey: "1:x",
+		seq:          5,
+	}
+	partitionWithNewerSurvivor := positionDeleteCandidate{
+		df:           newPosDelete(t, "del-p-newer.parquet").Build(),
+		partitionKey: "2:y",
+		seq:          5,
+	}
+
+	// "1:x" has a survivor at seq 3 (<= 5) → delete still applies → retain.
+	// "2:y" has a survivor at seq 8 (> 5) → delete predates it → dead.
+	// "0:_" has no survivor at all → dead.
+	minSurvivorSeq := map[string]int64{"1:x": 3, "2:y": 8}
+
+	dead := decideDeadPositionDeletes(
+		[]positionDeleteCandidate{
+			fileScopedCovered,
+			fileScopedLive,
+			partitionCovered,
+			partitionWithOlderSurvivor,
+			partitionWithNewerSurvivor,
+		},
+		rewritten,
+		minSurvivorSeq,
+	)
+
+	got := make(map[string]struct{}, len(dead))
+	for _, df := range dead {
+		got[df.FilePath()] = struct{}{}
+	}
+	assert.Equal(t, map[string]struct{}{
+		"del-a.parquet":         {},
+		"del-p-covered.parquet": {},
+		"del-p-newer.parquet":   {},
+	}, got, "only fully-covered deletes are dead; a delete with an older-or-equal surviving file is retained")
+}
+
+func newPosDelete(t *testing.T, path string) *iceberg.DataFileBuilder {
+	t.Helper()
+
+	b, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+
+	return b
+}

--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -88,7 +88,7 @@ func TestIsDeletionVector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isDeletionVector(tt.df))
+			assert.Equal(t, tt.expected, IsDeletionVector(tt.df))
 		})
 	}
 }

--- a/table/mor_delete_pruning_test.go
+++ b/table/mor_delete_pruning_test.go
@@ -282,9 +282,7 @@ func liveDVCount(t *testing.T, tbl *table.Table) int {
 				continue
 			}
 			df := entry.DataFile()
-			if df.FileFormat() == iceberg.PuffinFile &&
-				df.ContentType() == iceberg.EntryContentPosDeletes &&
-				df.ReferencedDataFile() != nil {
+			if table.IsDeletionVector(df) && df.ReferencedDataFile() != nil {
 				count++
 			}
 		}

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -39,7 +39,9 @@ type RewriteResult struct {
 	RemovedDataFiles int
 
 	// RemovedPositionDeleteFiles is the count of position delete files
-	// removed because their referenced data file was rewritten.
+	// removed because their referenced data file was rewritten or
+	// because they were passed via
+	// [RewriteDataFilesOptions.ExtraDeleteFilesToRemove].
 	RemovedPositionDeleteFiles int
 
 	// RemovedEqualityDeleteFiles is the count of equality delete files
@@ -145,15 +147,16 @@ type RewriteDataFilesOptions struct {
 	// per-group snapshot rather than being summed or split.
 	SnapshotProps iceberg.Properties
 
-	// ExtraDeleteFilesToRemove are delete files (typically equality
-	// deletes that are dead after the rewrite) that the caller wants
-	// expunged in the same snapshot as the rewrite. Honored only when
-	// PartialProgress is false.
+	// ExtraDeleteFilesToRemove are delete files that are dead after
+	// the rewrite and that the caller wants expunged in the same
+	// snapshot. Honored only when PartialProgress is false.
 	//
-	// Use [compaction.CollectDeadEqualityDeletes] to compute this list
-	// from the current snapshot. Position delete files that are fully
-	// applied are removed automatically and do NOT need to be passed
-	// in here.
+	// Use [compaction.CollectDeadEqualityDeletes] and
+	// [compaction.CollectDeadPositionDeletes] to compute this list
+	// from the current snapshot. Position deletes attached to
+	// rewritten tasks are already removed by the per-group staging;
+	// listing them again here is harmless (each file is removed and
+	// counted once).
 	ExtraDeleteFilesToRemove []iceberg.DataFile
 
 	// GroupOptions are forwarded to every [ExecuteCompactionGroup]
@@ -205,9 +208,11 @@ func WithCompactionScanConcurrency(n int) CompactionGroupOption {
 // applied (every referenced data file is in the rewrite set) are
 // removed automatically.
 //
-// Equality-delete cleanup is the caller's responsibility: compute the
-// dead set with [compaction.CollectDeadEqualityDeletes] (against the
-// same snapshot the rewrite is staged on) and pass it via
+// Cleanup beyond that per-group staging is the caller's
+// responsibility: compute the dead sets with
+// [compaction.CollectDeadEqualityDeletes] and
+// [compaction.CollectDeadPositionDeletes] (against the same snapshot
+// the rewrite is staged on) and pass them via
 // [RewriteDataFilesOptions.ExtraDeleteFilesToRemove]. The executor
 // only orchestrates the commit; it does not impose a cleanup policy.
 // This split keeps the pure spec predicate in table/compaction and
@@ -229,6 +234,7 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 
 	result := &RewriteResult{}
 	rewrite := t.NewRewrite(opts.SnapshotProps)
+	stagedDeleteFiles := make(map[string]struct{})
 
 	for _, group := range groups {
 		if err := ctx.Err(); err != nil {
@@ -250,15 +256,36 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 
 		rewrite.ApplyResult(gr)
 		accumulateGroupMetrics(result, gr)
+		for _, df := range gr.SafePosDeletes {
+			stagedDeleteFiles[df.FilePath()] = struct{}{}
+		}
+		for _, df := range gr.SafeDeletionVectors {
+			stagedDeleteFiles[df.FilePath()] = struct{}{}
+		}
 	}
 
 	if result.RewrittenGroups == 0 {
 		return result, nil
 	}
 
+	// Extra delete files may overlap what the groups already staged
+	// (e.g. [compaction.CollectDeadPositionDeletes] output includes
+	// deletes attached to rewritten tasks); ReplaceFiles rejects
+	// duplicate removals, so stage each file once.
 	for _, df := range opts.ExtraDeleteFilesToRemove {
+		if _, ok := stagedDeleteFiles[df.FilePath()]; ok {
+			continue
+		}
+		stagedDeleteFiles[df.FilePath()] = struct{}{}
 		rewrite.DeleteFile(df)
-		result.RemovedEqualityDeleteFiles++
+		switch {
+		case df.ContentType() == iceberg.EntryContentEqDeletes:
+			result.RemovedEqualityDeleteFiles++
+		case IsDeletionVector(df):
+			result.RemovedDeletionVectorFiles++
+		default:
+			result.RemovedPositionDeleteFiles++
+		}
 	}
 
 	if err := rewrite.Commit(ctx); err != nil {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -209,12 +209,12 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 	return out, nil
 }
 
-// isDeletionVector reports whether df is a deletion vector: a Puffin file with
+// IsDeletionVector reports whether df is a deletion vector: a Puffin file with
 // position-delete content. The content-type guard matters because df is an
 // arbitrary DataFile, so a non-pos-delete Puffin from an external writer must
 // not be misclassified. Keying on format rather than referenced_data_file
 // avoids misclassifying a Parquet pos-delete that legally sets it.
-func isDeletionVector(df iceberg.DataFile) bool {
+func IsDeletionVector(df iceberg.DataFile) bool {
 	return df.FileFormat() == iceberg.PuffinFile &&
 		df.ContentType() == iceberg.EntryContentPosDeletes
 }
@@ -737,7 +737,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 				case iceberg.EntryContentData:
 					entries.addDataEntry(e)
 				case iceberg.EntryContentPosDeletes:
-					if isDeletionVector(e.DataFile()) {
+					if IsDeletionVector(e.DataFile()) {
 						entries.addDVEntry(e)
 					} else {
 						entries.addPositionalDeleteEntry(e)

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -620,7 +620,7 @@ func (sp *snapshotProducer) deleteFileRemoved(df iceberg.DataFile) bool {
 	if _, ok := sp.deletedDeleteFiles[df.FilePath()]; ok {
 		return true
 	}
-	if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
+	if ref := df.ReferencedDataFile(); IsDeletionVector(df) && ref != nil {
 		want, ok := sp.deletedDVsByRef[*ref]
 
 		return ok && want.FilePath() == df.FilePath()
@@ -1000,7 +1000,7 @@ type removedFilePresence struct {
 }
 
 func (p *removedFilePresence) counts(df iceberg.DataFile) bool {
-	if isDeletionVector(df) {
+	if IsDeletionVector(df) {
 		ref := df.ReferencedDataFile()
 		if ref == nil {
 			return false
@@ -1059,7 +1059,7 @@ func (sp *snapshotProducer) checkRemovedFiles(parent *Snapshot) (*removedFilePre
 
 				continue
 			}
-			if isDeletionVector(df) {
+			if IsDeletionVector(df) {
 				// A DV without a referenced data file cannot be matched by ref;
 				// skip it rather than misclassifying it as a path-keyed delete file.
 				// The path must match too: a peer may have superseded our DV with

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -990,7 +990,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if path == "" {
 			return errors.New("delete file paths must be non-empty for ReplaceFiles")
 		}
-		if isDeletionVector(df) {
+		if IsDeletionVector(df) {
 			ref := df.ReferencedDataFile()
 			if ref == nil {
 				return errors.New("deletion vector to remove is missing referenced_data_file for ReplaceFiles")
@@ -1039,7 +1039,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if !isData {
 			if _, ok := setDeleteFilesToRemove[path]; ok {
 				markedDeleteForRemoval = append(markedDeleteForRemoval, df)
-			} else if ref := df.ReferencedDataFile(); isDeletionVector(df) && ref != nil {
+			} else if ref := df.ReferencedDataFile(); IsDeletionVector(df) && ref != nil {
 				if _, ok := dvRefsToRemove[*ref]; ok {
 					markedDVsForRemoval[*ref] = df
 				}
@@ -2006,7 +2006,7 @@ func (t *Transaction) collectExistingDVs(fs io.IO, files []iceberg.DataFile) (ma
 			continue
 		}
 		df := entry.DataFile()
-		if !isDeletionVector(df) {
+		if !IsDeletionVector(df) {
 			continue
 		}
 		ref := df.ReferencedDataFile()


### PR DESCRIPTION
Position-delete cleanup during a rewrite must re-check each delete against the full set of rewritten data files, which the per-group CollectSafePositionDeletes cannot do on its own. CollectDeadPositionDeletes walks the snapshot and returns the position deletes the rewrite makes dead: file-scoped ones when their single target is rewritten, partition-scoped ones when no surviving data file in their partition predates them (deletion vectors stay on the per-group path). The file_path/referenced_data_file resolution it shares with isFileScoped is folded into a single referencedDataFilePath helper.