### PR TITLE
fix(hadoop): remove table directory after purging files

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -881,8 +881,10 @@ func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 		log.Printf("WARNING: failing to purge some files in Hadoop table %s: %v", identifier, purgeErr)
 	}
 
-	// Delete the table directory root from the local storage
-	return c.DropTable(ctx, identifier)
+	// PurgeFiles removes the metadata files that DropTable uses to recognize a
+	// table. The table was already validated by LoadTable above, so remove its
+	// directory directly instead of checking it again after the purge.
+	return c.filesystem.RemoveAll(c.tableToPath(identifier))
 }
 
 func (c *Catalog) RenameTable(_ context.Context, _, _ table.Identifier) (*table.Table, error) {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1437,6 +1437,47 @@ func (s *HadoopCatalogTestSuite) TestDropTableVerifyCleanup() {
 	s.True(os.IsNotExist(statErr))
 }
 
+func (s *HadoopCatalogTestSuite) TestPurgeTable() {
+	ctx := context.Background()
+	ident := table.Identifier{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	tbl, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+
+	externalDataPath := filepath.Join(s.warehouse, "external", "data.parquet")
+	s.Require().NoError(os.MkdirAll(filepath.Dir(externalDataPath), 0o755))
+	s.Require().NoError(os.WriteFile(externalDataPath, []byte("data"), 0o644))
+
+	dataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		externalDataPath,
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		4,
+	)
+	s.Require().NoError(err)
+
+	tx := tbl.NewTransaction()
+	s.Require().NoError(tx.AddDataFiles(ctx, []iceberg.DataFile{dataFileBuilder.Build()}, nil))
+	_, err = tx.Commit(ctx)
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.cat.PurgeTable(ctx, ident))
+
+	_, statErr := os.Stat(filepath.Join(s.warehouse, "ns", "tbl"))
+	s.True(os.IsNotExist(statErr))
+	_, statErr = os.Stat(externalDataPath)
+	s.True(os.IsNotExist(statErr))
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
 func (s *HadoopCatalogTestSuite) TestDropTableShortIdentifier() {
 	err := s.cat.DropTable(context.Background(), []string{"tbl"})
 	s.Require().Error(err)


### PR DESCRIPTION
Hadoop `PurgeTable` deleted the current metadata file through `Table.PurgeFiles` and then called `DropTable`. Because `DropTable` uses loadable metadata to recognize a table, a successful file purge returned `ErrNoSuchTable` and left the table directory behind.

`PurgeTable` now removes the already-validated table path directly after best-effort file cleanup instead of checking the deleted metadata again. Regression coverage creates a table with an externally referenced data file and verifies that purge succeeds, removes the table directory, makes `CheckTableExists` return false, and deletes the external file.