### PR TITLE
fix(table): honor URI prefix mismatch modes in orphan cleanup

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -723,9 +723,13 @@ func normalizeNonURLPath(path string) string {
 // filePathKey returns the path component used to compare listed files with
 // references before applying scheme and authority mismatch policy.
 func filePathKey(file string) string {
-	parsedURL, err := url.Parse(file)
-	if err == nil && (parsedURL.Scheme != "" || parsedURL.Host != "") {
-		return normalizeNonURLPath(parsedURL.Path)
+	// A bare Windows path such as C:/data/file.parquet is parsed as a URL
+	// with scheme "c". Only parse URL-shaped values here so drive letters
+	// remain part of the comparison key.
+	if strings.Contains(file, "://") || strings.HasPrefix(strings.ToLower(file), "file:") {
+		if parsedURL, err := url.Parse(file); err == nil {
+			return normalizeNonURLPath(parsedURL.Path)
+		}
 	}
 
 	return normalizeNonURLPath(file)

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -212,6 +212,11 @@ type scannedFile struct {
 	size int64
 }
 
+type referencedFileIndex struct {
+	normalized map[string]struct{}
+	byPath     map[string][]string
+}
+
 func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
 	fs, err := t.fsF(ctx)
 	if err != nil {
@@ -257,18 +262,13 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	}
 
 	// Identify orphans.
-	normalizedRef := make(map[string]string, len(referencedFiles))
-	for refPath := range referencedFiles {
-		normalizedPath := normalizeFilePathWithConfig(refPath, cfg)
-		normalizedRef[normalizedPath] = refPath
-		normalizedRef[refPath] = refPath
-	}
+	referencedIndex := newReferencedFileIndex(referencedFiles, cfg)
 
 	var orphanFiles []string
 	orphanFileEntries := make([]OrphanFile, 0)
 	var totalOrphanSize int64
 	for _, f := range scannedFiles {
-		isOrphan, err := isFileOrphan(f.path, referencedFiles, normalizedRef, cfg)
+		isOrphan, err := isFileOrphan(f.path, referencedFiles, referencedIndex, cfg)
 		if err != nil {
 			return OrphanCleanupResult{}, fmt.Errorf("failed to identify orphan %s: %w", f.path, err)
 		}
@@ -452,7 +452,12 @@ func walkDirectory(fsys iceio.IO, root string, fn func(path string, info stdfs.F
 	return fmt.Errorf("filesystem %T does not implement iceio.ListableIO", fsys)
 }
 
-func isFileOrphan(file string, referencedFiles map[string]bool, normalizedReferencedFiles map[string]string, cfg *orphanCleanupConfig) (bool, error) {
+func isFileOrphan(
+	file string,
+	referencedFiles map[string]bool,
+	referencedIndex referencedFileIndex,
+	cfg *orphanCleanupConfig,
+) (bool, error) {
 	normalizedFile := normalizeFilePathWithConfig(file, cfg)
 
 	// Any presence in referencedFiles means referenced;
@@ -464,16 +469,45 @@ func isFileOrphan(file string, referencedFiles map[string]bool, normalizedRefere
 		return false, nil
 	}
 
-	if originalPath, exists := normalizedReferencedFiles[normalizedFile]; exists {
-		err := checkPrefixMismatch(originalPath, file, cfg)
-		if err != nil {
-			return false, err
-		}
-
+	if _, exists := referencedIndex.normalized[normalizedFile]; exists {
 		return false, nil
 	}
 
+	references := referencedIndex.byPath[filePathKey(normalizedFile)]
+	if len(references) == 0 {
+		return true, nil
+	}
+
+	for _, referencedPath := range references {
+		decision, err := checkPrefixMismatch(referencedPath, file, cfg)
+		if err != nil {
+			return false, err
+		}
+		if decision == prefixMismatchKeep {
+			return false, nil
+		}
+	}
+
 	return true, nil
+}
+
+func newReferencedFileIndex(referencedFiles map[string]bool, cfg *orphanCleanupConfig) referencedFileIndex {
+	index := referencedFileIndex{
+		normalized: make(map[string]struct{}, len(referencedFiles)*2),
+		byPath:     make(map[string][]string, len(referencedFiles)),
+	}
+	for referencedPath := range referencedFiles {
+		normalizedPath := normalizeFilePathWithConfig(referencedPath, cfg)
+		index.normalized[normalizedPath] = struct{}{}
+		index.normalized[referencedPath] = struct{}{}
+		pathKey := filePathKey(normalizedPath)
+		index.byPath[pathKey] = append(index.byPath[pathKey], referencedPath)
+	}
+	for pathKey := range index.byPath {
+		slices.Sort(index.byPath[pathKey])
+	}
+
+	return index
 }
 
 func deleteFiles(ctx context.Context, fs iceio.IO, orphanFiles []string, cfg *orphanCleanupConfig) ([]string, error) {
@@ -686,6 +720,17 @@ func normalizeNonURLPath(path string) string {
 	return strings.ReplaceAll(normalized, "\\", "/")
 }
 
+// filePathKey returns the path component used to compare listed files with
+// references before applying scheme and authority mismatch policy.
+func filePathKey(file string) string {
+	parsedURL, err := url.Parse(file)
+	if err == nil && (parsedURL.Scheme != "" || parsedURL.Host != "") {
+		return normalizeNonURLPath(parsedURL.Path)
+	}
+
+	return normalizeNonURLPath(file)
+}
+
 // applySchemeEquivalence maps schemes to their equivalent canonical form.
 //
 // Common equivalences include:
@@ -753,14 +798,21 @@ func applyAuthorityEquivalence(authority string, equalAuthorities map[string]str
 	return authority
 }
 
-// checkPrefixMismatch detects and handles prefix mismatches between referenced files and filesystem files
-func checkPrefixMismatch(referencedPath, filesystemPath string, cfg *orphanCleanupConfig) error {
+type prefixMismatchDecision int
+
+const (
+	prefixMismatchKeep prefixMismatchDecision = iota
+	prefixMismatchDeleteCandidate
+)
+
+// checkPrefixMismatch decides how to handle prefix mismatches between referenced files and filesystem files.
+func checkPrefixMismatch(referencedPath, filesystemPath string, cfg *orphanCleanupConfig) (prefixMismatchDecision, error) {
 	// Parse both paths as URLs to compare schemes and authorities
 	refURL, refErr := url.Parse(referencedPath)
 	fsURL, fsErr := url.Parse(filesystemPath)
 
 	if refErr != nil || fsErr != nil {
-		return nil
+		return prefixMismatchKeep, nil
 	}
 
 	refScheme := applySchemeEquivalence(refURL.Scheme, cfg.equalSchemes)
@@ -773,19 +825,19 @@ func checkPrefixMismatch(referencedPath, filesystemPath string, cfg *orphanClean
 	authMismatch := refAuth != fsAuth
 
 	if !schemeMismatch && !authMismatch {
-		return nil // No mismatch
+		return prefixMismatchKeep, nil
 	}
 
 	switch cfg.prefixMismatchMode {
 	case PrefixMismatchError:
-		return fmt.Errorf("prefix mismatch detected: referenced=%s (scheme=%s, auth=%s) vs filesystem=%s (scheme=%s, auth=%s)",
+		return prefixMismatchKeep, fmt.Errorf("prefix mismatch detected: referenced=%s (scheme=%s, auth=%s) vs filesystem=%s (scheme=%s, auth=%s)",
 			referencedPath, refScheme, refAuth, filesystemPath, fsScheme, fsAuth)
 	case PrefixMismatchIgnore:
-		return nil // Silently ignore mismatch
+		return prefixMismatchKeep, nil
 	case PrefixMismatchDelete:
-		return nil // Allow deletion (treat as orphan)
+		return prefixMismatchDeleteCandidate, nil
 	default:
-		return fmt.Errorf("unknown prefix mismatch mode: %d", cfg.prefixMismatchMode)
+		return prefixMismatchKeep, fmt.Errorf("unknown prefix mismatch mode: %d", cfg.prefixMismatchMode)
 	}
 }
 

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -345,7 +345,7 @@ func TestCheckPrefixMismatch(t *testing.T) {
 			testCfg := *cfg
 			testCfg.prefixMismatchMode = tt.mode
 
-			err := checkPrefixMismatch(tt.referencedPath, tt.filesystemPath, &testCfg)
+			decision, err := checkPrefixMismatch(tt.referencedPath, tt.filesystemPath, &testCfg)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -354,6 +354,11 @@ func TestCheckPrefixMismatch(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
+				if tt.mode == PrefixMismatchDelete && tt.referencedPath != tt.filesystemPath {
+					assert.Equal(t, prefixMismatchDeleteCandidate, decision)
+				} else {
+					assert.Equal(t, prefixMismatchKeep, decision)
+				}
 			}
 		})
 	}
@@ -423,16 +428,16 @@ func TestIsFileOrphan(t *testing.T) {
 			expectOrphan: false,
 		},
 	}
-	normalizedReferencedFiles := make(map[string]string)
-	for refPath := range referencedFiles {
-		normalizedPath := normalizeFilePathWithConfig(refPath, cfg)
-		normalizedReferencedFiles[normalizedPath] = refPath
-		normalizedReferencedFiles[refPath] = refPath
-	}
+	referencedIndex := newReferencedFileIndex(referencedFiles, cfg)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isOrphan, err := isFileOrphan(tt.file, referencedFiles, normalizedReferencedFiles, cfg)
+			isOrphan, err := isFileOrphan(
+				tt.file,
+				referencedFiles,
+				referencedIndex,
+				cfg,
+			)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectOrphan, isOrphan)
 		})
@@ -494,7 +499,7 @@ func TestOrphanCleanup_EdgeCases(t *testing.T) {
 			prefixMismatchMode: PrefixMismatchMode(999), // Invalid mode
 		}
 
-		err := checkPrefixMismatch("s3://bucket/file", "gs://bucket/file", cfg)
+		_, err := checkPrefixMismatch("s3://bucket/file", "gs://bucket/file", cfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown prefix mismatch mode")
 	})
@@ -683,6 +688,100 @@ func (m mockFileInfo) Mode() stdfs.FileMode { return m.mode }
 func (m mockFileInfo) ModTime() time.Time   { return time.Time{} }
 func (m mockFileInfo) IsDir() bool          { return m.mode.IsDir() }
 func (m mockFileInfo) Sys() any             { return nil }
+
+func TestDeleteOrphanFilesPrefixMismatchModes(t *testing.T) {
+	tests := []struct {
+		name           string
+		referencedPath string
+		listedPath     string
+	}{
+		{
+			name:           "scheme mismatch",
+			referencedPath: "s3://bucket/path/file.parquet",
+			listedPath:     "s3a://bucket/path/file.parquet",
+		},
+		{
+			name:           "authority mismatch",
+			referencedPath: "s3://bucket-a/path/file.parquet",
+			listedPath:     "s3://bucket-b/path/file.parquet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := iceberg.NewSchema(0, iceberg.NestedField{
+				ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+			})
+			meta, err := NewMetadata(
+				schema,
+				iceberg.UnpartitionedSpec,
+				UnsortedSortOrder,
+				"s3://bucket/table",
+				iceberg.Properties{PropertyFormatVersion: "2"},
+			)
+			require.NoError(t, err)
+			builder, err := MetadataBuilderFromBase(meta, "")
+			require.NoError(t, err)
+			require.NoError(t, builder.SetStatistics(StatisticsFile{
+				SnapshotID:      1,
+				StatisticsPath:  tt.referencedPath,
+				BlobMetadata:    []BlobMetadata{},
+				FileSizeInBytes: 4,
+			}))
+			meta, err = builder.Build()
+			require.NoError(t, err)
+
+			fsys := &mockListableIO{
+				entries: []mockWalkEntry{{
+					path: tt.listedPath,
+					info: mockFileInfo{name: "file.parquet", size: 4},
+				}},
+			}
+			tbl := New(
+				Identifier{"db", "tbl"},
+				meta,
+				"s3://bucket/table/metadata/v1.metadata.json",
+				func(context.Context) (io.IO, error) { return fsys, nil },
+				nil,
+			)
+
+			for _, mode := range []PrefixMismatchMode{
+				PrefixMismatchError,
+				PrefixMismatchIgnore,
+				PrefixMismatchDelete,
+			} {
+				t.Run(mode.String(), func(t *testing.T) {
+					var deleted []string
+					result, err := tbl.DeleteOrphanFiles(
+						context.Background(),
+						WithLocation("s3://bucket/path"),
+						WithFilesOlderThan(-time.Hour),
+						WithPrefixMismatchMode(mode),
+						WithDeleteFunc(func(path string) error {
+							deleted = append(deleted, path)
+
+							return nil
+						}),
+					)
+
+					switch mode {
+					case PrefixMismatchError:
+						require.ErrorContains(t, err, "prefix mismatch detected")
+						assert.Empty(t, deleted)
+					case PrefixMismatchIgnore:
+						require.NoError(t, err)
+						assert.Empty(t, result.OrphanFileLocations)
+						assert.Empty(t, deleted)
+					case PrefixMismatchDelete:
+						require.NoError(t, err)
+						assert.Equal(t, []string{tt.listedPath}, result.OrphanFileLocations)
+						assert.Equal(t, []string{tt.listedPath}, deleted)
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestDeleteFilesFallsBackToExistingBehavior(t *testing.T) {
 	mock := &mockPlainIO{}

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -158,6 +158,16 @@ func TestNormalizeNonURLPath(t *testing.T) {
 	}
 }
 
+func TestIsFileOrphanDoesNotAliasWindowsDrivePaths(t *testing.T) {
+	cfg := &orphanCleanupConfig{prefixMismatchMode: PrefixMismatchIgnore}
+	referencedFiles := map[string]bool{"C:/data/file.parquet": true}
+	index := newReferencedFileIndex(referencedFiles, cfg)
+
+	isOrphan, err := isFileOrphan("D:/data/file.parquet", referencedFiles, index, cfg)
+	require.NoError(t, err)
+	assert.True(t, isOrphan, "different Windows drives must not share a path key")
+}
+
 func TestVersionHintLocation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -755,7 +765,7 @@ func TestDeleteOrphanFilesPrefixMismatchModes(t *testing.T) {
 					result, err := tbl.DeleteOrphanFiles(
 						context.Background(),
 						WithLocation("s3://bucket/path"),
-						WithFilesOlderThan(-time.Hour),
+						WithFilesOlderThan(0),
 						WithPrefixMismatchMode(mode),
 						WithDeleteFunc(func(path string) error {
 							deleted = append(deleted, path)


### PR DESCRIPTION
## Summary

`DeleteOrphanFiles` compared full normalized URIs before checking scheme and authority mismatches. A listed file with the same object path as a reference but a non-equivalent prefix could therefore fall through as an orphan.

Orphan detection now indexes both normalized URIs and path components. Exact and configured-equivalent matches remain referenced; same-path prefix conflicts follow the configured policy:

- `ERROR` stops cleanup;
- `IGNORE` keeps the file;
- `DELETE` treats it as an orphan.

Windows drive letters remain part of path comparison keys.

## Testing

- `go test ./table`
- all three modes across scheme and authority mismatches
- Windows cross-drive regression coverage