### PR TITLE
fix(catalog): validate requirements for missing tables

### DIFF
--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -202,15 +202,17 @@ func UpdateAndStageTable(ctx context.Context, catprops iceberg.Properties, curre
 	)
 
 	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, err
-			}
-		}
-
 		baseMeta = current.Metadata()
 		metadataLoc = current.MetadataLocation()
-	} else {
+	}
+
+	for _, r := range reqs {
+		if err := r.Validate(baseMeta); err != nil {
+			return nil, err
+		}
+	}
+
+	if current == nil {
 		var err error
 		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
 		if err != nil {

--- a/catalog/internal/utils_test.go
+++ b/catalog/internal/utils_test.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAndStageTableValidatesRequirementsForMissingTable(t *testing.T) {
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "table")
+	tableUUID := uuid.New()
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	updates := []table.Update{
+		table.NewAssignUUIDUpdate(tableUUID),
+		table.NewUpgradeFormatVersionUpdate(2),
+		table.NewAddSchemaUpdate(schema),
+		table.NewSetCurrentSchemaUpdate(-1),
+		table.NewSetLocationUpdate(tableLocation),
+	}
+
+	staged, err := UpdateAndStageTable(
+		ctx,
+		nil,
+		nil,
+		table.Identifier{"db", "tbl"},
+		[]table.Requirement{table.AssertTableUUID(tableUUID)},
+		updates,
+		nil,
+	)
+
+	require.ErrorContains(t, err, "current table metadata does not exist")
+	require.Nil(t, staged)
+	_, statErr := os.Stat(tableLocation)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestUpdateAndStageTableAllowsCreateRequirementForMissingTable(t *testing.T) {
+	ctx := context.Background()
+	tableLocation := filepath.Join(t.TempDir(), "table")
+	tableUUID := uuid.New()
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+
+	staged, err := UpdateAndStageTable(
+		ctx,
+		nil,
+		nil,
+		table.Identifier{"db", "tbl"},
+		[]table.Requirement{table.AssertCreate()},
+		[]table.Update{
+			table.NewAssignUUIDUpdate(tableUUID),
+			table.NewUpgradeFormatVersionUpdate(2),
+			table.NewAddSchemaUpdate(schema),
+			table.NewSetCurrentSchemaUpdate(-1),
+			table.NewSetLocationUpdate(tableLocation),
+		},
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, staged)
+	require.Equal(t, tableUUID, staged.Metadata().TableUUID())
+	require.Equal(t, tableLocation, staged.Location())
+}


### PR DESCRIPTION
`UpdateAndStageTable` validated commit requirements only when the table already existed. For a missing table it constructed synthetic metadata and applied creation updates without calling `Validate(nil)`, allowing requirements such as table UUID, schema ID, or snapshot reference assertions to be bypassed across the SQL, Glue, and Hive catalogs.

Requirements are now validated before the helper chooses its staging metadata: existing tables validate against current metadata, while missing tables validate against nil. Regression coverage verifies that `AssertTableUUID` rejects an otherwise valid creation commit without writing metadata, while `AssertCreate` still stages the same creation updates successfully.
