### PR TITLE
fix(sql): distinguish dotted namespace components

### DIFF
--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -95,6 +95,33 @@ func UpdateTableMetadata(base table.Metadata, updates []table.Update, metadataLo
 }
 
 func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nspropsFn GetNamespacePropsFn, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (table.StagedTable, error) {
+	return createStagedTable(ctx, catprops, nspropsFn, ident, "", sc, opts...)
+}
+
+// CreateStagedTableWithNamespaceKey creates a staged table using namespaceKey
+// in its default warehouse location while retaining ident's namespace
+// components for namespace property lookup.
+func CreateStagedTableWithNamespaceKey(
+	ctx context.Context,
+	catprops iceberg.Properties,
+	nspropsFn GetNamespacePropsFn,
+	ident table.Identifier,
+	namespaceKey string,
+	sc *iceberg.Schema,
+	opts ...catalog.CreateTableOpt,
+) (table.StagedTable, error) {
+	return createStagedTable(ctx, catprops, nspropsFn, ident, namespaceKey, sc, opts...)
+}
+
+func createStagedTable(
+	ctx context.Context,
+	catprops iceberg.Properties,
+	nspropsFn GetNamespacePropsFn,
+	ident table.Identifier,
+	namespaceKey string,
+	sc *iceberg.Schema,
+	opts ...catalog.CreateTableOpt,
+) (table.StagedTable, error) {
 	var cfg catalog.CreateTableCfg
 	for _, opt := range opts {
 		opt(&cfg)
@@ -102,9 +129,12 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 
 	dbIdent := catalog.NamespaceFromIdent(ident)
 	tblname := catalog.TableNameFromIdent(ident)
-	dbname := strings.Join(dbIdent, ".")
+	if namespaceKey == "" {
+		namespaceKey = strings.Join(dbIdent, ".")
+	}
 
-	loc, err := ResolveTableLocation(ctx, cfg.Location, dbname, tblname, catprops, nspropsFn)
+	loc, err := ResolveTableLocationWithNamespace(
+		ctx, cfg.Location, dbIdent, namespaceKey, tblname, catprops, nspropsFn)
 	if err != nil {
 		return table.StagedTable{}, err
 	}
@@ -143,26 +173,45 @@ func CreateStagedTable(ctx context.Context, catprops iceberg.Properties, nsprops
 
 type GetNamespacePropsFn func(context.Context, table.Identifier) (iceberg.Properties, error)
 
-func ResolveTableLocation(ctx context.Context, loc, dbname, tablename string, catprops iceberg.Properties, nsprops GetNamespacePropsFn) (string, error) {
+func ResolveTableLocation(
+	ctx context.Context,
+	loc, dbname, tablename string,
+	catprops iceberg.Properties,
+	nsprops GetNamespacePropsFn,
+) (string, error) {
+	return ResolveTableLocationWithNamespace(
+		ctx, loc, strings.Split(dbname, "."), dbname, tablename, catprops, nsprops)
+}
+
+// ResolveTableLocationWithNamespace keeps namespace property lookup component-aware
+// while allowing catalogs to provide a distinct key for the default warehouse path.
+func ResolveTableLocationWithNamespace(
+	ctx context.Context,
+	loc string,
+	namespace table.Identifier,
+	namespaceKey, tablename string,
+	catprops iceberg.Properties,
+	nsprops GetNamespacePropsFn,
+) (string, error) {
 	if len(loc) == 0 {
-		dbprops, err := nsprops(ctx, strings.Split(dbname, "."))
+		dbprops, err := nsprops(ctx, namespace)
 		if err != nil {
 			return "", err
 		}
 
-		return getDefaultWarehouseLocation(dbname, tablename, dbprops, catprops)
+		return getDefaultWarehouseLocation(namespaceKey, tablename, dbprops, catprops)
 	}
 
 	return strings.TrimSuffix(loc, "/"), nil
 }
 
-func getDefaultWarehouseLocation(dbname, tablename string, nsprops, catprops iceberg.Properties) (string, error) {
+func getDefaultWarehouseLocation(namespaceKey, tablename string, nsprops, catprops iceberg.Properties) (string, error) {
 	if dblocation := nsprops.Get("location", ""); dblocation != "" {
 		return url.JoinPath(dblocation, tablename)
 	}
 
 	if warehousepath := catprops.Get("warehouse", ""); warehousepath != "" {
-		return url.JoinPath(warehousepath, dbname+".db", tablename)
+		return url.JoinPath(warehousepath, namespaceKey+".db", tablename)
 	}
 
 	return "", errors.New("no default path set, please specify a location when creating a table")

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -20,6 +20,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -57,6 +58,89 @@ const (
 	MSSQL    SupportedDialect = "mssql"
 	Oracle   SupportedDialect = "oracle"
 )
+
+const encodedNamespacePrefix = "__iceberg_namespace_v1__:"
+
+func namespaceToString(namespace table.Identifier) string {
+	legacy := strings.Join(namespace, ".")
+	if !strings.Contains(legacy, encodedNamespacePrefix) && !slices.ContainsFunc(namespace, func(part string) bool {
+		return strings.Contains(part, ".")
+	}) {
+		return legacy
+	}
+
+	encoded, err := json.Marshal(namespace)
+	if err != nil {
+		panic(err) // table.Identifier contains only strings
+	}
+
+	return encodedNamespacePrefix + string(encoded)
+}
+
+func namespaceFromString(namespace string) (table.Identifier, error) {
+	if !strings.HasPrefix(namespace, encodedNamespacePrefix) {
+		return strings.Split(namespace, "."), nil
+	}
+
+	var ident table.Identifier
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(namespace, encodedNamespacePrefix)), &ident); err != nil ||
+		len(ident) == 0 || namespaceToString(ident) != namespace {
+		// Before encoded namespaces existed, the prefix was valid ordinary
+		// namespace text. Only canonical, non-empty encodings claim the marker.
+		return strings.Split(namespace, "."), nil
+	}
+
+	return ident, nil
+}
+
+func namespaceStorageKeys(namespace table.Identifier) []string {
+	primary := namespaceToString(namespace)
+	legacy := strings.Join(namespace, ".")
+	if primary == legacy || slices.ContainsFunc(namespace, func(part string) bool {
+		return strings.Contains(part, ".")
+	}) {
+		return []string{primary}
+	}
+
+	// Only marker collisions get a legacy fallback. Dotted components must
+	// never fall back because their legacy key belongs to a different namespace.
+	return []string{primary, legacy}
+}
+
+func namespaceDescendantPrefixes(namespace table.Identifier) []string {
+	legacy := strings.Join(namespace, ".")
+	prefixes := make([]string, 0, 2)
+	if !slices.ContainsFunc(namespace, func(part string) bool { return strings.Contains(part, ".") }) {
+		prefixes = append(prefixes, legacy+".")
+	}
+
+	encoded, err := json.Marshal(namespace)
+	if err != nil {
+		panic(err) // table.Identifier contains only strings
+	}
+	prefixes = append(prefixes, encodedNamespacePrefix+string(encoded[:len(encoded)-1])+",")
+
+	return prefixes
+}
+
+func namespaceLikePrefix(prefix string) string {
+	return strings.NewReplacer("!", "!!", "%", "!%", "_", "!_").Replace(prefix) + "%"
+}
+
+func whereNamespaceParent(query *bun.SelectQuery, column string, parent table.Identifier) *bun.SelectQuery {
+	return query.WhereGroup(" AND ", func(query *bun.SelectQuery) *bun.SelectQuery {
+		keys := namespaceStorageKeys(parent)
+		query = query.Where("? = ?", bun.Ident(column), keys[0])
+		for _, key := range keys[1:] {
+			query = query.WhereOr("? = ?", bun.Ident(column), key)
+		}
+		for _, prefix := range namespaceDescendantPrefixes(parent) {
+			query = query.WhereOr("? LIKE ? ESCAPE '!'", bun.Ident(column), namespaceLikePrefix(prefix))
+		}
+
+		return query
+	})
+}
 
 const (
 	DialectKey           = "sql.dialect"
@@ -489,6 +573,40 @@ func (c *Catalog) namespaceExists(ctx context.Context, ns string) (bool, error) 
 	})
 }
 
+func (c *Catalog) resolveNamespaceKey(ctx context.Context, namespace table.Identifier) (string, bool, error) {
+	keys := namespaceStorageKeys(namespace)
+	for _, key := range keys {
+		exists, err := c.namespaceExists(ctx, key)
+		if err != nil {
+			return "", false, err
+		}
+		if exists {
+			return key, true, nil
+		}
+	}
+
+	return keys[0], false, nil
+}
+
+func (c *Catalog) namespaceKey(ctx context.Context, namespace table.Identifier) (string, error) {
+	keys := namespaceStorageKeys(namespace)
+	if len(keys) == 1 {
+		return keys[0], nil
+	}
+
+	for _, key := range keys {
+		exists, err := c.namespaceExists(ctx, key)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return key, nil
+		}
+	}
+
+	return keys[0], nil
+}
+
 func checkValidNamespace(ident table.Identifier) error {
 	if len(ident) < 1 {
 		return fmt.Errorf("%w: empty namespace identifier", catalog.ErrNoSuchNamespace)
@@ -498,21 +616,21 @@ func checkValidNamespace(ident table.Identifier) error {
 }
 
 func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
-	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, ident, sc, opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	nsIdent := catalog.NamespaceFromIdent(ident)
 	tblIdent := catalog.TableNameFromIdent(ident)
-	ns := strings.Join(nsIdent, ".")
-	exists, err := c.namespaceExists(ctx, ns)
+	ns, exists, err := c.resolveNamespaceKey(ctx, nsIdent)
 	if err != nil {
 		return nil, err
 	}
 
 	if !exists {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
+	}
+
+	staged, err := internal.CreateStagedTableWithNamespaceKey(
+		ctx, c.props, c.LoadNamespaceProperties, ident, ns, sc, opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
@@ -546,6 +664,10 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
 	ns := catalog.NamespaceFromIdent(ident)
 	tblName := catalog.TableNameFromIdent(ident)
+	nsKey, err := c.namespaceKey(ctx, ns)
+	if err != nil {
+		return nil, "", err
+	}
 
 	current, err := c.LoadTable(ctx, ident)
 	if err != nil && !errors.Is(err, catalog.ErrNoSuchTable) {
@@ -574,7 +696,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 			// not exist, so it is excluded from both the SET list and the WHERE.
 			upd := tx.NewUpdate().Model(&sqlIcebergTable{
 				CatalogName:              c.name,
-				TableNamespace:           strings.Join(ns, "."),
+				TableNamespace:           nsKey,
 				TableName:                tblName,
 				IcebergType:              sql.NullString{String: TableType, Valid: true},
 				MetadataLocation:         sql.NullString{Valid: true, String: staged.MetadataLocation()},
@@ -608,7 +730,7 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 
 		ins := tx.NewInsert().Model(&sqlIcebergTable{
 			CatalogName:      c.name,
-			TableNamespace:   strings.Join(ns, "."),
+			TableNamespace:   nsKey,
 			TableName:        tblName,
 			IcebergType:      sql.NullString{String: TableType, Valid: true},
 			MetadataLocation: sql.NullString{Valid: true, String: staged.MetadataLocation()},
@@ -632,12 +754,16 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
 	ns := catalog.NamespaceFromIdent(identifier)
 	tbl := catalog.TableNameFromIdent(identifier)
+	nsKey, err := c.namespaceKey(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
 
 	result, err := withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) (*sqlIcebergTable, error) {
 		t := new(sqlIcebergTable)
 		sel := tx.NewSelect().Model(t).
 			Where("catalog_name = ?", c.name).
-			Where("table_namespace = ?", strings.Join(ns, ".")).
+			Where("table_namespace = ?", nsKey).
 			Where("table_name = ?", tbl)
 		if c.isV0() {
 			sel = sel.ExcludeColumn("iceberg_type")
@@ -673,7 +799,10 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 }
 
 func (c *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {
-	ns := strings.Join(catalog.NamespaceFromIdent(identifier), ".")
+	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
+	if err != nil {
+		return err
+	}
 	tbl := catalog.TableNameFromIdent(identifier)
 
 	return withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
@@ -724,16 +853,18 @@ func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 }
 
 func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error) {
-	fromNs := strings.Join(catalog.NamespaceFromIdent(from), ".")
-	fromTbl := catalog.TableNameFromIdent(from)
-
-	toNs := strings.Join(catalog.NamespaceFromIdent(to), ".")
-	toTbl := catalog.TableNameFromIdent(to)
-
-	exists, err := c.namespaceExists(ctx, toNs)
+	fromNs, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(from))
 	if err != nil {
 		return nil, err
 	}
+	fromTbl := catalog.TableNameFromIdent(from)
+
+	toNs, exists, err := c.resolveNamespaceKey(ctx, catalog.NamespaceFromIdent(to))
+	if err != nil {
+		return nil, err
+	}
+	toTbl := catalog.TableNameFromIdent(to)
+
 	if !exists {
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, toNs)
 	}
@@ -805,7 +936,7 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
-	exists, err := c.namespaceExists(ctx, strings.Join(namespace, "."))
+	_, exists, err := c.resolveNamespaceKey(ctx, namespace)
 	if err != nil {
 		return err
 	}
@@ -818,7 +949,7 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		props = minimalNamespaceProps
 	}
 
-	nsToCreate := strings.Join(namespace, ".")
+	nsToCreate := namespaceToString(namespace)
 
 	return withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
 		toInsert := make([]sqlIcebergNamespaceProps, 0, len(props))
@@ -845,9 +976,7 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
-	nsToDelete := strings.Join(namespace, ".")
-
-	exists, err := c.namespaceExists(ctx, nsToDelete)
+	nsToDelete, exists, err := c.resolveNamespaceKey(ctx, namespace)
 	if err != nil {
 		return err
 	}
@@ -889,8 +1018,7 @@ func (c *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 		return nil, err
 	}
 
-	nsToLoad := strings.Join(namespace, ".")
-	exists, err := c.namespaceExists(ctx, nsToLoad)
+	nsToLoad, exists, err := c.resolveNamespaceKey(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -935,8 +1063,11 @@ func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 }
 
 func (c *Catalog) listTablesAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
+	ns := namespaceToString(namespace)
 	if len(namespace) > 0 {
-		exists, err := c.namespaceExists(ctx, strings.Join(namespace, "."))
+		var exists bool
+		var err error
+		ns, exists, err = c.resolveNamespaceKey(ctx, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -945,7 +1076,6 @@ func (c *Catalog) listTablesAll(ctx context.Context, namespace table.Identifier)
 		}
 	}
 
-	ns := strings.Join(namespace, ".")
 	tables, err := withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) ([]sqlIcebergTable, error) {
 		var tables []sqlIcebergTable
 		sel := tx.NewSelect().Model(&tables).
@@ -966,7 +1096,11 @@ func (c *Catalog) listTablesAll(ctx context.Context, namespace table.Identifier)
 
 	ret := make([]table.Identifier, len(tables))
 	for i, t := range tables {
-		ret[i] = append(strings.Split(t.TableNamespace, "."), t.TableName)
+		namespace, err := namespaceFromString(t.TableNamespace)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = append(namespace, t.TableName)
 	}
 
 	return ret, nil
@@ -979,8 +1113,7 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 		Column("namespace").Where("catalog_name = ?", c.name)
 
 	if len(parent) > 0 {
-		ns := strings.Join(parent, ".")
-		exists, err := c.namespaceExists(ctx, ns)
+		_, exists, err := c.resolveNamespaceKey(ctx, parent)
 		if err != nil {
 			return nil, err
 		}
@@ -988,9 +1121,8 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 			return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, strings.Join(parent, "."))
 		}
 
-		ns += "%"
-		tableQuery = tableQuery.Where("table_namespace like ?", ns)
-		nsQuery = nsQuery.Where("namespace like ?", ns)
+		tableQuery = whereNamespaceParent(tableQuery, "table_namespace", parent)
+		nsQuery = whereNamespaceParent(nsQuery, "namespace", parent)
 	}
 
 	namespaces, err := withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) ([]string, error) {
@@ -1009,9 +1141,15 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 		return nil, err
 	}
 
-	ret := make([]table.Identifier, len(namespaces))
-	for i, n := range namespaces {
-		ret[i] = strings.Split(n, ".")
+	ret := make([]table.Identifier, 0, len(namespaces))
+	for _, n := range namespaces {
+		ident, err := namespaceFromString(n)
+		if err != nil {
+			return nil, err
+		}
+		if len(parent) == 0 || (len(ident) >= len(parent) && slices.Equal(ident[:len(parent)], parent)) {
+			ret = append(ret, ident)
+		}
 	}
 
 	return ret, nil
@@ -1035,7 +1173,10 @@ func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 		return summary, err
 	}
 
-	nsToUpdate := strings.Join(namespace, ".")
+	nsToUpdate, err := c.namespaceKey(ctx, namespace)
+	if err != nil {
+		return summary, err
+	}
 
 	return summary, withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
 		var m *sqlIcebergNamespaceProps
@@ -1089,7 +1230,9 @@ func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 }
 
 func (c *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Identifier) (bool, error) {
-	return c.namespaceExists(ctx, strings.Join(namespace, "."))
+	_, exists, err := c.resolveNamespaceKey(ctx, namespace)
+
+	return exists, err
 }
 
 // CreateView creates a new view in the catalog.
@@ -1100,9 +1243,7 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 
 	nsIdent := catalog.NamespaceFromIdent(identifier)
 	viewIdent := catalog.TableNameFromIdent(identifier)
-	ns := strings.Join(nsIdent, ".")
-
-	exists, err := c.namespaceExists(ctx, ns)
+	ns, exists, err := c.resolveNamespaceKey(ctx, nsIdent)
 	if err != nil {
 		return err
 	}
@@ -1118,7 +1259,8 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 		return fmt.Errorf("%w: %s", catalog.ErrViewAlreadyExists, identifier)
 	}
 
-	loc, err := internal.ResolveTableLocation(ctx, "", ns, viewIdent, c.props, c.LoadNamespaceProperties)
+	loc, err := internal.ResolveTableLocationWithNamespace(
+		ctx, "", nsIdent, ns, viewIdent, c.props, c.LoadNamespaceProperties)
 	if err != nil {
 		return err
 	}
@@ -1170,8 +1312,11 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 		return nil, nil
 	}
 
+	ns := namespaceToString(namespace)
 	if len(namespace) > 0 {
-		exists, err := c.namespaceExists(ctx, strings.Join(namespace, "."))
+		var exists bool
+		var err error
+		ns, exists, err = c.resolveNamespaceKey(ctx, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -1180,7 +1325,6 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 		}
 	}
 
-	ns := strings.Join(namespace, ".")
 	views, err := withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) ([]sqlIcebergTable, error) {
 		var views []sqlIcebergTable
 		err := tx.NewSelect().Model(&views).
@@ -1197,7 +1341,11 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 
 	ret := make([]table.Identifier, len(views))
 	for i, v := range views {
-		ret[i] = append(strings.Split(v.TableNamespace, "."), v.TableName)
+		namespace, err := namespaceFromString(v.TableNamespace)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = append(namespace, v.TableName)
 	}
 
 	return ret, nil
@@ -1209,7 +1357,10 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 		return errViewsUnsupportedOnV0
 	}
 
-	ns := strings.Join(catalog.NamespaceFromIdent(identifier), ".")
+	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
+	if err != nil {
+		return err
+	}
 	viewName := catalog.TableNameFromIdent(identifier)
 
 	metadataLocation := ""
@@ -1281,7 +1432,10 @@ func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 		return false, nil
 	}
 
-	ns := strings.Join(catalog.NamespaceFromIdent(identifier), ".")
+	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
+	if err != nil {
+		return false, err
+	}
 	viewName := catalog.TableNameFromIdent(identifier)
 
 	return withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) (bool, error) {
@@ -1304,7 +1458,10 @@ func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (vi
 		return nil, errViewsUnsupportedOnV0
 	}
 
-	ns := strings.Join(catalog.NamespaceFromIdent(identifier), ".")
+	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
+	if err != nil {
+		return nil, err
+	}
 	viewName := catalog.TableNameFromIdent(identifier)
 
 	v, err := withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) (*sqlIcebergTable, error) {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1093,6 +1093,177 @@ func (s *SqliteCatalogTestSuite) TestListNamespaces() {
 	}
 }
 
+func (s *SqliteCatalogTestSuite) TestDottedNamespaceComponentsRemainDistinct() {
+	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
+	tag := databaseName()
+
+	for _, cat := range catalogs {
+		ctx := context.Background()
+		dotted := table.Identifier{"company_." + tag, "sales"}
+		hierarchical := table.Identifier{"company_", tag, "sales"}
+		dottedChild := append(slices.Clone(dotted), "regional")
+		hierarchicalChild := append(slices.Clone(hierarchical), "regional")
+		s.Require().NoError(cat.CreateNamespace(ctx, dotted, iceberg.Properties{"kind": "dotted"}))
+		s.Require().NoError(cat.CreateNamespace(ctx, hierarchical, iceberg.Properties{"kind": "hierarchical"}))
+		s.Require().NoError(cat.CreateNamespace(ctx, dottedChild, nil))
+		s.Require().NoError(cat.CreateNamespace(ctx, hierarchicalChild, nil))
+
+		namespaces, err := cat.ListNamespaces(ctx, nil)
+		s.Require().NoError(err)
+		s.Contains(namespaces, dotted)
+		s.Contains(namespaces, hierarchical)
+		s.Contains(namespaces, dottedChild)
+		s.Contains(namespaces, hierarchicalChild)
+
+		dottedNamespaces, err := cat.ListNamespaces(ctx, dotted)
+		s.Require().NoError(err)
+		s.ElementsMatch([]table.Identifier{dotted, dottedChild}, dottedNamespaces)
+		hierarchicalNamespaces, err := cat.ListNamespaces(ctx, hierarchical)
+		s.Require().NoError(err)
+		s.ElementsMatch([]table.Identifier{hierarchical, hierarchicalChild}, hierarchicalNamespaces)
+
+		dottedProps, err := cat.LoadNamespaceProperties(ctx, dotted)
+		s.Require().NoError(err)
+		s.Equal("dotted", dottedProps["kind"])
+		hierarchicalProps, err := cat.LoadNamespaceProperties(ctx, hierarchical)
+		s.Require().NoError(err)
+		s.Equal("hierarchical", hierarchicalProps["kind"])
+
+		dottedTable := append(slices.Clone(dotted), "orders")
+		hierarchicalTable := append(slices.Clone(hierarchical), "orders")
+		dottedCreated, err := cat.CreateTable(ctx, dottedTable, tableSchemaNested)
+		s.Require().NoError(err)
+		hierarchicalCreated, err := cat.CreateTable(ctx, hierarchicalTable, tableSchemaNested)
+		s.Require().NoError(err)
+		s.NotEqual(dottedCreated.Location(), hierarchicalCreated.Location())
+		s.NotEqual(dottedCreated.MetadataLocation(), hierarchicalCreated.MetadataLocation())
+
+		var dottedTables []table.Identifier
+		for ident, listErr := range cat.ListTables(ctx, dotted) {
+			s.Require().NoError(listErr)
+			dottedTables = append(dottedTables, ident)
+		}
+		s.Equal([]table.Identifier{dottedTable}, dottedTables)
+		var hierarchicalTables []table.Identifier
+		for ident, listErr := range cat.ListTables(ctx, hierarchical) {
+			s.Require().NoError(listErr)
+			hierarchicalTables = append(hierarchicalTables, ident)
+		}
+		s.Equal([]table.Identifier{hierarchicalTable}, hierarchicalTables)
+
+		renamed := append(slices.Clone(hierarchical), "renamed_orders")
+		loaded, err := cat.RenameTable(ctx, dottedTable, renamed)
+		s.Require().NoError(err)
+		s.Equal(renamed, loaded.Identifier())
+		_, err = cat.LoadTable(ctx, dottedTable)
+		s.ErrorIs(err, catalog.ErrNoSuchTable)
+		_, err = cat.LoadTable(ctx, hierarchicalTable)
+		s.Require().NoError(err)
+
+		s.Require().NoError(cat.DropTable(ctx, renamed))
+		s.Require().NoError(cat.DropTable(ctx, hierarchicalTable))
+		s.Require().NoError(cat.DropNamespace(ctx, dottedChild))
+		s.Require().NoError(cat.DropNamespace(ctx, hierarchicalChild))
+		s.Require().NoError(cat.DropNamespace(ctx, dotted))
+		s.Require().NoError(cat.DropNamespace(ctx, hierarchical))
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestDottedNamespaceUsesOwnLocationProperties() {
+	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
+
+	for i, cat := range catalogs {
+		ctx := context.Background()
+		namespace := table.Identifier{"company." + databaseName(), "sales"}
+		location := "file://" + filepath.Join(s.warehouse, fmt.Sprintf("dotted-location-%d", i))
+		s.Require().NoError(cat.CreateNamespace(ctx, namespace, iceberg.Properties{"location": location}))
+
+		tableIdent := append(slices.Clone(namespace), "orders")
+		createdTable, err := cat.CreateTable(ctx, tableIdent, tableSchemaNested)
+		s.Require().NoError(err)
+		s.Equal(location+"/orders", createdTable.Location())
+
+		viewIdent := append(slices.Clone(namespace), "orders_view")
+		s.Require().NoError(cat.CreateView(ctx, viewIdent, tableSchemaNested, "SELECT * FROM orders", nil))
+		createdView, err := cat.LoadView(ctx, viewIdent)
+		s.Require().NoError(err)
+		s.Equal(location+"/orders_view", createdView.Location())
+
+		s.Require().NoError(cat.DropView(ctx, viewIdent))
+		s.Require().NoError(cat.DropTable(ctx, tableIdent))
+		s.Require().NoError(cat.DropNamespace(ctx, namespace))
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestLegacyNamespaceEncodingPrefixRemainsReadable() {
+	ctx := context.Background()
+	cat := s.getCatalogSqlite()
+	db := s.getDB()
+	defer db.Close()
+
+	legacyName := "__iceberg_namespace_v1__:legacy_" + databaseName()
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO "iceberg_namespace_properties" `+
+			`("catalog_name", "namespace", "property_key", "property_value") VALUES (?, ?, ?, ?)`,
+		cat.Name(), legacyName, "owner", "legacy")
+	s.Require().NoError(err)
+
+	namespaces, err := cat.ListNamespaces(ctx, nil)
+	s.Require().NoError(err)
+	s.Contains(namespaces, table.Identifier{legacyName})
+
+	legacyIdent := table.Identifier{legacyName}
+	exists, err := cat.CheckNamespaceExists(ctx, legacyIdent)
+	s.Require().NoError(err)
+	s.True(exists)
+	children, err := cat.ListNamespaces(ctx, legacyIdent)
+	s.Require().NoError(err)
+	s.Contains(children, legacyIdent)
+	props, err := cat.LoadNamespaceProperties(ctx, legacyIdent)
+	s.Require().NoError(err)
+	s.Equal("legacy", props["owner"])
+	_, err = cat.UpdateNamespaceProperties(ctx, legacyIdent, nil, iceberg.Properties{"owner": "updated"})
+	s.Require().NoError(err)
+	props, err = cat.LoadNamespaceProperties(ctx, legacyIdent)
+	s.Require().NoError(err)
+	s.Equal("updated", props["owner"])
+
+	tableIdent := append(slices.Clone(legacyIdent), "orders")
+	created, err := cat.CreateTable(ctx, tableIdent, tableSchemaNested)
+	s.Require().NoError(err)
+	loaded, err := cat.LoadTable(ctx, tableIdent)
+	s.Require().NoError(err)
+	s.Equal(created.MetadataLocation(), loaded.MetadataLocation())
+
+	s.Require().NoError(cat.DropTable(ctx, tableIdent))
+	s.Require().NoError(cat.DropNamespace(ctx, legacyIdent))
+}
+
+func (s *SqliteCatalogTestSuite) TestListNamespacesEscapesLikeWildcards() {
+	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
+	tag := databaseName()
+
+	for _, cat := range catalogs {
+		ctx := context.Background()
+		parent := table.Identifier{"sales%_!" + tag}
+		child := append(slices.Clone(parent), "regional")
+		// This namespace would match the unescaped SQL pattern for parent.
+		decoy := table.Identifier{"salesZZX" + tag, "regional"}
+
+		s.Require().NoError(cat.CreateNamespace(ctx, parent, nil))
+		s.Require().NoError(cat.CreateNamespace(ctx, child, nil))
+		s.Require().NoError(cat.CreateNamespace(ctx, decoy, nil))
+
+		namespaces, err := cat.ListNamespaces(ctx, parent)
+		s.Require().NoError(err)
+		s.ElementsMatch([]table.Identifier{parent, child}, namespaces)
+
+		s.Require().NoError(cat.DropNamespace(ctx, child))
+		s.Require().NoError(cat.DropNamespace(ctx, parent))
+		s.Require().NoError(cat.DropNamespace(ctx, decoy))
+	}
+}
+
 func (s *SqliteCatalogTestSuite) TestLoadTableFromSelfIdentifier() {
 	tests := []struct {
 		cat   *sqlcat.Catalog


### PR DESCRIPTION
## Summary

- preserve the existing dot-joined representation for ordinary SQL namespaces
- use a versioned JSON representation only when a new namespace component contains a dot or would collide with the encoding marker
- resolve namespace properties from the original identifier components while using the encoded key for distinct default table and view locations
- decode namespaces consistently across tables, views, properties, existence checks, renames, and drops
- keep parent listing bounded in SQL for both legacy and encoded descendants, with escaped `LIKE` wildcards, then verify component ancestry after decoding

## Compatibility policy

Existing rows are not rewritten. A legacy value such as `a.b` keeps the catalog historical interpretation as the two-component namespace `[a, b]`; the catalog does not guess whether an old ambiguous row was originally intended as `[a.b]`. New dotted components use the reversible encoding, so `[a.b]` and `[a, b]` can coexist from this release forward without changing ordinary stored keys. Legacy rows containing the encoding marker fall back to their historical key when the suffix is not a canonical encoding.

## Testing

The regressions create the two previously colliding namespace shapes and verify their properties, default locations, and tables remain separate through create, list, load, rename, and drop. Dotted table and view creation also verifies namespace location properties are resolved from the original components. A directly inserted legacy marker-prefixed row remains usable through listing, property updates, table creation/load, and cleanup. Parent listing covers literal `%`, `_`, and the SQL escape character, including a namespace that would match an unescaped pattern.

- 20 repeated focused namespace test runs
- `go test ./catalog/sql ./catalog/hive ./catalog/glue`
- repository package tests excluding the locally hanging `io/gocloud` package
- `go vet ./catalog/sql ./catalog/hive ./catalog/glue ./catalog/internal`