### PR TITLE
fix(catalog): reject empty table identifiers

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -220,6 +220,10 @@ func TableNameFromIdent(ident table.Identifier) string {
 }
 
 func NamespaceFromIdent(ident table.Identifier) table.Identifier {
+	if len(ident) == 0 {
+		return nil
+	}
+
 	return ident[:len(ident)-1]
 }
 

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -863,8 +863,11 @@ func (c *Catalog) getDatabase(ctx context.Context, databaseName string) (*types.
 }
 
 func identifierToGlueTable(identifier table.Identifier) (string, string, error) {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return "", "", err
+	}
 	if len(identifier) != 2 {
-		return "", "", fmt.Errorf("invalid identifier, missing database name: %v", identifier)
+		return "", "", fmt.Errorf("%w: expected [database, table], got %v", catalog.ErrNoSuchTable, identifier)
 	}
 
 	return identifier[0], identifier[1], nil

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -2042,3 +2042,26 @@ func TestIsConcurrentModificationException(t *testing.T) {
 	require.False(t, isConcurrentModificationException(errors.New("network timeout")))
 	require.False(t, isConcurrentModificationException(nil))
 }
+
+func TestTableOperationsRejectEmptyIdentifiers(t *testing.T) {
+	ctx := context.Background()
+	cat := &Catalog{glueSvc: &mockGlueClient{}, props: iceberg.Properties{}}
+	valid := table.Identifier{"db", "table"}
+
+	for _, ident := range []table.Identifier{nil, {}, {"table"}} {
+		_, err := cat.CreateTable(ctx, ident, testSchema)
+		require.ErrorIs(t, err, catalog.ErrNoSuchNamespace)
+		_, err = cat.LoadTable(ctx, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, _, err = cat.CommitTable(ctx, ident, nil, nil)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		require.ErrorIs(t, cat.DropTable(ctx, ident), catalog.ErrNoSuchTable)
+		require.ErrorIs(t, cat.PurgeTable(ctx, ident), catalog.ErrNoSuchTable)
+		_, err = cat.RenameTable(ctx, ident, valid)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.RenameTable(ctx, valid, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.CheckTableExists(ctx, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	}
+}

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -897,8 +897,11 @@ func (c *Catalog) getIcebergTable(ctx context.Context, database, tableName strin
 }
 
 func identifierToTableName(identifier table.Identifier) (string, string, error) {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return "", "", err
+	}
 	if len(identifier) != 2 {
-		return "", "", fmt.Errorf("invalid identifier, expected [database, table]: %v", identifier)
+		return "", "", fmt.Errorf("%w: expected [database, table], got %v", catalog.ErrNoSuchTable, identifier)
 	}
 
 	return identifier[0], identifier[1], nil

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -254,7 +254,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 // identifier, version (with SQL representations), schema, and optional CreateViewOpt for location and properties.
 // Returns the created *view.View, or an error if the namespace is missing, a view/table already exists, or creation fails.
 func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, version *view.Version, schema *iceberg.Schema, opts ...catalog.CreateViewOpt) (*view.View, error) {
-	database, viewName, err := identifierToTableName(identifier)
+	database, viewName, err := identifierToViewName(identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +616,7 @@ func (c *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 
 // LoadView loads a view from the catalog.
 func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*view.View, error) {
-	database, viewName, err := identifierToTableName(identifier)
+	database, viewName, err := identifierToViewName(identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +650,7 @@ func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 
 // DropView drops a view from the catalog.
 func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {
-	database, viewName, err := identifierToTableName(identifier)
+	database, viewName, err := identifierToViewName(identifier)
 	if err != nil {
 		return err
 	}
@@ -691,7 +691,7 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 
 // CheckViewExists checks if a view exists in the catalog.
 func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifier) (bool, error) {
-	database, viewName, err := identifierToTableName(identifier)
+	database, viewName, err := identifierToViewName(identifier)
 	if err != nil {
 		return false, err
 	}
@@ -897,11 +897,19 @@ func (c *Catalog) getIcebergTable(ctx context.Context, database, tableName strin
 }
 
 func identifierToTableName(identifier table.Identifier) (string, string, error) {
-	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+	return identifierToObjectName(identifier, catalog.ValidateTableIdentifier, catalog.ErrNoSuchTable, "table")
+}
+
+func identifierToViewName(identifier table.Identifier) (string, string, error) {
+	return identifierToObjectName(identifier, catalog.ValidateViewIdentifier, catalog.ErrNoSuchView, "view")
+}
+
+func identifierToObjectName(identifier table.Identifier, validate func(table.Identifier) error, notFound error, objectType string) (string, string, error) {
+	if err := validate(identifier); err != nil {
 		return "", "", err
 	}
 	if len(identifier) != 2 {
-		return "", "", fmt.Errorf("%w: expected [database, table], got %v", catalog.ErrNoSuchTable, identifier)
+		return "", "", fmt.Errorf("%w: expected [database, %s], got %v", notFound, objectType, identifier)
 	}
 
 	return identifier[0], identifier[1], nil

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -1468,15 +1468,23 @@ func TestCreateView_TableAlreadyExists(t *testing.T) {
 }
 
 func TestCreateView_InvalidIdentifier(t *testing.T) {
-	assert := require.New(t)
-
 	cat := NewCatalogWithClient(&mockHiveClient{}, iceberg.Properties{})
-
-	ver, _ := view.NewVersionFromSQL(1, 0, "SELECT 1", table.Identifier{"db"})
 	schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "col", Type: iceberg.PrimitiveTypes.Int32, Required: true})
 
-	_, err := cat.CreateView(context.Background(), table.Identifier{"only_db"}, ver, schema)
-	assert.Error(err)
+	for _, ident := range []table.Identifier{nil, {}, {"only_db"}} {
+		ver, err := view.NewVersionFromSQL(1, 0, "SELECT 1", table.Identifier{"db"})
+		require.NoError(t, err)
+		_, err = cat.CreateView(context.Background(), ident, ver, schema)
+		require.ErrorIs(t, err, catalog.ErrNoSuchView)
+		require.NotErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.LoadView(context.Background(), ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchView)
+		require.NotErrorIs(t, err, catalog.ErrNoSuchTable)
+		require.ErrorIs(t, cat.DropView(context.Background(), ident), catalog.ErrNoSuchView)
+		_, err = cat.CheckViewExists(context.Background(), ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchView)
+		require.NotErrorIs(t, err, catalog.ErrNoSuchTable)
+	}
 }
 
 func TestCreateView_Success(t *testing.T) {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -1577,3 +1577,26 @@ func TestCreateView_VersionNoSQLRepresentation(t *testing.T) {
 
 	mockClient.AssertExpectations(t)
 }
+
+func TestTableOperationsRejectEmptyIdentifiers(t *testing.T) {
+	ctx := context.Background()
+	cat := NewCatalogWithClient(&mockHiveClient{}, iceberg.Properties{})
+	valid := table.Identifier{"db", "table"}
+
+	for _, ident := range []table.Identifier{nil, {}, {"table"}} {
+		_, err := cat.CreateTable(ctx, ident, testSchema)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.LoadTable(ctx, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, _, err = cat.CommitTable(ctx, ident, nil, nil)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		require.ErrorIs(t, cat.DropTable(ctx, ident), catalog.ErrNoSuchTable)
+		require.ErrorIs(t, cat.PurgeTable(ctx, ident), catalog.ErrNoSuchTable)
+		_, err = cat.RenameTable(ctx, ident, valid)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.RenameTable(ctx, valid, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+		_, err = cat.CheckTableExists(ctx, ident)
+		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	}
+}

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -45,6 +45,11 @@ func TestValidateTableIdentifier(t *testing.T) {
 	}
 }
 
+func TestNamespaceFromEmptyIdentifier(t *testing.T) {
+	require.Nil(t, catalog.NamespaceFromIdent(nil))
+	require.Nil(t, catalog.NamespaceFromIdent(table.Identifier{}))
+}
+
 func TestValidateViewIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view"}))
 

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -122,6 +122,13 @@ func createStagedTable(
 	sc *iceberg.Schema,
 	opts ...catalog.CreateTableOpt,
 ) (table.StagedTable, error) {
+	if len(ident) < 2 {
+		return table.StagedTable{}, fmt.Errorf("%w: missing namespace or invalid identifier %v", catalog.ErrNoSuchNamespace, ident)
+	}
+	if err := catalog.ValidateTableIdentifier(ident); err != nil {
+		return table.StagedTable{}, err
+	}
+
 	var cfg catalog.CreateTableCfg
 	for _, opt := range opts {
 		opt(&cfg)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -662,6 +662,10 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 }
 
 func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	if err := catalog.ValidateTableIdentifier(ident); err != nil {
+		return nil, "", err
+	}
+
 	ns := catalog.NamespaceFromIdent(ident)
 	tblName := catalog.TableNameFromIdent(ident)
 	nsKey, err := c.namespaceKey(ctx, ns)
@@ -752,6 +756,10 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 }
 
 func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return nil, err
+	}
+
 	ns := catalog.NamespaceFromIdent(identifier)
 	tbl := catalog.TableNameFromIdent(identifier)
 	nsKey, err := c.namespaceKey(ctx, ns)
@@ -799,6 +807,10 @@ func (c *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 }
 
 func (c *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return err
+	}
+
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
 	if err != nil {
 		return err
@@ -833,6 +845,10 @@ func (c *Catalog) DropTable(ctx context.Context, identifier table.Identifier) er
 }
 
 func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) error {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return err
+	}
+
 	tbl, err := c.LoadTable(ctx, identifier)
 	if err != nil {
 		return err
@@ -853,6 +869,13 @@ func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 }
 
 func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error) {
+	if err := catalog.ValidateTableIdentifier(from); err != nil {
+		return nil, err
+	}
+	if err := catalog.ValidateTableIdentifier(to); err != nil {
+		return nil, err
+	}
+
 	fromNs, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(from))
 	if err != nil {
 		return nil, err
@@ -919,6 +942,10 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 }
 
 func (c *Catalog) CheckTableExists(ctx context.Context, identifier table.Identifier) (bool, error) {
+	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
+		return false, err
+	}
+
 	_, err := c.LoadTable(ctx, identifier)
 	if err != nil {
 		if errors.Is(err, catalog.ErrNoSuchTable) {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -987,6 +987,31 @@ func (s *SqliteCatalogTestSuite) TestCreateTableWithoutNamespace() {
 	}
 }
 
+func (s *SqliteCatalogTestSuite) TestTableOperationsRejectEmptyIdentifiers() {
+	ctx := context.Background()
+	valid := table.Identifier{"db", "table"}
+
+	for _, cat := range []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()} {
+		for _, ident := range []table.Identifier{nil, {}, {"table"}} {
+			_, err := cat.CreateTable(ctx, ident, tableSchemaNested)
+			s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+
+			_, _, err = cat.CommitTable(ctx, ident, nil, nil)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			_, err = cat.LoadTable(ctx, ident)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			s.ErrorIs(cat.DropTable(ctx, ident), catalog.ErrNoSuchTable)
+			s.ErrorIs(cat.PurgeTable(ctx, ident), catalog.ErrNoSuchTable)
+			_, err = cat.RenameTable(ctx, ident, valid)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			_, err = cat.RenameTable(ctx, valid, ident)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+			_, err = cat.CheckTableExists(ctx, ident)
+			s.ErrorIs(err, catalog.ErrNoSuchTable)
+		}
+	}
+}
+
 func (s *SqliteCatalogTestSuite) TestListTables() {
 	catalogs := []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()}
 	tbl1, tbl2 := s.randomTableIdentifier(), s.randomHierarchicalIdentifier()


### PR DESCRIPTION
## Summary

`NamespaceFromIdent` sliced with an upper bound of -1 for an empty identifier, allowing invalid public API input to panic. The shared staging helper also derived the namespace before validating the table identifier.

`NamespaceFromIdent` now returns nil for empty input, and table creation validates before resolving locations or writing metadata. SQL table operations validate at their public boundaries, while Glue and Hive identifier conversion use the shared typed validators. Hive view operations retain `ErrNoSuchView` for malformed view identifiers instead of leaking the table-specific error from their shared shape parser.

Existing error conventions are preserved: missing namespaces during creation return `ErrNoSuchNamespace`; table lookup and mutation operations return `ErrNoSuchTable`; view operations return `ErrNoSuchView`.

## Testing

Regression coverage passes nil, empty, and one-component identifiers through create, load, commit, drop, purge, rename, and existence checks for SQL, Glue, and Hive. Hive create/load/drop/exists view operations also verify the view-specific typed error. Backend mocks receive no calls for rejected identifiers.

- `go test ./catalog/...`
- `go test ./...`
- `golangci-lint run --timeout=10m`