### PR TITLE
fix(table): return defensive metadata getter copies

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1761,15 +1761,15 @@ func (c *commonMetadata) Properties() iceberg.Properties {
 }
 
 func (c *commonMetadata) Statistics() iter.Seq[StatisticsFile] {
-	return slices.Values(c.StatisticsList)
+	return slices.Values(cloneStatisticsFiles(c.StatisticsList))
 }
 
 func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile] {
-	return slices.Values(c.PartitionStatsList)
+	return slices.Values(slices.Clone(c.PartitionStatsList))
 }
 
 func (c *commonMetadata) EncryptionKeys() iter.Seq[EncryptionKey] {
-	return slices.Values(c.EncryptionKeyList)
+	return slices.Values(cloneEncryptionKeys(c.EncryptionKeyList))
 }
 
 func cloneSchema(schema *iceberg.Schema) *iceberg.Schema {
@@ -1785,6 +1785,10 @@ func cloneSchema(schema *iceberg.Schema) *iceberg.Schema {
 }
 
 func cloneSchemas(schemas []*iceberg.Schema) []*iceberg.Schema {
+	if schemas == nil {
+		return nil
+	}
+
 	clones := make([]*iceberg.Schema, len(schemas))
 	for i, schema := range schemas {
 		clones[i] = cloneSchema(schema)
@@ -1797,9 +1801,36 @@ func cloneNestedFields(fields []iceberg.NestedField) []iceberg.NestedField {
 	clones := slices.Clone(fields)
 	for i := range clones {
 		clones[i].Type = cloneSchemaType(clones[i].Type)
+		clones[i].InitialDefault = cloneDefault(clones[i].InitialDefault)
+		clones[i].WriteDefault = cloneDefault(clones[i].WriteDefault)
 	}
 
 	return clones
+}
+
+func cloneDefault(value any) any {
+	switch value := value.(type) {
+	case []byte:
+		return slices.Clone(value)
+	case iceberg.BinaryLiteral:
+		return iceberg.BinaryLiteral(slices.Clone([]byte(value)))
+	case iceberg.FixedLiteral:
+		return iceberg.FixedLiteral(slices.Clone([]byte(value)))
+	case []any:
+		clones := make([]any, len(value))
+		for i, item := range value {
+			clones[i] = cloneDefault(item)
+		}
+		return clones
+	case map[string]any:
+		clones := make(map[string]any, len(value))
+		for key, item := range value {
+			clones[key] = cloneDefault(item)
+		}
+		return clones
+	default:
+		return value
+	}
 }
 
 func cloneSchemaType(typ iceberg.Type) iceberg.Type {
@@ -1836,6 +1867,10 @@ func clonePartitionSpec(spec iceberg.PartitionSpec) iceberg.PartitionSpec {
 }
 
 func clonePartitionSpecs(specs []iceberg.PartitionSpec) []iceberg.PartitionSpec {
+	if specs == nil {
+		return nil
+	}
+
 	clones := make([]iceberg.PartitionSpec, len(specs))
 	for i, spec := range specs {
 		clones[i] = clonePartitionSpec(spec)
@@ -1901,6 +1936,10 @@ func cloneSnapshotPtr(snapshot *Snapshot) *Snapshot {
 }
 
 func cloneSnapshots(snapshots []Snapshot) []Snapshot {
+	if snapshots == nil {
+		return nil
+	}
+
 	clones := make([]Snapshot, len(snapshots))
 	for i, snapshot := range snapshots {
 		clones[i] = cloneSnapshot(snapshot)
@@ -1921,9 +1960,56 @@ func cloneSortOrder(order SortOrder) SortOrder {
 }
 
 func cloneSortOrders(orders []SortOrder) []SortOrder {
+	if orders == nil {
+		return nil
+	}
+
 	clones := make([]SortOrder, len(orders))
 	for i, order := range orders {
 		clones[i] = cloneSortOrder(order)
+	}
+
+	return clones
+}
+
+func cloneStatisticsFiles(stats []StatisticsFile) []StatisticsFile {
+	if stats == nil {
+		return nil
+	}
+
+	clones := make([]StatisticsFile, len(stats))
+	for i, stat := range stats {
+		clones[i] = stat
+		if stat.KeyMetadata != nil {
+			value := *stat.KeyMetadata
+			clones[i].KeyMetadata = &value
+		}
+		if stat.BlobMetadata != nil {
+			clones[i].BlobMetadata = make([]BlobMetadata, len(stat.BlobMetadata))
+			for j, blob := range stat.BlobMetadata {
+				clones[i].BlobMetadata[j] = blob
+				clones[i].BlobMetadata[j].Fields = slices.Clone(blob.Fields)
+				clones[i].BlobMetadata[j].Properties = maps.Clone(blob.Properties)
+			}
+		}
+	}
+
+	return clones
+}
+
+func cloneEncryptionKeys(keys []EncryptionKey) []EncryptionKey {
+	if keys == nil {
+		return nil
+	}
+
+	clones := make([]EncryptionKey, len(keys))
+	for i, key := range keys {
+		clones[i] = key
+		if key.EncryptedByID != nil {
+			value := *key.EncryptedByID
+			clones[i].EncryptedByID = &value
+		}
+		clones[i].Properties = maps.Clone(key.Properties)
 	}
 
 	return clones

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1658,18 +1658,18 @@ func (c *commonMetadata) TableUUID() uuid.UUID       { return c.UUID }
 func (c *commonMetadata) Location() string           { return c.Loc }
 func (c *commonMetadata) LastUpdatedMillis() int64   { return c.LastUpdatedMS }
 func (c *commonMetadata) LastColumnID() int          { return c.LastColumnId }
-func (c *commonMetadata) Schemas() []*iceberg.Schema { return slices.Clone(c.SchemaList) }
+func (c *commonMetadata) Schemas() []*iceberg.Schema { return cloneSchemas(c.SchemaList) }
 func (c *commonMetadata) CurrentSchema() *iceberg.Schema {
 	for _, s := range c.SchemaList {
 		if s.ID == c.CurrentSchemaID {
-			return s
+			return cloneSchema(s)
 		}
 	}
 	panic("should never get here")
 }
 
 func (c *commonMetadata) PartitionSpecs() []iceberg.PartitionSpec {
-	return slices.Clone(c.Specs)
+	return clonePartitionSpecs(c.Specs)
 }
 
 func (c *commonMetadata) DefaultPartitionSpec() int {
@@ -1679,17 +1679,19 @@ func (c *commonMetadata) DefaultPartitionSpec() int {
 func (c *commonMetadata) PartitionSpec() iceberg.PartitionSpec {
 	for _, s := range c.Specs {
 		if s.ID() == c.DefaultSpecID {
-			return s
+			return clonePartitionSpec(s)
 		}
 	}
 
-	return *iceberg.UnpartitionedSpec
+	return clonePartitionSpec(*iceberg.UnpartitionedSpec)
 }
 
 func (c *commonMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
 	for _, s := range c.Specs {
 		if s.ID() == id {
-			return &s
+			clone := clonePartitionSpec(s)
+
+			return &clone
 		}
 	}
 
@@ -1768,6 +1770,78 @@ func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile]
 
 func (c *commonMetadata) EncryptionKeys() iter.Seq[EncryptionKey] {
 	return slices.Values(c.EncryptionKeyList)
+}
+
+func cloneSchema(schema *iceberg.Schema) *iceberg.Schema {
+	if schema == nil {
+		return nil
+	}
+
+	return iceberg.NewSchemaWithIdentifiers(
+		schema.ID,
+		slices.Clone(schema.IdentifierFieldIDs),
+		cloneNestedFields(schema.Fields())...,
+	)
+}
+
+func cloneSchemas(schemas []*iceberg.Schema) []*iceberg.Schema {
+	clones := make([]*iceberg.Schema, len(schemas))
+	for i, schema := range schemas {
+		clones[i] = cloneSchema(schema)
+	}
+
+	return clones
+}
+
+func cloneNestedFields(fields []iceberg.NestedField) []iceberg.NestedField {
+	clones := slices.Clone(fields)
+	for i := range clones {
+		clones[i].Type = cloneSchemaType(clones[i].Type)
+	}
+
+	return clones
+}
+
+func cloneSchemaType(typ iceberg.Type) iceberg.Type {
+	switch typ := typ.(type) {
+	case *iceberg.StructType:
+		return &iceberg.StructType{FieldList: cloneNestedFields(typ.FieldList)}
+	case *iceberg.ListType:
+		return &iceberg.ListType{
+			ElementID:       typ.ElementID,
+			Element:         cloneSchemaType(typ.Element),
+			ElementRequired: typ.ElementRequired,
+		}
+	case *iceberg.MapType:
+		return &iceberg.MapType{
+			KeyID:         typ.KeyID,
+			KeyType:       cloneSchemaType(typ.KeyType),
+			ValueID:       typ.ValueID,
+			ValueType:     cloneSchemaType(typ.ValueType),
+			ValueRequired: typ.ValueRequired,
+		}
+	default:
+		return typ
+	}
+}
+
+func clonePartitionSpec(spec iceberg.PartitionSpec) iceberg.PartitionSpec {
+	fields := make([]iceberg.PartitionField, spec.NumFields())
+	for i := range fields {
+		fields[i] = spec.Field(i)
+		fields[i].SourceIDs = slices.Clone(fields[i].SourceIDs)
+	}
+
+	return iceberg.NewPartitionSpecID(spec.ID(), fields...)
+}
+
+func clonePartitionSpecs(specs []iceberg.PartitionSpec) []iceberg.PartitionSpec {
+	clones := make([]iceberg.PartitionSpec, len(specs))
+	for i, spec := range specs {
+		clones[i] = clonePartitionSpec(spec)
+	}
+
+	return clones
 }
 
 func cloneSnapshotRef(ref SnapshotRef) SnapshotRef {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1563,6 +1563,7 @@ func (c *commonMetadata) Refs() iter.Seq2[string, SnapshotRef] {
 		}
 	}
 }
+
 func (c *commonMetadata) SnapshotLogs() iter.Seq[SnapshotLogEntry] {
 	return slices.Values(c.SnapshotLog)
 }
@@ -1701,12 +1702,14 @@ func (c *commonMetadata) LastPartitionSpecID() *int {
 	}
 
 	id := *c.LastPartitionID
+
 	return &id
 }
 
 func (c *commonMetadata) Snapshots() []Snapshot {
 	return cloneSnapshots(c.SnapshotList)
 }
+
 func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 	for i := range c.SnapshotList {
 		if c.SnapshotList[i].SnapshotID == id {
@@ -1736,6 +1739,7 @@ func (c *commonMetadata) CurrentSnapshot() *Snapshot {
 func (c *commonMetadata) SortOrders() []SortOrder {
 	return cloneSortOrders(c.SortOrderList)
 }
+
 func (c *commonMetadata) SortOrder() SortOrder {
 	for _, s := range c.SortOrderList {
 		if s.OrderID() == c.DefaultSortOrderID {
@@ -1818,6 +1822,7 @@ func cloneSnapshotPtr(snapshot *Snapshot) *Snapshot {
 	}
 
 	clone := cloneSnapshot(*snapshot)
+
 	return &clone
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1821,12 +1821,14 @@ func cloneDefault(value any) any {
 		for i, item := range value {
 			clones[i] = cloneDefault(item)
 		}
+
 		return clones
 	case map[string]any:
 		clones := make(map[string]any, len(value))
 		for key, item := range value {
 			clones[key] = cloneDefault(item)
 		}
+
 		return clones
 	default:
 		return value
@@ -1860,7 +1862,6 @@ func clonePartitionSpec(spec iceberg.PartitionSpec) iceberg.PartitionSpec {
 	fields := make([]iceberg.PartitionField, spec.NumFields())
 	for i := range fields {
 		fields[i] = spec.Field(i)
-		fields[i].SourceIDs = slices.Clone(fields[i].SourceIDs)
 	}
 
 	return iceberg.NewPartitionSpecID(spec.ID(), fields...)

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1550,8 +1550,19 @@ func initCommonMetadataForDeserialization() commonMetadata {
 	}
 }
 
-func (c *commonMetadata) Ref() SnapshotRef                     { return c.SnapshotRefs[MainBranch] }
-func (c *commonMetadata) Refs() iter.Seq2[string, SnapshotRef] { return maps.All(c.SnapshotRefs) }
+func (c *commonMetadata) Ref() SnapshotRef {
+	return cloneSnapshotRef(c.SnapshotRefs[MainBranch])
+}
+
+func (c *commonMetadata) Refs() iter.Seq2[string, SnapshotRef] {
+	return func(yield func(string, SnapshotRef) bool) {
+		for name, ref := range c.SnapshotRefs {
+			if !yield(name, cloneSnapshotRef(ref)) {
+				return
+			}
+		}
+	}
+}
 func (c *commonMetadata) SnapshotLogs() iter.Seq[SnapshotLogEntry] {
 	return slices.Values(c.SnapshotLog)
 }
@@ -1646,7 +1657,7 @@ func (c *commonMetadata) TableUUID() uuid.UUID       { return c.UUID }
 func (c *commonMetadata) Location() string           { return c.Loc }
 func (c *commonMetadata) LastUpdatedMillis() int64   { return c.LastUpdatedMS }
 func (c *commonMetadata) LastColumnID() int          { return c.LastColumnId }
-func (c *commonMetadata) Schemas() []*iceberg.Schema { return c.SchemaList }
+func (c *commonMetadata) Schemas() []*iceberg.Schema { return slices.Clone(c.SchemaList) }
 func (c *commonMetadata) CurrentSchema() *iceberg.Schema {
 	for _, s := range c.SchemaList {
 		if s.ID == c.CurrentSchemaID {
@@ -1657,7 +1668,7 @@ func (c *commonMetadata) CurrentSchema() *iceberg.Schema {
 }
 
 func (c *commonMetadata) PartitionSpecs() []iceberg.PartitionSpec {
-	return c.Specs
+	return slices.Clone(c.Specs)
 }
 
 func (c *commonMetadata) DefaultPartitionSpec() int {
@@ -1684,12 +1695,22 @@ func (c *commonMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
 	return nil
 }
 
-func (c *commonMetadata) LastPartitionSpecID() *int { return c.LastPartitionID }
-func (c *commonMetadata) Snapshots() []Snapshot     { return c.SnapshotList }
+func (c *commonMetadata) LastPartitionSpecID() *int {
+	if c.LastPartitionID == nil {
+		return nil
+	}
+
+	id := *c.LastPartitionID
+	return &id
+}
+
+func (c *commonMetadata) Snapshots() []Snapshot {
+	return cloneSnapshots(c.SnapshotList)
+}
 func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 	for i := range c.SnapshotList {
 		if c.SnapshotList[i].SnapshotID == id {
-			return &c.SnapshotList[i]
+			return cloneSnapshotPtr(&c.SnapshotList[i])
 		}
 	}
 
@@ -1712,15 +1733,17 @@ func (c *commonMetadata) CurrentSnapshot() *Snapshot {
 	return c.SnapshotByID(*c.CurrentSnapshotID)
 }
 
-func (c *commonMetadata) SortOrders() []SortOrder { return c.SortOrderList }
+func (c *commonMetadata) SortOrders() []SortOrder {
+	return cloneSortOrders(c.SortOrderList)
+}
 func (c *commonMetadata) SortOrder() SortOrder {
 	for _, s := range c.SortOrderList {
 		if s.OrderID() == c.DefaultSortOrderID {
-			return s
+			return cloneSortOrder(s)
 		}
 	}
 
-	return UnsortedSortOrder
+	return cloneSortOrder(UnsortedSortOrder)
 }
 
 func (c *commonMetadata) DefaultSortOrder() int {
@@ -1728,7 +1751,7 @@ func (c *commonMetadata) DefaultSortOrder() int {
 }
 
 func (c *commonMetadata) Properties() iceberg.Properties {
-	return c.Props
+	return maps.Clone(c.Props)
 }
 
 func (c *commonMetadata) Statistics() iter.Seq[StatisticsFile] {
@@ -1741,6 +1764,90 @@ func (c *commonMetadata) PartitionStatistics() iter.Seq[PartitionStatisticsFile]
 
 func (c *commonMetadata) EncryptionKeys() iter.Seq[EncryptionKey] {
 	return slices.Values(c.EncryptionKeyList)
+}
+
+func cloneSnapshotRef(ref SnapshotRef) SnapshotRef {
+	clone := ref
+	if ref.MinSnapshotsToKeep != nil {
+		value := *ref.MinSnapshotsToKeep
+		clone.MinSnapshotsToKeep = &value
+	}
+	if ref.MaxSnapshotAgeMs != nil {
+		value := *ref.MaxSnapshotAgeMs
+		clone.MaxSnapshotAgeMs = &value
+	}
+	if ref.MaxRefAgeMs != nil {
+		value := *ref.MaxRefAgeMs
+		clone.MaxRefAgeMs = &value
+	}
+
+	return clone
+}
+
+func cloneSnapshot(snapshot Snapshot) Snapshot {
+	clone := snapshot
+	if snapshot.ParentSnapshotID != nil {
+		value := *snapshot.ParentSnapshotID
+		clone.ParentSnapshotID = &value
+	}
+	if snapshot.SchemaID != nil {
+		value := *snapshot.SchemaID
+		clone.SchemaID = &value
+	}
+	if snapshot.FirstRowID != nil {
+		value := *snapshot.FirstRowID
+		clone.FirstRowID = &value
+	}
+	if snapshot.AddedRows != nil {
+		value := *snapshot.AddedRows
+		clone.AddedRows = &value
+	}
+	if snapshot.Summary != nil {
+		clone.Summary = &Summary{
+			Operation:  snapshot.Summary.Operation,
+			Properties: maps.Clone(snapshot.Summary.Properties),
+		}
+	}
+
+	return clone
+}
+
+func cloneSnapshotPtr(snapshot *Snapshot) *Snapshot {
+	if snapshot == nil {
+		return nil
+	}
+
+	clone := cloneSnapshot(*snapshot)
+	return &clone
+}
+
+func cloneSnapshots(snapshots []Snapshot) []Snapshot {
+	clones := make([]Snapshot, len(snapshots))
+	for i, snapshot := range snapshots {
+		clones[i] = cloneSnapshot(snapshot)
+	}
+
+	return clones
+}
+
+func cloneSortOrder(order SortOrder) SortOrder {
+	clone := order
+	clone.fields = make([]SortField, len(order.fields))
+	for i, field := range order.fields {
+		clone.fields[i] = field
+		clone.fields[i].SourceIDs = slices.Clone(field.SourceIDs)
+	}
+
+	return clone
+}
+
+func cloneSortOrders(orders []SortOrder) []SortOrder {
+	clones := make([]SortOrder, len(orders))
+	for i, order := range orders {
+		clones[i] = cloneSortOrder(order)
+	}
+
+	return clones
 }
 
 // preValidate updates values in the metadata struct with defaults based on

--- a/table/metadata_getters_test.go
+++ b/table/metadata_getters_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -30,11 +31,15 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 	refMinSnapshots := 2
 	refMaxSnapshotAge := int64(3)
 	refMaxAge := int64(4)
+	keyMetadata := "key-metadata"
+	encryptedByID := "root-key"
 	metadata := commonMetadata{
 		CurrentSchemaID: 1,
 		DefaultSpecID:   1,
 		SchemaList: []*iceberg.Schema{iceberg.NewSchemaWithIdentifiers(1, []int{1}, iceberg.NestedField{
 			ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+			InitialDefault: iceberg.BinaryLiteral{1, 2},
+			WriteDefault:   iceberg.FixedLiteral{3, 4},
 		})},
 		Specs: []iceberg.PartitionSpec{iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
 			SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
@@ -58,6 +63,26 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 			},
 		},
 		Props: map[string]string{"owner": "iceberg"},
+		StatisticsList: []StatisticsFile{{
+			SnapshotID:     2,
+			StatisticsPath: "stats.puffin",
+			KeyMetadata:    &keyMetadata,
+			BlobMetadata: []BlobMetadata{{
+				Type:       BlobTypeApacheDatasketchesThetaV1,
+				Fields:     []int32{1},
+				Properties: map[string]string{"source": "test"},
+			}},
+		}},
+		PartitionStatsList: []PartitionStatisticsFile{{
+			SnapshotID:     2,
+			StatisticsPath: "partition-stats.puffin",
+		}},
+		EncryptionKeyList: []EncryptionKey{{
+			KeyID:                "key-1",
+			EncryptedKeyMetadata: "encrypted",
+			EncryptedByID:        &encryptedByID,
+			Properties:           map[string]string{"scope": "table"},
+		}},
 		SortOrderList: []SortOrder{{
 			orderID: 1,
 			fields: []SortField{{
@@ -79,11 +104,14 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 	nestedFields := schemas[0].Fields()
 	nestedFields[0].Name = "mutated"
 	nestedFields[0].Type = iceberg.PrimitiveTypes.String
+	nestedFields[0].InitialDefault.(iceberg.BinaryLiteral)[0] = 99
+	nestedFields[0].WriteDefault.(iceberg.FixedLiteral)[0] = 99
 
 	partitionSpecs := metadata.PartitionSpecs()
 	partitionField := partitionSpecs[0].Field(0)
 	partitionField.SourceIDs[0] = 99
 	partitionField.Name = "mutated"
+	require.Equal(t, []int{1}, metadata.Specs[0].Field(0).SourceIDs)
 
 	currentSchema := metadata.CurrentSchema()
 	currentSchema.ID = 100
@@ -108,6 +136,18 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 	require.NotNil(t, current)
 	current.Summary.Properties["source"] = "mutated"
 
+	statistics := slices.Collect(metadata.Statistics())
+	statistics[0].BlobMetadata[0].Fields[0] = 99
+	statistics[0].BlobMetadata[0].Properties["source"] = "mutated"
+	*statistics[0].KeyMetadata = "mutated"
+
+	partitionStatistics := slices.Collect(metadata.PartitionStatistics())
+	partitionStatistics[0].StatisticsPath = "mutated"
+
+	encryptionKeys := slices.Collect(metadata.EncryptionKeys())
+	*encryptionKeys[0].EncryptedByID = "mutated"
+	encryptionKeys[0].Properties["scope"] = "mutated"
+
 	refs := metadata.Ref()
 	*refs.MinSnapshotsToKeep = 99
 	for _, ref := range metadata.Refs() {
@@ -119,6 +159,7 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 	for _, field := range fields {
 		field.SourceIDs[0] = 99
 	}
+	require.Equal(t, []int{10}, metadata.SortOrderList[0].fields[0].SourceIDs)
 
 	got, err := json.Marshal(metadata)
 	require.NoError(t, err)

--- a/table/metadata_getters_test.go
+++ b/table/metadata_getters_test.go
@@ -31,6 +31,14 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 	refMaxSnapshotAge := int64(3)
 	refMaxAge := int64(4)
 	metadata := commonMetadata{
+		CurrentSchemaID: 1,
+		DefaultSpecID:   1,
+		SchemaList: []*iceberg.Schema{iceberg.NewSchemaWithIdentifiers(1, []int{1}, iceberg.NestedField{
+			ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+		})},
+		Specs: []iceberg.PartitionSpec{iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+		})},
 		SnapshotList: []Snapshot{{
 			SnapshotID:       2,
 			ParentSnapshotID: &parentID,
@@ -64,6 +72,28 @@ func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
 
 	properties := metadata.Properties()
 	properties["owner"] = "mutated"
+
+	schemas := metadata.Schemas()
+	schemas[0].ID = 99
+	schemas[0].IdentifierFieldIDs[0] = 99
+	nestedFields := schemas[0].Fields()
+	nestedFields[0].Name = "mutated"
+	nestedFields[0].Type = iceberg.PrimitiveTypes.String
+
+	partitionSpecs := metadata.PartitionSpecs()
+	partitionField := partitionSpecs[0].Field(0)
+	partitionField.SourceIDs[0] = 99
+	partitionField.Name = "mutated"
+
+	currentSchema := metadata.CurrentSchema()
+	currentSchema.ID = 100
+	defaultSpec := metadata.PartitionSpec()
+	defaultSpecField := defaultSpec.Field(0)
+	defaultSpecField.SourceIDs[0] = 100
+	byIDSpec := metadata.PartitionSpecByID(1)
+	require.NotNil(t, byIDSpec)
+	byIDField := byIDSpec.Field(0)
+	byIDField.SourceIDs[0] = 101
 
 	snapshots := metadata.Snapshots()
 	snapshots[0].ParentSnapshotID = new(int64)

--- a/table/metadata_getters_test.go
+++ b/table/metadata_getters_test.go
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
+	parentID := int64(1)
+	refMinSnapshots := 2
+	refMaxSnapshotAge := int64(3)
+	refMaxAge := int64(4)
+	metadata := commonMetadata{
+		SnapshotList: []Snapshot{{
+			SnapshotID:       2,
+			ParentSnapshotID: &parentID,
+			Summary: &Summary{
+				Operation:  OpAppend,
+				Properties: map[string]string{"source": "test"},
+			},
+		}},
+		CurrentSnapshotID: &[]int64{2}[0],
+		SnapshotRefs: map[string]SnapshotRef{
+			MainBranch: {
+				SnapshotID:         2,
+				SnapshotRefType:    BranchRef,
+				MinSnapshotsToKeep: &refMinSnapshots,
+				MaxSnapshotAgeMs:   &refMaxSnapshotAge,
+				MaxRefAgeMs:        &refMaxAge,
+			},
+		},
+		Props: map[string]string{"owner": "iceberg"},
+		SortOrderList: []SortOrder{{
+			orderID: 1,
+			fields: []SortField{{
+				SourceIDs: []int{10},
+				Transform: iceberg.IdentityTransform{},
+			}},
+		}},
+	}
+
+	original, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	properties := metadata.Properties()
+	properties["owner"] = "mutated"
+
+	snapshots := metadata.Snapshots()
+	snapshots[0].ParentSnapshotID = new(int64)
+	snapshots[0].Summary.Properties["source"] = "mutated"
+
+	byID := metadata.SnapshotByID(2)
+	require.NotNil(t, byID)
+	*byID.ParentSnapshotID = 99
+	byID.Summary.Properties["source"] = "mutated"
+
+	current := metadata.CurrentSnapshot()
+	require.NotNil(t, current)
+	current.Summary.Properties["source"] = "mutated"
+
+	refs := metadata.Ref()
+	*refs.MinSnapshotsToKeep = 99
+	for _, ref := range metadata.Refs() {
+		*ref.MaxSnapshotAgeMs = 99
+	}
+
+	sortOrders := metadata.SortOrders()
+	fields := sortOrders[0].Fields()
+	for _, field := range fields {
+		field.SourceIDs[0] = 99
+	}
+
+	got, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	require.JSONEq(t, string(original), string(got))
+}


### PR DESCRIPTION
## Summary

Return defensive copies from table metadata getters so callers cannot mutate persisted metadata through returned maps, slices, pointers, or nested values.

The clones cover schemas and defaults, partition specs, snapshots and refs, sort orders, statistics/blob metadata, partition statistics, encryption keys, and properties. Nil slice behavior is preserved.

## Testing

- `go test ./table ./cmd/iceberg`
- regression coverage mutates every returned getter value—including binary defaults, source ID slices, blob metadata, and encryption properties—and verifies the underlying metadata remains unchanged