### PR TITLE
Infra: Group github/codeql-action bumps into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,10 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 7
+    groups:
+      # The codeql-action init/autobuild/analyze steps must all run the
+      # same version - split PRs cause a version mismatch that fails the
+      # Analyze jobs. Group them so a single PR bumps all of them together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
Thus, dependabot can update these two jobs in a single PR:

https://github.com/apache/iceberg-go/blob/e5748b15129dbe633b8142a118e668a6c79673a3/.github/workflows/codeql.yml#L48-L54

- https://github.com/apache/infrastructure-actions/pull/1028
