### PR TITLE
fix(table): include statistics in metadata equality

### DIFF
--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1714,6 +1714,37 @@ func (s *SqliteCatalogTestSuite) TestCommitTable() {
 	}
 }
 
+func (s *SqliteCatalogTestSuite) TestCommitTableWithStatisticsUpdate() {
+	ctx := context.Background()
+	cat := s.getCatalogSqlite()
+	tblID := s.randomTableIdentifier()
+
+	s.Require().NoError(cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+	tbl, err := cat.CreateTable(ctx, tblID, tableSchemaNested)
+	s.Require().NoError(err)
+
+	_, metadataLocation, err := cat.CommitTable(ctx, tblID, nil, []table.Update{
+		table.NewSetStatisticsUpdate(table.StatisticsFile{
+			SnapshotID:     1,
+			StatisticsPath: "file:///tmp/stats.puffin",
+			BlobMetadata:   []table.BlobMetadata{},
+		}),
+		table.NewSetPartitionStatisticsUpdate(table.PartitionStatisticsFile{
+			SnapshotID:     1,
+			StatisticsPath: "file:///tmp/partition-stats.parquet",
+		}),
+	})
+	s.Require().NoError(err)
+
+	s.NotEqual(tbl.MetadataLocation(), metadataLocation)
+	s.FileExists(strings.TrimPrefix(metadataLocation, "file://"))
+
+	loaded, err := cat.LoadTable(ctx, tblID)
+	s.Require().NoError(err)
+	s.Len(slices.Collect(loaded.Metadata().Statistics()), 1)
+	s.Len(slices.Collect(loaded.Metadata().PartitionStatistics()), 1)
+}
+
 func (s *SqliteCatalogTestSuite) TestCreateView() {
 	db := s.getCatalogSqlite()
 	s.Require().NoError(db.CreateSQLTables(context.Background()))

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1553,6 +1553,40 @@ func (c *commonMetadata) PreviousFiles() iter.Seq[MetadataLogEntry] {
 	return slices.Values(c.MetadataLog)
 }
 
+func stringPointerEqual(left, right *string) bool {
+	if left == right {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+
+	return *left == *right
+}
+
+func blobMetadataEqual(left, right BlobMetadata) bool {
+	return left.Type == right.Type &&
+		left.SnapshotID == right.SnapshotID &&
+		left.SequenceNumber == right.SequenceNumber &&
+		slices.Equal(left.Fields, right.Fields) &&
+		maps.Equal(left.Properties, right.Properties)
+}
+
+func statisticsFileEqual(left, right StatisticsFile) bool {
+	return left.SnapshotID == right.SnapshotID &&
+		left.StatisticsPath == right.StatisticsPath &&
+		left.FileSizeInBytes == right.FileSizeInBytes &&
+		left.FileFooterSizeInBytes == right.FileFooterSizeInBytes &&
+		stringPointerEqual(left.KeyMetadata, right.KeyMetadata) &&
+		slices.EqualFunc(left.BlobMetadata, right.BlobMetadata, blobMetadataEqual)
+}
+
+func partitionStatisticsFileEqual(left, right PartitionStatisticsFile) bool {
+	return left.SnapshotID == right.SnapshotID &&
+		left.StatisticsPath == right.StatisticsPath &&
+		left.FileSizeInBytes == right.FileSizeInBytes
+}
+
 func (c *commonMetadata) Equals(other *commonMetadata) bool {
 	if other == nil {
 		return false
@@ -1579,6 +1613,10 @@ func (c *commonMetadata) Equals(other *commonMetadata) bool {
 	case !iceinternal.SliceEqualHelper(c.SnapshotList, other.SnapshotList):
 		fallthrough
 	case !iceinternal.SliceEqualHelper(c.Specs, other.Specs):
+		fallthrough
+	case !slices.EqualFunc(c.StatisticsList, other.StatisticsList, statisticsFileEqual):
+		fallthrough
+	case !slices.EqualFunc(c.PartitionStatsList, other.PartitionStatsList, partitionStatisticsFileEqual):
 		fallthrough
 	case !maps.Equal(c.Props, other.Props):
 		fallthrough

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -309,6 +309,31 @@ func TestMetadataV3Parsing(t *testing.T) {
 	assert.Equal(t, int64(2000), *secondSnapshot.FirstRowID)
 }
 
+func TestMetadataEqualsIncludesStatistics(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	base, err := builder.Build()
+	require.NoError(t, err)
+
+	baseV2 := base.(*metadataV2)
+
+	clone := *baseV2
+	assert.True(t, base.Equals(&clone))
+
+	clone.StatisticsList = append(slices.Clone(clone.StatisticsList), StatisticsFile{
+		SnapshotID:     1,
+		StatisticsPath: "s3://bucket/stats.puffin",
+		BlobMetadata:   []BlobMetadata{},
+	})
+	assert.False(t, base.Equals(&clone))
+
+	clone = *baseV2
+	clone.PartitionStatsList = append(slices.Clone(clone.PartitionStatsList), PartitionStatisticsFile{
+		SnapshotID:     1,
+		StatisticsPath: "s3://bucket/partition-stats.parquet",
+	})
+	assert.False(t, base.Equals(&clone))
+}
+
 func TestMetadataV3Builder(t *testing.T) {
 	// Test creating v3 metadata with builder
 	schema := iceberg.NewSchema(0,


### PR DESCRIPTION
## Summary

- compare statistics and partition statistics in common metadata equality
- compare nested blob metadata, key metadata, slices, and maps explicitly
- add metadata equality and SQL catalog commit regressions

## Testing

- go test ./table ./catalog/sql