### PR TITLE
fix(hadoop): purge table root after metadata cleanup

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -883,8 +883,11 @@ func (c *Catalog) PurgeTable(ctx context.Context, identifier table.Identifier) e
 		log.Printf("WARNING: failing to purge some files in Hadoop table %s: %v", identifier, purgeErr)
 	}
 
-	// Delete the table directory root from the local storage
-	return c.DropTable(ctx, identifier)
+	if !tbl.Metadata().Properties().GetBool("gc.enabled", true) {
+		return c.filesystem.RemoveAll(c.metadataDir(identifier))
+	}
+
+	return c.filesystem.RemoveAll(c.tableToPath(identifier))
 }
 
 func (c *Catalog) RenameTable(_ context.Context, _, _ table.Identifier) (*table.Table, error) {

--- a/catalog/hadoop/hadoop_minio_integration_test.go
+++ b/catalog/hadoop/hadoop_minio_integration_test.go
@@ -22,6 +22,7 @@ package hadoop_test
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -174,6 +175,38 @@ func (s *HadoopMinIOIntegrationSuite) TestDropTableRemovesTableFromListingAndLoa
 		tables = append(tables, found)
 	}
 	s.Empty(tables)
+}
+
+func (s *HadoopMinIOIntegrationSuite) TestPurgeTableRemovesTableRoot() {
+	ns := table.Identifier{"purge_ns"}
+	ident := table.Identifier{"purge_ns", "tbl"}
+
+	s.Require().NoError(s.cat.CreateNamespace(s.ctx, ns, nil))
+	tbl, err := s.cat.CreateTable(s.ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+
+	fileIO, err := icebergio.LoadFS(s.ctx, s.props, s.warehouse)
+	s.Require().NoError(err)
+	statFS, ok := fileIO.(icebergio.StatIO)
+	s.Require().True(ok)
+	writeFS, ok := fileIO.(icebergio.WriteFileIO)
+	s.Require().True(ok)
+
+	dataPath := tbl.Location() + "/data/file.parquet"
+	s.Require().NoError(writeFS.WriteFile(dataPath, []byte("data")))
+
+	s.Require().NoError(s.cat.PurgeTable(s.ctx, ident))
+
+	_, err = statFS.Stat(tbl.MetadataLocation())
+	s.ErrorIs(err, fs.ErrNotExist)
+	_, err = statFS.Stat(dataPath)
+	s.ErrorIs(err, fs.ErrNotExist)
+	_, err = statFS.Stat(tbl.Location())
+	s.ErrorIs(err, fs.ErrNotExist)
+
+	exists, err := s.cat.CheckTableExists(s.ctx, ident)
+	s.Require().NoError(err)
+	s.False(exists)
 }
 
 func (s *HadoopMinIOIntegrationSuite) TestDropNamespaceAfterDropTable() {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1839,6 +1839,58 @@ func (s *HadoopCatalogTestSuite) TestCreateTableWithProperties() {
 	s.Equal("custom.value", tbl.Properties()["custom.key"])
 }
 
+func (s *HadoopCatalogTestSuite) TestPurgeTableRemovesTableRoot() {
+	ctx := context.Background()
+	ident := table.Identifier{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	tbl, err := s.cat.CreateTable(ctx, ident, s.testSchema())
+	s.Require().NoError(err)
+
+	tablePath := s.cat.tableToPath(ident)
+	dataPath := filepath.Join(tablePath, "data", "file.parquet")
+	s.Require().NoError(os.MkdirAll(filepath.Dir(dataPath), 0o755))
+	s.Require().NoError(os.WriteFile(dataPath, []byte("data"), 0o644))
+
+	s.Require().NoError(s.cat.PurgeTable(ctx, ident))
+
+	_, err = os.Stat(tbl.MetadataLocation())
+	s.ErrorIs(err, fs.ErrNotExist)
+	_, err = os.Stat(dataPath)
+	s.ErrorIs(err, fs.ErrNotExist)
+	_, err = os.Stat(tablePath)
+	s.ErrorIs(err, fs.ErrNotExist)
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
+func (s *HadoopCatalogTestSuite) TestPurgeTableGCDisabledPreservesData() {
+	ctx := context.Background()
+	ident := table.Identifier{"ns", "tbl"}
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	tbl, err := s.cat.CreateTable(ctx, ident, s.testSchema(),
+		catalog.WithProperties(iceberg.Properties{"gc.enabled": "false"}))
+	s.Require().NoError(err)
+
+	tablePath := s.cat.tableToPath(ident)
+	dataPath := filepath.Join(tablePath, "data", "file.parquet")
+	s.Require().NoError(os.MkdirAll(filepath.Dir(dataPath), 0o755))
+	s.Require().NoError(os.WriteFile(dataPath, []byte("data"), 0o644))
+
+	s.Require().NoError(s.cat.PurgeTable(ctx, ident))
+
+	_, err = os.Stat(tbl.MetadataLocation())
+	s.ErrorIs(err, fs.ErrNotExist)
+	s.FileExists(dataPath)
+
+	exists, err := s.cat.CheckTableExists(ctx, ident)
+	s.Require().NoError(err)
+	s.False(exists)
+}
+
 func (s *HadoopCatalogTestSuite) TestCreateTableShortIdentifier() {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- remove the Hadoop table root directly after purging files instead of calling DropTable after metadata deletion
- preserve data files when gc.enabled=false while removing table metadata
- add local and MinIO-backed purge regressions covering metadata, data, table-root, and CheckTableExists behavior

## Testing

- go test ./catalog/hadoop
- go test -tags integration ./catalog/hadoop -run ^$