### PR TITLE
fix(hive): keep catalog properties out of view metadata

### DIFF
--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -310,16 +310,16 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 	defaultNS := catalog.NamespaceFromIdent(identifier)
 	catalogName := "hive"
 
-	// Merge catalog props with view props so io.LoadFS can resolve and view metadata gets user properties.
-	props := make(iceberg.Properties)
+	ioProps := make(iceberg.Properties)
 	if c.opts.props != nil {
-		maps.Copy(props, c.opts.props)
+		maps.Copy(ioProps, c.opts.props)
 	}
 	if cfg.Properties != nil {
-		maps.Copy(props, cfg.Properties)
+		maps.Copy(ioProps, cfg.Properties)
 	}
 
-	createdView, err := view.CreateView(ctx, catalogName, identifier, freshSchema, viewSQL, defaultNS, loc, props)
+	createdView, err := view.CreateViewWithIOProperties(
+		ctx, catalogName, identifier, freshSchema, viewSQL, defaultNS, loc, ioProps, cfg.Properties)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1402,6 +1403,53 @@ func TestCreateView_Success(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(v)
 	assert.Equal(table.Identifier{"test_database", "new_view"}, v.Identifier())
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateViewDoesNotPersistCatalogProperties(t *testing.T) {
+	assert := require.New(t)
+
+	dir := t.TempDir()
+	loc := "file://" + filepath.ToSlash(filepath.Join(dir, "view_loc"))
+	catalogProps := iceberg.Properties{
+		"uri":                  "thrift://hive.example:9083",
+		"s3.secret-access-key": "catalog-secret",
+		"s3.session-token":     "catalog-session-token",
+		"s3.endpoint":          "https://storage.example",
+	}
+	viewProps := iceberg.Properties{"custom.view.property": "visible"}
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "safe_view").Return(nil, errNoSuchObject).Twice()
+	mockClient.On("CreateTable", mock.Anything, mock.Anything).Return(nil).Once()
+
+	cat := NewCatalogWithClient(mockClient, catalogProps)
+	ver, err := view.NewVersionFromSQL(1, 0, "SELECT 1 AS col", table.Identifier{"test_database"})
+	assert.NoError(err)
+	schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "col", Type: iceberg.PrimitiveTypes.Int32, Required: true})
+
+	created, err := cat.CreateView(context.Background(), TableIdentifier("test_database", "safe_view"), ver, schema,
+		catalog.WithViewLocation(loc), catalog.WithViewProperties(viewProps))
+	assert.NoError(err)
+
+	metadata, err := os.ReadFile(strings.TrimPrefix(created.MetadataLocation(), "file://"))
+	assert.NoError(err)
+	metadataJSON := string(metadata)
+	assert.Contains(metadataJSON, "custom.view.property")
+	assert.Contains(metadataJSON, "visible")
+	for _, value := range []string{
+		catalogProps["uri"],
+		catalogProps["s3.secret-access-key"],
+		catalogProps["s3.session-token"],
+		catalogProps["s3.endpoint"],
+	} {
+		assert.NotContains(metadataJSON, value)
+	}
+	for _, key := range []string{"uri", "s3.secret-access-key", "s3.session-token", "s3.endpoint"} {
+		assert.NotContains(metadataJSON, key)
+	}
 
 	mockClient.AssertExpectations(t)
 }

--- a/view/view.go
+++ b/view/view.go
@@ -114,6 +114,36 @@ func CreateView(
 	loc string,
 	props iceberg.Properties,
 ) (*View, error) {
+	return createView(ctx, catalogName, viewIdent, schema, viewSQL, defaultNS, loc, props, props)
+}
+
+// CreateViewWithIOProperties creates a view using ioProps to configure the
+// filesystem and metadataProps as the properties persisted in view metadata.
+func CreateViewWithIOProperties(
+	ctx context.Context,
+	catalogName string,
+	viewIdent table.Identifier,
+	schema *iceberg.Schema,
+	viewSQL string,
+	defaultNS table.Identifier,
+	loc string,
+	ioProps iceberg.Properties,
+	metadataProps iceberg.Properties,
+) (*View, error) {
+	return createView(ctx, catalogName, viewIdent, schema, viewSQL, defaultNS, loc, ioProps, metadataProps)
+}
+
+func createView(
+	ctx context.Context,
+	catalogName string,
+	viewIdent table.Identifier,
+	schema *iceberg.Schema,
+	viewSQL string,
+	defaultNS table.Identifier,
+	loc string,
+	ioProps iceberg.Properties,
+	metadataProps iceberg.Properties,
+) (*View, error) {
 	versionId := int64(1)
 
 	builder, err := NewMetadataBuilder()
@@ -137,7 +167,7 @@ func CreateView(
 			viewVersion,
 			schema,
 		).
-		SetProperties(props).
+		SetProperties(metadataProps).
 		Build()
 	if err != nil {
 		return nil, err
@@ -153,7 +183,7 @@ func CreateView(
 		return nil, fmt.Errorf("failed to marshal view metadata: %w", err)
 	}
 
-	fs, err := io.LoadFS(ctx, props, metadataLocation)
+	fs, err := io.LoadFS(ctx, ioProps, metadataLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load filesystem for view metadata: %w", err)
 	}


### PR DESCRIPTION
## Summary

- separate filesystem IO properties from persisted view metadata properties
- keep Hive catalog credentials, endpoints, and connection settings out of view metadata JSON
- add a regression covering fake S3/Hive secrets and custom view properties

## Testing

- go test ./...
- go test -tags integration ./catalog/hive -run ^$