### PR TITLE
fix(catalog): validate requirements when creating tables

### DIFF
--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -1652,6 +1653,53 @@ func TestGlueCheckTableNotExists(t *testing.T) {
 	exists, err := glueCatalog.CheckTableExists(context.TODO(), TableIdentifier("test_database", "nonexistent_table"))
 	assert.Nil(err)
 	assert.False(exists)
+}
+
+func TestGlueCommitTableValidatesRequirementsForMissingTable(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	snapshotID := int64(1)
+	tests := []struct {
+		name string
+		req  table.Requirement
+	}{
+		{"table_uuid", table.AssertTableUUID(uuid.New())},
+		{"current_schema_id", table.AssertCurrentSchemaID(0)},
+		{"ref_snapshot_id", table.AssertRefSnapshotID(table.MainBranch, &snapshotID)},
+	}
+
+	for _, tt := range tests {
+		ident := TableIdentifier("test_database", "requirement_"+tt.name)
+		mockGlueSvc := &mockGlueClient{}
+		mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+			DatabaseName: aws.String("test_database"),
+			Name:         aws.String(ident[1]),
+		}, mock.Anything).Return(&glue.GetTableOutput{}, &types.EntityNotFoundException{}).Once()
+
+		glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+		_, _, err := glueCatalog.CommitTable(ctx, ident, []table.Requirement{tt.req}, []table.Update{
+			table.NewSetLocationUpdate("file://" + filepath.Join(t.TempDir(), ident[1])),
+		})
+		assert.Error(err)
+		assert.Contains(err.Error(), "current table metadata does not exist")
+		mockGlueSvc.AssertExpectations(t)
+	}
+
+	ident := TableIdentifier("test_database", "requirement_assert_create")
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String(ident[1]),
+	}, mock.Anything).Return(&glue.GetTableOutput{}, &types.EntityNotFoundException{}).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+	_, _, err := glueCatalog.CommitTable(ctx, ident, []table.Requirement{table.AssertCreate()}, []table.Update{
+		table.NewSetLocationUpdate("file://" + filepath.Join(t.TempDir(), ident[1])),
+	})
+	assert.NoError(err)
+	mockGlueSvc.AssertExpectations(t)
 }
 
 func cleanupTable(t *testing.T, ctlg catalog.Catalog, tbIdent table.Identifier, awsCfg aws.Config) {

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -611,11 +611,13 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 	}
 
 	// Step 2: Validate requirements against current metadata.
+	var currentMetadata table.Metadata
 	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, "", err
-			}
+		currentMetadata = current.Metadata()
+	}
+	for _, r := range reqs {
+		if err := r.Validate(currentMetadata); err != nil {
+			return nil, "", err
 		}
 	}
 

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -2740,6 +2740,38 @@ func (s *HadoopCatalogTestSuite) TestCommitTableCreateViaCommit() {
 	s.Equal(meta.TableUUID(), loaded.Metadata().TableUUID())
 }
 
+func (s *HadoopCatalogTestSuite) TestCommitTableValidatesRequirementsForMissingTable() {
+	ctx := context.Background()
+	s.Require().NoError(os.Mkdir(filepath.Join(s.warehouse, "ns"), 0o755))
+
+	snapshotID := int64(1)
+	tests := []struct {
+		name string
+		req  table.Requirement
+	}{
+		{"table UUID", table.AssertTableUUID(uuid.New())},
+		{"current schema ID", table.AssertCurrentSchemaID(0)},
+		{"ref snapshot ID", table.AssertRefSnapshotID(table.MainBranch, &snapshotID)},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ident := []string{"ns", tt.name}
+			_, _, err := s.cat.CommitTable(ctx, ident, []table.Requirement{tt.req}, []table.Update{
+				table.NewSetLocationUpdate(s.cat.defaultTableLocation(ident)),
+			})
+			s.Require().Error(err)
+			s.Contains(err.Error(), "current table metadata does not exist")
+		})
+	}
+
+	ident := []string{"ns", "assert_create"}
+	_, _, err := s.cat.CommitTable(ctx, ident, []table.Requirement{table.AssertCreate()}, []table.Update{
+		table.NewSetLocationUpdate(s.cat.defaultTableLocation(ident)),
+	})
+	s.Require().NoError(err)
+}
+
 func (s *HadoopCatalogTestSuite) TestCommitTableShortIdentifier() {
 	_, _, err := s.cat.CommitTable(context.Background(), []string{"tbl"}, nil, nil)
 	s.Require().Error(err)

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/beltran/gohive/hive_metastore"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -526,6 +527,50 @@ func TestHiveDropTable(t *testing.T) {
 	err := hiveCatalog.DropTable(context.TODO(), TableIdentifier("test_database", "test_table"))
 	assert.NoError(err)
 
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveCommitTableValidatesRequirementsForMissingTable(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+	snapshotID := int64(1)
+	tests := []struct {
+		name string
+		req  table.Requirement
+	}{
+		{"table_uuid", table.AssertTableUUID(uuid.New())},
+		{"current_schema_id", table.AssertCurrentSchemaID(0)},
+		{"ref_snapshot_id", table.AssertRefSnapshotID(table.MainBranch, &snapshotID)},
+	}
+
+	newCatalog := func(tableName string) (*Catalog, *mockHiveClient) {
+		mockClient := &mockHiveClient{}
+		mockClient.On("Lock", mock.Anything, mock.AnythingOfType("*hive_metastore.LockRequest")).
+			Return(&hive_metastore.LockResponse{Lockid: 1, State: hive_metastore.LockState_ACQUIRED}, nil).Once()
+		mockClient.On("Unlock", mock.Anything, int64(1)).Return(nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", tableName).
+			Return(nil, errNoSuchObject).Once()
+
+		return NewCatalogWithClient(mockClient, iceberg.Properties{}), mockClient
+	}
+
+	for _, tt := range tests {
+		tableName := "requirement_" + tt.name
+		cat, mockClient := newCatalog(tableName)
+		_, _, err := cat.CommitTable(ctx, TableIdentifier("test_database", tableName), []table.Requirement{tt.req}, []table.Update{
+			table.NewSetLocationUpdate("file://" + filepath.Join(t.TempDir(), tableName)),
+		})
+		assert.Error(err)
+		assert.Contains(err.Error(), "current table metadata does not exist")
+		mockClient.AssertExpectations(t)
+	}
+
+	cat, mockClient := newCatalog("requirement_assert_create")
+	mockClient.On("CreateTable", mock.Anything, mock.Anything).Return(nil).Once()
+	_, _, err := cat.CommitTable(ctx, TableIdentifier("test_database", "requirement_assert_create"), []table.Requirement{table.AssertCreate()}, []table.Update{
+		table.NewSetLocationUpdate("file://" + filepath.Join(t.TempDir(), "requirement_assert_create")),
+	})
+	assert.NoError(err)
 	mockClient.AssertExpectations(t)
 }
 

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -197,23 +197,24 @@ func ParseMetadataVersion(location string) int {
 
 func UpdateAndStageTable(ctx context.Context, catprops iceberg.Properties, current *table.Table, ident table.Identifier, reqs []table.Requirement, updates []table.Update, cat table.CatalogIO) (*table.StagedTable, error) {
 	var (
-		baseMeta    table.Metadata
-		metadataLoc string
+		baseMeta        table.Metadata
+		currentMetadata table.Metadata
+		metadataLoc     string
 	)
 
 	if current != nil {
-		for _, r := range reqs {
-			if err := r.Validate(current.Metadata()); err != nil {
-				return nil, err
-			}
-		}
-
-		baseMeta = current.Metadata()
+		currentMetadata = current.Metadata()
+		baseMeta = currentMetadata
 		metadataLoc = current.MetadataLocation()
 	} else {
 		var err error
 		baseMeta, err = table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, "", nil)
 		if err != nil {
+			return nil, err
+		}
+	}
+	for _, r := range reqs {
+		if err := r.Validate(currentMetadata); err != nil {
 			return nil, err
 		}
 	}

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -40,6 +40,7 @@ import (
 	sqlcat "github.com/apache/iceberg-go/catalog/sql"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/uptrace/bun/driver/sqliteshim"
@@ -1743,6 +1744,42 @@ func (s *SqliteCatalogTestSuite) TestCommitTableWithStatisticsUpdate() {
 	s.Require().NoError(err)
 	s.Len(slices.Collect(loaded.Metadata().Statistics()), 1)
 	s.Len(slices.Collect(loaded.Metadata().PartitionStatistics()), 1)
+}
+
+func (s *SqliteCatalogTestSuite) TestCommitTableValidatesRequirementsForMissingTable() {
+	ctx := context.Background()
+	cat := s.getCatalogSqlite()
+
+	snapshotID := int64(1)
+	tests := []struct {
+		name string
+		req  table.Requirement
+	}{
+		{"table UUID", table.AssertTableUUID(uuid.New())},
+		{"current schema ID", table.AssertCurrentSchemaID(0)},
+		{"ref snapshot ID", table.AssertRefSnapshotID(table.MainBranch, &snapshotID)},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			tblID := s.randomTableIdentifier()
+			s.Require().NoError(cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+			location := "file://" + filepath.Join(s.warehouse, "requirement-check", tblID[1])
+
+			_, _, err := cat.CommitTable(ctx, tblID, []table.Requirement{tt.req}, []table.Update{
+				table.NewSetLocationUpdate(location),
+			})
+			s.Require().Error(err)
+			s.Contains(err.Error(), "current table metadata does not exist")
+		})
+	}
+
+	tblID := s.randomTableIdentifier()
+	s.Require().NoError(cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(tblID), nil))
+	_, _, err := cat.CommitTable(ctx, tblID, []table.Requirement{table.AssertCreate()}, []table.Update{
+		table.NewSetLocationUpdate("file://" + filepath.Join(s.warehouse, "create-via-commit", tblID[1])),
+	})
+	s.Require().NoError(err)
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateView() {


### PR DESCRIPTION
## Summary

- validate requirements against nil metadata for create-via-commit operations
- apply the same behavior to Hadoop
- add SQL, Glue, Hive, and Hadoop regressions for AssertCreate and non-create requirements

## Testing

- go test ./...