### PR TITLE
fix(cli): execute confirmed orphan cleanup plans

### DIFF
--- a/cmd/iceberg/clean_orphan_files.go
+++ b/cmd/iceberg/clean_orphan_files.go
@@ -40,19 +40,24 @@ func runCleanOrphanFiles(ctx context.Context, output Output, cat catalog.Catalog
 
 	opts := []table.OrphanCleanupOption{
 		table.WithFilesOlderThan(olderThan),
-		table.WithDryRun(true),
 	}
 
 	if cmd.Location != "" {
 		opts = append(opts, table.WithLocation(cmd.Location))
 	}
 
-	result, err := tbl.DeleteOrphanFiles(ctx, opts...)
+	plan, err := tbl.PlanOrphanFiles(ctx, opts...)
 	if err != nil {
 		output.Error(fmt.Errorf("orphan file scan failed: %w", err))
 		os.Exit(1)
 	}
 
+	planFiles := plan.Files()
+	result := table.OrphanCleanupResult{
+		OrphanFileLocations: planFiles,
+		OrphanFiles:         plan.OrphanFiles(),
+		TotalSizeBytes:      plan.TotalSizeBytes(),
+	}
 	cliResult := buildCleanOrphanFilesResult(tbl, result, cmd.DryRun)
 
 	if cmd.DryRun {
@@ -61,29 +66,27 @@ func runCleanOrphanFiles(ctx context.Context, output Output, cat catalog.Catalog
 		return
 	}
 
-	if len(result.OrphanFileLocations) == 0 {
+	if len(planFiles) == 0 {
 		output.CleanOrphanFilesResult(cliResult)
 
 		return
 	}
 
+	// Text output shows the exact plan before confirmation. JSON output emits
+	// only the final result so one invocation produces one JSON document.
+	if shouldPrintCleanOrphanPreview(output) {
+		previewResult := buildCleanOrphanFilesResult(tbl, result, true)
+		output.CleanOrphanFilesResult(previewResult)
+	}
+
 	prompt := fmt.Sprintf("Delete %d orphan file(s) (%s) from %s?",
-		len(result.OrphanFileLocations), formatBytes(result.TotalSizeBytes), tableIDString(tbl))
+		len(planFiles), formatBytes(plan.TotalSizeBytes()), tableIDString(tbl))
 	if err := confirmAction(prompt, cmd.Yes); err != nil {
 		output.Error(err)
 		os.Exit(1)
 	}
 
-	deleteOpts := []table.OrphanCleanupOption{
-		table.WithFilesOlderThan(olderThan),
-		table.WithDryRun(false),
-	}
-
-	if cmd.Location != "" {
-		deleteOpts = append(deleteOpts, table.WithLocation(cmd.Location))
-	}
-
-	deleteResult, err := tbl.DeleteOrphanFiles(ctx, deleteOpts...)
+	deleteResult, err := tbl.ExecuteOrphanCleanup(ctx, plan)
 	if err != nil {
 		output.Error(fmt.Errorf("orphan file deletion failed: %w", err))
 		os.Exit(1)
@@ -91,6 +94,15 @@ func runCleanOrphanFiles(ctx context.Context, output Output, cat catalog.Catalog
 
 	cliResult = buildCleanOrphanFilesResult(tbl, deleteResult, false)
 	output.CleanOrphanFilesResult(cliResult)
+}
+
+func shouldPrintCleanOrphanPreview(output Output) bool {
+	switch output.(type) {
+	case jsonOutput:
+		return false
+	default:
+		return true
+	}
 }
 
 func buildCleanOrphanFilesResult(tbl *table.Table, result table.OrphanCleanupResult, dryRun bool) CleanOrphanFilesResult {

--- a/cmd/iceberg/clean_orphan_files_test.go
+++ b/cmd/iceberg/clean_orphan_files_test.go
@@ -19,14 +19,85 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"io/fs"
 	"os"
 	"testing"
 
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	icebergio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type cleanOrphanCatalog struct {
+	catalog.Catalog
+	table *table.Table
+}
+
+func (c cleanOrphanCatalog) LoadTable(context.Context, table.Identifier) (*table.Table, error) {
+	return c.table, nil
+}
+
+type cleanOrphanOutput struct {
+	Output
+	results []CleanOrphanFilesResult
+	errors  []error
+}
+
+func (o *cleanOrphanOutput) CleanOrphanFilesResult(result CleanOrphanFilesResult) {
+	o.results = append(o.results, result)
+}
+
+func (o *cleanOrphanOutput) Error(err error) {
+	o.errors = append(o.errors, err)
+}
+
+func TestRunCleanOrphanFilesPreviewsPlanBeforeDeletion(t *testing.T) {
+	ctx := context.Background()
+	memFS := icebergio.NewMemFS()
+	location := "mem://preview/table"
+	metadataLocation := location + "/metadata/v1.metadata.json"
+	orphanPath := location + "/data/orphan.parquet"
+
+	meta, err := table.NewMetadata(iceberg.NewSchema(0), nil, table.UnsortedSortOrder, location, nil)
+	require.NoError(t, err)
+	require.NoError(t, memFS.WriteFile(metadataLocation, nil))
+	require.NoError(t, memFS.WriteFile(orphanPath, []byte("orphan")))
+
+	tbl := table.New(
+		table.Identifier{"db", "preview"},
+		meta,
+		metadataLocation,
+		func(context.Context) (icebergio.IO, error) { return memFS, nil },
+		nil,
+	)
+	output := &cleanOrphanOutput{}
+
+	runCleanOrphanFiles(ctx, output, cleanOrphanCatalog{table: tbl}, &CleanOrphanFilesCmd{
+		TableID:   "db.preview",
+		OlderThan: "1h",
+		Yes:       true,
+	})
+
+	require.Empty(t, output.errors)
+	require.Len(t, output.results, 2)
+	preview := output.results[0]
+	assert.True(t, preview.DryRun)
+	assert.Equal(t, 1, preview.OrphanFileCount)
+	require.Len(t, preview.OrphanFiles, 1)
+	assert.Equal(t, orphanPath, preview.OrphanFiles[0].Path)
+
+	deleted := output.results[1]
+	assert.False(t, deleted.DryRun)
+	assert.Equal(t, 1, deleted.OrphanFileCount)
+	assert.Equal(t, orphanPath, deleted.OrphanFiles[0].Path)
+	_, err = memFS.Open(orphanPath)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
 
 func TestBuildCleanOrphanFilesResultDryRun(t *testing.T) {
 	const metadata = `{
@@ -169,6 +240,11 @@ func TestBuildCleanOrphanFilesResultDeletedFiltersToDeletedFiles(t *testing.T) {
 	require.Len(t, result.OrphanFiles, 1)
 	assert.Equal(t, "s3://bucket/data/file2.parquet", result.OrphanFiles[0].Path)
 	assert.Equal(t, int64(2048), result.OrphanFiles[0].SizeBytes)
+}
+
+func TestShouldPrintCleanOrphanPreview(t *testing.T) {
+	assert.False(t, shouldPrintCleanOrphanPreview(jsonOutput{}))
+	assert.True(t, shouldPrintCleanOrphanPreview(textOutput{}))
 }
 
 func TestTextOutputCleanOrphanFilesResultEmpty(t *testing.T) {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -82,6 +82,8 @@ type orphanCleanupConfig struct {
 	prefixMismatchMode PrefixMismatchMode
 	equalSchemes       map[string]string
 	equalAuthorities   map[string]string
+	executingPlan      bool
+	invalidPlanOption  error
 	validationErr      error
 }
 
@@ -89,12 +91,14 @@ type OrphanCleanupOption func(*orphanCleanupConfig)
 
 func WithLocation(location string) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
+		rejectPlanOption(cfg, "WithLocation")
 		cfg.location = location
 	}
 }
 
 func WithFilesOlderThan(duration time.Duration) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
+		rejectPlanOption(cfg, "WithFilesOlderThan")
 		cfg.olderThan = duration
 		if duration < 0 && cfg.validationErr == nil {
 			cfg.validationErr = errors.New("orphan cleanup age must be non-negative")
@@ -131,6 +135,7 @@ func WithCleanupMaxConcurrency(maxWorkers int) OrphanCleanupOption {
 // that match listed files except for authority/scheme differences.
 func WithPrefixMismatchMode(mode PrefixMismatchMode) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
+		rejectPlanOption(cfg, "WithPrefixMismatchMode")
 		cfg.prefixMismatchMode = mode
 	}
 }
@@ -140,6 +145,7 @@ func WithPrefixMismatchMode(mode PrefixMismatchMode) OrphanCleanupOption {
 // The key can be a comma-separated list of schemes that map to the value scheme.
 func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
+		rejectPlanOption(cfg, "WithEqualSchemes")
 		if cfg.equalSchemes == nil {
 			cfg.equalSchemes = make(map[string]string)
 		}
@@ -154,6 +160,7 @@ func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
 // treats different S3 endpoints as equivalent. The key can be a comma-separated list.
 func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
+		rejectPlanOption(cfg, "WithEqualAuthorities")
 		if cfg.equalAuthorities == nil {
 			cfg.equalAuthorities = make(map[string]string)
 		}
@@ -179,12 +186,54 @@ type OrphanFile struct {
 	SizeBytes int64
 }
 
-// DeleteOrphanFiles identifies files under a table location that are no longer
-// referenced by table metadata and deletes them unless dry-run is enabled.
-//
-// The table filesystem must implement iceio.ListableIO so orphan cleanup can
-// fully enumerate candidate files before deciding what is safe to delete.
-func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
+// OrphanCleanupPlan contains the exact orphan files identified during one scan.
+// The file list is private so callers can only obtain copies, keeping the plan
+// stable between confirmation and execution.
+type OrphanCleanupPlan struct {
+	orphanFileLocations []string
+	orphanFiles         []OrphanFile
+	totalSizeBytes      int64
+	cutoff              time.Time
+}
+
+// Files returns a copy of the files in the cleanup plan.
+func (p OrphanCleanupPlan) Files() []string {
+	return slices.Clone(p.orphanFileLocations)
+}
+
+// OrphanFiles returns copies of the path and size entries in the cleanup plan.
+func (p OrphanCleanupPlan) OrphanFiles() []OrphanFile {
+	return slices.Clone(p.orphanFiles)
+}
+
+// TotalSizeBytes returns the combined size of files in the cleanup plan.
+func (p OrphanCleanupPlan) TotalSizeBytes() int64 {
+	return p.totalSizeBytes
+}
+
+// Cutoff returns the age cutoff used to create the cleanup plan. It is
+// informational only; executing a plan does not re-evaluate file ages.
+func (p OrphanCleanupPlan) Cutoff() time.Time {
+	return p.cutoff
+}
+
+func (p OrphanCleanupPlan) result() OrphanCleanupResult {
+	return OrphanCleanupResult{
+		OrphanFileLocations: p.Files(),
+		OrphanFiles:         p.OrphanFiles(),
+		TotalSizeBytes:      p.totalSizeBytes,
+	}
+}
+
+func newOrphanCleanupConfig(opts ...OrphanCleanupOption) *orphanCleanupConfig {
+	return newOrphanCleanupConfigWithMode(false, opts...)
+}
+
+func newExecutionOrphanCleanupConfig(opts ...OrphanCleanupOption) *orphanCleanupConfig {
+	return newOrphanCleanupConfigWithMode(true, opts...)
+}
+
+func newOrphanCleanupConfigWithMode(executingPlan bool, opts ...OrphanCleanupOption) *orphanCleanupConfig {
 	cfg := &orphanCleanupConfig{
 		location:           "",             // empty means use table's data location
 		olderThan:          72 * time.Hour, // 3 days ago
@@ -194,17 +243,70 @@ func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOptio
 		prefixMismatchMode: PrefixMismatchError,   // default to safest mode
 		equalSchemes:       nil,                   // no scheme equivalence by default
 		equalAuthorities:   nil,                   // no authority equivalence by default
+		executingPlan:      executingPlan,
 	}
 
-	// Apply functional options
 	for _, opt := range opts {
 		opt(cfg)
 	}
+
+	return cfg
+}
+
+func rejectPlanOption(cfg *orphanCleanupConfig, name string) {
+	if cfg.executingPlan && cfg.invalidPlanOption == nil {
+		cfg.invalidPlanOption = fmt.Errorf("%s is only valid while planning orphan cleanup", name)
+	}
+}
+
+// DeleteOrphanFiles identifies files under a table location that are no longer
+// referenced by table metadata and deletes them unless dry-run is enabled.
+//
+// The table filesystem must implement iceio.ListableIO so orphan cleanup can
+// fully enumerate candidate files before deciding what is safe to delete.
+func (t Table) DeleteOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
+	cfg := newOrphanCleanupConfig(opts...)
 	if cfg.validationErr != nil {
 		return OrphanCleanupResult{}, cfg.validationErr
 	}
+	plan, err := t.planOrphanFiles(ctx, cfg)
+	if err != nil {
+		return OrphanCleanupResult{}, err
+	}
+	if cfg.dryRun {
+		return plan.result(), nil
+	}
 
-	return t.executeOrphanCleanup(ctx, cfg)
+	return t.executeOrphanCleanup(ctx, plan, cfg)
+}
+
+// PlanOrphanFiles identifies orphan files without deleting anything. The
+// returned plan can be shown to a user and passed to ExecuteOrphanCleanup to
+// delete exactly that set.
+func (t Table) PlanOrphanFiles(ctx context.Context, opts ...OrphanCleanupOption) (OrphanCleanupPlan, error) {
+	cfg := newOrphanCleanupConfig(opts...)
+	if cfg.validationErr != nil {
+		return OrphanCleanupPlan{}, cfg.validationErr
+	}
+
+	return t.planOrphanFiles(ctx, cfg)
+}
+
+// ExecuteOrphanCleanup deletes exactly the files in plan. It does not perform
+// another orphan scan, so files appearing after planning are not included.
+func (t Table) ExecuteOrphanCleanup(ctx context.Context, plan OrphanCleanupPlan, opts ...OrphanCleanupOption) (OrphanCleanupResult, error) {
+	cfg := newExecutionOrphanCleanupConfig(opts...)
+	if cfg.validationErr != nil {
+		return OrphanCleanupResult{}, cfg.validationErr
+	}
+	if cfg.invalidPlanOption != nil {
+		return OrphanCleanupResult{}, cfg.invalidPlanOption
+	}
+	if cfg.dryRun {
+		return plan.result(), nil
+	}
+
+	return t.executeOrphanCleanup(ctx, plan, cfg)
 }
 
 type scannedFile struct {
@@ -217,10 +319,10 @@ type referencedFileIndex struct {
 	byPath     map[string][]string
 }
 
-func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
+func (t Table) planOrphanFiles(ctx context.Context, cfg *orphanCleanupConfig) (OrphanCleanupPlan, error) {
 	fs, err := t.fsF(ctx)
 	if err != nil {
-		return OrphanCleanupResult{}, fmt.Errorf("failed to get filesystem: %w", err)
+		return OrphanCleanupPlan{}, fmt.Errorf("failed to get filesystem: %w", err)
 	}
 
 	scanLocation := cfg.location
@@ -232,6 +334,7 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	// Each goroutine owns its variable exclusively — no shared writes.
 	var referencedFiles map[string]bool
 	var scannedFiles []scannedFile
+	cutoff := time.Now().Add(-cfg.olderThan)
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -242,8 +345,6 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	})
 
 	g.Go(func() error {
-		cutoff := time.Now().Add(-cfg.olderThan)
-
 		return walkDirectory(fs, scanLocation, func(path string, info stdfs.FileInfo) error {
 			if gctx.Err() != nil {
 				return gctx.Err()
@@ -258,7 +359,7 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	})
 
 	if err = g.Wait(); err != nil {
-		return OrphanCleanupResult{}, err
+		return OrphanCleanupPlan{}, err
 	}
 
 	// Identify orphans.
@@ -270,7 +371,7 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 	for _, f := range scannedFiles {
 		isOrphan, err := isFileOrphan(f.path, referencedFiles, referencedIndex, cfg)
 		if err != nil {
-			return OrphanCleanupResult{}, fmt.Errorf("failed to identify orphan %s: %w", f.path, err)
+			return OrphanCleanupPlan{}, fmt.Errorf("failed to identify orphan %s: %w", f.path, err)
 		}
 		if isOrphan {
 			orphanFiles = append(orphanFiles, f.path)
@@ -282,23 +383,31 @@ func (t Table) executeOrphanCleanup(ctx context.Context, cfg *orphanCleanupConfi
 		}
 	}
 
-	result := OrphanCleanupResult{
-		OrphanFileLocations: orphanFiles,
-		OrphanFiles:         orphanFileEntries,
-		TotalSizeBytes:      totalOrphanSize,
-	}
+	return OrphanCleanupPlan{
+		orphanFileLocations: orphanFiles,
+		orphanFiles:         orphanFileEntries,
+		totalSizeBytes:      totalOrphanSize,
+		cutoff:              cutoff,
+	}, nil
+}
 
-	if cfg.dryRun {
-		return result, nil
+func (t Table) executeOrphanCleanup(ctx context.Context, plan OrphanCleanupPlan, cfg *orphanCleanupConfig) (OrphanCleanupResult, error) {
+	fs, err := t.fsF(ctx)
+	if err != nil {
+		return OrphanCleanupResult{}, fmt.Errorf("failed to get filesystem: %w", err)
 	}
+	orphanFiles := plan.Files()
 	deletedFiles, err := deleteFiles(ctx, fs, orphanFiles, cfg)
 	if err != nil {
 		return OrphanCleanupResult{}, fmt.Errorf("failed to delete orphan files: %w", err)
 	}
 
-	result.DeletedFiles = deletedFiles
-
-	return result, nil
+	return OrphanCleanupResult{
+		OrphanFileLocations: orphanFiles,
+		OrphanFiles:         plan.OrphanFiles(),
+		DeletedFiles:        deletedFiles,
+		TotalSizeBytes:      plan.totalSizeBytes,
+	}, nil
 }
 
 // getReferencedFiles collects all files referenced by table metadata: previous metadata

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -86,6 +86,102 @@ func TestOrphanCleanupOptions(t *testing.T) {
 	assert.Equal(t, authorities, cfg.equalAuthorities)
 }
 
+func TestOrphanCleanupPlanDoesNotExpandAfterPlanning(t *testing.T) {
+	ctx := context.Background()
+	fs := io.NewMemFS()
+	location := "mem://plan-race/table"
+	metadataLocation := location + "/metadata/v1.metadata.json"
+
+	meta, err := NewMetadata(iceberg.NewSchema(0), nil, UnsortedSortOrder, location, nil)
+	require.NoError(t, err)
+	require.NoError(t, fs.WriteFile(metadataLocation, nil))
+
+	plannedOrphan := location + "/data/planned.parquet"
+	newOrphan := location + "/data/appeared-after-confirmation.parquet"
+	require.NoError(t, fs.WriteFile(plannedOrphan, []byte("planned")))
+
+	tbl := New(
+		[]string{"db", "plan_race"},
+		meta,
+		metadataLocation,
+		func(context.Context) (io.IO, error) { return fs, nil },
+		nil,
+	)
+
+	plan, err := tbl.PlanOrphanFiles(ctx, WithFilesOlderThan(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, []string{plannedOrphan}, plan.Files())
+	assert.Equal(t, []OrphanFile{{Path: plannedOrphan, SizeBytes: int64(len("planned"))}}, plan.OrphanFiles())
+	assert.False(t, plan.Cutoff().IsZero())
+
+	require.NoError(t, fs.WriteFile(newOrphan, []byte("new")))
+	_, err = tbl.ExecuteOrphanCleanup(ctx, plan, WithFilesOlderThan(time.Hour))
+	require.ErrorContains(t, err, "WithFilesOlderThan")
+
+	result, err := tbl.ExecuteOrphanCleanup(ctx, plan, WithCleanupMaxConcurrency(1))
+	require.NoError(t, err)
+	assert.Equal(t, []string{plannedOrphan}, result.DeletedFiles)
+
+	_, err = fs.Open(plannedOrphan)
+	assert.ErrorIs(t, err, stdfs.ErrNotExist)
+	file, err := fs.Open(newOrphan)
+	require.NoError(t, err)
+	assert.NoError(t, file.Close())
+}
+
+func TestExecuteOrphanCleanupRejectsPlanningOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  OrphanCleanupOption
+	}{
+		{name: "location", opt: WithLocation("mem://other")},
+		{name: "age", opt: WithFilesOlderThan(time.Hour)},
+		{name: "prefix mismatch mode", opt: WithPrefixMismatchMode(PrefixMismatchIgnore)},
+		{name: "equal schemes", opt: WithEqualSchemes(map[string]string{"s3a": "s3"})},
+		{name: "equal authorities", opt: WithEqualAuthorities(map[string]string{"old": "new"})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := (Table{}).ExecuteOrphanCleanup(context.Background(), OrphanCleanupPlan{}, tt.opt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "only valid while planning")
+		})
+	}
+}
+
+func TestPlanOrphanFilesHonorsModificationTimes(t *testing.T) {
+	ctx := context.Background()
+	location := "s3://bucket/mtime-table"
+	metadataLocation := location + "/metadata/v1.metadata.json"
+	oldPath := location + "/data/old.parquet"
+	recentPath := location + "/data/recent.parquet"
+	now := time.Now()
+
+	meta, err := NewMetadata(iceberg.NewSchema(0), nil, UnsortedSortOrder, location, nil)
+	require.NoError(t, err)
+	mockFS := &mockListableIO{
+		entries: []mockWalkEntry{
+			{path: location, info: mockFileInfo{name: "mtime-table", mode: stdfs.ModeDir}},
+			{path: metadataLocation, info: mockFileInfo{name: "v1.metadata.json"}},
+			{path: oldPath, info: mockFileInfo{name: "old.parquet", size: 10, modTime: now.Add(-2 * time.Hour)}},
+			{path: recentPath, info: mockFileInfo{name: "recent.parquet", size: 20, modTime: now.Add(-10 * time.Minute)}},
+		},
+	}
+	tbl := New(
+		Identifier{"db", "mtime"},
+		meta,
+		metadataLocation,
+		func(context.Context) (io.IO, error) { return mockFS, nil },
+		nil,
+	)
+
+	plan, err := tbl.PlanOrphanFiles(ctx, WithFilesOlderThan(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, []string{oldPath}, plan.Files())
+	assert.Equal(t, []OrphanFile{{Path: oldPath, SizeBytes: 10}}, plan.OrphanFiles())
+}
+
 func TestNormalizeFilePath(t *testing.T) {
 	cfg := &orphanCleanupConfig{
 		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
@@ -687,15 +783,16 @@ func (m *mockListableIO) WalkDir(root string, fn stdfs.WalkDirFunc) error {
 }
 
 type mockFileInfo struct {
-	name string
-	size int64
-	mode stdfs.FileMode
+	name    string
+	size    int64
+	mode    stdfs.FileMode
+	modTime time.Time
 }
 
 func (m mockFileInfo) Name() string         { return m.name }
 func (m mockFileInfo) Size() int64          { return m.size }
 func (m mockFileInfo) Mode() stdfs.FileMode { return m.mode }
-func (m mockFileInfo) ModTime() time.Time   { return time.Time{} }
+func (m mockFileInfo) ModTime() time.Time   { return m.modTime }
 func (m mockFileInfo) IsDir() bool          { return m.mode.IsDir() }
 func (m mockFileInfo) Sys() any             { return nil }
 


### PR DESCRIPTION
## Summary

Split orphan cleanup into an explicit plan and execution phase so confirmation applies to the exact files shown to the user.

- capture candidate paths, sizes, and the age cutoff in an immutable cleanup plan;
- show the planned files before confirmation while keeping JSON output to one final document;
- execute only the confirmed plan, without rescanning or adding newly appeared files;
- return the actual deleted-file result and sizes in the final CLI output;
- reject planning-only options when executing an existing plan.

The existing `DeleteOrphanFiles` path uses the same planning and execution flow.

## Testing

- `go test ./table ./cmd/iceberg`
- coordinated plan/execute coverage proves files appearing after planning remain untouched
- CLI coverage verifies preview and final deleted-file output
- real modification-time coverage verifies the age filter