### PR TITLE
fix: separate snapshot and reference expiration ages

### DIFF
--- a/table/transaction.go
+++ b/table/transaction.go
@@ -331,7 +331,8 @@ func WithRetainLast(n int) ExpireSnapshotsOpt {
 // WithOlderThan expires snapshots older than the given duration, measured from
 // the current time. It overrides the MaxSnapshotAgeMsKey ("max-snapshot-age-ms")
 // table property for this call. The most recent snapshots are still retained up
-// to the count set by WithRetainLast.
+// to the count set by WithRetainLast. This option does not expire branches or
+// tags based on their age; configure max-ref-age-ms on the ref or table for that.
 func WithOlderThan(t time.Duration) ExpireSnapshotsOpt {
 	return func(cfg *expireSnapshotsCfg) {
 		n := t.Milliseconds()
@@ -354,10 +355,11 @@ func WithPostCommit(postCommit bool) ExpireSnapshotsOpt {
 //
 // A snapshot is retained when it is referenced by a branch or tag, or when it
 // is needed to satisfy the retention rules. Retention is resolved per ref,
-// falling back through the ref's own settings, the options passed here, and
-// finally the table properties (MinSnapshotsToKeepKey, MaxSnapshotAgeMsKey,
-// MaxRefAgeMsKey), mirroring the Java implementation. The current snapshot of
-// the main branch is always kept.
+// with reference age falling back through the ref's max-ref-age-ms, the table's
+// MaxRefAgeMsKey property, and the specification default. Snapshot age falls
+// back through the ref's own settings, the options passed here, and finally the
+// table's MinSnapshotsToKeepKey and MaxSnapshotAgeMsKey properties. The current
+// snapshot of the main branch is always kept.
 //
 // By default the now-unreferenced manifests, manifest lists, and data files are
 // deleted once the commit lands; pass WithPostCommit(false) to defer that
@@ -415,7 +417,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 			return err
 		}
 
-		maxRefAgeMs := cmp.Or(ref.MaxRefAgeMs, cfg.maxSnapshotAgeMs, &propMaxRefAgeMs)
+		maxRefAgeMs := cmp.Or(ref.MaxRefAgeMs, &propMaxRefAgeMs)
 
 		refAge := nowMs - snap.TimestampMs
 		if refAge > *maxRefAgeMs && refName != MainBranch {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -44,6 +44,26 @@ func TestTransactionApplyKeepsDistinctRequirementsOfSameType(t *testing.T) {
 	requireContainsRefSnapshotRequirement(t, txn.reqs, "feature", &featureSnapshotID)
 }
 
+func TestExpireSnapshotsWithOlderThanDoesNotExpireSnapshotRefs(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	now := time.Now().UnixMilli()
+	oldTimestamp := time.Now().Add(-8 * 24 * time.Hour).UnixMilli()
+
+	txn.meta.snapshotList[0].TimestampMs = oldTimestamp
+	txn.meta.snapshotList[1].TimestampMs = now
+	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 20, BranchRef))
+	require.NoError(t, txn.meta.SetSnapshotRef("old-branch", 10, BranchRef))
+	require.NoError(t, txn.meta.SetSnapshotRef("old-tag", 10, TagRef))
+	txn.meta.lastUpdatedMS = now
+
+	require.NoError(t, txn.ExpireSnapshots(WithOlderThan(7*24*time.Hour)))
+
+	_, branchExists := txn.meta.refs["old-branch"]
+	_, tagExists := txn.meta.refs["old-tag"]
+	require.True(t, branchExists, "WithOlderThan must not expire a branch without max-ref-age-ms")
+	require.True(t, tagExists, "WithOlderThan must not expire a tag without max-ref-age-ms")
+}
+
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {
 	txn := newTransactionWithSnapshotRefs(t)
 


### PR DESCRIPTION
## What

`WithOlderThan` should control snapshot expiration only. Previously it was used as the fallback for `max-ref-age-ms`, so old non-main branches and tags could be removed even when no reference-age policy was configured.

Reference expiration now uses the ref policy, the table `max-ref-age-ms` property, and the specification default. The docs make the separation explicit, and a regression covers an old branch and tag.

## Tests

- `go test ./...`