### PR TITLE
fix(table): validate retry duration properties

### DIFF
--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -314,7 +314,9 @@ func TestReadRetryConfig_ClampsNegativeProperties(t *testing.T) {
 
 func TestReadRetryConfigRejectsUnsafeProperties(t *testing.T) {
 	maxUint := strconv.FormatUint(math.MaxUint64, 10)
+	maxUintMinusOne := strconv.FormatUint(math.MaxUint64-1, 10)
 	maxIntPlusOne := strconv.FormatUint(uint64(math.MaxInt64)+1, 10)
+	maxDurationPlusOne := strconv.FormatUint(maxRetryDurationMs+1, 10)
 
 	tests := []struct {
 		name  string
@@ -325,6 +327,11 @@ func TestReadRetryConfigRejectsUnsafeProperties(t *testing.T) {
 		{name: "maximum wait above max int64", key: CommitMaxRetryWaitMsKey, value: maxIntPlusOne},
 		{name: "total timeout above max int64", key: CommitTotalRetryTimeoutMsKey, value: maxIntPlusOne},
 		{name: "retry count max uint64", key: CommitNumRetriesKey, value: maxUint},
+		{name: "retry count max uint64 minus one", key: CommitNumRetriesKey, value: maxUintMinusOne},
+		{name: "minimum wait above maximum duration", key: CommitMinRetryWaitMsKey, value: maxDurationPlusOne},
+		{name: "maximum wait above maximum duration", key: CommitMaxRetryWaitMsKey, value: maxDurationPlusOne},
+		{name: "total timeout above maximum duration", key: CommitTotalRetryTimeoutMsKey, value: maxDurationPlusOne},
+		{name: "retry count above practical maximum", key: CommitNumRetriesKey, value: strconv.FormatUint(maxRetryCount+1, 10)},
 	}
 
 	for _, tt := range tests {
@@ -342,6 +349,14 @@ func TestReadRetryConfigRejectsUnsafeProperties(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, CommitMinRetryWaitMsKey)
 	assert.ErrorContains(t, err, CommitMaxRetryWaitMsKey)
+}
+
+func TestReadRetryConfigUsesDefaultForZeroTotalTimeout(t *testing.T) {
+	cfg, err := readRetryConfig(iceberg.Properties{
+		CommitTotalRetryTimeoutMsKey: "0",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(CommitTotalRetryTimeoutMsDefault), cfg.totalTimeoutMs)
 }
 
 func TestReadRetryConfigAcceptsLargestSafeDuration(t *testing.T) {

--- a/table/commit_retry_test.go
+++ b/table/commit_retry_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -298,16 +299,87 @@ func TestBackoffDuration_HandlesZeroInputs(t *testing.T) {
 
 func TestReadRetryConfig_ClampsNegativeProperties(t *testing.T) {
 	// Negative values in properties should be replaced with defaults.
-	cfg := readRetryConfig(iceberg.Properties{
+	cfg, err := readRetryConfig(iceberg.Properties{
 		CommitNumRetriesKey:          "-1",
 		CommitMinRetryWaitMsKey:      "-100",
 		CommitMaxRetryWaitMsKey:      "-1000",
 		CommitTotalRetryTimeoutMsKey: "-5",
 	})
+	require.NoError(t, err)
 	assert.Equal(t, uint(CommitNumRetriesDefault), cfg.numRetries)
-	assert.Equal(t, uint(CommitMinRetryWaitMsDefault), cfg.minWaitMs)
-	assert.Equal(t, uint(CommitMaxRetryWaitMsDefault), cfg.maxWaitMs)
-	assert.Equal(t, uint(CommitTotalRetryTimeoutMsDefault), cfg.totalTimeoutMs)
+	assert.Equal(t, uint64(CommitMinRetryWaitMsDefault), cfg.minWaitMs)
+	assert.Equal(t, uint64(CommitMaxRetryWaitMsDefault), cfg.maxWaitMs)
+	assert.Equal(t, uint64(CommitTotalRetryTimeoutMsDefault), cfg.totalTimeoutMs)
+}
+
+func TestReadRetryConfigRejectsUnsafeProperties(t *testing.T) {
+	maxUint := strconv.FormatUint(math.MaxUint64, 10)
+	maxIntPlusOne := strconv.FormatUint(uint64(math.MaxInt64)+1, 10)
+
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "minimum wait max uint64", key: CommitMinRetryWaitMsKey, value: maxUint},
+		{name: "maximum wait above max int64", key: CommitMaxRetryWaitMsKey, value: maxIntPlusOne},
+		{name: "total timeout above max int64", key: CommitTotalRetryTimeoutMsKey, value: maxIntPlusOne},
+		{name: "retry count max uint64", key: CommitNumRetriesKey, value: maxUint},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := readRetryConfig(iceberg.Properties{tt.key: tt.value})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.key)
+		})
+	}
+
+	_, err := readRetryConfig(iceberg.Properties{
+		CommitMinRetryWaitMsKey: "200",
+		CommitMaxRetryWaitMsKey: "100",
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, CommitMinRetryWaitMsKey)
+	assert.ErrorContains(t, err, CommitMaxRetryWaitMsKey)
+}
+
+func TestReadRetryConfigAcceptsLargestSafeDuration(t *testing.T) {
+	maxDurationMs := uint64(math.MaxInt64 / int64(time.Millisecond))
+	value := strconv.FormatUint(maxDurationMs, 10)
+
+	cfg, err := readRetryConfig(iceberg.Properties{
+		CommitMinRetryWaitMsKey:      value,
+		CommitMaxRetryWaitMsKey:      value,
+		CommitTotalRetryTimeoutMsKey: value,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, maxDurationMs, cfg.minWaitMs)
+	assert.Equal(t, maxDurationMs, cfg.maxWaitMs)
+	assert.Equal(t, maxDurationMs, cfg.totalTimeoutMs)
+	assert.Equal(t, time.Duration(maxDurationMs)*time.Millisecond,
+		backoffDuration(0, cfg.minWaitMs, cfg.maxWaitMs))
+}
+
+func TestBackoffDurationClampsUnsafeDirectInputs(t *testing.T) {
+	var got time.Duration
+	assert.NotPanics(t, func() {
+		got = backoffDuration(0, math.MaxUint64, math.MaxUint64)
+	})
+	assert.Equal(t, time.Duration(maxRetryDurationMs)*time.Millisecond, got)
+}
+
+func TestDoCommitRejectsUnsafeRetryProperty(t *testing.T) {
+	cat := &flakyCatalog{}
+	tbl := newRetryTestTable(t, cat, iceberg.Properties{
+		CommitMinRetryWaitMsKey: strconv.FormatUint(math.MaxUint64, 10),
+	})
+	cat.metadata = tbl.Metadata()
+
+	_, err := tbl.doCommit(t.Context(), nil, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, CommitMinRetryWaitMsKey)
+	assert.Zero(t, cat.attempts.Load())
 }
 
 // ---------------------------------------------------------------------------

--- a/table/table.go
+++ b/table/table.go
@@ -734,7 +734,10 @@ func rebuildSnapshotUpdates(ctx context.Context, updates []Update, freshMeta Met
 	return result, orphanedPaths, nil
 }
 
-const maxRetryDurationMs = uint64(math.MaxInt64 / int64(time.Millisecond))
+const (
+	maxRetryDurationMs = uint64(math.MaxInt64 / int64(time.Millisecond))
+	maxRetryCount      = uint64(math.MaxUint32)
+)
 
 type retryConfig struct {
 	numRetries     uint
@@ -744,18 +747,18 @@ type retryConfig struct {
 }
 
 func readRetryConfig(props iceberg.Properties) (retryConfig, error) {
-	numRetries := iceberg.PropUInt64(props, CommitNumRetriesKey, CommitNumRetriesDefault)
-	if numRetries >= uint64(^uint(0)) {
+	numRetries := props.GetUInt64(CommitNumRetriesKey, CommitNumRetriesDefault)
+	if numRetries >= uint64(^uint(0)) || numRetries > maxRetryCount {
 		return retryConfig{}, fmt.Errorf(
-			"invalid retry property %q=%d: retry count overflows the attempt count",
-			CommitNumRetriesKey, numRetries)
+			"invalid retry property %q=%d: retry count exceeds the maximum of %d",
+			CommitNumRetriesKey, numRetries, maxRetryCount)
 	}
 
 	cfg := retryConfig{
 		numRetries:     uint(numRetries),
-		minWaitMs:      iceberg.PropUInt64(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
-		maxWaitMs:      iceberg.PropUInt64(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
-		totalTimeoutMs: iceberg.PropUInt64(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+		minWaitMs:      props.GetUInt64(CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      props.GetUInt64(CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: props.GetUInt64(CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
 	}
 
 	if cfg.minWaitMs == 0 {
@@ -763,6 +766,9 @@ func readRetryConfig(props iceberg.Properties) (retryConfig, error) {
 	}
 	if cfg.maxWaitMs == 0 {
 		cfg.maxWaitMs = CommitMaxRetryWaitMsDefault
+	}
+	if cfg.totalTimeoutMs == 0 {
+		cfg.totalTimeoutMs = CommitTotalRetryTimeoutMsDefault
 	}
 
 	for _, property := range []struct {
@@ -786,13 +792,6 @@ func readRetryConfig(props iceberg.Properties) (retryConfig, error) {
 			"invalid retry properties %q=%d and %q=%d: minimum wait exceeds maximum wait",
 			CommitMinRetryWaitMsKey, cfg.minWaitMs,
 			CommitMaxRetryWaitMsKey, cfg.maxWaitMs)
-	}
-
-	jitterSpan := cfg.maxWaitMs - cfg.minWaitMs + 1
-	if jitterSpan == 0 || jitterSpan > uint64(math.MaxInt64) {
-		return retryConfig{}, fmt.Errorf(
-			"invalid retry properties %q and %q: jitter span overflows int64",
-			CommitMinRetryWaitMsKey, CommitMaxRetryWaitMsKey)
 	}
 
 	return cfg, nil
@@ -842,7 +841,9 @@ func backoffDuration(attempt uint, minMs, maxMs uint64) time.Duration {
 
 	// Jitter in [minMs, ceiling]: keeps a non-zero floor so concurrent
 	// writers don't all sample 0 and retry in lockstep.
-	//nolint:gosec // non-security randomness, jitter for retry spread
+	// Both conversions are safe because minMs and ceiling-minMs+1 are bounded
+	// by maxRetryDurationMs, which fits in int64.
+	//nolint:gosec // non-security randomness; bounded int64 conversions are safe
 	wait := int64(minMs) + rand.Int64N(int64(ceiling-minMs+1))
 
 	return time.Duration(wait) * time.Millisecond

--- a/table/table.go
+++ b/table/table.go
@@ -27,6 +27,7 @@ import (
 	"iter"
 	"log"
 	"maps"
+	"math"
 	"math/rand/v2"
 	"runtime"
 	"slices"
@@ -458,7 +459,10 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		apply(&co)
 	}
 
-	cfg := readRetryConfig(t.metadata.Properties())
+	cfg, err := readRetryConfig(t.metadata.Properties())
+	if err != nil {
+		return nil, err
+	}
 
 	// Bound total retry time with a derived context so both the wait loop
 	// and the CommitTable call itself respect the deadline uniformly.
@@ -730,20 +734,68 @@ func rebuildSnapshotUpdates(ctx context.Context, updates []Update, freshMeta Met
 	return result, orphanedPaths, nil
 }
 
+const maxRetryDurationMs = uint64(math.MaxInt64 / int64(time.Millisecond))
+
 type retryConfig struct {
 	numRetries     uint
-	minWaitMs      uint
-	maxWaitMs      uint
-	totalTimeoutMs uint
+	minWaitMs      uint64
+	maxWaitMs      uint64
+	totalTimeoutMs uint64
 }
 
-func readRetryConfig(props iceberg.Properties) retryConfig {
-	return retryConfig{
-		numRetries:     iceberg.PropUInt(props, CommitNumRetriesKey, CommitNumRetriesDefault),
-		minWaitMs:      iceberg.PropUInt(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
-		maxWaitMs:      iceberg.PropUInt(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
-		totalTimeoutMs: iceberg.PropUInt(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+func readRetryConfig(props iceberg.Properties) (retryConfig, error) {
+	numRetries := iceberg.PropUInt64(props, CommitNumRetriesKey, CommitNumRetriesDefault)
+	if numRetries >= uint64(^uint(0)) {
+		return retryConfig{}, fmt.Errorf(
+			"invalid retry property %q=%d: retry count overflows the attempt count",
+			CommitNumRetriesKey, numRetries)
 	}
+
+	cfg := retryConfig{
+		numRetries:     uint(numRetries),
+		minWaitMs:      iceberg.PropUInt64(props, CommitMinRetryWaitMsKey, CommitMinRetryWaitMsDefault),
+		maxWaitMs:      iceberg.PropUInt64(props, CommitMaxRetryWaitMsKey, CommitMaxRetryWaitMsDefault),
+		totalTimeoutMs: iceberg.PropUInt64(props, CommitTotalRetryTimeoutMsKey, CommitTotalRetryTimeoutMsDefault),
+	}
+
+	if cfg.minWaitMs == 0 {
+		cfg.minWaitMs = CommitMinRetryWaitMsDefault
+	}
+	if cfg.maxWaitMs == 0 {
+		cfg.maxWaitMs = CommitMaxRetryWaitMsDefault
+	}
+
+	for _, property := range []struct {
+		key   string
+		value uint64
+	}{
+		{CommitMinRetryWaitMsKey, cfg.minWaitMs},
+		{CommitMaxRetryWaitMsKey, cfg.maxWaitMs},
+		{CommitTotalRetryTimeoutMsKey, cfg.totalTimeoutMs},
+	} {
+		key, value := property.key, property.value
+		if value > maxRetryDurationMs {
+			return retryConfig{}, fmt.Errorf(
+				"invalid retry property %q=%d: exceeds maximum duration of %d milliseconds",
+				key, value, maxRetryDurationMs)
+		}
+	}
+
+	if cfg.minWaitMs > cfg.maxWaitMs {
+		return retryConfig{}, fmt.Errorf(
+			"invalid retry properties %q=%d and %q=%d: minimum wait exceeds maximum wait",
+			CommitMinRetryWaitMsKey, cfg.minWaitMs,
+			CommitMaxRetryWaitMsKey, cfg.maxWaitMs)
+	}
+
+	jitterSpan := cfg.maxWaitMs - cfg.minWaitMs + 1
+	if jitterSpan == 0 || jitterSpan > uint64(math.MaxInt64) {
+		return retryConfig{}, fmt.Errorf(
+			"invalid retry properties %q and %q: jitter span overflows int64",
+			CommitMinRetryWaitMsKey, CommitMaxRetryWaitMsKey)
+	}
+
+	return cfg, nil
 }
 
 // backoffDuration computes wait time for the given 0-based retry attempt
@@ -754,34 +806,44 @@ func readRetryConfig(props iceberg.Properties) retryConfig {
 // concurrent Go writers. Backoff is client-local, so this does not
 // affect cross-client interop.
 //
-// Inputs are trusted: readRetryConfig is responsible for normalizing
-// user-supplied properties (negatives, zero, min > max).
-func backoffDuration(attempt, minMs, maxMs uint) time.Duration {
+// Inputs from readRetryConfig are validated. The defensive bounds below also
+// keep direct callers from reaching an invalid random bound or duration.
+func backoffDuration(attempt uint, minMs, maxMs uint64) time.Duration {
 	if minMs == 0 {
 		minMs = CommitMinRetryWaitMsDefault
 	}
 	if maxMs == 0 {
 		maxMs = CommitMaxRetryWaitMsDefault
 	}
+	if minMs > maxRetryDurationMs {
+		minMs = maxRetryDurationMs
+	}
+	if maxMs > maxRetryDurationMs {
+		maxMs = maxRetryDurationMs
+	}
 	if minMs > maxMs {
 		minMs = maxMs
 	}
-	// Cap the shift count so the signed int64 below does not overflow
-	// past its operand width; overflow would just be clamped to maxMs
-	// anyway, so keep the math obvious instead.
+	// Cap the shift count so the exponential calculation stays within the
+	// bounded duration range.
 	if attempt > 62 {
 		attempt = 62
 	}
 
-	ceiling := int64(minMs) << attempt
-	if ceiling <= 0 || ceiling > int64(maxMs) {
-		ceiling = int64(maxMs)
+	var ceiling uint64
+	if minMs > maxRetryDurationMs>>attempt {
+		ceiling = maxMs
+	} else {
+		ceiling = minMs << attempt
+		if ceiling > maxMs {
+			ceiling = maxMs
+		}
 	}
 
 	// Jitter in [minMs, ceiling]: keeps a non-zero floor so concurrent
 	// writers don't all sample 0 and retry in lockstep.
 	//nolint:gosec // non-security randomness, jitter for retry spread
-	wait := int64(minMs) + rand.Int64N(ceiling-int64(minMs)+1)
+	wait := int64(minMs) + rand.Int64N(int64(ceiling-minMs+1))
 
 	return time.Duration(wait) * time.Millisecond
 }

--- a/types.go
+++ b/types.go
@@ -93,17 +93,29 @@ func (p Properties) GetInt64(key string, defVal int64) int64 {
 	return defVal
 }
 
-// PropUInt reads an unsigned-integer property by key. A missing key,
-// an unparseable value, or a negative value returns defVal — PropUInt
+// PropUInt64 reads an unsigned-integer property by key. A missing key,
+// an unparseable value, or a negative value returns defVal — PropUInt64
 // uses strconv.ParseUint, which rejects negatives rather than silently
 // wrapping them to a large positive number.
-func PropUInt(p Properties, key string, defVal uint) uint {
+func PropUInt64(p Properties, key string, defVal uint64) uint64 {
 	v, ok := p[key]
 	if !ok {
 		return defVal
 	}
 	n, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
+		return defVal
+	}
+
+	return n
+}
+
+// PropUInt reads an unsigned-integer property by key, preserving the legacy
+// fallback behavior while avoiding truncation on platforms where uint is
+// narrower than uint64.
+func PropUInt(p Properties, key string, defVal uint) uint {
+	n := PropUInt64(p, key, uint64(defVal))
+	if uint64(uint(n)) != n {
 		return defVal
 	}
 

--- a/types.go
+++ b/types.go
@@ -93,11 +93,11 @@ func (p Properties) GetInt64(key string, defVal int64) int64 {
 	return defVal
 }
 
-// PropUInt64 reads an unsigned-integer property by key. A missing key,
-// an unparseable value, or a negative value returns defVal — PropUInt64
+// GetUInt64 reads an unsigned-integer property by key. A missing key,
+// an unparseable value, or a negative value returns defVal. GetUInt64
 // uses strconv.ParseUint, which rejects negatives rather than silently
 // wrapping them to a large positive number.
-func PropUInt64(p Properties, key string, defVal uint64) uint64 {
+func (p Properties) GetUInt64(key string, defVal uint64) uint64 {
 	v, ok := p[key]
 	if !ok {
 		return defVal
@@ -114,7 +114,7 @@ func PropUInt64(p Properties, key string, defVal uint64) uint64 {
 // fallback behavior while avoiding truncation on platforms where uint is
 // narrower than uint64.
 func PropUInt(p Properties, key string, defVal uint) uint {
-	n := PropUInt64(p, key, uint64(defVal))
+	n := p.GetUInt64(key, uint64(defVal))
 	if uint64(uint(n)) != n {
 		return defVal
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -659,6 +659,7 @@ func TestPropUInt(t *testing.T) {
 		"n":       "42",
 		"neg":     "-7",
 		"garbage": "not-a-number",
+		"maxuint": "18446744073709551615",
 	}
 
 	assert.Equal(t, uint(42), iceberg.PropUInt(props, "n", 0))
@@ -666,6 +667,8 @@ func TestPropUInt(t *testing.T) {
 		"negative string must fall back, not wrap to a huge positive")
 	assert.Equal(t, uint(77), iceberg.PropUInt(props, "garbage", 77), "falls back on parse error")
 	assert.Equal(t, uint(5), iceberg.PropUInt(props, "missing", 5), "falls back on missing key")
+	assert.Equal(t, uint64(math.MaxUint64), iceberg.PropUInt64(props, "maxuint", 0),
+		"PropUInt64 must preserve the full uint64 range")
 }
 
 func TestGetInt64(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -667,8 +667,8 @@ func TestPropUInt(t *testing.T) {
 		"negative string must fall back, not wrap to a huge positive")
 	assert.Equal(t, uint(77), iceberg.PropUInt(props, "garbage", 77), "falls back on parse error")
 	assert.Equal(t, uint(5), iceberg.PropUInt(props, "missing", 5), "falls back on missing key")
-	assert.Equal(t, uint64(math.MaxUint64), iceberg.PropUInt64(props, "maxuint", 0),
-		"PropUInt64 must preserve the full uint64 range")
+	assert.Equal(t, uint64(math.MaxUint64), props.GetUInt64("maxuint", 0),
+		"GetUInt64 must preserve the full uint64 range")
 }
 
 func TestGetInt64(t *testing.T) {


### PR DESCRIPTION
## Summary

Commit retry properties are validated before unsigned values are converted to signed durations or used as retry counts.

- reject durations larger than the maximum safe `time.Duration`;
- reject reversed minimum/maximum waits;
- normalize explicit zero waits and total timeout to their defaults;
- cap retry counts at a practical `math.MaxUint32` limit;
- keep exponential backoff and jitter arithmetic overflow-safe;
- report the offending property in configuration errors.

A full-width `PropUInt64` helper preserves values long enough to validate them without truncation.

## Testing

- `go test . ./table`
- boundary coverage for `math.MaxUint64`, `maxRetryDurationMs + 1`, reversed waits, zero timeout, and retry-count overflow