### PR TITLE
feat(rest): Add support for Rename View endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Tests requiring Spark 4 (currently the variant and unknown-type tests) automatic
 | Load View                   |      |  X   |        |  X   |        |
 | List View                   |  X   |  X   |        |  X   |        |
 | Drop View                   |  X   |  X   |        |  X   |        |
+| Rename View                 |  X   |      |        |      |        |
 | Check View Exists           |  X   |  X   |        |  X   |        |
 
 ### Read/Write Data Support

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -2199,6 +2199,47 @@ func (r *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (*v
 	return view.New(identifier, metadata, rsp.MetadataLoc), nil
 }
 
+func (r *Catalog) RenameView(ctx context.Context, from, to table.Identifier) (*view.View, error) {
+	if err := r.endpoints.check(endpointRenameView); err != nil {
+		return nil, err
+	}
+	if err := catalog.ValidateViewIdentifier(from); err != nil {
+		return nil, err
+	}
+	if err := catalog.ValidateViewIdentifier(to); err != nil {
+		return nil, err
+	}
+
+	type payload struct {
+		Source      identifier `json:"source"`
+		Destination identifier `json:"destination"`
+	}
+	src := identifier{
+		Namespace: catalog.NamespaceFromIdent(from),
+		Name:      catalog.TableNameFromIdent(from),
+	}
+	dst := identifier{
+		Namespace: catalog.NamespaceFromIdent(to),
+		Name:      catalog.TableNameFromIdent(to),
+	}
+
+	path, err := endpointRenameView.reqPath()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = doPost[payload, any](ctx, r.baseURI, path, payload{Source: src, Destination: dst}, r.cl,
+		map[int]error{
+			http.StatusNotFound: catalog.ErrNoSuchView,
+			http.StatusConflict: catalog.ErrViewAlreadyExists,
+		}, allowNoContent())
+	if err != nil {
+		return nil, err
+	}
+
+	return r.LoadView(ctx, to)
+}
+
 // FunctionCatalog is an optional interface for catalogs that support the
 // function (SQL UDF) read endpoints defined by the REST spec: list and load.
 // The function endpoints are not part of the spec's assumed default endpoint

--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -304,7 +304,7 @@ func (s *RestIntegrationSuite) TestRenameView() {
 	fromIdent := catalog.ToIdentifier(TestNamespaceIdent, "test-view")
 	toIdent := catalog.ToIdentifier(TestNamespaceIdent, "renamed-view")
 
-	viewRepr := view.NewRepresentation(fmt.Sprintf("SELECT * FROM  %s.%s", TestNamespaceIdent, "test-table"), "trino")
+	viewRepr := view.NewRepresentation(fmt.Sprintf("SELECT * FROM %s.%s", TestNamespaceIdent, "test-table"), "trino")
 	viewVersion, err := view.NewVersion(1, 1, []view.Representation{viewRepr}, table.Identifier{TestNamespaceIdent})
 	s.Require().NoError(err)
 
@@ -317,6 +317,8 @@ func (s *RestIntegrationSuite) TestRenameView() {
 	s.Require().NoError(err)
 	s.Equal(toIdent, renamed.Identifier())
 	s.Equal(created.Metadata().ViewUUID(), renamed.Metadata().ViewUUID())
+	// A rename moves the pointer, it must not rewrite the metadata.
+	s.Equal(created.MetadataLocation(), renamed.MetadataLocation())
 
 	// The old name is gone, the new one exists
 	exists, err := s.cat.CheckViewExists(s.ctx, fromIdent)

--- a/catalog/rest/rest_integration_test.go
+++ b/catalog/rest/rest_integration_test.go
@@ -289,6 +289,49 @@ func (s *RestIntegrationSuite) TestUpdateView() {
 	s.Require().NoError(s.cat.DropView(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "test-view")))
 }
 
+func (s *RestIntegrationSuite) TestRenameView() {
+	s.ensureNamespace()
+
+	const location = "s3://warehouse/iceberg"
+	tbl, err := s.cat.CreateTable(s.ctx,
+		catalog.ToIdentifier(TestNamespaceIdent, "test-table"),
+		tableSchemaSimple, catalog.WithProperties(iceberg.Properties{"foobar": "baz"}),
+		catalog.WithLocation(location))
+	s.Require().NoError(err)
+	s.Require().NotNil(tbl)
+
+	// Create a view to rename
+	fromIdent := catalog.ToIdentifier(TestNamespaceIdent, "test-view")
+	toIdent := catalog.ToIdentifier(TestNamespaceIdent, "renamed-view")
+
+	viewRepr := view.NewRepresentation(fmt.Sprintf("SELECT * FROM  %s.%s", TestNamespaceIdent, "test-table"), "trino")
+	viewVersion, err := view.NewVersion(1, 1, []view.Representation{viewRepr}, table.Identifier{TestNamespaceIdent})
+	s.Require().NoError(err)
+
+	created, err := s.cat.CreateView(s.ctx, fromIdent, viewVersion, tableSchemaSimple,
+		catalog.WithViewProperties(iceberg.Properties{"foobar": "baz"}))
+	s.Require().NoError(err)
+
+	// Rename it
+	renamed, err := s.cat.RenameView(s.ctx, fromIdent, toIdent)
+	s.Require().NoError(err)
+	s.Equal(toIdent, renamed.Identifier())
+	s.Equal(created.Metadata().ViewUUID(), renamed.Metadata().ViewUUID())
+
+	// The old name is gone, the new one exists
+	exists, err := s.cat.CheckViewExists(s.ctx, fromIdent)
+	s.Require().NoError(err)
+	s.False(exists)
+
+	exists, err = s.cat.CheckViewExists(s.ctx, toIdent)
+	s.Require().NoError(err)
+	s.True(exists)
+
+	// Cleanup
+	s.Require().NoError(s.cat.DropTable(s.ctx, catalog.ToIdentifier(TestNamespaceIdent, "test-table")))
+	s.Require().NoError(s.cat.DropView(s.ctx, toIdent))
+}
+
 func (s *RestIntegrationSuite) TestWriteCommitTable() {
 	s.ensureNamespace()
 

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2660,6 +2660,103 @@ func (r *RestCatalogSuite) TestRegisterView409() {
 	r.ErrorContains(err, "The given view already exists")
 }
 
+func (r *RestCatalogSuite) TestRenameView204() {
+	const metadataLoc = "s3://bucket/warehouse/example.db/destination/metadata/00001.metadata.json"
+
+	r.mux.HandleFunc("/v1/views/rename", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodPost, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		var payload struct {
+			Source struct {
+				Namespace []string `json:"namespace"`
+				Name      string   `json:"name"`
+			} `json:"source"`
+			Destination struct {
+				Namespace []string `json:"namespace"`
+				Name      string   `json:"name"`
+			} `json:"destination"`
+		}
+		r.NoError(json.NewDecoder(req.Body).Decode(&payload))
+		r.Equal([]string{"example"}, payload.Source.Namespace)
+		r.Equal("source", payload.Source.Name)
+		r.Equal([]string{"example"}, payload.Destination.Namespace)
+		r.Equal("destination", payload.Destination.Name)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Mock the load view endpoint for loading the renamed view.
+	r.mux.HandleFunc("/v1/namespaces/example/views/destination", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodGet, req.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"metadata-location": %q, "metadata": %s, "config": {}}`,
+			metadataLoc, exampleViewMetadataJSON)
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	fromIdent := catalog.ToIdentifier("example", "source")
+	toIdent := catalog.ToIdentifier("example", "destination")
+
+	renamed, err := cat.RenameView(context.Background(), fromIdent, toIdent)
+	r.Require().NoError(err)
+
+	r.Equal(toIdent, renamed.Identifier())
+	r.Equal(metadataLoc, renamed.MetadataLocation())
+	r.Equal(uuid.MustParse("a1b2c3d4-e5f6-7890-1234-567890abcdef"), renamed.Metadata().ViewUUID())
+	r.Equal(exampleViewSQL, renamed.Metadata().CurrentVersion().Representations[0].Sql)
+}
+
+func (r *RestCatalogSuite) TestRenameView404() {
+	r.mux.HandleFunc("/v1/views/rename", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodPost, req.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{"error": errorResponse{
+			Message: "The given view does not exist",
+			Type:    "NoSuchViewException",
+			Code:    404,
+		}})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	_, err = cat.RenameView(context.Background(),
+		catalog.ToIdentifier("example", "source"), catalog.ToIdentifier("example", "destination"))
+	r.ErrorIs(err, catalog.ErrNoSuchView)
+	r.ErrorContains(err, "The given view does not exist")
+}
+
+func (r *RestCatalogSuite) TestRenameView409() {
+	r.mux.HandleFunc("/v1/views/rename", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodPost, req.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]any{"error": errorResponse{
+			Message: "The given view already exists",
+			Type:    "AlreadyExistsException",
+			Code:    409,
+		}})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	_, err = cat.RenameView(context.Background(),
+		catalog.ToIdentifier("example", "source"), catalog.ToIdentifier("example", "destination"))
+	r.ErrorIs(err, catalog.ErrViewAlreadyExists)
+	r.ErrorContains(err, "The given view already exists")
+}
+
 type mockTransport struct {
 	calls []struct {
 		method, path string

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2693,6 +2693,10 @@ func (r *RestCatalogSuite) TestRenameView204() {
 	r.mux.HandleFunc("/v1/namespaces/example/views/destination", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodGet, req.Method)
 
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"metadata-location": %q, "metadata": %s, "config": {}}`,
 			metadataLoc, exampleViewMetadataJSON)
@@ -2717,6 +2721,10 @@ func (r *RestCatalogSuite) TestRenameView404() {
 	r.mux.HandleFunc("/v1/views/rename", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
 
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(map[string]any{"error": errorResponse{
@@ -2738,6 +2746,10 @@ func (r *RestCatalogSuite) TestRenameView404() {
 func (r *RestCatalogSuite) TestRenameView409() {
 	r.mux.HandleFunc("/v1/views/rename", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodPost, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
@@ -2836,6 +2848,12 @@ func (r *RestCatalogSuite) TestTableAndViewIdentifiersRequireNamespace() {
 
 	_, err = cat.RenameTable(context.Background(), table.Identifier{"namespace", "source"}, table.Identifier{"destination"})
 	r.ErrorIs(err, catalog.ErrNoSuchTable)
+
+	_, err = cat.RenameView(context.Background(), table.Identifier{"source"}, table.Identifier{"namespace", "destination"})
+	r.ErrorIs(err, catalog.ErrNoSuchView)
+
+	_, err = cat.RenameView(context.Background(), table.Identifier{"namespace", "source"}, table.Identifier{"destination"})
+	r.ErrorIs(err, catalog.ErrNoSuchView)
 
 	err = cat.CommitTransaction(context.Background(), []table.TableCommit{
 		{Identifier: table.Identifier{"table"}},

--- a/website/src/feature-status.md
+++ b/website/src/feature-status.md
@@ -106,6 +106,7 @@ S3, GCS, and Azure require a blank import: `_ "github.com/apache/iceberg-go/io/g
 | Load View                   |      |  X   |        |  X   |        |
 | List View                   |  X   |  X   |        |  X   |        |
 | Drop View                   |  X   |  X   |        |  X   |        |
+| Rename View                 |  X   |      |        |      |        |
 | Check View Exists           |  X   |  X   |        |  X   |        |
 
 A Hadoop catalog is also available - see [`catalog/hadoop`](https://github.com/apache/iceberg-go/tree/main/catalog/hadoop).


### PR DESCRIPTION
We were missing support for `renameView` on the REST Catalog. It looks we started support and then never finished it? 