### PR TITLE
WitMaxConcurrency rewrite

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -116,10 +116,10 @@ func WithDeleteFunc(deleteFunc func(string) error) OrphanCleanupOption {
 	}
 }
 
-// WithMaxConcurrency sets the maximum number of goroutines for parallel deletion.
+// WithCleanupMaxConcurrency sets the maximum number of goroutines for parallel deletion.
 // Defaults to a reasonable number based on the system. Only used when deleteFunc is nil or when
 // the FileIO doesn't support bulk operations.
-func WithMaxConcurrency(maxWorkers int) OrphanCleanupOption {
+func WithCleanupMaxConcurrency(maxWorkers int) OrphanCleanupOption {
 	return func(cfg *orphanCleanupConfig) {
 		if maxWorkers > 0 {
 			cfg.maxConcurrency = maxWorkers

--- a/table/orphan_cleanup_integration_test.go
+++ b/table/orphan_cleanup_integration_test.go
@@ -359,7 +359,7 @@ func (s *OrphanCleanupIntegrationSuite) TestOrphanCleanupWithConcurrency() {
 
 			// Run orphan cleanup with specific concurrency
 			result, err := tbl.DeleteOrphanFiles(s.ctx,
-				table.WithMaxConcurrency(tc.concurrency),
+				table.WithCleanupMaxConcurrency(tc.concurrency),
 				table.WithFilesOlderThan(0),
 				table.WithDryRun(false),
 			)

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -71,7 +71,7 @@ func TestOrphanCleanupOptions(t *testing.T) {
 	WithDeleteFunc(deleteFunc)(cfg)
 	assert.NotNil(t, cfg.deleteFunc)
 
-	WithMaxConcurrency(8)(cfg)
+	WithCleanupMaxConcurrency(8)(cfg)
 	assert.Equal(t, 8, cfg.maxConcurrency)
 
 	WithPrefixMismatchMode(PrefixMismatchIgnore)(cfg)
@@ -772,7 +772,7 @@ func TestDeleteOrphanFilesPopulatesOrphanFileSizes(t *testing.T) {
 	result, err := tbl.DeleteOrphanFiles(context.Background(),
 		WithDryRun(true),
 		WithLocation("s3://bucket/table"),
-		WithMaxConcurrency(1),
+		WithCleanupMaxConcurrency(1),
 		WithFilesOlderThan(0), // Consider files created before the scan.
 	)
 

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -189,10 +189,7 @@ func WithCompactionTargetFileSize(size int64) CompactionGroupOption {
 
 // WithCompactionScanConcurrency sets the scan concurrency used when
 // reading the group's tasks. Forwarded to [Table.Scan] as
-// [WitMaxConcurrency]. Zero (the default) means runtime.GOMAXPROCS.
-//
-// TODO: the [WitMaxConcurrency] link enshrines a pre-existing typo
-// (missing `h`). Update this reference when that symbol is renamed.
+// [WithScanMaxConcurrency]. Zero (the default) means runtime.GOMAXPROCS.
 func WithCompactionScanConcurrency(n int) CompactionGroupOption {
 	return func(c *compactionGroupConfig) {
 		c.scanConcurrency = n
@@ -297,7 +294,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 
 	var scanOpts []ScanOption
 	if cfg.scanConcurrency > 0 {
-		scanOpts = append(scanOpts, WitMaxConcurrency(cfg.scanConcurrency))
+		scanOpts = append(scanOpts, WithScanMaxConcurrency(cfg.scanConcurrency))
 	}
 
 	// Preserve row lineage only when every source file in the group carries

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -189,7 +189,7 @@ func WithCompactionTargetFileSize(size int64) CompactionGroupOption {
 
 // WithCompactionScanConcurrency sets the scan concurrency used when
 // reading the group's tasks. Forwarded to [Table.Scan] as
-// [WithScanMaxConcurrency]. Zero (the default) means runtime.GOMAXPROCS.
+// [WithMaxConcurrency]. Zero (the default) means runtime.GOMAXPROCS.
 func WithCompactionScanConcurrency(n int) CompactionGroupOption {
 	return func(c *compactionGroupConfig) {
 		c.scanConcurrency = n
@@ -294,7 +294,7 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 
 	var scanOpts []ScanOption
 	if cfg.scanConcurrency > 0 {
-		scanOpts = append(scanOpts, WithScanMaxConcurrency(cfg.scanConcurrency))
+		scanOpts = append(scanOpts, WithMaxConcurrency(cfg.scanConcurrency))
 	}
 
 	// Preserve row lineage only when every source file in the group carries

--- a/table/scan_options_test.go
+++ b/table/scan_options_test.go
@@ -35,3 +35,34 @@ func TestWithSelectedFieldsDoesNotAliasCallerSlice(t *testing.T) {
 	assert.Equal(t, []string{"id", "name"}, scan.selectedFields)
 	assert.NotEqual(t, fields[0], scan.selectedFields[0])
 }
+
+func TestWithMaxConcurrency(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+		want int
+	}{
+		{"positive sets concurrency", 4, 4},
+		{"zero is a no-op", 0, 0},
+		{"negative is a no-op", -1, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scan := &Scan{}
+			WithMaxConcurrency(tc.n)(scan)
+			assert.Equal(t, tc.want, scan.concurrency)
+		})
+	}
+}
+
+// The deprecated WitMaxConcurrency alias must stay in lock-step with the
+// canonical WithMaxConcurrency so callers on the old name don't drift.
+func TestWitMaxConcurrencyAliasParity(t *testing.T) {
+	for _, n := range []int{-1, 0, 1, 8} {
+		canonical, alias := &Scan{}, &Scan{}
+		WithMaxConcurrency(n)(canonical)
+		WitMaxConcurrency(n)(alias)
+		assert.Equal(t, canonical.concurrency, alias.concurrency, "n=%d", n)
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -866,9 +866,9 @@ func WithLimit(n int64) ScanOption {
 	}
 }
 
-// WitMaxConcurrency sets the maximum concurrency for table scan and plan
+// WithScanMaxConcurrency sets the maximum concurrency for table scan and plan
 // operations. When unset it defaults to runtime.GOMAXPROCS.
-func WitMaxConcurrency(n int) ScanOption {
+func WithScanMaxConcurrency(n int) ScanOption {
 	if n <= 0 {
 		return noopOption
 	}
@@ -876,6 +876,14 @@ func WitMaxConcurrency(n int) ScanOption {
 	return func(scan *Scan) {
 		scan.concurrency = n
 	}
+}
+
+// WitMaxConcurrency is a deprecated alias for [WithScanMaxConcurrency], kept for
+// backwards compatibility with the pre-existing typo'd name.
+//
+// Deprecated: use [WithScanMaxConcurrency].
+func WitMaxConcurrency(n int) ScanOption {
+	return WithScanMaxConcurrency(n)
 }
 
 func WithOptions(opts iceberg.Properties) ScanOption {

--- a/table/table.go
+++ b/table/table.go
@@ -866,9 +866,9 @@ func WithLimit(n int64) ScanOption {
 	}
 }
 
-// WithScanMaxConcurrency sets the maximum concurrency for table scan and plan
+// WithMaxConcurrency sets the maximum concurrency for table scan and plan
 // operations. When unset it defaults to runtime.GOMAXPROCS.
-func WithScanMaxConcurrency(n int) ScanOption {
+func WithMaxConcurrency(n int) ScanOption {
 	if n <= 0 {
 		return noopOption
 	}
@@ -878,12 +878,12 @@ func WithScanMaxConcurrency(n int) ScanOption {
 	}
 }
 
-// WitMaxConcurrency is a deprecated alias for [WithScanMaxConcurrency], kept for
-// backwards compatibility with the pre-existing typo'd name.
+// WitMaxConcurrency is a deprecated alias for [WithMaxConcurrency], kept for
+// backward compatibility with the pre-existing typo'd name.
 //
-// Deprecated: use [WithScanMaxConcurrency].
+// Deprecated: use [WithMaxConcurrency].
 func WitMaxConcurrency(n int) ScanOption {
-	return WithScanMaxConcurrency(n)
+	return WithMaxConcurrency(n)
 }
 
 func WithOptions(opts iceberg.Properties) ScanOption {

--- a/website/src/api.md
+++ b/website/src/api.md
@@ -490,7 +490,7 @@ import (
 result, err := tbl.DeleteOrphanFiles(ctx,
     table.WithFilesOlderThan(72*time.Hour),
     table.WithDryRun(false),
-    table.WithMaxConcurrency(8),
+    table.WithCleanupMaxConcurrency(8),
 )
 if err != nil { /* ... */ }
 fmt.Printf("removed %d files\n", len(result.DeletedFiles))

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -199,7 +199,7 @@ There is no `PYICEBERG_*`-style env var convention. Use the YAML config file or 
 | Setting | Source | Effect |
 |---|---|---|
 | `max-workers` in `~/.iceberg-go.yaml` (`config.EnvConfig.MaxWorkers`) | YAML config | Worker pool size used by parallel column writes, snapshot producers, scan plan, equality-delete writers. Default `5`. |
-| `WithScanMaxConcurrency(n int) ScanOption` | Code (`table.WithScanMaxConcurrency`) | Per-scan override. `WitMaxConcurrency` (missing `h`) remains as a deprecated alias. |
+| `WithMaxConcurrency(n int) ScanOption` | Code (`table.WithMaxConcurrency`) | Per-scan override. `WitMaxConcurrency` (missing `h`) remains as a deprecated alias. |
 | `WithMaxWriteWorkers(n int)` | Code (per-write API on `WriteRecords`) | Per-write override of the worker count. |
 | `WithClusteredWrite()` | Code (per-write API on `WriteRecords`) | Forces single-threaded writes. Mutually exclusive with `WithMaxWriteWorkers`. |
 

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -199,7 +199,7 @@ There is no `PYICEBERG_*`-style env var convention. Use the YAML config file or 
 | Setting | Source | Effect |
 |---|---|---|
 | `max-workers` in `~/.iceberg-go.yaml` (`config.EnvConfig.MaxWorkers`) | YAML config | Worker pool size used by parallel column writes, snapshot producers, scan plan, equality-delete writers. Default `5`. |
-| `WitMaxConcurrency(n int) ScanOption` | Code (`table.WitMaxConcurrency`) | Per-scan override. Note: function name is `Wit...` (not `With...`) - this is a pre-existing typo in the public API. |
+| `WithScanMaxConcurrency(n int) ScanOption` | Code (`table.WithScanMaxConcurrency`) | Per-scan override. `WitMaxConcurrency` (missing `h`) remains as a deprecated alias. |
 | `WithMaxWriteWorkers(n int)` | Code (per-write API on `WriteRecords`) | Per-write override of the worker count. |
 | `WithClusteredWrite()` | Code (per-write API on `WriteRecords`) | Forces single-threaded writes. Mutually exclusive with `WithMaxWriteWorkers`. |
 


### PR DESCRIPTION
(I think we should have a discussion on this one)

We had a ScanOption named `WitMaxConcurrency`, which is obviously a typo. But, the correct name conflicts with an option in orpan_cleanups.go called `WithMaxConcurrency`.

I've renamed `WithMaxConcurrency` -> `WithScanMaxConcurrency`. Ideally, this conflict shouldn't happen in the first place, but we'll have to do some package renames to make that happen.