### PR TITLE
feat(transforms): read unknown partition and sort transforms (v3)

### DIFF
--- a/expr_json.go
+++ b/expr_json.go
@@ -594,6 +594,11 @@ func decodeTerm(raw json.RawMessage) (UnboundTerm, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%w: cannot parse transform term: %s", ErrInvalidArgument, err)
 		}
+		// Unknown transforms are tolerated in partition/sort metadata, but a
+		// filter expression referencing one can't be evaluated.
+		if _, ok := tf.(UnknownTransform); ok {
+			return nil, fmt.Errorf("%w: unknown transform in expression term: %s", ErrInvalidArgument, t.Transform)
+		}
 
 		return NewUnboundTransform(tf, Reference(t.Term)), nil
 	default:

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -450,12 +450,22 @@ func TestUnboundTransformBind(t *testing.T) {
 	assert.True(t, bound.Type().Equals(iceberg.PrimitiveTypes.Int32))
 }
 
-// TestUnmarshalExpressionTransformTermInvalid rejects an unparseable transform
+// TestUnmarshalExpressionTransformTermInvalid rejects an invalid transform
 // string rather than panicking or binding nonsense.
 func TestUnmarshalExpressionTransformTermInvalid(t *testing.T) {
 	_, err := iceberg.ParseExpr(
-		[]byte(`{"type":"eq","term":{"type":"transform","transform":"bogus[16]","term":"id"},"value":1}`), nil)
+		[]byte(`{"type":"eq","term":{"type":"transform","transform":"bucket[0]","term":"id"},"value":1}`), nil)
 	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "cannot parse transform term")
+}
+
+// An unknown transform parses fine, but a filter expression over one can't be
+// evaluated, so the term is rejected rather than silently mis-bound.
+func TestUnmarshalExpressionTransformTermUnknown(t *testing.T) {
+	_, err := iceberg.ParseExpr(
+		[]byte(`{"type":"eq","term":{"type":"transform","transform":"custom_transform[42]","term":"id"},"value":1}`), nil)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "unknown transform in expression term")
 }
 
 // TestUnmarshalExpressionFixedLength rejects a fixed value whose decoded length

--- a/partitions.go
+++ b/partitions.go
@@ -325,6 +325,14 @@ func validateTransform(transform Transform) error {
 		return t.validateWidth()
 	case *TruncateTransform:
 		return t.validateWidth()
+	case UnknownTransform:
+		// The zero value is constructible from outside the package and would
+		// serialize as "transform": "".
+		if t.String() == "" {
+			return fmt.Errorf("%w: unknown transform has no name", ErrInvalidTransform)
+		}
+
+		return nil
 	default:
 		return nil
 	}
@@ -730,6 +738,11 @@ func GeneratePartitionFieldName(schema *Schema, field PartitionField) (string, e
 
 	transform := field.Transform
 	switch t := transform.(type) {
+	case UnknownTransform:
+		// A generated name would embed the transform's brackets, e.g.
+		// "id_custom_transform[42]". Make the caller supply one.
+		return "", fmt.Errorf("%w: partition field using unknown transform %s must be given an explicit name",
+			ErrInvalidTransform, t)
 	case IdentityTransform:
 		return sourceName, nil
 	case VoidTransform:

--- a/partitions.go
+++ b/partitions.go
@@ -321,6 +321,8 @@ func validateTransform(transform Transform) error {
 		return t.validateWidth()
 	case *TruncateTransform:
 		return t.validateWidth()
+	case UnknownTransform:
+		return fmt.Errorf("%w: cannot write partition spec with unknown transform: %s", ErrInvalidTransform, t.String())
 	default:
 		return nil
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -125,6 +125,10 @@ func (p *PartitionField) UnmarshalJSON(b []byte) error {
 	_, hasSourceID := raw["source-id"]
 	_, hasSourceIDs := raw["source-ids"]
 
+	if tf, ok := raw["transform"]; !ok || string(tf) == "null" {
+		return fmt.Errorf("%w: partition field requires a transform", ErrInvalidTransform)
+	}
+
 	aux := struct {
 		SourceID        int    `json:"source-id"`
 		SourceIDs       []int  `json:"source-ids,omitempty"`

--- a/partitions.go
+++ b/partitions.go
@@ -321,8 +321,6 @@ func validateTransform(transform Transform) error {
 		return t.validateWidth()
 	case *TruncateTransform:
 		return t.validateWidth()
-	case UnknownTransform:
-		return fmt.Errorf("%w: cannot write partition spec with unknown transform: %s", ErrInvalidTransform, t.String())
 	default:
 		return nil
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -526,6 +526,24 @@ func TestPartitionSpecToPathWithDroppedLeadingSourceColumn(t *testing.T) {
 	assert.Equal(t, "foo=null/bar=7/baz=true", spec.PartitionToPath(record, schema))
 }
 
+// An unknown transform renders the partition value, so two different values
+// must not collapse to the same path -- that path string is the writer key.
+func TestPartitionSpecToPathUnknownTransform(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true})
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	spec := iceberg.NewPartitionSpecID(3, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: unknown, Name: "custom",
+	})
+
+	assert.Equal(t, "custom=1", spec.PartitionToPath(partitionRecord{int32(1)}, schema))
+	assert.Equal(t, "custom=2", spec.PartitionToPath(partitionRecord{int32(2)}, schema))
+	assert.Equal(t, "custom=null", spec.PartitionToPath(partitionRecord{nil}, schema))
+}
+
 func TestGetPartitionFieldName(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "str", Type: iceberg.PrimitiveTypes.String},
@@ -581,6 +599,25 @@ func TestGetPartitionFieldName(t *testing.T) {
 			assert.Equal(t, test.expectedName, name)
 		})
 	}
+}
+
+// Generating a name would embed the transform's brackets, so an unknown
+// transform needs an explicit one.
+func TestGetPartitionFieldNameUnknownTransform(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true})
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	_, err = iceberg.GeneratePartitionFieldName(schema,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Transform: unknown})
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+
+	name, err := iceberg.GeneratePartitionFieldName(schema,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Transform: unknown, Name: "custom"})
+	require.NoError(t, err)
+	assert.Equal(t, "custom", name)
 }
 
 func TestPartitionFieldUnmarshalJSON(t *testing.T) {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -254,6 +254,47 @@ func TestPartitionSpec_MarshalTextRejectsInvalidTruncateTransform(t *testing.T) 
 	require.ErrorContains(t, err, "width > 0")
 }
 
+// A v3 table may use a partition transform this implementation doesn't know.
+// Readers must load it and preserve it on write, ignoring it when filtering.
+func TestPartitionFieldUnknownTransformRoundTrip(t *testing.T) {
+	jsonData := `
+	{
+		"source-id": 1,
+		"field-id": 1000,
+		"transform": "custom_transform[42]",
+		"name": "id_custom"
+	}`
+	var field iceberg.PartitionField
+	err := json.Unmarshal([]byte(jsonData), &field)
+	require.NoError(t, err)
+
+	_, ok := field.Transform.(iceberg.UnknownTransform)
+	require.True(t, ok, "unknown transform should parse to UnknownTransform")
+	assert.Equal(t, "custom_transform[42]", field.Transform.String())
+
+	data, err := json.Marshal(field)
+	require.NoError(t, err)
+	assert.JSONEq(t, jsonData, string(data))
+}
+
+// Writers must not commit a partition spec that uses an unknown transform.
+func TestPartitionSpecRejectsUnknownTransform(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   1,
+		Name: "id",
+		Type: iceberg.PrimitiveTypes.Int32,
+	})
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	_, err = iceberg.NewPartitionSpecOpts(
+		iceberg.AddPartitionFieldBySourceID(1, "id_custom", unknown, schema, nil),
+	)
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+	require.ErrorContains(t, err, "custom_transform[42]")
+}
+
 func TestUnpartitionedWithVoidField(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 		SourceIDs: []int{3}, FieldID: 1001, Name: "void", Transform: iceberg.VoidTransform{},

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -277,8 +277,9 @@ func TestPartitionFieldUnknownTransformRoundTrip(t *testing.T) {
 	assert.JSONEq(t, jsonData, string(data))
 }
 
-// Writers must not commit a partition spec that uses an unknown transform.
-func TestPartitionSpecRejectsUnknownTransform(t *testing.T) {
+// Building a spec tolerates unknown transforms, matching Java's PartitionSpec
+// builder. Rejection happens later, only when evolving such a spec.
+func TestPartitionSpecAcceptsUnknownTransform(t *testing.T) {
 	schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID:   1,
 		Name: "id",
@@ -288,11 +289,13 @@ func TestPartitionSpecRejectsUnknownTransform(t *testing.T) {
 	unknown, err := iceberg.ParseTransform("custom_transform[42]")
 	require.NoError(t, err)
 
-	_, err = iceberg.NewPartitionSpecOpts(
+	spec, err := iceberg.NewPartitionSpecOpts(
 		iceberg.AddPartitionFieldBySourceID(1, "id_custom", unknown, schema, nil),
 	)
-	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
-	require.ErrorContains(t, err, "custom_transform[42]")
+	require.NoError(t, err)
+
+	_, ok := spec.Field(0).Transform.(iceberg.UnknownTransform)
+	assert.True(t, ok)
 }
 
 func TestUnpartitionedWithVoidField(t *testing.T) {

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1858,6 +1858,26 @@ func checkNoUnknownTransform(spec *iceberg.PartitionSpec) error {
 	return nil
 }
 
+// checkNoUnknownTransformInSpecs applies checkNoUnknownTransform to every spec
+// the given data files were written under. Delete writes target existing files,
+// so the relevant spec is each file's own, which may be an older one.
+func checkNoUnknownTransformInSpecs(meta Metadata, partitionContextByFilePath map[string]partitionContext) error {
+	seen := make(map[int32]struct{}, len(partitionContextByFilePath))
+	for _, pCtx := range partitionContextByFilePath {
+		if _, ok := seen[pCtx.specID]; ok {
+			continue
+		}
+		seen[pCtx.specID] = struct{}{}
+		if err := checkNoUnknownTransform(meta.PartitionSpecByID(int(pCtx.specID))); err != nil {
+			return err
+		}
+	}
+
+	currentSpec := meta.PartitionSpec()
+
+	return checkNoUnknownTransform(&currentSpec)
+}
+
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {
 	spec, err := meta.CurrentSpec()
 	if err == nil {
@@ -2007,6 +2027,15 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 
 	latestMetadata, err := meta.Build()
 	if err != nil {
+		return func(yield func(iceberg.DataFile, error) bool) {
+			yield(nil, err)
+		}
+	}
+
+	// Check the specs the targeted data files were written under, not just the
+	// current one: a table that has since evolved past the unknown transform
+	// still reaches this path through its historic specs.
+	if err := checkNoUnknownTransformInSpecs(latestMetadata, partitionContextByFilePath); err != nil {
 		return func(yield func(iceberg.DataFile, error) bool) {
 			yield(nil, err)
 		}

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1715,6 +1715,10 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 		return nil, fmt.Errorf("%w: cannot add files without a current spec", err)
 	}
 
+	if err := checkNoUnknownTransform(partitionSpec); err != nil {
+		return nil, err
+	}
+
 	currentSchema, currentSpec := meta.CurrentSchema(), *partitionSpec
 
 	dataFiles := make([]iceberg.DataFile, len(filePaths))
@@ -1837,7 +1841,34 @@ type recordWritingArgs struct {
 	existingDVs map[string]*dv.RoaringPositionBitmap
 }
 
+// checkNoUnknownTransform rejects writes against a spec containing an unknown
+// partition transform. We can't compute partition values for it, so writing
+// would produce null values under a field=<transform-name> dir that Java and
+// PyIceberg can't read. The spec forbids committing against such a spec.
+func checkNoUnknownTransform(spec *iceberg.PartitionSpec) error {
+	if spec == nil {
+		return nil
+	}
+	for _, f := range spec.Fields() {
+		if _, ok := f.Transform.(iceberg.UnknownTransform); ok {
+			return fmt.Errorf("%w: cannot write to a partition spec with unknown transform: %s", iceberg.ErrInvalidTransform, f.Transform)
+		}
+	}
+
+	return nil
+}
+
 func recordsToDataFiles(ctx context.Context, rootLocation string, meta *MetadataBuilder, args recordWritingArgs) (ret iter.Seq2[iceberg.DataFile, error]) {
+	spec, err := meta.CurrentSpec()
+	if err == nil {
+		err = checkNoUnknownTransform(spec)
+	}
+	if err != nil {
+		return func(yield func(iceberg.DataFile, error) bool) {
+			yield(nil, err)
+		}
+	}
+
 	if args.counter == nil {
 		args.counter = internal.Counter(0)
 	}

--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -681,3 +681,80 @@ func TestGeoArrowCRSToIcebergCRS(t *testing.T) {
 		}
 	})
 }
+
+// Delete writes target files written under whatever spec was current at the
+// time, so the guard has to look past the current spec.
+func TestCheckNoUnknownTransformInSpecs(t *testing.T) {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	tableSchema := schema()
+	cleanSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Name: "y", Transform: iceberg.IdentityTransform{},
+	})
+	unknownSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1001, Name: "y_custom", Transform: unknown,
+	})
+
+	// Specs are added in order; the last one added becomes the default, so the
+	// caller controls which spec is current and which is historic.
+	build := func(t *testing.T, specs ...iceberg.PartitionSpec) Metadata {
+		builder, err := NewMetadataBuilder(2)
+		require.NoError(t, err)
+		require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
+		require.NoError(t, builder.AddSchema(&tableSchema))
+		require.NoError(t, builder.SetCurrentSchemaID(-1))
+		sortOrder := sortOrder()
+		require.NoError(t, builder.AddSortOrder(&sortOrder))
+		require.NoError(t, builder.SetDefaultSortOrderID(-1))
+		for i := range specs {
+			require.NoError(t, builder.AddPartitionSpec(&specs[i], i == 0))
+		}
+		require.NoError(t, builder.SetDefaultSpecID(-1))
+		meta, err := builder.Build()
+		require.NoError(t, err)
+
+		return meta
+	}
+
+	specIDWithUnknown := func(t *testing.T, meta Metadata) int32 {
+		for _, spec := range meta.PartitionSpecs() {
+			specID := int32(spec.ID())
+			for _, f := range spec.Fields() {
+				if _, ok := f.Transform.(iceberg.UnknownTransform); ok {
+					return specID
+				}
+			}
+		}
+		t.Fatal("no spec with an unknown transform")
+
+		return 0
+	}
+
+	t.Run("unknown in current spec", func(t *testing.T) {
+		meta := build(t, cleanSpec, unknownSpec)
+		err := checkNoUnknownTransformInSpecs(meta, nil)
+		require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+		assert.ErrorContains(t, err, "custom_transform[42]")
+	})
+
+	t.Run("unknown only in historic spec", func(t *testing.T) {
+		meta := build(t, unknownSpec, cleanSpec)
+		files := map[string]partitionContext{
+			"s3://bucket/data/a.parquet": {specID: specIDWithUnknown(t, meta)},
+		}
+		require.ErrorIs(t, checkNoUnknownTransformInSpecs(meta, files), iceberg.ErrInvalidTransform)
+
+		// No file was written under the unknown spec, so there is nothing to reject.
+		require.NoError(t, checkNoUnknownTransformInSpecs(meta, nil))
+	})
+
+	t.Run("all specs clean", func(t *testing.T) {
+		meta := build(t, cleanSpec)
+		currentSpec := meta.PartitionSpec()
+		files := map[string]partitionContext{
+			"s3://bucket/data/a.parquet": {specID: int32(currentSpec.ID())},
+		}
+		require.NoError(t, checkNoUnknownTransformInSpecs(meta, files))
+	})
+}

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -822,6 +822,18 @@ func (*ProjectionTestSuite) idSpec() iceberg.PartitionSpec {
 	)
 }
 
+func (p *ProjectionTestSuite) unknownSpec() iceberg.PartitionSpec {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	p.Require().NoError(err)
+
+	return iceberg.NewPartitionSpec(
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: unknown, Name: "id_custom",
+		},
+	)
+}
+
 func (*ProjectionTestSuite) bucketSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
@@ -1154,6 +1166,15 @@ func (p *ProjectionTestSuite) TestProjectionCaseInsensitive() {
 	expr, err := project(iceberg.NotNull(iceberg.Reference("ID")))
 	p.Require().NoError(err)
 	p.True(expr.Equals(iceberg.NotNull(iceberg.Reference("id_part"))))
+}
+
+// Unknown partition transforms must not prune: Project returns nil, which
+// projects to AlwaysTrue.
+func (p *ProjectionTestSuite) TestUnknownTransformProjection() {
+	project := newInclusiveProjection(p.schema(), p.unknownSpec(), true)
+	expr, err := project(iceberg.LessThan(iceberg.Reference("id"), int64(5)))
+	p.Require().NoError(err)
+	p.Equal(iceberg.AlwaysTrue{}, expr)
 }
 
 func (p *ProjectionTestSuite) TestProjectEmptySpec() {

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -834,6 +834,24 @@ func (p *ProjectionTestSuite) unknownSpec() iceberg.PartitionSpec {
 	)
 }
 
+// Both fields partition the same column: the bucket field still prunes, the
+// unknown one contributes nothing.
+func (p *ProjectionTestSuite) bucketAndUnknownSpec() iceberg.PartitionSpec {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	p.Require().NoError(err)
+
+	return iceberg.NewPartitionSpec(
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000,
+			Transform: iceberg.BucketTransform{NumBuckets: 4}, Name: "id_bucket",
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1001,
+			Transform: unknown, Name: "id_custom",
+		},
+	)
+}
+
 func (*ProjectionTestSuite) bucketSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpec(
 		iceberg.PartitionField{
@@ -1175,6 +1193,17 @@ func (p *ProjectionTestSuite) TestUnknownTransformProjection() {
 	expr, err := project(iceberg.LessThan(iceberg.Reference("id"), int64(5)))
 	p.Require().NoError(err)
 	p.Equal(iceberg.AlwaysTrue{}, expr)
+}
+
+// An unknown field alongside a usable one must not disable the usable one's
+// pruning, and must not add a term of its own.
+func (p *ProjectionTestSuite) TestMixedSpecUnknownTransformProjection() {
+	spec := p.bucketAndUnknownSpec()
+	project := newInclusiveProjection(p.schema(), spec, true)
+
+	expr, err := project(iceberg.EqualTo(iceberg.Reference("id"), int64(5)))
+	p.Require().NoError(err)
+	p.True(expr.Equals(iceberg.EqualTo(iceberg.Reference("id_bucket"), int32(3))))
 }
 
 func (p *ProjectionTestSuite) TestProjectEmptySpec() {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -423,6 +423,13 @@ func TestMetadataV3ParsesUnknownTransforms(t *testing.T) {
 	_, ok = sf.Transform.(iceberg.UnknownTransform)
 	assert.True(t, ok, "unknown sort transform should load")
 	assert.Equal(t, "custom_sort[7]", sf.Transform.String())
+
+	// Marshalling back must preserve the unknown transforms verbatim, proving
+	// no write-path guard strips or rewrites them.
+	out, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "custom_transform[42]")
+	assert.Contains(t, string(out), "custom_sort[7]")
 }
 
 func TestMetadataEqualsIncludesStatistics(t *testing.T) {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -400,6 +400,31 @@ func assertMissingLastUpdatedMS(t *testing.T, metadata map[string]any) {
 	assert.ErrorContains(t, err, "last-updated-ms is absent or null")
 }
 
+// A full v3 metadata document must load when its partition spec and sort order
+// use unknown transforms — nothing on the metadata path may trip a guard.
+func TestMetadataV3ParsesUnknownTransforms(t *testing.T) {
+	j := strings.NewReplacer(
+		`{"name": "x", "transform": "identity", "source-id": 1, "field-id": 1000}`,
+		`{"name": "x", "transform": "custom_transform[42]", "source-id": 1, "field-id": 1000}`,
+		`{"transform": "bucket[4]", "source-id": 3, "direction": "desc", "null-order": "nulls-last"}`,
+		`{"transform": "custom_sort[7]", "source-id": 3, "direction": "desc", "null-order": "nulls-last"}`,
+	).Replace(ExampleTableMetadataV3)
+
+	meta, err := ParseMetadataBytes([]byte(j))
+	require.NoError(t, err)
+
+	spec := meta.PartitionSpec()
+	pf := spec.Field(0)
+	_, ok := pf.Transform.(iceberg.UnknownTransform)
+	assert.True(t, ok, "unknown partition transform should load")
+	assert.Equal(t, "custom_transform[42]", pf.Transform.String())
+
+	sf := meta.SortOrder().Field(1)
+	_, ok = sf.Transform.(iceberg.UnknownTransform)
+	assert.True(t, ok, "unknown sort transform should load")
+	assert.Equal(t, "custom_sort[7]", sf.Transform.String())
+}
+
 func TestMetadataEqualsIncludesStatistics(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	base, err := builder.Build()

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -1148,3 +1148,67 @@ func TestProjectionV3SchemaAlreadyHasRowID(t *testing.T) {
 		assert.Contains(t, seen, iceberg.RowIDFieldID, "_row_id must survive projection")
 	})
 }
+
+// A filter on the source column of an unknown partition field must not prune:
+// the same manifest summary would prune under an identity transform.
+func TestPlanFilesUnknownTransformDoesNotPrune(t *testing.T) {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	lower, upper := int32Bound(10), int32Bound(20)
+	dataPath := "mem://default/table/data.parquet"
+	manifestPath := "mem://default/table/metadata/manifest.avro"
+	manifestListPath := "mem://default/table/metadata/snap-7.avro"
+
+	plan := func(t *testing.T, transform iceberg.Transform) []FileScanTask {
+		t.Helper()
+
+		spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: transform,
+		})
+		memIO := iceio.NewMemFS()
+		scan, oldSchema, snapshotID := newSchemaEvolutionScanWithSnapshot(t, &spec, memIO, manifestListPath, nil)
+
+		// Metrics bounds cover the filter value so only partition pruning is
+		// in play.
+		dataFile, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData, dataPath,
+			iceberg.ParquetFile, nil, nil, nil, 1, 1024)
+		require.NoError(t, err)
+		entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID,
+			dataFile.LowerBoundValues(map[int][]byte{1: int32Bound(5)}).
+				UpperBoundValues(map[int][]byte{1: int32Bound(5)}).
+				Build(),
+		).SequenceNum(1).Build()
+
+		var manifestBytes bytes.Buffer
+		_, err = iceberg.WriteManifest(manifestPath, &manifestBytes, 2, spec, oldSchema, snapshotID,
+			[]iceberg.ManifestEntry{entry})
+		require.NoError(t, err)
+		require.NoError(t, memIO.WriteFile(manifestPath, manifestBytes.Bytes()))
+
+		// Partition summary excludes the filter value (id == 5).
+		manifest := iceberg.NewManifestFile(2, manifestPath, int64(manifestBytes.Len()), int32(spec.ID()), snapshotID).
+			Partitions([]iceberg.FieldSummary{{ContainsNull: false, LowerBound: &lower, UpperBound: &upper}}).
+			SequenceNum(1, 1).
+			Build()
+
+		var listBytes bytes.Buffer
+		seqNum := int64(1)
+		require.NoError(t, iceberg.WriteManifestList(2, &listBytes, snapshotID, nil, &seqNum, 0,
+			[]iceberg.ManifestFile{manifest}))
+		require.NoError(t, memIO.WriteFile(manifestListPath, listBytes.Bytes()))
+
+		tasks, err := scan.PlanFiles(context.Background())
+		require.NoError(t, err)
+
+		return tasks
+	}
+
+	t.Run("identity prunes", func(t *testing.T) {
+		assert.Empty(t, plan(t, iceberg.IdentityTransform{}))
+	})
+
+	t.Run("unknown does not prune", func(t *testing.T) {
+		assert.Len(t, plan(t, unknown), 1)
+	})
+}

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -249,6 +249,11 @@ func (s SortOrder) Len() int {
 	return len(s.fields)
 }
 
+// Field returns the sort field at index i.
+func (s SortOrder) Field(i int) SortField {
+	return s.fields[i]
+}
+
 func (s SortOrder) MarshalJSON() ([]byte, error) {
 	type Alias struct {
 		OrderID int         `json:"order-id"`
@@ -333,10 +338,6 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 			if err := validateSortSourceIDs(field.SourceIDs); err != nil {
 				return SortOrder{}, fmt.Errorf("%w: sort field at index %d has invalid source IDs: %v",
 					ErrInvalidSortSourceID, idx, err)
-			}
-			if u, ok := field.Transform.(iceberg.UnknownTransform); ok {
-				return SortOrder{}, fmt.Errorf("%w: cannot write sort order with unknown transform: %s",
-					ErrInvalidTransform, u.String())
 			}
 		}
 	}

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -334,6 +334,10 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 				return SortOrder{}, fmt.Errorf("%w: sort field at index %d has invalid source IDs: %v",
 					ErrInvalidSortSourceID, idx, err)
 			}
+			if u, ok := field.Transform.(iceberg.UnknownTransform); ok {
+				return SortOrder{}, fmt.Errorf("%w: cannot write sort order with unknown transform: %s",
+					ErrInvalidTransform, u.String())
+			}
 		}
 	}
 

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -146,6 +146,10 @@ func (s *SortField) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("%w: exactly one of source-id or source-ids is required", ErrInvalidSortSourceID)
 	}
 
+	if tf, ok := raw["transform"]; !ok || string(tf) == "null" {
+		return fmt.Errorf("%w: sort field requires a transform", iceberg.ErrInvalidTransform)
+	}
+
 	aux := struct {
 		SourceID        int           `json:"source-id"`
 		SourceIDs       []int         `json:"source-ids,omitempty"`

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -253,9 +253,11 @@ func (s SortOrder) Len() int {
 	return len(s.fields)
 }
 
-// Field returns the sort field at index i.
+// Field returns a copy of the sort field at index i, like Fields does, so a
+// caller can't reach the sort order's internals through SortField.SourceIDs.
+// It panics if i is out of range.
 func (s SortOrder) Field(i int) SortField {
-	return s.fields[i]
+	return cloneSortField(s.fields[i])
 }
 
 func (s SortOrder) MarshalJSON() ([]byte, error) {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -184,20 +184,20 @@ func TestSortOrderReturnsDefensiveCopies(t *testing.T) {
 	assert.Equal(t, 1, seen)
 }
 
-// Writers must not commit an un-evaluatable sort order; reads still load them
-// (TestUnmarshalUnknownSortTransform).
-func TestNewSortOrderRejectsUnknownTransform(t *testing.T) {
+// Unknown sort transforms are tolerated on write, matching Java (canTransform
+// stays true and nothing rejects them).
+func TestNewSortOrderAcceptsUnknownTransform(t *testing.T) {
 	unknown, err := iceberg.ParseTransform("custom_transform[42]")
 	require.NoError(t, err)
 
-	_, err = table.NewSortOrder(1, []table.SortField{{
+	order, err := table.NewSortOrder(1, []table.SortField{{
 		SourceIDs: []int{19},
 		Transform: unknown,
 		NullOrder: table.NullsFirst,
 		Direction: table.SortASC,
 	}})
-	require.ErrorIs(t, err, table.ErrInvalidTransform)
-	require.ErrorContains(t, err, "custom_transform[42]")
+	require.NoError(t, err)
+	assert.Equal(t, unknown, order.Field(0).Transform)
 }
 
 func TestSortOrderCheckCompatibilityWithValidTransform(t *testing.T) {
@@ -337,14 +337,7 @@ func TestUnmarshalUnknownSortTransform(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, order.Len())
 
-	var first table.SortField
-	for i, f := range order.Fields() {
-		if i == 0 {
-			first = f
-
-			break
-		}
-	}
+	first := order.Field(0)
 	_, ok := first.Transform.(iceberg.UnknownTransform)
 	assert.True(t, ok, "unknown transform should parse to UnknownTransform")
 	assert.Equal(t, "foobar", first.Transform.String())

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -304,13 +304,42 @@ func TestUnmarshalInvalidSortNullOrder(t *testing.T) {
 	assert.ErrorIs(t, err, table.ErrInvalidNullOrder)
 }
 
-func TestUnmarshalInvalidSortTransform(t *testing.T) {
-	badJson := `{
+// v3 readers must load sort orders that use unknown transforms, preserving
+// them for round-trip rather than failing.
+func TestUnmarshalUnknownSortTransform(t *testing.T) {
+	j := `{
 		"order-id": 22,
 		"fields": [
 			{"source-id": 19, "transform": "foobar", "direction": "asc", "null-order": "nulls-first"},
 			{"source-id": 25, "transform": "bucket[4]", "direction": "desc", "null-order": "nulls-last"},
 			{"source-id": 22, "transform": "void", "direction": "asc", "null-order": "nulls-first"}
+		]
+	}`
+
+	var order table.SortOrder
+	err := json.Unmarshal([]byte(j), &order)
+	require.NoError(t, err)
+	require.Equal(t, 3, order.Len())
+
+	var first table.SortField
+	for i, f := range order.Fields() {
+		if i == 0 {
+			first = f
+
+			break
+		}
+	}
+	_, ok := first.Transform.(iceberg.UnknownTransform)
+	assert.True(t, ok, "unknown transform should parse to UnknownTransform")
+	assert.Equal(t, "foobar", first.Transform.String())
+}
+
+// A malformed known sort transform still errors.
+func TestUnmarshalInvalidSortTransform(t *testing.T) {
+	badJson := `{
+		"order-id": 22,
+		"fields": [
+			{"source-id": 25, "transform": "bucket[0]", "direction": "desc", "null-order": "nulls-last"}
 		]
 	}`
 

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -184,6 +184,22 @@ func TestSortOrderReturnsDefensiveCopies(t *testing.T) {
 	assert.Equal(t, 1, seen)
 }
 
+// Writers must not commit an un-evaluatable sort order; reads still load them
+// (TestUnmarshalUnknownSortTransform).
+func TestNewSortOrderRejectsUnknownTransform(t *testing.T) {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	_, err = table.NewSortOrder(1, []table.SortField{{
+		SourceIDs: []int{19},
+		Transform: unknown,
+		NullOrder: table.NullsFirst,
+		Direction: table.SortASC,
+	}})
+	require.ErrorIs(t, err, table.ErrInvalidTransform)
+	require.ErrorContains(t, err, "custom_transform[42]")
+}
+
 func TestSortOrderCheckCompatibilityWithValidTransform(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 19, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -832,6 +832,29 @@ func (t *TableWritingTestSuite) TestAddFilesToBucketPartitionedTableFails() {
 	t.ErrorContains(err, "cannot infer partition value from parquet metadata for a non-linear partition field: baz_bucket_3 with transform bucket[3]")
 }
 
+func (t *TableWritingTestSuite) TestAddFilesToUnknownTransformSpecFails() {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	t.Require().NoError(err)
+
+	ident := table.Identifier{"default", "partitioned_table_unknown_fails_v" + strconv.Itoa(t.formatVersion)}
+	spec := iceberg.NewPartitionSpec(
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: unknown, Name: "baz_custom"})
+
+	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
+	filePath := fmt.Sprintf("%s/partitioned_table/test-unknown.parquet", t.location)
+	arrTable, err := array.TableFromJSON(memory.DefaultAllocator, t.arrSchema, []string{
+		`[{"foo": true, "bar": "bar_string", "baz": 1, "qux": "2024-03-07"}]`,
+	})
+	t.Require().NoError(err)
+	defer arrTable.Release()
+	t.writeParquet(mustFS(t.T(), tbl).(iceio.WriteFileIO), filePath, arrTable)
+
+	tx := tbl.NewTransaction()
+	err = tx.AddFiles(t.ctx, []string{filePath}, nil, false)
+	t.Require().ErrorIs(err, iceberg.ErrInvalidTransform)
+	t.ErrorContains(err, "custom_transform[42]")
+}
+
 func (t *TableWritingTestSuite) TestAddFilesToPartitionedTableFailsLowerAndUpperMismatch() {
 	ident := table.Identifier{"default", "partitioned_table_bucket_fails_v" + strconv.Itoa(t.formatVersion)}
 	spec := iceberg.NewPartitionSpec(

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -841,7 +841,7 @@ func (t *TableWritingTestSuite) TestAddFilesToUnknownTransformSpecFails() {
 		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: unknown, Name: "baz_custom"})
 
 	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
-	filePath := fmt.Sprintf("%s/partitioned_table/test-unknown.parquet", t.location)
+	filePath := t.location + "/partitioned_table/test-unknown.parquet"
 	arrTable, err := array.TableFromJSON(memory.DefaultAllocator, t.arrSchema, []string{
 		`[{"foo": true, "bar": "bar_string", "baz": 1, "qux": "2024-03-07"}]`,
 	})

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pterm/pterm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uptrace/bun/driver/sqliteshim"
@@ -830,29 +831,6 @@ func (t *TableWritingTestSuite) TestAddFilesToBucketPartitionedTableFails() {
 	err := tx.AddFiles(t.ctx, files, nil, false)
 	t.Error(err)
 	t.ErrorContains(err, "cannot infer partition value from parquet metadata for a non-linear partition field: baz_bucket_3 with transform bucket[3]")
-}
-
-func (t *TableWritingTestSuite) TestAddFilesToUnknownTransformSpecFails() {
-	unknown, err := iceberg.ParseTransform("custom_transform[42]")
-	t.Require().NoError(err)
-
-	ident := table.Identifier{"default", "partitioned_table_unknown_fails_v" + strconv.Itoa(t.formatVersion)}
-	spec := iceberg.NewPartitionSpec(
-		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: unknown, Name: "baz_custom"})
-
-	tbl := t.createTable(ident, t.formatVersion, spec, t.tableSchema)
-	filePath := t.location + "/partitioned_table/test-unknown.parquet"
-	arrTable, err := array.TableFromJSON(memory.DefaultAllocator, t.arrSchema, []string{
-		`[{"foo": true, "bar": "bar_string", "baz": 1, "qux": "2024-03-07"}]`,
-	})
-	t.Require().NoError(err)
-	defer arrTable.Release()
-	t.writeParquet(mustFS(t.T(), tbl).(iceio.WriteFileIO), filePath, arrTable)
-
-	tx := tbl.NewTransaction()
-	err = tx.AddFiles(t.ctx, []string{filePath}, nil, false)
-	t.Require().ErrorIs(err, iceberg.ErrInvalidTransform)
-	t.ErrorContains(err, "custom_transform[42]")
 }
 
 func (t *TableWritingTestSuite) TestAddFilesToPartitionedTableFailsLowerAndUpperMismatch() {
@@ -3405,4 +3383,183 @@ func equalSnapshotSummary(expected *table.Summary, actual *table.Summary) (err e
 	}
 
 	return nil
+}
+
+// The spec forbids committing files against a partition spec with an unknown
+// transform. Run across format versions -- v3 is where reading such a table is
+// required, so it's where the write rejection matters most.
+func TestWritesToUnknownTransformSpecFail(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "foo", Type: iceberg.PrimitiveTypes.Bool},
+		iceberg.NestedField{ID: 2, Name: "bar", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 4, Name: "baz", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 10, Name: "qux", Type: iceberg.PrimitiveTypes.Date})
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "foo", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		{Name: "bar", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "baz", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "qux", Type: arrow.FixedWidthTypes.Date32, Nullable: true},
+	}, nil)
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+	unknownSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{4}, FieldID: 1000, Transform: unknown, Name: "baz_custom",
+	})
+
+	fsF := func(ctx context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	newTable := func(t *testing.T, location string, formatVersion int, spec iceberg.PartitionSpec) *table.Table {
+		t.Helper()
+
+		meta, err := table.NewMetadata(tableSchema, &spec, table.UnsortedSortOrder, location,
+			iceberg.Properties{
+				table.PropertyFormatVersion: strconv.Itoa(formatVersion),
+				table.WriteDeleteModeKey:    table.WriteModeMergeOnRead,
+			})
+		require.NoError(t, err)
+		metaLoc := fmt.Sprintf("%s/metadata/%05d-%s.metadata.json", location, 1, uuid.New().String())
+
+		return table.New(table.Identifier{"default", "unknown_transform"}, meta, metaLoc, fsF, &mockedCatalog{meta})
+	}
+
+	for _, formatVersion := range []int{1, 2, 3} {
+		t.Run("v"+strconv.Itoa(formatVersion), func(t *testing.T) {
+			location := filepath.ToSlash(strings.ReplaceAll(t.TempDir(), "#", ""))
+			ctx := context.Background()
+
+			t.Run("AddFiles", func(t *testing.T) {
+				tbl := newTable(t, location, formatVersion, unknownSpec)
+				arrTable, err := array.TableFromJSON(memory.DefaultAllocator, arrSchema, []string{
+					`[{"foo": true, "bar": "bar_string", "baz": 1, "qux": "2024-03-07"}]`,
+				})
+				require.NoError(t, err)
+				defer arrTable.Release()
+
+				filePath := location + "/data/add-files.parquet"
+				fo, err := mustFS(t, tbl).(iceio.WriteFileIO).Create(filePath)
+				require.NoError(t, err)
+				require.NoError(t, pqarrow.WriteTable(arrTable, fo, arrTable.NumRows(), nil, pqarrow.DefaultWriterProps()))
+
+				err = tbl.NewTransaction().AddFiles(ctx, []string{filePath}, nil, false)
+				require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+				assert.ErrorContains(t, err, "custom_transform[42]")
+			})
+
+			t.Run("AddDataFiles", func(t *testing.T) {
+				tbl := newTable(t, location, formatVersion, unknownSpec)
+				df, err := iceberg.NewDataFileBuilder(unknownSpec, iceberg.EntryContentData,
+					location+"/data/add-data-files.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 1024)
+				require.NoError(t, err)
+
+				err = tbl.NewTransaction().AddDataFiles(ctx, []iceberg.DataFile{df.Build()}, nil)
+				require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+				assert.ErrorContains(t, err, "custom_transform[42]")
+			})
+
+			t.Run("WriteRecords", func(t *testing.T) {
+				tbl := newTable(t, location, formatVersion, unknownSpec)
+				arrTable, err := array.TableFromJSON(memory.DefaultAllocator, arrSchema, []string{
+					`[{"foo": true, "bar": "bar_string", "baz": 1, "qux": "2024-03-07"}]`,
+				})
+				require.NoError(t, err)
+				defer arrTable.Release()
+
+				_, err = tbl.AppendTable(ctx, arrTable, 1, nil)
+				require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+				assert.ErrorContains(t, err, "custom_transform[42]")
+			})
+
+			// v1 requires sequential partition field IDs, so a second spec can't
+			// be added there.
+			if formatVersion < 2 {
+				return
+			}
+
+			t.Run("Delete", func(t *testing.T) {
+				identitySpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+					SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz",
+				})
+				tbl := newTable(t, location, formatVersion, identitySpec)
+
+				// One partition, so deleting a subset writes delete files rather
+				// than dropping the whole data file.
+				arrTable, err := array.TableFromJSON(memory.DefaultAllocator, arrSchema, []string{
+					`[{"foo": false, "bar": "delete_me", "baz": 123, "qux": "2024-01-01"},
+					  {"foo": true, "bar": "keep_this", "baz": 123, "qux": "2024-01-02"}]`,
+				})
+				require.NoError(t, err)
+				defer arrTable.Release()
+
+				tbl, err = tbl.OverwriteTable(ctx, arrTable, 1, nil)
+				require.NoError(t, err)
+
+				// Evolve onto the unknown spec after the data is written, since
+				// writing against it directly is already rejected above.
+				evolvedSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+					SourceIDs: []int{4}, FieldID: 1001, Transform: unknown, Name: "baz_custom",
+				})
+				builder, err := table.MetadataBuilderFromBase(tbl.Metadata(), tbl.MetadataLocation())
+				require.NoError(t, err)
+				require.NoError(t, builder.AddPartitionSpec(&evolvedSpec, false))
+				require.NoError(t, builder.SetDefaultSpecID(-1))
+				evolved, err := builder.Build()
+				require.NoError(t, err)
+
+				tbl = table.New(tbl.Identifier(), evolved, tbl.MetadataLocation(), fsF, &mockedCatalog{evolved})
+
+				// The data is still readable; only the delete write is blocked.
+				scanned, err := tbl.Scan().ToArrowTable(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, int64(2), scanned.NumRows())
+
+				_, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("bar"), "delete_me"), nil)
+				require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+				assert.ErrorContains(t, err, "custom_transform[42]")
+			})
+		})
+	}
+}
+
+// Creating a table with an unknown-transform spec is allowed, matching Java's
+// builder; the spec sentence bites on write, not on create.
+func TestCreateTableWithUnknownTransformSpec(t *testing.T) {
+	ctx := context.Background()
+	location := filepath.ToSlash(strings.ReplaceAll(t.TempDir(), "#", ""))
+
+	cat, err := catalog.Load(ctx, "default", iceberg.Properties{
+		"uri":          ":memory:",
+		"type":         "sql",
+		sql.DriverKey:  sqliteshim.ShimName,
+		sql.DialectKey: string(sql.SQLite),
+		"warehouse":    "file://" + location,
+	})
+	require.NoError(t, err)
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: unknown, Name: "id_custom",
+	})
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32})
+
+	ident := table.Identifier{"default", "created_unknown"}
+	require.NoError(t, cat.CreateNamespace(ctx, catalog.NamespaceFromIdent(ident), nil))
+	tbl, err := cat.CreateTable(ctx, ident, sc,
+		catalog.WithPartitionSpec(&spec),
+		catalog.WithLocation("file://"+location),
+		catalog.WithProperties(iceberg.Properties{table.PropertyFormatVersion: "3"}))
+	require.NoError(t, err)
+
+	loaded, err := cat.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	loadedSpec := loaded.Metadata().PartitionSpec()
+	field := loadedSpec.Field(0)
+	_, ok := field.Transform.(iceberg.UnknownTransform)
+	assert.True(t, ok, "unknown transform should survive create and load")
+	assert.Equal(t, "custom_transform[42]", field.Transform.String())
+
+	// Evolving the spec of such a table is what's blocked.
+	_, err = tbl.NewTransaction().UpdateSpec(false).RemoveField("id_custom").Apply()
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
 }

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -729,6 +729,11 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 	if currentSpec == nil {
 		return nil, errors.New("could not get current partition spec: no current partition spec found")
 	}
+	// The spec forbids committing files against a spec with an unknown
+	// transform, whoever computed the partition tuple.
+	if err := checkNoUnknownTransform(currentSpec); err != nil {
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
 
 	expectedSpecID := int32(currentSpec.ID())
 	setToAdd := make(map[string]struct{}, len(dataFiles))

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -250,6 +250,9 @@ func (us *UpdateSpec) addField(sourceColName string, transform iceberg.Transform
 		}
 
 		// Validate the transform
+		if _, ok := transform.(iceberg.UnknownTransform); ok {
+			return fmt.Errorf("%w: cannot add partition field with unknown transform: %s", iceberg.ErrInvalidTransform, transform)
+		}
 		outputType := boundTerm.Type()
 		if !transform.CanTransform(outputType) {
 			return fmt.Errorf("%s cannot transform %s values from %s", transform.String(), outputType.String(), boundTerm.Ref().Field().Name)

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -54,6 +54,13 @@ type transformKey struct {
 	Transform string
 }
 
+// NewUpdateSpec starts a partition spec evolution.
+//
+// If the table's current spec contains an unknown transform, the returned
+// UpdateSpec carries an error and no evolution is possible -- including
+// renaming or dropping an unrelated field. That matches Java's
+// BaseUpdatePartitionSpec, which rejects at construction rather than at commit.
+// Loading such a table is still fine; only evolving its spec is blocked.
 func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 	us := &UpdateSpec{
 		txn:                   t,

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -86,6 +86,12 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 	nameToField := make(map[string]iceberg.PartitionField)
 	partitionSpec := t.tbl.Metadata().PartitionSpec()
 	for _, partitionField := range partitionSpec.Fields() {
+		if _, ok := partitionField.Transform.(iceberg.UnknownTransform); ok {
+			us.err = fmt.Errorf("%w: cannot update partition spec with unknown transform: %s",
+				iceberg.ErrInvalidTransform, partitionField.Transform)
+
+			return us
+		}
 		transformToField[transformKey{
 			SourceId:  partitionField.SourceID(),
 			Transform: partitionField.Transform.String(),

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -61,6 +61,30 @@ var testNonPartitionedTable = table.New([]string{"non_partitioned"}, testMetadat
 
 var testPartitionedTable = table.New([]string{"partitioned"}, testMetadataPartitioned, "", nil, nil)
 
+// Evolving a spec whose base already contains an unknown transform is rejected
+// up front with a clear error, matching Java's BaseUpdatePartitionSpec. Loading
+// the table is fine; only the update is blocked.
+func TestNewUpdateSpecRejectsUnknownTransformInBaseSpec(t *testing.T) {
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   iceberg.PartitionDataIDStart,
+		Name:      "id_custom",
+		Transform: unknown,
+	})
+	meta, err := table.NewMetadata(testSchema, &spec, table.UnsortedSortOrder, "", nil)
+	require.NoError(t, err)
+	tbl := table.New([]string{"unknown_spec"}, meta, "", nil, nil)
+
+	_, _, err = table.NewUpdateSpec(tbl.NewTransaction(), false).
+		AddField("name", iceberg.IdentityTransform{}, "name_identity").
+		BuildUpdates()
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+	require.ErrorContains(t, err, "custom_transform[42]")
+}
+
 func TestNewUpdateSpecWithNilTransactionReturnsError(t *testing.T) {
 	err := table.NewUpdateSpec(nil, false).Commit()
 	require.ErrorIs(t, err, table.ErrInvalidMetadata)

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -61,9 +61,6 @@ var testNonPartitionedTable = table.New([]string{"non_partitioned"}, testMetadat
 
 var testPartitionedTable = table.New([]string{"partitioned"}, testMetadataPartitioned, "", nil, nil)
 
-// Evolving a spec whose base already contains an unknown transform is rejected
-// up front with a clear error, matching Java's BaseUpdatePartitionSpec. Loading
-// the table is fine; only the update is blocked.
 func TestNewUpdateSpecRejectsUnknownTransformInBaseSpec(t *testing.T) {
 	unknown, err := iceberg.ParseTransform("custom_transform[42]")
 	require.NoError(t, err)

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -170,6 +170,20 @@ func TestUpdateSpecAddField(t *testing.T) {
 		})
 	}
 
+	t.Run("add unknown transform field", func(t *testing.T) {
+		unknown, err := iceberg.ParseTransform("custom_transform[42]")
+		require.NoError(t, err)
+
+		txn = testPartitionedTable.NewTransaction()
+		updates, reqs, err := table.NewUpdateSpec(txn, true).
+			AddField("id", unknown, "id_custom").
+			BuildUpdates()
+		require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+		assert.ErrorContains(t, err, "custom_transform[42]")
+		assert.Nil(t, updates)
+		assert.Nil(t, reqs)
+	})
+
 	t.Run("add duplicate partition field", func(t *testing.T) {
 		txn = testPartitionedTable.NewTransaction()
 		specUpdate := table.NewUpdateSpec(txn, true)

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -208,6 +208,44 @@ func (s *WriteRecordsTestSuite) TestWriteRecordsResolvesProjJSONCRSFromTableProp
 	s.Equal("projjson:geo.crs", readGeom.CRS())
 }
 
+func (s *WriteRecordsTestSuite) TestUnknownPartitionTransformRejected() {
+	loc := filepath.ToSlash(s.T().TempDir())
+
+	unknown, err := iceberg.ParseTransform("custom_transform[42]")
+	s.Require().NoError(err)
+
+	iceSch := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: iceberg.PartitionDataIDStart,
+		Name: "id_custom", Transform: unknown,
+	})
+	meta, err := table.NewMetadata(iceSch, &spec, table.UnsortedSortOrder, loc, iceberg.Properties{})
+	s.Require().NoError(err)
+	tbl := table.New(
+		table.Identifier{"test", "unknown_spec"}, meta,
+		filepath.Join(loc, "metadata", "v1.metadata.json"),
+		func(ctx context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		nil,
+	)
+
+	schema := s.arrowSchema()
+	records := func(yield func(arrow.RecordBatch, error) bool) {
+		rec := s.buildRecords(schema, 10)
+		defer rec.Release()
+		yield(rec, nil)
+	}
+
+	var got error
+	for _, err := range table.WriteRecords(s.ctx, tbl, schema, records) {
+		got = err
+	}
+	s.Require().ErrorIs(got, iceberg.ErrInvalidTransform)
+	s.ErrorContains(got, "custom_transform[42]")
+}
+
 func (s *WriteRecordsTestSuite) TestSmallTargetFileSizeProducesMultipleFiles() {
 	loc := filepath.ToSlash(s.T().TempDir())
 	tbl := s.newTable(loc)

--- a/transforms.go
+++ b/transforms.go
@@ -44,25 +44,32 @@ var (
 
 // ParseTransform takes the string representation of a transform as
 // defined in the iceberg spec, and produces the appropriate Transform
-// object or an error if the string is not a valid transform string.
+// object. Strings that don't name a known transform yield an
+// UnknownTransform rather than an error, so that v3 tables using transforms
+// this implementation doesn't recognize can still be read. A malformed known
+// transform (e.g. a bucket/truncate with a non-positive width) still errors.
 func ParseTransform(s string) (Transform, error) {
-	s = strings.ToLower(s)
+	lower := strings.ToLower(s)
 
-	if matches := bucketTransformRegex.FindStringSubmatch(s); len(matches) == 2 {
+	if matches := bucketTransformRegex.FindStringSubmatch(lower); len(matches) == 2 {
 		n, err := strconv.Atoi(matches[1])
-		if err == nil && n > 0 && n <= math.MaxInt32 {
-			return BucketTransform{NumBuckets: n}, nil
+		if err != nil || n <= 0 || n > math.MaxInt32 {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)
 		}
+
+		return BucketTransform{NumBuckets: n}, nil
 	}
 
-	if matches := truncateTransformRegex.FindStringSubmatch(s); len(matches) == 2 {
+	if matches := truncateTransformRegex.FindStringSubmatch(lower); len(matches) == 2 {
 		n, err := strconv.Atoi(matches[1])
-		if err == nil && n > 0 && n <= math.MaxInt32 {
-			return TruncateTransform{Width: n}, nil
+		if err != nil || n <= 0 || n > math.MaxInt32 {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)
 		}
+
+		return TruncateTransform{Width: n}, nil
 	}
 
-	switch s {
+	switch lower {
 	case "identity":
 		return IdentityTransform{}, nil
 	case "void":
@@ -77,7 +84,9 @@ func ParseTransform(s string) (Transform, error) {
 		return HourTransform{}, nil
 	}
 
-	return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)
+	// Unknown transform: v3 readers must load these and ignore them when
+	// filtering instead of failing. Keep the original string so it round-trips.
+	return UnknownTransform{name: s}, nil
 }
 
 // Transform is an interface for the various Transformation types
@@ -227,6 +236,49 @@ func (VoidTransform) ToHumanStr(any) string { return "null" }
 func (VoidTransform) ToHumanStrType(Type, any) string { return "null" }
 
 func (VoidTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {
+	return nil, nil
+}
+
+// UnknownTransform is a placeholder for a partition or sort transform that
+// this implementation doesn't recognize. The v3 spec requires readers to load
+// tables that use unknown transforms and to ignore those fields when
+// filtering; writers must not commit a partition spec that uses one.
+type UnknownTransform struct {
+	name string
+}
+
+func (t UnknownTransform) MarshalText() ([]byte, error) {
+	return []byte(t.name), nil
+}
+
+func (t UnknownTransform) String() string { return t.name }
+
+// CanTransform assumes an unknown transform could apply to any type -- the
+// real applicability isn't known.
+func (UnknownTransform) CanTransform(Type) bool { return true }
+
+// ResultType is unknown, so report string, matching the Java reference.
+func (UnknownTransform) ResultType(Type) Type { return StringType{} }
+
+func (UnknownTransform) PreservesOrder() bool { return false }
+
+func (t UnknownTransform) Equals(other Transform) bool {
+	o, ok := other.(UnknownTransform)
+
+	return ok && t.name == o.name
+}
+
+// Apply can't be evaluated for an unknown transform.
+func (UnknownTransform) Apply(Optional[Literal]) Optional[Literal] {
+	return Optional[Literal]{}
+}
+
+func (UnknownTransform) ToHumanStr(any) string { return "null" }
+
+func (UnknownTransform) ToHumanStrType(Type, any) string { return "null" }
+
+// Project returns nil so scans don't prune on an unknown partition field.
+func (UnknownTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {
 	return nil, nil
 }
 

--- a/transforms.go
+++ b/transforms.go
@@ -85,7 +85,8 @@ func ParseTransform(s string) (Transform, error) {
 	}
 
 	// Unknown transform: v3 readers must load these and ignore them when
-	// filtering instead of failing. Keep the original string so it round-trips.
+	// filtering instead of failing. Keep the original string, case and all, so it
+	// round-trips; Equals stays byte-for-byte, matching Java's UnknownTransform.
 	return UnknownTransform{name: s}, nil
 }
 

--- a/transforms.go
+++ b/transforms.go
@@ -273,9 +273,9 @@ func (UnknownTransform) Apply(Optional[Literal]) Optional[Literal] {
 	return Optional[Literal]{}
 }
 
-func (UnknownTransform) ToHumanStr(any) string { return "null" }
+func (t UnknownTransform) ToHumanStr(any) string { return t.name }
 
-func (UnknownTransform) ToHumanStrType(Type, any) string { return "null" }
+func (t UnknownTransform) ToHumanStrType(Type, any) string { return t.name }
 
 // Project returns nil so scans don't prune on an unknown partition field.
 func (UnknownTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -40,18 +40,16 @@ import (
 var (
 	bucketTransformRegex   = regexp.MustCompile(`^bucket\[(\d+)\]$`)
 	truncateTransformRegex = regexp.MustCompile(`^truncate\[(\d+)\]$`)
-	// Catches reserved bucket/truncate names with a malformed argument
-	// (missing, negative, non-numeric) so they error instead of falling
-	// through as unknown transforms.
-	reservedWidthRegex = regexp.MustCompile(`^(bucket|truncate)\[.*\]$`)
 )
 
 // ParseTransform takes the string representation of a transform as
 // defined in the iceberg spec, and produces the appropriate Transform
 // object. Strings that don't name a known transform yield an
 // UnknownTransform rather than an error, so that v3 tables using transforms
-// this implementation doesn't recognize can still be read. A malformed known
-// transform (e.g. a bucket/truncate with a non-positive width) still errors.
+// this implementation doesn't recognize can still be read. This mirrors Java's
+// Transforms.fromString: only a bucket/truncate whose width parses as a number
+// but is out of range (e.g. bucket[0]) is an error; anything else that doesn't
+// match the width pattern, like bucket[-1], is an unknown transform.
 func ParseTransform(s string) (Transform, error) {
 	if s == "" {
 		return nil, fmt.Errorf("%w: empty transform", ErrInvalidTransform)
@@ -90,12 +88,6 @@ func ParseTransform(s string) (Transform, error) {
 		return DayTransform{}, nil
 	case "hour":
 		return HourTransform{}, nil
-	}
-
-	// A reserved bucket/truncate name that didn't parse above has a bad
-	// argument; reject it rather than treat it as a forward-compat unknown.
-	if reservedWidthRegex.MatchString(lower) {
-		return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)
 	}
 
 	// Unknown transform: v3 readers must load these and ignore them when

--- a/transforms.go
+++ b/transforms.go
@@ -254,14 +254,22 @@ type UnknownTransform struct {
 	name string
 }
 
+// MarshalText rejects the zero value. UnknownTransform{} is a legal composite
+// literal outside this package, and an empty name would serialize to
+// "transform": "" -- metadata that can't be read back.
 func (t UnknownTransform) MarshalText() ([]byte, error) {
+	if t.name == "" {
+		return nil, fmt.Errorf("%w: unknown transform has no name", ErrInvalidTransform)
+	}
+
 	return []byte(t.name), nil
 }
 
 func (t UnknownTransform) String() string { return t.name }
 
-// CanTransform assumes an unknown transform could apply to any type -- the
-// real applicability isn't known.
+// CanTransform always returns true: compatibility with a source type is
+// unverifiable for an unknown transform, not verified. Callers such as
+// SortOrder.CheckCompatibility therefore accept any source type here.
 func (UnknownTransform) CanTransform(Type) bool { return true }
 
 // ResultType is unknown, so report string, matching the Java reference.
@@ -280,9 +288,17 @@ func (UnknownTransform) Apply(Optional[Literal]) Optional[Literal] {
 	return Optional[Literal]{}
 }
 
-func (t UnknownTransform) ToHumanStr(any) string { return t.name }
+// ToHumanStr renders the value, not the transform name. Java's
+// Transform#toHumanString default does the same and UnknownTransform doesn't
+// override it. Returning the name would be constant for a spec field, which
+// collapses distinct partitions into one PartitionToPath key.
+func (UnknownTransform) ToHumanStr(val any) string {
+	return IdentityTransform{}.ToHumanStr(val)
+}
 
-func (t UnknownTransform) ToHumanStrType(Type, any) string { return t.name }
+func (UnknownTransform) ToHumanStrType(typ Type, val any) string {
+	return IdentityTransform{}.ToHumanStrType(typ, val)
+}
 
 // Project returns nil so scans don't prune on an unknown partition field.
 func (UnknownTransform) Project(string, BoundPredicate) (UnboundPredicate, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -40,6 +40,10 @@ import (
 var (
 	bucketTransformRegex   = regexp.MustCompile(`^bucket\[(\d+)\]$`)
 	truncateTransformRegex = regexp.MustCompile(`^truncate\[(\d+)\]$`)
+	// Catches reserved bucket/truncate names with a malformed argument
+	// (missing, negative, non-numeric) so they error instead of falling
+	// through as unknown transforms.
+	reservedWidthRegex = regexp.MustCompile(`^(bucket|truncate)\[.*\]$`)
 )
 
 // ParseTransform takes the string representation of a transform as
@@ -49,6 +53,10 @@ var (
 // this implementation doesn't recognize can still be read. A malformed known
 // transform (e.g. a bucket/truncate with a non-positive width) still errors.
 func ParseTransform(s string) (Transform, error) {
+	if s == "" {
+		return nil, fmt.Errorf("%w: empty transform", ErrInvalidTransform)
+	}
+
 	lower := strings.ToLower(s)
 
 	if matches := bucketTransformRegex.FindStringSubmatch(lower); len(matches) == 2 {
@@ -82,6 +90,12 @@ func ParseTransform(s string) (Transform, error) {
 		return DayTransform{}, nil
 	case "hour":
 		return HourTransform{}, nil
+	}
+
+	// A reserved bucket/truncate name that didn't parse above has a bad
+	// argument; reject it rather than treat it as a forward-compat unknown.
+	if reservedWidthRegex.MatchString(lower) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidTransform, s)
 	}
 
 	// Unknown transform: v3 readers must load these and ignore them when

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -135,11 +135,46 @@ func TestParseTransform(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.toparse, string(txt))
 
+			// Human rendering is of the value, never the transform name.
 			u := tr.(iceberg.UnknownTransform)
-			assert.Equal(t, tt.toparse, u.ToHumanStr(nil))
-			assert.Equal(t, tt.toparse, u.ToHumanStrType(iceberg.StringType{}, nil))
+			assert.Equal(t, "null", u.ToHumanStr(nil))
+			assert.Equal(t, "abc", u.ToHumanStrType(iceberg.StringType{}, "abc"))
 		})
 	}
+}
+
+func TestUnknownTransformEquals(t *testing.T) {
+	custom, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+
+	same, err := iceberg.ParseTransform("custom_transform[42]")
+	require.NoError(t, err)
+	assert.True(t, custom.Equals(same))
+
+	other, err := iceberg.ParseTransform("other_transform[42]")
+	require.NoError(t, err)
+	assert.False(t, custom.Equals(other))
+
+	// Names compare byte-for-byte, matching Java's UnknownTransform.
+	upper, err := iceberg.ParseTransform("Custom_Transform[42]")
+	require.NoError(t, err)
+	assert.False(t, custom.Equals(upper))
+
+	assert.False(t, custom.Equals(iceberg.IdentityTransform{}))
+}
+
+// The zero value is constructible outside the package; it must not serialize
+// to "transform": "".
+func TestUnknownTransformRejectsEmptyName(t *testing.T) {
+	_, err := iceberg.UnknownTransform{}.MarshalText()
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32})
+	_, err = iceberg.NewPartitionSpecOpts(
+		iceberg.AddPartitionFieldBySourceID(1, "custom", iceberg.UnknownTransform{}, schema, nil),
+	)
+	require.ErrorIs(t, err, iceberg.ErrInvalidTransform)
 }
 
 func TestToHumanString(t *testing.T) {

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -127,6 +127,10 @@ func TestParseTransform(t *testing.T) {
 			txt, err := tr.MarshalText()
 			require.NoError(t, err)
 			assert.Equal(t, tt.toparse, string(txt))
+
+			u := tr.(iceberg.UnknownTransform)
+			assert.Equal(t, tt.toparse, u.ToHumanStr(nil))
+			assert.Equal(t, tt.toparse, u.ToHumanStrType(iceberg.StringType{}, nil))
 		})
 	}
 }

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -73,7 +73,8 @@ func TestParseTransform(t *testing.T) {
 		})
 	}
 
-	// Malformed known transforms (bucket/truncate with a bad width) still error.
+	// A bucket/truncate width that parses as a number but is out of range is an
+	// error, matching Java's Bucket.get/Truncate.get preconditions.
 	errorTests := []struct {
 		name    string
 		toparse string
@@ -84,13 +85,6 @@ func TestParseTransform(t *testing.T) {
 		{"truncate atoi overflow", "truncate[999999999999999999999999999999999999999]"},
 		{"bucket int32 overflow", "bucket[4294967296]"},
 		{"truncate int32 overflow", "truncate[4294967296]"},
-		// A reserved name with a missing/negative/non-numeric arg is malformed,
-		// not a forward-compat unknown transform.
-		{"bucket empty brackets", "bucket[]"},
-		{"truncate empty brackets", "truncate[]"},
-		{"bucket negative", "bucket[-1]"},
-		{"truncate negative", "truncate[-1]"},
-		{"bucket non-numeric", "bucket[abc]"},
 		{"empty string", ""},
 	}
 
@@ -118,6 +112,15 @@ func TestParseTransform(t *testing.T) {
 		{"truncate extra suffix", "truncatefoo[10]"},
 		{"truncate extra token", "truncate_garbage[4]"},
 		{"preserves original case", "Custom_V2[3]"},
+		// Java's width pattern is (\w+)\[(\d+)\], so a reserved name with a
+		// missing/negative/non-numeric width simply doesn't match and becomes an
+		// unknown transform rather than an error.
+		{"bucket empty brackets", "bucket[]"},
+		{"truncate empty brackets", "truncate[]"},
+		{"bucket negative", "bucket[-1]"},
+		{"truncate negative", "truncate[-1]"},
+		{"bucket non-numeric", "bucket[abc]"},
+		{"truncate non-numeric", "truncate[abc]"},
 	}
 
 	for _, tt := range unknownTests {

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -73,7 +73,32 @@ func TestParseTransform(t *testing.T) {
 		})
 	}
 
+	// Malformed known transforms (bucket/truncate with a bad width) still error.
 	errorTests := []struct {
+		name    string
+		toparse string
+	}{
+		{"bucket zero", "bucket[0]"},
+		{"truncate zero", "truncate[0]"},
+		{"bucket atoi overflow", "bucket[999999999999999999999999999999999999999]"},
+		{"truncate atoi overflow", "truncate[999999999999999999999999999999999999999]"},
+		{"bucket int32 overflow", "bucket[4294967296]"},
+		{"truncate int32 overflow", "truncate[4294967296]"},
+	}
+
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := iceberg.ParseTransform(tt.toparse)
+			assert.Nil(t, tr)
+			assert.ErrorIs(t, err, iceberg.ErrInvalidTransform)
+			assert.ErrorContains(t, err, tt.toparse)
+		})
+	}
+
+	// Unrecognized transform strings parse to an UnknownTransform (v3 requires
+	// readers to load unknown transforms) and round-trip verbatim, preserving
+	// the original casing.
+	unknownTests := []struct {
 		name    string
 		toparse string
 	}{
@@ -84,24 +109,24 @@ func TestParseTransform(t *testing.T) {
 		{"truncate no val", "truncate[]"},
 		{"bucket neg", "bucket[-1]"},
 		{"truncate neg", "truncate[-1]"},
-		{"bucket zero", "bucket[0]"},
-		{"truncate zero", "truncate[0]"},
-		{"bucket atoi overflow", "bucket[999999999999999999999999999999999999999]"},
-		{"truncate atoi overflow", "truncate[999999999999999999999999999999999999999]"},
-		{"bucket int32 overflow", "bucket[4294967296]"},
-		{"truncate int32 overflow", "truncate[4294967296]"},
 		{"bucket extra suffix", "bucketx[5]"},
 		{"bucket extra token", "bucket_extra[5]"},
 		{"truncate extra suffix", "truncatefoo[10]"},
 		{"truncate extra token", "truncate_garbage[4]"},
+		{"preserves original case", "Custom_V2[3]"},
 	}
 
-	for _, tt := range errorTests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range unknownTests {
+		t.Run("unknown/"+tt.name, func(t *testing.T) {
 			tr, err := iceberg.ParseTransform(tt.toparse)
-			assert.Nil(t, tr)
-			assert.ErrorIs(t, err, iceberg.ErrInvalidTransform)
-			assert.ErrorContains(t, err, tt.toparse)
+			require.NoError(t, err)
+			_, ok := tr.(iceberg.UnknownTransform)
+			assert.True(t, ok)
+			assert.Equal(t, tt.toparse, tr.String())
+
+			txt, err := tr.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.toparse, string(txt))
 		})
 	}
 }

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -84,6 +84,14 @@ func TestParseTransform(t *testing.T) {
 		{"truncate atoi overflow", "truncate[999999999999999999999999999999999999999]"},
 		{"bucket int32 overflow", "bucket[4294967296]"},
 		{"truncate int32 overflow", "truncate[4294967296]"},
+		// A reserved name with a missing/negative/non-numeric arg is malformed,
+		// not a forward-compat unknown transform.
+		{"bucket empty brackets", "bucket[]"},
+		{"truncate empty brackets", "truncate[]"},
+		{"bucket negative", "bucket[-1]"},
+		{"truncate negative", "truncate[-1]"},
+		{"bucket non-numeric", "bucket[abc]"},
+		{"empty string", ""},
 	}
 
 	for _, tt := range errorTests {
@@ -105,10 +113,6 @@ func TestParseTransform(t *testing.T) {
 		{"foobar", "foobar"},
 		{"bucket no brackets", "bucket"},
 		{"truncate no brackets", "truncate"},
-		{"bucket no val", "bucket[]"},
-		{"truncate no val", "truncate[]"},
-		{"bucket neg", "bucket[-1]"},
-		{"truncate neg", "truncate[-1]"},
 		{"bucket extra suffix", "bucketx[5]"},
 		{"bucket extra token", "bucket_extra[5]"},
 		{"truncate extra suffix", "truncatefoo[10]"},
@@ -121,7 +125,7 @@ func TestParseTransform(t *testing.T) {
 			tr, err := iceberg.ParseTransform(tt.toparse)
 			require.NoError(t, err)
 			_, ok := tr.(iceberg.UnknownTransform)
-			assert.True(t, ok)
+			require.True(t, ok)
 			assert.Equal(t, tt.toparse, tr.String())
 
 			txt, err := tr.MarshalText()


### PR DESCRIPTION
The v3 spec states that:

```
Partition fields that use an unknown transform can be read by ignoring the partition field for the purpose of filtering data files during scan planning. In v1 and v2, readers should ignore fields with unknown transforms while reading; this behavior is required in v3.
```

This introduces the concept of an UnknownTransform and then makes sure that v3 ignores it for partitioning.