### PR TITLE
fix(manifest): preserve empty partition list on rewrite

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -306,6 +306,27 @@ func (m *manifestFile) toV1(v1file *manifestFileV1) {
 	}
 }
 
+// ensurePartitionList normalizes the narrow case behind #1309: an inherited
+// manifest whose partition-field summary list is present but empty. Only an
+// empty-spec manifest has zero summaries, so in practice this is an
+// unpartitioned table. On decode that present-empty array becomes a non-nil
+// pointer over a nil slice, which the manifest-list writer would otherwise
+// re-encode as Avro null for the optional partitions union (field 507) — a
+// value strict readers such as Redshift Spectrum reject. Only that
+// present-but-nil slice is normalized back to an empty array. A genuinely
+// absent value (nil pointer) is left null, which is spec-legal because
+// partitions is optional; populated (partitioned) summaries are non-empty and
+// pass through untouched.
+func ensurePartitionList(partitions **[]FieldSummary) {
+	if *partitions == nil {
+		return
+	}
+	if **partitions == nil {
+		empty := []FieldSummary{}
+		*partitions = &empty
+	}
+}
+
 func (m *manifestFile) Version() int                     { return m.version }
 func (m *manifestFile) FilePath() string                 { return m.Path }
 func (m *manifestFile) Length() int64                    { return m.Len }
@@ -1531,6 +1552,7 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 		var tmp manifestFileV1
 		for _, file := range files {
 			file.(*manifestFile).toV1(&tmp)
+			ensurePartitionList(&tmp.PartitionList)
 			if err := m.writer.Encode(&tmp); err != nil {
 				return err
 			}
@@ -1553,6 +1575,7 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 			}
 
 			wrapped := *(file.(*manifestFile))
+			ensurePartitionList(&wrapped.PartitionList)
 			if m.version == 3 {
 				// Ref: https://github.com/apache/iceberg/blob/ea2071568dc66148b483a82eefedcd2992b435f7/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L157-L168
 				if wrapped.Content == ManifestContentData {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2384,6 +2384,259 @@ func newDatePartitionManifestEntry(t *testing.T, partitionSpec PartitionSpec, sn
 	return NewManifestEntry(EntryStatusADDED, &snapshotID, &seqNum, &seqNum, builder.Build())
 }
 
+type manifestListPartitionsRecord struct {
+	Path               string `avro:"manifest_path"`
+	Len                int64  `avro:"manifest_length"`
+	SpecID             int32  `avro:"partition_spec_id"`
+	Content            int32  `avro:"content"`
+	SeqNumber          int64  `avro:"sequence_number"`
+	MinSeqNumber       int64  `avro:"min_sequence_number"`
+	AddedSnapshotID    int64  `avro:"added_snapshot_id"`
+	AddedFilesCount    int32  `avro:"added_files_count"`
+	ExistingFilesCount int32  `avro:"existing_files_count"`
+	DeletedFilesCount  int32  `avro:"deleted_files_count"`
+	PartitionList      any    `avro:"partitions"`
+	AddedRowsCount     int64  `avro:"added_rows_count"`
+	ExistingRowsCount  int64  `avro:"existing_rows_count"`
+	DeletedRowsCount   int64  `avro:"deleted_rows_count"`
+	Key                []byte `avro:"key_metadata"`
+}
+
+func (m *ManifestTestSuite) manifestListPartitionValues(data []byte) []any {
+	rd, err := ocf.NewReader(bytes.NewReader(data))
+	m.Require().NoError(err)
+	defer func() {
+		m.Require().NoError(rd.Close())
+	}()
+
+	var partitions []any
+	for {
+		var rec manifestListPartitionsRecord
+		err := rd.Decode(&rec)
+		if errors.Is(err, io.EOF) {
+			return partitions
+		}
+		m.Require().NoError(err)
+		partitions = append(partitions, rec.PartitionList)
+	}
+}
+
+func (m *ManifestTestSuite) TestManifestListWriterPreservesEmptyPartitionArrayWhenRewritingInheritedManifest() {
+	seqNum := int64(1)
+	emptyPartitions := []FieldSummary{}
+	originalSnapshotID := int64(101)
+	original := NewManifestFile(2, "s3://bucket/table/metadata/m0.avro", 100, 0, originalSnapshotID).
+		Partitions(emptyPartitions).
+		AddedFiles(1).
+		AddedRows(10).
+		Build()
+
+	var originalList bytes.Buffer
+	err := WriteManifestList(2, &originalList, originalSnapshotID, nil, &seqNum, 0, []ManifestFile{original})
+	m.Require().NoError(err)
+
+	partitionValues := m.manifestListPartitionValues(originalList.Bytes())
+	m.Require().Len(partitionValues, 1)
+	m.Require().IsType([]any{}, partitionValues[0])
+
+	inherited, err := ReadManifestList(bytes.NewReader(originalList.Bytes()))
+	m.Require().NoError(err)
+	m.Require().Len(inherited, 1)
+
+	appendSnapshotID := int64(102)
+	newManifest := NewManifestFile(2, "s3://bucket/table/metadata/m1.avro", 50, 0, appendSnapshotID).
+		Partitions(emptyPartitions).
+		AddedFiles(1).
+		AddedRows(5).
+		Build()
+
+	seqNum = 2
+	var rewrittenList bytes.Buffer
+	err = WriteManifestList(2, &rewrittenList, appendSnapshotID, &originalSnapshotID, &seqNum, 0,
+		append([]ManifestFile{newManifest}, inherited...))
+	m.Require().NoError(err)
+
+	partitionValues = m.manifestListPartitionValues(rewrittenList.Bytes())
+	m.Require().Len(partitionValues, 2)
+	for _, value := range partitionValues {
+		m.Require().IsType([]any{}, value)
+		m.Empty(value)
+	}
+}
+
+func (m *ManifestTestSuite) TestManifestListWriterKeepsAbsentPartitionListNull() {
+	seqNum := int64(1)
+	snapshotID := int64(201)
+	// No Partitions(...) call: PartitionList stays nil (absent). partitions is
+	// optional in the manifest-list spec, so an absent value must round-trip as
+	// null rather than be normalized into an empty array.
+	manifest := NewManifestFile(2, "s3://bucket/table/metadata/m0.avro", 100, 0, snapshotID).
+		AddedFiles(1).
+		AddedRows(10).
+		Build()
+
+	var list bytes.Buffer
+	err := WriteManifestList(2, &list, snapshotID, nil, &seqNum, 0, []ManifestFile{manifest})
+	m.Require().NoError(err)
+
+	partitionValues := m.manifestListPartitionValues(list.Bytes())
+	m.Require().Len(partitionValues, 1)
+	m.Require().Nil(partitionValues[0])
+}
+
+func (m *ManifestTestSuite) TestManifestListV1WriterPartitionListEncoding() {
+	seqNum := int64(1)
+	snapshotID := int64(301)
+	// Exercise the version-1 encode path (the manifestFileV1 toV1 loop, distinct
+	// from the wrapped v2/v3 path): an absent PartitionList must stay null while
+	// a present-but-empty one must encode as an empty array.
+	absent := NewManifestFile(1, "s3://bucket/table/metadata/m0.avro", 100, 0, snapshotID).
+		AddedFiles(1).
+		AddedRows(10).
+		Build()
+	emptyPresent := NewManifestFile(1, "s3://bucket/table/metadata/m1.avro", 100, 0, snapshotID).
+		Partitions([]FieldSummary{}).
+		AddedFiles(1).
+		AddedRows(5).
+		Build()
+
+	var list bytes.Buffer
+	err := WriteManifestList(1, &list, snapshotID, nil, &seqNum, 0, []ManifestFile{absent, emptyPresent})
+	m.Require().NoError(err)
+
+	partitionValues := m.manifestListPartitionValues(list.Bytes())
+	m.Require().Len(partitionValues, 2)
+	m.Require().Nil(partitionValues[0])
+	m.Require().IsType([]any{}, partitionValues[1])
+	m.Empty(partitionValues[1])
+}
+
+func (m *ManifestTestSuite) TestManifestListWriterPreservesPopulatedPartitionSummariesOnRewrite() {
+	// Scope guard, NOT a #1309 reproduction. #1309's null-collapse only affects a
+	// present-but-empty partitions array, which requires a manifest with zero
+	// partition-field summaries — i.e. an empty spec / unpartitioned table. A
+	// partitioned table always has a non-empty summary list (one FieldSummary per
+	// partition field), so it is structurally immune to the collapse and passes
+	// even without the ensurePartitionList fix. This test documents that the fix
+	// is correctly narrowed to empty inherited summaries: a populated summary
+	// must survive the read -> rewrite round trip untouched — top-level array
+	// present and non-empty, every sub-field value preserved.
+	seqNum := int64(1)
+	originalSnapshotID := int64(401)
+	nan := false
+	lower := []byte{0x01, 0x02}
+	upper := []byte{0x0a, 0x0b}
+	summaries := []FieldSummary{{
+		ContainsNull: true,
+		ContainsNaN:  &nan,
+		LowerBound:   &lower,
+		UpperBound:   &upper,
+	}}
+
+	original := NewManifestFile(2, "s3://bucket/table/metadata/m0.avro", 100, 1, originalSnapshotID).
+		Partitions(summaries).
+		AddedFiles(1).
+		AddedRows(10).
+		Build()
+
+	var originalList bytes.Buffer
+	err := WriteManifestList(2, &originalList, originalSnapshotID, nil, &seqNum, 0, []ManifestFile{original})
+	m.Require().NoError(err)
+
+	inherited, err := ReadManifestList(bytes.NewReader(originalList.Bytes()))
+	m.Require().NoError(err)
+	m.Require().Len(inherited, 1)
+
+	appendSnapshotID := int64(402)
+	newManifest := NewManifestFile(2, "s3://bucket/table/metadata/m1.avro", 50, 1, appendSnapshotID).
+		Partitions(summaries).
+		AddedFiles(1).
+		AddedRows(5).
+		Build()
+
+	seqNum = 2
+	var rewrittenList bytes.Buffer
+	err = WriteManifestList(2, &rewrittenList, appendSnapshotID, &originalSnapshotID, &seqNum, 0,
+		append([]ManifestFile{newManifest}, inherited...))
+	m.Require().NoError(err)
+
+	// Top-level partitions must be a present, non-empty array for every record.
+	rawValues := m.manifestListPartitionValues(rewrittenList.Bytes())
+	m.Require().Len(rawValues, 2)
+	for i, value := range rawValues {
+		m.Require().IsTypef([]any{}, value, "record %d partitions must decode as an array", i)
+		m.Require().Lenf(value.([]any), 1, "record %d must keep its one partition-field summary", i)
+	}
+
+	// Sub-field values must survive the round trip unchanged.
+	rewritten, err := ReadManifestList(bytes.NewReader(rewrittenList.Bytes()))
+	m.Require().NoError(err)
+	m.Require().Len(rewritten, 2)
+	for i, mf := range rewritten {
+		parts := mf.Partitions()
+		m.Require().Lenf(parts, 1, "record %d should preserve one summary", i)
+		m.True(parts[0].ContainsNull, "record %d contains_null", i)
+		m.Require().NotNilf(parts[0].ContainsNaN, "record %d contains_nan", i)
+		m.False(*parts[0].ContainsNaN)
+		m.Require().NotNilf(parts[0].LowerBound, "record %d lower_bound", i)
+		m.Equal(lower, *parts[0].LowerBound)
+		m.Require().NotNilf(parts[0].UpperBound, "record %d upper_bound", i)
+		m.Equal(upper, *parts[0].UpperBound)
+	}
+}
+
+func (m *ManifestTestSuite) TestManifestEntryPresentEmptyListSurvivesRewrite() {
+	// Entry-level analogue of the #1309 concern. A data file's optional list
+	// columns (split_offsets, column_sizes, ...) are *[]T unions that decode to
+	// the exact same state that broke the manifest-list partitions field: a
+	// non-nil pointer over a nil slice. #1309 showed the manifest-*list* writer
+	// collapses that state to Avro null on rewrite; this asserts the manifest-
+	// *entry* writer does NOT — a present-but-empty list survives the decode ->
+	// re-encode round trip (what a manifest merge/rewrite performs) as a present
+	// array. It confirms the collapse is specific to the manifest-list path and
+	// that no entry-level normalization is required.
+	schema := NewSchema(0, NestedField{ID: 1, Name: "id", Type: PrimitiveTypes.Int64, Required: true})
+	spec := *UnpartitionedSpec
+	snapshotID := int64(10)
+
+	writeAndRead := func(entry ManifestEntry) *dataFile {
+		var buf bytes.Buffer
+		_, err := WriteManifest("/m.avro", &buf, 2, spec, schema, snapshotID, []ManifestEntry{entry})
+		m.Require().NoError(err)
+		rd, err := NewManifestReader(&manifestFile{version: 2, Path: "/m.avro"}, bytes.NewReader(buf.Bytes()))
+		m.Require().NoError(err)
+		defer func() { m.Require().NoError(rd.Close()) }()
+		e, err := rd.ReadEntry()
+		m.Require().NoError(err)
+
+		return e.DataFile().(*dataFile)
+	}
+
+	builder, err := NewDataFileBuilder(spec, EntryContentData, "s3://b/data/f.parquet", ParquetFile, nil, nil, nil, 1, 100)
+	m.Require().NoError(err)
+	// column_sizes is *[]colMap — an array of *records*, the same shape as the
+	// manifest-list partitions field (*[]FieldSummary); split_offsets is *[]int64,
+	// an array of primitives. Cover both so the record-element case (the one that
+	// actually broke for partitions) is guarded here too.
+	built := builder.SplitOffsets([]int64{}).ColumnSizes(map[int]int64{}).Build()
+	m.Require().NotNil(built.(*dataFile).Splits, "builder should keep split_offsets present")
+	m.Require().NotNil(built.(*dataFile).ColSizes, "builder should keep column_sizes present")
+
+	// First round trip mirrors reading an existing manifest: a present-empty
+	// array decodes to a non-nil pointer over a nil slice.
+	first := writeAndRead(NewManifestEntryBuilder(EntryStatusADDED, &snapshotID, built).SequenceNum(1).Build())
+	m.Require().NotNil(first.Splits, "decoded split_offsets must stay present, not null")
+	m.Require().NotNil(first.ColSizes, "decoded column_sizes must stay present, not null")
+
+	// Re-encoding the decoded entry is what a manifest rewrite/merge does. The
+	// present-empty lists must not collapse to null here.
+	second := writeAndRead(NewManifestEntryBuilder(EntryStatusADDED, &snapshotID, first).SequenceNum(1).Build())
+	m.Require().NotNil(second.Splits,
+		"present-empty split_offsets must survive a decode -> re-encode rewrite as a present array")
+	m.Require().NotNil(second.ColSizes,
+		"present-empty column_sizes must survive a decode -> re-encode rewrite as a present array")
+}
+
 func (m *ManifestTestSuite) TestWriteManifestListClosesWriterOnError() {
 	// A v2 manifest list cannot reference v3 manifests because the v2 entry
 	// schema has no first_row_id column; this gives us a deterministic

--- a/table/manifest_list_partitions_regression_test.go
+++ b/table/manifest_list_partitions_regression_test.go
@@ -1,0 +1,213 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+// End-to-end regression test for issue #1309: AddFiles() after a prior Delete()
+// produces a manifest list whose `partitions` field serializes as Avro null,
+// which Redshift Spectrum rejects ("Wrong type in Avro file. Field: partitions.
+// Expected: 12 (union). Got: 7 (null)").
+//
+// The trigger is the inheritance path: Delete() uses the mergeOverwrite producer
+// and the following AddFiles() uses fastAppend, which inherits the delete
+// snapshot's manifests unchanged. When the manifest list is rewritten, an
+// inherited manifest whose `partitions` summaries are present-but-empty (an
+// unpartitioned table has zero field summaries) round-trips as a non-nil pointer
+// to a nil slice, which the writer previously encoded as null instead of a
+// present empty array.
+//
+// The fix (ensurePartitionList in manifest.go) normalizes a present-but-nil
+// summary list back to an empty array so the union resolves to the array branch.
+// This test asserts every record in the final manifest list encodes `partitions`
+// as a present array, never null.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro/ocf"
+)
+
+// manifestListRecordV2 mirrors the version-2 manifest-list entry schema
+// (internal/avro_schemas.go, "manifest_list_file_v2"). Only PartitionList is
+// inspected, but the full record is declared so the reader schema derived from
+// these struct tags matches the writer schema field-for-field. PartitionList is
+// decoded as `any` so a null union member surfaces as a nil interface and a
+// present array surfaces as a non-nil []any.
+type manifestListRecordV2 struct {
+	Path               string `avro:"manifest_path"`
+	Len                int64  `avro:"manifest_length"`
+	SpecID             int32  `avro:"partition_spec_id"`
+	Content            int32  `avro:"content"`
+	SeqNumber          int64  `avro:"sequence_number"`
+	MinSeqNumber       int64  `avro:"min_sequence_number"`
+	AddedSnapshotID    int64  `avro:"added_snapshot_id"`
+	AddedFilesCount    int32  `avro:"added_files_count"`
+	ExistingFilesCount int32  `avro:"existing_files_count"`
+	DeletedFilesCount  int32  `avro:"deleted_files_count"`
+	PartitionList      any    `avro:"partitions"`
+	AddedRowsCount     int64  `avro:"added_rows_count"`
+	ExistingRowsCount  int64  `avro:"existing_rows_count"`
+	DeletedRowsCount   int64  `avro:"deleted_rows_count"`
+	Key                []byte `avro:"key_metadata"`
+}
+
+// readManifestListPartitionFields raw-decodes the manifest-list Avro file at
+// manifestListPath and returns the `partitions` union value for every record, in
+// file order. Reading the raw union (rather than the normalized ManifestFile) is
+// what lets the test distinguish a present empty array from null.
+func readManifestListPartitionFields(t *testing.T, fs iceio.IO, manifestListPath string) []any {
+	t.Helper()
+
+	f, err := fs.Open(manifestListPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	rd, err := ocf.NewReader(f)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rd.Close()) }()
+
+	var partitions []any
+	for {
+		var rec manifestListRecordV2
+		err := rd.Decode(&rec)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		partitions = append(partitions, rec.PartitionList)
+	}
+
+	return partitions
+}
+
+// TestManifestListPartitionsPresentAfterDeleteThenAddFiles reproduces the #1309
+// sequence (append -> delete -> add-files) on an unpartitioned v2 table and
+// asserts the final manifest list never encodes `partitions` as null.
+func TestManifestListPartitionsPresentAfterDeleteThenAddFiles(t *testing.T) {
+	ctx := context.Background()
+	location := filepath.ToSlash(t.TempDir())
+	fs := iceio.LocalFS{}
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+
+	// Default (copy-on-write) delete mode is what routes Delete() through the
+	// mergeOverwrite producer, so leave WriteDeleteMode unset.
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return fs, nil }
+	cat := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+	tbl := table.New(table.Identifier{"db", "list_partitions_1309"}, meta, metaLoc, fsF, cat)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+
+	// Step 1 — append initial data so the later Delete has a file to rewrite.
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1},{"id":2},{"id":3}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	// Step 2 — Delete (copy-on-write / mergeOverwrite). id==2 matches a subset of
+	// the file's rows, forcing a rewrite and an overwrite snapshot whose manifest
+	// is inherited by the next commit.
+	tbl, err = tbl.Delete(ctx, iceberg.EqualTo(iceberg.Reference("id"), int64(2)), nil)
+	require.NoError(t, err)
+
+	// Step 3 — AddFiles (fastAppend) inherits the delete snapshot's manifests.
+	// This is the commit whose manifest list #1309 reports as unreadable.
+	extraPath := location + "/data-extra.parquet"
+	writeInt64Parquet(t, fs, extraPath, arrowSchema, []int64{4, 5})
+
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.AddFiles(ctx, []string{extraPath}, nil, false))
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// The final manifest list references the inherited (delete) manifest plus the
+	// newly added one. Every record's `partitions` must be a present array; a nil
+	// (null) value is the #1309 regression.
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	require.NotEmpty(t, snap.ManifestList, "final snapshot must have a manifest list")
+
+	partitionFields := readManifestListPartitionFields(t, fs, snap.ManifestList)
+	require.GreaterOrEqual(t, len(partitionFields), 2,
+		"final manifest list should reference the inherited delete manifest and the added manifest")
+	for i, p := range partitionFields {
+		require.NotNilf(t, p,
+			"manifest-list record %d encoded `partitions` as Avro null; Redshift Spectrum "+
+				"rejects this (issue #1309) — it must be a present (empty) array", i)
+		require.IsTypef(t, []any{}, p,
+			"manifest-list record %d `partitions` should decode as an array", i)
+	}
+
+	// Local data-integrity smoke test (independent of the manifest-list fix
+	// above): iceberg-go's own reader round-trips the appended values — 1 and 3
+	// survive the delete of id==2, and 4 and 5 are added. This only exercises
+	// this library's read path; it does not reproduce or explain the issue's
+	// secondary Athena "NULL columns" symptom, which involves an external engine
+	// and is out of scope here.
+	require.Equal(t, []int64{1, 3, 4, 5}, idsInTable(t, tbl),
+		"iceberg-go must read the appended rows back with their real values")
+}
+
+// writeInt64Parquet writes a single-column ("id") Parquet file so AddFiles has a
+// real file to ingest.
+func writeInt64Parquet(t *testing.T, fs iceio.LocalFS, path string, arrowSchema *arrow.Schema, ids []int64) {
+	t.Helper()
+
+	bldr := array.NewInt64Builder(memory.DefaultAllocator)
+	defer bldr.Release()
+
+	bldr.AppendValues(ids, nil)
+	col := bldr.NewArray()
+	defer col.Release()
+
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{col}, int64(len(ids)))
+	defer rec.Release()
+
+	arrTbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer arrTbl.Release()
+
+	fo, err := fs.Create(path)
+	require.NoError(t, err)
+
+	require.NoError(t, pqarrow.WriteTable(arrTbl, fo, arrTbl.NumRows(),
+		nil, pqarrow.DefaultWriterProps()))
+}


### PR DESCRIPTION
Fixes #1309

## Summary

- preserve present-but-empty `partitions` arrays when inherited manifest-list entries are rewritten
- keep genuinely absent partition summaries encoded as Avro null
- leave populated partition summaries unchanged
- add unit and end-to-end coverage for `AddFiles` after a copy-on-write `Delete`

The regression occurred because an empty Avro array decoded as a non-nil pointer containing a nil Go slice. Re-encoding that value selected the null union branch, which strict readers such as Redshift Spectrum reject.

## Recovery note

This fix prevents new manifest-list rewrites from emitting null `partitions` values, but it does not repair manifest lists that a pre-fix iceberg-go version already wrote with null. Tables that already hit this issue must expire or recommit the affected snapshots so their manifest lists are rewritten before strict readers can consume them.

## Testing

- `go vet . ./table`
- `go test . -run '^TestManifests$' -count=1`
- `go test ./table -count=1 -timeout=3m`