### PR TITLE
feat(table): add history metadata table

### DIFF
--- a/table/inspect.go
+++ b/table/inspect.go
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+)
+
+// InspectTable exposes a table's metadata (snapshots, history, manifests, and
+// so on) as queryable Arrow tables. It mirrors the metadata tables offered by
+// the Java, PyIceberg, and Rust clients.
+//
+// Obtain one via Table.Inspect. Each method returns an array.RecordReader that
+// the caller is responsible for releasing.
+type InspectTable struct {
+	tbl Table
+}
+
+// Inspect returns an InspectTable for reading this table's metadata tables.
+func (t Table) Inspect() InspectTable {
+	return InspectTable{tbl: t}
+}
+
+// History returns the chronological log of every snapshot that was ever the
+// table's current snapshot, one row per snapshot-log entry. Rolled-back
+// snapshots remain visible but are flagged via is_current_ancestor.
+//
+// Columns:
+//   - made_current_at (timestamptz, required): when the snapshot became current
+//   - snapshot_id (long, required): the snapshot that became current
+//   - parent_id (long, optional): the snapshot's parent, null when the snapshot
+//     has no parent or has since been expired
+//   - is_current_ancestor (boolean, required): whether the snapshot is an
+//     ancestor of the current snapshot; false for rolled-back snapshots
+//
+// is_current_ancestor is derived by walking the current snapshot's parent
+// chain. If an intermediate ancestor has been expired (removed from the
+// snapshot list), that walk is truncated and snapshots below the gap are
+// reported as non-ancestors. Well-formed tables never hit this: ExpireSnapshots
+// keeps the current snapshot and its full ancestry intact. This matches the
+// silent-truncation behavior of the Java, PyIceberg, and Rust clients.
+//
+// The returned reader holds a single record batch. The caller must Release it.
+func (i InspectTable) History(ctx context.Context) (array.RecordReader, error) {
+	sc := historySchema()
+
+	arrowSchema, err := SchemaToArrowSchema(sc, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect history: build arrow schema: %w", err)
+	}
+
+	// Walk the current snapshot's parent chain once. Membership in this set
+	// is what tells the live lineage apart from rolled-back history entries.
+	// AncestorsOf already guards against cycles in malformed metadata, so a
+	// corrupt parent chain cannot hang the scan.
+	ancestors := make(map[int64]struct{})
+	if current := i.tbl.metadata.CurrentSnapshot(); current != nil {
+		for _, snap := range AncestorsOf(current.SnapshotID, i.tbl.metadata.SnapshotByID) {
+			ancestors[snap.SnapshotID] = struct{}{}
+		}
+	}
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer bldr.Release()
+
+	// Field positions and concrete builder types follow historySchema; the
+	// assertions are safe as long as the two stay in sync.
+	madeCurrentAt := bldr.Field(0).(*array.TimestampBuilder)
+	snapshotID := bldr.Field(1).(*array.Int64Builder)
+	parentID := bldr.Field(2).(*array.Int64Builder)
+	isCurrentAncestor := bldr.Field(3).(*array.BooleanBuilder)
+
+	for entry := range i.tbl.metadata.SnapshotLogs() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// Iceberg stores timestamps as epoch milliseconds; Arrow uses
+		// microseconds for the timestamptz type.
+		madeCurrentAt.Append(arrow.Timestamp(entry.TimestampMs * 1000))
+		snapshotID.Append(entry.SnapshotID)
+
+		// parent_id resolves through the live snapshot table, so an entry
+		// referencing an expired snapshot renders a null parent.
+		if snap := i.tbl.metadata.SnapshotByID(entry.SnapshotID); snap != nil && snap.ParentSnapshotID != nil {
+			parentID.Append(*snap.ParentSnapshotID)
+		} else {
+			parentID.AppendNull()
+		}
+
+		_, ok := ancestors[entry.SnapshotID]
+		isCurrentAncestor.Append(ok)
+	}
+
+	rec := bldr.NewRecordBatch()
+	// NewRecordReader retains rec, so release our reference unconditionally:
+	// on success the reader owns it, and on error NewRecordReader has already
+	// released its own retain. This avoids a deferred double-release.
+	rr, err := array.NewRecordReader(arrowSchema, []arrow.RecordBatch{rec})
+	rec.Release()
+	if err != nil {
+		return nil, fmt.Errorf("inspect history: new record reader: %w", err)
+	}
+
+	return rr, nil
+}
+
+// historySchema returns the Iceberg schema of the history metadata table. The
+// field IDs match the Java, PyIceberg, and Rust clients for cross-client parity.
+func historySchema() *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "made_current_at", Type: iceberg.PrimitiveTypes.TimestampTz, Required: true},
+		iceberg.NestedField{ID: 2, Name: "snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 3, Name: "parent_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 4, Name: "is_current_ancestor", Type: iceberg.PrimitiveTypes.Bool, Required: true},
+	)
+}

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// historyTestTable builds a table with a rollback in its snapshot log.
+//
+// Lineage:
+//
+//	S1 (root) ──▶ S2 (rolled back)
+//	  └────────▶ S3 (current)
+//
+// The snapshot log records the chronological order in which each snapshot
+// became current: S1, then S2, then (after rollback and re-append) S3. S3's
+// parent is S1, so S2 is NOT an ancestor of the current snapshot. A trailing
+// log entry references an expired snapshot (id 999, absent from the snapshot
+// list) to exercise the null-parent path.
+func historyTestTable() *Table {
+	const (
+		s1 = int64(101)
+		s2 = int64(102)
+		s3 = int64(103)
+		// expired is present in the snapshot log but not the snapshot list.
+		expired = int64(999)
+	)
+	current := s3
+	lastPartitionID := 999
+
+	meta := &metadataV2{commonMetadata: commonMetadata{
+		FormatVersion:   2,
+		UUID:            uuid.New(),
+		Loc:             "s3://test/history",
+		LastUpdatedMS:   1400,
+		LastColumnId:    1,
+		SchemaList:      []*iceberg.Schema{iceberg.NewSchema(0)},
+		CurrentSchemaID: 0,
+		Specs:           []iceberg.PartitionSpec{*iceberg.UnpartitionedSpec},
+		DefaultSpecID:   0,
+		LastPartitionID: &lastPartitionID,
+		Props:           iceberg.Properties{},
+		SnapshotList: []Snapshot{
+			{SnapshotID: s1, TimestampMs: 1100, ManifestList: "/snap-101.avro"},
+			{SnapshotID: s2, ParentSnapshotID: int64Ptr(s1), TimestampMs: 1200, ManifestList: "/snap-102.avro"},
+			{SnapshotID: s3, ParentSnapshotID: int64Ptr(s1), TimestampMs: 1300, ManifestList: "/snap-103.avro"},
+		},
+		CurrentSnapshotID: &current,
+		SnapshotLog: []SnapshotLogEntry{
+			{SnapshotID: s1, TimestampMs: 1100},
+			{SnapshotID: s2, TimestampMs: 1200},
+			{SnapshotID: s3, TimestampMs: 1300},
+			{SnapshotID: expired, TimestampMs: 1400},
+		},
+		SortOrderList:      []SortOrder{UnsortedSortOrder},
+		DefaultSortOrderID: 0,
+		SnapshotRefs:       map[string]SnapshotRef{MainBranch: {SnapshotID: current, SnapshotRefType: BranchRef}},
+	}}
+
+	return New(Identifier{"history"}, meta, "", nil, nil)
+}
+
+// collectRecord drains a RecordReader into a single record for assertions and
+// asserts the reader holds exactly one batch, matching History's contract.
+func collectRecord(t *testing.T, rr array.RecordReader) arrow.RecordBatch {
+	t.Helper()
+	require.True(t, rr.Next(), "expected at least one record batch")
+	rec := rr.RecordBatch()
+	rec.Retain()
+	require.False(t, rr.Next(), "expected exactly one record batch")
+
+	return rec
+}
+
+func TestInspectHistorySchema(t *testing.T) {
+	sc := historySchema()
+
+	require.Equal(t, []string{"made_current_at", "snapshot_id", "parent_id", "is_current_ancestor"},
+		testFieldNames(sc))
+
+	fields := sc.Fields()
+	require.Equal(t, 1, fields[0].ID)
+	require.Equal(t, 2, fields[1].ID)
+	require.Equal(t, 3, fields[2].ID)
+	require.Equal(t, 4, fields[3].ID)
+
+	require.True(t, fields[0].Required, "made_current_at is required")
+	require.True(t, fields[1].Required, "snapshot_id is required")
+	require.False(t, fields[2].Required, "parent_id is optional")
+	require.True(t, fields[3].Required, "is_current_ancestor is required")
+
+	require.Equal(t, iceberg.PrimitiveTypes.TimestampTz, fields[0].Type)
+	require.Equal(t, iceberg.PrimitiveTypes.Int64, fields[1].Type)
+	require.Equal(t, iceberg.PrimitiveTypes.Int64, fields[2].Type)
+	require.Equal(t, iceberg.PrimitiveTypes.Bool, fields[3].Type)
+}
+
+func TestInspectHistory(t *testing.T) {
+	tbl := historyTestTable()
+
+	rr, err := tbl.Inspect().History(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	rec := collectRecord(t, rr)
+	defer rec.Release()
+
+	require.EqualValues(t, 4, rec.NumRows())
+	require.EqualValues(t, 4, rec.NumCols())
+
+	// made_current_at must be timestamptz: microsecond precision, UTC.
+	tsType, ok := rec.Schema().Field(0).Type.(*arrow.TimestampType)
+	require.True(t, ok, "made_current_at must be an Arrow timestamp")
+	require.Equal(t, arrow.Microsecond, tsType.Unit)
+	require.Equal(t, "UTC", tsType.TimeZone)
+
+	madeCurrentAt := rec.Column(0).(*array.Timestamp)
+	snapshotID := rec.Column(1).(*array.Int64)
+	parentID := rec.Column(2).(*array.Int64)
+	isCurrentAncestor := rec.Column(3).(*array.Boolean)
+
+	// made_current_at is milliseconds promoted to microseconds.
+	require.EqualValues(t, 1100*1000, madeCurrentAt.Value(0))
+	require.EqualValues(t, 1400*1000, madeCurrentAt.Value(3))
+
+	require.EqualValues(t, 101, snapshotID.Value(0))
+	require.EqualValues(t, 102, snapshotID.Value(1))
+	require.EqualValues(t, 103, snapshotID.Value(2))
+	require.EqualValues(t, 999, snapshotID.Value(3))
+
+	// S1 is a root: no parent.
+	require.True(t, parentID.IsNull(0), "S1 has no parent")
+	// S2 and S3 both descend from S1.
+	require.False(t, parentID.IsNull(1))
+	require.EqualValues(t, 101, parentID.Value(1))
+	require.False(t, parentID.IsNull(2))
+	require.EqualValues(t, 101, parentID.Value(2))
+	// The expired snapshot cannot be resolved, so its parent is null.
+	require.True(t, parentID.IsNull(3), "expired snapshot resolves to a null parent")
+
+	// The current snapshot is S3, whose ancestry is {S1, S3}. S2 was rolled
+	// back and the expired entry is off-lineage: both are non-ancestors.
+	require.True(t, isCurrentAncestor.Value(0), "S1 is an ancestor of the current snapshot")
+	require.False(t, isCurrentAncestor.Value(1), "rolled-back S2 is not an ancestor")
+	require.True(t, isCurrentAncestor.Value(2), "current snapshot S3 is its own ancestor")
+	require.False(t, isCurrentAncestor.Value(3), "expired snapshot is not an ancestor")
+}
+
+// TestInspectHistoryEmpty covers a table with no snapshot log (e.g. freshly
+// created): History must yield an empty, well-formed record.
+func TestInspectHistoryEmpty(t *testing.T) {
+	lastPartitionID := 999
+	meta := &metadataV2{commonMetadata: commonMetadata{
+		FormatVersion:      2,
+		UUID:               uuid.New(),
+		Loc:                "s3://test/empty",
+		LastUpdatedMS:      1000,
+		LastColumnId:       1,
+		SchemaList:         []*iceberg.Schema{iceberg.NewSchema(0)},
+		CurrentSchemaID:    0,
+		Specs:              []iceberg.PartitionSpec{*iceberg.UnpartitionedSpec},
+		DefaultSpecID:      0,
+		LastPartitionID:    &lastPartitionID,
+		Props:              iceberg.Properties{},
+		SortOrderList:      []SortOrder{UnsortedSortOrder},
+		DefaultSortOrderID: 0,
+		SnapshotRefs:       map[string]SnapshotRef{},
+	}}
+	tbl := New(Identifier{"empty"}, meta, "", nil, nil)
+
+	rr, err := tbl.Inspect().History(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	rec := collectRecord(t, rr)
+	defer rec.Release()
+
+	require.EqualValues(t, 0, rec.NumRows())
+	require.EqualValues(t, 4, rec.NumCols())
+}
+
+// TestInspectHistoryNoCurrentSnapshot covers a table that has a populated
+// snapshot list and log but no current snapshot (e.g. after the current ref
+// was cleared). With no lineage to anchor against, every log entry is a
+// non-ancestor, but the rows are still emitted.
+func TestInspectHistoryNoCurrentSnapshot(t *testing.T) {
+	const s1 = int64(101)
+	lastPartitionID := 999
+	meta := &metadataV2{commonMetadata: commonMetadata{
+		FormatVersion:   2,
+		UUID:            uuid.New(),
+		Loc:             "s3://test/no-current",
+		LastUpdatedMS:   1100,
+		LastColumnId:    1,
+		SchemaList:      []*iceberg.Schema{iceberg.NewSchema(0)},
+		CurrentSchemaID: 0,
+		Specs:           []iceberg.PartitionSpec{*iceberg.UnpartitionedSpec},
+		DefaultSpecID:   0,
+		LastPartitionID: &lastPartitionID,
+		Props:           iceberg.Properties{},
+		SnapshotList: []Snapshot{
+			{SnapshotID: s1, TimestampMs: 1100, ManifestList: "/snap-101.avro"},
+		},
+		// CurrentSnapshotID intentionally nil.
+		SnapshotLog:        []SnapshotLogEntry{{SnapshotID: s1, TimestampMs: 1100}},
+		SortOrderList:      []SortOrder{UnsortedSortOrder},
+		DefaultSortOrderID: 0,
+		SnapshotRefs:       map[string]SnapshotRef{},
+	}}
+	tbl := New(Identifier{"no-current"}, meta, "", nil, nil)
+
+	rr, err := tbl.Inspect().History(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	rec := collectRecord(t, rr)
+	defer rec.Release()
+
+	require.EqualValues(t, 1, rec.NumRows())
+	isCurrentAncestor := rec.Column(3).(*array.Boolean)
+	require.False(t, isCurrentAncestor.Value(0), "no current snapshot means no ancestors")
+}
+
+// testFieldNames returns the top-level field names of an Iceberg schema in order.
+func testFieldNames(sc *iceberg.Schema) []string {
+	fields := sc.Fields()
+	names := make([]string, len(fields))
+	for i, f := range fields {
+		names[i] = f.Name
+	}
+
+	return names
+}


### PR DESCRIPTION
Add an inspect subsystem (Table.Inspect) and its first metadata table, History, mirroring the Java, PyIceberg, and Rust clients.

History exposes the snapshot log as an Arrow RecordReader with columns made_current_at (timestamp[us,UTC]), snapshot_id, parent_id, and is_current_ancestor (field IDs 1-4 for cross-client parity). Ancestry is computed by walking the current snapshot's parent chain via the existing AncestorsOf helper (cycle-guarded); rolled-back snapshots are flagged non-ancestors and expired snapshots render a null parent_id. The context is honored during iteration and errors are wrapped.