### PR TITLE
fix(sql): keep namespace drops atomic

### DIFF
--- a/catalog/sql/drop_namespace_internal_test.go
+++ b/catalog/sql/drop_namespace_internal_test.go
@@ -1,0 +1,384 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sql
+
+import (
+	"context"
+	dbsql "database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	_ "github.com/apache/iceberg-go/io/gocloud"
+	"github.com/apache/iceberg-go/table"
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+type namespaceRaceContextKey struct{}
+
+type namespaceRaceOperation string
+
+const (
+	dropNamespaceOperation    namespaceRaceOperation = "drop"
+	createObjectOperation     namespaceRaceOperation = "create-object"
+	updatePropertiesOperation namespaceRaceOperation = "update-properties"
+)
+
+type namespaceRaceHook struct {
+	dropAtDelete       chan struct{}
+	createAtInsert     chan struct{}
+	updateAtInsert     chan struct{}
+	releaseDrop        chan struct{}
+	dropDone           chan struct{}
+	releaseUpdate      chan struct{}
+	dropAtDeleteOnce   sync.Once
+	createAtInsertOnce sync.Once
+	updateAtInsertOnce sync.Once
+}
+
+func (h *namespaceRaceHook) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	operation, _ := ctx.Value(namespaceRaceContextKey{}).(namespaceRaceOperation)
+	query := event.Query
+
+	switch {
+	case operation == dropNamespaceOperation && event.Operation() == "DELETE" && strings.Contains(query, "iceberg_namespace_properties"):
+		h.dropAtDeleteOnce.Do(func() { close(h.dropAtDelete) })
+		<-h.releaseDrop
+	case operation == createObjectOperation && event.Operation() == "INSERT" && strings.Contains(query, "iceberg_tables"):
+		h.createAtInsertOnce.Do(func() { close(h.createAtInsert) })
+		<-h.releaseDrop
+		<-h.dropDone
+	case operation == updatePropertiesOperation && event.Operation() == "INSERT" && strings.Contains(query, "iceberg_namespace_properties"):
+		h.updateAtInsertOnce.Do(func() { close(h.updateAtInsert) })
+		<-h.releaseUpdate
+	}
+
+	return ctx
+}
+
+func (*namespaceRaceHook) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func newNamespaceRaceCatalog(t *testing.T) *Catalog {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "catalog.db")
+	db, err := dbsql.Open(sqliteshim.ShimName, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	db.SetMaxOpenConns(4)
+	_, err = db.Exec("PRAGMA journal_mode=WAL")
+	require.NoError(t, err)
+
+	warehouse := filepath.Join(t.TempDir(), "warehouse")
+	cat, err := NewCatalog("default", db, SQLite, iceberg.Properties{
+		"warehouse": "file://" + filepath.ToSlash(warehouse),
+	})
+	require.NoError(t, err)
+
+	return cat
+}
+
+type sqlStateTestError string
+
+func (e sqlStateTestError) Error() string    { return string(e) }
+func (e sqlStateTestError) SQLState() string { return string(e) }
+
+func TestRetrySerializableWriteTx(t *testing.T) {
+	t.Run("retries transient errors", func(t *testing.T) {
+		attempts := 0
+		err := retrySerializableWriteTx(context.Background(), func() error {
+			attempts++
+			if attempts == 1 {
+				return sqlStateTestError("40001")
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("does not retry permanent errors", func(t *testing.T) {
+		attempts := 0
+		permanentErr := errors.New("permanent error")
+		err := retrySerializableWriteTx(context.Background(), func() error {
+			attempts++
+
+			return permanentErr
+		})
+		require.ErrorIs(t, err, permanentErr)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("returns transient error after attempts are exhausted", func(t *testing.T) {
+		attempts := 0
+		transientErr := sqlStateTestError("40001")
+		err := retrySerializableWriteTx(context.Background(), func() error {
+			attempts++
+
+			return transientErr
+		})
+		require.ErrorIs(t, err, transientErr)
+		require.Equal(t, serializableWriteMaxAttempts, attempts)
+	})
+
+	t.Run("stops when context is canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		attempts := 0
+		err := retrySerializableWriteTx(ctx, func() error {
+			attempts++
+
+			return sqlStateTestError("40001")
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, attempts)
+	})
+}
+
+func TestRetryableSerializableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "postgres serialization", err: sqlStateTestError("40001")},
+		{name: "postgres deadlock", err: sqlStateTestError("40P01")},
+		{name: "mysql deadlock", err: &mysql.MySQLError{Number: 1213}},
+		{name: "mysql lock timeout", err: &mysql.MySQLError{Number: 1205}},
+		{name: "sqlite3 busy", err: errors.New("database is locked")},
+		{name: "oracle serialization", err: errors.New("ORA-08177: can't serialize access for this transaction")},
+		{name: "oracle deadlock", err: errors.New("ORA-00060: deadlock detected while waiting for resource")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.True(t, isRetryableSerializableError(tt.err))
+		})
+	}
+
+	require.False(t, isRetryableSerializableError(errors.New("constraint violation")))
+}
+
+func TestRetryableSerializableErrorFromSQLiteDriver(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "locked.db")
+	first, err := dbsql.Open(sqliteshim.ShimName, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+	second, err := dbsql.Open(sqliteshim.ShimName, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+
+	first.SetMaxOpenConns(1)
+	second.SetMaxOpenConns(1)
+	_, err = first.Exec("PRAGMA busy_timeout=0")
+	require.NoError(t, err)
+	_, err = second.Exec("PRAGMA busy_timeout=0")
+	require.NoError(t, err)
+	_, err = first.Exec("CREATE TABLE locks (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+
+	tx, err := first.Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	_, err = tx.Exec("INSERT INTO locks VALUES (1)")
+	require.NoError(t, err)
+
+	_, lockErr := second.Exec("INSERT INTO locks VALUES (2)")
+	require.Error(t, lockErr)
+	require.True(t, isRetryableSerializableError(lockErr), "unexpected SQLite lock error type %T: %v", lockErr, lockErr)
+}
+
+func TestDropNamespaceDoesNotRaceWithObjectCreation(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	tests := []struct {
+		name   string
+		create func(*testing.T, context.Context, *Catalog, table.Identifier) error
+		exists func(context.Context, *Catalog, table.Identifier) (bool, error)
+	}{
+		{
+			name: "create table",
+			create: func(_ *testing.T, ctx context.Context, cat *Catalog, ident table.Identifier) error {
+				_, err := cat.CreateTable(ctx, ident, schema)
+
+				return err
+			},
+			exists: func(ctx context.Context, cat *Catalog, ident table.Identifier) (bool, error) {
+				return cat.CheckTableExists(ctx, ident)
+			},
+		},
+		{
+			name: "create view",
+			create: func(_ *testing.T, ctx context.Context, cat *Catalog, ident table.Identifier) error {
+				return cat.CreateView(ctx, ident, schema, "SELECT 1", nil)
+			},
+			exists: func(ctx context.Context, cat *Catalog, ident table.Identifier) (bool, error) {
+				return cat.CheckViewExists(ctx, ident)
+			},
+		},
+		{
+			name: "commit table create",
+			create: func(t *testing.T, ctx context.Context, cat *Catalog, ident table.Identifier) error {
+				location := "file://" + filepath.ToSlash(filepath.Join(t.TempDir(), "table"))
+				_, _, err := cat.CommitTable(ctx, ident, []table.Requirement{table.AssertCreate()}, []table.Update{
+					table.NewSetLocationUpdate(location),
+				})
+
+				return err
+			},
+			exists: func(ctx context.Context, cat *Catalog, ident table.Identifier) (bool, error) {
+				return cat.CheckTableExists(ctx, ident)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cat := newNamespaceRaceCatalog(t)
+			namespace := table.Identifier{"race_namespace"}
+			objectID := table.Identifier{"race_namespace", "race_object"}
+			require.NoError(t, cat.CreateNamespace(context.Background(), namespace, nil))
+
+			hook := &namespaceRaceHook{
+				dropAtDelete:   make(chan struct{}),
+				createAtInsert: make(chan struct{}),
+				releaseDrop:    make(chan struct{}),
+				dropDone:       make(chan struct{}),
+			}
+			cat.db.AddQueryHook(hook)
+
+			released := false
+			defer func() {
+				if !released {
+					close(hook.releaseDrop)
+				}
+			}()
+
+			dropCtx := context.WithValue(context.Background(), namespaceRaceContextKey{}, dropNamespaceOperation)
+			createCtx := context.WithValue(context.Background(), namespaceRaceContextKey{}, createObjectOperation)
+			dropErrCh := make(chan error, 1)
+			createErrCh := make(chan error, 1)
+
+			go func() {
+				dropErr := cat.DropNamespace(dropCtx, namespace)
+				close(hook.dropDone)
+				dropErrCh <- dropErr
+			}()
+			select {
+			case <-hook.dropAtDelete:
+			case <-time.After(5 * time.Second):
+				t.Fatal("drop did not reach namespace deletion")
+			}
+
+			go func() { createErrCh <- tt.create(t, createCtx, cat, objectID) }()
+			select {
+			case <-hook.createAtInsert:
+			case <-time.After(5 * time.Second):
+				t.Fatal("creator did not reach catalog insertion")
+			}
+
+			close(hook.releaseDrop)
+			released = true
+			dropErr := <-dropErrCh
+			createErr := <-createErrCh
+			require.False(t, dropErr == nil && createErr == nil, "drop and create must not both report success")
+
+			objectExists, err := tt.exists(context.Background(), cat, objectID)
+			require.NoError(t, err)
+			namespaceExists, err := cat.CheckNamespaceExists(context.Background(), namespace)
+			require.NoError(t, err)
+
+			switch {
+			case createErr == nil:
+				require.Error(t, dropErr)
+				require.True(t, objectExists)
+				require.True(t, namespaceExists)
+			case dropErr == nil:
+				require.False(t, objectExists)
+				require.False(t, namespaceExists)
+			default:
+				require.Equal(t, namespaceExists, objectExists,
+					"failed operations must not leave an object without its namespace")
+			}
+		})
+	}
+}
+
+func TestDropNamespaceDoesNotRaceWithUpdateNamespaceProperties(t *testing.T) {
+	cat := newNamespaceRaceCatalog(t)
+	namespace := table.Identifier{"race_namespace"}
+	require.NoError(t, cat.CreateNamespace(context.Background(), namespace, iceberg.Properties{"owner": "before"}))
+
+	hook := &namespaceRaceHook{
+		updateAtInsert: make(chan struct{}),
+		releaseUpdate:  make(chan struct{}),
+	}
+	cat.db.AddQueryHook(hook)
+
+	released := false
+	defer func() {
+		if !released {
+			close(hook.releaseUpdate)
+		}
+	}()
+
+	updateCtx := context.WithValue(context.Background(), namespaceRaceContextKey{}, updatePropertiesOperation)
+	updateErrCh := make(chan error, 1)
+	go func() {
+		_, err := cat.UpdateNamespaceProperties(updateCtx, namespace, nil, iceberg.Properties{"owner": "after"})
+		updateErrCh <- err
+	}()
+
+	select {
+	case <-hook.updateAtInsert:
+	case <-time.After(5 * time.Second):
+		t.Fatal("property update did not reach namespace property insertion")
+	}
+
+	dropErrCh := make(chan error, 1)
+	go func() { dropErrCh <- cat.DropNamespace(context.Background(), namespace) }()
+	select {
+	case err := <-dropErrCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("namespace drop did not complete while property update was paused")
+	}
+
+	close(hook.releaseUpdate)
+	released = true
+
+	select {
+	case err := <-updateErrCh:
+		require.ErrorIs(t, err, catalog.ErrNoSuchNamespace)
+	case <-time.After(5 * time.Second):
+		t.Fatal("property update did not finish after namespace drop")
+	}
+
+	exists, err := cat.CheckNamespaceExists(context.Background(), namespace)
+	require.NoError(t, err)
+	require.False(t, exists)
+}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -29,6 +29,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 	_ "unsafe"
 
 	"github.com/apache/iceberg-go"
@@ -38,6 +39,7 @@ import (
 	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 	"github.com/uptrace/bun/dialect/feature"
@@ -299,6 +301,71 @@ func withWriteTx(ctx context.Context, db *bun.DB, fn func(context.Context, bun.T
 	})
 }
 
+const (
+	serializableWriteMaxAttempts = 3
+	serializableWriteRetryDelay  = 10 * time.Millisecond
+)
+
+func withSerializableWriteTx(ctx context.Context, db *bun.DB, fn func(context.Context, bun.Tx) error) error {
+	return retrySerializableWriteTx(ctx, func() error {
+		return db.RunInTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable}, func(ctx context.Context, tx bun.Tx) error {
+			return fn(ctx, tx)
+		})
+	})
+}
+
+func retrySerializableWriteTx(ctx context.Context, run func() error) error {
+	var err error
+	for attempt := 0; attempt < serializableWriteMaxAttempts; attempt++ {
+		err = run()
+		if err == nil || !isRetryableSerializableError(err) {
+			return err
+		}
+		if attempt == serializableWriteMaxAttempts-1 {
+			break
+		}
+
+		delay := serializableWriteRetryDelay << attempt
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return context.Cause(ctx)
+		case <-timer.C:
+		}
+	}
+
+	return err
+}
+
+func isRetryableSerializableError(err error) bool {
+	var stateErr interface{ SQLState() string }
+	if errors.As(err, &stateErr) {
+		switch stateErr.SQLState() {
+		case "40001", "40P01":
+			return true
+		}
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		switch mysqlErr.Number {
+		case 1205, 1213: // lock wait timeout, deadlock
+			return true
+		}
+	}
+
+	msg := err.Error()
+
+	// sqliteshim selects different SQLite drivers by build target. Their typed
+	// error APIs are incompatible, but both expose these stable lock messages.
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "ORA-08177") ||
+		strings.Contains(msg, "ORA-00060")
+}
+
 var _ catalog.PurgeableTable = (*Catalog)(nil)
 
 type Catalog struct {
@@ -337,6 +404,9 @@ func (c *Catalog) isV0() bool { return c.schemaVersion == schemaV0 }
 //
 // All interactions with the db are performed within transactions to ensure atomicity and transactional isolation
 // of catalog changes.
+//
+// SQLite callers that allow concurrent writers should configure WAL and a busy timeout in the driver DSN so the
+// settings apply to every pooled connection. NewCatalog does not mutate connection settings on the caller-owned db.
 func NewCatalog(name string, db *sql.DB, dialect SupportedDialect, props iceberg.Properties) (*Catalog, error) {
 	d, err := getDialect(dialect)
 	if err != nil {
@@ -584,30 +654,50 @@ func (c *Catalog) probeExists(ctx context.Context, query, what string) (bool, er
 
 func (c *Catalog) namespaceExists(ctx context.Context, ns string) (bool, error) {
 	return withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) (bool, error) {
-		// ColumnExpr("1") keeps the existence probe from selecting iceberg_type,
-		// which would not exist on a V0 schema.
-		exists, err := tx.NewSelect().Model((*sqlIcebergTable)(nil)).
-			ColumnExpr("1").
-			Where("catalog_name = ?", c.name).
-			Where("table_namespace = ?", ns).
-			Limit(1).Exists(ctx)
-		if err != nil {
-			return false, err
-		}
-		if exists {
-			return true, nil
-		}
-
-		return tx.NewSelect().Model((*sqlIcebergNamespaceProps)(nil)).
-			Where("catalog_name = ?", c.name).Where("namespace = ?", ns).
-			Limit(1).Exists(ctx)
+		return c.namespaceExistsInTx(ctx, tx, ns)
 	})
+}
+
+func (c *Catalog) namespaceExistsInTx(ctx context.Context, tx bun.Tx, ns string) (bool, error) {
+	// ColumnExpr("1") keeps the existence probe from selecting iceberg_type,
+	// which would not exist on a V0 schema.
+	exists, err := tx.NewSelect().Model((*sqlIcebergTable)(nil)).
+		ColumnExpr("1").
+		Where("catalog_name = ?", c.name).
+		Where("table_namespace = ?", ns).
+		Limit(1).Exists(ctx)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+
+	return tx.NewSelect().Model((*sqlIcebergNamespaceProps)(nil)).
+		ColumnExpr("1").
+		Where("catalog_name = ?", c.name).Where("namespace = ?", ns).
+		Limit(1).Exists(ctx)
 }
 
 func (c *Catalog) resolveNamespaceKey(ctx context.Context, namespace table.Identifier) (string, bool, error) {
 	keys := namespaceStorageKeys(namespace)
 	for _, key := range keys {
 		exists, err := c.namespaceExists(ctx, key)
+		if err != nil {
+			return "", false, err
+		}
+		if exists {
+			return key, true, nil
+		}
+	}
+
+	return keys[0], false, nil
+}
+
+func (c *Catalog) resolveNamespaceKeyInTx(ctx context.Context, tx bun.Tx, namespace table.Identifier) (string, bool, error) {
+	keys := namespaceStorageKeys(namespace)
+	for _, key := range keys {
+		exists, err := c.namespaceExistsInTx(ctx, tx, key)
 		if err != nil {
 			return "", false, err
 		}
@@ -677,7 +767,15 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil, err
 	}
 
-	err = withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+	err = withSerializableWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		exists, err := c.namespaceExistsInTx(ctx, tx, ns)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
+		}
+
 		ins := tx.NewInsert().Model(&sqlIcebergTable{
 			CatalogName:      c.name,
 			TableNamespace:   ns,
@@ -732,7 +830,11 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 		return nil, "", err
 	}
 
-	err = withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+	runWriteTx := withWriteTx
+	if current == nil {
+		runWriteTx = withSerializableWriteTx
+	}
+	err = runWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
 		if current != nil {
 			// On V1, the model-driven UPDATE emits every non-PK field, writing
 			// iceberg_type=TABLE; this also heals legacy NULLs on commit, and the
@@ -770,6 +872,14 @@ func (c *Catalog) CommitTable(ctx context.Context, ident table.Identifier, reqs 
 			}
 
 			return nil
+		}
+
+		exists, err := c.namespaceExistsInTx(ctx, tx, nsKey)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, nsKey)
 		}
 
 		ins := tx.NewInsert().Model(&sqlIcebergTable{
@@ -938,7 +1048,39 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		return nil, fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, toNs)
 	}
 
-	err = withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+	err = withSerializableWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		sourceExistsQuery := tx.NewSelect().Model(&sqlIcebergTable{
+			CatalogName:    c.name,
+			TableNamespace: fromNs,
+			TableName:      fromTbl,
+		}).ColumnExpr("1").WherePK()
+		if !c.isV0() {
+			sourceExistsQuery = sourceExistsQuery.Where("(iceberg_type = ? OR iceberg_type IS NULL)", TableType)
+		}
+		sourceExists, err := sourceExistsQuery.Exists(ctx)
+		if err != nil {
+			return fmt.Errorf("error encountered checking existence of table '%s': %w", from, err)
+		}
+		if !sourceExists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchTable, from)
+		}
+
+		sourceNamespaceExists, err := c.namespaceExistsInTx(ctx, tx, fromNs)
+		if err != nil {
+			return err
+		}
+		if !sourceNamespaceExists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, fromNs)
+		}
+
+		destinationNamespaceExists, err := c.namespaceExistsInTx(ctx, tx, toNs)
+		if err != nil {
+			return err
+		}
+		if !destinationNamespaceExists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, toNs)
+		}
+
 		exists, err := tx.NewSelect().Model(&sqlIcebergTable{
 			CatalogName:    c.name,
 			TableNamespace: toNs,
@@ -1049,37 +1191,32 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
-	nsToDelete, exists, err := c.resolveNamespaceKey(ctx, namespace)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, nsToDelete)
-	}
-
-	tbls := make([]table.Identifier, 0)
-	iter := c.ListTables(ctx, namespace)
-
-	for tbl, err := range iter {
-		tbls = append(tbls, tbl)
+	return withSerializableWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		nsToDelete, exists, err := c.resolveNamespaceKeyInTx(ctx, tx, namespace)
 		if err != nil {
 			return err
 		}
+		if !exists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, nsToDelete)
+		}
 
-		break // there is already at least a table
-	}
+		objectsExist, err := tx.NewSelect().Model((*sqlIcebergTable)(nil)).
+			ColumnExpr("1").
+			Where("catalog_name = ?", c.name).
+			Where("table_namespace = ?", nsToDelete).
+			Limit(1).Exists(ctx)
+		if err != nil {
+			return fmt.Errorf("error checking namespace '%s' for catalog objects: %w", nsToDelete, err)
+		}
+		if objectsExist {
+			return fmt.Errorf("%w: catalog objects exist in namespace %s", catalog.ErrNamespaceNotEmpty, nsToDelete)
+		}
 
-	if len(tbls) > 0 {
-		return fmt.Errorf("%w: %d tables exist in namespace %s", catalog.ErrNamespaceNotEmpty, len(tbls), nsToDelete)
-	}
-
-	return withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewDelete().Model((*sqlIcebergNamespaceProps)(nil)).
+		_, err = tx.NewDelete().Model((*sqlIcebergNamespaceProps)(nil)).
 			Where("catalog_name = ?", c.name).
 			Where("namespace = ?", nsToDelete).Exec(ctx)
 		if err != nil {
-			return fmt.Errorf("error deleting namespace '%s': %w", namespace, err)
+			return fmt.Errorf("error deleting namespace '%s': %w", nsToDelete, err)
 		}
 
 		return nil
@@ -1236,22 +1373,37 @@ func getUpdatedPropsAndUpdateSummary(currentProps iceberg.Properties, removals [
 
 func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table.Identifier, removals []string, updates iceberg.Properties) (catalog.PropertiesUpdateSummary, error) {
 	var summary catalog.PropertiesUpdateSummary
-	currentProps, err := c.LoadNamespaceProperties(ctx, namespace)
-	if err != nil {
+	if err := checkValidNamespace(namespace); err != nil {
 		return summary, err
 	}
 
-	_, summary, err = getUpdatedPropsAndUpdateSummary(currentProps, removals, updates)
-	if err != nil {
-		return summary, err
-	}
+	err := withSerializableWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		nsToUpdate, exists, err := c.resolveNamespaceKeyInTx(ctx, tx, namespace)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, nsToUpdate)
+		}
 
-	nsToUpdate, err := c.namespaceKey(ctx, namespace)
-	if err != nil {
-		return summary, err
-	}
+		var storedProps []sqlIcebergNamespaceProps
+		err = tx.NewSelect().Model(&storedProps).
+			Where("catalog_name = ?", c.name).
+			Where("namespace = ?", nsToUpdate).Scan(ctx)
+		if err != nil {
+			return fmt.Errorf("error loading namespace properties for '%s': %w", nsToUpdate, err)
+		}
 
-	return summary, withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		currentProps := make(iceberg.Properties, len(storedProps))
+		for _, prop := range storedProps {
+			currentProps[prop.PropertyKey] = prop.PropertyValue.String
+		}
+
+		_, nextSummary, err := getUpdatedPropsAndUpdateSummary(currentProps, removals, updates)
+		if err != nil {
+			return err
+		}
+
 		var m *sqlIcebergNamespaceProps
 		if len(removals) > 0 {
 			_, err := tx.NewDelete().Model(m).
@@ -1259,7 +1411,7 @@ func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 				Where("namespace = ?", nsToUpdate).
 				Where("property_key in (?)", bun.List(removals)).Exec(ctx)
 			if err != nil {
-				return fmt.Errorf("error deleting properties for '%s': %w", namespace, err)
+				return fmt.Errorf("error deleting properties for '%s': %w", nsToUpdate, err)
 			}
 		}
 
@@ -1288,18 +1440,22 @@ func (c *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 					Where("property_key in (?)", bun.List(slices.Collect(maps.Keys(updates)))).
 					Exec(ctx)
 				if err != nil {
-					return fmt.Errorf("error deleting properties for '%s': %w", namespace, err)
+					return fmt.Errorf("error deleting properties for '%s': %w", nsToUpdate, err)
 				}
 			}
 
 			_, err := q.Exec(ctx)
 			if err != nil {
-				return fmt.Errorf("error updating namespace properties for '%s': %w", namespace, err)
+				return fmt.Errorf("error updating namespace properties for '%s': %w", nsToUpdate, err)
 			}
 		}
 
+		summary = nextSummary
+
 		return nil
 	})
+
+	return summary, err
 }
 
 func (c *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Identifier) (bool, error) {
@@ -1344,8 +1500,16 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 	}
 	metadataLocation := createdView.MetadataLocation()
 
-	err = withWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewInsert().Model(&sqlIcebergTable{
+	err = withSerializableWriteTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) error {
+		exists, err := c.namespaceExistsInTx(ctx, tx, ns)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
+		}
+
+		_, err = tx.NewInsert().Model(&sqlIcebergTable{
 			CatalogName:      c.name,
 			TableNamespace:   ns,
 			TableName:        viewIdent,

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1852,6 +1852,31 @@ func (s *SqliteCatalogTestSuite) TestDropNamespace() {
 	}
 }
 
+func (s *SqliteCatalogTestSuite) TestDropNamespaceRejectsViewOnlyNamespace() {
+	cat := s.getCatalogSqlite()
+	ctx := context.Background()
+	namespace := table.Identifier{databaseName()}
+	viewID := append(slices.Clone(namespace), tableName())
+	viewSQL := "SELECT 1"
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	})
+
+	s.Require().NoError(cat.CreateNamespace(ctx, namespace, nil))
+	s.Require().NoError(cat.CreateView(ctx, viewID, schema, viewSQL, nil))
+
+	err := cat.DropNamespace(ctx, namespace)
+	s.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
+	s.ErrorContains(err, "catalog objects exist")
+
+	exists, err := cat.CheckNamespaceExists(ctx, namespace)
+	s.Require().NoError(err)
+	s.True(exists)
+	exists, err = cat.CheckViewExists(ctx, viewID)
+	s.Require().NoError(err)
+	s.True(exists)
+}
+
 func (s *SqliteCatalogTestSuite) TestDropNamespaceNotExist() {
 	tests := []struct {
 		cat       *sqlcat.Catalog

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/geoarrow/geoarrow-go v0.0.0-20260403143023-f54751c3e3a1
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -77,6 +78,7 @@ require (
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ cyphar.com/go-pathrs v0.2.1 h1:9nx1vOgwVvX1mNBWDu93+vaceedpbsDqo+XuBGL40b8=
 cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
@@ -328,6 +330,8 @@ github.com/go-openapi/swag/yamlutils v0.26.0 h1:H7O8l/8NJJQ/oiReEN+oMpnGMyt8G0hl
 github.com/go-openapi/swag/yamlutils v0.26.0/go.mod h1:1evKEGAtP37Pkwcc7EWMF0hedX0/x3Rkvei2wtG/TbU=
 github.com/go-openapi/validate v0.25.3 h1:4nzAIavcJ7WveHK2+V1UAkZK3kWcjzxZCzjfZAfavKs=
 github.com/go-openapi/validate v0.25.3/go.mod h1:GemfuGMyYpIaBoKpX3z8sLywrmxpzWVOoJ7R0VeAVuk=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=


### PR DESCRIPTION
## Summary

- check namespace existence, catalog-object emptiness, and property deletion in one serializable write transaction
- treat views and future object types as namespace contents instead of relying on the table-only `ListTables` result
- recheck source and destination namespaces inside serializable create, commit, and rename transactions so concurrent drops cannot leave orphaned objects
- reload namespace properties inside the serializable update transaction so a concurrent drop cannot recreate a namespace
- retry recognized serialization, deadlock, and database-lock failures with bounded, context-aware backoff
- keep view-only namespaces intact and return the object-neutral `ErrNamespaceNotEmpty` sentinel

## Why

On the V1 SQL schema, `ListTables` intentionally excludes views. `DropNamespace` used that filtered result to decide whether a namespace was empty, so a namespace containing only a view could report a successful drop while the view row—and therefore the namespace—still existed.

The old prechecks also left races with object creation, rename, and namespace property updates. Drop, creators, renames, and property updates now participate in serializable transactions and recheck the relevant namespaces in the same transaction as their writes. Property updates reload the current rows and recompute their update summary on every retry, preventing stale results and namespace resurrection.

Database engines can abort serializable transactions under contention. The retry classifier handles PostgreSQL SQL states, typed MySQL deadlock and lock-timeout errors, SQLite lock errors from the actual driver, and Oracle serialization and deadlock errors. Exhausted retries return the database error directly. The `NewCatalog` documentation also calls out the WAL and busy-timeout configuration expected for concurrent SQLite writers.

## Testing

- view-only namespace regression
- deterministic drop races covering `CreateTable`, `CreateView`, and the create branch of `CommitTable`
- deterministic drop versus namespace-property-update regression
- real SQLite driver lock classification plus PostgreSQL, MySQL, and Oracle retry classification
- retry exhaustion and cancellation coverage
- `go test ./catalog/sql`
- `go test -race ./catalog/sql`
- `go vet ./catalog/sql`