### PR TITLE
fix(glue): fence commits during table rename

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -26,6 +26,7 @@ import (
 	"maps"
 	"strconv"
 	"strings"
+	"time"
 	_ "unsafe"
 
 	"github.com/apache/iceberg-go"
@@ -55,6 +56,8 @@ const (
 	tableParamTableType                = "table_type"
 	tableParamMetadataLocation         = "metadata_location"
 	tableParamPreviousMetadataLocation = "previous_metadata_location"
+	tableParamRenameToken              = "iceberg.go.rename-token"
+	glueTypeIcebergRenaming            = "ICEBERG_RENAMING"
 
 	// The ID of the Glue Data Catalog where the tables reside. If none is provided, Glue
 	// automatically uses the caller's AWS account ID by default.
@@ -77,6 +80,7 @@ const (
 	icebergFieldIDKey       = "iceberg.field.id"
 	icebergFieldOptionalKey = "iceberg.field.optional"
 	icebergFieldCurrentKey  = "iceberg.field.current"
+	renameCleanupTimeout    = 5 * time.Second
 )
 
 var _ catalog.Catalog = (*Catalog)(nil)
@@ -379,10 +383,15 @@ func (c *Catalog) DropTable(ctx context.Context, identifier table.Identifier) er
 		return err
 	}
 
-	// Check if the table exists and is an Iceberg table.
-	_, err = c.getTable(ctx, database, tableName)
+	// Use the raw lookup so an explicit drop can recover a source left claimed
+	// by a rename process that terminated before delete or rollback.
+	glueTable, err := c.getRawTable(ctx, database, tableName)
 	if err != nil {
 		return err
+	}
+	tableType := glueTable.Parameters[tableParamTableType]
+	if !strings.EqualFold(tableType, glueTypeIceberg) && tableType != glueTypeIcebergRenaming {
+		return fmt.Errorf("table %s.%s is not an iceberg table", database, tableName)
 	}
 
 	params := &glue.DeleteTableInput{
@@ -443,37 +452,45 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch the table %s.%s: %w", fromDatabase, fromTable, err)
 	}
+	if aws.ToString(fromGlueTable.VersionId) == "" {
+		return nil, fmt.Errorf("failed to rename the table %s.%s: Glue table version id is missing", fromDatabase, fromTable)
+	}
 
 	// Create the new table.
 	_, err = c.glueSvc.CreateTable(ctx, &glue.CreateTableInput{
 		CatalogId:    c.catalogId,
 		DatabaseName: aws.String(toDatabase),
-		TableInput: &types.TableInput{
-			Name:              aws.String(toTable),
-			TableType:         fromGlueTable.TableType,
-			Owner:             fromGlueTable.Owner,
-			Description:       fromGlueTable.Description,
-			Parameters:        fromGlueTable.Parameters,
-			StorageDescriptor: fromGlueTable.StorageDescriptor,
-		},
+		TableInput:   glueTableInput(toTable, fromGlueTable),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the table %s.%s: %w", fromDatabase, fromTable, err)
 	}
 
-	// Revalidate the source table immediately before delete to narrow the
-	// rename race window. Glue does not offer a conditional DeleteTable, so
-	// this cannot eliminate the race if a commit lands after this read.
-	currentFromGlueTable, err := c.getTable(ctx, fromDatabase, fromTable)
+	// Claim the source with a conditional update before issuing Glue's
+	// unconditional delete. Changing table_type makes new Iceberg writers refuse
+	// the source, while VersionId rejects writers that loaded the previous version.
+	renameToken := fmt.Sprintf("%s.%s@%s", toDatabase, toTable, aws.ToString(fromGlueTable.VersionId))
+	claimInput := glueTableInput(fromTable, fromGlueTable)
+	claimInput.Parameters[tableParamTableType] = glueTypeIcebergRenaming
+	claimInput.Parameters[tableParamRenameToken] = renameToken
+	_, err = c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(fromDatabase),
+		TableInput:   claimInput,
+		VersionId:    fromGlueTable.VersionId,
+		SkipArchive:  aws.Bool(c.props.GetBool(SkipArchive, SkipArchiveDefault)),
+	})
 	if err != nil {
-		c.rollbackRenamedTable(ctx, toDatabase, toTable)
+		if isConcurrentModificationException(err) {
+			err = fmt.Errorf("%w: source table changed during rename: %w", table.ErrCommitFailed, err)
 
-		return nil, fmt.Errorf("failed to revalidate the table %s.%s before delete: %w", fromDatabase, fromTable, err)
-	}
-	if glueTableChangedDuringRename(fromGlueTable, currentFromGlueTable) {
-		c.rollbackRenamedTable(ctx, toDatabase, toTable)
+			return nil, errors.Join(err, c.rollbackRenameDestination(ctx, toDatabase, toTable))
+		}
+		err = fmt.Errorf("failed to claim the table %s.%s for rename: %w", fromDatabase, fromTable, err)
 
-		return nil, fmt.Errorf("failed to rename the table %s.%s: source table changed during rename", fromDatabase, fromTable)
+		return nil, errors.Join(err, c.recoverAmbiguousRenameClaim(
+			ctx, fromDatabase, fromTable, fromGlueTable, renameToken, toDatabase, toTable,
+		))
 	}
 
 	// Drop the old table.
@@ -483,23 +500,91 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		Name:         aws.String(fromTable),
 	})
 	if err != nil {
-		c.rollbackRenamedTable(ctx, toDatabase, toTable)
+		deleteErr := fmt.Errorf("failed to delete the source table %s.%s after claiming it for rename: %w", fromDatabase, fromTable, err)
+		rollbackErr := c.rollbackClaimedRename(ctx, fromDatabase, fromTable, fromGlueTable, renameToken, toDatabase, toTable)
 
-		return nil, fmt.Errorf("failed to rename the table %s.%s: %w", fromDatabase, fromTable, err)
+		return nil, errors.Join(deleteErr, rollbackErr)
 	}
 
 	return c.LoadTable(ctx, to)
 }
 
-func (c *Catalog) rollbackRenamedTable(ctx context.Context, database, tableName string) {
-	_, rollbackErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
+func (c *Catalog) rollbackRenameDestination(ctx context.Context, database, tableName string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), renameCleanupTimeout)
+	defer cancel()
+
+	return c.deleteRenameDestination(cleanupCtx, database, tableName)
+}
+
+func (c *Catalog) deleteRenameDestination(ctx context.Context, database, tableName string) error {
+	_, err := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
 		CatalogId:    c.catalogId,
 		DatabaseName: aws.String(database),
 		Name:         aws.String(tableName),
 	})
-	if rollbackErr != nil {
-		log.Printf("failed to rollback the new table %s.%s: %v", database, tableName, rollbackErr)
+	if err != nil {
+		return fmt.Errorf("failed to roll back rename destination %s.%s: %w", database, tableName, err)
 	}
+
+	return nil
+}
+
+func (c *Catalog) recoverAmbiguousRenameClaim(ctx context.Context, fromDatabase, fromTable string, original *types.Table, renameToken, toDatabase, toTable string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), renameCleanupTimeout)
+	defer cancel()
+
+	current, err := c.getRawTable(cleanupCtx, fromDatabase, fromTable)
+	if err != nil {
+		return fmt.Errorf("could not determine whether source table %s.%s was claimed; rename destination retained: %w", fromDatabase, fromTable, err)
+	}
+
+	if current.Parameters[tableParamTableType] == glueTypeIcebergRenaming &&
+		current.Parameters[tableParamRenameToken] == renameToken {
+		return c.restoreClaimedRename(cleanupCtx, fromDatabase, fromTable, original, current, toDatabase, toTable)
+	}
+	if strings.EqualFold(current.Parameters[tableParamTableType], glueTypeIceberg) {
+		return c.deleteRenameDestination(cleanupCtx, toDatabase, toTable)
+	}
+
+	return fmt.Errorf("could not determine whether source table %s.%s was claimed because its state changed; rename destination retained", fromDatabase, fromTable)
+}
+
+func (c *Catalog) rollbackClaimedRename(ctx context.Context, fromDatabase, fromTable string, original *types.Table, renameToken, toDatabase, toTable string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), renameCleanupTimeout)
+	defer cancel()
+
+	current, err := c.getRawTable(cleanupCtx, fromDatabase, fromTable)
+	if err != nil {
+		return fmt.Errorf("failed to reload claimed source table %s.%s for rollback: %w", fromDatabase, fromTable, err)
+	}
+	if current.Parameters[tableParamTableType] != glueTypeIcebergRenaming || current.Parameters[tableParamRenameToken] != renameToken {
+		return fmt.Errorf("cannot restore source table %s.%s: rename claim changed", fromDatabase, fromTable)
+	}
+
+	return c.restoreClaimedRename(cleanupCtx, fromDatabase, fromTable, original, current, toDatabase, toTable)
+}
+
+func (c *Catalog) restoreClaimedRename(ctx context.Context, fromDatabase, fromTable string, original, current *types.Table, toDatabase, toTable string) error {
+	if aws.ToString(current.VersionId) == "" {
+		return fmt.Errorf("cannot restore source table %s.%s: claimed Glue table version id is missing", fromDatabase, fromTable)
+	}
+
+	_, err := c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(fromDatabase),
+		TableInput:   glueTableInput(fromTable, original),
+		VersionId:    current.VersionId,
+		SkipArchive:  aws.Bool(c.props.GetBool(SkipArchive, SkipArchiveDefault)),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to restore source table %s.%s after rename failure: %w", fromDatabase, fromTable, err)
+	}
+
+	if err := c.deleteRenameDestination(ctx, toDatabase, toTable); err != nil {
+		return fmt.Errorf("restored source table but failed to roll back rename destination %s.%s: %w", toDatabase, toTable, err)
+	}
+
+	return nil
 }
 
 // CheckTableExists returns if an Iceberg table exists in the Glue catalog.
@@ -671,6 +756,23 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 
 // GetTable loads a table from the Glue Catalog using the given database and table name.
 func (c *Catalog) getTable(ctx context.Context, database, tableName string) (*types.Table, error) {
+	tbl, err := c.getRawTable(ctx, database, tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	tableType := tbl.Parameters[tableParamTableType]
+	if tableType == glueTypeIcebergRenaming {
+		return nil, fmt.Errorf("%w: table %s.%s is being renamed", table.ErrCommitFailed, database, tableName)
+	}
+	if !strings.EqualFold(tableType, glueTypeIceberg) {
+		return nil, fmt.Errorf("table %s.%s is not an iceberg table", database, tableName)
+	}
+
+	return tbl, nil
+}
+
+func (c *Catalog) getRawTable(ctx context.Context, database, tableName string) (*types.Table, error) {
 	tblRes, err := c.glueSvc.GetTable(ctx,
 		&glue.GetTableInput{
 			CatalogId:    c.catalogId,
@@ -686,13 +788,12 @@ func (c *Catalog) getTable(ctx context.Context, database, tableName string) (*ty
 
 		return nil, fmt.Errorf("failed to get table %s.%s: %w", database, tableName, err)
 	}
+	if tblRes == nil || tblRes.Table == nil {
+		return nil, fmt.Errorf("failed to get table %s.%s: missing Glue table response", database, tableName)
+	}
 
 	if aws.ToString(tblRes.Table.TableType) != glueTableType {
 		return nil, fmt.Errorf("table %s.%s is not an EXTERNAL_TABLE", database, tableName)
-	}
-
-	if !strings.EqualFold(tblRes.Table.Parameters[tableParamTableType], glueTypeIceberg) {
-		return nil, fmt.Errorf("table %s.%s is not an iceberg table", database, tableName)
 	}
 
 	return tblRes.Table, nil
@@ -720,6 +821,10 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 
 	// Keep this case-insensitive check consistent with getTable and filterTableListByType.
 	if !strings.EqualFold(glueTable.Parameters[tableParamTableType], glueTypeIceberg) {
+		if glueTable.Parameters[tableParamTableType] == glueTypeIcebergRenaming {
+			return nil, fmt.Errorf("%w: table %s.%s is being renamed", table.ErrCommitFailed, database, tableName)
+		}
+
 		return nil, fmt.Errorf("table %s.%s is not an iceberg table", database, tableName)
 	}
 
@@ -833,6 +938,29 @@ func constructTableInput(tableName string, staged *table.Table, previousGlueTabl
 	return tableInput
 }
 
+func glueTableInput(tableName string, tbl *types.Table) *types.TableInput {
+	parameters := maps.Clone(tbl.Parameters)
+	if parameters == nil {
+		parameters = make(map[string]string)
+	}
+
+	return &types.TableInput{
+		Name:              aws.String(tableName),
+		Description:       tbl.Description,
+		LastAccessTime:    tbl.LastAccessTime,
+		LastAnalyzedTime:  tbl.LastAnalyzedTime,
+		Owner:             tbl.Owner,
+		Parameters:        parameters,
+		PartitionKeys:     tbl.PartitionKeys,
+		Retention:         tbl.Retention,
+		StorageDescriptor: tbl.StorageDescriptor,
+		TableType:         tbl.TableType,
+		TargetTable:       tbl.TargetTable,
+		ViewExpandedText:  tbl.ViewExpandedText,
+		ViewOriginalText:  tbl.ViewOriginalText,
+	}
+}
+
 func constructDatabaseInput(database string, props iceberg.Properties) *types.DatabaseInput {
 	databaseInput := &types.DatabaseInput{
 		Name: aws.String(database),
@@ -863,29 +991,4 @@ func constructDatabaseInput(database string, props iceberg.Properties) *types.Da
 // add an Is method to a type from another package.
 func isConcurrentModificationException(err error) bool {
 	return errors.As(err, new(*types.ConcurrentModificationException))
-}
-
-func glueTableChangedDuringRename(original, current *types.Table) bool {
-	if original == nil || current == nil {
-		return true
-	}
-
-	originalVersionID := aws.ToString(original.VersionId)
-	currentVersionID := aws.ToString(current.VersionId)
-	if originalVersionID != "" || currentVersionID != "" {
-		// Glue returns the same VersionId across consecutive GetTable calls
-		// unless the table was updated, making this a stronger drift check
-		// than comparing metadata_location when both versions are present.
-		return originalVersionID != currentVersionID
-	}
-
-	return glueTableMetadataLocation(original) != glueTableMetadataLocation(current)
-}
-
-func glueTableMetadataLocation(tbl *types.Table) string {
-	if tbl == nil || tbl.Parameters == nil {
-		return ""
-	}
-
-	return tbl.Parameters[tableParamMetadataLocation]
 }

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -214,6 +214,29 @@ func TestGlueGetTable(t *testing.T) {
 	assert.Equal("s3://test-bucket/test_table/metadata/abc123-123.metadata.json", tbl.Parameters[tableParamMetadataLocation])
 }
 
+func TestGlueGetTableRenameClaimIsRetryable(t *testing.T) {
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String(glueTableType),
+			Parameters: map[string]string{
+				tableParamTableType:   glueTypeIcebergRenaming,
+				tableParamRenameToken: "new_database.new_table@v1",
+			},
+		},
+	}, nil).Once()
+
+	_, err := (&Catalog{glueSvc: mockGlueSvc}).getTable(context.Background(), "test_database", "test_table")
+
+	require.ErrorIs(t, err, table.ErrCommitFailed)
+	require.ErrorContains(t, err, "is being renamed")
+	mockGlueSvc.AssertExpectations(t)
+}
+
 func TestGlueConstructParametersPreservesReservedParameters(t *testing.T) {
 	assert := require.New(t)
 
@@ -553,6 +576,54 @@ func TestGlueDropTable(t *testing.T) {
 
 	err := glueCatalog.DropTable(context.TODO(), TableIdentifier("test_database", "test_table"))
 	assert.NoError(err)
+}
+
+func TestGlueDropTableAllowsOrphanedRenameClaim(t *testing.T) {
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String(glueTableType),
+			Parameters: map[string]string{
+				tableParamTableType:   glueTypeIcebergRenaming,
+				tableParamRenameToken: "new_database.new_table@v1",
+			},
+		},
+	}, nil).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	err := (&Catalog{glueSvc: mockGlueSvc}).DropTable(
+		context.Background(), TableIdentifier("test_database", "test_table"))
+
+	require.NoError(t, err)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGlueDropTableRejectsNonIcebergTable(t *testing.T) {
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:       aws.String("test_table"),
+			TableType:  aws.String(glueTableType),
+			Parameters: map[string]string{tableParamTableType: "HIVE"},
+		},
+	}, nil).Once()
+
+	err := (&Catalog{glueSvc: mockGlueSvc}).DropTable(
+		context.Background(), TableIdentifier("test_database", "test_table"))
+
+	require.ErrorContains(t, err, "is not an iceberg table")
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
 }
 
 func TestGluePurgeTable(t *testing.T) {
@@ -983,6 +1054,7 @@ func TestGlueRenameTable(t *testing.T) {
 		Table: &types.Table{
 			Name:         aws.String("test_table"),
 			DatabaseName: aws.String("test_database"),
+			VersionId:    aws.String("v1"),
 			Parameters: map[string]string{
 				tableParamTableType:        glueTypeIceberg,
 				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
@@ -992,7 +1064,7 @@ func TestGlueRenameTable(t *testing.T) {
 			Description:       aws.String("description"),
 			StorageDescriptor: &types.StorageDescriptor{},
 		},
-	}, nil).Twice()
+	}, nil).Once()
 
 	// Mock CreateTable response
 	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
@@ -1009,6 +1081,14 @@ func TestGlueRenameTable(t *testing.T) {
 			StorageDescriptor: &types.StorageDescriptor{},
 		},
 	}, mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
+
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		return aws.ToString(input.DatabaseName) == "test_database" &&
+			aws.ToString(input.VersionId) == "v1" &&
+			aws.ToString(input.TableInput.Name) == "test_table" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIcebergRenaming &&
+			input.TableInput.Parameters[tableParamRenameToken] == "new_test_database.new_test_table@v1"
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, nil).Once()
 
 	// Mock DeleteTable response for old table
 	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
@@ -1087,6 +1167,7 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 		Table: &types.Table{
 			Name:      aws.String("test_table"),
 			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v1"),
 			Parameters: map[string]string{
 				tableParamTableType:        glueTypeIceberg,
 				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
@@ -1095,7 +1176,7 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 			Description:       aws.String("description"),
 			StorageDescriptor: &types.StorageDescriptor{},
 		},
-	}, nil).Twice()
+	}, nil).Once()
 
 	// Mock CreateTable response
 	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
@@ -1110,11 +1191,45 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 		},
 	}, mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
 
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		return aws.ToString(input.VersionId) == "v1" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIcebergRenaming &&
+			input.TableInput.Parameters[tableParamRenameToken] == "test_database.new_test_table@v1"
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, nil).Once()
+
 	// Mock DeleteTable response for old table (fail)
 	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
 		DatabaseName: aws.String("test_database"),
 		Name:         aws.String("test_table"),
 	}, mock.Anything).Return(&glue.DeleteTableOutput{}, errors.New("delete table failed")).Once()
+
+	// Reload and conditionally restore the claimed source before removing the destination.
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v2"),
+			Parameters: map[string]string{
+				tableParamTableType:        glueTypeIcebergRenaming,
+				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/abc123-123.metadata.json",
+				tableParamRenameToken:      "test_database.new_test_table@v1",
+			},
+			Owner:             aws.String("owner"),
+			Description:       aws.String("description"),
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		_, hasRenameToken := input.TableInput.Parameters[tableParamRenameToken]
+
+		return aws.ToString(input.VersionId) == "v2" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIceberg &&
+			!hasRenameToken
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, nil).Once()
 
 	// Mock DeleteTable response for rollback (new table)
 	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
@@ -1129,13 +1244,99 @@ func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 	renamedTable, err := glueCatalog.RenameTable(context.TODO(), TableIdentifier("test_database", "test_table"), TableIdentifier("test_database", "new_test_table"))
 	assert.Error(err)
 	assert.Nil(renamedTable)
-	mockGlueSvc.AssertCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{
-		DatabaseName: aws.String("test_database"),
-		Name:         aws.String("new_test_table"),
-	}, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
 }
 
-func TestGlueRenameTable_SourceTableChangedRollback(t *testing.T) {
+func TestGlueRenameTable_AmbiguousClaimFailureRestoresSource(t *testing.T) {
+	assert := require.New(t)
+	mockGlueSvc := &mockGlueClient{}
+
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(&glue.GetDatabaseOutput{
+		Database: &types.Database{Name: aws.String("test_database")},
+	}, nil).Once()
+
+	originalParameters := map[string]string{
+		tableParamTableType:        glueTypeIceberg,
+		tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v1.metadata.json",
+		tableParamRenameToken:      "preexisting-value",
+	}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:              aws.String("test_table"),
+			TableType:         aws.String("EXTERNAL_TABLE"),
+			VersionId:         aws.String("v1"),
+			Parameters:        originalParameters,
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("CreateTable", mock.Anything, &glue.CreateTableInput{
+		DatabaseName: aws.String("test_database"),
+		TableInput: &types.TableInput{
+			Name:              aws.String("new_test_table"),
+			TableType:         aws.String("EXTERNAL_TABLE"),
+			Parameters:        originalParameters,
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
+
+	claimErr := errors.New("connection reset after update")
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		return aws.ToString(input.VersionId) == "v1" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIcebergRenaming &&
+			input.TableInput.Parameters[tableParamRenameToken] == "test_database.new_test_table@v1"
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, claimErr).Once()
+
+	// Glue accepted the claim but the client observed a transport error.
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v2"),
+			Parameters: map[string]string{
+				tableParamTableType:        glueTypeIcebergRenaming,
+				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v1.metadata.json",
+				tableParamRenameToken:      "test_database.new_test_table@v1",
+			},
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		return aws.ToString(input.VersionId) == "v2" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIceberg &&
+			input.TableInput.Parameters[tableParamRenameToken] == "preexisting-value"
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, nil).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("new_test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+	renamedTable, err := glueCatalog.RenameTable(
+		context.Background(),
+		TableIdentifier("test_database", "test_table"),
+		TableIdentifier("test_database", "new_test_table"),
+	)
+
+	assert.ErrorIs(err, claimErr)
+	assert.Nil(renamedTable)
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGlueRenameTable_ConcurrentCommitRollback(t *testing.T) {
 	assert := require.New(t)
 
 	mockGlueSvc := &mockGlueClient{}
@@ -1178,23 +1379,10 @@ func TestGlueRenameTable_SourceTableChangedRollback(t *testing.T) {
 		},
 	}, mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
 
-	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
-		DatabaseName: aws.String("test_database"),
-		Name:         aws.String("test_table"),
-	}, mock.Anything).Return(&glue.GetTableOutput{
-		Table: &types.Table{
-			Name:      aws.String("test_table"),
-			TableType: aws.String("EXTERNAL_TABLE"),
-			VersionId: aws.String("v2"),
-			Parameters: map[string]string{
-				tableParamTableType:        glueTypeIceberg,
-				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/v2.metadata.json",
-			},
-			Owner:             aws.String("owner"),
-			Description:       aws.String("description"),
-			StorageDescriptor: &types.StorageDescriptor{},
-		},
-	}, nil).Once()
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(input *glue.UpdateTableInput) bool {
+		return aws.ToString(input.VersionId) == "v1" &&
+			input.TableInput.Parameters[tableParamTableType] == glueTypeIcebergRenaming
+	}), mock.Anything).Return(&glue.UpdateTableOutput{}, &types.ConcurrentModificationException{}).Once()
 
 	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
 		DatabaseName: aws.String("test_database"),
@@ -1211,6 +1399,7 @@ func TestGlueRenameTable_SourceTableChangedRollback(t *testing.T) {
 		TableIdentifier("test_database", "new_test_table"),
 	)
 	assert.ErrorContains(err, "source table changed during rename")
+	assert.ErrorIs(err, table.ErrCommitFailed)
 	assert.Nil(renamedTable)
 
 	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, &glue.DeleteTableInput{


### PR DESCRIPTION
## Summary

- conditionally claim the Glue source table by `VersionId` before issuing the service's unconditional delete
- make the claimed source temporarily non-Iceberg so new writers stop, while stale writers fail the optimistic version check
- reconcile ambiguous claim responses before cleanup, restoring a claim that Glue applied despite returning an error
- restore the source conditionally if deletion fails, then remove the destination only after the source is visible again
- allow explicit `DropTable` to remove a rename claim orphaned by process termination while continuing to reject unrelated non-Iceberg tables
- run rollback with a detached, bounded context, preserve rollback failures, and retain pre-existing table parameters

## Why

Glue implements rename as create-destination followed by delete-source, but `DeleteTable` has no version condition. A commit could previously land after the final source read and then be deleted, leaving the destination on the older metadata version.

The conditional claim closes that window: a commit that wins first invalidates the rename's `VersionId`, while a rename that wins first prevents new Iceberg commits from advancing the source before deletion. For transport errors where Glue may have applied `UpdateTable`, recovery reads the raw source state and only removes the destination after the source is known to be visible again.

The claim is durable, so a process can terminate after claiming the source but before delete or rollback. Load, commit, and re-rename remain fenced, while an explicit drop provides an API recovery path for that orphaned claim.

## Testing

- concurrent commit/rename fencing
- source restoration after delete failure
- ambiguous successful-update response recovery and parameter preservation
- orphaned rename-claim drop recovery and non-Iceberg drop rejection
- 10 repeated focused rename/drop test runs
- `go test ./catalog/glue`
- `go test -race ./catalog/glue`
- `go vet ./catalog/glue`