### PR TITLE
fix(hive): clean up pending locks after cancellation

### DIFF
--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -32,6 +32,8 @@ import (
 // ErrLockAcquisitionFailed is returned when a lock cannot be acquired after all retries.
 var ErrLockAcquisitionFailed = errors.New("failed to acquire lock")
 
+const pendingLockCleanupTimeout = 5 * time.Second
+
 type HiveLock struct {
 	client HiveClient
 	lockId int64
@@ -46,7 +48,7 @@ type tableLockIdentifier struct {
 	table    string
 }
 
-func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLockIdentifier, opts *HiveOptions) (*HiveLock, error) {
+func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLockIdentifier, opts *HiveOptions) (_ *HiveLock, err error) {
 	identifiers = slices.Clone(identifiers)
 	slices.SortFunc(identifiers, func(a, b tableLockIdentifier) int {
 		if cmp := strings.Compare(a.database, b.database); cmp != 0 {
@@ -83,6 +85,19 @@ func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLoc
 		}, nil
 	}
 
+	cleanupPending := true
+	defer func() {
+		if !cleanupPending {
+			return
+		}
+
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), pendingLockCleanupTimeout)
+		defer cancel()
+		if cleanupErr := client.Unlock(cleanupCtx, lockResp.Lockid); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to release pending lock %d: %w", lockResp.Lockid, cleanupErr))
+		}
+	}()
+
 	// If not acquired immediately, wait and retry
 	for attempt := 0; attempt < opts.LockRetries; attempt++ {
 		// Wait before checking again
@@ -90,8 +105,6 @@ func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLoc
 
 		select {
 		case <-ctx.Done():
-			_ = client.Unlock(ctx, lockResp.Lockid)
-
 			return nil, ctx.Err()
 		case <-time.After(waitTime):
 		}
@@ -99,13 +112,13 @@ func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLoc
 		// Check lock state
 		checkResp, err := client.CheckLock(ctx, lockResp.Lockid)
 		if err != nil {
-			_ = client.Unlock(ctx, lockResp.Lockid)
-
 			return nil, fmt.Errorf("failed to check lock status: %w", err)
 		}
 
 		switch checkResp.State {
 		case hive_metastore.LockState_ACQUIRED:
+			cleanupPending = false
+
 			return &HiveLock{
 				client: client,
 				lockId: lockResp.Lockid,
@@ -121,8 +134,6 @@ func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLoc
 			return nil, fmt.Errorf("%w: unexpected lock state: %v", ErrLockAcquisitionFailed, checkResp.State)
 		}
 	}
-
-	_ = client.Unlock(ctx, lockResp.Lockid)
 
 	return nil, fmt.Errorf("%w: exhausted %d retries for tables %s", ErrLockAcquisitionFailed, opts.LockRetries, formatLockIdentifiers(identifiers))
 }

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -134,7 +134,11 @@ func TestAcquireLockExhaustsRetries(t *testing.T) {
 			State:  hive_metastore.LockState_WAITING,
 		}, nil)
 
-	mockClient.On("Unlock", ctx, int64(789)).Return(nil)
+	mockClient.On("Unlock", mock.MatchedBy(func(cleanupCtx context.Context) bool {
+		_, hasDeadline := cleanupCtx.Deadline()
+
+		return cleanupCtx.Err() == nil && hasDeadline
+	}), int64(789)).Return(nil)
 
 	lock, err := acquireLock(ctx, mockClient, "testdb", "testtable", opts)
 
@@ -165,6 +169,7 @@ func TestAcquireLockAborted(t *testing.T) {
 			Lockid: 111,
 			State:  hive_metastore.LockState_ABORT,
 		}, nil)
+	mockClient.On("Unlock", mock.Anything, int64(111)).Return(nil)
 
 	lock, err := acquireLock(ctx, mockClient, "testdb", "testtable", opts)
 
@@ -173,6 +178,26 @@ func TestAcquireLockAborted(t *testing.T) {
 	assert.ErrorIs(t, err, ErrLockAcquisitionFailed)
 	assert.Contains(t, err.Error(), "aborted")
 
+	mockClient.AssertExpectations(t)
+}
+
+func TestAcquireLockUnexpectedStateCleansUp(t *testing.T) {
+	mockClient := new(mockHiveClient)
+	ctx := context.Background()
+	opts := NewHiveOptions()
+	opts.LockMinWaitTime = time.Millisecond
+
+	mockClient.On("Lock", ctx, mock.AnythingOfType("*hive_metastore.LockRequest")).
+		Return(&hive_metastore.LockResponse{Lockid: 112, State: hive_metastore.LockState_WAITING}, nil)
+	mockClient.On("CheckLock", ctx, int64(112)).
+		Return(&hive_metastore.LockResponse{Lockid: 112, State: hive_metastore.LockState(99)}, nil)
+	mockClient.On("Unlock", mock.Anything, int64(112)).Return(nil)
+
+	lock, err := acquireLock(ctx, mockClient, "testdb", "testtable", opts)
+
+	require.Nil(t, lock)
+	require.ErrorIs(t, err, ErrLockAcquisitionFailed)
+	require.ErrorContains(t, err, "unexpected lock state")
 	mockClient.AssertExpectations(t)
 }
 
@@ -212,7 +237,7 @@ func TestAcquireLockCheckFails(t *testing.T) {
 		Return(nil, errors.New("check failed"))
 
 	// Lock should be released on error
-	mockClient.On("Unlock", ctx, int64(222)).Return(nil)
+	mockClient.On("Unlock", mock.Anything, int64(222)).Return(nil)
 
 	lock, err := acquireLock(ctx, mockClient, "testdb", "testtable", opts)
 
@@ -236,8 +261,12 @@ func TestAcquireLockContextCancelled(t *testing.T) {
 			State:  hive_metastore.LockState_WAITING,
 		}, nil)
 
-	// Lock should be released when context is cancelled
-	mockClient.On("Unlock", ctx, int64(333)).Return(nil)
+	// Lock cleanup must use a live, bounded context after the caller is cancelled.
+	mockClient.On("Unlock", mock.MatchedBy(func(cleanupCtx context.Context) bool {
+		_, hasDeadline := cleanupCtx.Deadline()
+
+		return cleanupCtx.Err() == nil && hasDeadline
+	}), int64(333)).Return(nil)
 
 	// Cancel context before the wait completes
 	go func() {
@@ -251,6 +280,29 @@ func TestAcquireLockContextCancelled(t *testing.T) {
 	require.Nil(t, lock)
 	assert.ErrorIs(t, err, context.Canceled)
 
+	mockClient.AssertExpectations(t)
+}
+
+func TestAcquireLockJoinsCleanupFailure(t *testing.T) {
+	mockClient := new(mockHiveClient)
+	ctx := context.Background()
+	opts := NewHiveOptions()
+	opts.LockMinWaitTime = time.Millisecond
+	opts.LockRetries = 1
+	checkErr := errors.New("check failed")
+	cleanupErr := errors.New("unlock failed")
+
+	mockClient.On("Lock", ctx, mock.AnythingOfType("*hive_metastore.LockRequest")).
+		Return(&hive_metastore.LockResponse{Lockid: 334, State: hive_metastore.LockState_WAITING}, nil)
+	mockClient.On("CheckLock", ctx, int64(334)).Return(nil, checkErr)
+	mockClient.On("Unlock", mock.Anything, int64(334)).Return(cleanupErr)
+
+	lock, err := acquireLock(ctx, mockClient, "testdb", "testtable", opts)
+
+	require.Nil(t, lock)
+	require.ErrorIs(t, err, checkErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.ErrorContains(t, err, "failed to release pending lock 334")
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

- defer pending-lock cleanup from the point where Hive returns a lock ID until ownership is transferred to `HiveLock`
- detach cleanup from caller cancellation while preserving context values, with a five-second timeout
- join unlock failures with the primary acquisition error instead of discarding them

## Why

The cancellation path passed an already-canceled context to `Unlock`, so a real metastore client could reject cleanup without sending it and leave the pending lock behind. Check failures and retry exhaustion also discarded cleanup errors.

## Testing

- `go test ./catalog/hive`
- `go vet ./catalog/hive`
- repository package suite excluding the locally hanging `io/gocloud` test binary
