### PR TITLE
feat(rest): implement WaitForPlan poller for scan planning

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -130,7 +130,9 @@ type errorResponse struct {
 	Code    int      `json:"code"`
 	Stack   []string `json:"stack,omitempty"`
 
-	wrapping error
+	wrapping   error
+	statusCode int
+	retryAfter string
 }
 
 type contextKey string
@@ -526,7 +528,10 @@ func setRequestHeaders(req *http.Request, headers map[string]string) {
 }
 
 func handleNon200(rsp *http.Response, override map[int]error, typeOverride map[string]error) error {
-	var e errorResponse
+	e := errorResponse{
+		statusCode: rsp.StatusCode,
+		retryAfter: rsp.Header.Get("Retry-After"),
+	}
 
 	// Only try to decode if there's a body (HEAD requests don't have one)
 	if rsp.ContentLength != 0 {
@@ -541,7 +546,13 @@ func handleNon200(rsp *http.Response, override map[int]error, typeOverride map[s
 
 		decErr := json.NewDecoder(rsp.Body).Decode(&payload)
 		if decErr != nil && decErr != io.EOF {
-			return fmt.Errorf("%w: failed to decode error response: %s", ErrRESTError, decErr.Error())
+			// Preserve the HTTP metadata even when the server returned a non-JSON
+			// error page. Callers such as WaitForPlan still need the status to apply
+			// transport-level retry policy; the wrapping sentinel retains the prior
+			// ErrRESTError classification for malformed error payloads.
+			e.wrapping = ErrRESTError
+
+			return fmt.Errorf("%w: failed to decode error response: %s", e, decErr.Error())
 		}
 
 		if e.Message == "" && e.Type == "" {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1382,6 +1382,43 @@ func TestHandleNon200_EmptyBodyFallback(t *testing.T) {
 	require.NotEqual(t, ": ", err.Error())
 }
 
+func TestHandleNon200_CapturesStatusAndRetryAfter(t *testing.T) {
+	body := `{"error":{"message":"busy","type":"ServiceUnavailable"}}`
+	rsp := &http.Response{
+		StatusCode:    http.StatusServiceUnavailable,
+		Header:        http.Header{"Retry-After": {"3"}},
+		ContentLength: int64(len(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := handleNon200(rsp, nil, nil)
+
+	var restErr errorResponse
+	require.ErrorAs(t, err, &restErr)
+	require.Equal(t, http.StatusServiceUnavailable, restErr.statusCode)
+	require.Equal(t, "3", restErr.retryAfter)
+	require.ErrorIs(t, err, ErrServiceUnavailable)
+}
+
+func TestHandleNon200_PreservesStatusOnMalformedBody(t *testing.T) {
+	// A non-JSON error page must still carry the HTTP status (so a poller can apply
+	// transport-level retry policy) and stay classified as ErrRESTError.
+	rsp := &http.Response{
+		StatusCode:    http.StatusBadGateway,
+		Header:        http.Header{"Retry-After": {"5"}},
+		ContentLength: int64(len("not json")),
+		Body:          io.NopCloser(bytes.NewBufferString("not json")),
+	}
+
+	err := handleNon200(rsp, nil, nil)
+
+	var restErr errorResponse
+	require.ErrorAs(t, err, &restErr)
+	require.Equal(t, http.StatusBadGateway, restErr.statusCode)
+	require.Equal(t, "5", restErr.retryAfter)
+	require.ErrorIs(t, err, ErrRESTError)
+}
+
 func TestHandleNon200_ErrorTypeOverride(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -25,9 +25,12 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -64,6 +67,13 @@ var ErrPlanFailed = fmt.Errorf("%w: scan plan failed", ErrRESTError)
 // was cancelled (by this client or another). Like a failed plan it is terminal,
 // so it surfaces as an error rather than a (resp, nil) the if-err idiom skips.
 var ErrPlanCancelled = fmt.Errorf("%w: scan plan cancelled", ErrRESTError)
+
+// ErrPlanPollExhausted is returned by WaitForPlan when polling reaches
+// WaitForPlanOptions.MaxRetries without the plan completing while the context is
+// still live. It bounds a plan that stays submitted forever when the caller
+// passes no context deadline, and is the Go analogue of Java's
+// RemotePlanTimeoutException.
+var ErrPlanPollExhausted = fmt.Errorf("%w: scan plan polling exhausted retries", ErrRESTError)
 
 // REST error.type values the scan-planning 404 responses carry. The spec models
 // a 404 on these endpoints as one of several distinct not-found conditions;
@@ -325,12 +335,273 @@ func (r *Catalog) FetchScanTasks(ctx context.Context, ident table.Identifier, re
 		withErrorTypeOverride(fetchScanTasksErrorTypes), requireBody())
 }
 
-// WaitForPlan polls a submitted plan to completion using jittered backoff,
-// cancelling the server-side plan if the context is cancelled. The total wait is
-// bounded by the context deadline; it returns an error if the deadline passes
-// while still submitted, or if the plan is cancelled, failed, or expired.
+// WaitForPlan polls a submitted plan to completion using jittered backoff. It
+// retries the idempotent-GET status set used by Java's REST transport
+// (408/429/500/502/503/504); every other HTTP error is terminal. A positive
+// Retry-After hint on a retried error response overrides the backoff, floored at
+// MinDelay and — only when the caller set no context deadline — capped at
+// MaxDelay; with a deadline the hint is honoured in full, bounded by that
+// deadline (so a rate-limiting 429/503 is respected rather than clamped). The
+// hint is read only from error responses, not from a 200 "submitted" body.
+//
+// It returns the completed planning result verbatim: a completed plan may carry
+// file-scan-tasks that are ready to read and/or plan-tasks (opaque handles that
+// still need FetchScanTasks). WaitForPlan does not expand plan-tasks — driving
+// that fanout is the caller's (PlanFiles') job — so "completed" does not imply
+// every task is a file-scan-task.
+//
+// Polling time is bounded by the caller's context deadline (the Go equivalent of
+// Java's REST_SCAN_PLANNING_POLL_TIMEOUT_MS). opts.MaxRetries is a separate
+// safety net for a caller that set no deadline: it caps the poll count and, when
+// exhausted, cancels the plan server-side and returns ErrPlanPollExhausted. The
+// default cap is disabled when the context has a deadline, so a longer deadline
+// is never silently cut short by the retry count.
+//
+// On context cancellation — or on retry exhaustion — WaitForPlan cancels the plan
+// server-side and then returns (the wrapped context error, errors.Is
+// context.Canceled / context.DeadlineExceeded; or ErrPlanPollExhausted). The
+// cancel is synchronous so a short-lived caller cannot exit before the plan is
+// released; it is best-effort and bounded by opts.CancelGracePeriod, so a stalled
+// cancel endpoint delays the return by at most that grace (see abandonPlan).
+//
+// It requires the fetchPlanningResult endpoint (returning ErrEndpointNotSupported
+// otherwise) and a non-empty planID (ErrInvalidArgument otherwise); the cancel is
+// best-effort, so cancelPlanning is not required. Other terminal errors from the
+// poll — *PlanFailedError (errors.Is ErrPlanFailed), ErrPlanCancelled,
+// ErrPlanExpired, or a gone table/namespace — are returned unchanged.
 func (r *Catalog) WaitForPlan(ctx context.Context, ident table.Identifier, planID string, opts WaitForPlanOptions) (CompletedPlanningResult, error) {
-	return CompletedPlanningResult{}, fmt.Errorf("%w: wait for plan", iceberg.ErrNotImplemented)
+	if err := r.endpoints.check(endpointFetchPlanResult); err != nil {
+		return CompletedPlanningResult{}, err
+	}
+	if planID == "" {
+		return CompletedPlanningResult{}, fmt.Errorf("%w: empty plan-id", iceberg.ErrInvalidArgument)
+	}
+
+	_, hasDeadline := ctx.Deadline()
+	minDelay, maxDelay, grace, maxRetries := resolveWaitOptions(opts, hasDeadline)
+	unlimited := maxRetries < 0
+	fetchOpts := FetchPlanningResultOptions{AccessDelegation: opts.AccessDelegation}
+
+	// Decorrelated jitter (AWS "Exponential Backoff And Jitter"): each sleep is a
+	// random duration in [minDelay, prevSleep*3] capped at maxDelay, so every wait
+	// stays within [minDelay, maxDelay] — minDelay a true floor, maxDelay a true
+	// cap — while spreading concurrent pollers to avoid a thundering herd. (This is
+	// deliberately not table.go's capped-exponential commit-retry backoff: many
+	// clients poll one plan endpoint, so decorrelated jitter de-synchronises them.)
+	sleep := minDelay
+	retries := 0
+	for {
+		retryAfter := time.Duration(0)
+		resp, err := r.FetchPlanningResult(ctx, ident, planID, fetchOpts)
+		switch {
+		case err != nil:
+			// A context cancellation mid-request surfaces as a transport error;
+			// funnel it through the same abandon-and-report path as a cancellation
+			// observed during the backoff sleep so the plan is cancelled server-side.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				r.abandonPlan(ctx, ident, planID, grace)
+
+				return CompletedPlanningResult{}, fmt.Errorf("waiting for plan %q on %v: %w", planID, ident, ctxErr)
+			}
+
+			// Retry the same idempotent GET statuses as Java's REST transport. Every
+			// other error — failed (*PlanFailedError), cancelled (ErrPlanCancelled),
+			// expired (ErrPlanExpired), a gone table/namespace, or a non-retryable
+			// HTTP status such as 501 — is terminal and propagates unchanged.
+			var retryable bool
+			retryAfter, retryable = scanPlanPollRetry(err)
+			if !retryable {
+				return CompletedPlanningResult{}, err
+			}
+		case resp.Status == PlanStatusCompleted:
+			return CompletedPlanningResult{
+				Status:             resp.Status,
+				ScanTasks:          resp.ScanTasks,
+				StorageCredentials: resp.StorageCredentials,
+			}, nil
+		case resp.Status == PlanStatusSubmitted:
+			// keep polling
+		default:
+			// FetchPlanningResult maps failed/cancelled to errors and its decoder
+			// rejects unknown statuses, so only completed/submitted reach here;
+			// guard the invariant rather than silently spin.
+			return CompletedPlanningResult{}, fmt.Errorf(
+				"%w: unexpected plan status %q while waiting for plan", ErrRESTError, resp.Status)
+		}
+
+		// The plan is still in flight (submitted or a retried HTTP response). Stop if the
+		// retry budget is spent — the safety net for a caller that set no deadline.
+		// Cancel the still-active plan server-side first, like the cancellation path
+		// (the OpenAPI contract and Java's cleanupPlanResources free abandoned plans).
+		if !unlimited && retries >= maxRetries {
+			r.abandonPlan(ctx, ident, planID, grace)
+
+			return CompletedPlanningResult{}, fmt.Errorf(
+				"waiting for plan %q on %v: %w after %d retries", planID, ident, ErrPlanPollExhausted, retries)
+		}
+		retries++
+
+		// Back off before the next poll. On cancellation, cancel the plan
+		// server-side (bounded, best-effort) before returning the context error.
+		sleep = nextScanPlanBackoff(sleep, minDelay, maxDelay)
+		sleep = applyRetryAfter(sleep, retryAfter, minDelay, maxDelay, hasDeadline)
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			r.abandonPlan(ctx, ident, planID, grace)
+
+			return CompletedPlanningResult{}, fmt.Errorf("waiting for plan %q on %v: %w", planID, ident, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+// scanPlanPollRetry reports whether err came from an HTTP status that Java's
+// REST transport retries for an idempotent GET. It also returns a positive
+// Retry-After delay, capped later by the caller's MaxDelay. The fallback for
+// ErrServiceUnavailable preserves compatibility with callers or transports that
+// return the sentinel without the package's concrete errorResponse wrapper.
+func scanPlanPollRetry(err error) (time.Duration, bool) {
+	var restErr errorResponse
+	if errors.As(err, &restErr) {
+		switch restErr.statusCode {
+		case http.StatusRequestTimeout,
+			http.StatusTooManyRequests,
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			return parseRetryAfter(restErr.retryAfter), true
+		default:
+			return 0, false
+		}
+	}
+
+	return 0, errors.Is(err, ErrServiceUnavailable)
+}
+
+// applyRetryAfter overrides the jittered backoff with a positive server
+// Retry-After hint, floored at minDelay. The hint is capped at maxDelay only when
+// the caller set no context deadline: with a deadline the poll loop's ctx.Done()
+// select already bounds an over-long hint, so genuine 429/503 backpressure is
+// honoured in full; without one, maxDelay stays the safety cap so a hostile or
+// accidental hint cannot become a single unbounded sleep. A non-positive hint
+// leaves the backoff unchanged.
+func applyRetryAfter(backoff, retryAfter, minDelay, maxDelay time.Duration, hasDeadline bool) time.Duration {
+	if retryAfter <= 0 {
+		return backoff
+	}
+
+	sleep := max(retryAfter, minDelay)
+	if !hasDeadline {
+		sleep = min(sleep, maxDelay)
+	}
+
+	return sleep
+}
+
+// parseRetryAfter accepts both Retry-After forms from RFC 9110: integer seconds
+// or an HTTP date. Invalid, expired, and non-positive values are ignored.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		const maxDuration = time.Duration(1<<63 - 1)
+		if seconds > int64(maxDuration/time.Second) {
+			return maxDuration
+		}
+
+		return time.Duration(seconds) * time.Second
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	delay := time.Until(retryAt)
+	if delay <= 0 {
+		return 0
+	}
+
+	return delay
+}
+
+// resolveWaitOptions normalizes user options into the effective backoff floor,
+// cap, cancel grace, and retry budget. A zero (or negative, for the durations)
+// field takes its DefaultWaitForPlanOptions value; an inverted floor/cap is
+// clamped so maxDelay >= minDelay (the invariant nextScanPlanBackoff relies on).
+//
+// A negative maxRetries is preserved as the "unlimited, bound only by context"
+// sentinel. A zero maxRetries resolves to unlimited when the context already has
+// a deadline (that deadline is the real bound, so the default cap must not cut it
+// short) and to the default cap otherwise (the safety net for a no-deadline
+// caller). An explicit positive maxRetries is always honoured.
+func resolveWaitOptions(opts WaitForPlanOptions, hasDeadline bool) (minDelay, maxDelay, grace time.Duration, maxRetries int) {
+	minDelay, maxDelay, grace, maxRetries = opts.MinDelay, opts.MaxDelay, opts.CancelGracePeriod, opts.MaxRetries
+	if minDelay <= 0 {
+		minDelay = DefaultWaitForPlanOptions.MinDelay
+	}
+	if maxDelay <= 0 {
+		maxDelay = DefaultWaitForPlanOptions.MaxDelay
+	}
+	if maxDelay < minDelay {
+		maxDelay = minDelay
+	}
+	if grace <= 0 {
+		grace = DefaultWaitForPlanOptions.CancelGracePeriod
+	}
+	if maxRetries == 0 {
+		if hasDeadline {
+			maxRetries = -1
+		} else {
+			maxRetries = DefaultWaitForPlanOptions.MaxRetries
+		}
+	}
+
+	return minDelay, maxDelay, grace, maxRetries
+}
+
+// nextScanPlanBackoff returns the next decorrelated-jitter sleep: a random
+// duration in [minDelay, min(prev*3, maxDelay)]. Callers guarantee
+// 0 < minDelay <= maxDelay and prev >= minDelay, so the ceiling is >= minDelay
+// and the sampled span is non-negative.
+func nextScanPlanBackoff(prev, minDelay, maxDelay time.Duration) time.Duration {
+	// Grow the ceiling geometrically but overflow-safe: prev*3 is only formed when
+	// it is known to stay <= maxDelay (hence <= MaxInt64); otherwise the ceiling is
+	// maxDelay. Without this guard a large prev (e.g. maxDelay == MaxInt64) would
+	// overflow prev*3 into a non-positive rand.Int64N argument and panic.
+	ceiling := maxDelay
+	if prev <= maxDelay/3 {
+		ceiling = prev * 3
+	}
+
+	// The +1 makes the upper bound inclusive; minDelay > 0 keeps the argument
+	// within (0, MaxInt64], so rand.Int64N never sees a non-positive n.
+	//nolint:gosec // non-security randomness, jitter for poll backoff spread
+	return minDelay + time.Duration(rand.Int64N(int64(ceiling-minDelay)+1))
+}
+
+// abandonPlan cancels a plan server-side after the caller's context is done. It
+// runs synchronously — WaitForPlan calls CancelPlanning and only then returns —
+// so a short-lived caller cannot exit before the plan is released, matching the
+// #1178 "call CancelPlanning, then return" contract. The caller's context is
+// already cancelled, so the DELETE runs on one detached from cancellation
+// (values, e.g. auth, preserved) bounded by grace, which caps how long a stalled
+// endpoint can delay the return. It is best-effort: the plan expires server-side
+// regardless, so any error — including a server that never advertised the cancel
+// endpoint — is dropped.
+func (r *Catalog) abandonPlan(ctx context.Context, ident table.Identifier, planID string, grace time.Duration) {
+	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), grace)
+	defer cancel()
+
+	_ = r.CancelPlanning(cctx, ident, planID)
 }
 
 func (r *Catalog) scanPlanningPath(ep endpoint, ident table.Identifier, extra ...string) ([]string, error) {
@@ -520,8 +791,9 @@ type PlanTableScanRequest struct {
 // (CompletedPlanningWithIDResult) and submitted (AsyncPlanningResult) responses
 // here; the wire decoder must validate PlanID != nil at unmarshal rather than
 // rely on the omitempty pointer. A cancelled status is invalid for this endpoint
-// and must be treated as an error. A failed status decodes successfully when it
-// carries Error; callers must branch on Status before dereferencing PlanID.
+// and must be treated as an error. A failed status decodes even when a
+// non-compliant server omits or malforms Error; callers must branch on Status
+// before dereferencing PlanID.
 type PlanTableScanResponse struct {
 	Status PlanStatus     `json:"status"`
 	PlanID *string        `json:"plan-id,omitempty"`
@@ -531,8 +803,13 @@ type PlanTableScanResponse struct {
 }
 
 func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
-	type planTableScanResponse PlanTableScanResponse
-	var resp planTableScanResponse
+	var resp struct {
+		Status PlanStatus      `json:"status"`
+		PlanID *string         `json:"plan-id,omitempty"`
+		Error  json.RawMessage `json:"error,omitempty"`
+		ScanTasks
+		StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return err
 	}
@@ -543,16 +820,19 @@ func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("%w: planTableScan response with status %q missing plan-id", ErrRESTError, resp.Status)
 		}
 	case PlanStatusFailed:
-		if resp.Error == nil {
-			return fmt.Errorf("%w: planTableScan failed response missing error", ErrRESTError)
-		}
 	case PlanStatusCancelled:
 		return fmt.Errorf("%w: planTableScan response has invalid status %q", ErrRESTError, resp.Status)
 	default:
 		return fmt.Errorf("%w: planTableScan response has unknown status %q", ErrRESTError, resp.Status)
 	}
 
-	*r = PlanTableScanResponse(resp)
+	*r = PlanTableScanResponse{
+		Status:             resp.Status,
+		PlanID:             resp.PlanID,
+		Error:              decodePlanningError(resp.Error),
+		ScanTasks:          resp.ScanTasks,
+		StorageCredentials: resp.StorageCredentials,
+	}
 
 	return nil
 }
@@ -567,8 +847,12 @@ type FetchPlanningResultResponse struct {
 }
 
 func (r *FetchPlanningResultResponse) UnmarshalJSON(data []byte) error {
-	type fetchPlanningResultResponse FetchPlanningResultResponse
-	var resp fetchPlanningResultResponse
+	var resp struct {
+		Status PlanStatus      `json:"status"`
+		Error  json.RawMessage `json:"error,omitempty"`
+		ScanTasks
+		StorageCredentials []StorageCredential `json:"storage-credentials,omitempty"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return err
 	}
@@ -576,16 +860,34 @@ func (r *FetchPlanningResultResponse) UnmarshalJSON(data []byte) error {
 	switch resp.Status {
 	case PlanStatusCompleted, PlanStatusSubmitted, PlanStatusCancelled:
 	case PlanStatusFailed:
-		if resp.Error == nil {
-			return fmt.Errorf("%w: fetchPlanningResult failed response missing error", ErrRESTError)
-		}
 	default:
 		return fmt.Errorf("%w: fetchPlanningResult response has unknown status %q", ErrRESTError, resp.Status)
 	}
 
-	*r = FetchPlanningResultResponse(resp)
+	*r = FetchPlanningResultResponse{
+		Status:             resp.Status,
+		Error:              decodePlanningError(resp.Error),
+		ScanTasks:          resp.ScanTasks,
+		StorageCredentials: resp.StorageCredentials,
+	}
 
 	return nil
+}
+
+// decodePlanningError parses the ErrorModel carried by a failed planning arm.
+// The spec requires an object, but Java deliberately treats a missing, null, or
+// primitive value as absent so the failed status itself still reaches callers.
+func decodePlanningError(raw json.RawMessage) *PlanningError {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var detail *PlanningError
+	if err := json.Unmarshal(raw, &detail); err != nil {
+		return nil
+	}
+
+	return detail
 }
 
 // FetchScanTasksRequest is the POST .../tasks request body.
@@ -607,20 +909,42 @@ type FetchScanTasksResponse struct {
 	ScanTasks
 }
 
-// DefaultWaitForPlanOptions is the conservative polling backoff used when
-// callers pass the zero-value WaitForPlanOptions.
+// DefaultWaitForPlanOptions is the conservative polling backoff, cancel grace,
+// and retry budget used when callers pass the zero-value WaitForPlanOptions.
+// MaxRetries mirrors Java's maxRetries=10, but it applies only when the caller
+// set no context deadline — with a deadline, the default cap is disabled so it
+// cannot cut a long deadline short (see resolveWaitOptions). A caller expecting a
+// long plan should therefore set a context deadline, not rely on this default.
 var DefaultWaitForPlanOptions = WaitForPlanOptions{
-	MinDelay: 100 * time.Millisecond,
-	MaxDelay: 5 * time.Second,
+	MinDelay:          100 * time.Millisecond,
+	MaxDelay:          5 * time.Second,
+	CancelGracePeriod: 5 * time.Second,
+	MaxRetries:        10,
 }
 
-// WaitForPlanOptions tunes the polling backoff. The total wait is bounded by the
-// caller's context deadline (context.WithTimeout). There is deliberately no
-// Timeout field to avoid duplicating the context and the zero-value footgun.
-// A zero MinDelay/MaxDelay uses DefaultWaitForPlanOptions.
+// WaitForPlanOptions tunes the polling backoff and bounds. The total polling wait
+// is bounded by whichever comes first: the caller's context deadline
+// (context.WithTimeout) or MaxRetries. There is deliberately no Timeout field —
+// the context is the time bound, avoiding a duplicated deadline and its
+// zero-value footgun. Zero MinDelay/MaxDelay/CancelGracePeriod values use
+// DefaultWaitForPlanOptions. Zero MaxRetries uses the default only without a
+// context deadline; with a deadline it is unlimited so the deadline remains the
+// authoritative bound.
 type WaitForPlanOptions struct {
 	MinDelay time.Duration
 	MaxDelay time.Duration
+	// CancelGracePeriod bounds the synchronous best-effort server-side cancel
+	// issued once the caller's context is done: it is the most WaitForPlan's
+	// return can be delayed past the deadline when the cancel endpoint stalls. A
+	// caller in a hurry can shrink it; a zero value uses DefaultWaitForPlanOptions.
+	CancelGracePeriod time.Duration
+	// MaxRetries caps the number of poll retries (attempts after the first) before
+	// WaitForPlan gives up with ErrPlanPollExhausted. It is the safety net for a
+	// caller that set no context deadline. Zero uses DefaultWaitForPlanOptions when
+	// the context has no deadline, and unlimited when it does (the deadline is the
+	// real bound). A negative value means unlimited; an explicit positive value is
+	// always honoured, even alongside a deadline.
+	MaxRetries int
 	// AccessDelegation is sent as the X-Iceberg-Access-Delegation header on each
 	// poll; nil uses the catalog default. Needed for async plans so the
 	// completed poll can return vended storage credentials.

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -198,12 +198,19 @@ func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
 	assert.Len(t, resp.DeleteFiles, 1)
 }
 
-func TestPlanTableScanResponseRejectsFailedWithoutError(t *testing.T) {
+func TestPlanTableScanResponseAcceptsFailedWithoutUsableError(t *testing.T) {
 	t.Parallel()
 
-	var resp PlanTableScanResponse
-	err := json.Unmarshal([]byte(`{"status":"failed"}`), &resp)
-	require.ErrorIs(t, err, ErrRESTError)
+	for _, payload := range []string{
+		`{"status":"failed"}`,
+		`{"status":"failed","error":null}`,
+		`{"status":"failed","error":"oops"}`,
+	} {
+		var resp PlanTableScanResponse
+		require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+		assert.Equal(t, PlanStatusFailed, resp.Status)
+		assert.Nil(t, resp.Error)
+	}
 }
 
 func TestPlanTableScanResponseAcceptsFailedWithError(t *testing.T) {
@@ -224,15 +231,22 @@ func TestPlanTableScanResponseRejectsUnknownStatus(t *testing.T) {
 	require.ErrorIs(t, err, ErrRESTError)
 }
 
-func TestFetchPlanningResultResponseRejectsMalformedResponses(t *testing.T) {
+func TestFetchPlanningResultResponseValidation(t *testing.T) {
 	t.Parallel()
 
-	t.Run("failed without error", func(t *testing.T) {
+	t.Run("failed without usable error is accepted", func(t *testing.T) {
 		t.Parallel()
 
-		var resp FetchPlanningResultResponse
-		err := json.Unmarshal([]byte(`{"status":"failed"}`), &resp)
-		require.ErrorIs(t, err, ErrRESTError)
+		for _, payload := range []string{
+			`{"status":"failed"}`,
+			`{"status":"failed","error":null}`,
+			`{"status":"failed","error":"oops"}`,
+		} {
+			var resp FetchPlanningResultResponse
+			require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+			assert.Equal(t, PlanStatusFailed, resp.Status)
+			assert.Nil(t, resp.Error)
+		}
 	})
 
 	t.Run("unknown status", func(t *testing.T) {
@@ -654,6 +668,28 @@ func TestFetchPlanningResultStatusArms(t *testing.T) {
 		require.ErrorAs(t, err, &pfe)
 		require.NotNil(t, pfe.Detail)
 		assert.Equal(t, "boom", pfe.Detail.Message)
+	})
+
+	t.Run("failed without usable error still returns PlanFailedError", func(t *testing.T) {
+		t.Parallel()
+
+		for _, payload := range []string{
+			`{"status":"failed"}`,
+			`{"status":"failed","error":"oops"}`,
+		} {
+			cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+				mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-123", func(w http.ResponseWriter, req *http.Request) {
+					_, err := w.Write([]byte(payload))
+					require.NoError(t, err)
+				})
+			})
+
+			_, err := cat.FetchPlanningResult(context.Background(), table.Identifier{"db", "tbl"}, "plan-123", FetchPlanningResultOptions{})
+			require.ErrorIs(t, err, ErrPlanFailed)
+			var pfe *PlanFailedError
+			require.ErrorAs(t, err, &pfe)
+			assert.Nil(t, pfe.Detail)
+		}
 	})
 }
 

--- a/catalog/rest/wait_for_plan_test.go
+++ b/catalog/rest/wait_for_plan_test.go
@@ -1,0 +1,668 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fastWaitOpts keeps the polling backoff sub-millisecond so multi-poll tests run
+// quickly; the poll count is driven by the fake server's responses, not the delay.
+var fastWaitOpts = WaitForPlanOptions{MinDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+
+func TestWaitForPlanCompletesAfterPolling(t *testing.T) {
+	t.Parallel()
+
+	var polls atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodGet, req.Method)
+			// Two "submitted" responses, then a "completed" one carrying tasks and
+			// vended credentials.
+			if polls.Add(1) <= 2 {
+				_, err := w.Write([]byte(`{"status":"submitted"}`))
+				require.NoError(t, err)
+
+				return
+			}
+			_, err := w.Write([]byte(`{"status":"completed","plan-tasks":["t1","t2"],` +
+				`"file-scan-tasks":[{}],"delete-files":[{}],` +
+				`"storage-credentials":[{"prefix":"s3://bucket/","config":{"k":"v"}}]}`))
+			require.NoError(t, err)
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.NoError(t, err)
+
+	assert.Equal(t, PlanStatusCompleted, res.Status)
+	assert.Equal(t, []string{"t1", "t2"}, res.PlanTasks)
+	assert.Len(t, res.FileScanTasks, 1)
+	assert.Len(t, res.DeleteFiles, 1)
+	require.Len(t, res.StorageCredentials, 1)
+	assert.Equal(t, "s3://bucket/", res.StorageCredentials[0].Prefix)
+	// Two submitted polls plus the completing poll.
+	assert.Equal(t, int32(3), polls.Load())
+}
+
+func TestWaitForPlanReturnsImmediatelyWhenCompleted(t *testing.T) {
+	t.Parallel()
+
+	var polls atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			polls.Add(1)
+			_, err := w.Write([]byte(`{"status":"completed","plan-tasks":["t1"]}`))
+			require.NoError(t, err)
+		})
+	})
+
+	// Zero-value options: exercises the DefaultWaitForPlanOptions fallback. A
+	// first-poll completion means no backoff sleep is incurred despite the
+	// conservative default delays.
+	res, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", WaitForPlanOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, PlanStatusCompleted, res.Status)
+	assert.Equal(t, []string{"t1"}, res.PlanTasks)
+	assert.Equal(t, int32(1), polls.Load())
+}
+
+func TestWaitForPlanPropagatesFailed(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"failed","error":{"message":"boom","type":"ValidationException","code":400}}`))
+			require.NoError(t, err)
+		})
+	})
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.ErrorIs(t, err, ErrPlanFailed)
+
+	var pfe *PlanFailedError
+	require.ErrorAs(t, err, &pfe)
+	require.NotNil(t, pfe.Detail)
+	assert.Equal(t, "boom", pfe.Detail.Message)
+}
+
+func TestWaitForPlanPropagatesFailedWithoutUsableError(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []string{
+		`{"status":"failed"}`,
+		`{"status":"failed","error":"oops"}`,
+	} {
+		cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+			mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+				_, err := w.Write([]byte(payload))
+				require.NoError(t, err)
+			})
+		})
+
+		_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+		require.ErrorIs(t, err, ErrPlanFailed)
+		var pfe *PlanFailedError
+		require.ErrorAs(t, err, &pfe)
+		assert.Nil(t, pfe.Detail)
+	}
+}
+
+func TestWaitForPlanPropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"cancelled"}`))
+			require.NoError(t, err)
+		})
+	})
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.ErrorIs(t, err, ErrPlanCancelled)
+}
+
+func TestWaitForPlanPropagatesExpired(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			writeRESTNotFound(t, w, errTypeNoSuchPlanID)
+		})
+	})
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.ErrorIs(t, err, ErrPlanExpired)
+}
+
+func TestWaitForPlanRetriesServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	var polls atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			if polls.Add(1) <= 2 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+
+				return
+			}
+			_, err := w.Write([]byte(`{"status":"completed","plan-tasks":["t1"]}`))
+			require.NoError(t, err)
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.NoError(t, err)
+	assert.Equal(t, PlanStatusCompleted, res.Status)
+	assert.Equal(t, []string{"t1"}, res.PlanTasks)
+	// Two 503s plus the completing poll.
+	assert.Equal(t, int32(3), polls.Load())
+}
+
+func TestWaitForPlanRetriesJavaIdempotentGETStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			t.Parallel()
+
+			var polls atomic.Int32
+			cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+				mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+					if polls.Add(1) == 1 {
+						w.WriteHeader(status)
+
+						return
+					}
+					_, err := w.Write([]byte(`{"status":"completed"}`))
+					require.NoError(t, err)
+				})
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+			require.NoError(t, err)
+			assert.Equal(t, int32(2), polls.Load())
+		})
+	}
+}
+
+func TestWaitForPlanRetriesStatusWithMalformedErrorBody(t *testing.T) {
+	t.Parallel()
+
+	var polls atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			if polls.Add(1) == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, err := w.Write([]byte("not json"))
+				require.NoError(t, err)
+
+				return
+			}
+			_, err := w.Write([]byte(`{"status":"completed"}`))
+			require.NoError(t, err)
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), polls.Load())
+}
+
+func TestWaitForPlanPropagatesTerminalServerStatuses(t *testing.T) {
+	t.Parallel()
+
+	// Statuses outside Java's idempotent retry set remain terminal.
+	for _, tc := range []struct {
+		status int
+		want   error
+	}{
+		{http.StatusNotImplemented, iceberg.ErrNotImplemented},
+		{http.StatusHTTPVersionNotSupported, ErrServerError},
+	} {
+		t.Run(strconv.Itoa(tc.status), func(t *testing.T) {
+			t.Parallel()
+
+			var polls atomic.Int32
+			cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+				mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+					polls.Add(1)
+					w.WriteHeader(tc.status)
+				})
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+			require.ErrorIs(t, err, tc.want)
+			assert.Equal(t, int32(1), polls.Load(), "a terminal status must not be retried")
+		})
+	}
+}
+
+func TestFetchPlanningResultPreservesRetryAfterForPoller(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+	})
+
+	_, err := cat.FetchPlanningResult(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", FetchPlanningResultOptions{})
+	require.Error(t, err)
+	delay, retryable := scanPlanPollRetry(err)
+	assert.True(t, retryable)
+	assert.Equal(t, 2*time.Second, delay)
+}
+
+func TestApplyRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		minD = time.Millisecond
+		maxD = 5 * time.Second
+	)
+	backoff := 250 * time.Millisecond
+
+	cases := []struct {
+		name        string
+		retryAfter  time.Duration
+		hasDeadline bool
+		want        time.Duration
+	}{
+		{"no hint keeps backoff", 0, false, backoff},
+		{"no hint keeps backoff (deadline)", 0, true, backoff},
+		{"hint within bounds is honoured", 2 * time.Second, false, 2 * time.Second},
+		{"tiny hint floored at minDelay", time.Microsecond, false, minD},
+		{"large hint clamped to maxDelay without deadline", 30 * time.Second, false, maxD},
+		{"large hint honoured in full with deadline", 30 * time.Second, true, 30 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := applyRetryAfter(backoff, tc.retryAfter, minD, maxD, tc.hasDeadline)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 2*time.Second, parseRetryAfter(" 2 "))
+	assert.Zero(t, parseRetryAfter("0"))
+	assert.Zero(t, parseRetryAfter("invalid"))
+
+	retryAt := time.Now().Add(10 * time.Second).UTC().Truncate(time.Second)
+	delay := parseRetryAfter(retryAt.Format(http.TimeFormat))
+	assert.Greater(t, delay, 8*time.Second)
+	assert.LessOrEqual(t, delay, 10*time.Second)
+}
+
+func TestWaitForPlanServiceUnavailableUntilDeadline(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			// The server never recovers; the poll must ride the backoff until the
+			// caller's context expires rather than surface the 503.
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	// Unlimited retries so this isolates the deadline path from the MaxRetries cap.
+	opts := fastWaitOpts
+	opts.MaxRetries = -1
+	_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", opts)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWaitForPlanCancelsServerSideOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	var deleteHit atomic.Bool
+	polled := make(chan struct{}, 8)
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult, endpointCancelPlanning}, func(mux *http.ServeMux) {
+		// The plan never completes: it stays submitted until the caller's context
+		// is cancelled.
+		mux.HandleFunc("GET /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			select {
+			case polled <- struct{}{}:
+			default:
+			}
+			_, err := w.Write([]byte(`{"status":"submitted"}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("DELETE /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			deleteHit.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-polled
+		cancel()
+	}()
+
+	_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.ErrorIs(t, err, context.Canceled)
+	// The cancel is synchronous: abandonPlan issues the DELETE and only then does
+	// WaitForPlan return, so the server-side plan is released before a short-lived
+	// caller could exit. It is guaranteed observed by now.
+	assert.True(t, deleteHit.Load(), "expected a best-effort server-side cancel before return")
+}
+
+func TestWaitForPlanBoundsSlowServerSideCancel(t *testing.T) {
+	t.Parallel()
+
+	var cancelStarted atomic.Bool
+	polled := make(chan struct{}, 8)
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult, endpointCancelPlanning}, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			select {
+			case polled <- struct{}{}:
+			default:
+			}
+			_, err := w.Write([]byte(`{"status":"submitted"}`))
+			require.NoError(t, err)
+		})
+		// The cancel endpoint stalls: it never responds until the client (bounded
+		// by the grace) gives up and drops the connection.
+		mux.HandleFunc("DELETE /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			cancelStarted.Store(true)
+			<-req.Context().Done()
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-polled
+		cancel()
+	}()
+
+	opts := fastWaitOpts
+	opts.CancelGracePeriod = 100 * time.Millisecond
+
+	// Run in a goroutine: without the grace bound a stalled cancel would hang
+	// WaitForPlan forever (its DELETE runs on a context detached from the caller's
+	// cancellation), so the failure mode is a hang, caught by the select timeout.
+	done := make(chan error, 1)
+	go func() {
+		_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", opts)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+		assert.True(t, cancelStarted.Load(), "expected the server-side cancel to be attempted")
+	case <-time.After(3 * time.Second):
+		t.Fatal("WaitForPlan hung on a stalled server-side cancel; CancelGracePeriod not enforced")
+	}
+}
+
+func TestWaitForPlanReturnsDeadlineWhileSubmitted(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"submitted"}`))
+			require.NoError(t, err)
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	// Unlimited retries so this isolates the deadline path from the MaxRetries cap.
+	opts := fastWaitOpts
+	opts.MaxRetries = -1
+	_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", opts)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWaitForPlanExhaustsMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	var polls atomic.Int32
+	var deleteHit atomic.Bool
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult, endpointCancelPlanning}, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			polls.Add(1)
+			_, err := w.Write([]byte(`{"status":"submitted"}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("DELETE /v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			deleteHit.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	// No context deadline: the MaxRetries cap is the only thing that stops an
+	// endlessly-submitted plan from polling forever.
+	opts := fastWaitOpts
+	opts.MaxRetries = 3
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", opts)
+	require.ErrorIs(t, err, ErrPlanPollExhausted)
+	// The initial poll plus MaxRetries further attempts, then it gives up.
+	assert.Equal(t, int32(4), polls.Load())
+	// Exhaustion must free the still-active server plan, like the cancellation
+	// path — the DELETE is synchronous, so it is observed by now.
+	assert.True(t, deleteHit.Load(), "exhaustion must cancel the abandoned plan server-side")
+}
+
+func TestWaitForPlanDeadlineDisablesDefaultRetryCap(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"submitted"}`))
+			require.NoError(t, err)
+		})
+	})
+
+	// A generous deadline that comfortably outlasts the default 10-retry budget
+	// (~20ms at this backoff). With default options the cap must be disabled by the
+	// deadline, so polling runs to the deadline (DeadlineExceeded) rather than
+	// stopping early with ErrPlanPollExhausted.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	_, err := cat.WaitForPlan(ctx, table.Identifier{"db", "tbl"}, "plan-1", fastWaitOpts)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, ErrPlanPollExhausted)
+}
+
+func TestWaitForPlanRequiresFetchEndpoint(t *testing.T) {
+	t.Parallel()
+
+	// A server that does not advertise fetchPlanningResult cannot be polled.
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, nil)
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", WaitForPlanOptions{})
+	require.ErrorIs(t, err, ErrEndpointNotSupported)
+}
+
+func TestWaitForPlanRejectsEmptyPlanID(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, nil)
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "", WaitForPlanOptions{})
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+}
+
+func TestResolveWaitOptions(t *testing.T) {
+	t.Parallel()
+
+	def := DefaultWaitForPlanOptions
+	cases := []struct {
+		name            string
+		in              WaitForPlanOptions
+		hasDeadline     bool
+		min, max, grace time.Duration
+		retries         int
+	}{
+		{
+			name:    "zero, no deadline: default cap applies",
+			in:      WaitForPlanOptions{},
+			min:     def.MinDelay,
+			max:     def.MaxDelay,
+			grace:   def.CancelGracePeriod,
+			retries: def.MaxRetries,
+		},
+		{
+			name:        "zero, with deadline: default cap disabled",
+			in:          WaitForPlanOptions{},
+			hasDeadline: true,
+			min:         def.MinDelay,
+			max:         def.MaxDelay,
+			grace:       def.CancelGracePeriod,
+			retries:     -1,
+		},
+		{
+			name:    "negative durations use defaults; negative retries stays unlimited",
+			in:      WaitForPlanOptions{MinDelay: -1, MaxDelay: -1, CancelGracePeriod: -1, MaxRetries: -1},
+			min:     def.MinDelay,
+			max:     def.MaxDelay,
+			grace:   def.CancelGracePeriod,
+			retries: -1,
+		},
+		{
+			name:    "inverted clamps cap up to floor",
+			in:      WaitForPlanOptions{MinDelay: 2 * time.Second, MaxDelay: time.Second},
+			min:     2 * time.Second,
+			max:     2 * time.Second,
+			grace:   def.CancelGracePeriod,
+			retries: def.MaxRetries,
+		},
+		{
+			name:        "explicit positive retries honored even with a deadline",
+			in:          WaitForPlanOptions{MinDelay: 5 * time.Millisecond, MaxDelay: 50 * time.Millisecond, CancelGracePeriod: 2 * time.Second, MaxRetries: 7},
+			hasDeadline: true,
+			min:         5 * time.Millisecond,
+			max:         50 * time.Millisecond,
+			grace:       2 * time.Second,
+			retries:     7,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			minDelay, maxDelay, grace, retries := resolveWaitOptions(tc.in, tc.hasDeadline)
+			assert.Equal(t, tc.min, minDelay)
+			assert.Equal(t, tc.max, maxDelay)
+			assert.Equal(t, tc.grace, grace)
+			assert.Equal(t, tc.retries, retries)
+		})
+	}
+}
+
+func TestNextScanPlanBackoffStaysInBoundsWithoutOverflow(t *testing.T) {
+	t.Parallel()
+
+	maxDur := time.Duration(math.MaxInt64)
+	cases := []struct {
+		name                   string
+		prev, minDel, maxDelay time.Duration
+	}{
+		// prev*3 overflows int64; the ceiling must clamp to maxDelay before
+		// sampling so rand.Int64N never sees a non-positive argument.
+		{"all max", maxDur, maxDur, maxDur},
+		{"max prev, small floor", maxDur, time.Millisecond, maxDur},
+		{"half-max prev", maxDur / 2, time.Nanosecond, maxDur},
+		// Ordinary tight bounds still hold their floor and cap.
+		{"equal min and max", time.Millisecond, time.Millisecond, time.Millisecond},
+		{"growing", 100 * time.Millisecond, 100 * time.Millisecond, 5 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Sample repeatedly: the bug is probabilistic across the RNG range.
+			for range 1000 {
+				got := nextScanPlanBackoff(tc.prev, tc.minDel, tc.maxDelay)
+				assert.GreaterOrEqual(t, got, tc.minDel)
+				assert.LessOrEqual(t, got, tc.maxDelay)
+			}
+		})
+	}
+}
+
+func TestWaitForPlanForwardsAccessDelegation(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchPlanResult}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "remote-signing", req.Header.Get(headerIcebergAccessDelegation))
+			_, err := w.Write([]byte(`{"status":"completed"}`))
+			require.NoError(t, err)
+		})
+	})
+
+	_, err := cat.WaitForPlan(context.Background(), table.Identifier{"db", "tbl"}, "plan-1", WaitForPlanOptions{
+		AccessDelegation: stringPtr("remote-signing"),
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Implements `Catalog.WaitForPlan` as part of [#1178](https://github.com/apache/iceberg-go/issues/1178), building on the merged scan-planning client methods (#1324).

The poller waits for an asynchronously submitted REST scan plan to complete and returns the completed planning result (task envelope and storage credentials).

## Changes

- Polls `FetchPlanningResult` using decorrelated-jitter backoff.
- Handles completed, submitted, failed, cancelled, and expired plans.
- Retries transient GET responses: `408`, `429`, `500`, `502`, `503`, and `504`.
- Supports integer and HTTP-date `Retry-After` headers.
- Uses the caller's context deadline as the primary timeout.
- Adds `MaxRetries` and `ErrPlanPollExhausted`.
- Cancels abandoned plans on context cancellation or retry exhaustion.
- Bounds cleanup using `CancelGracePeriod`.
- Forwards access-delegation headers while polling.
- Handles failed responses with missing or malformed error details.
- Threads HTTP status and `Retry-After` through the shared REST error type (`errorResponse`/`handleNon200`) so the poller can apply retry policy without re-plumbing each method. This is the only change outside the scan-planning surface.
- Adds overflow-safe backoff calculations and empty plan-ID validation.

When the context has a deadline, the default retry cap is disabled so polling continues until that deadline.

This PR implements the wait/poll phase only. Scan-task **payload decoding** (`RESTFileScanTask`/`RESTDeleteFile`), `plan-tasks` fan-out, and wiring `PlanFiles` end-to-end remain follow-up work.

## Testing

All pass, including under the race detector:

```text
go test ./catalog/rest
go test -race ./catalog/rest
go vet ./catalog/rest
