### PR TITLE
fix(table): avoid mutating binary upper bounds

### DIFF
--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -18,7 +18,6 @@
 package internal
 
 import (
-	"bytes"
 	"container/heap"
 	"context"
 	"encoding/binary"
@@ -27,6 +26,7 @@ import (
 	"iter"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -543,13 +543,10 @@ func TruncateUpperBoundText(s string, trunc int) string {
 
 func TruncateUpperBoundBinary(val []byte, trunc int) []byte {
 	if trunc >= len(val) {
-		return val
+		return slices.Clone(val)
 	}
 
-	result := val[:trunc]
-	if bytes.Equal(result, val) {
-		return result
-	}
+	result := slices.Clone(val[:trunc])
 
 	for i := len(result) - 1; i >= 0; i-- {
 		if result[i] < 255 {

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -70,8 +70,34 @@ func TestTruncateUpperBoundString(t *testing.T) {
 }
 
 func TestTruncateUpperBoundBinary(t *testing.T) {
-	assert.Equal(t, []byte{0x01, 0x03}, internal.TruncateUpperBoundBinary([]byte{0x01, 0x02, 0x03}, 2))
-	assert.Nil(t, internal.TruncateUpperBoundBinary([]byte{0xff, 0xff, 0x00}, 2))
+	tests := []struct {
+		name     string
+		value    []byte
+		truncate int
+		expected []byte
+	}{
+		{"increment", []byte{0x01, 0x02, 0x03}, 2, []byte{0x01, 0x03}},
+		{"carry", []byte{0x01, 0x02, 0xff, 0x03}, 3, []byte{0x01, 0x03, 0xff}},
+		{"all ff", []byte{0xff, 0xff, 0x00}, 2, nil},
+		{"no truncation", []byte{0x01, 0x02}, 2, []byte{0x01, 0x02}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := slices.Clone(tt.value)
+			first := internal.TruncateUpperBoundBinary(tt.value, tt.truncate)
+			second := internal.TruncateUpperBoundBinary(tt.value, tt.truncate)
+
+			assert.Equal(t, tt.expected, first)
+			assert.Equal(t, first, second)
+			assert.Equal(t, original, tt.value)
+
+			if len(first) > 0 {
+				first[0] ^= 0xff
+				assert.Equal(t, original, tt.value)
+			}
+		})
+	}
 }
 
 func TestMapExecAllWorkersError(t *testing.T) {


### PR DESCRIPTION
## Summary

- clone binary prefixes before incrementing truncated upper bounds
- return an owned copy when truncation is unnecessary
- verify repeated truncation is stable and never aliases or mutates the input

## Why

`TruncateUpperBoundBinary` sliced directly into the caller's byte array and incremented that shared prefix. Statistics aggregation could therefore mutate its stored maximum while merely calculating an upper bound, making later calls and comparisons depend on call order.

## Testing

- `go test ./table/internal -run TestTruncateUpperBoundBinary -count=20`
- `go test ./table/internal ./table`
- `go vet ./table/internal ./table`