### PR TITLE
fix(cli): fail closed on explicit config errors

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -18,6 +18,9 @@
 package main
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/alexflint/go-arg"
@@ -326,6 +329,57 @@ func TestResolveCatalogName(t *testing.T) {
 			assert.Equal(t, tt.want, resolveCatalogName(tt.explicitFlags, tt.flagValue))
 		})
 	}
+}
+
+func TestApplyConfigFileFailsClosed(t *testing.T) {
+	t.Run("explicit missing file", func(t *testing.T) {
+		args := Args{Config: filepath.Join(t.TempDir(), "missing.yaml")}
+		err := applyConfigFile(&args, map[string]bool{"config": true})
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("malformed file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(":\t[broken yaml"), 0o600))
+		args := Args{Config: path}
+		err := applyConfigFile(&args, map[string]bool{"config": true})
+		require.ErrorContains(t, err, "parse config file")
+		require.ErrorContains(t, err, path)
+	})
+
+	t.Run("missing selected catalog", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("catalog:\n  available:\n    type: rest\n"), 0o600))
+		args := Args{Config: path, CatalogName: "missing"}
+		err := applyConfigFile(&args, map[string]bool{"config": true, "catalog-name": true})
+		require.EqualError(t, err, `catalog "missing" not found in config file `+path)
+	})
+
+	t.Run("valid selected catalog", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("catalog:\n  selected:\n    type: rest\n    uri: http://catalog.example\n"), 0o600))
+		args := Args{Config: path, CatalogName: "selected"}
+		err := applyConfigFile(&args, map[string]bool{"config": true, "catalog-name": true})
+		require.NoError(t, err)
+		require.Equal(t, "http://catalog.example", args.URI)
+	})
+}
+
+func TestCLIExplicitMissingConfigFailsBeforeCatalogInit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a subprocess")
+	}
+
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+	cmd := exec.Command(os.Args[0], "list", "--config", path)
+	cmd.Env = append(os.Environ(), icebergCLISubprocessEnv+"=1")
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected non-zero exit; output: %s", out)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, string(out), "configuration error")
+	assert.Contains(t, string(out), path)
 }
 
 func TestMergeConfAwsProfile(t *testing.T) {

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -244,14 +244,9 @@ func main() {
 		}
 	}
 
-	configData := config.LoadConfig(args.Config)
-	fileCfg, err := config.ParseConfig(configData, resolveCatalogName(explicitFlags, args.CatalogName))
-	if err != nil {
-		log.Printf("warning: failed to parse config file: %v", err)
-	} else if fileCfg != nil {
-		mergeConf(fileCfg, &args, explicitFlags)
-	} else if len(configData) > 0 {
-		log.Printf("warning: catalog %q not found in config file", args.CatalogName)
+	if err := applyConfigFile(&args, explicitFlags); err != nil {
+		log.Printf("configuration error: %v", err)
+		os.Exit(1)
 	}
 
 	// Validate nested subcommands before catalog init.
@@ -814,6 +809,49 @@ func resolveCatalogName(explicitFlags map[string]bool, flagValue string) string 
 	}
 
 	return ""
+}
+
+func applyConfigFile(args *Args, explicitFlags map[string]bool) error {
+	configData, err := config.LoadConfigFile(args.Config)
+	if err != nil {
+		return err
+	}
+
+	catalogName := resolveCatalogName(explicitFlags, args.CatalogName)
+	fileCfg, err := config.ParseConfig(configData, catalogName)
+	if err != nil {
+		return fmt.Errorf("parse config file %s: %w", resolvedConfigPath(args.Config), err)
+	}
+	if fileCfg != nil {
+		mergeConf(fileCfg, args, explicitFlags)
+
+		return nil
+	}
+	if len(configData) == 0 {
+		return nil
+	}
+	if args.Config != "" || explicitFlags["catalog-name"] {
+		if catalogName == "" {
+			catalogName = "default"
+		}
+
+		return fmt.Errorf("catalog %q not found in config file %s", catalogName, resolvedConfigPath(args.Config))
+	}
+
+	log.Printf("warning: catalog %q not found in config file", args.CatalogName)
+
+	return nil
+}
+
+func resolvedConfigPath(configPath string) string {
+	if configPath == "" {
+		homeDir, _ := os.UserHomeDir()
+		configPath = filepath.Join(homeDir, ".iceberg-go.yaml")
+	}
+
+	path, _ := filepath.Abs(configPath)
+
+	return path
 }
 
 // mergeConf applies values from the file config into args for any option

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -51,23 +53,45 @@ type CatalogConfig struct {
 	RestOptions *RestOptions `yaml:"rest,omitempty"`
 }
 
+// LoadConfig returns configuration data when it can be read. It retains the
+// historical best-effort behavior; callers that must distinguish a missing
+// default from a broken explicit file should use LoadConfigFile.
 func LoadConfig(configPath string) []byte {
+	data, _ := LoadConfigFile(configPath)
+
+	return data
+}
+
+// LoadConfigFile loads configuration data and reports path and read failures.
+// A missing implicit home-directory configuration is not an error.
+func LoadConfigFile(configPath string) ([]byte, error) {
+	implicit := configPath == ""
 	var path string
-	if len(configPath) > 0 {
+	if !implicit {
 		path = configPath
 	} else {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("resolve home directory for config: %w", err)
 		}
 		path = filepath.Join(homeDir, cfgFile)
 	}
-	file, err := os.ReadFile(path)
+
+	path, err := filepath.Abs(path)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("resolve config path %q: %w", path, err)
 	}
 
-	return file
+	file, err := os.ReadFile(path)
+	if err != nil {
+		if implicit && errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("read config file %s: %w", path, err)
+	}
+
+	return file, nil
 }
 
 // ParseConfig unmarshals the config file once and resolves the catalog to use.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,11 +18,37 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadConfigFile(t *testing.T) {
+	t.Run("implicit missing config", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		data, err := LoadConfigFile("")
+		require.NoError(t, err)
+		assert.Nil(t, data)
+	})
+
+	t.Run("explicit missing config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+		_, err := LoadConfigFile(path)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		assert.ErrorContains(t, err, path)
+	})
+
+	t.Run("explicit path is directory", func(t *testing.T) {
+		path := t.TempDir()
+		_, err := LoadConfigFile(path)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, path)
+	})
+}
 
 var testArgs = []struct {
 	file     []byte


### PR DESCRIPTION
Explicit config failures currently fall back to CLI defaults, which is risky for commands that mutate catalog state.

This adds an error-reporting config loader while retaining the existing best-effort helper for compatibility. The CLI now exits before catalog initialization when an explicit config cannot be read, YAML is malformed, or the requested catalog is absent. A missing implicit home config remains optional. Diagnostics include the resolved config path.

Regression coverage includes implicit and explicit missing files, read failures, malformed YAML, absent catalog selection, valid config merging, and the CLI exit path.