### PR TITLE
test(rest): fix flaky TestWaitForPlanBoundsSlowServerSideCancel

### DIFF
--- a/catalog/rest/wait_for_plan_test.go
+++ b/catalog/rest/wait_for_plan_test.go
@@ -452,7 +452,11 @@ func TestWaitForPlanBoundsSlowServerSideCancel(t *testing.T) {
 	select {
 	case err := <-done:
 		require.ErrorIs(t, err, context.Canceled)
-		assert.True(t, cancelStarted.Load(), "expected the server-side cancel to be attempted")
+		// The server-side cancel runs on a context detached from the caller, so it
+		// may be issued slightly after WaitForPlan returns. Poll instead of reading
+		// the flag once to avoid a race with the detached cancel on slower runners.
+		assert.Eventually(t, cancelStarted.Load, time.Second, 5*time.Millisecond,
+			"expected the server-side cancel to be attempted")
 	case <-time.After(3 * time.Second):
 		t.Fatal("WaitForPlan hung on a stalled server-side cancel; CancelGracePeriod not enforced")
 	}


### PR DESCRIPTION
## What

`TestWaitForPlanBoundsSlowServerSideCancel` (added in #1469) is flaky. It failed on `main` in the `ubuntu-latest go1.25.8` cell of the `Go` workflow (run 29428513100 on commit 3648ea3) while passing on every other commit and matrix cell.

## Root cause

`WaitForPlan` issues the server-side cancel (`DELETE .../plan/plan-1`) on a context **detached** from the caller (bounded by `CancelGracePeriod`). When the caller's context is cancelled, `WaitForPlan` returns `context.Canceled` immediately, while the detached goroutine issues the `DELETE` (which sets `cancelStarted`) concurrently.

The test asserted `cancelStarted.Load()` **immediately** after `WaitForPlan` returned, so on a slower runner the assertion could execute before the detached cancel had been attempted. This is a race in the test, not in the product code.

## Fix

Poll the flag with `assert.Eventually` (1s budget, 5ms tick) instead of reading it exactly once, and add a comment explaining why so it isn't "simplified" back.

## Verification

- `go test ./catalog/rest/ -run TestWaitForPlan -race -count=50` → `ok`
- full `catalog/rest` package (`-count=1`) → `ok`
- `gofmt` / `go vet` clean
