### PR TITLE
refactor(table): centralize transaction metadata checks

### DIFF
--- a/table/addfiles_merge_regression_test.go
+++ b/table/addfiles_merge_regression_test.go
@@ -32,7 +32,7 @@ package table_test
 //
 // to:
 //
-//	updater := t.appendSnapshotProducer(fs, snapshotProps)
+//	updater := t.appendSnapshotProducer(meta, fs, snapshotProps)
 
 import (
 	"context"

--- a/table/commit.go
+++ b/table/commit.go
@@ -54,10 +54,14 @@ type TableCommit struct {
 // commit endpoint returns 204 No Content (no metadata), callers must
 // LoadTable after a successful CommitTransaction if they need updated state.
 func (t *Transaction) TableCommit() (TableCommit, error) {
+	if err := t.checkNotNil(); err != nil {
+		return TableCommit{}, err
+	}
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return TableCommit{}, err
 	}
 
@@ -65,7 +69,7 @@ func (t *Transaction) TableCommit() (TableCommit, error) {
 		return TableCommit{}, errors.New("transaction has already been committed")
 	}
 
-	if len(t.meta.updates) == 0 {
+	if len(meta.updates) == 0 {
 		return TableCommit{
 			Identifier:   slices.Clone(t.tbl.identifier),
 			Requirements: []Requirement{},
@@ -75,10 +79,10 @@ func (t *Transaction) TableCommit() (TableCommit, error) {
 
 	reqs := make([]Requirement, len(t.reqs), len(t.reqs)+1)
 	copy(reqs, t.reqs)
-	reqs = append(reqs, AssertTableUUID(t.meta.uuid))
+	reqs = append(reqs, AssertTableUUID(meta.uuid))
 
-	updates := make([]Update, len(t.meta.updates))
-	copy(updates, t.meta.updates)
+	updates := make([]Update, len(meta.updates))
+	copy(updates, meta.updates)
 
 	return TableCommit{
 		Identifier:   slices.Clone(t.tbl.identifier),

--- a/table/equality_delete_writer.go
+++ b/table/equality_delete_writer.go
@@ -105,16 +105,17 @@ func isFloatingPointType(typ iceberg.Type) bool {
 //	rd.AddDeletes(deleteFiles...)
 //	err = rd.Commit(ctx)
 func (t *Transaction) WriteEqualityDeletes(ctx context.Context, equalityFieldIDs []int, records iter.Seq2[arrow.RecordBatch, error]) ([]iceberg.DataFile, error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, err
 	}
 
-	if t.meta.formatVersion < 2 {
+	if meta.formatVersion < 2 {
 		return nil, fmt.Errorf("equality deletes require table format version >= 2, got v%d",
-			t.meta.formatVersion)
+			meta.formatVersion)
 	}
 
-	deleteSchema, err := equalityDeleteSchema(t.meta.CurrentSchema(), equalityFieldIDs)
+	deleteSchema, err := equalityDeleteSchema(meta.CurrentSchema(), equalityFieldIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (t *Transaction) WriteEqualityDeletes(ctx context.Context, equalityFieldIDs
 		counter:   internal.Counter(0),
 	}
 
-	dataFiles, err := equalityDeleteRecordsToDataFiles(ctx, t.tbl.Location(), t.meta, deleteSchema, equalityFieldIDs, args)
+	dataFiles, err := equalityDeleteRecordsToDataFiles(ctx, t.tbl.Location(), meta, deleteSchema, equalityFieldIDs, args)
 	if err != nil {
 		return nil, err
 	}

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -216,6 +216,9 @@ func WithCompactionScanConcurrency(n int) CompactionGroupOption {
 // [ExecuteCompactionGroup] and commit them via [Transaction.NewRewrite]
 // + [RewriteFiles.ApplyResult] + [RewriteFiles.Commit] instead.
 func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
+	if _, err := t.txnMeta(); err != nil {
+		return nil, err
+	}
 	if len(groups) == 0 {
 		return &RewriteResult{}, nil
 	}

--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -358,19 +358,24 @@ func manifestActiveFiles(fs iceio.IO, manifests []iceberg.ManifestFile) (int64, 
 // nothing on the transaction, so a following Commit is a true no-op; callers
 // can skip it either way.
 func (t *Transaction) RewriteManifests(ctx context.Context, opts ...RewriteManifestsOpt) (*RewriteManifestsResult, error) {
-	if t.meta.currentSnapshot() == nil {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	if meta.currentSnapshot() == nil {
 		return &RewriteManifestsResult{NoOpReason: NoOpNoSnapshot}, nil
 	}
 
 	cfg := rewriteManifestsCfg{
-		targetSizeBytes: int64(t.meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault)),
+		targetSizeBytes: int64(meta.props.GetInt(ManifestTargetSizeBytesKey, ManifestTargetSizeBytesDefault)),
 	}
 	for _, o := range opts {
 		o(&cfg)
 	}
 
 	if cfg.specID != nil {
-		if _, err := t.meta.GetSpecByID(*cfg.specID); err != nil {
+		if _, err := meta.GetSpecByID(*cfg.specID); err != nil {
 			return nil, fmt.Errorf("cannot rewrite manifests: unknown partition spec id %d: %w", *cfg.specID, err)
 		}
 	}

--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -101,7 +101,8 @@ func (rd *RowDelta) AddDeletes(files ...iceberg.DataFile) *RowDelta {
 // commit, if any file has an unexpected content type, or if the table
 // format version does not support delete files.
 func (rd *RowDelta) Commit(ctx context.Context) error {
-	if err := rd.txn.ensureInitialized(); err != nil {
+	meta, err := rd.txn.txnMeta()
+	if err != nil {
 		return err
 	}
 
@@ -110,9 +111,9 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 	}
 
 	// Delete files require format version >= 2.
-	if len(rd.delFiles) > 0 && rd.txn.meta.formatVersion < 2 {
+	if len(rd.delFiles) > 0 && meta.formatVersion < 2 {
 		return fmt.Errorf("delete files require table format version >= 2, got v%d",
-			rd.txn.meta.formatVersion)
+			meta.formatVersion)
 	}
 
 	for _, f := range rd.dataFiles {
@@ -122,7 +123,7 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 		}
 	}
 
-	schema := rd.txn.meta.CurrentSchema()
+	schema := meta.CurrentSchema()
 	for _, f := range rd.delFiles {
 		ct := f.ContentType()
 		if ct != iceberg.EntryContentPosDeletes && ct != iceberg.EntryContentEqDeletes {
@@ -204,7 +205,12 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 // Fast appends alongside a RowDelta see no validators from RowDelta:
 // data-only commits are as safe as a fastAppend.
 func (rd *RowDelta) validate(cc *conflictContext) error {
-	level, err := readIsolationLevel(rd.txn.meta.props,
+	meta, err := rd.txn.txnMeta()
+	if err != nil {
+		return err
+	}
+
+	level, err := readIsolationLevel(meta.props,
 		WriteDeleteIsolationLevelKey, WriteDeleteIsolationLevelDefault)
 	if err != nil {
 		return err
@@ -248,7 +254,7 @@ func (rd *RowDelta) validate(cc *conflictContext) error {
 		// build an OR-of-equalities filter from the eq-delete files'
 		// partition tuples so that concurrent appends to different
 		// partitions are not falsely rejected.
-		currentSpec, specErr := rd.txn.meta.CurrentSpec()
+		currentSpec, specErr := meta.CurrentSpec()
 		if specErr != nil {
 			return fmt.Errorf("reading current partition spec: %w", specErr)
 		}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -110,11 +110,40 @@ func (t *Transaction) ensureInitialized() error {
 	return nil
 }
 
+// txnMeta returns the transaction's metadata builder after verifying the
+// transaction is initialized. Entry points that need the builder should obtain
+// it here so the nil-transaction / deferred-init / nil-builder checks are
+// applied consistently in one place, rather than each caller having to remember
+// to call ensureInitialized before touching t.meta.
+func (t *Transaction) txnMeta() (*MetadataBuilder, error) {
+	if err := t.ensureInitialized(); err != nil {
+		return nil, err
+	}
+
+	return t.meta, nil
+}
+
+// checkNotNil rejects a nil transaction before any lock is taken. The
+// mutex-guarded entry points that return an error (Commit, TableCommit, apply)
+// must call this before t.mx.Lock(), which would panic on a nil receiver.
+// txnMeta covers the same case, but only after the lock is already held.
+func (t *Transaction) checkNotNil() error {
+	if t == nil {
+		return fmt.Errorf("%w: transaction is nil", ErrInvalidMetadata)
+	}
+
+	return nil
+}
+
 func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
+	if err := t.checkNotNil(); err != nil {
+		return err
+	}
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 
@@ -122,7 +151,7 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 		return errors.New("transaction has already been committed")
 	}
 
-	stagedMeta := t.meta.clone()
+	stagedMeta := meta.clone()
 	if stagedMeta == nil {
 		return errors.New("cannot apply updates to nil metadata")
 	}
@@ -223,8 +252,8 @@ func (t *Transaction) addValidator(v conflictValidatorFunc) {
 	t.validators = append(t.validators, v)
 }
 
-func (t *Transaction) appendSnapshotProducer(wfs io.WriteFileIO, props iceberg.Properties) *snapshotProducer {
-	manifestMerge := t.meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault)
+func (t *Transaction) appendSnapshotProducer(meta *MetadataBuilder, wfs io.WriteFileIO, props iceberg.Properties) *snapshotProducer {
+	manifestMerge := meta.props.GetBool(ManifestMergeEnabledKey, ManifestMergeEnabledDefault)
 	updateSnapshot := t.updateSnapshot(wfs, props, OpAppend)
 	if manifestMerge {
 		return updateSnapshot.mergeAppend()
@@ -243,7 +272,7 @@ func (t *Transaction) updateSnapshot(wfs io.WriteFileIO, props iceberg.Propertie
 }
 
 func (t *Transaction) SetProperties(props iceberg.Properties) error {
-	if err := t.ensureInitialized(); err != nil {
+	if _, err := t.txnMeta(); err != nil {
 		return err
 	}
 	if len(props) > 0 {
@@ -256,7 +285,7 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 // UpgradeFormatVersion upgrades the table to the given format version. Downgrading
 // is not allowed. If the table is already at the given version, this is a no-op.
 func (t *Transaction) UpgradeFormatVersion(version int) error {
-	if err := t.ensureInitialized(); err != nil {
+	if _, err := t.txnMeta(); err != nil {
 		return err
 	}
 
@@ -264,16 +293,17 @@ func (t *Transaction) UpgradeFormatVersion(version int) error {
 }
 
 func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
-	cs := t.meta.currentSnapshot()
+	cs := meta.currentSnapshot()
 	if cs == nil {
 		return errors.New("cannot rollback: table has no current snapshot")
 	}
 
 	lookup := func(id int64) *Snapshot {
-		s, _ := t.meta.SnapshotByID(id)
+		s, _ := meta.SnapshotByID(id)
 
 		return s
 	}
@@ -399,7 +429,8 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	if cfg.validationErr != nil {
 		return cfg.validationErr
 	}
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 
@@ -408,11 +439,11 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	// caller provides a value, fall back to the table property; when the
 	// table property is also absent use the constant default (math.MaxInt64,
 	// meaning "keep everything").
-	propMaxRefAgeMs := t.meta.props.GetInt64(MaxRefAgeMsKey, MaxRefAgeMsDefault)
-	propMinSnapshotsToKeep := t.meta.props.GetInt(MinSnapshotsToKeepKey, MinSnapshotsToKeepDefault)
-	propMaxSnapshotAgeMs := t.meta.props.GetInt64(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault)
+	propMaxRefAgeMs := meta.props.GetInt64(MaxRefAgeMsKey, MaxRefAgeMsDefault)
+	propMinSnapshotsToKeep := meta.props.GetInt(MinSnapshotsToKeepKey, MinSnapshotsToKeepDefault)
+	propMaxSnapshotAgeMs := meta.props.GetInt64(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault)
 
-	for refName, ref := range t.meta.refs {
+	for refName, ref := range meta.refs {
 		// Assert that this ref's snapshot ID hasn't changed concurrently.
 		// This ensures we don't accidentally expire snapshots that are now
 		// referenced by updated refs.
@@ -423,7 +454,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 			snapsToKeep[ref.SnapshotID] = struct{}{}
 		}
 
-		snap, err := t.meta.SnapshotByID(ref.SnapshotID)
+		snap, err := meta.SnapshotByID(ref.SnapshotID)
 		if err != nil {
 			return err
 		}
@@ -454,7 +485,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 		)
 
 		for {
-			snap, err := t.meta.SnapshotByID(snapId)
+			snap, err := meta.SnapshotByID(snapId)
 			if err != nil {
 				// Parent snapshot may have been removed by a previous expiration.
 				// Treat missing parent as end of chain - this is expected behavior.
@@ -479,7 +510,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 
 	var snapsToDelete []int64
 
-	for _, snap := range t.meta.snapshotList {
+	for _, snap := range meta.snapshotList {
 		if _, found := snapsToKeep[snap.SnapshotID]; !found {
 			snapsToDelete = append(snapsToDelete, snap.SnapshotID)
 		}
@@ -494,7 +525,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 }
 
 func (t *Transaction) AppendTable(ctx context.Context, tbl arrow.Table, batchSize int64, snapshotProps iceberg.Properties) error {
-	if err := t.ensureInitialized(); err != nil {
+	if _, err := t.txnMeta(); err != nil {
 		return err
 	}
 	rdr := array.NewTableReader(tbl, batchSize)
@@ -504,7 +535,8 @@ func (t *Transaction) AppendTable(ctx context.Context, tbl arrow.Table, batchSiz
 }
 
 func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapshotProps iceberg.Properties) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	fs, err := t.tbl.fsF(ctx)
@@ -515,8 +547,8 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 	if err != nil {
 		return err
 	}
-	appendFiles := t.appendSnapshotProducer(wfs, snapshotProps)
-	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
+	appendFiles := t.appendSnapshotProducer(meta, wfs, snapshotProps)
+	itr := recordsToDataFiles(ctx, t.tbl.Location(), meta, recordWritingArgs{
 		sc:        rdr.Schema(),
 		itr:       array.IterFromReader(rdr),
 		fs:        wfs,
@@ -547,7 +579,8 @@ func (t *Transaction) Append(ctx context.Context, rdr array.RecordReader, snapsh
 //
 // For now, we'll keep using an overwrite operation.
 func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, filesToAdd []string, snapshotProps iceberg.Properties) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	if len(filesToDelete) == 0 {
@@ -577,7 +610,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 		return errors.New("add file paths must be unique for ReplaceDataFiles")
 	}
 
-	s := t.meta.currentSnapshot()
+	s := meta.currentSnapshot()
 	if s == nil {
 		return fmt.Errorf("%w: cannot replace files in a table without an existing snapshot", ErrInvalidOperation)
 	}
@@ -610,8 +643,8 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 		return errors.New("cannot delete files that do not belong to the table")
 	}
 
-	if t.meta.NameMapping() == nil {
-		nameMapping := t.meta.CurrentSchema().NameMapping()
+	if meta.NameMapping() == nil {
+		nameMapping := meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
 			return err
@@ -629,7 +662,13 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 		updater.deleteDataFile(df)
 	}
 
-	dataFiles, err := filesToDataFiles(ctx, fs, t.meta, filesToAdd, 1)
+	// SetProperties above may have staged a name mapping, rebuilding t.meta;
+	// re-read the current builder through the accessor before parsing files.
+	meta, err = t.txnMeta()
+	if err != nil {
+		return err
+	}
+	dataFiles, err := filesToDataFiles(ctx, fs, meta, filesToAdd, 1)
 	if err != nil {
 		return err
 	}
@@ -678,7 +717,12 @@ func validateDataFilePartitionData(df iceberg.DataFile, spec *iceberg.PartitionS
 // first_row_id via inheritance at write time and the output files carry
 // explicit _row_id columns that win on read regardless.
 func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, operation string, requireFirstRowID bool) (map[string]struct{}, error) {
-	currentSpec, err := t.meta.CurrentSpec()
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	currentSpec, err := meta.CurrentSpec()
 	if err != nil {
 		return nil, fmt.Errorf("could not get current partition spec: %w", err)
 	}
@@ -723,7 +767,7 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 			return nil, fmt.Errorf("data file %s has invalid partition data for %s: %w", path, operation, err)
 		}
 
-		if requireFirstRowID && t.meta.formatVersion >= 3 && df.FirstRowID() == nil {
+		if requireFirstRowID && meta.formatVersion >= 3 && df.FirstRowID() == nil {
 			return nil, fmt.Errorf(
 				"data file %s is missing first_row_id which is required for v3 tables for %s: use DataFileBuilder.FirstRowID() to set it explicitly",
 				path, operation)
@@ -785,8 +829,13 @@ func WithoutDuplicateCheck() WriteOption {
 // does not already exist. This is extracted as a helper so it can be called
 // from any method that accepts WriteOption.
 func (t *Transaction) ensureNameMapping() error {
-	if t.meta.NameMapping() == nil {
-		nameMapping := t.meta.CurrentSchema().NameMapping()
+	meta, err := t.txnMeta()
+	if err != nil {
+		return err
+	}
+
+	if meta.NameMapping() == nil {
+		nameMapping := meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
 			return err
@@ -813,7 +862,7 @@ func (t *Transaction) ensureNameMapping() error {
 // Callers are responsible for ensuring each DataFile is valid and consistent with the table.
 // Supplying incorrect DataFile metadata can produce an invalid snapshot and break reads.
 func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
-	if err := t.ensureInitialized(); err != nil {
+	if _, err := t.txnMeta(); err != nil {
 		return err
 	}
 	if len(dataFiles) == 0 {
@@ -845,8 +894,16 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 		}
 	}
 
+	// ensureNameMapping above may have staged a name mapping, rebuilding t.meta;
+	// read the current builder through the accessor before inspecting the
+	// snapshot and creating the producer.
+	meta, err := t.txnMeta()
+	if err != nil {
+		return err
+	}
+
 	if !cfg.skipDuplicateCheck {
-		if s := t.meta.currentSnapshot(); s != nil {
+		if s := meta.currentSnapshot(); s != nil {
 			referenced := make([]string, 0)
 			for df, err := range s.dataFiles(fs, nil) {
 				if err != nil {
@@ -864,7 +921,7 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 		}
 	}
 
-	appendFiles := t.appendSnapshotProducer(wfs, snapshotProps)
+	appendFiles := t.appendSnapshotProducer(meta, wfs, snapshotProps)
 	for _, df := range dataFiles {
 		appendFiles.appendDataFile(df)
 	}
@@ -900,7 +957,8 @@ func (t *Transaction) AddDataFiles(ctx context.Context, dataFiles []iceberg.Data
 //   - Avoiding file scanning improves performance or reliability
 //   - Working with storage systems where immediate file reads may be unreliable
 func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesToDelete, filesToAdd []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	if len(filesToDelete) == 0 {
@@ -938,7 +996,7 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 		setToDelete[path] = struct{}{}
 	}
 
-	s := t.meta.currentSnapshot()
+	s := meta.currentSnapshot()
 	if s == nil {
 		return fmt.Errorf("%w: cannot replace files in a table without an existing snapshot", ErrInvalidOperation)
 	}
@@ -1010,7 +1068,8 @@ func (t *Transaction) ReplaceDataFilesWithDataFiles(ctx context.Context, filesTo
 // are replaced with new (compacted) data files, and delete files that are fully
 // applied are removed.
 func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataFilesToAdd, deleteFilesToRemove []iceberg.DataFile, snapshotProps iceberg.Properties, opts ...WriteOption) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	// Delegate data file replacement to existing logic.
@@ -1071,7 +1130,7 @@ func (t *Transaction) ReplaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		setDeleteFilesToRemove[path] = struct{}{}
 	}
 
-	s := t.meta.currentSnapshot()
+	s := meta.currentSnapshot()
 	if s == nil {
 		return fmt.Errorf("%w: cannot replace files in a table without an existing snapshot", ErrInvalidOperation)
 	}
@@ -1181,7 +1240,8 @@ func WithAddFilesConcurrency(concurrency int) AddFilesOption {
 }
 
 func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshotProps iceberg.Properties, ignoreDuplicates bool, opts ...AddFilesOption) error {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	addFilesOp := addFilesOperation{
@@ -1209,7 +1269,7 @@ func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshot
 	}
 
 	if !ignoreDuplicates {
-		if s := t.meta.currentSnapshot(); s != nil {
+		if s := meta.currentSnapshot(); s != nil {
 			referenced := make([]string, 0)
 			for df, err := range s.dataFiles(fs, nil) {
 				if err != nil {
@@ -1226,8 +1286,8 @@ func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshot
 		}
 	}
 
-	if t.meta.NameMapping() == nil {
-		nameMapping := t.meta.CurrentSchema().NameMapping()
+	if meta.NameMapping() == nil {
+		nameMapping := meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
 			return err
@@ -1238,9 +1298,16 @@ func (t *Transaction) AddFiles(ctx context.Context, filePaths []string, snapshot
 		}
 	}
 
-	updater := t.appendSnapshotProducer(wfs, snapshotProps)
+	// SetProperties above may have staged a name mapping, rebuilding t.meta;
+	// re-read the current builder through the accessor before creating the
+	// producer or parsing files.
+	meta, err = t.txnMeta()
+	if err != nil {
+		return err
+	}
+	updater := t.appendSnapshotProducer(meta, wfs, snapshotProps)
 
-	dataFiles, err := filesToDataFiles(ctx, fs, t.meta, filePaths, addFilesOp.concurrency)
+	dataFiles, err := filesToDataFiles(ctx, fs, meta, filePaths, addFilesOp.concurrency)
 	if err != nil {
 		return err
 	}
@@ -1342,7 +1409,7 @@ func WithOverwriteCaseInsensitive() OverwriteOption {
 // can be overridden using the WithOverwriteConcurrency option.
 // If concurrency <= 0, defaults to runtime.GOMAXPROCS(0).
 func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, snapshotProps iceberg.Properties, opts ...OverwriteOption) error {
-	if err := t.ensureInitialized(); err != nil {
+	if _, err := t.txnMeta(); err != nil {
 		return err
 	}
 	overwrite := overwriteOperation{
@@ -1359,7 +1426,15 @@ func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, sna
 		return err
 	}
 
-	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
+	// Re-read through the accessor: performCopyOnWriteDeletion may have staged a
+	// name mapping (which rebuilds t.meta), and the records must be written
+	// against that current builder.
+	meta, err := t.txnMeta()
+	if err != nil {
+		return err
+	}
+
+	itr := recordsToDataFiles(ctx, t.tbl.Location(), meta, recordWritingArgs{
 		sc:        rdr.Schema(),
 		itr:       array.IterFromReader(rdr),
 		fs:        wfs,
@@ -1400,7 +1475,8 @@ func (t *Transaction) Overwrite(ctx context.Context, rdr array.RecordReader, sna
 }
 
 func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation Operation, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, io.WriteFileIO, error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, nil, err
 	}
 	fs, err := t.tbl.fsF(ctx)
@@ -1412,8 +1488,8 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 		return nil, nil, err
 	}
 
-	if t.meta.NameMapping() == nil {
-		nameMapping := t.meta.CurrentSchema().NameMapping()
+	if meta.NameMapping() == nil {
+		nameMapping := meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
 			return nil, nil, err
@@ -1446,7 +1522,8 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 }
 
 func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotProps iceberg.Properties, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (*snapshotProducer, error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, err
 	}
 	fs, err := t.tbl.fsF(ctx)
@@ -1458,8 +1535,8 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 		return nil, err
 	}
 
-	if t.meta.NameMapping() == nil {
-		nameMapping := t.meta.CurrentSchema().NameMapping()
+	if meta.NameMapping() == nil {
+		nameMapping := meta.CurrentSchema().NameMapping()
 		mappingJson, err := json.Marshal(nameMapping)
 		if err != nil {
 			return nil, err
@@ -1549,7 +1626,8 @@ func WithDeleteCaseInsensitive() DeleteOption {
 // The concurrency parameter controls the level of parallelism for manifest processing and file rewriting and
 // can be overridden using the WithOverwriteConcurrency option. Defaults to runtime.GOMAXPROCS(0).
 func (t *Transaction) Delete(ctx context.Context, filter iceberg.BooleanExpression, snapshotProps iceberg.Properties, opts ...DeleteOption) (err error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return err
 	}
 	deleteOp := deleteOperation{
@@ -1564,8 +1642,8 @@ func (t *Transaction) Delete(ctx context.Context, filter iceberg.BooleanExpressi
 	writeDeleteMode := WriteDeleteModeDefault
 	// Only copy on write is supported on v1 so we ignore any override to the write delete mode unless the version is
 	// 2 and up
-	if t.meta.formatVersion > 1 {
-		writeDeleteMode = t.meta.props.Get(WriteDeleteModeKey, WriteDeleteModeDefault)
+	if meta.formatVersion > 1 {
+		writeDeleteMode = meta.props.Get(WriteDeleteModeKey, WriteDeleteModeDefault)
 	}
 	switch writeDeleteMode {
 	case WriteModeCopyOnWrite:
@@ -1595,7 +1673,12 @@ func (t *Transaction) Delete(ctx context.Context, filter iceberg.BooleanExpressi
 // per-file file_sequence_number map for rewrite candidates (used to
 // synthesize row-lineage columns when reading), and any error.
 func (t *Transaction) classifyFilesForDeletions(ctx context.Context, fs io.IO, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (filesToDelete, filesWithPartialDeletions []iceberg.DataFile, fileSeqByPath map[string]*int64, err error) {
-	s := t.meta.currentSnapshot()
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	s := meta.currentSnapshot()
 	if s == nil {
 		return nil, nil, nil, nil
 	}
@@ -1646,8 +1729,13 @@ func (t *fileClassificationTask) buildPartitionProjection(specID int) (iceberg.B
 // Returns files to delete completely, files to rewrite partially, the
 // per-file file_sequence_number map for rewrite candidates, and any error.
 func (t *Transaction) classifyFilesForFilteredDeletions(ctx context.Context, fs io.IO, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (filesToDelete, filesWithPartialDeletes []iceberg.DataFile, fileSeqByPath map[string]*int64, err error) {
-	schema := t.meta.CurrentSchema()
-	meta, err := t.meta.Build()
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	schema := meta.CurrentSchema()
+	builtMeta, err := meta.Build()
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1662,10 +1750,10 @@ func (t *Transaction) classifyFilesForFilteredDeletions(ctx context.Context, fs 
 		return nil, nil, nil, fmt.Errorf("failed to create strict metrics evaluator: %w", err)
 	}
 
-	classificationTask := newFileClassificationTask(meta, filter, caseSensitive)
+	classificationTask := newFileClassificationTask(builtMeta, filter, caseSensitive)
 	manifestEvaluators := newKeyDefaultMapWrapErr(classificationTask.buildManifestEvaluator)
 
-	s := t.meta.currentSnapshot()
+	s := meta.currentSnapshot()
 	var manifests []iceberg.ManifestFile
 	if s != nil {
 		manifests, err = s.Manifests(fs)
@@ -1772,13 +1860,18 @@ func (t *Transaction) classifyFilesForFilteredDeletions(ctx context.Context, fs 
 // used to synthesize _last_updated_sequence_number when the source row's value is null. The
 // filter binding and substrait conversion are computed once here and reused across every file.
 func (t *Transaction) rewriteFilesWithFilter(ctx context.Context, fs io.IO, updater *snapshotProducer, files []iceberg.DataFile, fileSeqByPath map[string]*int64, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) error {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return err
+	}
+
 	complementFilter := iceberg.NewNot(filter)
 
 	// Bind + convert the complement filter once for the whole rewrite. The
 	// per-batch filter function is reused across every record batch from
 	// every file in this rewrite — substrait conversion in particular is
 	// non-trivial so doing it inside the iterator loop wastes work.
-	postFilter, err := prepareBatchFilter(complementFilter, t.meta.CurrentSchema(), caseSensitive)
+	postFilter, err := prepareBatchFilter(complementFilter, meta.CurrentSchema(), caseSensitive)
 	if err != nil {
 		return err
 	}
@@ -1836,6 +1929,11 @@ type rewriteSingleFileArgs struct {
 // new files with filtered data. See [rewriteSingleFileArgs] for parameter
 // semantics.
 func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleFileArgs) ([]iceberg.DataFile, error) {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
 	scanTask := &FileScanTask{
 		File:   args.originalFile,
 		Start:  0,
@@ -1861,8 +1959,8 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 	// end. File-level skipping (against the bound filter's residual on file
 	// stats) could be re-enabled here without breaking _row_id synthesis,
 	// since synthesis depends only on within-file row positions.
-	preserveRowLineage := t.meta.formatVersion >= 3 && args.originalFile.FirstRowID() != nil
-	projectedSchema := t.meta.CurrentSchema()
+	preserveRowLineage := meta.formatVersion >= 3 && args.originalFile.FirstRowID() != nil
+	projectedSchema := meta.CurrentSchema()
 	var factoryOpts []writerFactoryOption
 	if preserveRowLineage {
 		projectedSchema = iceberg.SchemaWithRowLineage(projectedSchema)
@@ -1881,20 +1979,20 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 	// the one actually applied. Skip the wasted BindExpr in that case.
 	scanFilter := iceberg.BooleanExpression(iceberg.AlwaysTrue{})
 	if !preserveRowLineage {
-		boundFilter, err := iceberg.BindExpr(t.meta.CurrentSchema(), args.filter, args.caseSensitive)
+		boundFilter, err := iceberg.BindExpr(meta.CurrentSchema(), args.filter, args.caseSensitive)
 		if err != nil {
 			return nil, fmt.Errorf("failed to bind filter: %w", err)
 		}
 		scanFilter = boundFilter
 	}
 
-	meta, err := t.meta.Build()
+	builtMeta, err := meta.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build metadata: %w", err)
 	}
 
 	scanner := &arrowScan{
-		metadata:        meta,
+		metadata:        builtMeta,
 		fs:              args.fs,
 		projectedSchema: projectedSchema,
 		boundRowFilter:  scanFilter,
@@ -1958,7 +2056,7 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 	}
 
 	var result []iceberg.DataFile
-	itr := recordsToDataFiles(ctx, t.tbl.Location(), t.meta, recordWritingArgs{
+	itr := recordsToDataFiles(ctx, t.tbl.Location(), meta, recordWritingArgs{
 		sc:          arrowSchema,
 		itr:         releaseIter,
 		fs:          wfs,
@@ -1982,6 +2080,11 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 // record its referenced data file is omitted from the returned paths (it
 // cannot be existence-checked), matching RowDelta.validate and Java.
 func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO, updater *snapshotProducer, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int, commitUUID uuid.UUID) ([]string, error) {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
 	posDeleteRecIter, err := t.makePositionDeleteRecordsForFilter(ctx, fs, files, filter, caseSensitive, concurrency)
 	if err != nil {
 		return nil, err
@@ -2006,7 +2109,7 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		existingDVs       map[string]iceberg.DataFile
 		existingDVBitmaps map[string]*dv.RoaringPositionBitmap
 	)
-	if t.meta.formatVersion >= 3 {
+	if meta.formatVersion >= 3 {
 		existingDVs, err = t.collectExistingDVs(fs, files)
 		if err != nil {
 			return nil, err
@@ -2022,7 +2125,7 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 		}
 	}
 
-	posDeleteFiles := positionDeleteRecordsToDataFiles(ctx, t.tbl.Location(), t.meta, partitionContextByFilePath, recordWritingArgs{
+	posDeleteFiles := positionDeleteRecordsToDataFiles(ctx, t.tbl.Location(), meta, partitionContextByFilePath, recordWritingArgs{
 		sc:          PositionalDeleteArrowSchema,
 		itr:         posDeleteRecIter,
 		writeUUID:   &commitUUID,
@@ -2059,7 +2162,12 @@ func (t *Transaction) writePositionDeletesForFiles(ctx context.Context, fs io.IO
 // delete path to fold prior deletes into a new DV and remove the superseded
 // entries, preserving the spec's one-DV-per-data-file invariant.
 func (t *Transaction) collectExistingDVs(fs io.IO, files []iceberg.DataFile) (map[string]iceberg.DataFile, error) {
-	s := t.meta.currentSnapshot()
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	s := meta.currentSnapshot()
 	if s == nil {
 		return nil, nil
 	}
@@ -2100,6 +2208,11 @@ func (t *Transaction) collectExistingDVs(fs io.IO, files []iceberg.DataFile) (ma
 }
 
 func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs io.IO, files []iceberg.DataFile, filter iceberg.BooleanExpression, caseSensitive bool, concurrency int) (seq2 iter.Seq2[arrow.RecordBatch, error], err error) {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
 	tasks := make([]FileScanTask, 0, len(files))
 	for _, f := range files {
 		tasks = append(tasks, FileScanTask{
@@ -2109,20 +2222,20 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 		})
 	}
 
-	boundFilter, err := iceberg.BindExpr(t.meta.CurrentSchema(), filter, caseSensitive)
+	boundFilter, err := iceberg.BindExpr(meta.CurrentSchema(), filter, caseSensitive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind filter: %w", err)
 	}
 
-	meta, err := t.meta.Build()
+	builtMeta, err := meta.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build metadata: %w", err)
 	}
 
 	scanner := &arrowScan{
-		metadata:        meta,
+		metadata:        builtMeta,
 		fs:              fs,
-		projectedSchema: t.meta.CurrentSchema(),
+		projectedSchema: meta.CurrentSchema(),
 		boundRowFilter:  boundFilter,
 		caseSensitive:   caseSensitive,
 		rowLimit:        -1, // No limit
@@ -2186,10 +2299,11 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 }
 
 func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, err
 	}
-	updatedMeta, err := t.meta.Build()
+	updatedMeta, err := meta.Build()
 	if err != nil {
 		return nil, err
 	}
@@ -2217,10 +2331,11 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 }
 
 func (t *Transaction) StagedTable() (*StagedTable, error) {
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, err
 	}
-	updatedMeta, err := t.meta.Build()
+	updatedMeta, err := meta.Build()
 	if err != nil {
 		return nil, err
 	}
@@ -2237,10 +2352,14 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 }
 
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
+	if err := t.checkNotNil(); err != nil {
+		return nil, err
+	}
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	if err := t.ensureInitialized(); err != nil {
+	meta, err := t.txnMeta()
+	if err != nil {
 		return nil, err
 	}
 
@@ -2250,9 +2369,9 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 
 	t.committed = true
 
-	if len(t.meta.updates) > 0 {
-		t.reqs = append(t.reqs, AssertTableUUID(t.meta.uuid))
-		tbl, err := t.tbl.doCommit(ctx, t.meta.updates, t.reqs,
+	if len(meta.updates) > 0 {
+		t.reqs = append(t.reqs, AssertTableUUID(meta.uuid))
+		tbl, err := t.tbl.doCommit(ctx, meta.updates, t.reqs,
 			withCommitBranch(t.branch),
 			withCommitValidators(t.validators...),
 		)
@@ -2260,7 +2379,7 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 			return tbl, err
 		}
 
-		for _, u := range t.meta.updates {
+		for _, u := range meta.updates {
 			if perr := u.PostCommit(ctx, t.tbl, tbl); perr != nil {
 				err = errors.Join(err, perr)
 			}

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -171,6 +171,145 @@ func TestTransactionEnsureInitializedNilReceiver(t *testing.T) {
 	require.ErrorContains(t, err, "transaction is nil")
 }
 
+func TestTransactionTxnMetaNilReceiver(t *testing.T) {
+	var txn *Transaction
+
+	meta, err := txn.txnMeta()
+	require.Nil(t, meta)
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	require.ErrorContains(t, err, "transaction is nil")
+}
+
+// newBrokenTransaction builds a transaction whose deferred initialization fails
+// ("current schema is missing") because the base metadata reports a nil current
+// schema. It is non-nil and its mutex is usable, so it exercises the
+// post-lock/deferred-error path distinctly from a nil receiver.
+func newBrokenTransaction(t *testing.T) *Transaction {
+	t.Helper()
+
+	baseMeta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder, "table-location", nil)
+	require.NoError(t, err, "new metadata")
+
+	return New(Identifier{"db", "broken"}, brokenMetadata{Metadata: baseMeta}, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return nil, nil }, nil).NewTransaction()
+}
+
+// TestTransactionEntryPointsRejectNilAndBrokenTransaction asserts the public
+// contract that issue #1431 targets: each exported entry point below must
+// return an error (never panic) when the transaction is nil or failed to
+// initialize. It covers both terminal commit paths (Commit, TableCommit), the
+// metadata builders (UpdateSpec, UpdateSchema, RowDelta), and the compaction
+// entry points (RewriteManifests, RewriteDataFiles) — not just the txnMeta
+// accessor. OverwriteTable is exercised via Overwrite (it only wraps a reader
+// around it); NewRewrite is exercised via ReplaceFiles.
+func TestTransactionEntryPointsRejectNilAndBrokenTransaction(t *testing.T) {
+	dfBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		"file://data.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		10,
+		10,
+	)
+	require.NoError(t, err, "new data file builder")
+	dataFile := dfBuilder.Build()
+
+	ctx := context.Background()
+	entryPoints := []struct {
+		name string
+		call func(txn *Transaction) error
+	}{
+		{"SetProperties", func(txn *Transaction) error { return txn.SetProperties(iceberg.Properties{"k": "v"}) }},
+		{"UpgradeFormatVersion", func(txn *Transaction) error { return txn.UpgradeFormatVersion(2) }},
+		{"RollbackToSnapshot", func(txn *Transaction) error { return txn.RollbackToSnapshot(1) }},
+		{"ExpireSnapshots", func(txn *Transaction) error { return txn.ExpireSnapshots() }},
+		{"AppendTable", func(txn *Transaction) error { return txn.AppendTable(ctx, nil, 0, nil) }},
+		{"Append", func(txn *Transaction) error { return txn.Append(ctx, nil, nil) }},
+		{"AddDataFiles", func(txn *Transaction) error { return txn.AddDataFiles(ctx, []iceberg.DataFile{dataFile}, nil) }},
+		{"AddFiles", func(txn *Transaction) error { return txn.AddFiles(ctx, []string{"file://a.parquet"}, nil, false) }},
+		{"ReplaceDataFiles", func(txn *Transaction) error { return txn.ReplaceDataFiles(ctx, []string{"a"}, []string{"b"}, nil) }},
+		{"ReplaceDataFilesWithDataFiles", func(txn *Transaction) error {
+			return txn.ReplaceDataFilesWithDataFiles(ctx, []iceberg.DataFile{dataFile}, nil, nil)
+		}},
+		{"ReplaceFiles", func(txn *Transaction) error {
+			return txn.ReplaceFiles(ctx, []iceberg.DataFile{dataFile}, nil, []iceberg.DataFile{dataFile}, nil)
+		}},
+		{"Delete", func(txn *Transaction) error { return txn.Delete(ctx, iceberg.AlwaysTrue{}, nil) }},
+		{"Overwrite", func(txn *Transaction) error { return txn.Overwrite(ctx, nil, nil) }},
+		{"Scan", func(txn *Transaction) error {
+			_, err := txn.Scan()
+
+			return err
+		}},
+		{"StagedTable", func(txn *Transaction) error {
+			_, err := txn.StagedTable()
+
+			return err
+		}},
+		{"Commit", func(txn *Transaction) error {
+			_, err := txn.Commit(ctx)
+
+			return err
+		}},
+		{"TableCommit", func(txn *Transaction) error {
+			_, err := txn.TableCommit()
+
+			return err
+		}},
+		{"RewriteManifests", func(txn *Transaction) error {
+			_, err := txn.RewriteManifests(ctx)
+
+			return err
+		}},
+		{"RewriteDataFiles", func(txn *Transaction) error {
+			// A non-empty task group forces the path that would otherwise
+			// dereference t.tbl (panicking on a nil transaction).
+			groups := []CompactionTaskGroup{{Tasks: []FileScanTask{{}}}}
+			_, err := txn.RewriteDataFiles(ctx, groups, RewriteDataFilesOptions{})
+
+			return err
+		}},
+		{"WriteEqualityDeletes", func(txn *Transaction) error {
+			_, err := txn.WriteEqualityDeletes(ctx, []int{1}, nil)
+
+			return err
+		}},
+		{"UpdateSpec", func(txn *Transaction) error { return txn.UpdateSpec(true).AddIdentity("id").Commit() }},
+		{"UpdateSchema", func(txn *Transaction) error {
+			return txn.UpdateSchema(true, false).
+				AddColumn([]string{"new_col"}, iceberg.PrimitiveTypes.String, "", false, nil).
+				Commit()
+		}},
+		{"RowDelta", func(txn *Transaction) error { return txn.NewRowDelta(nil).AddRows(dataFile).Commit(ctx) }},
+	}
+
+	t.Run("nil transaction", func(t *testing.T) {
+		for _, ep := range entryPoints {
+			t.Run(ep.name, func(t *testing.T) {
+				var txn *Transaction
+				var err error
+				require.NotPanics(t, func() { err = ep.call(txn) })
+				require.ErrorIs(t, err, ErrInvalidMetadata)
+				require.ErrorContains(t, err, "transaction is nil")
+			})
+		}
+	})
+
+	t.Run("broken transaction", func(t *testing.T) {
+		for _, ep := range entryPoints {
+			t.Run(ep.name, func(t *testing.T) {
+				txn := newBrokenTransaction(t)
+				var err error
+				require.NotPanics(t, func() { err = ep.call(txn) })
+				require.ErrorContains(t, err, "current schema is missing")
+			})
+		}
+	})
+}
+
 type brokenMetadata struct {
 	Metadata
 }

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -158,8 +158,10 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 
 		return u
 	}
-	u.err = txn.ensureInitialized()
-	if u.err != nil {
+	meta, err := txn.txnMeta()
+	if err != nil {
+		u.err = err
+
 		return u
 	}
 
@@ -168,7 +170,7 @@ func NewUpdateSchema(txn *Transaction, caseSensitive bool, allowIncompatibleChan
 	// counter that preserves ids across schema evolution (including
 	// deletions) so that newly-allocated ids never collide with ids still
 	// referenced by historical schemas.
-	u.lastColumnID = txn.meta.LastColumnID()
+	u.lastColumnID = meta.LastColumnID()
 
 	for _, opt := range opts {
 		opt(u)
@@ -181,14 +183,12 @@ func (u *UpdateSchema) init() error {
 	if u.err != nil {
 		return u.err
 	}
-	if u.txn == nil {
-		return errors.New("transaction is nil")
-	}
-	if u.txn.meta == nil {
-		return errors.New("transaction meta is nil")
+	meta, err := u.txn.txnMeta()
+	if err != nil {
+		return err
 	}
 
-	u.schema = u.txn.meta.CurrentSchema()
+	u.schema = meta.CurrentSchema()
 	if u.schema == nil {
 		return errors.New("current schema is nil")
 	}
@@ -641,8 +641,13 @@ func (u *UpdateSchema) BuildUpdates() ([]Update, []Requirement, error) {
 		return nil, nil, err
 	}
 
+	meta, err := u.txn.txnMeta()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	existingSchemaID := -1
-	for _, schema := range u.txn.meta.schemaList {
+	for _, schema := range meta.schemaList {
 		if newSchema.Equals(schema) {
 			existingSchemaID = schema.ID
 
@@ -734,9 +739,14 @@ func (u *UpdateSchema) Apply() (*iceberg.Schema, error) {
 		identifierFieldIDs = append(identifierFieldIDs, field.ID)
 	}
 
+	meta, err := u.txn.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+
 	nextSchemaID := 1
-	if len(u.txn.meta.schemaList) > 0 {
-		nextSchemaID = 1 + slices.MaxFunc(u.txn.meta.schemaList, func(a, b *iceberg.Schema) int {
+	if len(meta.schemaList) > 0 {
+		nextSchemaID = 1 + slices.MaxFunc(meta.schemaList, func(a, b *iceberg.Schema) int {
 			return a.ID - b.ID
 		}).ID
 	}

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -73,7 +73,11 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 
 		return us
 	}
-	us.err = t.ensureInitialized()
+	// UpdateSpec reads exclusively from the committed table metadata
+	// (t.tbl.Metadata() / t.tbl.Schema()) rather than the transaction's
+	// metadata builder, but still routes its initialization check through the
+	// canonical txnMeta accessor for consistency.
+	_, us.err = t.txnMeta()
 	if us.err != nil {
 		return us
 	}


### PR DESCRIPTION
Closes #1431.

## Summary

- Add `txnMeta()` as the canonical checked accessor for transaction metadata.
- Route transaction entry points, builders, and internal helpers through the accessor.
- Return initialization errors for nil and broken transactions instead of panicking.
- Preserve fresh metadata reads after staged property updates rebuild the metadata builder.
- Add regression coverage for representative transaction operations.



## Testing

- `go test -count=1 ./table`
- `go test ./...`