### PR TITLE
fix(promotion): Require equal scale in decimal type promotion

### DIFF
--- a/types.go
+++ b/types.go
@@ -1108,11 +1108,12 @@ func PromoteType(fileType, readType Type) (Type, error) {
 		}
 	case DecimalType:
 		if rt, ok := readType.(DecimalType); ok {
-			if t.precision <= rt.precision && t.scale <= rt.scale {
+			// Only precision may widen; scale must stay the same (spec: widen precision only).
+			if t.scale == rt.scale && t.precision <= rt.precision {
 				return readType, nil
 			}
 
-			return nil, fmt.Errorf("%w: cannot reduce precision from %s to %s",
+			return nil, fmt.Errorf("%w: cannot promote %s to %s",
 				ErrResolve, fileType, readType)
 		}
 	case FixedType:

--- a/types_test.go
+++ b/types_test.go
@@ -973,3 +973,44 @@ func TestNestedFieldEqualsWithNonComparableDefaults(t *testing.T) {
 		Required: true,
 	}))
 }
+
+func TestPromoteType(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileType iceberg.Type
+		readType iceberg.Type
+		want     iceberg.Type
+		wantErr  bool
+	}{
+		{"int to long", iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.Int64, false},
+		{"float to double", iceberg.PrimitiveTypes.Float32, iceberg.PrimitiveTypes.Float64, iceberg.PrimitiveTypes.Float64, false},
+		{"string to binary", iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.Binary, false},
+		{"binary to string", iceberg.PrimitiveTypes.Binary, iceberg.PrimitiveTypes.String, iceberg.PrimitiveTypes.String, false},
+		{"fixed[16] to uuid", iceberg.FixedTypeOf(16), iceberg.PrimitiveTypes.UUID, iceberg.PrimitiveTypes.UUID, false},
+		{"unknown to any", iceberg.PrimitiveTypes.Unknown, iceberg.PrimitiveTypes.Int64, iceberg.PrimitiveTypes.Int64, false},
+
+		// Decimal: precision may widen, scale must stay the same.
+		{"decimal widen precision", iceberg.DecimalTypeOf(9, 2), iceberg.DecimalTypeOf(18, 2), iceberg.DecimalTypeOf(18, 2), false},
+		{"decimal same", iceberg.DecimalTypeOf(9, 2), iceberg.DecimalTypeOf(9, 2), iceberg.DecimalTypeOf(9, 2), false},
+		{"decimal narrow precision", iceberg.DecimalTypeOf(18, 2), iceberg.DecimalTypeOf(9, 2), nil, true},
+		{"decimal increase scale", iceberg.DecimalTypeOf(9, 2), iceberg.DecimalTypeOf(18, 4), nil, true},
+		{"decimal decrease scale", iceberg.DecimalTypeOf(9, 4), iceberg.DecimalTypeOf(18, 2), nil, true},
+
+		{"disallowed int to string", iceberg.PrimitiveTypes.Int32, iceberg.PrimitiveTypes.String, nil, true},
+		{"disallowed fixed[8] to uuid", iceberg.FixedTypeOf(8), iceberg.PrimitiveTypes.UUID, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := iceberg.PromoteType(tt.fileType, tt.readType)
+			if tt.wantErr {
+				require.ErrorIs(t, err, iceberg.ErrResolve)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Truef(t, tt.want.Equals(got), "expected: %s\ngot: %s", tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
When promoting decimals, the spec states that you can only widen precision. iceberg-go currently allows widening scale + precision.

We should match the spec + the other implementations.