### PR TITLE
fix(catalog): compare multi-table identifiers by component

### DIFF
--- a/catalog/multi_table_transaction.go
+++ b/catalog/multi_table_transaction.go
@@ -48,12 +48,12 @@ import (
 //
 //	err = mtx.Commit(ctx)
 type MultiTableTransaction struct {
-	cat       TransactionalCatalog
-	loader    Catalog
-	txns      []*table.Transaction
-	idents    []string
-	tableIDs  []table.Identifier
-	committed bool
+	cat        TransactionalCatalog
+	loader     Catalog
+	txns       []*table.Transaction
+	tableNames []string
+	tableIDs   []table.Identifier
+	committed  bool
 }
 
 // NewMultiTableTransaction creates a new multi-table transaction backed
@@ -86,14 +86,16 @@ func (m *MultiTableTransaction) AddTransaction(tx *table.Transaction) error {
 		return err
 	}
 
-	key := strings.Join(tc.Identifier, ".")
-	if slices.Contains(m.idents, key) {
-		return fmt.Errorf("duplicate table in multi-table transaction: %s", key)
+	for _, identifier := range m.tableIDs {
+		if slices.Equal(identifier, tc.Identifier) {
+			return fmt.Errorf("duplicate table in multi-table transaction: %s",
+				strings.Join(tc.Identifier, "."))
+		}
 	}
 
 	m.txns = append(m.txns, tx)
-	m.idents = append(m.idents, key)
-	m.tableIDs = append(m.tableIDs, tc.Identifier)
+	m.tableNames = append(m.tableNames, strings.Join(tc.Identifier, "."))
+	m.tableIDs = append(m.tableIDs, slices.Clone(tc.Identifier))
 
 	return nil
 }
@@ -127,7 +129,7 @@ func (m *MultiTableTransaction) Commit(ctx context.Context) error {
 
 	if err := m.cat.CommitTransaction(ctx, commits); err != nil {
 		return fmt.Errorf("commit transaction for tables [%s]: %w",
-			strings.Join(m.idents, ", "), err)
+			strings.Join(m.tableNames, ", "), err)
 	}
 
 	m.committed = true

--- a/catalog/multi_table_transaction_test.go
+++ b/catalog/multi_table_transaction_test.go
@@ -166,6 +166,29 @@ func TestMultiTableTransactionEmpty(t *testing.T) {
 	assert.ErrorIs(t, mtx.Commit(context.Background()), ErrEmptyCommitList)
 }
 
+func TestMultiTableTransactionDistinguishesIdentifierComponents(t *testing.T) {
+	stub := &stubCatalog{}
+	mtx := &MultiTableTransaction{cat: stub}
+
+	tx1 := mtxTestTable(t, "a.b", "c").NewTransaction()
+	require.NoError(t, tx1.SetProperties(map[string]string{"k": "v"}))
+	require.NoError(t, mtx.AddTransaction(tx1))
+
+	tx2 := mtxTestTable(t, "a", "b.c").NewTransaction()
+	require.NoError(t, tx2.SetProperties(map[string]string{"k": "v"}))
+	require.NoError(t, mtx.AddTransaction(tx2))
+
+	duplicate := mtxTestTable(t, "a.b", "c").NewTransaction()
+	require.NoError(t, duplicate.SetProperties(map[string]string{"k": "v"}))
+	assert.ErrorContains(t, mtx.AddTransaction(duplicate), "duplicate table")
+
+	require.NoError(t, mtx.Commit(context.Background()))
+	require.Len(t, stub.commits, 1)
+	require.Len(t, stub.commits[0], 2)
+	assert.Equal(t, table.Identifier{"a.b", "c"}, stub.commits[0][0].Identifier)
+	assert.Equal(t, table.Identifier{"a", "b.c"}, stub.commits[0][1].Identifier)
+}
+
 func TestNewMultiTableTransactionNonTransactional(t *testing.T) {
 	// nil doesn't implement TransactionalCatalog
 	_, err := NewMultiTableTransaction(nil)


### PR DESCRIPTION
## Summary

- compare structured table identifiers component by component when detecting duplicates
- keep dot-joined names only for human-readable errors
- clone identifiers retained for duplicate checks and post-commit reloads

## Problem

Multi-table transactions flattened identifiers with `strings.Join(identifier, ".")`. Distinct valid identifiers such as `["a.b", "c"]` and `["a", "b.c"]` both became `a.b.c`, so adding the second table incorrectly returned a duplicate-table error.

## Fix

Duplicate detection now compares the identifier slices directly with `slices.Equal`. The regression commits both formerly colliding tables and still verifies that an exact duplicate is rejected.

## Testing

- `go test ./catalog`
- `go test -race ./catalog`
- `go vet ./catalog`