### PR TITLE
fix(table): avoid panic pruning an empty snapshot log

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1073,7 +1073,7 @@ func (b *MetadataBuilder) updateSnapshotLog() error {
 				newSnapsLog = make([]SnapshotLogEntry, 0, len(b.snapshotLog)-len(newSnapsLog))
 			}
 		}
-		if b.currentSnapshotID != nil {
+		if b.currentSnapshotID != nil && len(newSnapsLog) != 0 {
 			last := newSnapsLog[len(newSnapsLog)-1]
 			if last.SnapshotID != *b.currentSnapshotID {
 				return fmt.Errorf("%w: cannot set invalid snapshot log: latest entry is not the current snapshot", iceberg.ErrInvalidArgument)

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -649,6 +649,48 @@ func TestRemoveSnapshotRemovesBranch(t *testing.T) {
 	}
 }
 
+func TestRemoveSnapshotsWithCurrentSnapshotAndEmptyLog(t *testing.T) {
+	const (
+		removedID = int64(100)
+		currentID = int64(200)
+	)
+	lastPartitionID := 999
+	meta := &metadataV2{
+		LastSeqNum: 0,
+		commonMetadata: commonMetadata{
+			FormatVersion:     2,
+			UUID:              uuid.New(),
+			Loc:               "s3://test/table",
+			LastUpdatedMS:     1000,
+			LastColumnId:      1,
+			SchemaList:        []*iceberg.Schema{iceberg.NewSchema(0)},
+			CurrentSchemaID:   0,
+			Specs:             []iceberg.PartitionSpec{*iceberg.UnpartitionedSpec},
+			DefaultSpecID:     0,
+			LastPartitionID:   &lastPartitionID,
+			Props:             iceberg.Properties{},
+			SnapshotList:      []Snapshot{{SnapshotID: removedID}, {SnapshotID: currentID}},
+			CurrentSnapshotID: ptr(currentID),
+			SnapshotLog:       []SnapshotLogEntry{},
+			SortOrderList:     []SortOrder{UnsortedSortOrder},
+			SnapshotRefs: map[string]SnapshotRef{
+				MainBranch: {SnapshotID: currentID, SnapshotRefType: BranchRef},
+			},
+		},
+	}
+
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.RemoveSnapshots([]int64{removedID}, false))
+
+	rebuilt, err := builder.Build()
+	require.NoError(t, err)
+	require.Empty(t, slices.Collect(rebuilt.SnapshotLogs()))
+	current := rebuilt.CurrentSnapshot()
+	require.NotNil(t, current)
+	require.Equal(t, currentID, current.SnapshotID)
+}
+
 // TestRemoveSnapshotsPrunesStatistics verifies that RemoveSnapshots also
 // prunes StatisticsList and PartitionStatsList entries whose SnapshotID
 // matches a removed snapshot. See iceberg-go#836.


### PR DESCRIPTION
## Summary

- avoid indexing the rebuilt snapshot log when it has no entries
- preserve an accepted empty log while retaining the current snapshot
- continue requiring the final entry of every nonempty log to reference the current snapshot

## Problem

Metadata can contain a current snapshot and an empty `snapshot-log`. When `RemoveSnapshots` removed a different snapshot, log maintenance rebuilt the empty log and unconditionally indexed its last entry, causing a slice-bounds panic.

## Fix

The current-snapshot consistency check now runs only when the rebuilt log contains an entry. No history is synthesized, and validation for nonempty logs is unchanged.

## Testing

- `go test ./table`
- targeted regression tests under `go test -race`
- `go vet ./table`