### PR TITLE
fix(hadoop): recognize UUID metadata versions above 99999

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -58,10 +58,10 @@ var versionPattern = regexp.MustCompile(`^v([0-9]+)(?:\.gz)?\.metadata\.json$`)
 
 // uuidMetadataPattern matches UUID-style metadata filenames produced by
 // Java/PyIceberg catalogs: 00000-<uuid>.metadata.json or
-// 00000-<uuid>.gz.metadata.json. The sequence is a 5-digit zero-padded
-// number and the UUID is in canonical 8-4-4-4-12 hex format.
+// 00000-<uuid>.gz.metadata.json. The numeric sequence has a minimum width
+// of 5 digits and the UUID is in canonical 8-4-4-4-12 hex format.
 var uuidMetadataPattern = regexp.MustCompile(
-	`^([0-9]{5})-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:\.gz)?\.metadata\.json$`,
+	`^([0-9]{5,})-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:\.gz)?\.metadata\.json$`,
 )
 
 // Claims expire aggressively so crashed writers do not permanently block a

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -544,21 +544,43 @@ func (s *HadoopCatalogTestSuite) TestVersionPatternRejects() {
 	}
 }
 
-func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameAcceptsZeroUUIDVersion() {
-	file, ok := metadataFileFromName(
-		"/tmp/00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json",
-		"00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json",
-	)
-	s.True(ok)
-	s.Equal(0, file.version)
-	s.Equal("/tmp/00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", file.location)
+func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameAcceptsUUIDVersions() {
+	tests := []struct {
+		filename   string
+		version    int
+		compressed bool
+	}{
+		{"00000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", 0, false},
+		{"99999-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", 99999, false},
+		{"100000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json", 100000, false},
+		{"1234567-a1b2c3d4-e5f6-7890-abcd-ef1234567890.gz.metadata.json", 1234567, true},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.filename, func() {
+			path := filepath.Join("metadata", tt.filename)
+			file, ok := metadataFileFromName(path, tt.filename)
+			s.True(ok)
+			s.Equal(tt.version, file.version)
+			s.Equal(tt.compressed, file.compressed)
+			s.Equal(path, file.location)
+		})
+	}
+}
+
+func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameRejectsShortUUIDVersion() {
+	filename := "9999-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"
+	_, ok := metadataFileFromName(filepath.Join("metadata", filename), filename)
+	s.False(ok)
 }
 
 func (s *HadoopCatalogTestSuite) TestMetadataFileFromNameRejectsOverflowVersion() {
-	_, ok := metadataFileFromName(
-		"/tmp/v99999999999999999999.metadata.json",
-		"v99999999999999999999.metadata.json",
-	)
+	hadoopName := "v99999999999999999999.metadata.json"
+	_, ok := metadataFileFromName(filepath.Join("metadata", hadoopName), hadoopName)
+	s.False(ok)
+
+	uuidName := "99999999999999999999-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"
+	_, ok = metadataFileFromName(filepath.Join("metadata", uuidName), uuidName)
 	s.False(ok)
 }
 
@@ -856,6 +878,21 @@ func (s *HadoopCatalogTestSuite) TestFindMetadataLocationUsesCanonicalPathForDup
 	s.Require().NoError(err)
 	s.Equal(3, ver)
 	s.Equal(filepath.Join(dir, "v3.metadata.json"), path)
+}
+
+func (s *HadoopCatalogTestSuite) TestFindMetadataLocationSelectsUUIDVersionBeyondPadding() {
+	ident := []string{"ns", "tbl"}
+	dir := s.cat.metadataDir(ident)
+	s.Require().NoError(os.MkdirAll(dir, 0o755))
+	previous := "99999-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json"
+	latest := "100000-a1b2c3d4-e5f6-7890-abcd-ef1234567890.gz.metadata.json"
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, previous), nil, 0o644))
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, latest), nil, 0o644))
+
+	path, version, err := s.cat.findMetadataLocation(ident)
+	s.Require().NoError(err)
+	s.Equal(100000, version)
+	s.Equal(filepath.Join(dir, latest), path)
 }
 
 // CreateNamespace tests


### PR DESCRIPTION
## Summary

- accept UUID-style metadata version prefixes with five or more digits
- retain the existing five-digit minimum and checked integer conversion
- cover the 99,999 to 100,000 boundary, gzip metadata, larger versions, short prefixes, and overflow

## Problem

Java formats these metadata versions with `%05d` and PyIceberg uses `:05d`; both specify a minimum width, not a maximum. Version 100,000 therefore produces a six-digit filename. The previous exact-five-digit regex ignored that file and could make the Hadoop catalog select stale metadata.

## Fix

The UUID filename pattern now accepts `{5,}` digits. Discovery still rejects short nonstandard prefixes and versions that overflow `int`, and numeric ordering continues to select the latest file.

## Testing

- `go test ./catalog/hadoop`
- `go test -race ./catalog/hadoop`
- `go vet ./catalog/hadoop`