### PR TITLE
fix(rest): stop pagination on repeated page tokens

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1079,29 +1079,46 @@ func (r *Catalog) fetchTableCreds(ctx context.Context, ident []string, location 
 	return resolveStorageCredentials(ret.StorageCredentials, location), nil
 }
 
+type identifierPageFetcher func(pageToken string) ([]table.Identifier, string, error)
+
+func paginateIdentifiers(fetch identifierPageFetcher, yield func(table.Identifier) bool) error {
+	seenTokens := make(map[string]struct{})
+	var pageToken string
+
+	for {
+		identifiers, nextPageToken, err := fetch(pageToken)
+		if err != nil {
+			return err
+		}
+		for _, identifier := range identifiers {
+			if !yield(identifier) {
+				return nil
+			}
+		}
+		if nextPageToken == "" {
+			return nil
+		}
+		if _, ok := seenTokens[nextPageToken]; ok {
+			return fmt.Errorf("%w: pagination cycle: repeated page token", ErrRESTError)
+		}
+
+		seenTokens[nextPageToken] = struct{}{}
+		pageToken = nextPageToken
+	}
+}
+
 // ListTables lists the tables in a namespace. If the server does not advertise
 // the list-tables endpoint, it yields no tables rather than an error.
 func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
-		var pageToken string
-
-		for {
-			tables, nextPageToken, err := r.listTablesPage(ctx, namespace, pageToken, pageSize)
-			if err != nil {
-				yield(table.Identifier{}, err)
-
-				return
-			}
-			for _, tbl := range tables {
-				if !yield(tbl, nil) {
-					return
-				}
-			}
-			if nextPageToken == "" {
-				return
-			}
-			pageToken = nextPageToken
+		err := paginateIdentifiers(func(pageToken string) ([]table.Identifier, string, error) {
+			return r.listTablesPage(ctx, namespace, pageToken, pageSize)
+		}, func(identifier table.Identifier) bool {
+			return yield(identifier, nil)
+		})
+		if err != nil {
+			yield(table.Identifier{}, err)
 		}
 	}
 }
@@ -1679,18 +1696,15 @@ func (r *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) ([]table.Identifier, error) {
 	var allNamespaces []table.Identifier
 	pageSize := r.getPageSize(ctx)
-	var pageToken string
+	err := paginateIdentifiers(func(pageToken string) ([]table.Identifier, string, error) {
+		return r.listNamespacesPage(ctx, parent, pageToken, pageSize)
+	}, func(identifier table.Identifier) bool {
+		allNamespaces = append(allNamespaces, identifier)
 
-	for {
-		namespaces, nextPageToken, err := r.listNamespacesPage(ctx, parent, pageToken, pageSize)
-		if err != nil {
-			return nil, err
-		}
-		allNamespaces = append(allNamespaces, namespaces...)
-		if nextPageToken == "" {
-			break
-		}
-		pageToken = nextPageToken
+		return true
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return allNamespaces, nil
@@ -1873,24 +1887,13 @@ func (r *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 func (r *Catalog) ListViews(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
-		var pageToken string
-
-		for {
-			views, nextPageToken, err := r.listViewsPage(ctx, namespace, pageToken, pageSize)
-			if err != nil {
-				yield(table.Identifier{}, err)
-
-				return
-			}
-			for _, view := range views {
-				if !yield(view, nil) {
-					return
-				}
-			}
-			if nextPageToken == "" {
-				return
-			}
-			pageToken = nextPageToken
+		err := paginateIdentifiers(func(pageToken string) ([]table.Identifier, string, error) {
+			return r.listViewsPage(ctx, namespace, pageToken, pageSize)
+		}, func(identifier table.Identifier) bool {
+			return yield(identifier, nil)
+		})
+		if err != nil {
+			yield(table.Identifier{}, err)
 		}
 	}
 }
@@ -2285,24 +2288,13 @@ type FunctionCatalog interface {
 func (r *Catalog) ListFunctions(ctx context.Context, namespace table.Identifier) iter.Seq2[table.Identifier, error] {
 	return func(yield func(table.Identifier, error) bool) {
 		pageSize := r.getPageSize(ctx)
-		var pageToken string
-
-		for {
-			functions, nextPageToken, err := r.listFunctionsPage(ctx, namespace, pageToken, pageSize)
-			if err != nil {
-				yield(table.Identifier{}, err)
-
-				return
-			}
-			for _, function := range functions {
-				if !yield(function, nil) {
-					return
-				}
-			}
-			if nextPageToken == "" {
-				return
-			}
-			pageToken = nextPageToken
+		err := paginateIdentifiers(func(pageToken string) ([]table.Identifier, string, error) {
+			return r.listFunctionsPage(ctx, namespace, pageToken, pageSize)
+		}, func(identifier table.Identifier) bool {
+			return yield(identifier, nil)
+		})
+		if err != nil {
+			yield(table.Identifier{}, err)
 		}
 	}
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -583,6 +583,66 @@ func (r *RestCatalogSuite) TestListTablesPagination() {
 	r.Require().NoError(lastErr)
 }
 
+func (r *RestCatalogSuite) TestListTablesPaginationCycle() {
+	const namespace = "accounting"
+	requestCount := 0
+	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if requestCount > 3 {
+			r.Fail("pagination continued after a repeated token")
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+
+			return
+		}
+
+		var name, nextPageToken string
+		switch req.URL.Query().Get("pageToken") {
+		case "":
+			name, nextPageToken = "first", "token-a"
+		case "token-a":
+			name, nextPageToken = "second", "token-b"
+		case "token-b":
+			name, nextPageToken = "third", "token-a"
+		default:
+			r.Fail("unexpected page token")
+			http.Error(w, "unexpected page token", http.StatusBadRequest)
+
+			return
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"identifiers": []any{map[string]any{
+				"namespace": []string{namespace},
+				"name":      name,
+			}},
+			"next-page-token": nextPageToken,
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	var identifiers []table.Identifier
+	var paginationErr error
+	for identifier, err := range cat.ListTables(context.Background(), catalog.ToIdentifier(namespace)) {
+		if err != nil {
+			paginationErr = err
+
+			break
+		}
+		identifiers = append(identifiers, identifier)
+	}
+
+	r.ErrorIs(paginationErr, rest.ErrRESTError)
+	r.ErrorContains(paginationErr, "pagination cycle: repeated page token")
+	r.Equal(3, requestCount)
+	r.Equal([]table.Identifier{
+		{"accounting", "first"},
+		{"accounting", "second"},
+		{"accounting", "third"},
+	}, identifiers)
+}
+
 func (r *RestCatalogSuite) TestListTablesPaginationErrorOnSubsequentPage() {
 	namespace := "accounting"
 	r.mux.HandleFunc("/v1/namespaces/"+namespace+"/tables", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Summary

- route namespace, table, view, and function listings through one pagination loop
- detect repeated nonempty page tokens before issuing another request
- preserve iterator results and early termination behavior

## Problem

REST listing loops stopped only when `next-page-token` was empty. A server returning `A → A` or `A → B → A` caused the client to request pages indefinitely and repeatedly yield duplicate objects.

## Fix

The shared pagination loop records every next-page token before requesting it. If a later response repeats a token, pagination stops and returns an error wrapping `ErrRESTError`. The opaque token itself is not copied into the error.

The end-to-end regression exercises `ListTables` with an `A → B → A` cycle, verifies all three received pages are delivered, and fails if a fourth request occurs. Existing pagination tests continue to cover normal multi-page results, subsequent-page failures, and callers stopping iteration early.

## Testing

- `go test ./catalog/rest`
- `go test -race ./catalog/rest`
- `go vet ./catalog/rest`