### PR TITLE
fix(io): avoid deadlock in MemFS WalkDir callbacks

### DIFF
--- a/io/mem.go
+++ b/io/mem.go
@@ -106,16 +106,29 @@ func (m *MemFS) WriteFile(name string, content []byte) error {
 }
 
 func (m *MemFS) WalkDir(root string, fn fs.WalkDirFunc) error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	type walkEntry struct {
+		path string
+		size int64
+	}
 
 	root = strings.TrimRight(root, "/")
+
+	m.mu.RLock()
+	var entries []walkEntry
 	for key, data := range m.files {
 		if !memPathInRoot(key, root) {
 			continue
 		}
-		info := &memFileInfo{name: filepath.Base(key), size: int64(len(data))}
-		if err := fn(key, fs.FileInfoToDirEntry(info), nil); err != nil {
+		entries = append(entries, walkEntry{
+			path: key,
+			size: int64(len(data)),
+		})
+	}
+	m.mu.RUnlock()
+
+	for _, entry := range entries {
+		info := &memFileInfo{name: filepath.Base(entry.path), size: entry.size}
+		if err := fn(entry.path, fs.FileInfoToDirEntry(info), nil); err != nil {
 			return err
 		}
 	}

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/fs"
 	"testing"
+	"time"
 
 	icebergio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
@@ -199,4 +200,39 @@ func TestMemIO_WalkDirDoesNotIncludeSiblingPrefixes(t *testing.T) {
 			}, walked)
 		})
 	}
+}
+
+func TestMemIO_WalkDirCallbackCanRemoveFiles(t *testing.T) {
+	memIO := icebergio.NewMemFS()
+	require.NoError(t, memIO.WriteFile("mem://bucket/root/1.txt", []byte("1")))
+	require.NoError(t, memIO.WriteFile("mem://bucket/root/2.txt", []byte("22")))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- memIO.WalkDir("mem://bucket/root", func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			return memIO.Remove(path)
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("WalkDir deadlocked when its callback removed a file")
+	}
+
+	var remaining []string
+	require.NoError(t, memIO.WalkDir("mem://bucket/root", func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		remaining = append(remaining, path)
+
+		return nil
+	}))
+	assert.Empty(t, remaining)
 }


### PR DESCRIPTION
## Summary

- snapshot matching MemFS paths and sizes under the read lock
- release the lock before building entries and invoking `WalkDir` callbacks
- cover callbacks that remove visited files without hanging

## Problem

`MemFS.WalkDir` invoked callbacks while holding `RLock`. A callback calling `Remove` or `WriteFile` then waited for the write lock, but `WalkDir` could not release its read lock until that callback returned.

## Fix

Treat each walk as a point-in-time snapshot of matching paths and sizes. Root normalization and callback entry construction happen outside the critical section, keeping the write-blocking window limited to reading the in-memory map. Existing filtering, metadata, map iteration order, and callback error behavior remain unchanged.

## Testing

- `go test ./io -run TestMemIO_WalkDir -count=20`
- `go test ./io`
- `go test -race ./io`
- `go vet ./io`