### PR TITLE
fix(hive): synchronize HMS table metadata on commit

### DIFF
--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -582,7 +582,12 @@ func (c *Catalog) CommitTable(ctx context.Context, identifier table.Identifier, 
 	}
 
 	if current != nil {
-		updatedHiveTbl := updateHiveTableForCommit(currentHiveTbl, staged.MetadataLocation())
+		updatedHiveTbl := updateHiveTableForCommit(
+			currentHiveTbl,
+			current.Metadata(),
+			staged.Metadata(),
+			staged.MetadataLocation(),
+		)
 
 		if err := c.client.AlterTable(ctx, database, tableName, updatedHiveTbl); err != nil {
 			return nil, "", fmt.Errorf("failed to commit table %s.%s: %w", database, tableName, err)

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -715,6 +715,75 @@ func TestHiveCommitTableValidatesRequirementsForMissingTable(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestHiveCommitTableSynchronizesHMSMetadata(t *testing.T) {
+	ctx := context.Background()
+	oldLocation := "file://" + filepath.Join(t.TempDir(), "old-location")
+	newLocation := "file://" + filepath.Join(t.TempDir(), "new-location")
+	oldMetadataLocation := oldLocation + "/metadata/v1.metadata.json"
+	currentProps := iceberg.Properties{
+		"changed":    "old",
+		"removed":    "value",
+		GCEnabledKey: "false",
+	}
+	current, err := table.NewMetadata(
+		testSchema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		oldLocation, currentProps,
+	)
+	require.NoError(t, err)
+	require.NoError(t, cataloginternal.WriteTableMetadata(
+		current, iceio.LocalFS{}, oldMetadataLocation, table.MetadataCompressionCodecNone,
+	))
+
+	existing := constructHiveTable(
+		"test_database", "test_table", oldLocation, oldMetadataLocation, testSchema, currentProps,
+	)
+	existing.Parameters["hms-owned"] = "keep"
+	newSchema := iceberg.NewSchema(
+		1,
+		iceberg.NestedField{ID: 1, Name: "renamed", Type: iceberg.PrimitiveTypes.String},
+	)
+	mockClient := &mockHiveClient{}
+	expectImmediateTableLock(mockClient, 1)
+	mockClient.On("GetTable", mock.Anything, "test_database", "test_table").
+		Return(existing, nil).Once()
+	var altered *hive_metastore.Table
+	mockClient.On("AlterTable", mock.Anything, "test_database", "test_table", mock.AnythingOfType("*hive_metastore.Table")).
+		Run(func(args mock.Arguments) {
+			altered = args.Get(3).(*hive_metastore.Table)
+		}).Return(nil).Once()
+	cat := NewCatalogWithClient(mockClient, iceberg.Properties{})
+
+	_, metadataLocation, err := cat.CommitTable(
+		ctx,
+		TableIdentifier("test_database", "test_table"),
+		nil,
+		[]table.Update{
+			table.NewAddSchemaUpdate(newSchema),
+			table.NewSetCurrentSchemaUpdate(newSchema.ID),
+			table.NewSetLocationUpdate(newLocation),
+			table.NewSetPropertiesUpdate(iceberg.Properties{
+				"changed":    "new",
+				"added":      "value",
+				GCEnabledKey: "true",
+			}),
+			table.NewRemovePropertiesUpdate([]string{"removed"}),
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, altered)
+	require.Equal(t, metadataLocation, altered.Parameters[MetadataLocationKey])
+	require.Equal(t, oldMetadataLocation, altered.Parameters[PreviousMetadataLocationKey])
+	require.Equal(t, "new", altered.Parameters["changed"])
+	require.Equal(t, "value", altered.Parameters["added"])
+	require.NotContains(t, altered.Parameters, "removed")
+	require.Equal(t, "keep", altered.Parameters["hms-owned"])
+	require.Equal(t, "true", altered.Parameters[ExternalTablePurgeKey])
+	require.Equal(t, newLocation, altered.Sd.Location)
+	require.Equal(t, schemaToHiveColumns(newSchema), altered.Sd.Cols)
+	mockClient.AssertExpectations(t)
+}
+
 func TestHiveDropTableLockFailureIsRetryable(t *testing.T) {
 	mockClient := &mockHiveClient{}
 	mockClient.On("Lock", mock.Anything, mock.AnythingOfType("*hive_metastore.LockRequest")).
@@ -1008,7 +1077,8 @@ func TestConstructHiveTablePreservesReservedParameters(t *testing.T) {
 			MetadataLocationKey:          "s3://wrong-bucket/metadata.json",
 			PreviousMetadataLocationKey:  "s3://wrong-bucket/previous.metadata.json",
 			ExternalKey:                  "FALSE",
-			"storage_handler":            "wrong.StorageHandler",
+			StorageHandlerKey:            "wrong.StorageHandler",
+			GCEnabledKey:                 "false",
 			"write.metadata.compression": "gzip",
 		},
 	)
@@ -1018,8 +1088,116 @@ func TestConstructHiveTablePreservesReservedParameters(t *testing.T) {
 	assert.Equal(metadataLocation, hiveTbl.Parameters[MetadataLocationKey])
 	assert.NotContains(hiveTbl.Parameters, PreviousMetadataLocationKey)
 	assert.Equal("TRUE", hiveTbl.Parameters[ExternalKey])
-	assert.Equal("org.apache.iceberg.mr.hive.HiveIcebergStorageHandler", hiveTbl.Parameters["storage_handler"])
+	assert.Equal(IcebergStorageHandler, hiveTbl.Parameters[StorageHandlerKey])
+	assert.Equal("false", hiveTbl.Parameters[ExternalTablePurgeKey])
 	assert.Equal("gzip", hiveTbl.Parameters["write.metadata.compression"])
+}
+
+func TestUpdateHiveTableForCommitSynchronizesMetadata(t *testing.T) {
+	currentProps := iceberg.Properties{
+		"changed":    "old",
+		"removed":    "value",
+		GCEnabledKey: "false",
+	}
+	existing := constructHiveTable(
+		"test_database",
+		"test_table",
+		"s3://bucket/old-location",
+		"s3://bucket/old-location/metadata/v1.metadata.json",
+		testSchema,
+		currentProps,
+	)
+	existing.Parameters["hms-owned"] = "keep"
+	existing.Sd.Parameters = map[string]string{"sd-owned": "keep"}
+	existing.Sd.SerdeInfo.Parameters = map[string]string{"serde-owned": "keep"}
+	originalParameters := maps.Clone(existing.Parameters)
+	originalStorageDescriptor := *existing.Sd
+	originalStorageDescriptor.Parameters = maps.Clone(existing.Sd.Parameters)
+	originalSerdeParameters := maps.Clone(existing.Sd.SerdeInfo.Parameters)
+
+	newSchema := iceberg.NewSchema(
+		1,
+		iceberg.NestedField{ID: 1, Name: "renamed", Type: iceberg.PrimitiveTypes.String},
+	)
+	newProps := iceberg.Properties{
+		"changed":                   "new",
+		"added":                     "value",
+		GCEnabledKey:                "true",
+		TableTypeKey:                "HIVE",
+		MetadataLocationKey:         "s3://wrong/metadata.json",
+		PreviousMetadataLocationKey: "s3://wrong/previous.json",
+		ExternalKey:                 "FALSE",
+		StorageHandlerKey:           "wrong.StorageHandler",
+	}
+	current, err := table.NewMetadata(
+		testSchema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		"s3://bucket/old-location", currentProps,
+	)
+	require.NoError(t, err)
+	staged, err := table.NewMetadata(
+		newSchema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		"s3://bucket/new-location", newProps,
+	)
+	require.NoError(t, err)
+
+	updated := updateHiveTableForCommit(
+		existing,
+		current,
+		staged,
+		"s3://bucket/new-location/metadata/v2.metadata.json",
+	)
+
+	require.Equal(t, "new", updated.Parameters["changed"])
+	require.Equal(t, "value", updated.Parameters["added"])
+	require.NotContains(t, updated.Parameters, "removed")
+	require.Equal(t, "keep", updated.Parameters["hms-owned"])
+	require.Equal(t, TableTypeIceberg, updated.Parameters[TableTypeKey])
+	require.Equal(t, "TRUE", updated.Parameters[ExternalKey])
+	require.Equal(t, IcebergStorageHandler, updated.Parameters[StorageHandlerKey])
+	require.Equal(t, "true", updated.Parameters[ExternalTablePurgeKey])
+	require.Equal(t, "s3://bucket/old-location/metadata/v1.metadata.json", updated.Parameters[PreviousMetadataLocationKey])
+	require.Equal(t, "s3://bucket/new-location/metadata/v2.metadata.json", updated.Parameters[MetadataLocationKey])
+	require.Equal(t, "s3://bucket/new-location", updated.Sd.Location)
+	require.Equal(t, schemaToHiveColumns(newSchema), updated.Sd.Cols)
+	require.Equal(t, originalStorageDescriptor.InputFormat, updated.Sd.InputFormat)
+	require.Equal(t, originalStorageDescriptor.OutputFormat, updated.Sd.OutputFormat)
+	require.Equal(t, originalStorageDescriptor.SerdeInfo, updated.Sd.SerdeInfo)
+	require.NotSame(t, existing.Sd.SerdeInfo, updated.Sd.SerdeInfo)
+	require.Equal(t, originalStorageDescriptor.Parameters, updated.Sd.Parameters)
+	updated.Sd.Parameters["sd-owned"] = "updated"
+	require.Equal(t, "keep", existing.Sd.Parameters["sd-owned"])
+	updated.Sd.SerdeInfo.Parameters["serde-owned"] = "updated"
+	require.Equal(t, "keep", existing.Sd.SerdeInfo.Parameters["serde-owned"])
+
+	require.Equal(t, originalParameters, existing.Parameters)
+	require.Equal(t, originalStorageDescriptor, *existing.Sd)
+	require.Equal(t, originalSerdeParameters, existing.Sd.SerdeInfo.Parameters)
+}
+
+func TestUpdateHiveTableForCommitBuildsMissingStorageDescriptor(t *testing.T) {
+	current, err := table.NewMetadata(
+		testSchema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		"s3://bucket/old-location", nil,
+	)
+	require.NoError(t, err)
+	staged, err := table.NewMetadata(
+		testSchema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		"s3://bucket/new-location", nil,
+	)
+	require.NoError(t, err)
+	existing := &hive_metastore.Table{
+		DbName: "test_database", TableName: "test_table",
+		Parameters: map[string]string{MetadataLocationKey: "old-metadata.json"},
+	}
+
+	updated := updateHiveTableForCommit(existing, current, staged, "new-metadata.json")
+
+	require.Equal(t, buildIcebergStorageDescriptor(staged.Location(), staged.CurrentSchema()), updated.Sd)
+	require.Nil(t, existing.Sd)
+}
+
+func TestSchemaToHiveColumnsHandlesNilSchema(t *testing.T) {
+	require.Nil(t, schemaToHiveColumns(nil))
 }
 
 func TestConstructHiveViewTablePreservesReservedParameters(t *testing.T) {

--- a/catalog/hive/options.go
+++ b/catalog/hive/options.go
@@ -41,6 +41,10 @@ const (
 	MetadataLocationKey         = "metadata_location"
 	PreviousMetadataLocationKey = "previous_metadata_location"
 	ExternalKey                 = "EXTERNAL"
+	StorageHandlerKey           = "storage_handler"
+	IcebergStorageHandler       = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler"
+	GCEnabledKey                = "gc.enabled"
+	ExternalTablePurgeKey       = "external.table.purge"
 
 	// Lock configuration property keys
 	LockCheckMinWaitTime = "lock-check-min-wait-time"

--- a/catalog/hive/schema.go
+++ b/catalog/hive/schema.go
@@ -20,13 +20,19 @@ package hive
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
 	"github.com/beltran/gohive/hive_metastore"
 )
 
 func schemaToHiveColumns(schema *iceberg.Schema) []*hive_metastore.FieldSchema {
+	if schema == nil {
+		return nil
+	}
+
 	columns := make([]*hive_metastore.FieldSchema, 0, len(schema.Fields()))
 	for _, field := range schema.Fields() {
 		columns = append(columns, fieldToHiveColumn(field))
@@ -136,46 +142,97 @@ func constructHiveTable(dbName, tableName, location, metadataLocation string, sc
 	for k, v := range props {
 		parameters[k] = v
 	}
+	setTranslatedIcebergProperties(parameters, props)
 	delete(parameters, PreviousMetadataLocationKey)
 
 	parameters[TableTypeKey] = TableTypeIceberg
 	parameters[MetadataLocationKey] = metadataLocation
 	parameters[ExternalKey] = "TRUE"
-	parameters["storage_handler"] = "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler"
+	parameters[StorageHandlerKey] = IcebergStorageHandler
 
 	return &hive_metastore.Table{
-		TableName: tableName,
-		DbName:    dbName,
-		TableType: TableTypeExternalTable,
-		Sd: &hive_metastore.StorageDescriptor{
-			Cols:         schemaToHiveColumns(schema),
-			Location:     location,
-			InputFormat:  "org.apache.iceberg.mr.hive.HiveIcebergInputFormat",
-			OutputFormat: "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
-			SerdeInfo: &hive_metastore.SerDeInfo{
-				SerializationLib: "org.apache.iceberg.mr.hive.HiveIcebergSerDe",
-			},
-		},
+		TableName:  tableName,
+		DbName:     dbName,
+		TableType:  TableTypeExternalTable,
+		Sd:         buildIcebergStorageDescriptor(location, schema),
 		Parameters: parameters,
 	}
 }
 
-func updateHiveTableForCommit(existing *hive_metastore.Table, newMetadataLocation string) *hive_metastore.Table {
-	// Copy the existing table
-	updated := *existing
+func buildIcebergStorageDescriptor(location string, schema *iceberg.Schema) *hive_metastore.StorageDescriptor {
+	return &hive_metastore.StorageDescriptor{
+		Cols:         schemaToHiveColumns(schema),
+		Location:     location,
+		InputFormat:  "org.apache.iceberg.mr.hive.HiveIcebergInputFormat",
+		OutputFormat: "org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
+		SerdeInfo: &hive_metastore.SerDeInfo{
+			SerializationLib: "org.apache.iceberg.mr.hive.HiveIcebergSerDe",
+		},
+	}
+}
 
-	// Update parameters
+func cloneStorageDescriptor(existing *hive_metastore.StorageDescriptor) *hive_metastore.StorageDescriptor {
+	cloned := *existing
+	cloned.Parameters = maps.Clone(existing.Parameters)
+	cloned.BucketCols = append([]string(nil), existing.BucketCols...)
+	cloned.SortCols = append([]*hive_metastore.Order(nil), existing.SortCols...)
+	if existing.SerdeInfo != nil {
+		serdeInfo := *existing.SerdeInfo
+		serdeInfo.Parameters = maps.Clone(existing.SerdeInfo.Parameters)
+		cloned.SerdeInfo = &serdeInfo
+	}
+
+	return &cloned
+}
+
+func setTranslatedIcebergProperties(parameters map[string]string, props iceberg.Properties) {
+	if value, ok := props[GCEnabledKey]; ok {
+		parameters[ExternalTablePurgeKey] = value
+	}
+}
+
+func updateHiveTableForCommit(
+	existing *hive_metastore.Table,
+	current, staged table.Metadata,
+	newMetadataLocation string,
+) *hive_metastore.Table {
+	updated := *existing
+	updated.Parameters = maps.Clone(existing.Parameters)
 	if updated.Parameters == nil {
 		updated.Parameters = make(map[string]string)
 	}
 
-	// Store previous metadata location
-	if oldLocation, ok := updated.Parameters[MetadataLocationKey]; ok {
+	// HMS has no ownership marker for user properties. As in the Java implementation,
+	// obsolete keys are assumed to have been written from the previous Iceberg metadata.
+	for key := range current.Properties() {
+		delete(updated.Parameters, key)
+	}
+	if _, ok := current.Properties()[GCEnabledKey]; ok {
+		delete(updated.Parameters, ExternalTablePurgeKey)
+	}
+	for key, value := range staged.Properties() {
+		updated.Parameters[key] = value
+	}
+	setTranslatedIcebergProperties(updated.Parameters, staged.Properties())
+	delete(updated.Parameters, PreviousMetadataLocationKey)
+
+	// Read the unmodified parameters so a property cannot replace the real previous pointer.
+	if oldLocation, ok := existing.Parameters[MetadataLocationKey]; ok {
 		updated.Parameters[PreviousMetadataLocationKey] = oldLocation
 	}
 
-	// Set new metadata location
+	updated.Parameters[TableTypeKey] = TableTypeIceberg
 	updated.Parameters[MetadataLocationKey] = newMetadataLocation
+	updated.Parameters[ExternalKey] = "TRUE"
+	updated.Parameters[StorageHandlerKey] = IcebergStorageHandler
+
+	if existing.Sd == nil {
+		updated.Sd = buildIcebergStorageDescriptor(staged.Location(), staged.CurrentSchema())
+	} else {
+		updated.Sd = cloneStorageDescriptor(existing.Sd)
+		updated.Sd.Cols = schemaToHiveColumns(staged.CurrentSchema())
+		updated.Sd.Location = staged.Location()
+	}
 
 	return &updated
 }


### PR DESCRIPTION
## Problem

Hive commits only advanced `metadata_location`. The HMS storage descriptor and table properties could stay stale after schema, location, or property updates. The update helper also reused the original parameters map.

## Changes

- refresh HMS columns and location from the committed Iceberg metadata
- apply property additions, changes, and removals while preserving unrelated HMS parameters
- maintain current and previous metadata pointers and reserved Iceberg parameters
- copy the parameters map and storage descriptor before updating them

## Testing

Added coverage for schema and location changes, property synchronization, reserved parameters, preserved HMS fields, and input immutability.

- `go test ./catalog/hive`