### PR TITLE
fix(glue): apply catalog properties when loading metadata

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -288,7 +288,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 		ctx,
 		[]string{tableName},
 		metadataLocation,
-		io.LoadFSFunc(nil, metadataLocation),
+		io.LoadFSFunc(c.props, metadataLocation),
 		c,
 	)
 	if err != nil {
@@ -837,7 +837,7 @@ func (c *Catalog) convertGlueToIceberg(ctx context.Context, glueTable *types.Tab
 		utils.WithAwsConfig(ctx, c.awsCfg),
 		TableIdentifier(database, tableName),
 		metadataLocation,
-		io.LoadFSFunc(nil, metadataLocation),
+		io.LoadFSFunc(c.props, metadataLocation),
 		c,
 	)
 	if err != nil {

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -382,6 +382,64 @@ func TestGlueConvertGlueToIcebergCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestGlueMetadataLoadsUseCatalogProperties(t *testing.T) {
+	const scheme = "gluecatalogprops"
+	const propertyKey = "custom.io.token"
+	const propertyValue = "configured"
+
+	memFS := iceio.NewMemFS()
+	metadataLocation := scheme + "://bucket/test_table/metadata/v1.metadata.json"
+	writeGluePurgeTableMetadata(
+		t,
+		memFS,
+		scheme+"://bucket/test_table",
+		metadataLocation,
+		nil,
+	)
+
+	iceio.Unregister(scheme)
+	iceio.Register(scheme, func(_ context.Context, _ *url.URL, props map[string]string) (iceio.IO, error) {
+		if props[propertyKey] != propertyValue {
+			return nil, errors.New("catalog properties were not passed to IO factory")
+		}
+
+		return memFS, nil
+	})
+	t.Cleanup(func() { iceio.Unregister(scheme) })
+
+	glueTable := gluePurgeTable(metadataLocation)
+	t.Run("load table", func(t *testing.T) {
+		cat := &Catalog{props: iceberg.Properties{propertyKey: propertyValue}}
+		loaded, err := cat.convertGlueToIceberg(context.Background(), &glueTable)
+		require.NoError(t, err)
+		require.Equal(t, metadataLocation, loaded.MetadataLocation())
+	})
+
+	t.Run("register table", func(t *testing.T) {
+		mockGlueSvc := &mockGlueClient{}
+		mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+			Return(&glue.CreateTableOutput{}, nil).Once()
+		mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+			DatabaseName: aws.String("test_database"),
+			Name:         aws.String("test_table"),
+		}, mock.Anything).Return(&glue.GetTableOutput{Table: &glueTable}, nil).Once()
+
+		cat := &Catalog{
+			glueSvc: mockGlueSvc,
+			awsCfg:  &aws.Config{},
+			props:   iceberg.Properties{propertyKey: propertyValue},
+		}
+		loaded, err := cat.RegisterTable(
+			context.Background(),
+			TableIdentifier("test_database", "test_table"),
+			metadataLocation,
+		)
+		require.NoError(t, err)
+		require.Equal(t, metadataLocation, loaded.MetadataLocation())
+		mockGlueSvc.AssertExpectations(t)
+	})
+}
+
 func TestGlueListTables(t *testing.T) {
 	assert := require.New(t)
 


### PR DESCRIPTION
## Problem

Glue loaded table metadata with a nil property map in both registration and normal table loading. Filesystem implementations that depend on catalog configuration could therefore fail even though the catalog was configured correctly.

## Changes

Pass the Glue catalog properties to the filesystem factory used by `RegisterTable` and `convertGlueToIceberg`.

## Testing

Added a property-dependent custom filesystem and exercised both registration and normal loading.

- `go test ./catalog/glue`