### PR TITLE
fix(rest): reject nil view versions

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -2043,6 +2043,9 @@ func (r *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 	if err := r.endpoints.check(endpointCreateView); err != nil {
 		return nil, err
 	}
+	if version == nil {
+		return nil, fmt.Errorf("%w: view version cannot be nil", iceberg.ErrInvalidArgument)
+	}
 
 	ns, viewName, err := r.splitViewIdentForPath(identifier)
 	if err != nil {

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -2546,6 +2546,19 @@ func (r *RestCatalogSuite) TestCreateView200() {
 	r.True(expectedViewMD.Equals(createdView.Metadata()))
 }
 
+func (r *RestCatalogSuite) TestCreateViewRejectsNilVersion() {
+	ctlg, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL)
+	r.Require().NoError(err)
+
+	_, err = ctlg.CreateView(
+		context.Background(),
+		table.Identifier{"ns", "view"},
+		nil,
+		iceberg.NewSchema(0),
+	)
+	r.ErrorIs(err, iceberg.ErrInvalidArgument)
+}
+
 func (r *RestCatalogSuite) TestCreateView409() {
 	ns := "ns"
 	viewName := "view"


### PR DESCRIPTION
## Problem

`CreateView` dereferenced the supplied view version without checking it, so a nil version caused a panic instead of a normal validation error.

## Changes

Reject nil view versions with `iceberg.ErrInvalidArgument` before copying or modifying the version.

## Testing

Added a regression test that passes a nil version and verifies the returned sentinel error.

- `go test ./catalog/rest`