### PR TITLE
fix(sql): reject table-view name collisions

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -135,7 +135,8 @@ type Catalog interface {
 	// RenameTable tells the catalog to rename a given table by the identifiers
 	// provided, and then loads and returns the destination table
 	RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error)
-	// CheckTableExists returns if the table exists
+	// CheckTableExists reports whether the identifier is registered as a table in
+	// the catalog. It does not validate that the table metadata file is readable.
 	CheckTableExists(ctx context.Context, identifier table.Identifier) (bool, error)
 	// ListNamespaces returns the list of available namespaces, optionally filtering by a
 	// parent namespace

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -135,8 +135,7 @@ type Catalog interface {
 	// RenameTable tells the catalog to rename a given table by the identifiers
 	// provided, and then loads and returns the destination table
 	RenameTable(ctx context.Context, from, to table.Identifier) (*table.Table, error)
-	// CheckTableExists reports whether the identifier is registered as a table in
-	// the catalog. It does not validate that the table metadata file is readable.
+	// CheckTableExists reports whether the table exists.
 	CheckTableExists(ctx context.Context, identifier table.Identifier) (bool, error)
 	// ListNamespaces returns the list of available namespaces, optionally filtering by a
 	// parent namespace

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -770,7 +770,7 @@ func (c *Catalog) checkIdentifierAvailable(
 	}
 
 	identifierName := strings.Join(identifier, ".")
-	if !c.isV0() && entry.IcebergType.String == ViewType {
+	if !c.isV0() && entry.IcebergType.Valid && entry.IcebergType.String == ViewType {
 		return fmt.Errorf("%w: %s", catalog.ErrViewAlreadyExists, identifierName)
 	}
 
@@ -846,9 +846,11 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil
 	})
 	if err != nil {
-		if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, tblIdent, ident); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
-			errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
-			err = collisionErr
+		if !errors.Is(err, catalog.ErrTableAlreadyExists) && !errors.Is(err, catalog.ErrViewAlreadyExists) {
+			if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, tblIdent, ident); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
+				errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
+				err = collisionErr
+			}
 		}
 		if cleanupErr := removeUncommittedMetadata(ctx, staged.MetadataLocation(), staged.FS); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)
@@ -1597,9 +1599,11 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 		return nil
 	})
 	if err != nil {
-		if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, viewIdent, identifier); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
-			errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
-			err = collisionErr
+		if !errors.Is(err, catalog.ErrTableAlreadyExists) && !errors.Is(err, catalog.ErrViewAlreadyExists) {
+			if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, viewIdent, identifier); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
+				errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
+				err = collisionErr
+			}
 		}
 		loadFS := io.LoadFSFunc(c.props, metadataLocation)
 		if cleanupErr := removeUncommittedMetadata(ctx, metadataLocation, loadFS); cleanupErr != nil {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -324,7 +324,6 @@ func retrySerializableWriteTx(ctx context.Context, run func() error) error {
 		if attempt == serializableWriteMaxAttempts-1 {
 			break
 		}
-
 		delay := serializableWriteRetryDelay << attempt
 		timer := time.NewTimer(delay)
 		select {
@@ -736,6 +735,56 @@ func checkValidNamespace(ident table.Identifier) error {
 	return nil
 }
 
+func removeUncommittedMetadata(ctx context.Context, metadataLocation string, loadFS table.FSysF) error {
+	fs, err := loadFS(context.WithoutCancel(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to load filesystem while removing uncommitted metadata %s: %w", metadataLocation, err)
+	}
+
+	if err := fs.Remove(metadataLocation); err != nil {
+		return fmt.Errorf("failed to remove uncommitted metadata %s: %w", metadataLocation, err)
+	}
+
+	return nil
+}
+
+func (c *Catalog) checkIdentifierAvailable(
+	ctx context.Context, tx bun.Tx, namespace, name string, identifier table.Identifier,
+) error {
+	entry := &sqlIcebergTable{
+		CatalogName:    c.name,
+		TableNamespace: namespace,
+		TableName:      name,
+	}
+	query := tx.NewSelect().Model(entry).WherePK()
+	if c.isV0() {
+		query = query.ExcludeColumn("iceberg_type")
+	}
+
+	err := query.Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error checking identifier availability: %w", err)
+	}
+
+	identifierName := strings.Join(identifier, ".")
+	if !c.isV0() && entry.IcebergType.String == ViewType {
+		return fmt.Errorf("%w: %s", catalog.ErrViewAlreadyExists, identifierName)
+	}
+
+	return fmt.Errorf("%w: %s", catalog.ErrTableAlreadyExists, identifierName)
+}
+
+func (c *Catalog) checkIdentifierAvailableInCatalog(
+	ctx context.Context, namespace, name string, identifier table.Identifier,
+) error {
+	return c.db.RunInTx(ctx, &sql.TxOptions{ReadOnly: true}, func(ctx context.Context, tx bun.Tx) error {
+		return c.checkIdentifierAvailable(ctx, tx, namespace, name, identifier)
+	})
+}
+
 func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
 	// Resolve the reporter before any mutation: this method ends in LoadTable,
 	// which is where the reporter is otherwise first built, so a bad
@@ -776,6 +825,10 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
 		}
 
+		if err := c.checkIdentifierAvailable(ctx, tx, ns, tblIdent, ident); err != nil {
+			return err
+		}
+
 		ins := tx.NewInsert().Model(&sqlIcebergTable{
 			CatalogName:      c.name,
 			TableNamespace:   ns,
@@ -793,6 +846,14 @@ func (c *Catalog) CreateTable(ctx context.Context, ident table.Identifier, sc *i
 		return nil
 	})
 	if err != nil {
+		if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, tblIdent, ident); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
+			errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
+			err = collisionErr
+		}
+		if cleanupErr := removeUncommittedMetadata(ctx, staged.MetadataLocation(), staged.FS); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+
 		return nil, err
 	}
 
@@ -1129,21 +1190,38 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 	return c.LoadTable(ctx, to)
 }
 
+// CheckTableExists reports whether the identifier has a table row in the
+// catalog. It does not validate that the referenced metadata file is readable.
 func (c *Catalog) CheckTableExists(ctx context.Context, identifier table.Identifier) (bool, error) {
 	if err := catalog.ValidateTableIdentifier(identifier); err != nil {
 		return false, err
 	}
 
-	_, err := c.LoadTable(ctx, identifier)
+	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
 	if err != nil {
-		if errors.Is(err, catalog.ErrNoSuchTable) {
-			return false, nil
-		}
-
 		return false, err
 	}
+	tableName := catalog.TableNameFromIdent(identifier)
 
-	return true, nil
+	return withReadTx(ctx, c.db, func(ctx context.Context, tx bun.Tx) (bool, error) {
+		query := tx.NewSelect().Model(&sqlIcebergTable{
+			CatalogName:    c.name,
+			TableNamespace: ns,
+			TableName:      tableName,
+		}).WherePK()
+		if c.isV0() {
+			query = query.ExcludeColumn("iceberg_type")
+		} else {
+			query = query.Where("(iceberg_type = ? OR iceberg_type IS NULL)", TableType)
+		}
+
+		exists, err := query.Exists(ctx)
+		if err != nil {
+			return false, fmt.Errorf("error checking table existence: %w", err)
+		}
+
+		return exists, nil
+	})
 }
 
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
@@ -1480,14 +1558,6 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 		return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
 	}
 
-	exists, err = c.CheckViewExists(ctx, identifier)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return fmt.Errorf("%w: %s", catalog.ErrViewAlreadyExists, identifier)
-	}
-
 	loc, err := internal.ResolveTableLocationWithNamespace(
 		ctx, "", nsIdent, ns, viewIdent, c.props, c.LoadNamespaceProperties)
 	if err != nil {
@@ -1509,6 +1579,10 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 			return fmt.Errorf("%w: %s", catalog.ErrNoSuchNamespace, ns)
 		}
 
+		if err := c.checkIdentifierAvailable(ctx, tx, ns, viewIdent, identifier); err != nil {
+			return err
+		}
+
 		_, err = tx.NewInsert().Model(&sqlIcebergTable{
 			CatalogName:      c.name,
 			TableNamespace:   ns,
@@ -1522,6 +1596,16 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, s
 
 		return nil
 	})
+	if err != nil {
+		if collisionErr := c.checkIdentifierAvailableInCatalog(ctx, ns, viewIdent, identifier); errors.Is(collisionErr, catalog.ErrTableAlreadyExists) ||
+			errors.Is(collisionErr, catalog.ErrViewAlreadyExists) {
+			err = collisionErr
+		}
+		loadFS := io.LoadFSFunc(c.props, metadataLocation)
+		if cleanupErr := removeUncommittedMetadata(ctx, metadataLocation, loadFS); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+	}
 
 	return err
 }

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2192,6 +2192,8 @@ func (s *SqliteCatalogTestSuite) TestConcurrentTableViewCollisionReturnsCatalogS
 	close(start)
 
 	first, second := <-results, <-results
+	s.Require().NotEqual(first.err == nil, second.err == nil,
+		"expected exactly one concurrent create to succeed; table/view results: %v / %v", first.err, second.err)
 	if first.err != nil {
 		first, second = second, first
 	}

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1045,7 +1045,7 @@ func (s *SqliteCatalogTestSuite) TestCreateDuplicatedTable() {
 		s.Require().NoError(err)
 
 		_, err = tt.cat.CreateTable(context.Background(), tt.tblID, tableSchemaNested)
-		s.ErrorContains(err, "failed to create table")
+		s.ErrorIs(err, catalog.ErrTableAlreadyExists)
 	}
 }
 
@@ -2121,6 +2121,135 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 	exists, err := db.CheckViewExists(context.Background(), []string{nsName, viewName})
 	s.Require().NoError(err)
 	s.True(exists)
+}
+
+func (s *SqliteCatalogTestSuite) TestCreateTableConflictsWithView() {
+	ctx := context.Background()
+	db := s.getCatalogSqlite()
+	identifier := s.randomTableIdentifier()
+	s.Require().NoError(db.CreateNamespace(ctx, catalog.NamespaceFromIdent(identifier), nil))
+	s.Require().NoError(db.CreateView(ctx, identifier, tableSchemaNested, "SELECT 1", nil))
+
+	metadataDir := filepath.Join(s.warehouse, identifier[0]+".db", identifier[1], "metadata")
+	before, err := os.ReadDir(metadataDir)
+	s.Require().NoError(err)
+
+	_, err = db.CreateTable(ctx, identifier, tableSchemaNested)
+	s.ErrorIs(err, catalog.ErrViewAlreadyExists)
+
+	after, err := os.ReadDir(metadataDir)
+	s.Require().NoError(err)
+	s.Len(after, len(before))
+}
+
+func (s *SqliteCatalogTestSuite) TestCreateViewConflictsWithTable() {
+	ctx := context.Background()
+	db := s.getCatalogSqlite()
+	identifier := s.randomTableIdentifier()
+	s.Require().NoError(db.CreateNamespace(ctx, catalog.NamespaceFromIdent(identifier), nil))
+	_, err := db.CreateTable(ctx, identifier, tableSchemaNested)
+	s.Require().NoError(err)
+
+	metadataDir := filepath.Join(s.warehouse, identifier[0]+".db", identifier[1], "metadata")
+	before, err := os.ReadDir(metadataDir)
+	s.Require().NoError(err)
+
+	err = db.CreateView(ctx, identifier, tableSchemaNested, "SELECT 1", nil)
+	s.ErrorIs(err, catalog.ErrTableAlreadyExists)
+
+	after, err := os.ReadDir(metadataDir)
+	s.Require().NoError(err)
+	s.Len(after, len(before))
+}
+
+func (s *SqliteCatalogTestSuite) TestConcurrentTableViewCollisionReturnsCatalogSentinel() {
+	ctx := context.Background()
+	sqlDB := s.getDB()
+	_, err := sqlDB.Exec("PRAGMA journal_mode=WAL")
+	s.Require().NoError(err)
+	s.Require().NoError(sqlDB.Close())
+
+	db := s.getCatalogSqlite()
+	identifier := s.randomTableIdentifier()
+	s.Require().NoError(db.CreateNamespace(ctx, catalog.NamespaceFromIdent(identifier), nil))
+
+	type createResult struct {
+		objectType string
+		err        error
+	}
+	start := make(chan struct{})
+	results := make(chan createResult, 2)
+	go func() {
+		<-start
+		_, err := db.CreateTable(ctx, identifier, tableSchemaNested)
+		results <- createResult{objectType: sqlcat.TableType, err: err}
+	}()
+	go func() {
+		<-start
+		err := db.CreateView(ctx, identifier, tableSchemaNested, "SELECT 1", nil)
+		results <- createResult{objectType: sqlcat.ViewType, err: err}
+	}()
+	close(start)
+
+	first, second := <-results, <-results
+	if first.err != nil {
+		first, second = second, first
+	}
+	s.Require().NoError(first.err)
+	if first.objectType == sqlcat.TableType {
+		s.ErrorIs(second.err, catalog.ErrTableAlreadyExists)
+	} else {
+		s.ErrorIs(second.err, catalog.ErrViewAlreadyExists)
+	}
+}
+
+func (s *SqliteCatalogTestSuite) TestCreateRemovesMetadataIfCatalogInsertFails() {
+	ctx := context.Background()
+	db := s.getCatalogSqlite()
+
+	sqlDB := s.getDB()
+	defer sqlDB.Close()
+	_, err := sqlDB.Exec(`
+		CREATE TRIGGER fail_catalog_insert
+		BEFORE INSERT ON iceberg_tables
+		BEGIN
+			SELECT RAISE(FAIL, 'forced insert failure');
+		END
+	`)
+	s.Require().NoError(err)
+
+	tests := []struct {
+		name   string
+		create func(table.Identifier) error
+	}{
+		{
+			name: "table",
+			create: func(identifier table.Identifier) error {
+				_, err := db.CreateTable(ctx, identifier, tableSchemaNested)
+
+				return err
+			},
+		},
+		{
+			name: "view",
+			create: func(identifier table.Identifier) error {
+				return db.CreateView(ctx, identifier, tableSchemaNested, "SELECT 1", nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			identifier := s.randomTableIdentifier()
+			s.Require().NoError(db.CreateNamespace(ctx, catalog.NamespaceFromIdent(identifier), nil))
+			s.Require().Error(tt.create(identifier))
+
+			metadataDir := filepath.Join(s.warehouse, identifier[0]+".db", identifier[1], "metadata")
+			entries, err := os.ReadDir(metadataDir)
+			s.Require().NoError(err)
+			s.Empty(entries)
+		})
+	}
 }
 
 func (s *SqliteCatalogTestSuite) TestDropView() {


### PR DESCRIPTION
## Problem

SQL tables and views share the same catalog key, but creation only checked for an existing object of the same kind. A table could write metadata where a view already existed, or vice versa, before the database rejected the catalog insert. A concurrent creator could also win after the prechecks and leave the losing request's metadata file behind.

## Changes

- reject table creation when the identifier is already registered as either a table or a view
- reject view creation when the identifier is already registered as either a view or a table
- return the matching catalog sentinel for conflicts found by the prechecks
- check and document table existence as catalog registration rather than metadata-file reachability
- remove newly written metadata when a catalog insert fails, using a non-cancelled cleanup context and the catalog filesystem properties

The prechecks make ordinary duplicate and cross-kind conflicts deterministic. A genuinely concurrent creator can still win between the precheck and insert, so the losing request keeps the database insert error; cleanup prevents that race from leaking its metadata file.

## Testing

- both table/view collision directions with unchanged metadata directories
- duplicate-table creation returns `ErrTableAlreadyExists`
- forced catalog insert failures remove table and view metadata
- `go test ./catalog/sql`
- `go test -race ./catalog/sql`
- `go vet ./catalog/sql`