### PR TITLE
fix(glue): accept empty root namespace identifiers

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -733,7 +733,7 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 		CatalogId: c.catalogId,
 	}
 
-	if parent != nil {
+	if len(parent) > 0 {
 		return nil, errors.New("hierarchical namespace is not supported")
 	}
 

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -553,6 +553,19 @@ func TestGlueListNamespaces(t *testing.T) {
 	assert.Equal([]string{"test_database"}, databases[0])
 }
 
+func TestGlueListNamespacesAcceptsEmptyRootIdentifier(t *testing.T) {
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabases", mock.Anything, &glue.GetDatabasesInput{}, mock.Anything).
+		Return(&glue.GetDatabasesOutput{}, nil).Once()
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+	databases, err := glueCatalog.ListNamespaces(context.Background(), table.Identifier{})
+
+	require.NoError(t, err)
+	require.Empty(t, databases)
+	mockGlueSvc.AssertExpectations(t)
+}
+
 func TestGlueDropTable(t *testing.T) {
 	assert := require.New(t)
 


### PR DESCRIPTION
## Problem

Glue treated an allocated empty identifier differently from nil when listing the root namespace. Callers using `table.Identifier{}` received a hierarchical-namespace error even though it represents the same root.

## Changes

Use identifier length to distinguish the root from unsupported non-empty hierarchical namespaces.

## Testing

Added coverage for an allocated empty root identifier.

- `go test ./catalog/glue`