### PR TITLE
feat(rest): decode REST scan-task payloads into FileScanTasks

### DIFF
--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -699,11 +699,7 @@ func idempotencyHeaderValue(idempotencyKey *string) (string, error) {
 	return *idempotencyKey, nil
 }
 
-// --- Wire types (sketch) ----------------------------------------------------
-//
-// Content-file, delete-file, and residual decoding lands with the scan-task
-// decoder PR; these sketch the request/response envelopes so the client
-// surface compiles and reads.
+// --- Wire types -------------------------------------------------------------
 
 // PlanStatus is the status of a server-side plan.
 type PlanStatus string
@@ -729,19 +725,8 @@ type PlanningError struct {
 	Stack   []string `json:"stack,omitempty"`
 }
 
-// RESTFileScanTask is the REST FileScanTask wire payload. The REST prefix
-// avoids confusion with table.FileScanTask, the decoded domain type. The
-// scan-task decoder PR fills in the content-file and residual fields; the named
-// type is committed here so ScanTasks does not expose json.RawMessage.
-type RESTFileScanTask struct{}
-
-// RESTDeleteFile is the REST DeleteFile wire payload. The scan-task decoder PR
-// fills in the position/equality delete-file variants.
-type RESTDeleteFile struct{}
-
 // ScanTasks carries the task payload shared by completed planning responses and
-// fetchScanTasks responses. Task/delete payload decoding lands with the
-// scan-task decoder PR.
+// fetchScanTasks responses.
 type ScanTasks struct {
 	PlanTasks     []string           `json:"plan-tasks,omitempty"`
 	FileScanTasks []RESTFileScanTask `json:"file-scan-tasks,omitempty"`
@@ -786,14 +771,13 @@ type PlanTableScanRequest struct {
 
 // PlanTableScanResponse is the POST .../plan response. The spec models this as
 // a `status`-discriminated union; the flat struct carries every arm's fields
-// with omitempty so none are discarded. Task/delete payloads are filled in by
-// the scan-task decoder PR. Per the spec, plan-id is required for both completed
-// (CompletedPlanningWithIDResult) and submitted (AsyncPlanningResult) responses
-// here; the wire decoder must validate PlanID != nil at unmarshal rather than
-// rely on the omitempty pointer. A cancelled status is invalid for this endpoint
-// and must be treated as an error. A failed status decodes even when a
-// non-compliant server omits or malforms Error; callers must branch on Status
-// before dereferencing PlanID.
+// with omitempty so none are discarded. Per the spec, plan-id is required for
+// both completed (CompletedPlanningWithIDResult) and submitted
+// (AsyncPlanningResult) responses here; the wire decoder must validate
+// PlanID != nil at unmarshal rather than rely on the omitempty pointer. A
+// cancelled status is invalid for this endpoint and must be treated as an
+// error. A failed status decodes even when a non-compliant server omits or
+// malforms Error; callers must branch on Status before dereferencing PlanID.
 type PlanTableScanResponse struct {
 	Status PlanStatus     `json:"status"`
 	PlanID *string        `json:"plan-id,omitempty"`
@@ -903,8 +887,7 @@ type FetchScanTasksRequest struct {
 }
 
 // FetchScanTasksResponse is the POST .../tasks response. May itself return more
-// plan-tasks for further fanout. Task/delete payloads decoded by the
-// scan-task decoder PR.
+// plan-tasks for further fanout.
 type FetchScanTasksResponse struct {
 	ScanTasks
 }

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -192,10 +192,10 @@ func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
 	require.NotNil(t, resp.PlanID)
 	assert.Equal(t, "abc", *resp.PlanID)
 	assert.Len(t, resp.PlanTasks, 1)
-	// TODO(Phase 2): assert decoded task/delete-file content once the
-	// scan-task decoder fills RESTFileScanTask and RESTDeleteFile.
-	assert.Len(t, resp.FileScanTasks, 1)
-	assert.Len(t, resp.DeleteFiles, 1)
+	require.Len(t, resp.FileScanTasks, 1)
+	require.NotNil(t, resp.FileScanTasks[0].DataFile)
+	require.Len(t, resp.DeleteFiles, 1)
+	assert.Equal(t, "position-deletes", resp.DeleteFiles[0].Content)
 }
 
 func TestPlanTableScanResponseAcceptsFailedWithoutUsableError(t *testing.T) {

--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -135,8 +135,8 @@ func DecodeScanTasks(
 		return nil, nil
 	}
 
-	// Decode every delete even if the server did not reference it. This catches
-	// a malformed response rather than silently ignoring corrupt wire data.
+	// Decode every delete before resolving references. This validates all wire
+	// entries, including an unreferenced entry that will be rejected below.
 	deletes := make([]iceberg.DataFile, len(wire.DeleteFiles))
 	for i := range wire.DeleteFiles {
 		decoded, err := decodeRESTDeleteFile(wire.DeleteFiles[i], metadata, "")
@@ -148,6 +148,7 @@ func DecodeScanTasks(
 
 	out := make([]table.FileScanTask, 0, len(wire.FileScanTasks))
 	dvOwners := make(map[int]string)
+	referencedDeletes := make([]bool, len(deletes))
 	for i := range wire.FileScanTasks {
 		wireTask := wire.FileScanTasks[i]
 		if wireTask.DataFile == nil {
@@ -187,6 +188,7 @@ func DecodeScanTasks(
 					ErrRESTError, i, ref)
 			}
 			seenRefs[ref] = struct{}{}
+			referencedDeletes[ref] = true
 
 			wireDelete := wire.DeleteFiles[ref]
 			if wireDelete.ReferencedDataFile != nil && *wireDelete.ReferencedDataFile != dataFile.FilePath() {
@@ -226,6 +228,14 @@ func DecodeScanTasks(
 		}
 
 		out = append(out, task)
+	}
+
+	for i, referenced := range referencedDeletes {
+		if !referenced {
+			return nil, fmt.Errorf(
+				"%w: decoding scan tasks: delete-files[%d] is not referenced by any file scan task",
+				ErrRESTError, i)
+		}
 	}
 
 	return out, nil

--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -385,13 +385,11 @@ func contentFileBuilder(
 	if wire.Content != wantContent {
 		return nil, "", fmt.Errorf("content is %q, want %q", wire.Content, wantContent)
 	}
-	// record-count and file-size may be 0 per the wire contract (e.g. an empty
-	// data file); only reject the negative values a conformant server never sends.
-	if wire.RecordCount < 0 {
-		return nil, "", fmt.Errorf("record-count must be non-negative: %d", wire.RecordCount)
+	if wire.RecordCount <= 0 {
+		return nil, "", fmt.Errorf("record-count must be positive: %d", wire.RecordCount)
 	}
-	if wire.FileSizeInBytes < 0 {
-		return nil, "", fmt.Errorf("file-size-in-bytes must be non-negative: %d", wire.FileSizeInBytes)
+	if wire.FileSizeInBytes <= 0 {
+		return nil, "", fmt.Errorf("file-size-in-bytes must be positive: %d", wire.FileSizeInBytes)
 	}
 
 	spec := metadata.PartitionSpecByID(wire.SpecID)

--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -1,0 +1,718 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/twmb/avro/atype"
+)
+
+// The exported REST wire types below are intentional: the low-level planning
+// methods expose ScanTasks directly, while DecodeScanTasks is the boundary for
+// callers that want table.FileScanTask domain objects.
+
+// RESTCountMap is the REST column-id-to-count representation. Keys and values
+// are parallel arrays because JSON object keys cannot preserve integer IDs.
+type RESTCountMap struct {
+	Keys   []int   `json:"keys"`
+	Values []int64 `json:"values"`
+}
+
+// RESTValueMap is the REST column-id-to-binary representation used for lower
+// and upper bounds. Java's ContentFileParser encodes each raw Iceberg binary
+// value as a hexadecimal string; these are not typed JSON partition values.
+type RESTValueMap struct {
+	Keys   []int    `json:"keys"`
+	Values []string `json:"values"`
+}
+
+// RESTContentFile contains the fields common to REST data and delete files.
+// Partition values remain raw until DecodeScanTasks resolves spec-id and the
+// result type of each partition transform.
+type RESTContentFile struct {
+	SpecID          int               `json:"spec-id"`
+	Partition       []json.RawMessage `json:"partition"`
+	Content         string            `json:"content"`
+	FilePath        string            `json:"file-path"`
+	FileFormat      string            `json:"file-format"`
+	FileSizeInBytes int64             `json:"file-size-in-bytes"`
+	RecordCount     int64             `json:"record-count"`
+	KeyMetadata     *string           `json:"key-metadata,omitempty"`
+	SplitOffsets    []int64           `json:"split-offsets,omitempty"`
+	SortOrderID     *int              `json:"sort-order-id,omitempty"`
+}
+
+// RESTDataFile is the data-file arm of the REST ContentFile union.
+type RESTDataFile struct {
+	RESTContentFile
+
+	FirstRowID      *int64        `json:"first-row-id,omitempty"`
+	ColumnSizes     *RESTCountMap `json:"column-sizes,omitempty"`
+	ValueCounts     *RESTCountMap `json:"value-counts,omitempty"`
+	NullValueCounts *RESTCountMap `json:"null-value-counts,omitempty"`
+	NaNValueCounts  *RESTCountMap `json:"nan-value-counts,omitempty"`
+	LowerBounds     *RESTValueMap `json:"lower-bounds,omitempty"`
+	UpperBounds     *RESTValueMap `json:"upper-bounds,omitempty"`
+}
+
+// RESTFileScanTask is the REST FileScanTask wire payload. Delete references
+// are zero-based indices into the DeleteFiles slice of the same ScanTasks
+// envelope; they must be resolved before responses are combined.
+type RESTFileScanTask struct {
+	DataFile             *RESTDataFile   `json:"data-file"`
+	DeleteFileReferences []int           `json:"delete-file-references,omitempty"`
+	ResidualFilter       json.RawMessage `json:"residual-filter,omitempty"`
+}
+
+// RESTDeleteFile is the position/equality arm of the REST ContentFile union.
+// Content discriminates the variant. Puffin position deletes are decoded as
+// deletion vectors and associated with the data file that references them.
+type RESTDeleteFile struct {
+	RESTContentFile
+
+	EqualityIDs []int `json:"equality-ids,omitempty"`
+	// ReferencedDataFile is emitted by Java's ContentFileParser for
+	// file-scoped position deletes and deletion vectors. It is not currently
+	// declared by the REST OpenAPI DeleteFile schema, so clients must also
+	// support deriving a DV's target from its FileScanTask association.
+	ReferencedDataFile *string `json:"referenced-data-file,omitempty"`
+	ContentOffset      *int64  `json:"content-offset,omitempty"`
+	ContentSizeInBytes *int64  `json:"content-size-in-bytes,omitempty"`
+}
+
+// DecodeScanTasks converts one REST ScanTasks envelope into domain scan tasks.
+// Delete-file references are scoped to one envelope, so callers must invoke
+// this before combining inline and fetchScanTasks responses.
+//
+// schema is the schema selected for the scan and is used to decode residual
+// literals. When nil, metadata.CurrentSchema is used.
+// fallbackResidual is used when a task omits residual-filter, as required by
+// the REST specification; it is commonly the original scan filter.
+func DecodeScanTasks(
+	wire ScanTasks,
+	metadata table.ScanPlanningMetadata,
+	schema *iceberg.Schema,
+	fallbackResidual iceberg.BooleanExpression,
+) ([]table.FileScanTask, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("%w: decoding scan tasks: table metadata is required", ErrRESTError)
+	}
+	if schema == nil {
+		schema = metadata.CurrentSchema()
+	}
+	if schema == nil {
+		return nil, fmt.Errorf("%w: decoding scan tasks: scan schema is required", ErrRESTError)
+	}
+	if len(wire.FileScanTasks) == 0 {
+		if len(wire.DeleteFiles) != 0 {
+			return nil, fmt.Errorf("%w: decoding scan tasks: %d delete files have no file scan tasks", ErrRESTError, len(wire.DeleteFiles))
+		}
+
+		return nil, nil
+	}
+
+	// Decode every delete even if the server did not reference it. This catches
+	// a malformed response rather than silently ignoring corrupt wire data.
+	deletes := make([]iceberg.DataFile, len(wire.DeleteFiles))
+	for i := range wire.DeleteFiles {
+		decoded, err := decodeRESTDeleteFile(wire.DeleteFiles[i], metadata, "")
+		if err != nil {
+			return nil, fmt.Errorf("%w: decoding scan tasks: delete-files[%d]: %w", ErrRESTError, i, err)
+		}
+		deletes[i] = decoded
+	}
+
+	out := make([]table.FileScanTask, 0, len(wire.FileScanTasks))
+	dvOwners := make(map[int]string)
+	for i := range wire.FileScanTasks {
+		wireTask := wire.FileScanTasks[i]
+		if wireTask.DataFile == nil {
+			return nil, fmt.Errorf("%w: decoding scan tasks: file-scan-tasks[%d] is missing data-file", ErrRESTError, i)
+		}
+
+		dataFile, err := decodeRESTDataFile(*wireTask.DataFile, metadata)
+		if err != nil {
+			return nil, fmt.Errorf("%w: decoding scan tasks: file-scan-tasks[%d].data-file: %w", ErrRESTError, i, err)
+		}
+
+		residual, err := decodeTaskResidual(wireTask.ResidualFilter, schema, fallbackResidual)
+		if err != nil {
+			return nil, fmt.Errorf("%w: decoding scan tasks: file-scan-tasks[%d].residual-filter: %w", ErrRESTError, i, err)
+		}
+
+		task := table.FileScanTask{
+			File:       dataFile,
+			Start:      0,
+			Length:     dataFile.FileSizeBytes(),
+			Residual:   residual,
+			FirstRowID: dataFile.FirstRowID(),
+		}
+		// The REST FileScanTask schema does not carry manifest data sequence
+		// numbers, so DataSequenceNumber intentionally remains nil.
+
+		seenRefs := make(map[int]struct{}, len(wireTask.DeleteFileReferences))
+		for j, ref := range wireTask.DeleteFileReferences {
+			if ref < 0 || ref >= len(deletes) {
+				return nil, fmt.Errorf(
+					"%w: decoding scan tasks: file-scan-tasks[%d].delete-file-references[%d] is %d, want 0 <= index < %d",
+					ErrRESTError, i, j, ref, len(deletes))
+			}
+			if _, ok := seenRefs[ref]; ok {
+				return nil, fmt.Errorf(
+					"%w: decoding scan tasks: file-scan-tasks[%d] repeats delete-file reference %d",
+					ErrRESTError, i, ref)
+			}
+			seenRefs[ref] = struct{}{}
+
+			wireDelete := wire.DeleteFiles[ref]
+			if wireDelete.ReferencedDataFile != nil && *wireDelete.ReferencedDataFile != dataFile.FilePath() {
+				return nil, fmt.Errorf(
+					"%w: decoding scan tasks: delete-files[%d].referenced-data-file is %q, task data-file is %q",
+					ErrRESTError, ref, *wireDelete.ReferencedDataFile, dataFile.FilePath())
+			}
+
+			deleteFile := deletes[ref]
+			if deleteFile.FileFormat() == iceberg.PuffinFile {
+				if owner, ok := dvOwners[ref]; ok && owner != dataFile.FilePath() {
+					return nil, fmt.Errorf(
+						"%w: decoding scan tasks: deletion vector %d is referenced by both %q and %q",
+						ErrRESTError, ref, owner, dataFile.FilePath())
+				}
+				dvOwners[ref] = dataFile.FilePath()
+				// Derive referenced-data-file from the FileScanTask association
+				// when the server omits Java's optional extension field.
+				deleteFile, err = decodeRESTDeleteFile(wireDelete, metadata, dataFile.FilePath())
+				if err != nil {
+					return nil, fmt.Errorf("%w: decoding scan tasks: delete-files[%d]: %w", ErrRESTError, ref, err)
+				}
+			}
+
+			switch deleteFile.ContentType() {
+			case iceberg.EntryContentEqDeletes:
+				task.EqualityDeleteFiles = append(task.EqualityDeleteFiles, deleteFile)
+			case iceberg.EntryContentPosDeletes:
+				if deleteFile.FileFormat() == iceberg.PuffinFile {
+					task.DeletionVectorFiles = append(task.DeletionVectorFiles, deleteFile)
+				} else {
+					task.DeleteFiles = append(task.DeleteFiles, deleteFile)
+				}
+			default:
+				return nil, fmt.Errorf("%w: decoding scan tasks: delete-files[%d] has non-delete content", ErrRESTError, ref)
+			}
+		}
+
+		out = append(out, task)
+	}
+
+	return out, nil
+}
+
+func decodeRESTDataFile(wire RESTDataFile, metadata table.ScanPlanningMetadata) (iceberg.DataFile, error) {
+	builder, _, err := contentFileBuilder(wire.RESTContentFile, iceberg.EntryContentData, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	columnSizes, err := decodeCountMap("column-sizes", wire.ColumnSizes)
+	if err != nil {
+		return nil, err
+	}
+	valueCounts, err := decodeCountMap("value-counts", wire.ValueCounts)
+	if err != nil {
+		return nil, err
+	}
+	nullCounts, err := decodeCountMap("null-value-counts", wire.NullValueCounts)
+	if err != nil {
+		return nil, err
+	}
+	nanCounts, err := decodeCountMap("nan-value-counts", wire.NaNValueCounts)
+	if err != nil {
+		return nil, err
+	}
+	lowerBounds, err := decodeValueMap("lower-bounds", wire.LowerBounds)
+	if err != nil {
+		return nil, err
+	}
+	upperBounds, err := decodeValueMap("upper-bounds", wire.UpperBounds)
+	if err != nil {
+		return nil, err
+	}
+
+	if wire.ColumnSizes != nil {
+		builder.ColumnSizes(columnSizes)
+	}
+	if wire.ValueCounts != nil {
+		builder.ValueCounts(valueCounts)
+	}
+	if wire.NullValueCounts != nil {
+		builder.NullValueCounts(nullCounts)
+	}
+	if wire.NaNValueCounts != nil {
+		builder.NaNValueCounts(nanCounts)
+	}
+	if wire.LowerBounds != nil {
+		builder.LowerBoundValues(lowerBounds)
+	}
+	if wire.UpperBounds != nil {
+		builder.UpperBoundValues(upperBounds)
+	}
+	if wire.FirstRowID != nil {
+		if *wire.FirstRowID < 0 {
+			return nil, fmt.Errorf("first-row-id must be non-negative: %d", *wire.FirstRowID)
+		}
+		builder.FirstRowID(*wire.FirstRowID)
+	}
+
+	return builder.Build(), nil
+}
+
+func decodeRESTDeleteFile(
+	wire RESTDeleteFile,
+	metadata table.ScanPlanningMetadata,
+	referencedDataFile string,
+) (iceberg.DataFile, error) {
+	var content iceberg.ManifestEntryContent
+	switch wire.Content {
+	case "position-deletes":
+		content = iceberg.EntryContentPosDeletes
+	case "equality-deletes":
+		content = iceberg.EntryContentEqDeletes
+	default:
+		return nil, fmt.Errorf("unknown delete content %q", wire.Content)
+	}
+
+	builder, format, err := contentFileBuilder(wire.RESTContentFile, content, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	switch content {
+	case iceberg.EntryContentEqDeletes:
+		if wire.ReferencedDataFile != nil || wire.ContentOffset != nil || wire.ContentSizeInBytes != nil {
+			return nil, errors.New("equality-deletes file must not carry position-delete reference or blob offsets")
+		}
+		if len(wire.EqualityIDs) == 0 {
+			return nil, errors.New("equality-deletes file is missing equality-ids")
+		}
+		seen := make(map[int]struct{}, len(wire.EqualityIDs))
+		for i, id := range wire.EqualityIDs {
+			if id <= 0 {
+				return nil, fmt.Errorf("equality-ids[%d] must be positive: %d", i, id)
+			}
+			if _, ok := seen[id]; ok {
+				return nil, fmt.Errorf("equality-ids contains duplicate field ID %d", id)
+			}
+			seen[id] = struct{}{}
+		}
+		builder.EqualityFieldIDs(slices.Clone(wire.EqualityIDs))
+	case iceberg.EntryContentPosDeletes:
+		if len(wire.EqualityIDs) != 0 {
+			return nil, errors.New("position-deletes file must not carry equality-ids")
+		}
+		if wire.ContentOffset != nil {
+			if *wire.ContentOffset < 0 {
+				return nil, fmt.Errorf("content-offset must be non-negative: %d", *wire.ContentOffset)
+			}
+			if wire.ContentSizeInBytes == nil {
+				return nil, errors.New("content-size-in-bytes is required when content-offset is present")
+			}
+			builder.ContentOffset(*wire.ContentOffset)
+		}
+		if wire.ContentSizeInBytes != nil {
+			if *wire.ContentSizeInBytes <= 0 {
+				return nil, fmt.Errorf("content-size-in-bytes must be positive: %d", *wire.ContentSizeInBytes)
+			}
+			builder.ContentSizeInBytes(*wire.ContentSizeInBytes)
+		}
+		if wire.ReferencedDataFile != nil {
+			if *wire.ReferencedDataFile == "" {
+				return nil, errors.New("referenced-data-file cannot be empty")
+			}
+			if referencedDataFile != "" && *wire.ReferencedDataFile != referencedDataFile {
+				return nil, fmt.Errorf(
+					"referenced-data-file is %q, task data-file is %q",
+					*wire.ReferencedDataFile, referencedDataFile)
+			}
+			builder.ReferencedDataFile(*wire.ReferencedDataFile)
+		}
+		if format == iceberg.PuffinFile {
+			if wire.ContentOffset == nil || wire.ContentSizeInBytes == nil {
+				return nil, errors.New("puffin deletion vector requires content-offset and content-size-in-bytes")
+			}
+			if wire.ReferencedDataFile == nil && referencedDataFile != "" {
+				builder.ReferencedDataFile(referencedDataFile)
+			}
+		}
+	}
+
+	return builder.Build(), nil
+}
+
+func contentFileBuilder(
+	wire RESTContentFile,
+	expectedContent iceberg.ManifestEntryContent,
+	metadata table.ScanPlanningMetadata,
+) (*iceberg.DataFileBuilder, iceberg.FileFormat, error) {
+	wantContent := map[iceberg.ManifestEntryContent]string{
+		iceberg.EntryContentData:       "data",
+		iceberg.EntryContentPosDeletes: "position-deletes",
+		iceberg.EntryContentEqDeletes:  "equality-deletes",
+	}[expectedContent]
+	if wire.Content != wantContent {
+		return nil, "", fmt.Errorf("content is %q, want %q", wire.Content, wantContent)
+	}
+	// record-count and file-size may be 0 per the wire contract (e.g. an empty
+	// data file); only reject the negative values a conformant server never sends.
+	if wire.RecordCount < 0 {
+		return nil, "", fmt.Errorf("record-count must be non-negative: %d", wire.RecordCount)
+	}
+	if wire.FileSizeInBytes < 0 {
+		return nil, "", fmt.Errorf("file-size-in-bytes must be non-negative: %d", wire.FileSizeInBytes)
+	}
+
+	spec := metadata.PartitionSpecByID(wire.SpecID)
+	if spec == nil {
+		return nil, "", fmt.Errorf("unknown partition spec ID %d", wire.SpecID)
+	}
+	partition, logicalTypes, fixedSizes, err := decodePartition(wire.Partition, spec, metadata)
+	if err != nil {
+		return nil, "", err
+	}
+
+	format, err := iceberg.FileFormatFromString(wire.FileFormat)
+	if err != nil {
+		return nil, "", err
+	}
+	builder, err := iceberg.NewDataFileBuilder(
+		*spec,
+		expectedContent,
+		wire.FilePath,
+		format,
+		partition,
+		logicalTypes,
+		fixedSizes,
+		wire.RecordCount,
+		wire.FileSizeInBytes,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if wire.KeyMetadata != nil {
+		key, err := hex.DecodeString(*wire.KeyMetadata)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid key-metadata hexadecimal value: %w", err)
+		}
+		builder.KeyMetadata(key)
+	}
+	if wire.SplitOffsets != nil {
+		for i, offset := range wire.SplitOffsets {
+			if offset < 0 {
+				return nil, "", fmt.Errorf("split-offsets[%d] must be non-negative: %d", i, offset)
+			}
+			if i > 0 && offset <= wire.SplitOffsets[i-1] {
+				return nil, "", errors.New("split-offsets must be strictly increasing")
+			}
+		}
+		builder.SplitOffsets(slices.Clone(wire.SplitOffsets))
+	}
+	if wire.SortOrderID != nil {
+		if *wire.SortOrderID < 0 {
+			return nil, "", fmt.Errorf("sort-order-id must be non-negative: %d", *wire.SortOrderID)
+		}
+		builder.SortOrderID(*wire.SortOrderID)
+	}
+
+	return builder, format, nil
+}
+
+func decodePartition(
+	values []json.RawMessage,
+	spec *iceberg.PartitionSpec,
+	metadata table.ScanPlanningMetadata,
+) (map[int]any, map[int]string, map[int]int, error) {
+	if len(values) != spec.NumFields() {
+		return nil, nil, nil, fmt.Errorf(
+			"partition for spec ID %d has %d values, want %d", spec.ID(), len(values), spec.NumFields())
+	}
+
+	partition := make(map[int]any, len(values))
+	logicalTypes := make(map[int]string)
+	fixedSizes := make(map[int]int)
+	for i, field := range spec.Fields() {
+		raw := values[i]
+		if isJSONNull(raw) {
+			partition[field.FieldID] = nil
+
+			continue
+		}
+
+		sourceType, ok := findFieldType(field.SourceID(), metadata)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf(
+				"partition field %q (ID %d) has unknown source field ID %d",
+				field.Name, field.FieldID, field.SourceID())
+		}
+		resultType := field.Transform.ResultType(sourceType)
+		literal, err := decodePartitionLiteral(raw, resultType)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("partition[%d] for field %q: %w", i, field.Name, err)
+		}
+		partition[field.FieldID] = literal.Any()
+		setPartitionLogicalType(field.FieldID, resultType, logicalTypes, fixedSizes)
+	}
+
+	return partition, logicalTypes, fixedSizes, nil
+}
+
+func findFieldType(fieldID int, metadata table.ScanPlanningMetadata) (iceberg.Type, bool) {
+	if current := metadata.CurrentSchema(); current != nil {
+		if typ, ok := current.FindTypeByID(fieldID); ok {
+			return typ, true
+		}
+	}
+	for _, schema := range metadata.Schemas() {
+		if schema == nil {
+			continue
+		}
+		if typ, ok := schema.FindTypeByID(fieldID); ok {
+			return typ, true
+		}
+	}
+
+	return nil, false
+}
+
+func setPartitionLogicalType(fieldID int, typ iceberg.Type, logicalTypes map[int]string, fixedSizes map[int]int) {
+	switch typ := typ.(type) {
+	case iceberg.DateType:
+		logicalTypes[fieldID] = atype.Date
+	case iceberg.TimeType:
+		logicalTypes[fieldID] = atype.TimeMicros
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		logicalTypes[fieldID] = atype.TimestampMicros
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		logicalTypes[fieldID] = atype.TimestampNanos
+	case iceberg.DecimalType:
+		logicalTypes[fieldID] = atype.Decimal
+		fixedSizes[fieldID] = typ.Scale()
+	case iceberg.UUIDType:
+		logicalTypes[fieldID] = atype.UUID
+	}
+}
+
+func decodeCountMap(name string, wire *RESTCountMap) (map[int]int64, error) {
+	if wire == nil {
+		return nil, nil
+	}
+	if len(wire.Keys) != len(wire.Values) {
+		return nil, fmt.Errorf("%s has %d keys and %d values", name, len(wire.Keys), len(wire.Values))
+	}
+
+	out := make(map[int]int64, len(wire.Keys))
+	for i, key := range wire.Keys {
+		if key <= 0 {
+			return nil, fmt.Errorf("%s contains invalid field ID %d", name, key)
+		}
+		if _, ok := out[key]; ok {
+			return nil, fmt.Errorf("%s contains duplicate field ID %d", name, key)
+		}
+		if wire.Values[i] < 0 {
+			return nil, fmt.Errorf("%s[%d] for field ID %d is negative", name, i, key)
+		}
+		out[key] = wire.Values[i]
+	}
+
+	return out, nil
+}
+
+func decodeValueMap(name string, wire *RESTValueMap) (map[int][]byte, error) {
+	if wire == nil {
+		return nil, nil
+	}
+	if len(wire.Keys) != len(wire.Values) {
+		return nil, fmt.Errorf("%s has %d keys and %d values", name, len(wire.Keys), len(wire.Values))
+	}
+
+	out := make(map[int][]byte, len(wire.Keys))
+	for i, key := range wire.Keys {
+		if key <= 0 {
+			return nil, fmt.Errorf("%s contains invalid field ID %d", name, key)
+		}
+		if _, ok := out[key]; ok {
+			return nil, fmt.Errorf("%s contains duplicate field ID %d", name, key)
+		}
+		decoded, err := hex.DecodeString(wire.Values[i])
+		if err != nil {
+			return nil, fmt.Errorf("%s[%d] for field ID %d is not hexadecimal: %w", name, i, key, err)
+		}
+		out[key] = decoded
+	}
+
+	return out, nil
+}
+
+func decodePartitionLiteral(raw json.RawMessage, typ iceberg.Type) (iceberg.Literal, error) {
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("null is not valid for %s", typ)
+	}
+
+	var literal iceberg.Literal
+	switch typ := typ.(type) {
+	case iceberg.BooleanType:
+		var value bool
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("invalid boolean value: %w", err)
+		}
+		literal = iceberg.BoolLiteral(value)
+	case iceberg.Int32Type:
+		value, err := decodeJSONInteger(raw, 32)
+		if err != nil {
+			return nil, err
+		}
+		literal = iceberg.Int32Literal(int32(value))
+	case iceberg.Int64Type:
+		value, err := decodeJSONInteger(raw, 64)
+		if err != nil {
+			return nil, err
+		}
+		literal = iceberg.Int64Literal(value)
+	case iceberg.Float32Type:
+		value, err := decodeJSONFloat(raw, 32)
+		if err != nil {
+			return nil, err
+		}
+		literal = iceberg.Float32Literal(float32(value))
+	case iceberg.Float64Type:
+		value, err := decodeJSONFloat(raw, 64)
+		if err != nil {
+			return nil, err
+		}
+		literal = iceberg.Float64Literal(value)
+	case iceberg.BinaryType, iceberg.FixedType:
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("invalid %s hexadecimal value: %w", typ, err)
+		}
+		decoded, err := hex.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s hexadecimal value: %w", typ, err)
+		}
+		literal, err = iceberg.BinaryLiteral(decoded).To(typ)
+		if err != nil {
+			return nil, err
+		}
+	case iceberg.StringType, iceberg.UUIDType, iceberg.DateType, iceberg.TimeType,
+		iceberg.TimestampType, iceberg.TimestampTzType, iceberg.TimestampNsType,
+		iceberg.TimestampTzNsType, iceberg.DecimalType:
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, fmt.Errorf("invalid %s value: %w", typ, err)
+		}
+		var err error
+		literal, err = iceberg.StringLiteral(value).To(typ)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported REST primitive type %s", typ)
+	}
+
+	return literal, nil
+}
+
+func decodeJSONInteger(raw json.RawMessage, bitSize int) (int64, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value json.Number
+	if err := dec.Decode(&value); err != nil {
+		return 0, fmt.Errorf("invalid integer value: %w", err)
+	}
+	parsed, err := value.Int64()
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer value %q: %w", value, err)
+	}
+	if bitSize == 32 && (parsed < math.MinInt32 || parsed > math.MaxInt32) {
+		return 0, fmt.Errorf("integer value %d is outside int32 range", parsed)
+	}
+
+	return parsed, nil
+}
+
+func decodeJSONFloat(raw json.RawMessage, bitSize int) (float64, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value json.Number
+	if err := dec.Decode(&value); err != nil {
+		return 0, fmt.Errorf("invalid floating-point value: %w", err)
+	}
+	parsed, err := value.Float64()
+	if err != nil {
+		return 0, fmt.Errorf("invalid floating-point value %q: %w", value, err)
+	}
+	if math.IsInf(parsed, 0) || math.IsNaN(parsed) {
+		return 0, errors.New("floating-point value must be finite")
+	}
+	if bitSize == 32 && (parsed > math.MaxFloat32 || parsed < -math.MaxFloat32) {
+		return 0, fmt.Errorf("floating-point value %v is outside float32 range", parsed)
+	}
+
+	return parsed, nil
+}
+
+func decodeTaskResidual(
+	raw json.RawMessage,
+	schema *iceberg.Schema,
+	fallback iceberg.BooleanExpression,
+) (iceberg.BooleanExpression, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return fallback, nil
+	}
+
+	// Accept the object spelling from the OpenAPI schema in addition to the
+	// bare booleans emitted by Java's ExpressionParser.
+	var constant struct {
+		Type string `json:"type"`
+	}
+	if trimmed[0] == '{' && json.Unmarshal(trimmed, &constant) == nil {
+		switch constant.Type {
+		case "true":
+			return iceberg.AlwaysTrue{}, nil
+		case "false":
+			return iceberg.AlwaysFalse{}, nil
+		}
+	}
+
+	return iceberg.ParseExpr(trimmed, schema)
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -219,6 +219,71 @@ func TestRESTValueMapMatchesJavaContentFileParser(t *testing.T) {
 	require.Error(t, err, "bounds are binary hex strings, not typed JSON values")
 }
 
+func TestRESTValueMapUsesIcebergBinaryEncoding(t *testing.T) {
+	t.Parallel()
+
+	var bounds RESTValueMap
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{
+			"keys": [1, 2, 3],
+			"values": ["22000000", "04D2", "15CD5B0700000000"]
+		}`),
+		&bounds,
+	))
+	decoded, err := decodeValueMap("lower-bounds", &bounds)
+	require.NoError(t, err)
+
+	decimalType := iceberg.DecimalTypeOf(9, 2)
+	tests := []struct {
+		name    string
+		fieldID int
+		typ     iceberg.Type
+		want    iceberg.Literal
+	}{
+		{
+			name:    "int little-endian",
+			fieldID: 1,
+			typ:     iceberg.PrimitiveTypes.Int32,
+			want:    iceberg.Int32Literal(34),
+		},
+		{
+			name:    "decimal big-endian",
+			fieldID: 2,
+			typ:     decimalType,
+			want:    mustLiteral(t, "12.34", decimalType),
+		},
+		{
+			name:    "timestamp little-endian",
+			fieldID: 3,
+			typ:     iceberg.PrimitiveTypes.Timestamp,
+			want:    iceberg.TimestampLiteral(123456789),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			literal, err := iceberg.LiteralFromBytes(tt.typ, decoded[tt.fieldID])
+			require.NoError(t, err)
+			assert.Truef(t, tt.want.Equals(literal), "got %s, want %s", literal, tt.want)
+		})
+	}
+}
+
+func TestDecodeScanTasksKeyMetadataMatchesJavaContentFileParser(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	wire := validScanTasksWire()
+	// This value mirrors Java TestContentFileParser's all-optional data-file
+	// fixture. SingleValueParser encodes binary values as hexadecimal strings.
+	wire.FileScanTasks[0].DataFile.KeyMetadata = stringPtr("00000000000000000000000000000000")
+
+	tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, make([]byte, 16), tasks[0].File.KeyMetadata())
+}
+
 func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 	t.Parallel()
 
@@ -269,6 +334,13 @@ func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 				w.FileScanTasks[0].DeleteFileReferences = []int{0, 0}
 			},
 			want: "repeats delete-file reference 0",
+		},
+		{
+			name: "unreferenced delete file",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DeleteFileReferences = nil
+			},
+			want: "delete-files[0] is not referenced by any file scan task",
 		},
 		{
 			name: "count map length mismatch",
@@ -484,8 +556,11 @@ func validScanTasksWire() ScanTasks {
 	deleteFile.FilePath = "s3://bucket/table/delete.parquet"
 
 	return ScanTasks{
-		FileScanTasks: []RESTFileScanTask{{DataFile: &RESTDataFile{RESTContentFile: data}}},
-		DeleteFiles:   []RESTDeleteFile{{RESTContentFile: deleteFile}},
+		FileScanTasks: []RESTFileScanTask{{
+			DataFile:             &RESTDataFile{RESTContentFile: data},
+			DeleteFileReferences: []int{0},
+		}},
+		DeleteFiles: []RESTDeleteFile{{RESTContentFile: deleteFile}},
 	}
 }
 

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -330,14 +330,28 @@ func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 			mutate: func(w *ScanTasks) {
 				w.FileScanTasks[0].DataFile.RecordCount = -1
 			},
-			want: "record-count must be non-negative",
+			want: "record-count must be positive",
+		},
+		{
+			name: "zero record count",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.RecordCount = 0
+			},
+			want: "record-count must be positive",
 		},
 		{
 			name: "negative file size",
 			mutate: func(w *ScanTasks) {
 				w.FileScanTasks[0].DataFile.FileSizeInBytes = -1
 			},
-			want: "file-size-in-bytes must be non-negative",
+			want: "file-size-in-bytes must be positive",
+		},
+		{
+			name: "zero file size",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.FileSizeInBytes = 0
+			},
+			want: "file-size-in-bytes must be positive",
 		},
 		{
 			name: "referenced data file disagrees with task",

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -1,0 +1,530 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeScanTasksFullPayload(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	var wire ScanTasks
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"file-scan-tasks": [{
+			"data-file": {
+				"spec-id": 7,
+				"partition": [34, "2026-07-17", "78797A21"],
+				"content": "data",
+				"file-path": "s3://bucket/table/data.parquet",
+				"file-format": "parquet",
+				"file-size-in-bytes": 4096,
+				"record-count": 100,
+				"key-metadata": "0A0B",
+				"split-offsets": [4, 128],
+				"sort-order-id": 3,
+				"first-row-id": 99,
+				"column-sizes": {"keys": [1, 2], "values": [800, 1200]},
+				"value-counts": {"keys": [1, 2], "values": [100, 100]},
+				"null-value-counts": {"keys": [1, 2], "values": [0, 1]},
+				"nan-value-counts": {"keys": [7], "values": [2]},
+				"lower-bounds": {
+					"keys": [8, 9],
+					"values": ["01000000", "02000000"]
+				},
+				"upper-bounds": {
+					"keys": [8, 9],
+					"values": ["05000000", "0A000000"]
+				}
+			},
+			"delete-file-references": [0, 1, 2],
+			"residual-filter": {"type": "eq", "term": "id", "value": 34}
+		}],
+		"delete-files": [
+			{
+				"spec-id": 7,
+				"partition": [34, "2026-07-17", "78797A21"],
+				"content": "position-deletes",
+				"file-path": "s3://bucket/table/pos-delete.parquet",
+				"file-format": "parquet",
+				"file-size-in-bytes": 512,
+				"record-count": 5
+			},
+			{
+				"spec-id": 7,
+				"partition": [34, "2026-07-17", "78797A21"],
+				"content": "equality-deletes",
+				"file-path": "s3://bucket/table/eq-delete.parquet",
+				"file-format": "parquet",
+				"file-size-in-bytes": 256,
+				"record-count": 3,
+				"equality-ids": [1, 2]
+			},
+			{
+				"spec-id": 7,
+				"partition": [34, "2026-07-17", "78797A21"],
+				"content": "position-deletes",
+				"file-path": "s3://bucket/table/deletes.puffin",
+				"file-format": "puffin",
+				"file-size-in-bytes": 1024,
+				"record-count": 7,
+				"referenced-data-file": "s3://bucket/table/data.parquet",
+				"content-offset": 25,
+				"content-size-in-bytes": 50
+			}
+		]
+	}`), &wire))
+
+	tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, iceberg.AlwaysTrue{})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	task := tasks[0]
+	assert.Equal(t, "s3://bucket/table/data.parquet", task.File.FilePath())
+	assert.Equal(t, int64(4096), task.Length)
+	assert.Zero(t, task.Start)
+	assert.Equal(t, map[int]any{
+		1000: int64(34),
+		1001: iceberg.Date(20651),
+		1002: []byte("xyz!"),
+	}, task.File.Partition())
+	assert.Equal(t, []byte{0x0a, 0x0b}, task.File.KeyMetadata())
+	assert.Equal(t, []int64{4, 128}, task.File.SplitOffsets())
+	assert.Equal(t, intPtr(3), task.File.SortOrderID())
+	assert.Equal(t, int64Ptr(99), task.FirstRowID)
+	assert.Equal(t, map[int]int64{1: 800, 2: 1200}, task.File.ColumnSizes())
+	assert.Equal(t, map[int]int64{1: 100, 2: 100}, task.File.ValueCounts())
+	assert.Equal(t, map[int]int64{1: 0, 2: 1}, task.File.NullValueCounts())
+	assert.Equal(t, map[int]int64{7: 2}, task.File.NaNValueCounts())
+
+	// These vectors mirror Java TestContentFileParser: bounds are hexadecimal
+	// encodings of raw Iceberg binary values, not typed JSON single-values.
+	assert.Equal(t, []byte{1, 0, 0, 0}, task.File.LowerBoundValues()[8])
+	assert.Equal(t, []byte{2, 0, 0, 0}, task.File.LowerBoundValues()[9])
+	assert.Equal(t, []byte{5, 0, 0, 0}, task.File.UpperBoundValues()[8])
+	assert.Equal(t, []byte{10, 0, 0, 0}, task.File.UpperBoundValues()[9])
+
+	require.NotNil(t, task.Residual)
+	assert.True(t, task.Residual.Equals(iceberg.EqualTo(iceberg.Reference("id"), int64(34))))
+	require.Len(t, task.DeleteFiles, 1)
+	assert.Equal(t, "s3://bucket/table/pos-delete.parquet", task.DeleteFiles[0].FilePath())
+	require.Len(t, task.EqualityDeleteFiles, 1)
+	assert.Equal(t, []int{1, 2}, task.EqualityDeleteFiles[0].EqualityFieldIDs())
+	require.Len(t, task.DeletionVectorFiles, 1)
+	dv := task.DeletionVectorFiles[0]
+	assert.Equal(t, iceberg.PuffinFile, dv.FileFormat())
+	assert.Equal(t, stringPtr("s3://bucket/table/data.parquet"), dv.ReferencedDataFile())
+	assert.Equal(t, int64Ptr(25), dv.ContentOffset())
+	assert.Equal(t, int64Ptr(50), dv.ContentSizeInBytes())
+}
+
+func TestDecodeScanTasksUsesFallbackAndAcceptsSpecConstants(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	fallback := iceberg.GreaterThan(iceberg.Reference("id"), int64(10))
+	wire := validScanTasksWire()
+
+	tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, fallback)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Same(t, fallback, tasks[0].Residual)
+
+	wire.FileScanTasks[0].ResidualFilter = json.RawMessage(`{"type":"false"}`)
+	tasks, err = DecodeScanTasks(wire, metadata, metadata.schema, fallback)
+	require.NoError(t, err)
+	assert.True(t, tasks[0].Residual.Equals(iceberg.AlwaysFalse{}))
+}
+
+func TestDecodeScanTasksKeepsDeleteReferencesEnvelopeLocal(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	first := validScanTasksWire()
+	first.FileScanTasks[0].DeleteFileReferences = []int{0}
+	first.DeleteFiles[0].FilePath = "s3://bucket/table/first-delete.parquet"
+	second := validScanTasksWire()
+	second.FileScanTasks[0].DataFile.FilePath = "s3://bucket/table/second-data.parquet"
+	second.FileScanTasks[0].DeleteFileReferences = []int{0}
+	second.DeleteFiles[0].FilePath = "s3://bucket/table/second-delete.parquet"
+
+	firstTasks, err := DecodeScanTasks(first, metadata, metadata.schema, nil)
+	require.NoError(t, err)
+	secondTasks, err := DecodeScanTasks(second, metadata, metadata.schema, nil)
+	require.NoError(t, err)
+
+	require.Len(t, firstTasks, 1)
+	require.Len(t, firstTasks[0].DeleteFiles, 1)
+	assert.Equal(t, "s3://bucket/table/first-delete.parquet", firstTasks[0].DeleteFiles[0].FilePath())
+	require.Len(t, secondTasks, 1)
+	require.Len(t, secondTasks[0].DeleteFiles, 1)
+	assert.Equal(t, "s3://bucket/table/second-delete.parquet", secondTasks[0].DeleteFiles[0].FilePath())
+}
+
+func TestDecodeScanTasksDerivesDeletionVectorTargetWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	wire := validScanTasksWire()
+	wire.FileScanTasks[0].DeleteFileReferences = []int{0}
+	wire.DeleteFiles[0].FileFormat = "puffin"
+	wire.DeleteFiles[0].ContentOffset = int64Ptr(10)
+	wire.DeleteFiles[0].ContentSizeInBytes = int64Ptr(20)
+
+	tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.Len(t, tasks[0].DeletionVectorFiles, 1)
+	assert.Equal(t, stringPtr("s3://bucket/table/data.parquet"), tasks[0].DeletionVectorFiles[0].ReferencedDataFile())
+}
+
+func TestRESTValueMapMatchesJavaContentFileParser(t *testing.T) {
+	t.Parallel()
+
+	var bounds RESTValueMap
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"keys":[3,4],"values":["01000000","02000000"]}`),
+		&bounds,
+	))
+	decoded, err := decodeValueMap("lower-bounds", &bounds)
+	require.NoError(t, err)
+	assert.Equal(t, map[int][]byte{
+		3: {1, 0, 0, 0},
+		4: {2, 0, 0, 0},
+	}, decoded)
+
+	err = json.Unmarshal([]byte(`{"keys":[3],"values":[1]}`), &bounds)
+	require.Error(t, err, "bounds are binary hex strings, not typed JSON values")
+}
+
+func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	tests := []struct {
+		name   string
+		mutate func(*ScanTasks)
+		want   string
+	}{
+		{
+			name: "missing data file",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile = nil
+			},
+			want: "missing data-file",
+		},
+		{
+			name: "unknown spec",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.SpecID = 99
+			},
+			want: "unknown partition spec ID 99",
+		},
+		{
+			name: "wrong partition width",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.Partition = nil
+			},
+			want: "has 0 values, want 3",
+		},
+		{
+			name: "negative delete reference",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DeleteFileReferences = []int{-1}
+			},
+			want: "want 0 <= index",
+		},
+		{
+			name: "out of range delete reference",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DeleteFileReferences = []int{1}
+			},
+			want: "want 0 <= index < 1",
+		},
+		{
+			name: "duplicate delete reference",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DeleteFileReferences = []int{0, 0}
+			},
+			want: "repeats delete-file reference 0",
+		},
+		{
+			name: "count map length mismatch",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.ValueCounts = &RESTCountMap{Keys: []int{1}, Values: []int64{}}
+			},
+			want: "value-counts has 1 keys and 0 values",
+		},
+		{
+			name: "non-hexadecimal bound",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.LowerBounds = &RESTValueMap{
+					Keys: []int{1}, Values: []string{"not-hex"},
+				}
+			},
+			want: "is not hexadecimal",
+		},
+		{
+			name: "bad residual",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].ResidualFilter = json.RawMessage(`{"type":"wat"}`)
+			},
+			want: "unknown expression type",
+		},
+		{
+			name: "missing equality ids",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].Content = "equality-deletes"
+				w.DeleteFiles[0].EqualityIDs = nil
+			},
+			want: "missing equality-ids",
+		},
+		{
+			name: "equality delete with blob range",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].Content = "equality-deletes"
+				w.DeleteFiles[0].EqualityIDs = []int{1}
+				w.DeleteFiles[0].ContentOffset = int64Ptr(10)
+				w.DeleteFiles[0].ContentSizeInBytes = int64Ptr(20)
+			},
+			want: "must not carry position-delete reference or blob offsets",
+		},
+		{
+			name: "position delete with equality ids",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].EqualityIDs = []int{1}
+			},
+			want: "must not carry equality-ids",
+		},
+		{
+			name: "puffin missing blob range",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].FileFormat = "puffin"
+			},
+			want: "requires content-offset and content-size-in-bytes",
+		},
+		{
+			name: "negative record count",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.RecordCount = -1
+			},
+			want: "record-count must be non-negative",
+		},
+		{
+			name: "negative file size",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.FileSizeInBytes = -1
+			},
+			want: "file-size-in-bytes must be non-negative",
+		},
+		{
+			name: "referenced data file disagrees with task",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].ReferencedDataFile = stringPtr("s3://bucket/table/other.parquet")
+				w.FileScanTasks[0].DeleteFileReferences = []int{0}
+			},
+			want: "task data-file",
+		},
+		{
+			name: "deletion vector referenced by different data files",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].FileFormat = "puffin"
+				w.DeleteFiles[0].ContentOffset = int64Ptr(10)
+				w.DeleteFiles[0].ContentSizeInBytes = int64Ptr(20)
+				w.FileScanTasks[0].DeleteFileReferences = []int{0}
+				secondDataFile := *w.FileScanTasks[0].DataFile
+				secondDataFile.FilePath = "s3://bucket/table/other.parquet"
+				w.FileScanTasks = append(w.FileScanTasks, RESTFileScanTask{
+					DataFile:             &secondDataFile,
+					DeleteFileReferences: []int{0},
+				})
+			},
+			want: "is referenced by both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wire := validScanTasksWire()
+			tt.mutate(&wire)
+			_, err := DecodeScanTasks(wire, metadata, metadata.schema, iceberg.AlwaysTrue{})
+			require.ErrorIs(t, err, ErrRESTError)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestDecodeScanTasksRejectsDeleteFilesWithoutTasks(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	wire := validScanTasksWire()
+	wire.FileScanTasks = nil
+
+	_, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+	require.ErrorIs(t, err, ErrRESTError)
+	assert.ErrorContains(t, err, "delete files have no file scan tasks")
+}
+
+func TestDecodePartitionLiteralCoversPrimitiveWireTypes(t *testing.T) {
+	t.Parallel()
+
+	decimalType := iceberg.DecimalTypeOf(9, 2)
+	fixedType := iceberg.FixedTypeOf(4)
+	tests := []struct {
+		name string
+		raw  string
+		typ  iceberg.Type
+		want iceberg.Literal
+	}{
+		{"boolean", `true`, iceberg.PrimitiveTypes.Bool, iceberg.BoolLiteral(true)},
+		{"int", `2147483647`, iceberg.PrimitiveTypes.Int32, iceberg.Int32Literal(2147483647)},
+		{"long above JSON exact float range", `9007199254740993`, iceberg.PrimitiveTypes.Int64, iceberg.Int64Literal(9007199254740993)},
+		{"float", `1.25`, iceberg.PrimitiveTypes.Float32, iceberg.Float32Literal(1.25)},
+		{"double", `1.25`, iceberg.PrimitiveTypes.Float64, iceberg.Float64Literal(1.25)},
+		{"string", `"hello"`, iceberg.PrimitiveTypes.String, iceberg.StringLiteral("hello")},
+		{"date", `"2026-07-17"`, iceberg.PrimitiveTypes.Date, mustLiteral(t, "2026-07-17", iceberg.PrimitiveTypes.Date)},
+		{"time", `"10:15:30.123456"`, iceberg.PrimitiveTypes.Time, mustLiteral(t, "10:15:30.123456", iceberg.PrimitiveTypes.Time)},
+		{"timestamp", `"2026-07-17T10:15:30.123456"`, iceberg.PrimitiveTypes.Timestamp, mustLiteral(t, "2026-07-17T10:15:30.123456", iceberg.PrimitiveTypes.Timestamp)},
+		{"timestamptz", `"2026-07-17T10:15:30.123456+00:00"`, iceberg.PrimitiveTypes.TimestampTz, mustLiteral(t, "2026-07-17T10:15:30.123456+00:00", iceberg.PrimitiveTypes.TimestampTz)},
+		{"timestamp nanos", `"2026-07-17T10:15:30.123456789"`, iceberg.PrimitiveTypes.TimestampNs, mustLiteral(t, "2026-07-17T10:15:30.123456789", iceberg.PrimitiveTypes.TimestampNs)},
+		{"timestamptz nanos", `"2026-07-17T10:15:30.123456789+00:00"`, iceberg.PrimitiveTypes.TimestampTzNs, mustLiteral(t, "2026-07-17T10:15:30.123456789+00:00", iceberg.PrimitiveTypes.TimestampTzNs)},
+		{"decimal", `"12.34"`, decimalType, mustLiteral(t, "12.34", decimalType)},
+		{"uuid", `"f79c3e09-677c-4bbd-a479-3f349cb785e7"`, iceberg.PrimitiveTypes.UUID, mustLiteral(t, "f79c3e09-677c-4bbd-a479-3f349cb785e7", iceberg.PrimitiveTypes.UUID)},
+		{"fixed", `"78797A21"`, fixedType, iceberg.FixedLiteral([]byte("xyz!"))},
+		{"binary", `"00FF10"`, iceberg.PrimitiveTypes.Binary, iceberg.BinaryLiteral([]byte{0, 255, 16})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := decodePartitionLiteral(json.RawMessage(tt.raw), tt.typ)
+			require.NoError(t, err)
+			assert.Truef(t, got.Equals(tt.want), "got %s (%T), want %s (%T)", got, got, tt.want, tt.want)
+		})
+	}
+}
+
+func TestDecodePartitionLiteralRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		raw  string
+		typ  iceberg.Type
+		want string
+	}{
+		{"null", `null`, iceberg.PrimitiveTypes.Int64, "null is not valid"},
+		{"int32 overflow", `2147483648`, iceberg.PrimitiveTypes.Int32, "outside int32 range"},
+		{"long fraction", `1.5`, iceberg.PrimitiveTypes.Int64, "invalid integer value"},
+		{"wrong fixed width", `"00FF"`, iceberg.FixedTypeOf(4), "different length"},
+		{"invalid binary hex", `"XYZ"`, iceberg.PrimitiveTypes.Binary, "hexadecimal"},
+		{"nested value", `{"x":1}`, iceberg.PrimitiveTypes.String, "invalid string value"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := decodePartitionLiteral(json.RawMessage(tt.raw), tt.typ)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func validScanTasksWire() ScanTasks {
+	data := RESTContentFile{
+		SpecID:          7,
+		Partition:       []json.RawMessage{json.RawMessage(`34`), json.RawMessage(`"2026-07-17"`), json.RawMessage(`"78797A21"`)},
+		Content:         "data",
+		FilePath:        "s3://bucket/table/data.parquet",
+		FileFormat:      "parquet",
+		FileSizeInBytes: 100,
+		RecordCount:     10,
+	}
+	deleteFile := data
+	deleteFile.Content = "position-deletes"
+	deleteFile.FilePath = "s3://bucket/table/delete.parquet"
+
+	return ScanTasks{
+		FileScanTasks: []RESTFileScanTask{{DataFile: &RESTDataFile{RESTContentFile: data}}},
+		DeleteFiles:   []RESTDeleteFile{{RESTContentFile: deleteFile}},
+	}
+}
+
+type scanTaskDecoderMetadata struct {
+	schema *iceberg.Schema
+	spec   iceberg.PartitionSpec
+}
+
+func newScanTaskDecoderMetadata() *scanTaskDecoderMetadata {
+	schema := iceberg.NewSchema(10,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 3, Name: "event_date", Type: iceberg.PrimitiveTypes.Date},
+		iceberg.NestedField{ID: 4, Name: "amount", Type: iceberg.DecimalTypeOf(9, 2)},
+		iceberg.NestedField{ID: 5, Name: "code", Type: iceberg.FixedTypeOf(4)},
+		iceberg.NestedField{ID: 6, Name: "event_time", Type: iceberg.PrimitiveTypes.TimestampTzNs},
+		iceberg.NestedField{ID: 7, Name: "score", Type: iceberg.PrimitiveTypes.Float64},
+		iceberg.NestedField{ID: 8, Name: "lower_int", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 9, Name: "upper_int", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	spec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "id_part", Transform: iceberg.IdentityTransform{}},
+		iceberg.PartitionField{SourceIDs: []int{3}, FieldID: 1001, Name: "date_part", Transform: iceberg.IdentityTransform{}},
+		iceberg.PartitionField{SourceIDs: []int{5}, FieldID: 1002, Name: "code_part", Transform: iceberg.IdentityTransform{}},
+	)
+
+	return &scanTaskDecoderMetadata{schema: schema, spec: spec}
+}
+
+func (m *scanTaskDecoderMetadata) CurrentSchema() *iceberg.Schema { return m.schema }
+func (m *scanTaskDecoderMetadata) Schemas() []*iceberg.Schema     { return []*iceberg.Schema{m.schema} }
+func (m *scanTaskDecoderMetadata) PartitionSpec() iceberg.PartitionSpec {
+	return m.spec
+}
+
+func (m *scanTaskDecoderMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
+	if id != m.spec.ID() {
+		return nil
+	}
+
+	return &m.spec
+}
+func (*scanTaskDecoderMetadata) CurrentSnapshot() *table.Snapshot   { return nil }
+func (*scanTaskDecoderMetadata) SnapshotByID(int64) *table.Snapshot { return nil }
+func (*scanTaskDecoderMetadata) Properties() iceberg.Properties     { return nil }
+
+func mustLiteral(t *testing.T, value string, typ iceberg.Type) iceberg.Literal {
+	t.Helper()
+	literal, err := iceberg.StringLiteral(value).To(typ)
+	require.NoError(t, err)
+
+	return literal
+}
+
+func intPtr(value int) *int       { return &value }
+func int64Ptr(value int64) *int64 { return &value }

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -18,6 +18,10 @@
 package codec
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/apache/iceberg-go"
@@ -27,7 +31,8 @@ import (
 
 // EncodeFileScanTask encodes a FileScanTask for cross-process transport.
 // Each carried DataFile is encoded with [EncodeDataFile] and wrapped in
-// a small record that also carries the scan range and v3 row lineage.
+// a small record that also carries the scan range and v3 row lineage. A task
+// residual, when present, is appended as a framed JSON extension.
 // The (spec, schema, version) triple must match what [DecodeFileScanTask]
 // is given on the receiver.
 //
@@ -79,8 +84,31 @@ func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, sch
 		FirstRowID:          task.FirstRowID,
 		DataSequenceNumber:  task.DataSequenceNumber,
 	}
+	encodedTask, err := fileScanTaskSchema.Encode(&envelope)
+	if err != nil {
+		return nil, err
+	}
+	if task.Residual == nil {
+		return encodedTask, nil
+	}
 
-	return fileScanTaskSchema.Encode(&envelope)
+	encoded, err := json.Marshal(task.Residual)
+	if err != nil && schema != nil {
+		// Unbound timestamp predicates need the field type to choose timestamp
+		// versus timestamptz JSON. Bind only as a marshal fallback; already-bound
+		// expressions marshal directly and must not be rebound.
+		if bound, bindErr := iceberg.BindExpr(schema, task.Residual, true); bindErr == nil {
+			encoded, err = json.Marshal(bound)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: residual: %w", err)
+	}
+	encodedTask = append(encodedTask, fileScanTaskResidualMagic...)
+	encodedTask = binary.AppendUvarint(encodedTask, uint64(len(encoded)))
+	encodedTask = append(encodedTask, encoded...)
+
+	return encodedTask, nil
 }
 
 // DecodeFileScanTask reverses [EncodeFileScanTask]. The triple
@@ -90,7 +118,8 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: unsupported format version %d", version)
 	}
 	var envelope fileScanTaskEnvelope
-	if _, err := fileScanTaskSchema.Decode(data, &envelope); err != nil {
+	rest, err := fileScanTaskSchema.Decode(data, &envelope)
+	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: decode: %w", err)
 	}
 	if envelope.Start < 0 {
@@ -115,6 +144,10 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: deletion vector files: %w", err)
 	}
+	residual, err := decodeFileScanTaskResidual(rest, schema)
+	if err != nil {
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: residual: %w", err)
+	}
 
 	return table.FileScanTask{
 		File:                file,
@@ -123,6 +156,7 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 		DeletionVectorFiles: dv,
 		Start:               envelope.Start,
 		Length:              envelope.Length,
+		Residual:            residual,
 		FirstRowID:          envelope.FirstRowID,
 		DataSequenceNumber:  envelope.DataSequenceNumber,
 	}, nil
@@ -135,24 +169,25 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 // table.FileScanTask gains, loses, renames, retypes, or reorders a
 // field. That forces a deliberate decision about whether the change
 // must be carried by [EncodeFileScanTask] / [DecodeFileScanTask]; when
-// extending, update fileScanTaskEnvelope, the schema JSON below, the
-// encode/decode bodies, and this shape together.
+// extending, update the base envelope or extension framing, the encode/decode
+// bodies, and this shape together.
 type fileScanTaskShape struct {
 	File                iceberg.DataFile
 	DeleteFiles         []iceberg.DataFile
 	EqualityDeleteFiles []iceberg.DataFile
 	DeletionVectorFiles []iceberg.DataFile
 	Start, Length       int64
+	Residual            iceberg.BooleanExpression
 	FirstRowID          *int64
 	DataSequenceNumber  *int64
 }
 
 var _ = table.FileScanTask(fileScanTaskShape{})
 
-// fileScanTaskEnvelope is the avro on-wire shape. The DataFile payloads
+// fileScanTaskEnvelope is the base Avro on-wire shape. The DataFile payloads
 // (File and the three delete-file lists) are themselves [EncodeDataFile]
-// bytes; this struct only frames them along with the scan range and v3
-// lineage.
+// bytes; this struct frames them with the scan range and v3 lineage. Optional
+// extensions such as Residual are appended after this stable base envelope.
 type fileScanTaskEnvelope struct {
 	File                []byte   `avro:"file"`
 	DeleteFiles         [][]byte `avro:"delete_files"`
@@ -181,12 +216,38 @@ const fileScanTaskSchemaJSON = `{
 
 var fileScanTaskSchema *avro.Schema
 
+// Residuals are framed as an optional extension after the original Avro
+// envelope. Keeping the envelope schema byte-for-byte stable lets the new
+// decoder read legacy payloads and lets legacy decoders continue reading the
+// known prefix (they already ignored the bytes returned by Schema.Decode).
+var fileScanTaskResidualMagic = []byte{0xf5, 'r', 'e', 's', 1}
+
 func init() {
 	s, err := avro.Parse(fileScanTaskSchemaJSON)
 	if err != nil {
 		panic("codec: fileScanTaskSchema invalid: " + err.Error())
 	}
 	fileScanTaskSchema = s
+}
+
+func decodeFileScanTaskResidual(data []byte, schema *iceberg.Schema) (iceberg.BooleanExpression, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if !bytes.HasPrefix(data, fileScanTaskResidualMagic) {
+		return nil, errors.New("unknown trailing extension")
+	}
+	data = data[len(fileScanTaskResidualMagic):]
+	size, n := binary.Uvarint(data)
+	if n <= 0 {
+		return nil, errors.New("invalid residual length")
+	}
+	data = data[n:]
+	if size != uint64(len(data)) {
+		return nil, fmt.Errorf("residual length is %d, payload has %d bytes", size, len(data))
+	}
+
+	return iceberg.ParseExpr(data, schema)
 }
 
 // checkDataFileSpecID verifies a data file's SpecID matches the codec spec.

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -18,6 +18,7 @@
 package codec
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -46,6 +47,30 @@ func TestDecodeFileScanTaskInnerErrorCarriesMarker(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "codec: DecodeFileScanTask: file:",
 		"an inner (primary-file) decode error must carry the function + sub-path marker")
+}
+
+func TestDecodeFileScanTaskResidualExtension(t *testing.T) {
+	schema := iceberg.NewSchema(123,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+	)
+	payload := []byte(`{"type":"eq","term":"id","value":42}`)
+	extension := append([]byte(nil), fileScanTaskResidualMagic...)
+	extension = binary.AppendUvarint(extension, uint64(len(payload)))
+	extension = append(extension, payload...)
+
+	residual, err := decodeFileScanTaskResidual(extension, schema)
+	require.NoError(t, err)
+	require.True(t, residual.Equals(iceberg.EqualTo(iceberg.Reference("id"), int64(42))))
+
+	legacy, err := decodeFileScanTaskResidual(nil, schema)
+	require.NoError(t, err)
+	require.Nil(t, legacy)
+
+	_, err = decodeFileScanTaskResidual([]byte("unknown"), schema)
+	require.ErrorContains(t, err, "unknown trailing extension")
+
+	_, err = decodeFileScanTaskResidual(extension[:len(extension)-1], schema)
+	require.ErrorContains(t, err, "residual length")
 }
 
 func TestDecodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -69,6 +69,8 @@ func TestEncodeDecodeFileScanTaskRoundTrip(t *testing.T) {
 			require.Equal(t, original.Length, decoded.Length)
 			require.Equal(t, original.FirstRowID, decoded.FirstRowID)
 			require.Equal(t, original.DataSequenceNumber, decoded.DataSequenceNumber)
+			require.NotNil(t, decoded.Residual)
+			require.True(t, decoded.Residual.Equals(original.Residual))
 		})
 	}
 }
@@ -154,6 +156,7 @@ func TestEncodeFileScanTaskEmptyDeleteLists(t *testing.T) {
 	task.DeleteFiles = nil
 	task.EqualityDeleteFiles = nil
 	task.DeletionVectorFiles = nil
+	task.Residual = nil
 
 	bytes, err := codec.EncodeFileScanTask(task, spec, schema, 2)
 	require.NoError(t, err)
@@ -163,6 +166,38 @@ func TestEncodeFileScanTaskEmptyDeleteLists(t *testing.T) {
 	require.Empty(t, decoded.DeleteFiles)
 	require.Empty(t, decoded.EqualityDeleteFiles)
 	require.Empty(t, decoded.DeletionVectorFiles)
+	require.Nil(t, decoded.Residual)
+}
+
+func TestEncodeFileScanTaskTimestampResidualUsesSchema(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "event_time", Type: iceberg.PrimitiveTypes.TimestampTz, Required: true},
+	)
+	spec := *iceberg.UnpartitionedSpec
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"s3://bucket/data.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		10,
+		100,
+	)
+	require.NoError(t, err)
+	task := table.FileScanTask{
+		File:     builder.Build(),
+		Length:   100,
+		Residual: iceberg.EqualTo(iceberg.Reference("event_time"), iceberg.Timestamp(1_700_000_000_000_000)),
+	}
+
+	encoded, err := codec.EncodeFileScanTask(task, spec, schema, 2)
+	require.NoError(t, err)
+	decoded, err := codec.DecodeFileScanTask(encoded, spec, schema, 2)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.Residual)
+	require.True(t, decoded.Residual.Equals(task.Residual))
 }
 
 func TestEncodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
@@ -206,6 +241,7 @@ func fullyPopulatedFileScanTask(t *testing.T, version int) (iceberg.PartitionSpe
 		DeleteFiles:        []iceberg.DataFile{delete1},
 		Start:              0,
 		Length:             1024 * 1024,
+		Residual:           iceberg.EqualTo(iceberg.Reference("id"), int64(42)),
 		FirstRowID:         &firstRow,
 		DataSequenceNumber: &dataSeq,
 	}

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -136,11 +136,6 @@ type ScanPlanningResult struct {
 //
 // SupportsRemoteScanPlanning reports whether the planner can complete a remote
 // plan end-to-end for the requested scan.
-//
-// Note: FileScanTask is proposed to gain a `Residual iceberg.BooleanExpression`
-// field so remote tasks can carry the server's residual filter. That field is
-// not added here because it would trip the codec/file_scan_task.go drift guard;
-// it lands with the scan-task decoder PR.
 type ScanPlanner interface {
 	SupportsRemoteScanPlanning() bool
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -901,6 +901,14 @@ type FileScanTask struct {
 	EqualityDeleteFiles []iceberg.DataFile // equality delete files
 	DeletionVectorFiles []iceberg.DataFile // deletion vectors (puffin files)
 	Start, Length       int64
+	// Residual is the portion of the scan filter that must still be evaluated
+	// for this task. Remote planners may simplify the original filter using
+	// file metadata; nil means the caller did not provide a task residual.
+	// ReadTasks currently applies the Scan's original row filter and does not
+	// consume this per-task value. Remote integration must preserve that original
+	// filter until per-task residual evaluation is wired; otherwise tasks read
+	// outside their originating Scan could under-filter rows.
+	Residual iceberg.BooleanExpression
 
 	// Row lineage (v3): constants used when reading to synthesize _row_id and _last_updated_sequence_number.
 	// FirstRowID is the effective first_row_id for this file (from manifest entry, after inheritance).


### PR DESCRIPTION
## Summary

Implements REST scan-task payload decoding as part of [#1178](https://github.com/apache/iceberg-go/issues/1178).

This converts REST `ScanTasks` responses into `table.FileScanTask` values, including data files, delete files, metrics, partitions, bounds, and residual filters.

## Changes

- Adds REST wire types for content files, count maps, bounds, data files, and delete files. These (`RESTContentFile`/`RESTDataFile`/`RESTFileScanTask`/`RESTDeleteFile`) are exported as part of the existing `ScanTasks` response surface introduced as stubs in #1324.
- Adds `DecodeScanTasks` with metadata-aware partition and residual decoding.
- Decodes partition values using their partition transform result types.
- Decodes lower and upper bounds from Java-compatible hexadecimal binary values.
- Resolves envelope-local delete-file references.
- Classifies positional deletes, equality deletes, and Puffin deletion vectors.
- Supports and validates Java's optional `referenced-data-file` field, while deriving the target for deletion vectors when omitted.
- Validates malformed metrics, references, content variants, file sizes, record counts, split offsets, and equality IDs.
- Adds `Residual` to `table.FileScanTask`.
- Extends the existing `FileScanTask` codec with an optional framed residual extension:
  - New decoders can read legacy payloads.
  - Existing decoders continue reading the unchanged Avro envelope prefix.

Bounds fixtures mirror Java's authoritative `TestContentFileParser`, where values are hexadecimal encodings of raw Iceberg binary values, for example:

    "lower-bounds":{"keys":[3,4],"values":["01000000","02000000"]}

## Scope

This PR implements decoding only. It does not add plan-task fanout, `PlanFiles` orchestration, storage-credential handling, capability enablement, or the fake REST planning server.

`DecodeScanTasks` is a standalone building block with no production caller in this PR; `PlanFiles` will invoke it in a follow-up.

`ReadTasks` currently continues applying the Scan's original row filter and does not consume per-task residuals. This preserves correctness for scans using their originating `Scan`, but applying task-specific residuals remains follow-up work before decoded tasks can be consumed independently.

Delete-file references are scoped to each `ScanTasks` response, so callers must decode each response before combining results.

## Testing

    go test ./...
    go test -race ./catalog/rest ./codec ./table
    go vet ./catalog/rest ./codec ./table
    git diff --check
