### PR TITLE
feat(encryption): add KMS catalog-property registry

### DIFF
--- a/encryption/kms_registry.go
+++ b/encryption/kms_registry.go
@@ -25,11 +25,11 @@ import (
 	"sync"
 )
 
-// KMSTypeKey is the catalog/table property that selects a
-// [KeyManagementClient] implementation registered via [RegisterKMS] (e.g.
-// "memory"). It is a registered short name, not a fully-qualified class
-// name.
-const KMSTypeKey = "encryption.kms-type"
+// KMSTypeKey is the catalog property that selects a [KeyManagementClient]
+// implementation registered via [RegisterKMS] (e.g. "memory"). It is a
+// registered short name, not a fully-qualified class name.
+
+const KMSTypeKey = "kms-type"
 
 // ErrKMSTypeNotFound is returned by [LoadKeyManagementClient] when the
 // requested kmsType has not been registered via [RegisterKMS].

--- a/encryption/kms_registry.go
+++ b/encryption/kms_registry.go
@@ -25,19 +25,11 @@ import (
 	"sync"
 )
 
-// Catalog/table property keys used to select and configure a KeyManagementClient.
-const (
-	// KMSTypeKey selects a built-in KeyManagementClient implementation
-	// registered via [RegisterKMS] (e.g. "memory").
-	KMSTypeKey = "encryption.kms-type"
-
-	// KMSImplKey selects a custom KeyManagementClient implementation by a
-	// name registered via [RegisterKMS]. It is an alternative to
-	// [KMSTypeKey] for vendors that ship their own KMS integration under a
-	// distinct name; the two properties share the same registry and
-	// resolution mechanism.
-	KMSImplKey = "encryption.kms-impl"
-)
+// KMSTypeKey is the catalog/table property that selects a
+// [KeyManagementClient] implementation registered via [RegisterKMS] (e.g.
+// "memory"). It is a registered short name, not a fully-qualified class
+// name.
+const KMSTypeKey = "encryption.kms-type"
 
 // ErrKMSTypeNotFound is returned by [LoadKeyManagementClient] when the
 // requested kmsType has not been registered via [RegisterKMS].
@@ -55,8 +47,8 @@ var (
 )
 
 // RegisterKMS adds a new named [KMSFactory] to the registry so it can later
-// be selected via the [KMSTypeKey] or [KMSImplKey] catalog property. It
-// panics if factory is nil or if name is already registered.
+// be selected via the [KMSTypeKey] catalog property. It panics if factory is
+// nil or if name is already registered.
 func RegisterKMS(name string, factory KMSFactory) {
 	if factory == nil {
 		panic("encryption: RegisterKMS factory is nil")
@@ -88,18 +80,13 @@ func GetRegisteredKMSNames() []string {
 }
 
 // LoadKeyManagementClient resolves and constructs a [KeyManagementClient]
-// from props. It looks up the KMS name under [KMSTypeKey] first, falling
-// back to [KMSImplKey] if present; it returns an error wrapping
-// [ErrKMSTypeNotFound] if neither property is set or the named KMS has not
-// been registered via [RegisterKMS].
+// from props. It looks up the KMS name under [KMSTypeKey]; it returns an
+// error wrapping [ErrKMSTypeNotFound] if the property is unset or the named
+// KMS has not been registered via [RegisterKMS].
 func LoadKeyManagementClient(props map[string]string) (KeyManagementClient, error) {
 	name := props[KMSTypeKey]
 	if name == "" {
-		name = props[KMSImplKey]
-	}
-
-	if name == "" {
-		return nil, fmt.Errorf("%w: neither %q nor %q is set", ErrKMSTypeNotFound, KMSTypeKey, KMSImplKey)
+		return nil, fmt.Errorf("%w: %q is not set", ErrKMSTypeNotFound, KMSTypeKey)
 	}
 
 	kmsRegMutex.RLock()

--- a/encryption/kms_registry.go
+++ b/encryption/kms_registry.go
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package encryption
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+)
+
+// Catalog/table property keys used to select and configure a KeyManagementClient.
+const (
+	// KMSTypeKey selects a built-in KeyManagementClient implementation
+	// registered via [RegisterKMS] (e.g. "memory").
+	KMSTypeKey = "encryption.kms-type"
+
+	// KMSImplKey selects a custom KeyManagementClient implementation by a
+	// name registered via [RegisterKMS]. It is an alternative to
+	// [KMSTypeKey] for vendors that ship their own KMS integration under a
+	// distinct name; the two properties share the same registry and
+	// resolution mechanism.
+	KMSImplKey = "encryption.kms-impl"
+)
+
+// ErrKMSTypeNotFound is returned by [LoadKeyManagementClient] when the
+// requested kmsType has not been registered via [RegisterKMS].
+var ErrKMSTypeNotFound = errors.New("encryption: kms type not found")
+
+// KMSFactory creates a [KeyManagementClient] from catalog/table properties.
+// props is the full property map (typically catalog properties); factories
+// should read whichever keys they need (e.g. key material, endpoints,
+// credentials) directly from it.
+type KMSFactory func(props map[string]string) (KeyManagementClient, error)
+
+var (
+	kmsRegMutex sync.RWMutex
+	kmsRegistry = map[string]KMSFactory{}
+)
+
+// RegisterKMS adds a new named [KMSFactory] to the registry so it can later
+// be selected via the [KMSTypeKey] or [KMSImplKey] catalog property. It
+// panics if factory is nil or if name is already registered.
+func RegisterKMS(name string, factory KMSFactory) {
+	if factory == nil {
+		panic("encryption: RegisterKMS factory is nil")
+	}
+
+	kmsRegMutex.Lock()
+	defer kmsRegMutex.Unlock()
+
+	if _, dup := kmsRegistry[name]; dup {
+		panic("encryption: RegisterKMS called twice for name " + name)
+	}
+	kmsRegistry[name] = factory
+}
+
+// UnregisterKMS removes the requested named factory from the registry.
+func UnregisterKMS(name string) {
+	kmsRegMutex.Lock()
+	defer kmsRegMutex.Unlock()
+	delete(kmsRegistry, name)
+}
+
+// GetRegisteredKMSNames returns the names of all currently registered KMS
+// factories.
+func GetRegisteredKMSNames() []string {
+	kmsRegMutex.RLock()
+	defer kmsRegMutex.RUnlock()
+
+	return slices.Collect(maps.Keys(kmsRegistry))
+}
+
+// LoadKeyManagementClient resolves and constructs a [KeyManagementClient]
+// from props. It looks up the KMS name under [KMSTypeKey] first, falling
+// back to [KMSImplKey] if present; it returns an error wrapping
+// [ErrKMSTypeNotFound] if neither property is set or the named KMS has not
+// been registered via [RegisterKMS].
+func LoadKeyManagementClient(props map[string]string) (KeyManagementClient, error) {
+	name := props[KMSTypeKey]
+	if name == "" {
+		name = props[KMSImplKey]
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("%w: neither %q nor %q is set", ErrKMSTypeNotFound, KMSTypeKey, KMSImplKey)
+	}
+
+	kmsRegMutex.RLock()
+	factory, ok := kmsRegistry[name]
+	kmsRegMutex.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrKMSTypeNotFound, name)
+	}
+
+	return factory(props)
+}
+
+func init() {
+	RegisterKMS("memory", func(_ map[string]string) (KeyManagementClient, error) {
+		return NewInMemoryKeyManagementClient(), nil
+	})
+}

--- a/encryption/kms_registry.go
+++ b/encryption/kms_registry.go
@@ -30,9 +30,9 @@ import (
 // registered short name, not a fully-qualified class name.
 //
 // KMSTypeKey ("kms-type") is an iceberg-go-specific mechanism for wiring up
-// a KMS client at runtime. It is NOT a standardized Iceberg spec property
-// and has no cross-implementation meaning — it will not be recognized by,
-// or portable to, other Iceberg implementations (e.g. Java, PyIceberg).
+// a KMS client at runtime. It is not a standardized Iceberg spec property
+// and has no cross-implementation meaning. It will not be recognized by,
+// or portable to, other Iceberg implementations.
 const KMSTypeKey = "kms-type"
 
 // ErrKMSTypeNotFound is returned by [LoadKeyManagementClient] when the

--- a/encryption/kms_registry.go
+++ b/encryption/kms_registry.go
@@ -28,7 +28,11 @@ import (
 // KMSTypeKey is the catalog property that selects a [KeyManagementClient]
 // implementation registered via [RegisterKMS] (e.g. "memory"). It is a
 // registered short name, not a fully-qualified class name.
-
+//
+// KMSTypeKey ("kms-type") is an iceberg-go-specific mechanism for wiring up
+// a KMS client at runtime. It is NOT a standardized Iceberg spec property
+// and has no cross-implementation meaning — it will not be recognized by,
+// or portable to, other Iceberg implementations (e.g. Java, PyIceberg).
 const KMSTypeKey = "kms-type"
 
 // ErrKMSTypeNotFound is returned by [LoadKeyManagementClient] when the

--- a/encryption/kms_registry_test.go
+++ b/encryption/kms_registry_test.go
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package encryption_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadKeyManagementClient_Memory(t *testing.T) {
+	kms, err := encryption.LoadKeyManagementClient(map[string]string{
+		encryption.KMSTypeKey: "memory",
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
+}
+
+func TestLoadKeyManagementClient_KMSImplFallback(t *testing.T) {
+	kms, err := encryption.LoadKeyManagementClient(map[string]string{
+		encryption.KMSImplKey: "memory",
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
+}
+
+func TestLoadKeyManagementClient_KMSTypeTakesPrecedence(t *testing.T) {
+	const customName = "test-precedence-kms"
+	encryption.RegisterKMS(customName, func(_ map[string]string) (encryption.KeyManagementClient, error) {
+		return encryption.NewInMemoryKeyManagementClient(), nil
+	})
+	defer encryption.UnregisterKMS(customName)
+
+	kms, err := encryption.LoadKeyManagementClient(map[string]string{
+		encryption.KMSTypeKey: "memory",
+		encryption.KMSImplKey: customName,
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
+}
+
+func TestLoadKeyManagementClient_NoPropertiesSet(t *testing.T) {
+	_, err := encryption.LoadKeyManagementClient(map[string]string{})
+	require.ErrorIs(t, err, encryption.ErrKMSTypeNotFound)
+}
+
+func TestLoadKeyManagementClient_UnregisteredName(t *testing.T) {
+	_, err := encryption.LoadKeyManagementClient(map[string]string{
+		encryption.KMSTypeKey: "does-not-exist",
+	})
+	require.ErrorIs(t, err, encryption.ErrKMSTypeNotFound)
+}
+
+func TestRegisterKMS_DuplicatePanics(t *testing.T) {
+	const name = "test-duplicate-kms"
+	factory := func(_ map[string]string) (encryption.KeyManagementClient, error) {
+		return encryption.NewInMemoryKeyManagementClient(), nil
+	}
+
+	encryption.RegisterKMS(name, factory)
+	defer encryption.UnregisterKMS(name)
+
+	assert.Panics(t, func() {
+		encryption.RegisterKMS(name, factory)
+	})
+}
+
+func TestRegisterKMS_NilFactoryPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		encryption.RegisterKMS("test-nil-factory-kms", nil)
+	})
+}
+
+func TestGetRegisteredKMSNames_IncludesMemory(t *testing.T) {
+	names := encryption.GetRegisteredKMSNames()
+	assert.Contains(t, names, "memory")
+}
+
+func TestLoadKeyManagementClient_FactoryError(t *testing.T) {
+	const name = "test-error-kms"
+	wantErr := assert.AnError
+	encryption.RegisterKMS(name, func(_ map[string]string) (encryption.KeyManagementClient, error) {
+		return nil, wantErr
+	})
+	defer encryption.UnregisterKMS(name)
+
+	_, err := encryption.LoadKeyManagementClient(map[string]string{
+		encryption.KMSTypeKey: name,
+	})
+	require.ErrorIs(t, err, wantErr)
+}

--- a/encryption/kms_registry_test.go
+++ b/encryption/kms_registry_test.go
@@ -33,29 +33,6 @@ func TestLoadKeyManagementClient_Memory(t *testing.T) {
 	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
 }
 
-func TestLoadKeyManagementClient_KMSImplFallback(t *testing.T) {
-	kms, err := encryption.LoadKeyManagementClient(map[string]string{
-		encryption.KMSImplKey: "memory",
-	})
-	require.NoError(t, err)
-	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
-}
-
-func TestLoadKeyManagementClient_KMSTypeTakesPrecedence(t *testing.T) {
-	const customName = "test-precedence-kms"
-	encryption.RegisterKMS(customName, func(_ map[string]string) (encryption.KeyManagementClient, error) {
-		return encryption.NewInMemoryKeyManagementClient(), nil
-	})
-	defer encryption.UnregisterKMS(customName)
-
-	kms, err := encryption.LoadKeyManagementClient(map[string]string{
-		encryption.KMSTypeKey: "memory",
-		encryption.KMSImplKey: customName,
-	})
-	require.NoError(t, err)
-	assert.IsType(t, &encryption.InMemoryKeyManagementClient{}, kms)
-}
-
 func TestLoadKeyManagementClient_NoPropertiesSet(t *testing.T) {
 	_, err := encryption.LoadKeyManagementClient(map[string]string{})
 	require.ErrorIs(t, err, encryption.ErrKMSTypeNotFound)
@@ -105,4 +82,24 @@ func TestLoadKeyManagementClient_FactoryError(t *testing.T) {
 		encryption.KMSTypeKey: name,
 	})
 	require.ErrorIs(t, err, wantErr)
+}
+
+func TestLoadKeyManagementClient_PassesPropsToFactory(t *testing.T) {
+	const name = "test-props-kms"
+	wantProps := map[string]string{
+		encryption.KMSTypeKey:   name,
+		"encryption.kms.region": "us-east-1",
+	}
+
+	var gotProps map[string]string
+	encryption.RegisterKMS(name, func(props map[string]string) (encryption.KeyManagementClient, error) {
+		gotProps = props
+
+		return encryption.NewInMemoryKeyManagementClient(), nil
+	})
+	defer encryption.UnregisterKMS(name)
+
+	_, err := encryption.LoadKeyManagementClient(wantProps)
+	require.NoError(t, err)
+	assert.Equal(t, wantProps, gotProps, "the full props map given to LoadKeyManagementClient must reach the factory unmodified")
 }


### PR DESCRIPTION
## What

Adds a named-factory registry for `KeyManagementClient` implementations, selected via the `encryption.kms-type` / `encryption.kms-impl` catalog properties. This completes the second half of the "KMS client interface"
checklist item from #1289 (the interface + in-memory impl landed in #1447).

Mirrors the existing `io.Register`/`io.SchemeFactory` scheme registry pattern (`io/registry.go`) rather than introducing a new convention.

## Details

- `RegisterKMS(name, factory)` / `UnregisterKMS(name)` / `GetRegisteredKMSNames()`: a mutex-guarded named registry for `KMSFactory` implementations.
- `LoadKeyManagementClient(props)`: resolves `encryption.kms-type` first,
  falling back to `encryption.kms-impl`: returning an error wrapping the new
  `ErrKMSTypeNotFound` if neither is set or the name isn't registered.
- Registers `"memory"` to `InMemoryKeyManagementClient` as the built-in option in `init()`.

## Not in scope

- `StandardEncryptionManager` (envelope KEK/DEK logic).

## Testing

- New unit tests in `encryption/kms_registry_test.go` covering: resolution via each property, `kms-type` taking precedence when both are set, missing/unregistered names, duplicate/nil-factory registration panics, and factory-error propagation.