### PR TITLE
test(rest): add fake server for REST scan planning

### DIFF
--- a/catalog/rest/internal/planfake/scenario.go
+++ b/catalog/rest/internal/planfake/scenario.go
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package planfake provides a deterministic in-process REST scan-planning
+// server for tests. It intentionally uses independent JSON responses instead
+// of the production REST wire structs.
+package planfake
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Scan-planning endpoint strings as advertised by GET /v1/config. These are
+// literal protocol fixtures, deliberately independent from catalog/rest's
+// endpoint constants so a production wire-format regression cannot update
+// both sides of a test unnoticed.
+const (
+	PlanTableScanEndpoint       = "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan"
+	FetchPlanningResultEndpoint = "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/{plan-id}"
+	CancelPlanningEndpoint      = "DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/{plan-id}"
+	FetchScanTasksEndpoint      = "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/tasks"
+)
+
+// Response is one HTTP response in a scenario. A zero Status means 200 OK.
+// Header and Body are cloned when the server is created and again before a
+// response is written, so callers may safely reuse or mutate their fixtures.
+// When Gate is non-nil, the server waits for it to close or receive a value
+// before writing the response. Cancelling the request releases the waiter;
+// closing the Server aborts the gated connection without manufacturing a
+// successful response.
+type Response struct {
+	Status int
+	Header http.Header
+	Body   json.RawMessage
+	Gate   <-chan struct{}
+}
+
+// ResponseSequence is an ordered sequence of responses for one scenario key.
+// Each request consumes the next response. Once exhausted, a sequence returns a
+// non-retryable scenario error unless RepeatLast is true, in which case its final
+// response is returned for every later request.
+type ResponseSequence struct {
+	Responses  []Response
+	RepeatLast bool
+}
+
+// ExpectedTarget is the decoded REST planning target accepted by a Scenario.
+// Namespace uses the REST namespace path representation (components joined by
+// the unit separator), while Prefix and Table are decoded path values.
+type ExpectedTarget struct {
+	Prefix    string
+	Namespace string
+	Table     string
+}
+
+// Scenario declares the responses returned by a Server. ExpectedTarget is
+// required for every planning operation; requests for another target, or a
+// planning request made without an expected target, receive a non-retryable
+// scenario error.
+//
+// Poll responses are keyed by decoded plan ID, task responses by the plan-task
+// value in the request body, and cancel responses by decoded plan ID. A missing
+// key, empty sequence, or exhausted non-repeating sequence returns a clear,
+// non-retryable scenario error.
+//
+// An all-zero ConfigResponse or PlanResponse means that response was not
+// configured. Use Response{Status: http.StatusOK} to model an intentional empty
+// 200 response. Scenario errors fail the owning test during cleanup unless a
+// test explicitly acknowledges their exact values with
+// Server.AcknowledgeScenarioErrors.
+type Scenario struct {
+	ExpectedTarget  *ExpectedTarget
+	ConfigResponse  Response
+	PlanResponse    Response
+	PollResponses   map[string]ResponseSequence
+	TaskResponses   map[string]ResponseSequence
+	CancelResponses map[string]ResponseSequence
+}
+
+// ConfigResponse returns a successful catalog configuration response that
+// advertises endpoints exactly as supplied.
+func ConfigResponse(endpoints ...string) Response {
+	body, err := json.Marshal(struct {
+		Defaults  map[string]string `json:"defaults"`
+		Overrides map[string]string `json:"overrides"`
+		Endpoints []string          `json:"endpoints"`
+	}{
+		Defaults:  map[string]string{},
+		Overrides: map[string]string{},
+		Endpoints: append([]string{}, endpoints...),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("planfake: encode config response: %v", err))
+	}
+
+	return Response{Status: http.StatusOK, Body: body}
+}
+
+func cloneResponse(resp Response) Response {
+	resp.Header = resp.Header.Clone()
+	resp.Body = append(json.RawMessage(nil), resp.Body...)
+
+	return resp
+}
+
+func cloneScenario(scenario Scenario) Scenario {
+	cloned := Scenario{
+		ConfigResponse: cloneResponse(scenario.ConfigResponse),
+		PlanResponse:   cloneResponse(scenario.PlanResponse),
+	}
+	if scenario.ExpectedTarget != nil {
+		target := *scenario.ExpectedTarget
+		cloned.ExpectedTarget = &target
+	}
+
+	if scenario.PollResponses != nil {
+		cloned.PollResponses = make(map[string]ResponseSequence, len(scenario.PollResponses))
+		for planID, sequence := range scenario.PollResponses {
+			cloned.PollResponses[planID] = cloneResponseSequence(sequence)
+		}
+	}
+	if scenario.TaskResponses != nil {
+		cloned.TaskResponses = make(map[string]ResponseSequence, len(scenario.TaskResponses))
+		for planTask, sequence := range scenario.TaskResponses {
+			cloned.TaskResponses[planTask] = cloneResponseSequence(sequence)
+		}
+	}
+	if scenario.CancelResponses != nil {
+		cloned.CancelResponses = make(map[string]ResponseSequence, len(scenario.CancelResponses))
+		for planID, sequence := range scenario.CancelResponses {
+			cloned.CancelResponses[planID] = cloneResponseSequence(sequence)
+		}
+	}
+
+	return cloned
+}
+
+func cloneResponseSequence(sequence ResponseSequence) ResponseSequence {
+	cloned := ResponseSequence{
+		Responses:  make([]Response, len(sequence.Responses)),
+		RepeatLast: sequence.RepeatLast,
+	}
+	for i, response := range sequence.Responses {
+		cloned.Responses[i] = cloneResponse(response)
+	}
+
+	return cloned
+}

--- a/catalog/rest/internal/planfake/server.go
+++ b/catalog/rest/internal/planfake/server.go
@@ -1,0 +1,563 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package planfake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Request is one request captured by the fake server. Path is the escaped wire
+// path, which preserves opaque plan IDs containing slashes or dot segments.
+// RawQuery is captured separately without decoding. Prefix, Namespace, Table,
+// PlanID, and PlanTask are decoded routing values when applicable.
+type Request struct {
+	Method    string
+	Path      string
+	RawQuery  string
+	Header    http.Header
+	Body      []byte
+	Prefix    string
+	Namespace string
+	Table     string
+	PlanID    string
+	PlanTask  string
+}
+
+// Server is a concurrency-safe in-process REST scan-planning server.
+type Server struct {
+	server    *httptest.Server
+	closeOnce sync.Once
+
+	mu             sync.Mutex
+	scenario       Scenario
+	requests       []Request
+	scenarioErrors []string
+	pollCounts     map[string]int
+	taskCounts     map[string]int
+	cancelCounts   map[string]int
+	pollChanged    chan struct{}
+	closed         chan struct{}
+}
+
+// New starts a fake server for scenario and registers cleanup with t.
+func New(t testing.TB, scenario Scenario) *Server {
+	t.Helper()
+
+	s := &Server{
+		scenario:     cloneScenario(scenario),
+		pollCounts:   make(map[string]int),
+		taskCounts:   make(map[string]int),
+		cancelCounts: make(map[string]int),
+		pollChanged:  make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(s.serveHTTP))
+	t.Cleanup(func() {
+		s.Close()
+		if scenarioErrors := s.ScenarioErrors(); len(scenarioErrors) != 0 {
+			t.Errorf("planfake: unexpected scenario error(s):\n- %s", strings.Join(scenarioErrors, "\n- "))
+		}
+	})
+
+	return s
+}
+
+// URL returns the fake server's base URL.
+func (s *Server) URL() string { return s.server.URL }
+
+// Close stops the fake server. It is safe to call more than once.
+func (s *Server) Close() {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+		// httptest.Server.Close waits for active handlers and only force-closes
+		// idle connections. Close the underlying HTTP server first so a handler
+		// blocked reading an unfinished request body cannot hang test cleanup.
+		_ = s.server.Config.Close()
+		s.server.Close()
+	})
+}
+
+// Requests returns a defensive copy of the complete request history.
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	requests := make([]Request, len(s.requests))
+	for i, request := range s.requests {
+		requests[i] = cloneRequest(request)
+	}
+
+	return requests
+}
+
+// ScenarioErrors returns a defensive copy of unacknowledged scenario-contract
+// errors observed by the server. Any errors left pending fail the owning test
+// during cleanup.
+func (s *Server) ScenarioErrors() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.scenarioErrors...)
+}
+
+// AcknowledgeScenarioErrors marks the currently pending scenario errors as
+// expected only when they exactly equal want in order. A mismatch leaves every
+// error pending so cleanup still fails, as do any errors observed later.
+func (s *Server) AcknowledgeScenarioErrors(want ...string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.scenarioErrors) != len(want) {
+		return fmt.Errorf("scenario errors mismatch: got %q, want %q", s.scenarioErrors, want)
+	}
+	for i := range want {
+		if s.scenarioErrors[i] != want[i] {
+			return fmt.Errorf("scenario errors mismatch: got %q, want %q", s.scenarioErrors, want)
+		}
+	}
+
+	s.scenarioErrors = nil
+
+	return nil
+}
+
+// PollCount returns the number of poll requests received for planID.
+func (s *Server) PollCount(planID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.pollCounts[planID]
+}
+
+// WaitForPollCount waits until at least the requested number of poll requests
+// have been received for planID. It returns ctx.Err if the context ends first,
+// or http.ErrServerClosed if the server closes before the threshold is reached.
+func (s *Server) WaitForPollCount(ctx context.Context, planID string, atLeast int) error {
+	for {
+		s.mu.Lock()
+		if s.pollCounts[planID] >= atLeast {
+			s.mu.Unlock()
+
+			return nil
+		}
+		changed := s.pollChanged
+		s.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.closed:
+			// Prefer success if the threshold and shutdown happened together.
+			s.mu.Lock()
+			reached := s.pollCounts[planID] >= atLeast
+			s.mu.Unlock()
+			if reached {
+				return nil
+			}
+
+			return http.ErrServerClosed
+		case <-changed:
+		}
+	}
+}
+
+// TaskCount returns the number of task-fetch requests received for planTask.
+func (s *Server) TaskCount(planTask string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.taskCounts[planTask]
+}
+
+// CancelCount returns the number of cancellation requests received for planID.
+func (s *Server) CancelCount(planID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.cancelCounts[planID]
+}
+
+type routeKind uint8
+
+const (
+	routeUnknown routeKind = iota
+	routeConfig
+	routePlan
+	routePoll
+	routeCancel
+	routeTasks
+)
+
+type route struct {
+	kind      routeKind
+	prefix    string
+	namespace string
+	table     string
+	planID    string
+}
+
+func (s *Server) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	select {
+	case <-s.closed:
+		panic(http.ErrAbortHandler)
+	default:
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		select {
+		case <-s.closed:
+			panic(http.ErrAbortHandler)
+		default:
+		}
+
+		message := fmt.Sprintf("reading request body: %v", err)
+		s.recordScenarioError(message)
+		writeResponse(w, errorResponse(http.StatusBadRequest, "PlanFakeRequestError", message))
+
+		return
+	}
+
+	route, routeErr := parseRoute(req.Method, req.URL.EscapedPath())
+	captured := Request{
+		Method:    req.Method,
+		Path:      req.URL.EscapedPath(),
+		RawQuery:  req.URL.RawQuery,
+		Header:    req.Header.Clone(),
+		Body:      append([]byte(nil), body...),
+		Prefix:    route.prefix,
+		Namespace: route.namespace,
+		Table:     route.table,
+		PlanID:    route.planID,
+	}
+	if routeErr != nil {
+		s.record(captured)
+		writeResponse(w, s.scenarioErrorResponse(fmt.Sprintf("invalid request path %q: %v", captured.Path, routeErr)))
+
+		return
+	}
+	if route.kind == routeTasks {
+		var taskRequest struct {
+			PlanTask string `json:"plan-task"`
+		}
+		if err := json.Unmarshal(body, &taskRequest); err != nil {
+			s.record(captured)
+			message := fmt.Sprintf("decoding plan-task request: %v", err)
+			s.recordScenarioError(message)
+			writeResponse(w, errorResponse(http.StatusBadRequest, "PlanFakeRequestError", message))
+
+			return
+		}
+		captured.PlanTask = taskRequest.PlanTask
+	}
+
+	response := s.responseFor(route, captured)
+	if !s.waitForGate(req.Context(), response.Gate) {
+		return
+	}
+	writeResponse(w, response)
+}
+
+func (s *Server) waitForGate(ctx context.Context, gate <-chan struct{}) bool {
+	if gate == nil {
+		return true
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	select {
+	case <-s.closed:
+		panic(http.ErrAbortHandler)
+	default:
+	}
+
+	select {
+	case <-gate:
+		if ctx.Err() != nil {
+			return false
+		}
+		select {
+		case <-s.closed:
+			panic(http.ErrAbortHandler)
+		default:
+		}
+
+		return true
+	case <-ctx.Done():
+		return false
+	case <-s.closed:
+		// Returning from a handler without writing would make net/http synthesize
+		// an empty 200 response. ErrAbortHandler instead closes the connection
+		// without logging a stack trace or manufacturing a successful response.
+		panic(http.ErrAbortHandler)
+	}
+}
+
+func (s *Server) record(request Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.requests = append(s.requests, cloneRequest(request))
+}
+
+func (s *Server) recordScenarioError(message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.scenarioErrors = append(s.scenarioErrors, message)
+}
+
+func (s *Server) scenarioErrorResponse(message string) Response {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.scenarioErrorResponseLocked(message)
+}
+
+// scenarioErrorResponseLocked records and returns a scenario error. The caller
+// must hold s.mu.
+func (s *Server) scenarioErrorResponseLocked(message string) Response {
+	s.scenarioErrors = append(s.scenarioErrors, message)
+
+	return scenarioError(message)
+}
+
+func (s *Server) responseFor(route route, request Request) Response {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.requests = append(s.requests, cloneRequest(request))
+	if route.kind != routeConfig && route.kind != routeUnknown {
+		if targetError := validateTarget(s.scenario.ExpectedTarget, route); targetError != "" {
+			return s.scenarioErrorResponseLocked(targetError)
+		}
+	}
+
+	switch route.kind {
+	case routeConfig:
+		if isZeroResponse(s.scenario.ConfigResponse) {
+			return s.scenarioErrorResponseLocked(
+				"config response is not configured; use an explicit 200 response to model an empty body")
+		}
+
+		return cloneResponse(s.scenario.ConfigResponse)
+	case routePlan:
+		if isZeroResponse(s.scenario.PlanResponse) {
+			return s.scenarioErrorResponseLocked(
+				"plan response is not configured; use an explicit 200 response to model an empty body")
+		}
+
+		return cloneResponse(s.scenario.PlanResponse)
+	case routePoll:
+		response := s.nextResponse("poll", route.planID, s.scenario.PollResponses, s.pollCounts)
+		s.signalPollChangedLocked()
+
+		return response
+	case routeCancel:
+		return s.nextResponse("cancel", route.planID, s.scenario.CancelResponses, s.cancelCounts)
+	case routeTasks:
+		return s.nextResponse("task", request.PlanTask, s.scenario.TaskResponses, s.taskCounts)
+	default:
+		return s.scenarioErrorResponseLocked(fmt.Sprintf("unexpected request %s %s", request.Method, request.Path))
+	}
+}
+
+func (s *Server) nextResponse(
+	kind, key string,
+	responses map[string]ResponseSequence,
+	counts map[string]int,
+) Response {
+	requestIndex := counts[key]
+	counts[key] = requestIndex + 1
+
+	sequence, ok := responses[key]
+	if !ok {
+		return s.scenarioErrorResponseLocked(
+			fmt.Sprintf("no %s responses configured for %q (missing response sequence)", kind, key))
+	}
+	if len(sequence.Responses) == 0 {
+		return s.scenarioErrorResponseLocked(
+			fmt.Sprintf("empty %s response sequence configured for %q", kind, key))
+	}
+	if requestIndex >= len(sequence.Responses) {
+		if !sequence.RepeatLast {
+			return s.scenarioErrorResponseLocked(fmt.Sprintf(
+				"%s response sequence for %q exhausted on request %d after %d configured responses",
+				kind, key, requestIndex+1, len(sequence.Responses)))
+		}
+		requestIndex = len(sequence.Responses) - 1
+	}
+
+	return cloneResponse(sequence.Responses[requestIndex])
+}
+
+// signalPollChangedLocked wakes all poll-count waiters. The caller must hold
+// s.mu so checking a count and subscribing to the next notification is atomic.
+func (s *Server) signalPollChangedLocked() {
+	close(s.pollChanged)
+	s.pollChanged = make(chan struct{})
+}
+
+func validateTarget(expected *ExpectedTarget, actual route) string {
+	if expected == nil {
+		return "expected planning target is not configured"
+	}
+	if expected.Namespace == "" || expected.Table == "" {
+		return "expected planning target must include namespace and table"
+	}
+	if actual.prefix == expected.Prefix && actual.namespace == expected.Namespace && actual.table == expected.Table {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"planning target mismatch: got prefix %q, namespace %q, table %q; want prefix %q, namespace %q, table %q",
+		actual.prefix, actual.namespace, actual.table, expected.Prefix, expected.Namespace, expected.Table)
+}
+
+func isZeroResponse(response Response) bool {
+	return response.Status == 0 && len(response.Header) == 0 && len(response.Body) == 0 && response.Gate == nil
+}
+
+func parseRoute(method, escapedPath string) (route, error) {
+	segments, err := pathSegments(escapedPath)
+	if err != nil {
+		return route{}, err
+	}
+	if segments[0] != "v1" {
+		return route{}, nil
+	}
+	if method == http.MethodGet && len(segments) == 2 && segments[1] == "config" {
+		return route{kind: routeConfig}, nil
+	}
+
+	tailLength := 0
+	kind := routeUnknown
+	switch {
+	case method == http.MethodPost && len(segments) >= 6 && segments[len(segments)-1] == "plan":
+		tailLength, kind = 5, routePlan
+	case method == http.MethodPost && len(segments) >= 6 && segments[len(segments)-1] == "tasks":
+		tailLength, kind = 5, routeTasks
+	case method == http.MethodGet && len(segments) >= 7 && segments[len(segments)-2] == "plan":
+		tailLength, kind = 6, routePoll
+	case method == http.MethodDelete && len(segments) >= 7 && segments[len(segments)-2] == "plan":
+		tailLength, kind = 6, routeCancel
+	default:
+		return route{}, nil
+	}
+
+	namespaceIndex := len(segments) - tailLength
+	tail := segments[namespaceIndex:]
+	if namespaceIndex < 1 || tail[0] != "namespaces" || tail[2] != "tables" {
+		return route{}, nil
+	}
+
+	matched := route{
+		kind:      kind,
+		prefix:    strings.Join(segments[1:namespaceIndex], "/"),
+		namespace: tail[1],
+		table:     tail[3],
+	}
+	if kind == routePoll || kind == routeCancel {
+		matched.planID = tail[5]
+	}
+
+	return matched, nil
+}
+
+func pathSegments(escapedPath string) ([]string, error) {
+	if !strings.HasPrefix(escapedPath, "/") || strings.HasPrefix(escapedPath, "//") {
+		return nil, errors.New("path must have exactly one leading slash")
+	}
+	if strings.HasSuffix(escapedPath, "/") {
+		return nil, errors.New("path must not have a trailing slash")
+	}
+
+	rawSegments := strings.Split(escapedPath[1:], "/")
+	segments := make([]string, len(rawSegments))
+	for i, segment := range rawSegments {
+		if segment == "" {
+			return nil, errors.New("path must not contain empty segments")
+		}
+		if segment == "." || segment == ".." {
+			return nil, errors.New("path must percent-encode dot segments")
+		}
+		decoded, err := url.PathUnescape(segment)
+		if err != nil {
+			return nil, err
+		}
+		segments[i] = decoded
+	}
+
+	return segments, nil
+}
+
+func cloneRequest(request Request) Request {
+	request.Header = request.Header.Clone()
+	request.Body = append([]byte(nil), request.Body...)
+
+	return request
+}
+
+func writeResponse(w http.ResponseWriter, response Response) {
+	for key, values := range response.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	if len(response.Body) != 0 && w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+
+	status := response.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	if len(response.Body) != 0 {
+		_, _ = w.Write(response.Body)
+	}
+}
+
+func errorResponse(status int, errorType, message string) Response {
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    errorType,
+			"code":    status,
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("planfake: encode error response: %v", err))
+	}
+
+	return Response{Status: status, Body: body}
+}
+
+func scenarioError(message string) Response {
+	return errorResponse(http.StatusUnprocessableEntity, "PlanFakeScenarioError", message)
+}

--- a/catalog/rest/internal/planfake/server_test.go
+++ b/catalog/rest/internal/planfake/server_test.go
@@ -1,0 +1,642 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package planfake
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerRoutesAndSequences(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{
+			Prefix:    "catalog",
+			Namespace: "db\x1fanalytics",
+			Table:     "events",
+		},
+		ConfigResponse: ConfigResponse(
+			PlanTableScanEndpoint,
+			FetchPlanningResultEndpoint,
+			CancelPlanningEndpoint,
+			FetchScanTasksEndpoint,
+		),
+		PlanResponse: Response{Status: http.StatusOK, Body: json.RawMessage(`{"status":"submitted","plan-id":"a/b"}`)},
+		PollResponses: map[string]ResponseSequence{
+			"a/b": {Responses: []Response{
+				{Body: json.RawMessage(`{"step":1}`)},
+				{Body: json.RawMessage(`{"step":2}`)},
+			}},
+		},
+		TaskResponses: map[string]ResponseSequence{
+			"root-task": {Responses: []Response{
+				{Body: json.RawMessage(`{"plan-tasks":["child-1"]}`)},
+				{Body: json.RawMessage(`{"plan-tasks":["child-2"]}`)},
+			}, RepeatLast: true},
+		},
+		CancelResponses: map[string]ResponseSequence{
+			"a/b": {Responses: []Response{{Status: http.StatusNoContent}}},
+		},
+	})
+	client := srv.server.Client()
+
+	response, _ := doPlanFakeRequest(t, client, http.MethodGet, srv.URL()+"/v1/config", "")
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	response, _ = doPlanFakeRequest(t, client, http.MethodPost,
+		srv.URL()+"/v1/catalog/namespaces/db%1Fanalytics/tables/events/plan", `{"snapshot-id":17}`)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	for _, wantStep := range []int{1, 2} {
+		response, body := doPlanFakeRequest(t, client, http.MethodGet,
+			srv.URL()+"/v1/catalog/namespaces/db%1Fanalytics/tables/events/plan/a%2Fb", "")
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.JSONEq(t, fmt.Sprintf(`{"step":%d}`, wantStep), string(body))
+	}
+	response, body := doPlanFakeRequest(t, client, http.MethodGet,
+		srv.URL()+"/v1/catalog/namespaces/db%1Fanalytics/tables/events/plan/a%2Fb", "")
+	assertPlanFakeScenarioError(t, response, body)
+	assert.Contains(t, strings.ToLower(string(body)), "exhaust")
+	require.NoError(t, srv.AcknowledgeScenarioErrors(
+		`poll response sequence for "a/b" exhausted on request 3 after 2 configured responses`))
+
+	for _, wantChild := range []string{"child-1", "child-2", "child-2"} {
+		response, body := doPlanFakeRequest(t, client, http.MethodPost,
+			srv.URL()+"/v1/catalog/namespaces/db%1Fanalytics/tables/events/tasks", `{"plan-task":"root-task"}`)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.JSONEq(t, fmt.Sprintf(`{"plan-tasks":[%q]}`, wantChild), string(body))
+	}
+
+	response, _ = doPlanFakeRequest(t, client, http.MethodDelete,
+		srv.URL()+"/v1/catalog/namespaces/db%1Fanalytics/tables/events/plan/a%2Fb", "")
+	assert.Equal(t, http.StatusNoContent, response.StatusCode)
+
+	assert.Equal(t, 3, srv.PollCount("a/b"))
+	assert.Equal(t, 3, srv.TaskCount("root-task"))
+	assert.Equal(t, 1, srv.CancelCount("a/b"))
+
+	requests := srv.Requests()
+	require.Len(t, requests, 9)
+	assert.Equal(t, "catalog", requests[1].Prefix)
+	assert.Equal(t, "db\x1fanalytics", requests[1].Namespace)
+	assert.Equal(t, "events", requests[1].Table)
+	assert.Equal(t, "a/b", requests[2].PlanID)
+	assert.Contains(t, requests[2].Path, "a%2Fb")
+	assert.Equal(t, "root-task", requests[5].PlanTask)
+}
+
+func TestServerRejectsUnexpectedTarget(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Prefix: "catalog", Namespace: "db", Table: "events"},
+		PlanResponse:   Response{Status: http.StatusOK, Body: json.RawMessage(`{"status":"completed"}`)},
+	})
+
+	response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodPost,
+		srv.URL()+"/v1/catalog/namespaces/db/tables/wrong-table/plan", `{}`)
+
+	assertPlanFakeScenarioError(t, response, body)
+	assert.Contains(t, strings.ToLower(string(body)), "target")
+	requests := srv.Requests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, "wrong-table", requests[0].Table)
+	require.NoError(t, srv.AcknowledgeScenarioErrors(
+		`planning target mismatch: got prefix "catalog", namespace "db", table "wrong-table"; `+
+			`want prefix "catalog", namespace "db", table "events"`))
+}
+
+func TestServerRequiresExpectedTarget(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		PlanResponse: Response{Status: http.StatusOK, Body: json.RawMessage(`{"status":"completed"}`)},
+	})
+
+	response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodPost,
+		srv.URL()+"/v1/namespaces/db/tables/events/plan", `{}`)
+
+	assertPlanFakeScenarioError(t, response, body)
+	assert.Contains(t, string(body), "expected planning target is not configured")
+	require.NoError(t, srv.AcknowledgeScenarioErrors("expected planning target is not configured"))
+}
+
+func TestServerRejectsNonCanonicalPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		path          string
+		scenarioError string
+	}{
+		{
+			name:          "trailing config slash",
+			path:          "/v1/config/",
+			scenarioError: `invalid request path "/v1/config/": path must not have a trailing slash`,
+		},
+		{
+			name:          "multiple leading slashes",
+			path:          "//v1/config",
+			scenarioError: `invalid request path "//v1/config": path must have exactly one leading slash`,
+		},
+		{
+			name:          "empty prefix segment",
+			path:          "/v1//namespaces/db/tables/events/plan",
+			scenarioError: `invalid request path "/v1//namespaces/db/tables/events/plan": path must not contain empty segments`,
+		},
+		{
+			name:          "trailing plan slash",
+			path:          "/v1/namespaces/db/tables/events/plan/",
+			scenarioError: `invalid request path "/v1/namespaces/db/tables/events/plan/": path must not have a trailing slash`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := New(t, Scenario{
+				ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+				ConfigResponse: ConfigResponse(),
+				PlanResponse:   Response{Status: http.StatusOK, Body: json.RawMessage(`{}`)},
+			})
+			method := http.MethodGet
+			if strings.Contains(test.path, "/plan") {
+				method = http.MethodPost
+			}
+
+			response, body := doPlanFakeRequest(t, srv.server.Client(), method, srv.URL()+test.path, `{}`)
+			assertPlanFakeScenarioError(t, response, body)
+			assert.Contains(t, strings.ToLower(string(body)), "invalid request path")
+			require.NoError(t, srv.AcknowledgeScenarioErrors(test.scenarioError))
+		})
+	}
+}
+
+func TestServerRejectsRawDotPlanIDsButAcceptsEscapedValues(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PollResponses: map[string]ResponseSequence{
+			".":  {Responses: []Response{{Status: http.StatusOK, Body: json.RawMessage(`{"plan-id":"."}`)}}},
+			"..": {Responses: []Response{{Status: http.StatusOK, Body: json.RawMessage(`{"plan-id":".."}`)}}},
+		},
+	})
+	client := srv.server.Client()
+	const planPath = "/v1/namespaces/db/tables/events/plan/"
+
+	for _, planID := range []string{".", ".."} {
+		response, body := doPlanFakeRequest(t, client, http.MethodGet, srv.URL()+planPath+planID, "")
+		assertPlanFakeScenarioError(t, response, body)
+		assert.Contains(t, strings.ToLower(string(body)), "dot")
+	}
+	require.NoError(t, srv.AcknowledgeScenarioErrors(
+		`invalid request path "/v1/namespaces/db/tables/events/plan/.": path must percent-encode dot segments`,
+		`invalid request path "/v1/namespaces/db/tables/events/plan/..": path must percent-encode dot segments`,
+	))
+
+	for _, test := range []struct {
+		escaped string
+		planID  string
+	}{
+		{escaped: "%2E", planID: "."},
+		{escaped: "%2E%2E", planID: ".."},
+	} {
+		response, body := doPlanFakeRequest(t, client, http.MethodGet, srv.URL()+planPath+test.escaped, "")
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.JSONEq(t, fmt.Sprintf(`{"plan-id":%q}`, test.planID), string(body))
+	}
+
+	assert.Equal(t, 1, srv.PollCount("."))
+	assert.Equal(t, 1, srv.PollCount(".."))
+}
+
+func TestServerCapturesRawQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{ConfigResponse: ConfigResponse()})
+	const rawQuery = "warehouse=s3%3A%2F%2Fbucket%2Fwarehouse&token=a+b"
+	response, _ := doPlanFakeRequest(t, srv.server.Client(), http.MethodGet,
+		srv.URL()+"/v1/config?"+rawQuery, "")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	requests := srv.Requests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, "/v1/config", requests[0].Path)
+	assert.Equal(t, rawQuery, requests[0].RawQuery)
+}
+
+func TestServerRejectsUnconfiguredTopLevelResponses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config", func(t *testing.T) {
+		t.Parallel()
+
+		srv := New(t, Scenario{})
+		response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodGet, srv.URL()+"/v1/config", "")
+
+		assertPlanFakeScenarioError(t, response, body)
+		assert.Contains(t, strings.ToLower(string(body)), "config")
+		assert.Contains(t, strings.ToLower(string(body)), "configured")
+		require.NoError(t, srv.AcknowledgeScenarioErrors(
+			"config response is not configured; use an explicit 200 response to model an empty body"))
+	})
+
+	t.Run("plan", func(t *testing.T) {
+		t.Parallel()
+
+		srv := New(t, Scenario{
+			ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		})
+		response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodPost,
+			srv.URL()+"/v1/namespaces/db/tables/events/plan", `{}`)
+
+		assertPlanFakeScenarioError(t, response, body)
+		assert.Contains(t, strings.ToLower(string(body)), "plan")
+		assert.Contains(t, strings.ToLower(string(body)), "configured")
+		require.NoError(t, srv.AcknowledgeScenarioErrors(
+			"plan response is not configured; use an explicit 200 response to model an empty body"))
+	})
+
+	t.Run("explicit empty responses", func(t *testing.T) {
+		t.Parallel()
+
+		srv := New(t, Scenario{
+			ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+			ConfigResponse: Response{Status: http.StatusOK},
+			PlanResponse:   Response{Status: http.StatusOK},
+		})
+		response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodGet, srv.URL()+"/v1/config", "")
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Empty(t, body)
+		response, body = doPlanFakeRequest(t, srv.server.Client(), http.MethodPost,
+			srv.URL()+"/v1/namespaces/db/tables/events/plan", `{}`)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Empty(t, body)
+	})
+}
+
+func TestServerGatedResponseReleasesOnRequestCancellation(t *testing.T) {
+	t.Parallel()
+
+	gate := make(chan struct{})
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PollResponses: map[string]ResponseSequence{
+			"plan-1": {Responses: []Response{{
+				Status: http.StatusOK,
+				Body:   json.RawMessage(`{"status":"submitted"}`),
+				Gate:   gate,
+			}}},
+		},
+	})
+	// Register after New so the gate closes before the server's LIFO cleanup if
+	// an assertion fails while a handler is still waiting.
+	t.Cleanup(func() { close(gate) })
+
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet,
+			srv.URL()+"/v1/namespaces/db/tables/events/plan/plan-1", nil)
+		if err != nil {
+			result <- err
+
+			return
+		}
+		response, err := srv.server.Client().Do(req)
+		if response != nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+		}
+		result <- err
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelWait()
+	require.NoError(t, srv.WaitForPollCount(waitCtx, "plan-1", 1))
+	cancelRequest()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-waitCtx.Done():
+		t.Fatalf("gated response did not release after request cancellation: %v", waitCtx.Err())
+	}
+}
+
+func TestServerGatedResponseAbortsOnServerClose(t *testing.T) {
+	t.Parallel()
+
+	gate := make(chan struct{})
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PollResponses: map[string]ResponseSequence{
+			"plan-1": {Responses: []Response{{
+				Status: http.StatusOK,
+				Body:   json.RawMessage(`{"status":"submitted"}`),
+				Gate:   gate,
+			}}},
+		},
+	})
+	// If the behavior regresses, release the handler before New's server cleanup
+	// runs so the failure is bounded instead of hanging the test process.
+	t.Cleanup(func() { close(gate) })
+
+	type requestResult struct {
+		response *http.Response
+		err      error
+	}
+	result := make(chan requestResult, 1)
+	go func() {
+		response, err := srv.server.Client().Get(
+			srv.URL() + "/v1/namespaces/db/tables/events/plan/plan-1")
+		result <- requestResult{response: response, err: err}
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelWait()
+	require.NoError(t, srv.WaitForPollCount(waitCtx, "plan-1", 1))
+	closeDone := make(chan struct{})
+	go func() {
+		srv.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case got := <-result:
+		if got.response != nil {
+			_ = got.response.Body.Close()
+		}
+		assert.Nil(t, got.response, "server shutdown must not turn an interrupted gated response into an implicit 200")
+		require.Error(t, got.err, "server shutdown must surface as a transport error")
+	case <-waitCtx.Done():
+		t.Fatalf("gated response did not abort after server shutdown: %v", waitCtx.Err())
+	}
+
+	select {
+	case <-closeDone:
+	case <-waitCtx.Done():
+		t.Fatalf("server shutdown did not finish after aborting the gated response: %v", waitCtx.Err())
+	}
+}
+
+func TestServerCloseAbortsHandlerBlockedReadingRequestBody(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PlanResponse:   Response{Status: http.StatusOK, Body: json.RawMessage(`{"status":"completed"}`)},
+	})
+	address := strings.TrimPrefix(srv.URL(), "http://")
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	connection, err := dialer.DialContext(t.Context(), "tcp", address)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = connection.Close() })
+
+	// Receiving 100 Continue proves the handler attempted to read the body. Leave
+	// the declared byte unsent so serveHTTP remains blocked inside io.ReadAll.
+	_, err = io.WriteString(connection, "POST /v1/namespaces/db/tables/events/plan HTTP/1.1\r\n"+
+		"Host: "+address+"\r\n"+
+		"Content-Length: 1\r\n"+
+		"Expect: 100-continue\r\n\r\n")
+	require.NoError(t, err)
+	require.NoError(t, connection.SetReadDeadline(time.Now().Add(5*time.Second)))
+	reader := bufio.NewReader(connection)
+	statusLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, "HTTP/1.1 100 Continue\r\n", statusLine)
+	blankLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, "\r\n", blankLine)
+
+	closeDone := make(chan struct{})
+	go func() {
+		srv.Close()
+		close(closeDone)
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelWait()
+	select {
+	case <-closeDone:
+	case <-waitCtx.Done():
+		t.Fatalf("server shutdown remained blocked on an unfinished request body: %v", waitCtx.Err())
+	}
+	assert.Empty(t, srv.ScenarioErrors())
+}
+
+func TestServerDefensivelyCopiesScenarioAndHistory(t *testing.T) {
+	t.Parallel()
+
+	header := http.Header{"X-Fixture": {"original"}}
+	body := json.RawMessage(`{"status":"completed","plan-id":"original"}`)
+	scenario := Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PlanResponse:   Response{Status: http.StatusOK, Header: header, Body: body},
+	}
+	srv := New(t, scenario)
+	client := srv.server.Client()
+
+	header.Set("X-Fixture", "mutated")
+	body[0] = '['
+	scenario.PlanResponse.Body = json.RawMessage(`{"status":"completed","plan-id":"replacement"}`)
+
+	response, responseBody := doPlanFakeRequest(t, client, http.MethodPost,
+		srv.URL()+"/v1/namespaces/db/tables/events/plan", `{"snapshot-id":17}`)
+	assert.Equal(t, "original", response.Header.Get("X-Fixture"))
+	assert.JSONEq(t, `{"status":"completed","plan-id":"original"}`, string(responseBody))
+
+	requests := srv.Requests()
+	require.Len(t, requests, 1)
+	requests[0].Header.Set("X-Changed", "yes")
+	requests[0].Body[0] = '['
+
+	requests = srv.Requests()
+	assert.Empty(t, requests[0].Header.Get("X-Changed"))
+	assert.JSONEq(t, `{"snapshot-id":17}`, string(requests[0].Body))
+}
+
+func TestServerHandlesConcurrentPollAndTaskRequests(t *testing.T) {
+	t.Parallel()
+
+	const requestCount = 50
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+		PollResponses: map[string]ResponseSequence{
+			"plan-1": {
+				Responses:  []Response{{Body: json.RawMessage(`{"status":"submitted"}`)}},
+				RepeatLast: true,
+			},
+		},
+		TaskResponses: map[string]ResponseSequence{
+			"root-task": {
+				Responses:  []Response{{Body: json.RawMessage(`{"plan-tasks":[]}`)}},
+				RepeatLast: true,
+			},
+		},
+	})
+	client := srv.server.Client()
+
+	requestCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	errCh := make(chan error, requestCount)
+	var wg sync.WaitGroup
+	for range requestCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for requestIndex, request := range []struct {
+				method string
+				url    string
+				body   string
+			}{
+				{http.MethodGet, srv.URL() + "/v1/namespaces/db/tables/events/plan/plan-1", ""},
+				{http.MethodPost, srv.URL() + "/v1/namespaces/db/tables/events/tasks", `{"plan-task":"root-task"}`},
+			} {
+				req, err := http.NewRequestWithContext(requestCtx, request.method, request.url, strings.NewReader(request.body))
+				if err != nil {
+					errCh <- fmt.Errorf("request %d: %w", requestIndex, err)
+
+					return
+				}
+				response, err := client.Do(req)
+				if err != nil {
+					errCh <- fmt.Errorf("request %d: %w", requestIndex, err)
+
+					return
+				}
+				_, readErr := io.Copy(io.Discard, response.Body)
+				closeErr := response.Body.Close()
+				if readErr != nil {
+					errCh <- fmt.Errorf("request %d: reading response: %w", requestIndex, readErr)
+
+					return
+				}
+				if closeErr != nil {
+					errCh <- fmt.Errorf("request %d: closing response: %w", requestIndex, closeErr)
+
+					return
+				}
+				if response.StatusCode != http.StatusOK {
+					errCh <- fmt.Errorf("request %d: unexpected status: %s", requestIndex, response.Status)
+
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, requestCount, srv.PollCount("plan-1"))
+	assert.Equal(t, requestCount, srv.TaskCount("root-task"))
+	assert.Len(t, srv.Requests(), requestCount*2)
+}
+
+func TestServerReturnsClearScenarioErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := New(t, Scenario{
+		ExpectedTarget: &ExpectedTarget{Namespace: "db", Table: "events"},
+	})
+	response, body := doPlanFakeRequest(t, srv.server.Client(), http.MethodPost,
+		srv.URL()+"/v1/namespaces/db/tables/events/tasks", `{"plan-task":"missing"}`)
+
+	assertPlanFakeScenarioError(t, response, body)
+	assert.Contains(t, string(body), `no task responses configured for \"missing\"`)
+	assert.Equal(t, 1, srv.TaskCount("missing"))
+	require.Len(t, srv.ScenarioErrors(), 1)
+	assert.Contains(t, srv.ScenarioErrors()[0], `no task responses configured for "missing"`)
+	require.Error(t, srv.AcknowledgeScenarioErrors("wrong error"))
+	assert.Equal(t, []string{`no task responses configured for "missing" (missing response sequence)`},
+		srv.ScenarioErrors(), "a mismatched acknowledgement must leave the error pending")
+	require.NoError(t, srv.AcknowledgeScenarioErrors(
+		`no task responses configured for "missing" (missing response sequence)`))
+	assert.Empty(t, srv.ScenarioErrors())
+}
+
+func TestConfigResponsePreservesAdvertisedEndpoints(t *testing.T) {
+	t.Parallel()
+
+	response := ConfigResponse(PlanTableScanEndpoint, FetchScanTasksEndpoint)
+	var body struct {
+		Defaults  map[string]string `json:"defaults"`
+		Overrides map[string]string `json:"overrides"`
+		Endpoints []string          `json:"endpoints"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body, &body))
+
+	assert.Empty(t, body.Defaults)
+	assert.Empty(t, body.Overrides)
+	assert.Equal(t, []string{PlanTableScanEndpoint, FetchScanTasksEndpoint}, body.Endpoints)
+
+	var empty struct {
+		Endpoints []string `json:"endpoints"`
+	}
+	require.NoError(t, json.Unmarshal(ConfigResponse().Body, &empty))
+	assert.NotNil(t, empty.Endpoints)
+	assert.Empty(t, empty.Endpoints)
+}
+
+func doPlanFakeRequest(
+	t *testing.T,
+	client *http.Client,
+	method, url, body string,
+) (*http.Response, []byte) {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(t.Context(), method, url, strings.NewReader(body))
+	require.NoError(t, err)
+	response, err := client.Do(request)
+	require.NoError(t, err)
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	return response, responseBody
+}
+
+func assertPlanFakeScenarioError(t *testing.T, response *http.Response, body []byte) {
+	t.Helper()
+
+	assert.GreaterOrEqual(t, response.StatusCode, http.StatusBadRequest)
+	assert.Less(t, response.StatusCode, http.StatusInternalServerError)
+	assert.NotEqual(t, http.StatusRequestTimeout, response.StatusCode)
+	assert.NotEqual(t, http.StatusTooManyRequests, response.StatusCode)
+	assert.Contains(t, string(body), "PlanFakeScenarioError")
+}

--- a/catalog/rest/scan_planning_fake_test.go
+++ b/catalog/rest/scan_planning_fake_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
 	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/catalog/rest/internal/planfake"
 	"github.com/apache/iceberg-go/table"
@@ -127,6 +128,41 @@ func TestPlanFakeCapabilityDiscovery(t *testing.T) {
 			assert.Equal(t, "/v1/config", requests[0].Path)
 		})
 	}
+}
+
+func TestPlanFakeConfigOverrideRoutesPlanningPrefix(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: planFakeJSONResponse(`{
+			"defaults": {},
+			"overrides": {"prefix": "server-prefix"},
+			"endpoints": [
+				"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan"
+			]
+		}`),
+		ExpectedTarget: &planfake.ExpectedTarget{
+			Prefix: "server-prefix", Namespace: "analytics", Table: "events",
+		},
+		PlanResponse: planFakeJSONResponse(`{
+			"status":"completed",
+			"plan-id":"prefix-plan"
+		}`),
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("client-prefix"))
+	require.NoError(t, err)
+
+	_, err = catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{})
+	require.NoError(t, err)
+
+	requests := srv.Requests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, http.MethodGet, requests[0].Method)
+	assert.Equal(t, "/v1/config", requests[0].Path)
+	assert.Equal(t, http.MethodPost, requests[1].Method)
+	assert.Equal(t, "/v1/server-prefix/namespaces/analytics/tables/events/plan", requests[1].Path)
+	assert.Equal(t, "server-prefix", requests[1].Prefix)
+	assert.Empty(t, srv.ScenarioErrors())
 }
 
 func TestPlanFakeSynchronousPlanningCapturesRequest(t *testing.T) {
@@ -256,6 +292,119 @@ func TestPlanFakeAsynchronousPlanningWaitsThroughRetry(t *testing.T) {
 	require.Len(t, pollRequests, 3)
 	for _, request := range pollRequests {
 		assert.Equal(t, accessDelegation, request.Header.Get("X-Iceberg-Access-Delegation"))
+	}
+}
+
+func TestPlanFakeSurfacesTerminalPlanningStatuses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("failed submission preserves structured detail", func(t *testing.T) {
+		t.Parallel()
+
+		srv := planfake.New(t, planfake.Scenario{
+			ConfigResponse: fullPlanningConfigResponse(),
+			ExpectedTarget: standardPlanFakeTarget(),
+			PlanResponse: planFakeJSONResponse(`{
+				"status":"failed",
+				"error":{
+					"message":"manifest read failed",
+					"type":"PlanningException",
+					"code":500,
+					"stack":["planner.go:42"]
+				}
+			}`),
+		})
+		catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+		require.NoError(t, err)
+
+		_, err = catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{})
+		require.ErrorIs(t, err, rest.ErrPlanFailed)
+		var failed *rest.PlanFailedError
+		require.ErrorAs(t, err, &failed)
+		require.NotNil(t, failed.Detail)
+		assert.Equal(t, "manifest read failed", failed.Detail.Message)
+		assert.Equal(t, "PlanningException", failed.Detail.Type)
+		assert.Equal(t, 500, failed.Detail.Code)
+		assert.Equal(t, []string{"planner.go:42"}, failed.Detail.Stack)
+		assert.Empty(t, srv.ScenarioErrors())
+	})
+
+	t.Run("cancelled poll returns cancellation sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		const planID = "cancelled-plan"
+		srv := planfake.New(t, planfake.Scenario{
+			ConfigResponse: fullPlanningConfigResponse(),
+			ExpectedTarget: standardPlanFakeTarget(),
+			PollResponses: map[string]planfake.ResponseSequence{
+				planID: {
+					Responses: []planfake.Response{
+						planFakeJSONResponse(`{"status":"cancelled"}`),
+					},
+				},
+			},
+		})
+		catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+		require.NoError(t, err)
+
+		_, err = catalog.WaitForPlan(t.Context(), standardPlanFakeIdentifier(), planID, rest.WaitForPlanOptions{})
+		require.ErrorIs(t, err, rest.ErrPlanCancelled)
+		assert.NotErrorIs(t, err, rest.ErrPlanFailed)
+		assert.Equal(t, 1, srv.PollCount(planID))
+		assert.Zero(t, srv.CancelCount(planID))
+		assert.Empty(t, srv.ScenarioErrors())
+	})
+}
+
+func TestPlanFakePlanSubmissionMapsMissingTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		errorType string
+		wantErr   error
+		notErr    error
+	}{
+		{
+			name:      "table",
+			errorType: "NoSuchTableException",
+			wantErr:   icebergcatalog.ErrNoSuchTable,
+			notErr:    icebergcatalog.ErrNoSuchNamespace,
+		},
+		{
+			name:      "namespace",
+			errorType: "NoSuchNamespaceException",
+			wantErr:   icebergcatalog.ErrNoSuchNamespace,
+			notErr:    icebergcatalog.ErrNoSuchTable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := planfake.New(t, planfake.Scenario{
+				ConfigResponse: fullPlanningConfigResponse(),
+				ExpectedTarget: standardPlanFakeTarget(),
+				PlanResponse: planfake.Response{
+					Status: http.StatusNotFound,
+					Body: json.RawMessage(`{
+						"error":{
+							"message":"planning target does not exist",
+							"type":"` + test.errorType + `",
+							"code":404
+						}
+					}`),
+				},
+			})
+			catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+			require.NoError(t, err)
+
+			_, err = catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{})
+			require.ErrorIs(t, err, test.wantErr)
+			assert.NotErrorIs(t, err, test.notErr)
+			assert.Empty(t, srv.ScenarioErrors())
+		})
 	}
 }
 

--- a/catalog/rest/scan_planning_fake_test.go
+++ b/catalog/rest/scan_planning_fake_test.go
@@ -1,0 +1,831 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go/catalog/rest"
+	"github.com/apache/iceberg-go/catalog/rest/internal/planfake"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanFakeCapabilityDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		endpoints        []string
+		wantPlan         bool
+		wantFullPlanning bool
+	}{
+		{
+			name: "all planning endpoints",
+			endpoints: []string{
+				planfake.PlanTableScanEndpoint,
+				planfake.FetchPlanningResultEndpoint,
+				planfake.CancelPlanningEndpoint,
+				planfake.FetchScanTasksEndpoint,
+			},
+			wantPlan:         true,
+			wantFullPlanning: true,
+		},
+		{
+			name:             "plan only",
+			endpoints:        []string{planfake.PlanTableScanEndpoint},
+			wantPlan:         true,
+			wantFullPlanning: false,
+		},
+		{
+			name: "missing plan submission",
+			endpoints: []string{
+				planfake.FetchPlanningResultEndpoint,
+				planfake.CancelPlanningEndpoint,
+				planfake.FetchScanTasksEndpoint,
+			},
+			wantPlan:         false,
+			wantFullPlanning: false,
+		},
+		{
+			name: "missing result fetch",
+			endpoints: []string{
+				planfake.PlanTableScanEndpoint,
+				planfake.CancelPlanningEndpoint,
+				planfake.FetchScanTasksEndpoint,
+			},
+			wantPlan:         true,
+			wantFullPlanning: false,
+		},
+		{
+			name: "missing cancellation",
+			endpoints: []string{
+				planfake.PlanTableScanEndpoint,
+				planfake.FetchPlanningResultEndpoint,
+				planfake.FetchScanTasksEndpoint,
+			},
+			wantPlan:         true,
+			wantFullPlanning: false,
+		},
+		{
+			name: "missing task fetch",
+			endpoints: []string{
+				planfake.PlanTableScanEndpoint,
+				planfake.FetchPlanningResultEndpoint,
+				planfake.CancelPlanningEndpoint,
+			},
+			wantPlan:         true,
+			wantFullPlanning: false,
+		},
+		{
+			name:             "no planning endpoints",
+			endpoints:        []string{"GET /v1/{prefix}/namespaces"},
+			wantPlan:         false,
+			wantFullPlanning: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := planfake.New(t, planfake.Scenario{
+				ConfigResponse: planfake.ConfigResponse(test.endpoints...),
+			})
+			catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL())
+			require.NoError(t, err)
+
+			assert.Equal(t, test.wantPlan, catalog.SupportsPlanTableScan())
+			assert.Equal(t, test.wantFullPlanning, catalog.SupportsFullRemoteScanPlanning())
+
+			requests := srv.Requests()
+			require.Len(t, requests, 1)
+			assert.Equal(t, http.MethodGet, requests[0].Method)
+			assert.Equal(t, "/v1/config", requests[0].Path)
+		})
+	}
+}
+
+func TestPlanFakeSynchronousPlanningCapturesRequest(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: &planfake.ExpectedTarget{
+			Prefix: "catalog", Namespace: "org\x1fanalytics", Table: "events",
+		},
+		PlanResponse: planFakeJSONResponse(canonicalCompletedPlanJSON),
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("catalog"))
+	require.NoError(t, err)
+
+	idempotencyKey := "0190b6c5-1c3d-7000-8000-000000000011"
+	accessDelegation := "remote-signing"
+	snapshotID := int64(123)
+	minimumRows := int64(50)
+	caseSensitive := false
+	useSnapshotSchema := true
+	response, err := catalog.PlanTableScan(t.Context(), table.Identifier{"org", "analytics", "events"}, rest.PlanTableScanRequest{
+		IdempotencyKey:    &idempotencyKey,
+		AccessDelegation:  &accessDelegation,
+		SnapshotID:        &snapshotID,
+		Select:            []string{"id", "payload"},
+		Filter:            json.RawMessage(`{"type":"eq","term":"id","value":34}`),
+		MinRowsRequested:  &minimumRows,
+		CaseSensitive:     &caseSensitive,
+		UseSnapshotSchema: &useSnapshotSchema,
+		StatsFields:       []string{"id", "payload"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, rest.PlanStatusCompleted, response.Status)
+	require.NotNil(t, response.PlanID)
+	assert.Equal(t, "plan-sync", *response.PlanID)
+	assert.Equal(t, []string{"inline-child"}, response.PlanTasks)
+	assert.Len(t, response.FileScanTasks, 1)
+	assert.Len(t, response.DeleteFiles, 1)
+	require.Len(t, response.StorageCredentials, 1)
+	assert.Equal(t, "s3://warehouse/table/", response.StorageCredentials[0].Prefix)
+	assert.Equal(t, "plan-key", response.StorageCredentials[0].Config["s3.access-key-id"])
+
+	requests := srv.Requests()
+	require.Len(t, requests, 2)
+	request := requests[1]
+	assert.Equal(t, http.MethodPost, request.Method)
+	assert.Equal(t, "/v1/catalog/namespaces/org%1Fanalytics/tables/events/plan", request.Path)
+	assert.Equal(t, "catalog", request.Prefix)
+	assert.Equal(t, "org\x1fanalytics", request.Namespace)
+	assert.Equal(t, "events", request.Table)
+	assert.Equal(t, idempotencyKey, request.Header.Get("Idempotency-Key"))
+	assert.Equal(t, accessDelegation, request.Header.Get("X-Iceberg-Access-Delegation"))
+	assert.JSONEq(t, `{
+		"snapshot-id": 123,
+		"select": ["id", "payload"],
+		"filter": {"type": "eq", "term": "id", "value": 34},
+		"min-rows-requested": 50,
+		"case-sensitive": false,
+		"use-snapshot-schema": true,
+		"stats-fields": ["id", "payload"]
+	}`, string(request.Body))
+}
+
+func TestPlanFakeAsynchronousPlanningWaitsThroughRetry(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: standardPlanFakeTarget(),
+		PlanResponse:   planFakeJSONResponse(`{"status":"submitted","plan-id":"plan-async"}`),
+		PollResponses: map[string]planfake.ResponseSequence{
+			"plan-async": {
+				Responses: []planfake.Response{
+					{
+						Status: http.StatusServiceUnavailable,
+						Body: json.RawMessage(`{
+						"error":{"message":"busy","type":"ServiceUnavailableException","code":503}
+					}`),
+					},
+					planFakeJSONResponse(`{"status":"submitted"}`),
+					planFakeJSONResponse(`{
+					"status":"completed",
+					"plan-tasks":["root-task"],
+					"storage-credentials":[{
+						"prefix":"s3://warehouse/table/",
+						"config":{"token":"async-token"}
+						}]
+				}`),
+				},
+			},
+		},
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+	require.NoError(t, err)
+
+	accessDelegation := "remote-signing"
+	initial, err := catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{
+		AccessDelegation: &accessDelegation,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, initial.PlanID)
+	assert.Equal(t, rest.PlanStatusSubmitted, initial.Status)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	completed, err := catalog.WaitForPlan(ctx, standardPlanFakeIdentifier(), *initial.PlanID, rest.WaitForPlanOptions{
+		MinDelay:          time.Millisecond,
+		MaxDelay:          2 * time.Millisecond,
+		CancelGracePeriod: time.Second,
+		MaxRetries:        10,
+		AccessDelegation:  &accessDelegation,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, rest.PlanStatusCompleted, completed.Status)
+	assert.Equal(t, []string{"root-task"}, completed.PlanTasks)
+	require.Len(t, completed.StorageCredentials, 1)
+	assert.Equal(t, "async-token", completed.StorageCredentials[0].Config["token"])
+	assert.Equal(t, 3, srv.PollCount("plan-async"))
+	assert.Zero(t, srv.CancelCount("plan-async"))
+
+	requests := srv.Requests()
+	assertPlanFakeUUIDv7Header(t, requests[1])
+	pollRequests := requestsForPlanFakeOperation(requests, http.MethodGet, "plan-async", "")
+	require.Len(t, pollRequests, 3)
+	for _, request := range pollRequests {
+		assert.Equal(t, accessDelegation, request.Header.Get("X-Iceberg-Access-Delegation"))
+	}
+}
+
+func TestPlanFakeWaitCancellationCleansUpServerPlan(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: standardPlanFakeTarget(),
+		PlanResponse:   planFakeJSONResponse(`{"status":"submitted","plan-id":"plan-cancel"}`),
+		PollResponses: map[string]planfake.ResponseSequence{
+			"plan-cancel": {
+				Responses:  []planfake.Response{planFakeJSONResponse(`{"status":"submitted"}`)},
+				RepeatLast: true,
+			},
+		},
+		CancelResponses: map[string]planfake.ResponseSequence{
+			"plan-cancel": {
+				Responses: []planfake.Response{{Status: http.StatusNoContent}},
+			},
+		},
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+	require.NoError(t, err)
+
+	initial, err := catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, initial.PlanID)
+
+	waitContext, cancelWait := context.WithCancel(t.Context())
+	defer cancelWait()
+	waitDone := make(chan error, 1)
+	go func() {
+		_, waitErr := catalog.WaitForPlan(waitContext, standardPlanFakeIdentifier(), *initial.PlanID, rest.WaitForPlanOptions{
+			MinDelay:          time.Hour,
+			MaxDelay:          time.Hour,
+			CancelGracePeriod: time.Second,
+		})
+		waitDone <- waitErr
+	}()
+
+	observeContext, cancelObserve := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelObserve()
+	require.NoError(t, srv.WaitForPollCount(observeContext, "plan-cancel", 1))
+	cancelWait()
+	err = waitForPlanFakeResult(t, observeContext, waitDone)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.GreaterOrEqual(t, srv.PollCount("plan-cancel"), 1)
+	assert.Equal(t, 1, srv.CancelCount("plan-cancel"))
+	assert.Empty(t, srv.ScenarioErrors())
+
+	requests := requestsForPlanFakeOperation(srv.Requests(), http.MethodDelete, "plan-cancel", "")
+	require.Len(t, requests, 1)
+	assert.Empty(t, requests[0].Header.Get("Idempotency-Key"))
+	assert.Empty(t, requests[0].Header.Get("X-Iceberg-Access-Delegation"))
+}
+
+func TestPlanFakeWaitCancellationBoundsStalledCleanup(t *testing.T) {
+	t.Parallel()
+
+	stalledCancel := make(chan struct{})
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: standardPlanFakeTarget(),
+		PlanResponse:   planFakeJSONResponse(`{"status":"submitted","plan-id":"plan-stalled-cancel"}`),
+		PollResponses: map[string]planfake.ResponseSequence{
+			"plan-stalled-cancel": {
+				Responses:  []planfake.Response{planFakeJSONResponse(`{"status":"submitted"}`)},
+				RepeatLast: true,
+			},
+		},
+		CancelResponses: map[string]planfake.ResponseSequence{
+			"plan-stalled-cancel": {
+				Responses: []planfake.Response{{Status: http.StatusNoContent, Gate: stalledCancel}},
+			},
+		},
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+	require.NoError(t, err)
+
+	initial, err := catalog.PlanTableScan(t.Context(), standardPlanFakeIdentifier(), rest.PlanTableScanRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, initial.PlanID)
+
+	waitContext, cancelWait := context.WithCancel(t.Context())
+	defer cancelWait()
+	waitDone := make(chan error, 1)
+	go func() {
+		_, waitErr := catalog.WaitForPlan(waitContext, standardPlanFakeIdentifier(), *initial.PlanID, rest.WaitForPlanOptions{
+			MinDelay:          time.Hour,
+			MaxDelay:          time.Hour,
+			CancelGracePeriod: 100 * time.Millisecond,
+		})
+		waitDone <- waitErr
+	}()
+
+	observeContext, cancelObserve := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelObserve()
+	require.NoError(t, srv.WaitForPollCount(observeContext, "plan-stalled-cancel", 1))
+	cancelWait()
+	err = waitForPlanFakeResult(t, observeContext, waitDone)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.GreaterOrEqual(t, srv.PollCount("plan-stalled-cancel"), 1)
+	assert.Equal(t, 1, srv.CancelCount("plan-stalled-cancel"))
+	assert.Empty(t, srv.ScenarioErrors())
+}
+
+func TestPlanFakeSupportsNestedAndReissuedTaskHandles(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: standardPlanFakeTarget(),
+		TaskResponses: map[string]planfake.ResponseSequence{
+			"root-task": {
+				Responses: []planfake.Response{planFakeJSONResponse(`{
+					"plan-tasks":["reissued-task","reissued-task"],
+					"file-scan-tasks":[` + rootFileScanTaskJSON + `]
+				}`)},
+			},
+			"reissued-task": {
+				Responses: []planfake.Response{
+					planFakeJSONResponse(`{"plan-tasks":["leaf-a"]}`),
+					planFakeJSONResponse(`{"plan-tasks":["leaf-b"]}`),
+				},
+			},
+			"leaf-a": {
+				Responses:  []planfake.Response{planFakeJSONResponse(envelopeAScanTasksJSON)},
+				RepeatLast: true,
+			},
+			"leaf-b": {
+				Responses:  []planfake.Response{planFakeJSONResponse(envelopeBScanTasksJSON)},
+				RepeatLast: true,
+			},
+			"grandchild": {
+				Responses: []planfake.Response{
+					planFakeJSONResponse(`{"file-scan-tasks":[` + grandchildFileScanTaskJSON + `]}`),
+				},
+			},
+		},
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+	require.NoError(t, err)
+
+	queue := []string{"root-task"}
+	responsesByHandle := make(map[string][]rest.FetchScanTasksResponse)
+	for len(queue) > 0 {
+		handle := queue[0]
+		queue = queue[1:]
+
+		response, err := catalog.FetchScanTasks(t.Context(), standardPlanFakeIdentifier(), rest.FetchScanTasksRequest{
+			PlanTask: handle,
+		})
+		require.NoError(t, err)
+		responsesByHandle[handle] = append(responsesByHandle[handle], response)
+		queue = append(queue, response.PlanTasks...)
+	}
+
+	assert.Equal(t, 1, srv.TaskCount("root-task"))
+	assert.Equal(t, 2, srv.TaskCount("reissued-task"))
+	assert.Equal(t, 1, srv.TaskCount("leaf-a"))
+	assert.Equal(t, 1, srv.TaskCount("leaf-b"))
+	assert.Equal(t, 1, srv.TaskCount("grandchild"))
+	require.Len(t, responsesByHandle["reissued-task"], 2)
+	assert.Equal(t, []string{"leaf-a"}, responsesByHandle["reissued-task"][0].PlanTasks)
+	assert.Equal(t, []string{"leaf-b"}, responsesByHandle["reissued-task"][1].PlanTasks)
+
+	// Both independently fetched envelopes use delete reference 0 and bind it to
+	// a different delete path. Keeping these raw envelopes separate is required
+	// before the decoder turns them into domain tasks.
+	require.Len(t, responsesByHandle["leaf-a"], 1)
+	assert.Len(t, responsesByHandle["leaf-a"][0].FileScanTasks, 1)
+	assert.Len(t, responsesByHandle["leaf-a"][0].DeleteFiles, 1)
+	require.Len(t, responsesByHandle["leaf-b"], 1)
+	assert.Len(t, responsesByHandle["leaf-b"][0].FileScanTasks, 1)
+	assert.Len(t, responsesByHandle["leaf-b"][0].DeleteFiles, 1)
+
+	// Fetch each leaf again as raw JSON through an independent HTTP client. This
+	// keeps the fixture assertion independent from production wire types and binds
+	// each handle to its own envelope-local delete reference and child handles.
+	leafA := fetchRawPlanTaskFixture(t, srv.URL(), "leaf-a")
+	assertEnvelopeLocalFixture(t, leafA, nil,
+		"s3://warehouse/table/envelope-a.parquet",
+		"s3://warehouse/table/envelope-a-delete.parquet")
+	leafB := fetchRawPlanTaskFixture(t, srv.URL(), "leaf-b")
+	assertEnvelopeLocalFixture(t, leafB, []string{"grandchild"},
+		"s3://warehouse/table/envelope-b.parquet",
+		"s3://warehouse/table/envelope-b-delete.parquet")
+	assert.Equal(t, 2, srv.TaskCount("leaf-a"))
+	assert.Equal(t, 2, srv.TaskCount("leaf-b"))
+
+	for _, request := range srv.Requests() {
+		if request.PlanTask == "" {
+			continue
+		}
+		assertPlanFakeUUIDv7Header(t, request)
+		assert.Empty(t, request.Header.Get("X-Iceberg-Access-Delegation"))
+	}
+}
+
+func TestPlanFakeModelsExpiredPlansAndTasks(t *testing.T) {
+	t.Parallel()
+
+	srv := planfake.New(t, planfake.Scenario{
+		ConfigResponse: fullPlanningConfigResponse(),
+		ExpectedTarget: standardPlanFakeTarget(),
+		PollResponses: map[string]planfake.ResponseSequence{
+			"expired-plan": {
+				Responses: []planfake.Response{{
+					Status: http.StatusNotFound,
+					Body: json.RawMessage(`{
+						"error":{"message":"expired","type":"NoSuchPlanIdException","code":404}
+					}`),
+				}},
+			},
+		},
+		TaskResponses: map[string]planfake.ResponseSequence{
+			"expired-task": {
+				Responses: []planfake.Response{{
+					Status: http.StatusNotFound,
+					Body: json.RawMessage(`{
+						"error":{"message":"expired","type":"NoSuchPlanTaskException","code":404}
+					}`),
+				}},
+			},
+		},
+	})
+	catalog, err := rest.NewCatalog(t.Context(), "rest", srv.URL(), rest.WithPrefix("warehouse"))
+	require.NoError(t, err)
+
+	_, err = catalog.FetchPlanningResult(t.Context(), standardPlanFakeIdentifier(), "expired-plan", rest.FetchPlanningResultOptions{})
+	require.ErrorIs(t, err, rest.ErrPlanExpired)
+
+	_, err = catalog.FetchScanTasks(t.Context(), standardPlanFakeIdentifier(), rest.FetchScanTasksRequest{
+		PlanTask: "expired-task",
+	})
+	require.ErrorIs(t, err, rest.ErrNoSuchPlanTask)
+}
+
+func TestPlanFakeIndependentWireFixtureContract(t *testing.T) {
+	t.Parallel()
+
+	canonical := parseRawPlanningFixture(t, canonicalCompletedPlanJSON)
+	assert.Equal(t, "completed", canonical.Status)
+	assert.Equal(t, "plan-sync", canonical.PlanID)
+	assert.Equal(t, []string{"inline-child"}, canonical.PlanTasks)
+	require.Len(t, canonical.FileScanTasks, 1)
+	require.Len(t, canonical.DeleteFiles, 1)
+
+	task := canonical.FileScanTasks[0]
+	assert.Equal(t, "data", task.DataFile.Content)
+	assert.Equal(t, "s3://warehouse/table/data.parquet", task.DataFile.FilePath)
+	require.Len(t, task.DataFile.Partition, 3)
+	assert.Equal(t, `34`, string(task.DataFile.Partition[0]), "integer partitions must remain typed JSON numbers")
+	assert.Equal(t, `"2026-07-17"`, string(task.DataFile.Partition[1]), "date partitions must remain typed JSON strings")
+	assert.Equal(t, `"78797A21"`, string(task.DataFile.Partition[2]), "fixed partitions must remain typed JSON strings")
+	assert.Equal(t, []int{1, 2}, task.DataFile.ColumnSizes.Keys)
+	assert.Equal(t, []int64{800, 1200}, task.DataFile.ColumnSizes.Values)
+	assert.Equal(t, []int{8, 9}, task.DataFile.LowerBounds.Keys)
+	assert.Equal(t, []string{"01000000", "02000000"}, task.DataFile.LowerBounds.Values,
+		"lower bounds must be Java-compatible hexadecimal binary values")
+	assert.Equal(t, []int{8, 9}, task.DataFile.UpperBounds.Keys)
+	assert.Equal(t, []string{"05000000", "0A000000"}, task.DataFile.UpperBounds.Values,
+		"upper bounds must be Java-compatible hexadecimal binary values")
+	assert.Equal(t, []int{0}, task.DeleteFileReferences)
+	assert.JSONEq(t, `{"type":"eq","term":"id","value":34}`, string(task.ResidualFilter))
+
+	assert.Equal(t, "position-deletes", canonical.DeleteFiles[0].Content)
+	assert.Equal(t, "s3://warehouse/table/delete.parquet", canonical.DeleteFiles[0].FilePath)
+	require.Len(t, canonical.DeleteFiles[0].Partition, 3)
+	assert.Equal(t, `34`, string(canonical.DeleteFiles[0].Partition[0]))
+	assert.Equal(t, `"2026-07-17"`, string(canonical.DeleteFiles[0].Partition[1]))
+	assert.Equal(t, `"78797A21"`, string(canonical.DeleteFiles[0].Partition[2]))
+	require.Len(t, canonical.StorageCredentials, 1)
+	assert.Equal(t, "s3://warehouse/table/", canonical.StorageCredentials[0].Prefix)
+	assert.Equal(t, map[string]string{"s3.access-key-id": "plan-key"}, canonical.StorageCredentials[0].Config)
+
+	assertEnvelopeLocalFixture(t, parseRawPlanningFixture(t, envelopeAScanTasksJSON), nil,
+		"s3://warehouse/table/envelope-a.parquet",
+		"s3://warehouse/table/envelope-a-delete.parquet")
+	assertEnvelopeLocalFixture(t, parseRawPlanningFixture(t, envelopeBScanTasksJSON), []string{"grandchild"},
+		"s3://warehouse/table/envelope-b.parquet",
+		"s3://warehouse/table/envelope-b-delete.parquet")
+}
+
+func standardPlanFakeTarget() *planfake.ExpectedTarget {
+	return &planfake.ExpectedTarget{Prefix: "warehouse", Namespace: "analytics", Table: "events"}
+}
+
+func standardPlanFakeIdentifier() table.Identifier {
+	return table.Identifier{"analytics", "events"}
+}
+
+func waitForPlanFakeResult(t *testing.T, ctx context.Context, result <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for WaitForPlan to return: %v", ctx.Err())
+
+		return nil
+	}
+}
+
+type rawPlanningFixture struct {
+	Status             string                        `json:"status"`
+	PlanID             string                        `json:"plan-id"`
+	PlanTasks          []string                      `json:"plan-tasks"`
+	FileScanTasks      []rawFileScanTaskFixture      `json:"file-scan-tasks"`
+	DeleteFiles        []rawDeleteFileFixture        `json:"delete-files"`
+	StorageCredentials []rawStorageCredentialFixture `json:"storage-credentials"`
+}
+
+type rawFileScanTaskFixture struct {
+	DataFile             rawDataFileFixture `json:"data-file"`
+	DeleteFileReferences []int              `json:"delete-file-references"`
+	ResidualFilter       json.RawMessage    `json:"residual-filter"`
+}
+
+type rawDataFileFixture struct {
+	SpecID      int                `json:"spec-id"`
+	Partition   []json.RawMessage  `json:"partition"`
+	Content     string             `json:"content"`
+	FilePath    string             `json:"file-path"`
+	LowerBounds rawValueMapFixture `json:"lower-bounds"`
+	UpperBounds rawValueMapFixture `json:"upper-bounds"`
+	ColumnSizes rawCountMapFixture `json:"column-sizes"`
+}
+
+type rawDeleteFileFixture struct {
+	SpecID    int               `json:"spec-id"`
+	Partition []json.RawMessage `json:"partition"`
+	Content   string            `json:"content"`
+	FilePath  string            `json:"file-path"`
+}
+
+type rawValueMapFixture struct {
+	Keys   []int    `json:"keys"`
+	Values []string `json:"values"`
+}
+
+type rawCountMapFixture struct {
+	Keys   []int   `json:"keys"`
+	Values []int64 `json:"values"`
+}
+
+type rawStorageCredentialFixture struct {
+	Prefix string            `json:"prefix"`
+	Config map[string]string `json:"config"`
+}
+
+func parseRawPlanningFixture(t *testing.T, body string) rawPlanningFixture {
+	t.Helper()
+
+	var fixture rawPlanningFixture
+	require.NoError(t, json.Unmarshal([]byte(body), &fixture))
+
+	return fixture
+}
+
+func fetchRawPlanTaskFixture(t *testing.T, serverURL, planTask string) rawPlanningFixture {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"plan-task": planTask})
+	require.NoError(t, err)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		serverURL+"/v1/warehouse/namespaces/analytics/tables/events/tasks", bytes.NewReader(body))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	idempotencyKey, err := uuid.NewV7()
+	require.NoError(t, err)
+	request.Header.Set("Idempotency-Key", idempotencyKey.String())
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	responseBody, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	require.NoError(t, readErr)
+	require.NoError(t, closeErr)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	return parseRawPlanningFixture(t, string(responseBody))
+}
+
+func assertEnvelopeLocalFixture(
+	t *testing.T,
+	fixture rawPlanningFixture,
+	wantPlanTasks []string,
+	wantDataPath, wantDeletePath string,
+) {
+	t.Helper()
+
+	assert.Equal(t, wantPlanTasks, fixture.PlanTasks)
+	require.Len(t, fixture.FileScanTasks, 1)
+	require.Len(t, fixture.DeleteFiles, 1)
+	task := fixture.FileScanTasks[0]
+	assert.Equal(t, wantDataPath, task.DataFile.FilePath)
+	assert.Equal(t, []int{0}, task.DeleteFileReferences,
+		"delete reference 0 must resolve within this response envelope")
+	assert.JSONEq(t, `true`, string(task.ResidualFilter))
+	assert.NotNil(t, task.DataFile.Partition)
+	assert.Empty(t, task.DataFile.Partition)
+	assert.Equal(t, wantDeletePath, fixture.DeleteFiles[0].FilePath)
+	assert.NotNil(t, fixture.DeleteFiles[0].Partition)
+	assert.Empty(t, fixture.DeleteFiles[0].Partition)
+}
+
+func fullPlanningConfigResponse() planfake.Response {
+	return planfake.ConfigResponse(
+		planfake.PlanTableScanEndpoint,
+		planfake.FetchPlanningResultEndpoint,
+		planfake.CancelPlanningEndpoint,
+		planfake.FetchScanTasksEndpoint,
+	)
+}
+
+func planFakeJSONResponse(body string) planfake.Response {
+	return planfake.Response{Status: http.StatusOK, Body: json.RawMessage(body)}
+}
+
+func requestsForPlanFakeOperation(
+	requests []planfake.Request,
+	method, planID, planTask string,
+) []planfake.Request {
+	matched := make([]planfake.Request, 0)
+	for _, request := range requests {
+		if request.Method == method && request.PlanID == planID && request.PlanTask == planTask {
+			matched = append(matched, request)
+		}
+	}
+
+	return matched
+}
+
+func assertPlanFakeUUIDv7Header(t *testing.T, request planfake.Request) {
+	t.Helper()
+
+	key := request.Header.Get("Idempotency-Key")
+	require.NotEmpty(t, key)
+	parsed, err := uuid.Parse(key)
+	require.NoError(t, err)
+	assert.Equal(t, uuid.Version(7), parsed.Version())
+}
+
+// The scan-task fixtures below are authored as literal REST JSON rather than
+// serialized with catalog/rest types. They follow Java's ContentFileParser
+// conventions: partition values are typed JSON values, while lower/upper bounds
+// are hexadecimal strings containing raw Iceberg binary single-value encodings.
+const canonicalCompletedPlanJSON = `{
+	"status": "completed",
+	"plan-id": "plan-sync",
+	"plan-tasks": ["inline-child"],
+	"file-scan-tasks": [` + canonicalFileScanTaskJSON + `],
+	"delete-files": [` + canonicalPositionDeleteJSON + `],
+	"storage-credentials": [{
+		"prefix": "s3://warehouse/table/",
+		"config": {"s3.access-key-id": "plan-key"}
+	}]
+}`
+
+const canonicalFileScanTaskJSON = `{
+	"data-file": {
+		"spec-id": 7,
+		"partition": [34, "2026-07-17", "78797A21"],
+		"content": "data",
+		"file-path": "s3://warehouse/table/data.parquet",
+		"file-format": "parquet",
+		"file-size-in-bytes": 4096,
+		"record-count": 100,
+		"column-sizes": {"keys": [1, 2], "values": [800, 1200]},
+		"lower-bounds": {"keys": [8, 9], "values": ["01000000", "02000000"]},
+		"upper-bounds": {"keys": [8, 9], "values": ["05000000", "0A000000"]}
+	},
+	"delete-file-references": [0],
+	"residual-filter": {"type": "eq", "term": "id", "value": 34}
+}`
+
+const canonicalPositionDeleteJSON = `{
+	"spec-id": 7,
+	"partition": [34, "2026-07-17", "78797A21"],
+	"content": "position-deletes",
+	"file-path": "s3://warehouse/table/delete.parquet",
+	"file-format": "parquet",
+	"file-size-in-bytes": 512,
+	"record-count": 5
+}`
+
+const rootFileScanTaskJSON = `{
+	"data-file": {
+		"spec-id": 0,
+		"partition": [],
+		"content": "data",
+		"file-path": "s3://warehouse/table/root.parquet",
+		"file-format": "parquet",
+		"file-size-in-bytes": 100,
+		"record-count": 10
+	},
+	"residual-filter": true
+}`
+
+const envelopeAFileScanTaskJSON = `{
+	"data-file": {
+		"spec-id": 0,
+		"partition": [],
+		"content": "data",
+		"file-path": "s3://warehouse/table/envelope-a.parquet",
+		"file-format": "parquet",
+		"file-size-in-bytes": 200,
+		"record-count": 20
+	},
+	"delete-file-references": [0],
+	"residual-filter": true
+}`
+
+const envelopeAPositionDeleteJSON = `{
+	"spec-id": 0,
+	"partition": [],
+	"content": "position-deletes",
+	"file-path": "s3://warehouse/table/envelope-a-delete.parquet",
+	"file-format": "parquet",
+	"file-size-in-bytes": 20,
+	"record-count": 2
+}`
+
+const envelopeAScanTasksJSON = `{
+	"file-scan-tasks": [` + envelopeAFileScanTaskJSON + `],
+	"delete-files": [` + envelopeAPositionDeleteJSON + `]
+}`
+
+const envelopeBFileScanTaskJSON = `{
+	"data-file": {
+		"spec-id": 0,
+		"partition": [],
+		"content": "data",
+		"file-path": "s3://warehouse/table/envelope-b.parquet",
+		"file-format": "parquet",
+		"file-size-in-bytes": 300,
+		"record-count": 30
+	},
+	"delete-file-references": [0],
+	"residual-filter": true
+}`
+
+const envelopeBPositionDeleteJSON = `{
+	"spec-id": 0,
+	"partition": [],
+	"content": "position-deletes",
+	"file-path": "s3://warehouse/table/envelope-b-delete.parquet",
+	"file-format": "parquet",
+	"file-size-in-bytes": 30,
+	"record-count": 3
+}`
+
+const envelopeBScanTasksJSON = `{
+	"plan-tasks": ["grandchild"],
+	"file-scan-tasks": [` + envelopeBFileScanTaskJSON + `],
+	"delete-files": [` + envelopeBPositionDeleteJSON + `]
+}`
+
+const grandchildFileScanTaskJSON = `{
+	"data-file": {
+		"spec-id": 0,
+		"partition": [],
+		"content": "data",
+		"file-path": "s3://warehouse/table/grandchild.parquet",
+		"file-format": "parquet",
+		"file-size-in-bytes": 400,
+		"record-count": 40
+	},
+	"residual-filter": true
+}`


### PR DESCRIPTION
Part of #1178.

## Summary

- Add a concurrency-safe in-process fake REST scan-planning server.
- Model config discovery, plan submission, polling, cancellation, and task fetching.
- Support deterministic response sequences, nested fan-out, duplicate task handles, request capture, storage credentials, and configurable failures.
- Exercise the existing low-level REST scan-planning client against independently authored wire payloads.

## Scope

This is test infrastructure only. It does not change `Catalog.PlanFiles`, scan-task decoding, planning modes, Java integration, or documentation.

## Testing

- `go test ./...`
- `go test -race ./catalog/rest/...`
- `go vet ./catalog/rest/...`
- `golangci-lint run --timeout=10m`
- `git diff --check`

