### PR TITLE
  feat(metrics): instrument scan planning and emit ScanReport (#1236)

### DIFF
--- a/metrics/reporters.go
+++ b/metrics/reporters.go
@@ -56,6 +56,25 @@ func (NopReporter) Report(context.Context, MetricsReport) {}
 // Close implements [Reporter]. NopReporter holds no resources, so it is a no-op.
 func (NopReporter) Close() error { return nil }
 
+// nopAware is implemented by reporters that can report whether they discard
+// every report, letting callers skip assembling a report that would be thrown
+// away. It is unexported: it is a hint for [IsNop], not part of the [Reporter]
+// contract.
+type nopAware interface {
+	isNop() bool
+}
+
+func (NopReporter) isNop() bool { return true }
+
+// IsNop reports whether r is known to discard every report — a bare
+// [NopReporter] or a [Combine] of only nop reporters. A false result does not
+// guarantee the report is consumed; it only means r is not a recognized no-op.
+func IsNop(r Reporter) bool {
+	n, ok := r.(nopAware)
+
+	return ok && n.isNop()
+}
+
 // LoggingReporter is a [Reporter] that logs each report via an [slog.Logger]. It
 // is a convenient default for development and debugging.
 type LoggingReporter struct {
@@ -173,6 +192,18 @@ type compositeReporter struct {
 }
 
 var _ Reporter = (*compositeReporter)(nil)
+
+// isNop reports true only when every wrapped reporter is itself a nop, so
+// Combine(NopReporter{}) is recognized as a no-op by [IsNop].
+func (c *compositeReporter) isNop() bool {
+	for _, r := range c.reporters {
+		if n, ok := r.(nopAware); !ok || !n.isNop() {
+			return false
+		}
+	}
+
+	return true
+}
 
 func (c *compositeReporter) Report(ctx context.Context, report MetricsReport) {
 	for _, r := range c.reporters {

--- a/metrics/reporters_test.go
+++ b/metrics/reporters_test.go
@@ -215,6 +215,24 @@ func TestCombine(t *testing.T) {
 	})
 }
 
+func TestIsNop(t *testing.T) {
+	t.Run("bare NopReporter is nop", func(t *testing.T) {
+		assert.True(t, IsNop(NopReporter{}))
+	})
+
+	t.Run("Combine of only nops is nop", func(t *testing.T) {
+		// The whole point: a wrapped nop must still be recognized so callers can
+		// skip assembling a report that would be discarded.
+		assert.True(t, IsNop(Combine(NopReporter{})))
+		assert.True(t, IsNop(Combine(NopReporter{}, NopReporter{})))
+	})
+
+	t.Run("Combine with a real reporter is not nop", func(t *testing.T) {
+		assert.False(t, IsNop(Combine(NopReporter{}, &countingReporter{})))
+		assert.False(t, IsNop(&countingReporter{}))
+	})
+}
+
 func TestInMemoryReporterConcurrent(t *testing.T) {
 	var r InMemoryReporter
 	const writers = 100

--- a/table/scan_metrics.go
+++ b/table/scan_metrics.go
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/metrics"
+)
+
+// scanMetricsAccumulator gathers scan-planning counts. Every field is written
+// from a single goroutine — the manifest counts in
+// fetchPartitionSpecFilteredManifestsWithSchema and the result/delete counts in
+// planFilesLocal after collectManifestEntriesWithSchema's concurrency barrier —
+// so plain integers are race-free; no field is touched from the concurrent
+// manifest workers.
+//
+// The scanned/skipped manifest counts measure partition-spec pruning (the
+// filter applied while listing manifests). The per-entry skipped-data-files /
+// skipped-delete-files counts (which would be incremented inside the concurrent
+// openManifest loop, and would use atomics) and indexed-delete-files are left
+// for a follow-up and omitted rather than reported as zero.
+type scanMetricsAccumulator struct {
+	totalDataManifests     int64
+	totalDeleteManifests   int64
+	scannedDataManifests   int64
+	scannedDeleteManifests int64
+	skippedDataManifests   int64
+	skippedDeleteManifests int64
+
+	resultDataFiles       int64
+	resultDeleteFiles     int64
+	totalFileSize         int64
+	totalDeleteFileSize   int64
+	positionalDeleteFiles int64
+	equalityDeleteFiles   int64
+	dvs                   int64
+}
+
+func counterCount(v int64) *metrics.CounterResult {
+	return metrics.NewCounterResult(metrics.UnitCount, v)
+}
+
+func counterBytes(v int64) *metrics.CounterResult {
+	return metrics.NewCounterResult(metrics.UnitBytes, v)
+}
+
+// applyResultDeleteMetrics derives the result-scoped delete-file metrics from
+// the planned tasks. Each delete file is counted once by path across all the
+// data files it applies to, split by kind (positional, equality, deletion
+// vector); positional deletes suppressed by a deletion vector never appear on a
+// task, so they are excluded. This keeps the counts consistent with
+// result-data-files and total-file-size-in-bytes.
+func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask) {
+	posDeletes := make(map[string]int64)
+	eqDeletes := make(map[string]int64)
+	dvs := make(map[string]int64)
+	for _, t := range tasks {
+		for _, df := range t.DeleteFiles {
+			posDeletes[df.FilePath()] = df.FileSizeBytes()
+		}
+		for _, df := range t.EqualityDeleteFiles {
+			eqDeletes[df.FilePath()] = df.FileSizeBytes()
+		}
+		for _, df := range t.DeletionVectorFiles {
+			dvs[df.FilePath()] = df.FileSizeBytes()
+		}
+	}
+
+	acc.positionalDeleteFiles = int64(len(posDeletes))
+	acc.equalityDeleteFiles = int64(len(eqDeletes))
+	acc.dvs = int64(len(dvs))
+	acc.resultDeleteFiles = acc.positionalDeleteFiles + acc.equalityDeleteFiles + acc.dvs
+	for _, deletes := range []map[string]int64{posDeletes, eqDeletes, dvs} {
+		for _, size := range deletes {
+			acc.totalDeleteFileSize += size
+		}
+	}
+}
+
+// buildScanReport assembles the ScanReport for a completed planning operation.
+// Only the metrics that are actually measured are populated; unmeasured ones
+// (e.g. skipped-data-files, indexed-delete-files) are left unset and omitted.
+func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, planning time.Duration) metrics.ScanReport {
+	// Resolve the schema the scan actually planned against (the snapshot schema
+	// for snapshot/as-of scans, the current schema otherwise). Best-effort: a
+	// report must never fail the scan, so fall back to the current schema.
+	schema, err := scan.effectiveSchema()
+	if err != nil || schema == nil {
+		schema = scan.metadata.CurrentSchema()
+	}
+
+	ids, names := scan.projectedFields(schema)
+
+	var snapshotID int64
+	if snap := scan.Snapshot(); snap != nil {
+		snapshotID = snap.SnapshotID
+	}
+
+	return metrics.ScanReport{
+		TableName:           strings.Join(scan.identifier, "."),
+		SnapshotID:          snapshotID,
+		SchemaID:            schema.ID,
+		ProjectedFieldIDs:   ids,
+		ProjectedFieldNames: names,
+		Metrics: metrics.ScanMetricsResult{
+			TotalPlanningDuration:      metrics.NewNanosTimerResult(1, planning.Nanoseconds()),
+			ResultDataFiles:            counterCount(acc.resultDataFiles),
+			ResultDeleteFiles:          counterCount(acc.resultDeleteFiles),
+			TotalDataManifests:         counterCount(acc.totalDataManifests),
+			TotalDeleteManifests:       counterCount(acc.totalDeleteManifests),
+			ScannedDataManifests:       counterCount(acc.scannedDataManifests),
+			ScannedDeleteManifests:     counterCount(acc.scannedDeleteManifests),
+			SkippedDataManifests:       counterCount(acc.skippedDataManifests),
+			SkippedDeleteManifests:     counterCount(acc.skippedDeleteManifests),
+			TotalFileSizeInBytes:       counterBytes(acc.totalFileSize),
+			TotalDeleteFileSizeInBytes: counterBytes(acc.totalDeleteFileSize),
+			EqualityDeleteFiles:        counterCount(acc.equalityDeleteFiles),
+			PositionalDeleteFiles:      counterCount(acc.positionalDeleteFiles),
+			DVs:                        counterCount(acc.dvs),
+		},
+	}
+}
+
+// projectedFields resolves the scan's selected fields to their ids and names
+// against schema. A "*" (or empty) selection projects all top-level fields.
+// Unresolvable names are skipped.
+func (scan *Scan) projectedFields(schema *iceberg.Schema) ([]int, []string) {
+	if len(scan.selectedFields) == 0 || slices.Contains(scan.selectedFields, "*") {
+		fields := schema.Fields()
+		ids := make([]int, len(fields))
+		names := make([]string, len(fields))
+		for i, f := range fields {
+			ids[i], names[i] = f.ID, f.Name
+		}
+
+		return ids, names
+	}
+
+	ids := make([]int, 0, len(scan.selectedFields))
+	names := make([]string, 0, len(scan.selectedFields))
+	for _, name := range scan.selectedFields {
+		nf, ok := schema.FindFieldByName(name)
+		if !ok && !scan.caseSensitive {
+			nf, ok = schema.FindFieldByNameCaseInsensitive(name)
+		}
+		if ok {
+			ids = append(ids, nf.ID)
+			names = append(names, nf.Name)
+		}
+	}
+
+	return ids, names
+}

--- a/table/scan_metrics.go
+++ b/table/scan_metrics.go
@@ -65,59 +65,35 @@ func counterBytes(v int64) *metrics.CounterResult {
 }
 
 // applyResultDeleteMetrics derives the result-scoped delete-file metrics from
-// the planned tasks. Each delete file is counted once by path across all the
-// data files it applies to, split by kind (positional, equality, deletion
-// vector); positional deletes suppressed by a deletion vector never appear on a
-// task, so they are excluded. This keeps the counts consistent with
-// result-data-files and total-file-size-in-bytes.
+// the planned tasks. Following Java's ScanMetricsUtil.fileTask, every delete
+// file is counted once per data-file task it applies to — a delete covering N
+// data files is counted N times — with no cross-task dedup, so these
+// Java-parity field names stay directly comparable with what Java consumers
+// report. Sizes accumulate the same way.
 //
-// Parity note: Java's ScanMetricsUtil.fileTask counts result-delete-files per
-// data-file task with no cross-task dedup, so a positional delete covering 5
-// data files counts as 5 there and once here. Counting once by path is the
-// deliberate choice for this result-scoped metric; keep it if touching this.
-//
-// Deletion vectors are keyed by the data file they reference, not by their
-// Puffin file path: a single Puffin file holds one DV blob per data file (see
-// DVWriter.Flush), so all DVs from one flush share a FilePath() and would
-// collapse into one entry if keyed by it. Their size is the per-blob
-// content_size_in_bytes, not the whole Puffin file size, matching Java's
-// ScanTaskUtil.contentSizeInBytes.
+// A deletion vector's size is its per-blob content_size_in_bytes (Java's
+// ScanTaskUtil.contentSizeInBytes), not the size of the Puffin file that holds
+// it: DVWriter.Flush packs one DV blob per data file into a single Puffin file,
+// so the Puffin length would over-count.
 func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask) {
-	posDeletes := make(map[string]int64)
-	eqDeletes := make(map[string]int64)
-	dvByRef := make(map[string]int64)
 	for _, t := range tasks {
 		for _, df := range t.DeleteFiles {
-			posDeletes[df.FilePath()] = df.FileSizeBytes()
+			acc.positionalDeleteFiles++
+			acc.totalDeleteFileSize += df.FileSizeBytes()
 		}
 		for _, df := range t.EqualityDeleteFiles {
-			eqDeletes[df.FilePath()] = df.FileSizeBytes()
+			acc.equalityDeleteFiles++
+			acc.totalDeleteFileSize += df.FileSizeBytes()
 		}
 		for _, df := range t.DeletionVectorFiles {
-			// Key by the referenced data file so multiple DVs sharing one
-			// Puffin path stay distinct; fall back to the Puffin path if the
-			// reference is somehow unset. Size is the per-blob content size.
-			key := df.FilePath()
-			if ref := df.ReferencedDataFile(); ref != nil {
-				key = *ref
-			}
-			var size int64
+			acc.dvs++
 			if csb := df.ContentSizeInBytes(); csb != nil {
-				size = *csb
+				acc.totalDeleteFileSize += *csb
 			}
-			dvByRef[key] = size
 		}
 	}
 
-	acc.positionalDeleteFiles = int64(len(posDeletes))
-	acc.equalityDeleteFiles = int64(len(eqDeletes))
-	acc.dvs = int64(len(dvByRef))
 	acc.resultDeleteFiles = acc.positionalDeleteFiles + acc.equalityDeleteFiles + acc.dvs
-	for _, deletes := range []map[string]int64{posDeletes, eqDeletes, dvByRef} {
-		for _, size := range deletes {
-			acc.totalDeleteFileSize += size
-		}
-	}
 }
 
 // buildScanReport assembles the ScanReport for a completed planning operation.
@@ -133,14 +109,17 @@ func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema *iceberg.S
 		snapshotID = snap.SnapshotID
 	}
 
-	// Serialize the actual row filter as Expression JSON. On a marshal error we
-	// leave Filter unset so ScanReport.MarshalJSON falls back to always-true
-	// rather than failing the scan; literal sanitization (Java's ExpressionUtil)
-	// is a follow-up.
+	// Serialize the scan's row filter as Expression JSON, first sanitizing it so
+	// predicate literals (which can be user data) never reach a reporter or REST
+	// metrics sink. On any error we leave Filter unset so ScanReport.MarshalJSON
+	// falls back to always-true rather than failing the scan or, worse, emitting
+	// unsanitized literals.
 	var filter json.RawMessage
 	if scan.rowFilter != nil {
-		if raw, err := json.Marshal(scan.rowFilter); err == nil {
-			filter = raw
+		if sanitized, err := iceberg.SanitizeExpression(scan.rowFilter); err == nil {
+			if raw, err := json.Marshal(sanitized); err == nil {
+				filter = raw
+			}
 		}
 	}
 
@@ -170,33 +149,40 @@ func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema *iceberg.S
 	}
 }
 
-// projectedFields resolves the scan's selected fields to their ids and names
-// against schema. A "*" (or empty) selection projects all top-level fields.
-// Unresolvable names are skipped.
+// projectedFields resolves the scan's projection to the field ids and dotted
+// column names it reads, matching Java's TypeUtil.getProjectedIds +
+// Schema.findColumnName: nested fields are reported by id and full dotted path,
+// not just top-level columns. schema is the schema the scan planned against and
+// is used to resolve names; ids are returned sorted for deterministic output.
+// Ids not resolvable to a name in schema (e.g. reserved row-lineage columns) are
+// skipped so ids and names stay aligned.
 func (scan *Scan) projectedFields(schema *iceberg.Schema) ([]int, []string) {
-	if len(scan.selectedFields) == 0 || slices.Contains(scan.selectedFields, "*") {
-		fields := schema.Fields()
-		ids := make([]int, len(fields))
-		names := make([]string, len(fields))
-		for i, f := range fields {
-			ids[i], names[i] = f.ID, f.Name
-		}
-
-		return ids, names
+	projected, err := scan.Projection()
+	if err != nil {
+		return nil, nil
 	}
 
-	ids := make([]int, 0, len(scan.selectedFields))
-	names := make([]string, 0, len(scan.selectedFields))
-	for _, name := range scan.selectedFields {
-		nf, ok := schema.FindFieldByName(name)
-		if !ok && !scan.caseSensitive {
-			nf, ok = schema.FindFieldByNameCaseInsensitive(name)
-		}
-		if ok {
-			ids = append(ids, nf.ID)
-			names = append(names, nf.Name)
-		}
+	idToField, err := iceberg.IndexByID(projected)
+	if err != nil {
+		return nil, nil
 	}
 
-	return ids, names
+	ids := make([]int, 0, len(idToField))
+	for id := range idToField {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	resolvedIDs := make([]int, 0, len(ids))
+	names := make([]string, 0, len(ids))
+	for _, id := range ids {
+		name, ok := schema.FindColumnName(id)
+		if !ok {
+			continue
+		}
+		resolvedIDs = append(resolvedIDs, id)
+		names = append(names, name)
+	}
+
+	return resolvedIDs, names
 }

--- a/table/scan_metrics.go
+++ b/table/scan_metrics.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"time"
@@ -69,10 +70,22 @@ func counterBytes(v int64) *metrics.CounterResult {
 // vector); positional deletes suppressed by a deletion vector never appear on a
 // task, so they are excluded. This keeps the counts consistent with
 // result-data-files and total-file-size-in-bytes.
+//
+// Parity note: Java's ScanMetricsUtil.fileTask counts result-delete-files per
+// data-file task with no cross-task dedup, so a positional delete covering 5
+// data files counts as 5 there and once here. Counting once by path is the
+// deliberate choice for this result-scoped metric; keep it if touching this.
+//
+// Deletion vectors are keyed by the data file they reference, not by their
+// Puffin file path: a single Puffin file holds one DV blob per data file (see
+// DVWriter.Flush), so all DVs from one flush share a FilePath() and would
+// collapse into one entry if keyed by it. Their size is the per-blob
+// content_size_in_bytes, not the whole Puffin file size, matching Java's
+// ScanTaskUtil.contentSizeInBytes.
 func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask) {
 	posDeletes := make(map[string]int64)
 	eqDeletes := make(map[string]int64)
-	dvs := make(map[string]int64)
+	dvByRef := make(map[string]int64)
 	for _, t := range tasks {
 		for _, df := range t.DeleteFiles {
 			posDeletes[df.FilePath()] = df.FileSizeBytes()
@@ -81,15 +94,26 @@ func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask
 			eqDeletes[df.FilePath()] = df.FileSizeBytes()
 		}
 		for _, df := range t.DeletionVectorFiles {
-			dvs[df.FilePath()] = df.FileSizeBytes()
+			// Key by the referenced data file so multiple DVs sharing one
+			// Puffin path stay distinct; fall back to the Puffin path if the
+			// reference is somehow unset. Size is the per-blob content size.
+			key := df.FilePath()
+			if ref := df.ReferencedDataFile(); ref != nil {
+				key = *ref
+			}
+			var size int64
+			if csb := df.ContentSizeInBytes(); csb != nil {
+				size = *csb
+			}
+			dvByRef[key] = size
 		}
 	}
 
 	acc.positionalDeleteFiles = int64(len(posDeletes))
 	acc.equalityDeleteFiles = int64(len(eqDeletes))
-	acc.dvs = int64(len(dvs))
+	acc.dvs = int64(len(dvByRef))
 	acc.resultDeleteFiles = acc.positionalDeleteFiles + acc.equalityDeleteFiles + acc.dvs
-	for _, deletes := range []map[string]int64{posDeletes, eqDeletes, dvs} {
+	for _, deletes := range []map[string]int64{posDeletes, eqDeletes, dvByRef} {
 		for _, size := range deletes {
 			acc.totalDeleteFileSize += size
 		}
@@ -97,22 +121,27 @@ func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask
 }
 
 // buildScanReport assembles the ScanReport for a completed planning operation.
+// schema is the schema the scan planned against, threaded in from the planner so
+// the report describes exactly what was used rather than re-resolving it here.
 // Only the metrics that are actually measured are populated; unmeasured ones
 // (e.g. skipped-data-files, indexed-delete-files) are left unset and omitted.
-func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, planning time.Duration) metrics.ScanReport {
-	// Resolve the schema the scan actually planned against (the snapshot schema
-	// for snapshot/as-of scans, the current schema otherwise). Best-effort: a
-	// report must never fail the scan, so fall back to the current schema.
-	schema, err := scan.effectiveSchema()
-	if err != nil || schema == nil {
-		schema = scan.metadata.CurrentSchema()
-	}
-
+func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema *iceberg.Schema, planning time.Duration) metrics.ScanReport {
 	ids, names := scan.projectedFields(schema)
 
 	var snapshotID int64
 	if snap := scan.Snapshot(); snap != nil {
 		snapshotID = snap.SnapshotID
+	}
+
+	// Serialize the actual row filter as Expression JSON. On a marshal error we
+	// leave Filter unset so ScanReport.MarshalJSON falls back to always-true
+	// rather than failing the scan; literal sanitization (Java's ExpressionUtil)
+	// is a follow-up.
+	var filter json.RawMessage
+	if scan.rowFilter != nil {
+		if raw, err := json.Marshal(scan.rowFilter); err == nil {
+			filter = raw
+		}
 	}
 
 	return metrics.ScanReport{
@@ -121,6 +150,7 @@ func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, planning time.Dur
 		SchemaID:            schema.ID,
 		ProjectedFieldIDs:   ids,
 		ProjectedFieldNames: names,
+		Filter:              filter,
 		Metrics: metrics.ScanMetricsResult{
 			TotalPlanningDuration:      metrics.NewNanosTimerResult(1, planning.Nanoseconds()),
 			ResultDataFiles:            counterCount(acc.resultDataFiles),

--- a/table/scan_metrics.go
+++ b/table/scan_metrics.go
@@ -97,12 +97,15 @@ func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask
 }
 
 // buildScanReport assembles the ScanReport for a completed planning operation.
-// schema is the schema the scan planned against, threaded in from the planner so
-// the report describes exactly what was used rather than re-resolving it here.
-// Only the metrics that are actually measured are populated; unmeasured ones
-// (e.g. skipped-data-files, indexed-delete-files) are left unset and omitted.
-func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema *iceberg.Schema, planning time.Duration) metrics.ScanReport {
-	ids, names := scan.projectedFields(schema)
+// schema is the schema the scan planned against and projected is the projected
+// (column-selected) schema, both threaded in from the planner so the report
+// describes exactly what was used rather than re-resolving it here. projected may
+// be nil when the projection could not be resolved, in which case the report
+// simply carries no projected fields. Only the metrics that are actually measured
+// are populated; unmeasured ones (e.g. skipped-data-files, indexed-delete-files)
+// are left unset and omitted.
+func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema, projected *iceberg.Schema, planning time.Duration) metrics.ScanReport {
+	ids, names := projectedFields(projected)
 
 	var snapshotID int64
 	if snap := scan.Snapshot(); snap != nil {
@@ -149,20 +152,22 @@ func (scan *Scan) buildScanReport(acc *scanMetricsAccumulator, schema *iceberg.S
 	}
 }
 
-// projectedFields resolves the scan's projection to the field ids and dotted
-// column names it reads, matching Java's TypeUtil.getProjectedIds +
-// Schema.findColumnName: nested fields are reported by id and full dotted path,
-// not just top-level columns. schema is the schema the scan planned against and
-// is used to resolve names; ids are returned sorted for deterministic output.
-// Ids not resolvable to a name in schema (e.g. reserved row-lineage columns) are
-// skipped so ids and names stay aligned.
-func (scan *Scan) projectedFields(schema *iceberg.Schema) ([]int, []string) {
-	projected, err := scan.Projection()
-	if err != nil {
+// projectedFields resolves the field ids and dotted column names the scan reads,
+// matching Java's TypeUtil.getProjectedIds + Schema.findColumnName: nested fields
+// are reported by id and full dotted path, not just top-level columns. It walks
+// the projected schema threaded in from the planner directly rather than
+// re-resolving scan.Projection(), so the report reflects exactly what planning
+// used and does not silently drop the projected fields if Projection() fails for
+// a reason planning never hit (e.g. the row-lineage version check). A nil schema
+// (projection unresolved) yields no projected fields. Ids are returned sorted for
+// deterministic output; an id not resolvable to a name in the schema (e.g. a
+// reserved row-lineage column) is skipped so ids and names stay aligned.
+func projectedFields(schema *iceberg.Schema) ([]int, []string) {
+	if schema == nil {
 		return nil, nil
 	}
 
-	idToField, err := iceberg.IndexByID(projected)
+	idToField, err := iceberg.IndexByID(schema)
 	if err != nil {
 		return nil, nil
 	}

--- a/table/scan_metrics_test.go
+++ b/table/scan_metrics_test.go
@@ -64,12 +64,14 @@ func TestBuildScanReport(t *testing.T) {
 		totalDeleteFileSize:   512,
 	}
 
-	sr := scan.buildScanReport(acc, 5*time.Millisecond)
+	sr := scan.buildScanReport(acc, meta.CurrentSchema(), 5*time.Millisecond)
 
 	assert.Equal(t, "db.tbl", sr.TableName)
 	assert.Equal(t, meta.CurrentSchema().ID, sr.SchemaID)
 	assert.Equal(t, []int{1, 2}, sr.ProjectedFieldIDs)
 	assert.Equal(t, []string{"id", "data"}, sr.ProjectedFieldNames)
+	// No row filter set: Filter stays unset and defaults to always-true on the wire.
+	assert.Nil(t, sr.Filter)
 
 	m := sr.Metrics
 	require.NotNil(t, m.TotalPlanningDuration)
@@ -111,7 +113,13 @@ func TestApplyResultDeleteMetrics(t *testing.T) {
 	posA := &mockDataFile{path: "s3://b/pos-a.parquet", filesize: 100}
 	posB := &mockDataFile{path: "s3://b/pos-b.parquet", filesize: 200}
 	eq := &mockDataFile{path: "s3://b/eq.parquet", filesize: 40}
-	dv := &mockDataFile{path: "s3://b/dv.puffin", filesize: 10}
+	// A DV is a Puffin file; its size is the per-blob content_size_in_bytes, not
+	// the whole Puffin file size, so filesize (the Puffin length) must be ignored.
+	dv := &dvMockDataFile{
+		mockDataFile:       mockDataFile{path: "s3://b/deletes.puffin", filesize: 9999},
+		referencedDataFile: strPtr("s3://b/data-2.parquet"),
+		contentSizeInBytes: int64Ptr(10),
+	}
 
 	// posA applies to both data files: it must be counted (and sized) once.
 	tasks := []FileScanTask{
@@ -134,13 +142,58 @@ func TestApplyResultDeleteMetrics(t *testing.T) {
 	assert.Equal(t, int64(1), acc.equalityDeleteFiles)
 	assert.Equal(t, int64(1), acc.dvs)
 	assert.Equal(t, int64(4), acc.resultDeleteFiles)
-	// 100 (posA once) + 200 (posB) + 40 (eq) + 10 (dv)
+	// 100 (posA once) + 200 (posB) + 40 (eq) + 10 (dv content size, not 9999)
 	assert.Equal(t, int64(350), acc.totalDeleteFileSize)
 }
 
-func TestPlanFilesEmitsScanReport(t *testing.T) {
-	// A table with no snapshot still completes planning (zero results) and must
-	// emit exactly one ScanReport through the configured reporter.
+func TestApplyResultDeleteMetricsDVsShareOnePuffin(t *testing.T) {
+	// DVWriter.Flush writes one Puffin file with a separate DV blob per data
+	// file, so both DVs below share a FilePath() and differ only by the data
+	// file they reference. Keying by referenced data file must keep them
+	// distinct (2 DVs), and each blob's own content size must be summed.
+	puffin := "s3://b/deletes.puffin"
+	ref1, ref2 := "s3://b/data-1.parquet", "s3://b/data-2.parquet"
+	dv1 := &dvMockDataFile{
+		mockDataFile:       mockDataFile{path: puffin, filesize: 9999},
+		referencedDataFile: &ref1,
+		contentSizeInBytes: int64Ptr(30),
+	}
+	dv2 := &dvMockDataFile{
+		mockDataFile:       mockDataFile{path: puffin, filesize: 9999},
+		referencedDataFile: &ref2,
+		contentSizeInBytes: int64Ptr(70),
+	}
+
+	tasks := []FileScanTask{
+		{File: &mockDataFile{path: ref1, filesize: 1000}, DeletionVectorFiles: []iceberg.DataFile{dv1}},
+		{File: &mockDataFile{path: ref2, filesize: 2000}, DeletionVectorFiles: []iceberg.DataFile{dv2}},
+	}
+
+	var acc scanMetricsAccumulator
+	acc.applyResultDeleteMetrics(tasks)
+
+	assert.Equal(t, int64(2), acc.dvs, "two DVs in one Puffin file must not collapse")
+	assert.Equal(t, int64(2), acc.resultDeleteFiles)
+	assert.Equal(t, int64(100), acc.totalDeleteFileSize, "sum of per-blob content sizes, not Puffin file size")
+}
+
+func TestBuildScanReportSetsFilter(t *testing.T) {
+	meta := metricsTestMetadata(t)
+	scan := &Scan{
+		metadata:       meta,
+		identifier:     Identifier{"db", "tbl"},
+		selectedFields: []string{"*"},
+		caseSensitive:  true,
+		rowFilter:      iceberg.AlwaysFalse{},
+	}
+
+	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), time.Millisecond)
+	assert.JSONEq(t, `false`, string(sr.Filter), "Filter must reflect the real row filter, not default to always-true")
+}
+
+func TestPlanFilesNoSnapshotEmitsNoReport(t *testing.T) {
+	// A table with no snapshot plans zero files and has no real snapshot id, so
+	// no ScanReport is emitted (matching Java, which skips the report entirely).
 	rep := &metrics.InMemoryReporter{}
 	meta := metricsTestMetadata(t)
 	tbl := New(Identifier{"db", "tbl"}, meta, "metadata.json", nil, nil,
@@ -150,16 +203,7 @@ func TestPlanFilesEmitsScanReport(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, tasks)
 
-	reports := rep.Reports()
-	require.Len(t, reports, 1)
-
-	sr, ok := reports[0].(metrics.ScanReport)
-	require.True(t, ok, "expected a ScanReport, got %T", reports[0])
-	assert.Equal(t, "db.tbl", sr.TableName)
-	assert.Equal(t, meta.CurrentSchema().ID, sr.SchemaID)
-	require.NotNil(t, sr.Metrics.TotalPlanningDuration)
-	require.NotNil(t, sr.Metrics.ResultDataFiles)
-	assert.Equal(t, int64(0), sr.Metrics.ResultDataFiles.Value)
+	assert.Empty(t, rep.Reports(), "no snapshot means no scan report")
 }
 
 func TestPlanFilesNopReporterDoesNotPanic(t *testing.T) {

--- a/table/scan_metrics_test.go
+++ b/table/scan_metrics_test.go
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func metricsTestMetadata(t *testing.T) Metadata {
+	t.Helper()
+	schema := iceberg.NewSchema(7,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+	)
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://bucket/tbl", iceberg.Properties{})
+	require.NoError(t, err)
+
+	return meta
+}
+
+func TestBuildScanReport(t *testing.T) {
+	meta := metricsTestMetadata(t)
+	scan := &Scan{
+		metadata:       meta,
+		identifier:     Identifier{"db", "tbl"},
+		selectedFields: []string{"*"},
+		caseSensitive:  true,
+	}
+
+	acc := &scanMetricsAccumulator{
+		totalDataManifests:    3,
+		scannedDataManifests:  2,
+		skippedDataManifests:  1,
+		totalDeleteManifests:  1,
+		resultDataFiles:       10,
+		totalFileSize:         2048,
+		positionalDeleteFiles: 1,
+		equalityDeleteFiles:   2,
+		dvs:                   1,
+		resultDeleteFiles:     4,
+		totalDeleteFileSize:   512,
+	}
+
+	sr := scan.buildScanReport(acc, 5*time.Millisecond)
+
+	assert.Equal(t, "db.tbl", sr.TableName)
+	assert.Equal(t, meta.CurrentSchema().ID, sr.SchemaID)
+	assert.Equal(t, []int{1, 2}, sr.ProjectedFieldIDs)
+	assert.Equal(t, []string{"id", "data"}, sr.ProjectedFieldNames)
+
+	m := sr.Metrics
+	require.NotNil(t, m.TotalPlanningDuration)
+	assert.Equal(t, metrics.TimeUnitNanoseconds, m.TotalPlanningDuration.TimeUnit)
+	assert.Equal(t, (5 * time.Millisecond).Nanoseconds(), m.TotalPlanningDuration.TotalDuration)
+	assert.Equal(t, int64(1), m.TotalPlanningDuration.Count)
+
+	require.NotNil(t, m.TotalDataManifests)
+	assert.Equal(t, metrics.UnitCount, m.TotalDataManifests.Unit)
+	assert.Equal(t, int64(3), m.TotalDataManifests.Value)
+	assert.Equal(t, int64(2), m.ScannedDataManifests.Value)
+	assert.Equal(t, int64(1), m.SkippedDataManifests.Value)
+	assert.Equal(t, int64(10), m.ResultDataFiles.Value)
+	assert.Equal(t, int64(4), m.ResultDeleteFiles.Value)
+	assert.Equal(t, int64(1), m.PositionalDeleteFiles.Value)
+	assert.Equal(t, int64(2), m.EqualityDeleteFiles.Value)
+	assert.Equal(t, int64(1), m.DVs.Value)
+
+	require.NotNil(t, m.TotalFileSizeInBytes)
+	assert.Equal(t, metrics.UnitBytes, m.TotalFileSizeInBytes.Unit)
+	assert.Equal(t, int64(2048), m.TotalFileSizeInBytes.Value)
+	assert.Equal(t, int64(512), m.TotalDeleteFileSizeInBytes.Value)
+
+	// Unmeasured metrics are left unset (omitted on the wire).
+	assert.Nil(t, m.SkippedDataFiles)
+	assert.Nil(t, m.IndexedDeleteFiles)
+}
+
+func TestProjectedFieldsSelectedSubset(t *testing.T) {
+	meta := metricsTestMetadata(t)
+	scan := &Scan{metadata: meta, selectedFields: []string{"data"}, caseSensitive: true}
+
+	ids, names := scan.projectedFields(meta.CurrentSchema())
+	assert.Equal(t, []int{2}, ids)
+	assert.Equal(t, []string{"data"}, names)
+}
+
+func TestApplyResultDeleteMetrics(t *testing.T) {
+	posA := &mockDataFile{path: "s3://b/pos-a.parquet", filesize: 100}
+	posB := &mockDataFile{path: "s3://b/pos-b.parquet", filesize: 200}
+	eq := &mockDataFile{path: "s3://b/eq.parquet", filesize: 40}
+	dv := &mockDataFile{path: "s3://b/dv.puffin", filesize: 10}
+
+	// posA applies to both data files: it must be counted (and sized) once.
+	tasks := []FileScanTask{
+		{
+			File:        &mockDataFile{path: "s3://b/data-1.parquet", filesize: 1000},
+			DeleteFiles: []iceberg.DataFile{posA, posB},
+		},
+		{
+			File:                &mockDataFile{path: "s3://b/data-2.parquet", filesize: 2000},
+			DeleteFiles:         []iceberg.DataFile{posA},
+			EqualityDeleteFiles: []iceberg.DataFile{eq},
+			DeletionVectorFiles: []iceberg.DataFile{dv},
+		},
+	}
+
+	var acc scanMetricsAccumulator
+	acc.applyResultDeleteMetrics(tasks)
+
+	assert.Equal(t, int64(2), acc.positionalDeleteFiles, "posA is shared, counted once")
+	assert.Equal(t, int64(1), acc.equalityDeleteFiles)
+	assert.Equal(t, int64(1), acc.dvs)
+	assert.Equal(t, int64(4), acc.resultDeleteFiles)
+	// 100 (posA once) + 200 (posB) + 40 (eq) + 10 (dv)
+	assert.Equal(t, int64(350), acc.totalDeleteFileSize)
+}
+
+func TestPlanFilesEmitsScanReport(t *testing.T) {
+	// A table with no snapshot still completes planning (zero results) and must
+	// emit exactly one ScanReport through the configured reporter.
+	rep := &metrics.InMemoryReporter{}
+	meta := metricsTestMetadata(t)
+	tbl := New(Identifier{"db", "tbl"}, meta, "metadata.json", nil, nil,
+		WithMetricsReporter(rep))
+
+	tasks, err := tbl.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, tasks)
+
+	reports := rep.Reports()
+	require.Len(t, reports, 1)
+
+	sr, ok := reports[0].(metrics.ScanReport)
+	require.True(t, ok, "expected a ScanReport, got %T", reports[0])
+	assert.Equal(t, "db.tbl", sr.TableName)
+	assert.Equal(t, meta.CurrentSchema().ID, sr.SchemaID)
+	require.NotNil(t, sr.Metrics.TotalPlanningDuration)
+	require.NotNil(t, sr.Metrics.ResultDataFiles)
+	assert.Equal(t, int64(0), sr.Metrics.ResultDataFiles.Value)
+}
+
+func TestPlanFilesNopReporterDoesNotPanic(t *testing.T) {
+	// Default (no reporter configured) must plan without panicking.
+	tbl := New(Identifier{"db", "tbl"}, metricsTestMetadata(t), "metadata.json", nil, nil)
+	assert.NotPanics(t, func() {
+		_, _ = tbl.Scan().PlanFiles(context.Background())
+	})
+}
+
+func TestPlanFilesRemoteDoesNotEmitScanReport(t *testing.T) {
+	// Remote (server-side) planning reports its own metrics; the client must not
+	// emit a local ScanReport (which would carry only zeroed counters).
+	rep := &metrics.InMemoryReporter{}
+	scan := &Scan{
+		planner:      &fakeScanPlanner{result: ScanPlanningResult{Tasks: []FileScanTask{{}}}, supports: true},
+		planningMode: ScanPlanningRemote,
+		reporter:     rep,
+	}
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Empty(t, rep.Reports(), "remote planning must not emit a local ScanReport")
+}

--- a/table/scan_metrics_test.go
+++ b/table/scan_metrics_test.go
@@ -109,6 +109,30 @@ func TestProjectedFieldsSelectedSubset(t *testing.T) {
 	assert.Equal(t, []string{"data"}, names)
 }
 
+func TestProjectedFieldsNested(t *testing.T) {
+	// Selecting a struct column must report its nested fields by id and full
+	// dotted path, not just the top-level column (Java's TypeUtil.getProjectedIds
+	// + Schema.findColumnName).
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "location", Required: false, Type: &iceberg.StructType{
+			FieldList: []iceberg.NestedField{
+				{ID: 3, Name: "lat", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+				{ID: 4, Name: "lon", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+			},
+		}},
+	)
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://bucket/tbl", iceberg.Properties{})
+	require.NoError(t, err)
+
+	scan := &Scan{metadata: meta, selectedFields: []string{"location"}, caseSensitive: true}
+
+	ids, names := scan.projectedFields(meta.CurrentSchema())
+	assert.Equal(t, []int{2, 3, 4}, ids)
+	assert.Equal(t, []string{"location", "location.lat", "location.lon"}, names)
+}
+
 func TestApplyResultDeleteMetrics(t *testing.T) {
 	posA := &mockDataFile{path: "s3://b/pos-a.parquet", filesize: 100}
 	posB := &mockDataFile{path: "s3://b/pos-b.parquet", filesize: 200}
@@ -121,7 +145,8 @@ func TestApplyResultDeleteMetrics(t *testing.T) {
 		contentSizeInBytes: int64Ptr(10),
 	}
 
-	// posA applies to both data files: it must be counted (and sized) once.
+	// posA applies to both data-file tasks: matching Java's per-task
+	// accumulation, it must be counted (and sized) once per task, i.e. twice.
 	tasks := []FileScanTask{
 		{
 			File:        &mockDataFile{path: "s3://b/data-1.parquet", filesize: 1000},
@@ -138,19 +163,21 @@ func TestApplyResultDeleteMetrics(t *testing.T) {
 	var acc scanMetricsAccumulator
 	acc.applyResultDeleteMetrics(tasks)
 
-	assert.Equal(t, int64(2), acc.positionalDeleteFiles, "posA is shared, counted once")
+	assert.Equal(t, int64(3), acc.positionalDeleteFiles, "posA counted once per task it applies to")
 	assert.Equal(t, int64(1), acc.equalityDeleteFiles)
 	assert.Equal(t, int64(1), acc.dvs)
-	assert.Equal(t, int64(4), acc.resultDeleteFiles)
-	// 100 (posA once) + 200 (posB) + 40 (eq) + 10 (dv content size, not 9999)
-	assert.Equal(t, int64(350), acc.totalDeleteFileSize)
+	assert.Equal(t, int64(5), acc.resultDeleteFiles)
+	// task 1: 100 (posA) + 200 (posB); task 2: 100 (posA) + 40 (eq) + 10 (dv
+	// content size, not 9999) = 450 total.
+	assert.Equal(t, int64(450), acc.totalDeleteFileSize)
 }
 
 func TestApplyResultDeleteMetricsDVsShareOnePuffin(t *testing.T) {
 	// DVWriter.Flush writes one Puffin file with a separate DV blob per data
 	// file, so both DVs below share a FilePath() and differ only by the data
-	// file they reference. Keying by referenced data file must keep them
-	// distinct (2 DVs), and each blob's own content size must be summed.
+	// file they reference. Each is planned on its own data-file task, so per-task
+	// counting reports 2 DVs, and each blob's own content size must be summed
+	// (never the shared Puffin file length).
 	puffin := "s3://b/deletes.puffin"
 	ref1, ref2 := "s3://b/data-1.parquet", "s3://b/data-2.parquet"
 	dv1 := &dvMockDataFile{
@@ -189,6 +216,25 @@ func TestBuildScanReportSetsFilter(t *testing.T) {
 
 	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), time.Millisecond)
 	assert.JSONEq(t, `false`, string(sr.Filter), "Filter must reflect the real row filter, not default to always-true")
+}
+
+func TestBuildScanReportSanitizesFilter(t *testing.T) {
+	// Predicate literals can be user data, so the emitted filter must be
+	// sanitized (Java's ExpressionUtil.sanitize) before it reaches a reporter.
+	meta := metricsTestMetadata(t)
+	scan := &Scan{
+		metadata:       meta,
+		identifier:     Identifier{"db", "tbl"},
+		selectedFields: []string{"*"},
+		caseSensitive:  true,
+		rowFilter:      iceberg.EqualTo(iceberg.Reference("data"), "secret-value"),
+	}
+
+	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), time.Millisecond)
+	require.NotNil(t, sr.Filter)
+	assert.NotContains(t, string(sr.Filter), "secret-value", "literal must not leak into the report")
+	assert.Contains(t, string(sr.Filter), "data", "column reference is preserved")
+	assert.Contains(t, string(sr.Filter), "(redacted)")
 }
 
 func TestPlanFilesNoSnapshotEmitsNoReport(t *testing.T) {

--- a/table/scan_metrics_test.go
+++ b/table/scan_metrics_test.go
@@ -18,11 +18,13 @@
 package table
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +66,7 @@ func TestBuildScanReport(t *testing.T) {
 		totalDeleteFileSize:   512,
 	}
 
-	sr := scan.buildScanReport(acc, meta.CurrentSchema(), 5*time.Millisecond)
+	sr := scan.buildScanReport(acc, meta.CurrentSchema(), meta.CurrentSchema(), 5*time.Millisecond)
 
 	assert.Equal(t, "db.tbl", sr.TableName)
 	assert.Equal(t, meta.CurrentSchema().ID, sr.SchemaID)
@@ -104,7 +106,9 @@ func TestProjectedFieldsSelectedSubset(t *testing.T) {
 	meta := metricsTestMetadata(t)
 	scan := &Scan{metadata: meta, selectedFields: []string{"data"}, caseSensitive: true}
 
-	ids, names := scan.projectedFields(meta.CurrentSchema())
+	projected, err := scan.Projection()
+	require.NoError(t, err)
+	ids, names := projectedFields(projected)
 	assert.Equal(t, []int{2}, ids)
 	assert.Equal(t, []string{"data"}, names)
 }
@@ -128,7 +132,9 @@ func TestProjectedFieldsNested(t *testing.T) {
 
 	scan := &Scan{metadata: meta, selectedFields: []string{"location"}, caseSensitive: true}
 
-	ids, names := scan.projectedFields(meta.CurrentSchema())
+	projected, err := scan.Projection()
+	require.NoError(t, err)
+	ids, names := projectedFields(projected)
 	assert.Equal(t, []int{2, 3, 4}, ids)
 	assert.Equal(t, []string{"location", "location.lat", "location.lon"}, names)
 }
@@ -214,7 +220,7 @@ func TestBuildScanReportSetsFilter(t *testing.T) {
 		rowFilter:      iceberg.AlwaysFalse{},
 	}
 
-	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), time.Millisecond)
+	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), meta.CurrentSchema(), time.Millisecond)
 	assert.JSONEq(t, `false`, string(sr.Filter), "Filter must reflect the real row filter, not default to always-true")
 }
 
@@ -230,7 +236,7 @@ func TestBuildScanReportSanitizesFilter(t *testing.T) {
 		rowFilter:      iceberg.EqualTo(iceberg.Reference("data"), "secret-value"),
 	}
 
-	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), time.Millisecond)
+	sr := scan.buildScanReport(&scanMetricsAccumulator{}, meta.CurrentSchema(), meta.CurrentSchema(), time.Millisecond)
 	require.NotNil(t, sr.Filter)
 	assert.NotContains(t, string(sr.Filter), "secret-value", "literal must not leak into the report")
 	assert.Contains(t, string(sr.Filter), "data", "column reference is preserved")
@@ -250,6 +256,72 @@ func TestPlanFilesNoSnapshotEmitsNoReport(t *testing.T) {
 	require.Empty(t, tasks)
 
 	assert.Empty(t, rep.Reports(), "no snapshot means no scan report")
+}
+
+func TestPlanFilesEmitsReportForRealSnapshot(t *testing.T) {
+	// Positive sibling to TestPlanFilesNoSnapshotEmitsNoReport: planning against a
+	// real snapshot with a live reporter must emit exactly one ScanReport carrying
+	// the scanned snapshot id and non-zero counters. This is the only test that
+	// reaches the Snapshot() != nil emission gate and the snapshotID =
+	// snap.SnapshotID population; the no-snapshot sibling cannot exercise them.
+	spec := *iceberg.UnpartitionedSpec
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+
+	const (
+		snapshotID       = int64(1)
+		manifestPath     = "mem://default/table-location/metadata/data-manifest.avro"
+		manifestListPath = "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	)
+
+	df := newTestDataFile(t, spec, "mem://default/table-location/data-1.parquet", nil)
+	entries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, int64Ptr(snapshotID), nil, nil, df),
+	}
+	var manifestBuf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
+
+	var listBuf bytes.Buffer
+	seqNum := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &seqNum, 0,
+		[]iceberg.ManifestFile{manifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: seqNum,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	rep := &metrics.InMemoryReporter{}
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil,
+		WithMetricsReporter(rep))
+
+	tasks, err := tbl.Scan().PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	reports := rep.Reports()
+	require.Len(t, reports, 1, "planning against a real snapshot must emit one report")
+	sr, ok := reports[0].(metrics.ScanReport)
+	require.True(t, ok, "reported metric must be a ScanReport")
+
+	assert.Equal(t, snapshotID, sr.SnapshotID, "report must carry the scanned snapshot id, not 0")
+	require.NotNil(t, sr.Metrics.ResultDataFiles)
+	assert.Equal(t, int64(1), sr.Metrics.ResultDataFiles.Value, "one data file was planned")
+	require.NotNil(t, sr.Metrics.TotalDataManifests)
+	assert.Equal(t, int64(1), sr.Metrics.TotalDataManifests.Value)
+	assert.Equal(t, int64(1), sr.Metrics.ScannedDataManifests.Value)
+	require.NotNil(t, sr.Metrics.TotalPlanningDuration)
+	assert.Equal(t, int64(1), sr.Metrics.TotalPlanningDuration.Count)
 }
 
 func TestPlanFilesNopReporterDoesNotPanic(t *testing.T) {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -654,6 +654,10 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 		return nil, err
 	}
 
+	// This path has no reporter behind it, so the manifest counts recorded into
+	// this accumulator are intentionally discarded. A future caller that needs
+	// those counts should use fetchPartitionSpecFilteredManifestsWithSchema and
+	// pass in an accumulator it actually reads.
 	return scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, &scanMetricsAccumulator{})
 }
 
@@ -838,33 +842,47 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	start := time.Now()
 	var acc scanMetricsAccumulator
 
-	results, err := scan.planFilesLocal(ctx, &acc)
+	// Resolve the planning schema once and thread it through both planning and
+	// the report, so the report describes exactly the schema that was used.
+	schema, err := scan.effectiveSchema()
 	if err != nil {
 		return nil, err
 	}
 
-	// Building the report is skipped for the no-op reporter — the opt-in default
-	// set by Table.Scan, and the nil-reporter case for scans constructed directly
-	// in tests (see Reporter, which maps nil to NopReporter). A NopReporter
-	// discards the report, so assembling one would be pure overhead.
-	rep := scan.Reporter()
-	if _, isNop := rep.(metrics.NopReporter); !isNop {
-		rep.Report(ctx, scan.buildScanReport(&acc, time.Since(start)))
+	results, err := scan.planFilesLocal(ctx, &acc, schema)
+	if err != nil {
+		return nil, err
+	}
+	// Snap the elapsed time right after planning so total-planning-duration
+	// reflects planning alone, not the report assembly below.
+	planningDuration := time.Since(start)
+
+	// Only emit a report when planning ran against a real snapshot. A table with
+	// no snapshot plans zero files and has no real snapshot id to report; Java
+	// skips the scan report entirely in that case, so we do too.
+	//
+	// Building the report is also skipped for a no-op reporter — the opt-in
+	// default set by Table.Scan, the nil-reporter case for scans constructed
+	// directly in tests (see Reporter, which maps nil to NopReporter), and a
+	// Combine of only nop reporters. A nop discards the report, so assembling
+	// one would be pure overhead.
+	if scan.Snapshot() != nil {
+		if rep := scan.Reporter(); !metrics.IsNop(rep) {
+			rep.Report(ctx, scan.buildScanReport(&acc, schema, planningDuration))
+		}
 	}
 
 	return results, nil
 }
 
 // planFilesLocal performs local scan planning: it reads and filters the
-// snapshot's manifests, builds the matching FileScanTasks, and records planning
-// metrics into acc for the caller to report.
-func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator) ([]FileScanTask, error) {
+// snapshot's manifests using schema, builds the matching FileScanTasks, and
+// records planning metrics into acc for the caller to report. It resets the
+// plan-scoped scan.planIO to nil, since local planning reads through the
+// table's default FileIO. It returns a nil slice (not an empty one) when there
+// is no snapshot or every manifest is pruned.
+func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) ([]FileScanTask, error) {
 	scan.planIO = nil
-
-	schema, err := scan.effectiveSchema()
-	if err != nil {
-		return nil, err
-	}
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -653,10 +654,13 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 		return nil, err
 	}
 
-	return scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema)
+	return scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, &scanMetricsAccumulator{})
 }
 
-func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Context, schema *iceberg.Schema) ([]iceberg.ManifestFile, error) {
+// fetchPartitionSpecFilteredManifestsWithSchema filters the snapshot's manifests
+// using the given schema. It records total/scanned/skipped manifest counts
+// (split by data vs delete content) into acc.
+func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Context, schema *iceberg.Schema, acc *scanMetricsAccumulator) ([]iceberg.ManifestFile, error) {
 	snap, err := scan.ResolveSnapshot()
 	if err != nil {
 		return nil, err
@@ -682,6 +686,13 @@ func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Cont
 	})
 	filtered := make([]iceberg.ManifestFile, 0, len(manifestList))
 	for _, mf := range manifestList {
+		isDelete := mf.ManifestContent() == iceberg.ManifestContentDeletes
+		if isDelete {
+			acc.totalDeleteManifests++
+		} else {
+			acc.totalDataManifests++
+		}
+
 		eval, err := manifestEvaluators.Get(int(mf.PartitionSpecID()))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build manifest evaluator for spec %d: %w", mf.PartitionSpecID(), err)
@@ -691,7 +702,16 @@ func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Cont
 			return nil, fmt.Errorf("failed to evaluate manifest %s: %w", mf.FilePath(), err)
 		}
 		if use {
+			if isDelete {
+				acc.scannedDeleteManifests++
+			} else {
+				acc.scannedDataManifests++
+			}
 			filtered = append(filtered, mf)
+		} else if isDelete {
+			acc.skippedDeleteManifests++
+		} else {
+			acc.skippedDataManifests++
 		}
 	}
 
@@ -788,8 +808,11 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	return entries, nil
 }
 
-// PlanFiles orchestrates the fetching and filtering of manifests, and then
-// building a list of FileScanTasks that match the current Scan criteria.
+// PlanFiles orchestrates the fetching and filtering of manifests, building a
+// list of FileScanTasks that match the current Scan criteria. When planning
+// happens locally it times the whole operation and emits a ScanReport to the
+// scan's reporter on success; remote (server-side) planning reports its own
+// metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	if scan.asOfTimestamp != nil {
 		snapshot, err := scan.ResolveSnapshot()
@@ -812,6 +835,30 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 		return nil, fmt.Errorf("%w: unknown scan planning mode %q", iceberg.ErrInvalidArgument, scan.planningMode)
 	}
 
+	start := time.Now()
+	var acc scanMetricsAccumulator
+
+	results, err := scan.planFilesLocal(ctx, &acc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Building the report is skipped for the no-op reporter — the opt-in default
+	// set by Table.Scan, and the nil-reporter case for scans constructed directly
+	// in tests (see Reporter, which maps nil to NopReporter). A NopReporter
+	// discards the report, so assembling one would be pure overhead.
+	rep := scan.Reporter()
+	if _, isNop := rep.(metrics.NopReporter); !isNop {
+		rep.Report(ctx, scan.buildScanReport(&acc, time.Since(start)))
+	}
+
+	return results, nil
+}
+
+// planFilesLocal performs local scan planning: it reads and filters the
+// snapshot's manifests, builds the matching FileScanTasks, and records planning
+// metrics into acc for the caller to report.
+func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator) ([]FileScanTask, error) {
 	scan.planIO = nil
 
 	schema, err := scan.effectiveSchema()
@@ -820,7 +867,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	}
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
-	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema)
+	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}
@@ -879,7 +926,14 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 			task.DataSequenceNumber = &s
 		}
 		results = append(results, task)
+		acc.totalFileSize += e.DataFile().FileSizeBytes()
 	}
+
+	acc.resultDataFiles = int64(len(results))
+	// Delete-file metrics are derived from the planned tasks so they are
+	// result-scoped, consistent with result-data-files and total-file-size (a
+	// DV-suppressed positional delete never lands on a task, so it is excluded).
+	acc.applyResultDeleteMetrics(results)
 
 	return results, nil
 }

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -868,7 +868,11 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	// one would be pure overhead.
 	if scan.Snapshot() != nil {
 		if rep := scan.Reporter(); !metrics.IsNop(rep) {
-			rep.Report(ctx, scan.buildScanReport(&acc, schema, planningDuration))
+			// Resolve the projected schema best-effort for the report's projected
+			// fields. Report assembly must never fail a scan, so a projection error
+			// just yields a report that omits projected fields.
+			projected, _ := scan.Projection()
+			rep.Report(ctx, scan.buildScanReport(&acc, schema, projected, planningDuration))
 		}
 	}
 

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -323,6 +323,92 @@ func TestFetchPartitionSpecFilteredManifests_InvalidSpecIDDoesNotPanic(t *testin
 	require.ErrorIs(t, err, ErrPartitionSpecNotFound)
 }
 
+// TestFetchManifestCountersWithRealSnapshot verifies the scanned/skipped/total
+// manifest accounting against a real snapshot with a mix of data and delete
+// manifests. Partition-spec pruning skips a non-overlapping data manifest, so
+// the scanned and skipped counters are both exercised (an empty-metadata test
+// leaves every counter at zero and would not catch a swapped scanned/skipped or
+// data/delete branch).
+func TestFetchManifestCountersWithRealSnapshot(t *testing.T) {
+	spec := partitionedSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+
+	// Identity partition on the int32 "id" column; encode partition bounds as
+	// 4-byte little-endian int32 so the manifest evaluator can decode them.
+	enc := func(v int32) *[]byte {
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, uint32(v))
+
+		return &b
+	}
+	match := enc(5)    // overlaps the id == 5 filter
+	noMatch := enc(10) // does not overlap
+
+	const (
+		snapshotID       = int64(1)
+		manifestListPath = "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	)
+	specID := int32(spec.ID())
+
+	dataScanned := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/data-scanned.avro", 100, specID, snapshotID).
+		Content(iceberg.ManifestContentData).
+		Partitions([]iceberg.FieldSummary{{ContainsNull: false, LowerBound: match, UpperBound: match}}).
+		Build()
+	dataSkipped := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/data-skipped.avro", 100, specID, snapshotID).
+		Content(iceberg.ManifestContentData).
+		Partitions([]iceberg.FieldSummary{{ContainsNull: false, LowerBound: noMatch, UpperBound: noMatch}}).
+		Build()
+	deleteScanned := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/delete-scanned.avro", 100, specID, snapshotID).
+		Content(iceberg.ManifestContentDeletes).
+		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{ContainsNull: false, LowerBound: match, UpperBound: match}}).
+		Build()
+
+	var listBuf bytes.Buffer
+	seqNum := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &seqNum, 0,
+		[]iceberg.ManifestFile{dataScanned, dataSkipped, deleteScanned}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: seqNum,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json", func(context.Context) (iceio.IO, error) {
+		return memIO, nil
+	}, nil)
+
+	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), int32(5))))
+
+	schema, err := scan.effectiveSchema()
+	require.NoError(t, err)
+
+	var acc scanMetricsAccumulator
+	filtered, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(context.Background(), schema, &acc)
+	require.NoError(t, err)
+
+	// Two data manifests, one delete manifest.
+	assert.Equal(t, int64(2), acc.totalDataManifests)
+	assert.Equal(t, int64(1), acc.totalDeleteManifests)
+	// The overlapping data and delete manifests are scanned; the non-overlapping
+	// data manifest is skipped. Delete manifests must land in the delete counters.
+	assert.Equal(t, int64(1), acc.scannedDataManifests)
+	assert.Equal(t, int64(1), acc.skippedDataManifests)
+	assert.Equal(t, int64(1), acc.scannedDeleteManifests)
+	assert.Equal(t, int64(0), acc.skippedDeleteManifests)
+	// Invariant: scanned + skipped == total, per content type.
+	assert.Equal(t, acc.totalDataManifests, acc.scannedDataManifests+acc.skippedDataManifests)
+	assert.Equal(t, acc.totalDeleteManifests, acc.scannedDeleteManifests+acc.skippedDeleteManifests)
+	assert.Len(t, filtered, 2, "only the overlapping manifests survive partition-spec filtering")
+}
+
 func TestBuildManifestEvaluatorWithInvalidSpecID(t *testing.T) {
 	schema := iceberg.NewSchema(
 		1,

--- a/visitors.go
+++ b/visitors.go
@@ -520,3 +520,84 @@ func (c columnNameTranslator) VisitBound(pred BoundPredicate) BooleanExpression 
 		panic(fmt.Errorf("%w: unsupported predicate: %s", ErrNotImplemented, pred))
 	}
 }
+
+// sanitizedLiteralMask is the placeholder substituted for every literal value in
+// a sanitized expression. It carries no information about the original value.
+const sanitizedLiteralMask = "(redacted)"
+
+// SanitizeExpression returns a copy of expr with every predicate literal replaced
+// by an opaque placeholder while preserving the boolean structure, column
+// references, and operations. It lets a filter be emitted somewhere untrusted
+// (e.g. a metrics ScanReport shipped to a REST sink) without leaking the literal
+// values a user scanned with, mirroring the intent of Java's ExpressionUtil.sanitize.
+//
+// Unlike Java, which substitutes type-shaped placeholders (e.g. "(2-digit-int)"),
+// every literal is masked with the same marker; the goal here is to withhold the
+// values, not to preserve their shape. Set predicates (IN / NOT IN) keep their
+// arity so the operation is not misrepresented, but the members are masked.
+func SanitizeExpression(expr BooleanExpression) (BooleanExpression, error) {
+	return VisitExpr(expr, sanitizeVisitor{})
+}
+
+type sanitizeVisitor struct{}
+
+func (sanitizeVisitor) VisitTrue() BooleanExpression  { return AlwaysTrue{} }
+func (sanitizeVisitor) VisitFalse() BooleanExpression { return AlwaysFalse{} }
+func (sanitizeVisitor) VisitNot(child BooleanExpression) BooleanExpression {
+	return NewNot(child)
+}
+
+func (sanitizeVisitor) VisitAnd(left, right BooleanExpression) BooleanExpression {
+	return NewAnd(left, right)
+}
+
+func (sanitizeVisitor) VisitOr(left, right BooleanExpression) BooleanExpression {
+	return NewOr(left, right)
+}
+
+func (sanitizeVisitor) VisitUnbound(pred UnboundPredicate) BooleanExpression {
+	switch p := pred.(type) {
+	case *unboundUnaryPredicate:
+		// No literal to mask; the op and term are safe to keep as-is.
+		return pred
+	case *unboundLiteralPredicate:
+		return sanitizeLiteralPredicate(p.op, p.term)
+	case *unboundSetPredicate:
+		return sanitizeSetPredicate(p.op, p.term, p.lits.Len())
+	default:
+		panic(fmt.Errorf("%w: unsupported predicate: %s", ErrNotImplemented, pred))
+	}
+}
+
+func (sanitizeVisitor) VisitBound(pred BoundPredicate) BooleanExpression {
+	// Rebuild over the column name as an unbound reference: the sanitized form is
+	// only serialized or logged, and an unbound predicate with a masked string
+	// literal serializes without needing the field's type.
+	ref := Reference(pred.Term().Ref().Field().Name)
+	switch p := pred.(type) {
+	case BoundUnaryPredicate:
+		return UnaryPredicate(p.Op(), ref)
+	case BoundLiteralPredicate:
+		return sanitizeLiteralPredicate(p.Op(), ref)
+	case BoundSetPredicate:
+		return sanitizeSetPredicate(p.Op(), ref, p.Literals().Len())
+	default:
+		panic(fmt.Errorf("%w: unsupported predicate: %s", ErrNotImplemented, pred))
+	}
+}
+
+func sanitizeLiteralPredicate(op Operation, term UnboundTerm) BooleanExpression {
+	return LiteralPredicate(op, term, NewLiteral(sanitizedLiteralMask))
+}
+
+// sanitizeSetPredicate rebuilds a set predicate with count masked members. The
+// masks are made distinct so the set does not collapse (which would turn IN into
+// EQ); the suffix reveals only the number of values, never a value itself.
+func sanitizeSetPredicate(op Operation, term UnboundTerm, count int) BooleanExpression {
+	masks := make([]Literal, count)
+	for i := range masks {
+		masks[i] = NewLiteral(fmt.Sprintf("%s-%d", sanitizedLiteralMask, i+1))
+	}
+
+	return SetPredicate(op, term, masks)
+}

--- a/visitors.go
+++ b/visitors.go
@@ -531,10 +531,13 @@ const sanitizedLiteralMask = "(redacted)"
 // (e.g. a metrics ScanReport shipped to a REST sink) without leaking the literal
 // values a user scanned with, mirroring the intent of Java's ExpressionUtil.sanitize.
 //
-// Unlike Java, which substitutes type-shaped placeholders (e.g. "(2-digit-int)"),
-// every literal is masked with the same marker; the goal here is to withhold the
-// values, not to preserve their shape. Set predicates (IN / NOT IN) keep their
-// arity so the operation is not misrepresented, but the members are masked.
+// The only guarantee is that no user value leaks: the exact placeholder text is
+// not part of the contract and may change. In particular, unlike Java — which
+// substitutes type-shaped placeholders (e.g. "(2-digit-int)") — every literal is
+// masked with the same marker, since the goal is to withhold the values, not to
+// preserve their shape or stay structurally comparable across clients. Set
+// predicates (IN / NOT IN) keep their arity so the operation is not
+// misrepresented, but the members are masked.
 func SanitizeExpression(expr BooleanExpression) (BooleanExpression, error) {
 	return VisitExpr(expr, sanitizeVisitor{})
 }

--- a/visitors_test.go
+++ b/visitors_test.go
@@ -18,6 +18,7 @@
 package iceberg_test
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"
@@ -651,5 +652,52 @@ func TestRewriteNot(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, out.Equals(tt.expected))
 		})
+	}
+}
+
+func TestSanitizeExpression(t *testing.T) {
+	// A literal predicate must keep its column and operation but never leak the
+	// literal a user scanned with.
+	eq := iceberg.EqualTo(iceberg.Reference("email"), "alice@example.com")
+	sanitized, err := iceberg.SanitizeExpression(eq)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(sanitized)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "alice@example.com", "literal must not leak")
+	assert.Contains(t, string(raw), "email", "column reference is preserved")
+	assert.Contains(t, string(raw), "(redacted)")
+
+	// IN keeps its arity (does not collapse to eq) while masking every member.
+	in := iceberg.IsIn(iceberg.Reference("id"), int32(1), int32(2), int32(3))
+	sanitized, err = iceberg.SanitizeExpression(in)
+	require.NoError(t, err)
+
+	raw, err = json.Marshal(in)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "\"in\"", "precondition: original is an in predicate")
+
+	raw, err = json.Marshal(sanitized)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "\"in\"", "in predicate must not collapse to eq")
+	for _, v := range []string{"1", "2", "3"} {
+		assert.NotContains(t, string(raw), "\""+v+"\"", "in literal must not leak")
+	}
+
+	// Unary predicates carry no literal and pass through unchanged; structure is
+	// preserved across and/or/not.
+	expr := iceberg.NewAnd(iceberg.IsNull(iceberg.Reference("name")), eq)
+	sanitized, err = iceberg.SanitizeExpression(expr)
+	require.NoError(t, err)
+	raw, err = json.Marshal(sanitized)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "is-null")
+	assert.NotContains(t, string(raw), "alice@example.com")
+
+	// Constant expressions are returned as-is.
+	for _, c := range []iceberg.BooleanExpression{iceberg.AlwaysTrue{}, iceberg.AlwaysFalse{}} {
+		got, err := iceberg.SanitizeExpression(c)
+		require.NoError(t, err)
+		assert.True(t, got.Equals(c))
 	}
 }

--- a/visitors_test.go
+++ b/visitors_test.go
@@ -684,6 +684,18 @@ func TestSanitizeExpression(t *testing.T) {
 		assert.NotContains(t, string(raw), "\""+v+"\"", "in literal must not leak")
 	}
 
+	// NOT IN rides the same set-predicate branch as IN: it must keep its op and
+	// arity while masking every member.
+	notIn := iceberg.NotIn(iceberg.Reference("id"), int32(4), int32(5))
+	sanitized, err = iceberg.SanitizeExpression(notIn)
+	require.NoError(t, err)
+	raw, err = json.Marshal(sanitized)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "not-in", "not-in predicate must not collapse or change op")
+	for _, v := range []string{"4", "5"} {
+		assert.NotContains(t, string(raw), "\""+v+"\"", "not-in literal must not leak")
+	}
+
 	// Unary predicates carry no literal and pass through unchanged; structure is
 	// preserved across and/or/not.
 	expr := iceberg.NewAnd(iceberg.IsNull(iceberg.Reference("name")), eq)


### PR DESCRIPTION
PR 4: Instruments local scan planning to gather scan metrics and emit a ScanReport through the scan's configured reporter.

  Builds on the reporter plumbing already merged in #1430 (Scan.Reporter(), catalog/table/scan wiring). No new public API — metrics-reporter-impl / WithMetricsReporter remain the entry points.

  Changes

  - PlanFiles now times local planning and, on success, emits a ScanReport via scan.Reporter().Report(...). Split into PlanFiles (mode dispatch + emission) and planFilesLocal (the local-planning body).
  - Manifest counts (total / scanned / skipped, split by data vs delete content) gathered in the single-goroutine manifest-filter loop.
  - Result-scoped metrics (result-data-files, result-delete-files, positional/equality/DV counts, total-file-size-in-bytes, total-delete-file-size-in-bytes) derived from the planned tasks — delete files counted once by path, and
  DV-suppressed positional deletes excluded, so they stay consistent with result-data-files.
  - Schema/filter/projected-fields resolved best-effort; report building never fails a scan.

  Behavior / scope

  - Opt-in, zero-overhead default: with the no-op reporter (the default) no report is built — the instrumented path costs only a few integer increments.
  - Remote planning reports its own metrics server-side and does not emit a local report.
  - Race-safe: all counters written from a single goroutine (manifest counts before the read barrier, result/delete counts after); verified under -race.
  - Omit, don't fabricate: scanned/skipped reflect partition-spec pruning; per-entry skipped-data-files / skipped-delete-files and indexed-delete-files are left unset (deferred) rather than reported as zero.

  Testing

  go test ./table/... ./metrics/... and -race on the scan/delete/DV planning suites. New tests: report assembly, projected-field resolution, result-scoped delete dedup (TestApplyResultDeleteMetrics), emit-on-local, no-emit-on-remote,
  and no-op-reporter safety.
  
  Related: #1236 