### PR TITLE
fix(io/gcs): authenticate the GCS client with provided credentials

### DIFF
--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -19,7 +19,9 @@ package gocloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 
 	"cloud.google.com/go/storage"
@@ -28,6 +30,7 @@ import (
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -67,15 +70,68 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	}
 }
 
+// gcsScope is the OAuth2 scope granting read/write access to GCS objects, used
+// when building a token source from explicitly-provided credentials.
+const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
+
+// gcsCredentials resolves the credentials used to authenticate the GCS client.
+//
+// Explicit service-account credentials supplied via the GCSJSONKey
+// (gcs.credentials-json) or GCSKeyPath (gcs.credentials-path) properties take
+// precedence. When neither is set it falls back to Application Default
+// Credentials, which may be nil — in which case the caller uses an anonymous
+// client.
+func gcsCredentials(ctx context.Context, props map[string]string) (*google.Credentials, error) {
+	// The credential type must be declared explicitly (defaulting to a
+	// service-account key, honouring GCSCredType when set) so that untrusted
+	// external_account configurations are not blindly accepted. This is why
+	// CredentialsFromJSONWithType is used rather than the deprecated
+	// CredentialsFromJSON.
+	credType := google.ServiceAccount
+	if v := props[io.GCSCredType]; v != "" {
+		credType = google.CredentialsType(v)
+	}
+
+	if jsonKey := props[io.GCSJSONKey]; jsonKey != "" {
+		creds, err := google.CredentialsFromJSONWithType(ctx, []byte(jsonKey), credType, gcsScope)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: parsing %s: %w", io.GCSJSONKey, err)
+		}
+
+		return creds, nil
+	}
+
+	if path := props[io.GCSKeyPath]; path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: reading %s %q: %w", io.GCSKeyPath, path, err)
+		}
+		creds, err := google.CredentialsFromJSONWithType(ctx, data, credType, gcsScope)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: parsing credentials file %q: %w", path, err)
+		}
+
+		return creds, nil
+	}
+
+	creds, _ := gcp.DefaultCredentials(ctx)
+
+	return creds, nil
+}
+
 // Construct a GCS bucket from a URL
 func createGCSBucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	gcscfg := ParseGCSConfig(props)
-	creds, _ := gcp.DefaultCredentials(ctx)
+
+	creds, err := gcsCredentials(ctx, props)
+	if err != nil {
+		return nil, err
+	}
+
 	var client *gcp.HTTPClient
 	if creds == nil {
 		client = gcp.NewAnonymousHTTPClient(gcp.DefaultTransport())
 	} else {
-		var err error
 		client, err = gcp.NewHTTPClient(
 			gcp.DefaultTransport(),
 			gcp.CredentialsTokenSource(creds))

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -18,11 +18,20 @@
 package gocloud
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// authorizedUserJSON is a minimal, non-secret credentials document. The
+// "authorized_user" type parses without a real RSA private key (unlike
+// "service_account"), keeping these tests hermetic.
+const authorizedUserJSON = `{"type":"authorized_user","client_id":"id","client_secret":"secret","refresh_token":"token"}`
 
 func TestParseGCSConfigUseJSONAPI(t *testing.T) {
 	t.Run("defaults to disabled", func(t *testing.T) {
@@ -44,4 +53,40 @@ func TestParseGCSConfigUseJSONAPI(t *testing.T) {
 		cfg := ParseGCSConfig(map[string]string{io.GCSUseJSONAPI: "not-a-bool"})
 		assert.Len(t, cfg.ClientOptions, 0)
 	})
+}
+
+// gcsCredentials must build credentials from an inline JSON key (GCSJSONKey)
+// rather than silently falling back to Application Default Credentials. This
+// guards the fix for the GCS FileIO ignoring explicitly-provided credentials.
+func TestGCSCredentialsFromInlineJSONKey(t *testing.T) {
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSJSONKey:  authorizedUserJSON,
+		io.GCSCredType: "authorized_user",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds, "GCSJSONKey should yield explicit credentials")
+	assert.JSONEq(t, authorizedUserJSON, string(creds.JSON),
+		"credentials must originate from the supplied key, not ADC")
+}
+
+// gcsCredentials must build credentials from a key file (GCSKeyPath).
+func TestGCSCredentialsFromKeyPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, []byte(authorizedUserJSON), 0o600))
+
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSKeyPath:  path,
+		io.GCSCredType: "authorized_user",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds, "GCSKeyPath should yield explicit credentials")
+	assert.JSONEq(t, authorizedUserJSON, string(creds.JSON))
+}
+
+// A missing key file is a hard error, not a silent fallback to ADC.
+func TestGCSCredentialsMissingKeyPath(t *testing.T) {
+	_, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSKeyPath: filepath.Join(t.TempDir(), "does-not-exist.json"),
+	})
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Problem

`createGCSBucket` (`io/gocloud/gcs.go`) always builds the authenticated HTTP client from **Application Default Credentials** — or an **anonymous** client when ADC is absent — and ignores the credentials parsed from the `gcs.jsonkey` (`GCSJSONKey`) and `gcs.keypath` (`GCSKeyPath`) properties:

```go
gcscfg := ParseGCSConfig(props)          // parses gcs.jsonkey / gcs.keypath into ClientOptions
creds, _ := gcp.DefaultCredentials(ctx)  // ← auth client comes from ADC only
...
bucket, err := gcsblob.OpenBucket(ctx, client, parsed.Host, gcscfg)
```

`ParseGCSConfig` does turn those properties into `WithAuthCredentialsJSON`/`WithAuthCredentialsFile` client options, but they are passed to `gcsblob.OpenBucket` alongside a pre-built `client` whose transport takes precedence — so the explicit credentials never authenticate the requests.

**Effect:** with a catalog configured with explicit GCS service-account credentials but **no** `GOOGLE_APPLICATION_CREDENTIALS` in the environment, GCS reads/writes go out **anonymously** and fail with `HTTP 403 AccessDenied: Anonymous caller does not have storage.objects.* access`. The credentials only take effect if the same account is *also* exported via the ADC env var.

## Fix

Resolve credentials from `gcs.jsonkey` / `gcs.keypath` first and build the client's token source from them; fall back to ADC (which may be nil → anonymous client) only when neither property is set. A new `gcsCredentials` helper does this resolution.

## Testing

Added `io/gocloud/gcs_test.go` unit tests (`authorized_user` credentials keep them hermetic — no RSA key or network needed):
- `TestGCSCredentialsFromInlineJSONKey` — `gcs.jsonkey` yields explicit credentials (not ADC).
- `TestGCSCredentialsFromKeyPath` — `gcs.keypath` yields explicit credentials.
- `TestGCSCredentialsMissingKeyPath` — a missing key file is a hard error, not a silent ADC fallback.

`go test ./io/gocloud/` passes (including the pre-existing `TestParseGCSConfigUseJSONAPI`).

Discovered while wiring GCS-backed Iceberg tables through a downstream tool: `gs://` warehouses route to the native GCS FileIO correctly, but the FileIO ignored the connection's service-account credentials, forcing use of `GOOGLE_APPLICATION_CREDENTIALS`.