### PR TITLE
fix(io/gcs): authenticate the GCS client with supplied credentials

### DIFF
--- a/io/config.go
+++ b/io/config.go
@@ -36,11 +36,15 @@ const (
 
 // Constants for GCS configuration options
 const (
-	GCSEndpoint   = "gcs.endpoint"
-	GCSKeyPath    = "gcs.keypath"
-	GCSJSONKey    = "gcs.jsonkey"
-	GCSCredType   = "gcs.credtype"
-	GCSUseJSONAPI = "gcs.usejsonapi"
+	GCSEndpoint       = "gcs.endpoint"
+	GCSServiceHost    = "gcs.service.host"
+	GCSKeyPath        = "gcs.keypath"
+	GCSJSONKey        = "gcs.jsonkey"
+	GCSCredType       = "gcs.credtype"
+	GCSUseJSONAPI     = "gcs.usejsonapi"
+	GCSOAuthToken     = "gcs.oauth2.token"
+	GCSOAuthExpiresAt = "gcs.oauth2.token-expires-at"
+	GCSNoAuth         = "gcs.no-auth"
 )
 
 // Constants for Azure configuration options

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -19,7 +19,9 @@ package gocloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 
 	"cloud.google.com/go/storage"
@@ -28,6 +30,7 @@ import (
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -67,15 +70,58 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	}
 }
 
+// gcsScope grants read/write access to GCS objects.
+const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
+
+// gcsCredentials builds credentials from the gcs.jsonkey / gcs.keypath
+// properties (defaulting to a service-account key, honouring gcs.credtype),
+// falling back to Application Default Credentials when neither is set.
+func gcsCredentials(ctx context.Context, props map[string]string) (*google.Credentials, error) {
+	credType := google.ServiceAccount
+	if v := props[io.GCSCredType]; v != "" {
+		credType = google.CredentialsType(v)
+	}
+
+	if jsonKey := props[io.GCSJSONKey]; jsonKey != "" {
+		creds, err := google.CredentialsFromJSONWithType(ctx, []byte(jsonKey), credType, gcsScope)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: parsing %s: %w", io.GCSJSONKey, err)
+		}
+
+		return creds, nil
+	}
+
+	if path := props[io.GCSKeyPath]; path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: reading %s %q: %w", io.GCSKeyPath, path, err)
+		}
+		creds, err := google.CredentialsFromJSONWithType(ctx, data, credType, gcsScope)
+		if err != nil {
+			return nil, fmt.Errorf("gcs: parsing credentials file %q: %w", path, err)
+		}
+
+		return creds, nil
+	}
+
+	creds, _ := gcp.DefaultCredentials(ctx)
+
+	return creds, nil
+}
+
 // Construct a GCS bucket from a URL
 func createGCSBucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	gcscfg := ParseGCSConfig(props)
-	creds, _ := gcp.DefaultCredentials(ctx)
+
+	creds, err := gcsCredentials(ctx, props)
+	if err != nil {
+		return nil, err
+	}
+
 	var client *gcp.HTTPClient
 	if creds == nil {
 		client = gcp.NewAnonymousHTTPClient(gcp.DefaultTransport())
 	} else {
-		var err error
 		client, err = gcp.NewHTTPClient(
 			gcp.DefaultTransport(),
 			gcp.CredentialsTokenSource(creds))

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -34,30 +34,31 @@ import (
 	"google.golang.org/api/option"
 )
 
-var allowedGCSCredTypes = map[string]option.CredentialsType{
-	"service_account":              option.ServiceAccount,
-	"authorized_user":              option.AuthorizedUser,
-	"impersonated_service_account": option.ImpersonatedServiceAccount,
-	"external_account":             option.ExternalAccount,
+var allowedGCSCredTypes = map[string]struct{}{
+	"service_account":              {},
+	"authorized_user":              {},
+	"impersonated_service_account": {},
+	"external_account":             {},
 }
 
-// ParseGCSConfig parses GCS properties and returns a configuration.
+func resolveGCSCredType(props map[string]string) (string, bool) {
+	v := props[io.GCSCredType]
+	if v == "" {
+		return "", false
+	}
+	if _, ok := allowedGCSCredTypes[v]; !ok {
+		return "", false
+	}
+
+	return v, true
+}
+
+// ParseGCSConfig parses non-credential GCS blob options; credentials are set on
+// the client by gcsCredentials, which supersedes any credential option here.
 func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	var o []option.ClientOption
 	if url := props[io.GCSEndpoint]; url != "" {
 		o = append(o, option.WithEndpoint(url))
-	}
-	var credType option.CredentialsType
-	if key := props[io.GCSCredType]; key != "" {
-		if ct, ok := allowedGCSCredTypes[key]; ok {
-			credType = ct
-		}
-	}
-	if key := props[io.GCSJSONKey]; key != "" {
-		o = append(o, option.WithAuthCredentialsJSON(credType, []byte(key)))
-	}
-	if path := props[io.GCSKeyPath]; path != "" {
-		o = append(o, option.WithAuthCredentialsFile(credType, path))
 	}
 	if v, ok := props[io.GCSUseJSONAPI]; ok {
 		if parse, err := strconv.ParseBool(v); err == nil && parse {
@@ -70,25 +71,27 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	}
 }
 
-// gcsScope grants read/write access to GCS objects.
 const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
 
-// gcsCredentials builds credentials from the gcs.jsonkey / gcs.keypath
-// properties (defaulting to a service-account key, honouring gcs.credtype),
-// falling back to Application Default Credentials when neither is set.
 func gcsCredentials(ctx context.Context, props map[string]string) (*google.Credentials, error) {
 	credType := google.ServiceAccount
-	if v := props[io.GCSCredType]; v != "" {
+	if v, ok := resolveGCSCredType(props); ok {
 		credType = google.CredentialsType(v)
 	}
 
-	if jsonKey := props[io.GCSJSONKey]; jsonKey != "" {
-		creds, err := google.CredentialsFromJSONWithType(ctx, []byte(jsonKey), credType, gcsScope)
+	// CredentialsFromJSONWithType requires the key's type to equal credType, so
+	// hint at gcs.credtype when a non-service-account key fails against it.
+	parse := func(data []byte, source string) (*google.Credentials, error) {
+		creds, err := google.CredentialsFromJSONWithType(ctx, data, credType, gcsScope)
 		if err != nil {
-			return nil, fmt.Errorf("gcs: parsing %s: %w", io.GCSJSONKey, err)
+			return nil, fmt.Errorf("gcs: parsing %s: set %s if the key is not a service account: %w", source, io.GCSCredType, err)
 		}
 
 		return creds, nil
+	}
+
+	if jsonKey := props[io.GCSJSONKey]; jsonKey != "" {
+		return parse([]byte(jsonKey), io.GCSJSONKey)
 	}
 
 	if path := props[io.GCSKeyPath]; path != "" {
@@ -96,12 +99,8 @@ func gcsCredentials(ctx context.Context, props map[string]string) (*google.Crede
 		if err != nil {
 			return nil, fmt.Errorf("gcs: reading %s %q: %w", io.GCSKeyPath, path, err)
 		}
-		creds, err := google.CredentialsFromJSONWithType(ctx, data, credType, gcsScope)
-		if err != nil {
-			return nil, fmt.Errorf("gcs: parsing credentials file %q: %w", path, err)
-		}
 
-		return creds, nil
+		return parse(data, fmt.Sprintf("%s %q", io.GCSKeyPath, path))
 	}
 
 	creds, _ := gcp.DefaultCredentials(ctx)
@@ -124,7 +123,8 @@ func createGCSBucket(ctx context.Context, parsed *url.URL, props map[string]stri
 	} else {
 		client, err = gcp.NewHTTPClient(
 			gcp.DefaultTransport(),
-			gcp.CredentialsTokenSource(creds))
+			gcp.CredentialsTokenSource(creds),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"time"
 
 	"cloud.google.com/go/storage"
 
@@ -30,6 +31,7 @@ import (
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -53,11 +55,21 @@ func resolveGCSCredType(props map[string]string) (string, bool) {
 	return v, true
 }
 
+// gcsEndpoint returns the endpoint override, preferring Iceberg's standard
+// gcs.service.host and falling back to gcs.endpoint.
+func gcsEndpoint(props map[string]string) string {
+	if v := props[io.GCSServiceHost]; v != "" {
+		return v
+	}
+
+	return props[io.GCSEndpoint]
+}
+
 // ParseGCSConfig parses non-credential GCS blob options; credentials are set on
 // the client by gcsCredentials, which supersedes any credential option here.
 func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 	var o []option.ClientOption
-	if url := props[io.GCSEndpoint]; url != "" {
+	if url := gcsEndpoint(props); url != "" {
 		o = append(o, option.WithEndpoint(url))
 	}
 	if v, ok := props[io.GCSUseJSONAPI]; ok {
@@ -74,6 +86,22 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
 
 func gcsCredentials(ctx context.Context, props map[string]string) (*google.Credentials, error) {
+	// Explicit no-auth wins over everything: use an anonymous client even when
+	// ADC is available.
+	if noAuth, err := strconv.ParseBool(props[io.GCSNoAuth]); err == nil && noAuth {
+		return nil, nil
+	}
+
+	// A vended OAuth2 access token (e.g. from a REST catalog) is used directly.
+	if tok := props[io.GCSOAuthToken]; tok != "" {
+		t := &oauth2.Token{AccessToken: tok}
+		if ms, err := strconv.ParseInt(props[io.GCSOAuthExpiresAt], 10, 64); err == nil {
+			t.Expiry = time.UnixMilli(ms)
+		}
+
+		return &google.Credentials{TokenSource: oauth2.StaticTokenSource(t)}, nil
+	}
+
 	credType := google.ServiceAccount
 	if v, ok := resolveGCSCredType(props); ok {
 		credType = google.CredentialsType(v)

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -18,11 +18,18 @@
 package gocloud
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// authorizedUserJSON parses without a real RSA key, keeping tests hermetic.
+const authorizedUserJSON = `{"type":"authorized_user","client_id":"id","client_secret":"secret","refresh_token":"token"}`
 
 func TestParseGCSConfigUseJSONAPI(t *testing.T) {
 	t.Run("defaults to disabled", func(t *testing.T) {
@@ -44,4 +51,38 @@ func TestParseGCSConfigUseJSONAPI(t *testing.T) {
 		cfg := ParseGCSConfig(map[string]string{io.GCSUseJSONAPI: "not-a-bool"})
 		assert.Len(t, cfg.ClientOptions, 0)
 	})
+}
+
+// Inline JSON key (gcs.jsonkey) yields explicit credentials, not ADC.
+func TestGCSCredentialsFromInlineJSONKey(t *testing.T) {
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSJSONKey:  authorizedUserJSON,
+		io.GCSCredType: "authorized_user",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds, "GCSJSONKey should yield explicit credentials")
+	assert.JSONEq(t, authorizedUserJSON, string(creds.JSON),
+		"credentials must originate from the supplied key, not ADC")
+}
+
+// gcsCredentials must build credentials from a key file (GCSKeyPath).
+func TestGCSCredentialsFromKeyPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, []byte(authorizedUserJSON), 0o600))
+
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSKeyPath:  path,
+		io.GCSCredType: "authorized_user",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds, "GCSKeyPath should yield explicit credentials")
+	assert.JSONEq(t, authorizedUserJSON, string(creds.JSON))
+}
+
+// A missing key file is a hard error, not a silent fallback to ADC.
+func TestGCSCredentialsMissingKeyPath(t *testing.T) {
+	_, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSKeyPath: filepath.Join(t.TempDir(), "does-not-exist.json"),
+	})
+	require.Error(t, err)
 }

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -28,8 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// authorizedUserJSON parses without a real RSA key, keeping tests hermetic.
-const authorizedUserJSON = `{"type":"authorized_user","client_id":"id","client_secret":"secret","refresh_token":"token"}`
+// Both parse without a real RSA key (the private key is only read lazily when a
+// token is fetched), keeping tests hermetic.
+const (
+	authorizedUserJSON = `{"type":"authorized_user","client_id":"id","client_secret":"secret","refresh_token":"token"}`
+	serviceAccountJSON = `{"type":"service_account","project_id":"p","private_key":"fake","client_email":"sa@p.iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}`
+)
 
 func TestParseGCSConfigUseJSONAPI(t *testing.T) {
 	t.Run("defaults to disabled", func(t *testing.T) {
@@ -85,4 +89,46 @@ func TestGCSCredentialsMissingKeyPath(t *testing.T) {
 		io.GCSKeyPath: filepath.Join(t.TempDir(), "does-not-exist.json"),
 	})
 	require.Error(t, err)
+}
+
+func TestResolveGCSCredType(t *testing.T) {
+	for _, ct := range []string{"service_account", "authorized_user", "impersonated_service_account", "external_account"} {
+		got, ok := resolveGCSCredType(map[string]string{io.GCSCredType: ct})
+		require.True(t, ok, ct)
+		assert.Equal(t, ct, got)
+	}
+
+	for name, props := range map[string]map[string]string{
+		"unset":   {},
+		"unknown": {io.GCSCredType: "not-a-real-type"},
+	} {
+		_, ok := resolveGCSCredType(props)
+		assert.False(t, ok, name)
+	}
+}
+
+func TestGCSCredentialsDefaultsToServiceAccount(t *testing.T) {
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSJSONKey: serviceAccountJSON,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.JSONEq(t, serviceAccountJSON, string(creds.JSON))
+}
+
+func TestGCSCredentialsNonServiceAccountNeedsCredType(t *testing.T) {
+	_, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSJSONKey: authorizedUserJSON,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), io.GCSCredType)
+}
+
+func TestGCSCredentialsIgnoresUnknownCredType(t *testing.T) {
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSJSONKey:  serviceAccountJSON,
+		io.GCSCredType: "not-a-real-type",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds)
 }

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
@@ -131,4 +133,36 @@ func TestGCSCredentialsIgnoresUnknownCredType(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, creds)
+}
+
+// gcs.no-auth yields nil credentials so the client is built anonymously.
+func TestGCSCredentialsNoAuth(t *testing.T) {
+	creds, err := gcsCredentials(context.Background(), map[string]string{io.GCSNoAuth: "true"})
+	require.NoError(t, err)
+	assert.Nil(t, creds)
+}
+
+// A vended gcs.oauth2.token is turned into a static token source, not dropped.
+func TestGCSCredentialsFromOAuthToken(t *testing.T) {
+	exp := time.Now().Add(time.Hour).UnixMilli()
+	creds, err := gcsCredentials(context.Background(), map[string]string{
+		io.GCSOAuthToken:     "vended-token",
+		io.GCSOAuthExpiresAt: strconv.FormatInt(exp, 10),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.NotNil(t, creds.TokenSource)
+
+	tok, err := creds.TokenSource.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "vended-token", tok.AccessToken)
+	assert.Equal(t, time.UnixMilli(exp), tok.Expiry)
+}
+
+// gcs.service.host is the standard endpoint key; gcs.endpoint is a fallback alias.
+func TestGCSEndpointPrefersServiceHost(t *testing.T) {
+	assert.Equal(t, "svc", gcsEndpoint(map[string]string{io.GCSServiceHost: "svc"}))
+	assert.Equal(t, "ep", gcsEndpoint(map[string]string{io.GCSEndpoint: "ep"}))
+	assert.Equal(t, "svc", gcsEndpoint(map[string]string{io.GCSServiceHost: "svc", io.GCSEndpoint: "ep"}))
+	assert.Empty(t, gcsEndpoint(map[string]string{}))
 }


### PR DESCRIPTION
## Problem

`createGCSBucket` (`io/gocloud/gcs.go`) builds the authenticated HTTP client from Application Default Credentials — or an anonymous client when ADC is absent — and ignores the credentials parsed from the `gcs.jsonkey` (`GCSJSONKey`) and `gcs.keypath` (`GCSKeyPath`) properties. `ParseGCSConfig` turns those into client options, but they are passed to `gcsblob.OpenBucket` alongside the pre-built client, whose transport takes precedence — so the explicit credentials never authenticate requests.

**Effect:** with a catalog configured with explicit GCS service-account credentials but **no** `GOOGLE_APPLICATION_CREDENTIALS` in the environment, GCS reads/writes go out **anonymously** and fail with `HTTP 403 AccessDenied`. The credentials only take effect if the same account is also exported via ADC.

## Fix

Resolve credentials from `gcs.jsonkey` / `gcs.keypath` first (via the non-deprecated `CredentialsFromJSONWithType`, defaulting to a service-account key and honouring `gcs.credtype`) and build the client's token source from them. Fall back to ADC (which may be nil → anonymous client) only when neither property is set.