### PR TITLE
fix(io/s3): let explicit s3.* credentials override the context AWS config

### DIFF
--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -54,7 +54,8 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 
 	if tok, ok := props["token"]; ok {
 		opts = append(opts, config.WithBearerAuthTokenProvider(
-			&bearer.StaticTokenProvider{Token: bearer.Token{Value: tok}}))
+			&bearer.StaticTokenProvider{Token: bearer.Token{Value: tok}},
+		))
 	}
 
 	if region, ok := props[io.S3Region]; ok {
@@ -67,7 +68,8 @@ func ParseAWSConfig(ctx context.Context, props map[string]string) (*aws.Config, 
 	token := props[io.S3SessionToken]
 	if accessKey != "" || secretAccessKey != "" || token != "" {
 		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			props[io.S3AccessKeyID], props[io.S3SecretAccessKey], props[io.S3SessionToken])))
+			props[io.S3AccessKeyID], props[io.S3SecretAccessKey], props[io.S3SessionToken],
+		)))
 	}
 
 	if proxy, ok := props[io.S3ProxyURI]; ok {
@@ -167,18 +169,35 @@ func resolveUsePathStyle(endpoint string, props map[string]string) bool {
 	return usePathStyle
 }
 
-func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
+// resolveS3AWSConfig returns the AWS config for the S3 FileIO, preferring an
+// ambient context config but letting explicit s3.* credentials override it.
+func resolveS3AWSConfig(ctx context.Context, props map[string]string) (*aws.Config, error) {
 	var (
 		awscfg *aws.Config
 		err    error
 	)
 	if v := utils.GetAwsConfig(ctx); v != nil {
 		awscfg = v
-	} else {
-		awscfg, err = ParseAWSConfig(ctx, props)
-		if err != nil {
-			return nil, err
-		}
+	} else if awscfg, err = ParseAWSConfig(ctx, props); err != nil {
+		return nil, err
+	}
+
+	// Copy before overriding so the shared context config stays untouched.
+	if props[io.S3AccessKeyID] != "" || props[io.S3SecretAccessKey] != "" {
+		cfg := *awscfg
+		cfg.Credentials = credentials.NewStaticCredentialsProvider(
+			props[io.S3AccessKeyID], props[io.S3SecretAccessKey], props[io.S3SessionToken],
+		)
+		awscfg = &cfg
+	}
+
+	return awscfg, nil
+}
+
+func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
+	awscfg, err := resolveS3AWSConfig(ctx, props)
+	if err != nil {
+		return nil, err
 	}
 
 	// Default HTTP client when not configured: use the SDK buildable client so

--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -173,25 +173,25 @@ func resolveUsePathStyle(endpoint string, props map[string]string) bool {
 // ambient context config but letting explicit s3.* credentials override it.
 func resolveS3AWSConfig(ctx context.Context, props map[string]string) (*aws.Config, error) {
 	var (
-		awscfg *aws.Config
-		err    error
+		base *aws.Config
+		err  error
 	)
 	if v := utils.GetAwsConfig(ctx); v != nil {
-		awscfg = v
-	} else if awscfg, err = ParseAWSConfig(ctx, props); err != nil {
+		base = v
+	} else if base, err = ParseAWSConfig(ctx, props); err != nil {
 		return nil, err
 	}
 
-	// Copy before overriding so the shared context config stays untouched.
+	// Always copy so neither the credential override nor the caller's later
+	// mutations (e.g. HTTPClient) touch a shared context config.
+	cfg := *base
 	if props[io.S3AccessKeyID] != "" || props[io.S3SecretAccessKey] != "" {
-		cfg := *awscfg
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(
 			props[io.S3AccessKeyID], props[io.S3SecretAccessKey], props[io.S3SessionToken],
 		)
-		awscfg = &cfg
 	}
 
-	return awscfg, nil
+	return &cfg, nil
 }
 
 func createS3Bucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {

--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -182,10 +182,21 @@ func resolveS3AWSConfig(ctx context.Context, props map[string]string) (*aws.Conf
 		return nil, err
 	}
 
-	// Always copy so neither the credential override nor the caller's later
-	// mutations (e.g. HTTPClient) touch a shared context config.
+	// Always copy so overrides (and the caller's later HTTPClient assignment)
+	// never touch a shared context config.
 	cfg := *base
-	if props[io.S3AccessKeyID] != "" || props[io.S3SecretAccessKey] != "" {
+
+	// Explicit region overrides the context config; an unset region falls through.
+	if r := props[io.S3Region]; r != "" {
+		cfg.Region = r
+	} else if r := props[io.S3ClientRegion]; r != "" {
+		cfg.Region = r
+	}
+
+	// A complete explicit key pair overrides the credentials. A partial set
+	// (missing the access key or secret) falls through to the context/default
+	// chain rather than installing a provider with blank fields.
+	if props[io.S3AccessKeyID] != "" && props[io.S3SecretAccessKey] != "" {
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(
 			props[io.S3AccessKeyID], props[io.S3SecretAccessKey], props[io.S3SessionToken],
 		)

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -75,6 +75,18 @@ func TestResolveS3AWSConfigCredentialPrecedence(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "PROPS", retrieve(t, cfg))
 	})
+
+	// The result is always a copy, so mutating it never touches the shared config.
+	t.Run("never mutates the shared ctx config", func(t *testing.T) {
+		t.Parallel()
+		shared := &aws.Config{Credentials: credentials.NewStaticCredentialsProvider("CTX", "ctxsecret", "")}
+		cfg, err := resolveS3AWSConfig(utils.WithAwsConfig(context.Background(), shared), map[string]string{})
+		require.NoError(t, err)
+		require.NotSame(t, shared, cfg)
+
+		cfg.HTTPClient = http.DefaultClient
+		assert.Nil(t, shared.HTTPClient, "shared ctx config must stay unmutated")
+	})
 }
 
 func TestParseAWSConfigRemoteSigningEnabled(t *testing.T) {

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -25,10 +25,57 @@ import (
 	"time"
 
 	"github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolveS3AWSConfigCredentialPrecedence(t *testing.T) {
+	t.Parallel()
+
+	retrieve := func(t *testing.T, cfg *aws.Config) string {
+		t.Helper()
+		creds, err := cfg.Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+
+		return creds.AccessKeyID
+	}
+
+	ctxCfg := aws.Config{Credentials: credentials.NewStaticCredentialsProvider("CTX", "ctxsecret", "")}
+	ctxWith := utils.WithAwsConfig(context.Background(), &ctxCfg)
+
+	// Explicit s3.* creds win over an ambient context config, without mutating it.
+	t.Run("explicit props override ctx config", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := resolveS3AWSConfig(ctxWith, map[string]string{
+			io.S3AccessKeyID: "PROPS", io.S3SecretAccessKey: "propssecret",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "PROPS", retrieve(t, cfg))
+		assert.Equal(t, "CTX", retrieve(t, &ctxCfg), "shared ctx config must not be mutated")
+	})
+
+	// With no s3.* creds, the context config is used unchanged.
+	t.Run("ctx config used when no props creds", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := resolveS3AWSConfig(ctxWith, map[string]string{})
+		require.NoError(t, err)
+		assert.Equal(t, "CTX", retrieve(t, cfg))
+	})
+
+	// With no context config, creds come from the s3.* props.
+	t.Run("props creds used when no ctx config", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := resolveS3AWSConfig(context.Background(), map[string]string{
+			io.S3AccessKeyID: "PROPS", io.S3SecretAccessKey: "propssecret", io.S3Region: "us-east-1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "PROPS", retrieve(t, cfg))
+	})
+}
 
 func TestParseAWSConfigRemoteSigningEnabled(t *testing.T) {
 	t.Parallel()

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -87,6 +87,24 @@ func TestResolveS3AWSConfigCredentialPrecedence(t *testing.T) {
 		cfg.HTTPClient = http.DefaultClient
 		assert.Nil(t, shared.HTTPClient, "shared ctx config must stay unmutated")
 	})
+
+	// A partial key set (missing the secret) must not clobber the context creds.
+	t.Run("partial props creds fall through", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := resolveS3AWSConfig(ctxWith, map[string]string{io.S3AccessKeyID: "PARTIAL"})
+		require.NoError(t, err)
+		assert.Equal(t, "CTX", retrieve(t, cfg), "incomplete override must keep ctx creds")
+	})
+
+	// Explicit region overrides the context config's region, without mutating it.
+	t.Run("explicit region overrides ctx config", func(t *testing.T) {
+		t.Parallel()
+		shared := &aws.Config{Region: "ctx-region", Credentials: credentials.NewStaticCredentialsProvider("CTX", "s", "")}
+		cfg, err := resolveS3AWSConfig(utils.WithAwsConfig(context.Background(), shared), map[string]string{io.S3Region: "props-region"})
+		require.NoError(t, err)
+		assert.Equal(t, "props-region", cfg.Region)
+		assert.Equal(t, "ctx-region", shared.Region, "shared ctx config must not be mutated")
+	})
 }
 
 func TestParseAWSConfigRemoteSigningEnabled(t *testing.T) {


### PR DESCRIPTION
## Problem

`createS3Bucket` (`io/gocloud/s3.go`) resolves the AWS config by preferring an ambient config injected into the context via `utils.WithAwsConfig` — for example the Glue catalog's own AWS config — and only falls back to `ParseAWSConfig(props)` when no context config exists. The **endpoint** is always read from the properties (`s3.endpoint`), but the **credentials** are whatever the context config carries.

So when a catalog whose API credentials are AWS (Glue) writes to a bucket reached via a custom `s3.endpoint` whose credentials differ — a local MinIO, or a cross-account / delegated-role S3 target — the metadata read-back authenticates with the catalog's AWS credentials instead of the explicitly supplied `s3.access-key-id`, and fails:

```
S3: GetObject ... api error InvalidAccessKeyId: The Access Key Id you provided does not exist in our records.
```

`s3.access-key-id` / `s3.secret-access-key` / `s3.session-token` are silently ignored whenever a context config is present (the endpoint is honoured, so the request reaches the right store — with the wrong credentials).

## Fix

Extract the resolution into `resolveS3AWSConfig`. When explicit `s3.*` credentials are present, layer a static credentials provider built from them over the resolved config — on a copy, so the shared context config is not mutated. Precedence becomes **explicit props > context config > default chain**, matching how `s3.endpoint` already behaves. The common case (Glue + AWS S3, where the storage creds *are* the catalog creds) is unchanged.