### PR TITLE
fix(hive): derive namespace location from the warehouse

### DIFF
--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -777,16 +777,6 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 }
 
 // CreateNamespace creates a new namespace in the catalog.
-// defaultNamespaceLocation derives <warehouse>/<db>.db, the metastore's
-// conventional database location, or "" when no warehouse is configured.
-func defaultNamespaceLocation(warehouse, database string) string {
-	if warehouse == "" {
-		return ""
-	}
-
-	return strings.TrimRight(warehouse, "/") + "/" + database + ".db"
-}
-
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
 	database, err := identifierToDatabase(namespace)
 	if err != nil {
@@ -824,6 +814,16 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 	}
 
 	return nil
+}
+
+// defaultNamespaceLocation derives <warehouse>/<db>.db, the metastore's
+// conventional database location, or "" when no warehouse is configured.
+func defaultNamespaceLocation(warehouse, database string) string {
+	if warehouse == "" {
+		return ""
+	}
+
+	return strings.TrimSuffix(warehouse, "/") + "/" + database + ".db"
 }
 
 // DropNamespace drops a namespace from the catalog.

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -368,7 +368,8 @@ func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, v
 	}
 
 	createdView, err := view.CreateViewWithIOProperties(
-		ctx, catalogName, identifier, freshSchema, viewSQL, defaultNS, loc, ioProps, cfg.Properties)
+		ctx, catalogName, identifier, freshSchema, viewSQL, defaultNS, loc, ioProps, cfg.Properties,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -776,6 +777,16 @@ func (c *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 }
 
 // CreateNamespace creates a new namespace in the catalog.
+// defaultNamespaceLocation derives <warehouse>/<db>.db, the metastore's
+// conventional database location, or "" when no warehouse is configured.
+func defaultNamespaceLocation(warehouse, database string) string {
+	if warehouse == "" {
+		return ""
+	}
+
+	return strings.TrimRight(warehouse, "/") + "/" + database + ".db"
+}
+
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
 	database, err := identifierToDatabase(namespace)
 	if err != nil {
@@ -796,6 +807,12 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		default:
 			db.Parameters[k] = v
 		}
+	}
+
+	// Derive a location from the warehouse when none is given, so the metastore
+	// is not handed an empty path (which it rejects).
+	if db.LocationUri == "" {
+		db.LocationUri = defaultNamespaceLocation(c.opts.Warehouse, database)
 	}
 
 	if err := c.client.CreateDatabase(ctx, db); err != nil {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -399,6 +399,28 @@ func TestHiveCreateNamespace(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestDefaultNamespaceLocation(t *testing.T) {
+	require.Equal(t, "s3://warehouse/db.db", defaultNamespaceLocation("s3://warehouse", "db"))
+	require.Equal(t, "s3://warehouse/db.db", defaultNamespaceLocation("s3://warehouse/", "db"))
+	require.Empty(t, defaultNamespaceLocation("", "db"))
+}
+
+func TestHiveCreateNamespaceDerivesLocationFromWarehouse(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("CreateDatabase", mock.Anything, mock.MatchedBy(func(db *hive_metastore.Database) bool {
+		return db.Name == "new_database" && db.LocationUri == "s3://warehouse/new_database.db"
+	})).Return(nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{Warehouse: "s3://warehouse/"})
+
+	err := hiveCatalog.CreateNamespace(context.TODO(), DatabaseIdentifier("new_database"), nil)
+	assert.NoError(err)
+
+	mockClient.AssertExpectations(t)
+}
+
 func TestHiveCreateNamespaceAlreadyExists(t *testing.T) {
 	assert := require.New(t)
 
@@ -770,7 +792,8 @@ func TestHivePurgeTableWithGCDisabled(t *testing.T) {
 	ctx := context.Background()
 	tableLocation := filepath.Join(t.TempDir(), "warehouse", "test_database", "test_table")
 	metadataLocation, dataFile := writeHivePurgeTableFilesWithProperties(
-		t, tableLocation, iceberg.Properties{"gc.enabled": "false"})
+		t, tableLocation, iceberg.Properties{"gc.enabled": "false"},
+	)
 	hiveTable := hivePurgeTable(metadataLocation, tableLocation)
 
 	mockClient := &mockHiveClient{}
@@ -990,7 +1013,8 @@ func TestHiveRegisterTableNoSuchNamespace(t *testing.T) {
 
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
-	_, err := hiveCatalog.RegisterTable(context.TODO(),
+	_, err := hiveCatalog.RegisterTable(
+		context.TODO(),
 		TableIdentifier("missing_db", "t"),
 		"s3://bucket/metadata/v1.metadata.json",
 	)
@@ -1011,7 +1035,8 @@ func TestHiveRegisterTableConflictsWithView(t *testing.T) {
 
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
-	_, err := hiveCatalog.RegisterTable(context.TODO(),
+	_, err := hiveCatalog.RegisterTable(
+		context.TODO(),
 		TableIdentifier("test_database", "test_table"),
 		"s3://bucket/metadata/v1.metadata.json",
 	)
@@ -1034,7 +1059,8 @@ func TestHiveRegisterTableAlreadyExists(t *testing.T) {
 
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
-	_, err := hiveCatalog.RegisterTable(context.TODO(),
+	_, err := hiveCatalog.RegisterTable(
+		context.TODO(),
 		TableIdentifier("test_database", "test_table"),
 		"s3://bucket/metadata/v1.metadata.json",
 	)
@@ -1055,7 +1081,8 @@ func TestHiveRegisterTableMetadataNotFound(t *testing.T) {
 
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
-	_, err := hiveCatalog.RegisterTable(context.TODO(),
+	_, err := hiveCatalog.RegisterTable(
+		context.TODO(),
 		TableIdentifier("test_database", "new_table"),
 		"s3://nonexistent-bucket/metadata/metadata.json",
 	)
@@ -1104,7 +1131,8 @@ func TestHiveRegisterTableSuccess(t *testing.T) {
 
 	// TODO: should we drop table here
 
-	tbl, err := hiveCatalog.RegisterTable(context.TODO(),
+	tbl, err := hiveCatalog.RegisterTable(
+		context.TODO(),
 		TableIdentifier("test_database", "reg_table"),
 		metaPath,
 	)

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -400,9 +400,23 @@ func TestHiveCreateNamespace(t *testing.T) {
 }
 
 func TestDefaultNamespaceLocation(t *testing.T) {
-	require.Equal(t, "s3://warehouse/db.db", defaultNamespaceLocation("s3://warehouse", "db"))
-	require.Equal(t, "s3://warehouse/db.db", defaultNamespaceLocation("s3://warehouse/", "db"))
-	require.Empty(t, defaultNamespaceLocation("", "db"))
+	tests := []struct {
+		name      string
+		warehouse string
+		want      string
+	}{
+		{"s3 warehouse", "s3://warehouse", "s3://warehouse/db.db"},
+		{"trailing slash", "s3://warehouse/", "s3://warehouse/db.db"},
+		{"double trailing slash trims one", "s3://warehouse//", "s3://warehouse//db.db"},
+		{"file scheme", "file:///wh", "file:///wh/db.db"},
+		{"file root keeps scheme", "file:///", "file:///db.db"},
+		{"no warehouse stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, defaultNamespaceLocation(tt.warehouse, "db"))
+		})
+	}
 }
 
 func TestHiveCreateNamespaceDerivesLocationFromWarehouse(t *testing.T) {
@@ -414,6 +428,38 @@ func TestHiveCreateNamespaceDerivesLocationFromWarehouse(t *testing.T) {
 	})).Return(nil).Once()
 
 	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{Warehouse: "s3://warehouse/"})
+
+	err := hiveCatalog.CreateNamespace(context.TODO(), DatabaseIdentifier("new_database"), nil)
+	assert.NoError(err)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveCreateNamespaceExplicitLocationWinsOverWarehouse(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("CreateDatabase", mock.Anything, mock.MatchedBy(func(db *hive_metastore.Database) bool {
+		return db.Name == "new_database" && db.LocationUri == "s3://explicit"
+	})).Return(nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{Warehouse: "s3://warehouse"})
+
+	err := hiveCatalog.CreateNamespace(context.TODO(), DatabaseIdentifier("new_database"), map[string]string{"location": "s3://explicit"})
+	assert.NoError(err)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestHiveCreateNamespaceNoWarehouseKeepsEmptyLocation(t *testing.T) {
+	assert := require.New(t)
+
+	mockClient := &mockHiveClient{}
+	mockClient.On("CreateDatabase", mock.Anything, mock.MatchedBy(func(db *hive_metastore.Database) bool {
+		return db.Name == "new_database" && db.LocationUri == ""
+	})).Return(nil).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
 
 	err := hiveCatalog.CreateNamespace(context.TODO(), DatabaseIdentifier("new_database"), nil)
 	assert.NoError(err)


### PR DESCRIPTION
## Problem

`CreateNamespace` (`catalog/hive/hive.go`) sets the Hive database `LocationUri` only from an explicit `location` / `Location` property. When none is provided — the common case (e.g. a client calls `CreateNamespace` with empty properties) — and the metastore has no default warehouse dir configured, the metastore is handed an empty location and rejects it:

```
MetaException: java.lang.IllegalArgumentException: Can not create a Path from an empty string
```

The catalog already carries the `warehouse` option, but `CreateNamespace` never uses it for the namespace location. (pyiceberg's Hive catalog derives the database location from the warehouse.)

## Fix

When no explicit location is given, derive `<warehouse>/<db>.db` — the metastore's conventional database location — from the catalog's `warehouse`. When no warehouse is configured the location stays empty, preserving the previous behavior (no regression for setups that rely on the metastore's own default warehouse dir).