### PR TITLE
fix(transforms): validate parameterized transform values

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -294,6 +294,10 @@ func validateTransform(transform Transform) error {
 		return t.validateNumBuckets()
 	case *BucketTransform:
 		return t.validateNumBuckets()
+	case TruncateTransform:
+		return t.validateWidth()
+	case *TruncateTransform:
+		return t.validateWidth()
 	default:
 		return nil
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -183,6 +183,21 @@ func TestPartitionSpecRejectsNegativeSpecID(t *testing.T) {
 	require.ErrorContains(t, err, "spec id must be non-negative: -1")
 }
 
+func TestPartitionSpecRejectsInvalidTruncateTransform(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID:   1,
+		Name: "id",
+		Type: iceberg.PrimitiveTypes.Int32,
+	})
+
+	_, err := iceberg.NewPartitionSpecOpts(
+		iceberg.AddPartitionFieldBySourceID(1, "id_truncate", iceberg.TruncateTransform{Width: 0}, schema, nil),
+	)
+
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "width > 0")
+}
+
 func TestPartitionSpec_MarshalTextRejectsInvalidBucketTransform(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{
@@ -196,6 +211,21 @@ func TestPartitionSpec_MarshalTextRejectsInvalidBucketTransform(t *testing.T) {
 	_, err := json.Marshal(spec)
 	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	require.ErrorContains(t, err, "numBuckets > 0")
+}
+
+func TestPartitionSpec_MarshalTextRejectsInvalidTruncateTransform(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(3,
+		iceberg.PartitionField{
+			SourceIDs: []int{1},
+			FieldID:   1000,
+			Name:      "bad_truncate",
+			Transform: iceberg.TruncateTransform{Width: 0},
+		},
+	)
+
+	_, err := json.Marshal(spec)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "width > 0")
 }
 
 func TestUnpartitionedWithVoidField(t *testing.T) {

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -310,6 +311,11 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 	for idx, field := range fields {
 		if field.Transform == nil {
 			return SortOrder{}, fmt.Errorf("%w: sort field at index %d has no transform", ErrInvalidTransform, idx)
+		}
+		if marshaler, ok := field.Transform.(encoding.TextMarshaler); ok {
+			if _, err := marshaler.MarshalText(); err != nil {
+				return SortOrder{}, fmt.Errorf("%w: sort field at index %d: %w", ErrInvalidTransform, idx, err)
+			}
 		}
 		if field.Direction != SortASC && field.Direction != SortDESC {
 			return SortOrder{}, fmt.Errorf("%w: sort field at index %d", ErrInvalidSortDirection, idx)

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -74,6 +74,28 @@ func TestNewSortOrderRejectsNilTransform(t *testing.T) {
 	assert.Contains(t, err.Error(), "has no transform")
 }
 
+func TestNewSortOrderRejectsInvalidParameterizedTransform(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		transform iceberg.Transform
+	}{
+		{"bucket", iceberg.BucketTransform{NumBuckets: 0}},
+		{"truncate", iceberg.TruncateTransform{Width: 0}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := table.NewSortOrder(1, []table.SortField{{
+				SourceIDs: []int{19},
+				Transform: tt.transform,
+				NullOrder: table.NullsFirst,
+				Direction: table.SortASC,
+			}})
+
+			require.ErrorIs(t, err, table.ErrInvalidTransform)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		})
+	}
+}
+
 func TestNewSortOrderRejectsInvalidSourceIDs(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -353,8 +353,14 @@ func (us *UpdateSpec) renameField(name string, newName string) updateSpecOp {
 }
 
 func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.PartitionField, error) {
+	transform, err := iceberg.ParseTransform(key.Transform)
+	if err != nil {
+		return iceberg.PartitionField{}, fmt.Errorf("%w: invalid partition transform %q: %w",
+			iceberg.ErrInvalidArgument, key.Transform, err)
+	}
+
 	if us.txn.tbl.Metadata().Version() == 2 {
-		sourceId, transform := key.SourceId, key.Transform
+		sourceId, transformName := key.SourceId, key.Transform
 		historicalFields := make([]iceberg.PartitionField, 0)
 		for _, spec := range us.txn.tbl.Metadata().PartitionSpecs() {
 			for _, field := range spec.Fields() {
@@ -362,7 +368,7 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 			}
 		}
 		for _, field := range historicalFields {
-			if field.SourceID() == sourceId && field.Transform.String() == transform {
+			if field.SourceID() == sourceId && field.Transform.String() == transformName {
 				if len(name) > 0 && field.Name == name {
 					return iceberg.PartitionField{
 						SourceIDs: []int{sourceId},
@@ -375,7 +381,6 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 		}
 	}
 	newFieldId := us.newFieldId()
-	transform, _ := iceberg.ParseTransform(key.Transform)
 	if name == "" {
 		tmpField := iceberg.PartitionField{
 			SourceIDs: []int{key.SourceId},

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -126,6 +126,26 @@ func TestUpdateSpecAddField(t *testing.T) {
 		assert.Nil(t, reqs)
 	})
 
+	for _, tt := range []struct {
+		name      string
+		transform iceberg.Transform
+	}{
+		{"bucket", iceberg.BucketTransform{NumBuckets: 0}},
+		{"truncate", iceberg.TruncateTransform{Width: 0}},
+	} {
+		t.Run("reject invalid "+tt.name+" transform parameters", func(t *testing.T) {
+			specUpdate := table.NewUpdateSpec(testNonPartitionedTable.NewTransaction(), true)
+			updates, reqs, err := specUpdate.
+				AddField("id", tt.transform, "invalid_transform").
+				BuildUpdates()
+
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			assert.ErrorContains(t, err, "invalid partition transform")
+			assert.Nil(t, updates)
+			assert.Nil(t, reqs)
+		})
+	}
+
 	t.Run("add duplicate partition field", func(t *testing.T) {
 		txn = testPartitionedTable.NewTransaction()
 		specUpdate := table.NewUpdateSpec(txn, true)

--- a/transforms.go
+++ b/transforms.go
@@ -252,6 +252,9 @@ func (t BucketTransform) validateNumBuckets() error {
 	if t.NumBuckets <= 0 {
 		return fmt.Errorf("%w: bucket transform requires numBuckets > 0", ErrInvalidArgument)
 	}
+	if t.NumBuckets > math.MaxInt32 {
+		return fmt.Errorf("%w: bucket transform requires numBuckets <= %d", ErrInvalidArgument, math.MaxInt32)
+	}
 
 	return nil
 }
@@ -456,10 +459,25 @@ type TruncateTransform struct {
 }
 
 func (t TruncateTransform) MarshalText() ([]byte, error) {
+	if err := t.validateWidth(); err != nil {
+		return nil, err
+	}
+
 	return []byte(t.String()), nil
 }
 
 func (t TruncateTransform) String() string { return fmt.Sprintf("truncate[%d]", t.Width) }
+
+func (t TruncateTransform) validateWidth() error {
+	if t.Width <= 0 {
+		return fmt.Errorf("%w: truncate transform requires width > 0", ErrInvalidArgument)
+	}
+	if t.Width > math.MaxInt32 {
+		return fmt.Errorf("%w: truncate transform requires width <= %d", ErrInvalidArgument, math.MaxInt32)
+	}
+
+	return nil
+}
 
 func (TruncateTransform) CanTransform(t Type) bool {
 	switch t.(type) {
@@ -485,6 +503,10 @@ func (t TruncateTransform) Equals(other Transform) bool {
 }
 
 func (t TruncateTransform) Transformer(src Type) (func(any) any, error) {
+	if err := t.validateWidth(); err != nil {
+		return nil, err
+	}
+
 	switch src.(type) {
 	case Int32Type:
 		return func(v any) any {
@@ -606,6 +628,10 @@ func (t TruncateTransform) ToHumanStrType(_ Type, val any) string {
 }
 
 func (t TruncateTransform) Project(name string, pred BoundPredicate) (UnboundPredicate, error) {
+	if err := t.validateWidth(); err != nil {
+		return nil, err
+	}
+
 	if _, ok := pred.Term().(*BoundTransform); ok {
 		return projectTransformPredicate(t, name, pred)
 	}

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -337,22 +338,19 @@ func TestManifestPartitionVals(t *testing.T) {
 }
 
 func TestBucketTransform_NumBucketsValidation(t *testing.T) {
-	transform := iceberg.BucketTransform{}
-	t.Run("ApplyRejectsInvalidBuckets", func(t *testing.T) {
+	testValidation := func(t *testing.T, transform iceberg.BucketTransform, errorContains string) {
+		t.Helper()
+
 		out := transform.Apply(iceberg.Optional[iceberg.Literal]{
 			Valid: true,
 			Val:   iceberg.Int32Literal(123),
 		})
 		require.False(t, out.Valid)
-	})
 
-	t.Run("TransformerRejectsInvalidBuckets", func(t *testing.T) {
 		fn := transform.Transformer(iceberg.PrimitiveTypes.String)
-		out := fn("abc")
-		require.False(t, out.Valid)
-	})
+		transformed := fn("abc")
+		require.False(t, transformed.Valid)
 
-	t.Run("ProjectRejectsInvalidBuckets", func(t *testing.T) {
 		schema := iceberg.NewSchema(1, iceberg.NestedField{
 			ID:   1,
 			Name: "id",
@@ -363,7 +361,84 @@ func TestBucketTransform_NumBucketsValidation(t *testing.T) {
 
 		_, err = transform.Project("id_bucket", bound.(iceberg.BoundPredicate))
 		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
-		require.ErrorContains(t, err, "numBuckets > 0")
+		require.ErrorContains(t, err, errorContains)
+	}
+
+	t.Run("non-positive", func(t *testing.T) {
+		testValidation(t, iceberg.BucketTransform{}, "numBuckets > 0")
+	})
+	t.Run("int32-overflow", func(t *testing.T) {
+		testValidation(t, iceberg.BucketTransform{NumBuckets: overflowingInt32TransformParameter(t)}, "numBuckets <=")
+	})
+}
+
+func overflowingInt32TransformParameter(t *testing.T) int {
+	t.Helper()
+	if strconv.IntSize < 64 {
+		t.Skip("an int cannot exceed math.MaxInt32 on this platform")
+	}
+
+	value := uint64(1) << 32
+
+	return int(value)
+}
+
+func TestTruncateTransform_WidthValidation(t *testing.T) {
+	testValidation := func(t *testing.T, transform iceberg.TruncateTransform, errorContains string) {
+		t.Helper()
+
+		out := transform.Apply(iceberg.Optional[iceberg.Literal]{
+			Valid: true,
+			Val:   iceberg.Int32Literal(123),
+		})
+		require.False(t, out.Valid)
+
+		fn, err := transform.Transformer(iceberg.PrimitiveTypes.Int32)
+		require.Nil(t, fn)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, errorContains)
+
+		schema := iceberg.NewSchema(1, iceberg.NestedField{
+			ID:   1,
+			Name: "id",
+			Type: iceberg.PrimitiveTypes.Int64,
+		})
+		bound, err := iceberg.EqualTo(iceberg.Reference("id"), int64(42)).Bind(schema, true)
+		require.NoError(t, err)
+
+		_, err = transform.Project("id_truncate", bound.(iceberg.BoundPredicate))
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, errorContains)
+	}
+
+	t.Run("non-positive", func(t *testing.T) {
+		testValidation(t, iceberg.TruncateTransform{}, "width > 0")
+	})
+	t.Run("int32-overflow", func(t *testing.T) {
+		testValidation(t, iceberg.TruncateTransform{Width: overflowingInt32TransformParameter(t)}, "width <=")
+	})
+}
+
+func TestTruncateTransform_MarshalTextRejectsInvalidWidths(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		_, err := iceberg.TruncateTransform{Width: 0}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "width > 0")
+	})
+	t.Run("negative", func(t *testing.T) {
+		_, err := iceberg.TruncateTransform{Width: -1}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "width > 0")
+	})
+	t.Run("int32-overflow", func(t *testing.T) {
+		_, err := iceberg.TruncateTransform{Width: overflowingInt32TransformParameter(t)}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "width <=")
+	})
+	t.Run("valid", func(t *testing.T) {
+		txt, err := iceberg.TruncateTransform{Width: 16}.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, "truncate[16]", string(txt))
 	})
 }
 
@@ -377,6 +452,11 @@ func TestBucketTransform_MarshalTextRejectsInvalidBuckets(t *testing.T) {
 		_, err := iceberg.BucketTransform{NumBuckets: -1}.MarshalText()
 		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 		require.ErrorContains(t, err, "numBuckets > 0")
+	})
+	t.Run("int32-overflow", func(t *testing.T) {
+		_, err := iceberg.BucketTransform{NumBuckets: overflowingInt32TransformParameter(t)}.MarshalText()
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "numBuckets <=")
 	})
 	t.Run("valid", func(t *testing.T) {
 		txt, err := iceberg.BucketTransform{NumBuckets: 16}.MarshalText()


### PR DESCRIPTION
## Summary

- validate directly constructed bucket counts and truncate widths before serialization or execution
- reject parameter values outside the parser-supported range of 1 through `math.MaxInt32`
- validate partition specs and sort orders eagerly when they are constructed

## Why

`ParseTransform` rejects invalid parameter values, but callers can construct the exported transform structs directly. A zero truncate width reaches integer modulo and panics, while values such as `1 << 32` narrow to zero in the int32 paths and can panic for both bucket and truncate transforms.

Partition specs and sort orders now reject these invalid transforms during construction instead of deferring the failure until metadata serialization.

## Testing

- `go test ./...`
- `go test -race ./codec/... ./table/...`
- `golangci-lint run --timeout=10m`
- focused transform, partition-spec, and sort-order regression tests