### PR TITLE
feat(table): aggregate geo bounds across data files at manifest level

### DIFF
--- a/table/internal/geo_codec.go
+++ b/table/internal/geo_codec.go
@@ -19,6 +19,7 @@ package internal
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 
 	"github.com/apache/iceberg-go"
@@ -160,15 +161,22 @@ func (a *geoBoundsAccumulator) layout() (geom.Layout, bool) {
 	hasZ := a.has[geoDimZ] && a.zGeoms == a.geoms
 	hasM := a.has[geoDimM] && a.mGeoms == a.geoms
 
+	return geoPointLayout(hasZ, hasM), true
+}
+
+// geoPointLayout selects the bound point layout implied by which optional
+// dimensions are present. X and Y are always assumed present; callers gate on
+// that before calling.
+func geoPointLayout(hasZ, hasM bool) geom.Layout {
 	switch {
 	case hasZ && hasM:
-		return geom.XYZM, true
+		return geom.XYZM
 	case hasZ:
-		return geom.XYZ, true
+		return geom.XYZ
 	case hasM:
-		return geom.XYM, true
+		return geom.XYM
 	default:
-		return geom.XY, true
+		return geom.XY
 	}
 }
 
@@ -266,3 +274,197 @@ func (g *geoStatsAgg) Update(interface{ HasMinMax() bool }) {}
 
 func (g *geoStatsAgg) MinAsBytes() ([]byte, error) { return g.lower, nil }
 func (g *geoStatsAgg) MaxAsBytes() ([]byte, error) { return g.upper, nil }
+
+// decodeGeoBound is the inverse of encodeGeoBound: it parses an Iceberg
+// geospatial single-value bound back into its per-dimension coordinates and the
+// layout it was written with. A 32-byte bound is XYM when its Z slot is NaN and
+// XYZM otherwise (see encodeGeoBound). ok is false when the length is not a
+// valid bound length (16, 24, or 32 bytes).
+func decodeGeoBound(data []byte) (vals [geoNumDims]float64, layout geom.Layout, ok bool) {
+	var n int
+	switch len(data) {
+	case 16:
+		n = 2
+	case 24:
+		n = 3
+	case 32:
+		n = 4
+	default:
+		return vals, geom.NoLayout, false
+	}
+
+	coords := make([]float64, n)
+	for i := range coords {
+		coords[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[i*8:]))
+	}
+
+	vals[geoDimX], vals[geoDimY] = coords[0], coords[1]
+	switch len(data) {
+	case 16:
+		layout = geom.XY
+	case 24:
+		vals[geoDimZ], layout = coords[2], geom.XYZ
+	case 32:
+		if math.IsNaN(coords[2]) {
+			vals[geoDimM], layout = coords[3], geom.XYM
+		} else {
+			vals[geoDimZ], vals[geoDimM], layout = coords[2], coords[3], geom.XYZM
+		}
+	}
+
+	return vals, layout, true
+}
+
+// layoutHasZM reports which optional dimensions a bound layout carries.
+func layoutHasZM(l geom.Layout) (hasZ, hasM bool) {
+	switch l {
+	case geom.XYZ:
+		return true, false
+	case geom.XYM:
+		return false, true
+	case geom.XYZM:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+// GeoBoundsAggregator combines the per-data-file geospatial bounds emitted by
+// geoBoundsAccumulator (the single-value serialization written into a
+// DataFile's lower/upper bounds; see Bounds) across multiple files into one
+// bounding box. It is the manifest-level analogue of the primitive min/max
+// aggregation the manifest writer already does per partition field, but geo
+// bounds are coordinate tuples with no total order, so they must never be
+// folded with a
+// scalar byte comparison: each bound is decoded to its coordinates and merged
+// dimension by dimension. The combined box is returned in the same
+// serialization, so it round-trips through a manifest bound exactly like a
+// per-file one.
+//
+// The aggregator is geometry-only: it folds each dimension with a scalar
+// min/max, which is correct for geometry's planar bounds but wrong for
+// geography. A geography box may cross the antimeridian, encoded as lower_x >
+// upper_x (spec Appendix D); scalar min/max would silently unwrap it (merging a
+// wrapped [170, -170] with [10, 20] yields [10, 20], dropping the wrapped
+// range), producing a box that prunes rows it should keep. Because the bound
+// bytes carry no type, callers must declare geography via NewGeoBoundsAggregator
+// so Add can reject it (see Add). iceberg-go itself emits no per-file bounds for
+// geography (see Bounds), so the common path — passing empty geography bounds
+// through — is a harmless no-op; only non-empty geography bounds (e.g. from files
+// written by another engine) are refused, until geodesic/antimeridian-aware
+// aggregation is added.
+type GeoBoundsAggregator struct {
+	min [geoNumDims]float64
+	max [geoNumDims]float64
+	has [geoNumDims]bool
+
+	// n counts the files added; zFiles and mFiles count how many carried a Z / M
+	// dimension. An optional dimension is only emitted when every file carried it
+	// (count == n) - the same omit-on-ambiguity rule geoBoundsAccumulator applies
+	// across geometries within a single file. Emitting a Z/M that some files lack
+	// would imply those files have a value in range and drive wrong-answer
+	// pruning.
+	n      int
+	zFiles int
+	mFiles int
+
+	// isGeography marks a geography column, whose bounds must not be folded with
+	// scalar min/max (see the type doc); Add refuses non-empty geography bounds.
+	isGeography bool
+}
+
+// NewGeoBoundsAggregator returns an aggregator for a single geo column. Pass
+// isGeography=true for geography columns so Add refuses their bounds rather than
+// mis-merging antimeridian-crossing boxes (see GeoBoundsAggregator). The
+// zero-value GeoBoundsAggregator is a valid geometry aggregator.
+func NewGeoBoundsAggregator(isGeography bool) *GeoBoundsAggregator {
+	return &GeoBoundsAggregator{isGeography: isGeography}
+}
+
+// Add merges one data file's lower and upper geo bounds into the aggregate. The
+// two bounds must share a layout, which they always do: a file's lower and upper
+// are written together by geoBoundsAccumulator. An empty pair (nil/empty lower
+// and upper) contributes nothing, so files without geo bounds - including every
+// geography file written by iceberg-go - can be passed through harmlessly. It
+// errors when a bound is a non-empty but invalid length, when lower and upper
+// disagree on layout, or when a non-empty bound is added to a geography
+// aggregator (scalar folding would mis-merge antimeridian-crossing boxes; see
+// GeoBoundsAggregator).
+func (g *GeoBoundsAggregator) Add(lower, upper []byte) error {
+	if len(lower) == 0 && len(upper) == 0 {
+		return nil
+	}
+
+	if g.isGeography {
+		return fmt.Errorf("%w: cannot aggregate geography geo bounds; "+
+			"scalar min/max folding mis-merges antimeridian-crossing boxes",
+			iceberg.ErrNotImplemented)
+	}
+
+	lo, loLayout, ok := decodeGeoBound(lower)
+	if !ok {
+		return fmt.Errorf("%w: geo lower bound must be 16, 24, or 32 bytes, got %d",
+			iceberg.ErrInvalidBinSerialization, len(lower))
+	}
+	hi, hiLayout, ok := decodeGeoBound(upper)
+	if !ok {
+		return fmt.Errorf("%w: geo upper bound must be 16, 24, or 32 bytes, got %d",
+			iceberg.ErrInvalidBinSerialization, len(upper))
+	}
+	if loLayout != hiLayout {
+		return fmt.Errorf("%w: geo lower/upper bounds have mismatched layouts (%v vs %v)",
+			iceberg.ErrInvalidBinSerialization, loLayout, hiLayout)
+	}
+
+	g.n++
+	g.update(geoDimX, lo[geoDimX], hi[geoDimX])
+	g.update(geoDimY, lo[geoDimY], hi[geoDimY])
+
+	if hasZ, hasM := layoutHasZM(loLayout); hasZ || hasM {
+		if hasZ {
+			g.zFiles++
+			g.update(geoDimZ, lo[geoDimZ], hi[geoDimZ])
+		}
+		if hasM {
+			g.mFiles++
+			g.update(geoDimM, lo[geoDimM], hi[geoDimM])
+		}
+	}
+
+	return nil
+}
+
+// update folds one file's per-dimension lower/upper into the running min/max.
+func (g *GeoBoundsAggregator) update(dim int, lo, hi float64) {
+	if math.IsNaN(lo) || math.IsNaN(hi) {
+		return
+	}
+
+	if !g.has[dim] {
+		g.min[dim], g.max[dim] = lo, hi
+		g.has[dim] = true
+
+		return
+	}
+
+	if lo < g.min[dim] {
+		g.min[dim] = lo
+	}
+	if hi > g.max[dim] {
+		g.max[dim] = hi
+	}
+}
+
+// Bounds returns the combined lower and upper bound points in the Iceberg
+// geospatial single-value serialization, or nil when no file contributed a
+// bounding box. An optional Z/M dimension is dropped unless every added file
+// carried it (see the field docs).
+func (g *GeoBoundsAggregator) Bounds() (lower, upper []byte) {
+	if g.n == 0 || g.isGeography || !g.has[geoDimX] || !g.has[geoDimY] {
+		return nil, nil
+	}
+
+	layout := geoPointLayout(g.has[geoDimZ] && g.zFiles == g.n, g.has[geoDimM] && g.mFiles == g.n)
+
+	return encodeGeoBound(g.min, layout), encodeGeoBound(g.max, layout)
+}

--- a/table/internal/geo_codec_internal_test.go
+++ b/table/internal/geo_codec_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twpayne/go-geom"
@@ -257,4 +258,168 @@ func TestEncodeGeoBoundRoundTrip(t *testing.T) {
 
 	assert.Len(t, encodeGeoBound(vals, geom.XYZM), 32)
 	assert.Equal(t, []float64{1, 2, 3, 4}, decodeBound(t, encodeGeoBound(vals, geom.XYZM)))
+}
+
+// encGeo encodes a bound point from explicit coordinates for aggregator tests.
+func encGeo(x, y float64) []byte {
+	var v [geoNumDims]float64
+	v[geoDimX], v[geoDimY] = x, y
+
+	return encodeGeoBound(v, geom.XY)
+}
+
+func encGeoZ(x, y, z float64) []byte {
+	var v [geoNumDims]float64
+	v[geoDimX], v[geoDimY], v[geoDimZ] = x, y, z
+
+	return encodeGeoBound(v, geom.XYZ)
+}
+
+func encGeoM(x, y, mv float64) []byte {
+	var v [geoNumDims]float64
+	v[geoDimX], v[geoDimY], v[geoDimM] = x, y, mv
+
+	return encodeGeoBound(v, geom.XYM)
+}
+
+// TestDecodeGeoBound pins that decodeGeoBound is the exact inverse of
+// encodeGeoBound for each layout, including the XYM/XYZM disambiguation by the
+// NaN Z slot, and rejects invalid lengths.
+func TestDecodeGeoBound(t *testing.T) {
+	var v [geoNumDims]float64
+	v[geoDimX], v[geoDimY], v[geoDimZ], v[geoDimM] = 1, 2, 3, 4
+
+	xy, layout, ok := decodeGeoBound(encodeGeoBound(v, geom.XY))
+	require.True(t, ok)
+	assert.Equal(t, geom.XY, layout)
+	assert.Equal(t, [2]float64{1, 2}, [2]float64{xy[geoDimX], xy[geoDimY]})
+
+	xyz, layout, ok := decodeGeoBound(encodeGeoBound(v, geom.XYZ))
+	require.True(t, ok)
+	assert.Equal(t, geom.XYZ, layout)
+	assert.Equal(t, float64(3), xyz[geoDimZ])
+
+	xym, layout, ok := decodeGeoBound(encodeGeoBound(v, geom.XYM))
+	require.True(t, ok)
+	assert.Equal(t, geom.XYM, layout, "NaN Z slot must decode as XYM, not XYZM")
+	assert.Equal(t, float64(4), xym[geoDimM])
+
+	xyzm, layout, ok := decodeGeoBound(encodeGeoBound(v, geom.XYZM))
+	require.True(t, ok)
+	assert.Equal(t, geom.XYZM, layout)
+	assert.Equal(t, [2]float64{3, 4}, [2]float64{xyzm[geoDimZ], xyzm[geoDimM]})
+
+	for _, n := range []int{0, 8, 15, 40} {
+		_, _, ok := decodeGeoBound(make([]byte, n))
+		assert.False(t, ok, "length %d must be rejected", n)
+	}
+}
+
+func TestGeoBoundsAggregatorXY(t *testing.T) {
+	var agg GeoBoundsAggregator
+	require.NoError(t, agg.Add(encGeo(5, 5), encGeo(10, 20)))
+	require.NoError(t, agg.Add(encGeo(1, 8), encGeo(30, 12)))
+
+	lower, upper := agg.Bounds()
+	require.Len(t, lower, 16)
+	assert.Equal(t, []float64{1, 5}, decodeBound(t, lower))
+	assert.Equal(t, []float64{30, 20}, decodeBound(t, upper))
+}
+
+func TestGeoBoundsAggregatorXYZ(t *testing.T) {
+	var agg GeoBoundsAggregator
+	require.NoError(t, agg.Add(encGeoZ(1, 2, 3), encGeoZ(4, 5, 6)))
+	require.NoError(t, agg.Add(encGeoZ(0, 1, -1), encGeoZ(2, 9, 3)))
+
+	lower, upper := agg.Bounds()
+	require.Len(t, lower, 24)
+	assert.Equal(t, []float64{0, 1, -1}, decodeBound(t, lower))
+	assert.Equal(t, []float64{4, 9, 6}, decodeBound(t, upper))
+}
+
+func TestGeoBoundsAggregatorXYM(t *testing.T) {
+	var agg GeoBoundsAggregator
+	require.NoError(t, agg.Add(encGeoM(1, 2, 50), encGeoM(4, 5, 100)))
+	require.NoError(t, agg.Add(encGeoM(0, 1, 10), encGeoM(2, 9, 70)))
+
+	lower, upper := agg.Bounds()
+	require.Len(t, lower, 32)
+	lo := decodeBound(t, lower)
+	assert.Equal(t, []float64{0, 1}, lo[:2])
+	assert.True(t, math.IsNaN(lo[2]), "XYM lower Z slot must be NaN")
+	assert.Equal(t, float64(10), lo[3])
+	hi := decodeBound(t, upper)
+	assert.Equal(t, float64(100), hi[3])
+}
+
+// TestGeoBoundsAggregatorMixedDimensionDropsZ verifies the omit-on-ambiguity
+// rule across files: a file carrying Z followed by a plain-XY file must collapse
+// to an XY box, since not every file carried Z. Emitting Z would claim the XY
+// file has a Z value in range.
+func TestGeoBoundsAggregatorMixedDimensionDropsZ(t *testing.T) {
+	var agg GeoBoundsAggregator
+	require.NoError(t, agg.Add(encGeoZ(1, 2, 3), encGeoZ(4, 5, 6)))
+	require.NoError(t, agg.Add(encGeo(0, 1), encGeo(10, 9)))
+
+	lower, upper := agg.Bounds()
+	require.Len(t, lower, 16, "a file without Z must collapse the aggregate to XY")
+	assert.Equal(t, []float64{0, 1}, decodeBound(t, lower))
+	assert.Equal(t, []float64{10, 9}, decodeBound(t, upper))
+}
+
+// TestGeoBoundsAggregatorEmptyInputs verifies that empty bound pairs (as emitted
+// for geography or all-null geometry columns) contribute nothing.
+func TestGeoBoundsAggregatorEmptyInputs(t *testing.T) {
+	var agg GeoBoundsAggregator
+	require.NoError(t, agg.Add(nil, nil))
+	require.NoError(t, agg.Add([]byte{}, []byte{}))
+
+	lower, upper := agg.Bounds()
+	assert.Nil(t, lower)
+	assert.Nil(t, upper)
+}
+
+func TestGeoBoundsAggregatorInvalidLength(t *testing.T) {
+	var agg GeoBoundsAggregator
+	assert.Error(t, agg.Add([]byte{0x01, 0x02}, encGeo(1, 2)))
+	assert.Error(t, agg.Add(encGeo(1, 2), []byte{0x01, 0x02}))
+}
+
+// TestGeoBoundsAggregatorMismatchedLayouts guards against combining a lower and
+// upper of different dimensionality, which would silently corrupt the box.
+func TestGeoBoundsAggregatorMismatchedLayouts(t *testing.T) {
+	var agg GeoBoundsAggregator
+	assert.Error(t, agg.Add(encGeo(1, 2), encGeoZ(4, 5, 6)))
+}
+
+// TestGeoBoundsAggregatorRejectsGeography verifies a geography aggregator refuses
+// non-empty bounds: scalar min/max folding would silently unwrap an
+// antimeridian-crossing box (lower_x > upper_x), producing bounds that prune rows
+// they should keep. Empty bounds - what iceberg-go emits for geography - stay a
+// harmless no-op, and the aggregate produces no box.
+func TestGeoBoundsAggregatorRejectsGeography(t *testing.T) {
+	agg := NewGeoBoundsAggregator(true)
+
+	require.NoError(t, agg.Add(nil, nil))
+	require.NoError(t, agg.Add([]byte{}, []byte{}))
+
+	// A wrapped box that scalar folding would mis-merge must be refused.
+	err := agg.Add(encGeo(170, 10), encGeo(-170, 20))
+	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+
+	lower, upper := agg.Bounds()
+	assert.Nil(t, lower)
+	assert.Nil(t, upper)
+}
+
+// TestNewGeoBoundsAggregatorGeometry verifies the constructor's geometry path
+// aggregates identically to the zero value.
+func TestNewGeoBoundsAggregatorGeometry(t *testing.T) {
+	agg := NewGeoBoundsAggregator(false)
+	require.NoError(t, agg.Add(encGeo(5, 5), encGeo(10, 20)))
+	require.NoError(t, agg.Add(encGeo(1, 8), encGeo(30, 12)))
+
+	lower, upper := agg.Bounds()
+	assert.Equal(t, []float64{1, 5}, decodeBound(t, lower))
+	assert.Equal(t, []float64{30, 20}, decodeBound(t, upper))
 }

--- a/table/internal/geo_codec_manifest_test.go
+++ b/table/internal/geo_codec_manifest_test.go
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	iceberg "github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encGeoXY encodes an XY bound point in the Iceberg geospatial single-value
+// serialization (little-endian float64 X, Y) without reaching into the internal
+// encoder, so this stays a black-box test of the manifest round-trip.
+func encGeoXY(x, y float64) []byte {
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint64(buf[0:], math.Float64bits(x))
+	binary.LittleEndian.PutUint64(buf[8:], math.Float64bits(y))
+
+	return buf
+}
+
+func decGeoXY(b []byte) (x, y float64) {
+	return math.Float64frombits(binary.LittleEndian.Uint64(b[0:])),
+		math.Float64frombits(binary.LittleEndian.Uint64(b[8:]))
+}
+
+// TestManifestGeoBoundsRoundTripAndAggregate writes a manifest holding several
+// data files whose geometry column carries per-file bounds, reads it back, and
+// checks two things #993 requires: each file's bound round-trips and decodes as
+// an (unorderable) GeoLiteral rather than a plain binary literal, and the
+// GeoBoundsAggregator combines the per-file boxes across files into the correct
+// overall bounding box.
+func TestManifestGeoBoundsRoundTripAndAggregate(t *testing.T) {
+	const geoFieldID = 1
+	geoType := iceberg.GeometryType{}
+	schema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: geoFieldID, Name: "geom", Type: geoType, Required: false,
+	})
+	spec := iceberg.NewPartitionSpec() // geometry cannot be a partition source
+
+	type fileBounds struct{ loX, loY, hiX, hiY float64 }
+	files := []fileBounds{
+		{loX: 5, loY: 5, hiX: 10, hiY: 20},
+		{loX: 1, loY: 8, hiX: 30, hiY: 12},
+		{loX: -4, loY: 0, hiX: 3, hiY: 40},
+	}
+
+	snapshotID := int64(42)
+	entries := make([]iceberg.ManifestEntry, 0, len(files))
+	for i, fb := range files {
+		df, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData,
+			[]string{"/data/a.parquet", "/data/b.parquet", "/data/c.parquet"}[i],
+			iceberg.ParquetFile, nil, nil, nil, 10, 1000,
+		)
+		require.NoError(t, err)
+		df.LowerBoundValues(map[int][]byte{geoFieldID: encGeoXY(fb.loX, fb.loY)})
+		df.UpperBoundValues(map[int][]byte{geoFieldID: encGeoXY(fb.hiX, fb.hiY)})
+		entries = append(entries, iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, nil, nil, df.Build()))
+	}
+
+	var buf bytes.Buffer
+	mf, err := iceberg.WriteManifest("/geo-manifest.avro", &buf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err)
+
+	read, err := iceberg.ReadManifest(mf, bytes.NewReader(buf.Bytes()), false)
+	require.NoError(t, err)
+	require.Len(t, read, len(files))
+
+	var agg internal.GeoBoundsAggregator
+	for i, entry := range read {
+		lb := entry.DataFile().LowerBoundValues()[geoFieldID]
+		ub := entry.DataFile().UpperBoundValues()[geoFieldID]
+		require.Len(t, lb, 16, "file %d lower bound must round-trip", i)
+		require.Len(t, ub, 16, "file %d upper bound must round-trip", i)
+
+		// The bound must decode as a GeoLiteral, not a comparable BinaryLiteral,
+		// so nothing downstream silently orders coordinate bytes.
+		lit, err := iceberg.LiteralFromBytes(geoType, lb)
+		require.NoError(t, err)
+		_, ok := lit.(iceberg.GeoLiteral)
+		assert.True(t, ok, "geo bound must decode as GeoLiteral, got %T", lit)
+
+		require.NoError(t, agg.Add(lb, ub))
+	}
+
+	lower, upper := agg.Bounds()
+	require.Len(t, lower, 16)
+	require.Len(t, upper, 16)
+
+	loX, loY := decGeoXY(lower)
+	hiX, hiY := decGeoXY(upper)
+	assert.Equal(t, [2]float64{-4, 0}, [2]float64{loX, loY}, "aggregate lower is per-dimension min")
+	assert.Equal(t, [2]float64{30, 40}, [2]float64{hiX, hiY}, "aggregate upper is per-dimension max")
+}


### PR DESCRIPTION
Add GeoBoundsAggregator to combine per-file geometry bounds into one bounding box via per-dimension min/max, never a scalar byte compare, so the unorderable geo bounds stay honest. decodeGeoBound inverts the single-value serialization; the same omit-on-ambiguity rule for Z/M applies across files, and geography files contribute nothing.

Wiring the aggregate into scan-time pruning lands in a follow-up PR.

Fix: #993 