### PR TITLE
fix(table): validate snapshot references

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -908,6 +908,9 @@ func (b *MetadataBuilder) SetSnapshotRef(
 			return fmt.Errorf("%w: invalid snapshot ref option: %w", iceberg.ErrInvalidArgument, err)
 		}
 	}
+	if err := ref.validate(); err != nil {
+		return fmt.Errorf("%w: invalid snapshot ref: %w", iceberg.ErrInvalidArgument, err)
+	}
 
 	var maxRefAgeMs, maxSnapshotAgeMs int64
 	var minSnapshotsToKeep int

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -481,6 +481,21 @@ func TestSetRef(t *testing.T) {
 	require.Len(t, builder.snapshotLog, 1)
 }
 
+func TestSetRefRejectsInvalidTypeAndTagRetention(t *testing.T) {
+	builder := builderWithoutChanges(2)
+
+	err := builder.SetSnapshotRef("invalid", 1, RefType("invalid"))
+	require.ErrorIs(t, err, ErrInvalidRefType)
+
+	err = builder.SetSnapshotRef("tag", 1, TagRef, WithMinSnapshotsToKeep(1))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "tags do not support setting min snapshots to keep")
+
+	err = builder.SetSnapshotRef("tag", 1, TagRef, WithMaxSnapshotAgeMs(1))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "tags do not support setting max snapshot age")
+}
+
 func TestAddPartitionSpecForV1RequiresSequentialIDs(t *testing.T) {
 	builder := builderWithoutChanges(1)
 

--- a/table/refs.go
+++ b/table/refs.go
@@ -20,7 +20,10 @@ package table
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
+
+	"github.com/apache/iceberg-go"
 )
 
 const MainBranch = "main"
@@ -49,17 +52,63 @@ func (s *SnapshotRef) Equals(rhs SnapshotRef) bool {
 }
 
 func (s *SnapshotRef) UnmarshalJSON(b []byte) error {
-	type Alias SnapshotRef
-	aux := (*Alias)(s)
-
-	if err := json.Unmarshal(b, aux); err != nil {
+	aux := struct {
+		SnapshotID         *int64   `json:"snapshot-id"`
+		SnapshotRefType    *RefType `json:"type"`
+		MinSnapshotsToKeep *int     `json:"min-snapshots-to-keep,omitempty"`
+		MaxSnapshotAgeMs   *int64   `json:"max-snapshot-age-ms,omitempty"`
+		MaxRefAgeMs        *int64   `json:"max-ref-age-ms,omitempty"`
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
+	if aux.SnapshotID == nil {
+		return fmt.Errorf("%w: snapshot ref is missing required snapshot-id", iceberg.ErrInvalidArgument)
+	}
+	if aux.SnapshotRefType == nil {
+		return fmt.Errorf("%w: snapshot ref is missing required type", iceberg.ErrInvalidArgument)
+	}
+
+	ref := SnapshotRef{
+		SnapshotID:         *aux.SnapshotID,
+		SnapshotRefType:    *aux.SnapshotRefType,
+		MinSnapshotsToKeep: aux.MinSnapshotsToKeep,
+		MaxSnapshotAgeMs:   aux.MaxSnapshotAgeMs,
+		MaxRefAgeMs:        aux.MaxRefAgeMs,
+	}
+	if err := ref.validate(); err != nil {
+		return err
+	}
+
+	*s = ref
+
+	return nil
+}
+
+func (s SnapshotRef) validate() error {
 	switch s.SnapshotRefType {
 	case BranchRef, TagRef:
 	default:
 		return ErrInvalidRefType
+	}
+
+	if s.MinSnapshotsToKeep != nil && *s.MinSnapshotsToKeep <= 0 {
+		return fmt.Errorf("%w: min snapshots to keep must be greater than 0", iceberg.ErrInvalidArgument)
+	}
+	if s.MaxSnapshotAgeMs != nil && *s.MaxSnapshotAgeMs <= 0 {
+		return fmt.Errorf("%w: max snapshot age must be greater than 0 ms", iceberg.ErrInvalidArgument)
+	}
+	if s.MaxRefAgeMs != nil && *s.MaxRefAgeMs <= 0 {
+		return fmt.Errorf("%w: max reference age must be greater than 0 ms", iceberg.ErrInvalidArgument)
+	}
+	if s.SnapshotRefType == TagRef {
+		if s.MinSnapshotsToKeep != nil {
+			return fmt.Errorf("%w: tags do not support setting min snapshots to keep", iceberg.ErrInvalidArgument)
+		}
+		if s.MaxSnapshotAgeMs != nil {
+			return fmt.Errorf("%w: tags do not support setting max snapshot age", iceberg.ErrInvalidArgument)
+		}
 	}
 
 	return nil

--- a/table/refs_test.go
+++ b/table/refs_test.go
@@ -21,8 +21,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidSnapshotRef(t *testing.T) {
@@ -68,7 +70,7 @@ func TestSnapshotTagRef(t *testing.T) {
 	ref := `{
 		"snapshot-id": 3051729675574597004,
 		"type": "tag",
-		"min-snapshots-to-keep": 10
+		"max-ref-age-ms": 10
 	}`
 
 	var snapRef table.SnapshotRef
@@ -77,7 +79,34 @@ func TestSnapshotTagRef(t *testing.T) {
 
 	assert.Equal(t, table.TagRef, snapRef.SnapshotRefType)
 	assert.Equal(t, int64(3051729675574597004), snapRef.SnapshotID)
-	assert.Equal(t, 10, *snapRef.MinSnapshotsToKeep)
-	assert.Nil(t, snapRef.MaxRefAgeMs)
+	assert.Nil(t, snapRef.MinSnapshotsToKeep)
+	assert.Equal(t, int64(10), *snapRef.MaxRefAgeMs)
 	assert.Nil(t, snapRef.MaxSnapshotAgeMs)
+}
+
+func TestSnapshotRefRequiresFields(t *testing.T) {
+	for _, ref := range []string{
+		`{"type":"branch"}`,
+		`{"snapshot-id":1}`,
+	} {
+		var snapRef table.SnapshotRef
+		err := json.Unmarshal([]byte(ref), &snapRef)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	}
+}
+
+func TestSnapshotRefRejectsInvalidRetention(t *testing.T) {
+	tests := []string{
+		`{"snapshot-id":1,"type":"branch","min-snapshots-to-keep":0}`,
+		`{"snapshot-id":1,"type":"branch","max-snapshot-age-ms":-1}`,
+		`{"snapshot-id":1,"type":"branch","max-ref-age-ms":0}`,
+		`{"snapshot-id":1,"type":"tag","min-snapshots-to-keep":1}`,
+		`{"snapshot-id":1,"type":"tag","max-snapshot-age-ms":1}`,
+	}
+
+	for _, ref := range tests {
+		var snapRef table.SnapshotRef
+		err := json.Unmarshal([]byte(ref), &snapRef)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	}
 }


### PR DESCRIPTION
## Summary

- require `snapshot-id` and `type` when decoding snapshot references
- reject non-positive retention values
- reject branch-only retention settings on tags during decoding and metadata updates

## Why

The Java `SnapshotRef` builder and parser enforce these invariants, but Go only checked the reference type while decoding. Programmatic metadata updates also allowed tag references with `min-snapshots-to-keep` or `max-snapshot-age-ms`, producing metadata Java rejects.

## Testing

- `go test ./...`
- `go test -race ./table`
- `go vet ./...`