### PR TITLE
fix(table): tolerate missing snapshot summary operation

### DIFF
--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -222,7 +222,15 @@ func (s *Summary) UnmarshalJSON(b []byte) (err error) {
 
 	op, ok := alias[operationKey]
 	if !ok {
-		return ErrMissingOperation
+		// Match Java's compatibility behavior for older snapshots that contain
+		// summary properties but omit the required operation.
+		s.Operation = ""
+		if len(alias) > 0 {
+			s.Operation = OpOverwrite
+		}
+		s.Properties = alias
+
+		return nil
 	}
 
 	if s.Operation, err = ValidOperation(op); err != nil {

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,10 +94,19 @@ func TestSerializeSnapshotWithProps(t *testing.T) {
 	}`, string(data))
 }
 
-func TestMissingOperation(t *testing.T) {
+func TestMissingOperationDefaultsToOverwrite(t *testing.T) {
 	var summary table.Summary
 	err := json.Unmarshal([]byte(`{"foo": "bar"}`), &summary)
-	assert.ErrorIs(t, err, table.ErrMissingOperation)
+	require.NoError(t, err)
+	assert.Equal(t, table.OpOverwrite, summary.Operation)
+	assert.Equal(t, iceberg.Properties{"foo": "bar"}, summary.Properties)
+}
+
+func TestEmptySummary(t *testing.T) {
+	var summary table.Summary
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &summary))
+	assert.Empty(t, summary.Operation)
+	assert.Empty(t, summary.Properties)
 }
 
 func TestInvalidOperation(t *testing.T) {


### PR DESCRIPTION
## Summary

- default a non-empty snapshot summary without `operation` to `overwrite`
- preserve the remaining summary properties

## Why

Java uses this fallback for compatibility with older snapshot metadata. Go returned `ErrMissingOperation` instead, so it could not load metadata that Java accepts.

## Testing

- `go test ./...`
- `go test -race ./table`
- `go vet ./...`