### PR TITLE
fix(partitions): assign missing partition field IDs

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -425,15 +425,38 @@ func (ps PartitionSpec) MarshalJSON() ([]byte, error) {
 
 func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 	aux := struct {
-		ID     int              `json:"spec-id"`
-		Fields []PartitionField `json:"fields"`
-	}{ID: ps.id, Fields: ps.fields}
+		ID     int               `json:"spec-id"`
+		Fields []json.RawMessage `json:"fields"`
+	}{ID: ps.id}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
-	ps.id, ps.fields = aux.ID, aux.Fields
+	fields := make([]PartitionField, len(aux.Fields))
+	for i, rawField := range aux.Fields {
+		var keys map[string]json.RawMessage
+		if err := json.Unmarshal(rawField, &keys); err != nil {
+			return err
+		}
+		if rawFieldID, ok := keys["field-id"]; ok {
+			var fieldID *int
+			if err := json.Unmarshal(rawFieldID, &fieldID); err != nil {
+				return fmt.Errorf("%w: invalid partition field ID: %w", ErrInvalidPartitionSpec, err)
+			}
+			if fieldID == nil {
+				return fmt.Errorf("%w: partition field ID cannot be null", ErrInvalidPartitionSpec)
+			}
+		}
+		if err := json.Unmarshal(rawField, &fields[i]); err != nil {
+			return err
+		}
+	}
+
+	ps.id, ps.fields = aux.ID, fields
+	if err := ps.assignPartitionFieldIds(nil); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
+	}
 	ps.initialize()
 
 	return nil

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -261,6 +261,65 @@ func TestSerializePartitionSpec(t *testing.T) {
 	assert.True(t, spec.Equals(outspec))
 }
 
+func TestDeserializePartitionSpecWithoutFieldIDs(t *testing.T) {
+	data := []byte(`{
+		"spec-id": 3,
+		"fields": [
+			{"source-id": 1, "transform": "identity", "name": "id"},
+			{"source-id": 2, "transform": "bucket[16]", "name": "data_bucket"}
+		]
+	}`)
+
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal(data, &spec))
+	require.Equal(t, 1000, spec.Field(0).FieldID)
+	require.Equal(t, 1001, spec.Field(1).FieldID)
+}
+
+func TestDeserializePartitionSpecWithPartiallyMissingFieldIDs(t *testing.T) {
+	data := []byte(`{
+		"spec-id": 3,
+		"fields": [
+			{"source-id": 1, "field-id": 1000, "transform": "identity", "name": "id"},
+			{"source-id": 2, "transform": "bucket[16]", "name": "data_bucket"}
+		]
+	}`)
+
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal(data, &spec))
+	require.Equal(t, 1000, spec.Field(0).FieldID)
+	require.Equal(t, 1001, spec.Field(1).FieldID)
+}
+
+func TestDeserializePartitionSpecAssignsAfterExistingFieldIDs(t *testing.T) {
+	data := []byte(`{
+		"spec-id": 3,
+		"fields": [
+			{"source-id": 1, "transform": "identity", "name": "id"},
+			{"source-id": 2, "field-id": 1001, "transform": "bucket[16]", "name": "data_bucket"}
+		]
+	}`)
+
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal(data, &spec))
+	require.Equal(t, 1002, spec.Field(0).FieldID)
+	require.Equal(t, 1001, spec.Field(1).FieldID)
+}
+
+func TestDeserializePartitionSpecWithNullFieldID(t *testing.T) {
+	data := []byte(`{
+		"spec-id": 3,
+		"fields": [
+			{"source-id": 1, "field-id": null, "transform": "identity", "name": "id"}
+		]
+	}`)
+
+	var spec iceberg.PartitionSpec
+	err := json.Unmarshal(data, &spec)
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	require.ErrorContains(t, err, "partition field ID cannot be null")
+}
+
 func TestPartitionType(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(3,
 		iceberg.PartitionField{

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1506,7 +1506,105 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 		return nil, ErrInvalidMetadataFormatVersion
 	}
 
-	return ret, json.Unmarshal(b, ret)
+	normalized, err := assignMissingPartitionFieldIDs(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, json.Unmarshal(normalized, ret)
+}
+
+func assignMissingPartitionFieldIDs(b []byte) ([]byte, error) {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(b, &metadata); err != nil {
+		return nil, err
+	}
+
+	type rawPartitionSpec struct {
+		ID     int                          `json:"spec-id"`
+		Fields []map[string]json.RawMessage `json:"fields"`
+	}
+
+	var specs []rawPartitionSpec
+	usesSpecList := false
+	if rawSpecs, ok := metadata["partition-specs"]; ok {
+		if err := json.Unmarshal(rawSpecs, &specs); err != nil {
+			return nil, err
+		}
+		usesSpecList = true
+	} else if rawFields, ok := metadata["partition-spec"]; ok {
+		var fields []map[string]json.RawMessage
+		if err := json.Unmarshal(rawFields, &fields); err != nil {
+			return nil, err
+		}
+		specs = []rawPartitionSpec{{Fields: fields}}
+	} else {
+		return b, nil
+	}
+
+	lastAssignedID := iceberg.PartitionDataIDStart - 1
+	lastPartitionIDSet := false
+	if rawLastPartitionID, ok := metadata["last-partition-id"]; ok {
+		var lastPartitionID *int
+		if err := json.Unmarshal(rawLastPartitionID, &lastPartitionID); err == nil && lastPartitionID != nil {
+			lastAssignedID = max(lastAssignedID, *lastPartitionID)
+			lastPartitionIDSet = true
+		}
+	}
+
+	missingFields := make([]map[string]json.RawMessage, 0)
+	for _, spec := range specs {
+		for _, field := range spec.Fields {
+			rawFieldID, ok := field["field-id"]
+			if !ok {
+				missingFields = append(missingFields, field)
+
+				continue
+			}
+
+			var fieldID *int
+			if err := json.Unmarshal(rawFieldID, &fieldID); err == nil && fieldID != nil {
+				lastAssignedID = max(lastAssignedID, *fieldID)
+			}
+		}
+	}
+
+	if len(missingFields) == 0 {
+		return b, nil
+	}
+
+	for _, field := range missingFields {
+		lastAssignedID++
+		rawFieldID, err := json.Marshal(lastAssignedID)
+		if err != nil {
+			return nil, err
+		}
+		field["field-id"] = rawFieldID
+	}
+
+	if usesSpecList {
+		rawSpecs, err := json.Marshal(specs)
+		if err != nil {
+			return nil, err
+		}
+		metadata["partition-specs"] = rawSpecs
+	} else {
+		rawFields, err := json.Marshal(specs[0].Fields)
+		if err != nil {
+			return nil, err
+		}
+		metadata["partition-spec"] = rawFields
+	}
+
+	if lastPartitionIDSet {
+		rawLastPartitionID, err := json.Marshal(lastAssignedID)
+		if err != nil {
+			return nil, err
+		}
+		metadata["last-partition-id"] = rawLastPartitionID
+	}
+
+	return json.Marshal(metadata)
 }
 
 // https://iceberg.apache.org/spec/#iceberg-table-spec

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1331,6 +1331,48 @@ func TestTableMetadataV2MissingSchemas(t *testing.T) {
 	require.Nil(t, meta)
 }
 
+func TestAssignMissingPartitionFieldIDsAcrossSpecs(t *testing.T) {
+	input := []byte(`{
+		"format-version": 2,
+		"last-partition-id": 1003,
+		"partition-specs": [
+			{
+				"spec-id": 0,
+				"fields": [
+					{"source-id": 1, "field-id": 1000, "transform": "identity", "name": "id"},
+					{"source-id": 2, "transform": "identity", "name": "data"}
+				]
+			},
+			{
+				"spec-id": 1,
+				"fields": [
+					{"source-id": 3, "transform": "bucket[16]", "name": "category_bucket"}
+				]
+			}
+		]
+	}`)
+
+	normalized, err := assignMissingPartitionFieldIDs(input)
+	require.NoError(t, err)
+
+	var parsed struct {
+		LastPartitionID int `json:"last-partition-id"`
+		Specs           []struct {
+			ID     int `json:"spec-id"`
+			Fields []struct {
+				FieldID int `json:"field-id"`
+			} `json:"fields"`
+		} `json:"partition-specs"`
+	}
+	require.NoError(t, json.Unmarshal(normalized, &parsed))
+	require.Equal(t, 1005, parsed.LastPartitionID)
+	require.Equal(t, 0, parsed.Specs[0].ID)
+	require.Equal(t, 1, parsed.Specs[1].ID)
+	require.Equal(t, 1000, parsed.Specs[0].Fields[0].FieldID)
+	require.Equal(t, 1004, parsed.Specs[0].Fields[1].FieldID)
+	require.Equal(t, 1005, parsed.Specs[1].Fields[0].FieldID)
+}
+
 func TestTableDataV2NoSnapshots(t *testing.T) {
 	data := `{
             "format-version" : 2,


### PR DESCRIPTION
## Summary

- assign missing partition field IDs after the greatest of 999, `last-partition-id`, or any explicit field ID
- preserve explicit IDs and assign only the missing fields
- allocate IDs across all specs in table metadata so generated IDs cannot collide between specs
- update `last-partition-id` when it is present and reject explicit null field IDs

## Why

Older partition spec JSON may omit field IDs. Java assigns those IDs from `PARTITION_DATA_ID_START`, while Go decoded every missing ID as zero. That loses field identity and can make partition fields collide.

The metadata parser needs table-wide context because partition field IDs are shared across specs. Standalone partition specs use the same allocation rule within the spec.

## Testing

- `go test -count=1 . ./table`
- full CI