### PR TITLE
fix(table): avoid mutating sort fields during marshaling

### DIFF
--- a/table/sorting.go
+++ b/table/sorting.go
@@ -98,16 +98,18 @@ func (s *SortField) String() string {
 	return fmt.Sprintf("%s(%d) %s %s", s.Transform, s.SourceID(), s.Direction, s.NullOrder)
 }
 
-func (s *SortField) MarshalJSON() ([]byte, error) {
-	if s.Direction == "" {
-		s.Direction = SortASC
+func (s SortField) MarshalJSON() ([]byte, error) {
+	direction := s.Direction
+	if direction == "" {
+		direction = SortASC
 	}
 
-	if s.NullOrder == "" {
-		if s.Direction == SortASC {
-			s.NullOrder = NullsFirst
+	nullOrder := s.NullOrder
+	if nullOrder == "" {
+		if direction == SortASC {
+			nullOrder = NullsFirst
 		} else {
-			s.NullOrder = NullsLast
+			nullOrder = NullsLast
 		}
 	}
 
@@ -117,7 +119,7 @@ func (s *SortField) MarshalJSON() ([]byte, error) {
 			Transform iceberg.Transform `json:"transform"`
 			Direction SortDirection     `json:"direction"`
 			NullOrder NullOrder         `json:"null-order"`
-		}{s.SourceIDs, s.Transform, s.Direction, s.NullOrder})
+		}{s.SourceIDs, s.Transform, direction, nullOrder})
 	}
 
 	return json.Marshal(struct {
@@ -125,7 +127,7 @@ func (s *SortField) MarshalJSON() ([]byte, error) {
 		Transform iceberg.Transform `json:"transform"`
 		Direction SortDirection     `json:"direction"`
 		NullOrder NullOrder         `json:"null-order"`
-	}{s.SourceID(), s.Transform, s.Direction, s.NullOrder})
+	}{s.SourceID(), s.Transform, direction, nullOrder})
 }
 
 func (s *SortField) UnmarshalJSON(b []byte) error {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -359,3 +359,33 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 		assert.NotContains(t, string(data), `"source-ids"`)
 	})
 }
+
+func TestSortFieldMarshalAppliesDefaultsWithoutMutatingReceiver(t *testing.T) {
+	field := table.SortField{
+		SourceIDs: []int{1},
+		Transform: iceberg.IdentityTransform{},
+	}
+	expected := `{
+		"source-id": 1,
+		"transform": "identity",
+		"direction": "asc",
+		"null-order": "nulls-first"
+	}`
+
+	for _, tt := range []struct {
+		name  string
+		input any
+	}{
+		{"value", field},
+		{"pointer", &field},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.JSONEq(t, expected, string(data))
+		})
+	}
+
+	assert.Empty(t, field.Direction)
+	assert.Empty(t, field.NullOrder)
+}


### PR DESCRIPTION
## Summary

- compute default sort direction and null order in local variables
- preserve the existing JSON output without changing the `SortField` receiver
- use a value receiver so both `SortField` values and pointers use the custom encoder

## Why

`SortField.MarshalJSON` wrote default values back into the field being serialized. Marshaling should be read-only; mutating caller state is surprising and can race when a field is serialized concurrently. The pointer receiver also meant marshaling a `SortField` value bypassed the custom JSON shape entirely.

## Testing

- `go test ./...`
- `go test -race ./table`
- `golangci-lint run --timeout=10m`
- `go vet ./...`