### PR TITLE
fix(table): make summary equality nil-safe

### DIFF
--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -199,7 +199,7 @@ func (s *Summary) Equals(other *Summary) bool {
 		return true
 	}
 
-	if s != nil && other == nil {
+	if s == nil || other == nil {
 		return false
 	}
 

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -106,6 +106,24 @@ func TestInvalidOperation(t *testing.T) {
 	assert.ErrorContains(t, err, "found 'foobar'")
 }
 
+func TestSummaryEqualsHandlesNil(t *testing.T) {
+	var nilSummary *table.Summary
+	summary := &table.Summary{Operation: table.OpAppend}
+
+	assert.True(t, nilSummary.Equals(nil))
+	assert.False(t, nilSummary.Equals(summary))
+	assert.False(t, summary.Equals(nilSummary))
+}
+
+func TestSnapshotEqualsHandlesMissingSummary(t *testing.T) {
+	withSummary := Snapshot()
+	withoutSummary := withSummary
+	withoutSummary.Summary = nil
+
+	assert.False(t, withoutSummary.Equals(withSummary))
+	assert.False(t, withSummary.Equals(withoutSummary))
+}
+
 func TestSnapshotString(t *testing.T) {
 	snapshot := Snapshot()
 	assert.Equal(t, `append: id=25, parent_id=19, schema_id=3, sequence_number=200, timestamp_ms=1602638573590, manifest_list=s3:/a/b/c.avro`,


### PR DESCRIPTION
## Summary

- handle nil snapshot summaries symmetrically in `Summary.Equals`
- cover direct summary comparison and `Snapshot.Equals` in both operand orders

## Why

`Summary.Equals` handled a non-nil receiver with a nil argument, but not the reverse. Comparing a snapshot without a summary to one with a summary dereferenced the nil receiver and panicked. Equality should return false regardless of operand order.

## Testing

- `go test ./...`
- `go test -race ./table`
- `golangci-lint run --timeout=10m`
- `go vet ./...`