### PR TITLE
fix(table): honor parquet row group byte target

### DIFF
--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -120,6 +120,7 @@ type WriteFileInfo struct {
 	FileName         string
 	StatsCols        map[int]StatisticsCollector
 	WriteProps       any
+	RowGroupBytes    int64
 	Content          iceberg.ManifestEntryContent
 	EqualityFieldIDs []int
 	SortOrderID      int

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -324,6 +324,28 @@ func (parquetFormat) GetWriteProperties(props iceberg.Properties) any {
 	return writerProps
 }
 
+// ParquetRowGroupTargetSizeBytes returns the configured uncompressed row-group
+// size target. Iceberg Java rejects invalid and non-positive values rather than
+// silently falling back to the default.
+func ParquetRowGroupTargetSizeBytes(props iceberg.Properties) (int64, error) {
+	value, ok := props[ParquetRowGroupSizeBytesKey]
+	if !ok {
+		return ParquetRowGroupSizeBytesDefault, nil
+	}
+
+	size, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid %s value %q: %v",
+			iceberg.ErrInvalidArgument, ParquetRowGroupSizeBytesKey, value, err)
+	}
+	if size <= 0 {
+		return 0, fmt.Errorf("%w: %s must be greater than 0, got %d",
+			iceberg.ErrInvalidArgument, ParquetRowGroupSizeBytesKey, size)
+	}
+
+	return size, nil
+}
+
 func (p parquetFormat) WriteDataFile(ctx context.Context, fs iceio.WriteFileIO, partitionValues map[int]any, info WriteFileInfo, batches []arrow.RecordBatch) (iceberg.DataFile, error) {
 	w, err := p.NewFileWriter(ctx, fs, partitionValues, info, batches[0].Schema())
 	if err != nil {
@@ -351,17 +373,18 @@ func writeDataFileBatches(w FileWriter, batches []arrow.RecordBatch) (iceberg.Da
 // lifecycle. It writes Arrow record batches to a Parquet file and tracks bytes
 // written for rolling file decisions.
 type ParquetFileWriter struct {
-	pqWriter    *pqarrow.FileWriter
-	counter     *internal.CountingWriter
-	fileCloser  io.Closer
-	fs          iceio.WriteFileIO
-	format      parquetFormat
-	info        WriteFileInfo
-	partition   map[int]any
-	colMapping  map[string]int
-	geoCols     []geoColumn
-	geoAccs     map[int]*geoBoundsAccumulator
-	arrowSchema *arrow.Schema
+	pqWriter      *pqarrow.FileWriter
+	counter       *internal.CountingWriter
+	fileCloser    io.Closer
+	fs            iceio.WriteFileIO
+	format        parquetFormat
+	info          WriteFileInfo
+	partition     map[int]any
+	colMapping    map[string]int
+	geoCols       []geoColumn
+	geoAccs       map[int]*geoBoundsAccumulator
+	arrowSchema   *arrow.Schema
+	rowGroupBytes int64
 }
 
 // geoColumn locates a top-level geometry/geography column: its position in the
@@ -397,6 +420,15 @@ func collectGeoColumns(sc *arrow.Schema, colMapping map[string]int) []geoColumn 
 func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 	partitionValues map[int]any, info WriteFileInfo, arrowSchema *arrow.Schema,
 ) (FileWriter, error) {
+	rowGroupTargetSizeBytes := info.RowGroupBytes
+	if rowGroupTargetSizeBytes == 0 {
+		rowGroupTargetSizeBytes = ParquetRowGroupSizeBytesDefault
+	}
+	if rowGroupTargetSizeBytes < 0 {
+		return nil, fmt.Errorf("%w: row-group target size must be greater than 0, got %d",
+			iceberg.ErrInvalidArgument, rowGroupTargetSizeBytes)
+	}
+
 	fw, err := fs.Create(info.FileName)
 	if err != nil {
 		return nil, err
@@ -439,17 +471,18 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 	}
 
 	return &ParquetFileWriter{
-		pqWriter:    writer,
-		counter:     counter,
-		fileCloser:  fw,
-		fs:          fs,
-		format:      p,
-		info:        info,
-		partition:   partitionValues,
-		colMapping:  colMapping,
-		geoCols:     geoCols,
-		geoAccs:     geoAccs,
-		arrowSchema: arrowSchema,
+		pqWriter:      writer,
+		counter:       counter,
+		fileCloser:    fw,
+		fs:            fs,
+		format:        p,
+		info:          info,
+		partition:     partitionValues,
+		colMapping:    colMapping,
+		geoCols:       geoCols,
+		geoAccs:       geoAccs,
+		arrowSchema:   arrowSchema,
+		rowGroupBytes: rowGroupTargetSizeBytes,
 	}, nil
 }
 
@@ -511,6 +544,16 @@ func getWriteProperties(writeProps any, arrowSchema *arrow.Schema) (*parquet.Wri
 func (w *ParquetFileWriter) Write(batch arrow.RecordBatch) error {
 	if err := w.accumulateGeoBounds(batch); err != nil {
 		return err
+	}
+
+	// Rotate before writing the next non-empty batch. Rotating immediately after
+	// crossing the target would leave an empty trailing row group when the file
+	// is closed without another write.
+	if batch.NumRows() > 0 &&
+		w.pqWriter.RowGroupTotalBytesWritten() >= w.rowGroupBytes {
+		if err := w.pqWriter.NewBufferedRowGroupChecked(); err != nil {
+			return err
+		}
 	}
 
 	return w.pqWriter.WriteBuffered(batch)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1281,6 +1281,138 @@ func TestGetWritePropertiesBloomFilter(t *testing.T) {
 	})
 }
 
+func TestParquetRowGroupTargetSizeBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		props     iceberg.Properties
+		expected  int64
+		errString string
+	}{
+		{
+			name:     "default",
+			props:    iceberg.Properties{},
+			expected: internal.ParquetRowGroupSizeBytesDefault,
+		},
+		{
+			name: "configured",
+			props: iceberg.Properties{
+				internal.ParquetRowGroupSizeBytesKey: "4096",
+			},
+			expected: 4096,
+		},
+		{
+			name: "not an integer",
+			props: iceberg.Properties{
+				internal.ParquetRowGroupSizeBytesKey: "large",
+			},
+			errString: "invalid write.parquet.row-group-size-bytes value",
+		},
+		{
+			name: "zero",
+			props: iceberg.Properties{
+				internal.ParquetRowGroupSizeBytesKey: "0",
+			},
+			errString: "must be greater than 0",
+		},
+		{
+			name: "negative",
+			props: iceberg.Properties{
+				internal.ParquetRowGroupSizeBytesKey: "-1",
+			},
+			errString: "must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := internal.ParquetRowGroupTargetSizeBytes(tt.props)
+			if tt.errString != "" {
+				require.ErrorContains(t, err, tt.errString)
+				require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestParquetRowGroupTargetRotatesBeforeNextBatch(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	icebergSchema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: 1, Name: "value", Type: iceberg.PrimitiveTypes.String, Required: false,
+	})
+	arrowSchema, err := table.SchemaToArrowSchema(icebergSchema, nil, true, false)
+	require.NoError(t, err)
+
+	buildBatch := func(value string) arrow.RecordBatch {
+		bldr := array.NewRecordBuilder(mem, arrowSchema)
+		defer bldr.Release()
+		bldr.Field(0).(*array.StringBuilder).Append(value)
+
+		return bldr.NewRecordBatch()
+	}
+
+	first := buildBatch(strings.Repeat("a", 1024))
+	defer first.Release()
+	second := buildBatch(strings.Repeat("b", 1024))
+	defer second.Release()
+
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+	// Keep the page size below the batch size so Arrow flushes the first batch
+	// and RowGroupTotalBytesWritten can observe it before the second write.
+	writeProps := format.GetWriteProperties(iceberg.Properties{
+		internal.ParquetPageSizeBytesKey: "1",
+	})
+	for _, tt := range []struct {
+		name          string
+		targetBytes   int64
+		wantRowGroups int
+	}{
+		{name: "target reached", targetBytes: 1, wantRowGroups: 2},
+		{name: "target not reached", targetBytes: math.MaxInt64, wantRowGroups: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fsys := iceio.NewMemFS()
+			_, err = format.WriteDataFile(context.Background(), fsys, nil, internal.WriteFileInfo{
+				FileSchema: icebergSchema,
+				Spec:       *iceberg.UnpartitionedSpec,
+				FileName:   "row-groups.parquet",
+				StatsCols: map[int]internal.StatisticsCollector{
+					1: {
+						FieldID:    1,
+						Mode:       internal.MetricsMode{Typ: internal.MetricModeFull},
+						ColName:    "value",
+						IcebergTyp: iceberg.PrimitiveTypes.String,
+					},
+				},
+				WriteProps:    writeProps,
+				RowGroupBytes: tt.targetBytes,
+				Content:       iceberg.EntryContentData,
+			}, []arrow.RecordBatch{first, second})
+			require.NoError(t, err)
+
+			input, err := fsys.Open("row-groups.parquet")
+			require.NoError(t, err)
+			defer input.Close()
+
+			reader, err := file.NewParquetReader(input)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			require.Equal(t, tt.wantRowGroups, reader.MetaData().NumRowGroups())
+			for rowGroup := range reader.MetaData().NumRowGroups() {
+				require.Positive(t, reader.MetaData().RowGroup(rowGroup).NumRows(),
+					"rotation must not create an empty trailing row group")
+			}
+		})
+	}
+}
+
 func TestParquetBatchSizeFromTableProperties(t *testing.T) {
 	t.Run("default batch size when no properties in context", func(t *testing.T) {
 		ctx := context.Background()

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -59,6 +59,7 @@ type writerFactory struct {
 	fileSchema       *iceberg.Schema
 	arrowSchema      *arrow.Schema
 	writeProps       any
+	rowGroupBytes    int64
 	statsCols        map[int]tblutils.StatisticsCollector
 	currentSpec      iceberg.PartitionSpec
 	fileFormat       iceberg.FileFormat
@@ -151,6 +152,13 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 
 	format := tblutils.GetFileFormat(fileFormat)
 
+	rowGroupTargetSizeBytes, err := tblutils.ParquetRowGroupTargetSizeBytes(meta.props)
+	if err != nil {
+		stopCount()
+
+		return nil, err
+	}
+
 	arrowSchema, err := SchemaToArrowSchema(fileSchema, nil, true, false)
 	if err != nil {
 		stopCount()
@@ -177,6 +185,7 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		fileSchema:     fileSchema,
 		arrowSchema:    arrowSchema,
 		writeProps:     format.GetWriteProperties(meta.props),
+		rowGroupBytes:  rowGroupTargetSizeBytes,
 		currentSpec:    *currentSpec,
 		fileFormat:     fileFormat,
 		format:         format,
@@ -264,6 +273,7 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		FileName:         filePath,
 		StatsCols:        w.statsCols,
 		WriteProps:       w.writeProps,
+		RowGroupBytes:    w.rowGroupBytes,
 		Spec:             w.currentSpec,
 		Content:          w.content,
 		EqualityFieldIDs: w.equalityFieldIDs,

--- a/table/writer.go
+++ b/table/writer.go
@@ -164,12 +164,18 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 		return nil, err
 	}
 
+	rowGroupTargetSizeBytes, err := internal.ParquetRowGroupTargetSizeBytes(w.props)
+	if err != nil {
+		return nil, err
+	}
+
 	return w.format.WriteDataFile(ctx, w.fs, partitionValues, internal.WriteFileInfo{
 		FileSchema:       w.fileSchema,
 		Content:          w.content,
 		FileName:         filePath,
 		StatsCols:        statsCols,
 		WriteProps:       w.format.GetWriteProperties(w.props),
+		RowGroupBytes:    rowGroupTargetSizeBytes,
 		Spec:             *currentSpec,
 		EqualityFieldIDs: w.equalityFieldIDs,
 		SortOrderID:      task.SortOrderID,


### PR DESCRIPTION
## Summary

* honor `write.parquet.row-group-size-bytes` when writing buffered Parquet row groups
* start a new row group before the next non-empty batch after the byte target is reached
* avoid creating an empty trailing row group when the file is closed
* reject invalid and non-positive target values, matching Iceberg Java behavior
* preserve `write.parquet.row-group-limit` as an independent row-count ceiling

## Why

`write.parquet.row-group-size-bytes` is exported and documented, but the Go Parquet writer did not read it. Changing the property therefore had no effect on generated row groups.

Arrow Go v18.7 provides `RowGroupTotalBytesWritten` and `NewBufferedRowGroupChecked`, allowing the writer to apply the configured uncompressed byte target safely.

Rotation happens before the next non-empty batch instead of immediately after reaching the target. This prevents closing the writer from producing an empty trailing row group.

## Testing

* added coverage for the default and configured byte targets
* added coverage for malformed, zero, and negative values
* added a Parquet metadata regression test verifying that:

  * a small target creates multiple row groups
  * each row group contains data
  * no empty trailing row group is produced
* `git diff --check`
