### PR TITLE
fix(table): reject null position deletes

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -451,6 +451,9 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 
 	filePathCol := tbl.Column(tbl.Schema().FieldIndices("file_path")[0]).Data()
 	posCol := tbl.Column(tbl.Schema().FieldIndices("pos")[0]).Data()
+	if posCol.NullN() > 0 {
+		return nil, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
+	}
 
 	return groupPosDeletesByFilePath(ctx, filePathCol, posCol)
 }

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -24,7 +24,10 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -263,6 +266,38 @@ func TestCollectPosDeletePositionsRejectsUnsupportedPosType(t *testing.T) {
 	_, err := collectPosDeletePositions(positionDeletes{posCol})
 	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 	assert.Contains(t, err.Error(), "unsupported pos column type")
+}
+
+func TestReadDeletesRejectsNullPos(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	defer mem.AssertSize(t, 0)
+
+	fields := PositionalDeleteArrowSchema.Fields()
+	fields[1].Nullable = true
+	deleteSchema := arrow.NewSchema(fields, nil)
+	deletePath := "mem://bucket/deletes/null-pos.parquet"
+	dataPath := "mem://bucket/data/data.parquet"
+
+	rec := mustLoadRecordBatchFromJSON(deleteSchema, `[
+		{"file_path": "`+dataPath+`", "pos": null}
+	]`)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(deleteSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	memFS := iceio.NewMemFS()
+	fw, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)),
+		pqarrow.DefaultWriterProps()))
+	require.NoError(t, fw.Close())
+
+	deletes, err := readDeletes(ctx, memFS, newPosDeleteFile(t, deletePath, 1, 128))
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Nil(t, deletes)
+	assert.Contains(t, err.Error(), "null pos in position delete file")
 }
 
 // TestProcessPositionalDeletesAcrossBatches is the regression net for the


### PR DESCRIPTION
## Motivation

The Iceberg position delete schema requires `pos` values to be non-null. The Arrow scanner currently reads the raw `Int64Values` backing slice without checking the validity bitmap, so a malformed delete file containing a null position may be interpreted as a real row position instead of returning an invalid-schema error.

## Changes

- Reject null values in position delete `pos` chunks with `iceberg.ErrInvalidSchema`.
- Add a regression test covering a nullable position array and verifying the error contract.