### PR TITLE
fix(glue): map fixed types to binary

### DIFF
--- a/catalog/glue/schema.go
+++ b/catalog/glue/schema.go
@@ -120,7 +120,7 @@ func icebergTypeToGlueType(typ iceberg.Type) string {
 	case iceberg.DecimalType:
 		return fmt.Sprintf("decimal(%d,%d)", t.Precision(), t.Scale())
 	case iceberg.FixedType:
-		return fmt.Sprintf("binary(%d)", t.Len())
+		return "binary"
 	case *iceberg.StructType:
 		// For struct types, create a struct<field1:type1,field2:type2,...> representation
 		var fieldStrings []string

--- a/catalog/glue/schema_test.go
+++ b/catalog/glue/schema_test.go
@@ -101,7 +101,16 @@ func TestIcebergTypeToGlueType(t *testing.T) {
 		{
 			name:     "fixed type",
 			input:    iceberg.FixedTypeOf(16),
-			expected: "binary(16)",
+			expected: "binary",
+		},
+		{
+			name: "nested fixed type",
+			input: &iceberg.ListType{
+				ElementID:       1,
+				Element:         iceberg.FixedTypeOf(16),
+				ElementRequired: true,
+			},
+			expected: "array<binary>",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- map Iceberg fixed types to Glue `binary` instead of the unsupported parameterized `binary(n)` form
- cover fixed types nested inside container types
- align Glue schema conversion with Iceberg Java and PyIceberg

## Testing

- `go test ./catalog/glue`