### PR TITLE
fix(glue): reject dropping non-empty namespaces

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -685,16 +685,23 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
+	// Glue has no conditional database delete, so a concurrent table creation can still race this check.
 	tables, err := c.glueSvc.GetTables(ctx, &glue.GetTablesInput{
 		CatalogId:    c.catalogId,
 		DatabaseName: aws.String(databaseName),
 		MaxResults:   aws.Int32(1),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to check namespace %s for tables: %w", databaseName, err)
+		return fmt.Errorf("failed to list tables in namespace %s: %w", databaseName, err)
 	}
 	if len(tables.TableList) > 0 {
-		return fmt.Errorf("%w: %s", catalog.ErrNamespaceNotEmpty, databaseName)
+		tableType := "non-Iceberg"
+		if strings.EqualFold(tables.TableList[0].Parameters[tableParamTableType], glueTypeIceberg) {
+			tableType = "Iceberg"
+		}
+
+		return fmt.Errorf("%w: cannot drop namespace %s because it still contains %s tables",
+			catalog.ErrNamespaceNotEmpty, databaseName, tableType)
 	}
 
 	params := &glue.DeleteDatabaseInput{CatalogId: c.catalogId, Name: aws.String(databaseName)}

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -685,6 +685,18 @@ func (c *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
+	tables, err := c.glueSvc.GetTables(ctx, &glue.GetTablesInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(databaseName),
+		MaxResults:   aws.Int32(1),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check namespace %s for tables: %w", databaseName, err)
+	}
+	if len(tables.TableList) > 0 {
+		return fmt.Errorf("%w: %s", catalog.ErrNamespaceNotEmpty, databaseName)
+	}
+
 	params := &glue.DeleteDatabaseInput{CatalogId: c.catalogId, Name: aws.String(databaseName)}
 	_, err = c.glueSvc.DeleteDatabase(ctx, params)
 	if err != nil {

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -892,8 +892,6 @@ func TestGlueCreateNamespace(t *testing.T) {
 }
 
 func TestGlueDropNamespace(t *testing.T) {
-	assert := require.New(t)
-
 	mockGlueSvc := &mockGlueClient{}
 
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
@@ -907,6 +905,11 @@ func TestGlueDropNamespace(t *testing.T) {
 		},
 	}, nil).Once()
 
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_namespace"),
+		MaxResults:   aws.Int32(1),
+	}, mock.Anything).Return(&glue.GetTablesOutput{}, nil).Once()
+
 	mockGlueSvc.On("DeleteDatabase", mock.Anything, &glue.DeleteDatabaseInput{
 		Name: aws.String("test_namespace"),
 	}, mock.Anything).Return(&glue.DeleteDatabaseOutput{}, nil).Once()
@@ -916,7 +919,60 @@ func TestGlueDropNamespace(t *testing.T) {
 	}
 
 	err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
-	assert.NoError(err)
+	require.NoError(t, err)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+func TestGlueDropNamespaceNotEmpty(t *testing.T) {
+	for _, tableType := range []string{glueTypeIceberg, "EXTERNAL_TABLE"} {
+		t.Run(tableType, func(t *testing.T) {
+			mockGlueSvc := &mockGlueClient{}
+
+			mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+				Name: aws.String("test_namespace"),
+			}, mock.Anything).Return(&glue.GetDatabaseOutput{
+				Database: &types.Database{Name: aws.String("test_namespace")},
+			}, nil).Once()
+			mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+				DatabaseName: aws.String("test_namespace"),
+				MaxResults:   aws.Int32(1),
+			}, mock.Anything).Return(&glue.GetTablesOutput{
+				TableList: []types.Table{{
+					Name:       aws.String("test_table"),
+					Parameters: map[string]string{tableParamTableType: tableType},
+				}},
+			}, nil).Once()
+
+			glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+			err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
+
+			require.ErrorIs(t, err, catalog.ErrNamespaceNotEmpty)
+			mockGlueSvc.AssertNotCalled(t, "DeleteDatabase", mock.Anything, mock.Anything, mock.Anything)
+			mockGlueSvc.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGlueDropNamespaceGetTablesError(t *testing.T) {
+	mockGlueSvc := &mockGlueClient{}
+	errGetTables := errors.New("get tables failed")
+
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_namespace"),
+	}, mock.Anything).Return(&glue.GetDatabaseOutput{
+		Database: &types.Database{Name: aws.String("test_namespace")},
+	}, nil).Once()
+	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		DatabaseName: aws.String("test_namespace"),
+		MaxResults:   aws.Int32(1),
+	}, mock.Anything).Return(&glue.GetTablesOutput{}, errGetTables).Once()
+
+	glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+	err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
+
+	require.ErrorIs(t, err, errGetTables)
+	mockGlueSvc.AssertNotCalled(t, "DeleteDatabase", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
 }
 
 func TestGlueCheckNamespaceExists(t *testing.T) {

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -893,9 +893,11 @@ func TestGlueCreateNamespace(t *testing.T) {
 
 func TestGlueDropNamespace(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
+	catalogID := aws.String("test_catalog")
 
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
-		Name: aws.String("test_namespace"),
+		CatalogId: catalogID,
+		Name:      aws.String("test_namespace"),
 	}, mock.Anything).Return(&glue.GetDatabaseOutput{
 		Database: &types.Database{
 			Name: aws.String("test_namespace"),
@@ -906,16 +908,19 @@ func TestGlueDropNamespace(t *testing.T) {
 	}, nil).Once()
 
 	mockGlueSvc.On("GetTables", mock.Anything, &glue.GetTablesInput{
+		CatalogId:    catalogID,
 		DatabaseName: aws.String("test_namespace"),
 		MaxResults:   aws.Int32(1),
 	}, mock.Anything).Return(&glue.GetTablesOutput{}, nil).Once()
 
 	mockGlueSvc.On("DeleteDatabase", mock.Anything, &glue.DeleteDatabaseInput{
-		Name: aws.String("test_namespace"),
+		CatalogId: catalogID,
+		Name:      aws.String("test_namespace"),
 	}, mock.Anything).Return(&glue.DeleteDatabaseOutput{}, nil).Once()
 
 	glueCatalog := &Catalog{
-		glueSvc: mockGlueSvc,
+		glueSvc:   mockGlueSvc,
+		catalogId: catalogID,
 	}
 
 	err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
@@ -924,8 +929,17 @@ func TestGlueDropNamespace(t *testing.T) {
 }
 
 func TestGlueDropNamespaceNotEmpty(t *testing.T) {
-	for _, tableType := range []string{glueTypeIceberg, "EXTERNAL_TABLE"} {
-		t.Run(tableType, func(t *testing.T) {
+	tests := []struct {
+		name            string
+		tableType       string
+		expectedMessage string
+	}{
+		{name: "iceberg table", tableType: glueTypeIceberg, expectedMessage: "still contains Iceberg tables"},
+		{name: "non-Iceberg table", tableType: glueTableType, expectedMessage: "still contains non-Iceberg tables"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			mockGlueSvc := &mockGlueClient{}
 
 			mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
@@ -939,7 +953,7 @@ func TestGlueDropNamespaceNotEmpty(t *testing.T) {
 			}, mock.Anything).Return(&glue.GetTablesOutput{
 				TableList: []types.Table{{
 					Name:       aws.String("test_table"),
-					Parameters: map[string]string{tableParamTableType: tableType},
+					Parameters: map[string]string{tableParamTableType: tt.tableType},
 				}},
 			}, nil).Once()
 
@@ -947,6 +961,7 @@ func TestGlueDropNamespaceNotEmpty(t *testing.T) {
 			err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
 
 			require.ErrorIs(t, err, catalog.ErrNamespaceNotEmpty)
+			require.ErrorContains(t, err, tt.expectedMessage)
 			mockGlueSvc.AssertNotCalled(t, "DeleteDatabase", mock.Anything, mock.Anything, mock.Anything)
 			mockGlueSvc.AssertExpectations(t)
 		})
@@ -971,6 +986,7 @@ func TestGlueDropNamespaceGetTablesError(t *testing.T) {
 	err := glueCatalog.DropNamespace(context.TODO(), DatabaseIdentifier("test_namespace"))
 
 	require.ErrorIs(t, err, errGetTables)
+	require.ErrorContains(t, err, "failed to list tables in namespace test_namespace")
 	mockGlueSvc.AssertNotCalled(t, "DeleteDatabase", mock.Anything, mock.Anything, mock.Anything)
 	mockGlueSvc.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

- check a Glue database for tables before dropping its namespace
- return `catalog.ErrNamespaceNotEmpty` when any table exists
- avoid deleting the database when Glue cannot determine whether it is empty

The check includes both Iceberg and non-Iceberg tables because deleting a Glue database makes all tables in that database inaccessible.

## Testing

- `go test ./catalog/glue`