### PR TITLE
fix(glue): use canonical comment property for descriptions

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -973,6 +973,8 @@ func constructParameters(staged *table.Table, previousGlueTable *types.Table) ma
 
 	maps.Copy(parameters, staged.Properties())
 	delete(parameters, tableParamPreviousMetadataLocation)
+	delete(parameters, PropsKeyDescription)
+	delete(parameters, legacyPropsKeyDescription)
 
 	if previousGlueTable != nil {
 		if previousMetadataLocation, ok := previousGlueTable.Parameters[tableParamMetadataLocation]; ok {

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -50,8 +50,9 @@ const (
 	glueTableType   = "EXTERNAL_TABLE"
 
 	// property keys
-	PropsKeyLocation    = "location"
-	PropsKeyDescription = "Description"
+	PropsKeyLocation          = "location"
+	PropsKeyDescription       = "comment"
+	legacyPropsKeyDescription = "Description"
 
 	// glue table parameter keys
 	tableParamTableType                = "table_type"
@@ -731,6 +732,12 @@ func (c *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 			props[k] = v
 		}
 	}
+	if description, ok := props[legacyPropsKeyDescription]; ok {
+		delete(props, legacyPropsKeyDescription)
+		if _, hasComment := props[PropsKeyDescription]; !hasComment {
+			props[PropsKeyDescription] = description
+		}
+	}
 	if database.Description != nil {
 		props[PropsKeyDescription] = aws.ToString(database.Description)
 	}
@@ -989,7 +996,7 @@ func constructTableInput(tableName string, staged *table.Table, previousGlueTabl
 		},
 	}
 
-	if comment, ok := staged.Properties()[PropsKeyDescription]; ok {
+	if comment, ok := descriptionProperty(staged.Properties()); ok {
 		tableInput.Description = aws.String(comment)
 	}
 
@@ -1024,11 +1031,14 @@ func constructDatabaseInput(database string, props iceberg.Properties) *types.Da
 		Name: aws.String(database),
 	}
 
+	if description, ok := descriptionProperty(props); ok {
+		databaseInput.Description = aws.String(description)
+	}
+
 	parameters := map[string]string{}
 	for k, v := range props {
 		switch k {
-		case PropsKeyDescription:
-			databaseInput.Description = aws.String(v)
+		case PropsKeyDescription, legacyPropsKeyDescription:
 		case PropsKeyLocation:
 			databaseInput.LocationUri = aws.String(v)
 		default:
@@ -1039,6 +1049,16 @@ func constructDatabaseInput(database string, props iceberg.Properties) *types.Da
 	databaseInput.Parameters = parameters
 
 	return databaseInput
+}
+
+func descriptionProperty(props iceberg.Properties) (string, bool) {
+	if description, ok := props[PropsKeyDescription]; ok {
+		return description, true
+	}
+
+	description, ok := props[legacyPropsKeyDescription]
+
+	return description, ok
 }
 
 // isConcurrentModificationException reports whether err is or wraps

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -280,6 +280,63 @@ func TestGlueConstructParametersPreservesReservedParameters(t *testing.T) {
 	assert.Equal("value", params["custom"])
 }
 
+func TestGlueConstructDescriptionCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		props    iceberg.Properties
+		expected string
+	}{
+		{
+			name:     "canonical comment",
+			props:    iceberg.Properties{PropsKeyDescription: "canonical"},
+			expected: "canonical",
+		},
+		{
+			name:     "legacy description",
+			props:    iceberg.Properties{legacyPropsKeyDescription: "legacy"},
+			expected: "legacy",
+		},
+		{
+			name: "canonical comment wins",
+			props: iceberg.Properties{
+				PropsKeyDescription:       "canonical",
+				legacyPropsKeyDescription: "legacy",
+			},
+			expected: "canonical",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			databaseInput := constructDatabaseInput("test_namespace", tt.props)
+			require.Equal(t, tt.expected, aws.ToString(databaseInput.Description))
+			require.NotContains(t, databaseInput.Parameters, PropsKeyDescription)
+			require.NotContains(t, databaseInput.Parameters, legacyPropsKeyDescription)
+
+			metadata, err := table.NewMetadata(
+				testSchema,
+				iceberg.UnpartitionedSpec,
+				table.UnsortedSortOrder,
+				"s3://test-bucket/test_table",
+				tt.props,
+			)
+			require.NoError(t, err)
+			staged := table.New(
+				TableIdentifier("test_database", "test_table"),
+				metadata,
+				"s3://test-bucket/test_table/metadata/v1.metadata.json",
+				nil,
+				nil,
+			)
+
+			tableInput := constructTableInput("test_table", staged, nil)
+			require.Equal(t, tt.expected, aws.ToString(tableInput.Description))
+			require.NotContains(t, tableInput.Parameters, PropsKeyDescription)
+			require.NotContains(t, tableInput.Parameters, legacyPropsKeyDescription)
+		})
+	}
+}
+
 func TestGlueGetTableCaseInsensitive(t *testing.T) {
 	assert := require.New(t)
 
@@ -883,12 +940,65 @@ func TestGlueCreateNamespace(t *testing.T) {
 	}
 
 	props := map[string]string{
-		PropsKeyDescription: "Test Description",
-		PropsKeyLocation:    "s3://test-location",
+		"comment":        "Test Description",
+		PropsKeyLocation: "s3://test-location",
 	}
 
 	err := glueCatalog.CreateNamespace(context.TODO(), DatabaseIdentifier("test_namespace"), props)
 	assert.NoError(err)
+}
+
+func TestGlueLoadNamespacePropertiesNormalizesDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		parameters  map[string]string
+		description *string
+		expected    iceberg.Properties
+	}{
+		{
+			name:       "legacy parameter",
+			parameters: map[string]string{legacyPropsKeyDescription: "legacy", "key": "value"},
+			expected:   iceberg.Properties{PropsKeyDescription: "legacy", "key": "value"},
+		},
+		{
+			name:       "canonical parameter",
+			parameters: map[string]string{PropsKeyDescription: "canonical", "key": "value"},
+			expected:   iceberg.Properties{PropsKeyDescription: "canonical", "key": "value"},
+		},
+		{
+			name: "native description wins",
+			parameters: map[string]string{
+				legacyPropsKeyDescription: "legacy",
+				PropsKeyDescription:       "parameter",
+				"key":                     "value",
+			},
+			description: aws.String("native"),
+			expected:    iceberg.Properties{PropsKeyDescription: "native", "key": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGlueSvc := &mockGlueClient{}
+			mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+				Name: aws.String("test_namespace"),
+			}, mock.Anything).Return(&glue.GetDatabaseOutput{
+				Database: &types.Database{
+					Name:        aws.String("test_namespace"),
+					Parameters:  tt.parameters,
+					Description: tt.description,
+				},
+			}, nil).Once()
+
+			glueCatalog := &Catalog{glueSvc: mockGlueSvc}
+			props, err := glueCatalog.LoadNamespaceProperties(
+				context.Background(), DatabaseIdentifier("test_namespace"))
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, props)
+			mockGlueSvc.AssertExpectations(t)
+		})
+	}
 }
 
 func TestGlueDropNamespace(t *testing.T) {


### PR DESCRIPTION
## Summary

Glue uses `comment` as the canonical property for namespace and table descriptions, while older catalogs may still provide the legacy `Description` parameter.

This change:

- writes canonical `comment` properties without leaking description fields into Glue parameters;
- accepts legacy `Description` values when loading namespaces;
- gives canonical `comment` values deterministic precedence over legacy values;
- preserves native Glue descriptions as the highest-priority namespace value;
- applies the same compatibility behavior to namespace and table creation.

## Testing

- `go test ./catalog/glue`
- `go test ./catalog/...`
- `git diff --check`