### PR TITLE
fix(glue): preserve existing column comments

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -988,13 +988,18 @@ func constructParameters(staged *table.Table, previousGlueTable *types.Table) ma
 }
 
 func constructTableInput(tableName string, staged *table.Table, previousGlueTable *types.Table) *types.TableInput {
+	var existingColumns []types.Column
+	if previousGlueTable != nil && previousGlueTable.StorageDescriptor != nil {
+		existingColumns = previousGlueTable.StorageDescriptor.Columns
+	}
+
 	tableInput := &types.TableInput{
 		Name:       aws.String(tableName),
 		TableType:  aws.String(glueTableType),
 		Parameters: constructParameters(staged, previousGlueTable),
 		StorageDescriptor: &types.StorageDescriptor{
 			Location: aws.String(staged.Location()),
-			Columns:  schemasToGlueColumns(staged.Metadata()),
+			Columns:  schemasToGlueColumns(staged.Metadata(), existingColumns),
 		},
 	}
 

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -337,6 +337,53 @@ func TestGlueConstructDescriptionCompatibility(t *testing.T) {
 	}
 }
 
+func TestGlueConstructTableInputPreservesExistingColumnComments(t *testing.T) {
+	metadata, err := table.NewMetadata(
+		testSchema,
+		nil,
+		table.UnsortedSortOrder,
+		"s3://test-bucket/test_table",
+		nil,
+	)
+	require.NoError(t, err)
+	staged := table.New(
+		TableIdentifier("test_database", "test_table"),
+		metadata,
+		"s3://test-bucket/test_table/metadata/v2.metadata.json",
+		nil,
+		nil,
+	)
+	previous := &types.Table{
+		StorageDescriptor: &types.StorageDescriptor{
+			Columns: []types.Column{
+				{
+					Name:       aws.String("foo"),
+					Comment:    aws.String("existing comment"),
+					Parameters: map[string]string{icebergFieldIDKey: "1"},
+				},
+			},
+		},
+	}
+
+	input := constructTableInput("test_table", staged, previous)
+	columns := make(map[string]types.Column, len(input.StorageDescriptor.Columns))
+	for _, column := range input.StorageDescriptor.Columns {
+		columns[aws.ToString(column.Name)] = column
+	}
+
+	require.Equal(t, "existing comment", aws.ToString(columns["foo"].Comment))
+	require.Nil(t, columns["bar"].Comment)
+	require.Nil(t, columns["baz"].Comment)
+
+	withoutStorageDescriptor := &types.Table{}
+	for _, previous := range []*types.Table{nil, withoutStorageDescriptor} {
+		input := constructTableInput("test_table", staged, previous)
+		for _, column := range input.StorageDescriptor.Columns {
+			require.Nil(t, column.Comment)
+		}
+	}
+}
+
 func TestGlueGetTableCaseInsensitive(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/glue/schema.go
+++ b/catalog/glue/schema.go
@@ -30,7 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 )
 
-func schemasToGlueColumns(metadata table.Metadata) []types.Column {
+func schemasToGlueColumns(metadata table.Metadata, existingColumns []types.Column) []types.Column {
 	results := make(map[string]types.Column)
 
 	for _, field := range schemaToGlueColumns(metadata.CurrentSchema(), true) {
@@ -46,6 +46,56 @@ func schemasToGlueColumns(metadata table.Metadata) []types.Column {
 			if _, ok := results[aws.ToString(field.Name)]; !ok {
 				results[aws.ToString(field.Name)] = field
 			}
+		}
+	}
+
+	existingComments := make(map[string]string)
+	for _, column := range existingColumns {
+		fieldID := column.Parameters[icebergFieldIDKey]
+		if fieldID == "" || column.Comment == nil {
+			continue
+		}
+		if _, ok := existingComments[fieldID]; !ok {
+			existingComments[fieldID] = aws.ToString(column.Comment)
+		}
+	}
+
+	// Preserve nil for fields that have never had an Iceberg doc, but keep an
+	// explicit empty string when a documented field was cleared in a later schema.
+	clearedComments := make(map[string]struct{})
+	currentSchema := metadata.CurrentSchema()
+	for _, field := range currentSchema.Fields() {
+		if field.Doc != "" {
+			continue
+		}
+
+		for _, schema := range metadata.Schemas() {
+			if schema.ID == currentSchema.ID {
+				continue
+			}
+			if previous, ok := schema.FindFieldByID(field.ID); ok && previous.Doc != "" {
+				clearedComments[strconv.Itoa(field.ID)] = struct{}{}
+
+				break
+			}
+		}
+	}
+
+	for name, column := range results {
+		if column.Comment != nil {
+			continue
+		}
+
+		fieldID := column.Parameters[icebergFieldIDKey]
+		if _, ok := clearedComments[fieldID]; ok {
+			column.Comment = aws.String("")
+			results[name] = column
+
+			continue
+		}
+		if comment, ok := existingComments[fieldID]; ok {
+			column.Comment = aws.String(comment)
+			results[name] = column
 		}
 	}
 
@@ -74,14 +124,16 @@ func schemaToGlueColumns(schema *iceberg.Schema, isCurrent bool) []types.Column 
 // fieldToGlueColumn converts an Iceberg nested field to a Glue column.
 func fieldToGlueColumn(field iceberg.NestedField, isCurrent bool) types.Column {
 	column := types.Column{
-		Name:    aws.String(field.Name),
-		Comment: aws.String(field.Doc),
-		Type:    aws.String(icebergTypeToGlueType(field.Type)),
+		Name: aws.String(field.Name),
+		Type: aws.String(icebergTypeToGlueType(field.Type)),
 		Parameters: map[string]string{
 			icebergFieldIDKey:       strconv.Itoa(field.ID),
 			icebergFieldOptionalKey: strconv.FormatBool(!field.Required),
 			icebergFieldCurrentKey:  strconv.FormatBool(isCurrent),
 		},
+	}
+	if field.Doc != "" {
+		column.Comment = aws.String(field.Doc)
 	}
 
 	return column

--- a/catalog/glue/schema_test.go
+++ b/catalog/glue/schema_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIcebergTypeToGlueType(t *testing.T) {
@@ -162,6 +163,23 @@ func TestFieldToGlueColumn(t *testing.T) {
 				Comment: aws.String("Price with 2 decimal places"),
 				Parameters: map[string]string{
 					icebergFieldIDKey:       "2",
+					icebergFieldOptionalKey: "true",
+					icebergFieldCurrentKey:  "true",
+				},
+			},
+		},
+		{
+			name: "field without doc",
+			field: iceberg.NestedField{
+				ID:   3,
+				Name: "undocumented",
+				Type: iceberg.PrimitiveTypes.String,
+			},
+			expected: types.Column{
+				Name: aws.String("undocumented"),
+				Type: aws.String("string"),
+				Parameters: map[string]string{
+					icebergFieldIDKey:       "3",
 					icebergFieldOptionalKey: "true",
 					icebergFieldCurrentKey:  "true",
 				},
@@ -413,9 +431,8 @@ func TestSchemasToGlueColumns(t *testing.T) {
 
 	expectedColumns := []types.Column{
 		{
-			Name:    aws.String("id"),
-			Type:    aws.String("bigint"),
-			Comment: aws.String(""),
+			Name: aws.String("id"),
+			Type: aws.String("bigint"),
 			Parameters: map[string]string{
 				icebergFieldIDKey:       "1",
 				icebergFieldOptionalKey: "false",
@@ -423,9 +440,8 @@ func TestSchemasToGlueColumns(t *testing.T) {
 			},
 		},
 		{
-			Name:    aws.String("name"),
-			Type:    aws.String("string"),
-			Comment: aws.String(""),
+			Name: aws.String("name"),
+			Type: aws.String("string"),
 			Parameters: map[string]string{
 				icebergFieldIDKey:       "2",
 				icebergFieldOptionalKey: "false",
@@ -433,9 +449,8 @@ func TestSchemasToGlueColumns(t *testing.T) {
 			},
 		},
 		{
-			Name:    aws.String("address"),
-			Type:    aws.String("string"),
-			Comment: aws.String(""),
+			Name: aws.String("address"),
+			Type: aws.String("string"),
 			Parameters: map[string]string{
 				icebergFieldIDKey:       "3",
 				icebergFieldOptionalKey: "true",
@@ -444,19 +459,78 @@ func TestSchemasToGlueColumns(t *testing.T) {
 		},
 	}
 	metadata, err := table.NewMetadata(schemas[0], nil, table.SortOrder{}, "s3://example/path", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mb, err := table.MetadataBuilderFromBase(metadata, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = mb.AddSchema(schemas[1])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = mb.SetCurrentSchemaID(1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	metadata, err = mb.Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	columns := schemasToGlueColumns(metadata)
+	columns := schemasToGlueColumns(metadata, nil)
 	assert.Equal(t, expectedColumns, columns)
+}
+
+func TestSchemasToGlueColumnsPreservesExistingCommentsByFieldID(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "renamed", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 2, Name: "reused", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 3, Name: "overridden", Type: iceberg.PrimitiveTypes.String, Doc: "iceberg comment"},
+		iceberg.NestedField{ID: 4, Name: "missing", Type: iceberg.PrimitiveTypes.String},
+	)
+	metadata, err := table.NewMetadata(schema, nil, table.SortOrder{}, "s3://example/path", nil)
+	require.NoError(t, err)
+
+	existingComment := aws.String("existing comment")
+	existingColumns := []types.Column{
+		{Name: aws.String("old_name"), Comment: existingComment, Parameters: map[string]string{icebergFieldIDKey: "1"}},
+		{Name: aws.String("duplicate"), Comment: aws.String("duplicate comment"), Parameters: map[string]string{icebergFieldIDKey: "1"}},
+		{Name: aws.String("reused"), Comment: aws.String("stale comment"), Parameters: map[string]string{icebergFieldIDKey: "99"}},
+		{Name: aws.String("overridden"), Comment: aws.String("existing comment"), Parameters: map[string]string{icebergFieldIDKey: "3"}},
+		{Name: aws.String("missing"), Parameters: map[string]string{icebergFieldIDKey: "4"}},
+	}
+
+	columns := schemasToGlueColumns(metadata, existingColumns)
+	byName := make(map[string]types.Column, len(columns))
+	for _, column := range columns {
+		byName[aws.ToString(column.Name)] = column
+	}
+	*existingComment = "mutated after conversion"
+
+	assert.Equal(t, "existing comment", aws.ToString(byName["renamed"].Comment))
+	assert.Nil(t, byName["reused"].Comment)
+	assert.Equal(t, "iceberg comment", aws.ToString(byName["overridden"].Comment))
+	assert.Nil(t, byName["missing"].Comment)
+}
+
+func TestSchemasToGlueColumnsClearsPreviousIcebergComment(t *testing.T) {
+	previousSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "field", Type: iceberg.PrimitiveTypes.String, Doc: "old comment"},
+	)
+	metadata, err := table.NewMetadata(previousSchema, nil, table.SortOrder{}, "s3://example/path", nil)
+	require.NoError(t, err)
+
+	mb, err := table.MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+	require.NoError(t, mb.AddSchema(iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "field", Type: iceberg.PrimitiveTypes.String},
+	)))
+	require.NoError(t, mb.SetCurrentSchemaID(1))
+	metadata, err = mb.Build()
+	require.NoError(t, err)
+
+	columns := schemasToGlueColumns(metadata, []types.Column{{
+		Name:       aws.String("field"),
+		Comment:    aws.String("old comment"),
+		Parameters: map[string]string{icebergFieldIDKey: "1"},
+	}})
+	require.Len(t, columns, 1)
+
+	require.NotNil(t, columns[0].Comment)
+	assert.Empty(t, aws.ToString(columns[0].Comment))
 }


### PR DESCRIPTION
## Problem

Glue table updates rebuild storage descriptor columns from Iceberg metadata. When a field has no Iceberg documentation, this replaces an existing Glue column comment with an empty value during otherwise unrelated commits.

## Changes

- preserve existing Glue column comments by column name when the Iceberg field doc is empty
- keep non-empty Iceberg field docs authoritative
- use the first existing comment when old Glue columns contain duplicate names
- safely handle tables without an existing storage descriptor

## Testing

- `go test ./...`
- `golangci-lint run --timeout=10m`
