### PR TITLE
fix(hadoop): return fully qualified child namespaces

### DIFF
--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1060,7 +1061,7 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 			// if a table, not a namespace, don't descend
 			return fs.SkipDir
 		}
-		result = append(result, table.Identifier{d.Name()})
+		result = append(result, append(slices.Clone(parent), d.Name()))
 		// found a namespace dir, don't recurse into it
 		return fs.SkipDir
 	})

--- a/catalog/hadoop/hadoop.go
+++ b/catalog/hadoop/hadoop.go
@@ -1061,7 +1061,8 @@ func (c *Catalog) ListNamespaces(_ context.Context, parent table.Identifier) ([]
 			// if a table, not a namespace, don't descend
 			return fs.SkipDir
 		}
-		result = append(result, append(slices.Clone(parent), d.Name()))
+		child := append(slices.Clone(parent), d.Name())
+		result = append(result, child)
 		// found a namespace dir, don't recurse into it
 		return fs.SkipDir
 	})

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1062,17 +1062,19 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesEmpty() {
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesNested() {
-	parentDir := filepath.Join(s.warehouse, "a")
-	s.Require().NoError(os.MkdirAll(filepath.Join(parentDir, "child1"), 0o755))
-	s.Require().NoError(os.MkdirAll(filepath.Join(parentDir, "child2"), 0o755))
+	ctx := context.Background()
+	parent := table.Identifier{"a"}
+	expected := []table.Identifier{{"a", "child1"}, {"a", "child2"}}
+	s.Require().NoError(s.cat.CreateNamespace(ctx, parent, nil))
+	for _, namespace := range expected {
+		s.Require().NoError(s.cat.CreateNamespace(ctx, namespace, nil))
+	}
 
-	namespaces, err := s.cat.ListNamespaces(context.Background(), []string{"a"})
+	namespaces, err := s.cat.ListNamespaces(ctx, parent)
 	s.Require().NoError(err)
-	s.Len(namespaces, 2)
-	s.Contains(namespaces, table.Identifier{"a", "child1"})
-	s.Contains(namespaces, table.Identifier{"a", "child2"})
+	s.ElementsMatch(expected, namespaces)
 	for _, namespace := range namespaces {
-		exists, err := s.cat.CheckNamespaceExists(context.Background(), namespace)
+		exists, err := s.cat.CheckNamespaceExists(ctx, namespace)
 		s.Require().NoError(err)
 		s.True(exists)
 	}

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1069,8 +1069,13 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesNested() {
 	namespaces, err := s.cat.ListNamespaces(context.Background(), []string{"a"})
 	s.Require().NoError(err)
 	s.Len(namespaces, 2)
-	s.Contains(namespaces, table.Identifier{"child1"})
-	s.Contains(namespaces, table.Identifier{"child2"})
+	s.Contains(namespaces, table.Identifier{"a", "child1"})
+	s.Contains(namespaces, table.Identifier{"a", "child2"})
+	for _, namespace := range namespaces {
+		exists, err := s.cat.CheckNamespaceExists(context.Background(), namespace)
+		s.Require().NoError(err)
+		s.True(exists)
+	}
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesParentNotExists() {

--- a/catalog/hadoop/hadoop_test.go
+++ b/catalog/hadoop/hadoop_test.go
@@ -1065,10 +1065,12 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesNested() {
 	ctx := context.Background()
 	parent := table.Identifier{"a"}
 	expected := []table.Identifier{{"a", "child1"}, {"a", "child2"}}
+	grandchild := table.Identifier{"a", "child1", "grandchild"}
 	s.Require().NoError(s.cat.CreateNamespace(ctx, parent, nil))
 	for _, namespace := range expected {
 		s.Require().NoError(s.cat.CreateNamespace(ctx, namespace, nil))
 	}
+	s.Require().NoError(s.cat.CreateNamespace(ctx, grandchild, nil))
 
 	namespaces, err := s.cat.ListNamespaces(ctx, parent)
 	s.Require().NoError(err)
@@ -1078,6 +1080,14 @@ func (s *HadoopCatalogTestSuite) TestListNamespacesNested() {
 		s.Require().NoError(err)
 		s.True(exists)
 	}
+
+	namespaces, err = s.cat.ListNamespaces(ctx, expected[0])
+	s.Require().NoError(err)
+	s.Require().Equal([]table.Identifier{grandchild}, namespaces)
+
+	exists, err := s.cat.CheckNamespaceExists(ctx, namespaces[0])
+	s.Require().NoError(err)
+	s.True(exists)
 }
 
 func (s *HadoopCatalogTestSuite) TestListNamespacesParentNotExists() {


### PR DESCRIPTION
## Motivation

For a nested namespace such as `["a", "child"]`, `ListNamespaces(ctx, ["a"])` currently returns only `["child"]`. The truncated identifier cannot be passed back to catalog methods such as `CheckNamespaceExists`, `LoadNamespaceProperties`, or `ListTables` because those methods interpret it as a root namespace.

## Changes

- Build listed child identifiers by appending the directory name to the requested parent.
- Create nested namespaces through the catalog API in the regression test.
- Verify the exact fully qualified results and round-trip every returned identifier through `CheckNamespaceExists`.

## Testing

- `go test ./...`
- `golangci-lint run ./catalog/hadoop`