### PR TITLE
fix(view): reject null and duplicate metadata entries

### DIFF
--- a/view/metadata.go
+++ b/view/metadata.go
@@ -435,7 +435,7 @@ func (m *metadata) validate() error {
 		return fmt.Errorf("%w: at least one schema is required", ErrInvalidViewMetadata)
 	}
 
-	if err := m.checkSchemaAndVersionIDs(); err != nil {
+	if err := m.checkSchemaAndVersionEntries(); err != nil {
 		return err
 	}
 
@@ -454,7 +454,7 @@ func (m *metadata) validate() error {
 	return nil
 }
 
-func (m *metadata) checkSchemaAndVersionIDs() error {
+func (m *metadata) checkSchemaAndVersionEntries() error {
 	schemaIDs := make(map[int]struct{}, len(m.SchemaList))
 	for i, schema := range m.SchemaList {
 		if schema == nil {

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -435,6 +435,10 @@ func (m *metadata) validate() error {
 		return fmt.Errorf("%w: at least one schema is required", ErrInvalidViewMetadata)
 	}
 
+	if err := m.checkSchemaAndVersionIDs(); err != nil {
+		return err
+	}
+
 	if err := m.checkCurrentVersionExists(); err != nil {
 		return err
 	}
@@ -445,6 +449,32 @@ func (m *metadata) validate() error {
 
 	if err := m.checkDialectsUnique(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *metadata) checkSchemaAndVersionIDs() error {
+	schemaIDs := make(map[int]struct{}, len(m.SchemaList))
+	for i, schema := range m.SchemaList {
+		if schema == nil {
+			return fmt.Errorf("%w: schema at index %d is null", ErrInvalidViewMetadata, i)
+		}
+		if _, ok := schemaIDs[schema.ID]; ok {
+			return fmt.Errorf("%w: duplicate schema-id %d", ErrInvalidViewMetadata, schema.ID)
+		}
+		schemaIDs[schema.ID] = struct{}{}
+	}
+
+	versionIDs := make(map[int64]struct{}, len(m.VersionList))
+	for i, version := range m.VersionList {
+		if version == nil {
+			return fmt.Errorf("%w: version at index %d is null", ErrInvalidViewMetadata, i)
+		}
+		if _, ok := versionIDs[version.VersionID]; ok {
+			return fmt.Errorf("%w: duplicate version-id %d", ErrInvalidViewMetadata, version.VersionID)
+		}
+		versionIDs[version.VersionID] = struct{}{}
 	}
 
 	return nil

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -492,13 +492,10 @@ func (m *metadata) checkCurrentVersionExists() error {
 }
 
 func (m *metadata) checkVersionSchemasExist() error {
-	schemaIDs := make(map[int]bool)
-	for _, schema := range m.SchemaList {
-		schemaIDs[schema.ID] = true
-	}
+	schemasByID := m.lazySchemasByID()
 
 	for _, version := range m.VersionList {
-		if !schemaIDs[version.SchemaID] {
+		if _, ok := schemasByID[version.SchemaID]; !ok {
 			return fmt.Errorf("%w: version %d references unknown schema-id %d",
 				ErrInvalidViewMetadata, version.VersionID, version.SchemaID)
 		}

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -196,7 +196,7 @@ func TestValidMetadataDeserialization(t *testing.T) {
 	assert.Equal(t, int64(1), meta.CurrentVersionIDValue)
 }
 
-func TestRejectsNullAndDuplicateSchemaAndVersionEntries(t *testing.T) {
+func TestParseMetadataRejectsNullAndDuplicateEntries(t *testing.T) {
 	tests := []struct {
 		name       string
 		mutate     func(map[string]any)
@@ -242,9 +242,12 @@ func TestRejectsNullAndDuplicateSchemaAndVersionEntries(t *testing.T) {
 			encoded, err := json.Marshal(doc)
 			require.NoError(t, err)
 
-			_, err = ParseMetadataBytes(encoded)
-			require.ErrorIs(t, err, ErrInvalidViewMetadata)
-			assert.ErrorContains(t, err, tt.errMessage)
+			var parseErr error
+			require.NotPanics(t, func() {
+				_, parseErr = ParseMetadataBytes(encoded)
+			})
+			require.ErrorIs(t, parseErr, ErrInvalidViewMetadata)
+			assert.ErrorContains(t, parseErr, tt.errMessage)
 		})
 	}
 }

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -196,6 +196,59 @@ func TestValidMetadataDeserialization(t *testing.T) {
 	assert.Equal(t, int64(1), meta.CurrentVersionIDValue)
 }
 
+func TestRejectsNullAndDuplicateSchemaAndVersionEntries(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(map[string]any)
+		errMessage string
+	}{
+		{
+			name: "null schema",
+			mutate: func(doc map[string]any) {
+				doc["schemas"] = []any{nil}
+			},
+			errMessage: "schema at index 0 is null",
+		},
+		{
+			name: "duplicate schema ID",
+			mutate: func(doc map[string]any) {
+				schemas := doc["schemas"].([]any)
+				doc["schemas"] = append(schemas, schemas[0])
+			},
+			errMessage: "duplicate schema-id 0",
+		},
+		{
+			name: "null version",
+			mutate: func(doc map[string]any) {
+				doc["versions"] = []any{nil}
+			},
+			errMessage: "version at index 0 is null",
+		},
+		{
+			name: "duplicate version ID",
+			mutate: func(doc map[string]any) {
+				versions := doc["versions"].([]any)
+				doc["versions"] = append(versions, versions[0])
+			},
+			errMessage: "duplicate version-id 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc map[string]any
+			require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &doc))
+			tt.mutate(doc)
+			encoded, err := json.Marshal(doc)
+			require.NoError(t, err)
+
+			_, err = ParseMetadataBytes(encoded)
+			require.ErrorIs(t, err, ErrInvalidViewMetadata)
+			assert.ErrorContains(t, err, tt.errMessage)
+		})
+	}
+}
+
 func TestMissingViewUUID(t *testing.T) {
 	invalidJSON := `{
 		"format-version": 1,


### PR DESCRIPTION
## Motivation

View metadata validation dereferences every schema and version entry without first checking for `null`, so malformed metadata can panic during parsing instead of returning `ErrInvalidViewMetadata`.

Duplicate schema or version IDs are also accepted. The metadata keeps all duplicate entries in the public lists while its ID indexes retain only one, making `CurrentSchema` and `CurrentVersion` depend on array order.

## Changes

- Reject null schema and version entries before any validation dereferences them.
- Reject duplicate `schema-id` and `version-id` values before constructing or using ID lookups.
- Add regression cases for null and duplicate schemas and versions, including an explicit no-panic assertion.

## Testing

- `go test ./...`
- `golangci-lint run ./view`