### PR TITLE
fix(udf): protect metadata and identifiers from mutation

### DIFF
--- a/udf/metadata.go
+++ b/udf/metadata.go
@@ -80,6 +80,7 @@ type Representation interface {
 	// isRepresentation seals the interface to the implementations in
 	// this package.
 	isRepresentation()
+	clone() Representation
 }
 
 // SQLRepresentation stores the function body as a SQL expression in a
@@ -105,6 +106,7 @@ func NewSQLRepresentation(dialect, sql string) (SQLRepresentation, error) {
 
 func (SQLRepresentation) RepresentationType() string { return "sql" }
 func (SQLRepresentation) isRepresentation()          {}
+func (r SQLRepresentation) clone() Representation    { return r }
 
 func (r SQLRepresentation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
@@ -122,11 +124,16 @@ type UnknownRepresentation struct {
 	raw json.RawMessage
 }
 
-// Raw returns the representation's original JSON.
+// Raw returns a copy of the representation's original JSON.
 func (r UnknownRepresentation) Raw() json.RawMessage { return slices.Clone(r.raw) }
 
 func (r UnknownRepresentation) RepresentationType() string { return r.TypeName }
 func (UnknownRepresentation) isRepresentation()            {}
+func (r UnknownRepresentation) clone() Representation {
+	r.raw = slices.Clone(r.raw)
+
+	return r
+}
 
 func (r UnknownRepresentation) MarshalJSON() ([]byte, error) {
 	return slices.Clone(r.raw), nil
@@ -148,14 +155,10 @@ func representationsEqual(a, b Representation) bool {
 }
 
 func cloneRepresentations(representations []Representation) []Representation {
-	cloned := make([]Representation, len(representations))
+	cloned := slices.Clone(representations)
 	for i, repr := range representations {
-		switch r := repr.(type) {
-		case UnknownRepresentation:
-			r.raw = slices.Clone(r.raw)
-			cloned[i] = r
-		default:
-			cloned[i] = r
+		if repr != nil {
+			cloned[i] = repr.clone()
 		}
 	}
 
@@ -696,14 +699,14 @@ type Metadata interface {
 	// Location returns the function's base location, used to create
 	// metadata file locations. It may be empty.
 	Location() string
-	// Definitions returns the function's definitions, one per signature.
+	// Definitions returns deep copies of the function's definitions, one per signature.
 	Definitions() []*Definition
-	// DefinitionByID returns the definition with the given definition-id.
+	// DefinitionByID returns a deep copy of the definition with the given definition-id.
 	DefinitionByID(definitionID string) (*Definition, bool)
-	// DefinitionLog returns the history of definition version selections.
+	// DefinitionLog returns a deep copy of the definition version selection history.
 	DefinitionLog() []DefinitionLogEntry
-	// Properties returns the function's properties. Entries are treated
-	// as hints, not strict rules.
+	// Properties returns a copy of the function's properties. Entries are
+	// treated as hints, not strict rules.
 	Properties() iceberg.Properties
 	// Secure reports whether this is a secure function whose sensitive
 	// information engines should not leak to end users.

--- a/udf/metadata.go
+++ b/udf/metadata.go
@@ -123,7 +123,7 @@ type UnknownRepresentation struct {
 }
 
 // Raw returns the representation's original JSON.
-func (r UnknownRepresentation) Raw() json.RawMessage { return r.raw }
+func (r UnknownRepresentation) Raw() json.RawMessage { return slices.Clone(r.raw) }
 
 func (r UnknownRepresentation) RepresentationType() string { return r.TypeName }
 func (UnknownRepresentation) isRepresentation()            {}
@@ -145,6 +145,21 @@ func representationsEqual(a, b Representation) bool {
 	default:
 		return false
 	}
+}
+
+func cloneRepresentations(representations []Representation) []Representation {
+	cloned := make([]Representation, len(representations))
+	for i, repr := range representations {
+		switch r := repr.(type) {
+		case UnknownRepresentation:
+			r.raw = slices.Clone(r.raw)
+			cloned[i] = r
+		default:
+			cloned[i] = r
+		}
+	}
+
+	return cloned
 }
 
 func unmarshalRepresentation(b json.RawMessage) (Representation, error) {
@@ -284,7 +299,7 @@ func (v *DefinitionVersion) Clone() *DefinitionVersion {
 	}
 
 	cloned := *v
-	cloned.Representations = slices.Clone(v.Representations)
+	cloned.Representations = cloneRepresentations(v.Representations)
 
 	return &cloned
 }
@@ -475,8 +490,12 @@ func (d *Definition) Clone() *Definition {
 	}
 
 	cloned := *d
-	// Type values are immutable, so sharing them across clones is safe.
-	cloned.Parameters = slices.Clone(d.Parameters)
+	cloned.Parameters = make([]Parameter, len(d.Parameters))
+	for i, parameter := range d.Parameters {
+		cloned.Parameters[i] = parameter
+		cloned.Parameters[i].Type = cloneType(parameter.Type)
+	}
+	cloned.ReturnType = cloneType(d.ReturnType)
 	cloned.Versions = cloneSlice(d.Versions)
 	if d.ReturnNullable != nil {
 		nullable := *d.ReturnNullable
@@ -733,19 +752,24 @@ type metadata struct {
 	lazyDefinitionsByID func() map[string]*Definition
 }
 
-func (m *metadata) FormatVersion() int                  { return m.FormatVersionValue }
-func (m *metadata) FunctionUUID() uuid.UUID             { return *m.UUID }
-func (m *metadata) Location() string                    { return m.Loc }
-func (m *metadata) Definitions() []*Definition          { return m.DefinitionList }
-func (m *metadata) DefinitionLog() []DefinitionLogEntry { return m.DefinitionLogList }
-func (m *metadata) Properties() iceberg.Properties      { return m.Props }
-func (m *metadata) Secure() bool                        { return m.SecureValue }
-func (m *metadata) Doc() string                         { return m.DocValue }
+func (m *metadata) FormatVersion() int         { return m.FormatVersionValue }
+func (m *metadata) FunctionUUID() uuid.UUID    { return *m.UUID }
+func (m *metadata) Location() string           { return m.Loc }
+func (m *metadata) Definitions() []*Definition { return cloneSlice(m.DefinitionList) }
+func (m *metadata) DefinitionLog() []DefinitionLogEntry {
+	return cloneDefinitionLog(m.DefinitionLogList)
+}
+func (m *metadata) Properties() iceberg.Properties { return maps.Clone(m.Props) }
+func (m *metadata) Secure() bool                   { return m.SecureValue }
+func (m *metadata) Doc() string                    { return m.DocValue }
 
 func (m *metadata) DefinitionByID(definitionID string) (*Definition, bool) {
 	def, ok := m.lazyDefinitionsByID()[definitionID]
+	if !ok {
+		return nil, false
+	}
 
-	return def, ok
+	return def.Clone(), true
 }
 
 func (m *metadata) Equals(other Metadata) bool {

--- a/udf/metadata_builder.go
+++ b/udf/metadata_builder.go
@@ -67,6 +67,9 @@ func NewDefinition(functionType FunctionType, params []Parameter, returnType Typ
 	// Keep parameters non-nil so a zero-parameter definition serializes as
 	// the required empty list rather than null.
 	parameters := slices.Clone(params)
+	for i := range parameters {
+		parameters[i].Type = cloneType(parameters[i].Type)
+	}
 	if parameters == nil {
 		parameters = []Parameter{}
 	}
@@ -74,7 +77,7 @@ func NewDefinition(functionType FunctionType, params []Parameter, returnType Typ
 	def := &Definition{
 		DefinitionID:     definitionID,
 		Parameters:       parameters,
-		ReturnType:       returnType,
+		ReturnType:       cloneType(returnType),
 		CurrentVersionID: -1,
 		FunctionType:     functionType,
 	}
@@ -127,7 +130,7 @@ func NewDefinitionVersion(representations []Representation, opts ...DefinitionVe
 	}
 
 	version := &DefinitionVersion{
-		Representations: slices.Clone(representations),
+		Representations: cloneRepresentations(representations),
 		TimestampMS:     time.Now().UnixMilli(),
 	}
 

--- a/udf/metadata_getters_test.go
+++ b/udf/metadata_getters_test.go
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-scalar.json")
+
+	properties := meta.Properties()
+	properties["mutated"] = "true"
+	assert.NotContains(t, meta.Properties(), "mutated")
+
+	definitions := meta.Definitions()
+	definitions[0].DefinitionID = "mutated"
+	definitions[0].Parameters[0].Name = "mutated"
+	definitions[0].Versions[0].VersionID = 99
+	definitions[0].Versions[0].Representations[0] = SQLRepresentation{Dialect: "mutated", SQL: "mutated"}
+
+	gotDefinitions := meta.Definitions()
+	assert.Equal(t, "int", gotDefinitions[0].DefinitionID)
+	assert.Equal(t, "x", gotDefinitions[0].Parameters[0].Name)
+	assert.Equal(t, 1, gotDefinitions[0].Versions[0].VersionID)
+	assert.Equal(t, SQLRepresentation{Dialect: "trino", SQL: "x + 2"}, gotDefinitions[0].Versions[0].Representations[0])
+
+	definition, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	definition.Doc = "mutated"
+	definition, ok = meta.DefinitionByID("int")
+	require.True(t, ok)
+	assert.Equal(t, "Add one to the input integer", definition.Doc)
+
+	log := meta.DefinitionLog()
+	log[0].TimestampMS = 0
+	log[0].DefinitionVersions[0].DefinitionID = "mutated"
+	assert.Equal(t, int64(1734507000123), meta.DefinitionLog()[0].TimestampMS)
+	assert.Equal(t, "int", meta.DefinitionLog()[0].DefinitionVersions[0].DefinitionID)
+}
+
+func TestDefinitionCopiesNestedTypes(t *testing.T) {
+	meta := parseFixture(t, "udf-metadata-table.json")
+	definition, ok := meta.DefinitionByID("string")
+	require.True(t, ok)
+
+	returnType := definition.ReturnType.(StructType)
+	returnType.Fields[0].Name = "mutated"
+
+	definition, ok = meta.DefinitionByID("string")
+	require.True(t, ok)
+	assert.Equal(t, "name", definition.ReturnType.(StructType).Fields[0].Name)
+}
+
+func TestUnknownRepresentationRawReturnsCopy(t *testing.T) {
+	meta, err := ParseMetadataString(unknownRepresentationJSON)
+	require.NoError(t, err)
+	definition, ok := meta.DefinitionByID("int")
+	require.True(t, ok)
+	unknown := definition.CurrentVersion().Representations[0].(UnknownRepresentation)
+
+	raw := unknown.Raw()
+	raw[0] = 'x'
+
+	definition, ok = meta.DefinitionByID("int")
+	require.True(t, ok)
+	unknown = definition.CurrentVersion().Representations[0].(UnknownRepresentation)
+	assert.Equal(t, byte('{'), unknown.Raw()[0])
+}

--- a/udf/metadata_getters_test.go
+++ b/udf/metadata_getters_test.go
@@ -70,6 +70,24 @@ func TestDefinitionCopiesNestedTypes(t *testing.T) {
 	assert.Equal(t, "name", definition.ReturnType.(StructType).Fields[0].Name)
 }
 
+func TestNewDefinitionCopiesInputTypes(t *testing.T) {
+	stringType, err := PrimitiveTypeOf("string")
+	require.NoError(t, err)
+	fields := []StructField{{Name: "value", Type: stringType}}
+	structType := StructType{Fields: fields}
+	parameters := []Parameter{{Name: "values", Type: ListType{Element: structType}}}
+
+	definition, err := NewDefinition(FunctionTypeUDTF, parameters, structType)
+	require.NoError(t, err)
+	parameters[0].Name = "mutated"
+	fields[0].Name = "mutated"
+
+	assert.Equal(t, "values", definition.Parameters[0].Name)
+	parameterType := definition.Parameters[0].Type.(ListType).Element.(StructType)
+	assert.Equal(t, "value", parameterType.Fields[0].Name)
+	assert.Equal(t, "value", definition.ReturnType.(StructType).Fields[0].Name)
+}
+
 func TestUnknownRepresentationRawReturnsCopy(t *testing.T) {
 	meta, err := ParseMetadataString(unknownRepresentationJSON)
 	require.NoError(t, err)

--- a/udf/types.go
+++ b/udf/types.go
@@ -215,6 +215,28 @@ func canonicalString(t Type) string {
 	return sb.String()
 }
 
+func cloneType(t Type) Type {
+	switch v := t.(type) {
+	case nil:
+		return nil
+	case PrimitiveType:
+		return v
+	case ListType:
+		return ListType{Element: cloneType(v.Element)}
+	case MapType:
+		return MapType{Key: cloneType(v.Key), Value: cloneType(v.Value)}
+	case StructType:
+		fields := make([]StructField, len(v.Fields))
+		for i, field := range v.Fields {
+			fields[i] = StructField{Name: field.Name, Type: cloneType(field.Type)}
+		}
+
+		return StructType{Fields: fields}
+	default:
+		return v
+	}
+}
+
 // validateType checks that t and all nested types are fully specified.
 // PrimitiveType values are valid by construction; composite types built as
 // literals may carry nil children, which this rejects.

--- a/udf/types.go
+++ b/udf/types.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -47,6 +48,7 @@ type Type interface {
 	// canonicalTo writes the canonical string form, sealing the
 	// interface to the implementations in this package.
 	canonicalTo(sb *strings.Builder)
+	clone() Type
 }
 
 // PrimitiveType is a primitive or semi-structured UDF type, stored as the
@@ -93,6 +95,7 @@ func (p PrimitiveType) Equals(other Type) bool {
 }
 
 func (p PrimitiveType) canonicalTo(sb *strings.Builder) { sb.WriteString(p.name) }
+func (p PrimitiveType) clone() Type                     { return p }
 
 func (p PrimitiveType) MarshalJSON() ([]byte, error) { return json.Marshal(p.name) }
 
@@ -114,6 +117,8 @@ func (l ListType) canonicalTo(sb *strings.Builder) {
 	l.Element.canonicalTo(sb)
 	sb.WriteString(">")
 }
+
+func (l ListType) clone() Type { return ListType{Element: cloneType(l.Element)} }
 
 func (l ListType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
@@ -142,6 +147,10 @@ func (m MapType) canonicalTo(sb *strings.Builder) {
 	sb.WriteString(",")
 	m.Value.canonicalTo(sb)
 	sb.WriteString(">")
+}
+
+func (m MapType) clone() Type {
+	return MapType{Key: cloneType(m.Key), Value: cloneType(m.Value)}
 }
 
 func (m MapType) MarshalJSON() ([]byte, error) {
@@ -193,6 +202,15 @@ func (s StructType) canonicalTo(sb *strings.Builder) {
 	sb.WriteString(">")
 }
 
+func (s StructType) clone() Type {
+	fields := slices.Clone(s.Fields)
+	for i := range fields {
+		fields[i].Type = cloneType(fields[i].Type)
+	}
+
+	return StructType{Fields: fields}
+}
+
 func (s StructType) MarshalJSON() ([]byte, error) {
 	fields := make([]struct {
 		Name string `json:"name"`
@@ -216,25 +234,11 @@ func canonicalString(t Type) string {
 }
 
 func cloneType(t Type) Type {
-	switch v := t.(type) {
-	case nil:
+	if t == nil {
 		return nil
-	case PrimitiveType:
-		return v
-	case ListType:
-		return ListType{Element: cloneType(v.Element)}
-	case MapType:
-		return MapType{Key: cloneType(v.Key), Value: cloneType(v.Value)}
-	case StructType:
-		fields := make([]StructField, len(v.Fields))
-		for i, field := range v.Fields {
-			fields[i] = StructField{Name: field.Name, Type: cloneType(field.Type)}
-		}
-
-		return StructType{Fields: fields}
-	default:
-		return v
 	}
+
+	return t.clone()
 }
 
 // validateType checks that t and all nested types are fully specified.

--- a/udf/types_test.go
+++ b/udf/types_test.go
@@ -237,6 +237,7 @@ type sealedFakeType struct{}
 func (sealedFakeType) String() string                  { return "fake" }
 func (sealedFakeType) Equals(Type) bool                { return false }
 func (sealedFakeType) canonicalTo(sb *strings.Builder) {}
+func (s sealedFakeType) clone() Type                   { return s }
 
 func TestValidateType(t *testing.T) {
 	intType := mustPrimitive(t, "int")

--- a/udf/udf.go
+++ b/udf/udf.go
@@ -36,7 +36,7 @@ type UDF struct {
 // location.
 func New(ident table.Identifier, meta Metadata, metadataLocation string) *UDF {
 	return &UDF{
-		identifier:       ident,
+		identifier:       slices.Clone(ident),
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 	}
@@ -52,7 +52,7 @@ func (u UDF) Equals(other UDF) bool {
 		u.metadata.Equals(other.metadata)
 }
 
-func (u UDF) Identifier() table.Identifier   { return u.identifier }
+func (u UDF) Identifier() table.Identifier   { return slices.Clone(u.identifier) }
 func (u UDF) Metadata() Metadata             { return u.metadata }
 func (u UDF) MetadataLocation() string       { return u.metadataLocation }
 func (u UDF) Definitions() []*Definition     { return u.metadata.Definitions() }

--- a/udf/udf_test.go
+++ b/udf/udf_test.go
@@ -31,8 +31,12 @@ func TestUDF(t *testing.T) {
 	location := "s3://bucket/functions/add_one/metadata/00001-x.metadata.json"
 
 	fn := New(ident, meta, location)
+	ident[0] = "mutated"
 
-	assert.Equal(t, ident, fn.Identifier())
+	assert.Equal(t, table.Identifier{"accounting", "add_one"}, fn.Identifier())
+	returnedIdent := fn.Identifier()
+	returnedIdent[0] = "mutated"
+	assert.Equal(t, table.Identifier{"accounting", "add_one"}, fn.Identifier())
 	assert.Equal(t, location, fn.MetadataLocation())
 	assert.True(t, meta.Equals(fn.Metadata()))
 	assert.Len(t, fn.Definitions(), 2)
@@ -45,10 +49,10 @@ func TestUDF(t *testing.T) {
 	differentIdent := New(table.Identifier{"accounting", "other"}, meta, location)
 	assert.False(t, fn.Equals(*differentIdent))
 
-	differentLocation := New(ident, meta, "s3://bucket/elsewhere")
+	differentLocation := New(table.Identifier{"accounting", "add_one"}, meta, "s3://bucket/elsewhere")
 	assert.False(t, fn.Equals(*differentLocation))
 
-	differentMetadata := New(ident, parseFixture(t, "udf-metadata-table.json"), location)
+	differentMetadata := New(table.Identifier{"accounting", "add_one"}, parseFixture(t, "udf-metadata-table.json"), location)
 	assert.False(t, fn.Equals(*differentMetadata))
 
 	require.NotNil(t, fn.Metadata())


### PR DESCRIPTION
## Motivation

UDF metadata is documented as immutable, but its getters expose internal maps, slices, pointers, nested type fields, and raw JSON buffers. Mutating a definition returned by `Definitions` or `DefinitionByID` can even leave the lazy definition index keyed by the old ID while the stored definition contains a new one.

Table metadata getters already return defensive copies following #1444. Applying the same boundary to UDF metadata keeps the metadata APIs consistent rather than leaving UDF values externally mutable.

The loaded UDF identifier has the same aliasing problem at construction and access.

## Changes

- Return defensive copies from definition, definition-log, property, and raw-representation getters.
- Deep-copy definition versions, nested UDF types, and unknown representation JSON.
- Make cloning part of the sealed type and representation contracts so new implementations must define copy behavior.
- Clone identifiers both when constructing a UDF and when returning its identifier.
- Document the copy guarantees on metadata getters and add mutation regression coverage.

## Testing

- `go test ./...`
- `golangci-lint run ./udf`