### PR TITLE
fix(partitions): retain dropped-source partition fields

### DIFF
--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -107,7 +107,7 @@ func (d *dataFile) MarshalAvroEntry(spec PartitionSpec, schema *Schema, version 
 		return nil, err
 	}
 	clone := cloneDataFileAvroFields(d)
-	partitionData, err := avroEncodePartitionData(d.Partition(), maps.nameToID, maps.idToType, maps.idToFixedSize)
+	partitionData, err := avroEncodePartitionData(d.Partition(), maps)
 	if err != nil {
 		return nil, err
 	}
@@ -209,13 +209,20 @@ func cloneDataFileAvroFields(src *dataFile) *dataFile {
 // iceberg-typed values like Date or Decimal) into the name-keyed
 // avro-friendly map the manifest-entry schema expects. Idempotent:
 // values already in primitive form pass through unchanged.
-func avroEncodePartitionData(idKeyed map[int]any, nameToID map[string]int, logicalTypes map[int]string, fixedSizes map[int]int) (map[string]any, error) {
-	converted, err := avroPartitionData(idKeyed, logicalTypes, fixedSizes)
+func avroEncodePartitionData(idKeyed map[int]any, fields dataFileFieldMaps) (map[string]any, error) {
+	converted, err := avroPartitionData(idKeyed, fields.idToType, fields.idToFixedSize)
 	if err != nil {
 		return nil, err
 	}
 	out := make(map[string]any, len(converted))
-	for name, id := range nameToID {
+	for name, id := range fields.nameToID {
+		if _, unknown := fields.unknownFieldIDs[id]; unknown {
+			// UnknownType has no value representation and is encoded as Avro
+			// null. Normalize historical values whose source type was dropped.
+			out[name] = nil
+
+			continue
+		}
 		if v, ok := converted[id]; ok {
 			out[name] = v
 		}
@@ -229,6 +236,7 @@ type dataFileFieldMaps struct {
 	idToType         map[int]string
 	idToFixedSize    map[int]int
 	idToDecimalScale map[int]int
+	unknownFieldIDs  map[int]struct{}
 }
 
 // dataFileSchemaCacheKey identifies a cached avro schema by the

--- a/data_file_codec_test.go
+++ b/data_file_codec_test.go
@@ -66,6 +66,33 @@ func TestManifestEntrySchemaForCachesByPartitionAvroFingerprint(t *testing.T) {
 		"identical (partition type, version) inputs must reuse the cached schema")
 }
 
+func TestDataFileCodecWithDroppedPartitionSource(t *testing.T) {
+	spec := NewPartitionSpec(
+		PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "dropped", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{2}, FieldID: 1001, Name: "bucketed", Transform: BucketTransform{NumBuckets: 8}},
+	)
+	schema := NewSchema(0)
+
+	builder, err := NewDataFileBuilder(
+		spec,
+		EntryContentData,
+		"s3://bucket/table/data.parquet",
+		ParquetFile,
+		map[int]any{1000: "historical-value", 1001: int32(3)},
+		nil,
+		nil,
+		1,
+		1024,
+	)
+	require.NoError(t, err)
+
+	encoded, err := builder.Build().(*dataFile).MarshalAvroEntry(spec, schema, 2)
+	require.NoError(t, err)
+	decoded, err := unmarshalAvroDataFileEntry(encoded, spec, schema, 2)
+	require.NoError(t, err)
+	require.Equal(t, map[int]any{1000: nil, 1001: int32(3)}, decoded.Partition())
+}
+
 // TestManifestEntrySchemaForDistinguishesSameSpecIDDifferentPartitionTypes
 // guards against the cache-key collision that would occur if the cache
 // were keyed only by spec.ID(). Two tables can both use

--- a/manifest.go
+++ b/manifest.go
@@ -1092,10 +1092,10 @@ func (p *unknownPartitionFieldStats) toSummary() FieldSummary {
 	return FieldSummary{ContainsNull: p.containsNull, ContainsNaN: &containsNaN}
 }
 
-func (p *unknownPartitionFieldStats) update(value any) error {
-	if value == nil {
-		p.containsNull = true
-	}
+func (p *unknownPartitionFieldStats) update(any) error {
+	// Dropped-source values are normalized to Avro null when the entry is
+	// encoded, even if an in-memory data file still carries a historical value.
+	p.containsNull = true
 
 	return nil
 }

--- a/manifest.go
+++ b/manifest.go
@@ -448,6 +448,7 @@ func getFieldIDMap(sc *avro.Schema) dataFileFieldMaps {
 	logicalTypes := make(map[int]string)
 	fixedSizes := make(map[int]int)
 	decimalScales := make(map[int]int)
+	unknownFieldIDs := make(map[int]struct{})
 
 	entryField := getField(root, "data_file")
 	partitionField := getField(entryField.Type, "partition")
@@ -468,6 +469,9 @@ func getFieldIDMap(sc *avro.Schema) dataFileFieldMaps {
 		if typ.Type == atype.Union {
 			typ = typ.Branches[len(typ.Branches)-1]
 		}
+		if typ.Type == atype.Null {
+			unknownFieldIDs[fid] = struct{}{}
+		}
 		if typ.LogicalType != "" {
 			logicalTypes[fid] = typ.LogicalType
 			if typ.LogicalType == atype.Decimal {
@@ -482,6 +486,7 @@ func getFieldIDMap(sc *avro.Schema) dataFileFieldMaps {
 		idToType:         logicalTypes,
 		idToFixedSize:    fixedSizes,
 		idToDecimalScale: decimalScales,
+		unknownFieldIDs:  unknownFieldIDs,
 	}
 }
 
@@ -1075,8 +1080,30 @@ type partitionFieldStats[T LiteralType] struct {
 	cmp Comparator[T]
 }
 
+// unknownPartitionFieldStats records null presence but omits bounds because
+// the dropped source type needed to encode and compare non-null values is lost.
+type unknownPartitionFieldStats struct {
+	containsNull bool
+}
+
+func (p *unknownPartitionFieldStats) toSummary() FieldSummary {
+	containsNaN := false
+
+	return FieldSummary{ContainsNull: p.containsNull, ContainsNaN: &containsNaN}
+}
+
+func (p *unknownPartitionFieldStats) update(value any) error {
+	if value == nil {
+		p.containsNull = true
+	}
+
+	return nil
+}
+
 func newPartitionFieldStat(typ PrimitiveType) (fieldStats, error) {
 	switch typ.(type) {
+	case UnknownType:
+		return &unknownPartitionFieldStats{}, nil
 	case BooleanType:
 		return &partitionFieldStats[bool]{cmp: getComparator[bool]()}, nil
 	case Int32Type:
@@ -1227,9 +1254,7 @@ type ManifestWriter struct {
 	schema  *Schema
 	content ManifestContent
 
-	partFieldNameToID map[string]int
-	partFieldIDToType map[int]string
-	partFieldIDToSize map[int]int
+	partFieldMaps dataFileFieldMaps
 
 	snapshotID    int64
 	addedFiles    int32
@@ -1279,18 +1304,16 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 	fieldMaps := getFieldIDMap(fileSchema)
 
 	w := &ManifestWriter{
-		impl:              impl,
-		version:           version,
-		output:            out,
-		spec:              spec,
-		content:           ManifestContentData,
-		schema:            schema,
-		partFieldNameToID: fieldMaps.nameToID,
-		partFieldIDToType: fieldMaps.idToType,
-		partFieldIDToSize: fieldMaps.idToFixedSize,
-		snapshotID:        snapshotID,
-		minSeqNum:         -1,
-		partitions:        make([]map[int]any, 0),
+		impl:          impl,
+		version:       version,
+		output:        out,
+		spec:          spec,
+		content:       ManifestContentData,
+		schema:        schema,
+		partFieldMaps: fieldMaps,
+		snapshotID:    snapshotID,
+		minSeqNum:     -1,
+		partitions:    make([]map[int]any, 0),
 	}
 
 	for _, apply := range opts {
@@ -1422,7 +1445,7 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	entryToEncode := *entry
 	if dataFile, ok := entry.DataFile().(*dataFile); ok {
 		encodeDataFile := cloneDataFileAvroFields(dataFile)
-		encodePartition, err := avroEncodePartitionData(partition, w.partFieldNameToID, w.partFieldIDToType, w.partFieldIDToSize)
+		encodePartition, err := avroEncodePartitionData(partition, w.partFieldMaps)
 		if err != nil {
 			return err
 		}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -480,6 +480,27 @@ var (
 	)
 )
 
+func TestConstructPartitionSummariesWithDroppedSource(t *testing.T) {
+	spec := NewPartitionSpec(PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "dropped", Transform: IdentityTransform{},
+	})
+	schema := NewSchema(0)
+
+	summaries, err := constructPartitionSummaries(spec, schema, []map[int]any{{1000: nil}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected one partition summary, got %d", len(summaries))
+	}
+	if !summaries[0].ContainsNull {
+		t.Fatal("expected the unknown partition field summary to contain null")
+	}
+	if summaries[0].LowerBound != nil || summaries[0].UpperBound != nil {
+		t.Fatal("expected the unknown partition field summary to omit bounds")
+	}
+}
+
 type ManifestTestSuite struct {
 	suite.Suite
 
@@ -2243,9 +2264,11 @@ func TestAvroEncodePartitionDataUsesDeclaredDecimalFixedSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converted, err := avroEncodePartitionData(
 				map[int]any{decimalFieldID: tt.value},
-				map[string]int{"price": decimalFieldID},
-				map[int]string{decimalFieldID: atype.Decimal},
-				map[int]int{decimalFieldID: internal.DecimalRequiredBytes(tt.precision)},
+				dataFileFieldMaps{
+					nameToID:      map[string]int{"price": decimalFieldID},
+					idToType:      map[int]string{decimalFieldID: atype.Decimal},
+					idToFixedSize: map[int]int{decimalFieldID: internal.DecimalRequiredBytes(tt.precision)},
+				},
 			)
 			if tt.wantErr {
 				if err == nil {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -486,7 +486,7 @@ func TestConstructPartitionSummariesWithDroppedSource(t *testing.T) {
 	})
 	schema := NewSchema(0)
 
-	summaries, err := constructPartitionSummaries(spec, schema, []map[int]any{{1000: nil}})
+	summaries, err := constructPartitionSummaries(spec, schema, []map[int]any{{1000: "historical-value"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -506,20 +506,20 @@ func (ps *PartitionSpec) LastAssignedFieldID() int {
 	return id
 }
 
-type activePartitionField struct {
+type resolvedPartitionField struct {
 	field      PartitionField
 	resultType Type
 }
 
-func (ps *PartitionSpec) activePartitionFields(schema *Schema) []activePartitionField {
-	fields := make([]activePartitionField, 0, len(ps.fields))
+func (ps *PartitionSpec) resolvedPartitionFields(schema *Schema) []resolvedPartitionField {
+	fields := make([]resolvedPartitionField, 0, len(ps.fields))
 	for _, field := range ps.fields {
-		sourceType, ok := schema.FindTypeByID(field.SourceID())
-		if !ok {
-			continue
+		sourceType := Type(UnknownType{})
+		if typ, ok := schema.FindTypeByID(field.SourceID()); ok {
+			sourceType = typ
 		}
 
-		fields = append(fields, activePartitionField{
+		fields = append(fields, resolvedPartitionField{
 			field:      field,
 			resultType: field.Transform.ResultType(sourceType),
 		})
@@ -537,21 +537,16 @@ func (ps *PartitionSpec) activePartitionFields(schema *Schema) []activePartition
 //     have the result field and it may be null.
 //
 // There is a case where we can guarantee that a partition field in the first
-// and only parittion spec that uses a required source column will never be
+// and only partition spec that uses a required source column will never be
 // null, but it doesn't seem worth tracking this case.
 //
-// Note: the result is compacted. A partition field whose source column is not
-// present in schema (for example, the column was dropped) is omitted rather
-// than retained, so the returned struct does NOT positionally correspond to a
-// manifest's partition FieldSummary list, which is ordered by the full
-// partition spec. It must therefore not be used to index positional partition
-// summaries; build a schema that keeps every spec field (with an UnknownType
-// placeholder for dropped sources) for that purpose — see manifestPartitionFields
-// in the table package.
+// If a source column is missing, UnknownType is passed to the transform. This
+// retains the field's position and lets transforms with fixed result types,
+// such as bucket, continue to resolve their result type.
 func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
-	activeFields := ps.activePartitionFields(schema)
-	nestedFields := make([]NestedField, 0, len(activeFields))
-	for _, field := range activeFields {
+	resolvedFields := ps.resolvedPartitionFields(schema)
+	nestedFields := make([]NestedField, 0, len(resolvedFields))
+	for _, field := range resolvedFields {
 		nestedFields = append(nestedFields, NestedField{
 			ID:       field.field.FieldID,
 			Name:     field.field.Name,
@@ -571,9 +566,9 @@ func (ps *PartitionSpec) PartitionType(schema *Schema) *StructType {
 // This does not apply the transforms to the data, it is assumed the provided data
 // has already been transformed appropriately.
 func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
-	activeFields := ps.activePartitionFields(sc)
+	resolvedFields := ps.resolvedPartitionFields(sc)
 
-	if len(activeFields) == 0 {
+	if len(resolvedFields) == 0 {
 		return ""
 	}
 
@@ -581,22 +576,22 @@ func (ps *PartitionSpec) PartitionToPath(data StructLike, sc *Schema) string {
 	// Estimate capacity: escaped_name + "=" + escaped_value + "/" per field
 	var sb strings.Builder
 	estimatedSize := 0
-	for i := range activeFields {
-		estimatedSize += len(activeFields[i].field.EscapedName()) + 20 // name + "=" + avg value + "/"
+	for i := range resolvedFields {
+		estimatedSize += len(resolvedFields[i].field.EscapedName()) + 20 // name + "=" + avg value + "/"
 	}
 	sb.Grow(estimatedSize)
 
-	for i := range activeFields {
+	for i := range resolvedFields {
 		if i > 0 {
 			sb.WriteByte('/')
 		}
 
 		// Use pre-escaped field name (now guaranteed to be initialized)
-		sb.WriteString(activeFields[i].field.EscapedName())
+		sb.WriteString(resolvedFields[i].field.EscapedName())
 		sb.WriteByte('=')
 
 		// Only escape the value (which changes per row)
-		valueStr := activeFields[i].field.Transform.ToHumanStrType(activeFields[i].resultType, data.Get(i))
+		valueStr := resolvedFields[i].field.Transform.ToHumanStrType(resolvedFields[i].resultType, data.Get(i))
 		sb.WriteString(url.QueryEscape(valueStr))
 	}
 

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -291,6 +291,21 @@ func TestPartitionType(t *testing.T) {
 	}
 	actual := spec.PartitionType(tableSchemaSimple)
 	assert.Truef(t, expected.Equals(actual), "expected: %s, got: %s", expected, actual)
+
+	droppedSourceSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 2, Name: "int", Type: iceberg.PrimitiveTypes.Int32},
+	)
+	expectedWithDroppedSources := &iceberg.StructType{
+		FieldList: []iceberg.NestedField{
+			{ID: 1000, Name: "str_truncate", Type: iceberg.UnknownType{}},
+			{ID: 1001, Name: "int_bucket", Type: iceberg.PrimitiveTypes.Int32},
+			{ID: 1002, Name: "bool_identity", Type: iceberg.UnknownType{}},
+			{ID: 1003, Name: "str_void", Type: iceberg.UnknownType{}},
+		},
+	}
+	actual = spec.PartitionType(droppedSourceSchema)
+	assert.Truef(t, expectedWithDroppedSources.Equals(actual),
+		"expected: %s, got: %s", expectedWithDroppedSources, actual)
 }
 
 type partitionRecord []any
@@ -348,8 +363,8 @@ func TestPartitionSpecToPathWithDroppedLeadingSourceColumn(t *testing.T) {
 		},
 	)
 
-	record := partitionRecord{int32(7), true}
-	assert.Equal(t, "bar=7/baz=true", spec.PartitionToPath(record, schema))
+	record := partitionRecord{nil, int32(7), true}
+	assert.Equal(t, "foo=null/bar=7/baz=true", spec.PartitionToPath(record, schema))
 }
 
 func TestGetPartitionFieldName(t *testing.T) {

--- a/schema_conversions.go
+++ b/schema_conversions.go
@@ -58,6 +58,8 @@ func partitionTypeToAvroSchema(t *StructType) (*avro.Schema, error) {
 			node = internal.NullableNode(internal.FixedNode(typ.Len()))
 		case DecimalType:
 			node = internal.NullableNode(internal.DecimalNode(typ.precision, typ.scale))
+		case UnknownType:
+			node = internal.NullNode
 		default:
 			return nil, fmt.Errorf("unsupported partition type: %s", f.Type.String())
 		}

--- a/schema_conversions_test.go
+++ b/schema_conversions_test.go
@@ -158,6 +158,23 @@ func TestPartitionTypeToAvroSchemaNullableAndNonNullable(t *testing.T) {
 	})
 }
 
+func TestPartitionTypeToAvroSchemaUnknownType(t *testing.T) {
+	partitionType := &StructType{FieldList: []NestedField{
+		{ID: 1, Name: "dropped", Type: UnknownType{}, Required: false},
+	}}
+
+	schema, err := partitionTypeToAvroSchema(partitionType)
+	require.NoError(t, err)
+
+	encoded, err := schema.Encode(map[string]any{"dropped": nil})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	_, err = schema.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Nil(t, decoded["dropped"])
+}
+
 // TestPartitionTypeToAvroSchemaDuplicateNamedTypes verifies that a
 // partition spec containing multiple fields of the same named Avro type
 // (UUID, Fixed, Decimal) compiles without "duplicate named type" errors.

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -39,7 +39,8 @@ const (
 // manifest file has rows that might or might not match a given partition filter by using
 // the stats provided in the partitions (UpperBound/LowerBound/ContainsNull/ContainsNaN).
 func newManifestEvaluator(spec iceberg.PartitionSpec, schema *iceberg.Schema, partitionFilter iceberg.BooleanExpression, caseSensitive bool) (func(iceberg.ManifestFile) (bool, error), error) {
-	partSchema := iceberg.NewSchema(0, manifestPartitionFields(spec, schema)...)
+	partType := spec.PartitionType(schema)
+	partSchema := iceberg.NewSchema(0, partType.FieldList...)
 	filter, err := iceberg.RewriteNotExpr(partitionFilter)
 	if err != nil {
 		return nil, err
@@ -51,30 +52,6 @@ func newManifestEvaluator(spec iceberg.PartitionSpec, schema *iceberg.Schema, pa
 	}
 
 	return (&manifestEvalVisitor{partitionFilter: boundFilter}).Eval, nil
-}
-
-// manifestPartitionFields builds the partition-struct fields for evaluating
-// manifest FieldSummary lists. Summaries are positional per the spec's full
-// field list, so unlike PartitionSpec.PartitionType (which compacts fields
-// whose source column is missing from the schema), every spec field must be
-// kept. A dropped-source field becomes an Unknown-typed placeholder that no
-// projected predicate can reference, preserving positions of later fields.
-func manifestPartitionFields(spec iceberg.PartitionSpec, schema *iceberg.Schema) []iceberg.NestedField {
-	fields := make([]iceberg.NestedField, 0, spec.NumFields())
-	for _, field := range spec.Fields() {
-		typ := iceberg.Type(iceberg.UnknownType{})
-		if sourceType, ok := schema.FindTypeByID(field.SourceID()); ok {
-			typ = field.Transform.ResultType(sourceType)
-		}
-		fields = append(fields, iceberg.NestedField{
-			ID:       field.FieldID,
-			Name:     field.Name,
-			Type:     typ,
-			Required: false,
-		})
-	}
-
-	return fields
 }
 
 type manifestEvalVisitor struct {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -251,9 +251,10 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 		if !ok {
 			return nil, fmt.Errorf("failed to find partition field ID %d in spec", partitionField.ID)
 		}
+		partitionFieldsInfo[i].fieldID = partitionField.ID
 		colName, ok := schema.FindColumnName(sourceField.SourceID())
 		if !ok {
-			return nil, fmt.Errorf("failed to find source field ID %d in schema", sourceField.SourceID())
+			continue
 		}
 		colIndices := record.Schema().FieldIndices(colName)
 		if len(colIndices) == 0 {
@@ -274,7 +275,7 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 	for row := range record.NumRows() {
 		for i := range partitionFields {
 			col := partitionColumns[i]
-			if !col.IsNull(int(row)) {
+			if col != nil && !col.IsNull(int(row)) {
 				fieldInfo := partitionFieldsInfo[i]
 				sourceField := fieldInfo.sourceField
 				val, err := getArrowValueAsIcebergLiteral(col, int(row), fieldInfo.sourceType)

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -610,9 +610,10 @@ func (s *FanoutWriterTestSuite) TestGetRecordPartitionsWithDroppedLeadingSourceC
 	partitions, err := getRecordPartitions(spec, icebergSchema, testRecord)
 	s.Require().NoError(err)
 	s.Require().Len(partitions, 1)
-	s.Equal(int32(7), partitions[0].partitionRec.Get(0))
-	s.Equal(true, partitions[0].partitionRec.Get(1))
-	s.Equal("bar=7/baz=true", spec.PartitionToPath(partitions[0].partitionRec, icebergSchema))
+	s.Nil(partitions[0].partitionRec.Get(0))
+	s.Equal(int32(7), partitions[0].partitionRec.Get(1))
+	s.Equal(true, partitions[0].partitionRec.Get(2))
+	s.Equal("foo=null/bar=7/baz=true", spec.PartitionToPath(partitions[0].partitionRec, icebergSchema))
 }
 
 func (s *FanoutWriterTestSuite) TestVoidTransform() {


### PR DESCRIPTION
## Problem

`PartitionSpec.PartitionType(schema)` compacted away fields whose source columns were no longer present. Manifest partition summaries are positional against the complete partition spec, so the compacted type was unsafe for positional consumers.

#1191 fixed the active manifest-pruning bug with a separate `manifestPartitionFields` implementation. That left two definitions of a partition type and made the same positional bug easy to reintroduce elsewhere.

## Fix

Make `PartitionType` retain every spec field in order and use it as the single source of truth.

When a source column is missing, `UnknownType` is passed to the transform:

- source-dependent transforms such as identity, truncate, and void resolve to `UnknownType`
- fixed-result transforms such as bucket and time transforms retain their known result type

This matches [current Java Iceberg behavior](https://github.com/apache/iceberg/blob/470f4642bdda336bac5372c79c762a2654dfe3f3/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L188-L200), which is slightly more precise than degrading every dropped-source transform to unknown.

The supporting audit also:

- removes `manifestPartitionFields` and uses `PartitionType` for manifest evaluation
- maps unknown partition fields to Avro `null`
- detects unknown field IDs from the generated entry schema and normalizes stale historical values to null during encoding
- records null presence without inventing lower or upper bounds for unknown fields
- preserves full field positions in partition paths and fanout records

## Safety

Projected filters cannot reference a dropped source ID, so unknown placeholders remain unreferenced during expression binding.

A rewritten historical entry may still carry the old non-null partition value. Its source type is no longer available, so that value cannot be encoded or compared safely. Normalizing only schema-identified unknown fields to null keeps the entry writable and positionally correct; fixed-result fields continue to encode with their known types.

## Tests

Coverage includes:

- source-dependent and fixed-result type resolution
- positional manifest pruning with dropped fields
- Avro schema conversion
- data-file codec round-trip from a stale non-null value to null
- manifest summary construction
- partition paths and fanout partition records

Validation:

- `go test -count=1 ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout=10m`

Fixes #1205