### PR TITLE
fix(transforms): bucket timestamp nanos at microsecond precision

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -291,6 +291,12 @@ func hashHelperInt[T ~int32 | ~int64](v any) uint32 {
 	return murmur3.Sum32(b)
 }
 
+func hashTimestampNano(v any) uint32 {
+	micros := internal.FloorDiv(int64(v.(TimestampNano)), int64(time.Microsecond))
+
+	return hashHelperInt[int64](micros)
+}
+
 func (t BucketTransform) Equals(other Transform) bool {
 	rhs, ok := other.(BucketTransform)
 	if !ok {
@@ -330,7 +336,7 @@ func (t BucketTransform) Apply(value Optional[Literal]) Optional[Literal] {
 	case TimestampLiteral:
 		hash = hashHelperInt[int64](int64(v))
 	case TimestampNsLiteral:
-		hash = hashHelperInt[int64](int64(v))
+		hash = hashTimestampNano(TimestampNano(v))
 	default:
 		return Optional[Literal]{}
 	}
@@ -364,7 +370,7 @@ func (t BucketTransform) Transformer(src Type) func(any) Optional[int32] {
 	case TimestampTzType:
 		h = hashHelperInt[Timestamp]
 	case TimestampNsType, TimestampTzNsType:
-		h = hashHelperInt[TimestampNano]
+		h = hashTimestampNano
 	case DecimalType:
 		h = func(v any) uint32 {
 			b, _ := DecimalLiteral(v.(Decimal)).MarshalBinary()

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -624,12 +624,23 @@ func TestYearMonthTransformNanoseconds(t *testing.T) {
 
 func TestBucketTransformTimestampNanoseconds(t *testing.T) {
 	transform := iceberg.BucketTransform{NumBuckets: 16}
+	specBucket := int32(6)
 	values := []struct {
-		name string
-		ts   iceberg.TimestampNano
+		name       string
+		nanos      iceberg.TimestampNano
+		micros     iceberg.Timestamp
+		wantBucket *int32
 	}{
-		{name: "post-epoch", ts: iceberg.TimestampNano(123456789)},
-		{name: "pre-epoch", ts: iceberg.TimestampNano(-1)},
+		{name: "post-epoch", nanos: iceberg.TimestampNano(123456789), micros: iceberg.Timestamp(123456)},
+		{name: "sub-microsecond", nanos: iceberg.TimestampNano(1), micros: iceberg.Timestamp(0)},
+		{name: "pre-epoch", nanos: iceberg.TimestampNano(-1), micros: iceberg.Timestamp(-1)},
+		{name: "negative microsecond boundary", nanos: iceberg.TimestampNano(-1000), micros: iceberg.Timestamp(-1)},
+		{
+			name:       "spec appendix B",
+			nanos:      iceberg.TimestampNano(time.Date(2017, 11, 16, 22, 31, 8, 1_001, time.UTC).UnixNano()),
+			micros:     iceberg.Timestamp(time.Date(2017, 11, 16, 22, 31, 8, 1_001, time.UTC).UnixMicro()),
+			wantBucket: &specBucket,
+		},
 	}
 
 	for _, srcType := range []iceberg.Type{
@@ -644,13 +655,22 @@ func TestBucketTransformTimestampNanoseconds(t *testing.T) {
 				t.Run(tt.name, func(t *testing.T) {
 					applied := transform.Apply(iceberg.Optional[iceberg.Literal]{
 						Valid: true,
-						Val:   iceberg.NewLiteral(tt.ts),
+						Val:   iceberg.NewLiteral(tt.nanos),
 					})
 					require.True(t, applied.Valid)
+					expected := transform.Apply(iceberg.Optional[iceberg.Literal]{
+						Valid: true,
+						Val:   iceberg.NewLiteral(tt.micros),
+					})
+					require.True(t, expected.Valid)
+					assert.Equal(t, expected.Val, applied.Val)
+					if tt.wantBucket != nil {
+						assert.Equal(t, iceberg.Int32Literal(*tt.wantBucket), applied.Val)
+					}
 
 					var transformed iceberg.Optional[int32]
 					require.NotPanics(t, func() {
-						transformed = fn(tt.ts)
+						transformed = fn(tt.nanos)
 					})
 					require.True(t, transformed.Valid)
 					assert.Equal(t, applied.Val, iceberg.NewLiteral(transformed.Val))
@@ -660,7 +680,7 @@ func TestBucketTransformTimestampNanoseconds(t *testing.T) {
 						Name: "ts",
 						Type: srcType,
 					})
-					bound, err := iceberg.EqualTo(iceberg.Reference("ts"), tt.ts).Bind(schema, true)
+					bound, err := iceberg.EqualTo(iceberg.Reference("ts"), tt.nanos).Bind(schema, true)
 					require.NoError(t, err)
 
 					projected, err := transform.Project("ts_bucket", bound.(iceberg.BoundPredicate))


### PR DESCRIPTION
## Problem

Iceberg bucket transforms hash timestamps as their microsecond integer representation. `timestamp_ns` and `timestamptz_ns` were instead hashing the raw nanosecond value, so the same instant could land in a different bucket depending on its timestamp precision.

That breaks partition compatibility with other Iceberg implementations and can make equality projection prune the wrong files.

## Fix

Convert nanoseconds to microseconds before Murmur3 hashing, and use the same helper from both `Apply` and `Transformer`. Predicate projection delegates to those paths, so all three entry points now agree.

The conversion uses floor division. This matters before the Unix epoch: `-1ns` belongs to microsecond `-1`, while ordinary Go integer division would truncate it to `0`.

This follows the [Iceberg Appendix B hash requirements](https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements) and mirrors [Java Iceberg’s timestamp-nano bucket implementation](https://github.com/apache/iceberg/blob/470f4642bdda336bac5372c79c762a2654dfe3f3/api/src/main/java/org/apache/iceberg/transforms/Bucket.java#L235-L247).

## Tests

Coverage verifies:

- `timestamp_ns` and `timestamptz_ns`
- `Apply`, `Transformer`, and equality projection
- positive and sub-microsecond values
- pre-epoch values and the negative microsecond boundary
- the Appendix B example that must produce bucket `6` for 16 buckets

Validation:

- `go test -count=1 ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout=10m`

Fixes #1498