### PR TITLE
fix(transforms): avoid hour string overflow

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -1097,7 +1097,8 @@ func (HourTransform) Apply(value Optional[Literal]) (out Optional[Literal]) {
 func (HourTransform) ToHumanStr(val any) string {
 	switch v := val.(type) {
 	case int32:
-		tm := epochTM.Add(time.Duration(v) * time.Hour)
+		seconds := int64(v) * int64(time.Hour/time.Second)
+		tm := time.Unix(seconds, 0).UTC()
 
 		return tm.Format("2006-01-02-15")
 	default:

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -122,6 +122,8 @@ func TestToHumanString(t *testing.T) {
 		{iceberg.DayTransform{}, nil, "null"},
 		{iceberg.HourTransform{}, nil, "null"},
 		{iceberg.HourTransform{}, int32(420042), "2017-12-01-18"},
+		{iceberg.HourTransform{}, int32(4645896), "2500-01-01-00"},
+		{iceberg.HourTransform{}, int32(-4119936), "1500-01-01-00"},
 		{iceberg.YearTransform{}, int32(-1), "1969"},
 		{iceberg.MonthTransform{}, int32(-1), "1969-12"},
 		{iceberg.DayTransform{}, int32(-1), "1969-12-31"},


### PR DESCRIPTION
## Summary

- convert hour ordinals through Unix seconds instead of time.Duration
- avoid duration overflow for valid dates outside roughly 1677 to 2262
- cover years before and after that range

This preserves the direct epoch-hour behavior used by the Java implementation.

## Testing

- go test . -count=1
- all repository packages except io/gocloud