### PR TITLE
fix(table): reject invalid schema entries

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2054,11 +2054,23 @@ func (c *commonMetadata) preValidate() {
 }
 
 func (c *commonMetadata) checkSchemas() error {
-	// check that current-schema-id is present in schemas
-	for _, s := range c.SchemaList {
-		if s.ID == c.CurrentSchemaID {
-			return nil
+	seen := make(map[int]struct{}, len(c.SchemaList))
+	currentFound := false
+	for i, s := range c.SchemaList {
+		if s == nil {
+			return fmt.Errorf("%w: schema at index %d is null", ErrInvalidMetadata, i)
 		}
+		if _, ok := seen[s.ID]; ok {
+			return fmt.Errorf("%w: duplicate schema ID %d", ErrInvalidMetadata, s.ID)
+		}
+		seen[s.ID] = struct{}{}
+
+		if s.ID == c.CurrentSchemaID {
+			currentFound = true
+		}
+	}
+	if currentFound {
+		return nil
 	}
 
 	return fmt.Errorf("%w: current-schema-id %d can't be found in any schema",

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"slices"
@@ -531,6 +532,36 @@ func TestCurrentSchemaNotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidMetadata)
 	assert.ErrorContains(t, err, "current-schema-id 2 can't be found in any schema")
+}
+
+func TestRejectInvalidSchemaEntries(t *testing.T) {
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &metadata))
+
+	t.Run("null schema", func(t *testing.T) {
+		invalid := maps.Clone(metadata)
+		invalid["schemas"] = []any{nil}
+		data, err := json.Marshal(invalid)
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() {
+			_, err = ParseMetadataBytes(data)
+		})
+		require.ErrorIs(t, err, ErrInvalidMetadata)
+		assert.ErrorContains(t, err, "schema at index 0 is null")
+	})
+
+	t.Run("duplicate schema ID", func(t *testing.T) {
+		invalid := maps.Clone(metadata)
+		schemas := invalid["schemas"].([]any)
+		invalid["schemas"] = append(slices.Clone(schemas), schemas[0])
+		data, err := json.Marshal(invalid)
+		require.NoError(t, err)
+
+		_, err = ParseMetadataBytes(data)
+		require.ErrorIs(t, err, ErrInvalidMetadata)
+		assert.ErrorContains(t, err, "duplicate schema ID 0")
+	})
 }
 
 func TestSortOrderNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject null entries in the table metadata schemas list
- reject duplicate schema IDs, including duplicates after the current schema
- return ErrInvalidMetadata instead of allowing a nil dereference

This matches the non-null, unique schema indexing used by the Java implementation.

## Testing

- go test ./table -count=1
- all repository packages except io/gocloud