### PR TITLE
fix(puffin): return defensive metadata copies

### DIFF
--- a/puffin/puffin_reader.go
+++ b/puffin/puffin_reader.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sort"
 )
 
@@ -123,12 +125,32 @@ func NewReader(r ReaderAtSeeker, opts ...ReaderOption) (*Reader, error) {
 
 // Blobs returns the blob metadata entries from the footer.
 func (r *Reader) Blobs() []BlobMetadata {
-	return r.footer.Blobs
+	return cloneBlobMetadataList(r.footer.Blobs)
 }
 
 // Properties returns the file-level properties from the footer.
 func (r *Reader) Properties() map[string]string {
-	return r.footer.Properties
+	return maps.Clone(r.footer.Properties)
+}
+
+func cloneBlobMetadataList(blobs []BlobMetadata) []BlobMetadata {
+	cloned := make([]BlobMetadata, len(blobs))
+	for i, blob := range blobs {
+		cloned[i] = cloneBlobMetadata(blob)
+	}
+
+	return cloned
+}
+
+func cloneBlobMetadata(blob BlobMetadata) BlobMetadata {
+	blob.Fields = slices.Clone(blob.Fields)
+	blob.Properties = maps.Clone(blob.Properties)
+	if blob.CompressionCodec != nil {
+		codec := *blob.CompressionCodec
+		blob.CompressionCodec = &codec
+	}
+
+	return blob
 }
 
 // defaultFooterReadSize is the initial read size when reading the footer.
@@ -233,7 +255,7 @@ func (r *Reader) ReadBlob(index int) (*BlobData, error) {
 		return nil, err
 	}
 
-	return &BlobData{Metadata: meta, Data: data}, nil
+	return &BlobData{Metadata: cloneBlobMetadata(meta), Data: data}, nil
 }
 
 // ReadBlobByMetadata reads a blob using its metadata directly.
@@ -298,7 +320,7 @@ func (r *Reader) ReadAllBlobs() ([]*BlobData, error) {
 		if err != nil {
 			return nil, fmt.Errorf("puffin: read blob %d: %w", ib.index, err)
 		}
-		results[ib.index] = &BlobData{Metadata: ib.meta, Data: data}
+		results[ib.index] = &BlobData{Metadata: cloneBlobMetadata(ib.meta), Data: data}
 	}
 
 	return results, nil

--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -158,6 +158,41 @@ func TestAddBlobCopiesMetadataInputs(t *testing.T) {
 	assert.Equal(t, map[string]string{"ndv": "10"}, blobs[0].Properties)
 }
 
+func TestReaderReturnsMetadataCopies(t *testing.T) {
+	w, buf := newWriter()
+	require.NoError(t, w.AddProperties(map[string]string{"file": "original"}))
+	_, err := w.AddBlob(puffin.BlobMetadataInput{
+		Type:       puffin.BlobTypeDataSketchesTheta,
+		Fields:     []int32{1},
+		Properties: map[string]string{"blob": "original"},
+	}, []byte("sketch"))
+	require.NoError(t, err)
+	require.NoError(t, w.Finish())
+
+	r := newReader(t, buf)
+	blobs := r.Blobs()
+	blobs[0].Type = puffin.BlobTypeDeletionVector
+	blobs[0].Fields[0] = 2
+	blobs[0].Properties["blob"] = "changed"
+	r.Properties()["file"] = "changed"
+
+	blob, err := r.ReadBlob(0)
+	require.NoError(t, err)
+	blob.Metadata.Fields[0] = 3
+	blob.Metadata.Properties["blob"] = "changed again"
+
+	all, err := r.ReadAllBlobs()
+	require.NoError(t, err)
+	all[0].Metadata.Fields[0] = 4
+	all[0].Metadata.Properties["blob"] = "changed again"
+
+	actual := r.Blobs()[0]
+	assert.Equal(t, puffin.BlobTypeDataSketchesTheta, actual.Type)
+	assert.Equal(t, []int32{1}, actual.Fields)
+	assert.Equal(t, "original", actual.Properties["blob"])
+	assert.Equal(t, "original", r.Properties()["file"])
+}
+
 // TestEmptyFile verifies that a puffin file with no blobs is valid.
 // Empty files are valid per spec and used when no statistics exist yet.
 func TestEmptyFile(t *testing.T) {


### PR DESCRIPTION
## Summary

- return independent blob and file property metadata from Reader
- deep-copy nested fields, properties, and compression codec pointers
- protect cached footer metadata through ReadBlob and ReadAllBlobs results

This matches the immutable metadata exposure in the Java implementation and the borrowed immutable accessors in Rust.

## Testing

- go test ./puffin -count=1
- all repository packages except io/gocloud