### PR TITLE
fix(literals): reject timestamp nanos overflow

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -824,9 +824,11 @@ func (t TimestampLiteral) To(typ Type) (Literal, error) {
 		return t, nil
 	case TimestampTzType:
 		return t, nil
-	case TimestampNsType:
-		return TimestampNsLiteral(Timestamp(t).ToNanos()), nil
-	case TimestampTzNsType:
+	case TimestampNsType, TimestampTzNsType:
+		if t > math.MaxInt64/1000 || t < math.MinInt64/1000 {
+			return nil, fmt.Errorf("%w: timestamp %d is outside the nanosecond range", ErrBadCast, t)
+		}
+
 		return TimestampNsLiteral(Timestamp(t).ToNanos()), nil
 	case DateType:
 		return DateLiteral(Timestamp(t).ToDate()), nil

--- a/literals_test.go
+++ b/literals_test.go
@@ -235,6 +235,35 @@ func TestTimestampNanoLiteralConversions(t *testing.T) {
 	}
 }
 
+func TestTimestampLiteralToNanosRejectsOverflow(t *testing.T) {
+	targets := []iceberg.Type{
+		iceberg.PrimitiveTypes.TimestampNs,
+		iceberg.PrimitiveTypes.TimestampTzNs,
+	}
+
+	for _, target := range targets {
+		t.Run(target.String(), func(t *testing.T) {
+			for _, value := range []iceberg.TimestampLiteral{
+				iceberg.TimestampLiteral(math.MaxInt64/1000 + 1),
+				iceberg.TimestampLiteral(math.MinInt64/1000 - 1),
+			} {
+				actual, err := value.To(target)
+				assert.Nil(t, actual)
+				assert.ErrorIs(t, err, iceberg.ErrBadCast)
+			}
+
+			for _, value := range []iceberg.TimestampLiteral{
+				iceberg.TimestampLiteral(math.MaxInt64 / 1000),
+				iceberg.TimestampLiteral(math.MinInt64 / 1000),
+			} {
+				actual, err := value.To(target)
+				require.NoError(t, err)
+				assert.Equal(t, iceberg.TimestampNsLiteral(value*1000), actual)
+			}
+		})
+	}
+}
+
 func TestInt64Conversions(t *testing.T) {
 	tests := []struct {
 		from iceberg.Int64Literal


### PR DESCRIPTION
## Summary

- check microsecond timestamp bounds before converting to nanoseconds
- return ErrBadCast instead of silently wrapping int64 values
- cover both timestamp_ns variants and both overflow directions

This follows the checked multiplication used by the Java implementation.

## Testing

- go test . -count=1
- all repository packages except io/gocloud