### PR TITLE
fix(table): return defensive sort field copies

### DIFF
--- a/table/sorting.go
+++ b/table/sorting.go
@@ -341,6 +341,18 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 
 func cloneSortField(field SortField) SortField {
 	field.SourceIDs = slices.Clone(field.SourceIDs)
+	switch transform := field.Transform.(type) {
+	case *iceberg.BucketTransform:
+		if transform != nil {
+			cloned := *transform
+			field.Transform = &cloned
+		}
+	case *iceberg.TruncateTransform:
+		if transform != nil {
+			cloned := *transform
+			field.Transform = &cloned
+		}
+	}
 
 	return field
 }

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -235,7 +235,13 @@ func (s SortOrder) OrderID() int {
 }
 
 func (s SortOrder) Fields() iter.Seq2[int, SortField] {
-	return slices.All(s.fields)
+	return func(yield func(int, SortField) bool) {
+		for i, field := range s.fields {
+			if !yield(i, cloneSortField(field)) {
+				return
+			}
+		}
+	}
 }
 
 func (s SortOrder) Len() int {
@@ -325,7 +331,18 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 		}
 	}
 
-	return SortOrder{orderID, fields}, nil
+	fieldCopies := make([]SortField, len(fields))
+	for i, field := range fields {
+		fieldCopies[i] = cloneSortField(field)
+	}
+
+	return SortOrder{orderID, fieldCopies}, nil
+}
+
+func cloneSortField(field SortField) SortField {
+	field.SourceIDs = slices.Clone(field.SourceIDs)
+
+	return field
 }
 
 func (s SortOrder) IsUnsorted() bool {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -134,9 +134,10 @@ func TestNewSortOrderAcceptsValidTransform(t *testing.T) {
 
 func TestSortOrderReturnsDefensiveCopies(t *testing.T) {
 	sourceIDs := []int{19, 20}
+	transform := &iceberg.BucketTransform{NumBuckets: 16}
 	fields := []table.SortField{{
 		SourceIDs: sourceIDs,
-		Transform: iceberg.IdentityTransform{},
+		Transform: transform,
 		NullOrder: table.NullsFirst,
 		Direction: table.SortASC,
 	}}
@@ -144,14 +145,17 @@ func TestSortOrderReturnsDefensiveCopies(t *testing.T) {
 	require.NoError(t, err)
 
 	sourceIDs[0] = 99
+	transform.NumBuckets = 32
 	fields[0].Direction = table.SortDESC
 	for _, field := range sortOrder.Fields() {
 		field.SourceIDs[0] = 98
+		field.Transform.(*iceberg.BucketTransform).NumBuckets = 64
 	}
 
 	seen := 0
 	for _, field := range sortOrder.Fields() {
 		assert.Equal(t, []int{19, 20}, field.SourceIDs)
+		assert.Equal(t, 16, field.Transform.(*iceberg.BucketTransform).NumBuckets)
 		assert.Equal(t, table.SortASC, field.Direction)
 		seen++
 	}

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -132,6 +132,32 @@ func TestNewSortOrderAcceptsValidTransform(t *testing.T) {
 	assert.Equal(t, 1, sortOrder.Len())
 }
 
+func TestSortOrderReturnsDefensiveCopies(t *testing.T) {
+	sourceIDs := []int{19, 20}
+	fields := []table.SortField{{
+		SourceIDs: sourceIDs,
+		Transform: iceberg.IdentityTransform{},
+		NullOrder: table.NullsFirst,
+		Direction: table.SortASC,
+	}}
+	sortOrder, err := table.NewSortOrder(1, fields)
+	require.NoError(t, err)
+
+	sourceIDs[0] = 99
+	fields[0].Direction = table.SortDESC
+	for _, field := range sortOrder.Fields() {
+		field.SourceIDs[0] = 98
+	}
+
+	seen := 0
+	for _, field := range sortOrder.Fields() {
+		assert.Equal(t, []int{19, 20}, field.SourceIDs)
+		assert.Equal(t, table.SortASC, field.Direction)
+		seen++
+	}
+	assert.Equal(t, 1, seen)
+}
+
 func TestSortOrderCheckCompatibilityWithValidTransform(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 19, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},


### PR DESCRIPTION
## What changed

- Copy the SortField slice and each SourceIDs slice in NewSortOrder.
- Yield fresh SourceIDs slices from SortOrder.Fields.
- Preserve the existing validation and serialization behavior.

## Why

SortOrder is expected to remain stable after construction and validation. Previously it retained the caller-owned field slice, while Fields returned values whose SourceIDs still shared internal backing arrays. Mutating either value could silently change later serialization and compatibility checks.

The regression test mutates both constructor inputs and iterator results, then reads the order again to verify that its fields remain unchanged.

## Testing

- go test ./table
- go vet ./table