### PR TITLE
fix(hive): cap lock backoff without overflow

### DIFF
--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"slices"
 	"strings"
 	"time"
@@ -148,12 +147,17 @@ func formatLockIdentifiers(identifiers []tableLockIdentifier) string {
 }
 
 func calculateBackoff(attempt int, minWait, maxWait time.Duration) time.Duration {
-	wait := time.Duration(float64(minWait) * math.Pow(2, float64(attempt)))
-	if wait > maxWait {
-		wait = maxWait
+	if minWait >= maxWait {
+		return maxWait
+	}
+	if attempt <= 0 || minWait <= 0 {
+		return minWait
+	}
+	if attempt > 62 || minWait > maxWait>>attempt {
+		return maxWait
 	}
 
-	return wait
+	return minWait << attempt
 }
 
 func (l *HiveLock) Release(ctx context.Context) error {

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -337,6 +337,8 @@ func TestCalculateBackoff(t *testing.T) {
 		{3, 800 * time.Millisecond}, // 100ms * 2^3 = 800ms
 		{4, 1 * time.Second},        // 100ms * 2^4 = 1.6s, capped at 1s
 		{10, 1 * time.Second},       // Capped at maxWait
+		{63, 1 * time.Second},       // Capped without overflowing time.Duration
+		{1000, 1 * time.Second},     // Large retry counts remain capped
 	}
 
 	for _, tt := range tests {
@@ -345,6 +347,10 @@ func TestCalculateBackoff(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+
+	maxDuration := time.Duration(1<<63 - 1)
+	assert.Equal(t, time.Duration(1)<<62, calculateBackoff(62, time.Nanosecond, maxDuration))
+	assert.Equal(t, maxDuration, calculateBackoff(63, time.Nanosecond, maxDuration))
 }
 
 func TestLockConfigurationParsing(t *testing.T) {


### PR DESCRIPTION
## What changed

Replace floating-point exponential backoff calculation with bounded integer arithmetic. The calculation now clamps to LockMaxWaitTime before either the shift count or time.Duration can overflow.

## Why

Lock retry counts are configurable. At sufficiently large attempts, converting the floating-point result back to time.Duration produced a negative duration. time.After then returned immediately, bypassing the configured maximum wait and causing rapid lock polling.

Values below the overflow boundary retain exact exponential behavior, while larger attempts saturate at the configured maximum.

## Testing

- go test ./catalog/hive
- go vet ./catalog/hive
- boundary coverage at attempts 62 and 63 using the maximum time.Duration