### PR TITLE
fix(partitions): return defensive field copies

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -370,10 +370,7 @@ func NewPartitionSpec(fields ...PartitionField) PartitionSpec {
 func NewPartitionSpecID(id int, fields ...PartitionField) PartitionSpec {
 	fieldCopies := make([]PartitionField, len(fields))
 	for i, field := range fields {
-		fieldCopies[i] = field
-		if field.SourceIDs != nil {
-			fieldCopies[i].SourceIDs = slices.Clone(field.SourceIDs)
-		}
+		fieldCopies[i] = clonePartitionField(field)
 	}
 	ret := PartitionSpec{id: id, fields: fieldCopies}
 	ret.initialize()
@@ -409,7 +406,13 @@ func (ps PartitionSpec) Equals(other PartitionSpec) bool {
 
 // Fields returns an iterator over the partition fields in this spec.
 func (ps *PartitionSpec) Fields() iter.Seq2[int, PartitionField] {
-	return slices.All(ps.fields)
+	return func(yield func(int, PartitionField) bool) {
+		for i, field := range ps.fields {
+			if !yield(i, clonePartitionField(field)) {
+				return
+			}
+		}
+	}
 }
 
 func (ps PartitionSpec) MarshalJSON() ([]byte, error) {
@@ -448,9 +451,11 @@ func (ps *PartitionSpec) initialize() {
 	}
 }
 
-func (ps *PartitionSpec) ID() int                    { return ps.id }
-func (ps *PartitionSpec) NumFields() int             { return len(ps.fields) }
-func (ps *PartitionSpec) Field(i int) PartitionField { return ps.fields[i] }
+func (ps *PartitionSpec) ID() int        { return ps.id }
+func (ps *PartitionSpec) NumFields() int { return len(ps.fields) }
+func (ps *PartitionSpec) Field(i int) PartitionField {
+	return clonePartitionField(ps.fields[i])
+}
 
 func (ps PartitionSpec) IsUnpartitioned() bool {
 	if len(ps.fields) == 0 {
@@ -467,7 +472,23 @@ func (ps PartitionSpec) IsUnpartitioned() bool {
 }
 
 func (ps *PartitionSpec) FieldsBySourceID(fieldID int) []PartitionField {
-	return slices.Clone(ps.sourceIdToFields[fieldID])
+	fields := ps.sourceIdToFields[fieldID]
+	if fields == nil {
+		return nil
+	}
+
+	clones := make([]PartitionField, len(fields))
+	for i, field := range fields {
+		clones[i] = clonePartitionField(field)
+	}
+
+	return clones
+}
+
+func clonePartitionField(field PartitionField) PartitionField {
+	field.SourceIDs = slices.Clone(field.SourceIDs)
+
+	return field
 }
 
 func (ps PartitionSpec) String() string {

--- a/partitions.go
+++ b/partitions.go
@@ -487,6 +487,18 @@ func (ps *PartitionSpec) FieldsBySourceID(fieldID int) []PartitionField {
 
 func clonePartitionField(field PartitionField) PartitionField {
 	field.SourceIDs = slices.Clone(field.SourceIDs)
+	switch transform := field.Transform.(type) {
+	case *BucketTransform:
+		if transform != nil {
+			cloned := *transform
+			field.Transform = &cloned
+		}
+	case *TruncateTransform:
+		if transform != nil {
+			cloned := *transform
+			field.Transform = &cloned
+		}
+	}
 
 	return field
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -75,21 +75,27 @@ func TestPartitionSpec(t *testing.T) {
 }
 
 func TestPartitionSpecFieldGettersReturnCopies(t *testing.T) {
+	transform := &iceberg.BucketTransform{NumBuckets: 16}
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceIDs: []int{1, 2}, FieldID: 1000, Name: "multi", Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1, 2}, FieldID: 1000, Name: "multi", Transform: transform,
 	})
+	transform.NumBuckets = 32
 
 	field := spec.Field(0)
 	field.SourceIDs[0] = 99
+	field.Transform.(*iceberg.BucketTransform).NumBuckets = 64
 
 	for _, iterField := range spec.Fields() {
 		iterField.SourceIDs[0] = 98
+		iterField.Transform.(*iceberg.BucketTransform).NumBuckets = 128
 	}
 
 	bySource := spec.FieldsBySourceID(1)
 	bySource[0].SourceIDs[0] = 97
+	bySource[0].Transform.(*iceberg.BucketTransform).NumBuckets = 256
 
 	assert.Equal(t, []int{1, 2}, spec.Field(0).SourceIDs)
+	assert.Equal(t, 16, spec.Field(0).Transform.(*iceberg.BucketTransform).NumBuckets)
 	assert.Len(t, spec.FieldsBySourceID(1), 1)
 	assert.Nil(t, spec.FieldsBySourceID(99))
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -74,6 +74,26 @@ func TestPartitionSpec(t *testing.T) {
 	assert.Equal(t, 1002, spec3.LastAssignedFieldID())
 }
 
+func TestPartitionSpecFieldGettersReturnCopies(t *testing.T) {
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1, 2}, FieldID: 1000, Name: "multi", Transform: iceberg.IdentityTransform{},
+	})
+
+	field := spec.Field(0)
+	field.SourceIDs[0] = 99
+
+	for _, iterField := range spec.Fields() {
+		iterField.SourceIDs[0] = 98
+	}
+
+	bySource := spec.FieldsBySourceID(1)
+	bySource[0].SourceIDs[0] = 97
+
+	assert.Equal(t, []int{1, 2}, spec.Field(0).SourceIDs)
+	assert.Len(t, spec.FieldsBySourceID(1), 1)
+	assert.Nil(t, spec.FieldsBySourceID(99))
+}
+
 func TestNewPartitionSpecIDCopiesFields(t *testing.T) {
 	sourceIDs := []int{1}
 	fields := make([]iceberg.PartitionField, 1)


### PR DESCRIPTION
## What changed

- Clone SourceIDs for fields returned by PartitionSpec.Field and PartitionSpec.Fields.
- Deep-copy fields returned by FieldsBySourceID instead of cloning only the outer slice.
- Preserve a nil result when no fields match a source ID.
- Reuse the same field-copy helper during construction.

## Why

PartitionField is returned by value, but its SourceIDs slice previously shared backing storage with the spec. A caller could mutate a supposedly read-only result, alter later serialization, and leave the cached source ID lookup keyed by an outdated value.

The regression test mutates results from all three getter paths and verifies that the spec and lookup remain unchanged.

## Testing

- go test .
- go vet .