### PR TITLE
fix(view): return defensive metadata copies

### DIFF
--- a/view/metadata.go
+++ b/view/metadata.go
@@ -365,10 +365,15 @@ func (m *metadata) Equals(other Metadata) bool {
 func (m *metadata) FormatVersion() int         { return m.FormatVersionValue }
 func (m *metadata) ViewUUID() uuid.UUID        { return *m.UUID }
 func (m *metadata) Location() string           { return m.Loc }
-func (m *metadata) Versions() []*Version       { return m.VersionList }
-func (m *metadata) Schemas() []*iceberg.Schema { return m.SchemaList }
+func (m *metadata) Versions() []*Version       { return cloneSlice(m.VersionList) }
+func (m *metadata) Schemas() []*iceberg.Schema { return cloneSchemas(m.SchemaList) }
 func (m *metadata) SchemasByID() map[int]*iceberg.Schema {
-	return maps.Clone(m.lazySchemasByID())
+	clones := make(map[int]*iceberg.Schema, len(m.SchemaList))
+	for id, schema := range m.lazySchemasByID() {
+		clones[id] = cloneSchema(schema)
+	}
+
+	return clones
 }
 
 func (m *metadata) CurrentVersionID() int64 {
@@ -376,6 +381,10 @@ func (m *metadata) CurrentVersionID() int64 {
 }
 
 func (m *metadata) CurrentVersion() *Version {
+	return m.currentVersion().Clone()
+}
+
+func (m *metadata) currentVersion() *Version {
 	version, ok := m.lazyVersionsByID()[m.CurrentVersionIDValue]
 	if !ok {
 		panic("current version not found")
@@ -385,7 +394,7 @@ func (m *metadata) CurrentVersion() *Version {
 }
 
 func (m *metadata) CurrentSchemaID() int {
-	return m.CurrentVersion().SchemaID
+	return m.currentVersion().SchemaID
 }
 
 func (m *metadata) CurrentSchema() *iceberg.Schema {
@@ -394,15 +403,101 @@ func (m *metadata) CurrentSchema() *iceberg.Schema {
 		panic("current schema not found")
 	}
 
-	return schema
+	return cloneSchema(schema)
 }
 
 func (m *metadata) VersionLog() []VersionLogEntry {
-	return m.VersionLogList
+	return slices.Clone(m.VersionLogList)
 }
 
 func (m *metadata) Properties() iceberg.Properties {
-	return m.Props
+	return maps.Clone(m.Props)
+}
+
+func cloneSchema(schema *iceberg.Schema) *iceberg.Schema {
+	if schema == nil {
+		return nil
+	}
+
+	return iceberg.NewSchemaWithIdentifiers(
+		schema.ID,
+		slices.Clone(schema.IdentifierFieldIDs),
+		cloneNestedFields(schema.Fields())...,
+	)
+}
+
+func cloneSchemas(schemas []*iceberg.Schema) []*iceberg.Schema {
+	if schemas == nil {
+		return nil
+	}
+
+	clones := make([]*iceberg.Schema, len(schemas))
+	for i, schema := range schemas {
+		clones[i] = cloneSchema(schema)
+	}
+
+	return clones
+}
+
+func cloneNestedFields(fields []iceberg.NestedField) []iceberg.NestedField {
+	clones := slices.Clone(fields)
+	for i := range clones {
+		clones[i].Type = cloneSchemaType(clones[i].Type)
+		clones[i].InitialDefault = cloneDefault(clones[i].InitialDefault)
+		clones[i].WriteDefault = cloneDefault(clones[i].WriteDefault)
+	}
+
+	return clones
+}
+
+func cloneSchemaType(typ iceberg.Type) iceberg.Type {
+	switch typ := typ.(type) {
+	case *iceberg.StructType:
+		return &iceberg.StructType{FieldList: cloneNestedFields(typ.FieldList)}
+	case *iceberg.ListType:
+		return &iceberg.ListType{
+			ElementID:       typ.ElementID,
+			Element:         cloneSchemaType(typ.Element),
+			ElementRequired: typ.ElementRequired,
+		}
+	case *iceberg.MapType:
+		return &iceberg.MapType{
+			KeyID:         typ.KeyID,
+			KeyType:       cloneSchemaType(typ.KeyType),
+			ValueID:       typ.ValueID,
+			ValueType:     cloneSchemaType(typ.ValueType),
+			ValueRequired: typ.ValueRequired,
+		}
+	default:
+		return typ
+	}
+}
+
+func cloneDefault(value any) any {
+	switch value := value.(type) {
+	case []byte:
+		return slices.Clone(value)
+	case iceberg.BinaryLiteral:
+		return iceberg.BinaryLiteral(slices.Clone([]byte(value)))
+	case iceberg.FixedLiteral:
+		return iceberg.FixedLiteral(slices.Clone([]byte(value)))
+	case []any:
+		clones := make([]any, len(value))
+		for i, item := range value {
+			clones[i] = cloneDefault(item)
+		}
+
+		return clones
+	case map[string]any:
+		clones := make(map[string]any, len(value))
+		for key, item := range value {
+			clones[key] = cloneDefault(item)
+		}
+
+		return clones
+	default:
+		return value
+	}
 }
 
 func (m *metadata) validate() error {

--- a/view/metadata_builder_test.go
+++ b/view/metadata_builder_test.go
@@ -325,7 +325,8 @@ func TestViewMetadataAndUpdates(t *testing.T) {
 	assert.Equal(t, *md.CurrentVersion(), *v3)
 	assert.Equal(t, props, md.Properties())
 	assert.Equal(t, "location", md.Location())
-	assert.Equal(t, []*iceberg.Schema{s1, s2}, md.Schemas())
+	assert.True(t, s1.Equals(md.Schemas()[0]))
+	assert.True(t, s2.Equals(md.Schemas()[1]))
 	assert.Equal(t, s2.ID, md.CurrentSchemaID())
 
 	// Updates

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -524,6 +524,92 @@ func TestCloneSlice(t *testing.T) {
 	assert.NotEqualValues(t, x, clonedX)
 }
 
+func TestMetadataGettersReturnDefensiveCopies(t *testing.T) {
+	md, err := ParseMetadataString(exampleViewJSON)
+	require.NoError(t, err)
+
+	currentVersion := md.CurrentVersion()
+	currentVersion.Summary["summaryProp"] = "changed"
+	currentVersion.Representations[0].Sql = "select changed"
+	currentVersion.DefaultNamespace[0] = "changed"
+
+	versions := md.Versions()
+	versions[0].VersionID = 99
+
+	currentSchema := md.CurrentSchema()
+	currentSchema.ID = 99
+	currentSchema.IdentifierFieldIDs[0] = 99
+
+	schemas := md.Schemas()
+	schemas[0].ID = 98
+
+	schemasByID := md.SchemasByID()
+	schemasByID[0].ID = 97
+	delete(schemasByID, 0)
+
+	versionLog := md.VersionLog()
+	versionLog[0].VersionID = 99
+
+	props := md.Properties()
+	props["prop"] = "changed"
+
+	assert.Equal(t, int64(1), md.CurrentVersion().VersionID)
+	assert.Equal(t, "summaryVal", md.CurrentVersion().Summary["summaryProp"])
+	assert.Equal(t, "select * from ns.tbl", md.CurrentVersion().Representations[0].Sql)
+	assert.Equal(t, "accounting", md.CurrentVersion().DefaultNamespace[0])
+	assert.Equal(t, 0, md.CurrentSchema().ID)
+	assert.Equal(t, 0, md.CurrentSchema().IdentifierFieldIDs[0])
+	assert.Equal(t, 0, md.Schemas()[0].ID)
+	assert.Equal(t, 0, md.SchemasByID()[0].ID)
+	assert.Equal(t, int64(1), md.VersionLog()[0].VersionID)
+	assert.Equal(t, "value", md.Properties()["prop"])
+}
+
+func TestCloneSchemaCopiesNestedValues(t *testing.T) {
+	schema := iceberg.NewSchemaWithIdentifiers(1, []int{1},
+		iceberg.NestedField{
+			ID: 1, Name: "struct", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{{
+				ID: 2, Name: "nested", Type: iceberg.PrimitiveTypes.Binary,
+				InitialDefault: []byte{1}, WriteDefault: iceberg.BinaryLiteral{2},
+			}}},
+		},
+		iceberg.NestedField{
+			ID: 3, Name: "list", Type: &iceberg.ListType{
+				ElementID: 4, Element: &iceberg.StructType{FieldList: []iceberg.NestedField{{
+					ID: 5, Name: "element", Type: iceberg.PrimitiveTypes.String,
+				}}},
+			},
+		},
+		iceberg.NestedField{
+			ID: 6, Name: "map", Type: &iceberg.MapType{
+				KeyID: 7, KeyType: iceberg.PrimitiveTypes.String, ValueID: 8,
+				ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{{
+					ID: 9, Name: "value", Type: iceberg.PrimitiveTypes.String,
+				}}},
+			},
+		},
+	)
+
+	cloned := cloneSchema(schema)
+	cloned.IdentifierFieldIDs[0] = 99
+	structField := cloned.Field(0).Type.(*iceberg.StructType)
+	structField.FieldList[0].Name = "changed"
+	structField.FieldList[0].InitialDefault.([]byte)[0] = 9
+	structField.FieldList[0].WriteDefault.(iceberg.BinaryLiteral)[0] = 9
+	listField := cloned.Field(1).Type.(*iceberg.ListType)
+	listField.Element.(*iceberg.StructType).FieldList[0].Name = "changed"
+	mapField := cloned.Field(2).Type.(*iceberg.MapType)
+	mapField.ValueType.(*iceberg.StructType).FieldList[0].Name = "changed"
+
+	assert.Equal(t, []int{1}, schema.IdentifierFieldIDs)
+	originalStruct := schema.Field(0).Type.(*iceberg.StructType)
+	assert.Equal(t, "nested", originalStruct.FieldList[0].Name)
+	assert.Equal(t, []byte{1}, originalStruct.FieldList[0].InitialDefault)
+	assert.Equal(t, iceberg.BinaryLiteral{2}, originalStruct.FieldList[0].WriteDefault)
+	assert.Equal(t, "element", schema.Field(1).Type.(*iceberg.ListType).Element.(*iceberg.StructType).FieldList[0].Name)
+	assert.Equal(t, "value", schema.Field(2).Type.(*iceberg.MapType).ValueType.(*iceberg.StructType).FieldList[0].Name)
+}
+
 var exampleViewJSON = `{
 	"view-uuid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
 	"format-version": 1,


### PR DESCRIPTION
## What changed

- Deep-copy versions returned by CurrentVersion and Versions, including summaries, representations, and default namespaces.
- Deep-copy schemas returned by CurrentSchema, Schemas, and SchemasByID.
- Copy nested struct, list, and map types, identifier IDs, and mutable default values.
- Clone version logs and properties.
- Keep CurrentSchemaID on an internal lookup path to avoid an unnecessary defensive copy.

## Why

View metadata getters previously exposed internal pointers, maps, and slices. Callers could mutate persisted metadata without using the metadata builder. SchemasByID cloned only the map, so mutating a returned schema could also invalidate the cached schema lookup.

Regression coverage mutates every affected getter and separately verifies nested schema types, byte-slice defaults, and binary literal defaults.

## Testing

- go test ./view
- go vet ./view