### PR TITLE
fix(view): report metadata writer close errors

### DIFF
--- a/view/view.go
+++ b/view/view.go
@@ -193,15 +193,23 @@ func createView(
 		return nil, errors.New("filesystem IO does not support writing")
 	}
 
-	out, err := wfs.Create(metadataLocation)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create view metadata file: %w", err)
-	}
-	defer internal.CheckedClose(out, &err)
-
-	if _, err := out.Write(viewMetadataBytes); err != nil {
-		return nil, fmt.Errorf("failed to write view metadata: %w", err)
+	if err := writeViewMetadata(wfs, metadataLocation, viewMetadataBytes); err != nil {
+		return nil, err
 	}
 
 	return New(viewIdent, viewMD, metadataLocation), nil
+}
+
+func writeViewMetadata(wfs io.WriteFileIO, metadataLocation string, data []byte) (err error) {
+	out, err := wfs.Create(metadataLocation)
+	if err != nil {
+		return fmt.Errorf("failed to create view metadata file: %w", err)
+	}
+	defer internal.CheckedClose(out, &err)
+
+	if _, err := out.Write(data); err != nil {
+		return fmt.Errorf("failed to write view metadata: %w", err)
+	}
+
+	return nil
 }

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -115,4 +117,31 @@ func (t *ViewTestSuite) TestCreateViewJoinsTrailingSlashMetadataLocation() {
 
 func (t *ViewTestSuite) TestLocation() {
 	t.Equal("s3://bucket/test/location", t.view.Location())
+}
+
+func TestCreateViewReturnsMetadataCloseError(t *testing.T) {
+	var mockfs internal.MockFS
+	mockfs.Test(t)
+	mockfs.On("Create", mock.Anything).
+		Return(&internal.MockFile{Contents: bytes.NewReader(nil), ErrOnClose: true}, nil)
+	defer mockfs.AssertExpectations(t)
+
+	const scheme = "view-close-error"
+	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		return &mockfs, nil
+	})
+	defer iceio.Unregister(scheme)
+
+	createdView, err := CreateView(
+		t.Context(),
+		"test-catalog",
+		[]string{"ns", "test_view"},
+		newTestSchema(0),
+		"select 1",
+		[]string{"ns"},
+		scheme+"://bucket/test-view",
+		nil,
+	)
+	require.EqualError(t, err, "error on close")
+	require.Nil(t, createdView)
 }


### PR DESCRIPTION
## What changed

Move metadata writing into a helper with a named error result. CreateView now returns a View only after the metadata writer closes successfully.

## Why

The previous code deferred CheckedClose against a local error variable and then returned explicit values. Updating that local variable during the deferred close could not change the error already selected for return. Filesystems that flush or finalize writes during Close could therefore report a failure while CreateView returned success.

The regression test exercises the public CreateView path with a registered filesystem whose writer fails during Close. It verifies that the error is returned and no View is produced.

## Testing

- go test ./view
- go vet ./view