### PR TITLE
fix(view): protect identifiers from mutation

### DIFF
--- a/view/view.go
+++ b/view/view.go
@@ -44,7 +44,7 @@ func (t View) Equals(other View) bool {
 		t.metadata.Equals(other.metadata)
 }
 
-func (t View) Identifier() table.Identifier     { return t.identifier }
+func (t View) Identifier() table.Identifier     { return slices.Clone(t.identifier) }
 func (t View) Metadata() Metadata               { return t.metadata }
 func (t View) MetadataLocation() string         { return t.metadataLocation }
 func (t View) CurrentVersion() *Version         { return t.metadata.CurrentVersion() }
@@ -56,7 +56,7 @@ func (t View) Schemas() map[int]*iceberg.Schema { return t.metadata.SchemasByID(
 
 func New(ident table.Identifier, meta Metadata, metadataLocation string) *View {
 	return &View{
-		identifier:       ident,
+		identifier:       slices.Clone(ident),
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 	}

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -145,3 +145,15 @@ func TestCreateViewReturnsMetadataCloseError(t *testing.T) {
 	require.EqualError(t, err, "error on close")
 	require.Nil(t, createdView)
 }
+
+func (t *ViewTestSuite) TestIdentifierReturnsDefensiveCopy() {
+	identifier := []string{"namespace", "view"}
+	vw := New(identifier, nil, "metadata.json")
+
+	identifier[0] = "changed-input"
+	t.Equal([]string{"namespace", "view"}, vw.Identifier())
+
+	returned := vw.Identifier()
+	returned[1] = "changed-output"
+	t.Equal([]string{"namespace", "view"}, vw.Identifier())
+}


### PR DESCRIPTION
## What changed

Copy view identifiers when constructing a View and when returning Identifier.

## Why

View identifiers are slices. New previously retained the caller-owned slice, and Identifier returned that same backing array. Either path allowed external mutation to change the identity of an existing View and affect equality or catalog behavior.

The regression test mutates both the constructor input and the getter result.

## Testing

- go test ./view
- go vet ./view
- go test ./...