### PR TITLE
fix(manifest): return defensive metadata copies

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -152,8 +152,19 @@ func (b *ManifestBuilder) Partitions(p []FieldSummary) *ManifestBuilder {
 		return b
 	}
 
-	copied := make([]FieldSummary, len(p))
-	for i, partition := range p {
+	copied := cloneFieldSummaries(p)
+	b.m.PartitionList = &copied
+
+	return b
+}
+
+func cloneFieldSummaries(partitions []FieldSummary) []FieldSummary {
+	if partitions == nil {
+		return nil
+	}
+
+	copied := make([]FieldSummary, len(partitions))
+	for i, partition := range partitions {
 		copiedPartition := partition
 		if partition.LowerBound != nil {
 			lowerBound := slices.Clone(*partition.LowerBound)
@@ -170,9 +181,8 @@ func (b *ManifestBuilder) Partitions(p []FieldSummary) *ManifestBuilder {
 
 		copied[i] = copiedPartition
 	}
-	b.m.PartitionList = &copied
 
-	return b
+	return copied
 }
 
 func (b *ManifestBuilder) KeyMetadata(km []byte) *ManifestBuilder {
@@ -381,7 +391,7 @@ func (m *manifestFile) KeyMetadata() []byte {
 		return nil
 	}
 
-	return *m.Key
+	return slices.Clone(*m.Key)
 }
 
 func (m *manifestFile) Partitions() []FieldSummary {
@@ -389,10 +399,18 @@ func (m *manifestFile) Partitions() []FieldSummary {
 		return nil
 	}
 
-	return *m.PartitionList
+	return cloneFieldSummaries(*m.PartitionList)
 }
 
-func (m *manifestFile) FirstRowID() *int64 { return m.FirstRowIDValue }
+func (m *manifestFile) FirstRowID() *int64 {
+	if m.FirstRowIDValue == nil {
+		return nil
+	}
+
+	firstRowID := *m.FirstRowIDValue
+
+	return &firstRowID
+}
 
 func (m *manifestFile) HasAddedFiles() bool    { return m.AddedFilesCount != 0 }
 func (m *manifestFile) HasExistingFiles() bool { return m.ExistingFilesCount != 0 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1983,6 +1983,42 @@ func (m *ManifestTestSuite) TestManifestBuilderKeyMetadataCopiesInput() {
 	m.Assert().Equal([]byte{0x00, 0x01, 0x02}, manifest.KeyMetadata())
 }
 
+func (m *ManifestTestSuite) TestManifestFileGettersReturnDefensiveCopies() {
+	containsNaN := true
+	lowerBound := []byte{0x00, 0x01}
+	upperBound := []byte{0x02, 0x03}
+	manifest := NewManifestFile(3, "file.avro", 1, 1, entrySnapshotID).
+		Partitions([]FieldSummary{{
+			ContainsNull: true,
+			ContainsNaN:  &containsNaN,
+			LowerBound:   &lowerBound,
+			UpperBound:   &upperBound,
+		}}).
+		KeyMetadata([]byte{0x04, 0x05}).
+		Build()
+	firstRowID := int64(10)
+	manifest.(*manifestFile).FirstRowIDValue = &firstRowID
+
+	keyMetadata := manifest.KeyMetadata()
+	keyMetadata[0] = 0xff
+	partitions := manifest.Partitions()
+	partitions[0].ContainsNull = false
+	*partitions[0].ContainsNaN = false
+	(*partitions[0].LowerBound)[0] = 0xff
+	(*partitions[0].UpperBound)[0] = 0xff
+	returnedFirstRowID := manifest.FirstRowID()
+	*returnedFirstRowID = 99
+
+	m.Equal([]byte{0x04, 0x05}, manifest.KeyMetadata())
+	currentPartitions := manifest.Partitions()
+	m.Require().Len(currentPartitions, 1)
+	m.True(currentPartitions[0].ContainsNull)
+	m.True(*currentPartitions[0].ContainsNaN)
+	m.Equal([]byte{0x00, 0x01}, *currentPartitions[0].LowerBound)
+	m.Equal([]byte{0x02, 0x03}, *currentPartitions[0].UpperBound)
+	m.Equal(int64(10), *manifest.FirstRowID())
+}
+
 // equalityIDsSchemaIsInt asserts equality_ids uses Avro "int", not "long".
 func (m *ManifestTestSuite) equalityIDsSchemaIsInt(sc *avro.Schema) {
 	m.T().Helper()


### PR DESCRIPTION
## What changed

- Clone key metadata returned by ManifestFile.
- Deep-copy partition summaries, including bounds and nullable ContainsNaN values.
- Copy the nullable first row ID before returning it.
- Reuse the partition summary copy helper for builder inputs and getter outputs.

## Why

ManifestFile getters exposed slices and pointers owned by decoded manifest-list entries. A caller could mutate key metadata, partition bounds, summary flags, or first row IDs and silently change later planning or manifest rewrite behavior.

The regression test mutates every affected getter and verifies that subsequent reads remain unchanged.

## Testing

- go test .
- go vet .
- go test ./...