### PR TITLE
fix(io): reject invalid MemFS offsets

### DIFF
--- a/io/mem.go
+++ b/io/mem.go
@@ -165,6 +165,8 @@ func (f *memFile) Seek(offset int64, whence int) (int64, error) {
 		abs = f.pos + offset
 	case io.SeekEnd:
 		abs = int64(len(f.data)) + offset
+	default:
+		return 0, &fs.PathError{Op: "seek", Path: f.name, Err: fs.ErrInvalid}
 	}
 	if abs < 0 {
 		return 0, &fs.PathError{Op: "seek", Path: f.name, Err: fs.ErrInvalid}
@@ -175,6 +177,9 @@ func (f *memFile) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, &fs.PathError{Op: "readat", Path: f.name, Err: fs.ErrInvalid}
+	}
 	if off >= int64(len(f.data)) {
 		return 0, io.EOF
 	}

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -141,6 +141,29 @@ func TestMemIO_RemoveMissingReturnsNotExist(t *testing.T) {
 	require.ErrorIs(t, memIO.Remove("does-not-exist.txt"), fs.ErrNotExist)
 }
 
+func TestMemIO_FileRejectsInvalidOffsets(t *testing.T) {
+	memIO := icebergio.NewMemFS()
+	require.NoError(t, memIO.WriteFile("file.txt", []byte("abc")))
+
+	file, err := memIO.Open("file.txt")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, file.Close()) })
+
+	_, err = file.ReadAt(make([]byte, 1), -1)
+	require.ErrorIs(t, err, fs.ErrInvalid)
+
+	pos, err := file.Seek(1, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), pos)
+
+	_, err = file.Seek(0, 99)
+	require.ErrorIs(t, err, fs.ErrInvalid)
+
+	pos, err = file.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), pos)
+}
+
 func TestMemIO_WalkDir(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What changed

Validate negative ReadAt offsets and unknown Seek whence values in MemFS. Both cases now return a PathError wrapping fs.ErrInvalid, and a rejected seek leaves the current position unchanged.

## Why

ReadAt previously sliced with a negative index and panicked. Seek accepted any unknown whence value as an absolute position of zero, silently moving the file cursor instead of reporting invalid input.

The regression test covers both public file operations and verifies that an invalid seek does not alter the cursor.

## Testing

- go test ./io
- go vet ./io
- go test ./...