### PR TITLE
fix(exprs): protect bound literal sets from mutation

### DIFF
--- a/bound_set_literal_view.go
+++ b/bound_set_literal_view.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"fmt"
+	"slices"
+)
+
+type readOnlyLiteralSet struct {
+	Set[Literal]
+}
+
+func (readOnlyLiteralSet) Add(...Literal) {
+	panic(fmt.Errorf("%w: cannot add to read-only literal set", ErrInvalidArgument))
+}
+
+func (s readOnlyLiteralSet) Equals(other Set[Literal]) bool {
+	if rhs, ok := other.(readOnlyLiteralSet); ok {
+		other = rhs.Set
+	}
+
+	return s.Set.Equals(other)
+}
+
+func cloneBoundLiteral(lit Literal) Literal {
+	switch lit := lit.(type) {
+	case BinaryLiteral:
+		return BinaryLiteral(slices.Clone(lit))
+	case FixedLiteral:
+		return FixedLiteral(slices.Clone(lit))
+	case GeoLiteral:
+		lit.val = slices.Clone(lit.val)
+
+		return lit
+	default:
+		return lit
+	}
+}
+
+func (s readOnlyLiteralSet) Members() []Literal {
+	members := s.Set.Members()
+	for i, literal := range members {
+		members[i] = cloneBoundLiteral(literal)
+	}
+
+	return members
+}
+
+func (s readOnlyLiteralSet) All(fn func(Literal) bool) bool {
+	return s.Set.All(func(literal Literal) bool {
+		return fn(cloneBoundLiteral(literal))
+	})
+}
+
+type boundSetLiteralRef interface {
+	boundSetLiteralsRef() Set[Literal]
+}
+
+func (bsp *boundSetPredicate[T]) boundSetLiteralsRef() Set[Literal] {
+	return bsp.lits
+}
+
+func boundSetLiteralsForVisit(predicate BoundPredicate) Set[Literal] {
+	if ref, ok := predicate.(boundSetLiteralRef); ok {
+		return ref.boundSetLiteralsRef()
+	}
+
+	setPredicate, ok := predicate.(BoundSetPredicate)
+	if !ok {
+		panic(fmt.Errorf("%w: %s predicate %T does not implement BoundSetPredicate",
+			ErrNotImplemented, predicate.Op(), predicate))
+	}
+
+	return setPredicate.Literals()
+}

--- a/bound_set_literal_view.go
+++ b/bound_set_literal_view.go
@@ -22,22 +22,6 @@ import (
 	"slices"
 )
 
-type readOnlyLiteralSet struct {
-	Set[Literal]
-}
-
-func (readOnlyLiteralSet) Add(...Literal) {
-	panic(fmt.Errorf("%w: cannot add to read-only literal set", ErrInvalidArgument))
-}
-
-func (s readOnlyLiteralSet) Equals(other Set[Literal]) bool {
-	if rhs, ok := other.(readOnlyLiteralSet); ok {
-		other = rhs.Set
-	}
-
-	return s.Set.Equals(other)
-}
-
 func cloneBoundLiteral(lit Literal) Literal {
 	switch lit := lit.(type) {
 	case BinaryLiteral:
@@ -53,19 +37,13 @@ func cloneBoundLiteral(lit Literal) Literal {
 	}
 }
 
-func (s readOnlyLiteralSet) Members() []Literal {
-	members := s.Set.Members()
-	for i, literal := range members {
-		members[i] = cloneBoundLiteral(literal)
+func cloneBoundLiteralSet(lits Set[Literal]) Set[Literal] {
+	cloned := newLiteralSet()
+	for _, literal := range lits.Members() {
+		cloned.Add(cloneBoundLiteral(literal))
 	}
 
-	return members
-}
-
-func (s readOnlyLiteralSet) All(fn func(Literal) bool) bool {
-	return s.Set.All(func(literal Literal) bool {
-		return fn(cloneBoundLiteral(literal))
-	})
+	return cloned
 }
 
 type boundSetLiteralRef interface {

--- a/bound_set_literal_view_internal_test.go
+++ b/bound_set_literal_view_internal_test.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type boundSetVisitVisitor struct {
+	needle Literal
+}
+
+func (*boundSetVisitVisitor) VisitTrue() bool                    { return true }
+func (*boundSetVisitVisitor) VisitFalse() bool                   { return false }
+func (*boundSetVisitVisitor) VisitNot(bool) bool                 { return false }
+func (*boundSetVisitVisitor) VisitAnd(bool, bool) bool           { return false }
+func (*boundSetVisitVisitor) VisitOr(bool, bool) bool            { return false }
+func (*boundSetVisitVisitor) VisitUnbound(UnboundPredicate) bool { return false }
+func (*boundSetVisitVisitor) VisitBound(BoundPredicate) bool     { return false }
+func (v *boundSetVisitVisitor) VisitIn(_ BoundTerm, lits Set[Literal]) bool {
+	return lits.Contains(v.needle)
+}
+func (*boundSetVisitVisitor) VisitNotIn(BoundTerm, Set[Literal]) bool { return false }
+func (*boundSetVisitVisitor) VisitIsNan(BoundTerm) bool               { return false }
+func (*boundSetVisitVisitor) VisitNotNan(BoundTerm) bool              { return false }
+func (*boundSetVisitVisitor) VisitIsNull(BoundTerm) bool              { return false }
+func (*boundSetVisitVisitor) VisitNotNull(BoundTerm) bool             { return false }
+func (*boundSetVisitVisitor) VisitEqual(BoundTerm, Literal) bool      { return false }
+func (*boundSetVisitVisitor) VisitNotEqual(BoundTerm, Literal) bool   { return false }
+func (*boundSetVisitVisitor) VisitGreaterEqual(BoundTerm, Literal) bool {
+	return false
+}
+func (*boundSetVisitVisitor) VisitGreater(BoundTerm, Literal) bool { return false }
+func (*boundSetVisitVisitor) VisitLessEqual(BoundTerm, Literal) bool {
+	return false
+}
+func (*boundSetVisitVisitor) VisitLess(BoundTerm, Literal) bool { return false }
+func (*boundSetVisitVisitor) VisitStartsWith(BoundTerm, Literal) bool {
+	return false
+}
+func (*boundSetVisitVisitor) VisitNotStartsWith(BoundTerm, Literal) bool {
+	return false
+}
+
+func TestVisitBoundPredicateRefDoesNotAllocate(t *testing.T) {
+	predicate, err := IsIn(Reference("value"), "hello", "world").(UnboundPredicate).Bind(
+		NewSchema(1, NestedField{ID: 1, Name: "value", Type: PrimitiveTypes.String}), true,
+	)
+	require.NoError(t, err)
+
+	visitor := &boundSetVisitVisitor{needle: NewLiteral("hello")}
+	bound := predicate.(BoundPredicate)
+	var found bool
+
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		found = VisitBoundPredicateRef(bound, visitor, internal.BoundPredicateRef{})
+	}))
+	assert.True(t, found)
+}

--- a/bound_set_literal_view_internal_test.go
+++ b/bound_set_literal_view_internal_test.go
@@ -57,6 +57,7 @@ func (*boundSetVisitVisitor) VisitLess(BoundTerm, Literal) bool { return false }
 func (*boundSetVisitVisitor) VisitStartsWith(BoundTerm, Literal) bool {
 	return false
 }
+
 func (*boundSetVisitVisitor) VisitNotStartsWith(BoundTerm, Literal) bool {
 	return false
 }

--- a/bound_set_literal_view_test.go
+++ b/bound_set_literal_view_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBoundSetPredicateLiteralViewClonesMutableMembers(t *testing.T) {
+func TestBoundSetPredicateLiteralsCloneMutableMembers(t *testing.T) {
 	t.Parallel()
 
 	geometry, err := iceberg.GeometryTypeOf("srid:4326")
@@ -85,7 +85,7 @@ func TestBoundSetPredicateLiteralViewClonesMutableMembers(t *testing.T) {
 				value[0] ^= 0xff
 			}
 			for _, expected := range expectedLiterals {
-				assert.True(t, literals.Contains(expected))
+				assert.True(t, bound.(iceberg.BoundSetPredicate).Literals().Contains(expected))
 			}
 
 			assert.True(t, literals.All(func(literal iceberg.Literal) bool {
@@ -99,7 +99,7 @@ func TestBoundSetPredicateLiteralViewClonesMutableMembers(t *testing.T) {
 				return true
 			}))
 			for _, expected := range expectedLiterals {
-				assert.True(t, literals.Contains(expected))
+				assert.True(t, bound.(iceberg.BoundSetPredicate).Literals().Contains(expected))
 			}
 		})
 	}

--- a/bound_set_literal_view_test.go
+++ b/bound_set_literal_view_test.go
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg_test
+
+import (
+	"slices"
+	"testing"
+
+	iceberg "github.com/apache/iceberg-go"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundSetPredicateLiteralViewClonesMutableMembers(t *testing.T) {
+	t.Parallel()
+
+	geometry, err := iceberg.GeometryTypeOf("srid:4326")
+	require.NoError(t, err)
+	geography, err := iceberg.GeographyTypeOf("srid:4326", "spherical")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		typ  iceberg.Type
+	}{
+		{name: "binary", typ: iceberg.PrimitiveTypes.Binary},
+		{name: "fixed", typ: iceberg.FixedTypeOf(16)},
+		{name: "geometry", typ: geometry},
+		{name: "geography", typ: geography},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inputs := [][]byte{
+				[]byte("0123456789abcdef"),
+				[]byte("fedcba9876543210"),
+			}
+			predicateLiterals := make([]iceberg.Literal, len(inputs))
+			expectedLiterals := make([]iceberg.Literal, len(inputs))
+			for i, input := range inputs {
+				expected, err := iceberg.LiteralFromBytes(tt.typ, slices.Clone(input))
+				require.NoError(t, err)
+				expectedLiterals[i] = expected
+
+				if tt.typ.Equals(geometry) || tt.typ.Equals(geography) {
+					predicateLiterals[i], err = iceberg.LiteralFromBytes(tt.typ, slices.Clone(input))
+					require.NoError(t, err)
+				} else {
+					predicateLiterals[i] = iceberg.NewLiteral(slices.Clone(input))
+				}
+			}
+
+			predicate := iceberg.SetPredicate(
+				iceberg.OpIn,
+				iceberg.Reference("value"),
+				predicateLiterals,
+			)
+			schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "value", Type: tt.typ})
+
+			bound, err := predicate.(iceberg.UnboundPredicate).Bind(schema, true)
+			require.NoError(t, err)
+			literals := bound.(iceberg.BoundSetPredicate).Literals()
+
+			for _, literal := range literals.Members() {
+				value, ok := literal.Any().([]byte)
+				require.True(t, ok)
+				value[0] ^= 0xff
+			}
+			for _, expected := range expectedLiterals {
+				assert.True(t, literals.Contains(expected))
+			}
+
+			assert.True(t, literals.All(func(literal iceberg.Literal) bool {
+				value, ok := literal.Any().([]byte)
+				assert.True(t, ok)
+				if !ok {
+					return false
+				}
+				value[0] ^= 0xff
+
+				return true
+			}))
+			for _, expected := range expectedLiterals {
+				assert.True(t, literals.Contains(expected))
+			}
+		})
+	}
+}

--- a/exprs.go
+++ b/exprs.go
@@ -1010,17 +1010,13 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 }
 
 func newBoundSetPredicate[T LiteralType](op Operation, term BoundTerm, lits Set[Literal]) *boundSetPredicate[T] {
-	return &boundSetPredicate[T]{
-		op: op, term: term.(bound[T]), lits: lits,
-		literalView: readOnlyLiteralSet{Set: lits},
-	}
+	return &boundSetPredicate[T]{op: op, term: term.(bound[T]), lits: lits}
 }
 
 type boundSetPredicate[T LiteralType] struct {
-	op          Operation
-	term        bound[T]
-	lits        Set[Literal]
-	literalView Set[Literal]
+	op   Operation
+	term bound[T]
+	lits Set[Literal]
 }
 
 func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
@@ -1037,7 +1033,7 @@ func (bsp *boundSetPredicate[T]) Op() Operation { return bsp.op }
 func (bsp *boundSetPredicate[T]) Negate() BooleanExpression {
 	return &boundSetPredicate[T]{
 		op: bsp.op.Negate(), term: bsp.term,
-		lits: bsp.lits, literalView: bsp.literalView,
+		lits: bsp.lits,
 	}
 }
 func (bsp *boundSetPredicate[T]) Term() BoundTerm     { return bsp.term }
@@ -1061,7 +1057,7 @@ func (bsp *boundSetPredicate[T]) AsUnbound(r Reference, lits []Literal) UnboundP
 }
 
 func (bsp *boundSetPredicate[T]) Literals() Set[Literal] {
-	return bsp.literalView
+	return cloneBoundLiteralSet(bsp.lits)
 }
 
 type BoundTransform struct {

--- a/exprs.go
+++ b/exprs.go
@@ -956,7 +956,7 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 		if err != nil {
 			return nil, err
 		}
-		typedSet.Add(casted)
+		typedSet.Add(cloneBoundLiteral(casted))
 	}
 
 	switch typedSet.Len() {
@@ -1010,13 +1010,17 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 }
 
 func newBoundSetPredicate[T LiteralType](op Operation, term BoundTerm, lits Set[Literal]) *boundSetPredicate[T] {
-	return &boundSetPredicate[T]{op: op, term: term.(bound[T]), lits: lits}
+	return &boundSetPredicate[T]{
+		op: op, term: term.(bound[T]), lits: lits,
+		literalView: readOnlyLiteralSet{Set: lits},
+	}
 }
 
 type boundSetPredicate[T LiteralType] struct {
-	op   Operation
-	term bound[T]
-	lits Set[Literal]
+	op          Operation
+	term        bound[T]
+	lits        Set[Literal]
+	literalView Set[Literal]
 }
 
 func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
@@ -1033,7 +1037,7 @@ func (bsp *boundSetPredicate[T]) Op() Operation { return bsp.op }
 func (bsp *boundSetPredicate[T]) Negate() BooleanExpression {
 	return &boundSetPredicate[T]{
 		op: bsp.op.Negate(), term: bsp.term,
-		lits: bsp.lits,
+		lits: bsp.lits, literalView: bsp.literalView,
 	}
 }
 func (bsp *boundSetPredicate[T]) Term() BoundTerm     { return bsp.term }
@@ -1057,7 +1061,7 @@ func (bsp *boundSetPredicate[T]) AsUnbound(r Reference, lits []Literal) UnboundP
 }
 
 func (bsp *boundSetPredicate[T]) Literals() Set[Literal] {
-	return bsp.lits
+	return bsp.literalView
 }
 
 type BoundTransform struct {

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -19,6 +19,7 @@ package iceberg_test
 
 import (
 	"math"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -28,6 +29,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type containsBoundSetVisitor struct {
+	FooBoundExprVisitor
+	needle iceberg.Literal
+	found  bool
+}
+
+func (v *containsBoundSetVisitor) VisitIn(_ iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal]) []string {
+	v.found = literals.Contains(v.needle)
+
+	return nil
+}
 
 type ExprA struct{}
 
@@ -470,6 +483,104 @@ func TestInNotInSimplifications(t *testing.T) {
 		assert.Equal(t, 2, bsp.Literals().Len())
 		assert.True(t, bsp.Literals().Contains(iceberg.NewLiteral("hello")))
 		assert.True(t, bsp.Literals().Contains(iceberg.NewLiteral("world")))
+	})
+
+	t.Run("bound literals are isolated", func(t *testing.T) {
+		isin := iceberg.IsIn(iceberg.Reference("foo"), "hello", "world")
+		bound, err := isin.(iceberg.UnboundPredicate).Bind(tableSchemaSimple, true)
+		require.NoError(t, err)
+
+		bsp := bound.(iceberg.BoundSetPredicate)
+		literals := bsp.Literals()
+		assert.PanicsWithError(t, "invalid argument: cannot add to read-only literal set", func() {
+			literals.Add(iceberg.NewLiteral("injected"))
+		})
+
+		assert.Equal(t, 2, bsp.Literals().Len())
+		assert.False(t, bsp.Literals().Contains(iceberg.NewLiteral("injected")))
+	})
+
+	t.Run("bound literal values are isolated", func(t *testing.T) {
+		geometry, err := iceberg.GeometryTypeOf("srid:4326")
+		require.NoError(t, err)
+		geography, err := iceberg.GeographyTypeOf("srid:4326", "spherical")
+		require.NoError(t, err)
+
+		tests := []struct {
+			name string
+			typ  iceberg.Type
+			lits func([]byte, []byte) []iceberg.Literal
+		}{
+			{
+				name: "binary",
+				typ:  iceberg.PrimitiveTypes.Binary,
+				lits: func(first, second []byte) []iceberg.Literal {
+					return []iceberg.Literal{iceberg.NewLiteral(first), iceberg.NewLiteral(second)}
+				},
+			},
+			{
+				name: "fixed",
+				typ:  iceberg.FixedTypeOf(16),
+				lits: func(first, second []byte) []iceberg.Literal {
+					return []iceberg.Literal{iceberg.NewLiteral(first), iceberg.NewLiteral(second)}
+				},
+			},
+			{
+				name: "geometry",
+				typ:  geometry,
+				lits: func(first, second []byte) []iceberg.Literal {
+					firstLit, err := iceberg.LiteralFromBytes(geometry, first)
+					require.NoError(t, err)
+					secondLit, err := iceberg.LiteralFromBytes(geometry, second)
+					require.NoError(t, err)
+
+					return []iceberg.Literal{firstLit, secondLit}
+				},
+			},
+			{
+				name: "geography",
+				typ:  geography,
+				lits: func(first, second []byte) []iceberg.Literal {
+					firstLit, err := iceberg.LiteralFromBytes(geography, first)
+					require.NoError(t, err)
+					secondLit, err := iceberg.LiteralFromBytes(geography, second)
+					require.NoError(t, err)
+
+					return []iceberg.Literal{firstLit, secondLit}
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				first := []byte("0123456789abcdef")
+				second := []byte("fedcba9876543210")
+				expected := slices.Clone(first)
+				isin := iceberg.SetPredicate(iceberg.OpIn, iceberg.Reference("value"), tt.lits(first, second))
+				schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "value", Type: tt.typ})
+
+				bound, err := isin.(iceberg.UnboundPredicate).Bind(schema, true)
+				require.NoError(t, err)
+				first[0] = 0xff
+
+				expectedLiteral, err := iceberg.LiteralFromBytes(tt.typ, expected)
+				require.NoError(t, err)
+				assert.True(t, bound.(iceberg.BoundSetPredicate).Literals().Contains(expectedLiteral))
+			})
+		}
+	})
+
+	t.Run("access bound literals without allocating", func(t *testing.T) {
+		isin := iceberg.IsIn(iceberg.Reference("foo"), "hello", "world")
+		bound, err := isin.(iceberg.UnboundPredicate).Bind(tableSchemaSimple, true)
+		require.NoError(t, err)
+		predicate := bound.(iceberg.BoundPredicate)
+		visitor := &containsBoundSetVisitor{needle: iceberg.NewLiteral("hello")}
+
+		assert.Zero(t, testing.AllocsPerRun(100, func() {
+			iceberg.VisitBoundPredicate(predicate, visitor)
+		}))
+		assert.True(t, visitor.found)
 	})
 
 	t.Run("bind dedup to eq", func(t *testing.T) {

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -38,6 +38,7 @@ type containsBoundSetVisitor struct {
 
 func (v *containsBoundSetVisitor) VisitIn(_ iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal]) []string {
 	v.found = literals.Contains(v.needle)
+	literals.Add(iceberg.NewLiteral("visitor-injected"))
 
 	return nil
 }
@@ -492,9 +493,7 @@ func TestInNotInSimplifications(t *testing.T) {
 
 		bsp := bound.(iceberg.BoundSetPredicate)
 		literals := bsp.Literals()
-		assert.PanicsWithError(t, "invalid argument: cannot add to read-only literal set", func() {
-			literals.Add(iceberg.NewLiteral("injected"))
-		})
+		literals.Add(iceberg.NewLiteral("injected"))
 
 		assert.Equal(t, 2, bsp.Literals().Len())
 		assert.False(t, bsp.Literals().Contains(iceberg.NewLiteral("injected")))
@@ -570,17 +569,16 @@ func TestInNotInSimplifications(t *testing.T) {
 		}
 	})
 
-	t.Run("access bound literals without allocating", func(t *testing.T) {
+	t.Run("bound predicate visitors receive detached literals", func(t *testing.T) {
 		isin := iceberg.IsIn(iceberg.Reference("foo"), "hello", "world")
 		bound, err := isin.(iceberg.UnboundPredicate).Bind(tableSchemaSimple, true)
 		require.NoError(t, err)
 		predicate := bound.(iceberg.BoundPredicate)
 		visitor := &containsBoundSetVisitor{needle: iceberg.NewLiteral("hello")}
 
-		assert.Zero(t, testing.AllocsPerRun(100, func() {
-			iceberg.VisitBoundPredicate(predicate, visitor)
-		}))
+		iceberg.VisitBoundPredicate(predicate, visitor)
 		assert.True(t, visitor.found)
+		assert.Equal(t, 2, predicate.(iceberg.BoundSetPredicate).Literals().Len())
 	})
 
 	t.Run("bind dedup to eq", func(t *testing.T) {

--- a/internal/bound_predicate_ref.go
+++ b/internal/bound_predicate_ref.go
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+// BoundPredicateRef authorizes the zero-copy bound-predicate visitor path for
+// trusted visitors in this module.
+type BoundPredicateRef struct{}

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/google/uuid"
 )
@@ -568,7 +569,7 @@ func (m *manifestEvalVisitor) VisitUnbound(iceberg.UnboundPredicate) bool {
 }
 
 func (m *manifestEvalVisitor) VisitBound(pred iceberg.BoundPredicate) bool {
-	return iceberg.VisitBoundPredicate(pred, m)
+	return iceberg.VisitBoundPredicateRef(pred, m, iceberginternal.BoundPredicateRef{})
 }
 
 func (m *manifestEvalVisitor) VisitNot(child bool) bool       { return !child }
@@ -821,7 +822,7 @@ func (m *inclusiveMetricsEval) VisitUnbound(iceberg.UnboundPredicate) bool {
 }
 
 func (m *inclusiveMetricsEval) VisitBound(pred iceberg.BoundPredicate) bool {
-	return iceberg.VisitBoundPredicate(pred, m)
+	return iceberg.VisitBoundPredicateRef(pred, m, iceberginternal.BoundPredicateRef{})
 }
 
 func (m *inclusiveMetricsEval) VisitIsNull(t iceberg.BoundTerm) bool {
@@ -1319,7 +1320,7 @@ func (m *strictMetricsEval) VisitUnbound(iceberg.UnboundPredicate) bool {
 }
 
 func (m *strictMetricsEval) VisitBound(pred iceberg.BoundPredicate) bool {
-	return iceberg.VisitBoundPredicate(pred, m)
+	return iceberg.VisitBoundPredicateRef(pred, m, iceberginternal.BoundPredicateRef{})
 }
 
 func (m *strictMetricsEval) VisitIsNull(t iceberg.BoundTerm) bool {
@@ -1741,7 +1742,7 @@ func (c *bloomPredicateCollector) VisitUnbound(_ iceberg.UnboundPredicate) []int
 }
 
 func (c *bloomPredicateCollector) VisitBound(pred iceberg.BoundPredicate) []internal.RowGroupBloomPred {
-	return iceberg.VisitBoundPredicate(pred, c)
+	return iceberg.VisitBoundPredicateRef(pred, c, iceberginternal.BoundPredicateRef{})
 }
 
 func (c *bloomPredicateCollector) VisitEqual(t iceberg.BoundTerm, lit iceberg.Literal) []internal.RowGroupBloomPred {

--- a/transforms.go
+++ b/transforms.go
@@ -193,7 +193,7 @@ func (t IdentityTransform) Project(name string, pred BoundPredicate) (UnboundPre
 	case BoundLiteralPredicate:
 		return p.AsUnbound(Reference(name), p.Literal()), nil
 	case BoundSetPredicate:
-		return p.AsUnbound(Reference(name), p.Literals().Members()), nil
+		return p.AsUnbound(Reference(name), boundSetLiteralsForVisit(p).Members()), nil
 	}
 
 	return nil, nil
@@ -1153,7 +1153,7 @@ func removeTransform(partName string, pred BoundPredicate) (UnboundPredicate, er
 	case BoundLiteralPredicate:
 		return p.AsUnbound(Reference(partName), p.Literal()), nil
 	case BoundSetPredicate:
-		return p.AsUnbound(Reference(partName), p.Literals().Members()), nil
+		return p.AsUnbound(Reference(partName), boundSetLiteralsForVisit(p).Members()), nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot replace transform in unknown predicate: %s",
@@ -1279,7 +1279,7 @@ func literalLen(lit Literal) int {
 }
 
 func setApplyTransform[T LiteralType](name string, pred BoundSetPredicate, fn func(any) Optional[T]) UnboundPredicate {
-	lits := pred.Literals().Members()
+	lits := boundSetLiteralsForVisit(pred).Members()
 	for i, l := range lits {
 		lits[i] = transformLiteral(fn, l)
 	}

--- a/utils.go
+++ b/utils.go
@@ -160,9 +160,6 @@ func (l literalSet) Members() []Literal {
 }
 
 func (l literalSet) Equals(other Set[Literal]) bool {
-	if rhs, ok := other.(readOnlyLiteralSet); ok {
-		other = rhs.Set
-	}
 	rhs, ok := other.(literalSet)
 	if !ok {
 		return false

--- a/utils.go
+++ b/utils.go
@@ -160,6 +160,9 @@ func (l literalSet) Members() []Literal {
 }
 
 func (l literalSet) Equals(other Set[Literal]) bool {
+	if rhs, ok := other.(readOnlyLiteralSet); ok {
+		other = rhs.Set
+	}
 	rhs, ok := other.(literalSet)
 	if !ok {
 		return false

--- a/visitors.go
+++ b/visitors.go
@@ -42,7 +42,9 @@ type BooleanExprVisitor[T any] interface {
 // BoundBooleanExprVisitor builds on BooleanExprVisitor by adding interface
 // methods for visiting bound expressions, because we do casting of literals
 // during binding you can assume that the BoundTerm and the Literal passed
-// to a method have the same type.
+// to a method have the same type. Sets passed to VisitIn and VisitNotIn are
+// borrowed read-only views; visitors must not call Add or retain and mutate
+// their literal values.
 type BoundBooleanExprVisitor[T any] interface {
 	BooleanExprVisitor[T]
 
@@ -134,9 +136,9 @@ func visitBoolExpr[T any](e BooleanExpression, visitor BooleanExprVisitor[T]) T 
 func VisitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisitor[T]) T {
 	switch e.Op() {
 	case OpIn:
-		return visitor.VisitIn(e.Term(), e.(BoundSetPredicate).Literals())
+		return visitor.VisitIn(e.Term(), boundSetLiteralsForVisit(e))
 	case OpNotIn:
-		return visitor.VisitNotIn(e.Term(), e.(BoundSetPredicate).Literals())
+		return visitor.VisitNotIn(e.Term(), boundSetLiteralsForVisit(e))
 	case OpIsNan:
 		return visitor.VisitIsNan(e.Term())
 	case OpNotNan:
@@ -590,7 +592,7 @@ func (c columnNameTranslator) VisitBound(pred BoundPredicate) BooleanExpression 
 	case BoundLiteralPredicate:
 		return p.AsUnbound(ref, p.Literal())
 	case BoundSetPredicate:
-		return p.AsUnbound(ref, p.Literals().Members())
+		return p.AsUnbound(ref, boundSetLiteralsForVisit(p).Members())
 	default:
 		panic(fmt.Errorf("%w: unsupported predicate: %s", ErrNotImplemented, pred))
 	}
@@ -674,7 +676,7 @@ func (sanitizeVisitor) VisitBound(pred BoundPredicate) BooleanExpression {
 	case BoundLiteralPredicate:
 		return sanitizeLiteralPredicate(p.Op(), ref)
 	case BoundSetPredicate:
-		return sanitizeSetPredicate(p.Op(), ref, p.Literals().Len())
+		return sanitizeSetPredicate(p.Op(), ref, boundSetLiteralsForVisit(p).Len())
 	default:
 		panic(fmt.Errorf("%w: unsupported predicate: %s", ErrNotImplemented, pred))
 	}

--- a/visitors.go
+++ b/visitors.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/apache/iceberg-go/internal"
 	"github.com/google/uuid"
 )
 
@@ -43,8 +44,9 @@ type BooleanExprVisitor[T any] interface {
 // methods for visiting bound expressions, because we do casting of literals
 // during binding you can assume that the BoundTerm and the Literal passed
 // to a method have the same type. Sets passed to VisitIn and VisitNotIn are
-// borrowed read-only views; visitors must not call Add or retain and mutate
-// their literal values.
+// detached when dispatched through VisitBoundPredicate. The internal
+// VisitBoundPredicateRef path may pass borrowed sets to trusted built-in
+// visitors, which must not call Add or mutate their literal values.
 type BoundBooleanExprVisitor[T any] interface {
 	BooleanExprVisitor[T]
 
@@ -133,12 +135,25 @@ func visitBoolExpr[T any](e BooleanExpression, visitor BooleanExprVisitor[T]) T 
 // panics with an error wrapping ErrNotImplemented. When reached through VisitExpr
 // that panic is recovered into a returned error; a caller invoking this directly
 // must implement the extension or recover the panic itself.
+// Set predicates are dispatched with detached literal sets. Trusted built-in
+// visitors that need the zero-copy path can use [VisitBoundPredicateRef].
 func VisitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisitor[T]) T {
+	return visitBoundPredicate(e, visitor, false)
+}
+
+// VisitBoundPredicateRef is the zero-copy dispatch path for trusted visitors
+// inside this module. It is gated by an internal token so external visitors
+// use VisitBoundPredicate and receive a detached set.
+func VisitBoundPredicateRef[T any](e BoundPredicate, visitor BoundBooleanExprVisitor[T], _ internal.BoundPredicateRef) T {
+	return visitBoundPredicate(e, visitor, true)
+}
+
+func visitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisitor[T], borrowed bool) T {
 	switch e.Op() {
 	case OpIn:
-		return visitor.VisitIn(e.Term(), boundSetLiteralsForVisit(e))
+		return visitor.VisitIn(e.Term(), literalSetForVisit(e, borrowed))
 	case OpNotIn:
-		return visitor.VisitNotIn(e.Term(), boundSetLiteralsForVisit(e))
+		return visitor.VisitNotIn(e.Term(), literalSetForVisit(e, borrowed))
 	case OpIsNan:
 		return visitor.VisitIsNan(e.Term())
 	case OpNotNan:
@@ -182,6 +197,19 @@ func VisitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisito
 		return gv.VisitBBoxNotIntersects(e.Term(), bbox)
 	}
 	panic(fmt.Errorf("%w: unhandled bound predicate type: %s", ErrNotImplemented, e))
+}
+
+func literalSetForVisit(predicate BoundPredicate, borrowed bool) Set[Literal] {
+	setPredicate, ok := predicate.(BoundSetPredicate)
+	if !ok {
+		panic(fmt.Errorf("%w: %s predicate %T does not implement BoundSetPredicate",
+			ErrNotImplemented, predicate.Op(), predicate))
+	}
+	if borrowed {
+		return boundSetLiteralsForVisit(predicate)
+	}
+
+	return setPredicate.Literals()
 }
 
 // BindExpr recursively binds each portion of an expression using the provided schema.
@@ -255,7 +283,7 @@ func (e *exprEvaluator) VisitUnbound(UnboundPredicate) bool {
 }
 
 func (e *exprEvaluator) VisitBound(pred BoundPredicate) bool {
-	return VisitBoundPredicate(pred, e)
+	return visitBoundPredicate(pred, e, true)
 }
 
 func (*exprEvaluator) VisitTrue() bool                { return true }


### PR DESCRIPTION
## Summary

Return detached literal sets from bound predicates and keep the scan-planning fast path allocation-free.

## Why

Set has a mutating Add method. Returning the internal set let callers and expression visitors change an already-bound predicate, which could affect later evaluation and projection results.

## What changed

- BoundSetPredicate.Literals returns a fresh mutable set with cloned byte-backed literals.
- The public VisitBoundPredicate helper gives visitors detached sets.
- Trusted Iceberg-Go evaluators use an internal capability-gated borrowed path for zero-copy visits and treat those sets as read-only.

## Tests

- Covers binary, fixed, geometry, and geography literal ownership
- Covers mutation through Literals and a custom visitor
- go test .
- go test ./table
- go vet .
- go test ./...