### PR TITLE
fix(name_mapping): isolate updated mappings

### DIFF
--- a/name_mapping.go
+++ b/name_mapping.go
@@ -182,16 +182,20 @@ func (u *updateNameMappingVisitor) Fields(st []MappedField, fieldResults []Mappe
 
 func (u *updateNameMappingVisitor) Field(field MappedField, fieldResult []MappedField) MappedField {
 	if field.FieldID == nil {
-		return field
+		return MappedField{
+			Names:  slices.Clone(field.Names),
+			Fields: fieldResult,
+		}
 	}
 
-	fieldNames := field.Names
+	fieldID := *field.FieldID
+	fieldNames := slices.Clone(field.Names)
 	if update, exists := u.updates[*field.FieldID]; exists && !slices.Contains(fieldNames, update.Name) {
 		fieldNames = append(fieldNames, update.Name)
 	}
 
 	return MappedField{
-		FieldID: field.FieldID,
+		FieldID: &fieldID,
 		Names:   fieldNames,
 		Fields:  u.addNewFields(fieldResult, *field.FieldID),
 	}

--- a/name_mapping.go
+++ b/name_mapping.go
@@ -204,7 +204,8 @@ func (u *updateNameMappingVisitor) Field(field MappedField, fieldResult []Mapped
 func (u *updateNameMappingVisitor) removeReassignedNames(field MappedField, assignments map[string]int) *MappedField {
 	removedNames := make(map[string]struct{})
 	for _, name := range field.Names {
-		if assignedID, exists := assignments[name]; exists && assignedID != *field.FieldID {
+		assignedID, exists := assignments[name]
+		if exists && (field.FieldID == nil || assignedID != *field.FieldID) {
 			removedNames[name] = struct{}{}
 		}
 	}

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -184,6 +184,38 @@ func TestUpdateNameMapping(t *testing.T) {
 		assert.Equal(t, originalMapping, result)
 	})
 
+	t.Run("result does not alias the original", func(t *testing.T) {
+		fieldID, childID := 1, 2
+		parentNames := make([]string, 2)
+		parentNames[0] = "parent"
+		original := iceberg.NameMapping{{
+			FieldID: &fieldID,
+			Names:   parentNames[:1],
+			Fields: []iceberg.MappedField{{
+				FieldID: &childID,
+				Names:   []string{"child"},
+			}},
+		}}
+
+		result, err := iceberg.UpdateNameMapping(
+			original,
+			map[int]iceberg.NestedField{1: {ID: 1, Name: "renamed-parent"}},
+			map[int][]iceberg.NestedField{},
+		)
+		require.NoError(t, err)
+		assert.Empty(t, parentNames[1])
+
+		*result[0].FieldID = 10
+		result[0].Names[0] = "changed-parent"
+		*result[0].Fields[0].FieldID = 20
+		result[0].Fields[0].Names[0] = "changed-child"
+
+		assert.Equal(t, 1, *original[0].FieldID)
+		assert.Equal(t, []string{"parent"}, original[0].Names)
+		assert.Equal(t, 2, *original[0].Fields[0].FieldID)
+		assert.Equal(t, []string{"child"}, original[0].Fields[0].Names)
+	})
+
 	t.Run("update mapping with updates and adds", func(t *testing.T) {
 		updates := map[int]iceberg.NestedField{
 			1: {ID: 1, Name: "foo_update", Type: &iceberg.StringType{}},

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -185,17 +185,26 @@ func TestUpdateNameMapping(t *testing.T) {
 	})
 
 	t.Run("result does not alias the original", func(t *testing.T) {
-		fieldID, childID := 1, 2
+		fieldID, childID, anonymousChildID := 1, 2, 3
 		parentNames := make([]string, 2)
 		parentNames[0] = "parent"
-		original := iceberg.NameMapping{{
-			FieldID: &fieldID,
-			Names:   parentNames[:1],
-			Fields: []iceberg.MappedField{{
-				FieldID: &childID,
-				Names:   []string{"child"},
-			}},
-		}}
+		original := iceberg.NameMapping{
+			{
+				FieldID: &fieldID,
+				Names:   parentNames[:1],
+				Fields: []iceberg.MappedField{{
+					FieldID: &childID,
+					Names:   []string{"child"},
+				}},
+			},
+			{
+				Names: []string{"anonymous"},
+				Fields: []iceberg.MappedField{{
+					FieldID: &anonymousChildID,
+					Names:   []string{"anonymous-child"},
+				}},
+			},
+		}
 
 		result, err := iceberg.UpdateNameMapping(
 			original,
@@ -209,11 +218,17 @@ func TestUpdateNameMapping(t *testing.T) {
 		result[0].Names[0] = "changed-parent"
 		*result[0].Fields[0].FieldID = 20
 		result[0].Fields[0].Names[0] = "changed-child"
+		result[1].Names[0] = "changed-anonymous"
+		*result[1].Fields[0].FieldID = 30
+		result[1].Fields[0].Names[0] = "changed-anonymous-child"
 
 		assert.Equal(t, 1, *original[0].FieldID)
 		assert.Equal(t, []string{"parent"}, original[0].Names)
 		assert.Equal(t, 2, *original[0].Fields[0].FieldID)
 		assert.Equal(t, []string{"child"}, original[0].Fields[0].Names)
+		assert.Equal(t, []string{"anonymous"}, original[1].Names)
+		assert.Equal(t, 3, *original[1].Fields[0].FieldID)
+		assert.Equal(t, []string{"anonymous-child"}, original[1].Fields[0].Names)
 	})
 
 	t.Run("update mapping with updates and adds", func(t *testing.T) {

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -231,6 +231,44 @@ func TestUpdateNameMapping(t *testing.T) {
 		assert.Equal(t, []string{"anonymous-child"}, original[1].Fields[0].Names)
 	})
 
+	t.Run("update nested field under anonymous parent", func(t *testing.T) {
+		childID := 1
+		original := iceberg.NameMapping{{
+			Names: []string{"anonymous"},
+			Fields: []iceberg.MappedField{{
+				FieldID: &childID,
+				Names:   []string{"child"},
+			}},
+		}}
+
+		result, err := iceberg.UpdateNameMapping(
+			original,
+			map[int]iceberg.NestedField{1: {ID: 1, Name: "renamed-child"}},
+			map[int][]iceberg.NestedField{},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"child", "renamed-child"}, result[0].Fields[0].Names)
+	})
+
+	t.Run("remove reassigned name from anonymous field", func(t *testing.T) {
+		fieldID := 1
+		original := iceberg.NameMapping{
+			{Names: []string{"renamed"}},
+			{FieldID: &fieldID, Names: []string{"original"}},
+		}
+
+		result, err := iceberg.UpdateNameMapping(
+			original,
+			map[int]iceberg.NestedField{1: {ID: 1, Name: "renamed"}},
+			map[int][]iceberg.NestedField{},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, iceberg.NameMapping{{
+			FieldID: makeID(1),
+			Names:   []string{"original", "renamed"},
+		}}, result)
+	})
+
 	t.Run("update mapping with updates and adds", func(t *testing.T) {
 		updates := map[int]iceberg.NestedField{
 			1: {ID: 1, Name: "foo_update", Type: &iceberg.StringType{}},


### PR DESCRIPTION
## What changed

Clone mapped field IDs and name slices while building the result of UpdateNameMapping. Fields without IDs now retain the independently visited child results as well.

## Why

The update visitor reused FieldID pointers from the input mapping. Mutating the returned mapping could therefore change the original. Appending a renamed field to a name slice with spare capacity could also write into the input backing array during the update itself.

The regression test covers both alias paths across parent and nested fields.

## Testing

- go test .
- go vet .
- go test ./...