### PR TITLE
fix(table): invalidate shredded variant bounds only on the field's own residual

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1099,8 +1099,8 @@ func (p parquetFormat) collectVariantBounds(meta *metadata.FileMetaData, arrowSc
 		}
 		for _, lf := range enumerateVariantLeaves([]string{f.Name}, vt.TypedValue()) {
 			byTyped[lf.typedPath] = &leafAgg{leaf: lf, parentID: parentID}
-			for _, vp := range lf.valuePaths {
-				residualParent[vp] = struct{}{}
+			if lf.ownResidual != "" {
+				residualParent[lf.ownResidual] = struct{}{}
 			}
 		}
 	}
@@ -1165,7 +1165,7 @@ func (p parquetFormat) collectVariantBounds(meta *metadata.FileMetaData, arrowSc
 		if e.invalid || e.agg == nil {
 			continue
 		}
-		if slices.ContainsFunc(e.leaf.valuePaths, func(vp string) bool { return residualBad[vp] }) {
+		if e.leaf.ownResidual != "" && residualBad[e.leaf.ownResidual] {
 			continue
 		}
 		lo, hi := e.agg.Min(), e.agg.Max()

--- a/table/internal/variant_bounds.go
+++ b/table/internal/variant_bounds.go
@@ -48,7 +48,7 @@ func isNaNLiteral(lit iceberg.Literal) bool {
 type variantLeaf struct {
 	jsonPath    string
 	typedPath   string
-	valuePaths  []string
+	ownResidual string
 	icebergType iceberg.PrimitiveType
 }
 
@@ -56,13 +56,13 @@ type variantLeaf struct {
 func enumerateVariantLeaves(variantColPath []string, tv arrow.Field) []variantLeaf {
 	var out []variantLeaf
 	rootValue := joinPath(append(cloneStrs(variantColPath), "value"))
-	walkVariantTyped(append(cloneStrs(variantColPath), "typed_value"), []string{rootValue}, nil, tv.Type, &out)
+	walkVariantTyped(append(cloneStrs(variantColPath), "typed_value"), rootValue, nil, tv.Type, &out)
 
 	return out
 }
 
-// walkVariantTyped collects primitive leaves from a shredded typed_value subtree, carrying every ancestor residual value path.
-func walkVariantTyped(typedPath []string, valuePaths []string, fields []string, dt arrow.DataType, out *[]variantLeaf) {
+// walkVariantTyped collects primitive leaves from a shredded typed_value subtree, carrying each leaf's own residual value path.
+func walkVariantTyped(typedPath []string, ownResidual string, fields []string, dt arrow.DataType, out *[]variantLeaf) {
 	switch dt.(type) {
 	case *arrow.StructType:
 		t := dt.(*arrow.StructType)
@@ -75,11 +75,11 @@ func walkVariantTyped(typedPath []string, valuePaths []string, fields []string, 
 			if !hasTyped {
 				continue
 			}
-			childValues := valuePaths
+			childResidual := ""
 			if _, hasVal := grp.FieldIdx("value"); hasVal {
-				childValues = append(cloneStrs(valuePaths), joinPath(append(cloneStrs(typedPath), f.Name, "value")))
+				childResidual = joinPath(append(cloneStrs(typedPath), f.Name, "value"))
 			}
-			walkVariantTyped(append(cloneStrs(typedPath), f.Name, "typed_value"), childValues,
+			walkVariantTyped(append(cloneStrs(typedPath), f.Name, "typed_value"), childResidual,
 				append(cloneStrs(fields), f.Name), grp.Field(tvIdx).Type, out)
 		}
 	case *arrow.ListType, *arrow.LargeListType, *arrow.FixedSizeListType:
@@ -92,7 +92,7 @@ func walkVariantTyped(typedPath []string, valuePaths []string, fields []string, 
 		*out = append(*out, variantLeaf{
 			jsonPath:    normalizedVariantPath(fields),
 			typedPath:   joinPath(typedPath),
-			valuePaths:  cloneStrs(valuePaths),
+			ownResidual: ownResidual,
 			icebergType: it,
 		})
 	}

--- a/table/internal/variant_bounds_test.go
+++ b/table/internal/variant_bounds_test.go
@@ -82,12 +82,12 @@ func TestEnumerateVariantLeavesNestedObject(t *testing.T) {
 	assert.Len(t, leaves, 3)
 
 	assert.Equal(t, "payload.typed_value.a.typed_value", got["$['a']"].typedPath)
-	assert.Equal(t, []string{"payload.value", "payload.typed_value.a.value"}, got["$['a']"].valuePaths)
+	assert.Equal(t, "payload.typed_value.a.value", got["$['a']"].ownResidual)
 	assert.Equal(t, iceberg.PrimitiveTypes.Int64, got["$['a']"].icebergType)
 	assert.Equal(t, iceberg.PrimitiveTypes.Int32, got["$['n']"].icebergType)
 	assert.Equal(t, "payload.typed_value.location.typed_value.latitude.typed_value", got["$['location']['latitude']"].typedPath)
-	// nested leaf carries the full ancestor residual chain: root, location, latitude.
-	assert.Equal(t, []string{"payload.value", "payload.typed_value.location.value", "payload.typed_value.location.typed_value.latitude.value"}, got["$['location']['latitude']"].valuePaths)
+	// nested leaf carries only its own residual value column, not ancestor residuals.
+	assert.Equal(t, "payload.typed_value.location.typed_value.latitude.value", got["$['location']['latitude']"].ownResidual)
 	assert.Equal(t, iceberg.PrimitiveTypes.Float64, got["$['location']['latitude']"].icebergType)
 }
 
@@ -97,7 +97,7 @@ func TestEnumerateVariantLeavesRootScalar(t *testing.T) {
 	require.Len(t, leaves, 1)
 	assert.Equal(t, "$", leaves[0].jsonPath)
 	assert.Equal(t, "payload.typed_value", leaves[0].typedPath)
-	assert.Equal(t, []string{"payload.value"}, leaves[0].valuePaths)
+	assert.Equal(t, "payload.value", leaves[0].ownResidual)
 	assert.Equal(t, iceberg.PrimitiveTypes.Int64, leaves[0].icebergType)
 }
 
@@ -343,10 +343,10 @@ func TestCollectVariantBoundsNestedAncestorResidual(t *testing.T) {
 	}
 	info := metadata.ChunkMetaInfo{NumValues: 2, DataPageOffset: 4, IndexPageOffset: -1, CompressedSize: 8, UncompressedSize: 8}
 
-	// locValStats is the ancestor (location) residual value column under test.
+	// locValStats is the ancestor (location) residual; latValStats is the leaf (latitude) residual.
 	// Column order (depth-first leaves): payload.metadata, payload.value,
 	// location.value, latitude.value, latitude.typed_value.
-	build := func(locValStats metadata.EncodedStatistics) *metadata.FileMetaData {
+	build := func(locValStats, latValStats metadata.EncodedStatistics) *metadata.FileMetaData {
 		fmb := metadata.NewFileMetadataBuilder(schema.NewSchema(root), parquet.NewWriterProperties(), nil)
 		set := func(rg *metadata.RowGroupMetaDataBuilder, st metadata.EncodedStatistics) {
 			c := rg.NextColumnChunk()
@@ -357,9 +357,9 @@ func TestCollectVariantBoundsNestedAncestorResidual(t *testing.T) {
 		}
 		rg := fmb.AppendRowGroup()
 		set(rg, allNull())   // payload.metadata
-		set(rg, allNull())   // payload.value (root residual, benign)
-		set(rg, locValStats) // location.value (ancestor residual under test)
-		set(rg, allNull())   // latitude.value (leaf residual, benign)
+		set(rg, allNull())   // payload.value (root residual)
+		set(rg, locValStats) // location.value (ancestor residual)
+		set(rg, latValStats) // latitude.value (leaf residual)
 		set(rg, latMinMax()) // latitude.typed_value (produces the bound)
 		require.NoError(t, rg.Finish(40, 0))
 		fmd, err := fmb.Finish()
@@ -368,17 +368,21 @@ func TestCollectVariantBoundsNestedAncestorResidual(t *testing.T) {
 		return fmd
 	}
 
-	// location residual has non-null (non-object location) values: latitude bound must drop.
 	nonNull := metadata.EncodedStatistics{}
 	nonNull.SetNullCount(0)
-	lo, hi := parquetFormat{}.collectVariantBounds(build(nonNull), arrowSchema, colMapping, statsCols)
-	assert.NotContains(t, lo, 1, "latitude bound must drop when the location ancestor residual has non-null values")
-	assert.NotContains(t, hi, 1)
 
-	// location residual all-null: latitude bound kept.
-	lo2, hi2 := parquetFormat{}.collectVariantBounds(build(allNull()), arrowSchema, colMapping, statsCols)
-	assert.Contains(t, lo2, 1, "latitude bound kept when the location ancestor residual is all-null")
-	assert.Contains(t, hi2, 1)
+	// non-null ancestor residual keeps the bound; only the leaf's own residual drops it.
+	lo, hi := parquetFormat{}.collectVariantBounds(build(nonNull, allNull()), arrowSchema, colMapping, statsCols)
+	assert.Contains(t, lo, 1, "latitude bound kept when only the location ancestor residual is non-null")
+	assert.Contains(t, hi, 1)
+
+	lo2, hi2 := parquetFormat{}.collectVariantBounds(build(allNull(), nonNull), arrowSchema, colMapping, statsCols)
+	assert.NotContains(t, lo2, 1, "latitude bound dropped when the latitude leaf residual is non-null")
+	assert.NotContains(t, hi2, 1)
+
+	lo3, hi3 := parquetFormat{}.collectVariantBounds(build(allNull(), allNull()), arrowSchema, colMapping, statsCols)
+	assert.Contains(t, lo3, 1, "latitude bound kept when all residuals are all-null")
+	assert.Contains(t, hi3, 1)
 }
 
 func TestTruncateVariantBound(t *testing.T) {


### PR DESCRIPTION
`collectVariantBounds` dropped a shredded field's bound when any ancestor object's residual `value` column was non-null. Now it drops only when the field's own `value` residual is non-null.

Per the Iceberg spec [Bounds for Variant](https://github.com/apache/iceberg/blob/main/format/spec.md), a field's bounds must be accurate for its non-null values. A row whose ancestor is a scalar has the descendant field absent (null), so it is outside the bound and cannot invalidate it. This matches Java `ParquetMetrics.object()`/`value()`, where the object residual is trusted and only the field's own residual invalidates its bound.

Serialization unchanged; only which fields get a bound. Follow-up to [#1478](https://github.com/apache/iceberg-go/pull/1478).