### PR TITLE
fix(io): strip GCS-incompatible SDK headers on reads too

### DIFF
--- a/io/gocloud/s3.go
+++ b/io/gocloud/s3.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -244,30 +243,23 @@ func stripS3InputChecksumAlgorithm(stack *smithymiddleware.Stack) error {
 	return nil
 }
 
-// SDK-internal headers that GCS's S3 interop endpoint doesn't expect in the SigV4 signed set
+// SDK-internal headers GCS's S3 interop endpoint rejects in the SigV4 signed set; removing
+// them before signing (all ops, reads included) avoids SignatureDoesNotMatch.
 var gcsIncompatibleSignedHeaders = []string{
 	"Amz-Sdk-Invocation-Id",
 	"Amz-Sdk-Request",
 	"Accept-Encoding",
 }
 
-// limits header stripping to write ops;
-// reads must keep Accept-Encoding: identity so responses aren't silently gzip-decompressed.
-var gcsStripSignedHeaderOps = map[string]struct{}{
-	"PutObject":             {},
-	"UploadPart":            {},
-	"CreateMultipartUpload": {},
-}
-
+// stripGCSIncompatibleSignedHeaders removes those headers before signing, then re-adds
+// Accept-Encoding: identity after signing so it's on the wire but unsigned (no gzip, GCS-safe).
 func stripGCSIncompatibleSignedHeaders(stack *smithymiddleware.Stack) error {
-	m := smithymiddleware.FinalizeMiddlewareFunc(
+	strip := smithymiddleware.FinalizeMiddlewareFunc(
 		"iceberg-go/strip-gcs-incompatible-signed-headers",
 		func(ctx context.Context, in smithymiddleware.FinalizeInput, next smithymiddleware.FinalizeHandler) (smithymiddleware.FinalizeOutput, smithymiddleware.Metadata, error) {
-			if _, isWrite := gcsStripSignedHeaderOps[awsmiddleware.GetOperationName(ctx)]; isWrite {
-				if req, ok := in.Request.(*smithyhttp.Request); ok {
-					for _, h := range gcsIncompatibleSignedHeaders {
-						req.Header.Del(h)
-					}
+			if req, ok := in.Request.(*smithyhttp.Request); ok {
+				for _, h := range gcsIncompatibleSignedHeaders {
+					req.Header.Del(h)
 				}
 			}
 
@@ -275,8 +267,26 @@ func stripGCSIncompatibleSignedHeaders(stack *smithymiddleware.Stack) error {
 		},
 	)
 
-	if err := stack.Finalize.Insert(m, "Signing", smithymiddleware.Before); err != nil {
-		return stack.Finalize.Add(m, smithymiddleware.Before)
+	restore := smithymiddleware.FinalizeMiddlewareFunc(
+		"iceberg-go/restore-accept-encoding-identity",
+		func(ctx context.Context, in smithymiddleware.FinalizeInput, next smithymiddleware.FinalizeHandler) (smithymiddleware.FinalizeOutput, smithymiddleware.Metadata, error) {
+			if req, ok := in.Request.(*smithyhttp.Request); ok {
+				req.Header.Set("Accept-Encoding", "identity")
+			}
+
+			return next.HandleFinalize(ctx, in)
+		},
+	)
+
+	if err := stack.Finalize.Insert(strip, "Signing", smithymiddleware.Before); err != nil {
+		if err := stack.Finalize.Add(strip, smithymiddleware.Before); err != nil {
+			return err
+		}
+	}
+	if err := stack.Finalize.Insert(restore, "Signing", smithymiddleware.After); err != nil {
+		if err := stack.Finalize.Add(restore, smithymiddleware.After); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/io/gocloud/s3_test.go
+++ b/io/gocloud/s3_test.go
@@ -416,6 +416,53 @@ func TestCompatModeTransferManagerNoAwsChunked(t *testing.T) {
 	assertNoAwsChunkedWriteHeaders(t, captured, "transfer-manager PutObject")
 }
 
+func TestCompatModeGetObjectStripsSignedHeaders(t *testing.T) {
+	t.Parallel()
+
+	var captured http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := aws.Config{
+		Region:      "auto",
+		Credentials: credentials.NewStaticCredentialsProvider("AKIA-TEST", "secret-test", ""),
+		HTTPClient:  srv.Client(),
+	}
+	client := s3.NewFromConfig(cfg, compatModeS3Options(srv.URL))
+
+	out, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("test-key"),
+	})
+	require.NoError(t, err)
+	_ = out.Body.Close()
+
+	require.NotNil(t, captured)
+
+	// SDK-internal headers must be stripped on reads too; otherwise GCS's S3 interop
+	// endpoint returns SignatureDoesNotMatch when loading table metadata (GetObject).
+	for _, h := range []string{"Amz-Sdk-Invocation-Id", "Amz-Sdk-Request"} {
+		assert.Emptyf(t, captured.Get(h),
+			"GetObject must not send SDK-internal header %s on the wire, got %q", h, captured.Get(h))
+	}
+	auth := captured.Get("Authorization")
+	require.NotEmpty(t, auth, "Authorization header must be set")
+	// None of these may appear in the signed set, or GCS rejects with SignatureDoesNotMatch.
+	for _, h := range []string{"amz-sdk-invocation-id", "amz-sdk-request", "accept-encoding"} {
+		assert.NotContainsf(t, auth, h,
+			"SignedHeaders in Authorization must not list %q on reads, got Authorization=%q", h, auth)
+	}
+
+	// Re-added as identity after signing: on the wire (no silent gzip) but not in the
+	// signature checked above.
+	assert.Equal(t, "identity", captured.Get("Accept-Encoding"),
+		"GetObject must keep Accept-Encoding: identity on the wire")
+}
+
 func TestS3CompatModeEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The `strip-gcs-incompatible-signed-headers` compat-mode middleware (added in #1423) removes `Amz-Sdk-Invocation-Id`, `Amz-Sdk-Request`, and `Accept-Encoding` from the SigV4 signed set only for **write** operations (`PutObject`/`UploadPart`/`CreateMultipartUpload`).

**Read** operations still send those headers signed. Against Google Cloud Storage's S3-interop endpoint (`storage.googleapis.com` + HMAC keys), a `GetObject`/`HeadObject` — e.g. loading a table's `metadata.json` during a table-exists check — is rejected with:

```
operation error S3: GetObject, StatusCode: 403 ... SignatureDoesNotMatch
```

So writes succeed but any subsequent read fails, making GCS S3-interop unusable end to end.

## Fix

- Strip `Amz-Sdk-Invocation-Id` / `Amz-Sdk-Request` / `Accept-Encoding` before signing on **every** operation (reads included), so none of them are in the SigV4 signed set.
- Re-add `Accept-Encoding: identity` in a middleware inserted **after** the Signing step, so it is present on the wire but **not** part of the signature. This keeps GCS happy while still suppressing the HTTP transport's transparent gzip, so read responses aren't silently decompressed (which would drop `Content-Length`).

Only affects the S3-compat path (`s3.compat-mode=true`); the normal AWS S3 path is unchanged.