### PR TITLE
fix(table): repair broken build from stray internal.Enumerated reference

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1024,7 +1024,7 @@ func (as *arrowScan) processRecords(
 		if err != nil {
 			return err
 		}
-		out <- enumeratedRecord{Record: internal.Enumerated[arrow.RecordBatch]{
+		out <- enumeratedRecord{Record: tblutils.Enumerated[arrow.RecordBatch]{
 			Value: array.NewRecordBatch(emptySchema, nil, 0), Index: idx, Last: true,
 		}, Task: task}
 	}


### PR DESCRIPTION
## What

`table/arrow_scanner.go` fails to compile on `main`:

```
table/arrow_scanner.go:1027:35: undefined: internal
```

## Why

#1426 aliased the `github.com/apache/iceberg-go/table/internal` import to `tblutils` and updated the call sites, but one reference in `processRecords` was left as bare `internal.Enumerated`. There is no import named `internal`, so the `table` package no longer builds.

## Fix

Point the stray reference at the `tblutils` alias, matching the 22 other call sites in the file. One line.

```
go build ./table/   # passes
go vet ./table/     # passes
```