### PR TITLE
fix(ci): make labeler config parse under actions/labeler v7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,12 +18,11 @@
 # Pull request labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
 INFRA:
   - changed-files:
-    - any-glob-to-any-file: [
-        ".github/workflows/**/*",
-        ".github/labeler.yml",
-        ".asf.yaml",
-        ".gitattributes",
-        ".gitignore",
-        ".pre-commit-config.yaml",
-        "dev/**/*"
-      ]
+      - any-glob-to-any-file:
+          - ".github/workflows/**/*"
+          - ".github/labeler.yml"
+          - ".asf.yaml"
+          - ".gitattributes"
+          - ".gitignore"
+          - ".pre-commit-config.yaml"
+          - "dev/**/*"


### PR DESCRIPTION
A stricter YAML parser bundled with `actions/labeler` v7 (bumped in #1553) rejects the multi-line **flow-style** list in `.github/labeler.yml`, so the `triage` job now fails on every PR:

```
YAMLException: deficient indentation (29:7)  in .github/labeler.yml
```

The flow-style `any-glob-to-any-file: [ … ]` block was added in #910 and parsed fine under v6.x; v7 tightened parsing and exposed it.

## Fix

Convert the `INFRA` rule's `any-glob-to-any-file` list from flow style to canonical block style. Single file, no label-semantics change — the same seven globs still map to `INFRA`. Verified the result parses cleanly with `js-yaml` (the parser `actions/labeler` uses).

## Note for reviewers

This PR's own `triage` check will still show red: the labeler workflow runs on `pull_request_target` and reads the config from the **base branch** (still-broken `main`), not from this PR. It will go green for all PRs once this merges.