### PR TITLE
fix(cli): report successful drop operation in cli

### DIFF
--- a/cmd/iceberg/drop_test.go
+++ b/cmd/iceberg/drop_test.go
@@ -128,7 +128,7 @@ func TestRunDropTable(t *testing.T) {
 	runDrop(context.Background(), &errOut, cat, cmd)
 
 	assert.True(t, cat.dropCalled)
-	assert.Equal(t, table.Identifier{"db", "events"}, cat.dropIdent)
+	assert.Equal(t, "Table db.events dropped successfully", errOut.lastText)
 	assert.NoError(t, errOut.lastErr)
 }
 
@@ -172,7 +172,7 @@ func TestRunDropTablePurgeSupported(t *testing.T) {
 	runDrop(context.Background(), &errOut, cat, cmd)
 
 	assert.True(t, cat.purgeCalled)
-	assert.Equal(t, table.Identifier{"db", "events"}, cat.purgeIdent)
+	assert.Equal(t, "Table db.events purged successfully", errOut.lastText)
 	assert.NoError(t, errOut.lastErr)
 }
 

--- a/cmd/iceberg/drop_test.go
+++ b/cmd/iceberg/drop_test.go
@@ -35,6 +35,8 @@ type mockCatalogForDrop struct {
 	dropCalled     bool
 	dropIdent      table.Identifier
 	dropErr        error
+	dropNamespaceCalled	bool
+	dropNamespaceIdent	table.Identifier
 	checkExists    bool
 	checkExistsErr error
 }
@@ -83,6 +85,8 @@ func (m *mockCatalogForDrop) CreateNamespace(ctx context.Context, namespace tabl
 }
 
 func (m *mockCatalogForDrop) DropNamespace(ctx context.Context, namespace table.Identifier) error {
+	m.dropNamespaceCalled = true
+	m.dropNamespaceIdent = namespace
 	return nil
 }
 
@@ -130,6 +134,26 @@ func TestRunDropTable(t *testing.T) {
 	assert.True(t, cat.dropCalled)
 	assert.Equal(t, "Table db.events dropped successfully", errOut.lastText)
 	assert.NoError(t, errOut.lastErr)
+}
+
+func TestRunDropNamespace(t *testing.T) {
+	cat := &mockCatalogForDrop{
+		catalogType: catalog.SQL,
+	}
+
+	cmd := &DropCmd{
+		Namespace: &DropNamespaceCmd{
+			Identifier: "db",
+		},
+	}
+
+	var errOut errCapture
+	runDrop(context.Background(), &errOut, cat, cmd)
+
+	assert.True(t, cat.dropNamespaceCalled)
+	assert.Equal(t, table.Identifier{"db"}, cat.dropNamespaceIdent)
+  	assert.Equal(t, "Namespace db dropped successfully", errOut.lastText)
+  	assert.NoError(t, errOut.lastErr)
 }
 
 func TestRunDropTablePurgeNotSupported(t *testing.T) {

--- a/cmd/iceberg/drop_test.go
+++ b/cmd/iceberg/drop_test.go
@@ -31,14 +31,14 @@ import (
 )
 
 type mockCatalogForDrop struct {
-	catalogType    catalog.Type
-	dropCalled     bool
-	dropIdent      table.Identifier
-	dropErr        error
-	dropNamespaceCalled	bool
-	dropNamespaceIdent	table.Identifier
-	checkExists    bool
-	checkExistsErr error
+	catalogType         catalog.Type
+	dropCalled          bool
+	dropIdent           table.Identifier
+	dropErr             error
+	dropNamespaceCalled bool
+	dropNamespaceIdent  table.Identifier
+	checkExists         bool
+	checkExistsErr      error
 }
 
 func (m *mockCatalogForDrop) CatalogType() catalog.Type {
@@ -87,6 +87,7 @@ func (m *mockCatalogForDrop) CreateNamespace(ctx context.Context, namespace tabl
 func (m *mockCatalogForDrop) DropNamespace(ctx context.Context, namespace table.Identifier) error {
 	m.dropNamespaceCalled = true
 	m.dropNamespaceIdent = namespace
+
 	return nil
 }
 
@@ -132,6 +133,7 @@ func TestRunDropTable(t *testing.T) {
 	runDrop(context.Background(), &errOut, cat, cmd)
 
 	assert.True(t, cat.dropCalled)
+	assert.Equal(t, table.Identifier{"db", "events"}, cat.dropIdent)
 	assert.Equal(t, "Table db.events dropped successfully", errOut.lastText)
 	assert.NoError(t, errOut.lastErr)
 }
@@ -152,8 +154,8 @@ func TestRunDropNamespace(t *testing.T) {
 
 	assert.True(t, cat.dropNamespaceCalled)
 	assert.Equal(t, table.Identifier{"db"}, cat.dropNamespaceIdent)
-  	assert.Equal(t, "Namespace db dropped successfully", errOut.lastText)
-  	assert.NoError(t, errOut.lastErr)
+	assert.Equal(t, "Namespace db dropped successfully", errOut.lastText)
+	assert.NoError(t, errOut.lastErr)
 }
 
 func TestRunDropTablePurgeNotSupported(t *testing.T) {
@@ -196,6 +198,7 @@ func TestRunDropTablePurgeSupported(t *testing.T) {
 	runDrop(context.Background(), &errOut, cat, cmd)
 
 	assert.True(t, cat.purgeCalled)
+	assert.Equal(t, table.Identifier{"db", "events"}, cat.purgeIdent)
 	assert.Equal(t, "Table db.events purged successfully", errOut.lastText)
 	assert.NoError(t, errOut.lastErr)
 }

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -563,6 +563,8 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 		if err != nil {
 			output.Error(err)
 			osExit(1)
+
+			return
 		}
 
 		output.Text("Namespace " + cmd.Namespace.Identifier + " dropped successfully")
@@ -574,12 +576,14 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 			if !ok {
 				output.Error(fmt.Errorf("catalog %s does not support purge", cat.CatalogType()))
 				osExit(1)
+
 				return
 			}
 
 			if err := purger.PurgeTable(ctx, ident); err != nil {
 				output.Error(err)
 				osExit(1)
+
 				return
 			}
 
@@ -591,6 +595,8 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 		if err := cat.DropTable(ctx, ident); err != nil {
 			output.Error(err)
 			osExit(1)
+
+			return
 		}
 
 		output.Text("Table " + cmd.Table.Identifier + " dropped successfully")

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -564,23 +564,33 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 			output.Error(err)
 			osExit(1)
 		}
+
+		output.Text("Namespace " + cmd.Namespace.Identifier + " dropped successfully")
 	case cmd.Table != nil:
 		ident := catalog.ToIdentifier(cmd.Table.Identifier)
-		var err error
+
 		if cmd.Table.Purge {
-			if purger, ok := cat.(catalog.PurgeableTable); ok {
-				err = purger.PurgeTable(ctx, ident)
-			} else {
+			purger, ok := cat.(catalog.PurgeableTable)
+			if !ok {
 				output.Error(fmt.Errorf("catalog %s does not support purge", cat.CatalogType()))
 				osExit(1)
 			}
-		} else {
-			err = cat.DropTable(ctx, ident)
+
+			if err := purger.PurgeTable(ctx, ident); err != nil {
+				output.Error(err)
+				osExit(1)
+			}
+
+			output.Text("Table " + cmd.Table.Identifier + " purged successfully")
+
+			return
 		}
-		if err != nil {
+
+		if err := cat.DropTable(ctx, ident); err != nil {
 			output.Error(err)
 			osExit(1)
 		}
+		output.Text("Table " + cmd.Table.Identifier + " dropped successfully")
 	}
 }
 

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -574,11 +574,13 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 			if !ok {
 				output.Error(fmt.Errorf("catalog %s does not support purge", cat.CatalogType()))
 				osExit(1)
+				return
 			}
 
 			if err := purger.PurgeTable(ctx, ident); err != nil {
 				output.Error(err)
 				osExit(1)
+				return
 			}
 
 			output.Text("Table " + cmd.Table.Identifier + " purged successfully")

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -592,6 +592,7 @@ func runDrop(ctx context.Context, output Output, cat catalog.Catalog, cmd *DropC
 			output.Error(err)
 			osExit(1)
 		}
+
 		output.Text("Table " + cmd.Table.Identifier + " dropped successfully")
 	}
 }

--- a/cmd/iceberg/upgrade_rollback_test.go
+++ b/cmd/iceberg/upgrade_rollback_test.go
@@ -713,7 +713,7 @@ func int64Ptr(v int64) *int64 {
 
 type errCapture struct {
 	textOutput
-	lastErr error
+	lastErr  error
 	lastText string
 }
 

--- a/cmd/iceberg/upgrade_rollback_test.go
+++ b/cmd/iceberg/upgrade_rollback_test.go
@@ -714,10 +714,15 @@ func int64Ptr(v int64) *int64 {
 type errCapture struct {
 	textOutput
 	lastErr error
+	lastText string
 }
 
 func (e *errCapture) Error(err error) {
 	e.lastErr = err
+}
+
+func (e *errCapture) Text(val string) {
+	e.lastText = val
 }
 
 func captureExit(f func()) (exitCode int) {


### PR DESCRIPTION
## Summary
- Priunt success message after dropping a namespace/table
- Printt distinct success message when `drop table --purge`

## Testing
did not add test code (no exists create/rename cmd)

- `go test ./cmd/iceberg` (fails existing build error in `table/arrow_scanner.go:1027:35: undefined: internal`)