### PR TITLE
fix(table): use table internal Enumerated in arrow scanner

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1024,7 +1024,7 @@ func (as *arrowScan) processRecords(
 		if err != nil {
 			return err
 		}
-		out <- enumeratedRecord{Record: internal.Enumerated[arrow.RecordBatch]{
+		out <- enumeratedRecord{Record: tblutils.Enumerated[arrow.RecordBatch]{
 			Value: array.NewRecordBatch(emptySchema, nil, 0), Index: idx, Last: true,
 		}, Task: task}
 	}


### PR DESCRIPTION
  ## What changed

  Use `tblutils.Enumerated` when emitting the empty final record batch from `arrowScan.processRecords`. [Refer this comment](https://github.com/apache/iceberg-go/pull/1566#discussion_r3666328662).

  ## Why

The empty-batch sentinel path should use the same `table/internal` `Enumerated` type as the rest of the arrow scanner. Referring to `internal.Enumerated` uses the wrong package qualifier and breaks the table package build.

## Testing

 - `go test ./table`