### PR TITLE
ci: fix labeler config YAML indentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,12 +18,11 @@
 # Pull request labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
 INFRA:
   - changed-files:
-    - any-glob-to-any-file: [
-        ".github/workflows/**/*",
-        ".github/labeler.yml",
-        ".asf.yaml",
-        ".gitattributes",
-        ".gitignore",
-        ".pre-commit-config.yaml",
-        "dev/**/*"
-      ]
+    - any-glob-to-any-file:
+        - ".github/workflows/**/*"
+        - ".github/labeler.yml"
+        - ".asf.yaml"
+        - ".gitattributes"
+        - ".gitignore"
+        - ".pre-commit-config.yaml"
+        - "dev/**/*"


### PR DESCRIPTION
actions/labeler v6.1.0 parses .github/labeler.yml with js-yaml warnings promoted to errors. The multi-line flow-style sequence had its closing bracket indented less than its items, which js-yaml now rejects as "deficient indentation", failing the triage job on every open PR.

Convert the flow-style list to a block-style list, which parses cleanly and produces the identical config structure.