### PR TITLE
fix(sql): validate view identifiers at API boundaries

### DIFF
--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -95,17 +95,21 @@ func TestValidateViewIdentifier(t *testing.T) {
 func TestValidateNamespaceIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace"}))
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", "namespace"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", ""}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "."}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", ".."}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "child/name"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "child\nname"}))
 
-	for _, ident := range []table.Identifier{
-		nil,
-		{},
-		{"namespace", ""},
-		{"namespace", "."},
-		{"namespace", ".."},
-		{"namespace", "child/name"},
-		{"namespace", "child\nname"},
-	} {
-		require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	for _, ident := range []table.Identifier{nil, {}} {
+		t.Run("empty identifier", func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+		})
+	}
+	for _, ident := range []table.Identifier{{"\x00"}, {"parent", "child\x00"}} {
+		t.Run("null character", func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+		})
 	}
 }
 

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -92,6 +92,23 @@ func TestValidateViewIdentifier(t *testing.T) {
 	require.NotErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchTable)
 }
 
+func TestValidateNamespaceIdentifier(t *testing.T) {
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", "namespace"}))
+
+	for _, ident := range []table.Identifier{
+		nil,
+		{},
+		{"namespace", ""},
+		{"namespace", "."},
+		{"namespace", ".."},
+		{"namespace", "child/name"},
+		{"namespace", "child\nname"},
+	} {
+		require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	}
+}
+
 func TestValidateFunctionIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function"}))
 

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -92,27 +92,6 @@ func TestValidateViewIdentifier(t *testing.T) {
 	require.NotErrorIs(t, catalog.ValidateViewIdentifier(table.Identifier{"namespace", "view/name"}), catalog.ErrNoSuchTable)
 }
 
-func TestValidateNamespaceIdentifier(t *testing.T) {
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace"}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", "namespace"}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", ""}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "."}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", ".."}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "child/name"}))
-	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace", "child\nname"}))
-
-	for _, ident := range []table.Identifier{nil, {}} {
-		t.Run("empty identifier", func(t *testing.T) {
-			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
-		})
-	}
-	for _, ident := range []table.Identifier{{"\x00"}, {"parent", "child\x00"}} {
-		t.Run("null character", func(t *testing.T) {
-			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
-		})
-	}
-}
-
 func TestValidateFunctionIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateFunctionIdentifier(table.Identifier{"namespace", "function"}))
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1233,10 +1233,6 @@ func (c *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 }
 
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
-	if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
-		return err
-	}
-
 	for key := range props {
 		if isReservedNamespaceProperty(key) {
 			return fmt.Errorf("%w: cannot create namespace with reserved namespace property %q", iceberg.ErrInvalidArgument, key)
@@ -1676,10 +1672,6 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 		return nil, nil
 	}
 
-	if err := checkValidNamespace(namespace); err != nil {
-		return nil, err
-	}
-
 	ns := namespaceToString(namespace)
 	if len(namespace) > 0 {
 		var exists bool
@@ -1723,10 +1715,6 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {
 	if c.isV0() {
 		return errViewsUnsupportedOnV0
-	}
-
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return err
 	}
 
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1721,6 +1721,10 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 		return errViewsUnsupportedOnV0
 	}
 
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return err
+	}
+
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
 	if err != nil {
 		return err

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1581,6 +1581,10 @@ func (c *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Iden
 
 // CreateView creates a new view in the catalog.
 func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, viewSQL string, props iceberg.Properties) error {
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return err
+	}
+
 	if c.isV0() {
 		return errViewsUnsupportedOnV0
 	}
@@ -1713,6 +1717,10 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 
 // DropView deletes a view from the catalog.
 func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return err
+	}
+
 	if c.isV0() {
 		return errViewsUnsupportedOnV0
 	}
@@ -1788,6 +1796,10 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 
 // CheckViewExists returns true if a view exists in the catalog.
 func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifier) (bool, error) {
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return false, err
+	}
+
 	if c.isV0() {
 		return false, nil
 	}
@@ -1814,6 +1826,10 @@ func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 
 // LoadView loads a view from the catalog.
 func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (view.Metadata, error) {
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return nil, err
+	}
+
 	if c.isV0() {
 		return nil, errViewsUnsupportedOnV0
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1721,10 +1721,6 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 		return errViewsUnsupportedOnV0
 	}
 
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return err
-	}
-
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
 	if err != nil {
 		return err

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1672,6 +1672,12 @@ func (c *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 }
 
 func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
+	if len(namespace) > 0 {
+		if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
+			return nil, err
+		}
+	}
+
 	if c.isV0() {
 		return nil, nil
 	}

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1233,6 +1233,10 @@ func (c *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 }
 
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
+	if err := checkValidNamespace(namespace); err != nil {
+		return err
+	}
+
 	for key := range props {
 		if isReservedNamespaceProperty(key) {
 			return fmt.Errorf("%w: cannot create namespace with reserved namespace property %q", iceberg.ErrInvalidArgument, key)

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1233,7 +1233,7 @@ func (c *Catalog) CheckTableExists(ctx context.Context, identifier table.Identif
 }
 
 func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifier, props iceberg.Properties) error {
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
 		return err
 	}
 
@@ -1581,12 +1581,12 @@ func (c *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Iden
 
 // CreateView creates a new view in the catalog.
 func (c *Catalog) CreateView(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, viewSQL string, props iceberg.Properties) error {
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return err
-	}
-
 	if c.isV0() {
 		return errViewsUnsupportedOnV0
+	}
+
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return err
 	}
 
 	nsIdent := catalog.NamespaceFromIdent(identifier)
@@ -1672,14 +1672,12 @@ func (c *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 }
 
 func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) ([]table.Identifier, error) {
-	if len(namespace) > 0 {
-		if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
-			return nil, err
-		}
-	}
-
 	if c.isV0() {
 		return nil, nil
+	}
+
+	if err := checkValidNamespace(namespace); err != nil {
+		return nil, err
 	}
 
 	ns := namespaceToString(namespace)
@@ -1723,12 +1721,12 @@ func (c *Catalog) listViewsAll(ctx context.Context, namespace table.Identifier) 
 
 // DropView deletes a view from the catalog.
 func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) error {
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return err
-	}
-
 	if c.isV0() {
 		return errViewsUnsupportedOnV0
+	}
+
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return err
 	}
 
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
@@ -1802,12 +1800,12 @@ func (c *Catalog) DropView(ctx context.Context, identifier table.Identifier) err
 
 // CheckViewExists returns true if a view exists in the catalog.
 func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifier) (bool, error) {
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return false, err
-	}
-
 	if c.isV0() {
 		return false, nil
+	}
+
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return false, err
 	}
 
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))
@@ -1832,12 +1830,12 @@ func (c *Catalog) CheckViewExists(ctx context.Context, identifier table.Identifi
 
 // LoadView loads a view from the catalog.
 func (c *Catalog) LoadView(ctx context.Context, identifier table.Identifier) (view.Metadata, error) {
-	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
-		return nil, err
-	}
-
 	if c.isV0() {
 		return nil, errViewsUnsupportedOnV0
+	}
+
+	if err := catalog.ValidateViewIdentifier(identifier); err != nil {
+		return nil, err
 	}
 
 	ns, err := c.namespaceKey(ctx, catalog.NamespaceFromIdent(identifier))

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2274,9 +2274,6 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 			err := cat.CreateView(context.Background(), test.identifier, nil, "", nil)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
-			err = cat.DropView(context.Background(), test.identifier)
-			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
-
 			_, err = cat.CheckViewExists(context.Background(), test.identifier)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
@@ -2458,6 +2455,36 @@ func (s *SqliteCatalogTestSuite) TestDropView() {
 	err = db.DropView(context.Background(), []string{nsName, "nonexistent"})
 	s.Error(err)
 	s.ErrorIs(err, catalog.ErrNoSuchView)
+}
+
+func (s *SqliteCatalogTestSuite) TestDropViewRemovesLegacyInvalidView() {
+	ctx := context.Background()
+	db := s.getCatalogSqlite()
+	s.Require().NoError(db.CreateSQLTables(ctx))
+
+	nsName := databaseName()
+	viewName := "nested/view"
+	s.Require().NoError(db.CreateNamespace(ctx, []string{nsName}, nil))
+
+	sqldb := s.getDB()
+	defer sqldb.Close()
+
+	_, err := sqldb.ExecContext(ctx,
+		`INSERT INTO iceberg_tables `+
+			`(catalog_name, table_namespace, table_name, iceberg_type) VALUES (?, ?, ?, ?)`,
+		db.Name(), nsName, viewName, sqlcat.ViewType,
+	)
+	s.Require().NoError(err)
+
+	s.Require().NoError(db.DropView(ctx, table.Identifier{nsName, viewName}))
+
+	var count int
+	s.Require().NoError(sqldb.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM iceberg_tables `+
+			`WHERE catalog_name = ? AND table_namespace = ? AND table_name = ? AND iceberg_type = ?`,
+		db.Name(), nsName, viewName, sqlcat.ViewType,
+	).Scan(&count))
+	s.Zero(count)
 }
 
 func (s *SqliteCatalogTestSuite) TestDropViewWithInvalidMetadataLocation() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2221,33 +2221,35 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 	t.Parallel()
 
-	invalid := []table.Identifier{
-		nil,
-		{},
-		{"view"},
-		{"ns", ""},
-		{"ns", "."},
-		{"ns", ".."},
-		{"ns", "nested/view"},
-		{"ns", "view\nname"},
+	invalid := []struct {
+		name       string
+		identifier table.Identifier
+	}{
+		{name: "nil", identifier: nil},
+		{name: "empty", identifier: table.Identifier{}},
+		{name: "missing namespace", identifier: table.Identifier{"view"}},
+		{name: "empty name", identifier: table.Identifier{"ns", ""}},
+		{name: "dot name", identifier: table.Identifier{"ns", "."}},
+		{name: "parent name", identifier: table.Identifier{"ns", ".."}},
+		{name: "path separator", identifier: table.Identifier{"ns", "nested/view"}},
+		{name: "control character", identifier: table.Identifier{"ns", "view\nname"}},
 	}
 
 	cat := &sqlcat.Catalog{}
-	for _, identifier := range invalid {
-		identifier := identifier
-		t.Run(fmt.Sprint(identifier), func(t *testing.T) {
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := cat.CreateView(context.Background(), identifier, nil, "", nil)
+			err := cat.CreateView(context.Background(), test.identifier, nil, "", nil)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
-			err = cat.DropView(context.Background(), identifier)
+			err = cat.DropView(context.Background(), test.identifier)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
-			_, err = cat.CheckViewExists(context.Background(), identifier)
+			_, err = cat.CheckViewExists(context.Background(), test.identifier)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
-			_, err = cat.LoadView(context.Background(), identifier)
+			_, err = cat.LoadView(context.Background(), test.identifier)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 		})
 	}

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2272,6 +2272,7 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 		for _, err := range cat.ListViews(context.Background(), table.Identifier{".."}) {
 			yielded = true
 			gotErr = err
+
 			break
 		}
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2245,6 +2245,7 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 	})
 	require.NoError(t, err)
 	cat := loaded.(*sqlcat.Catalog)
+	require.NoError(t, cat.CreateSQLTables(context.Background()))
 	for _, test := range invalid {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -2262,6 +2263,21 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 		})
 	}
+
+	t.Run("list views rejects missing namespace", func(t *testing.T) {
+		t.Parallel()
+
+		yielded := false
+		var gotErr error
+		for _, err := range cat.ListViews(context.Background(), table.Identifier{".."}) {
+			yielded = true
+			gotErr = err
+			break
+		}
+
+		require.True(t, yielded)
+		require.ErrorIs(t, gotErr, catalog.ErrNoSuchNamespace)
+	})
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateTableConflictsWithView() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2218,6 +2218,41 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 	s.True(exists)
 }
 
+func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	invalid := []table.Identifier{
+		nil,
+		{},
+		{"view"},
+		{"ns", ""},
+		{"ns", "."},
+		{"ns", ".."},
+		{"ns", "nested/view"},
+		{"ns", "view\nname"},
+	}
+
+	cat := &sqlcat.Catalog{}
+	for _, identifier := range invalid {
+		identifier := identifier
+		t.Run(fmt.Sprint(identifier), func(t *testing.T) {
+			t.Parallel()
+
+			err := cat.CreateView(context.Background(), identifier, nil, "", nil)
+			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
+
+			err = cat.DropView(context.Background(), identifier)
+			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
+
+			_, err = cat.CheckViewExists(context.Background(), identifier)
+			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
+
+			_, err = cat.LoadView(context.Background(), identifier)
+			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
+		})
+	}
+}
+
 func (s *SqliteCatalogTestSuite) TestCreateTableConflictsWithView() {
 	ctx := context.Background()
 	db := s.getCatalogSqlite()

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1770,6 +1770,16 @@ func (s *SqliteCatalogTestSuite) TestCreateDuplicateNamespace() {
 	}
 }
 
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsEmptyIdentifier() {
+	ctx := context.Background()
+	for _, cat := range []*sqlcat.Catalog{s.getCatalogMemory(), s.getCatalogSqlite()} {
+		for _, namespace := range []table.Identifier{nil, {}} {
+			err := cat.CreateNamespace(ctx, namespace, nil)
+			s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		}
+	}
+}
+
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceSharingPrefix() {
 	tests := []struct {
 		cat       *sqlcat.Catalog

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uptrace/bun/driver/sqliteshim"
 )
@@ -2235,7 +2236,15 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 		{name: "control character", identifier: table.Identifier{"ns", "view\nname"}},
 	}
 
-	cat := &sqlcat.Catalog{}
+	loaded, err := catalog.Load(context.Background(), "default", iceberg.Properties{
+		"uri":                   ":memory:",
+		sqlcat.DriverKey:        sqliteshim.ShimName,
+		sqlcat.DialectKey:       string(sqlcat.SQLite),
+		sqlcat.SchemaVersionKey: sqlcat.SchemaVersionV1,
+		"type":                  "sql",
+	})
+	require.NoError(t, err)
+	cat := loaded.(*sqlcat.Catalog)
 	for _, test := range invalid {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -2500,19 +2509,25 @@ func (s *SqliteCatalogTestSuite) TestListViews() {
 	}
 
 	viewsIter = db.ListViews(context.Background(), []string{"nonexistent"})
+	yielded := false
 	for _, err := range viewsIter {
+		yielded = true
 		s.Error(err)
 		s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 
 		break
 	}
+	s.Require().True(yielded)
 
 	viewsIter = db.ListViews(context.Background(), []string{".."})
+	yielded = false
 	for _, err := range viewsIter {
+		yielded = true
 		s.ErrorIs(err, catalog.ErrNoSuchNamespace)
 
 		break
 	}
+	s.Require().True(yielded)
 }
 
 func (s *SqliteCatalogTestSuite) TestLoadView() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2506,6 +2506,13 @@ func (s *SqliteCatalogTestSuite) TestListViews() {
 
 		break
 	}
+
+	viewsIter = db.ListViews(context.Background(), []string{".."})
+	for _, err := range viewsIter {
+		s.ErrorIs(err, catalog.ErrNoSuchNamespace)
+
+		break
+	}
 }
 
 func (s *SqliteCatalogTestSuite) TestLoadView() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2220,6 +2220,14 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 	exists, err := db.CheckViewExists(context.Background(), []string{nsName, viewName})
 	s.Require().NoError(err)
 	s.True(exists)
+
+	foundNested := false
+	for identifier, err := range db.ListViews(context.Background(), nestedNamespace) {
+		s.Require().NoError(err)
+		s.Equal(append(nestedNamespace, viewName), identifier)
+		foundNested = true
+	}
+	s.True(foundNested)
 }
 
 func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2207,12 +2207,15 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 	nsName := databaseName()
 	viewName := tableName()
 	s.Require().NoError(db.CreateNamespace(context.Background(), []string{nsName}, nil))
+	nestedNamespace := table.Identifier{nsName, "child"}
+	s.Require().NoError(db.CreateNamespace(context.Background(), nestedNamespace, nil))
 
 	viewSQL := "SELECT * FROM test_table"
 	schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
 	})
 	s.Require().NoError(db.CreateView(context.Background(), []string{nsName, viewName}, schema, viewSQL, nil))
+	s.Require().NoError(db.CreateView(context.Background(), append(nestedNamespace, viewName), schema, viewSQL, nil))
 
 	exists, err := db.CheckViewExists(context.Background(), []string{nsName, viewName})
 	s.Require().NoError(err)
@@ -2220,8 +2223,6 @@ func (s *SqliteCatalogTestSuite) TestCreateView() {
 }
 
 func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
-	t.Parallel()
-
 	invalid := []struct {
 		name       string
 		identifier table.Identifier
@@ -2246,10 +2247,12 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 	require.NoError(t, err)
 	cat := loaded.(*sqlcat.Catalog)
 	require.NoError(t, cat.CreateSQLTables(context.Background()))
+	for _, err := range cat.ListViews(context.Background(), nil) {
+		require.NoError(t, err, "ListViews with a nil namespace must not reject the root namespace")
+	}
+
 	for _, test := range invalid {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
 			err := cat.CreateView(context.Background(), test.identifier, nil, "", nil)
 			assert.ErrorIs(t, err, catalog.ErrNoSuchView)
 
@@ -2265,8 +2268,6 @@ func TestViewOperationsRejectInvalidIdentifiers(t *testing.T) {
 	}
 
 	t.Run("list views rejects missing namespace", func(t *testing.T) {
-		t.Parallel()
-
 		yielded := false
 		var gotErr error
 		for _, err := range cat.ListViews(context.Background(), table.Identifier{".."}) {


### PR DESCRIPTION
## Summary

Validate view identifiers before SQL catalog operations do any database or filesystem work.

## Why

SQL view operations skipped the shared identifier validation used by other catalogs. Names such as .. or nested/view could reach location resolution, where path normalization changes their meaning.

## What changed

Create, load, drop, and existence checks now validate view identifiers before resolving locations or accessing storage.

## Tests

- go test ./catalog/sql
- go vet ./catalog/sql