### PR TITLE
fix(hive): propagate object-loading failures during listing

### DIFF
--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -154,7 +154,7 @@ func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 					continue
 				}
 
-				yield(nil, fmt.Errorf("failed to load table %s.%s while listing: %w", database, tableName, err))
+				yield(table.Identifier{}, fmt.Errorf("failed to load table %s.%s while listing: %w", database, tableName, err))
 
 				return
 			}
@@ -667,7 +667,7 @@ func (c *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 					continue
 				}
 
-				yield(nil, fmt.Errorf("failed to load view %s.%s while listing: %w", database, viewName, err))
+				yield(table.Identifier{}, fmt.Errorf("failed to load view %s.%s while listing: %w", database, viewName, err))
 
 				return
 			}
@@ -1020,11 +1020,12 @@ func isNoSuchObjectError(err error) bool {
 		return false
 	}
 
-	errStr := err.Error()
+	var noSuchObjectErr *hive_metastore.NoSuchObjectException
+	if errors.As(err, &noSuchObjectErr) {
+		return true
+	}
 
-	return strings.Contains(errStr, "NoSuchObjectException") ||
-		strings.Contains(errStr, "not found") ||
-		strings.Contains(errStr, "does not exist")
+	return strings.Contains(err.Error(), "NoSuchObjectException")
 }
 
 func isAlreadyExistsError(err error) bool {

--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -150,7 +150,13 @@ func (c *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 		for _, tableName := range tableNames {
 			tbl, err := c.client.GetTable(ctx, database, tableName)
 			if err != nil {
-				continue
+				if isNoSuchObjectError(err) {
+					continue
+				}
+
+				yield(nil, fmt.Errorf("failed to load table %s.%s while listing: %w", database, tableName, err))
+
+				return
 			}
 			if isIcebergTable(tbl) {
 				if !yield(TableIdentifier(database, tableName), nil) {
@@ -657,8 +663,13 @@ func (c *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 		for _, viewName := range viewNames {
 			tbl, err := c.client.GetTable(ctx, database, viewName)
 			if err != nil {
-				// Skip tables we fail to load, mirroring table listing behavior.
-				continue
+				if isNoSuchObjectError(err) {
+					continue
+				}
+
+				yield(nil, fmt.Errorf("failed to load view %s.%s while listing: %w", database, viewName, err))
+
+				return
 			}
 			if isIcebergView(tbl) {
 				if !yield(TableIdentifier(database, viewName), nil) {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -308,6 +308,7 @@ func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
 			if err != nil {
 				require.Equal(t, table.Identifier{}, identifier)
 				gotErr = err
+
 				break
 			}
 		}
@@ -1531,6 +1532,7 @@ func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
 			if err != nil {
 				require.Equal(t, table.Identifier{}, identifier)
 				gotErr = err
+
 				break
 			}
 		}

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -313,7 +313,6 @@ func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
 		}
 		require.ErrorIs(t, gotErr, loadErr)
 		require.ErrorContains(t, gotErr, "failed to load table test_database.broken while listing")
-		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_table")
 		mockClient.AssertNumberOfCalls(t, "GetTable", 2)
 		mockClient.AssertExpectations(t)
 	})
@@ -1537,7 +1536,6 @@ func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
 		}
 		require.ErrorIs(t, gotErr, loadErr)
 		require.ErrorContains(t, gotErr, "failed to load view test_database.broken while listing")
-		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_view")
 		mockClient.AssertNumberOfCalls(t, "GetTable", 2)
 		mockClient.AssertExpectations(t)
 	})

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -280,6 +280,38 @@ func TestHiveListTablesEmpty(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
+	t.Run("skips concurrently deleted tables", func(t *testing.T) {
+		mockClient := &mockHiveClient{}
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"deleted", "test_table"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "deleted").Return(nil, errNoSuchObject).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "test_table").Return(testIcebergHiveTable1, nil).Once()
+
+		var tables []table.Identifier
+		for identifier, err := range NewCatalogWithClient(mockClient, nil).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
+			require.NoError(t, err)
+			tables = append(tables, identifier)
+		}
+		require.Equal(t, []table.Identifier{TableIdentifier("test_database", "test_table")}, tables)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("propagates operational failures", func(t *testing.T) {
+		loadErr := errors.New("metastore unavailable")
+		mockClient := &mockHiveClient{}
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"broken", "test_table"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "broken").Return(nil, loadErr).Once()
+
+		var gotErr error
+		for _, err := range NewCatalogWithClient(mockClient, nil).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
+			gotErr = err
+		}
+		require.ErrorIs(t, gotErr, loadErr)
+		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_table")
+		mockClient.AssertExpectations(t)
+	})
+}
+
 func TestHiveListNamespaces(t *testing.T) {
 	assert := require.New(t)
 
@@ -1441,6 +1473,40 @@ func TestHiveListViews(t *testing.T) {
 	assert.Equal(TableIdentifier("test_database", "test_view"), views[0])
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
+	t.Run("skips concurrently deleted views", func(t *testing.T) {
+		mockClient := &mockHiveClient{}
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"deleted", "test_view"}, nil).Once()
+		mockClient.On("GetDatabase", mock.Anything, "test_database").Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "deleted").Return(nil, errNoSuchObject).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "test_view").Return(testIcebergHiveView, nil).Once()
+
+		var views []table.Identifier
+		for identifier, err := range NewCatalogWithClient(mockClient, nil).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
+			require.NoError(t, err)
+			views = append(views, identifier)
+		}
+		require.Equal(t, []table.Identifier{TableIdentifier("test_database", "test_view")}, views)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("propagates operational failures", func(t *testing.T) {
+		loadErr := errors.New("metastore unavailable")
+		mockClient := &mockHiveClient{}
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"broken", "test_view"}, nil).Once()
+		mockClient.On("GetDatabase", mock.Anything, "test_database").Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "broken").Return(nil, loadErr).Once()
+
+		var gotErr error
+		for _, err := range NewCatalogWithClient(mockClient, nil).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
+			gotErr = err
+		}
+		require.ErrorIs(t, gotErr, loadErr)
+		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_view")
+		mockClient.AssertExpectations(t)
+	})
 }
 
 func TestHiveLoadView(t *testing.T) {

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -205,7 +205,7 @@ var testIcebergHiveView = &hive_metastore.Table{
 
 // Error helpers for mocking
 var (
-	errNoSuchObject     = errors.New("NoSuchObjectException: object not found")
+	errNoSuchObject     = &hive_metastore.NoSuchObjectException{}
 	errAlreadyExists    = errors.New("AlreadyExistsException: object already exists")
 	errInvalidOperation = errors.New("InvalidOperationException: Database is not empty")
 )
@@ -288,7 +288,7 @@ func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
 		mockClient.On("GetTable", mock.Anything, "test_database", "test_table").Return(testIcebergHiveTable1, nil).Once()
 
 		var tables []table.Identifier
-		for identifier, err := range NewCatalogWithClient(mockClient, nil).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
+		for identifier, err := range NewCatalogWithClient(mockClient, iceberg.Properties{}).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
 			require.NoError(t, err)
 			tables = append(tables, identifier)
 		}
@@ -297,19 +297,45 @@ func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
 	})
 
 	t.Run("propagates operational failures", func(t *testing.T) {
-		loadErr := errors.New("metastore unavailable")
+		loadErr := errors.New("metastore host not found")
 		mockClient := &mockHiveClient{}
-		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"broken", "test_table"}, nil).Once()
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"deleted", "broken", "test_table"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "deleted").Return(nil, errNoSuchObject).Once()
 		mockClient.On("GetTable", mock.Anything, "test_database", "broken").Return(nil, loadErr).Once()
 
 		var gotErr error
-		for _, err := range NewCatalogWithClient(mockClient, nil).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
-			gotErr = err
+		for identifier, err := range NewCatalogWithClient(mockClient, iceberg.Properties{}).ListTables(context.Background(), DatabaseIdentifier("test_database")) {
+			if err != nil {
+				require.Equal(t, table.Identifier{}, identifier)
+				gotErr = err
+				break
+			}
 		}
 		require.ErrorIs(t, gotErr, loadErr)
 		require.ErrorContains(t, gotErr, "failed to load table test_database.broken while listing")
 		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_table")
+		mockClient.AssertNumberOfCalls(t, "GetTable", 2)
 		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestIsNoSuchObjectError(t *testing.T) {
+	t.Run("recognizes typed thrift exception", func(t *testing.T) {
+		require.True(t, isNoSuchObjectError(&hive_metastore.NoSuchObjectException{}))
+	})
+
+	t.Run("recognizes wrapped thrift exception", func(t *testing.T) {
+		err := errors.Join(errors.New("failed to load object"), &hive_metastore.NoSuchObjectException{})
+
+		require.True(t, isNoSuchObjectError(err))
+	})
+
+	t.Run("recognizes narrow exception name fallback", func(t *testing.T) {
+		require.True(t, isNoSuchObjectError(errors.New("NoSuchObjectException: object disappeared")))
+	})
+
+	t.Run("does not classify operational not-found message", func(t *testing.T) {
+		require.False(t, isNoSuchObjectError(errors.New("metastore host not found")))
 	})
 }
 
@@ -1485,7 +1511,7 @@ func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
 		mockClient.On("GetTable", mock.Anything, "test_database", "test_view").Return(testIcebergHiveView, nil).Once()
 
 		var views []table.Identifier
-		for identifier, err := range NewCatalogWithClient(mockClient, nil).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
+		for identifier, err := range NewCatalogWithClient(mockClient, iceberg.Properties{}).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
 			require.NoError(t, err)
 			views = append(views, identifier)
 		}
@@ -1494,19 +1520,25 @@ func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
 	})
 
 	t.Run("propagates operational failures", func(t *testing.T) {
-		loadErr := errors.New("metastore unavailable")
+		loadErr := errors.New("metastore host not found")
 		mockClient := &mockHiveClient{}
-		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"broken", "test_view"}, nil).Once()
+		mockClient.On("GetTables", mock.Anything, "test_database", "*").Return([]string{"deleted", "broken", "test_view"}, nil).Once()
 		mockClient.On("GetDatabase", mock.Anything, "test_database").Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+		mockClient.On("GetTable", mock.Anything, "test_database", "deleted").Return(nil, errNoSuchObject).Once()
 		mockClient.On("GetTable", mock.Anything, "test_database", "broken").Return(nil, loadErr).Once()
 
 		var gotErr error
-		for _, err := range NewCatalogWithClient(mockClient, nil).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
-			gotErr = err
+		for identifier, err := range NewCatalogWithClient(mockClient, iceberg.Properties{}).ListViews(context.Background(), DatabaseIdentifier("test_database")) {
+			if err != nil {
+				require.Equal(t, table.Identifier{}, identifier)
+				gotErr = err
+				break
+			}
 		}
 		require.ErrorIs(t, gotErr, loadErr)
 		require.ErrorContains(t, gotErr, "failed to load view test_database.broken while listing")
 		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_view")
+		mockClient.AssertNumberOfCalls(t, "GetTable", 2)
 		mockClient.AssertExpectations(t)
 	})
 }

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -307,6 +307,7 @@ func TestHiveListTablesHandlesObjectLoadingErrors(t *testing.T) {
 			gotErr = err
 		}
 		require.ErrorIs(t, gotErr, loadErr)
+		require.ErrorContains(t, gotErr, "failed to load table test_database.broken while listing")
 		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_table")
 		mockClient.AssertExpectations(t)
 	})
@@ -1504,6 +1505,7 @@ func TestHiveListViewsHandlesObjectLoadingErrors(t *testing.T) {
 			gotErr = err
 		}
 		require.ErrorIs(t, gotErr, loadErr)
+		require.ErrorContains(t, gotErr, "failed to load view test_database.broken while listing")
 		mockClient.AssertNotCalled(t, "GetTable", mock.Anything, "test_database", "test_view")
 		mockClient.AssertExpectations(t)
 	})


### PR DESCRIPTION
## What changed

Hive table and view listing now skips only objects that disappear between `GetTables` and `GetTable`. Other metastore errors are returned through the iterator and stop the listing.

## Why

Previously every `GetTable` error was ignored. Connection, authorization, cancellation, and other operational failures therefore looked like successful but incomplete listings.

Regression coverage verifies both concurrent deletion and operational failure behavior for tables and views.

## Testing

- `go test ./catalog/hive`
- `go vet ./catalog/hive`