### PR TITLE
fix(hive): preserve RegisterTable creation errors

### DIFF
--- a/catalog/hive/hive.go
+++ b/catalog/hive/hive.go
@@ -293,7 +293,7 @@ func (c *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 			return nil, fmt.Errorf("%w: %s.%s", catalog.ErrTableAlreadyExists, database, tableName)
 		}
 
-		return nil, fmt.Errorf("failed to register table %s.%s: %s", database, tableName, err)
+		return nil, fmt.Errorf("failed to register table %s.%s: %w", database, tableName, err)
 	}
 
 	return c.LoadTable(ctx, identifier)

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -1367,6 +1367,26 @@ func TestHiveRegisterTableSuccess(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestHiveRegisterTablePreservesCreateError(t *testing.T) {
+	metaPath, err := filepath.Abs(filepath.Join("..", "..", "table", "testdata", "TableMetadataV2Valid.json"))
+	require.NoError(t, err)
+
+	createErr := errors.New("metastore unavailable")
+	mockClient := &mockHiveClient{}
+	mockClient.On("GetDatabase", mock.Anything, "test_database").
+		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+	mockClient.On("GetTable", mock.Anything, "test_database", "reg_table").
+		Return(nil, errNoSuchObject).Times(2)
+	mockClient.On("CreateTable", mock.Anything, mock.AnythingOfType("*hive_metastore.Table")).
+		Return(createErr).Once()
+
+	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+	_, err = hiveCatalog.RegisterTable(context.Background(), TableIdentifier("test_database", "reg_table"), metaPath)
+	require.ErrorContains(t, err, "failed to register table")
+	require.ErrorIs(t, err, createErr)
+	mockClient.AssertExpectations(t)
+}
+
 func TestHiveCheckViewExists(t *testing.T) {
 	assert := require.New(t)
 

--- a/catalog/hive/hive_test.go
+++ b/catalog/hive/hive_test.go
@@ -1371,20 +1371,31 @@ func TestHiveRegisterTablePreservesCreateError(t *testing.T) {
 	metaPath, err := filepath.Abs(filepath.Join("..", "..", "table", "testdata", "TableMetadataV2Valid.json"))
 	require.NoError(t, err)
 
-	createErr := errors.New("metastore unavailable")
-	mockClient := &mockHiveClient{}
-	mockClient.On("GetDatabase", mock.Anything, "test_database").
-		Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
-	mockClient.On("GetTable", mock.Anything, "test_database", "reg_table").
-		Return(nil, errNoSuchObject).Times(2)
-	mockClient.On("CreateTable", mock.Anything, mock.AnythingOfType("*hive_metastore.Table")).
-		Return(createErr).Once()
+	tests := []struct {
+		name      string
+		createErr error
+	}{
+		{name: "metastore failure", createErr: errors.New("metastore unavailable")},
+		{name: "canceled context", createErr: context.Canceled},
+	}
 
-	hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
-	_, err = hiveCatalog.RegisterTable(context.Background(), TableIdentifier("test_database", "reg_table"), metaPath)
-	require.ErrorContains(t, err, "failed to register table")
-	require.ErrorIs(t, err, createErr)
-	mockClient.AssertExpectations(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockClient := &mockHiveClient{}
+			mockClient.On("GetDatabase", mock.Anything, "test_database").
+				Return(&hive_metastore.Database{Name: "test_database"}, nil).Once()
+			mockClient.On("GetTable", mock.Anything, "test_database", "reg_table").
+				Return(nil, errNoSuchObject).Times(2)
+			mockClient.On("CreateTable", mock.Anything, mock.AnythingOfType("*hive_metastore.Table")).
+				Return(test.createErr).Once()
+
+			hiveCatalog := NewCatalogWithClient(mockClient, iceberg.Properties{})
+			_, err := hiveCatalog.RegisterTable(context.Background(), TableIdentifier("test_database", "reg_table"), metaPath)
+			require.ErrorContains(t, err, "failed to register table test_database.reg_table")
+			require.ErrorIs(t, err, test.createErr)
+			mockClient.AssertExpectations(t)
+		})
+	}
 }
 
 func TestHiveCheckViewExists(t *testing.T) {


### PR DESCRIPTION
## What changed

Wrap the Hive metastore `CreateTable` failure returned by `RegisterTable` with `%w`.

## Why

The previous `%s` formatting converted the cause to text, preventing callers from detecting context, transport, or typed metastore errors with `errors.Is` and `errors.As`.

The regression test verifies that the original creation error remains discoverable.

## Testing

- `go test ./catalog/hive`
- `go vet ./catalog/hive`