### PR TITLE
fix(io): parse local file URIs consistently

### DIFF
--- a/io/local.go
+++ b/io/local.go
@@ -35,15 +35,19 @@ func localPath(name string) (string, error) {
 		return name, nil
 	}
 
+	schemeEnd := strings.IndexByte(name, ':')
+	firstSeparator := strings.IndexAny(name, `/\`)
+	if schemeEnd < 0 || (firstSeparator >= 0 && firstSeparator < schemeEnd) {
+		return name, nil
+	}
+	scheme := name[:schemeEnd]
+	if !strings.EqualFold(scheme, "file") {
+		return "", fmt.Errorf("unsupported local filesystem scheme %q", scheme)
+	}
+
 	parsed, err := url.Parse(name)
 	if err != nil {
 		return "", fmt.Errorf("invalid local file path %q: %w", name, err)
-	}
-	if parsed.Scheme == "" {
-		return name, nil
-	}
-	if !strings.EqualFold(parsed.Scheme, "file") {
-		return "", fmt.Errorf("unsupported local filesystem scheme %q", parsed.Scheme)
 	}
 	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
 		return "", fmt.Errorf("unsupported file URI authority %q", parsed.Host)

--- a/io/local.go
+++ b/io/local.go
@@ -18,7 +18,9 @@
 package io
 
 import (
+	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,16 +30,54 @@ import (
 // the local file system.
 type LocalFS struct{}
 
+func localPath(name string) (string, error) {
+	if filepath.VolumeName(name) != "" {
+		return name, nil
+	}
+
+	parsed, err := url.Parse(name)
+	if err != nil {
+		return "", fmt.Errorf("invalid local file path %q: %w", name, err)
+	}
+	if parsed.Scheme == "" {
+		return name, nil
+	}
+	if !strings.EqualFold(parsed.Scheme, "file") {
+		return "", fmt.Errorf("unsupported local filesystem scheme %q", parsed.Scheme)
+	}
+	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+		return "", fmt.Errorf("unsupported file URI authority %q", parsed.Host)
+	}
+	if parsed.Opaque != "" {
+		return parsed.Opaque, nil
+	}
+
+	return parsed.Path, nil
+}
+
 func (LocalFS) Open(name string) (File, error) {
-	return os.Open(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Open(path)
 }
 
 func (LocalFS) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.ReadFile(path)
 }
 
 func (LocalFS) Create(name string) (FileWriter, error) {
-	filename := strings.TrimPrefix(name, "file://")
+	filename, err := localPath(name)
+	if err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return nil, err
 	}
@@ -46,7 +86,10 @@ func (LocalFS) Create(name string) (FileWriter, error) {
 }
 
 func (LocalFS) WriteFile(name string, content []byte) error {
-	filename := strings.TrimPrefix(name, "file://")
+	filename, err := localPath(name)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return err
 	}
@@ -55,42 +98,92 @@ func (LocalFS) WriteFile(name string, content []byte) error {
 }
 
 func (LocalFS) Remove(name string) error {
-	return os.Remove(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(path)
 }
 
 func (LocalFS) RemoveAll(name string) error {
-	return os.RemoveAll(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(path)
 }
 
 func (LocalFS) WalkDir(root string, fn fs.WalkDirFunc) error {
-	return filepath.WalkDir(strings.TrimPrefix(root, "file://"), fn)
+	path, err := localPath(root)
+	if err != nil {
+		return err
+	}
+
+	return filepath.WalkDir(path, fn)
 }
 
 func (LocalFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return os.ReadDir(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.ReadDir(path)
 }
 
-func (LocalFS) MkdirAll(path string) error {
-	return os.MkdirAll(strings.TrimPrefix(path, "file://"), 0o755)
+func (LocalFS) MkdirAll(name string) error {
+	path, err := localPath(name)
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(path, 0o755)
 }
 
-func (LocalFS) Mkdir(path string) error {
-	return os.Mkdir(strings.TrimPrefix(path, "file://"), 0o755)
+func (LocalFS) Mkdir(name string) error {
+	path, err := localPath(name)
+	if err != nil {
+		return err
+	}
+
+	return os.Mkdir(path, 0o755)
 }
 
 func (LocalFS) Stat(name string) (fs.FileInfo, error) {
-	return os.Stat(strings.TrimPrefix(name, "file://"))
+	path, err := localPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Stat(path)
 }
 
 func (LocalFS) Rename(oldpath, newpath string) error {
-	return os.Rename(strings.TrimPrefix(oldpath, "file://"), strings.TrimPrefix(newpath, "file://"))
+	oldpath, err := localPath(oldpath)
+	if err != nil {
+		return err
+	}
+	newpath, err = localPath(newpath)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(oldpath, newpath)
 }
 
 func (LocalFS) RenameNoReplace(oldpath, newpath string) error {
-	oldpath = strings.TrimPrefix(oldpath, "file://")
-	newpath = strings.TrimPrefix(newpath, "file://")
+	oldpath, err := localPath(oldpath)
+	if err != nil {
+		return err
+	}
+	newpath, err = localPath(newpath)
+	if err != nil {
+		return err
+	}
 
-	if err := os.Link(oldpath, newpath); err != nil {
+	if err = os.Link(oldpath, newpath); err != nil {
 		return err
 	}
 

--- a/io/local.go
+++ b/io/local.go
@@ -60,10 +60,21 @@ func localPath(name string) (string, error) {
 		return "", fmt.Errorf("unsupported file URI authority %q", parsed.Host)
 	}
 	if parsed.Opaque != "" {
-		return parsed.Opaque, nil
+		return filepath.FromSlash(parsed.Opaque), nil
 	}
 
-	return parsed.Path, nil
+	path := parsed.Path
+	if filepath.Separator == '\\' && isWindowsDrivePath(path) {
+		path = path[1:]
+	}
+
+	return filepath.FromSlash(path), nil
+}
+
+func isWindowsDrivePath(path string) bool {
+	return len(path) >= 3 && path[0] == '/' &&
+		((path[1] >= 'a' && path[1] <= 'z') || (path[1] >= 'A' && path[1] <= 'Z')) &&
+		path[2] == ':'
 }
 
 func (LocalFS) Open(name string) (File, error) {

--- a/io/local.go
+++ b/io/local.go
@@ -41,6 +41,13 @@ func localPath(name string) (string, error) {
 		return name, nil
 	}
 	scheme := name[:schemeEnd]
+	// A colon is valid in a native POSIX filename. Treat non-file names as
+	// URIs only when they have an authority delimiter, preserving paths such as
+	// "partition:2026/data.parquet" while still rejecting s3:// and similar
+	// locations passed directly to LocalFS.
+	if !strings.EqualFold(scheme, "file") && !strings.HasPrefix(name[schemeEnd+1:], "//") {
+		return name, nil
+	}
 	if !strings.EqualFold(scheme, "file") {
 		return "", fmt.Errorf("unsupported local filesystem scheme %q", scheme)
 	}

--- a/io/local.go
+++ b/io/local.go
@@ -57,14 +57,23 @@ func localPath(name string) (string, error) {
 		return "", fmt.Errorf("invalid local file path %q: %w", name, err)
 	}
 	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
-		return "", fmt.Errorf("unsupported file URI authority %q", parsed.Host)
-	}
-	if parsed.Opaque != "" {
-		return filepath.FromSlash(parsed.Opaque), nil
+		if filepath.Separator != '\\' || !isWindowsDriveHost(parsed.Host) {
+			return "", fmt.Errorf("unsupported file URI authority %q", parsed.Host)
+		}
 	}
 
 	path := parsed.Path
-	if filepath.Separator == '\\' && isWindowsDrivePath(path) {
+	if parsed.Opaque != "" {
+		var err error
+		path, err = url.PathUnescape(parsed.Opaque)
+		if err != nil {
+			return "", fmt.Errorf("invalid local file path %q: %w", name, err)
+		}
+	}
+
+	if filepath.Separator == '\\' && isWindowsDriveHost(parsed.Host) {
+		path = parsed.Host + path
+	} else if filepath.Separator == '\\' && isWindowsDrivePath(path) {
 		path = path[1:]
 	}
 
@@ -75,6 +84,12 @@ func isWindowsDrivePath(path string) bool {
 	return len(path) >= 3 && path[0] == '/' &&
 		((path[1] >= 'a' && path[1] <= 'z') || (path[1] >= 'A' && path[1] <= 'Z')) &&
 		path[2] == ':'
+}
+
+func isWindowsDriveHost(host string) bool {
+	return len(host) == 2 &&
+		((host[0] >= 'a' && host[0] <= 'z') || (host[0] >= 'A' && host[0] <= 'Z')) &&
+		host[1] == ':'
 }
 
 func (LocalFS) Open(name string) (File, error) {
@@ -183,35 +198,35 @@ func (LocalFS) Stat(name string) (fs.FileInfo, error) {
 }
 
 func (LocalFS) Rename(oldpath, newpath string) error {
-	oldpath, err := localPath(oldpath)
+	src, err := localPath(oldpath)
 	if err != nil {
 		return err
 	}
-	newpath, err = localPath(newpath)
+	dst, err := localPath(newpath)
 	if err != nil {
 		return err
 	}
 
-	return os.Rename(oldpath, newpath)
+	return os.Rename(src, dst)
 }
 
 func (LocalFS) RenameNoReplace(oldpath, newpath string) error {
-	oldpath, err := localPath(oldpath)
+	src, err := localPath(oldpath)
 	if err != nil {
 		return err
 	}
-	newpath, err = localPath(newpath)
+	dst, err := localPath(newpath)
 	if err != nil {
 		return err
 	}
 
-	if err = os.Link(oldpath, newpath); err != nil {
+	if err = os.Link(src, dst); err != nil {
 		return err
 	}
 
 	// Publishing already succeeded once the hard link exists. Removing the
 	// source temp file is best-effort cleanup.
-	_ = os.Remove(oldpath)
+	_ = os.Remove(src)
 
 	return nil
 }

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -107,6 +107,11 @@ func TestLocalFSWriteFileCreatesParentDirectories(t *testing.T) {
 			path:     fileURI(filepath.Join(dir, "scheme", "nested", "file.txt")),
 			readPath: filepath.Join(dir, "scheme", "nested", "file.txt"),
 		},
+		{
+			name:     "escaped file scheme",
+			path:     fileURI(filepath.Join(dir, "scheme with space", "nested", "file.txt")),
+			readPath: filepath.Join(dir, "scheme with space", "nested", "file.txt"),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NoError(t, LocalFS{}.WriteFile(tt.path, content))
@@ -131,6 +136,23 @@ func TestLocalFSParsesFileURIs(t *testing.T) {
 		singleSlashFileURI(path),
 		"file:" + filepath.ToSlash(path),
 		localhostFileURI(path),
+	} {
+		content, err := (LocalFS{}).ReadFile(name)
+		require.NoError(t, err, name)
+		assert.Equal(t, []byte("metadata"), content)
+	}
+}
+
+func TestLocalFSParsesEscapedFileURIsConsistently(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata with space%20.txt")
+	require.NoError(t, os.WriteFile(path, []byte("metadata"), 0o600))
+
+	for _, name := range []string{
+		fileURI(path),
+		singleSlashFileURI(path),
 	} {
 		content, err := (LocalFS{}).ReadFile(name)
 		require.NoError(t, err, name)
@@ -183,10 +205,10 @@ func singleSlashFileURI(path string) string {
 	hasVolume := filepath.VolumeName(path) != ""
 	pathSlash := filepath.ToSlash(path)
 	if hasVolume {
-		return "file:/" + pathSlash
+		pathSlash = "/" + pathSlash
 	}
 
-	return "file:" + pathSlash
+	return "file:" + (&url.URL{Path: pathSlash}).EscapedPath()
 }
 
 func localhostFileURI(path string) string {

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -115,6 +115,27 @@ func TestLocalFSWriteFileCreatesParentDirectories(t *testing.T) {
 	}
 }
 
+func TestLocalFSParsesFileURIs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+	require.NoError(t, os.WriteFile(path, []byte("metadata"), 0o600))
+
+	for _, name := range []string{path, "file://" + filepath.ToSlash(path), "file:" + filepath.ToSlash(path), "file://localhost" + filepath.ToSlash(path)} {
+		content, err := (LocalFS{}).ReadFile(name)
+		require.NoError(t, err, name)
+		assert.Equal(t, []byte("metadata"), content)
+	}
+}
+
+func TestLocalFSRejectsUnsupportedFileURIAuthority(t *testing.T) {
+	t.Parallel()
+
+	_, err := (LocalFS{}).Open("file://remotehost/tmp/metadata.json")
+	require.ErrorContains(t, err, `unsupported file URI authority "remotehost"`)
+}
+
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -136,6 +136,17 @@ func TestLocalFSRejectsUnsupportedFileURIAuthority(t *testing.T) {
 	require.ErrorContains(t, err, `unsupported file URI authority "remotehost"`)
 }
 
+func TestLocalFSPreservesPlainPathsWithRawPercent(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "discount:100%off.txt")
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0o600))
+
+	content, err := (LocalFS{}).ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), content)
+}
+
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -147,6 +147,15 @@ func TestLocalFSPreservesPlainPathsWithRawPercent(t *testing.T) {
 	assert.Equal(t, []byte("content"), content)
 }
 
+func TestLocalFSPreservesRelativePathsWithColon(t *testing.T) {
+	t.Parallel()
+
+	path := "partition:2026/data.parquet"
+	got, err := localPath(path)
+	require.NoError(t, err)
+	assert.Equal(t, path, got)
+}
+
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
 }

--- a/io/local_test.go
+++ b/io/local_test.go
@@ -19,10 +19,10 @@ package io
 
 import (
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,7 +73,7 @@ func TestLocalFSWalkDirWithFileScheme(t *testing.T) {
 	lfs := LocalFS{}
 
 	var files []string
-	err := lfs.WalkDir("file://"+dir, func(path string, d fs.DirEntry, err error) error {
+	err := lfs.WalkDir(fileURI(dir), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -93,22 +93,25 @@ func TestLocalFSWriteFileCreatesParentDirectories(t *testing.T) {
 	content := []byte("content")
 
 	for _, tt := range []struct {
-		name string
-		path string
+		name     string
+		path     string
+		readPath string
 	}{
 		{
-			name: "plain path",
-			path: filepath.Join(dir, "plain", "nested", "file.txt"),
+			name:     "plain path",
+			path:     filepath.Join(dir, "plain", "nested", "file.txt"),
+			readPath: filepath.Join(dir, "plain", "nested", "file.txt"),
 		},
 		{
-			name: "file scheme",
-			path: "file://" + filepath.Join(dir, "scheme", "nested", "file.txt"),
+			name:     "file scheme",
+			path:     fileURI(filepath.Join(dir, "scheme", "nested", "file.txt")),
+			readPath: filepath.Join(dir, "scheme", "nested", "file.txt"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NoError(t, LocalFS{}.WriteFile(tt.path, content))
 
-			got, err := os.ReadFile(strings.TrimPrefix(tt.path, "file://"))
+			got, err := os.ReadFile(tt.readPath)
 			require.NoError(t, err)
 			assert.Equal(t, content, got)
 		})
@@ -122,7 +125,13 @@ func TestLocalFSParsesFileURIs(t *testing.T) {
 	path := filepath.Join(dir, "metadata.json")
 	require.NoError(t, os.WriteFile(path, []byte("metadata"), 0o600))
 
-	for _, name := range []string{path, "file://" + filepath.ToSlash(path), "file:" + filepath.ToSlash(path), "file://localhost" + filepath.ToSlash(path)} {
+	for _, name := range []string{
+		path,
+		fileURI(path),
+		singleSlashFileURI(path),
+		"file:" + filepath.ToSlash(path),
+		localhostFileURI(path),
+	} {
 		content, err := (LocalFS{}).ReadFile(name)
 		require.NoError(t, err, name)
 		assert.Equal(t, []byte("metadata"), content)
@@ -158,6 +167,36 @@ func TestLocalFSPreservesRelativePathsWithColon(t *testing.T) {
 
 func TestLocalFSImplementsListableIO(t *testing.T) {
 	var _ ListableIO = LocalFS{}
+}
+
+func fileURI(path string) string {
+	hasVolume := filepath.VolumeName(path) != ""
+	path = filepath.ToSlash(path)
+	if hasVolume {
+		path = "/" + path
+	}
+
+	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+func singleSlashFileURI(path string) string {
+	hasVolume := filepath.VolumeName(path) != ""
+	pathSlash := filepath.ToSlash(path)
+	if hasVolume {
+		return "file:/" + pathSlash
+	}
+
+	return "file:" + pathSlash
+}
+
+func localhostFileURI(path string) string {
+	hasVolume := filepath.VolumeName(path) != ""
+	path = filepath.ToSlash(path)
+	if hasVolume {
+		path = "/" + path
+	}
+
+	return (&url.URL{Scheme: "file", Host: "localhost", Path: path}).String()
 }
 
 func TestLocalFSRenameNoReplaceDoesNotOverwrite(t *testing.T) {

--- a/io/local_windows_test.go
+++ b/io/local_windows_test.go
@@ -33,6 +33,7 @@ func TestLocalFSParsesWindowsDriveFileURIs(t *testing.T) {
 
 	pathSlash := filepath.ToSlash(path)
 	for _, name := range []string{
+		"file://" + pathSlash,
 		"file:///" + pathSlash,
 		"file:/" + pathSlash,
 		"file://localhost/" + pathSlash,

--- a/io/local_windows_test.go
+++ b/io/local_windows_test.go
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build windows
+
+package io
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalFSParsesWindowsDriveFileURIs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metadata.json")
+	require.NoError(t, os.WriteFile(path, []byte("metadata"), 0o600))
+
+	pathSlash := filepath.ToSlash(path)
+	for _, name := range []string{
+		"file:///" + pathSlash,
+		"file:/" + pathSlash,
+		"file://localhost/" + pathSlash,
+	} {
+		content, err := (LocalFS{}).ReadFile(name)
+		require.NoError(t, err, name)
+		require.Equal(t, []byte("metadata"), content)
+	}
+}


### PR DESCRIPTION
## What changed

Centralize LocalFS path conversion with URI-aware parsing and use it across reads, writes, directory operations, metadata operations, removal, and renames.

The parser accepts plain native paths, `file:///path`, `file:/path`, and localhost file URIs. It rejects non-file schemes and non-local authorities instead of turning them into surprising relative paths. Native volume paths remain untouched.

## Why

Blindly trimming only `file://` left valid single-slash file URIs unusable and converted file URI authorities into relative filesystem paths.

## Testing

- `go test ./io`
- `go vet ./io`