### PR TITLE
fix(rest): surface failures refreshing expired credentials

### DIFF
--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -136,10 +136,6 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	default:
 		freshCreds, err := v.fetchCreds(ctx, v.identifier)
 		if err != nil {
-			if !v.expired() {
-				return v.cachedIO, nil
-			}
-
 			return nil, fmt.Errorf("refresh vended credentials for %s: %w", v.location, err)
 		}
 
@@ -151,9 +147,6 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	if err != nil {
 		if v.cachedIO == nil {
 			return nil, err
-		}
-		if !v.expired() {
-			return v.cachedIO, nil
 		}
 
 		return nil, fmt.Errorf("load filesystem with refreshed credentials for %s: %w", v.location, err)

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -136,7 +136,11 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	default:
 		freshCreds, err := v.fetchCreds(ctx, v.identifier)
 		if err != nil {
-			return v.cachedIO, nil
+			if !v.expired() {
+				return v.cachedIO, nil
+			}
+
+			return nil, fmt.Errorf("refresh vended credentials for %s: %w", v.location, err)
 		}
 
 		config = maps.Clone(v.props)
@@ -145,11 +149,11 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 
 	newIO, err := iceio.LoadFS(ctx, config, v.location)
 	if err != nil {
-		if v.cachedIO != nil {
+		if v.cachedIO != nil && !v.expired() {
 			return v.cachedIO, nil
 		}
 
-		return nil, err
+		return nil, fmt.Errorf("load filesystem with refreshed credentials for %s: %w", v.location, err)
 	}
 
 	v.cachedIO = newIO

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -149,7 +149,10 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 
 	newIO, err := iceio.LoadFS(ctx, config, v.location)
 	if err != nil {
-		if v.cachedIO != nil && !v.expired() {
+		if v.cachedIO == nil {
+			return nil, err
+		}
+		if !v.expired() {
 			return v.cachedIO, nil
 		}
 

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -153,7 +153,7 @@ func TestVendedCredsConcurrentAccess(t *testing.T) {
 	assert.NotNil(t, r.cachedIO, "cachedIO should be set after initial load")
 }
 
-func TestVendedCredsGracefulDegradation(t *testing.T) {
+func TestVendedCredsReturnsRefreshFailureForExpiredCredentials(t *testing.T) {
 	t.Parallel()
 
 	fetchErr := errors.New("network error")
@@ -170,8 +170,27 @@ func TestVendedCredsGracefulDegradation(t *testing.T) {
 	r.expiresAt = now.Add(-time.Second)
 
 	got, err := r.loadFS(context.Background())
-	require.NoError(t, err, "should not return error when cached IO exists and refresh fails")
-	assert.Equal(t, existingIO, got, "should return cached IO on refresh failure")
+	require.ErrorIs(t, err, fetchErr)
+	require.ErrorContains(t, err, "refresh vended credentials for file:///tmp/test")
+	assert.Nil(t, got)
+}
+
+func TestVendedCredsReturnsLoadFailureForExpiredCredentials(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	r := newTestRefresher(func(ctx context.Context, ident []string) (iceberg.Properties, error) {
+		return iceberg.Properties{}, nil
+	})
+	r.nowFunc = func() time.Time { return now }
+	r.location = "notascheme://bucket/path"
+	r.cachedIO = iceio.LocalFS{}
+	r.expiresAt = now.Add(-time.Second)
+
+	got, err := r.loadFS(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "load filesystem with refreshed credentials for notascheme://bucket/path")
+	assert.Nil(t, got)
 }
 
 func TestVendedCredsErrorWhenInitialLoadFails(t *testing.T) {

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -46,12 +46,13 @@ func newTestRefresher(fetchCreds func(ctx context.Context, ident []string) (iceb
 func TestVendedCredsCachedIOReturnedWhenNotExpired(t *testing.T) {
 	t.Parallel()
 
+	refreshErr := errors.New("refresh unavailable")
 	var callCount atomic.Int32
 
 	r := newTestRefresher(func(ctx context.Context, ident []string) (iceberg.Properties, error) {
 		callCount.Add(1)
 
-		return iceberg.Properties{}, nil
+		return nil, refreshErr
 	})
 
 	// Seed cached IO and set expiry in the future.

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -204,6 +204,7 @@ func TestVendedCredsErrorWhenInitialLoadFails(t *testing.T) {
 
 	got, err := r.loadFS(context.Background())
 	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "refreshed credentials")
 	assert.Nil(t, got)
 }
 


### PR DESCRIPTION
## What changed

Return credential-fetch and filesystem-construction failures when the cached vended credentials are already expired. A cached filesystem may still be reused when a proactive refresh fails before hard expiry.

## Why

The expired path previously returned a known-expired client with a nil error. The subsequent storage request then failed with an authentication error while the actual refresh failure was lost.

This distinction remains compatible with proactive refresh behavior: still-valid credentials can degrade gracefully, while hard-expired credentials fail at the refresh boundary with the actionable cause.

## Testing

- `go test ./catalog/rest`
- `go vet ./catalog/rest`