### PR TITLE
fix(puffin): reject trailing data in footer payloads

### DIFF
--- a/puffin/puffin_reader.go
+++ b/puffin/puffin_reader.go
@@ -230,6 +230,9 @@ func (r *Reader) readFooter() error {
 		return fmt.Errorf("puffin: decode footer JSON: %w", err)
 	}
 
+	// FooterPayloadSize defines a single JSON footer object. Reject trailing
+	// content deliberately, even though some other Iceberg implementations
+	// accept padding or additional values inside the footer payload.
 	if decoder.More() {
 		return errors.New("puffin: unexpected content after footer JSON")
 	}

--- a/puffin/puffin_reader.go
+++ b/puffin/puffin_reader.go
@@ -230,10 +230,11 @@ func (r *Reader) readFooter() error {
 		return fmt.Errorf("puffin: decode footer JSON: %w", err)
 	}
 
-	if _, err := decoder.Token(); err == nil {
-		return errors.New("puffin: footer contains multiple JSON values")
-	} else if !errors.Is(err, io.EOF) {
-		return fmt.Errorf("puffin: trailing data after footer JSON: %w", err)
+	if decoder.More() {
+		return errors.New("puffin: unexpected content after footer JSON")
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return errors.New("puffin: unexpected content after footer JSON")
 	}
 
 	// Validate blob metadata

--- a/puffin/puffin_reader.go
+++ b/puffin/puffin_reader.go
@@ -224,9 +224,17 @@ func (r *Reader) readFooter() error {
 	}
 
 	payloadReader := io.NewSectionReader(r.r, footerStart+MagicSize, payloadSize)
+	decoder := json.NewDecoder(payloadReader)
 	var footer Footer
-	if err := json.NewDecoder(payloadReader).Decode(&footer); err != nil {
+	if err := decoder.Decode(&footer); err != nil {
 		return fmt.Errorf("puffin: decode footer JSON: %w", err)
+	}
+
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err == nil {
+		return errors.New("puffin: footer contains multiple JSON values")
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("puffin: trailing data after footer JSON: %w", err)
 	}
 
 	// Validate blob metadata

--- a/puffin/puffin_reader.go
+++ b/puffin/puffin_reader.go
@@ -230,8 +230,7 @@ func (r *Reader) readFooter() error {
 		return fmt.Errorf("puffin: decode footer JSON: %w", err)
 	}
 
-	var extra json.RawMessage
-	if err := decoder.Decode(&extra); err == nil {
+	if _, err := decoder.Token(); err == nil {
 		return errors.New("puffin: footer contains multiple JSON values")
 	} else if !errors.Is(err, io.EOF) {
 		return fmt.Errorf("puffin: trailing data after footer JSON: %w", err)

--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -601,6 +601,7 @@ func TestReaderRejectsTrailingFooterData(t *testing.T) {
 		{name: "single object", payload: `{"blobs":[]}`},
 		{name: "trailing whitespace", payload: "{\"blobs\":[]} \n\t"},
 		{name: "second JSON value", payload: `{"blobs":[]}{"blobs":[]}`, wantErr: "multiple JSON values"},
+		{name: "second scalar value", payload: `{"blobs":[]}42`, wantErr: "multiple JSON values"},
 		{name: "trailing garbage", payload: `{"blobs":[]}garbage`, wantErr: "trailing data"},
 	}
 

--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -19,6 +19,7 @@ package puffin_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"math"
 	"os"
@@ -147,6 +148,15 @@ func validFileWithBlob() []byte {
 	w.Finish()
 
 	return buf.Bytes()
+}
+
+func fileWithFooterPayload(payload []byte) []byte {
+	data := append([]byte("PFA1PFA1"), payload...)
+	trailer := make([]byte, 12)
+	binary.LittleEndian.PutUint32(trailer[:4], uint32(len(payload)))
+	copy(trailer[8:], "PFA1")
+
+	return append(data, trailer...)
 }
 
 // --- Tests ---
@@ -578,6 +588,32 @@ func TestReaderInvalidFile(t *testing.T) {
 		_, err := puffin.NewReader(nil)
 		assert.ErrorContains(t, err, "nil")
 	})
+}
+
+func TestReaderRejectsTrailingFooterData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+		wantErr string
+	}{
+		{name: "single object", payload: `{"blobs":[]}`},
+		{name: "trailing whitespace", payload: "{\"blobs\":[]} \n\t"},
+		{name: "second JSON value", payload: `{"blobs":[]}{"blobs":[]}`, wantErr: "multiple JSON values"},
+		{name: "trailing garbage", payload: `{"blobs":[]}garbage`, wantErr: "trailing data"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := puffin.NewReader(bytes.NewReader(fileWithFooterPayload([]byte(test.payload))))
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
 }
 
 // TestReaderBlobAccess verifies blob access methods work correctly.

--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -600,13 +600,15 @@ func TestReaderRejectsTrailingFooterData(t *testing.T) {
 	}{
 		{name: "single object", payload: `{"blobs":[]}`},
 		{name: "trailing whitespace", payload: "{\"blobs\":[]} \n\t"},
-		{name: "second JSON value", payload: `{"blobs":[]}{"blobs":[]}`, wantErr: "multiple JSON values"},
-		{name: "second scalar value", payload: `{"blobs":[]}42`, wantErr: "multiple JSON values"},
-		{name: "trailing garbage", payload: `{"blobs":[]}garbage`, wantErr: "trailing data"},
+		{name: "second JSON value", payload: `{"blobs":[]}{"blobs":[]}`, wantErr: "unexpected content after footer JSON"},
+		{name: "second scalar value", payload: `{"blobs":[]}42`, wantErr: "unexpected content after footer JSON"},
+		{name: "trailing garbage", payload: `{"blobs":[]}garbage`, wantErr: "unexpected content after footer JSON"},
+		{name: "trailing closing delimiter", payload: `{"blobs":[]} ]`, wantErr: "unexpected content after footer JSON"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := puffin.NewReader(bytes.NewReader(fileWithFooterPayload([]byte(test.payload))))
 			if test.wantErr == "" {
 				require.NoError(t, err)


### PR DESCRIPTION
## What changed

After decoding the Puffin footer object, require the bounded footer payload reader to contain only JSON whitespace before EOF.

## Why

A single `json.Decoder.Decode` call accepted the first JSON value and silently ignored a second value or non-whitespace garbage, even though the trailer declared those bytes as part of the footer payload.

Unknown fields within the footer object remain allowed for forward compatibility.

## Testing

- `go test ./puffin`
- `go vet ./puffin`