### PR TITLE
fix(table): calculate snapshot summary totals as int64

### DIFF
--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -530,12 +530,12 @@ func updateSnapshotSummaries(sum Summary, previous iceberg.Properties) (Summary,
 	}
 
 	updateTotals := func(totalProp, addedProp, removedProp string) {
-		newTotal := previous.GetInt(totalProp, 0)
-		newTotal += sum.Properties.GetInt(addedProp, 0)
-		newTotal -= sum.Properties.GetInt(removedProp, 0)
+		newTotal := previous.GetInt64(totalProp, 0)
+		newTotal += sum.Properties.GetInt64(addedProp, 0)
+		newTotal -= sum.Properties.GetInt64(removedProp, 0)
 
 		if newTotal >= 0 {
-			sum.Properties[totalProp] = strconv.Itoa(newTotal)
+			sum.Properties[totalProp] = strconv.FormatInt(newTotal, 10)
 		}
 	}
 

--- a/table/snapshots_internal_test.go
+++ b/table/snapshots_internal_test.go
@@ -217,3 +217,18 @@ func TestUpdateSnapshotSummariesUnsupportedOperation(t *testing.T) {
 	_, err := updateSnapshotSummaries(Summary{Operation: Operation("scan")}, nil)
 	assert.ErrorIs(t, err, iceberg.ErrNotImplemented)
 }
+
+func TestUpdateSnapshotSummariesPreservesLargeTotals(t *testing.T) {
+	t.Parallel()
+
+	result, err := updateSnapshotSummaries(Summary{Operation: OpAppend, Properties: iceberg.Properties{
+		addedRecordsKey:  "1000000000",
+		addedFileSizeKey: "1000000000",
+	}}, iceberg.Properties{
+		totalRecordsKey:  "3000000000",
+		totalFileSizeKey: "8000000000",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "4000000000", result.Properties[totalRecordsKey])
+	assert.Equal(t, "9000000000", result.Properties[totalFileSizeKey])
+}


### PR DESCRIPTION
## What changed

Calculate snapshot summary totals with `GetInt64` and format them with `strconv.FormatInt`.

## Why

Snapshot totals such as record counts and file sizes were parsed through platform-sized `int`. On 32-bit systems, ordinary Iceberg totals above `math.MaxInt32` could truncate or wrap.

The regression test adds values above the 32-bit range and verifies their exact totals.

## Testing

- `go test ./table`
- `go vet ./table`