### PR TITLE
fix(io/gcs): propagate application-default credential errors

### DIFF
--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -131,7 +131,10 @@ func gcsCredentials(ctx context.Context, props map[string]string) (*google.Crede
 		return parse(data, fmt.Sprintf("%s %q", io.GCSKeyPath, path))
 	}
 
-	creds, _ := gcp.DefaultCredentials(ctx)
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gcs: loading application default credentials: %w", err)
+	}
 
 	return creds, nil
 }

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -132,7 +132,7 @@ func gcsCredentials(ctx context.Context, props map[string]string) (*google.Crede
 	}
 
 	creds, err := gcp.DefaultCredentials(ctx)
-	if err != nil {
+	if err != nil && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
 		return nil, fmt.Errorf("gcs: loading application default credentials: %w", err)
 	}
 

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -132,7 +132,7 @@ func gcsCredentials(ctx context.Context, props map[string]string) (*google.Crede
 	}
 
 	creds, err := gcp.DefaultCredentials(ctx)
-	if err != nil && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
+	if err != nil {
 		return nil, fmt.Errorf("gcs: loading application default credentials: %w", err)
 	}
 

--- a/io/gocloud/gcs.go
+++ b/io/gocloud/gcs.go
@@ -86,6 +86,14 @@ func ParseGCSConfig(props map[string]string) *gcsblob.Options {
 const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
 
 func gcsCredentials(ctx context.Context, props map[string]string) (*google.Credentials, error) {
+	return gcsCredentialsWithDefault(ctx, props, gcp.DefaultCredentials)
+}
+
+func gcsCredentialsWithDefault(
+	ctx context.Context,
+	props map[string]string,
+	defaultCredentials func(context.Context) (*google.Credentials, error),
+) (*google.Credentials, error) {
 	// Explicit no-auth wins over everything: use an anonymous client even when
 	// ADC is available.
 	if noAuth, err := strconv.ParseBool(props[io.GCSNoAuth]); err == nil && noAuth {
@@ -131,9 +139,12 @@ func gcsCredentials(ctx context.Context, props map[string]string) (*google.Crede
 		return parse(data, fmt.Sprintf("%s %q", io.GCSKeyPath, path))
 	}
 
-	creds, err := gcp.DefaultCredentials(ctx)
+	creds, err := defaultCredentials(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("gcs: loading application default credentials: %w", err)
+		return nil, fmt.Errorf("gcs: no credentials found; set %s=true for anonymous/public bucket access: %w", io.GCSNoAuth, err)
+	}
+	if creds == nil {
+		return nil, fmt.Errorf("gcs: no credentials found; set %s=true for anonymous/public bucket access", io.GCSNoAuth)
 	}
 
 	return creds, nil

--- a/io/gocloud/gcs_integration_test.go
+++ b/io/gocloud/gcs_integration_test.go
@@ -115,6 +115,7 @@ func (s *GCSIOTestSuite) TestGCSWarehouse() {
 		"type":            "sql",
 		"warehouse":       fmt.Sprintf("gs://%s/iceberg/", gcsBucketName),
 		io.GCSEndpoint:    fmt.Sprintf("http://%s/", gcsEndpoint),
+		io.GCSNoAuth:      "true",
 		io.GCSUseJSONAPI:  "true",
 	}
 

--- a/io/gocloud/gcs_integration_test.go
+++ b/io/gocloud/gcs_integration_test.go
@@ -115,8 +115,9 @@ func (s *GCSIOTestSuite) TestGCSWarehouse() {
 		"type":            "sql",
 		"warehouse":       fmt.Sprintf("gs://%s/iceberg/", gcsBucketName),
 		io.GCSEndpoint:    fmt.Sprintf("http://%s/", gcsEndpoint),
-		io.GCSNoAuth:      "true",
-		io.GCSUseJSONAPI:  "true",
+		// The local fake-gcs-server intentionally has no application credentials.
+		io.GCSNoAuth:     "true",
+		io.GCSUseJSONAPI: "true",
 	}
 
 	cat, err := catalog.Load(context.Background(), "default", properties)

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -173,6 +173,18 @@ func TestGCSCredentialsPropagatesADCError(t *testing.T) {
 		assert.Nil(t, creds)
 	})
 
+	t.Run("no-auth skips default credentials", func(t *testing.T) {
+		called := false
+		creds, err := gcsCredentialsWithDefault(context.Background(), map[string]string{io.GCSNoAuth: "true"},
+			func(context.Context) (*google.Credentials, error) {
+				called = true
+				return nil, errors.New("default credentials should not be requested")
+			})
+		require.NoError(t, err)
+		assert.Nil(t, creds)
+		assert.False(t, called)
+	})
+
 	creds, err := gcsCredentials(context.Background(), map[string]string{io.GCSNoAuth: "true"})
 	require.NoError(t, err)
 	assert.Nil(t, creds)

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -178,6 +178,7 @@ func TestGCSCredentialsPropagatesADCError(t *testing.T) {
 		creds, err := gcsCredentialsWithDefault(context.Background(), map[string]string{io.GCSNoAuth: "true"},
 			func(context.Context) (*google.Credentials, error) {
 				called = true
+
 				return nil, errors.New("default credentials should not be requested")
 			})
 		require.NoError(t, err)

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -19,6 +19,7 @@ package gocloud
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -28,6 +29,7 @@ import (
 	"github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/google"
 )
 
 // Both parse without a real RSA key (the private key is only read lazily when a
@@ -143,14 +145,35 @@ func TestGCSCredentialsNoAuth(t *testing.T) {
 }
 
 func TestGCSCredentialsPropagatesADCError(t *testing.T) {
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "missing.json"))
+	t.Run("missing configured file", func(t *testing.T) {
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "missing.json"))
 
-	creds, err := gcsCredentials(context.Background(), nil)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "gcs: loading application default credentials")
-	assert.Nil(t, creds)
+		creds, err := gcsCredentials(context.Background(), nil)
+		require.ErrorContains(t, err, "gcs: no credentials found")
+		require.ErrorContains(t, err, io.GCSNoAuth)
+		assert.Nil(t, creds)
+	})
 
-	creds, err = gcsCredentials(context.Background(), map[string]string{io.GCSNoAuth: "true"})
+	t.Run("no configured credentials", func(t *testing.T) {
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+		creds, err := gcsCredentialsWithDefault(context.Background(), nil,
+			func(context.Context) (*google.Credentials, error) {
+				return nil, errors.New("application default credentials unavailable")
+			})
+		require.ErrorContains(t, err, "gcs: no credentials found")
+		require.ErrorContains(t, err, io.GCSNoAuth)
+		assert.Nil(t, creds)
+	})
+
+	t.Run("nil credentials", func(t *testing.T) {
+		creds, err := gcsCredentialsWithDefault(context.Background(), nil,
+			func(context.Context) (*google.Credentials, error) { return nil, nil })
+		require.ErrorContains(t, err, "gcs: no credentials found")
+		assert.Nil(t, creds)
+	})
+
+	creds, err := gcsCredentials(context.Background(), map[string]string{io.GCSNoAuth: "true"})
 	require.NoError(t, err)
 	assert.Nil(t, creds)
 }

--- a/io/gocloud/gcs_test.go
+++ b/io/gocloud/gcs_test.go
@@ -142,6 +142,19 @@ func TestGCSCredentialsNoAuth(t *testing.T) {
 	assert.Nil(t, creds)
 }
 
+func TestGCSCredentialsPropagatesADCError(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "missing.json"))
+
+	creds, err := gcsCredentials(context.Background(), nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "gcs: loading application default credentials")
+	assert.Nil(t, creds)
+
+	creds, err = gcsCredentials(context.Background(), map[string]string{io.GCSNoAuth: "true"})
+	require.NoError(t, err)
+	assert.Nil(t, creds)
+}
+
 // A vended gcs.oauth2.token is turned into a static token source, not dropped.
 func TestGCSCredentialsFromOAuthToken(t *testing.T) {
 	exp := time.Now().Add(time.Hour).UnixMilli()


### PR DESCRIPTION
## Summary

Return application-default credential discovery errors from GCS configuration.

## Why

ADC errors were discarded and a nil credential result was treated as anonymous access. Misconfigured credentials could then fail later with an unrelated storage authorization error.

## What changed

Credential discovery errors now include source context. Anonymous access remains available explicitly through gcs.no-auth, which still takes precedence.

## Tests

- go test ./io/gocloud -run TestGCSCredentials
- go vet ./io/gocloud