### PR TITLE
fix(literals): reject oversized fixed-width values

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -34,5 +34,6 @@ var (
 	ErrBadCast                 = errors.New("could not cast value")
 	ErrBadLiteral              = errors.New("invalid literal value")
 	ErrInvalidBinSerialization = errors.New("invalid binary serialization")
+	ErrInvalidFixedLength      = errors.New("invalid fixed literal length")
 	ErrResolve                 = errors.New("cannot resolve type")
 )

--- a/literals.go
+++ b/literals.go
@@ -201,8 +201,8 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 			copy(padded, data)
 			data = padded
 		} else if len(data) > t.Len() {
-			return nil, fmt.Errorf("%w: fixed[%d] value has %d bytes",
-				ErrInvalidBinSerialization, t.Len(), len(data))
+			return nil, fmt.Errorf("%w: %w: fixed[%d] value has %d bytes",
+				ErrInvalidBinSerialization, ErrInvalidFixedLength, t.Len(), len(data))
 		}
 		var v FixedLiteral
 		err := v.UnmarshalBinary(data)

--- a/literals.go
+++ b/literals.go
@@ -193,13 +193,16 @@ func LiteralFromBytes(typ Type, data []byte) (Literal, error) {
 
 		return GeoLiteral{val: data, typ: typ}, nil
 	case FixedType:
-		if len(data) != t.Len() {
+		if len(data) < t.Len() {
 			// looks like some writers will write a prefix of the fixed length
 			// for lower/upper bounds instead of the full length. so let's pad
 			// it out to the full length if unpacking a fixed length literal
 			padded := make([]byte, t.Len())
 			copy(padded, data)
 			data = padded
+		} else if len(data) > t.Len() {
+			return nil, fmt.Errorf("%w: fixed[%d] value has %d bytes",
+				ErrInvalidBinSerialization, t.Len(), len(data))
 		}
 		var v FixedLiteral
 		err := v.UnmarshalBinary(data)

--- a/literals_test.go
+++ b/literals_test.go
@@ -19,7 +19,6 @@ package iceberg_test
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 	"strconv"
 	"testing"
@@ -1206,27 +1205,25 @@ func TestLiteralFromBytesFixedWidth(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		data    []byte
-		want    iceberg.FixedLiteral
-		wantErr bool
+		name        string
+		data        []byte
+		want        iceberg.FixedLiteral
+		errContains string
 	}{
 		{name: "exact", data: []byte{1, 2, 3, 4}, want: iceberg.FixedLiteral{1, 2, 3, 4}},
 		{name: "short", data: []byte{1, 2, 3}, want: iceberg.FixedLiteral{1, 2, 3, 0}},
-		{name: "empty", data: nil, wantErr: true},
-		{name: "one byte oversized", data: []byte{1, 2, 3, 4, 5}, wantErr: true},
-		{name: "large oversized", data: make([]byte, 100), wantErr: true},
+		{name: "zero length", data: []byte{}, want: iceberg.FixedLiteral{0, 0, 0, 0}},
+		{name: "nil", data: nil, errContains: "invalid binary serialization"},
+		{name: "one byte oversized", data: []byte{1, 2, 3, 4, 5}, errContains: "fixed[4] value has 5 bytes"},
+		{name: "large oversized", data: make([]byte, 100), errContains: "fixed[4] value has 100 bytes"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			literal, err := iceberg.LiteralFromBytes(iceberg.FixedTypeOf(4), test.data)
-			if test.wantErr {
+			if test.errContains != "" {
 				require.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)
-				if len(test.data) > 4 {
-					require.ErrorContains(t, err, "fixed[4]")
-					require.ErrorContains(t, err, fmt.Sprintf("%d bytes", len(test.data)))
-				}
+				require.ErrorContains(t, err, test.errContains)
 
 				return
 			}

--- a/literals_test.go
+++ b/literals_test.go
@@ -19,6 +19,7 @@ package iceberg_test
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"strconv"
 	"testing"
@@ -1197,6 +1198,40 @@ func TestUnmarshalBinary(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Truef(t, tt.result.Equals(lit), "expected: %s, got: %s", tt.result, lit)
+		})
+	}
+}
+
+func TestLiteralFromBytesFixedWidth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		data    []byte
+		want    iceberg.FixedLiteral
+		wantErr bool
+	}{
+		{name: "exact", data: []byte{1, 2, 3, 4}, want: iceberg.FixedLiteral{1, 2, 3, 4}},
+		{name: "short", data: []byte{1, 2, 3}, want: iceberg.FixedLiteral{1, 2, 3, 0}},
+		{name: "empty", data: nil, wantErr: true},
+		{name: "one byte oversized", data: []byte{1, 2, 3, 4, 5}, wantErr: true},
+		{name: "large oversized", data: make([]byte, 100), wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			literal, err := iceberg.LiteralFromBytes(iceberg.FixedTypeOf(4), test.data)
+			if test.wantErr {
+				require.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)
+				if len(test.data) > 4 {
+					require.ErrorContains(t, err, "fixed[4]")
+					require.ErrorContains(t, err, fmt.Sprintf("%d bytes", len(test.data)))
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, literal)
 		})
 	}
 }

--- a/literals_test.go
+++ b/literals_test.go
@@ -1227,6 +1227,7 @@ func TestLiteralFromBytesFixedWidth(t *testing.T) {
 					require.ErrorContains(t, err, "fixed[4]")
 					require.ErrorContains(t, err, fmt.Sprintf("%d bytes", len(test.data)))
 				}
+
 				return
 			}
 

--- a/literals_test.go
+++ b/literals_test.go
@@ -1209,13 +1209,14 @@ func TestLiteralFromBytesFixedWidth(t *testing.T) {
 		data        []byte
 		want        iceberg.FixedLiteral
 		errContains string
+		oversized   bool
 	}{
 		{name: "exact", data: []byte{1, 2, 3, 4}, want: iceberg.FixedLiteral{1, 2, 3, 4}},
 		{name: "short", data: []byte{1, 2, 3}, want: iceberg.FixedLiteral{1, 2, 3, 0}},
 		{name: "zero length", data: []byte{}, want: iceberg.FixedLiteral{0, 0, 0, 0}},
 		{name: "nil", data: nil, errContains: "invalid binary serialization"},
-		{name: "one byte oversized", data: []byte{1, 2, 3, 4, 5}, errContains: "fixed[4] value has 5 bytes"},
-		{name: "large oversized", data: make([]byte, 100), errContains: "fixed[4] value has 100 bytes"},
+		{name: "one byte oversized", data: []byte{1, 2, 3, 4, 5}, errContains: "fixed[4] value has 5 bytes", oversized: true},
+		{name: "large oversized", data: make([]byte, 100), errContains: "fixed[4] value has 100 bytes", oversized: true},
 	}
 
 	for _, test := range tests {
@@ -1223,6 +1224,9 @@ func TestLiteralFromBytesFixedWidth(t *testing.T) {
 			literal, err := iceberg.LiteralFromBytes(iceberg.FixedTypeOf(4), test.data)
 			if test.errContains != "" {
 				require.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)
+				if test.oversized {
+					require.ErrorIs(t, err, iceberg.ErrInvalidFixedLength)
+				}
 				require.ErrorContains(t, err, test.errContains)
 
 				return

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -74,7 +75,12 @@ func (m *manifestEvalVisitor) Eval(manifest iceberg.ManifestFile) (bool, error) 
 		partitionFilter: m.partitionFilter,
 	}
 
-	return iceberg.VisitExpr(ev.partitionFilter, &ev)
+	result, err := iceberg.VisitExpr(ev.partitionFilter, &ev)
+	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+		return rowsMightMatch, nil
+	}
+
+	return result, err
 }
 
 func removeBoundCmp[T iceberg.LiteralType](bound iceberg.Literal, vals []iceberg.Literal, cmpToDelete int) []iceberg.Literal {
@@ -760,7 +766,12 @@ func (m *inclusiveMetricsEval) TestRowGroup(rgmeta *metadata.RowGroupMetaData, c
 		}
 	}
 
-	return iceberg.VisitExpr(m.expr, m)
+	result, err := iceberg.VisitExpr(m.expr, m)
+	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+		return rowsMightMatch, nil
+	}
+
+	return result, err
 }
 
 func (m *inclusiveMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
@@ -778,7 +789,12 @@ func (m *inclusiveMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 	ev.nanCounts = file.NaNValueCounts()
 	ev.lowerBounds, ev.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
 
-	return iceberg.VisitExpr(m.expr, &ev)
+	result, err := iceberg.VisitExpr(m.expr, &ev)
+	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+		return rowsMightMatch, nil
+	}
+
+	return result, err
 }
 
 func (m *inclusiveMetricsEval) mayContainNull(fieldID int) bool {
@@ -1249,7 +1265,12 @@ func (m *strictMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 	ev.nanCounts = file.NaNValueCounts()
 	ev.lowerBounds, ev.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
 
-	return iceberg.VisitExpr(m.expr, &ev)
+	result, err := iceberg.VisitExpr(m.expr, &ev)
+	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+		return rowsMightNotMatch, nil
+	}
+
+	return result, err
 }
 
 func (m *strictMetricsEval) VisitUnbound(iceberg.UnboundPredicate) bool {

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -76,7 +76,7 @@ func (m *manifestEvalVisitor) Eval(manifest iceberg.ManifestFile) (bool, error) 
 	}
 
 	result, err := iceberg.VisitExpr(ev.partitionFilter, &ev)
-	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+	if errors.Is(err, iceberg.ErrInvalidFixedLength) {
 		return rowsMightMatch, nil
 	}
 
@@ -767,7 +767,7 @@ func (m *inclusiveMetricsEval) TestRowGroup(rgmeta *metadata.RowGroupMetaData, c
 	}
 
 	result, err := iceberg.VisitExpr(m.expr, m)
-	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+	if errors.Is(err, iceberg.ErrInvalidFixedLength) {
 		return rowsMightMatch, nil
 	}
 
@@ -790,7 +790,7 @@ func (m *inclusiveMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 	ev.lowerBounds, ev.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
 
 	result, err := iceberg.VisitExpr(m.expr, &ev)
-	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+	if errors.Is(err, iceberg.ErrInvalidFixedLength) {
 		return rowsMightMatch, nil
 	}
 
@@ -1266,7 +1266,7 @@ func (m *strictMetricsEval) Eval(file iceberg.DataFile) (bool, error) {
 	ev.lowerBounds, ev.upperBounds = file.LowerBoundValues(), file.UpperBoundValues()
 
 	result, err := iceberg.VisitExpr(m.expr, &ev)
-	if errors.Is(err, iceberg.ErrInvalidBinSerialization) {
+	if errors.Is(err, iceberg.ErrInvalidFixedLength) {
 		return rowsMightNotMatch, nil
 	}
 

--- a/table/evaluators_invalid_bounds_test.go
+++ b/table/evaluators_invalid_bounds_test.go
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMalformedFixedBoundsAreConservative(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "value", Type: iceberg.FixedTypeOf(4),
+	})
+	expr := iceberg.EqualTo(iceberg.Reference("value"), []byte{1, 2, 3, 4})
+	malformed := []byte{1, 2, 3, 4, 5}
+
+	t.Run("manifest evaluator keeps the manifest", func(t *testing.T) {
+		spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "value", Transform: iceberg.IdentityTransform{},
+		})
+		eval, err := newManifestEvaluator(spec, schema, expr, true)
+		require.NoError(t, err)
+
+		manifest := iceberg.NewManifestFile(2, "manifest.avro", 1, 0, 1).
+			AddedFiles(1).
+			Partitions([]iceberg.FieldSummary{{LowerBound: &malformed, UpperBound: &malformed}}).
+			Build()
+		matches, err := eval(manifest)
+		require.NoError(t, err)
+		require.True(t, matches)
+	})
+
+	builder, err := iceberg.NewDataFileBuilder(
+		iceberg.NewPartitionSpec(), iceberg.EntryContentData, "file.parquet",
+		iceberg.ParquetFile, nil, nil, nil, 1, 1,
+	)
+	require.NoError(t, err)
+	dataFile := builder.
+		ValueCounts(map[int]int64{1: 1}).
+		NullValueCounts(map[int]int64{1: 0}).
+		LowerBoundValues(map[int][]byte{1: malformed}).
+		UpperBoundValues(map[int][]byte{1: malformed}).
+		Build()
+
+	t.Run("inclusive evaluator keeps the file", func(t *testing.T) {
+		eval, err := newInclusiveMetricsEvaluator(schema, expr, true, false)
+		require.NoError(t, err)
+		matches, err := eval(dataFile)
+		require.NoError(t, err)
+		require.True(t, matches)
+	})
+
+	t.Run("strict evaluator does not prove a match", func(t *testing.T) {
+		eval, err := newStrictMetricsEvaluator(schema, expr, true, false)
+		require.NoError(t, err)
+		matches, err := eval(dataFile)
+		require.NoError(t, err)
+		require.False(t, matches)
+	})
+}


### PR DESCRIPTION
## What changed

Continue padding shortened fixed-width bounds for compatibility, but reject inputs larger than the declared fixed width with `ErrInvalidBinSerialization`.

## Why

The previous `len != width` branch copied every mismatched value into a width-sized buffer. Oversized values were silently truncated into a different valid value, which could corrupt bounds used for pruning.

Regression coverage includes exact, shortened, empty, one-byte oversized, and substantially oversized inputs, with expected and actual lengths asserted for oversize errors.

## Testing

- `go test .`
- `go vet .`