### PR TITLE
fix(types): floor negative nanosecond timestamps

### DIFF
--- a/literals_test.go
+++ b/literals_test.go
@@ -201,8 +201,8 @@ func TestTimestampNanoLiteralConversions(t *testing.T) {
 		{
 			name:              "negative timestamp",
 			nanoLit:           iceberg.TimestampNsLiteral(-1234567890123456789),
-			expectedMicro:     iceberg.Timestamp(-1234567890123456),
-			expectedRoundTrip: iceberg.TimestampNano(-1234567890123456000),
+			expectedMicro:     iceberg.Timestamp(-1234567890123457),
+			expectedRoundTrip: iceberg.TimestampNano(-1234567890123457000),
 		},
 		{
 			name:              "maximum precision truncation",
@@ -232,6 +232,36 @@ func TestTimestampNanoLiteralConversions(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, tt.expectedRoundTrip, iceberg.TimestampNano(nanoValue))
 		})
+	}
+}
+
+func TestTimestampNanoToMicrosFloorsNegativeValues(t *testing.T) {
+	tests := []struct {
+		nanos  iceberg.TimestampNano
+		micros iceberg.Timestamp
+	}{
+		{nanos: -1001, micros: -2},
+		{nanos: -1000, micros: -1},
+		{nanos: -999, micros: -1},
+		{nanos: -1, micros: -1},
+		{nanos: 0, micros: 0},
+		{nanos: 1, micros: 0},
+		{nanos: 999, micros: 0},
+		{nanos: 1000, micros: 1},
+		{nanos: 1001, micros: 1},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.micros, tt.nanos.ToMicros())
+
+		for _, target := range []iceberg.Type{
+			iceberg.PrimitiveTypes.Timestamp,
+			iceberg.PrimitiveTypes.TimestampTz,
+		} {
+			converted, err := iceberg.TimestampNsLiteral(tt.nanos).To(target)
+			require.NoError(t, err)
+			assert.Equal(t, iceberg.TimestampLiteral(tt.micros), converted)
+		}
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -799,7 +799,7 @@ func (t TimestampNano) ToTime() time.Time {
 }
 
 func (t TimestampNano) ToMicros() Timestamp {
-	return Timestamp(int64(t) / 1000)
+	return Timestamp(internal.FloorDiv(int64(t), 1000))
 }
 
 func (t TimestampNano) ToDate() Date {


### PR DESCRIPTION
## What changed

Use signed floor division when converting nanosecond timestamps to microseconds. Add boundary coverage around zero and verify casts to both timestamp variants.

## Why

Go integer division truncates toward zero. For pre-epoch timestamps with sub-microsecond precision, that could move the converted value forward by one microsecond and even cross the Unix epoch.

## Testing

- `go test .`