### PR TITLE
fix(substrait): convert nanosecond timestamp literals

### DIFF
--- a/table/substrait/substrait.go
+++ b/table/substrait/substrait.go
@@ -318,6 +318,16 @@ func toSubstraitLiteral(typ iceberg.Type, lit iceberg.Literal) expr.Literal {
 		}
 
 		return toPrimitiveSubstraitLiteral(types.Timestamp(lit))
+	case iceberg.TimestampNsLiteral:
+		if typ.Equals(iceberg.PrimitiveTypes.TimestampTzNs) {
+			return expr.NewPrecisionTimestampTzLiteral(
+				int64(lit), types.PrecisionNanoSeconds, types.NullabilityRequired,
+			)
+		}
+
+		return expr.NewPrecisionTimestampLiteral(
+			int64(lit), types.PrecisionNanoSeconds, types.NullabilityRequired,
+		)
 	case iceberg.DateLiteral:
 		return toPrimitiveSubstraitLiteral(types.Date(lit))
 	case iceberg.TimeLiteral:

--- a/table/substrait/substrait.go
+++ b/table/substrait/substrait.go
@@ -21,6 +21,7 @@ import (
 	_ "embed"
 	"encoding/binary"
 	"fmt"
+	"sort"
 	"strings"
 	"unsafe"
 
@@ -348,6 +349,10 @@ func toSubstraitLiteralSet(typ iceberg.Type, lits []iceberg.Literal) expr.ListLi
 	if len(lits) == 0 {
 		return nil
 	}
+
+	sort.Slice(lits, func(i, j int) bool {
+		return lits[i].String() < lits[j].String()
+	})
 
 	out := make([]expr.Literal, len(lits))
 	for i, l := range lits {

--- a/table/substrait/substrait_test.go
+++ b/table/substrait/substrait_test.go
@@ -142,6 +142,7 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 		name       string
 		fieldType  iceberg.Type
 		predicate  iceberg.BooleanExpression
+		wantExpr   string
 		wantValues []string
 		wantType   string
 	}{
@@ -149,6 +150,7 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 			name:       "timestamp equality",
 			fieldType:  iceberg.PrimitiveTypes.TimestampNs,
 			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(123456789)),
+			wantExpr:   "equal(.field(0) => precision_timestamp?<9>, precision_timestamp<9>(1970-01-01 00:00:00.123456789)) => boolean?",
 			wantValues: []string{"1970-01-01 00:00:00.123456789"},
 			wantType:   "precision_timestamp<9>",
 		},
@@ -156,6 +158,7 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 			name:       "timestamp with timezone equality before epoch",
 			fieldType:  iceberg.PrimitiveTypes.TimestampTzNs,
 			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(-123456789)),
+			wantExpr:   "equal(.field(0) => precision_timestamp_tz?<9>, precision_timestamp_tz<9>(1969-12-31T23:59:59.876543211Z)) => boolean?",
 			wantValues: []string{"1969-12-31T23:59:59.876543211Z"},
 			wantType:   "precision_timestamp_tz<9>",
 		},
@@ -173,6 +176,18 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 			wantValues: []string{"1969-12-31T23:59:59.999999999Z", "1970-01-01T00:00:00.000001001Z"},
 			wantType:   "precision_timestamp_tz<9>",
 		},
+		{
+			name:      "timestamp greater than",
+			fieldType: iceberg.PrimitiveTypes.TimestampNs,
+			predicate: iceberg.GreaterThan(iceberg.Reference("ts"), iceberg.TimestampNano(42)),
+			wantExpr:  "gt(.field(0) => precision_timestamp?<9>, precision_timestamp<9>(1970-01-01 00:00:00.000000042)) => boolean?",
+		},
+		{
+			name:      "timestamp with timezone less than",
+			fieldType: iceberg.PrimitiveTypes.TimestampTzNs,
+			predicate: iceberg.LessThan(iceberg.Reference("ts"), iceberg.TimestampNano(-42)),
+			wantExpr:  "lt(.field(0) => precision_timestamp_tz?<9>, precision_timestamp_tz<9>(1969-12-31T23:59:59.999999958Z)) => boolean?",
+		},
 	}
 
 	for _, tt := range tests {
@@ -183,10 +198,15 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 
 			_, converted, err := substrait.ConvertExpr(sc, bound, true)
 			require.NoError(t, err)
+			if tt.wantExpr != "" {
+				assert.Equal(t, tt.wantExpr, converted.String())
+			}
 			for _, value := range tt.wantValues {
 				assert.Contains(t, converted.String(), value)
 			}
-			assert.Contains(t, converted.String(), tt.wantType)
+			if tt.wantType != "" {
+				assert.Contains(t, converted.String(), tt.wantType)
+			}
 		})
 	}
 }

--- a/table/substrait/substrait_test.go
+++ b/table/substrait/substrait_test.go
@@ -137,6 +137,60 @@ func TestExprs(t *testing.T) {
 	}
 }
 
+func TestNanosecondTimestampLiterals(t *testing.T) {
+	tests := []struct {
+		name       string
+		fieldType  iceberg.Type
+		predicate  iceberg.BooleanExpression
+		wantValues []string
+		wantType   string
+	}{
+		{
+			name:       "timestamp equality",
+			fieldType:  iceberg.PrimitiveTypes.TimestampNs,
+			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(123456789)),
+			wantValues: []string{"1970-01-01 00:00:00.123456789"},
+			wantType:   "precision_timestamp<9>",
+		},
+		{
+			name:       "timestamp with timezone equality before epoch",
+			fieldType:  iceberg.PrimitiveTypes.TimestampTzNs,
+			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(-123456789)),
+			wantValues: []string{"1969-12-31T23:59:59.876543211Z"},
+			wantType:   "precision_timestamp_tz<9>",
+		},
+		{
+			name:       "timestamp in",
+			fieldType:  iceberg.PrimitiveTypes.TimestampNs,
+			predicate:  iceberg.IsIn(iceberg.Reference("ts"), iceberg.TimestampNano(1), iceberg.TimestampNano(1001)),
+			wantValues: []string{"1970-01-01 00:00:00.000000001", "1970-01-01 00:00:00.000001001"},
+			wantType:   "precision_timestamp<9>",
+		},
+		{
+			name:       "timestamp with timezone not in",
+			fieldType:  iceberg.PrimitiveTypes.TimestampTzNs,
+			predicate:  iceberg.NotIn(iceberg.Reference("ts"), iceberg.TimestampNano(-1), iceberg.TimestampNano(1001)),
+			wantValues: []string{"1969-12-31T23:59:59.999999999Z", "1970-01-01T00:00:00.000001001Z"},
+			wantType:   "precision_timestamp_tz<9>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "ts", Type: tt.fieldType})
+			bound, err := iceberg.BindExpr(sc, tt.predicate, true)
+			require.NoError(t, err)
+
+			_, converted, err := substrait.ConvertExpr(sc, bound, true)
+			require.NoError(t, err)
+			for _, value := range tt.wantValues {
+				assert.Contains(t, converted.String(), value)
+			}
+			assert.Contains(t, converted.String(), tt.wantType)
+		})
+	}
+}
+
 func TestVariantSchemaConversionDoesNotPanic(t *testing.T) {
 	sc := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},

--- a/table/substrait/substrait_test.go
+++ b/table/substrait/substrait_test.go
@@ -139,42 +139,34 @@ func TestExprs(t *testing.T) {
 
 func TestNanosecondTimestampLiterals(t *testing.T) {
 	tests := []struct {
-		name       string
-		fieldType  iceberg.Type
-		predicate  iceberg.BooleanExpression
-		wantExpr   string
-		wantValues []string
-		wantType   string
+		name      string
+		fieldType iceberg.Type
+		predicate iceberg.BooleanExpression
+		wantExpr  string
 	}{
 		{
-			name:       "timestamp equality",
-			fieldType:  iceberg.PrimitiveTypes.TimestampNs,
-			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(123456789)),
-			wantExpr:   "equal(.field(0) => precision_timestamp?<9>, precision_timestamp<9>(1970-01-01 00:00:00.123456789)) => boolean?",
-			wantValues: []string{"1970-01-01 00:00:00.123456789"},
-			wantType:   "precision_timestamp<9>",
+			name:      "timestamp equality",
+			fieldType: iceberg.PrimitiveTypes.TimestampNs,
+			predicate: iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(123456789)),
+			wantExpr:  "equal(.field(0) => precision_timestamp?<9>, precision_timestamp<9>(1970-01-01 00:00:00.123456789)) => boolean?",
 		},
 		{
-			name:       "timestamp with timezone equality before epoch",
-			fieldType:  iceberg.PrimitiveTypes.TimestampTzNs,
-			predicate:  iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(-123456789)),
-			wantExpr:   "equal(.field(0) => precision_timestamp_tz?<9>, precision_timestamp_tz<9>(1969-12-31T23:59:59.876543211Z)) => boolean?",
-			wantValues: []string{"1969-12-31T23:59:59.876543211Z"},
-			wantType:   "precision_timestamp_tz<9>",
+			name:      "timestamp with timezone equality before epoch",
+			fieldType: iceberg.PrimitiveTypes.TimestampTzNs,
+			predicate: iceberg.EqualTo(iceberg.Reference("ts"), iceberg.TimestampNano(-123456789)),
+			wantExpr:  "equal(.field(0) => precision_timestamp_tz?<9>, precision_timestamp_tz<9>(1969-12-31T23:59:59.876543211Z)) => boolean?",
 		},
 		{
-			name:       "timestamp in",
-			fieldType:  iceberg.PrimitiveTypes.TimestampNs,
-			predicate:  iceberg.IsIn(iceberg.Reference("ts"), iceberg.TimestampNano(1), iceberg.TimestampNano(1001)),
-			wantValues: []string{"1970-01-01 00:00:00.000000001", "1970-01-01 00:00:00.000001001"},
-			wantType:   "precision_timestamp<9>",
+			name:      "timestamp in",
+			fieldType: iceberg.PrimitiveTypes.TimestampNs,
+			predicate: iceberg.IsIn(iceberg.Reference("ts"), iceberg.TimestampNano(1), iceberg.TimestampNano(1001)),
+			wantExpr:  "is_in(.field(0) => precision_timestamp?<9>, list<precision_timestamp<9>>([precision_timestamp<9>(1970-01-01 00:00:00.000000001) precision_timestamp<9>(1970-01-01 00:00:00.000001001)])) => boolean?",
 		},
 		{
-			name:       "timestamp with timezone not in",
-			fieldType:  iceberg.PrimitiveTypes.TimestampTzNs,
-			predicate:  iceberg.NotIn(iceberg.Reference("ts"), iceberg.TimestampNano(-1), iceberg.TimestampNano(1001)),
-			wantValues: []string{"1969-12-31T23:59:59.999999999Z", "1970-01-01T00:00:00.000001001Z"},
-			wantType:   "precision_timestamp_tz<9>",
+			name:      "timestamp with timezone not in",
+			fieldType: iceberg.PrimitiveTypes.TimestampTzNs,
+			predicate: iceberg.NotIn(iceberg.Reference("ts"), iceberg.TimestampNano(-1), iceberg.TimestampNano(1001)),
+			wantExpr:  "not(is_in(.field(0) => precision_timestamp_tz?<9>, list<precision_timestamp_tz<9>>([precision_timestamp_tz<9>(1969-12-31T23:59:59.999999999Z) precision_timestamp_tz<9>(1970-01-01T00:00:00.000001001Z)])) => boolean?) => boolean?",
 		},
 		{
 			name:      "timestamp greater than",
@@ -198,15 +190,7 @@ func TestNanosecondTimestampLiterals(t *testing.T) {
 
 			_, converted, err := substrait.ConvertExpr(sc, bound, true)
 			require.NoError(t, err)
-			if tt.wantExpr != "" {
-				assert.Equal(t, tt.wantExpr, converted.String())
-			}
-			for _, value := range tt.wantValues {
-				assert.Contains(t, converted.String(), value)
-			}
-			if tt.wantType != "" {
-				assert.Contains(t, converted.String(), tt.wantType)
-			}
+			assert.Equal(t, tt.wantExpr, converted.String())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Convert Iceberg nanosecond timestamp literals to Substrait precision-timestamp literals.

## Why

Schema conversion supported timestamp_ns and timestamptz_ns, but expression conversion had no matching literal case and panicked for predicates containing them.

## What changed

Both timestamp variants now preserve their timezone distinction and raw nanosecond value. Equality, pre-epoch, IN, and NOT IN cases are covered.

## Tests

- go test ./table/substrait