### PR TITLE
fix(puffin): poison writers after write failures

### DIFF
--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -74,10 +74,12 @@ func defaultBlobInput() puffin.BlobMetadataInput {
 
 func TestWriterRejectsOperationsAfterPartialWriteFailure(t *testing.T) {
 	tests := []struct {
-		name     string
-		failCall int
+		name           string
+		failCall       int
+		failsDuringAdd bool
 	}{
-		{name: "blob", failCall: 2},
+		// NewWriter writes first, AddBlob writes second, and Finish writes calls 3-5.
+		{name: "blob", failCall: 2, failsDuringAdd: true},
 		{name: "footer magic", failCall: 3},
 		{name: "footer payload", failCall: 4},
 		{name: "footer trailer", failCall: 5},
@@ -91,7 +93,7 @@ func TestWriterRejectsOperationsAfterPartialWriteFailure(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = writer.AddBlob(defaultBlobInput(), []byte("first blob payload"))
-			if tt.failCall == 2 {
+			if tt.failsDuringAdd {
 				require.ErrorIs(t, err, writeErr)
 			} else {
 				require.NoError(t, err)
@@ -125,6 +127,9 @@ func TestWriterRejectsOperationsAfterShortWrite(t *testing.T) {
 	_, err = writer.AddBlob(defaultBlobInput(), []byte("second blob payload"))
 	assert.ErrorContains(t, err, "short write")
 	assert.ErrorContains(t, writer.Finish(), "short write")
+	assert.ErrorContains(t, writer.AddProperties(map[string]string{"key": "value"}), "short write")
+	assert.ErrorContains(t, writer.ClearProperties(), "short write")
+	assert.ErrorContains(t, writer.SetCreatedBy("test"), "short write")
 	assert.Equal(t, callsAfterFailure, output.calls)
 }
 

--- a/puffin/puffin_test.go
+++ b/puffin/puffin_test.go
@@ -19,6 +19,7 @@ package puffin_test
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"os"
 	"path"
@@ -38,6 +39,25 @@ func newWriter() (*puffin.Writer, *bytes.Buffer) {
 	return w, buf
 }
 
+type partialFailWriter struct {
+	bytes.Buffer
+	failCall int
+	calls    int
+	err      error
+}
+
+func (w *partialFailWriter) Write(data []byte) (int, error) {
+	w.calls++
+	if w.calls == w.failCall {
+		partial := len(data) / 2
+		_, _ = w.Buffer.Write(data[:partial])
+
+		return partial, w.err
+	}
+
+	return w.Buffer.Write(data)
+}
+
 func newReader(t *testing.T, buf *bytes.Buffer) *puffin.Reader {
 	r, err := puffin.NewReader(bytes.NewReader(buf.Bytes()))
 	require.NoError(t, err)
@@ -50,6 +70,62 @@ func defaultBlobInput() puffin.BlobMetadataInput {
 		Type:   puffin.BlobTypeDataSketchesTheta,
 		Fields: []int32{},
 	}
+}
+
+func TestWriterRejectsOperationsAfterPartialWriteFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		failCall int
+	}{
+		{name: "blob", failCall: 2},
+		{name: "footer magic", failCall: 3},
+		{name: "footer payload", failCall: 4},
+		{name: "footer trailer", failCall: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeErr := errors.New("injected partial write")
+			output := &partialFailWriter{failCall: tt.failCall, err: writeErr}
+			writer, err := puffin.NewWriter(output)
+			require.NoError(t, err)
+
+			_, err = writer.AddBlob(defaultBlobInput(), []byte("first blob payload"))
+			if tt.failCall == 2 {
+				require.ErrorIs(t, err, writeErr)
+			} else {
+				require.NoError(t, err)
+				require.ErrorIs(t, writer.Finish(), writeErr)
+			}
+
+			callsAfterFailure := output.calls
+			bytesAfterFailure := output.Len()
+
+			_, err = writer.AddBlob(defaultBlobInput(), []byte("second blob payload"))
+			assert.ErrorIs(t, err, writeErr)
+			assert.ErrorIs(t, writer.Finish(), writeErr)
+			assert.ErrorIs(t, writer.AddProperties(map[string]string{"key": "value"}), writeErr)
+			assert.ErrorIs(t, writer.ClearProperties(), writeErr)
+			assert.ErrorIs(t, writer.SetCreatedBy("test"), writeErr)
+			assert.Equal(t, callsAfterFailure, output.calls)
+			assert.Equal(t, bytesAfterFailure, output.Len())
+		})
+	}
+}
+
+func TestWriterRejectsOperationsAfterShortWrite(t *testing.T) {
+	output := &partialFailWriter{failCall: 2}
+	writer, err := puffin.NewWriter(output)
+	require.NoError(t, err)
+
+	_, err = writer.AddBlob(defaultBlobInput(), []byte("first blob payload"))
+	require.ErrorContains(t, err, "short write")
+
+	callsAfterFailure := output.calls
+	_, err = writer.AddBlob(defaultBlobInput(), []byte("second blob payload"))
+	assert.ErrorContains(t, err, "short write")
+	assert.ErrorContains(t, writer.Finish(), "short write")
+	assert.Equal(t, callsAfterFailure, output.calls)
 }
 
 func validFile() []byte {

--- a/puffin/puffin_writer.go
+++ b/puffin/puffin_writer.go
@@ -53,6 +53,7 @@ type Writer struct {
 	blobs     []BlobMetadata
 	props     map[string]string
 	done      bool
+	failed    error
 	createdBy string
 }
 
@@ -89,6 +90,9 @@ func NewWriter(w io.Writer) (*Writer, error) {
 // SetProperties merges the provided properties into the file-level properties
 // written to the footer. Can be called multiple times before Finish.
 func (w *Writer) AddProperties(props map[string]string) error {
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot set properties: writer previously failed: %w", w.failed)
+	}
 	if w.done {
 		return errors.New("puffin: cannot set properties: writer already finalized")
 	}
@@ -101,6 +105,9 @@ func (w *Writer) AddProperties(props map[string]string) error {
 
 // ClearProperties removes all file-level properties.
 func (w *Writer) ClearProperties() error {
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot clear properties: writer previously failed: %w", w.failed)
+	}
 	if w.done {
 		return errors.New("puffin: cannot clear properties: writer already finalized")
 	}
@@ -112,6 +119,9 @@ func (w *Writer) ClearProperties() error {
 // SetCreatedBy overrides the default "created-by" property written to the footer.
 // The default value is "iceberg-go". Example: "MyApp version 1.2.3".
 func (w *Writer) SetCreatedBy(createdBy string) error {
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot set created-by: writer previously failed: %w", w.failed)
+	}
 	if w.done {
 		return errors.New("puffin: cannot set created-by: writer already finalized")
 	}
@@ -127,6 +137,9 @@ func (w *Writer) SetCreatedBy(createdBy string) error {
 // Returns the complete BlobMetadata including the computed Offset and Length.
 // The input.Type is required; use constants like ApacheDataSketchesThetaV1.
 func (w *Writer) AddBlob(input BlobMetadataInput, data []byte) (BlobMetadata, error) {
+	if w.failed != nil {
+		return BlobMetadata{}, fmt.Errorf("puffin: cannot add blob: writer previously failed: %w", w.failed)
+	}
 	if w.done {
 		return BlobMetadata{}, errors.New("puffin: cannot add blob: writer already finalized")
 	}
@@ -182,7 +195,7 @@ func (w *Writer) AddBlob(input BlobMetadataInput, data []byte) (BlobMetadata, er
 		Properties:     properties,
 	}
 
-	if err := writeAll(w.w, data); err != nil {
+	if err := w.write(data); err != nil {
 		return BlobMetadata{}, fmt.Errorf("puffin: write blob: %w", err)
 	}
 
@@ -199,6 +212,9 @@ func (w *Writer) AddBlob(input BlobMetadataInput, data []byte) (BlobMetadata, er
 // Must be called exactly once after all blobs are written.
 // After Finish returns, no further operations are allowed on the writer.
 func (w *Writer) Finish() error {
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot finish: writer previously failed: %w", w.failed)
+	}
 	if w.done {
 		return errors.New("puffin: cannot finish: writer already finalized")
 	}
@@ -235,12 +251,12 @@ func (w *Writer) Finish() error {
 	}
 
 	// Write footer start magic
-	if err := writeAll(w.w, magic[:]); err != nil {
+	if err := w.write(magic[:]); err != nil {
 		return fmt.Errorf("puffin: write footer magic: %w", err)
 	}
 
 	// Write footer payload
-	if err := writeAll(w.w, payload); err != nil {
+	if err := w.write(payload); err != nil {
 		return fmt.Errorf("puffin: write footer payload: %w", err)
 	}
 
@@ -250,11 +266,21 @@ func (w *Writer) Finish() error {
 	binary.LittleEndian.PutUint32(trailer[4:8], 0) // flags = 0 (uncompressed)
 	copy(trailer[8:12], magic[:])
 
-	if err := writeAll(w.w, trailer[:]); err != nil {
+	if err := w.write(trailer[:]); err != nil {
 		return fmt.Errorf("puffin: write footer trailer: %w", err)
 	}
 
 	w.done = true
+
+	return nil
+}
+
+func (w *Writer) write(data []byte) error {
+	if err := writeAll(w.w, data); err != nil {
+		w.failed = err
+
+		return err
+	}
 
 	return nil
 }

--- a/puffin/puffin_writer.go
+++ b/puffin/puffin_writer.go
@@ -47,6 +47,9 @@ import (
 //	    return err
 //	}
 //	return w.Finish()
+//
+// Writer cannot be reused after a physical write fails. Once poisoned, all
+// subsequent operations return the original write error without changing state.
 type Writer struct {
 	w         io.Writer
 	offset    int64
@@ -90,11 +93,11 @@ func NewWriter(w io.Writer) (*Writer, error) {
 // SetProperties merges the provided properties into the file-level properties
 // written to the footer. Can be called multiple times before Finish.
 func (w *Writer) AddProperties(props map[string]string) error {
-	if w.failed != nil {
-		return fmt.Errorf("puffin: cannot set properties: writer previously failed: %w", w.failed)
-	}
 	if w.done {
 		return errors.New("puffin: cannot set properties: writer already finalized")
+	}
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot set properties: writer previously failed: %w", w.failed)
 	}
 	for k, v := range props {
 		w.props[k] = v
@@ -105,11 +108,11 @@ func (w *Writer) AddProperties(props map[string]string) error {
 
 // ClearProperties removes all file-level properties.
 func (w *Writer) ClearProperties() error {
-	if w.failed != nil {
-		return fmt.Errorf("puffin: cannot clear properties: writer previously failed: %w", w.failed)
-	}
 	if w.done {
 		return errors.New("puffin: cannot clear properties: writer already finalized")
+	}
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot clear properties: writer previously failed: %w", w.failed)
 	}
 	w.props = make(map[string]string)
 
@@ -119,11 +122,11 @@ func (w *Writer) ClearProperties() error {
 // SetCreatedBy overrides the default "created-by" property written to the footer.
 // The default value is "iceberg-go". Example: "MyApp version 1.2.3".
 func (w *Writer) SetCreatedBy(createdBy string) error {
-	if w.failed != nil {
-		return fmt.Errorf("puffin: cannot set created-by: writer previously failed: %w", w.failed)
-	}
 	if w.done {
 		return errors.New("puffin: cannot set created-by: writer already finalized")
+	}
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot set created-by: writer previously failed: %w", w.failed)
 	}
 	if createdBy == "" {
 		return errors.New("puffin: cannot set created-by: value cannot be empty")
@@ -137,11 +140,11 @@ func (w *Writer) SetCreatedBy(createdBy string) error {
 // Returns the complete BlobMetadata including the computed Offset and Length.
 // The input.Type is required; use constants like ApacheDataSketchesThetaV1.
 func (w *Writer) AddBlob(input BlobMetadataInput, data []byte) (BlobMetadata, error) {
-	if w.failed != nil {
-		return BlobMetadata{}, fmt.Errorf("puffin: cannot add blob: writer previously failed: %w", w.failed)
-	}
 	if w.done {
 		return BlobMetadata{}, errors.New("puffin: cannot add blob: writer already finalized")
+	}
+	if w.failed != nil {
+		return BlobMetadata{}, fmt.Errorf("puffin: cannot add blob: writer previously failed: %w", w.failed)
 	}
 	if input.Type == "" {
 		return BlobMetadata{}, errors.New("puffin: cannot add blob: type is required")
@@ -212,11 +215,11 @@ func (w *Writer) AddBlob(input BlobMetadataInput, data []byte) (BlobMetadata, er
 // Must be called exactly once after all blobs are written.
 // After Finish returns, no further operations are allowed on the writer.
 func (w *Writer) Finish() error {
-	if w.failed != nil {
-		return fmt.Errorf("puffin: cannot finish: writer previously failed: %w", w.failed)
-	}
 	if w.done {
 		return errors.New("puffin: cannot finish: writer already finalized")
+	}
+	if w.failed != nil {
+		return fmt.Errorf("puffin: cannot finish: writer previously failed: %w", w.failed)
 	}
 
 	// Build footer


### PR DESCRIPTION
## What changed

Record the first physical write failure on a Puffin writer and reject every subsequent mutation, blob write, or finish attempt while preserving the original cause. Route blob and footer writes through the shared failure-tracking path.

Add fault-injection coverage for partial failures during blob, footer magic, footer payload, and trailer writes, plus short writes that return no underlying error. The tests verify that no additional writes occur afterward.

## Why

An `io.Writer` may consume bytes and return an error or report a short write. Reusing the Puffin writer afterward left its logical offset behind the physical stream and could emit corrupt metadata.

## Testing

- `go test ./puffin -count=1`