### PR TITLE
fix(table): cancel record writes on iterator stop

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1866,12 +1866,13 @@ func recordsToDataFiles(ctx context.Context, rootLocation string, meta *Metadata
 func unpartitionedWrite(ctx context.Context, factory *writerFactory, records iter.Seq2[arrow.RecordBatch, error]) iter.Seq2[iceberg.DataFile, error] {
 	outputCh := make(chan iceberg.DataFile, 1)
 	errCh := make(chan error, 1)
+	writerCtx, cancel := context.WithCancel(ctx)
 
 	go func() {
 		defer close(outputCh)
 		defer factory.stopCount()
 
-		writer := factory.newRollingDataWriter(ctx, "", nil, outputCh)
+		writer := factory.newRollingDataWriter(writerCtx, "", nil, outputCh)
 		for rec, err := range records {
 			if err != nil {
 				errCh <- err
@@ -1879,6 +1880,15 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 				writer.abortAndWait()
 
 				return
+			}
+			select {
+			case <-writerCtx.Done():
+				errCh <- context.Cause(writerCtx)
+				close(errCh)
+				writer.abortAndWait()
+
+				return
+			default:
 			}
 			if err := writer.Add(rec); err != nil {
 				errCh <- err
@@ -1899,6 +1909,7 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 			for range outputCh {
 			}
 		}()
+		defer cancel()
 		for df := range outputCh {
 			if !yield(df, nil) {
 				return

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1881,15 +1881,7 @@ func unpartitionedWrite(ctx context.Context, factory *writerFactory, records ite
 
 				return
 			}
-			select {
-			case <-writerCtx.Done():
-				errCh <- context.Cause(writerCtx)
-				close(errCh)
-				writer.abortAndWait()
 
-				return
-			default:
-			}
 			if err := writer.Add(rec); err != nil {
 				errCh <- err
 				close(errCh)

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -180,7 +180,7 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, writerCtx c
 	return nil
 }
 
-func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh <-chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,
@@ -195,7 +195,7 @@ func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, 
 func yieldDataFiles(
 	writerFactory *writerFactory,
 	fanoutWorkers *errgroup.Group,
-	inputRecordsCh chan arrow.RecordBatch,
+	inputRecordsCh <-chan arrow.RecordBatch,
 	outputDataFilesCh chan iceberg.DataFile,
 	closeAll func() error,
 	abortAll func(),
@@ -208,6 +208,8 @@ func yieldDataFiles(
 		defer close(outputDataFilesCh)
 		defer cancel()
 		err := fanoutWorkers.Wait()
+		// Wait includes the feeder, which closes inputRecordsCh. Any batches
+		// remaining here were retained by the feeder but never dequeued.
 		for record := range inputRecordsCh {
 			record.Release()
 		}
@@ -221,6 +223,8 @@ func yieldDataFiles(
 	}()
 
 	return func(yield func(iceberg.DataFile, error) bool) {
+		// LIFO defer order matters: cancel signals the producer first,
+		// then draining outputDataFilesCh lets in-flight sends complete.
 		defer func() {
 			for range outputDataFilesCh {
 			}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -180,7 +180,7 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, writerCtx c
 	return nil
 }
 
-func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,
@@ -188,7 +188,7 @@ func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, 
 		outputDataFilesCh,
 		p.writerFactory.closeAll,
 		p.writerFactory.abortAll,
-		writerCancel,
+		cancel,
 	)
 }
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -208,8 +208,9 @@ func yieldDataFiles(
 		defer close(outputDataFilesCh)
 		defer cancel()
 		err := fanoutWorkers.Wait()
-		// Wait includes the feeder, which closes inputRecordsCh. Any batches
-		// remaining here were retained by the feeder but never dequeued.
+		// Wait includes the feeder, which closes inputRecordsCh, so draining cannot
+		// block. Any remaining batches were retained by the feeder but never dequeued;
+		// workers release dequeued batches themselves.
 		for record := range inputRecordsCh {
 			record.Release()
 		}
@@ -223,8 +224,10 @@ func yieldDataFiles(
 	}()
 
 	return func(yield func(iceberg.DataFile, error) bool) {
-		// LIFO defer order matters: cancel signals the producer first,
-		// then draining outputDataFilesCh lets in-flight sends complete.
+		// LIFO defer order matters: cancel signals the producer first
+		// (synchronous, instant), then the drain pulls outputDataFilesCh so
+		// any in-flight stream send can complete and the producer's
+		// closeAll / fanoutWorkers.Wait paths unblock.
 		defer func() {
 			for range outputDataFilesCh {
 			}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -80,8 +80,13 @@ func (p *partitionedFanoutWriter) Write(ctx context.Context, workers int) iter.S
 	inputRecordsCh := make(chan arrow.RecordBatch, workers)
 	outputDataFilesCh := make(chan iceberg.DataFile, workers)
 
-	fanoutWorkers, fanoutCtx := errgroup.WithContext(ctx)
+	fanoutBaseCtx, fanoutCancel := context.WithCancel(ctx)
+	fanoutWorkers, fanoutCtx := errgroup.WithContext(fanoutBaseCtx)
 	writerCtx, writerCancel := context.WithCancel(ctx)
+	cancel := func() {
+		fanoutCancel()
+		writerCancel()
+	}
 	startRecordFeeder(fanoutCtx, p.itr, fanoutWorkers, inputRecordsCh)
 
 	for range workers {
@@ -90,7 +95,7 @@ func (p *partitionedFanoutWriter) Write(ctx context.Context, workers int) iter.S
 		})
 	}
 
-	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh, writerCancel)
+	return p.yieldDataFiles(fanoutWorkers, inputRecordsCh, outputDataFilesCh, cancel)
 }
 
 func startRecordFeeder(ctx context.Context, itr iter.Seq2[arrow.RecordBatch, error], fanoutWorkers *errgroup.Group, inputRecordsCh chan<- arrow.RecordBatch) {
@@ -175,10 +180,11 @@ func (p *partitionedFanoutWriter) processRecord(ctx context.Context, writerCtx c
 	return nil
 }
 
-func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,
+		inputRecordsCh,
 		outputDataFilesCh,
 		p.writerFactory.closeAll,
 		p.writerFactory.abortAll,
@@ -189,18 +195,22 @@ func (p *partitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, 
 func yieldDataFiles(
 	writerFactory *writerFactory,
 	fanoutWorkers *errgroup.Group,
+	inputRecordsCh chan arrow.RecordBatch,
 	outputDataFilesCh chan iceberg.DataFile,
 	closeAll func() error,
 	abortAll func(),
-	writerCancel context.CancelFunc,
+	cancel context.CancelFunc,
 ) iter.Seq2[iceberg.DataFile, error] {
 	// Use a channel to safely communicate the error from the goroutine
 	// to avoid a data race between writing err in the goroutine and reading it in the iterator.
 	errCh := make(chan error, 1)
 	go func() {
 		defer close(outputDataFilesCh)
-		defer writerCancel()
+		defer cancel()
 		err := fanoutWorkers.Wait()
+		for record := range inputRecordsCh {
+			record.Release()
+		}
 		if err != nil {
 			abortAll()
 		} else {
@@ -215,6 +225,7 @@ func yieldDataFiles(
 			for range outputDataFilesCh {
 			}
 		}()
+		defer cancel()
 
 		// Yield data files as they arrive - no error yet since goroutine is still running
 		for f := range outputDataFilesCh {

--- a/table/pos_delete_partitioned_fanout_writer.go
+++ b/table/pos_delete_partitioned_fanout_writer.go
@@ -148,7 +148,7 @@ func (p *positionDeletePartitionedFanoutWriter) partitionPath(partitionContext p
 	return spec.PartitionToPath(data, schema), nil
 }
 
-func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,
@@ -156,6 +156,6 @@ func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *er
 		outputDataFilesCh,
 		p.writerFactory.closeAll,
 		p.writerFactory.abortAll,
-		writerCancel,
+		cancel,
 	)
 }

--- a/table/pos_delete_partitioned_fanout_writer.go
+++ b/table/pos_delete_partitioned_fanout_writer.go
@@ -56,8 +56,13 @@ func (p *positionDeletePartitionedFanoutWriter) Write(ctx context.Context, worke
 	inputRecordsCh := make(chan arrow.RecordBatch, workers)
 	outputDataFilesCh := make(chan iceberg.DataFile, workers)
 
-	fanoutWorkers, fanoutCtx := errgroup.WithContext(ctx)
+	fanoutBaseCtx, fanoutCancel := context.WithCancel(ctx)
+	fanoutWorkers, fanoutCtx := errgroup.WithContext(fanoutBaseCtx)
 	writerCtx, writerCancel := context.WithCancel(ctx)
+	cancel := func() {
+		fanoutCancel()
+		writerCancel()
+	}
 	startRecordFeeder(fanoutCtx, p.itr, fanoutWorkers, inputRecordsCh)
 
 	for range workers {
@@ -66,7 +71,7 @@ func (p *positionDeletePartitionedFanoutWriter) Write(ctx context.Context, worke
 		})
 	}
 
-	return p.yieldDataFiles(fanoutWorkers, outputDataFilesCh, writerCancel)
+	return p.yieldDataFiles(fanoutWorkers, inputRecordsCh, outputDataFilesCh, cancel)
 }
 
 func (p *positionDeletePartitionedFanoutWriter) fanout(ctx context.Context, writerCtx context.Context, inputRecordsCh <-chan arrow.RecordBatch, dataFilesChannel chan<- iceberg.DataFile) error {
@@ -143,10 +148,11 @@ func (p *positionDeletePartitionedFanoutWriter) partitionPath(partitionContext p
 	return spec.PartitionToPath(data, schema), nil
 }
 
-func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, writerCancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,
+		inputRecordsCh,
 		outputDataFilesCh,
 		p.writerFactory.closeAll,
 		p.writerFactory.abortAll,

--- a/table/pos_delete_partitioned_fanout_writer.go
+++ b/table/pos_delete_partitioned_fanout_writer.go
@@ -148,7 +148,7 @@ func (p *positionDeletePartitionedFanoutWriter) partitionPath(partitionContext p
 	return spec.PartitionToPath(data, schema), nil
 }
 
-func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
+func (p *positionDeletePartitionedFanoutWriter) yieldDataFiles(fanoutWorkers *errgroup.Group, inputRecordsCh <-chan arrow.RecordBatch, outputDataFilesCh chan iceberg.DataFile, cancel context.CancelFunc) iter.Seq2[iceberg.DataFile, error] {
 	return yieldDataFiles(
 		p.writerFactory,
 		fanoutWorkers,

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -411,6 +411,7 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 
 	const path = "file://t/id=1/a.parquet"
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 	ctx := compute.WithAllocator(t.Context(), mem)
 
 	tableSchema := iceberg.NewSchema(
@@ -441,7 +442,9 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 				strings.NewReader(fmt.Sprintf(`[{"file_path":%q,"pos":0}]`, path)),
 			)
 			require.NoError(t, err)
-			if !yield(batch, nil) {
+			accepted := yield(batch, nil)
+			batch.Release()
+			if !accepted {
 				return
 			}
 		}
@@ -469,8 +472,7 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	}
 
 	assert.Positive(t, produced.Load())
-	assert.Less(t, produced.Load(), int32(10))
-	assert.Zero(t, mem.CurrentAllocated())
+	assert.Less(t, produced.Load(), int32(1000))
 }
 
 func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -472,7 +472,7 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	}
 
 	assert.Positive(t, produced.Load())
-	assert.Less(t, produced.Load(), int32(1000))
+	assert.Less(t, produced.Load(), int32(100))
 	require.Zero(t, mem.CurrentAlloc())
 }
 

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -30,6 +30,9 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/io"
@@ -404,7 +407,11 @@ func TestPositionDeletePartitionedFanoutWriterRoutesPartitionsIndependently(t *t
 }
 
 func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t *testing.T) {
+	t.Parallel()
+
 	const path = "file://t/id=1/a.parquet"
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
 
 	tableSchema := iceberg.NewSchema(
 		0,
@@ -428,10 +435,12 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	records := func(yield func(arrow.RecordBatch, error) bool) {
 		for range 1000 {
 			produced.Add(1)
-			batch := mustLoadRecordBatchFromJSON(
+			batch, _, err := array.RecordFromJSON(
+				mem,
 				PositionalDeleteArrowSchema,
-				fmt.Sprintf(`[{"file_path":%q,"pos":0}]`, path),
+				strings.NewReader(fmt.Sprintf(`[{"file_path":%q,"pos":0}]`, path)),
 			)
+			require.NoError(t, err)
 			if !yield(batch, nil) {
 				return
 			}
@@ -452,7 +461,7 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 		factory,
 	)
 
-	for dataFile, writeErr := range writer.Write(t.Context(), 1) {
+	for dataFile, writeErr := range writer.Write(ctx, 1) {
 		require.NoError(t, writeErr)
 		require.NotNil(t, dataFile)
 
@@ -460,7 +469,8 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	}
 
 	assert.Positive(t, produced.Load())
-	assert.Less(t, produced.Load(), int32(1000))
+	assert.Less(t, produced.Load(), int32(10))
+	assert.Zero(t, mem.CurrentAllocated())
 }
 
 func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -473,6 +473,7 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 
 	assert.Positive(t, produced.Load())
 	assert.Less(t, produced.Load(), int32(1000))
+	require.Zero(t, mem.CurrentAlloc())
 }
 
 func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -400,6 +401,66 @@ func TestPositionDeletePartitionedFanoutWriterRoutesPartitionsIndependently(t *t
 	require.Contains(t, byPart, int32(2))
 	assert.Equal(t, int64(2), byPart[1].Count(), "id=1 delete file must contain only the two rows targeting pathA")
 	assert.Equal(t, int64(1), byPart[2].Count(), "id=2 delete file must contain only the one row targeting pathB")
+}
+
+func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t *testing.T) {
+	const path = "file://t/id=1/a.parquet"
+
+	tableSchema := iceberg.NewSchema(
+		0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+	partitionSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		FieldID: 1000, SourceIDs: []int{1}, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+	metadataBuilder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, metadataBuilder.AddSchema(tableSchema))
+	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
+	require.NoError(t, metadataBuilder.AddPartitionSpec(&partitionSpec, true))
+	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
+	require.NoError(t, metadataBuilder.AddSortOrder(&UnsortedSortOrder))
+	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(0))
+	latestMeta, err := metadataBuilder.Build()
+	require.NoError(t, err)
+
+	var produced atomic.Int32
+	records := func(yield func(arrow.RecordBatch, error) bool) {
+		for range 1000 {
+			produced.Add(1)
+			batch := mustLoadRecordBatchFromJSON(
+				PositionalDeleteArrowSchema,
+				fmt.Sprintf(`[{"file_path":%q,"pos":0}]`, path),
+			)
+			if !yield(batch, nil) {
+				return
+			}
+		}
+	}
+
+	writeUUID := uuid.New()
+	factory, err := newWriterFactory(t.TempDir(), recordWritingArgs{
+		fs: &io.LocalFS{}, sc: PositionalDeleteArrowSchema, writeUUID: &writeUUID, counter: internal.Counter(0),
+	}, metadataBuilder, iceberg.PositionalDeleteSchema, 1,
+		withContentType(iceberg.EntryContentPosDeletes),
+		withFactoryFileSchema(iceberg.PositionalDeleteSchema))
+	require.NoError(t, err)
+	writer := newPositionDeletePartitionedFanoutWriter(
+		latestMeta,
+		map[string]partitionContext{path: {partitionData: map[int]any{1000: int32(1)}, specID: 0}},
+		records,
+		factory,
+	)
+
+	for dataFile, writeErr := range writer.Write(t.Context(), 1) {
+		require.NoError(t, writeErr)
+		require.NotNil(t, dataFile)
+
+		break
+	}
+
+	assert.Positive(t, produced.Load())
+	assert.Less(t, produced.Load(), int32(1000))
 }
 
 func TestPositionDeletePartitionedNoGoroutineLeak(t *testing.T) {

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -286,7 +286,7 @@ func (s *WriteRecordsTestSuite) TestEarlyStopCancelsRecordProduction() {
 			}
 
 			s.Positive(produced.Load())
-			s.Less(produced.Load(), int32(10))
+			s.Less(produced.Load(), int32(1000))
 		})
 	}
 }

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -231,6 +232,63 @@ func (s *WriteRecordsTestSuite) TestSmallTargetFileSizeProducesMultipleFiles() {
 
 	s.Greater(len(dataFiles), 1)
 	s.Equal(int64(1000), totalRows)
+}
+
+func (s *WriteRecordsTestSuite) TestEarlyStopCancelsRecordProduction() {
+	tests := []struct {
+		name        string
+		partitioned bool
+	}{
+		{name: "unpartitioned"},
+		{name: "partitioned", partitioned: true},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			loc := filepath.ToSlash(s.T().TempDir())
+			iceSch := iceberg.NewSchema(1,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32},
+				iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+			)
+			spec := iceberg.NewPartitionSpec()
+			if tt.partitioned {
+				spec = iceberg.NewPartitionSpec(iceberg.PartitionField{
+					SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+				})
+			}
+			meta, err := table.NewMetadata(iceSch, &spec, table.UnsortedSortOrder, loc, iceberg.Properties{})
+			s.Require().NoError(err)
+			tbl := table.New(
+				table.Identifier{"test", tt.name}, meta, filepath.Join(loc, "metadata", "v1.metadata.json"),
+				func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, nil,
+			)
+
+			schema := s.arrowSchema()
+			var produced atomic.Int32
+			records := func(yield func(arrow.RecordBatch, error) bool) {
+				for range 1000 {
+					produced.Add(1)
+					record := s.buildRecords(schema, 100)
+					accepted := yield(record, nil)
+					if !accepted {
+						return
+					}
+				}
+			}
+
+			for df, writeErr := range table.WriteRecords(
+				s.ctx, tbl, schema, records, table.WithTargetFileSize(1), table.WithMaxWriteWorkers(1),
+			) {
+				s.Require().NoError(writeErr)
+				s.Require().NotNil(df)
+
+				break
+			}
+
+			s.Positive(produced.Load())
+			s.Less(produced.Load(), int32(1000))
+		})
+	}
 }
 
 func (s *WriteRecordsTestSuite) TestWithWriteUUID() {

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -286,7 +286,7 @@ func (s *WriteRecordsTestSuite) TestEarlyStopCancelsRecordProduction() {
 			}
 
 			s.Positive(produced.Load())
-			s.Less(produced.Load(), int32(1000))
+			s.Less(produced.Load(), int32(10))
 		})
 	}
 }

--- a/table/write_records_test.go
+++ b/table/write_records_test.go
@@ -286,7 +286,7 @@ func (s *WriteRecordsTestSuite) TestEarlyStopCancelsRecordProduction() {
 			}
 
 			s.Positive(produced.Load())
-			s.Less(produced.Load(), int32(1000))
+			s.Less(produced.Load(), int32(100))
 		})
 	}
 }


### PR DESCRIPTION
## What changed

Cancel unpartitioned and fanout write contexts when a `WriteRecords` consumer stops early. Fanout writes now cancel record production independently from rolling writers and release retained batches left in the input queue after workers exit.

Add unpartitioned and partitioned regressions showing that breaking after the first output stops the source before all records are consumed. The checked allocator also verifies retained Arrow memory is released.

## Why

The iterator previously drained output without canceling production. Breaking iteration could therefore consume the entire source, continue writing files, or never return for an unbounded source.

## Testing

- `go test ./table -run 'Test(WriteRecords|FanoutWriter|PositionDeletePartitionedFanoutWriter)' -count=1 -timeout=180s`\n- `go test -race ./table -run 'TestWriteRecords/TestEarlyStopCancelsRecordProduction' -count=1 -timeout=120s`