### PR TITLE
fix(rest): close internally owned transports

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -194,8 +194,8 @@ type PurgeableTable interface {
 }
 
 // Closer is an optional interface implemented by catalogs that hold releasable
-// resources — currently a metrics reporter, and in future a stateful (e.g.
-// HTTP-backed) one. It is not part of [Catalog] because adding a method to that
+// resources — currently a metrics reporter and stateful resources (e.g.
+// HTTP-backed clients). It is not part of [Catalog] because adding a method to that
 // widely-implemented interface would break every external implementation; a
 // follow-up may promote it. Callers holding a [Catalog] from [Load] should
 // release it via a type assertion:

--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -28,6 +28,11 @@ import (
 
 type Option func(*options)
 
+// TransportFactory creates a transport owned by the REST catalog and returns
+// the cleanup function to run when the catalog is closed. The TLS config is
+// the one configured with WithTLSConfig.
+type TransportFactory func(*tls.Config) (http.RoundTripper, func())
+
 func WithCredential(cred string) Option {
 	return func(o *options) {
 		o.credential = cred
@@ -162,6 +167,15 @@ func WithCustomTransport(transport http.RoundTripper) Option {
 	}
 }
 
+// WithTransportFactory configures a catalog-owned transport factory. The
+// returned cleanup function is called when the catalog is closed. Use
+// WithCustomTransport when the caller owns the transport instead.
+func WithTransportFactory(factory TransportFactory) Option {
+	return func(o *options) {
+		o.transportFactory = factory
+	}
+}
+
 type options struct {
 	awsConfig         aws.Config
 	awsConfigSet      bool
@@ -180,7 +194,7 @@ type options struct {
 	audience          string
 	resource          string
 	transport         http.RoundTripper
-	transportFactory  func(*tls.Config) (http.RoundTripper, func())
+	transportFactory  TransportFactory
 	headers           map[string]string
 
 	oauthTLSConfig *tls.Config

--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -180,6 +180,7 @@ type options struct {
 	audience          string
 	resource          string
 	transport         http.RoundTripper
+	transportFactory  func(*tls.Config) (http.RoundTripper, func())
 	headers           map[string]string
 
 	oauthTLSConfig *tls.Config

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1078,7 +1078,8 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*options, err
 func (r *Catalog) Name() string              { return r.name }
 func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
-// Close releases transports created by the catalog and its metrics reporter.
+// Close drains idle connections from transports created by the catalog and
+// closes its metrics reporter.
 // Caller-provided transports remain caller-owned. Close is safe to call more
 // than once. Callers holding a [catalog.Catalog] can reach this via a
 // [catalog.Closer] type assertion.

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -34,6 +34,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -766,6 +767,10 @@ var _ catalog.PurgeableTable = (*Catalog)(nil)
 type Catalog struct {
 	baseURI *url.URL
 	cl      *http.Client
+	// closeSession releases transports owned by the catalog. Caller-provided
+	// transports are excluded when the session is constructed.
+	closeSession     func()
+	closeSessionOnce sync.Once
 
 	name string
 	// Retained catalog properties are reused for table/view IO and may carry
@@ -914,7 +919,7 @@ func (r *Catalog) init(ctx context.Context, ops *options, uri string) error {
 		return err
 	}
 
-	r.cl, _, err = r.createSession(ctx, ops)
+	r.cl, r.closeSession, err = r.createSession(ctx, ops)
 	if err != nil {
 		return err
 	}
@@ -1066,11 +1071,18 @@ func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*options, err
 func (r *Catalog) Name() string              { return r.name }
 func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
-// Close releases the catalog's metrics reporter. The REST catalog does not own
-// the lifetime of the HTTP client it was configured with, so only the reporter
-// is released. Callers holding a [catalog.Catalog] can reach this via a
-// [catalog.Closer] type assertion.
-func (r *Catalog) Close() error { return r.reporter.Close() }
+// Close releases transports created by the catalog and its metrics reporter.
+// Caller-provided transports remain caller-owned. Callers holding a
+// [catalog.Catalog] can reach this via a [catalog.Closer] type assertion.
+func (r *Catalog) Close() error {
+	r.closeSessionOnce.Do(func() {
+		if r.closeSession != nil {
+			r.closeSession()
+		}
+	})
+
+	return r.reporter.Close()
+}
 
 var _ catalog.Closer = (*Catalog)(nil)
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -771,6 +771,7 @@ type Catalog struct {
 	// transports are excluded when the session is constructed.
 	closeSession     func()
 	closeSessionOnce sync.Once
+	closeErr         error
 
 	name string
 	// Retained catalog properties are reused for table/view IO and may carry
@@ -938,6 +939,12 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 	var cleanupFuncs []func()
 	if opts.transport != nil {
 		baseTransport = opts.transport
+	} else if opts.transportFactory != nil {
+		var cleanup func()
+		baseTransport, cleanup = opts.transportFactory(opts.tlsConfig)
+		if cleanup != nil {
+			cleanupFuncs = append(cleanupFuncs, cleanup)
+		}
 	} else {
 		transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: opts.tlsConfig}
 		baseTransport = transport
@@ -1072,16 +1079,18 @@ func (r *Catalog) Name() string              { return r.name }
 func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
 // Close releases transports created by the catalog and its metrics reporter.
-// Caller-provided transports remain caller-owned. Callers holding a
-// [catalog.Catalog] can reach this via a [catalog.Closer] type assertion.
+// Caller-provided transports remain caller-owned. Close is safe to call more
+// than once. Callers holding a [catalog.Catalog] can reach this via a
+// [catalog.Closer] type assertion.
 func (r *Catalog) Close() error {
 	r.closeSessionOnce.Do(func() {
 		if r.closeSession != nil {
 			r.closeSession()
 		}
+		r.closeErr = r.reporter.Close()
 	})
 
-	return r.reporter.Close()
+	return r.closeErr
 }
 
 var _ catalog.Closer = (*Catalog)(nil)

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1710,16 +1710,12 @@ func TestCatalogCloseReleasesOwnedSessionOnce(t *testing.T) {
 	})
 
 	var transports []*closeTrackingTransport
-	withTrackingTransport := func(o *options) {
-		o.transportFactory = func(*tls.Config) (http.RoundTripper, func()) {
-			transport := &closeTrackingTransport{RoundTripper: http.DefaultTransport}
-			transports = append(transports, transport)
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL, WithTransportFactory(func(*tls.Config) (http.RoundTripper, func()) {
+		transport := &closeTrackingTransport{RoundTripper: http.DefaultTransport}
+		transports = append(transports, transport)
 
-			return transport, transport.CloseIdleConnections
-		}
-	}
-
-	cat, err := NewCatalog(context.Background(), "rest", srv.URL, withTrackingTransport)
+		return transport, transport.CloseIdleConnections
+	}))
 	require.NoError(t, err)
 	require.Len(t, transports, 2)
 	assert.True(t, transports[0].closed.Load(), "bootstrap transport should be closed after config fetch")

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1696,6 +1696,15 @@ func (t *closeTrackingTransport) CloseIdleConnections() {
 	t.closed.Store(true)
 }
 
+func TestCatalogCloseReleasesOwnedSessionOnce(t *testing.T) {
+	var calls atomic.Int32
+	cat := &Catalog{closeSession: func() { calls.Add(1) }}
+
+	require.NoError(t, cat.Close())
+	require.NoError(t, cat.Close())
+	assert.Equal(t, int32(1), calls.Load())
+}
+
 func TestFetchConfigDoesNotCloseCustomTransport(t *testing.T) {
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1697,12 +1697,57 @@ func (t *closeTrackingTransport) CloseIdleConnections() {
 }
 
 func TestCatalogCloseReleasesOwnedSessionOnce(t *testing.T) {
-	var calls atomic.Int32
-	cat := &Catalog{closeSession: func() { calls.Add(1) }}
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{},
+		})
+	})
+
+	var transports []*closeTrackingTransport
+	withTrackingTransport := func(o *options) {
+		o.transportFactory = func(*tls.Config) (http.RoundTripper, func()) {
+			transport := &closeTrackingTransport{RoundTripper: http.DefaultTransport}
+			transports = append(transports, transport)
+
+			return transport, transport.CloseIdleConnections
+		}
+	}
+
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL, withTrackingTransport)
+	require.NoError(t, err)
+	require.Len(t, transports, 2)
+	assert.True(t, transports[0].closed.Load(), "bootstrap transport should be closed after config fetch")
+	assert.False(t, transports[1].closed.Load(), "catalog transport should remain open until Close")
 
 	require.NoError(t, cat.Close())
 	require.NoError(t, cat.Close())
-	assert.Equal(t, int32(1), calls.Load())
+	assert.True(t, transports[1].closed.Load())
+}
+
+func TestCatalogCloseDoesNotReleaseCustomTransport(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{},
+		})
+	})
+
+	base := &closeTrackingTransport{RoundTripper: http.DefaultTransport}
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL, WithCustomTransport(base))
+	require.NoError(t, err)
+	require.NoError(t, cat.Close())
+	assert.False(t, base.closed.Load(), "user-provided transports must remain caller-owned")
 }
 
 func TestFetchConfigDoesNotCloseCustomTransport(t *testing.T) {


### PR DESCRIPTION
## Summary

Close HTTP and OAuth transports allocated internally by the REST catalog.

## Why

Initialization built cleanup callbacks for internal transports but discarded the callback for the final long-lived session. Catalog.Close could therefore leave idle connection pools open.

## What changed

Catalog.Close now closes catalog-owned transports and keeps caller-provided transports caller-owned. Session cleanup is idempotent.

## Tests

- go test ./catalog/rest