### PR TITLE
fix(expr): reject trailing data after boolean expressions

### DIFF
--- a/expr_json.go
+++ b/expr_json.go
@@ -418,7 +418,11 @@ func decodeExpr(raw json.RawMessage, schema *Schema, caseSensitive bool) (Boolea
 	if err != nil {
 		return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
 	}
-	if b, ok := tok.(bool); ok {
+	if _, ok := tok.(bool); ok {
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
+		}
 		if b {
 			return AlwaysTrue{}, nil
 		}

--- a/expr_json.go
+++ b/expr_json.go
@@ -21,7 +21,9 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"math"
 	"sort"
 	"strings"
@@ -418,11 +420,7 @@ func decodeExpr(raw json.RawMessage, schema *Schema, caseSensitive bool) (Boolea
 	if err != nil {
 		return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
 	}
-	if _, ok := tok.(bool); ok {
-		var b bool
-		if err := json.Unmarshal(raw, &b); err != nil {
-			return nil, fmt.Errorf("%w: cannot parse expression: %s", ErrInvalidArgument, err)
-		}
+	if b, ok := tok.(bool); ok {
 		if b {
 			return AlwaysTrue{}, nil
 		}
@@ -492,8 +490,21 @@ func decodeExpr(raw json.RawMessage, schema *Schema, caseSensitive bool) (Boolea
 // without inspecting bytes by hand.
 func firstToken(raw json.RawMessage) (json.Token, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := tok.(bool); ok {
+		if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+			if err == nil {
+				return nil, errors.New("trailing data after boolean expression")
+			}
 
-	return dec.Token()
+			return nil, err
+		}
+	}
+
+	return tok, nil
 }
 
 func decodePredicate(op Operation, node exprNode, schema *Schema, caseSensitive bool) (BooleanExpression, error) {

--- a/expr_json_test.go
+++ b/expr_json_test.go
@@ -393,6 +393,20 @@ func TestUnmarshalExpressionErrors(t *testing.T) {
 	}
 }
 
+func TestUnmarshalBooleanExpressionRejectsTrailingData(t *testing.T) {
+	for _, input := range []string{
+		`true false`,
+		`false null`,
+		`true{}`,
+		`false garbage`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			_, err := iceberg.ParseExpr([]byte(input), nil)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		})
+	}
+}
+
 // TestExpressionTransformTermRoundTrip covers a residual filter whose term is a
 // partition transform, e.g. a Java server's bucket[100](id) <= 50.
 func TestExpressionTransformTermRoundTrip(t *testing.T) {


### PR DESCRIPTION
## What changed

Fully decode top-level boolean expressions before returning `AlwaysTrue` or `AlwaysFalse`. This rejects malformed input containing a valid boolean followed by additional JSON or other trailing data.

## Why

The expression decoder previously inspected only the first token for booleans. Inputs such as `true false` were therefore accepted even though they are not valid JSON values. Object expressions already reject trailing data through `json.Unmarshal`.

## Testing

- `go test ./...`