### PR TITLE
fix(manifest): make empty writer close terminal

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrInvalidFormatVersion    = fmt.Errorf("%w: invalid format version", ErrInvalidArgument)
 	ErrInvalidSchema           = errors.New("invalid schema")
 	ErrInvalidPartitionSpec    = errors.New("invalid partition spec")
+	ErrEmptyManifest           = errors.New("empty manifest file has been written")
 	ErrInvalidTransform        = errors.New("invalid transform syntax")
 	ErrType                    = errors.New("type error")
 	ErrBadCast                 = errors.New("could not cast value")

--- a/manifest.go
+++ b/manifest.go
@@ -1365,7 +1365,7 @@ func (w *ManifestWriter) Close() error {
 
 	var emptyErr error
 	if w.addedFiles+w.existingFiles+w.deletedFiles == 0 {
-		emptyErr = errors.New("empty manifest file has been written")
+		emptyErr = ErrEmptyManifest
 	}
 
 	var writerErr error

--- a/manifest.go
+++ b/manifest.go
@@ -1368,7 +1368,19 @@ func (w *ManifestWriter) Close() error {
 		emptyErr = errors.New("empty manifest file has been written")
 	}
 
-	w.closeErr = errors.Join(emptyErr, w.writer.Close())
+	var writerErr error
+	if w.writer != nil {
+		writerErr = w.writer.Close()
+	}
+
+	switch {
+	case emptyErr == nil:
+		w.closeErr = writerErr
+	case writerErr == nil:
+		w.closeErr = emptyErr
+	default:
+		w.closeErr = errors.Join(emptyErr, writerErr)
+	}
 
 	return w.closeErr
 }
@@ -1756,7 +1768,11 @@ func WriteManifest(
 	if err != nil {
 		return nil, err
 	}
-	defer internal.CheckedClose(w, &err)
+	defer func() {
+		if !w.closed {
+			internal.CheckedClose(w, &err)
+		}
+	}()
 
 	for _, entry := range entries {
 		if err := w.addEntry(entry.(*manifestEntry)); err != nil {
@@ -1793,7 +1809,11 @@ func WriteManifestV3(
 	if err != nil {
 		return nil, 0, err
 	}
-	defer internal.CheckedClose(w, &err)
+	defer func() {
+		if !w.closed {
+			internal.CheckedClose(w, &err)
+		}
+	}()
 
 	for _, entry := range entries {
 		if err := w.addEntry(entry.(*manifestEntry)); err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -1261,9 +1261,10 @@ func constructPartitionSummaries(spec PartitionSpec, schema *Schema, partitions 
 }
 
 type ManifestWriter struct {
-	closed  bool
-	version int
-	impl    writerImpl
+	closed   bool
+	closeErr error
+	version  int
+	impl     writerImpl
 
 	output io.Writer
 	writer *ocf.Writer
@@ -1358,16 +1359,18 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 
 func (w *ManifestWriter) Close() error {
 	if w.closed {
-		return nil
+		return w.closeErr
 	}
-
-	if w.addedFiles+w.existingFiles+w.deletedFiles == 0 {
-		return errors.New("empty manifest file has been written")
-	}
-
 	w.closed = true
 
-	return w.writer.Close()
+	var emptyErr error
+	if w.addedFiles+w.existingFiles+w.deletedFiles == 0 {
+		emptyErr = errors.New("empty manifest file has been written")
+	}
+
+	w.closeErr = errors.Join(emptyErr, w.writer.Close())
+
+	return w.closeErr
 }
 
 type ManifestFileOption func(mf *manifestFile)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -531,6 +531,24 @@ func (c manifestCloseErrorCodec) Close() error {
 	return c.err
 }
 
+func (m *ManifestTestSuite) setManifestWriterCloseError(writer *ManifestWriter, closeErr error) {
+	m.T().Helper()
+
+	avroSchema := writer.writer.Schema()
+	m.Require().NoError(writer.writer.Close())
+
+	replacement, err := ocf.NewWriter(
+		io.Discard,
+		avroSchema,
+		ocf.WithCodec(manifestCloseErrorCodec{
+			Codec: ocf.DeflateCodec(flate.DefaultCompression),
+			err:   closeErr,
+		}),
+	)
+	m.Require().NoError(err)
+	writer.writer = replacement
+}
+
 func (m *ManifestTestSuite) writeManifestList() {
 	err := WriteManifestList(1, &m.v1ManifestList, snapshotID, nil, nil, 0, manifestFileRecordsV1)
 	m.Require().NoError(err)
@@ -2109,27 +2127,50 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 }
 
 func (m *ManifestTestSuite) TestEmptyManifestWriterCloseIsTerminal() {
-	var out bytes.Buffer
-	writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID)
-	m.Require().NoError(err)
+	for _, version := range []int{1, 2, 3} {
+		m.Run("v"+strconv.Itoa(version), func() {
+			var out bytes.Buffer
+			writer, err := NewManifestWriter(version, &out, *UnpartitionedSpec, testSchema, snapshotID)
+			m.Require().NoError(err)
 
-	firstErr := writer.Close()
-	m.Require().EqualError(firstErr, "empty manifest file has been written")
-	m.ErrorContains(writer.Add(manifestEntryV2Records[0]), "closed manifest writer")
-	m.Equal(firstErr, writer.Close())
+			firstErr := writer.Close()
+			m.Require().ErrorIs(firstErr, ErrEmptyManifest)
+			m.ErrorContains(writer.Add(manifestEntryV2Records[0]), "closed manifest writer")
+			m.Same(firstErr, writer.Close())
 
-	_, err = writer.ToManifestFile("manifest.avro", int64(out.Len()))
-	m.Equal(firstErr, err)
+			_, err = writer.ToManifestFile("manifest.avro", int64(out.Len()))
+			m.Same(firstErr, err)
+
+			manifest := NewManifestFile(
+				version,
+				"manifest.avro",
+				int64(out.Len()),
+				int32(UnpartitionedSpec.ID()),
+				snapshotID,
+			).Build()
+			entries, err := ReadManifest(manifest, bytes.NewReader(out.Bytes()), false)
+			m.Require().NoError(err)
+			m.Empty(entries)
+		})
+	}
 }
 
 func (m *ManifestTestSuite) TestManifestWriterSuccessfulCloseIsTerminal() {
-	var out bytes.Buffer
-	writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID)
-	m.Require().NoError(err)
-	m.Require().NoError(writer.Add(manifestEntryV2Records[0]))
+	entries := map[int]ManifestEntry{
+		1: manifestEntryV1Records[0],
+		2: manifestEntryV2Records[0],
+		3: manifestEntryV3Records[0],
+	}
+	for _, version := range []int{1, 2, 3} {
+		m.Run("v"+strconv.Itoa(version), func() {
+			writer, err := NewManifestWriter(version, io.Discard, *UnpartitionedSpec, testSchema, snapshotID)
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Add(entries[version]))
 
-	m.NoError(writer.Close())
-	m.NoError(writer.Close())
+			m.NoError(writer.Close())
+			m.NoError(writer.Close())
+		})
+	}
 }
 
 func (m *ManifestTestSuite) TestEmptyManifestWriterCloseAfterConstructionFailure() {
@@ -2149,65 +2190,84 @@ func (m *ManifestTestSuite) TestEmptyManifestWriterCloseAfterConstructionFailure
 	m.NotPanics(func() {
 		closeErr = writer.Close()
 	})
-	m.EqualError(closeErr, "empty manifest file has been written")
+	m.ErrorIs(closeErr, ErrEmptyManifest)
 
-	// Close returns the cached result after becoming terminal.
-	m.Equal(closeErr, writer.Close())
+	m.Same(closeErr, writer.Close())
 }
 
 func (m *ManifestTestSuite) TestEmptyManifestWriterCloseJoinsUnderlyingError() {
-	writer, err := NewManifestWriter(
-		2,
-		io.Discard,
-		*UnpartitionedSpec,
-		testSchema,
-		snapshotID,
-	)
-	m.Require().NoError(err)
+	for _, version := range []int{1, 2, 3} {
+		m.Run("v"+strconv.Itoa(version), func() {
+			writer, err := NewManifestWriter(
+				version,
+				io.Discard,
+				*UnpartitionedSpec,
+				testSchema,
+				snapshotID,
+			)
+			m.Require().NoError(err)
 
-	avroSchema := writer.writer.Schema()
-	m.Require().NoError(writer.writer.Close())
+			underlyingErr := errors.New("underlying close failed")
+			m.setManifestWriterCloseError(writer, underlyingErr)
 
-	underlyingErr := errors.New("underlying close failed")
-	writer.writer, err = ocf.NewWriter(
-		io.Discard,
-		avroSchema,
-		ocf.WithCodec(manifestCloseErrorCodec{
-			Codec: ocf.DeflateCodec(flate.DefaultCompression),
-			err:   underlyingErr,
-		}),
-	)
-	m.Require().NoError(err)
+			firstErr := writer.Close()
+			m.Require().ErrorIs(firstErr, ErrEmptyManifest)
+			m.ErrorIs(firstErr, underlyingErr)
+			m.EqualError(
+				firstErr,
+				"empty manifest file has been written\nunderlying close failed",
+			)
+			m.Same(firstErr, writer.Close())
+		})
+	}
+}
 
-	firstErr := writer.Close()
-	m.Require().Error(firstErr)
-	m.ErrorIs(firstErr, underlyingErr)
-	m.EqualError(
-		firstErr,
-		"empty manifest file has been written\nunderlying close failed",
-	)
+func (m *ManifestTestSuite) TestManifestWriterCloseAfterAddEntryFailure() {
+	entries := map[int]ManifestEntry{
+		1: manifestEntryV1Records[0],
+		2: manifestEntryV2Records[0],
+		3: manifestEntryV3Records[0],
+	}
+	for _, version := range []int{1, 2, 3} {
+		m.Run("v"+strconv.Itoa(version), func() {
+			writer, err := NewManifestWriter(version, io.Discard, *UnpartitionedSpec, testSchema, snapshotID)
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Add(entries[version]))
 
-	// Close returns the cached combined result after becoming terminal.
-	m.Equal(firstErr, writer.Close())
+			m.Require().Error(writer.addEntry(&manifestEntry{EntryStatus: ManifestEntryStatus(-1)}))
+
+			underlyingErr := errors.New("underlying close failed")
+			m.setManifestWriterCloseError(writer, underlyingErr)
+
+			firstErr := writer.Close()
+			m.Require().Same(underlyingErr, firstErr)
+			m.False(errors.Is(firstErr, ErrEmptyManifest))
+			m.Same(firstErr, writer.Close())
+		})
+	}
 }
 
 func (m *ManifestTestSuite) TestWriteManifestEmptyErrorIsNotDuplicated() {
+	for _, version := range []int{1, 2, 3} {
+		m.Run("v"+strconv.Itoa(version), func() {
+			var out bytes.Buffer
+
+			_, err := WriteManifest(
+				"manifest.avro",
+				&out,
+				version,
+				*UnpartitionedSpec,
+				testSchema,
+				snapshotID,
+				nil,
+			)
+			m.ErrorIs(err, ErrEmptyManifest)
+			m.Same(ErrEmptyManifest, err)
+		})
+	}
+
 	var out bytes.Buffer
-
-	_, err := WriteManifest(
-		"manifest.avro",
-		&out,
-		2,
-		*UnpartitionedSpec,
-		testSchema,
-		snapshotID,
-		nil,
-	)
-	m.EqualError(err, "empty manifest file has been written")
-
-	out.Reset()
-
-	_, _, err = WriteManifestV3(
+	_, _, err := WriteManifestV3(
 		"manifest.avro",
 		&out,
 		0,
@@ -2216,7 +2276,8 @@ func (m *ManifestTestSuite) TestWriteManifestEmptyErrorIsNotDuplicated() {
 		snapshotID,
 		nil,
 	)
-	m.EqualError(err, "empty manifest file has been written")
+	m.ErrorIs(err, ErrEmptyManifest)
+	m.Same(ErrEmptyManifest, err)
 }
 
 func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing.T) {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2091,6 +2091,20 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 	m.Equal("[]", string(md["partition-spec"]))
 }
 
+func (m *ManifestTestSuite) TestEmptyManifestWriterCloseIsTerminal() {
+	var out bytes.Buffer
+	writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID)
+	m.Require().NoError(err)
+
+	firstErr := writer.Close()
+	m.Require().EqualError(firstErr, "empty manifest file has been written")
+	m.ErrorContains(writer.Add(manifestEntryV2Records[0]), "closed manifest writer")
+	m.Equal(firstErr, writer.Close())
+
+	_, err = writer.ToManifestFile("manifest.avro", int64(out.Len()))
+	m.Equal(firstErr, err)
+}
+
 func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing.T) {
 	schema := NewSchema(
 		0,

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -514,6 +514,23 @@ type ManifestTestSuite struct {
 	v3ManifestEntries bytes.Buffer
 }
 
+type manifestFailingWriter struct {
+	err error
+}
+
+func (w manifestFailingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type manifestCloseErrorCodec struct {
+	ocf.Codec
+	err error
+}
+
+func (c manifestCloseErrorCodec) Close() error {
+	return c.err
+}
+
 func (m *ManifestTestSuite) writeManifestList() {
 	err := WriteManifestList(1, &m.v1ManifestList, snapshotID, nil, nil, 0, manifestFileRecordsV1)
 	m.Require().NoError(err)
@@ -2103,6 +2120,103 @@ func (m *ManifestTestSuite) TestEmptyManifestWriterCloseIsTerminal() {
 
 	_, err = writer.ToManifestFile("manifest.avro", int64(out.Len()))
 	m.Equal(firstErr, err)
+}
+
+func (m *ManifestTestSuite) TestManifestWriterSuccessfulCloseIsTerminal() {
+	var out bytes.Buffer
+	writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID)
+	m.Require().NoError(err)
+	m.Require().NoError(writer.Add(manifestEntryV2Records[0]))
+
+	m.NoError(writer.Close())
+	m.NoError(writer.Close())
+}
+
+func (m *ManifestTestSuite) TestEmptyManifestWriterCloseAfterConstructionFailure() {
+	writeErr := errors.New("write failed")
+
+	writer, err := NewManifestWriter(
+		2,
+		manifestFailingWriter{err: writeErr},
+		*UnpartitionedSpec,
+		testSchema,
+		snapshotID,
+	)
+	m.Require().ErrorIs(err, writeErr)
+	m.Require().NotNil(writer)
+
+	var closeErr error
+	m.NotPanics(func() {
+		closeErr = writer.Close()
+	})
+	m.EqualError(closeErr, "empty manifest file has been written")
+
+	// Close returns the cached result after becoming terminal.
+	m.Equal(closeErr, writer.Close())
+}
+
+func (m *ManifestTestSuite) TestEmptyManifestWriterCloseJoinsUnderlyingError() {
+	writer, err := NewManifestWriter(
+		2,
+		io.Discard,
+		*UnpartitionedSpec,
+		testSchema,
+		snapshotID,
+	)
+	m.Require().NoError(err)
+
+	avroSchema := writer.writer.Schema()
+	m.Require().NoError(writer.writer.Close())
+
+	underlyingErr := errors.New("underlying close failed")
+	writer.writer, err = ocf.NewWriter(
+		io.Discard,
+		avroSchema,
+		ocf.WithCodec(manifestCloseErrorCodec{
+			Codec: ocf.DeflateCodec(flate.DefaultCompression),
+			err:   underlyingErr,
+		}),
+	)
+	m.Require().NoError(err)
+
+	firstErr := writer.Close()
+	m.Require().Error(firstErr)
+	m.ErrorIs(firstErr, underlyingErr)
+	m.EqualError(
+		firstErr,
+		"empty manifest file has been written\nunderlying close failed",
+	)
+
+	// Close returns the cached combined result after becoming terminal.
+	m.Equal(firstErr, writer.Close())
+}
+
+func (m *ManifestTestSuite) TestWriteManifestEmptyErrorIsNotDuplicated() {
+	var out bytes.Buffer
+
+	_, err := WriteManifest(
+		"manifest.avro",
+		&out,
+		2,
+		*UnpartitionedSpec,
+		testSchema,
+		snapshotID,
+		nil,
+	)
+	m.EqualError(err, "empty manifest file has been written")
+
+	out.Reset()
+
+	_, _, err = WriteManifestV3(
+		"manifest.avro",
+		&out,
+		0,
+		*UnpartitionedSpec,
+		testSchema,
+		snapshotID,
+		nil,
+	)
+	m.EqualError(err, "empty manifest file has been written")
 }
 
 func TestReadManifestDecodesNilLogicalPartitionValueFromNullableUnion(t *testing.T) {

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -220,7 +220,12 @@ func (of *overwriteFiles) existingManifests(parent *Snapshot) ([]iceberg.Manifes
 				return nil, err
 			}
 			defer internal.CheckedClose(fileCloser, &retErr)
-			defer internal.CheckedClose(wr, &retErr)
+			writerClosed := false
+			defer func() {
+				if !writerClosed {
+					internal.CheckedClose(wr, &retErr)
+				}
+			}()
 
 			for _, entry := range notDeleted {
 				if err := wr.Existing(entry); err != nil {
@@ -229,6 +234,7 @@ func (of *overwriteFiles) existingManifests(parent *Snapshot) ([]iceberg.Manifes
 			}
 
 			// close the writer to force a flush and ensure counter.Count is accurate
+			writerClosed = true
 			if err := wr.Close(); err != nil {
 				return nil, err
 			}
@@ -375,7 +381,12 @@ func (m *manifestMergeManager) createManifest(specID int, bin []iceberg.Manifest
 		return nil, err
 	}
 	defer internal.CheckedClose(fileCloser, &err)
-	defer internal.CheckedClose(wr, &err)
+	writerClosed := false
+	defer func() {
+		if !writerClosed {
+			internal.CheckedClose(wr, &err)
+		}
+	}()
 
 	for _, manifest := range bin {
 		for entry, err := range m.snap.iterManifestEntries(manifest, false) {
@@ -402,6 +413,7 @@ func (m *manifestMergeManager) createManifest(specID int, bin []iceberg.Manifest
 	}
 
 	// close the writer to force a flush and ensure counter.Count is accurate
+	writerClosed = true
 	if err := wr.Close(); err != nil {
 		return nil, err
 	}
@@ -834,7 +846,12 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 				if err != nil {
 					return nil, err
 				}
-				defer internal.CheckedClose(wr, &retErr)
+				writerClosed := false
+				defer func() {
+					if !writerClosed {
+						internal.CheckedClose(wr, &retErr)
+					}
+				}()
 
 				for _, entry := range entries {
 					if err := wr.Delete(entry); err != nil {
@@ -842,6 +859,7 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 					}
 				}
 
+				writerClosed = true
 				if err := wr.Close(); err != nil {
 					return nil, err
 				}
@@ -904,7 +922,12 @@ func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, 
 		return nil, err
 	}
 	defer internal.CheckedClose(out, &retErr)
-	defer internal.CheckedClose(wr, &retErr)
+	writerClosed := false
+	defer func() {
+		if !writerClosed {
+			internal.CheckedClose(wr, &retErr)
+		}
+	}()
 
 	for _, df := range files {
 		err := wr.Add(iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &sp.snapshotID,
@@ -915,6 +938,7 @@ func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, 
 	}
 
 	// close the writer to force a flush and ensure counter.Count is accurate
+	writerClosed = true
 	if err := wr.Close(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Make the first ManifestWriter.Close call terminal, including for an empty manifest.

## Why

An empty-manifest error previously left the writer open. Entries could be added afterward, and a later Close or ToManifestFile call could turn the original failure into success.

## What changed

The writer now closes its OCF writer, stores the combined close result, and returns that same result from later close attempts.

## Tests

- Added coverage for repeated close, adding after close, and ToManifestFile after a failed close
- go test ./...