### PR TITLE
fix(codec): reject nil data files in scan tasks

### DIFF
--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -255,6 +255,9 @@ func decodeFileScanTaskResidual(data []byte, schema *iceberg.Schema) (iceberg.Bo
 // carrying a different spec would silently mis-map or drop partition values and
 // still succeed. Every file in a FileScanTask must therefore share spec.ID().
 func checkDataFileSpecID(f iceberg.DataFile, spec iceberg.PartitionSpec) error {
+	if f == nil {
+		return fmt.Errorf("%w: data file is nil", iceberg.ErrInvalidArgument)
+	}
 	if int(f.SpecID()) != spec.ID() {
 		return fmt.Errorf("data file spec id %d does not match codec spec id %d (partition evolution requires per-spec grouping)", f.SpecID(), spec.ID())
 	}

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
@@ -255,7 +256,7 @@ func decodeFileScanTaskResidual(data []byte, schema *iceberg.Schema) (iceberg.Bo
 // carrying a different spec would silently mis-map or drop partition values and
 // still succeed. Every file in a FileScanTask must therefore share spec.ID().
 func checkDataFileSpecID(f iceberg.DataFile, spec iceberg.PartitionSpec) error {
-	if f == nil {
+	if isNilDataFile(f) {
 		return fmt.Errorf("%w: data file is nil", iceberg.ErrInvalidArgument)
 	}
 	if int(f.SpecID()) != spec.ID() {
@@ -263,6 +264,20 @@ func checkDataFileSpecID(f iceberg.DataFile, spec iceberg.PartitionSpec) error {
 	}
 
 	return nil
+}
+
+func isNilDataFile(f iceberg.DataFile) bool {
+	if f == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(f)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 func encodeDataFileSlice(files []iceberg.DataFile, spec iceberg.PartitionSpec, schema *iceberg.Schema, version int) ([][]byte, error) {

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -161,6 +161,31 @@ func TestEncodeFileScanTaskRejectsNilDataFiles(t *testing.T) {
 	}
 }
 
+func TestEncodeFileScanTaskRejectsTypedNilDataFiles(t *testing.T) {
+	spec, schema, task := fullyPopulatedFileScanTask(t, 3)
+	var typedNil *stubDataFile
+	tests := []struct {
+		name   string
+		update func(*table.FileScanTask)
+		part   string
+	}{
+		{"primary file", func(task *table.FileScanTask) { task.File = typedNil }, "data file is nil"},
+		{"delete file", func(task *table.FileScanTask) { task.DeleteFiles = []iceberg.DataFile{typedNil} }, "delete files: entry 0"},
+		{"equality delete file", func(task *table.FileScanTask) { task.EqualityDeleteFiles = []iceberg.DataFile{typedNil} }, "equality delete files: entry 0"},
+		{"deletion vector file", func(task *table.FileScanTask) { task.DeletionVectorFiles = []iceberg.DataFile{typedNil} }, "deletion vector files: entry 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := task
+			tt.update(&task)
+			_, err := codec.EncodeFileScanTask(task, spec, schema, 3)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, tt.part)
+		})
+	}
+}
+
 func TestDecodeFileScanTaskErrorCarriesMarker(t *testing.T) {
 	schema := iceberg.NewSchema(123,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -137,6 +137,30 @@ func TestEncodeFileScanTaskRejectsMismatchedPrimaryDataFileSpec(t *testing.T) {
 		"error must include the codec's spec id")
 }
 
+func TestEncodeFileScanTaskRejectsNilDataFiles(t *testing.T) {
+	spec, schema, task := fullyPopulatedFileScanTask(t, 2)
+	tests := []struct {
+		name   string
+		update func(*table.FileScanTask)
+		part   string
+	}{
+		{"primary file", func(task *table.FileScanTask) { task.File = nil }, "data file is nil"},
+		{"delete file", func(task *table.FileScanTask) { task.DeleteFiles = []iceberg.DataFile{nil} }, "delete files: entry 0"},
+		{"equality delete file", func(task *table.FileScanTask) { task.EqualityDeleteFiles = []iceberg.DataFile{nil} }, "equality delete files: entry 0"},
+		{"deletion vector file", func(task *table.FileScanTask) { task.DeletionVectorFiles = []iceberg.DataFile{nil} }, "deletion vector files: entry 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := task
+			tt.update(&task)
+			_, err := codec.EncodeFileScanTask(task, spec, schema, 2)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, tt.part)
+		})
+	}
+}
+
 func TestDecodeFileScanTaskErrorCarriesMarker(t *testing.T) {
 	schema := iceberg.NewSchema(123,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},


### PR DESCRIPTION
## Summary

Return a codec error instead of panicking when a FileScanTask contains a nil file.

## Why

The shared spec ID check called SpecID without checking the interface value first.

## What changed

The primary file and all three secondary file lists now reject nil entries before accessing file metadata.

## Tests

- Added coverage for the primary file and all three secondary file lists
- go test ./codec