### PR TITLE
fix(manifest): reject unsupported format versions

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -546,10 +546,10 @@ type hasFieldToIDMap interface {
 	setFieldIDToDecimalScaleMap(map[int]int)
 }
 
-// ManifestFile is the interface which covers both V1 and V2 manifest files.
+// ManifestFile is the interface which covers manifest files for supported table versions.
 type ManifestFile interface {
 	// Version returns the version number of this manifest file.
-	// It should be 1 or 2.
+	// It should be 1, 2, or 3.
 	Version() int
 	// FilePath is the location URI of this manifest file.
 	FilePath() string
@@ -743,6 +743,9 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 		if err != nil {
 			return nil, fmt.Errorf("manifest file's 'format-version' metadata is invalid: %w", err)
 		}
+	}
+	if err := validateManifestFormatVersion(formatVersion); err != nil {
+		return nil, err
 	}
 	// The manifest's own metadata is authoritative for its version. A v2/v3
 	// manifest list may reference older manifests so a table can be upgraded
@@ -1015,6 +1018,9 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 
 			version = v
 		}
+		if err := validateManifestFormatVersion(version); err != nil {
+			return nil, err
+		}
 
 		if version == 1 {
 			return manifestFileV1Reader, nil
@@ -1031,6 +1037,14 @@ func ReadManifestList(in io.Reader) ([]ManifestFile, error) {
 	}
 
 	return decodeManifests[*manifestFile](rd, version)
+}
+
+func validateManifestFormatVersion(version int) error {
+	if version < 1 || version > 3 {
+		return fmt.Errorf("unsupported manifest format version: %d", version)
+	}
+
+	return nil
 }
 
 type writerImpl interface {

--- a/manifest.go
+++ b/manifest.go
@@ -546,10 +546,10 @@ type hasFieldToIDMap interface {
 	setFieldIDToDecimalScaleMap(map[int]int)
 }
 
-// ManifestFile is the interface which covers manifest files for supported table versions.
+// ManifestFile is the interface for version 1, 2, and 3 manifest files.
 type ManifestFile interface {
 	// Version returns the version number of this manifest file.
-	// It should be 1, 2, or 3.
+	// It must be 1, 2, or 3.
 	Version() int
 	// FilePath is the location URI of this manifest file.
 	FilePath() string

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1026,6 +1026,23 @@ func (m *ManifestTestSuite) TestReadManifestListMissingFormatVersion() {
 	m.Empty(files) // the file has no entries, just headers
 }
 
+func (m *ManifestTestSuite) TestReadManifestListRejectsUnsupportedFormatVersion() {
+	for _, version := range []int{-1, 0, 4} {
+		m.Run(strconv.Itoa(version), func() {
+			fileSchema, err := internal.NewManifestFileSchema(2)
+			m.Require().NoError(err)
+			var buf bytes.Buffer
+			writer, err := ocf.NewWriter(&buf, fileSchema,
+				ocf.WithMetadata(map[string][]byte{"format-version": []byte(strconv.Itoa(version))}))
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Close())
+
+			_, err = ReadManifestList(&buf)
+			m.ErrorContains(err, "unsupported manifest format version")
+		})
+	}
+}
+
 // writeManifestNoFormatVersion writes a valid v1 manifest entry Avro file that
 // omits the "format-version" metadata key, simulating files produced by the Java
 // Iceberg library (format-version is optional for v1 per the Iceberg spec).
@@ -1077,6 +1094,34 @@ func (m *ManifestTestSuite) TestNewManifestReaderMissingFormatVersion() {
 	m.Require().NoError(err)
 	m.Equal(1, reader.Version())
 	m.NoError(reader.Close())
+}
+
+func (m *ManifestTestSuite) TestNewManifestReaderRejectsUnsupportedFormatVersion() {
+	for _, version := range []int{-1, 0, 4} {
+		m.Run(strconv.Itoa(version), func() {
+			spec := NewPartitionSpec()
+			partitionSchema, err := partitionTypeToAvroSchema(spec.PartitionType(testSchema))
+			m.Require().NoError(err)
+			entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 1)
+			m.Require().NoError(err)
+			schemaJSON, err := json.Marshal(testSchema)
+			m.Require().NoError(err)
+			var manifest bytes.Buffer
+			writer, err := ocf.NewWriter(&manifest, entrySchema, ocf.WithMetadata(map[string][]byte{
+				"format-version":    []byte(strconv.Itoa(version)),
+				"schema":            schemaJSON,
+				"schema-id":         []byte(strconv.Itoa(testSchema.ID)),
+				"partition-spec":    []byte("[]"),
+				"partition-spec-id": []byte("0"),
+				"content":           []byte("data"),
+			}))
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Close())
+
+			_, err = NewManifestReader(&manifestFile{version: version}, &manifest)
+			m.ErrorContains(err, "unsupported manifest format version")
+		})
+	}
 }
 
 func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritance() {


### PR DESCRIPTION
## What changed

Validate manifest and manifest-list format versions before selecting a reader schema. Versions 1, 2, and 3 remain supported, and a missing version still defaults to version 1.

## Why

Manifest lists previously routed every version other than 1 through the v2/v3 reader. Manifest files also accepted arbitrary integers. Unknown versions could therefore be interpreted with a schema whose semantics may not match the file.

## Testing

- Added manifest and manifest-list cases for versions -1, 0, and 4
- Existing version 1, 2, 3, and missing-version coverage remains intact
- `go test ./...`