### PR TITLE
fix(rest): reject blob offsets on non-Puffin delete files

### DIFF
--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -343,6 +343,9 @@ func decodeRESTDeleteFile(
 		if len(wire.EqualityIDs) != 0 {
 			return nil, errors.New("position-deletes file must not carry equality-ids")
 		}
+		if format != iceberg.PuffinFile && (wire.ContentOffset != nil || wire.ContentSizeInBytes != nil) {
+			return nil, errors.New("content-offset and content-size-in-bytes are only valid for Puffin deletion vectors")
+		}
 		if wire.ContentOffset != nil {
 			if *wire.ContentOffset < 0 {
 				return nil, fmt.Errorf("content-offset must be non-negative: %d", *wire.ContentOffset)

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -391,6 +391,28 @@ func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 			want: "must not carry equality-ids",
 		},
 		{
+			name: "non-Puffin position delete with content offset",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].ContentOffset = int64Ptr(10)
+			},
+			want: "only valid for Puffin deletion vectors",
+		},
+		{
+			name: "non-Puffin position delete with content size",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].ContentSizeInBytes = int64Ptr(20)
+			},
+			want: "only valid for Puffin deletion vectors",
+		},
+		{
+			name: "non-Puffin position delete with blob range",
+			mutate: func(w *ScanTasks) {
+				w.DeleteFiles[0].ContentOffset = int64Ptr(10)
+				w.DeleteFiles[0].ContentSizeInBytes = int64Ptr(20)
+			},
+			want: "only valid for Puffin deletion vectors",
+		},
+		{
 			name: "puffin missing blob range",
 			mutate: func(w *ScanTasks) {
 				w.DeleteFiles[0].FileFormat = "puffin"


### PR DESCRIPTION
## What changed

Reject `content-offset` and `content-size-in-bytes` on position-delete files unless the file format is Puffin.

## Why

These fields locate a deletion-vector blob inside a Puffin file. The decoder required them for Puffin files but accepted them on Parquet, Avro, and ORC position-delete files, creating an inconsistent `DataFile`.

## Testing

- Added cases for offset only, size only, and both fields on a non-Puffin position-delete file
- Existing Puffin and equality-delete validation remains covered
- `go test ./catalog/rest`