### PR TITLE
fix(rest): reject NUL in namespace identifiers

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -255,10 +255,6 @@ func validateIdentifier(ident table.Identifier, notFoundErr error) error {
 			notFoundErr, strings.Join(ident, "."))
 	}
 
-	return validateIdentifierComponents(ident, notFoundErr)
-}
-
-func validateIdentifierComponents(ident table.Identifier, notFoundErr error) error {
 	for _, part := range ident {
 		if part == "" || part == "." || part == ".." || strings.Contains(part, "/") {
 			return fmt.Errorf("%w: invalid identifier component %q in %v",
@@ -281,7 +277,7 @@ func validateIdentifierComponents(ident table.Identifier, notFoundErr error) err
 // intentionally left to the catalog implementation so existing namespaces
 // remain readable across clients.
 func ValidateNamespaceIdentifier(ident table.Identifier) error {
-	if len(ident) < 1 {
+	if len(ident) == 0 {
 		return fmt.Errorf("%w: empty namespace identifier", ErrNoSuchNamespace)
 	}
 

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -255,6 +255,10 @@ func validateIdentifier(ident table.Identifier, notFoundErr error) error {
 			notFoundErr, strings.Join(ident, "."))
 	}
 
+	return validateIdentifierComponents(ident, notFoundErr)
+}
+
+func validateIdentifierComponents(ident table.Identifier, notFoundErr error) error {
 	for _, part := range ident {
 		if part == "" || part == "." || part == ".." || strings.Contains(part, "/") {
 			return fmt.Errorf("%w: invalid identifier component %q in %v",
@@ -270,6 +274,15 @@ func validateIdentifier(ident table.Identifier, notFoundErr error) error {
 	}
 
 	return nil
+}
+
+// ValidateNamespaceIdentifier checks that an identifier contains at least one valid namespace level.
+func ValidateNamespaceIdentifier(ident table.Identifier) error {
+	if len(ident) < 1 {
+		return fmt.Errorf("%w: empty namespace identifier", ErrNoSuchNamespace)
+	}
+
+	return validateIdentifierComponents(ident, ErrNoSuchNamespace)
 }
 
 // ValidateTableIdentifier checks that an identifier contains at least one valid namespace level and a table name.

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -276,7 +276,10 @@ func validateIdentifierComponents(ident table.Identifier, notFoundErr error) err
 	return nil
 }
 
-// ValidateNamespaceIdentifier checks that an identifier contains at least one valid namespace level.
+// ValidateNamespaceIdentifier checks that an identifier contains at least one
+// namespace level and no null characters. Other namespace component rules are
+// intentionally left to the catalog implementation so existing namespaces
+// remain readable across clients.
 func ValidateNamespaceIdentifier(ident table.Identifier) error {
 	if len(ident) < 1 {
 		return fmt.Errorf("%w: empty namespace identifier", ErrNoSuchNamespace)

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -282,7 +282,14 @@ func ValidateNamespaceIdentifier(ident table.Identifier) error {
 		return fmt.Errorf("%w: empty namespace identifier", ErrNoSuchNamespace)
 	}
 
-	return validateIdentifierComponents(ident, ErrNoSuchNamespace)
+	for _, part := range ident {
+		if strings.ContainsRune(part, '\x00') {
+			return fmt.Errorf("%w: invalid null character in namespace identifier component %q in %v",
+				ErrNoSuchNamespace, part, strings.Join(ident, "."))
+		}
+	}
+
+	return nil
 }
 
 // ValidateTableIdentifier checks that an identifier contains at least one valid namespace level and a table name.

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -48,18 +48,22 @@ func TestValidateTableIdentifier(t *testing.T) {
 func TestValidateNamespaceIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace"}))
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", "namespace"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{""}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"."}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{".."}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace/child"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace\nchild"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", ""}))
 
-	for _, ident := range []table.Identifier{
-		nil,
-		{},
-		{""},
-		{"."},
-		{".."},
-		{"namespace/child"},
-		{"namespace\nchild"},
-		{"parent", ""},
-	} {
-		require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	for _, ident := range []table.Identifier{nil, {}} {
+		t.Run("empty identifier", func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+		})
+	}
+	for _, ident := range []table.Identifier{{"\x00"}, {"parent", "child\x00"}} {
+		t.Run("null character", func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+		})
 	}
 }
 

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -55,14 +55,26 @@ func TestValidateNamespaceIdentifier(t *testing.T) {
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace\nchild"}))
 	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", ""}))
 
-	for _, ident := range []table.Identifier{nil, {}} {
-		t.Run("empty identifier", func(t *testing.T) {
-			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	for _, tt := range []struct {
+		name  string
+		ident table.Identifier
+	}{
+		{name: "nil", ident: nil},
+		{name: "empty", ident: table.Identifier{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(tt.ident), catalog.ErrNoSuchNamespace)
 		})
 	}
-	for _, ident := range []table.Identifier{{"\x00"}, {"parent", "child\x00"}} {
-		t.Run("null character", func(t *testing.T) {
-			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	for _, tt := range []struct {
+		name  string
+		ident table.Identifier
+	}{
+		{name: "null character in first component", ident: table.Identifier{"\x00"}},
+		{name: "null character in nested component", ident: table.Identifier{"parent", "child\x00"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(tt.ident), catalog.ErrNoSuchNamespace)
 		})
 	}
 }

--- a/catalog/identifier_test.go
+++ b/catalog/identifier_test.go
@@ -45,6 +45,24 @@ func TestValidateTableIdentifier(t *testing.T) {
 	}
 }
 
+func TestValidateNamespaceIdentifier(t *testing.T) {
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"namespace"}))
+	require.NoError(t, catalog.ValidateNamespaceIdentifier(table.Identifier{"parent", "namespace"}))
+
+	for _, ident := range []table.Identifier{
+		nil,
+		{},
+		{""},
+		{"."},
+		{".."},
+		{"namespace/child"},
+		{"namespace\nchild"},
+		{"parent", ""},
+	} {
+		require.ErrorIs(t, catalog.ValidateNamespaceIdentifier(ident), catalog.ErrNoSuchNamespace)
+	}
+}
+
 func TestNamespaceFromEmptyIdentifier(t *testing.T) {
 	require.Nil(t, catalog.NamespaceFromIdent(nil))
 	require.Nil(t, catalog.NamespaceFromIdent(table.Identifier{}))

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1075,11 +1075,7 @@ func (r *Catalog) Close() error { return r.reporter.Close() }
 var _ catalog.Closer = (*Catalog)(nil)
 
 func checkValidNamespace(ident table.Identifier) error {
-	if len(ident) < 1 {
-		return fmt.Errorf("%w: empty namespace identifier", catalog.ErrNoSuchNamespace)
-	}
-
-	return nil
+	return catalog.ValidateNamespaceIdentifier(ident)
 }
 
 func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {
@@ -1795,6 +1791,12 @@ func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 }
 
 func (r *Catalog) listNamespacesPage(ctx context.Context, parent table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
+	if len(parent) != 0 {
+		if err := catalog.ValidateNamespaceIdentifier(parent); err != nil {
+			return nil, "", err
+		}
+	}
+
 	// Unsupported listing yields an empty result rather than an error.
 	if !r.endpoints.allowed(endpointListNamespaces) {
 		return nil, "", nil

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1075,7 +1075,11 @@ func (r *Catalog) Close() error { return r.reporter.Close() }
 var _ catalog.Closer = (*Catalog)(nil)
 
 func checkValidNamespace(ident table.Identifier) error {
-	return catalog.ValidateNamespaceIdentifier(ident)
+	if len(ident) < 1 {
+		return fmt.Errorf("%w: empty namespace identifier", catalog.ErrNoSuchNamespace)
+	}
+
+	return nil
 }
 
 func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {
@@ -1734,7 +1738,7 @@ func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
 		return err
 	}
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1074,8 +1074,24 @@ func (r *Catalog) Close() error { return r.reporter.Close() }
 
 var _ catalog.Closer = (*Catalog)(nil)
 
-func checkValidNamespace(ident table.Identifier) error {
-	return catalog.ValidateNamespaceIdentifier(ident)
+func (r *Catalog) checkValidNamespace(ident table.Identifier) error {
+	if err := catalog.ValidateNamespaceIdentifier(ident); err != nil {
+		return err
+	}
+
+	separator := r.decodedNamespaceSeparator()
+	if separator == "" {
+		return nil
+	}
+
+	for _, part := range ident {
+		if strings.Contains(part, separator) {
+			return fmt.Errorf("%w: namespace component %q contains the namespace separator %q in %v",
+				catalog.ErrNoSuchNamespace, part, separator, strings.Join(ident, "."))
+		}
+	}
+
+	return nil
 }
 
 func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {
@@ -1185,7 +1201,7 @@ func (r *Catalog) ListTables(ctx context.Context, namespace table.Identifier) it
 }
 
 func (r *Catalog) listTablesPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}
 	// Unsupported listing yields an empty result rather than an error.
@@ -1244,16 +1260,20 @@ func (r *Catalog) encodeNamespace(namespace table.Identifier) string {
 	return strings.Join(encoded, r.nsSeparator())
 }
 
+func (r *Catalog) decodedNamespaceSeparator() string {
+	sep, err := url.PathUnescape(r.nsSeparator())
+	if err != nil {
+		return r.nsSeparator()
+	}
+
+	return sep
+}
+
 // namespaceToQueryParam joins the raw namespace levels with the decoded
 // separator for use as a query-parameter value, which the HTTP layer then
 // percent-encodes. Mirrors RESTUtil.namespaceToQueryParam in Java.
 func (r *Catalog) namespaceToQueryParam(namespace table.Identifier) string {
-	sep, err := url.PathUnescape(r.nsSeparator())
-	if err != nil {
-		sep = r.nsSeparator()
-	}
-
-	return strings.Join(namespace, sep)
+	return strings.Join(namespace, r.decodedNamespaceSeparator())
 }
 
 func (r *Catalog) splitIdentForPath(ident table.Identifier) (string, string, error) {
@@ -1734,7 +1754,7 @@ func (r *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 		return err
 	}
 
-	if err := catalog.ValidateNamespaceIdentifier(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return err
 	}
 
@@ -1756,7 +1776,7 @@ func (r *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 		return err
 	}
 
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return err
 	}
 
@@ -1792,7 +1812,7 @@ func (r *Catalog) ListNamespaces(ctx context.Context, parent table.Identifier) (
 
 func (r *Catalog) listNamespacesPage(ctx context.Context, parent table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
 	if len(parent) != 0 {
-		if err := catalog.ValidateNamespaceIdentifier(parent); err != nil {
+		if err := r.checkValidNamespace(parent); err != nil {
 			return nil, "", err
 		}
 	}
@@ -1841,7 +1861,7 @@ func (r *Catalog) LoadNamespaceProperties(ctx context.Context, namespace table.I
 		return nil, err
 	}
 
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return nil, err
 	}
 
@@ -1871,7 +1891,7 @@ func (r *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 		return catalog.PropertiesUpdateSummary{}, err
 	}
 
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return catalog.PropertiesUpdateSummary{}, err
 	}
 
@@ -1892,7 +1912,7 @@ func (r *Catalog) UpdateNamespaceProperties(ctx context.Context, namespace table
 }
 
 func (r *Catalog) CheckNamespaceExists(ctx context.Context, namespace table.Identifier) (bool, error) {
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return false, err
 	}
 
@@ -1985,7 +2005,7 @@ func (r *Catalog) ListViews(ctx context.Context, namespace table.Identifier) ite
 }
 
 func (r *Catalog) listViewsPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}
 	// Unsupported listing yields an empty result rather than an error.
@@ -2389,7 +2409,7 @@ func (r *Catalog) ListFunctions(ctx context.Context, namespace table.Identifier)
 }
 
 func (r *Catalog) listFunctionsPage(ctx context.Context, namespace table.Identifier, pageToken string, pageSize int) ([]table.Identifier, string, error) {
-	if err := checkValidNamespace(namespace); err != nil {
+	if err := r.checkValidNamespace(namespace); err != nil {
 		return nil, "", err
 	}
 	// Unsupported listing yields an empty result rather than an error.

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1075,11 +1075,7 @@ func (r *Catalog) Close() error { return r.reporter.Close() }
 var _ catalog.Closer = (*Catalog)(nil)
 
 func checkValidNamespace(ident table.Identifier) error {
-	if len(ident) < 1 {
-		return fmt.Errorf("%w: empty namespace identifier", catalog.ErrNoSuchNamespace)
-	}
-
-	return nil
+	return catalog.ValidateNamespaceIdentifier(ident)
 }
 
 func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1832,6 +1832,31 @@ func TestEncodeNamespace(t *testing.T) {
 	}
 }
 
+func TestCheckValidNamespaceRejectsDecodedSeparator(t *testing.T) {
+	tests := []struct {
+		name      string
+		separator string
+		namespace table.Identifier
+		wantErr   bool
+	}{
+		{name: "default separator in component", namespace: table.Identifier{"a\x1fb"}, wantErr: true},
+		{name: "configured separator in component", separator: "%2E", namespace: table.Identifier{"a.b"}, wantErr: true},
+		{name: "separator between components", namespace: table.Identifier{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cat := &Catalog{namespaceSeparator: tt.separator}
+			err := cat.checkValidNamespace(tt.namespace)
+			if tt.wantErr {
+				require.ErrorIs(t, err, catalog.ErrNoSuchNamespace)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestNamespaceSeparatorFromConfig(t *testing.T) {
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -807,7 +807,7 @@ func (r *RestCatalogSuite) TestListNamespaceWithParent200() {
 	r.Equal([]table.Identifier{{"accounting", "tax"}}, results)
 }
 
-func (r *RestCatalogSuite) TestNamespaceOperationsRejectNull() {
+func (r *RestCatalogSuite) TestNamespaceOperationsRejectInvalidComponents() {
 	requestCount := 0
 	r.mux.HandleFunc("/v1/namespaces", func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
@@ -819,17 +819,31 @@ func (r *RestCatalogSuite) TestNamespaceOperationsRejectNull() {
 	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
 	r.Require().NoError(err)
 
-	namespace := table.Identifier{"bad\x00name"}
-	r.ErrorIs(cat.CreateNamespace(context.Background(), namespace, nil), catalog.ErrNoSuchNamespace)
-	r.ErrorIs(cat.DropNamespace(context.Background(), namespace), catalog.ErrNoSuchNamespace)
-	_, err = cat.LoadNamespaceProperties(context.Background(), namespace)
-	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
-	_, err = cat.UpdateNamespaceProperties(context.Background(), namespace, nil, nil)
-	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
-	_, err = cat.CheckNamespaceExists(context.Background(), namespace)
-	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
-	_, err = cat.ListNamespaces(context.Background(), namespace)
-	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	for _, namespace := range []table.Identifier{
+		{"bad\x00name"},
+		{"a\x1fb"},
+	} {
+		r.ErrorIs(cat.CreateNamespace(context.Background(), namespace, nil), catalog.ErrNoSuchNamespace)
+		r.ErrorIs(cat.DropNamespace(context.Background(), namespace), catalog.ErrNoSuchNamespace)
+		_, err = cat.LoadNamespaceProperties(context.Background(), namespace)
+		r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		_, err = cat.UpdateNamespaceProperties(context.Background(), namespace, nil, nil)
+		r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		_, err = cat.CheckNamespaceExists(context.Background(), namespace)
+		r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		_, err = cat.ListNamespaces(context.Background(), namespace)
+		r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+
+		for _, err := range cat.ListTables(context.Background(), namespace) {
+			r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		}
+		for _, err := range cat.ListViews(context.Background(), namespace) {
+			r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		}
+		for _, err := range cat.ListFunctions(context.Background(), namespace) {
+			r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+		}
+	}
 
 	r.Zero(requestCount)
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -807,6 +807,33 @@ func (r *RestCatalogSuite) TestListNamespaceWithParent200() {
 	r.Equal([]table.Identifier{{"accounting", "tax"}}, results)
 }
 
+func (r *RestCatalogSuite) TestNamespaceOperationsRejectNull() {
+	requestCount := 0
+	r.mux.HandleFunc("/v1/namespaces", func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+	})
+	r.mux.HandleFunc("/v1/namespaces/", func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	namespace := table.Identifier{"bad\x00name"}
+	r.ErrorIs(cat.CreateNamespace(context.Background(), namespace, nil), catalog.ErrNoSuchNamespace)
+	r.ErrorIs(cat.DropNamespace(context.Background(), namespace), catalog.ErrNoSuchNamespace)
+	_, err = cat.LoadNamespaceProperties(context.Background(), namespace)
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	_, err = cat.UpdateNamespaceProperties(context.Background(), namespace, nil, nil)
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	_, err = cat.CheckNamespaceExists(context.Background(), namespace)
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+	_, err = cat.ListNamespaces(context.Background(), namespace)
+	r.ErrorIs(err, catalog.ErrNoSuchNamespace)
+
+	r.Zero(requestCount)
+}
+
 func (r *RestCatalogSuite) TestListNamespaces400() {
 	r.mux.HandleFunc("/v1/namespaces", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodGet, req.Method)


### PR DESCRIPTION
## Summary

Reject NUL characters in namespace identifiers at REST catalog boundaries.

## Why

REST namespace operations previously checked only that an identifier had at least one component. A NUL character is not a valid namespace component character and can lead to inconsistent behavior across catalog implementations.

## What changed

The catalog package now exposes shared namespace validation, and REST namespace creation uses it before performing storage or catalog work.

The validation intentionally remains compatible with existing namespaces: empty components, `.`, `..`, path separators, and newlines are not rejected here. Empty namespace identifiers remain rejected by catalog operations that require a concrete namespace.

## Tests

- Added valid single-level and nested namespace cases
- Added empty, NUL, and compatibility cases
- `go test ./catalog ./catalog/rest`