### PR TITLE
fix(dv): validate deletion-vector blob identity

### DIFF
--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -20,6 +20,7 @@ package dv
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"log/slog"
@@ -39,6 +40,8 @@ const (
 	dvCardinalityProperty        = "cardinality"
 	dvReferencedDataFileProperty = "referenced-data-file"
 )
+
+var ErrInvalidDeletionVector = errors.New("invalid deletion vector")
 
 const (
 	// DVMagicNumber is the magic number for deletion vectors.
@@ -151,11 +154,13 @@ func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
 //
 // ReadDV also requires the selected blob to be a deletion-vector blob whose
 // referenced-data-file property matches the manifest. This is stricter than
-// clients that only use the manifest offset and size, but prevents a valid
-// Puffin blob for another data file from being applied here. A missing or
-// empty referenced-data-file property is fatal because it cannot establish
-// blob identity; a missing cardinality property is only warned about because
-// the manifest record_count still bounds the decoded bitmap.
+// Java's DVUtil.readDV and PyIceberg, which read by offset and size without
+// validating blob type or referenced-data-file, but prevents a valid Puffin
+// blob for another data file from being applied here. A missing or empty
+// referenced-data-file property is fatal because it cannot establish blob
+// identity; a missing cardinality property is only warned about because the
+// manifest record_count still bounds the decoded bitmap. The compression
+// codec is also rejected because deletion-vector-v1 stores raw bytes here.
 //
 // Blobs missing the spec-required cardinality property are still validated
 // against the manifest record_count and accepted with a slog warning rather
@@ -171,7 +176,7 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	}
 	manifestReferencedDataFile := dvFile.ReferencedDataFile()
 	if manifestReferencedDataFile == nil || *manifestReferencedDataFile == "" {
-		return nil, fmt.Errorf("DV file %s missing ReferencedDataFile", dvFile.FilePath())
+		return nil, fmt.Errorf("%w: DV file %s missing or empty %s property", ErrInvalidDeletionVector, dvFile.FilePath(), dvReferencedDataFileProperty)
 	}
 
 	size := *dvFile.ContentSizeInBytes()
@@ -193,20 +198,24 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	offset := *dvFile.ContentOffset()
 	blob, err := findBlobMetadataByRange(reader.Blobs(), offset, size)
 	if err != nil {
-		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
+		return nil, fmt.Errorf("%w: DV file %s: %w", ErrInvalidDeletionVector, dvFile.FilePath(), err)
 	}
 	if blob.Type != puffin.BlobTypeDeletionVector {
-		return nil, fmt.Errorf("DV file %s: blob at offset %d has type %q, expected %q",
+		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d has type %q, expected %q", ErrInvalidDeletionVector,
 			dvFile.FilePath(), offset, blob.Type, puffin.BlobTypeDeletionVector)
+	}
+	if blob.CompressionCodec != nil && *blob.CompressionCodec != "" {
+		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d uses unsupported compression codec %q",
+			ErrInvalidDeletionVector, dvFile.FilePath(), offset, *blob.CompressionCodec)
 	}
 
 	referencedDataFile, ok := blob.Properties[dvReferencedDataFileProperty]
 	if !ok || referencedDataFile == "" {
-		return nil, fmt.Errorf("DV file %s: blob at offset %d missing or empty %s property",
+		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d missing or empty %s property", ErrInvalidDeletionVector,
 			dvFile.FilePath(), offset, dvReferencedDataFileProperty)
 	}
 	if referencedDataFile != *manifestReferencedDataFile {
-		return nil, fmt.Errorf("DV file %s: manifest referenced_data_file %q does not match puffin %s %q",
+		return nil, fmt.Errorf("%w: DV file %s: manifest referenced_data_file %q does not match puffin %s %q", ErrInvalidDeletionVector,
 			dvFile.FilePath(), *manifestReferencedDataFile, dvReferencedDataFileProperty, referencedDataFile)
 	}
 
@@ -252,7 +261,8 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 }
 
 // findBlobMetadataByRange returns the footer entry identified by the
-// manifest's content offset and size.
+// manifest's content offset and size. On error it returns a zero-value
+// puffin.BlobMetadata; callers must check the error before reading the value.
 func findBlobMetadataByRange(blobs []puffin.BlobMetadata, offset, size int64) (puffin.BlobMetadata, error) {
 	for _, b := range blobs {
 		if b.Offset != offset {

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -35,7 +35,10 @@ import (
 // writer attaches it; the reader uses it to detect truncated bitmaps whose
 // CRC happens to validate (the CRC covers the bytes that ARE present, not
 // the bytes that should have been).
-const dvCardinalityProperty = "cardinality"
+const (
+	dvCardinalityProperty        = "cardinality"
+	dvReferencedDataFileProperty = "referenced-data-file"
+)
 
 const (
 	// DVMagicNumber is the magic number for deletion vectors.
@@ -158,6 +161,10 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	if dvFile.ContentOffset() == nil || dvFile.ContentSizeInBytes() == nil {
 		return nil, fmt.Errorf("DV file %s missing ContentOffset/ContentSizeInBytes", dvFile.FilePath())
 	}
+	manifestReferencedDataFile := dvFile.ReferencedDataFile()
+	if manifestReferencedDataFile == nil || *manifestReferencedDataFile == "" {
+		return nil, fmt.Errorf("DV file %s missing ReferencedDataFile", dvFile.FilePath())
+	}
 
 	size := *dvFile.ContentSizeInBytes()
 	if size < 0 || size > int64(puffin.DefaultMaxBlobSize) {
@@ -176,9 +183,23 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	}
 
 	offset := *dvFile.ContentOffset()
-	blobData := make([]byte, size)
-	if _, err := reader.ReadAt(blobData, offset); err != nil {
-		return nil, fmt.Errorf("read DV blob at offset %d: %w", offset, err)
+	blob, err := findBlobMetadata(reader.Blobs(), offset, size)
+	if err != nil {
+		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
+	}
+	if blob.Type != puffin.BlobTypeDeletionVector {
+		return nil, fmt.Errorf("DV file %s: blob at offset %d has type %q, expected %q",
+			dvFile.FilePath(), offset, blob.Type, puffin.BlobTypeDeletionVector)
+	}
+
+	referencedDataFile, ok := blob.Properties[dvReferencedDataFileProperty]
+	if !ok || referencedDataFile == "" {
+		return nil, fmt.Errorf("DV file %s: blob at offset %d missing %s property",
+			dvFile.FilePath(), offset, dvReferencedDataFileProperty)
+	}
+	if referencedDataFile != *manifestReferencedDataFile {
+		return nil, fmt.Errorf("DV file %s: manifest referenced data file %q disagrees with puffin %s property %q",
+			dvFile.FilePath(), *manifestReferencedDataFile, dvReferencedDataFileProperty, referencedDataFile)
 	}
 
 	// Manifest record_count (field 103) is a required, non-nullable long, so it
@@ -188,7 +209,7 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 
 	// The puffin blob independently declares its cardinality via the spec-
 	// mandated property; when present it is a second source to cross-check.
-	puffinCardinality, hasPuffinCardinality, err := blobCardinality(reader.Blobs(), offset, size)
+	puffinCardinality, hasPuffinCardinality, err := blobCardinality(blob)
 	if err != nil {
 		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
 	}
@@ -211,23 +232,20 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 			"dv_file", dvFile.FilePath(), "offset", offset)
 	}
 
+	blobData := make([]byte, size)
+	if _, err := reader.ReadAt(blobData, offset); err != nil {
+		return nil, fmt.Errorf("read DV blob at offset %d: %w", offset, err)
+	}
+
 	// Validate the decoded bitmap against the manifest record_count (always
 	// present, including zero). When the puffin property is present it has
 	// already been confirmed to agree with this value above.
 	return DeserializeDV(blobData, manifestCardinality)
 }
 
-// blobCardinality returns the cardinality declared by the puffin blob at the
-// manifest entry's (offset, size). The bool indicates whether the property was
-// present:
-//
-//   - (n, true, nil)  — property found and parsed successfully
-//   - (0, false, nil) — matching blob found but no cardinality property
-//   - (_, _, err)     — manifest/footer mismatch or property unparseable
-//
-// Keeping the sentinel out of the int64 return channel avoids leaking
-// DeserializeDV's "-1 means skip" convention up the call chain.
-func blobCardinality(blobs []puffin.BlobMetadata, offset, size int64) (int64, bool, error) {
+// findBlobMetadata returns the footer entry identified by the manifest's
+// content offset and size.
+func findBlobMetadata(blobs []puffin.BlobMetadata, offset, size int64) (puffin.BlobMetadata, error) {
 	for _, b := range blobs {
 		if b.Offset != offset {
 			continue
@@ -237,26 +255,31 @@ func blobCardinality(blobs []puffin.BlobMetadata, offset, size int64) (int64, bo
 			// disagrees with the puffin footer on how big this blob is.
 			// Surface that distinct condition rather than rolling it into
 			// "no blob at offset" — different writer bug, different fix.
-			return 0, false, fmt.Errorf("blob at offset %d has length %d, manifest says %d", offset, b.Length, size)
-		}
-		v, ok := b.Properties[dvCardinalityProperty]
-		if !ok {
-			return 0, false, nil
-		}
-		parsed, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return 0, false, fmt.Errorf("invalid %s property %q: %w", dvCardinalityProperty, v, err)
-		}
-		if parsed < 0 {
-			// Negative is meaningless for a count of deleted positions, and
-			// `-1` specifically aliases DeserializeDV's skip-validation
-			// sentinel — accepting it would silently disable the very check
-			// this layer was added to perform.
-			return 0, false, fmt.Errorf("%s property must be non-negative, got %d", dvCardinalityProperty, parsed)
+			return puffin.BlobMetadata{}, fmt.Errorf("blob at offset %d has length %d, manifest says %d", offset, b.Length, size)
 		}
 
-		return parsed, true, nil
+		return b, nil
 	}
 
-	return 0, false, fmt.Errorf("no blob in puffin footer at offset %d, size %d", offset, size)
+	return puffin.BlobMetadata{}, fmt.Errorf("no blob in puffin footer at offset %d, size %d", offset, size)
+}
+
+// blobCardinality returns the cardinality declared by a Puffin blob. The bool
+// indicates whether the property was present.
+func blobCardinality(blob puffin.BlobMetadata) (int64, bool, error) {
+	v, ok := blob.Properties[dvCardinalityProperty]
+	if !ok {
+		return 0, false, nil
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid %s property %q: %w", dvCardinalityProperty, v, err)
+	}
+	if parsed < 0 {
+		// Negative is meaningless for a count of deleted positions, and -1
+		// would disable cardinality validation in DeserializeDV.
+		return 0, false, fmt.Errorf("%s property must be non-negative, got %d", dvCardinalityProperty, parsed)
+	}
+
+	return parsed, true, nil
 }

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -183,7 +183,7 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	}
 
 	offset := *dvFile.ContentOffset()
-	blob, err := findBlobMetadata(reader.Blobs(), offset, size)
+	blob, err := findBlobMetadataByRange(reader.Blobs(), offset, size)
 	if err != nil {
 		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
 	}
@@ -198,7 +198,7 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 			dvFile.FilePath(), offset, dvReferencedDataFileProperty)
 	}
 	if referencedDataFile != *manifestReferencedDataFile {
-		return nil, fmt.Errorf("DV file %s: manifest referenced data file %q disagrees with puffin %s property %q",
+		return nil, fmt.Errorf("DV file %s: manifest referenced_data_file %q does not match puffin %s %q",
 			dvFile.FilePath(), *manifestReferencedDataFile, dvReferencedDataFileProperty, referencedDataFile)
 	}
 
@@ -243,9 +243,9 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 	return DeserializeDV(blobData, manifestCardinality)
 }
 
-// findBlobMetadata returns the footer entry identified by the manifest's
-// content offset and size.
-func findBlobMetadata(blobs []puffin.BlobMetadata, offset, size int64) (puffin.BlobMetadata, error) {
+// findBlobMetadataByRange returns the footer entry identified by the
+// manifest's content offset and size.
+func findBlobMetadataByRange(blobs []puffin.BlobMetadata, offset, size int64) (puffin.BlobMetadata, error) {
 	for _, b := range blobs {
 		if b.Offset != offset {
 			continue

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -194,7 +194,7 @@ func ReadDV(fs iceio.IO, dvFile iceberg.DataFile) (*RoaringPositionBitmap, error
 
 	referencedDataFile, ok := blob.Properties[dvReferencedDataFileProperty]
 	if !ok || referencedDataFile == "" {
-		return nil, fmt.Errorf("DV file %s: blob at offset %d missing %s property",
+		return nil, fmt.Errorf("DV file %s: blob at offset %d missing or empty %s property",
 			dvFile.FilePath(), offset, dvReferencedDataFileProperty)
 	}
 	if referencedDataFile != *manifestReferencedDataFile {

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -149,6 +149,14 @@ func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
 // stale manifest record_count against a freshly written blob) is a writer bug
 // and fails fast. The bitmap is then validated against the manifest count.
 //
+// ReadDV also requires the selected blob to be a deletion-vector blob whose
+// referenced-data-file property matches the manifest. This is stricter than
+// clients that only use the manifest offset and size, but prevents a valid
+// Puffin blob for another data file from being applied here. A missing or
+// empty referenced-data-file property is fatal because it cannot establish
+// blob identity; a missing cardinality property is only warned about because
+// the manifest record_count still bounds the decoded bitmap.
+//
 // Blobs missing the spec-required cardinality property are still validated
 // against the manifest record_count and accepted with a slog warning rather
 // than rejected — the Go writer always emits the property, but third-party

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -162,18 +162,23 @@ func writeRawPuffinWithDVBlobNoCardinality(t *testing.T, dir string, dvBlobBytes
 	})
 }
 
-func writeRawPuffinBlob(t *testing.T, dir, name string, blobBytes []byte, blobType puffin.BlobType, props map[string]string) (string, puffin.BlobMetadata) {
+func writeRawPuffinBlob(t *testing.T, dir, name string, blobBytes []byte, blobType puffin.BlobType, props map[string]string, compressionCodec ...string) (string, puffin.BlobMetadata) {
 	t.Helper()
 
 	const puffinMagic = "PFA1"
+	var codec *string
+	if len(compressionCodec) > 0 {
+		codec = &compressionCodec[0]
+	}
 	meta := puffin.BlobMetadata{
-		Type:           blobType,
-		Fields:         []int32{2147483546},
-		SnapshotID:     -1,
-		SequenceNumber: -1,
-		Offset:         int64(puffin.MagicSize),
-		Length:         int64(len(blobBytes)),
-		Properties:     props,
+		Type:             blobType,
+		Fields:           []int32{2147483546},
+		SnapshotID:       -1,
+		SequenceNumber:   -1,
+		Offset:           int64(puffin.MagicSize),
+		Length:           int64(len(blobBytes)),
+		Properties:       props,
+		CompressionCodec: codec,
 	}
 
 	payload, err := json.Marshal(puffin.Footer{Blobs: []puffin.BlobMetadata{meta}})
@@ -428,7 +433,7 @@ func TestReadDVMissingReferencedDataFile(t *testing.T) {
 			dvFile.referencedDataFile = tt.referenced
 
 			_, err := ReadDV(iceio.LocalFS{}, dvFile)
-			assert.ErrorContains(t, err, "missing ReferencedDataFile")
+			assert.ErrorContains(t, err, "missing or empty referenced-data-file property")
 		})
 	}
 }
@@ -551,6 +556,35 @@ func TestReadDVValidatesBlobMetadata(t *testing.T) {
 
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
 		assert.ErrorContains(t, err, `has type "test-blob", expected "deletion-vector-v1"`)
+	})
+
+	t.Run("exact path comparison does not normalize URI schemes", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
+			dvReferencedDataFileProperty: "s3a://bucket/data/data-001.parquet",
+			dvCardinalityProperty:        "5",
+		})
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		require.ErrorIs(t, err, ErrInvalidDeletionVector)
+		assert.ErrorContains(t, err, "manifest referenced_data_file")
+		assert.ErrorContains(t, err, "s3://bucket/data/data-001.parquet")
+		assert.ErrorContains(t, err, "s3a://bucket/data/data-001.parquet")
+	})
+
+	t.Run("compression codec is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writeRawPuffinBlob(t, dir, "raw-dv-compressed.puffin", dvBlobBytes,
+			puffin.BlobTypeDeletionVector, map[string]string{
+				dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+				dvCardinalityProperty:        "5",
+			}, "zstd")
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		require.ErrorIs(t, err, ErrInvalidDeletionVector)
+		assert.ErrorContains(t, err, "unsupported compression codec")
 	})
 }
 

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -113,6 +113,7 @@ func writePuffinWithDVBlobAndProps(t *testing.T, dir string, dvBlobBytes []byte,
 		data:  dvBlobBytes,
 		props: props,
 	})
+
 	return path, metas[0]
 }
 

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -394,15 +394,25 @@ func TestReadDVMissingContentMetadata(t *testing.T) {
 }
 
 // Why: a deletion vector manifest entry must identify the data file it applies to.
-// Condition: ReferencedDataFile is nil even though offset and size are present.
+// Condition: ReferencedDataFile is nil or empty even though offset and size are present.
 // Assertion: ReadDV rejects the entry before opening the Puffin file.
 func TestReadDVMissingReferencedDataFile(t *testing.T) {
-	offset, size := int64(4), int64(50)
-	dvFile := newDVTestFile("missing.puffin", 5, &offset, &size)
-	dvFile.referencedDataFile = nil
+	for _, tt := range []struct {
+		name       string
+		referenced *string
+	}{
+		{name: "nil", referenced: nil},
+		{name: "empty", referenced: strPtr("")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			offset, size := int64(4), int64(50)
+			dvFile := newDVTestFile("missing.puffin", 5, &offset, &size)
+			dvFile.referencedDataFile = tt.referenced
 
-	_, err := ReadDV(iceio.LocalFS{}, dvFile)
-	assert.ErrorContains(t, err, "missing ReferencedDataFile")
+			_, err := ReadDV(iceio.LocalFS{}, dvFile)
+			assert.ErrorContains(t, err, "missing ReferencedDataFile")
+		})
+	}
 }
 
 // Why: negative or absurdly large blob sizes should be rejected before allocation.
@@ -444,7 +454,7 @@ func TestReadDVInvalidPuffin(t *testing.T) {
 // is a deletion vector for the manifest's referenced data file.
 // Condition: the matched blob has conflicting, missing, or non-DV identity metadata.
 // Assertion: ReadDV rejects each case before decoding the blob payload.
-func TestReadDVBlobIdentity(t *testing.T) {
+func TestReadDVValidatesBlobMetadata(t *testing.T) {
 	dvBlobBytes := readDVTestData(t, "small-alternating-values-position-index.bin")
 
 	t.Run("mismatched referenced data file", func(t *testing.T) {
@@ -457,7 +467,7 @@ func TestReadDVBlobIdentity(t *testing.T) {
 
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "manifest referenced data file")
+		assert.ErrorContains(t, err, "manifest referenced_data_file")
 		assert.ErrorContains(t, err, "data-001.parquet")
 		assert.ErrorContains(t, err, "data-002.parquet")
 	})

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -139,20 +139,23 @@ func writePuffinWithDVBlobAndProps(t *testing.T, dir string, dvBlobBytes []byte,
 // writer) is to assemble the bytes directly. The reader's validateBlobs does
 // not require the property, so this file loads cleanly.
 func writeRawPuffinWithDVBlobNoCardinality(t *testing.T, dir string, dvBlobBytes []byte) (string, puffin.BlobMetadata) {
+	return writeRawPuffinBlob(t, dir, "raw-dv-no-cardinality.puffin", dvBlobBytes, puffin.BlobTypeDeletionVector, map[string]string{
+		"referenced-data-file": "s3://bucket/data/data-001.parquet",
+	})
+}
+
+func writeRawPuffinBlob(t *testing.T, dir, name string, blobBytes []byte, blobType puffin.BlobType, props map[string]string) (string, puffin.BlobMetadata) {
 	t.Helper()
 
 	const puffinMagic = "PFA1"
 	meta := puffin.BlobMetadata{
-		Type:           puffin.BlobTypeDeletionVector,
+		Type:           blobType,
 		Fields:         []int32{2147483546},
 		SnapshotID:     -1,
 		SequenceNumber: -1,
 		Offset:         int64(puffin.MagicSize),
-		Length:         int64(len(dvBlobBytes)),
-		Properties: map[string]string{
-			// No "cardinality" — that is the whole point of this fixture.
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-		},
+		Length:         int64(len(blobBytes)),
+		Properties:     props,
 	}
 
 	payload, err := json.Marshal(puffin.Footer{Blobs: []puffin.BlobMetadata{meta}})
@@ -160,7 +163,7 @@ func writeRawPuffinWithDVBlobNoCardinality(t *testing.T, dir string, dvBlobBytes
 
 	var buf bytes.Buffer
 	buf.WriteString(puffinMagic) // header magic
-	buf.Write(dvBlobBytes)       // blob at offset MagicSize
+	buf.Write(blobBytes)         // blob at offset MagicSize
 	buf.WriteString(puffinMagic) // footer start magic
 	buf.Write(payload)           // footer JSON payload
 
@@ -170,7 +173,7 @@ func writeRawPuffinWithDVBlobNoCardinality(t *testing.T, dir string, dvBlobBytes
 	copy(trailer[8:12], puffinMagic)
 	buf.Write(trailer[:])
 
-	path := filepath.Join(dir, "raw-dv-no-cardinality.puffin")
+	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
 
 	return path, meta
@@ -390,6 +393,18 @@ func TestReadDVMissingContentMetadata(t *testing.T) {
 	})
 }
 
+// Why: a deletion vector manifest entry must identify the data file it applies to.
+// Condition: ReferencedDataFile is nil even though offset and size are present.
+// Assertion: ReadDV rejects the entry before opening the Puffin file.
+func TestReadDVMissingReferencedDataFile(t *testing.T) {
+	offset, size := int64(4), int64(50)
+	dvFile := newDVTestFile("missing.puffin", 5, &offset, &size)
+	dvFile.referencedDataFile = nil
+
+	_, err := ReadDV(iceio.LocalFS{}, dvFile)
+	assert.ErrorContains(t, err, "missing ReferencedDataFile")
+}
+
 // Why: negative or absurdly large blob sizes should be rejected before allocation.
 // Condition: ContentSizeInBytes set to -1.
 // Assertion: returns an error containing "out of valid range".
@@ -425,9 +440,55 @@ func TestReadDVInvalidPuffin(t *testing.T) {
 	assert.ErrorContains(t, err, "create puffin reader")
 }
 
+// Why: offset, size, and cardinality cannot prove that the selected Puffin blob
+// is a deletion vector for the manifest's referenced data file.
+// Condition: the matched blob has conflicting, missing, or non-DV identity metadata.
+// Assertion: ReadDV rejects each case before decoding the blob payload.
+func TestReadDVBlobIdentity(t *testing.T) {
+	dvBlobBytes := readDVTestData(t, "small-alternating-values-position-index.bin")
+
+	t.Run("mismatched referenced data file", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
+			"referenced-data-file": "s3://bucket/data/data-002.parquet",
+			"cardinality":          "5",
+		})
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "manifest referenced data file")
+		assert.ErrorContains(t, err, "data-001.parquet")
+		assert.ErrorContains(t, err, "data-002.parquet")
+	})
+
+	t.Run("missing puffin referenced data file", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writeRawPuffinBlob(t, dir, "raw-dv-no-reference.puffin", dvBlobBytes,
+			puffin.BlobTypeDeletionVector, map[string]string{"cardinality": "5"})
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		assert.ErrorContains(t, err, "missing referenced-data-file property")
+	})
+
+	t.Run("wrong blob type", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writeRawPuffinBlob(t, dir, "raw-wrong-type.puffin", dvBlobBytes,
+			puffin.BlobType("test-blob"), map[string]string{
+				"referenced-data-file": "s3://bucket/data/data-001.parquet",
+				"cardinality":          "5",
+			})
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		assert.ErrorContains(t, err, `has type "test-blob", expected "deletion-vector-v1"`)
+	})
+}
+
 // Why: manifest-provided blob ranges must point into the Puffin blob area, not arbitrary offsets.
 // Condition: valid Puffin file, but content offset is forced to 0, which points before the blob region.
-// Assertion: returns an error containing "read DV blob at offset 0".
+// Assertion: returns an error indicating that no footer blob matches the range.
 func TestReadDVInvalidBlobRange(t *testing.T) {
 	dvBlobBytes := readDVTestData(t, "small-alternating-values-position-index.bin")
 
@@ -436,7 +497,7 @@ func TestReadDVInvalidBlobRange(t *testing.T) {
 
 	offset, size := int64(0), meta.Length
 	_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
-	assert.ErrorContains(t, err, "read DV blob at offset 0")
+	assert.ErrorContains(t, err, "no blob in puffin footer at offset 0")
 }
 
 // TestReadDVCardinalityValidation pins the spec-mandated check that the

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -100,8 +100,8 @@ func writePuffinWithDVBlob(t *testing.T, dir string, dvBlobBytes []byte) (string
 	// safe. Tests that exercise other bitmap sizes call
 	// writePuffinWithDVBlobAndProps directly with their own cardinality.
 	return writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-		"referenced-data-file": "s3://bucket/data/data-001.parquet",
-		"cardinality":          "5",
+		dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+		dvCardinalityProperty:        "5",
 	})
 }
 
@@ -109,6 +109,19 @@ func writePuffinWithDVBlob(t *testing.T, dir string, dvBlobBytes []byte) (string
 // caller-supplied blob properties — used by the cardinality-validation tests
 // to inject the spec-mandated `cardinality` property (or omit it).
 func writePuffinWithDVBlobAndProps(t *testing.T, dir string, dvBlobBytes []byte, props map[string]string) (string, puffin.BlobMetadata) {
+	path, metas := writePuffinWithDVBlobs(t, dir, testPuffinBlobInput{
+		data:  dvBlobBytes,
+		props: props,
+	})
+	return path, metas[0]
+}
+
+type testPuffinBlobInput struct {
+	data  []byte
+	props map[string]string
+}
+
+func writePuffinWithDVBlobs(t *testing.T, dir string, blobs ...testPuffinBlobInput) (string, []puffin.BlobMetadata) {
 	t.Helper()
 
 	path := filepath.Join(dir, "test-dv.puffin")
@@ -119,17 +132,21 @@ func writePuffinWithDVBlobAndProps(t *testing.T, dir string, dvBlobBytes []byte,
 	w, err := puffin.NewWriter(f)
 	require.NoError(t, err)
 
-	meta, err := w.AddBlob(puffin.BlobMetadataInput{
-		Type:           puffin.BlobTypeDeletionVector,
-		SnapshotID:     -1,
-		SequenceNumber: -1,
-		Fields:         []int32{2147483546},
-		Properties:     props,
-	}, dvBlobBytes)
-	require.NoError(t, err)
+	metas := make([]puffin.BlobMetadata, 0, len(blobs))
+	for _, blob := range blobs {
+		meta, err := w.AddBlob(puffin.BlobMetadataInput{
+			Type:           puffin.BlobTypeDeletionVector,
+			SnapshotID:     -1,
+			SequenceNumber: -1,
+			Fields:         []int32{2147483546},
+			Properties:     blob.props,
+		}, blob.data)
+		require.NoError(t, err)
+		metas = append(metas, meta)
+	}
 	require.NoError(t, w.Finish())
 
-	return path, meta
+	return path, metas
 }
 
 // writeRawPuffinWithDVBlobNoCardinality hand-builds a Puffin file whose DV blob
@@ -140,7 +157,7 @@ func writePuffinWithDVBlobAndProps(t *testing.T, dir string, dvBlobBytes []byte,
 // not require the property, so this file loads cleanly.
 func writeRawPuffinWithDVBlobNoCardinality(t *testing.T, dir string, dvBlobBytes []byte) (string, puffin.BlobMetadata) {
 	return writeRawPuffinBlob(t, dir, "raw-dv-no-cardinality.puffin", dvBlobBytes, puffin.BlobTypeDeletionVector, map[string]string{
-		"referenced-data-file": "s3://bucket/data/data-001.parquet",
+		dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
 	})
 }
 
@@ -460,10 +477,37 @@ func TestReadDVValidatesBlobMetadata(t *testing.T) {
 	t.Run("mismatched referenced data file", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-002.parquet",
-			"cardinality":          "5",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-002.parquet",
+			dvCardinalityProperty:        "5",
 		})
 		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "manifest referenced_data_file")
+		assert.ErrorContains(t, err, "data-001.parquet")
+		assert.ErrorContains(t, err, "data-002.parquet")
+	})
+
+	t.Run("offset redirects to a different blob", func(t *testing.T) {
+		dir := t.TempDir()
+		path, metas := writePuffinWithDVBlobs(t, dir,
+			testPuffinBlobInput{
+				data: dvBlobBytes,
+				props: map[string]string{
+					dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+					dvCardinalityProperty:        "5",
+				},
+			},
+			testPuffinBlobInput{
+				data: dvBlobBytes,
+				props: map[string]string{
+					dvReferencedDataFileProperty: "s3://bucket/data/data-002.parquet",
+					dvCardinalityProperty:        "5",
+				},
+			},
+		)
+		offset, size := metas[1].Offset, metas[1].Length
 
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
 		require.Error(t, err)
@@ -475,19 +519,32 @@ func TestReadDVValidatesBlobMetadata(t *testing.T) {
 	t.Run("missing puffin referenced data file", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writeRawPuffinBlob(t, dir, "raw-dv-no-reference.puffin", dvBlobBytes,
-			puffin.BlobTypeDeletionVector, map[string]string{"cardinality": "5"})
+			puffin.BlobTypeDeletionVector, map[string]string{dvCardinalityProperty: "5"})
 		offset, size := meta.Offset, meta.Length
 
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
-		assert.ErrorContains(t, err, "missing referenced-data-file property")
+		assert.ErrorContains(t, err, "missing or empty referenced-data-file property")
+	})
+
+	t.Run("empty puffin referenced data file", func(t *testing.T) {
+		dir := t.TempDir()
+		path, meta := writeRawPuffinBlob(t, dir, "raw-dv-empty-reference.puffin", dvBlobBytes,
+			puffin.BlobTypeDeletionVector, map[string]string{
+				dvReferencedDataFileProperty: "",
+				dvCardinalityProperty:        "5",
+			})
+		offset, size := meta.Offset, meta.Length
+
+		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
+		assert.ErrorContains(t, err, "missing or empty referenced-data-file property")
 	})
 
 	t.Run("wrong blob type", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writeRawPuffinBlob(t, dir, "raw-wrong-type.puffin", dvBlobBytes,
 			puffin.BlobType("test-blob"), map[string]string{
-				"referenced-data-file": "s3://bucket/data/data-001.parquet",
-				"cardinality":          "5",
+				dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+				dvCardinalityProperty:        "5",
 			})
 		offset, size := meta.Offset, meta.Length
 
@@ -521,8 +578,8 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 	t.Run("matching cardinality passes", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-			"cardinality":          "5",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+			dvCardinalityProperty:        "5",
 		})
 		offset, size := meta.Offset, meta.Length
 		bm, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
@@ -537,8 +594,8 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 		emptyBlob := readDVTestData(t, "empty-position-index.bin")
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, emptyBlob, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-			"cardinality":          "0",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+			dvCardinalityProperty:        "0",
 		})
 		offset, size := meta.Offset, meta.Length
 		bm, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 0, &offset, &size))
@@ -549,9 +606,9 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 	t.Run("manifest disagreeing with puffin property is rejected", func(t *testing.T) {
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
 			// Puffin says 99; the manifest entry below says 5.
-			"cardinality": "99",
+			dvCardinalityProperty: "99",
 		})
 		offset, size := meta.Offset, meta.Length
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 5, &offset, &size))
@@ -568,8 +625,8 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 		// Must error rather than fall back to trusting the blob property.
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-			"cardinality":          "5",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+			dvCardinalityProperty:        "5",
 		})
 		offset, size := meta.Offset, meta.Length
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 0, &offset, &size))
@@ -583,8 +640,8 @@ func TestReadDVCardinalityValidation(t *testing.T) {
 		// against the agreed-upon expected cardinality.
 		dir := t.TempDir()
 		path, meta := writePuffinWithDVBlobAndProps(t, dir, dvBlobBytes, map[string]string{
-			"referenced-data-file": "s3://bucket/data/data-001.parquet",
-			"cardinality":          "99",
+			dvReferencedDataFileProperty: "s3://bucket/data/data-001.parquet",
+			dvCardinalityProperty:        "99",
 		})
 		offset, size := meta.Offset, meta.Length
 		_, err := ReadDV(iceio.LocalFS{}, newDVTestFile(path, 99, &offset, &size))

--- a/table/dv/dv_cross_client_test.go
+++ b/table/dv/dv_cross_client_test.go
@@ -82,7 +82,7 @@ func TestCrossClientReadJavaMultiBlobDV(t *testing.T) {
 
 	seen := make(map[string]struct{}, len(expected))
 	for i, blob := range blobs {
-		ref, ok := blob.Properties["referenced-data-file"]
+		ref, ok := blob.Properties[dvReferencedDataFileProperty]
 		require.True(t, ok, "blob %d missing referenced-data-file property", i)
 		want, ok := expected[ref]
 		require.Truef(t, ok, "blob %d references unexpected data file %q", i, ref)
@@ -173,7 +173,7 @@ func loadJavaPuffinBlob(t *testing.T, fixture string, blobIdx int, referencedDat
 	require.Greaterf(t, len(blobs), blobIdx, "fixture %s has only %d blob(s)", fixture, len(blobs))
 	blob := blobs[blobIdx]
 
-	cardStr, ok := blob.Properties["cardinality"]
+	cardStr, ok := blob.Properties[dvCardinalityProperty]
 	require.Truef(t, ok, "blob %d missing cardinality property", blobIdx)
 	cardinality, err := strconv.ParseInt(cardStr, 10, 64)
 	require.NoErrorf(t, err, "parse cardinality %q", cardStr)

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -202,8 +202,8 @@ func (w *DVWriter) Flush(_ context.Context, location string) ([]iceberg.DataFile
 			SequenceNumber: -1,
 			Fields:         []int32{},
 			Properties: map[string]string{
-				dvCardinalityProperty:  strconv.FormatInt(cardinality, 10),
-				"referenced-data-file": dataFilePath,
+				dvCardinalityProperty:        strconv.FormatInt(cardinality, 10),
+				dvReferencedDataFileProperty: dataFilePath,
 			},
 		}, dvBytes)
 		if err != nil {

--- a/table/dv_scanner_read_test.go
+++ b/table/dv_scanner_read_test.go
@@ -193,6 +193,15 @@ func TestReadAllDeletionVectors(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing referenced_data_file")
 	})
 
+	t.Run("DV identity mismatch propagates from ReadDV", func(t *testing.T) {
+		puffinPath, offset, length, card := writeDVPuffinFixture(t, []uint64{0}, "file:///table/data/data-001.parquet")
+		dvFile := newDVMockDataFile(puffinPath, "file:///table/data/data-002.parquet", offset, length, card)
+
+		_, err := readAllDeletionVectors(ctx, fs, []FileScanTask{{DeletionVectorFiles: []iceberg.DataFile{dvFile}}}, 1)
+		require.ErrorIs(t, err, dv.ErrInvalidDeletionVector)
+		assert.Contains(t, err.Error(), "manifest referenced_data_file")
+	})
+
 	t.Run("DV missing content_offset is rejected", func(t *testing.T) {
 		// content_offset is required by spec; without it ReadDV can't
 		// locate the blob. Pinned at the pre-pass so two such entries


### PR DESCRIPTION
## Summary

Validate that a Puffin deletion-vector blob matches its manifest entry.

## Why

ReadDV selected a blob by offset and length and checked cardinality, but did not verify the blob type or referenced data file. A malformed manifest entry could therefore read a deletion vector for another data file.

## What changed

ReadDV now requires a non-empty referenced data file, checks for type deletion-vector-v1, and verifies the footer's referenced-data-file property before decoding. Existing cardinality checks remain unchanged.

## Tests

- Added mismatched and missing data-file reference cases
- Added a non-DV blob case
- Added nil and empty manifest reference cases
- go test ./table/dv
- go test ./...
- golangci-lint run --timeout=10m