### PR TITLE
fix(table): reject ambiguous equality-delete columns

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1167,7 +1167,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 	}
 
 	if len(eqDeleteSets) > 0 {
-		eqFn, eqErr := processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, task.Value.File.FilePath())
+		eqFn, eqErr := processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, iceSchema, task.Value.File.FilePath())
 		if eqErr != nil {
 			return eqErr
 		}
@@ -1481,7 +1481,7 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 	}
 
 	eqDeleteSets, err := readAllEqualityDeleteFiles(ctx, as.fs,
-		as.metadata.CurrentSchema(), tasks, as.concurrency)
+		as.metadata.CurrentSchema(), as.metadata.NameMapping(), tasks, as.concurrency)
 	if err != nil {
 		// Positional deletes were fully loaded; release them before aborting.
 		releasePerFilePosDeletes(deletesPerFile)

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1167,7 +1167,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 	}
 
 	if len(eqDeleteSets) > 0 {
-		eqFn, eqErr := processEqualityDeletes(ctx, eqDeleteSets)
+		eqFn, eqErr := processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, task.Value.File.FilePath())
 		if eqErr != nil {
 			return eqErr
 		}

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -217,11 +217,15 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 		colNames[i] = name
 		indices := tbl.Schema().FieldIndices(name)
-		if len(indices) == 0 {
+		switch len(indices) {
+		case 0:
 			return nil, nil, fmt.Errorf("equality delete column %q not found in delete file %s", name, dataFile.FilePath())
+		case 1:
+			colIndices[i] = indices[0]
+		default:
+			return nil, nil, fmt.Errorf("equality delete column %q is ambiguous in delete file %s: found %d columns",
+				name, dataFile.FilePath(), len(indices))
 		}
-
-		colIndices[i] = indices[0]
 	}
 
 	// Build the set of encoded delete keys by iterating aligned batches.

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -148,15 +148,19 @@ func resolveArrowField(schema *arrow.Schema, fieldID int, fieldName, filePath st
 }
 
 func arrowArrayAtField(record arrow.RecordBatch, ref arrowFieldRef, fieldID int, fieldName, filePath string) (arrow.Array, error) {
+	location := filePath
+	if location == "" {
+		location = "data record"
+	}
 	if len(ref.path) == 0 || ref.path[0] >= int(record.NumCols()) {
-		return nil, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, filePath)
+		return nil, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
 	}
 
 	result := record.Column(ref.path[0])
 	for _, index := range ref.path[1:] {
 		structArray, ok := result.(*array.Struct)
 		if !ok || index >= structArray.NumField() {
-			return nil, fmt.Errorf("equality field ID %d (%s) has unsupported nested path in %s", fieldID, fieldName, filePath)
+			return nil, fmt.Errorf("equality field ID %d (%s) has unsupported nested path in %s", fieldID, fieldName, location)
 		}
 		result = structArray.Field(index)
 	}
@@ -330,7 +334,7 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 	for i, fid := range fieldIDs {
 		name, ok := tableSchema.FindColumnName(fid)
 		if !ok {
-			return nil, nil, fmt.Errorf("equality delete field ID %d not found in table schema", fid)
+			return nil, nil, fmt.Errorf("equality delete field ID %d not found in table schema for %s", fid, dataFile.FilePath())
 		}
 
 		ref, err := resolveArrowField(tbl.Schema(), fid, name, dataFile.FilePath())

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -54,93 +53,73 @@ type arrowFieldRef struct {
 	path []int
 }
 
-func resolveArrowField(schema *arrow.Schema, fieldID int, fieldName, filePath string) (arrowFieldRef, error) {
-	type candidate struct {
-		ref           arrowFieldRef
-		pathName      string
-		hasIDMetadata bool
-	}
+type arrowFieldRefsByID map[int][]arrowFieldRef
 
-	var (
-		idMatches   []candidate
-		nameMatches []candidate
-		pathMatches []candidate
-	)
-	targetName := fieldName
-	if dot := strings.LastIndexByte(targetName, '.'); dot >= 0 {
-		targetName = targetName[dot+1:]
-	}
-
-	var visit func([]arrow.Field, []int, string)
-	visit = func(fields []arrow.Field, parentPath []int, parentName string) {
-		for i, field := range fields {
-			path := append(append([]int(nil), parentPath...), i)
-			pathName := field.Name
-			if parentName != "" {
-				pathName = parentName + "." + field.Name
-			}
-			fieldIDValue := getFieldID(field)
-			fieldHasIDMetadata := fieldIDValue != nil
-
-			if fieldIDValue != nil && *fieldIDValue == fieldID {
-				idMatches = append(idMatches, candidate{ref: arrowFieldRef{path: path}, pathName: pathName, hasIDMetadata: fieldHasIDMetadata})
-			}
-			if field.Name == targetName {
-				match := candidate{ref: arrowFieldRef{path: path}, pathName: pathName, hasIDMetadata: fieldHasIDMetadata}
-				nameMatches = append(nameMatches, match)
-				if pathName == fieldName {
-					pathMatches = append(pathMatches, match)
-				}
-			}
-
-			if nested, ok := field.Type.(*arrow.StructType); ok {
-				visit(nested.Fields(), path, pathName)
-			}
-		}
-	}
-	visit(schema.Fields(), nil, "")
-
+func equalityFieldLocation(filePath string) string {
 	location := filePath
 	if location == "" {
 		location = "data record"
 	}
 
-	if fieldID > 0 {
-		if len(idMatches) == 1 {
-			return idMatches[0].ref, nil
-		}
-		if len(idMatches) > 1 {
-			return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields",
-				ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(idMatches))
-		}
-	}
-	if len(pathMatches) == 1 {
-		if pathMatches[0].hasIDMetadata {
-			return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
-		}
+	return location
+}
 
-		return pathMatches[0].ref, nil
+// indexArrowFields derives Arrow child paths from the structurally aligned,
+// ID-resolved Iceberg file schema. It deliberately ignores names: dots in an
+// Iceberg name are literal and must not be interpreted as a path.
+func indexArrowFields(schema *iceberg.Schema) arrowFieldRefsByID {
+	refs := make(arrowFieldRefsByID)
+	if schema == nil {
+		return refs
 	}
-	if len(pathMatches) > 1 {
-		return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields named %q",
-			ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(pathMatches), fieldName)
-	}
-	if len(nameMatches) == 1 {
-		if nameMatches[0].hasIDMetadata {
-			return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
-		}
 
-		return nameMatches[0].ref, nil
-	}
-	if len(nameMatches) > 1 {
-		for _, match := range nameMatches {
-			if match.hasIDMetadata {
-				return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+	var visit func([]iceberg.NestedField, []int)
+	visit = func(fields []iceberg.NestedField, parentPath []int) {
+		for i, field := range fields {
+			path := append(append([]int(nil), parentPath...), i)
+			refs[field.ID] = append(refs[field.ID], arrowFieldRef{path: path})
+
+			if nested, ok := field.Type.(*iceberg.StructType); ok {
+				visit(nested.Fields(), path)
 			}
 		}
+	}
+	visit(schema.Fields(), nil)
 
-		return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields named %q",
-			ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(nameMatches), targetName)
+	return refs
+}
+
+// indexArrowFieldsByMetadata is used for delete files whose Arrow fields carry
+// IDs directly, before any name mapping is needed.
+func indexArrowFieldsByMetadata(schema *arrow.Schema) arrowFieldRefsByID {
+	refs := make(arrowFieldRefsByID)
+	var visit func([]arrow.Field, []int)
+	visit = func(fields []arrow.Field, parentPath []int) {
+		for i, field := range fields {
+			path := append(append([]int(nil), parentPath...), i)
+			if id := getFieldID(field); id != nil {
+				refs[*id] = append(refs[*id], arrowFieldRef{path: path})
+			}
+
+			if nested, ok := field.Type.(*arrow.StructType); ok {
+				visit(nested.Fields(), path)
+			}
+		}
+	}
+	visit(schema.Fields(), nil)
+
+	return refs
+}
+
+func resolveArrowField(refs arrowFieldRefsByID, fieldID int, fieldName, filePath string) (arrowFieldRef, error) {
+	matches := refs[fieldID]
+	location := equalityFieldLocation(filePath)
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields",
+			ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(matches))
 	}
 
 	return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
@@ -203,7 +182,7 @@ func makeArrowFieldEncoder(record arrow.RecordBatch, ref arrowFieldRef, fieldID 
 // the tasks and builds per-task delete key sets. Returns nil if there are
 // no equality deletes. Delete files with different equality field IDs are
 // kept as separate sets (not merged).
-func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceberg.Schema, tasks []FileScanTask, concurrency int) (map[int][]*equalityDeleteSet, error) {
+func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceberg.Schema, nameMapping iceberg.NameMapping, tasks []FileScanTask, concurrency int) (map[int][]*equalityDeleteSet, error) {
 	type deleteFileInfo struct {
 		file     iceberg.DataFile
 		fieldIDs []int
@@ -253,7 +232,7 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 
 		for _, info := range uniqueDeletes {
 			g.Go(func() error {
-				keys, colNames, err := readEqualityDeleteFile(ctx, fs, schema, info.file, info.fieldIDs)
+				keys, colNames, err := readEqualityDeleteFile(ctx, fs, schema, nameMapping, info.file, info.fieldIDs)
 				if err != nil {
 					return err
 				}
@@ -340,7 +319,7 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 
 // readEqualityDeleteFile reads a single equality delete file and returns
 // the set of encoded delete keys and the column names used.
-func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *iceberg.Schema, dataFile iceberg.DataFile, fieldIDs []int) (set[string], []string, error) {
+func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *iceberg.Schema, nameMapping iceberg.NameMapping, dataFile iceberg.DataFile, fieldIDs []int) (set[string], []string, error) {
 	src, err := internal.GetFile(ctx, fs, dataFile, true)
 	if err != nil {
 		return nil, nil, err
@@ -358,6 +337,33 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 	}
 	defer tbl.Release()
 
+	hasFieldIDs, err := VisitArrowSchema(tbl.Schema(), hasIDs{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var fileSchema *iceberg.Schema
+	if !hasFieldIDs {
+		if nameMapping == nil {
+			nameMapping = tableSchema.NameMapping()
+		}
+
+		fileSchema, err = ArrowSchemaToIcebergWithOptions(tbl.Schema(), ArrowToIcebergOptions{
+			NameMapping: nameMapping,
+			TableSchema: tableSchema,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var fieldRefsByID arrowFieldRefsByID
+	if hasFieldIDs {
+		fieldRefsByID = indexArrowFieldsByMetadata(tbl.Schema())
+	} else {
+		fieldRefsByID = indexArrowFields(fileSchema)
+	}
+
 	// Resolve column names from field IDs.
 	colNames := make([]string, len(fieldIDs))
 	fieldRefs := make([]arrowFieldRef, len(fieldIDs))
@@ -368,7 +374,7 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 			return nil, nil, fmt.Errorf("equality delete field ID %d not found in table schema for %s", fid, dataFile.FilePath())
 		}
 
-		ref, err := resolveArrowField(tbl.Schema(), fid, name, dataFile.FilePath())
+		ref, err := resolveArrowField(fieldRefsByID, fid, name, dataFile.FilePath())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -677,7 +683,8 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 // typed column encoders once per batch, then iterates rows without per-row type
 // switches. Each delete set is applied independently because sets may have
 // different field IDs.
-func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*equalityDeleteSet, dataFilePath string) (recProcessFn, error) {
+func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*equalityDeleteSet, fileSchema *iceberg.Schema, dataFilePath string) (recProcessFn, error) {
+	fieldRefsByID := indexArrowFields(fileSchema)
 	fieldRefs := make([][]arrowFieldRef, len(eqDeleteSets))
 	for i, eqDel := range eqDeleteSets {
 		if len(eqDel.fieldIDs) != len(eqDel.colNames) {
@@ -686,27 +693,18 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 		}
 
 		fieldRefs[i] = make([]arrowFieldRef, len(eqDel.fieldIDs))
-	}
+		for fieldIdx, fieldID := range eqDel.fieldIDs {
+			ref, err := resolveArrowField(fieldRefsByID, fieldID, eqDel.colNames[fieldIdx], dataFilePath)
+			if err != nil {
+				return nil, err
+			}
 
-	fieldsResolved := false
+			fieldRefs[i][fieldIdx] = ref
+		}
+	}
 
 	return func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
 		defer r.Release()
-
-		if !fieldsResolved {
-			for setIdx, eqDel := range eqDeleteSets {
-				for fieldIdx, fieldID := range eqDel.fieldIDs {
-					ref, err := resolveArrowField(r.Schema(), fieldID, eqDel.colNames[fieldIdx], dataFilePath)
-					if err != nil {
-						return nil, err
-					}
-
-					fieldRefs[setIdx][fieldIdx] = ref
-				}
-			}
-
-			fieldsResolved = true
-		}
 
 		mem := compute.GetAllocator(ctx)
 		numRows := int(r.NumRows())

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -47,6 +48,120 @@ type equalityDeleteSet struct {
 	keys     set[string]
 	fieldIDs []int
 	colNames []string
+}
+
+type arrowFieldRef struct {
+	path []int
+}
+
+func resolveArrowField(schema *arrow.Schema, fieldID int, fieldName, filePath string) (arrowFieldRef, error) {
+	type candidate struct {
+		ref           arrowFieldRef
+		pathName      string
+		hasIDMetadata bool
+	}
+
+	var (
+		idMatches   []candidate
+		nameMatches []candidate
+		pathMatches []candidate
+	)
+	targetName := fieldName
+	if dot := strings.LastIndexByte(targetName, '.'); dot >= 0 {
+		targetName = targetName[dot+1:]
+	}
+
+	var visit func([]arrow.Field, []int, string)
+	visit = func(fields []arrow.Field, parentPath []int, parentName string) {
+		for i, field := range fields {
+			path := append(append([]int(nil), parentPath...), i)
+			pathName := field.Name
+			if parentName != "" {
+				pathName = parentName + "." + field.Name
+			}
+			fieldIDValue := getFieldID(field)
+			fieldHasIDMetadata := fieldIDValue != nil
+
+			if fieldIDValue != nil && *fieldIDValue == fieldID {
+				idMatches = append(idMatches, candidate{ref: arrowFieldRef{path: path}, pathName: pathName, hasIDMetadata: fieldHasIDMetadata})
+			}
+			if field.Name == targetName {
+				match := candidate{ref: arrowFieldRef{path: path}, pathName: pathName, hasIDMetadata: fieldHasIDMetadata}
+				nameMatches = append(nameMatches, match)
+				if pathName == fieldName {
+					pathMatches = append(pathMatches, match)
+				}
+			}
+
+			if nested, ok := field.Type.(*arrow.StructType); ok {
+				visit(nested.Fields(), path, pathName)
+			}
+		}
+	}
+	visit(schema.Fields(), nil, "")
+
+	location := filePath
+	if location == "" {
+		location = "data record"
+	}
+
+	if fieldID > 0 {
+		switch len(idMatches) {
+		case 1:
+			return idMatches[0].ref, nil
+		case 0:
+		default:
+			return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields",
+				ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(idMatches))
+		}
+	}
+	if len(pathMatches) == 1 {
+		if pathMatches[0].hasIDMetadata {
+			return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+		}
+
+		return pathMatches[0].ref, nil
+	}
+	if len(pathMatches) > 1 {
+		return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields named %q",
+			ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(pathMatches), fieldName)
+	}
+	if len(nameMatches) == 1 {
+		if nameMatches[0].hasIDMetadata {
+			return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+		}
+
+		return nameMatches[0].ref, nil
+	}
+	if len(nameMatches) > 1 {
+		for _, match := range nameMatches {
+			if match.hasIDMetadata {
+				return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+			}
+		}
+
+		return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields named %q",
+			ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(nameMatches), targetName)
+	}
+
+	return arrowFieldRef{}, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+}
+
+func arrowArrayAtField(record arrow.RecordBatch, ref arrowFieldRef, fieldID int, fieldName, filePath string) (arrow.Array, error) {
+	if len(ref.path) == 0 || ref.path[0] >= int(record.NumCols()) {
+		return nil, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, filePath)
+	}
+
+	result := record.Column(ref.path[0])
+	for _, index := range ref.path[1:] {
+		structArray, ok := result.(*array.Struct)
+		if !ok || index >= structArray.NumField() {
+			return nil, fmt.Errorf("equality field ID %d (%s) has unsupported nested path in %s", fieldID, fieldName, filePath)
+		}
+		result = structArray.Field(index)
+	}
+
+	return result, nil
 }
 
 // readAllEqualityDeleteFiles reads all unique equality delete files from
@@ -210,7 +325,7 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 	// Resolve column names from field IDs.
 	colNames := make([]string, len(fieldIDs))
-	colIndices := make([]int, len(fieldIDs))
+	fieldRefs := make([]arrowFieldRef, len(fieldIDs))
 
 	for i, fid := range fieldIDs {
 		name, ok := tableSchema.FindColumnName(fid)
@@ -218,17 +333,13 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 			return nil, nil, fmt.Errorf("equality delete field ID %d not found in table schema", fid)
 		}
 
-		colNames[i] = name
-		indices := tbl.Schema().FieldIndices(name)
-		switch len(indices) {
-		case 0:
-			return nil, nil, fmt.Errorf("equality delete column %q not found in delete file %s", name, dataFile.FilePath())
-		case 1:
-			colIndices[i] = indices[0]
-		default:
-			return nil, nil, fmt.Errorf("%w: %q in delete file %s: found %d columns",
-				ErrAmbiguousEqualityColumn, name, dataFile.FilePath(), len(indices))
+		ref, err := resolveArrowField(tbl.Schema(), fid, name, dataFile.FilePath())
+		if err != nil {
+			return nil, nil, err
 		}
+
+		colNames[i] = name
+		fieldRefs[i] = ref
 	}
 
 	// Build the set of encoded delete keys by iterating aligned batches.
@@ -241,9 +352,13 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 	for tr.Next() {
 		rec := tr.RecordBatch()
-		encoders := make([]colEncoder, len(colIndices))
-		for i, idx := range colIndices {
-			encoders[i] = makeColEncoder(rec.Column(idx))
+		encoders := make([]colEncoder, len(fieldRefs))
+		for i, ref := range fieldRefs {
+			column, err := arrowArrayAtField(rec, ref, fieldIDs[i], colNames[i], dataFile.FilePath())
+			if err != nil {
+				return nil, nil, err
+			}
+			encoders[i] = makeColEncoder(column)
 		}
 
 		numRows := int(rec.NumRows())
@@ -357,7 +472,7 @@ func encodeArrowValue(buf *bytes.Buffer, arr arrow.Array, idx int) {
 // rows whose equality key columns match any entry in the delete sets.
 // Each set is applied independently (they may have different field IDs).
 func processEqualityDeletes(ctx context.Context, eqDeleteSets []*equalityDeleteSet) (recProcessFn, error) {
-	return processEqualityDeletesColumnar(ctx, eqDeleteSets)
+	return processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, "")
 }
 
 // colEncoder writes the value at row idx to buf. Resolved once per column
@@ -534,6 +649,10 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 // processEqualityDeletesColumnar resolves typed column encoders once per
 // batch, then iterates rows without per-row type switches.
 func processEqualityDeletesColumnar(ctx context.Context, eqDeleteSets []*equalityDeleteSet) (recProcessFn, error) {
+	return processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, "")
+}
+
+func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*equalityDeleteSet, dataFilePath string) (recProcessFn, error) {
 	return func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
 		defer r.Release()
 
@@ -554,16 +673,20 @@ func processEqualityDeletesColumnar(ctx context.Context, eqDeleteSets []*equalit
 		for _, eqDel := range eqDeleteSets {
 			encoders := make([]colEncoder, len(eqDel.colNames))
 			for i, name := range eqDel.colNames {
-				indices := r.Schema().FieldIndices(name)
-				if len(indices) == 0 {
-					return nil, fmt.Errorf("equality delete column %q not found in data record", name)
-				}
-				if len(indices) > 1 {
-					return nil, fmt.Errorf("%w: %q in data record: found %d columns",
-						ErrAmbiguousEqualityColumn, name, len(indices))
+				fieldID := 0
+				if i < len(eqDel.fieldIDs) {
+					fieldID = eqDel.fieldIDs[i]
 				}
 
-				encoders[i] = makeColEncoder(r.Column(indices[0]))
+				ref, err := resolveArrowField(r.Schema(), fieldID, name, dataFilePath)
+				if err != nil {
+					return nil, err
+				}
+				column, err := arrowArrayAtField(r, ref, fieldID, name, dataFilePath)
+				if err != nil {
+					return nil, err
+				}
+				encoders[i] = makeColEncoder(column)
 			}
 
 			for row := 0; row < numRows; row++ {

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -148,24 +148,56 @@ func resolveArrowField(schema *arrow.Schema, fieldID int, fieldName, filePath st
 }
 
 func arrowArrayAtField(record arrow.RecordBatch, ref arrowFieldRef, fieldID int, fieldName, filePath string) (arrow.Array, error) {
+	result, _, err := arrowArraysAtField(record, ref, fieldID, fieldName, filePath)
+
+	return result, err
+}
+
+func arrowArraysAtField(record arrow.RecordBatch, ref arrowFieldRef, fieldID int, fieldName, filePath string) (arrow.Array, []arrow.Array, error) {
 	location := filePath
 	if location == "" {
 		location = "data record"
 	}
 	if len(ref.path) == 0 || ref.path[0] >= int(record.NumCols()) {
-		return nil, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
+		return nil, nil, fmt.Errorf("equality field ID %d (%s) not found in %s", fieldID, fieldName, location)
 	}
 
 	result := record.Column(ref.path[0])
+	parents := make([]arrow.Array, 0, len(ref.path)-1)
 	for _, index := range ref.path[1:] {
 		structArray, ok := result.(*array.Struct)
 		if !ok || index >= structArray.NumField() {
-			return nil, fmt.Errorf("equality field ID %d (%s) has unsupported nested path in %s", fieldID, fieldName, location)
+			return nil, nil, fmt.Errorf("equality field ID %d (%s) has unsupported nested path in %s", fieldID, fieldName, location)
 		}
+		parents = append(parents, result)
 		result = structArray.Field(index)
 	}
 
-	return result, nil
+	return result, parents, nil
+}
+
+func makeArrowFieldEncoder(record arrow.RecordBatch, ref arrowFieldRef, fieldID int, fieldName, filePath string) (colEncoder, error) {
+	column, parents, err := arrowArraysAtField(record, ref, fieldID, fieldName, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	encoder := makeColEncoder(column)
+	if len(parents) == 0 {
+		return encoder, nil
+	}
+
+	return func(buf *bytes.Buffer, row int) {
+		for _, parent := range parents {
+			if parent.IsNull(row) {
+				buf.WriteByte(0)
+
+				return
+			}
+		}
+
+		encoder(buf, row)
+	}, nil
 }
 
 // readAllEqualityDeleteFiles reads all unique equality delete files from
@@ -358,11 +390,10 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 		rec := tr.RecordBatch()
 		encoders := make([]colEncoder, len(fieldRefs))
 		for i, ref := range fieldRefs {
-			column, err := arrowArrayAtField(rec, ref, fieldIDs[i], colNames[i], dataFile.FilePath())
+			encoders[i], err = makeArrowFieldEncoder(rec, ref, fieldIDs[i], colNames[i], dataFile.FilePath())
 			if err != nil {
 				return nil, nil, err
 			}
-			encoders[i] = makeColEncoder(column)
 		}
 
 		numRows := int(rec.NumRows())
@@ -686,11 +717,10 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 				if err != nil {
 					return nil, err
 				}
-				column, err := arrowArrayAtField(r, ref, fieldID, name, dataFilePath)
+				encoders[i], err = makeArrowFieldEncoder(r, ref, fieldID, name, dataFilePath)
 				if err != nil {
 					return nil, err
 				}
-				encoders[i] = makeColEncoder(column)
 			}
 
 			for row := 0; row < numRows; row++ {

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"unsafe"
@@ -35,6 +36,8 @@ import (
 	"github.com/apache/iceberg-go/table/internal"
 	"golang.org/x/sync/errgroup"
 )
+
+var ErrAmbiguousEqualityColumn = errors.New("equality delete column is ambiguous")
 
 // equalityDeleteSet holds the set of delete keys and the column names
 // used to look them up in data records. Each set corresponds to one
@@ -223,8 +226,8 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 		case 1:
 			colIndices[i] = indices[0]
 		default:
-			return nil, nil, fmt.Errorf("equality delete column %q is ambiguous in delete file %s: found %d columns",
-				name, dataFile.FilePath(), len(indices))
+			return nil, nil, fmt.Errorf("%w: %q in delete file %s: found %d columns",
+				ErrAmbiguousEqualityColumn, name, dataFile.FilePath(), len(indices))
 		}
 	}
 
@@ -554,6 +557,10 @@ func processEqualityDeletesColumnar(ctx context.Context, eqDeleteSets []*equalit
 				indices := r.Schema().FieldIndices(name)
 				if len(indices) == 0 {
 					return nil, fmt.Errorf("equality delete column %q not found in data record", name)
+				}
+				if len(indices) > 1 {
+					return nil, fmt.Errorf("%w: %q in data record: found %d columns",
+						ErrAmbiguousEqualityColumn, name, len(indices))
 				}
 
 				encoders[i] = makeColEncoder(r.Column(indices[0]))

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -106,11 +106,10 @@ func resolveArrowField(schema *arrow.Schema, fieldID int, fieldName, filePath st
 	}
 
 	if fieldID > 0 {
-		switch len(idMatches) {
-		case 1:
+		if len(idMatches) == 1 {
 			return idMatches[0].ref, nil
-		case 0:
-		default:
+		}
+		if len(idMatches) > 1 {
 			return arrowFieldRef{}, fmt.Errorf("%w: equality field ID %d (%s) in %s: found %d fields",
 				ErrAmbiguousEqualityColumn, fieldID, fieldName, location, len(idMatches))
 		}
@@ -503,13 +502,6 @@ func encodeArrowValue(buf *bytes.Buffer, arr arrow.Array, idx int) {
 	}
 }
 
-// processEqualityDeletes returns a pipeline function that filters out
-// rows whose equality key columns match any entry in the delete sets.
-// Each set is applied independently (they may have different field IDs).
-func processEqualityDeletes(ctx context.Context, eqDeleteSets []*equalityDeleteSet) (recProcessFn, error) {
-	return processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, "")
-}
-
 // colEncoder writes the value at row idx to buf. Resolved once per column
 // to avoid per-row type switches.
 type colEncoder func(buf *bytes.Buffer, row int)
@@ -681,15 +673,40 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 	}
 }
 
-// processEqualityDeletesColumnar resolves typed column encoders once per
-// batch, then iterates rows without per-row type switches.
-func processEqualityDeletesColumnar(ctx context.Context, eqDeleteSets []*equalityDeleteSet) (recProcessFn, error) {
-	return processEqualityDeletesColumnarForFile(ctx, eqDeleteSets, "")
-}
-
+// processEqualityDeletesColumnarForFile resolves field paths once per file and
+// typed column encoders once per batch, then iterates rows without per-row type
+// switches. Each delete set is applied independently because sets may have
+// different field IDs.
 func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*equalityDeleteSet, dataFilePath string) (recProcessFn, error) {
+	fieldRefs := make([][]arrowFieldRef, len(eqDeleteSets))
+	for i, eqDel := range eqDeleteSets {
+		if len(eqDel.fieldIDs) != len(eqDel.colNames) {
+			return nil, fmt.Errorf("%w: equality delete set has %d field IDs and %d column names",
+				iceberg.ErrInvalidArgument, len(eqDel.fieldIDs), len(eqDel.colNames))
+		}
+
+		fieldRefs[i] = make([]arrowFieldRef, len(eqDel.fieldIDs))
+	}
+
+	fieldsResolved := false
+
 	return func(r arrow.RecordBatch) (arrow.RecordBatch, error) {
 		defer r.Release()
+
+		if !fieldsResolved {
+			for setIdx, eqDel := range eqDeleteSets {
+				for fieldIdx, fieldID := range eqDel.fieldIDs {
+					ref, err := resolveArrowField(r.Schema(), fieldID, eqDel.colNames[fieldIdx], dataFilePath)
+					if err != nil {
+						return nil, err
+					}
+
+					fieldRefs[setIdx][fieldIdx] = ref
+				}
+			}
+
+			fieldsResolved = true
+		}
 
 		mem := compute.GetAllocator(ctx)
 		numRows := int(r.NumRows())
@@ -705,19 +722,11 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 
 		var keyBuf bytes.Buffer
 
-		for _, eqDel := range eqDeleteSets {
+		for setIdx, eqDel := range eqDeleteSets {
 			encoders := make([]colEncoder, len(eqDel.colNames))
 			for i, name := range eqDel.colNames {
-				fieldID := 0
-				if i < len(eqDel.fieldIDs) {
-					fieldID = eqDel.fieldIDs[i]
-				}
-
-				ref, err := resolveArrowField(r.Schema(), fieldID, name, dataFilePath)
-				if err != nil {
-					return nil, err
-				}
-				encoders[i], err = makeArrowFieldEncoder(r, ref, fieldID, name, dataFilePath)
+				var err error
+				encoders[i], err = makeArrowFieldEncoder(r, fieldRefs[setIdx][i], eqDel.fieldIDs[i], name, dataFilePath)
 				if err != nil {
 					return nil, err
 				}

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -49,7 +49,7 @@ func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.Rec
 				defer rec.Release()
 
 				delSet := buildDel(nDel)
-				filterFn, err := processEqualityDeletes(ctx, []*equalityDeleteSet{delSet})
+				filterFn, err := processEqualityDeletesColumnarForFile(ctx, []*equalityDeleteSet{delSet}, "data.parquet")
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
 )
 
 func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.RecordBatch, buildDel func(int) *equalityDeleteSet) {
@@ -49,7 +50,11 @@ func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.Rec
 				defer rec.Release()
 
 				delSet := buildDel(nDel)
-				filterFn, err := processEqualityDeletesColumnarForFile(ctx, []*equalityDeleteSet{delSet}, "data.parquet")
+				fileSchema := iceberg.NewSchema(0,
+					iceberg.NestedField{ID: 1, Name: "first", Type: iceberg.PrimitiveTypes.Int64},
+					iceberg.NestedField{ID: 2, Name: "second", Type: iceberg.PrimitiveTypes.Int64},
+				)
+				filterFn, err := processEqualityDeletesColumnarForFile(ctx, []*equalityDeleteSet{delSet}, fileSchema, "data.parquet")
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -247,15 +247,26 @@ func TestProcessEqualityDeletesRejectsAmbiguousDataColumns(t *testing.T) {
 	first.Release()
 	second.Release()
 
-	process, err := processEqualityDeletesColumnar(context.Background(), []*equalityDeleteSet{{
+	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
 		keys:     make(set[string]),
 		fieldIDs: []int{1},
 		colNames: []string{"id"},
-	}})
+	}}, "data.parquet")
 	require.NoError(t, err)
 
 	_, err = process(record)
 	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
+}
+
+func TestProcessEqualityDeletesRejectsMismatchedFieldMetadata(t *testing.T) {
+	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
+		keys:     make(set[string]),
+		fieldIDs: []int{1},
+		colNames: []string{"id", "other"},
+	}}, "data.parquet")
+
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Nil(t, process)
 }
 
 func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -76,6 +76,42 @@ func TestMakeColEncoderMatchesGenericForNullFastPathTypes(t *testing.T) {
 	}
 }
 
+func TestMakeArrowFieldEncoderHonorsNullStructParents(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	childBuilder := array.NewInt64Builder(mem)
+	childBuilder.Append(123)
+	childBuilder.Append(456)
+	child := childBuilder.NewArray()
+	childBuilder.Release()
+	defer child.Release()
+	structArray, err := array.NewStructArrayWithNulls(
+		[]arrow.Array{child}, []string{"id"}, memory.NewBufferBytes([]byte{0x02}), 1, 0)
+	require.NoError(t, err)
+	structType := structArray.DataType().(*arrow.StructType)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "person", Type: structType}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{structArray}, 2)
+	structArray.Release()
+	defer record.Release()
+
+	assert.False(t, record.Column(0).(*array.Struct).Field(0).IsNull(0), "child storage must remain valid under the null parent")
+
+	encoder, err := makeArrowFieldEncoder(record, arrowFieldRef{path: []int{0, 0}}, 1, "person.id", "")
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+	encoder(&got, 0)
+	assert.Equal(t, []byte{0}, got.Bytes())
+
+	got.Reset()
+	encoder(&got, 1)
+	var want bytes.Buffer
+	encodeArrowValue(&want, record.Column(0).(*array.Struct).Field(0), 1)
+	assert.Equal(t, want.Bytes(), got.Bytes())
+}
+
 type encoderArrayShape int
 
 const (

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -212,10 +212,42 @@ func TestProcessEqualityDeletesRejectsAmbiguousDataColumns(t *testing.T) {
 
 	process, err := processEqualityDeletesColumnar(context.Background(), []*equalityDeleteSet{{
 		keys:     make(set[string]),
+		fieldIDs: []int{1},
 		colNames: []string{"id"},
 	}})
 	require.NoError(t, err)
 
 	_, err = process(record)
 	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
+}
+
+func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "id",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"}),
+		},
+		{
+			Name:     "id",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
+		},
+		{
+			Name: "record",
+			Type: arrow.StructOf(arrow.Field{
+				Name:     "value",
+				Type:     arrow.PrimitiveTypes.Int64,
+				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "3"}),
+			}),
+		},
+	}, nil)
+
+	ref, err := resolveArrowField(schema, 2, "id", "data.parquet")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, ref.path)
+
+	ref, err = resolveArrowField(schema, 3, "record.value", "data.parquet")
+	require.NoError(t, err)
+	assert.Equal(t, []int{2, 0}, ref.path)
 }

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -314,6 +314,7 @@ func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
 				}
 				assert.Contains(t, err.Error(), test.wantErr.Error())
 				assert.Contains(t, err.Error(), "data.parquet")
+
 				return
 			}
 

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -250,4 +251,74 @@ func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {
 	ref, err = resolveArrowField(schema, 3, "record.value", "data.parquet")
 	require.NoError(t, err)
 	assert.Equal(t, []int{2, 0}, ref.path)
+}
+
+func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		schema    *arrow.Schema
+		fieldID   int
+		fieldName string
+		wantPath  []int
+		wantErr   error
+	}{
+		{
+			name: "renamed field uses matching ID",
+			schema: arrow.NewSchema([]arrow.Field{{
+				Name: "renamed", Type: arrow.PrimitiveTypes.Int64,
+				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "7"}),
+			}}, nil),
+			fieldID: 7, fieldName: "old_name", wantPath: []int{0},
+		},
+		{
+			name: "unique name with wrong ID is rejected",
+			schema: arrow.NewSchema([]arrow.Field{{
+				Name: "id", Type: arrow.PrimitiveTypes.Int64,
+				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
+			}}, nil),
+			fieldID: 1, fieldName: "id", wantErr: errors.New("not found"),
+		},
+		{
+			name: "duplicate IDs are rejected",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "left", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
+				{Name: "right", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
+			}, nil),
+			fieldID: 1, fieldName: "left", wantErr: ErrAmbiguousEqualityColumn,
+		},
+		{
+			name: "repeated nested leaf names are ambiguous without IDs",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "left", Type: arrow.StructOf(arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})},
+				{Name: "right", Type: arrow.StructOf(arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})},
+			}, nil),
+			fieldName: "value", wantErr: ErrAmbiguousEqualityColumn,
+		},
+		{
+			name: "case-sensitive name fallback remains unique",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+				{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
+			}, nil),
+			fieldName: "id", wantPath: []int{0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ref, err := resolveArrowField(test.schema, test.fieldID, test.fieldName, "data.parquet")
+			if test.wantErr != nil {
+				require.Error(t, err)
+				if test.wantErr == ErrAmbiguousEqualityColumn {
+					assert.ErrorIs(t, err, test.wantErr)
+				}
+				assert.Contains(t, err.Error(), test.wantErr.Error())
+				assert.Contains(t, err.Error(), "data.parquet")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantPath, ref.path)
+		})
+	}
 }

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -224,6 +224,7 @@ func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
 		t.Context(),
 		iceio.NewMemFS(),
 		schema,
+		nil,
 		[]FileScanTask{{EqualityDeleteFiles: []iceberg.DataFile{deleteFile}}},
 		1,
 	)
@@ -231,13 +232,15 @@ func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
 	require.ErrorContains(t, err, "empty-equality-fields.parquet")
 }
 
-func TestProcessEqualityDeletesRejectsAmbiguousDataColumns(t *testing.T) {
+func TestProcessEqualityDeletesUsesStructuralFieldPaths(t *testing.T) {
 	builder := array.NewInt64Builder(memory.DefaultAllocator)
 	builder.Append(1)
 	first := builder.NewArray()
 	builder.Append(2)
 	second := builder.NewArray()
 	builder.Release()
+	var key bytes.Buffer
+	encodeArrowValue(&key, first, 0)
 
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
@@ -247,15 +250,21 @@ func TestProcessEqualityDeletesRejectsAmbiguousDataColumns(t *testing.T) {
 	first.Release()
 	second.Release()
 
+	fileSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "left", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "right", Type: iceberg.PrimitiveTypes.Int64},
+	)
 	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
-		keys:     make(set[string]),
+		keys:     set[string]{key.String(): {}},
 		fieldIDs: []int{1},
 		colNames: []string{"id"},
-	}}, "data.parquet")
+	}}, fileSchema, "data.parquet")
 	require.NoError(t, err)
 
-	_, err = process(record)
-	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
+	result, err := process(record)
+	require.NoError(t, err)
+	assert.Zero(t, result.NumRows())
+	result.Release()
 }
 
 func TestProcessEqualityDeletesRejectsMismatchedFieldMetadata(t *testing.T) {
@@ -263,39 +272,27 @@ func TestProcessEqualityDeletesRejectsMismatchedFieldMetadata(t *testing.T) {
 		keys:     make(set[string]),
 		fieldIDs: []int{1},
 		colNames: []string{"id", "other"},
-	}}, "data.parquet")
+	}}, iceberg.NewSchema(0), "data.parquet")
 
 	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	assert.Nil(t, process)
 }
 
 func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {
-	schema := arrow.NewSchema([]arrow.Field{
-		{
-			Name:     "id",
-			Type:     arrow.PrimitiveTypes.Int64,
-			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"}),
-		},
-		{
-			Name:     "id",
-			Type:     arrow.PrimitiveTypes.Int64,
-			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
-		},
-		{
-			Name: "record",
-			Type: arrow.StructOf(arrow.Field{
-				Name:     "value",
-				Type:     arrow.PrimitiveTypes.Int64,
-				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "3"}),
-			}),
-		},
-	}, nil)
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "renamed", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 4, Name: "record", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+			{ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Int64},
+		}}},
+	)
 
-	ref, err := resolveArrowField(schema, 2, "id", "data.parquet")
+	refs := indexArrowFields(schema)
+	ref, err := resolveArrowField(refs, 2, "id", "data.parquet")
 	require.NoError(t, err)
 	assert.Equal(t, []int{1}, ref.path)
 
-	ref, err = resolveArrowField(schema, 3, "record.value", "data.parquet")
+	ref, err = resolveArrowField(refs, 3, "record.value", "data.parquet")
 	require.NoError(t, err)
 	assert.Equal(t, []int{2, 0}, ref.path)
 }
@@ -303,7 +300,7 @@ func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {
 func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
 	tests := []struct {
 		name      string
-		schema    *arrow.Schema
+		schema    *iceberg.Schema
 		fieldID   int
 		fieldName string
 		wantPath  []int
@@ -311,49 +308,33 @@ func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
 	}{
 		{
 			name: "renamed field uses matching ID",
-			schema: arrow.NewSchema([]arrow.Field{{
-				Name: "renamed", Type: arrow.PrimitiveTypes.Int64,
-				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "7"}),
-			}}, nil),
+			schema: iceberg.NewSchema(0, iceberg.NestedField{
+				ID: 7, Name: "renamed", Type: iceberg.PrimitiveTypes.Int64,
+			}),
 			fieldID: 7, fieldName: "old_name", wantPath: []int{0},
 		},
 		{
-			name: "unique name with wrong ID is rejected",
-			schema: arrow.NewSchema([]arrow.Field{{
-				Name: "id", Type: arrow.PrimitiveTypes.Int64,
-				Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
-			}}, nil),
+			name: "missing ID is rejected even if a name matches",
+			schema: iceberg.NewSchema(0, iceberg.NestedField{
+				ID: 2, Name: "id", Type: iceberg.PrimitiveTypes.Int64,
+			}),
 			fieldID: 1, fieldName: "id", wantErr: errors.New("not found"),
 		},
 		{
-			name: "duplicate IDs are rejected",
-			schema: arrow.NewSchema([]arrow.Field{
-				{Name: "left", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
-				{Name: "right", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
-			}, nil),
-			fieldID: 1, fieldName: "left", wantErr: ErrAmbiguousEqualityColumn,
-		},
-		{
-			name: "repeated nested leaf names are ambiguous without IDs",
-			schema: arrow.NewSchema([]arrow.Field{
-				{Name: "left", Type: arrow.StructOf(arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})},
-				{Name: "right", Type: arrow.StructOf(arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})},
-			}, nil),
-			fieldName: "value", wantErr: ErrAmbiguousEqualityColumn,
-		},
-		{
-			name: "case-sensitive name fallback remains unique",
-			schema: arrow.NewSchema([]arrow.Field{
-				{Name: "id", Type: arrow.PrimitiveTypes.Int64},
-				{Name: "ID", Type: arrow.PrimitiveTypes.Int64},
-			}, nil),
-			fieldName: "id", wantPath: []int{0},
+			name: "literal dotted name is distinct from nested path",
+			schema: iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "user.id", Type: iceberg.PrimitiveTypes.Int64},
+				iceberg.NestedField{ID: 2, Name: "user", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 3, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+				}}},
+			),
+			fieldID: 1, fieldName: "user.id", wantPath: []int{0},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ref, err := resolveArrowField(test.schema, test.fieldID, test.fieldName, "data.parquet")
+			ref, err := resolveArrowField(indexArrowFields(test.schema), test.fieldID, test.fieldName, "data.parquet")
 			if test.wantErr != nil {
 				require.Error(t, err)
 				if test.wantErr == ErrAmbiguousEqualityColumn {
@@ -369,4 +350,15 @@ func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
 			assert.Equal(t, test.wantPath, ref.path)
 		})
 	}
+}
+
+func TestResolveArrowFieldRejectsDuplicateMetadataIDs(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "left", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
+		{Name: "right", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
+	}, nil)
+
+	_, err := resolveArrowField(indexArrowFieldsByMetadata(schema), 1, "id", "data.parquet")
+	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
+	require.ErrorContains(t, err, "data.parquet")
 }

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -191,4 +192,30 @@ func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrEmptyEqualityFieldIDs)
 	require.ErrorContains(t, err, "empty-equality-fields.parquet")
+}
+
+func TestProcessEqualityDeletesRejectsAmbiguousDataColumns(t *testing.T) {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	first := builder.NewArray()
+	builder.Append(2)
+	second := builder.NewArray()
+	builder.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{first, second}, 1)
+	first.Release()
+	second.Release()
+
+	process, err := processEqualityDeletesColumnar(context.Background(), []*equalityDeleteSet{{
+		keys:     make(set[string]),
+		colNames: []string{"id"},
+	}})
+	require.NoError(t, err)
+
+	_, err = process(record)
+	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
 }

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
@@ -120,6 +122,55 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 	}
 
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows with id=2 and id=4 deleted")
+}
+
+func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
+	tbl := newEqDeleteReadTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, false, false)
+	require.NoError(t, err)
+	dataPath := tbl.Location() + "/data/data.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "one"}]`)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	deleteSchema, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		nil, true, false)
+	require.NoError(t, err)
+	duplicateSchema := arrow.NewSchema([]arrow.Field{deleteSchema.Field(0), deleteSchema.Field(0)}, nil)
+	deletePath := tbl.Location() + "/data/delete.parquet"
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	first := builder.NewArray()
+	builder.Append(2)
+	second := builder.NewArray()
+	builder.Release()
+	batch := array.NewRecordBatch(duplicateSchema, []arrow.Array{first, second}, 1)
+	first.Release()
+	second.Release()
+	deleteTable := array.NewTableFromRecords(duplicateSchema, []arrow.RecordBatch{batch})
+	batch.Release()
+	file, err := iceio.LocalFS{}.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(deleteTable, file, 1,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	deleteTable.Release()
+	deleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	deleteBuilder.EqualityFieldIDs([]int{1})
+	tx = tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddDeletes(deleteBuilder.Build())
+	require.NoError(t, rd.Commit(t.Context()))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	_, _, err = tbl.Scan().ToArrowRecords(t.Context())
+	require.ErrorContains(t, err, `equality delete column "id" is ambiguous`)
 }
 
 func TestEqualityDeleteDoesNotAffectSameSnapshot(t *testing.T) {

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -154,6 +154,7 @@ func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	batch.Release()
 	file, err := iceio.LocalFS{}.Create(deletePath)
 	require.NoError(t, err)
+	defer file.Close()
 	require.NoError(t, pqarrow.WriteTable(deleteTable, file, 1,
 		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
 	deleteTable.Release()
@@ -170,7 +171,7 @@ func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = tbl.Scan().ToArrowRecords(t.Context())
-	require.ErrorContains(t, err, `equality delete column "id" is ambiguous`)
+	require.ErrorIs(t, err, table.ErrAmbiguousEqualityColumn)
 }
 
 func TestEqualityDeleteDoesNotAffectSameSnapshot(t *testing.T) {

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -356,6 +356,7 @@ func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	batch.Release()
 	file, err := iceio.LocalFS{}.Create(deletePath)
 	require.NoError(t, err)
+	defer file.Close()
 	require.NoError(t, pqarrow.WriteTable(deleteTable, file, 1,
 		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
 	deleteTable.Release()

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -19,7 +19,7 @@ package table_test
 
 import (
 	"context"
-	"io/fs"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,16 +39,26 @@ import (
 func newEqDeleteReadTestTable(t *testing.T) *table.Table {
 	t.Helper()
 
-	location := filepath.ToSlash(t.TempDir())
-
 	iceSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
 	)
 
+	return newEqDeleteReadTestTableWithSchema(t, iceSchema, nil)
+}
+
+func newEqDeleteReadTestTableWithSchema(t *testing.T, iceSchema *iceberg.Schema, properties iceberg.Properties) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	if properties == nil {
+		properties = iceberg.Properties{}
+	}
+	properties[table.PropertyFormatVersion] = "2"
+
 	meta, err := table.NewMetadata(iceSchema, iceberg.UnpartitionedSpec,
 		table.UnsortedSortOrder, location,
-		iceberg.Properties{table.PropertyFormatVersion: "2"})
+		properties)
 	require.NoError(t, err)
 
 	return table.New(
@@ -59,6 +69,15 @@ func newEqDeleteReadTestTable(t *testing.T) *table.Table {
 		},
 		&rowDeltaCatalog{metadata: meta},
 	)
+}
+
+func nameMappingProperties(t *testing.T, mapping iceberg.NameMapping) iceberg.Properties {
+	t.Helper()
+
+	mappingJSON, err := json.Marshal(mapping)
+	require.NoError(t, err)
+
+	return iceberg.Properties{table.DefaultNameMappingKey: string(mappingJSON)}
 }
 
 func TestEqualityDeleteReadRoundTrip(t *testing.T) {
@@ -183,6 +202,130 @@ func TestEqualityDeleteReadResolvesRenamedDataColumnByFieldID(t *testing.T) {
 	assert.Equal(t, []int64{1, 3}, ids)
 }
 
+func TestEqualityDeleteReadResolvesRenamedDataColumnByNameMapping(t *testing.T) {
+	iceSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+	)
+	mapping := iceSchema.NameMapping()
+	mapping[0].Names = append(mapping[0].Names, "legacy_id")
+	tbl := newEqDeleteReadTestTableWithSchema(t, iceSchema, nameMappingProperties(t, mapping))
+
+	dataSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "legacy_id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	dataPath := tbl.Location() + "/data/data-name-mapped.parquet"
+	writeParquetFile(t, dataPath, dataSchema, `[
+		{"legacy_id": 1, "data": "one"},
+		{"legacy_id": 2, "data": "two"},
+		{"legacy_id": 3, "data": "three"}
+	]`)
+	dataBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		dataPath, iceberg.ParquetFile, nil, nil, nil, 3, mustFileSize(t, dataPath))
+	require.NoError(t, err)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddDataFiles(t.Context(), []iceberg.DataFile{dataBuilder.Build()}, nil))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	deleteSchema, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		nil, true, false)
+	require.NoError(t, err)
+	deletePath := tbl.Location() + "/data/delete-name-mapped.parquet"
+	writeParquetFile(t, deletePath, deleteSchema, `[{"id": 2}]`)
+
+	deleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	deleteBuilder.EqualityFieldIDs([]int{1})
+
+	tx = tbl.NewTransaction()
+	rowDelta := tx.NewRowDelta(nil)
+	rowDelta.AddDeletes(deleteBuilder.Build())
+	require.NoError(t, rowDelta.Commit(t.Context()))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	_, records, err := tbl.Scan(table.WithSelectedFields("id")).ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	var ids []int64
+	for record, err := range records {
+		require.NoError(t, err)
+		column := record.Column(0).(*array.Int64)
+		for i := 0; i < column.Len(); i++ {
+			ids = append(ids, column.Value(i))
+		}
+		record.Release()
+	}
+
+	assert.Equal(t, []int64{1, 3}, ids)
+}
+
+func TestEqualityDeleteReadResolvesLiteralDottedColumnName(t *testing.T) {
+	iceSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "user.id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+	)
+	tbl := newEqDeleteReadTestTableWithSchema(t, iceSchema, nameMappingProperties(t, iceSchema.NameMapping()))
+
+	dataSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "user.id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	dataPath := tbl.Location() + "/data/data-dotted-name.parquet"
+	writeParquetFile(t, dataPath, dataSchema, `[
+		{"user.id": 1, "data": "one"},
+		{"user.id": 2, "data": "two"},
+		{"user.id": 3, "data": "three"}
+	]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	deleteSchema, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "user.id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		nil, true, false)
+	require.NoError(t, err)
+	deletePath := tbl.Location() + "/data/delete-dotted-name.parquet"
+	writeParquetFile(t, deletePath, deleteSchema, `[{"user.id": 2}]`)
+
+	deleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	deleteBuilder.EqualityFieldIDs([]int{1})
+
+	tx = tbl.NewTransaction()
+	rowDelta := tx.NewRowDelta(nil)
+	rowDelta.AddDeletes(deleteBuilder.Build())
+	require.NoError(t, rowDelta.Commit(t.Context()))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	_, records, err := tbl.Scan().ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	var ids []int64
+	for record, err := range records {
+		require.NoError(t, err)
+		column := record.Column(0).(*array.Int64)
+		for i := 0; i < column.Len(); i++ {
+			ids = append(ids, column.Value(i))
+		}
+		record.Release()
+	}
+
+	assert.Equal(t, []int64{1, 3}, ids)
+}
+
 func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	tbl := newEqDeleteReadTestTable(t)
 	arrowSc, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, false, false)
@@ -213,13 +356,8 @@ func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	batch.Release()
 	file, err := iceio.LocalFS{}.Create(deletePath)
 	require.NoError(t, err)
-	writeErr := pqarrow.WriteTable(deleteTable, file, 1,
-		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps())
-	closeErr := file.Close()
-	require.NoError(t, writeErr)
-	if closeErr != nil {
-		require.ErrorIs(t, closeErr, fs.ErrClosed)
-	}
+	require.NoError(t, pqarrow.WriteTable(deleteTable, file, 1,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
 	deleteTable.Release()
 	deleteBuilder, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -19,6 +19,7 @@ package table_test
 
 import (
 	"context"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -154,9 +155,13 @@ func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	batch.Release()
 	file, err := iceio.LocalFS{}.Create(deletePath)
 	require.NoError(t, err)
-	defer file.Close()
-	require.NoError(t, pqarrow.WriteTable(deleteTable, file, 1,
-		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	writeErr := pqarrow.WriteTable(deleteTable, file, 1,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps())
+	closeErr := file.Close()
+	require.NoError(t, writeErr)
+	if closeErr != nil {
+		require.ErrorIs(t, closeErr, fs.ErrClosed)
+	}
 	deleteTable.Release()
 	deleteBuilder, err := iceberg.NewDataFileBuilder(
 		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -125,6 +125,64 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows with id=2 and id=4 deleted")
 }
 
+func TestEqualityDeleteReadResolvesRenamedDataColumnByFieldID(t *testing.T) {
+	tbl := newEqDeleteReadTestTable(t)
+
+	dataSchema, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, true, false)
+	require.NoError(t, err)
+	dataFields := dataSchema.Fields()
+	dataFields[0].Name = "legacy_id"
+	dataMetadata := dataSchema.Metadata()
+	dataSchema = arrow.NewSchema(dataFields, &dataMetadata)
+
+	dataPath := tbl.Location() + "/data/data-renamed.parquet"
+	writeParquetFile(t, dataPath, dataSchema, `[
+		{"legacy_id": 1, "data": "one"},
+		{"legacy_id": 2, "data": "two"},
+		{"legacy_id": 3, "data": "three"}
+	]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	deleteSchema, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		nil, true, false)
+	require.NoError(t, err)
+	deletePath := tbl.Location() + "/data/delete-renamed.parquet"
+	writeParquetFile(t, deletePath, deleteSchema, `[{"id": 2}]`)
+
+	deleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	deleteBuilder.EqualityFieldIDs([]int{1})
+
+	tx = tbl.NewTransaction()
+	rowDelta := tx.NewRowDelta(nil)
+	rowDelta.AddDeletes(deleteBuilder.Build())
+	require.NoError(t, rowDelta.Commit(t.Context()))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	_, records, err := tbl.Scan(table.WithSelectedFields("id")).ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	var ids []int64
+	for record, err := range records {
+		require.NoError(t, err)
+		column := record.Column(0).(*array.Int64)
+		for i := 0; i < column.Len(); i++ {
+			ids = append(ids, column.Value(i))
+		}
+		record.Release()
+	}
+
+	assert.Equal(t, []int64{1, 3}, ids)
+}
+
 func TestEqualityDeleteReadRejectsAmbiguousColumns(t *testing.T) {
 	tbl := newEqDeleteReadTestTable(t)
 	arrowSc, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, false, false)


### PR DESCRIPTION
## Summary

Resolve equality-delete fields by Iceberg field ID on both delete files and data files.

## Why

Arrow permits duplicate field names, and Iceberg columns can be renamed or stored in legacy files without embedded field IDs. Equality-delete filtering must bind to Iceberg field identity instead of selecting the first matching Arrow name.

## What changed

- Build a per-file field ID to Arrow path index from the ID-resolved physical schema
- Use embedded Parquet field IDs when present and the table name mapping when IDs are absent
- Support equality fields nested in structs, including null parent structs
- Reject duplicate physical field IDs and ambiguous equality-delete columns
- Validate equality field ID and column-name metadata before filtering
- Reuse resolved field paths across record batches while rebuilding array encoders per batch

## Tests

- Duplicate equality columns and duplicate field IDs
- Renamed physical columns with embedded field IDs
- Renamed physical columns resolved through a name mapping
- Literal dotted column names without embedded field IDs
- Nested struct paths and null parent structs
- Mismatched equality field metadata
- `go test ./table`
- Focused equality-delete tests with the race detector