### PR TITLE
fix(codec): validate scan ranges against file size

### DIFF
--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -135,9 +135,6 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: file: %w", err)
 	}
-	if err := validateScanRange(envelope.Start, envelope.Length, file.FileSizeBytes()); err != nil {
-		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: %w", err)
-	}
 	del, err := decodeDataFileSlice(envelope.DeleteFiles, spec, schema, version)
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: delete files: %w", err)

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -58,6 +58,9 @@ func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, sch
 	if err := checkDataFileSpecID(task.File, spec); err != nil {
 		return nil, fmt.Errorf("codec: EncodeFileScanTask: %w", err)
 	}
+	if err := validateScanRange(task.Start, task.Length, task.File.FileSizeBytes()); err != nil {
+		return nil, fmt.Errorf("codec: EncodeFileScanTask: %w", err)
+	}
 	fileBytes, err := EncodeDataFile(task.File, spec, schema, version)
 	if err != nil {
 		return nil, fmt.Errorf("codec: EncodeFileScanTask: file: %w", err)
@@ -132,6 +135,9 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: file: %w", err)
 	}
+	if err := validateScanRange(envelope.Start, envelope.Length, file.FileSizeBytes()); err != nil {
+		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: %w", err)
+	}
 	del, err := decodeDataFileSlice(envelope.DeleteFiles, spec, schema, version)
 	if err != nil {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: delete files: %w", err)
@@ -160,6 +166,14 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 		FirstRowID:          envelope.FirstRowID,
 		DataSequenceNumber:  envelope.DataSequenceNumber,
 	}, nil
+}
+
+func validateScanRange(start, length, fileSize int64) error {
+	if start > fileSize || length > fileSize-start {
+		return fmt.Errorf("scan range start=%d length=%d exceeds file size %d", start, length, fileSize)
+	}
+
+	return nil
 }
 
 // fileScanTaskShape is a compile-time drift guard for FileScanTask.

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -169,6 +169,8 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 }
 
 func validateScanRange(start, length, fileSize int64) error {
+	// Check the end as a subtraction after confirming start <= fileSize so
+	// start+length cannot overflow int64.
 	if start > fileSize || length > fileSize-start {
 		return fmt.Errorf("scan range start=%d length=%d exceeds file size %d", start, length, fileSize)
 	}

--- a/codec/file_scan_task.go
+++ b/codec/file_scan_task.go
@@ -43,6 +43,8 @@ import (
 // partition spec than the data file; the caller is responsible for
 // partitioning the FileScanTask by per-file specID and calling
 // EncodeFileScanTask once per group.
+// The scan range is checked against the DataFile's recorded file size, which
+// is manifest metadata rather than a filesystem stat.
 func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, schema *iceberg.Schema, version int) ([]byte, error) {
 	if version < 1 || version > 3 {
 		return nil, fmt.Errorf("codec: EncodeFileScanTask: unsupported format version %d", version)
@@ -116,6 +118,9 @@ func EncodeFileScanTask(task table.FileScanTask, spec iceberg.PartitionSpec, sch
 
 // DecodeFileScanTask reverses [EncodeFileScanTask]. The triple
 // (spec, schema, version) must match the encoder.
+// Decode accepts non-negative ranges beyond the recorded file size for
+// interoperability with foreign encoders; callers that re-encode the task
+// must validate the range before doing so.
 func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg.Schema, version int) (table.FileScanTask, error) {
 	if version < 1 || version > 3 {
 		return table.FileScanTask{}, fmt.Errorf("codec: DecodeFileScanTask: unsupported format version %d", version)
@@ -165,9 +170,11 @@ func DecodeFileScanTask(data []byte, spec iceberg.PartitionSpec, schema *iceberg
 	}, nil
 }
 
+// validateScanRange checks a non-negative scan range against a recorded file
+// size. Callers must reject negative start and length values first. The end is
+// checked as a subtraction after confirming start <= fileSize, so the
+// fileSize-start subtraction cannot underflow and start+length cannot overflow.
 func validateScanRange(start, length, fileSize int64) error {
-	// Check the end as a subtraction after confirming start <= fileSize so
-	// start+length cannot overflow int64.
 	if start > fileSize || length > fileSize-start {
 		return fmt.Errorf("scan range start=%d length=%d exceeds file size %d", start, length, fileSize)
 	}

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -19,11 +19,36 @@ package codec
 
 import (
 	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateScanRange(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		start, length     int64
+		fileSize          int64
+		shouldReturnError bool
+	}{
+		{name: "full file", length: 100, fileSize: 100},
+		{name: "empty range at EOF", start: 100, fileSize: 100},
+		{name: "start after EOF", start: 101, fileSize: 100, shouldReturnError: true},
+		{name: "end after EOF", start: 99, length: 2, fileSize: 100, shouldReturnError: true},
+		{name: "overflowing end", start: math.MaxInt64, length: 1, fileSize: 100, shouldReturnError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScanRange(tt.start, tt.length, tt.fileSize)
+			if tt.shouldReturnError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 // TestDecodeFileScanTaskInnerErrorCarriesMarker covers an inner decode path:
 // the outer Avro envelope decodes fine, but the framed primary-file blob is not

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -149,5 +149,5 @@ func TestDecodeFileScanTaskRejectsRangeBeyondFileSize(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = DecodeFileScanTask(envelope, spec, nil, 2)
-	require.ErrorContains(t, err, "scan range start=90 length=11 exceeds file size 100")
+	require.ErrorContains(t, err, "exceeds file size")
 }

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -110,3 +110,19 @@ func TestDecodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
 		require.Contains(t, err.Error(), "length must be non-negative")
 	})
 }
+
+func TestDecodeFileScanTaskRejectsRangeBeyondFileSize(t *testing.T) {
+	spec := *iceberg.UnpartitionedSpec
+	builder, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData,
+		"data.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 100)
+	require.NoError(t, err)
+	file, err := EncodeDataFile(builder.Build(), spec, nil, 2)
+	require.NoError(t, err)
+	envelope, err := fileScanTaskSchema.Encode(&fileScanTaskEnvelope{
+		File: file, Start: 90, Length: 11,
+	})
+	require.NoError(t, err)
+
+	_, err = DecodeFileScanTask(envelope, spec, nil, 2)
+	require.ErrorContains(t, err, "scan range start=90 length=11 exceeds file size 100")
+}

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -37,7 +37,7 @@ func TestValidateScanRange(t *testing.T) {
 		{name: "empty range at EOF", start: 100, fileSize: 100},
 		{name: "start after EOF", start: 101, fileSize: 100, shouldReturnError: true},
 		{name: "end after EOF", start: 99, length: 2, fileSize: 100, shouldReturnError: true},
-		{name: "overflowing end", start: math.MaxInt64, length: 1, fileSize: 100, shouldReturnError: true},
+		{name: "start plus length overflows", start: math.MaxInt64 - 1, length: 2, fileSize: math.MaxInt64, shouldReturnError: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateScanRange(tt.start, tt.length, tt.fileSize)

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -136,7 +136,7 @@ func TestDecodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
 	})
 }
 
-func TestDecodeFileScanTaskRejectsRangeBeyondFileSize(t *testing.T) {
+func TestDecodeFileScanTaskAllowsRangeBeyondFileSize(t *testing.T) {
 	spec := *iceberg.UnpartitionedSpec
 	builder, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData,
 		"data.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 100)
@@ -148,6 +148,8 @@ func TestDecodeFileScanTaskRejectsRangeBeyondFileSize(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = DecodeFileScanTask(envelope, spec, nil, 2)
-	require.ErrorContains(t, err, "exceeds file size")
+	decoded, err := DecodeFileScanTask(envelope, spec, nil, 2)
+	require.NoError(t, err)
+	require.Equal(t, int64(90), decoded.Start)
+	require.Equal(t, int64(11), decoded.Length)
 }

--- a/codec/file_scan_task_internal_test.go
+++ b/codec/file_scan_task_internal_test.go
@@ -35,9 +35,14 @@ func TestValidateScanRange(t *testing.T) {
 	}{
 		{name: "full file", length: 100, fileSize: 100},
 		{name: "empty range at EOF", start: 100, fileSize: 100},
+		{name: "empty file", fileSize: 0},
+		{name: "one byte at EOF", start: 100, length: 1, fileSize: 100, shouldReturnError: true},
+		{name: "maximum file size with empty range", start: math.MaxInt64, fileSize: math.MaxInt64},
+		{name: "maximum file size boundary", start: math.MaxInt64 - 1, length: 1, fileSize: math.MaxInt64},
 		{name: "start after EOF", start: 101, fileSize: 100, shouldReturnError: true},
 		{name: "end after EOF", start: 99, length: 2, fileSize: 100, shouldReturnError: true},
 		{name: "start plus length overflows", start: math.MaxInt64 - 1, length: 2, fileSize: math.MaxInt64, shouldReturnError: true},
+		{name: "negative file size", fileSize: -1, shouldReturnError: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateScanRange(tt.start, tt.length, tt.fileSize)

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -18,6 +18,7 @@
 package codec_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -219,6 +220,37 @@ func TestEncodeFileScanTaskRejectsNegativeScanRanges(t *testing.T) {
 		require.Contains(t, err.Error(), "codec: EncodeFileScanTask:")
 		require.Contains(t, err.Error(), "length must be non-negative")
 	})
+}
+
+func TestEncodeFileScanTaskValidatesRangeAgainstFileSize(t *testing.T) {
+	spec, schema, base := fullyPopulatedFileScanTask(t, 2)
+	fileSize := base.File.FileSizeBytes()
+	tests := []struct {
+		name        string
+		start       int64
+		length      int64
+		shouldError bool
+	}{
+		{"full file", 0, fileSize, false},
+		{"suffix ending at EOF", fileSize - 1, 1, false},
+		{"zero length at EOF", fileSize, 0, false},
+		{"start after EOF", fileSize + 1, 0, true},
+		{"range ends after EOF", fileSize - 1, 2, true},
+		{"overflowing range", math.MaxInt64, 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := base
+			task.Start, task.Length = tt.start, tt.length
+			_, err := codec.EncodeFileScanTask(task, spec, schema, 2)
+			if tt.shouldError {
+				require.ErrorContains(t, err, "exceeds file size")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func fullyPopulatedFileScanTask(t *testing.T, version int) (iceberg.PartitionSpec, *iceberg.Schema, table.FileScanTask) {

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -236,7 +236,6 @@ func TestEncodeFileScanTaskValidatesRangeAgainstFileSize(t *testing.T) {
 		{"zero length at EOF", fileSize, 0, false},
 		{"start after EOF", fileSize + 1, 0, true},
 		{"range ends after EOF", fileSize - 1, 2, true},
-		{"overflowing range", math.MaxInt64, 1, true},
 	}
 
 	for _, tt := range tests {
@@ -251,6 +250,16 @@ func TestEncodeFileScanTaskValidatesRangeAgainstFileSize(t *testing.T) {
 			}
 		})
 	}
+
+	overflowFile := newScanTaskDataFileWithFileSize(t, spec,
+		"s3://bucket/ns/tbl/data/overflow.parquet", iceberg.EntryContentData,
+		iceberg.ParquetFile, "", 2, math.MaxInt64)
+	overflowTask := base
+	overflowTask.File = overflowFile
+	overflowTask.Start = math.MaxInt64 - 1
+	overflowTask.Length = 2
+	_, err := codec.EncodeFileScanTask(overflowTask, spec, schema, 2)
+	require.ErrorContains(t, err, "exceeds file size")
 }
 
 func fullyPopulatedFileScanTask(t *testing.T, version int) (iceberg.PartitionSpec, *iceberg.Schema, table.FileScanTask) {
@@ -298,6 +307,10 @@ func fullyPopulatedFileScanTask(t *testing.T, version int) (iceberg.PartitionSpe
 }
 
 func newScanTaskDataFile(t *testing.T, spec iceberg.PartitionSpec, path string, content iceberg.ManifestEntryContent, format iceberg.FileFormat, referencedDataFile string, version int) iceberg.DataFile {
+	return newScanTaskDataFileWithFileSize(t, spec, path, content, format, referencedDataFile, version, 1024*1024)
+}
+
+func newScanTaskDataFileWithFileSize(t *testing.T, spec iceberg.PartitionSpec, path string, content iceberg.ManifestEntryContent, format iceberg.FileFormat, referencedDataFile string, version int, fileSize int64) iceberg.DataFile {
 	t.Helper()
 	builder, err := iceberg.NewDataFileBuilder(
 		spec,
@@ -308,7 +321,7 @@ func newScanTaskDataFile(t *testing.T, spec iceberg.PartitionSpec, path string, 
 		map[int]string{},
 		map[int]int{},
 		1024,
-		1024*1024,
+		fileSize,
 	)
 	require.NoError(t, err)
 	builder.


### PR DESCRIPTION
## Summary

Validate FileScanTask byte ranges produced by the codec without making decode stricter than the interchange format.

## Why

The encoder should not produce negative or out-of-file ranges. Decode still rejects negative values, but Java and other implementations may send a range whose end is beyond the declared file size, so decode should preserve that task rather than add a client-specific EOF rule.

## What changed

- Encode validates that the range fits within the primary data file.
- Encode and decode reject negative starts and lengths.
- The encode-time check uses subtraction so start plus length cannot overflow.
- Decode does not compare the range with file size.

## Tests

- Added full-file, suffix, and zero-length-at-EOF cases
- Added beyond-EOF and integer-overflow encode cases
- Added decode coverage for a range beyond file size
- Added malformed-envelope decode coverage
- go test ./codec