### PR TITLE
fix(table): keep generated snapshot IDs non-negative

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -45,22 +45,18 @@ const (
 )
 
 func generateSnapshotID() int64 {
-	var (
-		rndUUID = uuid.New()
-		out     [8]byte
-	)
+	return snapshotIDFromUUID(uuid.New())
+}
+
+func snapshotIDFromUUID(id uuid.UUID) int64 {
+	var out [8]byte
 
 	for i := range 8 {
-		lhs, rhs := rndUUID[i], rndUUID[i+8]
+		lhs, rhs := id[i], id[i+8]
 		out[i] = lhs ^ rhs
 	}
 
-	snapshotID := int64(binary.LittleEndian.Uint64(out[:]))
-	if snapshotID < 0 {
-		snapshotID = -snapshotID
-	}
-
-	return snapshotID
+	return int64(binary.LittleEndian.Uint64(out[:]) & math.MaxInt64)
 }
 
 // Metadata for an iceberg table as specified in the Iceberg spec

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"io"
 	"maps"
+	"math"
 	"os"
 	"path"
 	"slices"
@@ -38,11 +39,16 @@ import (
 )
 
 func TestSnapshotIDFromUUIDClearsSignBit(t *testing.T) {
-	id := uuid.UUID{7: 0x80}
-	require.Equal(t, int64(0), snapshotIDFromUUID(id))
+	for _, id := range []uuid.UUID{
+		{7: 0x80},
+		{15: 0x80},
+	} {
+		require.Zero(t, snapshotIDFromUUID(id))
+	}
 
-	id[0] = 42
-	require.Equal(t, int64(42), snapshotIDFromUUID(id))
+	require.Equal(t, int64(math.MaxInt64), snapshotIDFromUUID(uuid.UUID{
+		0: 0xff, 1: 0xff, 2: 0xff, 3: 0xff, 4: 0xff, 5: 0xff, 6: 0xff, 7: 0xff,
+	}))
 }
 
 const ExampleTableMetadataV2 = `{

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -37,6 +37,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSnapshotIDFromUUIDClearsSignBit(t *testing.T) {
+	id := uuid.UUID{7: 0x80}
+	require.Equal(t, int64(0), snapshotIDFromUUID(id))
+
+	id[0] = 42
+	require.Equal(t, int64(42), snapshotIDFromUUID(id))
+}
+
 const ExampleTableMetadataV2 = `{
     "format-version": 2,
     "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",


### PR DESCRIPTION
## What changed

Clear the sign bit before converting the UUID-derived snapshot ID to `int64`. The UUID folding logic is extracted into a small deterministic helper for regression coverage.

## Why

Negating a negative value does not make `math.MinInt64` positive because signed negation overflows back to the same value. Clearing the sign bit guarantees that generated snapshot IDs are nonnegative for every input.

## Testing

- Added deterministic coverage for an XOR result with only the sign bit set
- Added coverage showing the remaining value bits are preserved
- `go test ./table`