### PR TITLE
fix(table): guard DV filtering against stale row counts

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -576,6 +576,11 @@ func filterByDeletionVector(ctx context.Context, bitmap *dv.RoaringPositionBitma
 
 				return compute.FilterRecordBatch(ctx, r, sliced, compute.DefaultFilterOptions())
 			}
+			if currentIdx >= rowCount {
+				r.Retain()
+
+				return r, nil
+			}
 
 			// A stale manifest count can be smaller than the rows emitted by
 			// the file. Preserve rows beyond the mask rather than slicing past

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -560,16 +560,36 @@ func filterByDeletionVector(ctx context.Context, bitmap *dv.RoaringPositionBitma
 			currentIdx := nextIdx
 			nextIdx += nrows
 
-			// Wrap (and slice) the shared keep-mask buffer for this batch.
-			// array.NewSlice on a Boolean array tracks the bit-level offset,
-			// so we don't need byte-aligned slicing — currentIdx can land
-			// anywhere within a byte.
-			full := array.NewBoolean(int(rowCount), buf, nil, 0)
-			defer full.Release()
-			sliced := array.NewSlice(full, currentIdx, nextIdx).(*array.Boolean)
-			defer sliced.Release()
+			if nextIdx <= rowCount {
+				// Wrap (and slice) the shared keep-mask buffer for this batch.
+				// array.NewSlice on a Boolean array tracks the bit-level offset,
+				// so we don't need byte-aligned slicing — currentIdx can land
+				// anywhere within a byte.
+				full := array.NewBoolean(int(rowCount), buf, nil, 0)
+				defer full.Release()
+				sliced := array.NewSlice(full, currentIdx, nextIdx).(*array.Boolean)
+				defer sliced.Release()
 
-			return compute.FilterRecordBatch(ctx, r, sliced, compute.DefaultFilterOptions())
+				return compute.FilterRecordBatch(ctx, r, sliced, compute.DefaultFilterOptions())
+			}
+
+			// A stale manifest count can be smaller than the rows emitted by
+			// the file. Preserve rows beyond the mask rather than slicing past
+			// its bounds and panicking.
+			bldr := array.NewBooleanBuilder(mem)
+			defer bldr.Release()
+			bldr.Reserve(int(nrows))
+			for pos := currentIdx; pos < nextIdx; pos++ {
+				if pos >= rowCount {
+					bldr.Append(true)
+				} else {
+					bldr.Append(keepBits[pos>>3]&(1<<(uint(pos)&7)) != 0)
+				}
+			}
+			mask := bldr.NewBooleanArray()
+			defer mask.Release()
+
+			return compute.FilterRecordBatch(ctx, r, mask, compute.DefaultFilterOptions())
 		}
 
 		bldr := array.NewBooleanBuilder(mem)

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -530,6 +530,10 @@ func processPositionalDeletes(ctx context.Context, deletes set[int64], cursor *r
 	}
 }
 
+func deletionVectorKeepsRow(keepBits []byte, rowCount, pos int64) bool {
+	return pos >= rowCount || keepBits[pos>>3]&(1<<(uint(pos)&7)) != 0
+}
+
 // filterByDeletionVector returns a pipeline step that drops rows present in
 // the bitmap by precomputing a bit-packed keep-mask covering the whole file
 // once and slicing the relevant range per batch into compute.FilterRecordBatch.
@@ -580,11 +584,7 @@ func filterByDeletionVector(ctx context.Context, bitmap *dv.RoaringPositionBitma
 			defer bldr.Release()
 			bldr.Reserve(int(nrows))
 			for pos := currentIdx; pos < nextIdx; pos++ {
-				if pos >= rowCount {
-					bldr.Append(true)
-				} else {
-					bldr.Append(keepBits[pos>>3]&(1<<(uint(pos)&7)) != 0)
-				}
+				bldr.Append(deletionVectorKeepsRow(keepBits, rowCount, pos))
 			}
 			mask := bldr.NewBooleanArray()
 			defer mask.Release()
@@ -600,14 +600,7 @@ func filterByDeletionVector(ctx context.Context, bitmap *dv.RoaringPositionBitma
 			// keepBits is sized for rowCount; a pos past it means row-group
 			// metadata and the manifest's File.Count() disagree. Keep the row
 			// rather than indexing out of bounds.
-			if pos >= rowCount {
-				bldr.Append(true)
-
-				continue
-			}
-			// Test keep bit at absolute position pos: byte pos/8, bit pos%8,
-			// LSB-first (the layout the fast path's array.NewBoolean reads).
-			bldr.Append(keepBits[pos>>3]&(1<<(uint(pos)&7)) != 0)
+			bldr.Append(deletionVectorKeepsRow(keepBits, rowCount, pos))
 		}
 		mask := bldr.NewBooleanArray()
 		defer mask.Release()

--- a/table/dv_scanner_read_test.go
+++ b/table/dv_scanner_read_test.go
@@ -347,3 +347,25 @@ func TestFilterByDeletionVectorOutOfBoundsPosition(t *testing.T) {
 	defer out.Release()
 	assert.Equal(t, []int64{0, 1, 2}, out.Column(0).(*array.Int64).Int64Values())
 }
+
+func TestFilterByDeletionVectorStaleRowCount(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewGoAllocator()
+
+	bitmap := dv.NewRoaringPositionBitmap()
+	bitmap.Set(1)
+	filter := filterByDeletionVector(ctx, bitmap, 2, (&rowPositionSource{}).cursor())
+
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues([]int64{0, 1, 2}, nil)
+	col := bldr.NewArray()
+	defer col.Release()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "pos", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	batch := array.NewRecordBatch(schema, []arrow.Array{col}, 3)
+
+	out, err := filter(batch)
+	require.NoError(t, err)
+	defer out.Release()
+	assert.Equal(t, []int64{0, 2}, out.Column(0).(*array.Int64).Int64Values())
+}

--- a/table/dv_scanner_read_test.go
+++ b/table/dv_scanner_read_test.go
@@ -354,18 +354,27 @@ func TestFilterByDeletionVectorStaleRowCount(t *testing.T) {
 
 	bitmap := dv.NewRoaringPositionBitmap()
 	bitmap.Set(1)
-	filter := filterByDeletionVector(ctx, bitmap, 2, (&rowPositionSource{}).cursor())
+	bitmap.Set(3)
+	filter := filterByDeletionVector(ctx, bitmap, 4, (&rowPositionSource{}).cursor())
 
-	bldr := array.NewInt64Builder(mem)
-	defer bldr.Release()
-	bldr.AppendValues([]int64{0, 1, 2}, nil)
-	col := bldr.NewArray()
-	defer col.Release()
-	schema := arrow.NewSchema([]arrow.Field{{Name: "pos", Type: arrow.PrimitiveTypes.Int64}}, nil)
-	batch := array.NewRecordBatch(schema, []arrow.Array{col}, 3)
+	mkBatch := func(values ...int64) arrow.RecordBatch {
+		bldr := array.NewInt64Builder(mem)
+		defer bldr.Release()
+		bldr.AppendValues(values, nil)
+		col := bldr.NewArray()
+		defer col.Release()
+		schema := arrow.NewSchema([]arrow.Field{{Name: "pos", Type: arrow.PrimitiveTypes.Int64}}, nil)
 
-	out, err := filter(batch)
+		return array.NewRecordBatch(schema, []arrow.Array{col}, int64(len(values)))
+	}
+
+	withinCount, err := filter(mkBatch(0, 1, 2))
 	require.NoError(t, err)
-	defer out.Release()
-	assert.Equal(t, []int64{0, 2}, out.Column(0).(*array.Int64).Int64Values())
+	defer withinCount.Release()
+	assert.Equal(t, []int64{0, 2}, withinCount.Column(0).(*array.Int64).Int64Values())
+
+	beyondCount, err := filter(mkBatch(3, 4, 5))
+	require.NoError(t, err)
+	defer beyondCount.Release()
+	assert.Equal(t, []int64{4, 5}, beyondCount.Column(0).(*array.Int64).Int64Values())
 }

--- a/table/dv_scanner_read_test.go
+++ b/table/dv_scanner_read_test.go
@@ -352,11 +352,6 @@ func TestFilterByDeletionVectorStaleRowCount(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewGoAllocator()
 
-	bitmap := dv.NewRoaringPositionBitmap()
-	bitmap.Set(1)
-	bitmap.Set(3)
-	filter := filterByDeletionVector(ctx, bitmap, 4, (&rowPositionSource{}).cursor())
-
 	mkBatch := func(values ...int64) arrow.RecordBatch {
 		bldr := array.NewInt64Builder(mem)
 		defer bldr.Release()
@@ -368,18 +363,46 @@ func TestFilterByDeletionVectorStaleRowCount(t *testing.T) {
 		return array.NewRecordBatch(schema, []arrow.Array{col}, int64(len(values)))
 	}
 
-	withinCount, err := filter(mkBatch(0, 1, 2))
+	bitmap := dv.NewRoaringPositionBitmap()
+	bitmap.Set(1)
+	bitmap.Set(3)
+	filter := filterByDeletionVector(ctx, bitmap, 4, (&rowPositionSource{}).cursor())
+
+	withinCount, err := filter(mkBatch(0, 1))
 	require.NoError(t, err)
 	defer withinCount.Release()
-	assert.Equal(t, []int64{0, 2}, withinCount.Column(0).(*array.Int64).Int64Values())
+	assert.Equal(t, []int64{0}, withinCount.Column(0).(*array.Int64).Int64Values())
 
-	beyondCount, err := filter(mkBatch(3, 4, 5))
+	boundaryCount, err := filter(mkBatch(2, 3))
 	require.NoError(t, err)
-	defer beyondCount.Release()
-	assert.Equal(t, []int64{4, 5}, beyondCount.Column(0).(*array.Int64).Int64Values())
+	defer boundaryCount.Release()
+	assert.Equal(t, []int64{2}, boundaryCount.Column(0).(*array.Int64).Int64Values())
 
-	fullyBeyondCount, err := filter(mkBatch(6, 7))
+	straddlingFilter := filterByDeletionVector(ctx, bitmap, 4, (&rowPositionSource{}).cursor())
+	straddlingPrefix, err := straddlingFilter(mkBatch(0, 1))
 	require.NoError(t, err)
-	defer fullyBeyondCount.Release()
-	assert.Equal(t, []int64{6, 7}, fullyBeyondCount.Column(0).(*array.Int64).Int64Values())
+	defer straddlingPrefix.Release()
+	assert.Equal(t, []int64{0}, straddlingPrefix.Column(0).(*array.Int64).Int64Values())
+
+	straddlingCount, err := straddlingFilter(mkBatch(2, 3, 4, 5))
+	require.NoError(t, err)
+	defer straddlingCount.Release()
+	assert.Equal(t, []int64{2, 4, 5}, straddlingCount.Column(0).(*array.Int64).Int64Values())
+
+	boundaryFilter := filterByDeletionVector(ctx, bitmap, 4, (&rowPositionSource{}).cursor())
+	boundaryBatch, err := boundaryFilter(mkBatch(0, 1, 2, 3))
+	require.NoError(t, err)
+	defer boundaryBatch.Release()
+	assert.Equal(t, []int64{0, 2}, boundaryBatch.Column(0).(*array.Int64).Int64Values())
+
+	afterBoundary, err := boundaryFilter(mkBatch(4, 5))
+	require.NoError(t, err)
+	defer afterBoundary.Release()
+	assert.Equal(t, []int64{4, 5}, afterBoundary.Column(0).(*array.Int64).Int64Values())
+
+	zeroRowCountFilter := filterByDeletionVector(ctx, bitmap, 0, (&rowPositionSource{}).cursor())
+	zeroRowCount, err := zeroRowCountFilter(mkBatch(6, 7))
+	require.NoError(t, err)
+	defer zeroRowCount.Release()
+	assert.Equal(t, []int64{6, 7}, zeroRowCount.Column(0).(*array.Int64).Int64Values())
 }

--- a/table/dv_scanner_read_test.go
+++ b/table/dv_scanner_read_test.go
@@ -377,4 +377,9 @@ func TestFilterByDeletionVectorStaleRowCount(t *testing.T) {
 	require.NoError(t, err)
 	defer beyondCount.Release()
 	assert.Equal(t, []int64{4, 5}, beyondCount.Column(0).(*array.Int64).Int64Values())
+
+	fullyBeyondCount, err := filter(mkBatch(6, 7))
+	require.NoError(t, err)
+	defer fullyBeyondCount.Release()
+	assert.Equal(t, []int64{6, 7}, fullyBeyondCount.Column(0).(*array.Int64).Int64Values())
 }


### PR DESCRIPTION
## Summary

Prevent deletion-vector filtering from panicking when a data file emits more rows than its manifest `record_count`.

## Problem

The contiguous fast path builds a keep mask sized from `DataFile.Count()` and slices it using the rows emitted by each Arrow batch. If the manifest count is stale or otherwise smaller than the physical file, the batch end falls outside the mask and `array.NewSlice` panics.

The row-group-pruned path already handles this mismatch by preserving positions beyond the mask. The contiguous path should behave the same way.

## Fix

Keep the existing zero-copy mask slice while a batch is within the declared row count. If a batch crosses that boundary, build a bounded mask for that batch and keep rows whose positions are beyond the declared count. Once a batch is entirely beyond the mask, pass it through without allocating an all-true filter. In-range deletion-vector positions are still applied normally.

## Tests

Added coverage across three batches: one within the manifest count, one crossing it, and one entirely beyond it. The test verifies in-range deletes while preserving rows beyond the declared count.

```
go test ./table -count=1
```