### PR TITLE
fix(manifest): reject row ID allocation overflow

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1599,6 +1599,10 @@ func NewManifestListWriterV3(out io.Writer, snapshotId, sequenceNumber, firstRow
 }
 
 func advanceRowID(firstRowID, existingRows, addedRows int64) (int64, error) {
+	if existingRows == -1 || addedRows == -1 {
+		return 0, fmt.Errorf("%w: cannot assign row-lineage IDs with unknown row counts: existing=%d added=%d",
+			ErrInvalidArgument, existingRows, addedRows)
+	}
 	if existingRows < 0 || addedRows < 0 {
 		return 0, fmt.Errorf("%w: row counts must be non-negative: existing=%d added=%d",
 			ErrInvalidArgument, existingRows, addedRows)

--- a/manifest.go
+++ b/manifest.go
@@ -1599,9 +1599,14 @@ func NewManifestListWriterV3(out io.Writer, snapshotId, sequenceNumber, firstRow
 }
 
 func advanceRowID(firstRowID, existingRows, addedRows int64) (int64, error) {
-	if existingRows == -1 || addedRows == -1 {
-		return 0, fmt.Errorf("%w: cannot assign row-lineage IDs with unknown row counts: existing=%d added=%d",
-			ErrInvalidArgument, existingRows, addedRows)
+	if firstRowID < 0 {
+		return 0, fmt.Errorf("%w: first row ID must be non-negative: %d", ErrInvalidArgument, firstRowID)
+	}
+	if existingRows == -1 {
+		existingRows = 0
+	}
+	if addedRows == -1 {
+		addedRows = 0
 	}
 	if existingRows < 0 || addedRows < 0 {
 		return 0, fmt.Errorf("%w: row counts must be non-negative: existing=%d added=%d",
@@ -1646,9 +1651,17 @@ func (m *ManifestListWriter) NextRowID() *int64 {
 	return m.nextRowID
 }
 
-func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
+func (m *ManifestListWriter) AddManifests(files []ManifestFile) (err error) {
 	if len(files) == 0 {
 		return nil
+	}
+	if m.version == 3 && m.nextRowID != nil {
+		batchStartRowID := *m.nextRowID
+		defer func() {
+			if err != nil {
+				*m.nextRowID = batchStartRowID
+			}
+		}()
 	}
 
 	switch m.version {
@@ -1846,7 +1859,7 @@ func WriteManifestV3(
 	raw.FirstRowIDValue = &v
 	nextFirstRowID, err = advanceRowID(firstRowID, raw.ExistingRowsCount, raw.AddedRowsCount)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("manifest %q: %w", filename, err)
 	}
 
 	return raw, nextFirstRowID, nil

--- a/manifest.go
+++ b/manifest.go
@@ -1666,6 +1666,8 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 
 	case 2, 3:
 		for _, file := range files {
+			var assignedNextRowID *int64
+
 			// Per the Iceberg spec a v2 manifest list may reference v1 manifest
 			// files (and a v3 list may reference v1 or v2 manifests) so that a
 			// table can be upgraded without rewriting historical manifests. The
@@ -1693,7 +1695,7 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 								return fmt.Errorf("manifest %q: %w", wrapped.Path, err)
 							}
 							wrapped.FirstRowIDValue = &firstRowID
-							*m.nextRowID = nextRowID
+							assignedNextRowID = &nextRowID
 						}
 					}
 				}
@@ -1721,6 +1723,9 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 			}
 			if err := m.writer.Encode(wrapped); err != nil {
 				return err
+			}
+			if assignedNextRowID != nil {
+				*m.nextRowID = *assignedNextRowID
 			}
 		}
 	default:

--- a/manifest.go
+++ b/manifest.go
@@ -1573,6 +1573,10 @@ func NewManifestListWriterV2(out io.Writer, snapshotID, sequenceNumber int64, pa
 }
 
 func NewManifestListWriterV3(out io.Writer, snapshotId, sequenceNumber, firstRowID int64, parentSnapshot *int64) (*ManifestListWriter, error) {
+	if firstRowID < 0 {
+		return nil, fmt.Errorf("%w: first row ID must be non-negative: %d", ErrInvalidArgument, firstRowID)
+	}
+
 	m := &ManifestListWriter{
 		version:          3,
 		out:              out,
@@ -1592,6 +1596,19 @@ func NewManifestListWriterV3(out io.Writer, snapshotId, sequenceNumber, firstRow
 		"first-row-id":       []byte(strconv.FormatInt(firstRowID, 10)),
 		"parent-snapshot-id": []byte(parentSnapshotStr),
 	})
+}
+
+func advanceRowID(firstRowID, existingRows, addedRows int64) (int64, error) {
+	if existingRows < 0 || addedRows < 0 {
+		return 0, fmt.Errorf("%w: row counts must be non-negative: existing=%d added=%d",
+			ErrInvalidArgument, existingRows, addedRows)
+	}
+	if existingRows > math.MaxInt64-firstRowID || addedRows > math.MaxInt64-firstRowID-existingRows {
+		return 0, fmt.Errorf("%w: assigning %d existing and %d added rows from first row ID %d overflows int64",
+			ErrInvalidArgument, existingRows, addedRows, firstRowID)
+	}
+
+	return firstRowID + existingRows + addedRows, nil
 }
 
 func (m *ManifestListWriter) init(meta map[string][]byte) error {
@@ -1671,8 +1688,12 @@ func (m *ManifestListWriter) AddManifests(files []ManifestFile) error {
 					if wrapped.FirstRowIDValue == nil {
 						if m.nextRowID != nil {
 							firstRowID := *m.nextRowID
+							nextRowID, err := advanceRowID(firstRowID, wrapped.ExistingRowsCount, wrapped.AddedRowsCount)
+							if err != nil {
+								return fmt.Errorf("manifest %q: %w", wrapped.Path, err)
+							}
 							wrapped.FirstRowIDValue = &firstRowID
-							*m.nextRowID += wrapped.ExistingRowsCount + wrapped.AddedRowsCount
+							*m.nextRowID = nextRowID
 						}
 					}
 				}
@@ -1784,6 +1805,10 @@ func WriteManifestV3(
 	snapshotID int64,
 	entries []ManifestEntry,
 ) (mf ManifestFile, nextFirstRowID int64, err error) {
+	if firstRowID < 0 {
+		return nil, 0, fmt.Errorf("%w: first row ID must be non-negative: %d", ErrInvalidArgument, firstRowID)
+	}
+
 	cnt := &internal.CountingWriter{W: out}
 
 	w, err := NewManifestWriter(3, cnt, spec, schema, snapshotID)
@@ -1810,7 +1835,10 @@ func WriteManifestV3(
 	raw := mf.(*manifestFile)
 	v := firstRowID
 	raw.FirstRowIDValue = &v
-	nextFirstRowID = firstRowID + raw.AddedRowsCount + raw.ExistingRowsCount
+	nextFirstRowID, err = advanceRowID(firstRowID, raw.ExistingRowsCount, raw.AddedRowsCount)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	return raw, nextFirstRowID, nil
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1235,6 +1235,22 @@ func (m *ManifestTestSuite) TestWriteManifestV3() {
 		m.EqualValues(520, nextID) // 500 + 10 + 10
 	})
 
+	m.Run("rejects negative first row ID", func() {
+		var buf bytes.Buffer
+		_, _, err := WriteManifestV3("/manifest.avro", &buf, -1, partitionSpec, testSchema, entrySnapshotID, entries)
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "first row ID must be non-negative")
+	})
+
+	m.Run("rejects next row ID overflow", func() {
+		var buf bytes.Buffer
+		_, _, err := WriteManifestV3(
+			"/manifest.avro", &buf, math.MaxInt64-count, partitionSpec, testSchema, entrySnapshotID, entries,
+		)
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "overflows int64")
+	})
+
 	m.Run("read inheritance from manifest", func() {
 		var buf bytes.Buffer
 		firstRowID := int64(500)
@@ -2428,6 +2444,37 @@ func (m *ManifestTestSuite) TestV3ManifestListWriterRowIDTracking() {
 	m.EqualValues(int64(3800), *writer.NextRowID()-firstRowID)
 	err = writer.Close()
 	m.Require().NoError(err)
+}
+
+func (m *ManifestTestSuite) TestV3ManifestListWriterRejectsInvalidRowIDRanges() {
+	m.Run("negative first row ID", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, -1, nil)
+		m.Nil(writer)
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "first row ID must be non-negative")
+	})
+
+	m.Run("negative row count", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, 0, nil)
+		m.Require().NoError(err)
+		manifest := NewManifestFile(3, "negative.avro", 100, 1, snapshotID).AddedRows(-1).Build()
+		err = writer.AddManifests([]ManifestFile{manifest})
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "row counts must be non-negative")
+	})
+
+	m.Run("overflow", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, math.MaxInt64, nil)
+		m.Require().NoError(err)
+		manifest := NewManifestFile(3, "overflow.avro", 100, 1, snapshotID).AddedRows(1).Build()
+		err = writer.AddManifests([]ManifestFile{manifest})
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "overflows int64")
+		m.EqualValues(math.MaxInt64, *writer.NextRowID())
+	})
 }
 
 func (m *ManifestTestSuite) TestV3ManifestListWriterAssignedRowIDDelta() {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2459,7 +2459,7 @@ func (m *ManifestTestSuite) TestV3ManifestListWriterRejectsInvalidRowIDRanges() 
 		var buf bytes.Buffer
 		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, 0, nil)
 		m.Require().NoError(err)
-		manifest := NewManifestFile(3, "negative.avro", 100, 1, snapshotID).AddedRows(-1).Build()
+		manifest := NewManifestFile(3, "negative.avro", 100, 1, snapshotID).AddedRows(-2).Build()
 		err = writer.AddManifests([]ManifestFile{manifest})
 		m.Require().ErrorIs(err, ErrInvalidArgument)
 		m.Require().ErrorContains(err, "row counts must be non-negative")
@@ -3145,6 +3145,28 @@ func (m *ManifestTestSuite) TestV3ManifestListAcceptsV1AndV2Manifests() {
 	// assigned (assignment is data-only per the v3 ManifestListWriter rules).
 	m.Equal(ManifestContentDeletes, v2Entry.ManifestContent())
 	m.Nil(v2Entry.FirstRowID(), "delete manifests must not be assigned first_row_id")
+}
+
+func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCounts() {
+	legacy := *(manifestFileRecordsV1[0].(*manifestFile))
+	legacy.AddedRowsCount = -1
+	legacy.ExistingRowsCount = -1
+
+	var v1Buf bytes.Buffer
+	m.Require().NoError(WriteManifestList(1, &v1Buf, snapshotID, nil, nil, 0, []ManifestFile{&legacy}))
+	manifests, err := ReadManifestList(&v1Buf)
+	m.Require().NoError(err)
+	m.Require().Len(manifests, 1)
+
+	var v3Buf bytes.Buffer
+	writer, err := NewManifestListWriterV3(&v3Buf, snapshotID, 1, 1000, nil)
+	m.Require().NoError(err)
+	err = writer.AddManifests(manifests)
+	m.Require().ErrorIs(err, ErrInvalidArgument)
+	m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
+	m.Require().ErrorContains(err, legacy.Path)
+	m.EqualValues(1000, *writer.NextRowID())
+	m.Require().NoError(writer.Close())
 }
 
 // TestV2ManifestListRejectsV3Manifests confirms that a v2 manifest list still

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2465,11 +2465,32 @@ func (m *ManifestTestSuite) TestV3ManifestListWriterRejectsInvalidRowIDRanges() 
 		m.Require().ErrorContains(err, "row counts must be non-negative")
 	})
 
+	m.Run("negative existing row count", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, 0, nil)
+		m.Require().NoError(err)
+		manifest := NewManifestFile(3, "negative-existing.avro", 100, 1, snapshotID).ExistingRows(-2).Build()
+		err = writer.AddManifests([]ManifestFile{manifest})
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "row counts must be non-negative")
+	})
+
 	m.Run("overflow", func() {
 		var buf bytes.Buffer
 		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, math.MaxInt64, nil)
 		m.Require().NoError(err)
 		manifest := NewManifestFile(3, "overflow.avro", 100, 1, snapshotID).AddedRows(1).Build()
+		err = writer.AddManifests([]ManifestFile{manifest})
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, "overflows int64")
+		m.EqualValues(math.MaxInt64, *writer.NextRowID())
+	})
+
+	m.Run("existing row count overflow", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, math.MaxInt64, nil)
+		m.Require().NoError(err)
+		manifest := NewManifestFile(3, "overflow-existing.avro", 100, 1, snapshotID).ExistingRows(1).Build()
 		err = writer.AddManifests([]ManifestFile{manifest})
 		m.Require().ErrorIs(err, ErrInvalidArgument)
 		m.Require().ErrorContains(err, "overflows int64")
@@ -2484,6 +2505,20 @@ func (m *ManifestTestSuite) TestV3ManifestListWriterRejectsInvalidRowIDRanges() 
 		err = writer.AddManifests([]ManifestFile{manifest})
 		m.Require().ErrorContains(err, "unassigned sequence number")
 		m.EqualValues(10, *writer.NextRowID())
+	})
+
+	m.Run("batch failure leaves cursor unchanged", func() {
+		var buf bytes.Buffer
+		startRowID := int64(math.MaxInt64 - 5)
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, startRowID, nil)
+		m.Require().NoError(err)
+		manifests := []ManifestFile{
+			NewManifestFile(3, "valid.avro", 100, 1, snapshotID).AddedRows(5).Build(),
+			NewManifestFile(3, "overflow.avro", 100, 1, snapshotID).AddedRows(1).Build(),
+		}
+		err = writer.AddManifests(manifests)
+		m.Require().ErrorContains(err, "overflows int64")
+		m.EqualValues(startRowID, *writer.NextRowID())
 	})
 }
 
@@ -3147,7 +3182,7 @@ func (m *ManifestTestSuite) TestV3ManifestListAcceptsV1AndV2Manifests() {
 	m.Nil(v2Entry.FirstRowID(), "delete manifests must not be assigned first_row_id")
 }
 
-func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCounts() {
+func (m *ManifestTestSuite) TestV3ManifestListAssignsZeroForV1ManifestWithUnknownRowCounts() {
 	legacy := *(manifestFileRecordsV1[0].(*manifestFile))
 	legacy.AddedRowsCount = -1
 	legacy.ExistingRowsCount = -1
@@ -3161,10 +3196,7 @@ func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCou
 	var v3Buf bytes.Buffer
 	writer, err := NewManifestListWriterV3(&v3Buf, snapshotID, 1, 1000, nil)
 	m.Require().NoError(err)
-	err = writer.AddManifests(manifests)
-	m.Require().ErrorIs(err, ErrInvalidArgument)
-	m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
-	m.Require().ErrorContains(err, legacy.Path)
+	m.Require().NoError(writer.AddManifests(manifests))
 	m.EqualValues(1000, *writer.NextRowID())
 	m.Require().NoError(writer.Close())
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2475,6 +2475,16 @@ func (m *ManifestTestSuite) TestV3ManifestListWriterRejectsInvalidRowIDRanges() 
 		m.Require().ErrorContains(err, "overflows int64")
 		m.EqualValues(math.MaxInt64, *writer.NextRowID())
 	})
+
+	m.Run("later validation failure leaves cursor unchanged", func() {
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, 10, nil)
+		m.Require().NoError(err)
+		manifest := NewManifestFile(3, "other-snapshot.avro", 100, 1, snapshotID+1).AddedRows(5).Build()
+		err = writer.AddManifests([]ManifestFile{manifest})
+		m.Require().ErrorContains(err, "unassigned sequence number")
+		m.EqualValues(10, *writer.NextRowID())
+	})
 }
 
 func (m *ManifestTestSuite) TestV3ManifestListWriterAssignedRowIDDelta() {


### PR DESCRIPTION
## What changed

Validate every row-ID range assigned by the v3 manifest writers before advancing the cursor:

- reject negative initial row IDs
- reject negative added or existing row counts
- detect `int64` overflow while allocating a manifest range
- advance `NextRowID` only after manifest validation and encoding succeed

The same checked arithmetic is used by `WriteManifestV3` when it returns the next available row ID.

## Why

V3 row lineage requires non-negative row IDs. The manifest-list writer previously added `existing_rows_count` and `added_rows_count` directly to its cursor. Near `math.MaxInt64`, that addition could wrap and assign a negative `first_row_id` to the next manifest. Invalid counts or a later validation failure could also move the in-memory cursor even though the manifest was rejected.

This could produce overlapping or invalid row-ID ranges in metadata written near the boundary.

## Testing

- negative initial row ID
- negative manifest row count
- manifest-list range overflow
- `WriteManifestV3` range overflow
- cursor remains unchanged after overflow or later validation failure
- `go test .`
- `go vet .`