### PR TITLE
fix(schema): replace state during JSON decoding

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -277,10 +277,11 @@ func (s *Schema) FieldIDs() []int {
 
 func (s *Schema) UnmarshalJSON(b []byte) error {
 	type Alias Schema
+	var decoded Schema
 	aux := struct {
 		Fields []NestedField `json:"fields"`
 		*Alias
-	}{Alias: (*Alias)(s)}
+	}{Alias: (*Alias)(&decoded)}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
@@ -290,12 +291,13 @@ func (s *Schema) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s.init()
-
-	s.fields = aux.Fields
-	if s.IdentifierFieldIDs == nil {
-		s.IdentifierFieldIDs = []int{}
+	decoded.fields = aux.Fields
+	if decoded.IdentifierFieldIDs == nil {
+		decoded.IdentifierFieldIDs = []int{}
 	}
+
+	*s = decoded
+	s.init()
 
 	return nil
 }

--- a/schema.go
+++ b/schema.go
@@ -296,7 +296,14 @@ func (s *Schema) UnmarshalJSON(b []byte) error {
 		decoded.IdentifierFieldIDs = []int{}
 	}
 
-	*s = decoded
+	s.ID = decoded.ID
+	s.IdentifierFieldIDs = decoded.IdentifierFieldIDs
+	s.fields = decoded.fields
+	s.idToName.Store(nil)
+	s.idToField.Store(nil)
+	s.nameToID.Store(nil)
+	s.nameToIDLower.Store(nil)
+	s.idToAccessor.Store(nil)
 	s.init()
 
 	return nil

--- a/schema_test.go
+++ b/schema_test.go
@@ -570,6 +570,50 @@ func TestUnmarshalSchema(t *testing.T) {
 	assert.True(t, tableSchemaSimple.Equals(&schema))
 }
 
+func TestUnmarshalSchemaReplacesExistingState(t *testing.T) {
+	schema := iceberg.NewSchemaWithIdentifiers(7, []int{1},
+		iceberg.NestedField{ID: 1, Name: "old", Type: iceberg.PrimitiveTypes.String},
+	)
+	_, ok := schema.FindFieldByID(1)
+	require.True(t, ok)
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"type": "struct",
+		"fields": [{"id": 2, "name": "new", "type": "long", "required": true}]
+	}`), schema))
+
+	assert.Zero(t, schema.ID)
+	assert.Empty(t, schema.IdentifierFieldIDs)
+	assert.Equal(t, 1, schema.NumFields())
+	_, ok = schema.FindFieldByID(1)
+	assert.False(t, ok)
+	field, ok := schema.FindFieldByID(2)
+	require.True(t, ok)
+	assert.Equal(t, "new", field.Name)
+}
+
+func TestUnmarshalSchemaPreservesExistingStateOnError(t *testing.T) {
+	schema := iceberg.NewSchemaWithIdentifiers(7, []int{1},
+		iceberg.NestedField{ID: 1, Name: "old", Type: iceberg.PrimitiveTypes.String},
+	)
+
+	err := json.Unmarshal([]byte(`{
+		"type": "struct",
+		"fields": [
+			{"id": 2, "name": "first", "type": "long", "required": true},
+			{"id": 2, "name": "duplicate", "type": "string", "required": false}
+		]
+	}`), schema)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+
+	assert.Equal(t, 7, schema.ID)
+	assert.Equal(t, []int{1}, schema.IdentifierFieldIDs)
+	assert.Equal(t, 1, schema.NumFields())
+	field, ok := schema.FindFieldByID(1)
+	require.True(t, ok)
+	assert.Equal(t, "old", field.Name)
+}
+
 func TestUnmarshalSchemaRejectsDuplicateFieldIDs(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/schema_test.go
+++ b/schema_test.go
@@ -611,6 +611,16 @@ func TestUnmarshalSchemaPreservesExistingStateOnError(t *testing.T) {
 	schema := iceberg.NewSchemaWithIdentifiers(7, []int{1},
 		iceberg.NestedField{ID: 1, Name: "old", Type: iceberg.PrimitiveTypes.String},
 	)
+	_, ok := schema.FindFieldByID(1)
+	require.True(t, ok)
+	_, ok = schema.FindColumnName(1)
+	require.True(t, ok)
+	_, ok = schema.FindFieldByName("old")
+	require.True(t, ok)
+	_, ok = schema.FindFieldByNameCaseInsensitive("OLD")
+	require.True(t, ok)
+	assert.Contains(t, schema.NameMapping().String(), "old")
+	assert.False(t, schema.FieldHasOptionalParent(1))
 
 	err := json.Unmarshal([]byte(`{
 		"type": "struct",
@@ -627,6 +637,16 @@ func TestUnmarshalSchemaPreservesExistingStateOnError(t *testing.T) {
 	field, ok := schema.FindFieldByID(1)
 	require.True(t, ok)
 	assert.Equal(t, "old", field.Name)
+	_, ok = schema.FindColumnName(1)
+	require.True(t, ok)
+	field, ok = schema.FindFieldByName("old")
+	require.True(t, ok)
+	assert.Equal(t, "old", field.Name)
+	field, ok = schema.FindFieldByNameCaseInsensitive("OLD")
+	require.True(t, ok)
+	assert.Equal(t, "old", field.Name)
+	assert.Contains(t, schema.NameMapping().String(), "old")
+	assert.False(t, schema.FieldHasOptionalParent(1))
 }
 
 func TestUnmarshalSchemaRejectsDuplicateFieldIDs(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -576,6 +576,13 @@ func TestUnmarshalSchemaReplacesExistingState(t *testing.T) {
 	)
 	_, ok := schema.FindFieldByID(1)
 	require.True(t, ok)
+	_, ok = schema.FindColumnName(1)
+	require.True(t, ok)
+	_, ok = schema.FindFieldByName("old")
+	require.True(t, ok)
+	_, ok = schema.FindFieldByNameCaseInsensitive("OLD")
+	require.True(t, ok)
+	assert.Contains(t, schema.NameMapping().String(), "old")
 
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"type": "struct",
@@ -587,9 +594,17 @@ func TestUnmarshalSchemaReplacesExistingState(t *testing.T) {
 	assert.Equal(t, 1, schema.NumFields())
 	_, ok = schema.FindFieldByID(1)
 	assert.False(t, ok)
+	_, ok = schema.FindColumnName(1)
+	assert.False(t, ok)
+	_, ok = schema.FindFieldByName("old")
+	assert.False(t, ok)
+	_, ok = schema.FindFieldByNameCaseInsensitive("OLD")
+	assert.False(t, ok)
 	field, ok := schema.FindFieldByID(2)
 	require.True(t, ok)
 	assert.Equal(t, "new", field.Name)
+	assert.Contains(t, schema.NameMapping().String(), "new")
+	assert.NotContains(t, schema.NameMapping().String(), "old")
 }
 
 func TestUnmarshalSchemaPreservesExistingStateOnError(t *testing.T) {


### PR DESCRIPTION
## What changed

Make `Schema.UnmarshalJSON` decode and validate into fresh temporary state, then replace the receiver only after the complete document is valid. On success, clear every cached lookup index and rebuild the lazy parent and name-mapping functions for the new schema.

## Why

The decoder previously unmarshaled through the existing receiver. Reusing a `Schema` could therefore retain values omitted from the next document, including `schema-id` and `identifier-field-ids`. Cached lookups could continue returning fields from the previous schema.

Duplicate-field validation also ran after the receiver had already been modified, so invalid input could leave a partially updated schema behind. Decoding transactionally gives successful reuse replacement semantics while preserving the original value on error.

## Testing

- reused receiver clears omitted schema metadata
- ID, name, case-insensitive name, and name-mapping caches reflect the replacement schema
- invalid duplicate IDs preserve the original schema
- `go test .`
- `go vet .`