### PR TITLE
fix(cli): use standard property keys when creating a namespace

### DIFF
--- a/cmd/iceberg/create_test.go
+++ b/cmd/iceberg/create_test.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCatalogForCreate struct {
+	mockCatalogForDrop
+
+	createNamespaceCalled bool
+	createNamespaceIdent  table.Identifier
+	createNamespaceProps  iceberg.Properties
+	createNamespaceErr    error
+}
+
+func (m *mockCatalogForCreate) CatalogType() catalog.Type {
+	return catalog.REST
+}
+
+func (m *mockCatalogForCreate) CreateNamespace(_ context.Context, namespace table.Identifier, props iceberg.Properties) error {
+	m.createNamespaceCalled = true
+	m.createNamespaceIdent = namespace
+	m.createNamespaceProps = props
+
+	return m.createNamespaceErr
+}
+
+func (m *mockCatalogForCreate) CreateTable(context.Context, table.Identifier, *iceberg.Schema, ...catalog.CreateTableOpt) (*table.Table, error) {
+	panic("CreateTable must not be called")
+}
+
+func TestRunCreateNamespaceUsesCanonicalLowercaseProps(t *testing.T) {
+	cat := &mockCatalogForCreate{}
+
+	cmd := &CreateCmd{
+		Namespace: &CreateNamespaceCmd{
+			Identifier:  "db",
+			Description: "Test Description",
+			LocationURI: "s3://test-location",
+		},
+	}
+
+	var out errCapture
+
+	runCreate(context.Background(), &out, cat, cmd)
+
+	assert.True(t, cat.createNamespaceCalled)
+	assert.Equal(t, table.Identifier{"db"}, cat.createNamespaceIdent)
+	assert.Equal(t, iceberg.Properties{
+		"comment":  "Test Description",
+		"location": "s3://test-location",
+	}, cat.createNamespaceProps)
+	assert.Equal(t, "Namespace db created successfully", out.lastText)
+	assert.NoError(t, out.lastErr)
+}

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -462,11 +462,11 @@ func runCreate(ctx context.Context, output Output, cat catalog.Catalog, cmd *Cre
 		ns := cmd.Namespace
 		props := iceberg.Properties{}
 		if ns.Description != "" {
-			props["Description"] = ns.Description
+			props["comment"] = ns.Description
 		}
 
 		if ns.LocationURI != "" {
-			props["Location"] = ns.LocationURI
+			props["location"] = ns.LocationURI
 		}
 
 		err := cat.CreateNamespace(ctx, catalog.ToIdentifier(ns.Identifier), props)


### PR DESCRIPTION
## Summary
`iceberg create namespace` set the `Description`/`Location` properties with capitalized keys. Glue's `constructDatabaseInput` only recognizes the lowercase `comment`/`location` keys (Hive's uppercase handling is a legacy fallback, not the standard), so `--location-uri` was silently dropped into the namespace's generic parameter map instead of `DatabaseInput.LocationUri` for Glue catalogs, while the CLI reported success.

Use `comment`/`location`, matching the keys catalogs actually read
(`catalog/glue/glue.go`, `catalog/hive/hive.go`, `catalog/internal/utils.go`).

## Test Plan
`go test ./cmd/iceberg`