### PR TITLE
fix(catalog/sql): return ErrNamespaceAlreadyExists on a concurrent create

### DIFF
--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1284,8 +1284,8 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 			return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, insertErr)
 		}
 
-		// Only Postgres aborts the whole tx on a failed insert, so only it needs a
-		// savepoint to keep the re-check runnable; Oracle has no RELEASE SAVEPOINT.
+		// Postgres aborts the whole tx on a failed insert, so only it needs the
+		// savepoint for the re-check; SQLite/MySQL don't, and Oracle can't RELEASE it.
 		if tx.Dialect().Name() == dialect.PG {
 			sp, err := tx.BeginTx(ctx, nil)
 			if err != nil {

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1269,15 +1269,33 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 			})
 		}
 
-		_, err := tx.NewInsert().Model(&toInsert).Exec(ctx)
+		// Run the insert in a savepoint so a failure can be rolled back without
+		// aborting the whole transaction (Postgres); the re-check then still runs.
+		sp, err := tx.BeginTx(ctx, nil)
 		if err != nil {
-			// A concurrent writer may have inserted since the check above; if the
-			// re-check itself fails, fall through to the insert error.
-			if _, exists, checkErr := c.resolveNamespaceKeyInTx(ctx, tx, namespace); checkErr == nil && exists {
+			return fmt.Errorf("error creating savepoint for namespace '%s': %w", namespace, err)
+		}
+
+		if _, err = sp.NewInsert().Model(&toInsert).Exec(ctx); err != nil {
+			if rbErr := sp.Rollback(); rbErr != nil {
+				// A failed rollback poisons the tx (Postgres); keep both causes.
+				return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(err, rbErr))
+			}
+			// A concurrent writer may have won the race; return the sentinel in the
+			// same form as the pre-check above so both paths are identical.
+			_, exists, checkErr := c.resolveNamespaceKeyInTx(ctx, tx, namespace)
+			if checkErr == nil && exists {
 				return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(namespace, "."))
+			}
+			if checkErr != nil {
+				return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(err, checkErr))
 			}
 
 			return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, err)
+		}
+
+		if err = sp.Commit(); err != nil {
+			return fmt.Errorf("error releasing savepoint for namespace '%s': %w", namespace, err)
 		}
 
 		return nil

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1271,9 +1271,9 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 
 		_, err := tx.NewInsert().Model(&toInsert).Exec(ctx)
 		if err != nil {
-			// A concurrent writer can insert between the check above and here, and
-			// the driver's duplicate-key error is not what callers match on.
-			if _, exists, checkErr := c.resolveNamespaceKey(ctx, namespace); checkErr == nil && exists {
+			// A concurrent writer may have inserted since the check above; if the
+			// re-check itself fails, fall through to the insert error.
+			if _, exists, checkErr := c.resolveNamespaceKeyInTx(ctx, tx, namespace); checkErr == nil && exists {
 				return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(namespace, "."))
 			}
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1269,33 +1269,46 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 			})
 		}
 
-		// Run the insert in a savepoint so a failure can be rolled back without
-		// aborting the whole transaction (Postgres); the re-check then still runs.
-		sp, err := tx.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("error creating savepoint for namespace '%s': %w", namespace, err)
-		}
-
-		if _, err = sp.NewInsert().Model(&toInsert).Exec(ctx); err != nil {
-			if rbErr := sp.Rollback(); rbErr != nil {
-				// A failed rollback poisons the tx (Postgres); keep both causes.
-				return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(err, rbErr))
-			}
-			// A concurrent writer may have won the race; return the sentinel in the
-			// same form as the pre-check above so both paths are identical.
+		// A concurrent writer may have won the race; return the sentinel in the same
+		// form as the pre-check above. This must stay the first read on the outer tx
+		// so MySQL's REPEATABLE READ snapshot lands after the winner committed.
+		recheck := func(insertErr error) error {
 			_, exists, checkErr := c.resolveNamespaceKeyInTx(ctx, tx, namespace)
 			if checkErr == nil && exists {
 				return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(namespace, "."))
 			}
 			if checkErr != nil {
-				return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(err, checkErr))
+				return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(insertErr, checkErr))
 			}
 
-			return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, err)
+			return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, insertErr)
 		}
 
-		if err = sp.Commit(); err != nil {
-			return fmt.Errorf("error releasing savepoint for namespace '%s': %w", namespace, err)
+		// Only Postgres aborts the whole tx on a failed insert, so only it needs a
+		// savepoint to keep the re-check runnable; Oracle has no RELEASE SAVEPOINT.
+		if tx.Dialect().Name() == dialect.PG {
+			sp, err := tx.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("error creating savepoint for namespace '%s': %w", namespace, err)
+			}
+
+			if _, err = sp.NewInsert().Model(&toInsert).Exec(ctx); err != nil {
+				if rbErr := sp.Rollback(); rbErr != nil {
+					return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, errors.Join(err, rbErr))
+				}
+
+				return recheck(err)
+			}
+
+			if err = sp.Commit(); err != nil {
+				return fmt.Errorf("error releasing savepoint for namespace '%s': %w", namespace, err)
+			}
+
+			return nil
+		}
+
+		if _, err := tx.NewInsert().Model(&toInsert).Exec(ctx); err != nil {
+			return recheck(err)
 		}
 
 		return nil

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -1271,6 +1271,12 @@ func (c *Catalog) CreateNamespace(ctx context.Context, namespace table.Identifie
 
 		_, err := tx.NewInsert().Model(&toInsert).Exec(ctx)
 		if err != nil {
+			// A concurrent writer can insert between the check above and here, and
+			// the driver's duplicate-key error is not what callers match on.
+			if _, exists, checkErr := c.resolveNamespaceKey(ctx, namespace); checkErr == nil && exists {
+				return fmt.Errorf("%w: %s", catalog.ErrNamespaceAlreadyExists, strings.Join(namespace, "."))
+			}
+
 			return fmt.Errorf("error inserting namespace properties for namespace '%s': %w", namespace, err)
 		}
 

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -20,6 +20,7 @@ package sql_test
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -1951,6 +1953,7 @@ func (s *SqliteCatalogTestSuite) TestCreateNamespaceConcurrent() {
 	close(errs)
 
 	created, alreadyExists := 0, 0
+	var unexpected []error
 	for err := range errs {
 		switch {
 		case err == nil:
@@ -1958,12 +1961,101 @@ func (s *SqliteCatalogTestSuite) TestCreateNamespaceConcurrent() {
 		case errors.Is(err, catalog.ErrNamespaceAlreadyExists):
 			alreadyExists++
 		default:
-			s.Failf("unexpected error", "want nil or ErrNamespaceAlreadyExists, got %v", err)
+			unexpected = append(unexpected, err)
 		}
 	}
 
+	s.Empty(unexpected, "want nil or ErrNamespaceAlreadyExists")
 	s.Equal(1, created)
 	s.Equal(writers-1, alreadyExists)
+}
+
+// plantingDriver wraps the sqlite driver and, once, inserts the namespace row
+// on the same connection just before the catalog's own insert.
+type plantingDriver struct {
+	base      driver.Driver
+	namespace string
+	planted   atomic.Bool
+}
+
+func (d *plantingDriver) Open(dsn string) (driver.Conn, error) {
+	conn, err := d.base.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &plantingConn{Conn: conn, drv: d}, nil
+}
+
+type plantingConn struct {
+	driver.Conn
+	drv *plantingDriver
+}
+
+func (c *plantingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	// Same statement would be rolled back with the failing insert, so the plant
+	// goes in as its own statement first.
+	if strings.Contains(query, "iceberg_namespace_properties") && strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "INSERT") && c.drv.planted.CompareAndSwap(false, true) {
+		if _, err := execer.ExecContext(ctx, "INSERT INTO iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) VALUES (?, ?, ?, ?)",
+			[]driver.NamedValue{
+				{Ordinal: 1, Value: "default"},
+				{Ordinal: 2, Value: c.drv.namespace},
+				{Ordinal: 3, Value: "exists"},
+				{Ordinal: 4, Value: "true"},
+			}); err != nil {
+			return nil, err
+		}
+	}
+
+	return execer.ExecContext(ctx, query, args)
+}
+
+func (c *plantingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	return queryer.QueryContext(ctx, query, args)
+}
+
+func (c *plantingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return c.Conn.(driver.ConnBeginTx).BeginTx(ctx, opts)
+}
+
+func (c *plantingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return c.Conn.(driver.ConnPrepareContext).PrepareContext(ctx, query)
+}
+
+// The concurrent test above cannot tell whether a loser returned from the check
+// before the insert or from the recovery after it. This one only passes if the
+// insert ran and failed.
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceLosesInsertRace() {
+	ctx := context.Background()
+	namespace := table.Identifier{databaseName()}
+
+	base, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	s.Require().NoError(err)
+	s.Require().NoError(base.Close())
+
+	drvName := "sqlite-planting-" + namespace[0]
+	sql.Register(drvName, &plantingDriver{base: base.Driver(), namespace: namespace[0]})
+
+	sqldb, err := sql.Open(drvName, s.catalogUri())
+	s.Require().NoError(err)
+	defer sqldb.Close()
+	sqldb.SetMaxOpenConns(1)
+
+	cat, err := sqlcat.NewCatalog("default", sqldb, sqlcat.SQLite, iceberg.Properties{"warehouse": "file://" + s.warehouse})
+	s.Require().NoError(err)
+
+	err = cat.CreateNamespace(ctx, namespace, nil)
+	s.ErrorIs(err, catalog.ErrNamespaceAlreadyExists)
+	s.Contains(err.Error(), namespace[0])
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsReservedProperty() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2067,6 +2067,12 @@ func (c *pgAbortConn) QueryContext(ctx context.Context, query string, args []dri
 		return nil, errEmulatedAborted
 	}
 
+	// Postgres probes information_schema for schema-version detection; sqlite has
+	// no such view, so answer as the V1 table this suite creates (column present).
+	if strings.Contains(query, "information_schema") {
+		return &boolRows{val: true}, nil
+	}
+
 	// The namespace exists on the re-check only in the unique-violation case: a
 	// concurrent winner committed the row. An unrelated failure leaves it absent.
 	if isNamespaceExistsProbe(query) {
@@ -2118,7 +2124,7 @@ func (r *boolRows) Next(dest []driver.Value) error {
 	return nil
 }
 
-func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) *sqlcat.Catalog {
+func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) (*sqlcat.Catalog, *pgAbortDriver) {
 	base, err := sql.Open(sqliteshim.ShimName, ":memory:")
 	s.Require().NoError(err)
 	s.Require().NoError(base.Close())
@@ -2126,7 +2132,8 @@ func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) *sqlcat.Cat
 	// drvName derives from databaseName() (unique per call); sql.Register panics
 	// on a duplicate name, so this must not become a fixed string.
 	drvName := "sqlite-pgabort-" + databaseName()
-	sql.Register(drvName, &pgAbortDriver{base: base.Driver(), mode: mode})
+	drv := &pgAbortDriver{base: base.Driver(), mode: mode}
+	sql.Register(drvName, drv)
 
 	sqldb, err := sql.Open(drvName, s.catalogUri())
 	s.Require().NoError(err)
@@ -2135,33 +2142,37 @@ func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) *sqlcat.Cat
 	// transaction that follows it.
 	sqldb.SetMaxOpenConns(1)
 
-	cat, err := sqlcat.NewCatalog("default", sqldb, sqlcat.SQLite, iceberg.Properties{"warehouse": "file://" + s.warehouse})
+	// Postgres dialect so the savepoint-backed recovery path runs; the driver
+	// above emulates Postgres aborting the tx over an sqlite base.
+	cat, err := sqlcat.NewCatalog("default", sqldb, sqlcat.Postgres, iceberg.Properties{"warehouse": "file://" + s.warehouse})
 	s.Require().NoError(err)
 
-	return cat
+	return cat, drv
 }
 
 // Emulates Postgres aborting the transaction: only passes if the savepoint let
 // the re-check recover the sentinel, which SQLite alone cannot show.
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceLosesInsertRace() {
 	namespace := table.Identifier{databaseName()}
-	cat := s.newAbortCatalog(failUnique)
+	cat, drv := s.newAbortCatalog(failUnique)
 
 	err := cat.CreateNamespace(context.Background(), namespace, nil)
 	s.ErrorIs(err, catalog.ErrNamespaceAlreadyExists)
 	s.Contains(err.Error(), namespace[0])
+	s.True(drv.insertAttempted.Load(), "the emulated insert must have run")
 }
 
 // An unrelated insert failure on an absent namespace must surface its own
 // error, not a misleading ErrNamespaceAlreadyExists.
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceInsertFailureSurfacesOriginalError() {
 	namespace := table.Identifier{databaseName()}
-	cat := s.newAbortCatalog(failUnrelated)
+	cat, drv := s.newAbortCatalog(failUnrelated)
 
 	err := cat.CreateNamespace(context.Background(), namespace, nil)
 	s.Error(err)
 	s.NotErrorIs(err, catalog.ErrNamespaceAlreadyExists)
 	s.Contains(err.Error(), "disk I/O error")
+	s.True(drv.insertAttempted.Load(), "the emulated insert must have run")
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsReservedProperty() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"math/rand/v2"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -1909,6 +1912,58 @@ func (s *SqliteCatalogTestSuite) TestLoadEmptyNamespaceProperties() {
 		s.Require().NoError(err)
 		s.Empty(props)
 	}
+}
+
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceConcurrent() {
+	// Two callers creating the same namespace: exactly one succeeds and the other
+	// gets ErrNamespaceAlreadyExists, not the driver's duplicate-key error.
+	const writers = 8
+
+	// A busy timeout so the writers queue on the sqlite lock instead of failing
+	// with SQLITE_BUSY, which is a different contention problem to this one.
+	loaded, err := catalog.Load(context.Background(), "default", iceberg.Properties{
+		"uri":             s.catalogUri() + "?_pragma=" + url.QueryEscape("busy_timeout(10000)"),
+		sqlcat.DriverKey:  sqliteshim.ShimName,
+		sqlcat.DialectKey: string(sqlcat.SQLite),
+		"type":            "sql",
+		"warehouse":       "file://" + s.warehouse,
+	})
+	s.Require().NoError(err)
+
+	cat := loaded.(*sqlcat.Catalog)
+	ctx := context.Background()
+	namespace := table.Identifier{databaseName()}
+
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+
+	var wg sync.WaitGroup
+	for range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- cat.CreateNamespace(ctx, namespace, nil)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	created, alreadyExists := 0, 0
+	for err := range errs {
+		switch {
+		case err == nil:
+			created++
+		case errors.Is(err, catalog.ErrNamespaceAlreadyExists):
+			alreadyExists++
+		default:
+			s.Failf("unexpected error", "want nil or ErrNamespaceAlreadyExists, got %v", err)
+		}
+	}
+
+	s.Equal(1, created)
+	s.Equal(writers-1, alreadyExists)
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsReservedProperty() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -1981,6 +1981,9 @@ const (
 	// failUnrelated: insert fails for an unrelated reason and the namespace does
 	// not exist -- the original error must survive, not become "already exists".
 	failUnrelated
+	// insertSucceeds: the insert commits, exercising the savepoint happy path
+	// (SAVEPOINT -> insert -> RELEASE SAVEPOINT) on the Postgres branch.
+	insertSucceeds
 )
 
 var (
@@ -2046,12 +2049,18 @@ func (c *pgAbortConn) ExecContext(ctx context.Context, query string, args []driv
 
 	if isNamespaceInsert(query) {
 		c.drv.insertAttempted.Store(true)
-		c.drv.aborted.Store(true)
-		if c.drv.mode == failUnique {
+		switch c.drv.mode {
+		case insertSucceeds:
+			return execer.ExecContext(ctx, query, args)
+		case failUnrelated:
+			c.drv.aborted.Store(true)
+
+			return nil, errEmulatedUnrelated
+		default:
+			c.drv.aborted.Store(true)
+
 			return nil, errEmulatedUnique
 		}
-
-		return nil, errEmulatedUnrelated
 	}
 
 	return execer.ExecContext(ctx, query, args)
@@ -2148,6 +2157,117 @@ func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) (*sqlcat.Ca
 	s.Require().NoError(err)
 
 	return cat, drv
+}
+
+// dupInsertDriver emulates a dialect that rolls back only the failing statement
+// (SQLite): the namespace insert trips a unique violation without poisoning the
+// tx, so the re-check runs on the same tx and recovers the sentinel.
+type dupInsertDriver struct {
+	base            driver.Driver
+	insertAttempted atomic.Bool
+}
+
+func (d *dupInsertDriver) Open(dsn string) (driver.Conn, error) {
+	conn, err := d.base.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dupInsertConn{Conn: conn, drv: d}, nil
+}
+
+type dupInsertConn struct {
+	driver.Conn
+	drv *dupInsertDriver
+}
+
+func (c *dupInsertConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	if isNamespaceInsert(query) {
+		c.drv.insertAttempted.Store(true)
+
+		return nil, errEmulatedUnique
+	}
+
+	return execer.ExecContext(ctx, query, args)
+}
+
+func (c *dupInsertConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	// After the insert, the namespace exists on the re-check; before it, absent.
+	if isNamespaceExistsProbe(query) {
+		return &boolRows{val: c.drv.insertAttempted.Load()}, nil
+	}
+
+	return queryer.QueryContext(ctx, query, args)
+}
+
+func (c *dupInsertConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginTx, ok := c.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrBadConn
+	}
+
+	return beginTx.BeginTx(ctx, opts)
+}
+
+func (c *dupInsertConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	prepCtx, ok := c.Conn.(driver.ConnPrepareContext)
+	if !ok {
+		return nil, driver.ErrBadConn
+	}
+
+	return prepCtx.PrepareContext(ctx, query)
+}
+
+func (s *SqliteCatalogTestSuite) newDupCatalog() (*sqlcat.Catalog, *dupInsertDriver) {
+	base, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	s.Require().NoError(err)
+	s.Require().NoError(base.Close())
+
+	drvName := "sqlite-dupinsert-" + databaseName()
+	drv := &dupInsertDriver{base: base.Driver()}
+	sql.Register(drvName, drv)
+
+	sqldb, err := sql.Open(drvName, s.catalogUri())
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { _ = sqldb.Close() })
+	sqldb.SetMaxOpenConns(1)
+
+	// SQLite dialect so the non-Postgres recovery branch (plain insert + re-check)
+	// runs; the driver rolls back only the failing statement, so no savepoint.
+	cat, err := sqlcat.NewCatalog("default", sqldb, sqlcat.SQLite, iceberg.Properties{"warehouse": "file://" + s.warehouse})
+	s.Require().NoError(err)
+
+	return cat, drv
+}
+
+// Pins the non-Postgres branch: on SQLite a lost insert race recovers the
+// sentinel via the re-check without a savepoint.
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceLosesInsertRaceSQLite() {
+	namespace := table.Identifier{databaseName()}
+	cat, drv := s.newDupCatalog()
+
+	err := cat.CreateNamespace(context.Background(), namespace, nil)
+	s.ErrorIs(err, catalog.ErrNamespaceAlreadyExists)
+	s.Contains(err.Error(), namespace[0])
+	s.True(drv.insertAttempted.Load(), "the emulated insert must have run")
+}
+
+// Exercises the Postgres savepoint happy path: SAVEPOINT -> insert -> RELEASE.
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceSucceedsThroughSavepoint() {
+	namespace := table.Identifier{databaseName()}
+	cat, drv := s.newAbortCatalog(insertSucceeds)
+
+	err := cat.CreateNamespace(context.Background(), namespace, nil)
+	s.Require().NoError(err)
+	s.True(drv.insertAttempted.Load(), "the emulated insert must have run")
 }
 
 // Emulates Postgres aborting the transaction: only passes if the savepoint let

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"math/rand/v2"
 	"net/url"
@@ -1970,92 +1971,197 @@ func (s *SqliteCatalogTestSuite) TestCreateNamespaceConcurrent() {
 	s.Equal(writers-1, alreadyExists)
 }
 
-// plantingDriver wraps the sqlite driver and, once, inserts the namespace row
-// on the same connection just before the catalog's own insert.
-type plantingDriver struct {
-	base      driver.Driver
-	namespace string
-	planted   atomic.Bool
+// insertFailure selects how the emulated namespace insert fails.
+type insertFailure int
+
+const (
+	// failUnique: insert trips the unique constraint and the namespace exists on
+	// the re-check -- the raced create-if-absent that the fix must recover.
+	failUnique insertFailure = iota
+	// failUnrelated: insert fails for an unrelated reason and the namespace does
+	// not exist -- the original error must survive, not become "already exists".
+	failUnrelated
+)
+
+var (
+	errEmulatedUnique    = errors.New("UNIQUE constraint failed: iceberg_namespace_properties.catalog_name, iceberg_namespace_properties.namespace, iceberg_namespace_properties.property_key")
+	errEmulatedUnrelated = errors.New("disk I/O error")
+	errEmulatedAborted   = errors.New("current transaction is aborted, commands ignored until end of transaction block")
+)
+
+// pgAbortDriver emulates Postgres for the create race: after the namespace
+// insert fails it refuses statements until a ROLLBACK TO SAVEPOINT clears it.
+type pgAbortDriver struct {
+	base            driver.Driver
+	mode            insertFailure
+	insertAttempted atomic.Bool
+	aborted         atomic.Bool
 }
 
-func (d *plantingDriver) Open(dsn string) (driver.Conn, error) {
+func (d *pgAbortDriver) Open(dsn string) (driver.Conn, error) {
 	conn, err := d.base.Open(dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	return &plantingConn{Conn: conn, drv: d}, nil
+	return &pgAbortConn{Conn: conn, drv: d}, nil
 }
 
-type plantingConn struct {
+type pgAbortConn struct {
 	driver.Conn
-	drv *plantingDriver
+	drv *pgAbortDriver
 }
 
-func (c *plantingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+// These match bun's emitted SQL: an "INSERT"/"EXISTS" statement naming the
+// namespace table, and its "ROLLBACK TO SAVEPOINT" prefix.
+func isNamespaceInsert(query string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "INSERT") &&
+		strings.Contains(query, "iceberg_namespace_properties")
+}
+
+func isNamespaceExistsProbe(query string) bool {
+	return strings.Contains(strings.ToUpper(query), "EXISTS") &&
+		strings.Contains(query, "iceberg_namespace_properties")
+}
+
+func isRollbackToSavepoint(query string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "ROLLBACK TO SAVEPOINT")
+}
+
+func (c *pgAbortConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	execer, ok := c.Conn.(driver.ExecerContext)
 	if !ok {
 		return nil, driver.ErrSkip
 	}
-	// Same statement would be rolled back with the failing insert, so the plant
-	// goes in as its own statement first.
-	if strings.Contains(query, "iceberg_namespace_properties") && strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "INSERT") && c.drv.planted.CompareAndSwap(false, true) {
-		if _, err := execer.ExecContext(ctx, "INSERT INTO iceberg_namespace_properties (catalog_name, namespace, property_key, property_value) VALUES (?, ?, ?, ?)",
-			[]driver.NamedValue{
-				{Ordinal: 1, Value: "default"},
-				{Ordinal: 2, Value: c.drv.namespace},
-				{Ordinal: 3, Value: "exists"},
-				{Ordinal: 4, Value: "true"},
-			}); err != nil {
-			return nil, err
+
+	if c.drv.aborted.Load() {
+		if isRollbackToSavepoint(query) {
+			c.drv.aborted.Store(false)
+
+			return execer.ExecContext(ctx, query, args)
 		}
+
+		return nil, errEmulatedAborted
+	}
+
+	if isNamespaceInsert(query) {
+		c.drv.insertAttempted.Store(true)
+		c.drv.aborted.Store(true)
+		if c.drv.mode == failUnique {
+			return nil, errEmulatedUnique
+		}
+
+		return nil, errEmulatedUnrelated
 	}
 
 	return execer.ExecContext(ctx, query, args)
 }
 
-func (c *plantingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+func (c *pgAbortConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	queryer, ok := c.Conn.(driver.QueryerContext)
 	if !ok {
 		return nil, driver.ErrSkip
 	}
 
+	if c.drv.aborted.Load() {
+		return nil, errEmulatedAborted
+	}
+
+	// The namespace exists on the re-check only in the unique-violation case: a
+	// concurrent winner committed the row. An unrelated failure leaves it absent.
+	if isNamespaceExistsProbe(query) {
+		return &boolRows{val: c.drv.insertAttempted.Load() && c.drv.mode == failUnique}, nil
+	}
+
 	return queryer.QueryContext(ctx, query, args)
 }
 
-func (c *plantingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return c.Conn.(driver.ConnBeginTx).BeginTx(ctx, opts)
+func (c *pgAbortConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginTx, ok := c.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrBadConn
+	}
+
+	return beginTx.BeginTx(ctx, opts)
 }
 
-func (c *plantingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
-	return c.Conn.(driver.ConnPrepareContext).PrepareContext(ctx, query)
+func (c *pgAbortConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	prepCtx, ok := c.Conn.(driver.ConnPrepareContext)
+	if !ok {
+		return nil, driver.ErrBadConn
+	}
+
+	return prepCtx.PrepareContext(ctx, query)
 }
 
-// The concurrent test above cannot tell whether a loser returned from the check
-// before the insert or from the recovery after it. This one only passes if the
-// insert ran and failed.
-func (s *SqliteCatalogTestSuite) TestCreateNamespaceLosesInsertRace() {
-	ctx := context.Background()
-	namespace := table.Identifier{databaseName()}
+// boolRows is a single-row, single-column result carrying a SQL EXISTS answer.
+type boolRows struct {
+	val  bool
+	done bool
+}
 
+func (r *boolRows) Columns() []string { return []string{"exists"} }
+func (r *boolRows) Close() error      { return nil }
+func (r *boolRows) Next(dest []driver.Value) error {
+	// bun's Exists() scans SELECT EXISTS via QueryRowContext.Scan(&bool), so it
+	// keys on the value: emit one 0/1 row, not an empty result (that is ErrNoRows).
+	if r.done {
+		return io.EOF
+	}
+	r.done = true
+	if r.val {
+		dest[0] = int64(1)
+	} else {
+		dest[0] = int64(0)
+	}
+
+	return nil
+}
+
+func (s *SqliteCatalogTestSuite) newAbortCatalog(mode insertFailure) *sqlcat.Catalog {
 	base, err := sql.Open(sqliteshim.ShimName, ":memory:")
 	s.Require().NoError(err)
 	s.Require().NoError(base.Close())
 
-	drvName := "sqlite-planting-" + namespace[0]
-	sql.Register(drvName, &plantingDriver{base: base.Driver(), namespace: namespace[0]})
+	// drvName derives from databaseName() (unique per call); sql.Register panics
+	// on a duplicate name, so this must not become a fixed string.
+	drvName := "sqlite-pgabort-" + databaseName()
+	sql.Register(drvName, &pgAbortDriver{base: base.Driver(), mode: mode})
 
 	sqldb, err := sql.Open(drvName, s.catalogUri())
 	s.Require().NoError(err)
-	defer sqldb.Close()
+	s.T().Cleanup(func() { _ = sqldb.Close() })
+	// Single connection so the driver's abort state spans the pre-check and the
+	// transaction that follows it.
 	sqldb.SetMaxOpenConns(1)
 
 	cat, err := sqlcat.NewCatalog("default", sqldb, sqlcat.SQLite, iceberg.Properties{"warehouse": "file://" + s.warehouse})
 	s.Require().NoError(err)
 
-	err = cat.CreateNamespace(ctx, namespace, nil)
+	return cat
+}
+
+// Emulates Postgres aborting the transaction: only passes if the savepoint let
+// the re-check recover the sentinel, which SQLite alone cannot show.
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceLosesInsertRace() {
+	namespace := table.Identifier{databaseName()}
+	cat := s.newAbortCatalog(failUnique)
+
+	err := cat.CreateNamespace(context.Background(), namespace, nil)
 	s.ErrorIs(err, catalog.ErrNamespaceAlreadyExists)
 	s.Contains(err.Error(), namespace[0])
+}
+
+// An unrelated insert failure on an absent namespace must surface its own
+// error, not a misleading ErrNamespaceAlreadyExists.
+func (s *SqliteCatalogTestSuite) TestCreateNamespaceInsertFailureSurfacesOriginalError() {
+	namespace := table.Identifier{databaseName()}
+	cat := s.newAbortCatalog(failUnrelated)
+
+	err := cat.CreateNamespace(context.Background(), namespace, nil)
+	s.Error(err)
+	s.NotErrorIs(err, catalog.ErrNamespaceAlreadyExists)
+	s.Contains(err.Error(), "disk I/O error")
 }
 
 func (s *SqliteCatalogTestSuite) TestCreateNamespaceRejectsReservedProperty() {

--- a/catalog/sql/sql_test.go
+++ b/catalog/sql/sql_test.go
@@ -2084,7 +2084,12 @@ func (c *pgAbortConn) QueryContext(ctx context.Context, query string, args []dri
 
 	// The namespace exists on the re-check only in the unique-violation case: a
 	// concurrent winner committed the row. An unrelated failure leaves it absent.
+	// In the success case the insert is real, so let the probe read true persistence.
 	if isNamespaceExistsProbe(query) {
+		if c.drv.mode == insertSucceeds {
+			return queryer.QueryContext(ctx, query, args)
+		}
+
 		return &boolRows{val: c.drv.insertAttempted.Load() && c.drv.mode == failUnique}, nil
 	}
 
@@ -2265,9 +2270,15 @@ func (s *SqliteCatalogTestSuite) TestCreateNamespaceSucceedsThroughSavepoint() {
 	namespace := table.Identifier{databaseName()}
 	cat, drv := s.newAbortCatalog(insertSucceeds)
 
-	err := cat.CreateNamespace(context.Background(), namespace, nil)
+	ctx := context.Background()
+	err := cat.CreateNamespace(ctx, namespace, nil)
 	s.Require().NoError(err)
 	s.True(drv.insertAttempted.Load(), "the emulated insert must have run")
+
+	// The row must survive RELEASE SAVEPOINT; a ROLLBACK there would persist none.
+	exists, err := cat.CheckNamespaceExists(ctx, namespace)
+	s.Require().NoError(err)
+	s.True(exists, "the namespace must persist through the savepoint commit")
 }
 
 // Emulates Postgres aborting the transaction: only passes if the savepoint let


### PR DESCRIPTION
## Problem

`CreateNamespace` in the sql catalog resolves the namespace key, returns `ErrNamespaceAlreadyExists` if it is present, and otherwise inserts the properties. Two callers creating the same namespace both pass that check, and the loser's insert violates the primary key on `iceberg_namespace_properties`. The driver's error is returned unwrapped:

```
error inserting namespace properties for namespace '[raw]': constraint failed:
UNIQUE constraint failed: iceberg_namespace_properties.catalog_name,
iceberg_namespace_properties.namespace, iceberg_namespace_properties.property_key (1555)
```

Callers that write `errors.Is(err, catalog.ErrNamespaceAlreadyExists)` — the contract the other implementations honour, and the natural way to write create-if-absent — see a failure for a namespace that does exist. It surfaces as an intermittent first-run failure in any tool that loads two tables into a new namespace concurrently; that is how I ran into it.

## Fix

Re-resolve the namespace key when the insert fails, and return `ErrNamespaceAlreadyExists` if it is present now. An insert that failed for any other reason is returned exactly as before.

I kept the pre-check rather than replacing it with an upsert: it keeps the common path a single read, and the behaviour on the raced path is then identical to the non-raced one.