### PR TITLE
fix(hive): jitter lock-retry waits to decorrelate contending clients

### DIFF
--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -208,10 +208,7 @@ func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 	// is itself >= maxWait the loop cannot run at all, and options.go accepts that
 	// configuration, so leaving the floor at d/2 there would allow a wait of a third
 	// of the configured minimum.
-	floor := d / 2
-	if minWait > floor {
-		floor = minWait
-	}
+	floor := max(minWait, d/2)
 	for scheduled := minWait; scheduled > 0 && scheduled < maxWait; scheduled <<= 1 {
 		if scheduled > floor {
 			floor = scheduled

--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"time"
@@ -100,7 +101,11 @@ func acquireLocks(ctx context.Context, client HiveClient, identifiers []tableLoc
 	// If not acquired immediately, wait and retry
 	for attempt := 0; attempt < opts.LockRetries; attempt++ {
 		// Wait before checking again
-		waitTime := calculateBackoff(attempt, opts.LockMinWaitTime, opts.LockMaxWaitTime)
+		waitTime := applyJitter(
+			calculateBackoff(attempt, opts.LockMinWaitTime, opts.LockMaxWaitTime),
+			opts.LockMinWaitTime,
+			opts.LockMaxWaitTime,
+		)
 
 		select {
 		case <-ctx.Done():
@@ -158,6 +163,75 @@ func calculateBackoff(attempt int, minWait, maxWait time.Duration) time.Duration
 	}
 
 	return minWait << attempt
+}
+
+// applyJitter spreads a backoff interval by adding a random amount on top of it,
+// bounded so the result never exceeds maxWait.
+//
+// calculateBackoff is a pure function of the attempt number and the configured
+// bounds, so every client waiting on the same table lock computes an identical
+// sequence of delays. Contention is the precondition for entering the retry loop
+// at all, which means those clients are waiting simultaneously by construction:
+// they re-check the lock in lockstep, and each round of CheckLock calls arrives
+// at the metastore as a burst. Spreading the wait decorrelates them.
+//
+// The jitter is added rather than subtracted so that the result is never shorter
+// than the interval calculateBackoff produced. That keeps the guarantee implied
+// by the lock-check-min-wait-time property: a caller who configures a minimum
+// wait never polls sooner than it.
+//
+// Once the backoff saturates at maxWait there is no headroom left to add into.
+// calculateBackoff reaches that point deliberately, so leaving it unjittered
+// would put contending clients back in lockstep for every retry after the
+// sequence tops out. The wait is therefore spread downwards instead. Drawing
+// below maxWait breaks no contract, because it is an upper bound on the polling
+// interval rather than a target.
+//
+// How far down it may draw is the subtle part. Flooring at half the interval is
+// wrong: the last attempt that did not saturate waited for its own full interval,
+// which is somewhere in [maxWait/2, maxWait), so a floor of maxWait/2 lets the
+// first saturated attempt wait less than the attempt before it did. That inverts
+// the one property callers rely on, which is that the wait between lock checks
+// only ever grows. The floor is therefore the last interval the doubling sequence
+// produced before it hit the cap, recovered by replaying the sequence. It is a
+// bound the schedule has already cleared, so honouring it keeps the guaranteed
+// minimum monotonic across the saturation boundary, and it can never fall below
+// minWait because minWait is where the sequence starts.
+func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+
+	// A caller that hands in an interval already past the cap is outside the
+	// contract; leave it exactly as given rather than silently reshaping it.
+	headroom := maxWait - d
+	if headroom < 0 {
+		return d
+	}
+
+	// Add up to another full interval, without exceeding the configured maximum.
+	extra := d
+	if headroom < extra {
+		extra = headroom
+	}
+	if extra > 0 {
+		return d + time.Duration(rand.Int64N(int64(extra)+1))
+	}
+
+	// Replay the doubling sequence and keep the largest interval that still fitted
+	// under the cap. The guard on scheduled keeps a non-positive or overflowing
+	// minWait from spinning here; in that case the half-interval floor stands.
+	floor := d / 2
+	for scheduled := minWait; scheduled > 0 && scheduled < maxWait; scheduled <<= 1 {
+		if scheduled > floor {
+			floor = scheduled
+		}
+	}
+	if floor >= d {
+		return d
+	}
+
+	return d - time.Duration(rand.Int64N(int64(d-floor)+1))
 }
 
 func (l *HiveLock) Release(ctx context.Context) error {

--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -165,38 +165,20 @@ func calculateBackoff(attempt int, minWait, maxWait time.Duration) time.Duration
 	return minWait << attempt
 }
 
-// applyJitter spreads a backoff interval by adding a random amount on top of it,
-// bounded so the result never exceeds maxWait.
+// applyJitter spreads a backoff interval so clients contending for the same lock
+// stop re-polling in lockstep. calculateBackoff is a pure function of the attempt
+// and the configured bounds, and contention is the precondition for retrying at
+// all, so without this every waiter issues its CheckLock calls at the same instants
+// and each round reaches the metastore as a burst.
 //
-// calculateBackoff is a pure function of the attempt number and the configured
-// bounds, so every client waiting on the same table lock computes an identical
-// sequence of delays. Contention is the precondition for entering the retry loop
-// at all, which means those clients are waiting simultaneously by construction:
-// they re-check the lock in lockstep, and each round of CheckLock calls arrives
-// at the metastore as a burst. Spreading the wait decorrelates them.
-//
-// The jitter is added rather than subtracted so that the result is never shorter
-// than the interval calculateBackoff produced. That keeps the guarantee implied
-// by the lock-check-min-wait-time property: a caller who configures a minimum
-// wait never polls sooner than it.
-//
-// Once the backoff saturates at maxWait there is no headroom left to add into.
-// calculateBackoff reaches that point deliberately, so leaving it unjittered
-// would put contending clients back in lockstep for every retry after the
-// sequence tops out. The wait is therefore spread downwards instead. Drawing
-// below maxWait breaks no contract, because it is an upper bound on the polling
-// interval rather than a target.
-//
-// How far down it may draw is the subtle part. Flooring at half the interval is
-// wrong: the last attempt that did not saturate waited for its own full interval,
-// which is somewhere in [maxWait/2, maxWait), so a floor of maxWait/2 lets the
-// first saturated attempt wait less than the attempt before it did. That inverts
-// the one property callers rely on, which is that the wait between lock checks
-// only ever grows. The floor is therefore the last interval the doubling sequence
-// produced before it hit the cap, recovered by replaying the sequence. It is a
-// bound the schedule has already cleared, so honouring it keeps the guaranteed
-// minimum monotonic across the saturation boundary, and it can never fall below
-// minWait because minWait is where the sequence starts.
+// The invariants, in the order the code establishes them:
+//   - below the cap the jitter is added rather than centred, so the wait is never
+//     shorter than the interval calculateBackoff produced;
+//   - at the cap there is no headroom left to add into, so the wait is spread
+//     downward instead, floored at the last interval the sequence produced before
+//     it saturated — a bound the schedule has already cleared, which stops a later
+//     attempt from being allowed to wait less than an earlier one;
+//   - the result never exceeds maxWait and never falls below minWait.
 func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 	if d <= 0 {
 		return d
@@ -220,8 +202,16 @@ func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 
 	// Replay the doubling sequence and keep the largest interval that still fitted
 	// under the cap. The guard on scheduled keeps a non-positive or overflowing
-	// minWait from spinning here; in that case the half-interval floor stands.
+	// minWait from spinning here.
+	//
+	// minWait is applied before the replay rather than relying on it. When minWait
+	// is itself >= maxWait the loop cannot run at all, and options.go accepts that
+	// configuration, so leaving the floor at d/2 there would allow a wait of a third
+	// of the configured minimum.
 	floor := d / 2
+	if minWait > floor {
+		floor = minWait
+	}
 	for scheduled := minWait; scheduled > 0 && scheduled < maxWait; scheduled <<= 1 {
 		if scheduled > floor {
 			floor = scheduled

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -508,6 +508,68 @@ func TestApplyJitterAtCapFloorsAtTheLastUncappedInterval(t *testing.T) {
 	}
 }
 
+// A caller may configure minWait above maxWait; options.go accepts it, and
+// calculateBackoff resolves it by returning maxWait. The downward spread must not
+// then draw below the configured minimum. Flooring at half the interval would
+// permit a third of it, because the replay loop cannot run when minWait is already
+// past the cap.
+func TestApplyJitterHonoursMinWaitAboveMaxWait(t *testing.T) {
+	minWait := 90 * time.Second
+	maxWait := 60 * time.Second
+
+	d := calculateBackoff(0, minWait, maxWait)
+	require.Equal(t, maxWait, d, "calculateBackoff resolves this configuration to the cap")
+
+	for i := 0; i < 2000; i++ {
+		got := applyJitter(d, minWait, maxWait)
+		assert.Equal(t, maxWait, got,
+			"with minWait past the cap the wait cannot be spread at all without breaking it")
+	}
+}
+
+// Exercises the wiring at the acquireLocks call site rather than the helper alone,
+// and pins the aggregate delay. The schedule is 10ms, 20ms, 40ms, 80ms, and each
+// draw adds up to one further interval, so the total falls in [150ms, 300ms]. Only
+// the lower bound is asserted tightly; the ceiling is loose because a busy CI box
+// can add arbitrary scheduling delay on top, and a flaky timing test is worse than
+// no timing test.
+func TestAcquireLocksAggregateRetryDelayStaysWithinBound(t *testing.T) {
+	mockClient := new(mockHiveClient)
+	ctx := context.Background()
+	opts := NewHiveOptions()
+	opts.LockMinWaitTime = 10 * time.Millisecond
+	opts.LockMaxWaitTime = time.Second
+	opts.LockRetries = 4
+
+	mockClient.On("Lock", ctx, mock.AnythingOfType("*hive_metastore.LockRequest")).
+		Return(&hive_metastore.LockResponse{
+			Lockid: 901,
+			State:  hive_metastore.LockState_WAITING,
+		}, nil)
+	mockClient.On("CheckLock", ctx, int64(901)).
+		Return(&hive_metastore.LockResponse{
+			Lockid: 901,
+			State:  hive_metastore.LockState_WAITING,
+		}, nil)
+	mockClient.On("Unlock", mock.Anything, int64(901)).Return(nil)
+
+	start := time.Now()
+	lock, err := acquireLocks(ctx, mockClient,
+		[]tableLockIdentifier{{database: "testdb", table: "testtable"}}, opts)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, lock)
+	assert.ErrorIs(t, err, ErrLockAcquisitionFailed)
+
+	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond,
+		"the jittered waits must never sum to less than the unjittered schedule")
+	assert.Less(t, elapsed, 5*time.Second,
+		"the jittered waits must stay bounded by roughly twice the schedule")
+
+	mockClient.AssertExpectations(t)
+}
+
 func TestApplyJitterRespectsMaxWait(t *testing.T) {
 	minWait := 100 * time.Millisecond
 	maxWait := 1 * time.Second

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -404,3 +404,133 @@ func TestLockConfigurationDefaults(t *testing.T) {
 	assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
 	assert.Equal(t, DefaultLockCheckRetries, opts.LockRetries)
 }
+
+func TestApplyJitterBelowCapNeverShorterThanInput(t *testing.T) {
+	minWait := time.Millisecond
+	maxWait := time.Minute
+
+	for _, d := range []time.Duration{
+		time.Millisecond,
+		100 * time.Millisecond,
+		time.Second,
+	} {
+		for i := 0; i < 500; i++ {
+			got := applyJitter(d, minWait, maxWait)
+			assert.GreaterOrEqual(t, got, d,
+				"jitter must never wait less than the configured interval")
+			assert.LessOrEqual(t, got, min(2*d, maxWait),
+				"jitter must not exceed one extra interval or the configured maximum")
+		}
+	}
+}
+
+// Once calculateBackoff tops out there is no headroom to add into, so the wait
+// is spread downwards. It must still vary, or every retry after the sequence
+// saturates puts contending clients back in lockstep.
+func TestApplyJitterAtCapStaysWithinBoundsAndVaries(t *testing.T) {
+	minWait := 100 * time.Millisecond
+	maxWait := time.Second
+
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 500; i++ {
+		got := applyJitter(maxWait, minWait, maxWait)
+		assert.GreaterOrEqual(t, got, maxWait/2,
+			"the spread at the cap must not exceed one half interval")
+		assert.LessOrEqual(t, got, maxWait,
+			"the wait must never exceed the configured maximum")
+		seen[got] = struct{}{}
+	}
+
+	assert.Greater(t, len(seen), 1,
+		"waits at the cap must vary so contending clients do not poll in lockstep")
+}
+
+// The spread at the cap must never poll sooner than a configured minimum wait,
+// which is reachable whenever minWait is more than half of maxWait.
+func TestApplyJitterAtCapNeverPollsSoonerThanMinWait(t *testing.T) {
+	minWait := 40 * time.Second
+	maxWait := time.Minute
+
+	for i := 0; i < 500; i++ {
+		assert.GreaterOrEqual(t, applyJitter(maxWait, minWait, maxWait), minWait,
+			"a caller who configures a minimum wait must never poll sooner than it")
+	}
+}
+
+// The guaranteed minimum must not fall as the sequence saturates. The attempt
+// before the cap waits for its own full interval, so flooring the spread at half
+// the cap would let the first saturated attempt poll sooner than the one before
+// it, which inverts the property that the wait between checks only ever grows.
+//
+// Reaching the cap takes a lowered lock-check-max-wait-time or a raised retry
+// count; the defaults (100ms, 1 minute, 4 retries) top out at 800ms and never
+// saturate. The values below are the smallest that put the boundary in range.
+func TestApplyJitterMinimumIsMonotonicAcrossTheCap(t *testing.T) {
+	minWait := 100 * time.Millisecond
+	maxWait := time.Second
+
+	// The sequence runs 100ms, 200ms, 400ms, 800ms, then saturates at 1s.
+	// Attempt 3 draws from [800ms, 1s]; attempt 4 is the first capped one.
+	//
+	// The bound compared against is exact, not sampled. Below the cap the jitter is
+	// added on top, so the interval itself is the floor and no estimate is needed.
+	// Sampling both sides instead would compare two noisy minima that sit a hair
+	// above the same true floor, and which of them lands lower is chance.
+	var floor time.Duration
+	for attempt := 0; attempt < 8; attempt++ {
+		d := calculateBackoff(attempt, minWait, maxWait)
+
+		for i := 0; i < 2000; i++ {
+			assert.GreaterOrEqual(t, applyJitter(d, minWait, maxWait), floor,
+				"attempt %d may not be allowed to wait less than an earlier attempt", attempt)
+		}
+
+		if d < maxWait {
+			floor = d
+		}
+	}
+}
+
+// The specific boundary above, pinned so a future change to the floor cannot
+// quietly reintroduce the dip without failing on the exact numbers.
+func TestApplyJitterAtCapFloorsAtTheLastUncappedInterval(t *testing.T) {
+	minWait := 100 * time.Millisecond
+	maxWait := time.Second
+
+	assert.Equal(t, 800*time.Millisecond, calculateBackoff(3, minWait, maxWait),
+		"the last interval before the cap")
+	assert.Equal(t, maxWait, calculateBackoff(4, minWait, maxWait),
+		"the first interval at the cap")
+
+	for i := 0; i < 2000; i++ {
+		assert.GreaterOrEqual(t, applyJitter(maxWait, minWait, maxWait), 800*time.Millisecond,
+			"the spread at the cap must not reach below the last uncapped interval")
+	}
+}
+
+func TestApplyJitterRespectsMaxWait(t *testing.T) {
+	minWait := 100 * time.Millisecond
+	maxWait := 1 * time.Second
+
+	for i := 0; i < 500; i++ {
+		// d above the cap should not be inflated further.
+		assert.Equal(t, 2*time.Second, applyJitter(2*time.Second, minWait, maxWait))
+	}
+}
+
+func TestApplyJitterVaries(t *testing.T) {
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 500; i++ {
+		seen[applyJitter(time.Second, time.Millisecond, time.Minute)] = struct{}{}
+	}
+
+	// A deterministic implementation returns one value. The range here is a
+	// second wide, so observing a single value across 500 draws is not chance.
+	assert.Greater(t, len(seen), 1,
+		"waits must vary so that clients contending for the same lock do not poll in lockstep")
+}
+
+func TestApplyJitterNonPositive(t *testing.T) {
+	assert.Equal(t, time.Duration(0), applyJitter(0, time.Millisecond, time.Minute))
+	assert.Equal(t, -time.Second, applyJitter(-time.Second, time.Millisecond, time.Minute))
+}


### PR DESCRIPTION
## The problem

`calculateBackoff` is a pure function of the attempt number and the configured bounds, so every client computes the same sequence of delays — 100ms, 200ms, 400ms, 800ms on the defaults.

That matters more here than in a typical retry loop, because of *why* a client is in the loop. `acquireLocks` only retries when the lock was not granted immediately, which means another client holds it. Multiple waiters are the precondition, not an unlucky coincidence. They therefore sleep for identical durations and issue their `CheckLock` calls at the same instants, so each polling round reaches the metastore as a burst — the load pattern backoff exists to prevent.

## The change

```go
waitTime := applyJitter(
    calculateBackoff(attempt, opts.LockMinWaitTime, opts.LockMaxWaitTime),
    opts.LockMinWaitTime,
    opts.LockMaxWaitTime,
)
```

**The jitter is added on top of the interval, not centred on it.** Equal jitter (`d/2 + rand(d/2)`) is the more familiar formula, but it halves the wait, which would let a caller poll sooner than the `lock-check-min-wait-time` they configured. The result is drawn from `[d, min(2d, maxWait)]`.

**Once the sequence saturates at `maxWait` there is no headroom left to add into.** That is not an edge case — it is the state a persistently contended client stays in, so leaving it unjittered would put clients back in lockstep exactly when it matters most. The wait is spread *downwards* there instead. A cap is an upper bound on the polling interval rather than a target, so drawing below it breaks no contract.

**How far down it may draw is the subtle part.** Flooring at half the interval would let the first saturated attempt wait *less* than the attempt before it, because the last unsaturated interval lands in `[maxWait/2, maxWait)`. Concretely, with `lock-check-min-wait-time=100ms` and `lock-check-max-wait-time=1s`: attempt 3 draws from `[800ms, 1s]`, but a `maxWait/2` floor would give attempt 4 `[500ms, 1s]`. Both bounds still hold, but a later check polling sooner than an earlier one inverts the property the retry loop exists to provide.

The floor is therefore the last interval the doubling sequence produced before it hit the cap, recovered by replaying the sequence. That value is a bound the schedule has already cleared, and it cannot fall below `minWait`, because that is where the sequence starts.

**Jitter is applied at the call site, not inside `calculateBackoff`.** `TestCalculateBackoff` asserts exact durations per attempt, and determinism is a reasonable property for that function to keep. Leaving the calculation pure keeps the existing contract and its tests untouched, and makes the new behaviour separately testable.

## Reachability, stated plainly

The saturated path is config-gated. The defaults — `lock-check-min-wait-time=100ms`, `lock-check-max-wait-time=1 minute`, `lock-check-retries=4` — top out at 800ms and **never** reach the cap. Hitting it needs a lowered `lock-check-max-wait-time` or roughly `lock-check-retries >= 11`. The below-cap additive jitter is what applies on the defaults.

## Testing

`go build ./...`, `go vet ./catalog/hive/`, and `gofmt` are clean. The full `catalog/hive` package passes, and the jitter tests were run with `-count=5` to check for flakiness. `TestCalculateBackoff` is unmodified and still passes.

New tests:

| Test | Asserts |
|---|---|
| `TestApplyJitterBelowCapNeverShorterThanInput` | result in `[d, min(2d, maxWait)]` across three magnitudes |
| `TestApplyJitterMinimumIsMonotonicAcrossTheCap` | no attempt may draw below an earlier attempt's guaranteed floor |
| `TestApplyJitterAtCapFloorsAtTheLastUncappedInterval` | the boundary above, pinned to the exact numbers |
| `TestApplyJitterAtCapStaysWithinBoundsAndVaries` | the saturated wait still varies, so clients do not re-lockstep |
| `TestApplyJitterAtCapNeverPollsSoonerThanMinWait` | the downward spread respects a configured minimum |
| `TestApplyJitterVaries` | fails if the implementation regresses to deterministic |
| `TestApplyJitterNonPositive` | non-positive inputs pass through unchanged |

The two monotonicity tests were checked against the defect they describe: reverting only the floor logic fails both, with draws around 500–750ms against an 800ms floor.

The monotonicity test compares against the exact interval rather than a sampled minimum. Sampling both sides compares two noisy values sitting a hair above the same true floor, and which one lands lower is chance — that version was flaky and was replaced.

## Note

I have not reproduced multi-client metastore contention; the reasoning is from the code. If maintainers would prefer a different floor at the cap, or the jitter bound made configurable rather than fixed at one interval, both are small changes and I am happy to make them.
