### PR TITLE
fix(view): snapshot property update inputs

### DIFF
--- a/view/updates.go
+++ b/view/updates.go
@@ -20,6 +20,8 @@ package view
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/apache/iceberg-go"
 	"github.com/google/uuid"
@@ -207,7 +209,7 @@ type setPropertiesUpdate struct {
 func NewSetPropertiesUpdate(updates iceberg.Properties) *setPropertiesUpdate {
 	return &setPropertiesUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateSetProperties},
-		Updates:    updates,
+		Updates:    maps.Clone(updates),
 	}
 }
 
@@ -228,7 +230,7 @@ type removePropertiesUpdate struct {
 func NewRemovePropertiesUpdate(removals []string) *removePropertiesUpdate {
 	return &removePropertiesUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateRemoveProperties},
-		Removals:   removals,
+		Removals:   slices.Clone(removals),
 	}
 }
 

--- a/view/updates_test.go
+++ b/view/updates_test.go
@@ -145,12 +145,25 @@ func TestPropertyUpdateConstructorsCopyInputs(t *testing.T) {
 	assert.Equal(t, []string{"old-property"}, remove.Removals)
 }
 
+func TestPropertyUpdateConstructorsPreserveNilness(t *testing.T) {
+	var nilProps iceberg.Properties
+	emptyProps := iceberg.Properties{}
+	assert.Nil(t, NewSetPropertiesUpdate(nilProps).Updates)
+	assert.NotNil(t, NewSetPropertiesUpdate(emptyProps).Updates)
+
+	var nilRemovals []string
+	emptyRemovals := []string{}
+	assert.Nil(t, NewRemovePropertiesUpdate(nilRemovals).Removals)
+	assert.NotNil(t, NewRemovePropertiesUpdate(emptyRemovals).Removals)
+}
+
 func TestMetadataBuilderPropertyChangesCopyInputs(t *testing.T) {
 	props := iceberg.Properties{"owner": "alice"}
 	removals := []string{"old-property"}
 
 	base, err := newTestBuilder().
 		SetLoc("location").
+		SetProperties(iceberg.Properties{"old-property": "value"}).
 		AddSchema(newTestSchema(0)).
 		AddVersion(newTestVersion(1, 0)).
 		SetCurrentVersionID(1).
@@ -159,11 +172,13 @@ func TestMetadataBuilderPropertyChangesCopyInputs(t *testing.T) {
 
 	builder, err := MetadataBuilderFromBase(base)
 	require.NoError(t, err)
-	result, err := builder.SetProperties(props).RemoveProperties(removals).Build()
-	require.NoError(t, err)
+	builder.SetProperties(props).RemoveProperties(removals)
 
 	props["owner"] = "bob"
 	removals[0] = "new-property"
+
+	result, err := builder.Build()
+	require.NoError(t, err)
 
 	assert.Equal(t, iceberg.Properties{"owner": "alice"}, result.Properties())
 	assert.Equal(t, iceberg.Properties{"owner": "alice"}, result.Changes[0].(*setPropertiesUpdate).Updates)

--- a/view/updates_test.go
+++ b/view/updates_test.go
@@ -131,3 +131,41 @@ func TestUpdatesUnmarshalJSONReplacesExistingSlice(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`[]`), &updates))
 	assert.Empty(t, updates)
 }
+
+func TestPropertyUpdateConstructorsCopyInputs(t *testing.T) {
+	props := iceberg.Properties{"owner": "alice"}
+	set := NewSetPropertiesUpdate(props)
+	props["owner"] = "bob"
+	props["team"] = "iceberg"
+	assert.Equal(t, iceberg.Properties{"owner": "alice"}, set.Updates)
+
+	removals := []string{"old-property"}
+	remove := NewRemovePropertiesUpdate(removals)
+	removals[0] = "new-property"
+	assert.Equal(t, []string{"old-property"}, remove.Removals)
+}
+
+func TestMetadataBuilderPropertyChangesCopyInputs(t *testing.T) {
+	props := iceberg.Properties{"owner": "alice"}
+	removals := []string{"old-property"}
+
+	base, err := newTestBuilder().
+		SetLoc("location").
+		AddSchema(newTestSchema(0)).
+		AddVersion(newTestVersion(1, 0)).
+		SetCurrentVersionID(1).
+		Build()
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(base)
+	require.NoError(t, err)
+	result, err := builder.SetProperties(props).RemoveProperties(removals).Build()
+	require.NoError(t, err)
+
+	props["owner"] = "bob"
+	removals[0] = "new-property"
+
+	assert.Equal(t, iceberg.Properties{"owner": "alice"}, result.Properties())
+	assert.Equal(t, iceberg.Properties{"owner": "alice"}, result.Changes[0].(*setPropertiesUpdate).Updates)
+	assert.Equal(t, []string{"old-property"}, result.Changes[1].(*removePropertiesUpdate).Removals)
+}


### PR DESCRIPTION
## Summary

Copy map and slice inputs when creating view property updates.

## Why

The constructors retained caller-owned maps and slices. A later mutation could make the metadata builder and the emitted catalog update disagree.

## What changed

NewSetPropertiesUpdate and NewRemovePropertiesUpdate now copy their inputs, so a staged update cannot change after construction.

## Tests

- Added constructor ownership tests for maps and slices
- Added builder coverage for metadata and emitted changes
- go test ./view