### PR TITLE
fix(view): replace metadata state during JSON decoding

### DIFF
--- a/view/metadata.go
+++ b/view/metadata.go
@@ -671,6 +671,7 @@ func (m *metadata) UnmarshalJSON(b []byte) error {
 	}
 
 	*m = next
+	m.init()
 
 	return nil
 }

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -671,6 +671,7 @@ func (m *metadata) UnmarshalJSON(b []byte) error {
 	}
 
 	*m = next
+	// init() rebinds the lazy-index closures to m after the value copy.
 	m.init()
 
 	return nil

--- a/view/metadata.go
+++ b/view/metadata.go
@@ -654,18 +654,25 @@ func (m *metadata) init() {
 
 func (m *metadata) UnmarshalJSON(b []byte) error {
 	type Alias metadata
-	aux := (*Alias)(m)
-
-	aux.FormatVersionValue = -1
-	aux.CurrentVersionIDValue = -1
+	next := metadata{
+		FormatVersionValue:    -1,
+		CurrentVersionIDValue: -1,
+	}
+	aux := (*Alias)(&next)
 
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
 
-	m.init()
+	next.init()
 
-	return m.validate()
+	if err := next.validate(); err != nil {
+		return err
+	}
+
+	*m = next
+
+	return nil
 }
 
 // NewMetadata creates a new view metadata object using the provided version, schema, location, and props,

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -141,6 +142,28 @@ func TestUnmarshalViewMetadata(t *testing.T) {
 	assert.Equal(t, []VersionLogEntry{{TimestampMS: 1000, VersionID: 1}}, md.VersionLog())
 	assert.Equal(t, []Representation{NewRepresentation("select * from ns.tbl", "trino")}, md.CurrentVersion().Representations)
 	assert.Equal(t, iceberg.Properties{"prop": "value"}, md.Properties())
+}
+
+func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
+	var metadata metadata
+	require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &metadata))
+
+	var reduced map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &reduced))
+	delete(reduced, "properties")
+	delete(reduced, "version-log")
+	reducedData, err := json.Marshal(reduced)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(reducedData, &metadata))
+	assert.Empty(t, metadata.Props)
+	assert.Empty(t, metadata.VersionLogList)
+
+	invalid := strings.Replace(exampleViewJSON, `"current-version-id": 1`, `"current-version-id": 99`, 1)
+	require.Error(t, json.Unmarshal([]byte(invalid), &metadata))
+	assert.Equal(t, int64(1), metadata.CurrentVersionIDValue)
+	assert.Empty(t, metadata.Props)
+	assert.Empty(t, metadata.VersionLogList)
 }
 
 func TestValidMetadataDeserialization(t *testing.T) {

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -166,6 +166,42 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 	assert.Empty(t, metadata.VersionLogList)
 }
 
+func TestMetadataUnmarshalReplacesLookupCaches(t *testing.T) {
+	var metadata metadata
+	require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &metadata))
+
+	// Prime every lookup cache before replacing the metadata.
+	assert.Equal(t, int64(1), metadata.CurrentVersion().VersionID)
+	assert.Equal(t, 0, metadata.CurrentSchema().ID)
+	assert.Contains(t, metadata.SchemasByID(), 0)
+
+	var replacement map[string]any
+	require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &replacement))
+	replacement["current-version-id"] = int64(2)
+	replacement["versions"].([]any)[0].(map[string]any)["version-id"] = int64(2)
+	replacement["versions"].([]any)[0].(map[string]any)["schema-id"] = 2
+	replacement["schemas"].([]any)[0].(map[string]any)["schema-id"] = 2
+	replacement["version-log"].([]any)[0].(map[string]any)["version-id"] = int64(2)
+	replacementData, err := json.Marshal(replacement)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(replacementData, &metadata))
+	assert.Equal(t, int64(2), metadata.CurrentVersion().VersionID)
+	assert.Equal(t, 2, metadata.CurrentSchema().ID)
+	assert.NotContains(t, metadata.SchemasByID(), 0)
+	assert.Contains(t, metadata.SchemasByID(), 2)
+
+	_, oldVersionExists := metadata.lazyVersionsByID()[1]
+	_, newVersionExists := metadata.lazyVersionsByID()[2]
+	assert.False(t, oldVersionExists)
+	assert.True(t, newVersionExists)
+
+	invalid := strings.Replace(string(replacementData), `"current-version-id":2`, `"current-version-id":99`, 1)
+	require.Error(t, json.Unmarshal([]byte(invalid), &metadata))
+	assert.Equal(t, int64(2), metadata.CurrentVersion().VersionID)
+	assert.Equal(t, 2, metadata.CurrentSchema().ID)
+}
+
 func TestValidMetadataDeserialization(t *testing.T) {
 	validJSON := `{
 		"view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",

--- a/view/metadata_test.go
+++ b/view/metadata_test.go
@@ -159,11 +159,40 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 	assert.Empty(t, metadata.Props)
 	assert.Empty(t, metadata.VersionLogList)
 
+	beforeFailure, err := json.Marshal(&metadata)
+	require.NoError(t, err)
 	invalid := strings.Replace(exampleViewJSON, `"current-version-id": 1`, `"current-version-id": 99`, 1)
 	require.Error(t, json.Unmarshal([]byte(invalid), &metadata))
-	assert.Equal(t, int64(1), metadata.CurrentVersionIDValue)
-	assert.Empty(t, metadata.Props)
-	assert.Empty(t, metadata.VersionLogList)
+	afterFailure, err := json.Marshal(&metadata)
+	require.NoError(t, err)
+	assert.Equal(t, beforeFailure, afterFailure)
+}
+
+func TestMetadataUnmarshalDoesNotMutateInputAndRoundTripsAfterReuse(t *testing.T) {
+	input := []byte(exampleViewJSON)
+	originalInput := append([]byte(nil), input...)
+
+	var md metadata
+	require.NoError(t, json.Unmarshal(input, &md))
+	assert.Equal(t, originalInput, input)
+
+	var replacement map[string]any
+	require.NoError(t, json.Unmarshal([]byte(exampleViewJSON), &replacement))
+	replacement["current-version-id"] = int64(2)
+	replacement["versions"].([]any)[0].(map[string]any)["version-id"] = int64(2)
+	replacement["versions"].([]any)[0].(map[string]any)["schema-id"] = 2
+	replacement["schemas"].([]any)[0].(map[string]any)["schema-id"] = 2
+	replacementData, err := json.Marshal(replacement)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(replacementData, &md))
+
+	encoded, err := json.Marshal(&md)
+	require.NoError(t, err)
+	var roundTripped metadata
+	require.NoError(t, json.Unmarshal(encoded, &roundTripped))
+	reencoded, err := json.Marshal(&roundTripped)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(encoded), string(reencoded))
 }
 
 func TestMetadataUnmarshalReplacesLookupCaches(t *testing.T) {


### PR DESCRIPTION
## Summary

Make view metadata JSON decoding replace the receiver state only after validation succeeds.

## Why

Reusing a metadata value could retain omitted properties or version-log entries. A failed decode could also leave the receiver partially updated.

## What changed

The decoder now uses fresh state, initializes lookup indexes, validates the complete document, and replaces the receiver only after success. The final receiver's indexes are rebuilt as well.

## Tests

- Added coverage for omitted fields being cleared on reuse
- Added lookup-cache replacement coverage
- Added failed-decode state preservation coverage
- go test ./view