### PR TITLE
fix(table): preserve field state on failed JSON decoding

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -142,14 +142,16 @@ func (p *PartitionField) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	p.FieldID = aux.FieldID
-	p.Name = aux.Name
+	next := PartitionField{
+		FieldID: aux.FieldID,
+		Name:    aux.Name,
+	}
 
 	var err error
-	if p.Transform, err = ParseTransform(aux.TransformString); err != nil {
+	if next.Transform, err = ParseTransform(aux.TransformString); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 	}
-	if err := validateTransform(p.Transform); err != nil {
+	if err := validateTransform(next.Transform); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 	}
 
@@ -157,25 +159,27 @@ func (p *PartitionField) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("%w: partition source-ids cannot be empty", ErrInvalidPartitionSpec)
 	}
 	if !hasSourceID && !hasSourceIDs {
-		if _, isVoid := p.Transform.(VoidTransform); !isVoid {
+		if _, isVoid := next.Transform.(VoidTransform); !isVoid {
 			return fmt.Errorf("%w: partition field requires source-id or source-ids", ErrInvalidPartitionSpec)
 		}
 		// Preserve compatibility with historical source-less void tombstones.
-		p.SourceIDs = []int{0}
+		next.SourceIDs = []int{0}
 	} else if len(aux.SourceIDs) > 0 {
-		p.SourceIDs = aux.SourceIDs
+		next.SourceIDs = aux.SourceIDs
 	} else {
-		p.SourceIDs = []int{aux.SourceID}
+		next.SourceIDs = []int{aux.SourceID}
 	}
-	for _, sourceID := range p.SourceIDs {
-		_, isVoid := p.Transform.(VoidTransform)
+	for _, sourceID := range next.SourceIDs {
+		_, isVoid := next.Transform.(VoidTransform)
 		if sourceID <= 0 && (!isVoid || hasSourceID || hasSourceIDs) {
 			return fmt.Errorf("%w: partition source ID must be positive: %d", ErrInvalidPartitionSpec, sourceID)
 		}
 	}
-	if p.Name == "" {
+	if next.Name == "" {
 		return fmt.Errorf("%w: partition name cannot be empty", ErrInvalidPartitionSpec)
 	}
+
+	*p = next
 
 	return nil
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -778,6 +778,27 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 	})
 }
 
+func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
+	field := iceberg.PartitionField{
+		SourceIDs: []int{7},
+		FieldID:   1007,
+		Name:      "old",
+		Transform: iceberg.IdentityTransform{},
+	}
+
+	err := json.Unmarshal([]byte(`{
+		"source-id": 1,
+		"field-id": 1000,
+		"transform": "not-a-transform",
+		"name": "new"
+	}`), &field)
+	require.Error(t, err)
+	assert.Equal(t, []int{7}, field.SourceIDs)
+	assert.Equal(t, 1007, field.FieldID)
+	assert.Equal(t, "old", field.Name)
+	assert.Equal(t, iceberg.IdentityTransform{}, field.Transform)
+}
+
 func TestPartitionSpecUnmarshalRejectsInvalidStructure(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -803,7 +803,7 @@ func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
 	}{
 		{
 			name: "invalid transform",
-			data: `{"source-id":1,"field-id":1000,"transform":"not-a-transform","name":"new"}`,
+			data: `{"source-id":1,"field-id":1000,"transform":"bucket[0]","name":"new"}`,
 		},
 		{
 			name: "non-positive source ID",

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -779,24 +779,40 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 }
 
 func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
-	field := iceberg.PartitionField{
+	initial := iceberg.PartitionField{
 		SourceIDs: []int{7},
 		FieldID:   1007,
 		Name:      "old",
 		Transform: iceberg.IdentityTransform{},
 	}
 
-	err := json.Unmarshal([]byte(`{
-		"source-id": 1,
-		"field-id": 1000,
-		"transform": "not-a-transform",
-		"name": "new"
-	}`), &field)
-	require.Error(t, err)
-	assert.Equal(t, []int{7}, field.SourceIDs)
-	assert.Equal(t, 1007, field.FieldID)
-	assert.Equal(t, "old", field.Name)
-	assert.Equal(t, iceberg.IdentityTransform{}, field.Transform)
+	for _, test := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "invalid transform",
+			data: `{"source-id":1,"field-id":1000,"transform":"not-a-transform","name":"new"}`,
+		},
+		{
+			name: "non-positive source ID",
+			data: `{"source-id":0,"field-id":1000,"transform":"identity","name":"new"}`,
+		},
+		{
+			name: "missing source ID",
+			data: `{"field-id":1000,"transform":"identity","name":"new"}`,
+		},
+		{
+			name: "empty name",
+			data: `{"source-id":1,"field-id":1000,"transform":"identity","name":""}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			field := initial
+			require.Error(t, json.Unmarshal([]byte(test.data), &field))
+			assert.Equal(t, initial, field)
+		})
+	}
 }
 
 func TestPartitionSpecUnmarshalRejectsInvalidStructure(t *testing.T) {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -852,6 +852,7 @@ func TestPartitionFieldUnmarshalReplacesStateOnSuccess(t *testing.T) {
 	assert.Equal(t, []int{2}, field.SourceIDs)
 	assert.Equal(t, 1001, field.FieldID)
 	assert.Equal(t, "new field", field.Name)
+	assert.Equal(t, iceberg.IdentityTransform{}, field.Transform)
 	assert.Equal(t, "new+field", field.EscapedName())
 }
 

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -757,6 +757,23 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		assert.ErrorContains(t, err, "partition field cannot contain both source-id and source-ids")
 	})
 
+	t.Run("unmarshal rejects empty source-ids", func(t *testing.T) {
+		var field iceberg.PartitionField
+		err := json.Unmarshal([]byte(`{
+			"source-ids": [],
+			"field-id": 1002,
+			"transform": "identity",
+			"name": "identity"
+		}`), &field)
+		require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+		assert.ErrorContains(t, err, "source-ids cannot be empty")
+	})
+
+	t.Run("unmarshal rejects malformed JSON", func(t *testing.T) {
+		var field iceberg.PartitionField
+		require.Error(t, json.Unmarshal([]byte(`{"source-id":`), &field))
+	})
+
 	t.Run("unmarshal source-less void tombstone", func(t *testing.T) {
 		jsonData := `
 		{
@@ -779,13 +796,6 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 }
 
 func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
-	initial := iceberg.PartitionField{
-		SourceIDs: []int{7},
-		FieldID:   1007,
-		Name:      "old",
-		Transform: iceberg.IdentityTransform{},
-	}
-
 	for _, test := range []struct {
 		name string
 		data string
@@ -808,11 +818,38 @@ func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			initial := iceberg.PartitionField{
+				SourceIDs: []int{7},
+				FieldID:   1007,
+				Name:      "old",
+				Transform: iceberg.IdentityTransform{},
+			}
 			field := initial
 			require.Error(t, json.Unmarshal([]byte(test.data), &field))
 			assert.Equal(t, initial, field)
 		})
 	}
+}
+
+func TestPartitionFieldUnmarshalReplacesStateOnSuccess(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "old field",
+		Transform: iceberg.IdentityTransform{},
+	})
+	field := spec.Field(0)
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"source-id": 2,
+		"field-id": 1001,
+		"transform": "identity",
+		"name": "new field"
+	}`), &field))
+
+	assert.Equal(t, []int{2}, field.SourceIDs)
+	assert.Equal(t, "new field", field.Name)
+	assert.Equal(t, "new+field", field.EscapedName())
 }
 
 func TestPartitionSpecUnmarshalRejectsInvalidStructure(t *testing.T) {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -769,9 +769,9 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		assert.ErrorContains(t, err, "source-ids cannot be empty")
 	})
 
-	t.Run("unmarshal rejects malformed JSON", func(t *testing.T) {
+	t.Run("unmarshal rejects non-object JSON", func(t *testing.T) {
 		var field iceberg.PartitionField
-		require.Error(t, json.Unmarshal([]byte(`{"source-id":`), &field))
+		require.Error(t, json.Unmarshal([]byte(`[1, 2]`), &field))
 	})
 
 	t.Run("unmarshal source-less void tombstone", func(t *testing.T) {
@@ -784,6 +784,7 @@ func TestPartitionFieldUnmarshalJSON(t *testing.T) {
 		var field iceberg.PartitionField
 		require.NoError(t, json.Unmarshal([]byte(jsonData), &field))
 		assert.Equal(t, 0, field.SourceID())
+		assert.Equal(t, []int{0}, field.SourceIDs)
 	})
 
 	t.Run("unmarshal void with source id", func(t *testing.T) {
@@ -825,6 +826,7 @@ func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
 				Transform: iceberg.IdentityTransform{},
 			}
 			field := initial
+			field.SourceIDs = slices.Clone(initial.SourceIDs)
 			require.Error(t, json.Unmarshal([]byte(test.data), &field))
 			assert.Equal(t, initial, field)
 		})
@@ -833,7 +835,7 @@ func TestPartitionFieldUnmarshalPreservesStateOnError(t *testing.T) {
 
 func TestPartitionFieldUnmarshalReplacesStateOnSuccess(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
-		SourceIDs: []int{1},
+		SourceIDs: []int{1, 2},
 		FieldID:   1000,
 		Name:      "old field",
 		Transform: iceberg.IdentityTransform{},
@@ -848,6 +850,7 @@ func TestPartitionFieldUnmarshalReplacesStateOnSuccess(t *testing.T) {
 	}`), &field))
 
 	assert.Equal(t, []int{2}, field.SourceIDs)
+	assert.Equal(t, 1001, field.FieldID)
 	assert.Equal(t, "new field", field.Name)
 	assert.Equal(t, "new+field", field.EscapedName())
 }

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -162,35 +162,39 @@ func (s *SortField) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s.Direction = aux.Direction
-	s.NullOrder = aux.NullOrder
-
-	if hasSourceIDs {
-		s.SourceIDs = aux.SourceIDs
-	} else {
-		s.SourceIDs = []int{aux.SourceID}
+	next := SortField{
+		Direction: aux.Direction,
+		NullOrder: aux.NullOrder,
 	}
 
-	if err := validateSortSourceIDs(s.SourceIDs); err != nil {
+	if hasSourceIDs {
+		next.SourceIDs = aux.SourceIDs
+	} else {
+		next.SourceIDs = []int{aux.SourceID}
+	}
+
+	if err := validateSortSourceIDs(next.SourceIDs); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidSortSourceID, err)
 	}
 
 	var err error
-	if s.Transform, err = iceberg.ParseTransform(aux.TransformString); err != nil {
+	if next.Transform, err = iceberg.ParseTransform(aux.TransformString); err != nil {
 		return err
 	}
 
-	switch s.Direction {
+	switch next.Direction {
 	case SortASC, SortDESC:
 	default:
 		return ErrInvalidSortDirection
 	}
 
-	switch s.NullOrder {
+	switch next.NullOrder {
 	case NullsFirst, NullsLast:
 	default:
 		return ErrInvalidNullOrder
 	}
+
+	*s = next
 
 	return nil
 }

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -358,13 +358,6 @@ func TestUnmarshalInvalidSortTransform(t *testing.T) {
 }
 
 func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
-	initial := table.SortField{
-		SourceIDs: []int{7},
-		Transform: iceberg.IdentityTransform{},
-		Direction: table.SortDESC,
-		NullOrder: table.NullsLast,
-	}
-
 	for _, test := range []struct {
 		name string
 		data string
@@ -387,6 +380,12 @@ func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			initial := table.SortField{
+				SourceIDs: []int{7},
+				Transform: iceberg.IdentityTransform{},
+				Direction: table.SortDESC,
+				NullOrder: table.NullsLast,
+			}
 			field := initial
 			require.Error(t, json.Unmarshal([]byte(test.data), &field))
 			assert.Equal(t, initial, field)
@@ -410,6 +409,11 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot contain both source-id and source-ids")
+	})
+
+	t.Run("unmarshal rejects malformed JSON", func(t *testing.T) {
+		var field table.SortField
+		require.Error(t, json.Unmarshal([]byte(`{"source-id":`), &field))
 	})
 
 	t.Run("unmarshal rejects missing/invalid source ids", func(t *testing.T) {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -387,10 +387,16 @@ func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
 				NullOrder: table.NullsLast,
 			}
 			field := initial
+			field.SourceIDs = []int{7}
 			require.Error(t, json.Unmarshal([]byte(test.data), &field))
 			assert.Equal(t, initial, field)
 		})
 	}
+}
+
+func TestSortFieldUnmarshalJSON(t *testing.T) {
+	var field table.SortField
+	require.Error(t, json.Unmarshal([]byte(`[1, 2]`), &field))
 }
 
 func TestSortFieldMultiArgSourceIDs(t *testing.T) {
@@ -409,11 +415,6 @@ func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 		err := json.Unmarshal([]byte(jsonData), &field)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot contain both source-id and source-ids")
-	})
-
-	t.Run("unmarshal rejects malformed JSON", func(t *testing.T) {
-		var field table.SortField
-		require.Error(t, json.Unmarshal([]byte(`{"source-id":`), &field))
 	})
 
 	t.Run("unmarshal rejects missing/invalid source ids", func(t *testing.T) {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -358,24 +358,40 @@ func TestUnmarshalInvalidSortTransform(t *testing.T) {
 }
 
 func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
-	field := table.SortField{
+	initial := table.SortField{
 		SourceIDs: []int{7},
 		Transform: iceberg.IdentityTransform{},
 		Direction: table.SortDESC,
 		NullOrder: table.NullsLast,
 	}
 
-	err := json.Unmarshal([]byte(`{
-		"source-id": 1,
-		"transform": "not-a-transform",
-		"direction": "asc",
-		"null-order": "nulls-first"
-	}`), &field)
-	require.Error(t, err)
-	assert.Equal(t, []int{7}, field.SourceIDs)
-	assert.Equal(t, iceberg.IdentityTransform{}, field.Transform)
-	assert.Equal(t, table.SortDESC, field.Direction)
-	assert.Equal(t, table.NullsLast, field.NullOrder)
+	for _, test := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "invalid transform",
+			data: `{"source-id":1,"transform":"not-a-transform","direction":"asc","null-order":"nulls-first"}`,
+		},
+		{
+			name: "non-positive source ID",
+			data: `{"source-id":0,"transform":"identity","direction":"asc","null-order":"nulls-first"}`,
+		},
+		{
+			name: "invalid direction",
+			data: `{"source-id":1,"transform":"identity","direction":"not-a-direction","null-order":"nulls-first"}`,
+		},
+		{
+			name: "invalid null order",
+			data: `{"source-id":1,"transform":"identity","direction":"asc","null-order":"not-a-null-order"}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			field := initial
+			require.Error(t, json.Unmarshal([]byte(test.data), &field))
+			assert.Equal(t, initial, field)
+		})
+	}
 }
 
 func TestSortFieldMultiArgSourceIDs(t *testing.T) {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -364,7 +364,7 @@ func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
 	}{
 		{
 			name: "invalid transform",
-			data: `{"source-id":1,"transform":"not-a-transform","direction":"asc","null-order":"nulls-first"}`,
+			data: `{"source-id":1,"transform":"bucket[0]","direction":"asc","null-order":"nulls-first"}`,
 		},
 		{
 			name: "non-positive source ID",

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -357,6 +357,27 @@ func TestUnmarshalInvalidSortTransform(t *testing.T) {
 	assert.ErrorIs(t, err, iceberg.ErrInvalidTransform)
 }
 
+func TestSortFieldUnmarshalPreservesStateOnError(t *testing.T) {
+	field := table.SortField{
+		SourceIDs: []int{7},
+		Transform: iceberg.IdentityTransform{},
+		Direction: table.SortDESC,
+		NullOrder: table.NullsLast,
+	}
+
+	err := json.Unmarshal([]byte(`{
+		"source-id": 1,
+		"transform": "not-a-transform",
+		"direction": "asc",
+		"null-order": "nulls-first"
+	}`), &field)
+	require.Error(t, err)
+	assert.Equal(t, []int{7}, field.SourceIDs)
+	assert.Equal(t, iceberg.IdentityTransform{}, field.Transform)
+	assert.Equal(t, table.SortDESC, field.Direction)
+	assert.Equal(t, table.NullsLast, field.NullOrder)
+}
+
 func TestSortFieldMultiArgSourceIDs(t *testing.T) {
 	t.Run("unmarshal with source-ids", func(t *testing.T) {
 		jsonData := `{"source-ids": [2, 3], "transform": "identity", "direction": "asc", "null-order": "nulls-first"}`


### PR DESCRIPTION
## Summary

Make partition and sort field JSON decoding safe to retry on a reused receiver.

## Why

Malformed transforms or invalid sort options could leave a field containing a mixture of new and old state because assignments happened before validation finished.

## What changed

Both decoders now validate a local value completely and assign it only after success. Valid JSON behavior and existing validation rules are unchanged.

## Tests

- Added failed-decode coverage for invalid transforms, source IDs, names, sort directions, and null orders
- go test . ./table