### PR TITLE
fix(table): replace metadata state during JSON decoding

### DIFF
--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -42,6 +42,7 @@ import (
 func constructTestTable(t *testing.T, writeStats []string) (*metadata.FileMetaData, Metadata) {
 	tableMeta, err := ParseMetadataString(`{
 		"format-version": 2,
+		"last-sequence-number": 0,
         "location": "s3://bucket/test/location",
         "last-column-id": 7,
         "current-schema-id": 0,

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -152,6 +152,7 @@ func newAbortTestWriter(t *testing.T, fs iceio.WriteFileIO, fileName string) int
 func constructTestTablePrimitiveTypes(t *testing.T) (*metadata.FileMetaData, table.Metadata) {
 	tableMeta, err := table.ParseMetadataString(`{
         "format-version": 2,
+        "last-sequence-number": 0,
         "location": "s3://bucket/test/location",
         "last-column-id": 7,
         "current-schema-id": 0,
@@ -639,6 +640,7 @@ func TestNanosecondTimestampMetrics(t *testing.T) {
 
 	tableMeta, err := table.ParseMetadataString(`{
 		"format-version": 3,
+		"last-sequence-number": 0,
 		"location": "s3://bucket/test/location",
 		"last-column-id": 2,
 		"current-schema-id": 0,
@@ -825,6 +827,7 @@ func TestDecimalPhysicalTypes(t *testing.T) {
 			// Create table metadata with decimal type
 			tableMeta, err := table.ParseMetadataString(fmt.Sprintf(`{
 				"format-version": 2,
+				"last-sequence-number": 0,
 				"location": "s3://bucket/test/location",
 				"last-column-id": 1,
 				"current-schema-id": 0,

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2762,10 +2762,15 @@ type SequenceNumberValidator interface {
 
 // checkLastSequenceNumber validates that all snapshots have sequence numbers <= the last sequence number
 func checkLastSequenceNumber(validator SequenceNumberValidator, snapshotList []Snapshot) error {
+	lastSequenceNumber := validator.LastSequenceNumber()
+	if lastSequenceNumber == -1 {
+		return fmt.Errorf("%w: last-sequence-number is required for format versions greater than 1", ErrInvalidMetadata)
+	}
+
 	for _, snap := range snapshotList {
-		if snap.SequenceNumber > validator.LastSequenceNumber() {
+		if snap.SequenceNumber > lastSequenceNumber {
 			return fmt.Errorf("%w: snapshot %d has sequence number %d which is greater than last-sequence-number %d",
-				ErrInvalidMetadata, snap.SnapshotID, snap.SequenceNumber, validator.LastSequenceNumber())
+				ErrInvalidMetadata, snap.SnapshotID, snap.SequenceNumber, lastSequenceNumber)
 		}
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1692,7 +1692,8 @@ type commonMetadata struct {
 
 func initCommonMetadataForDeserialization() commonMetadata {
 	return commonMetadata{
-		// Negative sentinels distinguish omitted required fields from explicit zero values.
+		// These fields use negative sentinels so validation can distinguish omitted
+		// values from explicit zero values.
 		LastColumnId:       -1,
 		CurrentSchemaID:    -1,
 		DefaultSpecID:      -1,
@@ -2666,6 +2667,10 @@ func (m *metadataV3) UnmarshalJSON(b []byte) error {
 	aux := (*Alias)(next)
 
 	if err := json.Unmarshal(b, aux); err != nil {
+		return err
+	}
+
+	if err := rejectFieldsBeyondVersion(aux.FormatVersion); err != nil {
 		return err
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1512,11 +1512,11 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 	var ret Metadata
 	switch ver.FormatVersion {
 	case 1:
-		ret = initMetadataV1Deser()
+		ret = &metadataV1{}
 	case 2:
-		ret = initMetadataV2Deser()
+		ret = &metadataV2{}
 	case 3:
-		ret = initMetadataV3Deser()
+		ret = &metadataV3{}
 	default:
 		return nil, ErrInvalidMetadataFormatVersion
 	}
@@ -1692,6 +1692,7 @@ type commonMetadata struct {
 
 func initCommonMetadataForDeserialization() commonMetadata {
 	return commonMetadata{
+		// Negative sentinels distinguish omitted required fields from explicit zero values.
 		LastColumnId:       -1,
 		CurrentSchemaID:    -1,
 		DefaultSpecID:      -1,
@@ -2505,9 +2506,6 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 	next := initMetadataV1Deser()
 	aux := (*Alias)(next)
 
-	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
-	aux.LastColumnId = -1
-
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
@@ -2586,9 +2584,6 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 	type Alias metadataV2
 	next := initMetadataV2Deser()
 	aux := (*Alias)(next)
-
-	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
-	aux.LastColumnId = -1
 
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
@@ -2669,9 +2664,6 @@ func (m *metadataV3) UnmarshalJSON(b []byte) error {
 	type Alias metadataV3
 	next := initMetadataV3Deser()
 	aux := (*Alias)(next)
-
-	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
-	aux.LastColumnId = -1
 
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2502,7 +2502,8 @@ func (m *metadataV1) preValidate() {
 
 func (m *metadataV1) UnmarshalJSON(b []byte) error {
 	type Alias metadataV1
-	aux := (*Alias)(m)
+	next := initMetadataV1Deser()
+	aux := (*Alias)(next)
 
 	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
 	aux.LastColumnId = -1
@@ -2530,9 +2531,15 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	m.preValidate()
+	next.preValidate()
 
-	return m.validate()
+	if err := next.validate(); err != nil {
+		return err
+	}
+
+	*m = *next
+
+	return nil
 }
 
 func (m *metadataV1) ToV2() metadataV2 {
@@ -2577,7 +2584,8 @@ func (m *metadataV2) Equals(other Metadata) bool {
 
 func (m *metadataV2) UnmarshalJSON(b []byte) error {
 	type Alias metadataV2
-	aux := (*Alias)(m)
+	next := initMetadataV2Deser()
+	aux := (*Alias)(next)
 
 	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
 	aux.LastColumnId = -1
@@ -2594,9 +2602,15 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	m.preValidate()
+	next.preValidate()
 
-	return m.validate()
+	if err := next.validate(); err != nil {
+		return err
+	}
+
+	*m = *next
+
+	return nil
 }
 
 func (m *metadataV2) validate() error {
@@ -2653,7 +2667,8 @@ func (m *metadataV3) Equals(other Metadata) bool {
 
 func (m *metadataV3) UnmarshalJSON(b []byte) error {
 	type Alias metadataV3
-	aux := (*Alias)(m)
+	next := initMetadataV3Deser()
+	aux := (*Alias)(next)
 
 	// Set LastColumnId to -1 to indicate that it is not set as LastColumnId = 0 is a valid value for when no schema is present
 	aux.LastColumnId = -1
@@ -2662,9 +2677,15 @@ func (m *metadataV3) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	m.preValidate()
+	next.preValidate()
 
-	return m.validate()
+	if err := next.validate(); err != nil {
+		return err
+	}
+
+	*m = *next
+
+	return nil
 }
 
 // MarshalJSON serializes v3 metadata with the spec-mandated emission of

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -421,6 +421,9 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			assert.Empty(t, common.StatisticsList)
 			assert.Empty(t, common.PartitionStatsList)
 			assert.Empty(t, common.EncryptionKeyList)
+			// With no snapshots, an omitted last-sequence-number retains the
+			// legacy -1 sentinel. This documents current behavior, not the
+			// desired metadata normalization.
 			switch metadata := tt.target.(type) {
 			case *metadataV2:
 				assert.Equal(t, int64(-1), metadata.LastSeqNum)
@@ -454,7 +457,7 @@ func TestMetadataUnmarshalPreservesStateOnError(t *testing.T) {
 		{
 			name:    "v1",
 			data:    ExampleTableMetadataV1,
-			invalid: strings.Replace(ExampleTableMetadataV1, `"id": 2, "name": "y"`, `"id": 1, "name": "y"`, 1),
+			invalid: strings.Replace(ExampleTableMetadataV1, `"current-snapshot-id": -1`, `"current-snapshot-id": 999`, 1),
 			target:  &metadataV1{},
 		},
 		{

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -382,6 +382,22 @@ func TestMetadataV2UnmarshalPreservesStateOnError(t *testing.T) {
 	assert.Len(t, metadata.SnapshotList, 2)
 }
 
+func TestMetadataV2UnmarshalRejectsMissingRequiredStateOnReuse(t *testing.T) {
+	var metadata metadataV2
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &metadata))
+
+	var reduced map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &reduced))
+	delete(reduced, "default-spec-id")
+	reducedData, err := json.Marshal(reduced)
+	require.NoError(t, err)
+
+	require.Error(t, json.Unmarshal(reducedData, &metadata))
+	assert.Equal(t, 0, metadata.DefaultSpecID)
+	assert.Equal(t, 1, metadata.CurrentSchemaID)
+	assert.Len(t, metadata.SnapshotList, 2)
+}
+
 func TestLastUpdatedMSPresence(t *testing.T) {
 	tests := []struct {
 		name string

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -337,7 +337,29 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, json.Unmarshal([]byte(tt.data), tt.target))
+			initialData := []byte(tt.data)
+			if tt.name == "v1" {
+				var initial map[string]any
+				require.NoError(t, json.Unmarshal(initialData, &initial))
+				initial["properties"] = map[string]any{"seed": "value"}
+				initial["current-snapshot-id"] = int64(1925)
+				initial["snapshot-log"] = []any{map[string]any{"snapshot-id": int64(1925), "timestamp-ms": int64(1)}}
+				initial["metadata-log"] = []any{map[string]any{"metadata-file": "s3://bucket/old.json", "timestamp-ms": int64(1)}}
+				initial["refs"] = map[string]any{"main": map[string]any{"snapshot-id": int64(1925), "type": "branch"}}
+				var err error
+				initialData, err = json.Marshal(initial)
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, json.Unmarshal(initialData, tt.target))
+
+			common := metadataCommon(tt.target)
+			require.NotEmpty(t, common.Props)
+			require.NotEmpty(t, common.SnapshotList)
+			require.NotEmpty(t, common.SnapshotLog)
+			require.NotEmpty(t, common.MetadataLog)
+			require.NotEmpty(t, common.SnapshotRefs)
+			require.NotNil(t, common.CurrentSnapshotID)
 
 			var reduced map[string]json.RawMessage
 			require.NoError(t, json.Unmarshal([]byte(tt.data), &reduced))
@@ -351,15 +373,7 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 
 			require.NoError(t, json.Unmarshal(reducedData, tt.target))
 
-			var common *commonMetadata
-			switch metadata := tt.target.(type) {
-			case *metadataV1:
-				common = &metadata.commonMetadata
-			case *metadataV2:
-				common = &metadata.commonMetadata
-			case *metadataV3:
-				common = &metadata.commonMetadata
-			}
+			common = metadataCommon(tt.target)
 			assert.Empty(t, common.Props)
 			assert.Empty(t, common.SnapshotList)
 			assert.Empty(t, common.SnapshotLog)
@@ -370,16 +384,59 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 	}
 }
 
-func TestMetadataV2UnmarshalPreservesStateOnError(t *testing.T) {
-	var metadata metadataV2
-	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &metadata))
+func metadataCommon(target any) *commonMetadata {
+	switch metadata := target.(type) {
+	case *metadataV1:
+		return &metadata.commonMetadata
+	case *metadataV2:
+		return &metadata.commonMetadata
+	case *metadataV3:
+		return &metadata.commonMetadata
+	default:
+		panic("unsupported metadata type")
+	}
+}
 
-	invalid := strings.Replace(ExampleTableMetadataV2, `"current-schema-id": 1`, `"current-schema-id": 99`, 1)
-	require.Error(t, json.Unmarshal([]byte(invalid), &metadata))
+func TestMetadataUnmarshalPreservesStateOnError(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		invalid string
+		target  any
+	}{
+		{
+			name:    "v1",
+			data:    ExampleTableMetadataV1,
+			invalid: strings.Replace(ExampleTableMetadataV1, `"id": 2, "name": "y"`, `"id": 1, "name": "y"`, 1),
+			target:  &metadataV1{},
+		},
+		{
+			name:    "v2",
+			data:    ExampleTableMetadataV2,
+			invalid: strings.Replace(ExampleTableMetadataV2, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
+			target:  &metadataV2{},
+		},
+		{
+			name:    "v3",
+			data:    ExampleTableMetadataV3,
+			invalid: strings.Replace(ExampleTableMetadataV3, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
+			target:  &metadataV3{},
+		},
+	}
 
-	assert.Equal(t, 1, metadata.CurrentSchemaID)
-	assert.Equal(t, "134217728", metadata.Props["read.split.target.size"])
-	assert.Len(t, metadata.SnapshotList, 2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, json.Unmarshal([]byte(tt.data), tt.target))
+			before, err := json.Marshal(tt.target)
+			require.NoError(t, err)
+
+			require.Error(t, json.Unmarshal([]byte(tt.invalid), tt.target))
+
+			after, err := json.Marshal(tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, before, after)
+		})
+	}
 }
 
 func TestMetadataV2UnmarshalRejectsMissingRequiredStateOnReuse(t *testing.T) {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -338,18 +338,41 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			initialData := []byte(tt.data)
-			if tt.name == "v1" {
-				var initial map[string]any
-				require.NoError(t, json.Unmarshal(initialData, &initial))
-				initial["properties"] = map[string]any{"seed": "value"}
-				initial["current-snapshot-id"] = int64(1925)
-				initial["snapshot-log"] = []any{map[string]any{"snapshot-id": int64(1925), "timestamp-ms": int64(1)}}
-				initial["metadata-log"] = []any{map[string]any{"metadata-file": "s3://bucket/old.json", "timestamp-ms": int64(1)}}
-				initial["refs"] = map[string]any{"main": map[string]any{"snapshot-id": int64(1925), "type": "branch"}}
-				var err error
-				initialData, err = json.Marshal(initial)
+			var initial map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(initialData, &initial))
+			setJSON := func(key string, value any) {
+				encoded, err := json.Marshal(value)
 				require.NoError(t, err)
+				initial[key] = encoded
 			}
+			snapshotID := int64(1925)
+			if tt.name != "v1" {
+				snapshotID = 3055729675574597004
+			}
+			setJSON("properties", map[string]any{"seed": "value"})
+			setJSON("current-snapshot-id", snapshotID)
+			setJSON("snapshot-log", []any{map[string]any{"snapshot-id": snapshotID, "timestamp-ms": int64(1)}})
+			setJSON("metadata-log", []any{map[string]any{"metadata-file": "s3://bucket/old.json", "timestamp-ms": int64(1)}})
+			setJSON("refs", map[string]any{"main": map[string]any{"snapshot-id": snapshotID, "type": "branch"}})
+			setJSON("last-partition-id", int64(1000))
+			setJSON("statistics", []any{map[string]any{
+				"snapshot-id": snapshotID, "statistics-path": "s3://bucket/stats.puffin",
+				"file-size-in-bytes": int64(1), "file-footer-size-in-bytes": int64(1), "blob-metadata": []any{},
+			}})
+			setJSON("partition-statistics", []any{map[string]any{
+				"snapshot-id": snapshotID, "statistics-path": "s3://bucket/partition-stats.parquet", "file-size-in-bytes": int64(1),
+			}})
+			if tt.name == "v2" || tt.name == "v3" {
+				setJSON("last-sequence-number", int64(34))
+			}
+			if tt.name == "v3" {
+				setJSON("encryption-keys", []any{map[string]any{
+					"key-id": "key-1", "encrypted-key-metadata": "YWJj",
+				}})
+			}
+			var err error
+			initialData, err = json.Marshal(initial)
+			require.NoError(t, err)
 
 			require.NoError(t, json.Unmarshal(initialData, tt.target))
 
@@ -360,14 +383,28 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			require.NotEmpty(t, common.MetadataLog)
 			require.NotEmpty(t, common.SnapshotRefs)
 			require.NotNil(t, common.CurrentSnapshotID)
+			require.NotNil(t, common.LastPartitionID)
+			require.NotEmpty(t, common.StatisticsList)
+			require.NotEmpty(t, common.PartitionStatsList)
+			switch metadata := tt.target.(type) {
+			case *metadataV2:
+				require.Equal(t, int64(34), metadata.LastSeqNum)
+			case *metadataV3:
+				require.Equal(t, int64(34), metadata.LastSeqNum)
+			}
+			if tt.name == "v3" {
+				require.NotEmpty(t, common.EncryptionKeyList)
+			}
 
 			var reduced map[string]json.RawMessage
 			require.NoError(t, json.Unmarshal([]byte(tt.data), &reduced))
 			for _, key := range []string{
 				"properties", "current-snapshot-id", "snapshots", "snapshot-log", "metadata-log", "refs",
+				"statistics", "partition-statistics", "encryption-keys", "last-sequence-number",
 			} {
 				delete(reduced, key)
 			}
+			reduced["last-partition-id"] = json.RawMessage("1001")
 			reducedData, err := json.Marshal(reduced)
 			require.NoError(t, err)
 
@@ -380,6 +417,16 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			assert.Empty(t, common.MetadataLog)
 			assert.Empty(t, common.SnapshotRefs)
 			assert.Nil(t, common.CurrentSnapshotID)
+			assert.Equal(t, 1001, *common.LastPartitionID)
+			assert.Empty(t, common.StatisticsList)
+			assert.Empty(t, common.PartitionStatsList)
+			assert.Empty(t, common.EncryptionKeyList)
+			switch metadata := tt.target.(type) {
+			case *metadataV2:
+				assert.Equal(t, int64(-1), metadata.LastSeqNum)
+			case *metadataV3:
+				assert.Equal(t, int64(-1), metadata.LastSeqNum)
+			}
 		})
 	}
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -345,10 +345,12 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 				require.NoError(t, err)
 				initial[key] = encoded
 			}
-			snapshotID := int64(1925)
-			if tt.name != "v1" {
-				snapshotID = 3055729675574597004
+			var snapshots []struct {
+				SnapshotID int64 `json:"snapshot-id"`
 			}
+			require.NoError(t, json.Unmarshal(initial["snapshots"], &snapshots))
+			require.NotEmpty(t, snapshots)
+			snapshotID := snapshots[len(snapshots)-1].SnapshotID
 			setJSON("properties", map[string]any{"seed": "value"})
 			setJSON("current-snapshot-id", snapshotID)
 			setJSON("snapshot-log", []any{map[string]any{"snapshot-id": snapshotID, "timestamp-ms": int64(1)}})
@@ -387,6 +389,8 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			require.NotEmpty(t, common.StatisticsList)
 			require.NotEmpty(t, common.PartitionStatsList)
 			switch metadata := tt.target.(type) {
+			case *metadataV1:
+				require.Equal(t, int64(0), metadata.LastSequenceNumber())
 			case *metadataV2:
 				require.Equal(t, int64(34), metadata.LastSeqNum)
 			case *metadataV3:
@@ -425,6 +429,8 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			// legacy -1 sentinel. This documents current behavior, not the
 			// desired metadata normalization.
 			switch metadata := tt.target.(type) {
+			case *metadataV1:
+				assert.Equal(t, int64(0), metadata.LastSequenceNumber())
 			case *metadataV2:
 				assert.Equal(t, int64(-1), metadata.LastSeqNum)
 			case *metadataV3:
@@ -449,58 +455,75 @@ func metadataCommon(target any) *commonMetadata {
 
 func TestMetadataUnmarshalPreservesStateOnError(t *testing.T) {
 	tests := []struct {
-		name    string
-		data    string
-		invalid string
-		target  any
+		name      string
+		data      string
+		invalid   string
+		malformed string
+		target    any
 	}{
 		{
-			name:    "v1",
-			data:    ExampleTableMetadataV1,
-			invalid: strings.Replace(ExampleTableMetadataV1, `"current-snapshot-id": -1`, `"current-snapshot-id": 999`, 1),
-			target:  &metadataV1{},
+			name:      "v1",
+			data:      ExampleTableMetadataV1,
+			invalid:   strings.Replace(ExampleTableMetadataV1, `"current-snapshot-id": -1`, `"current-snapshot-id": 999`, 1),
+			malformed: "not json {",
+			target:    &metadataV1{},
 		},
 		{
-			name:    "v2",
-			data:    ExampleTableMetadataV2,
-			invalid: strings.Replace(ExampleTableMetadataV2, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
-			target:  &metadataV2{},
+			name:      "v2",
+			data:      ExampleTableMetadataV2,
+			invalid:   strings.Replace(ExampleTableMetadataV2, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
+			malformed: "not json {",
+			target:    &metadataV2{},
 		},
 		{
-			name:    "v3",
-			data:    ExampleTableMetadataV3,
-			invalid: strings.Replace(ExampleTableMetadataV3, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
-			target:  &metadataV3{},
+			name:      "v3",
+			data:      ExampleTableMetadataV3,
+			invalid:   strings.Replace(ExampleTableMetadataV3, `"current-schema-id": 1`, `"current-schema-id": 99`, 1),
+			malformed: "not json {",
+			target:    &metadataV3{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, json.Unmarshal([]byte(tt.data), tt.target))
-			before, err := json.Marshal(tt.target)
-			require.NoError(t, err)
+			for _, invalid := range []struct {
+				name string
+				data string
+			}{
+				{name: "validation", data: tt.invalid},
+				{name: "json", data: tt.malformed},
+			} {
+				t.Run(invalid.name, func(t *testing.T) {
+					require.NoError(t, json.Unmarshal([]byte(tt.data), tt.target))
+					before, err := json.Marshal(tt.target)
+					require.NoError(t, err)
 
-			require.Error(t, json.Unmarshal([]byte(tt.invalid), tt.target))
+					require.Error(t, json.Unmarshal([]byte(invalid.data), tt.target))
 
-			after, err := json.Marshal(tt.target)
-			require.NoError(t, err)
-			assert.Equal(t, before, after)
+					after, err := json.Marshal(tt.target)
+					require.NoError(t, err)
+					assert.Equal(t, before, after)
+				})
+			}
 		})
 	}
 }
 
 func TestMetadataV2UnmarshalRejectsMissingRequiredStateOnReuse(t *testing.T) {
+	seedData := strings.Replace(ExampleTableMetadataV2, `"spec-id": 0`, `"spec-id": 7`, 1)
+	seedData = strings.Replace(seedData, `"default-spec-id": 0`, `"default-spec-id": 7`, 1)
+
 	var metadata metadataV2
-	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &metadata))
+	require.NoError(t, json.Unmarshal([]byte(seedData), &metadata))
 
 	var reduced map[string]json.RawMessage
-	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &reduced))
+	require.NoError(t, json.Unmarshal([]byte(seedData), &reduced))
 	delete(reduced, "default-spec-id")
 	reducedData, err := json.Marshal(reduced)
 	require.NoError(t, err)
 
 	require.Error(t, json.Unmarshal(reducedData, &metadata))
-	assert.Equal(t, 0, metadata.DefaultSpecID)
+	assert.Equal(t, 7, metadata.DefaultSpecID)
 	assert.Equal(t, 1, metadata.CurrentSchemaID)
 	assert.Len(t, metadata.SnapshotList, 2)
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -412,6 +412,19 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			reducedData, err := json.Marshal(reduced)
 			require.NoError(t, err)
 
+			if tt.name != "v1" {
+				before, err := json.Marshal(tt.target)
+				require.NoError(t, err)
+
+				err = json.Unmarshal(reducedData, tt.target)
+				require.ErrorContains(t, err, "last-sequence-number is required")
+
+				after, err := json.Marshal(tt.target)
+				require.NoError(t, err)
+				assert.Equal(t, before, after)
+				return
+			}
+
 			require.NoError(t, json.Unmarshal(reducedData, tt.target))
 
 			common = metadataCommon(tt.target)
@@ -425,17 +438,7 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 			assert.Empty(t, common.StatisticsList)
 			assert.Empty(t, common.PartitionStatsList)
 			assert.Empty(t, common.EncryptionKeyList)
-			// With no snapshots, an omitted last-sequence-number retains the
-			// legacy -1 sentinel. This documents current behavior, not the
-			// desired metadata normalization.
-			switch metadata := tt.target.(type) {
-			case *metadataV1:
-				assert.Equal(t, int64(0), metadata.LastSequenceNumber())
-			case *metadataV2:
-				assert.Equal(t, int64(-1), metadata.LastSeqNum)
-			case *metadataV3:
-				assert.Equal(t, int64(-1), metadata.LastSeqNum)
-			}
+			assert.Equal(t, int64(0), tt.target.(*metadataV1).LastSequenceNumber())
 		})
 	}
 }
@@ -826,6 +829,7 @@ func TestInvalidFormatVersion(t *testing.T) {
 func TestCurrentSchemaNotFound(t *testing.T) {
 	schemaNotFound := `{
         "format-version": 2,
+        "last-sequence-number": 34,
         "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
         "location": "s3://bucket/test/location",
         "last-updated-ms": 1602638573874,
@@ -966,6 +970,7 @@ func TestRejectsStoredPartitionSpecWithoutID(t *testing.T) {
 func TestSortOrderNotFound(t *testing.T) {
 	metadataSortOrderNotFound := `{
         "format-version": 2,
+        "last-sequence-number": 34,
         "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
         "location": "s3://bucket/test/location",
         "last-updated-ms": 1602638573874,
@@ -1010,6 +1015,7 @@ func TestSortOrderNotFound(t *testing.T) {
 func TestSortOrderUnsorted(t *testing.T) {
 	sortOrderUnsorted := `{
         "format-version": 2,
+        "last-sequence-number": 34,
         "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
         "location": "s3://bucket/test/location",
         "last-updated-ms": 1602638573874,
@@ -1649,6 +1655,7 @@ func TestMetadataV2Validation(t *testing.T) {
 	// Test case 2: JSON with explicit last-column-id field
 	withColumnID := `{
 		"format-version": 2,
+		"last-sequence-number": 34,
 		"table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
 		"location": "s3://bucket/test/location",
 		"last-updated-ms": 1602638573874,

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -324,6 +324,64 @@ func TestMetadataV3Parsing(t *testing.T) {
 	assert.Equal(t, int64(2000), *secondSnapshot.FirstRowID)
 }
 
+func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   string
+		target any
+	}{
+		{name: "v1", data: ExampleTableMetadataV1, target: &metadataV1{}},
+		{name: "v2", data: ExampleTableMetadataV2, target: &metadataV2{}},
+		{name: "v3", data: ExampleTableMetadataV3, target: &metadataV3{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, json.Unmarshal([]byte(tt.data), tt.target))
+
+			var reduced map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(tt.data), &reduced))
+			for _, key := range []string{
+				"properties", "current-snapshot-id", "snapshots", "snapshot-log", "metadata-log", "refs",
+			} {
+				delete(reduced, key)
+			}
+			reducedData, err := json.Marshal(reduced)
+			require.NoError(t, err)
+
+			require.NoError(t, json.Unmarshal(reducedData, tt.target))
+
+			var common *commonMetadata
+			switch metadata := tt.target.(type) {
+			case *metadataV1:
+				common = &metadata.commonMetadata
+			case *metadataV2:
+				common = &metadata.commonMetadata
+			case *metadataV3:
+				common = &metadata.commonMetadata
+			}
+			assert.Empty(t, common.Props)
+			assert.Empty(t, common.SnapshotList)
+			assert.Empty(t, common.SnapshotLog)
+			assert.Empty(t, common.MetadataLog)
+			assert.Empty(t, common.SnapshotRefs)
+			assert.Nil(t, common.CurrentSnapshotID)
+		})
+	}
+}
+
+func TestMetadataV2UnmarshalPreservesStateOnError(t *testing.T) {
+	var metadata metadataV2
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &metadata))
+
+	invalid := strings.Replace(ExampleTableMetadataV2, `"current-schema-id": 1`, `"current-schema-id": 99`, 1)
+	require.Error(t, json.Unmarshal([]byte(invalid), &metadata))
+
+	assert.Equal(t, 1, metadata.CurrentSchemaID)
+	assert.Equal(t, "134217728", metadata.Props["read.split.target.size"])
+	assert.Len(t, metadata.SnapshotList, 2)
+}
+
 func TestLastUpdatedMSPresence(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1410,7 +1468,9 @@ func TestMetadataV1Validation(t *testing.T) {
 	}`
 
 	// Parse each test case
-	var meta1, meta2, meta3 metadataV1
+	meta1 := initMetadataV1Deser()
+	meta2 := initMetadataV1Deser()
+	meta3 := initMetadataV1Deser()
 
 	// Test case 1: Verify LastColumnId is -1 when not specified
 	require.Error(t, meta1.UnmarshalJSON([]byte(noColumnID)))
@@ -1450,6 +1510,7 @@ func TestMetadataV2Validation(t *testing.T) {
 		"current-schema-id": 0,
 		"last-partition-id": 1000,
 		"schemas": [{"type":"struct","schema-id":0,"fields":[]}],
+		"default-spec-id": 0,
 		"partition-specs": [{"spec-id": 0, "fields": []}],
 		"properties": {},
         "default-sort-order-id": 0,
@@ -1469,13 +1530,16 @@ func TestMetadataV2Validation(t *testing.T) {
 		"last-column-id": 0,
 		"last-partition-id": 1000,
 		"schemas": [{"type":"struct","schema-id":0,"fields":[]}],
+		"default-spec-id": 0,
 		"partition-specs": [{"spec-id": 0, "fields": []}],
 		"sort-orders": [],
 		"default-sort-order-id": 0
 	}`
 
 	// Parse each test case
-	var meta1, meta2, meta3 metadataV2
+	meta1 := initMetadataV2Deser()
+	meta2 := initMetadataV2Deser()
+	meta3 := initMetadataV2Deser()
 
 	// Test case 1: Verify LastColumnId is -1 when not specified
 	require.Error(t, meta1.UnmarshalJSON([]byte(noColumnID)))

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -422,6 +422,7 @@ func TestMetadataUnmarshalReplacesReceiverState(t *testing.T) {
 				after, err := json.Marshal(tt.target)
 				require.NoError(t, err)
 				assert.Equal(t, before, after)
+
 				return
 			}
 


### PR DESCRIPTION
## Summary

Make table metadata JSON decoding replace receiver state for format versions 1, 2, and 3.

## Why

Decoding through aliases of the existing receiver allowed omitted properties, snapshots, refs, logs, and current-snapshot state to survive from an earlier document. Validation errors could also leave partial changes behind.

## What changed

Each version decodes into fresh state, applies version-specific defaults and sentinels before validation, and replaces the receiver only after success. The deserialization sentinels are applied on every path, so direct v2 and v3 decoding rejects omitted normalized state such as `default-spec-id` and `next-row-id`, matching `ParseMetadataBytes`. Reused receivers also no longer leak stale snapshot refs or v1 schema state into the new document.

## Tests

- Added receiver-reuse coverage for v1, v2, and v3
- Added failed-decode state preservation coverage for validation and malformed JSON errors
- Added coverage for omitted required state
- go test ./table