### PR TITLE
INFRA: Use PR titles for squash commits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,6 +30,7 @@ github:
 
   enabled_merge_buttons:
     squash: true
+    squash_commit_message: PR_TITLE_AND_COMMIT_DETAILS
     merge: false
     rebase: false
 


### PR DESCRIPTION
Context: https://github.com/apache/iceberg/issues/17467

Configure squash merges to always use the pull request title while preserving the existing commit-message details in the squash commit body.
