### PR TITLE
feat(metrics): add REST metrics reporter (#1236)

### DIFF
--- a/catalog/rest/auth.go
+++ b/catalog/rest/auth.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -30,6 +31,19 @@ type AuthManager interface {
 	AuthHeader() (string, string, error)
 }
 
+// ContextAuthManager is an optional interface an AuthManager may implement to
+// honor a caller-supplied context (deadline and cancellation) while producing
+// the authorization header. sessionTransport prefers AuthHeaderWithContext when
+// the manager implements it, so a request's deadline also bounds the auth step
+// rather than only the request/response cycle. A manager implementing only
+// AuthManager still works, but its auth step cannot be interrupted mid-call —
+// bounding that case is the implementer's responsibility.
+type ContextAuthManager interface {
+	AuthManager
+	// AuthHeaderWithContext returns the authorization header, honoring ctx.
+	AuthHeaderWithContext(ctx context.Context) (string, string, error)
+}
+
 // Oauth2AuthManager is an implementation of the AuthManager interface which
 // uses an oauth2.TokenSource to provide bearer tokens. The token source
 // handles caching, thread-safe refresh, and expiry management.
@@ -37,8 +51,29 @@ type Oauth2AuthManager struct {
 	tokenSource oauth2.TokenSource
 }
 
+var _ ContextAuthManager = (*Oauth2AuthManager)(nil)
+
 // AuthHeader returns the authorization header with the bearer token.
 func (o *Oauth2AuthManager) AuthHeader() (string, string, error) {
+	return o.authHeader()
+}
+
+// AuthHeaderWithContext returns the authorization header, honoring ctx. A
+// cached, unexpired token is returned without any network call, so a bounded
+// caller (such as the metrics dispatcher) pays no auth latency in the common
+// case. When a refresh is required it goes through the token-refresh HTTP
+// client, whose Timeout bounds how long a stalled token endpoint can block; the
+// ctx check here additionally short-circuits work for a caller whose deadline
+// has already elapsed.
+func (o *Oauth2AuthManager) AuthHeaderWithContext(ctx context.Context) (string, string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", "", err
+	}
+
+	return o.authHeader()
+}
+
+func (o *Oauth2AuthManager) authHeader() (string, string, error) {
 	tok, err := o.tokenSource.Token()
 	if err != nil {
 		var re *oauth2.RetrieveError

--- a/catalog/rest/metrics_reporter.go
+++ b/catalog/rest/metrics_reporter.go
@@ -118,8 +118,11 @@ type metricsJob struct {
 // rather than accumulating goroutines and connections. Close cancels in-flight
 // reports and drains the workers.
 type metricsDispatcher struct {
-	jobs      chan metricsJob
-	timeout   time.Duration
+	jobs    chan metricsJob
+	timeout time.Duration
+	// ctx/cancel are the dispatcher's own lifecycle context, deliberately stored
+	// on the struct (the documented exception to "don't store a context in a
+	// struct"): Close cancels it to abort in-flight reports and stop the workers.
 	ctx       context.Context
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
@@ -278,9 +281,20 @@ func (d *metricsDispatcher) close() {
 			close(done)
 		}()
 
+		// Explicit timer with a deferred Stop rather than time.After, which would
+		// leak a live timer (up to the full timeout) on the common path where the
+		// workers finish first — it adds up in a process that cycles through many
+		// catalogs.
+		t := time.NewTimer(d.timeout)
+		defer t.Stop()
 		select {
 		case <-done:
-		case <-time.After(d.timeout):
+		case <-t.C:
+			// Shutdown budget expired before the workers returned (a report wedged in
+			// auth, say). d.ctx is already cancelled, so each worker self-exits once
+			// its attempt unblocks — nothing leaks — but Close can return here before
+			// the workers have fully stopped; do not tear down a shared transport on
+			// the assumption that they have.
 		}
 
 		close(d.closeDone)

--- a/catalog/rest/metrics_reporter.go
+++ b/catalog/rest/metrics_reporter.go
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/iceberg-go/metrics"
+)
+
+// keyReportMetricsEnabled opts a REST catalog into POSTing scan/commit reports
+// to the catalog's metrics endpoint. It is disabled by default so existing
+// users see no new network traffic unless they turn it on.
+const keyReportMetricsEnabled = "rest.metrics-reporting-enabled"
+
+// restMetricsReporter POSTs metrics reports to a table's REST metrics endpoint
+// (POST .../tables/{table}/metrics). It is bound to a single table's path and
+// satisfies metrics.Reporter.
+type restMetricsReporter struct {
+	baseURI *url.URL
+	cl      *http.Client
+	path    []string // table metrics path, relative to baseURI
+}
+
+var _ metrics.Reporter = (*restMetricsReporter)(nil)
+
+// Report wraps the report in a ReportMetricsRequest and POSTs it on a
+// background goroutine. Per the Reporter contract it never blocks or fails the
+// observed scan/commit: the send is detached from the caller's cancellation,
+// and any error is logged and swallowed.
+func (rep *restMetricsReporter) Report(ctx context.Context, report metrics.MetricsReport) {
+	if report == nil {
+		return
+	}
+
+	req := metrics.NewReportMetricsRequest(report)
+	// Detach from the caller's cancellation (the scan/commit is already done)
+	// while preserving any context values used by the HTTP client.
+	sendCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Default().Warn("iceberg: panic while reporting metrics to REST catalog", "recovered", r)
+			}
+		}()
+
+		if _, err := doPost[metrics.ReportMetricsRequest, struct{}](
+			sendCtx, rep.baseURI, rep.path, req, rep.cl, nil, allowNoContent()); err != nil {
+			slog.Default().Warn("iceberg: failed to report metrics to REST catalog", "error", err)
+		}
+	}()
+}
+
+// Close satisfies [metrics.Reporter]. The reporter is stateless — it borrows
+// the catalog's shared HTTP client rather than owning one — so there is nothing
+// to release.
+func (rep *restMetricsReporter) Close() error { return nil }

--- a/catalog/rest/metrics_reporter.go
+++ b/catalog/rest/metrics_reporter.go
@@ -22,7 +22,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	iceberg "github.com/apache/iceberg-go"
@@ -39,23 +41,28 @@ const (
 	// keyReportMetricsEnabledLegacy is the historical dotted spelling, accepted
 	// as an alias so existing configs keep working.
 	keyReportMetricsEnabledLegacy = "rest.metrics-reporting-enabled"
-	// keyReportMetricsTimeoutMs bounds a single report's total auth + request +
-	// response cycle, in milliseconds. Read from the client-supplied properties
-	// only.
+	// keyReportMetricsTimeoutMs bounds a single report's request and response
+	// cycle, in milliseconds. Read from the client-supplied properties only. Auth
+	// (token refresh) is bounded separately by the OAuth refresh client Timeout.
 	keyReportMetricsTimeoutMs = "rest-metrics-reporting-timeout-ms"
 
-	// defaultReportMetricsTimeout bounds a single report's total auth + request
-	// + response cycle when keyReportMetricsTimeoutMs is unset. Telemetry is safe
-	// to drop, so the bound is deliberately short.
+	// defaultReportMetricsTimeout bounds a single report's request and response
+	// cycle when keyReportMetricsTimeoutMs is unset. Telemetry is safe to drop, so
+	// the bound is deliberately short.
 	defaultReportMetricsTimeout = 10 * time.Second
 	// metricsDispatchWorkers is the fixed number of goroutines draining the
 	// dispatch queue, capping the reporter's concurrent connection use.
 	metricsDispatchWorkers = 4
 	// metricsDispatchQueueSize bounds how many reports may await dispatch.
-	// Reports offered while the queue is full are dropped (and logged) rather
-	// than queued without limit, so a stalled endpoint cannot make reporting grow
-	// without bound.
+	// Reports offered while the queue is full are dropped (and counted, then
+	// logged in aggregate) rather than queued without limit, so a stalled
+	// endpoint cannot make reporting grow without bound.
 	metricsDispatchQueueSize = 128
+	// metricsStatsInterval is how often the dispatcher emits an aggregated
+	// warning summarizing dropped and failed reports. Aggregating keeps a stalled
+	// or unavailable endpoint from amplifying into one log line per report while
+	// still surfacing back-pressure.
+	metricsStatsInterval = 30 * time.Second
 )
 
 // reportMetricsEnabled reports whether the client opted into REST metrics
@@ -63,9 +70,19 @@ const (
 // given the client-supplied properties only (never the server-merged config) so
 // a server cannot flip the default and turn on outbound telemetry the client
 // never asked for.
+//
+// The canonical key wins whenever it is present, so a client that has migrated
+// to it and explicitly set it to false is honored even if a stale legacy dotted
+// key lingers in the config. The legacy key is consulted only when the canonical
+// key is absent.
 func reportMetricsEnabled(props iceberg.Properties) bool {
-	return props.GetBool(keyReportMetricsEnabled, false) ||
-		props.GetBool(keyReportMetricsEnabledLegacy, false)
+	if v, ok := props[keyReportMetricsEnabled]; ok {
+		enabled, err := strconv.ParseBool(v)
+
+		return err == nil && enabled
+	}
+
+	return props.GetBool(keyReportMetricsEnabledLegacy, false)
 }
 
 // reportMetricsTimeout resolves the per-report deadline from the client-supplied
@@ -82,6 +99,11 @@ func reportMetricsTimeout(props iceberg.Properties) time.Duration {
 
 // metricsJob is a single report awaiting dispatch to a table's metrics endpoint.
 type metricsJob struct {
+	// ctx carries the observed scan/commit's context values (trace spans,
+	// request-scoped attributes) with its cancellation detached — the scan/commit
+	// is already done, so its cancellation must not abort the report, but its
+	// values should still propagate to the outbound request.
+	ctx     context.Context
 	baseURI *url.URL
 	cl      *http.Client
 	path    []string
@@ -92,32 +114,38 @@ type metricsJob struct {
 // pool of workers draining a bounded queue. It is owned by the catalog and
 // shared across that catalog's table reporters, so concurrent report volume
 // stays bounded no matter how many tables are loaded or how often they are
-// scanned. A stalled endpoint sheds load — reports are dropped and logged —
+// scanned. A stalled endpoint sheds load — reports are dropped and counted —
 // rather than accumulating goroutines and connections. Close cancels in-flight
 // reports and drains the workers.
 type metricsDispatcher struct {
-	jobs    chan metricsJob
-	timeout time.Duration
-	ctx     context.Context
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	logger  *slog.Logger // nil means resolve slog.Default at call time
+	jobs      chan metricsJob
+	timeout   time.Duration
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	logger    *slog.Logger // nil means resolve slog.Default at call time
+	dropped   atomic.Uint64
+	failed    atomic.Uint64
+	closeOnce sync.Once
+	closeDone chan struct{}
 }
 
 func newMetricsDispatcher(workers, queueSize int, timeout time.Duration, logger *slog.Logger) *metricsDispatcher {
 	ctx, cancel := context.WithCancel(context.Background())
 	d := &metricsDispatcher{
-		jobs:    make(chan metricsJob, queueSize),
-		timeout: timeout,
-		ctx:     ctx,
-		cancel:  cancel,
-		logger:  logger,
+		jobs:      make(chan metricsJob, queueSize),
+		timeout:   timeout,
+		ctx:       ctx,
+		cancel:    cancel,
+		logger:    logger,
+		closeDone: make(chan struct{}),
 	}
 
-	d.wg.Add(workers)
+	d.wg.Add(workers + 1)
 	for range workers {
 		go d.worker()
 	}
+	go d.reportStats()
 
 	return d
 }
@@ -155,28 +183,38 @@ func (d *metricsDispatcher) send(job metricsJob) {
 		}
 	}()
 
-	// Derive from the dispatcher context so Close cancels in-flight requests,
-	// and add the per-report deadline so a stalled endpoint cannot pin a worker
-	// (and its connection) indefinitely. The deadline covers auth plus the full
-	// request and response cycle.
-	ctx, cancel := context.WithTimeout(d.ctx, d.timeout)
+	// Bound the report by the per-report deadline, starting from the job's
+	// context so the caller's values (trace spans, request-scoped attributes)
+	// still reach the transport, and tie the derived context to dispatcher
+	// shutdown so Close cancels in-flight requests. The deadline covers the
+	// request and response cycle; a token refresh triggered by auth is bounded
+	// separately by the OAuth refresh client's Timeout.
+	ctx, cancel := context.WithTimeout(job.ctx, d.timeout)
 	defer cancel()
+	stop := context.AfterFunc(d.ctx, cancel)
+	defer stop()
 
 	if _, err := doPost[metrics.ReportMetricsRequest, struct{}](
 		ctx, job.baseURI, job.path, job.req, job.cl, nil, allowNoContent()); err != nil {
 		// A report interrupted by Close (dispatcher context cancelled) is expected
-		// shutdown behavior, not a failure worth logging. A per-report timeout
-		// leaves the dispatcher context live, so genuine timeouts still surface.
+		// shutdown behavior, not a failure worth counting. A per-report timeout
+		// leaves the dispatcher context live, so genuine failures still surface.
 		if d.ctx.Err() != nil {
 			return
 		}
-		d.log().Warn("iceberg: failed to report metrics to REST catalog", "error", err)
+		d.failed.Add(1)
+		// The transport error embeds the request URL, which can carry a sensitive
+		// host, prefix, namespace or table name, so keep the detail at Debug and
+		// let reportStats surface the aggregate count at Warn.
+		d.log().Debug("iceberg: failed to report metrics to REST catalog", "error", err)
 	}
 }
 
 // submit offers a job to the queue without blocking. It drops the report (and
-// logs the drop, so back-pressure is visible rather than silent) when the queue
-// is full, and ignores reports once the dispatcher is closed.
+// counts the drop, aggregated and logged by reportStats so back-pressure is
+// visible without amplifying into one log line per drop) when the queue is
+// full, and ignores reports once the dispatcher is closed. Every path here is
+// non-blocking so Report never blocks the observed scan/commit.
 func (d *metricsDispatcher) submit(job metricsJob) {
 	select {
 	case <-d.ctx.Done():
@@ -188,25 +226,67 @@ func (d *metricsDispatcher) submit(job metricsJob) {
 	case d.jobs <- job:
 	case <-d.ctx.Done():
 	default:
-		d.log().Warn("iceberg: metrics report dropped; dispatch queue full")
+		d.dropped.Add(1)
+	}
+}
+
+// reportStats periodically emits an aggregated warning summarizing reports
+// dropped (queue full) and failed (endpoint errors) since the last tick, so a
+// stalled or unavailable endpoint surfaces as bounded, rate-limited log volume
+// rather than one line per report. A final summary is emitted on shutdown.
+func (d *metricsDispatcher) reportStats() {
+	defer d.wg.Done()
+
+	ticker := time.NewTicker(metricsStatsInterval)
+	defer ticker.Stop()
+
+	var lastDropped, lastFailed uint64
+	flush := func() {
+		dropped, failed := d.dropped.Load(), d.failed.Load()
+		if dropped == lastDropped && failed == lastFailed {
+			return
+		}
+		d.log().Warn("iceberg: REST metrics reports dropped or failed",
+			"dropped", dropped-lastDropped, "dropped_total", dropped,
+			"failed", failed-lastFailed, "failed_total", failed)
+		lastDropped, lastFailed = dropped, failed
+	}
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			flush()
+
+			return
+		case <-ticker.C:
+			flush()
+		}
 	}
 }
 
 // close cancels in-flight reports and waits for the workers to return, bounded
-// by the report timeout so shutdown cannot hang on a stalled endpoint.
+// by the report timeout so shutdown cannot hang on a stalled endpoint. It is
+// one-shot: repeated calls block until the first completes, then return, so no
+// extra waiter goroutine is spawned per call.
 func (d *metricsDispatcher) close() {
-	d.cancel()
+	d.closeOnce.Do(func() {
+		d.cancel()
 
-	done := make(chan struct{})
-	go func() {
-		d.wg.Wait()
-		close(done)
-	}()
+		done := make(chan struct{})
+		go func() {
+			d.wg.Wait()
+			close(done)
+		}()
 
-	select {
-	case <-done:
-	case <-time.After(d.timeout):
-	}
+		select {
+		case <-done:
+		case <-time.After(d.timeout):
+		}
+
+		close(d.closeDone)
+	})
+
+	<-d.closeDone
 }
 
 // restMetricsReporter POSTs metrics reports for a single table to its REST
@@ -224,14 +304,21 @@ var _ metrics.Reporter = (*restMetricsReporter)(nil)
 // Report wraps the report in a ReportMetricsRequest and hands it to the
 // catalog's dispatcher, returning immediately. Per the Reporter contract it
 // never blocks or fails the observed scan/commit: dispatch is asynchronous and
-// bounded, the send is detached from the caller's cancellation (the scan/commit
-// is already done), and any error is logged and swallowed by the dispatcher.
-func (rep *restMetricsReporter) Report(_ context.Context, report metrics.MetricsReport) {
+// bounded, and any error is counted and swallowed by the dispatcher. The
+// caller's context is detached from cancellation (the scan/commit is already
+// done) but its values are preserved so trace spans and request-scoped
+// attributes still propagate to the outbound report.
+func (rep *restMetricsReporter) Report(ctx context.Context, report metrics.MetricsReport) {
 	if report == nil {
 		return
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	rep.dispatcher.submit(metricsJob{
+		ctx:     context.WithoutCancel(ctx),
 		baseURI: rep.baseURI,
 		cl:      rep.cl,
 		path:    rep.path,

--- a/catalog/rest/metrics_reporter.go
+++ b/catalog/rest/metrics_reporter.go
@@ -22,55 +22,225 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
+	iceberg "github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/metrics"
 )
 
-// keyReportMetricsEnabled opts a REST catalog into POSTing scan/commit reports
-// to the catalog's metrics endpoint. It is disabled by default so existing
-// users see no new network traffic unless they turn it on.
-const keyReportMetricsEnabled = "rest.metrics-reporting-enabled"
+const (
+	// keyReportMetricsEnabled opts a REST catalog into POSTing scan/commit
+	// reports to the catalog's metrics endpoint. It is disabled by default so
+	// existing users see no new network traffic unless they turn it on. This is
+	// the canonical, cross-implementation spelling used by Iceberg Java and the
+	// Iceberg docs; keyReportMetricsEnabledLegacy is accepted as an alias.
+	keyReportMetricsEnabled = "rest-metrics-reporting-enabled"
+	// keyReportMetricsEnabledLegacy is the historical dotted spelling, accepted
+	// as an alias so existing configs keep working.
+	keyReportMetricsEnabledLegacy = "rest.metrics-reporting-enabled"
+	// keyReportMetricsTimeoutMs bounds a single report's total auth + request +
+	// response cycle, in milliseconds. Read from the client-supplied properties
+	// only.
+	keyReportMetricsTimeoutMs = "rest-metrics-reporting-timeout-ms"
 
-// restMetricsReporter POSTs metrics reports to a table's REST metrics endpoint
-// (POST .../tables/{table}/metrics). It is bound to a single table's path and
-// satisfies metrics.Reporter.
-type restMetricsReporter struct {
+	// defaultReportMetricsTimeout bounds a single report's total auth + request
+	// + response cycle when keyReportMetricsTimeoutMs is unset. Telemetry is safe
+	// to drop, so the bound is deliberately short.
+	defaultReportMetricsTimeout = 10 * time.Second
+	// metricsDispatchWorkers is the fixed number of goroutines draining the
+	// dispatch queue, capping the reporter's concurrent connection use.
+	metricsDispatchWorkers = 4
+	// metricsDispatchQueueSize bounds how many reports may await dispatch.
+	// Reports offered while the queue is full are dropped (and logged) rather
+	// than queued without limit, so a stalled endpoint cannot make reporting grow
+	// without bound.
+	metricsDispatchQueueSize = 128
+)
+
+// reportMetricsEnabled reports whether the client opted into REST metrics
+// reporting, accepting both the canonical and the legacy dotted key. It must be
+// given the client-supplied properties only (never the server-merged config) so
+// a server cannot flip the default and turn on outbound telemetry the client
+// never asked for.
+func reportMetricsEnabled(props iceberg.Properties) bool {
+	return props.GetBool(keyReportMetricsEnabled, false) ||
+		props.GetBool(keyReportMetricsEnabledLegacy, false)
+}
+
+// reportMetricsTimeout resolves the per-report deadline from the client-supplied
+// properties, falling back to defaultReportMetricsTimeout for a missing or
+// non-positive value.
+func reportMetricsTimeout(props iceberg.Properties) time.Duration {
+	ms := props.GetInt(keyReportMetricsTimeoutMs, int(defaultReportMetricsTimeout/time.Millisecond))
+	if ms <= 0 {
+		return defaultReportMetricsTimeout
+	}
+
+	return time.Duration(ms) * time.Millisecond
+}
+
+// metricsJob is a single report awaiting dispatch to a table's metrics endpoint.
+type metricsJob struct {
 	baseURI *url.URL
 	cl      *http.Client
-	path    []string // table metrics path, relative to baseURI
+	path    []string
+	req     metrics.ReportMetricsRequest
+}
+
+// metricsDispatcher POSTs metrics reports to REST metrics endpoints on a fixed
+// pool of workers draining a bounded queue. It is owned by the catalog and
+// shared across that catalog's table reporters, so concurrent report volume
+// stays bounded no matter how many tables are loaded or how often they are
+// scanned. A stalled endpoint sheds load — reports are dropped and logged —
+// rather than accumulating goroutines and connections. Close cancels in-flight
+// reports and drains the workers.
+type metricsDispatcher struct {
+	jobs    chan metricsJob
+	timeout time.Duration
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	logger  *slog.Logger // nil means resolve slog.Default at call time
+}
+
+func newMetricsDispatcher(workers, queueSize int, timeout time.Duration, logger *slog.Logger) *metricsDispatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &metricsDispatcher{
+		jobs:    make(chan metricsJob, queueSize),
+		timeout: timeout,
+		ctx:     ctx,
+		cancel:  cancel,
+		logger:  logger,
+	}
+
+	d.wg.Add(workers)
+	for range workers {
+		go d.worker()
+	}
+
+	return d
+}
+
+func (d *metricsDispatcher) log() *slog.Logger {
+	if d.logger != nil {
+		return d.logger
+	}
+
+	return slog.Default()
+}
+
+func (d *metricsDispatcher) worker() {
+	defer d.wg.Done()
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case job := <-d.jobs:
+			d.send(job)
+		}
+	}
+}
+
+func (d *metricsDispatcher) send(job metricsJob) {
+	// If the dispatcher is already shutting down, drop the report before doing
+	// any work: the derived context would be cancelled immediately anyway.
+	if d.ctx.Err() != nil {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			d.log().Warn("iceberg: panic while reporting metrics to REST catalog", "recovered", r)
+		}
+	}()
+
+	// Derive from the dispatcher context so Close cancels in-flight requests,
+	// and add the per-report deadline so a stalled endpoint cannot pin a worker
+	// (and its connection) indefinitely. The deadline covers auth plus the full
+	// request and response cycle.
+	ctx, cancel := context.WithTimeout(d.ctx, d.timeout)
+	defer cancel()
+
+	if _, err := doPost[metrics.ReportMetricsRequest, struct{}](
+		ctx, job.baseURI, job.path, job.req, job.cl, nil, allowNoContent()); err != nil {
+		// A report interrupted by Close (dispatcher context cancelled) is expected
+		// shutdown behavior, not a failure worth logging. A per-report timeout
+		// leaves the dispatcher context live, so genuine timeouts still surface.
+		if d.ctx.Err() != nil {
+			return
+		}
+		d.log().Warn("iceberg: failed to report metrics to REST catalog", "error", err)
+	}
+}
+
+// submit offers a job to the queue without blocking. It drops the report (and
+// logs the drop, so back-pressure is visible rather than silent) when the queue
+// is full, and ignores reports once the dispatcher is closed.
+func (d *metricsDispatcher) submit(job metricsJob) {
+	select {
+	case <-d.ctx.Done():
+		return
+	default:
+	}
+
+	select {
+	case d.jobs <- job:
+	case <-d.ctx.Done():
+	default:
+		d.log().Warn("iceberg: metrics report dropped; dispatch queue full")
+	}
+}
+
+// close cancels in-flight reports and waits for the workers to return, bounded
+// by the report timeout so shutdown cannot hang on a stalled endpoint.
+func (d *metricsDispatcher) close() {
+	d.cancel()
+
+	done := make(chan struct{})
+	go func() {
+		d.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d.timeout):
+	}
+}
+
+// restMetricsReporter POSTs metrics reports for a single table to its REST
+// metrics endpoint (POST .../tables/{table}/metrics) via the catalog-owned
+// dispatcher. It satisfies metrics.Reporter.
+type restMetricsReporter struct {
+	baseURI    *url.URL
+	cl         *http.Client
+	path       []string // table metrics path, relative to baseURI
+	dispatcher *metricsDispatcher
 }
 
 var _ metrics.Reporter = (*restMetricsReporter)(nil)
 
-// Report wraps the report in a ReportMetricsRequest and POSTs it on a
-// background goroutine. Per the Reporter contract it never blocks or fails the
-// observed scan/commit: the send is detached from the caller's cancellation,
-// and any error is logged and swallowed.
-func (rep *restMetricsReporter) Report(ctx context.Context, report metrics.MetricsReport) {
+// Report wraps the report in a ReportMetricsRequest and hands it to the
+// catalog's dispatcher, returning immediately. Per the Reporter contract it
+// never blocks or fails the observed scan/commit: dispatch is asynchronous and
+// bounded, the send is detached from the caller's cancellation (the scan/commit
+// is already done), and any error is logged and swallowed by the dispatcher.
+func (rep *restMetricsReporter) Report(_ context.Context, report metrics.MetricsReport) {
 	if report == nil {
 		return
 	}
 
-	req := metrics.NewReportMetricsRequest(report)
-	// Detach from the caller's cancellation (the scan/commit is already done)
-	// while preserving any context values used by the HTTP client.
-	sendCtx := context.WithoutCancel(ctx)
-
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.Default().Warn("iceberg: panic while reporting metrics to REST catalog", "recovered", r)
-			}
-		}()
-
-		if _, err := doPost[metrics.ReportMetricsRequest, struct{}](
-			sendCtx, rep.baseURI, rep.path, req, rep.cl, nil, allowNoContent()); err != nil {
-			slog.Default().Warn("iceberg: failed to report metrics to REST catalog", "error", err)
-		}
-	}()
+	rep.dispatcher.submit(metricsJob{
+		baseURI: rep.baseURI,
+		cl:      rep.cl,
+		path:    rep.path,
+		req:     metrics.NewReportMetricsRequest(report),
+	})
 }
 
-// Close satisfies [metrics.Reporter]. The reporter is stateless — it borrows
-// the catalog's shared HTTP client rather than owning one — so there is nothing
-// to release.
+// Close satisfies [metrics.Reporter]. A per-table reporter holds no resources of
+// its own: the goroutines that dispatch its reports live in the catalog-owned
+// dispatcher (closed by Catalog.Close), and it only borrows the catalog's shared
+// HTTP client. So there is nothing to release here.
 func (rep *restMetricsReporter) Close() error { return nil }

--- a/catalog/rest/metrics_reporter_test.go
+++ b/catalog/rest/metrics_reporter_test.go
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturedRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+// captureTransport records the request it receives and returns 204 No Content,
+// avoiding any real network listener.
+type captureTransport struct {
+	ch    chan capturedRequest
+	block <-chan struct{} // if non-nil, RoundTrip waits on it before responding
+	err   error           // if non-nil, returned instead of a response
+}
+
+func (c *captureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(r.Body)
+	if c.ch != nil {
+		c.ch <- capturedRequest{method: r.Method, path: r.URL.Path, body: body}
+	}
+	if c.block != nil {
+		<-c.block
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusNoContent,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newTestReporter(t *testing.T, tr *captureTransport) *restMetricsReporter {
+	t.Helper()
+	base, err := url.Parse("http://catalog.invalid")
+	require.NoError(t, err)
+
+	return &restMetricsReporter{
+		baseURI: base,
+		cl:      &http.Client{Transport: tr},
+		path:    []string{"namespaces", "db", "tables", "t", "metrics"},
+	}
+}
+
+func TestRESTMetricsReporterPostsScanReport(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	rep := newTestReporter(t, &captureTransport{ch: received})
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t", SnapshotID: 99})
+
+	select {
+	case req := <-received:
+		assert.Equal(t, http.MethodPost, req.method)
+		assert.Equal(t, "/namespaces/db/tables/t/metrics", req.path)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(req.body, &m))
+		assert.Equal(t, "scan-report", m["report-type"])
+		assert.Equal(t, "db.t", m["table-name"])
+		assert.Contains(t, m, "metrics", "report fields are flattened alongside report-type")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+func TestRESTMetricsReporterPostsCommitReport(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	rep := newTestReporter(t, &captureTransport{ch: received})
+
+	rep.Report(context.Background(), metrics.CommitReport{TableName: "db.t", Operation: "append"})
+
+	select {
+	case req := <-received:
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(req.body, &m))
+		assert.Equal(t, "commit-report", m["report-type"])
+		assert.Equal(t, "append", m["operation"])
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+func TestRESTMetricsReporterNilReportIsNoop(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	rep := newTestReporter(t, &captureTransport{ch: received})
+
+	rep.Report(context.Background(), nil)
+
+	select {
+	case <-received:
+		t.Fatal("nil report must not produce a POST")
+	case <-time.After(200 * time.Millisecond):
+		// expected: nothing sent
+	}
+}
+
+func TestRESTMetricsReporterReportDoesNotBlockOnSlowServer(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	rep := newTestReporter(t, &captureTransport{block: block})
+
+	done := make(chan struct{})
+	go func() {
+		rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Report returned promptly despite the hanging transport.
+	case <-time.After(time.Second):
+		t.Fatal("Report blocked on a slow server")
+	}
+}

--- a/catalog/rest/metrics_reporter_test.go
+++ b/catalog/rest/metrics_reporter_test.go
@@ -649,6 +649,7 @@ func TestMetricsDispatcherCloseCancelsInFlight(t *testing.T) {
 	tr := &ctxBlockTransport{started: make(chan struct{}, 1), ctxErr: make(chan error, 1)}
 	// A long per-report timeout so it is Close, not the deadline, that unblocks.
 	d := newMetricsDispatcher(1, 1, time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close) // guard against a t.Fatal below leaking the worker
 	rep := reporterWith(t, tr, d, nil)
 
 	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
@@ -686,6 +687,7 @@ func TestMetricsDispatcherCloseDropsQueuedReports(t *testing.T) {
 	// One worker, roomy queue: the worker is occupied by the first report while
 	// the rest pile up behind it.
 	d := newMetricsDispatcher(1, 8, time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close) // guard against a t.Fatal below leaking the worker
 	rep := reporterWith(t, tr, d, nil)
 
 	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
@@ -737,10 +739,12 @@ func TestReportMetricsTimeout(t *testing.T) {
 }
 
 // TestMetricsReportingEnablementPrecedence pins that reporting is enabled only
-// by client-supplied configuration: server-vended defaults and overrides setting
-// the key must not turn it on, and the server must advertise the endpoint.
-// Table-response properties likewise cannot enable it, since enablement is
-// resolved once at init from the client properties alone.
+// by a client opt-in: server-vended defaults and overrides setting the key must
+// not turn it on, and the server must advertise the endpoint. Table-response
+// properties likewise cannot enable it, since enablement is resolved once at
+// init from the client properties. Disabling is safe in either direction, so an
+// explicit server override false does suppress a client that opted in, while a
+// mere server default cannot.
 func TestMetricsReportingEnablementPrecedence(t *testing.T) {
 	cfg := func(defaults, overrides map[string]any, endpoints []string) map[string]any {
 		m := map[string]any{
@@ -788,6 +792,35 @@ func TestMetricsReportingEnablementPrecedence(t *testing.T) {
 			name:        "client enables but endpoint not advertised",
 			serverCfg:   cfg(nil, nil, []string{"GET /v1/{prefix}/namespaces"}),
 			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+		},
+		{
+			// The production path: the server advertises an explicit endpoint list
+			// that includes the metrics endpoint, exercising resolveEndpoints /
+			// endpointFromString parsing of the template rather than the
+			// fallback-to-defaults path the cases above hit. A parse regression here
+			// would silently disable reporting for servers that advertise it.
+			name: "client enables and metrics endpoint advertised",
+			serverCfg: cfg(nil, nil, []string{
+				"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics",
+			}),
+			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+			wantEnabled: true,
+		},
+		{
+			// Disabling is always safe, so an explicit server override false honors
+			// an operator suppressing reporting fleet-wide even for a client that
+			// opted in — matching how a Java client resolves the merged config.
+			name:        "server override disables client opt-in",
+			serverCfg:   cfg(nil, map[string]any{keyReportMetricsEnabled: "false"}, nil),
+			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+		},
+		{
+			// A mere server default cannot flip off a client opt-in: client props beat
+			// server defaults in the merge, so the resolved value stays true.
+			name:        "server default cannot disable client opt-in",
+			serverCfg:   cfg(map[string]any{keyReportMetricsEnabled: "false"}, nil, nil),
+			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+			wantEnabled: true,
 		},
 	}
 

--- a/catalog/rest/metrics_reporter_test.go
+++ b/catalog/rest/metrics_reporter_test.go
@@ -22,20 +22,25 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	iceberg "github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type capturedRequest struct {
-	method string
-	path   string
-	body   []byte
+	method      string
+	path        string // decoded path
+	escapedPath string // percent-encoded path
+	body        []byte
 }
 
 // captureTransport records the request it receives and returns 204 No Content,
@@ -49,7 +54,12 @@ type captureTransport struct {
 func (c *captureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	body, _ := io.ReadAll(r.Body)
 	if c.ch != nil {
-		c.ch <- capturedRequest{method: r.Method, path: r.URL.Path, body: body}
+		c.ch <- capturedRequest{
+			method:      r.Method,
+			path:        r.URL.Path,
+			escapedPath: r.URL.EscapedPath(),
+			body:        body,
+		}
 	}
 	if c.block != nil {
 		<-c.block
@@ -65,15 +75,93 @@ func (c *captureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func newTestReporter(t *testing.T, tr *captureTransport) *restMetricsReporter {
+// ctxBlockTransport blocks until the request context is done, then reports the
+// context error. It lets a test prove that a report has a finite deadline
+// (timeout) and that Close cancels an in-flight request. entered counts how many
+// requests reached the transport.
+type ctxBlockTransport struct {
+	entered atomic.Int32
+	started chan struct{} // signalled once when RoundTrip is entered
+	ctxErr  chan error    // receives the context error once it fires
+}
+
+func (c *ctxBlockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.entered.Add(1)
+	select {
+	case c.started <- struct{}{}:
+	default:
+	}
+	<-r.Context().Done()
+	err := r.Context().Err()
+	select {
+	case c.ctxErr <- err:
+	default:
+	}
+
+	return nil, err
+}
+
+// concurrencyTransport blocks every RoundTrip on release, recording how many run
+// concurrently and how many were delivered in total. It lets a test prove the
+// dispatcher bounds concurrency and drops excess reports.
+type concurrencyTransport struct {
+	inFlight  atomic.Int32
+	maxSeen   atomic.Int32
+	delivered atomic.Int32
+	release   chan struct{}
+}
+
+func (c *concurrencyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	n := c.inFlight.Add(1)
+	for {
+		m := c.maxSeen.Load()
+		if n <= m || c.maxSeen.CompareAndSwap(m, n) {
+			break
+		}
+	}
+	c.delivered.Add(1)
+	<-c.release
+	c.inFlight.Add(-1)
+
+	return &http.Response{
+		StatusCode: http.StatusNoContent,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// newTestDispatcher builds a dispatcher with the production pool sizing and a
+// discarding logger, registering Close as cleanup.
+func newTestDispatcher(t *testing.T, timeout time.Duration) *metricsDispatcher {
+	t.Helper()
+	d := newMetricsDispatcher(metricsDispatchWorkers, metricsDispatchQueueSize, timeout,
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close)
+
+	return d
+}
+
+func newTestReporter(t *testing.T, tr http.RoundTripper) *restMetricsReporter {
+	t.Helper()
+
+	return reporterWith(t, tr, newTestDispatcher(t, 5*time.Second), nil)
+}
+
+// reporterWith builds a reporter bound to the given transport and dispatcher. A
+// nil path uses the default single-level namespace path.
+func reporterWith(t *testing.T, tr http.RoundTripper, d *metricsDispatcher, path []string) *restMetricsReporter {
 	t.Helper()
 	base, err := url.Parse("http://catalog.invalid")
 	require.NoError(t, err)
+	if path == nil {
+		path = []string{"namespaces", "db", "tables", "t", "metrics"}
+	}
 
 	return &restMetricsReporter{
-		baseURI: base,
-		cl:      &http.Client{Transport: tr},
-		path:    []string{"namespaces", "db", "tables", "t", "metrics"},
+		baseURI:    base,
+		cl:         &http.Client{Transport: tr},
+		path:       path,
+		dispatcher: d,
 	}
 }
 
@@ -145,4 +233,255 @@ func TestRESTMetricsReporterReportDoesNotBlockOnSlowServer(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Report blocked on a slow server")
 	}
+}
+
+// TestRESTMetricsReporterEscapesFullPath proves the request goes to the full
+// /v1/{prefix}/... URL and that namespace and table segments needing escaping
+// are percent-encoded.
+func TestRESTMetricsReporterEscapesFullPath(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	base, err := url.Parse("http://catalog.invalid/v1/my-prefix")
+	require.NoError(t, err)
+	rep := &restMetricsReporter{
+		baseURI:    base,
+		cl:         &http.Client{Transport: &captureTransport{ch: received}},
+		path:       []string{"namespaces", "a b", "tables", "t x", "metrics"},
+		dispatcher: newTestDispatcher(t, 5*time.Second),
+	}
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "a b.t x"})
+
+	select {
+	case req := <-received:
+		assert.Equal(t, "/v1/my-prefix/namespaces/a b/tables/t x/metrics", req.path)
+		assert.Equal(t, "/v1/my-prefix/namespaces/a%20b/tables/t%20x/metrics", req.escapedPath)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+// TestMetricsDispatcherReportHasFiniteTimeout proves a report does not hang
+// forever against a black-holing endpoint: the per-report deadline fires and the
+// request context reports DeadlineExceeded.
+func TestMetricsDispatcherReportHasFiniteTimeout(t *testing.T) {
+	tr := &ctxBlockTransport{started: make(chan struct{}, 1), ctxErr: make(chan error, 1)}
+	d := newMetricsDispatcher(1, 1, 100*time.Millisecond, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close)
+	rep := reporterWith(t, tr, d, nil)
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+
+	select {
+	case err := <-tr.ctxErr:
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "report must time out rather than hang")
+	case <-time.After(3 * time.Second):
+		t.Fatal("report did not observe a finite timeout")
+	}
+}
+
+// TestMetricsDispatcherBoundsConcurrencyAndDrops proves the worker pool caps
+// concurrent sends and sheds excess reports rather than queueing them without
+// limit.
+func TestMetricsDispatcherBoundsConcurrencyAndDrops(t *testing.T) {
+	const (
+		workers = 2
+		queue   = 3
+		extra   = 3 // reports offered once the pool and queue are saturated
+	)
+	tr := &concurrencyTransport{release: make(chan struct{})}
+	d := newMetricsDispatcher(workers, queue, 5*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close)
+	rep := reporterWith(t, tr, d, nil)
+
+	// Fill every worker; each blocks in RoundTrip, leaving the queue empty.
+	for range workers {
+		rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	}
+	require.Eventually(t, func() bool {
+		return tr.inFlight.Load() == workers
+	}, 3*time.Second, 5*time.Millisecond, "workers never saturated")
+
+	// Fill the queue (workers are blocked, so nothing drains it), then offer more
+	// than fits — the surplus must be dropped, not queued.
+	for range queue + extra {
+		rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	}
+
+	// Concurrency stayed within the pool while everything was blocked.
+	assert.LessOrEqual(t, tr.maxSeen.Load(), int32(workers), "concurrency exceeded the worker pool")
+
+	close(tr.release)
+
+	// Only workers + queue reports are ever delivered; the extra were dropped.
+	require.Eventually(t, func() bool {
+		return tr.inFlight.Load() == 0 && tr.delivered.Load() == workers+queue
+	}, 3*time.Second, 5*time.Millisecond, "expected exactly workers+queue reports delivered")
+
+	assert.LessOrEqual(t, tr.maxSeen.Load(), int32(workers), "concurrency exceeded the worker pool")
+}
+
+// TestMetricsDispatcherCloseCancelsInFlight proves Close cancels an in-flight
+// report and returns promptly rather than waiting on the stalled endpoint.
+func TestMetricsDispatcherCloseCancelsInFlight(t *testing.T) {
+	tr := &ctxBlockTransport{started: make(chan struct{}, 1), ctxErr: make(chan error, 1)}
+	// A long per-report timeout so it is Close, not the deadline, that unblocks.
+	d := newMetricsDispatcher(1, 1, time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rep := reporterWith(t, tr, d, nil)
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+
+	select {
+	case <-tr.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("report never reached the transport")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		d.close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return; in-flight report was not cancelled")
+	}
+
+	select {
+	case err := <-tr.ctxErr:
+		assert.ErrorIs(t, err, context.Canceled, "Close must cancel in-flight reports")
+	case <-time.After(time.Second):
+		t.Fatal("in-flight request context was not cancelled")
+	}
+}
+
+// TestMetricsDispatcherCloseDropsQueuedReports proves that reports still waiting
+// in the queue when Close is called are dropped rather than sent to the endpoint.
+func TestMetricsDispatcherCloseDropsQueuedReports(t *testing.T) {
+	tr := &ctxBlockTransport{started: make(chan struct{}, 1), ctxErr: make(chan error, 8)}
+	// One worker, roomy queue: the worker is occupied by the first report while
+	// the rest pile up behind it.
+	d := newMetricsDispatcher(1, 8, time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rep := reporterWith(t, tr, d, nil)
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	select {
+	case <-tr.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first report never reached the transport")
+	}
+
+	// Queue several more behind the busy worker.
+	for range 5 {
+		rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	}
+
+	d.close()
+
+	// Only the in-flight report ever reached the transport; the queued reports
+	// were discarded on shutdown rather than sent.
+	assert.Equal(t, int32(1), tr.entered.Load(),
+		"queued reports must be dropped on Close, not sent")
+}
+
+func TestReportMetricsEnabled(t *testing.T) {
+	assert.False(t, reportMetricsEnabled(iceberg.Properties{}))
+	assert.True(t, reportMetricsEnabled(iceberg.Properties{keyReportMetricsEnabled: "true"}))
+	assert.True(t, reportMetricsEnabled(iceberg.Properties{keyReportMetricsEnabledLegacy: "true"}),
+		"the historical dotted key is accepted as an alias")
+	assert.False(t, reportMetricsEnabled(iceberg.Properties{keyReportMetricsEnabled: "false"}))
+}
+
+func TestReportMetricsTimeout(t *testing.T) {
+	assert.Equal(t, defaultReportMetricsTimeout, reportMetricsTimeout(iceberg.Properties{}))
+	assert.Equal(t, 250*time.Millisecond, reportMetricsTimeout(iceberg.Properties{keyReportMetricsTimeoutMs: "250"}))
+	assert.Equal(t, defaultReportMetricsTimeout, reportMetricsTimeout(iceberg.Properties{keyReportMetricsTimeoutMs: "0"}),
+		"a non-positive timeout falls back to the default")
+	assert.Equal(t, defaultReportMetricsTimeout, reportMetricsTimeout(iceberg.Properties{keyReportMetricsTimeoutMs: "bogus"}))
+}
+
+// TestMetricsReportingEnablementPrecedence pins that reporting is enabled only
+// by client-supplied configuration: server-vended defaults and overrides setting
+// the key must not turn it on, and the server must advertise the endpoint.
+// Table-response properties likewise cannot enable it, since enablement is
+// resolved once at init from the client properties alone.
+func TestMetricsReportingEnablementPrecedence(t *testing.T) {
+	cfg := func(defaults, overrides map[string]any, endpoints []string) map[string]any {
+		m := map[string]any{
+			"defaults":  orEmpty(defaults),
+			"overrides": orEmpty(overrides),
+		}
+		if endpoints != nil {
+			m["endpoints"] = endpoints
+		}
+
+		return m
+	}
+
+	tests := []struct {
+		name        string
+		serverCfg   map[string]any
+		clientProps iceberg.Properties
+		wantEnabled bool
+	}{
+		{
+			name:      "off by default",
+			serverCfg: cfg(nil, nil, nil),
+		},
+		{
+			name:      "server default cannot enable",
+			serverCfg: cfg(map[string]any{keyReportMetricsEnabled: "true"}, nil, nil),
+		},
+		{
+			name:      "server override cannot enable",
+			serverCfg: cfg(nil, map[string]any{keyReportMetricsEnabled: "true"}, nil),
+		},
+		{
+			name:        "client enables",
+			serverCfg:   cfg(nil, nil, nil),
+			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+			wantEnabled: true,
+		},
+		{
+			name:        "client legacy key enables",
+			serverCfg:   cfg(nil, nil, nil),
+			clientProps: iceberg.Properties{keyReportMetricsEnabledLegacy: "true"},
+			wantEnabled: true,
+		},
+		{
+			name:        "client enables but endpoint not advertised",
+			serverCfg:   cfg(nil, nil, []string{"GET /v1/{prefix}/namespaces"}),
+			clientProps: iceberg.Properties{keyReportMetricsEnabled: "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(tt.serverCfg)
+			})
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			cat, err := newCatalogFromProps(context.Background(), "rest", srv.URL, tt.clientProps)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = cat.Close() })
+
+			if tt.wantEnabled {
+				assert.NotNil(t, cat.metricsDispatcher, "reporting should be enabled")
+			} else {
+				assert.Nil(t, cat.metricsDispatcher, "reporting must stay off")
+			}
+		})
+	}
+}
+
+func orEmpty(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+
+	return m
 }

--- a/catalog/rest/metrics_reporter_test.go
+++ b/catalog/rest/metrics_reporter_test.go
@@ -21,17 +21,21 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	iceberg "github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/metrics"
+	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +44,7 @@ type capturedRequest struct {
 	method      string
 	path        string // decoded path
 	escapedPath string // percent-encoded path
+	header      http.Header
 	body        []byte
 }
 
@@ -58,6 +63,7 @@ func (c *captureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 			method:      r.Method,
 			path:        r.URL.Path,
 			escapedPath: r.URL.EscapedPath(),
+			header:      r.Header.Clone(), // the SDK may reuse the request; snapshot it
 			body:        body,
 		}
 	}
@@ -260,6 +266,323 @@ func TestRESTMetricsReporterEscapesFullPath(t *testing.T) {
 	}
 }
 
+// rotatingAuthManager returns a distinct bearer header on each call, standing in
+// for a token source that refreshes between reports.
+type rotatingAuthManager struct{ n atomic.Int32 }
+
+func (m *rotatingAuthManager) AuthHeader() (string, string, error) {
+	return "Authorization", fmt.Sprintf("Bearer tok-%d", m.n.Add(1)), nil
+}
+
+// ctxAuthManager records whether the context-aware path was taken and returns a
+// header value identifying which method produced it.
+type ctxAuthManager struct{ usedContext atomic.Bool }
+
+func (m *ctxAuthManager) AuthHeader() (string, string, error) {
+	return "Authorization", "context-free", nil
+}
+
+func (m *ctxAuthManager) AuthHeaderWithContext(ctx context.Context) (string, string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", "", err
+	}
+	m.usedContext.Store(true)
+
+	return "Authorization", "with-context", nil
+}
+
+// blockingHandler blocks in Handle until released, so a test can prove the drop
+// path never logs synchronously on the caller's goroutine.
+type blockingHandler struct{ release <-chan struct{} }
+
+func (h *blockingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *blockingHandler) Handle(context.Context, slog.Record) error {
+	<-h.release
+
+	return nil
+}
+func (h *blockingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *blockingHandler) WithGroup(string) slog.Handler      { return h }
+
+// recordingHandler captures emitted records so a test can assert the aggregated
+// warning content.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+
+	return nil
+}
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) warnings() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []slog.Record
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}
+
+// reporterWithSession builds a reporter whose client runs through a
+// sessionTransport (auth + default headers) wrapping the given transport, so a
+// test can assert the metrics POST goes out authenticated.
+func reporterWithSession(t *testing.T, auth AuthManager, tr http.RoundTripper) *restMetricsReporter {
+	t.Helper()
+	session := &sessionTransport{
+		RoundTripper:   tr,
+		authManager:    auth,
+		defaultHeaders: http.Header{},
+	}
+	session.defaultHeaders.Set("Content-Type", "application/json")
+
+	return reporterWith(t, session, newTestDispatcher(t, 5*time.Second), nil)
+}
+
+// TestRESTMetricsReporterSendsAuthenticatedRequest pins that the metrics POST
+// reuses the catalog's authenticated client: the Authorization header the auth
+// manager produces and the catalog's default Content-Type both go out on the
+// wire. Without this a refactor that dispatched metrics through a bare
+// http.Client would keep every other test green.
+func TestRESTMetricsReporterSendsAuthenticatedRequest(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	rep := reporterWithSession(t, staticAuthManager{key: "Authorization", value: "Bearer tok-abc"}, &captureTransport{ch: received})
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+
+	select {
+	case req := <-received:
+		assert.Equal(t, "Bearer tok-abc", req.header.Get("Authorization"),
+			"metrics POST must carry the catalog's Authorization header")
+		assert.Equal(t, "application/json", req.header.Get("Content-Type"),
+			"catalog default headers must be forwarded")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+// TestRESTMetricsReporterRefetchesCredentialPerReport proves auth runs per
+// request, so a credential that rotates between reports is picked up rather than
+// captured once.
+func TestRESTMetricsReporterRefetchesCredentialPerReport(t *testing.T) {
+	received := make(chan capturedRequest, 2)
+	// One worker serializes the two reports so credentials are handed out in order.
+	d := newMetricsDispatcher(1, 8, 5*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(d.close)
+	session := &sessionTransport{
+		RoundTripper:   &captureTransport{ch: received},
+		authManager:    &rotatingAuthManager{},
+		defaultHeaders: http.Header{},
+	}
+	rep := reporterWith(t, session, d, nil)
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+
+	seen := make(map[string]bool)
+	for range 2 {
+		select {
+		case req := <-received:
+			seen[req.header.Get("Authorization")] = true
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for a metrics POST")
+		}
+	}
+	assert.True(t, seen["Bearer tok-1"] && seen["Bearer tok-2"],
+		"each report must fetch a fresh credential, got %v", seen)
+}
+
+// TestSessionTransportPrefersContextAuthManager proves sessionTransport uses the
+// context-aware auth path when the manager implements ContextAuthManager, so a
+// request deadline can bound the auth step.
+func TestSessionTransportPrefersContextAuthManager(t *testing.T) {
+	received := make(chan capturedRequest, 1)
+	auth := &ctxAuthManager{}
+	rep := reporterWithSession(t, auth, &captureTransport{ch: received})
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+
+	select {
+	case req := <-received:
+		assert.Equal(t, "with-context", req.header.Get("Authorization"),
+			"the context-aware auth path must be preferred")
+		assert.True(t, auth.usedContext.Load())
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+// TestRESTMetricsReporterPreservesContextValues proves the caller's context
+// values (trace spans, request-scoped attributes) reach the outbound report even
+// though the caller's cancellation is detached.
+func TestRESTMetricsReporterPreservesContextValues(t *testing.T) {
+	type ctxKey struct{}
+	got := make(chan any, 1)
+	tr := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		got <- r.Context().Value(ctxKey{})
+
+		return &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	rep := newTestReporter(t, tr)
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "trace-123")
+	rep.Report(ctx, metrics.ScanReport{TableName: "db.t"})
+
+	select {
+	case v := <-got:
+		assert.Equal(t, "trace-123", v, "caller context values must propagate to the report")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
+// TestMetricsDispatcherDropCountsWithoutBlocking proves that dropping a report on
+// a full queue neither blocks the caller nor logs synchronously: the logger here
+// blocks in Handle, yet every Report returns promptly and the drops are counted.
+func TestMetricsDispatcherDropCountsWithoutBlocking(t *testing.T) {
+	release := make(chan struct{})
+	handlerRelease := make(chan struct{})
+	tr := &concurrencyTransport{release: release}
+	d := newMetricsDispatcher(1, 1, time.Minute, slog.New(&blockingHandler{release: handlerRelease}))
+	t.Cleanup(func() {
+		close(handlerRelease)
+		close(release)
+		d.close()
+	})
+	rep := reporterWith(t, tr, d, nil)
+
+	// Occupy the single worker; the next report fills the queue, the rest drop.
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	require.Eventually(t, func() bool {
+		return tr.inFlight.Load() == 1
+	}, 3*time.Second, 5*time.Millisecond, "worker never saturated")
+
+	for range 4 { // 1 fills the queue, 3 are dropped
+		done := make(chan struct{})
+		go func() {
+			rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Report blocked; the drop path must not log synchronously")
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return d.dropped.Load() == 3
+	}, 3*time.Second, 5*time.Millisecond, "expected exactly the surplus reports to be dropped")
+}
+
+// TestMetricsDispatcherAggregatesDropWarning proves the drop/failure counters
+// surface as a single aggregated warning (carrying the counts) rather than one
+// log line per dropped report. The shutdown flush is used to make the assertion
+// deterministic without waiting on the stats ticker.
+func TestMetricsDispatcherAggregatesDropWarning(t *testing.T) {
+	handler := &recordingHandler{}
+	release := make(chan struct{})
+	tr := &concurrencyTransport{release: release}
+	d := newMetricsDispatcher(1, 1, time.Minute, slog.New(handler))
+	rep := reporterWith(t, tr, d, nil)
+
+	// Occupy the worker, fill the queue, then overflow: three reports drop.
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	require.Eventually(t, func() bool {
+		return tr.inFlight.Load() == 1
+	}, 3*time.Second, 5*time.Millisecond, "worker never saturated")
+	for range 4 {
+		rep.Report(context.Background(), metrics.ScanReport{TableName: "db.t"})
+	}
+	require.Eventually(t, func() bool {
+		return d.dropped.Load() == 3
+	}, 3*time.Second, 5*time.Millisecond)
+
+	close(release)
+	d.close() // triggers the final aggregated flush
+
+	warnings := handler.warnings()
+	require.Len(t, warnings, 1, "drops must aggregate into a single warning, not one per drop")
+	attrs := map[string]any{}
+	warnings[0].Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+
+		return true
+	})
+	assert.Equal(t, uint64(3), attrs["dropped"], "the aggregated warning must carry the drop count")
+}
+
+// TestMetricsDispatcherCloseIsIdempotent proves repeated and concurrent Close
+// calls are safe and cheap: they do not panic and each returns, spawning no
+// extra waiter goroutine per call.
+func TestMetricsDispatcherCloseIsIdempotent(t *testing.T) {
+	d := newMetricsDispatcher(2, 4, 5*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.close()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("concurrent Close calls did not all return")
+	}
+
+	// A further Close after the fact is still safe.
+	d.close()
+}
+
+// TestRESTMetricsReporterBuildsPathThroughProduction runs the real path
+// composition — splitIdentForPath (encodeNamespace) and endpointReportMetrics
+// .reqPath — for a multi-level namespace with segments needing escaping, so a
+// regression in that composition or in the separator handling is caught rather
+// than bypassed by a hand-built path.
+func TestRESTMetricsReporterBuildsPathThroughProduction(t *testing.T) {
+	c := &Catalog{namespaceSeparator: defaultNamespaceSeparator}
+	ns, tbl, err := c.splitIdentForPath(table.Identifier{"a b", "d e", "t x"})
+	require.NoError(t, err)
+	path, err := endpointReportMetrics.reqPath(ns, tbl)
+	require.NoError(t, err)
+
+	received := make(chan capturedRequest, 1)
+	base, err := url.Parse("http://catalog.invalid/v1/my-prefix")
+	require.NoError(t, err)
+	rep := reporterWith(t, &captureTransport{ch: received}, newTestDispatcher(t, 5*time.Second), path)
+	rep.baseURI = base
+
+	rep.Report(context.Background(), metrics.ScanReport{TableName: "a b.d e.t x"})
+
+	select {
+	case req := <-received:
+		// The namespace levels are percent-encoded and joined by the encoded
+		// separator (%1F); the table segment is escaped by the URL builder.
+		assert.Equal(t, "/v1/my-prefix/namespaces/a%20b%1Fd%20e/tables/t%20x/metrics", req.escapedPath)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the async metrics POST")
+	}
+}
+
 // TestMetricsDispatcherReportHasFiniteTimeout proves a report does not hang
 // forever against a black-holing endpoint: the per-report deadline fires and the
 // request context reports DeadlineExceeded.
@@ -391,6 +714,18 @@ func TestReportMetricsEnabled(t *testing.T) {
 	assert.True(t, reportMetricsEnabled(iceberg.Properties{keyReportMetricsEnabledLegacy: "true"}),
 		"the historical dotted key is accepted as an alias")
 	assert.False(t, reportMetricsEnabled(iceberg.Properties{keyReportMetricsEnabled: "false"}))
+
+	// The canonical key wins whenever it is present: a client that migrated to it
+	// and explicitly disabled reporting is honored even if a stale legacy dotted
+	// key still lingers in the config.
+	assert.False(t, reportMetricsEnabled(iceberg.Properties{
+		keyReportMetricsEnabled:       "false",
+		keyReportMetricsEnabledLegacy: "true",
+	}), "an explicit canonical false must override a lingering legacy true")
+	assert.True(t, reportMetricsEnabled(iceberg.Properties{
+		keyReportMetricsEnabled:       "true",
+		keyReportMetricsEnabledLegacy: "false",
+	}), "an explicit canonical true wins over a legacy false")
 }
 
 func TestReportMetricsTimeout(t *testing.T) {
@@ -484,4 +819,26 @@ func orEmpty(m map[string]any) map[string]any {
 	}
 
 	return m
+}
+
+// TestTableResponsePropertiesCannotEnableReporting pins the invariant behind the
+// enablement doc comment: enablement is resolved once from the client-supplied
+// properties, so a property arriving later on a table-load response reaches only
+// the table-local config and can never turn reporting on. A future refactor that
+// resolved enablement from merged properties would flip the first assertion and
+// fail here.
+func TestTableResponsePropertiesCannotEnableReporting(t *testing.T) {
+	clientProps := iceberg.Properties{} // the client did not opt in
+	require.False(t, reportMetricsEnabled(clientProps))
+
+	// A table response carrying the enable key would enable reporting only if it
+	// reached the client properties — it does not, so the client properties that
+	// gate the dispatcher stay unchanged and reporting stays off.
+	tableResponseProps := iceberg.Properties{keyReportMetricsEnabled: "true"}
+	ifItLeaked := maps.Clone(clientProps)
+	maps.Copy(ifItLeaked, tableResponseProps)
+	assert.True(t, reportMetricsEnabled(ifItLeaked),
+		"sanity: the key would enable reporting if it reached the client properties")
+	assert.False(t, reportMetricsEnabled(clientProps),
+		"but the client properties are the ones that gate the dispatcher, and they are untouched")
 }

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -790,6 +790,12 @@ type Catalog struct {
 	// metrics-reporter-impl cannot select (or, via an unregistered name, break)
 	// a reporter the client never asked for.
 	reporterProps iceberg.Properties
+	// metricsDispatcher POSTs scan/commit reports to the server's metrics
+	// endpoint on a bounded worker pool shared across this catalog's table
+	// reporters. It is nil unless the client opted in (reportMetricsEnabled, read
+	// from reporterProps) and the server advertises the endpoint. Owned here and
+	// closed by Close.
+	metricsDispatcher *metricsDispatcher
 }
 
 func newCatalogFromProps(ctx context.Context, name string, uri string, p iceberg.Properties) (*Catalog, error) {
@@ -928,6 +934,16 @@ func (r *Catalog) init(ctx context.Context, ops *options, uri string) error {
 		r.baseURI = r.baseURI.JoinPath(ops.prefix)
 	}
 	r.props = toProps(ops)
+
+	// Stand up the metrics dispatcher only when the client opted in and the
+	// server advertises the endpoint. Enablement is read from the
+	// client-supplied properties alone (see reporterProps): a server-vended
+	// default, override, or table-response property must never turn on outbound
+	// telemetry the client never asked for.
+	if reportMetricsEnabled(r.reporterProps) && r.endpoints.check(endpointReportMetrics) == nil {
+		r.metricsDispatcher = newMetricsDispatcher(
+			metricsDispatchWorkers, metricsDispatchQueueSize, reportMetricsTimeout(r.reporterProps), nil)
+	}
 
 	return nil
 }
@@ -1079,7 +1095,8 @@ func (r *Catalog) Name() string              { return r.name }
 func (r *Catalog) CatalogType() catalog.Type { return catalog.REST }
 
 // Close drains idle connections from transports created by the catalog and
-// closes its metrics reporter.
+// releases its metrics reporter. Closing the metrics dispatcher cancels any
+// in-flight reports and drains its workers so outbound telemetry stops.
 // Caller-provided transports remain caller-owned. Close is safe to call more
 // than once. Callers holding a [catalog.Catalog] can reach this via a
 // [catalog.Closer] type assertion.
@@ -1087,6 +1104,9 @@ func (r *Catalog) Close() error {
 	r.closeSessionOnce.Do(func() {
 		if r.closeSession != nil {
 			r.closeSession()
+		}
+		if r.metricsDispatcher != nil {
+			r.metricsDispatcher.close()
 		}
 		r.closeErr = r.reporter.Close()
 	})
@@ -1143,12 +1163,18 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
-	// Opt-in: POST scan/commit reports to the catalog's metrics endpoint, but
-	// only when enabled and the server advertises the endpoint.
-	if config.GetBool(keyReportMetricsEnabled, false) && r.endpoints.check(endpointReportMetrics) == nil {
+	// Opt-in: POST scan/commit reports to the catalog's metrics endpoint via the
+	// catalog-owned dispatcher. It is non-nil only when the client enabled
+	// reporting and the server advertises the endpoint (see init).
+	if r.metricsDispatcher != nil {
 		if ns, tbl, idErr := r.splitIdentForPath(identifier); idErr == nil {
 			if path, pErr := endpointReportMetrics.reqPath(ns, tbl); pErr == nil {
-				reporter = metrics.Combine(reporter, &restMetricsReporter{baseURI: r.baseURI, cl: r.cl, path: path})
+				reporter = metrics.Combine(reporter, &restMetricsReporter{
+					baseURI:    r.baseURI,
+					cl:         r.cl,
+					path:       path,
+					dispatcher: r.metricsDispatcher,
+				})
 			}
 		}
 	}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1143,6 +1143,15 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize metrics reporter: %w", err)
 	}
+	// Opt-in: POST scan/commit reports to the catalog's metrics endpoint, but
+	// only when enabled and the server advertises the endpoint.
+	if config.GetBool(keyReportMetricsEnabled, false) && r.endpoints.check(endpointReportMetrics) == nil {
+		if ns, tbl, idErr := r.splitIdentForPath(identifier); idErr == nil {
+			if path, pErr := endpointReportMetrics.reqPath(ns, tbl); pErr == nil {
+				reporter = metrics.Combine(reporter, &restMetricsReporter{baseURI: r.baseURI, cl: r.cl, path: path})
+			}
+		}
+	}
 
 	return table.New(
 		identifier,

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -29,6 +29,7 @@ import (
 	"hash"
 	"io"
 	"iter"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/url"
@@ -956,11 +957,19 @@ func (r *Catalog) init(ctx context.Context, ops *options, uri string) error {
 	r.props = toProps(ops)
 
 	// Stand up the metrics dispatcher only when the client opted in and the
-	// server advertises the endpoint. Enablement is read from the
-	// client-supplied properties alone (see reporterProps): a server-vended
-	// default, override, or table-response property must never turn on outbound
-	// telemetry the client never asked for.
-	if reportMetricsEnabled(r.reporterProps) && r.endpoints.check(endpointReportMetrics) == nil {
+	// server advertises the endpoint. Enablement of outbound telemetry is read
+	// from the client-supplied properties alone (see reporterProps): a server
+	// must never be able to turn on reporting the client never asked for.
+	//
+	// Disabling, however, is always safe, so an explicit server-side false is
+	// honored: r.props is the merged config (server defaults < client < server
+	// overrides), so an override setting the key false resolves to false here and
+	// suppresses a client that opted in — matching how a Java client resolves it
+	// and letting an operator switch reporting off fleet-wide. A mere server
+	// default cannot flip off a client opt-in, since client props beat defaults in
+	// the merge.
+	if reportMetricsEnabled(r.reporterProps) && reportMetricsEnabled(r.props) &&
+		r.endpoints.check(endpointReportMetrics) == nil {
 		r.metricsDispatcher = newMetricsDispatcher(
 			metricsDispatchWorkers, metricsDispatchQueueSize, reportMetricsTimeout(r.reporterProps), nil)
 	}
@@ -1187,15 +1196,22 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 	// catalog-owned dispatcher. It is non-nil only when the client enabled
 	// reporting and the server advertises the endpoint (see init).
 	if r.metricsDispatcher != nil {
-		if ns, tbl, idErr := r.splitIdentForPath(identifier); idErr == nil {
-			if path, pErr := endpointReportMetrics.reqPath(ns, tbl); pErr == nil {
-				reporter = metrics.Combine(reporter, &restMetricsReporter{
-					baseURI:    r.baseURI,
-					cl:         r.cl,
-					path:       path,
-					dispatcher: r.metricsDispatcher,
-				})
-			}
+		if ns, tbl, idErr := r.splitIdentForPath(identifier); idErr != nil {
+			// Unreachable for a valid identifier that already loaded above, but if it
+			// ever regresses, log why the REST reporter was dropped rather than let
+			// metrics silently vanish with no signal.
+			slog.Debug("iceberg: skipping REST metrics reporter, cannot split identifier",
+				"error", idErr)
+		} else if path, pErr := endpointReportMetrics.reqPath(ns, tbl); pErr != nil {
+			slog.Debug("iceberg: skipping REST metrics reporter, cannot build metrics path",
+				"error", pErr)
+		} else {
+			reporter = metrics.Combine(reporter, &restMetricsReporter{
+				baseURI:    r.baseURI,
+				cl:         r.cl,
+				path:       path,
+				dispatcher: r.metricsDispatcher,
+			})
 		}
 	}
 

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -263,7 +263,18 @@ func (s *sessionTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Authorization header by supplying its own. Do not reorder this before the
 	// default-header loop.
 	if s.authManager != nil && r.Context().Value(skipOAuth) == nil {
-		k, v, err := s.authManager.AuthHeader()
+		var (
+			k, v string
+			err  error
+		)
+		// Prefer the context-aware path so the request deadline also bounds auth,
+		// falling back to the context-free method for managers that do not
+		// implement ContextAuthManager.
+		if cm, ok := s.authManager.(ContextAuthManager); ok {
+			k, v, err = cm.AuthHeaderWithContext(r.Context())
+		} else {
+			k, v, err = s.authManager.AuthHeader()
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -830,6 +841,13 @@ func NewCatalog(ctx context.Context, name, uri string, opts ...Option) (*Catalog
 	return r, nil
 }
 
+// defaultOAuthTimeout bounds a single OAuth token-refresh request made by the
+// built-in Oauth2AuthManager. oauth2's TokenSource.Token() takes no context, so
+// this Timeout on the refresh client is what keeps a stalled or black-holing
+// token endpoint from blocking auth — and therefore any request that triggers a
+// refresh, including asynchronous metrics reports — indefinitely.
+const defaultOAuthTimeout = 60 * time.Second
+
 // setupOAuthManager creates an Oauth2AuthManager based on the provided options.
 // It uses golang.org/x/oauth2 for token management, caching, and thread-safe refresh.
 // The returned cleanup closes an internally-created OAuth transport, if any.
@@ -886,11 +904,12 @@ func setupOAuthManager(r *Catalog, cl *http.Client, opts *options) (AuthManager,
 	// Add skip oauth so we don't get in cycles trying to refresh the token
 	ctx := context.WithValue(context.Background(), skipOAuth, true)
 
-	// If a separate TLS config is provided for the OAuth2 server, create a
-	// dedicated HTTP client for token requests instead of reusing the catalog
-	// client. This is needed when the OAuth2 server is a different host with
-	// different TLS requirements.
-	oauthClient := cl
+	// Token refresh uses a client with a Timeout so a stalled token endpoint
+	// cannot block auth forever (oauth2's Token() takes no context). By default
+	// this reuses the catalog client's transport — preserving its TLS, proxy and
+	// header behavior — but as a distinct *http.Client so the Timeout applies to
+	// refresh alone and not to ordinary catalog requests.
+	oauthClient := &http.Client{Transport: cl.Transport, Timeout: defaultOAuthTimeout}
 	var closeIdleConnections func()
 	if opts.oauthTLSConfig != nil {
 		transport := &http.Transport{
@@ -899,6 +918,7 @@ func setupOAuthManager(r *Catalog, cl *http.Client, opts *options) (AuthManager,
 		}
 		oauthClient = &http.Client{
 			Transport: transport,
+			Timeout:   defaultOAuthTimeout,
 		}
 		closeIdleConnections = transport.CloseIdleConnections
 	}

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -74,6 +74,30 @@ The most option-rich surface. Source: [`catalog/rest/options.go`](https://github
 | Catalog routing | `WithPrefix`, `WithWarehouseLocation`, `WithMetadataLocation` |
 | Pass-through | `WithAdditionalProps` |
 
+#### Metrics reporting
+
+The REST catalog can POST scan and commit metrics to the catalog's
+`.../tables/{table}/metrics` endpoint. These properties are passed as
+client-supplied catalog properties.
+
+| Property | Description |
+|---|---|
+| `rest-metrics-reporting-enabled` | Opt into POSTing metrics reports. **Off by default.** |
+| `rest.metrics-reporting-enabled` | Legacy dotted alias; consulted only when the canonical key above is absent. |
+| `rest-metrics-reporting-timeout-ms` | Per-report request/response deadline in milliseconds. Default `10000`. |
+
+> **Note on cross-client parity.** Iceberg Java defaults metrics reporting to
+> *on* (`METRICS_REPORTING_ENABLED_DEFAULT=true`); iceberg-go deliberately
+> defaults it *off*, so no client emits new outbound telemetry unless it
+> explicitly opts in. A Java client that never set the flag will therefore stop
+> reporting when ported here until `rest-metrics-reporting-enabled=true` is set.
+> Enablement is read from client properties only — a server cannot turn on
+> reporting the client never asked for — but an explicit server override setting
+> the flag to `false` *is* honored (disabling is always safe), so an operator can
+> suppress reporting fleet-wide. `rest-metrics-reporting-timeout-ms` is a
+> Go-specific extension with no Java, PyIceberg, or Rust equivalent; do not
+> assume parity on it in multi-client deployments.
+
 ### Hive (`catalog/hive`)
 
 Source: [`catalog/hive/options.go`](https://github.com/apache/iceberg-go/blob/main/catalog/hive/options.go).


### PR DESCRIPTION
 6th PR of the metrics reporting framework. Implements the previously stubbed catalog metrics endpoint:
  
  restMetricsReporter POSTs a ReportMetricsRequest to a table's POST .../tables/{table}/metrics endpoint. The send runs on a background goroutine detached from the caller's cancellation, and any error is logged and swallowed, so
  reporting never blocks or fails the observed scan/commit.
  The REST catalog combines it with the configured reporter when loading a table, gated on the opt-in rest.metrics-reporting-enabled property and on the server advertising the endpoint. It is off by default, so existing REST users
  see no new /metrics traffic.
  Tests use a custom RoundTripper (no network listener) to assert the async POST, the flattened report-type wire format, nil-report no-op, and that Report never blocks on a slow server.

  Behavior change (all REST catalog users): OAuth token refresh now runs on an *http.Client with a 60s timeout (defaultOAuthTimeout). Because oauth2's TokenSource.Token() takes no context, this timeout is what bounds a stalled or  black-holing token endpoint. It applies to every REST catalog user, not just metrics opt-ins — a token endpoint that previously hung indefinitely will now fail refresh after 60s. Worth calling out in release notes.

  Related to #1236