### PR TITLE
fix(table): make time-travel lookup order independent

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -296,20 +296,17 @@ func (scan *Scan) ResolveSnapshot() (*Snapshot, error) {
 	}
 
 	if scan.asOfTimestamp != nil {
-		entries := slices.Collect(scan.metadata.SnapshotLogs())
-		for i := len(entries) - 1; i >= 0; i-- {
-			entry := entries[i]
-			if entry.TimestampMs <= *scan.asOfTimestamp {
-				snap := scan.metadata.SnapshotByID(entry.SnapshotID)
-				if snap == nil {
-					break
-				}
-
-				return snap, nil
-			}
+		entry, ok := snapshotLogEntryAsOf(scan.metadata.SnapshotLogs(), *scan.asOfTimestamp, true)
+		if !ok {
+			return nil, fmt.Errorf("no snapshot found for timestamp %d", *scan.asOfTimestamp)
 		}
 
-		return nil, fmt.Errorf("no snapshot found for timestamp %d", *scan.asOfTimestamp)
+		snap := scan.metadata.SnapshotByID(entry.SnapshotID)
+		if snap == nil {
+			return nil, fmt.Errorf("%w: snapshot log references unknown snapshot %d", ErrInvalidMetadata, entry.SnapshotID)
+		}
+
+		return snap, nil
 	}
 
 	return scan.metadata.CurrentSnapshot(), nil

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -436,7 +436,7 @@ func snapshotLogEntryAsOf(entries iter.Seq[SnapshotLogEntry], timestampMs int64,
 			eligible = entry.TimestampMs <= timestampMs
 		}
 
-		if eligible && (!found || entry.TimestampMs >= best.TimestampMs) {
+		if eligible && (!found || entry.TimestampMs > best.TimestampMs) {
 			best = entry
 			found = true
 		}

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -420,6 +420,31 @@ type SnapshotLogEntry struct {
 	TimestampMs int64 `json:"timestamp-ms"`
 }
 
+// snapshotLogEntryAsOf returns the log entry with the greatest eligible
+// timestamp. Snapshot-log entries can be out of chronological order when
+// commits have small clock skews, so the result must not depend on iteration
+// order.
+func snapshotLogEntryAsOf(entries iter.Seq[SnapshotLogEntry], timestampMs int64, inclusive bool) (SnapshotLogEntry, bool) {
+	var (
+		best  SnapshotLogEntry
+		found bool
+	)
+
+	for entry := range entries {
+		eligible := entry.TimestampMs < timestampMs
+		if inclusive {
+			eligible = entry.TimestampMs <= timestampMs
+		}
+
+		if eligible && (!found || entry.TimestampMs > best.TimestampMs) {
+			best = entry
+			found = true
+		}
+	}
+
+	return best, found
+}
+
 type SnapshotSummaryCollector struct {
 	metrics                          updateMetrics
 	partitionMetrics                 map[string]updateMetrics

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -436,7 +436,7 @@ func snapshotLogEntryAsOf(entries iter.Seq[SnapshotLogEntry], timestampMs int64,
 			eligible = entry.TimestampMs <= timestampMs
 		}
 
-		if eligible && (!found || entry.TimestampMs > best.TimestampMs) {
+		if eligible && (!found || entry.TimestampMs >= best.TimestampMs) {
 			best = entry
 			found = true
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -890,12 +890,9 @@ func backoffDuration(attempt uint, minMs, maxMs uint64) time.Duration {
 
 // SnapshotAsOf finds the snapshot that was current as of or right before the given timestamp.
 func (t Table) SnapshotAsOf(timestampMs int64, inclusive bool) *Snapshot {
-	entries := slices.Collect(t.metadata.SnapshotLogs())
-	for i := len(entries) - 1; i >= 0; i-- {
-		entry := entries[i]
-		if (inclusive && entry.TimestampMs <= timestampMs) || (!inclusive && entry.TimestampMs < timestampMs) {
-			return t.metadata.SnapshotByID(entry.SnapshotID)
-		}
+	entry, ok := snapshotLogEntryAsOf(t.metadata.SnapshotLogs(), timestampMs, inclusive)
+	if ok {
+		return t.metadata.SnapshotByID(entry.SnapshotID)
 	}
 
 	return nil

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -125,6 +125,61 @@ func TestSnapshotAsOf(t *testing.T) {
 	})
 }
 
+func TestSnapshotAsOfWithOutOfOrderSnapshotLog(t *testing.T) {
+	baseTime := time.Now().Add(5 * time.Second).UnixMilli()
+	snapshots := []Snapshot{
+		{SnapshotID: 1000, TimestampMs: baseTime + 2000, SequenceNumber: 1},
+		{SnapshotID: 2000, TimestampMs: baseTime + 1000, SequenceNumber: 2},
+		{SnapshotID: 3000, TimestampMs: baseTime + 3000, SequenceNumber: 3},
+	}
+	snapshotLog := []SnapshotLogEntry{
+		{SnapshotID: 1000, TimestampMs: baseTime + 2000},
+		{SnapshotID: 2000, TimestampMs: baseTime + 1000},
+		{SnapshotID: 3000, TimestampMs: baseTime + 3000},
+	}
+
+	meta, err := createTestMetadata(snapshots, snapshotLog)
+	require.NoError(t, err)
+
+	tbl := Table{
+		identifier: []string{"db", "table"},
+		metadata:   meta,
+	}
+
+	queryTime := baseTime + 2500
+	snapshot := tbl.SnapshotAsOf(queryTime, true)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, int64(1000), snapshot.SnapshotID)
+
+	scan := tbl.Scan(WithSnapshotAsOf(queryTime))
+	snapshot, err = scan.ResolveSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, int64(1000), snapshot.SnapshotID)
+
+	snapshot = tbl.SnapshotAsOf(baseTime+2000, false)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, int64(2000), snapshot.SnapshotID)
+}
+
+func TestResolveSnapshotRejectsUnknownSnapshotLogEntry(t *testing.T) {
+	baseTime := time.Now().Add(5 * time.Second).UnixMilli()
+	snapshots := []Snapshot{
+		{SnapshotID: 1000, TimestampMs: baseTime + 1000, SequenceNumber: 1},
+	}
+	snapshotLog := []SnapshotLogEntry{
+		{SnapshotID: 1000, TimestampMs: baseTime + 1000},
+		{SnapshotID: 2000, TimestampMs: baseTime + 2000},
+	}
+
+	meta, err := createTestMetadata(snapshots, snapshotLog)
+	require.NoError(t, err)
+
+	scan := (Table{metadata: meta}).Scan(WithSnapshotAsOf(baseTime + 2500))
+	_, err = scan.ResolveSnapshot()
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+}
+
 func TestTable_WithSnapshotAsOf(t *testing.T) {
 	baseTime := time.Now()
 

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -162,7 +162,7 @@ func TestSnapshotAsOfWithOutOfOrderSnapshotLog(t *testing.T) {
 	assert.Equal(t, int64(2000), snapshot.SnapshotID)
 }
 
-func TestSnapshotAsOfWithEqualTimestampsUsesLaterLogEntry(t *testing.T) {
+func TestSnapshotAsOfWithEqualTimestampsUsesFirstLogEntry(t *testing.T) {
 	baseTime := time.Now().Add(5 * time.Second).UnixMilli()
 	snapshots := []Snapshot{
 		{SnapshotID: 1000, TimestampMs: baseTime + 1000, SequenceNumber: 1},
@@ -179,13 +179,13 @@ func TestSnapshotAsOfWithEqualTimestampsUsesLaterLogEntry(t *testing.T) {
 	tbl := Table{metadata: meta}
 	snapshot := tbl.SnapshotAsOf(baseTime+1000, true)
 	require.NotNil(t, snapshot)
-	assert.Equal(t, int64(2000), snapshot.SnapshotID)
+	assert.Equal(t, int64(1000), snapshot.SnapshotID)
 
 	scan := tbl.Scan(WithSnapshotAsOf(baseTime + 1000))
 	snapshot, err = scan.ResolveSnapshot()
 	require.NoError(t, err)
 	require.NotNil(t, snapshot)
-	assert.Equal(t, int64(2000), snapshot.SnapshotID)
+	assert.Equal(t, int64(1000), snapshot.SnapshotID)
 }
 
 func TestResolveSnapshotRejectsUnknownSnapshotLogEntry(t *testing.T) {

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -162,6 +162,32 @@ func TestSnapshotAsOfWithOutOfOrderSnapshotLog(t *testing.T) {
 	assert.Equal(t, int64(2000), snapshot.SnapshotID)
 }
 
+func TestSnapshotAsOfWithEqualTimestampsUsesLaterLogEntry(t *testing.T) {
+	baseTime := time.Now().Add(5 * time.Second).UnixMilli()
+	snapshots := []Snapshot{
+		{SnapshotID: 1000, TimestampMs: baseTime + 1000, SequenceNumber: 1},
+		{SnapshotID: 2000, TimestampMs: baseTime + 1000, SequenceNumber: 2},
+	}
+	snapshotLog := []SnapshotLogEntry{
+		{SnapshotID: 1000, TimestampMs: baseTime + 1000},
+		{SnapshotID: 2000, TimestampMs: baseTime + 1000},
+	}
+
+	meta, err := createTestMetadata(snapshots, snapshotLog)
+	require.NoError(t, err)
+
+	tbl := Table{metadata: meta}
+	snapshot := tbl.SnapshotAsOf(baseTime+1000, true)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, int64(2000), snapshot.SnapshotID)
+
+	scan := tbl.Scan(WithSnapshotAsOf(baseTime + 1000))
+	snapshot, err = scan.ResolveSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.Equal(t, int64(2000), snapshot.SnapshotID)
+}
+
 func TestResolveSnapshotRejectsUnknownSnapshotLogEntry(t *testing.T) {
 	baseTime := time.Now().Add(5 * time.Second).UnixMilli()
 	snapshots := []Snapshot{


### PR DESCRIPTION
## Summary

Make time-travel lookups choose the correct snapshot even when the snapshot log is out of order.

## Why

The old backward walk returned the first entry at or before the requested time. With timestamps such as 2000, 1000, and 3000, an as-of lookup at 2500 incorrectly returned the 1000 snapshot.

## What changed

Table.SnapshotAsOf and Scan.ResolveSnapshot now scan the full log and select the eligible entry with the greatest timestamp. Equal timestamps keep the first entry encountered. A selected log entry that references a missing snapshot now returns ErrInvalidMetadata.

## Tests

- go test ./table