### PR TITLE
fix(table): reject tags as transaction targets

### DIFF
--- a/table/requirements.go
+++ b/table/requirements.go
@@ -155,8 +155,9 @@ func (a *assertTableUuid) Validate(meta Metadata) error {
 
 type assertRefSnapshotID struct {
 	baseRequirement
-	Ref        string `json:"ref"`
-	SnapshotID *int64 `json:"snapshot-id"`
+	Ref           string `json:"ref"`
+	SnapshotID    *int64 `json:"snapshot-id"`
+	requireBranch bool
 }
 
 // AssertRefSnapshotID creates a requirement which ensures that the table branch
@@ -167,6 +168,15 @@ func AssertRefSnapshotID(ref string, id *int64) Requirement {
 		baseRequirement: baseRequirement{Type: reqAssertRefSnapshotID},
 		Ref:             ref,
 		SnapshotID:      id,
+	}
+}
+
+func assertBranchRefSnapshotID(ref string, id *int64) Requirement {
+	return &assertRefSnapshotID{
+		baseRequirement: baseRequirement{Type: reqAssertRefSnapshotID},
+		Ref:             ref,
+		SnapshotID:      id,
+		requireBranch:   true,
 	}
 }
 
@@ -185,6 +195,10 @@ func (a *assertRefSnapshotID) Validate(meta Metadata) error {
 	}
 
 	if r != nil {
+		if a.requireBranch && r.SnapshotRefType != BranchRef {
+			return fmt.Errorf("requirement failed: ref %q is a %s; tags cannot be transaction targets", a.Ref, r.SnapshotRefType)
+		}
+
 		if a.SnapshotID == nil {
 			return fmt.Errorf("requirement failed: %s %q was created concurrently", r.SnapshotRefType, a.Ref)
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -183,6 +183,12 @@ func (t Table) newBrokenTransaction(branch string, err error) *Transaction {
 // callers to receive the precise initialization error instead of hitting
 // panic/undefined behavior later.
 func (t Table) NewTransactionOnBranchWithError(branch string) (*Transaction, error) {
+	for name, ref := range t.metadata.Refs() {
+		if name == branch && ref.SnapshotRefType != BranchRef {
+			return nil, fmt.Errorf("%w: %s is not a branch", iceberg.ErrInvalidArgument, branch)
+		}
+	}
+
 	meta, err := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
 	if err != nil {
 		return nil, err

--- a/table/table.go
+++ b/table/table.go
@@ -184,9 +184,15 @@ func (t Table) newBrokenTransaction(branch string, err error) *Transaction {
 // panic/undefined behavior later.
 func (t Table) NewTransactionOnBranchWithError(branch string) (*Transaction, error) {
 	for name, ref := range t.metadata.Refs() {
-		if name == branch && ref.SnapshotRefType != BranchRef {
-			return nil, fmt.Errorf("%w: %s is not a branch", iceberg.ErrInvalidArgument, branch)
+		if name != branch {
+			continue
 		}
+		if ref.SnapshotRefType != BranchRef {
+			return nil, fmt.Errorf("%w: ref %q is a %s; tags cannot be transaction targets",
+				iceberg.ErrInvalidArgument, branch, ref.SnapshotRefType)
+		}
+
+		break
 	}
 
 	meta, err := MetadataBuilderFromBase(t.metadata, t.metadataLocation)
@@ -561,6 +567,9 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 			}
 			current = fresh.metadata
 			reqs = rewriteRefSnapshotRequirements(reqs, co.branch, current)
+			if err := validateBranchRequirement(reqs, co.branch, current); err != nil {
+				return nil, err
+			}
 
 			// Rebuild snapshot manifest lists to inherit all files committed
 			// by concurrent writers since the snapshot was originally built.
@@ -573,6 +582,10 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 			}
 			orphanedManifests = append(orphanedManifests, orphaned...)
 			updates = rebuiltUpdates
+		}
+
+		if err := validateBranchRequirement(reqs, co.branch, current); err != nil {
+			return nil, err
 		}
 
 		// Pre-flight client-side conflict validation. Producers can
@@ -708,7 +721,11 @@ func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Met
 	for i, r := range reqs {
 		if a, ok := r.(*assertRefSnapshotID); ok && a.Ref == branch {
 			newID := head.SnapshotID
-			out[i] = AssertRefSnapshotID(branch, &newID)
+			if a.requireBranch {
+				out[i] = assertBranchRefSnapshotID(branch, &newID)
+			} else {
+				out[i] = AssertRefSnapshotID(branch, &newID)
+			}
 
 			continue
 		}
@@ -716,6 +733,16 @@ func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Met
 	}
 
 	return out
+}
+
+func validateBranchRequirement(reqs []Requirement, branch string, meta Metadata) error {
+	for _, req := range reqs {
+		if ref, ok := req.(*assertRefSnapshotID); ok && ref.requireBranch && ref.Ref == branch {
+			return ref.Validate(meta)
+		}
+	}
+
+	return nil
 }
 
 // rebuildSnapshotUpdates returns a new slice of updates where any

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -240,6 +240,37 @@ func requirementSemanticKey(r Requirement) (string, error) {
 	return string(data), nil
 }
 
+func transactionRequirements(reqs []Requirement, branch string, base Metadata) []Requirement {
+	if branch == "" {
+		branch = MainBranch
+	}
+
+	out := slices.Clone(reqs)
+	for i, req := range out {
+		if ref, ok := req.(*assertRefSnapshotID); ok && ref.Ref == branch {
+			if ref.requireBranch {
+				return out
+			}
+
+			out[i] = assertBranchRefSnapshotID(branch, ref.SnapshotID)
+
+			return out
+		}
+	}
+
+	var snapshotID *int64
+	for name, ref := range base.Refs() {
+		if name == branch {
+			id := ref.SnapshotID
+			snapshotID = &id
+
+			break
+		}
+	}
+
+	return append(out, assertBranchRefSnapshotID(branch, snapshotID))
+}
+
 // addValidator appends a conflict validator under t.mx. Producers
 // that register validators from outside doCommit (RowDelta, RewriteFiles)
 // must use this helper rather than mutating t.validators directly —
@@ -2373,7 +2404,7 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	}
 
 	if len(meta.updates) > 0 {
-		reqs := append(slices.Clone(t.reqs), AssertTableUUID(meta.uuid))
+		reqs := append(transactionRequirements(t.reqs, t.branch, t.tbl.metadata), AssertTableUUID(meta.uuid))
 		tbl, err := t.tbl.doCommit(ctx, meta.updates, reqs,
 			withCommitBranch(t.branch),
 			withCommitValidators(t.validators...),

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -97,6 +97,37 @@ func TestNewTransactionOnBranchWithErrorReturnsTransactionInitError(t *testing.T
 	require.Nil(t, txn)
 }
 
+func TestNewTransactionOnBranchRejectsTags(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	require.NoError(t, txn.meta.SetSnapshotRef("release", 10, TagRef))
+
+	meta, err := txn.meta.Build()
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "table"}, meta, "metadata.json", nil, nil)
+
+	before := tbl.Metadata()
+	transaction, err := tbl.NewTransactionOnBranchWithError("release")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.Nil(t, transaction)
+	require.True(t, before.Equals(tbl.Metadata()))
+
+	legacyTransaction := tbl.NewTransactionOnBranch("release")
+	require.ErrorIs(t, legacyTransaction.initErr, iceberg.ErrInvalidArgument)
+}
+
+func TestNewTransactionOnBranchAllowsBranchesAndNewRefs(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	meta, err := txn.meta.Build()
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "table"}, meta, "metadata.json", nil, nil)
+
+	for _, branch := range []string{MainBranch, "feature", "new-branch"} {
+		transaction, err := tbl.NewTransactionOnBranchWithError(branch)
+		require.NoError(t, err, branch)
+		require.NotNil(t, transaction, branch)
+	}
+}
+
 func TestNewTransactionOnBranchKeepsLegacySignatureAndFailsOnUse(t *testing.T) {
 	baseMeta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder, "table-location", nil)
 	require.NoError(t, err, "new metadata")

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -113,6 +113,32 @@ func TestNewTransactionOnBranchRejectsTags(t *testing.T) {
 
 	legacyTransaction := tbl.NewTransactionOnBranch("release")
 	require.ErrorIs(t, legacyTransaction.initErr, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, legacyTransaction.SetProperties(iceberg.Properties{"k": "v"}), "tags cannot be transaction targets")
+}
+
+func TestTransactionCommitRejectsSameIDTagRace(t *testing.T) {
+	seed := newTransactionWithSnapshotRefs(t)
+	baseMeta, err := seed.meta.Build()
+	require.NoError(t, err)
+
+	head := baseMeta.SnapshotByName(MainBranch)
+	require.NotNil(t, head)
+	tagBuilder, err := MetadataBuilderFromBase(baseMeta, "")
+	require.NoError(t, err)
+	require.NoError(t, tagBuilder.SetSnapshotRef(MainBranch, head.SnapshotID, TagRef))
+	tagMeta, err := tagBuilder.Build()
+	require.NoError(t, err)
+
+	cat := &headTrackingCatalog{metadata: tagMeta}
+	tbl := New(Identifier{"db", "tag-race"}, baseMeta, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberg.Properties{"k": "v"}))
+
+	_, err = txn.Commit(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "tags cannot be transaction targets")
+	require.Equal(t, int32(1), cat.attempts.Load())
 }
 
 func TestNewTransactionOnBranchAllowsBranchesAndNewRefs(t *testing.T) {


### PR DESCRIPTION
## Summary

Reject existing tags as transaction targets.

## Why

NewTransactionOnBranch accepted a tag name as a write target. A later commit could then treat the tag like a branch and replace it.

## What changed

NewTransactionOnBranchWithError checks the existing ref type before creating the transaction. Existing tags return ErrInvalidArgument, while branches and missing refs keep their current behavior.

## Tests

- go test ./table