### PR TITLE
fix(table): keep scan ref selectors exclusive

### DIFF
--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -81,6 +81,22 @@ func TestScanPlanningRemotePropagatesPlannerError(t *testing.T) {
 	require.ErrorIs(t, err, want)
 }
 
+func TestScanPlanningRemoteRejectsConflictingSnapshotSelectors(t *testing.T) {
+	t.Parallel()
+
+	planner := &fakeScanPlanner{supports: true}
+	scan := &Scan{
+		planner:      planner,
+		planningMode: ScanPlanningRemote,
+	}
+	WithSnapshotID(1000)(scan)
+	WithSnapshotAsOf(2000)(scan)
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.False(t, planner.called)
+}
+
 func TestScanPlanningAutoUsesCapablePlanner(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +148,14 @@ func TestTransactionScanCopiesIdentifier(t *testing.T) {
 	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
 }
 
+func TestTransactionScanRejectsConflictingSnapshotSelectors(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+
+	scan, err := txn.Scan(WithSnapshotID(1000), WithSnapshotAsOf(2000))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	assert.Nil(t, scan)
+}
+
 func TestScanPlanningUnknownModeErrors(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +169,7 @@ type fakeScanPlanner struct {
 	result   ScanPlanningResult
 	supports bool
 	err      error
+	called   bool
 	// captured after PlanFiles receives it
 	receivedIdentifier Identifier
 }
@@ -152,6 +177,7 @@ type fakeScanPlanner struct {
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
+	f.called = true
 	f.receivedIdentifier = req.Identifier
 
 	return f.result, f.err

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -239,6 +239,7 @@ type Scan struct {
 	caseSensitive  bool
 	snapshotID     *int64
 	asOfTimestamp  *int64
+	selectorErr    error
 	options        iceberg.Properties
 	limit          int64
 
@@ -266,11 +267,18 @@ func (scan *Scan) Reporter() metrics.Reporter {
 	return scan.reporter
 }
 
+// UseRef selects a named snapshot reference. UseRef(MainBranch) is an
+// intentional no-op that returns a clone, so it remains valid even when the
+// scan already has an explicit snapshot or as-of selector. Any conflicting
+// selectors recorded by scan options are still surfaced by scan execution.
 func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if name == MainBranch {
 		out := *scan
 
 		return &out, nil
+	}
+	if scan.selectorErr != nil {
+		return nil, scan.selectorErr
 	}
 
 	if scan.snapshotID != nil {
@@ -296,6 +304,10 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 // the table's current snapshot; explicit snapshot IDs and as-of timestamps
 // must resolve to an existing snapshot.
 func (scan *Scan) ResolveSnapshot() (*Snapshot, error) {
+	if scan.selectorErr != nil {
+		return nil, scan.selectorErr
+	}
+
 	if scan.snapshotID != nil {
 		snap := scan.metadata.SnapshotByID(*scan.snapshotID)
 		if snap == nil {
@@ -332,6 +344,10 @@ func (scan *Scan) Snapshot() *Snapshot {
 }
 
 func (scan *Scan) Projection() (*iceberg.Schema, error) {
+	if scan.selectorErr != nil {
+		return nil, scan.selectorErr
+	}
+
 	curSchema, err := scan.effectiveSchema()
 	if err != nil {
 		return nil, err
@@ -386,6 +402,10 @@ func (scan *Scan) Projection() (*iceberg.Schema, error) {
 }
 
 func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
+	if scan.selectorErr != nil {
+		return nil, scan.selectorErr
+	}
+
 	curSchema := scan.metadata.CurrentSchema()
 	if scan.snapshotID == nil && scan.asOfTimestamp == nil {
 		// Live scans intentionally use the table's current schema. A schema-only
@@ -817,6 +837,10 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 // scan's reporter on success; remote (server-side) planning reports its own
 // metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
+	if scan.selectorErr != nil {
+		return nil, scan.selectorErr
+	}
+
 	if scan.asOfTimestamp != nil {
 		snapshot, err := scan.ResolveSnapshot()
 		if err != nil {
@@ -1026,6 +1050,10 @@ func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[
 // scan's projection, row filters, and positional delete handling. This is useful when
 // the caller has already planned or selected specific tasks to read.
 func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
+	if scan.selectorErr != nil {
+		return nil, nil, scan.selectorErr
+	}
+
 	var (
 		boundFilter iceberg.BooleanExpression
 		err         error

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -267,9 +267,19 @@ func (scan *Scan) Reporter() metrics.Reporter {
 }
 
 func (scan *Scan) UseRef(name string) (*Scan, error) {
+	if name == MainBranch {
+		out := *scan
+
+		return &out, nil
+	}
+
 	if scan.snapshotID != nil {
 		return nil, fmt.Errorf("%w: cannot override ref, already set snapshot id %d",
 			iceberg.ErrInvalidArgument, *scan.snapshotID)
+	}
+	if scan.asOfTimestamp != nil {
+		return nil, fmt.Errorf("%w: cannot override ref, already set as-of timestamp %d",
+			iceberg.ErrInvalidArgument, *scan.asOfTimestamp)
 	}
 
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -267,10 +267,10 @@ func (scan *Scan) Reporter() metrics.Reporter {
 	return scan.reporter
 }
 
-// UseRef selects a named snapshot reference. UseRef(MainBranch) is an
-// intentional no-op that returns a clone, so it remains valid even when the
-// scan already has an explicit snapshot or as-of selector. Any conflicting
-// selectors recorded by scan options are still surfaced by scan execution.
+// UseRef selects a named snapshot reference. UseRef(MainBranch) is the one
+// intentional exception to selector exclusivity: it returns a clone without
+// changing an existing snapshot or as-of selector. Any conflicting selectors
+// recorded by scan options are still surfaced by scan execution.
 func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if name == MainBranch {
 		out := *scan

--- a/table/table.go
+++ b/table/table.go
@@ -1052,15 +1052,25 @@ func WithSnapshotID(n int64) ScanOption {
 	}
 
 	return func(scan *Scan) {
+		if scan.asOfTimestamp != nil {
+			scan.selectorErr = fmt.Errorf("%w: cannot select snapshot ID %d when as-of timestamp %d is already selected",
+				iceberg.ErrInvalidArgument, n, *scan.asOfTimestamp)
+
+			return
+		}
 		scan.snapshotID = &n
-		scan.asOfTimestamp = nil
 	}
 }
 
 func WithSnapshotAsOf(timeStampMs int64) ScanOption {
 	return func(scan *Scan) {
+		if scan.snapshotID != nil {
+			scan.selectorErr = fmt.Errorf("%w: cannot select as-of timestamp %d when snapshot ID %d is already selected",
+				iceberg.ErrInvalidArgument, timeStampMs, *scan.snapshotID)
+
+			return
+		}
 		scan.asOfTimestamp = &timeStampMs
-		scan.snapshotID = nil
 	}
 }
 

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -232,6 +232,14 @@ func TestScanUseRefKeepsSnapshotSelectorsExclusive(t *testing.T) {
 	require.Equal(t, &snapshotID, mainScan.snapshotID)
 	require.Nil(t, mainScan.asOfTimestamp)
 
+	conflictingScan := tbl.Scan(WithSnapshotAsOf(asOfTimestamp), WithSnapshotID(snapshotID))
+	_, err = conflictingScan.UseRef("feature")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	mainScan, err = conflictingScan.UseRef(MainBranch)
+	require.NoError(t, err, "UseRef(main) should remain a no-op clone for a conflicting scan")
+	require.NotSame(t, conflictingScan, mainScan)
+	require.ErrorIs(t, mainScan.selectorErr, iceberg.ErrInvalidArgument)
+
 	liveScan := tbl.Scan()
 	mainScan, err = liveScan.UseRef(MainBranch)
 	require.NoError(t, err)
@@ -328,15 +336,29 @@ func TestTable_WithSnapshotAsOf(t *testing.T) {
 		assert.Contains(t, recordsErr.Error(), "no snapshot found for timestamp")
 	})
 
-	t.Run("WithSnapshotID clears conflicting WithSnapshotAsOf option", func(t *testing.T) {
+	t.Run("WithSnapshotID records conflicting WithSnapshotAsOf option", func(t *testing.T) {
 		timestamp := baseTime.Add(30 * time.Minute).UnixMilli()
-		// WithSnapshotID should clear any previous asOfTimestamp
 		scan := table.Scan(WithSnapshotAsOf(timestamp), WithSnapshotID(9999))
 		require.NotNil(t, scan)
 
-		// Should use snapshot ID, not timestamp
-		assert.Equal(t, &[]int64{9999}[0], scan.snapshotID)
+		assert.ErrorIs(t, scan.selectorErr, iceberg.ErrInvalidArgument)
+		assert.Nil(t, scan.snapshotID)
+		assert.Equal(t, &timestamp, scan.asOfTimestamp)
+		_, err := scan.ResolveSnapshot()
+		assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	})
+
+	t.Run("WithSnapshotAsOf records conflicting WithSnapshotID option", func(t *testing.T) {
+		snapshotID := int64(9999)
+		timestamp := baseTime.Add(30 * time.Minute).UnixMilli()
+		scan := table.Scan(WithSnapshotID(snapshotID), WithSnapshotAsOf(timestamp))
+		require.NotNil(t, scan)
+
+		assert.ErrorIs(t, scan.selectorErr, iceberg.ErrInvalidArgument)
+		assert.Equal(t, &snapshotID, scan.snapshotID)
 		assert.Nil(t, scan.asOfTimestamp)
+		_, err := scan.Projection()
+		assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 	})
 }
 

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -206,6 +206,47 @@ func TestResolveSnapshotRejectsUnknownSnapshotLogEntry(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidMetadata)
 }
 
+func TestScanUseRefKeepsSnapshotSelectorsExclusive(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	require.NoError(t, txn.meta.SetSnapshotRef("release", 20, TagRef))
+
+	meta, err := txn.meta.Build()
+	require.NoError(t, err)
+	tbl := Table{metadata: meta}
+
+	asOfTimestamp := time.Now().UnixMilli()
+	asOfScan := tbl.Scan(WithSnapshotAsOf(asOfTimestamp))
+	_, err = asOfScan.UseRef("feature")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+	mainScan, err := asOfScan.UseRef(MainBranch)
+	require.NoError(t, err)
+	require.NotSame(t, asOfScan, mainScan)
+	require.Nil(t, mainScan.snapshotID)
+	require.Equal(t, &asOfTimestamp, mainScan.asOfTimestamp)
+
+	snapshotID := int64(10)
+	snapshotScan := tbl.Scan(WithSnapshotID(snapshotID))
+	mainScan, err = snapshotScan.UseRef(MainBranch)
+	require.NoError(t, err)
+	require.Equal(t, &snapshotID, mainScan.snapshotID)
+	require.Nil(t, mainScan.asOfTimestamp)
+
+	liveScan := tbl.Scan()
+	mainScan, err = liveScan.UseRef(MainBranch)
+	require.NoError(t, err)
+	require.Nil(t, mainScan.snapshotID)
+	require.Nil(t, mainScan.asOfTimestamp)
+
+	branchScan, err := liveScan.UseRef("feature")
+	require.NoError(t, err)
+	require.Equal(t, int64(20), *branchScan.snapshotID)
+
+	tagScan, err := liveScan.UseRef("release")
+	require.NoError(t, err)
+	require.Equal(t, int64(20), *tagScan.snapshotID)
+}
+
 func TestTable_WithSnapshotAsOf(t *testing.T) {
 	baseTime := time.Now()
 

--- a/table/time_travel_test.go
+++ b/table/time_travel_test.go
@@ -218,6 +218,9 @@ func TestScanUseRefKeepsSnapshotSelectorsExclusive(t *testing.T) {
 	asOfScan := tbl.Scan(WithSnapshotAsOf(asOfTimestamp))
 	_, err = asOfScan.UseRef("feature")
 	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "as-of timestamp")
+	require.Nil(t, asOfScan.snapshotID)
+	require.Equal(t, &asOfTimestamp, asOfScan.asOfTimestamp)
 
 	mainScan, err := asOfScan.UseRef(MainBranch)
 	require.NoError(t, err)
@@ -227,6 +230,12 @@ func TestScanUseRefKeepsSnapshotSelectorsExclusive(t *testing.T) {
 
 	snapshotID := int64(10)
 	snapshotScan := tbl.Scan(WithSnapshotID(snapshotID))
+	_, err = snapshotScan.UseRef("feature")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "snapshot id")
+	require.Equal(t, &snapshotID, snapshotScan.snapshotID)
+	require.Nil(t, snapshotScan.asOfTimestamp)
+
 	mainScan, err = snapshotScan.UseRef(MainBranch)
 	require.NoError(t, err)
 	require.Equal(t, &snapshotID, mainScan.snapshotID)
@@ -249,10 +258,17 @@ func TestScanUseRefKeepsSnapshotSelectorsExclusive(t *testing.T) {
 	branchScan, err := liveScan.UseRef("feature")
 	require.NoError(t, err)
 	require.Equal(t, int64(20), *branchScan.snapshotID)
+	_, err = branchScan.UseRef("release")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "snapshot id")
 
 	tagScan, err := liveScan.UseRef("release")
 	require.NoError(t, err)
 	require.Equal(t, int64(20), *tagScan.snapshotID)
+
+	_, err = liveScan.UseRef("unknown")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	require.ErrorContains(t, err, "unknown ref=unknown")
 }
 
 func TestTable_WithSnapshotAsOf(t *testing.T) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2366,6 +2366,9 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
+	if s.selectorErr != nil {
+		return nil, s.selectorErr
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
## Summary

Keep scan reference selectors mutually exclusive.

## Why

UseRef could be applied after an as-of timestamp had been selected. The scan then contained both selectors, and the ref snapshot took precedence over the historical timestamp.

## What changed

UseRef treats main as a no-op and returns ErrInvalidArgument when a non-main ref is selected after a snapshot ID or as-of timestamp. Snapshot ID and as-of timestamp options also record a selector conflict instead of silently replacing one another.

## Tests

- go test ./table