### PR TITLE
fix(rest): accept legacy content enum values

### DIFF
--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -305,13 +305,8 @@ func decodeRESTDeleteFile(
 	metadata table.ScanPlanningMetadata,
 	referencedDataFile string,
 ) (iceberg.DataFile, error) {
-	var content iceberg.ManifestEntryContent
-	switch wire.Content {
-	case "position-deletes":
-		content = iceberg.EntryContentPosDeletes
-	case "equality-deletes":
-		content = iceberg.EntryContentEqDeletes
-	default:
+	content, ok := parseRESTFileContent(wire.Content)
+	if !ok || content == iceberg.EntryContentData {
 		return nil, fmt.Errorf("unknown delete content %q", wire.Content)
 	}
 
@@ -387,12 +382,13 @@ func contentFileBuilder(
 	expectedContent iceberg.ManifestEntryContent,
 	metadata table.ScanPlanningMetadata,
 ) (*iceberg.DataFileBuilder, iceberg.FileFormat, error) {
+	actualContent, ok := parseRESTFileContent(wire.Content)
 	wantContent := map[iceberg.ManifestEntryContent]string{
 		iceberg.EntryContentData:       "data",
 		iceberg.EntryContentPosDeletes: "position-deletes",
 		iceberg.EntryContentEqDeletes:  "equality-deletes",
 	}[expectedContent]
-	if wire.Content != wantContent {
+	if !ok || actualContent != expectedContent {
 		return nil, "", fmt.Errorf("content is %q, want %q", wire.Content, wantContent)
 	}
 	if wire.RecordCount <= 0 {
@@ -456,6 +452,19 @@ func contentFileBuilder(
 	}
 
 	return builder, format, nil
+}
+
+func parseRESTFileContent(value string) (iceberg.ManifestEntryContent, bool) {
+	switch value {
+	case "data", "DATA":
+		return iceberg.EntryContentData, true
+	case "position-deletes", "POSITION_DELETES":
+		return iceberg.EntryContentPosDeletes, true
+	case "equality-deletes", "EQUALITY_DELETES":
+		return iceberg.EntryContentEqDeletes, true
+	default:
+		return 0, false
+	}
 }
 
 func decodePartition(

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -140,6 +140,31 @@ func TestDecodeScanTasksFullPayload(t *testing.T) {
 	assert.Equal(t, int64Ptr(50), dv.ContentSizeInBytes())
 }
 
+func TestDecodeScanTasksAcceptsLegacyJavaContentValues(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	for _, tt := range []struct {
+		name       string
+		deleteType string
+		equalityID []int
+	}{
+		{name: "position deletes", deleteType: "POSITION_DELETES"},
+		{name: "equality deletes", deleteType: "EQUALITY_DELETES", equalityID: []int{1}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wire := validScanTasksWire()
+			wire.FileScanTasks[0].DataFile.Content = "DATA"
+			wire.DeleteFiles[0].Content = tt.deleteType
+			wire.DeleteFiles[0].EqualityIDs = tt.equalityID
+
+			tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+			require.NoError(t, err)
+			require.Len(t, tasks, 1)
+		})
+	}
+}
+
 func TestDecodeScanTasksUsesFallbackAndAcceptsSpecConstants(t *testing.T) {
 	t.Parallel()
 
@@ -306,6 +331,13 @@ func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 				w.FileScanTasks[0].DataFile.SpecID = 99
 			},
 			want: "unknown partition spec ID 99",
+		},
+		{
+			name: "unknown content",
+			mutate: func(w *ScanTasks) {
+				w.FileScanTasks[0].DataFile.Content = "Data"
+			},
+			want: `content is "Data", want "data"`,
 		},
 		{
 			name: "wrong partition width",


### PR DESCRIPTION
## Summary

Accept the legacy uppercase content values used by older Java REST responses.

## Why

Some responses use DATA, POSITION_DELETES, and EQUALITY_DELETES, while the decoder only accepted the canonical lowercase values.

## What changed

The three exact legacy aliases now map to the same internal content values. Canonical values remain the expected form, and file-format parsing is unchanged.

## Tests

- go test ./catalog/rest