### PR TITLE
fix(partitions): require fields in partition spec JSON

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -18,6 +18,7 @@
 package iceberg
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -454,20 +455,34 @@ func (ps PartitionSpec) MarshalJSON() ([]byte, error) {
 }
 
 func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
-	aux := struct {
-		ID     int               `json:"spec-id"`
-		Fields []json.RawMessage `json:"fields"`
-	}{ID: ps.id}
-
-	if err := json.Unmarshal(b, &aux); err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if aux.ID < 0 {
-		return fmt.Errorf("%w: spec ID must be non-negative: %d", ErrInvalidPartitionSpec, aux.ID)
+
+	rawID, ok := raw["spec-id"]
+	if !ok || bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
+		return fmt.Errorf("%w: partition spec is missing required spec-id", ErrInvalidPartitionSpec)
+	}
+	var id int
+	if err := json.Unmarshal(rawID, &id); err != nil {
+		return fmt.Errorf("%w: invalid partition spec ID: %w", ErrInvalidPartitionSpec, err)
+	}
+	if id < 0 {
+		return fmt.Errorf("%w: spec ID must be non-negative: %d", ErrInvalidPartitionSpec, id)
 	}
 
-	fields := make([]PartitionField, len(aux.Fields))
-	for i, rawField := range aux.Fields {
+	rawFields, ok := raw["fields"]
+	if !ok || bytes.Equal(bytes.TrimSpace(rawFields), []byte("null")) {
+		return fmt.Errorf("%w: partition spec is missing required fields", ErrInvalidPartitionSpec)
+	}
+	var rawFieldList []json.RawMessage
+	if err := json.Unmarshal(rawFields, &rawFieldList); err != nil {
+		return fmt.Errorf("%w: invalid partition spec fields: %w", ErrInvalidPartitionSpec, err)
+	}
+
+	fields := make([]PartitionField, len(rawFieldList))
+	for i, rawField := range rawFieldList {
 		var keys map[string]json.RawMessage
 		if err := json.Unmarshal(rawField, &keys); err != nil {
 			return err
@@ -489,11 +504,12 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	ps.id, ps.fields = aux.ID, fields
-	if err := ps.assignPartitionFieldIds(nil); err != nil {
+	decoded := PartitionSpec{id: id, fields: fields}
+	if err := decoded.assignPartitionFieldIds(nil); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 	}
-	ps.initialize()
+	decoded.initialize()
+	*ps = decoded
 
 	return nil
 }

--- a/partitions.go
+++ b/partitions.go
@@ -457,16 +457,17 @@ func (ps PartitionSpec) MarshalJSON() ([]byte, error) {
 func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
+		return fmt.Errorf("%w: invalid partition spec JSON: %w", ErrInvalidPartitionSpec, err)
 	}
 
-	rawID, ok := raw["spec-id"]
-	if !ok || bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
-		return fmt.Errorf("%w: partition spec is missing required spec-id", ErrInvalidPartitionSpec)
-	}
-	var id int
-	if err := json.Unmarshal(rawID, &id); err != nil {
-		return fmt.Errorf("%w: invalid partition spec ID: %w", ErrInvalidPartitionSpec, err)
+	id := InitialPartitionSpecID
+	if rawID, ok := raw["spec-id"]; ok {
+		if bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
+			return fmt.Errorf("%w: partition spec spec-id cannot be null", ErrInvalidPartitionSpec)
+		}
+		if err := json.Unmarshal(rawID, &id); err != nil {
+			return fmt.Errorf("%w: invalid partition spec ID: %w", ErrInvalidPartitionSpec, err)
+		}
 	}
 	if id < 0 {
 		return fmt.Errorf("%w: spec ID must be non-negative: %d", ErrInvalidPartitionSpec, id)
@@ -485,7 +486,7 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 	for i, rawField := range rawFieldList {
 		var keys map[string]json.RawMessage
 		if err := json.Unmarshal(rawField, &keys); err != nil {
-			return err
+			return fmt.Errorf("%w: invalid partition field JSON: %w", ErrInvalidPartitionSpec, err)
 		}
 		if rawFieldID, ok := keys["field-id"]; ok {
 			var fieldID *int
@@ -497,7 +498,7 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if err := json.Unmarshal(rawField, &fields[i]); err != nil {
-			return err
+			return fmt.Errorf("%w: invalid partition field: %w", ErrInvalidPartitionSpec, err)
 		}
 	}
 	if err := validatePartitionFields(fields); err != nil {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -317,6 +317,27 @@ func TestSerializePartitionSpec(t *testing.T) {
 	assert.True(t, spec.Equals(outspec))
 }
 
+func TestDeserializePartitionSpecRequiresTopLevelFields(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{name: "missing spec id", data: `{"fields": []}`},
+		{name: "null spec id", data: `{"spec-id": null, "fields": []}`},
+		{name: "missing fields", data: `{"spec-id": 3}`},
+		{name: "null fields", data: `{"spec-id": 3, "fields": null}`},
+		{name: "non-array fields", data: `{"spec-id": 3, "fields": {}}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := iceberg.NewPartitionSpecID(7)
+			err := json.Unmarshal([]byte(tt.data), &spec)
+			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+			assert.Equal(t, 7, spec.ID())
+			assert.Zero(t, spec.NumFields())
+		})
+	}
+}
+
 func TestDeserializePartitionSpecWithoutFieldIDs(t *testing.T) {
 	data := []byte(`{
 		"spec-id": 3,

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -318,11 +318,17 @@ func TestSerializePartitionSpec(t *testing.T) {
 }
 
 func TestDeserializePartitionSpecRequiresTopLevelFields(t *testing.T) {
+	t.Run("missing spec id defaults to initial id", func(t *testing.T) {
+		spec := iceberg.NewPartitionSpecID(7)
+		require.NoError(t, json.Unmarshal([]byte(`{"fields": []}`), &spec))
+		assert.Equal(t, iceberg.InitialPartitionSpecID, spec.ID())
+		assert.Zero(t, spec.NumFields())
+	})
+
 	for _, tt := range []struct {
 		name string
 		data string
 	}{
-		{name: "missing spec id", data: `{"fields": []}`},
 		{name: "null spec id", data: `{"spec-id": null, "fields": []}`},
 		{name: "missing fields", data: `{"spec-id": 3}`},
 		{name: "null fields", data: `{"spec-id": 3, "fields": null}`},
@@ -334,6 +340,16 @@ func TestDeserializePartitionSpecRequiresTopLevelFields(t *testing.T) {
 			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 			assert.Equal(t, 7, spec.ID())
 			assert.Zero(t, spec.NumFields())
+		})
+	}
+}
+
+func TestDeserializePartitionSpecWrapsMalformedJSON(t *testing.T) {
+	for _, data := range []string{`[]`, `{"fields": [1]}`} {
+		t.Run(data, func(t *testing.T) {
+			var spec iceberg.PartitionSpec
+			err := json.Unmarshal([]byte(data), &spec)
+			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 		})
 	}
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/binary"
 	"encoding/json"
@@ -1524,12 +1525,44 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := requirePartitionSpecIDs(normalized); err != nil {
+		return nil, err
+	}
 
 	if err := json.Unmarshal(normalized, ret); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
 	}
 
 	return ret, nil
+}
+
+func requirePartitionSpecIDs(b []byte) error {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(b, &metadata); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+	}
+
+	rawSpecs, ok := metadata["partition-specs"]
+	if !ok {
+		return nil
+	}
+
+	var specs []json.RawMessage
+	if err := json.Unmarshal(rawSpecs, &specs); err != nil {
+		return fmt.Errorf("%w: invalid partition-specs: %w", ErrInvalidMetadata, err)
+	}
+	for i, rawSpec := range specs {
+		var spec map[string]json.RawMessage
+		if err := json.Unmarshal(rawSpec, &spec); err != nil {
+			return fmt.Errorf("%w: invalid partition spec at index %d: %w", ErrInvalidMetadata, i, err)
+		}
+		rawID, ok := spec["spec-id"]
+		if !ok || bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
+			return fmt.Errorf("%w: partition spec at index %d is missing required spec-id", ErrInvalidMetadata, i)
+		}
+	}
+
+	return nil
 }
 
 func assignMissingPartitionFieldIDs(b []byte) ([]byte, error) {

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -711,6 +711,22 @@ func TestRejectStructurallyInvalidHistoricalPartitionSpec(t *testing.T) {
 	assert.ErrorContains(t, err, "spec ID must be non-negative")
 }
 
+func TestRejectsStoredPartitionSpecWithoutID(t *testing.T) {
+	var metadata map[string]any
+	decoder := json.NewDecoder(strings.NewReader(ExampleTableMetadataV2))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&metadata))
+	specs := metadata["partition-specs"].([]any)
+	delete(specs[0].(map[string]any), "spec-id")
+
+	data, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	_, err = ParseMetadataBytes(data)
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "missing required spec-id")
+}
+
 func TestSortOrderNotFound(t *testing.T) {
 	metadataSortOrderNotFound := `{
         "format-version": 2,

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -540,6 +540,15 @@ func TestUnmarshalUpdates(t *testing.T) {
 	}
 }
 
+func TestUnmarshalAddSpecWithoutIDUsesInitialSpecID(t *testing.T) {
+	var updates Updates
+	require.NoError(t, json.Unmarshal([]byte(`[{"action":"add-spec","spec":{"fields":[]}}]`), &updates))
+	require.Len(t, updates, 1)
+	update := updates[0].(*addPartitionSpecUpdate)
+	require.NotNil(t, update.Spec)
+	assert.Equal(t, iceberg.InitialPartitionSpecID, update.Spec.ID())
+}
+
 func TestUnmarshalUpdatesReplacesExistingSlice(t *testing.T) {
 	var updates Updates
 	require.NoError(t, json.Unmarshal([]byte(`[


### PR DESCRIPTION
## Summary

Require spec-id and fields when decoding partition specs.

## Why

Missing fields were treated as an empty list, and a reused PartitionSpec could retain its old ID when spec-id was omitted.

## What changed

Both fields are now required and validated in temporary state. The receiver is replaced only after successful decoding. Compatibility for omitted partition field-id values is unchanged.

## Tests

- go test .