### PR TITLE
fix(table): preserve unknown statistics blob types

### DIFF
--- a/table/statistics.go
+++ b/table/statistics.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // BlobType is the type of blob in a Puffin file
@@ -49,6 +50,9 @@ func (bt *BlobType) UnmarshalJSON(data []byte) error {
 	}
 
 	*bt = BlobType(s)
+	if s == "" {
+		return fmt.Errorf("invalid blob type: %s", s)
+	}
 
 	return nil
 }

--- a/table/statistics.go
+++ b/table/statistics.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-// BlobType is the type of blob in a Puffin file
+// BlobType is the type of blob in a Puffin file.
 type BlobType string
 
 const (
@@ -30,6 +30,9 @@ const (
 	BlobTypeDeletionVectorV1          BlobType = "deletion-vector-v1"
 )
 
+// IsKnown reports whether bt is one of the standard blob types understood by
+// this package. Unknown non-empty wire values may still be preserved for
+// forward compatibility.
 func (bt BlobType) IsKnown() bool {
 	switch bt {
 	case BlobTypeApacheDatasketchesThetaV1, BlobTypeDeletionVectorV1:
@@ -39,6 +42,9 @@ func (bt BlobType) IsKnown() bool {
 	}
 }
 
+// IsValid reports whether bt is non-nil and names a standard blob type.
+// Unknown non-empty values can be decoded and preserved, but are not valid for
+// operations that require a known blob type.
 func (bt *BlobType) IsValid() bool {
 	return bt != nil && bt.IsKnown()
 }

--- a/table/statistics.go
+++ b/table/statistics.go
@@ -19,7 +19,6 @@ package table
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // BlobType is the type of blob in a Puffin file
@@ -30,13 +29,17 @@ const (
 	BlobTypeDeletionVectorV1          BlobType = "deletion-vector-v1"
 )
 
-func (bt *BlobType) IsValid() bool {
-	switch *bt {
+func (bt BlobType) IsKnown() bool {
+	switch bt {
 	case BlobTypeApacheDatasketchesThetaV1, BlobTypeDeletionVectorV1:
 		return true
 	default:
 		return false
 	}
+}
+
+func (bt *BlobType) IsValid() bool {
+	return bt != nil && bt.IsKnown()
 }
 
 func (bt *BlobType) UnmarshalJSON(data []byte) error {
@@ -46,9 +49,6 @@ func (bt *BlobType) UnmarshalJSON(data []byte) error {
 	}
 
 	*bt = BlobType(s)
-	if !bt.IsValid() {
-		return fmt.Errorf("invalid blob type: %s", s)
-	}
 
 	return nil
 }

--- a/table/statistics_test.go
+++ b/table/statistics_test.go
@@ -53,6 +53,7 @@ func TestMetadataPreservesUnknownStatisticsBlobType(t *testing.T) {
 	require.Len(t, stats[0].BlobMetadata, 1)
 	assert.Equal(t, BlobType("vendor-sketch-v1"), stats[0].BlobMetadata[0].Type)
 	assert.False(t, stats[0].BlobMetadata[0].Type.IsKnown())
+	assert.False(t, stats[0].BlobMetadata[0].Type.IsValid())
 }
 
 func TestBlobTypeRejectsNullAndEmptyValues(t *testing.T) {

--- a/table/statistics_test.go
+++ b/table/statistics_test.go
@@ -54,3 +54,14 @@ func TestMetadataPreservesUnknownStatisticsBlobType(t *testing.T) {
 	assert.Equal(t, BlobType("vendor-sketch-v1"), stats[0].BlobMetadata[0].Type)
 	assert.False(t, stats[0].BlobMetadata[0].Type.IsKnown())
 }
+
+func TestBlobTypeRejectsNullAndEmptyValues(t *testing.T) {
+	for _, value := range []string{"null", `""`} {
+		t.Run(value, func(t *testing.T) {
+			var blob BlobMetadata
+			err := json.Unmarshal([]byte(`{"type":`+value+`}`), &blob)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid blob type")
+		})
+	}
+}

--- a/table/statistics_test.go
+++ b/table/statistics_test.go
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataPreservesUnknownStatisticsBlobType(t *testing.T) {
+	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")
+	require.NoError(t, err)
+
+	meta.(*metadataV2).StatisticsList = []StatisticsFile{{
+		SnapshotID:     3055729675574597004,
+		StatisticsPath: "s3://bucket/stats/vendor.puffin",
+		BlobMetadata: []BlobMetadata{{
+			Type:           BlobType("vendor-sketch-v1"),
+			SnapshotID:     3055729675574597004,
+			SequenceNumber: 2,
+			Fields:         []int32{1},
+			Properties:     map[string]string{"source": "vendor"},
+		}},
+	}}
+
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	decoded, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+
+	stats := make([]StatisticsFile, 0, 1)
+	for stat := range decoded.Statistics() {
+		stats = append(stats, stat)
+	}
+	require.Len(t, stats, 1)
+	require.Len(t, stats[0].BlobMetadata, 1)
+	assert.Equal(t, BlobType("vendor-sketch-v1"), stats[0].BlobMetadata[0].Type)
+	assert.False(t, stats[0].BlobMetadata[0].Type.IsKnown())
+}


### PR DESCRIPTION
## Summary

Preserve vendor-defined statistics blob types during JSON decoding.

## Why

Statistics blob types are informational, but decoding rejected any type outside the two constants known by this package. A table with a vendor-defined type could fail to load.

## What changed

Blob metadata now preserves any JSON string type. IsKnown still identifies the standard types known by this package, and specialized readers can continue to reject payloads they do not understand.

## Tests

- go test ./table