### PR TITLE
fix(table): require fields in update decoders

### DIFF
--- a/table/updates.go
+++ b/table/updates.go
@@ -92,7 +92,7 @@ var requiredUpdateFields = map[string][]string{
 	UpdateRemoveProperties:          {"removals"},
 	UpdateRemoveSpec:                {"spec-ids"},
 	UpdateRemoveSchemas:             {"schema-ids"},
-	UpdateSetStatistics:             {"snapshot-id", "statistics"},
+	UpdateSetStatistics:             {"statistics"},
 	UpdateRemoveStatistics:          {"snapshot-id"},
 	UpdateSetPartitionStatistics:    {"partition-statistics"},
 	UpdateRemovePartitionStatistics: {"snapshot-id"},

--- a/table/updates.go
+++ b/table/updates.go
@@ -132,10 +132,17 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		updates = make(Updates, 0, len(rawUpdates))
 	}
 	for _, raw := range rawUpdates {
-		var base baseUpdate
-		if err := json.Unmarshal(raw, &base); err != nil {
+		var baseWire struct {
+			Action *string `json:"action"`
+		}
+		if err := json.Unmarshal(raw, &baseWire); err != nil {
 			return err
 		}
+		if baseWire.Action == nil {
+			return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+		}
+
+		base := baseUpdate{ActionName: *baseWire.Action}
 
 		var upd Update
 		switch base.ActionName {

--- a/table/updates.go
+++ b/table/updates.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -72,6 +73,53 @@ type Update interface {
 }
 
 type Updates []Update
+
+var requiredUpdateFields = map[string][]string{
+	UpdateAssignUUID:                {"uuid"},
+	UpdateUpgradeFormatVersion:      {"format-version"},
+	UpdateAddSchema:                 {"schema"},
+	UpdateSetCurrentSchema:          {"schema-id"},
+	UpdateAddSpec:                   {"spec"},
+	UpdateSetDefaultSpec:            {"spec-id"},
+	UpdateAddSortOrder:              {"sort-order"},
+	UpdateSetDefaultSortOrder:       {"sort-order-id"},
+	UpdateAddSnapshot:               {"snapshot"},
+	UpdateSetSnapshotRef:            {"ref-name", "type", "snapshot-id"},
+	UpdateRemoveSnapshots:           {"snapshot-ids"},
+	UpdateRemoveSnapshotRef:         {"ref-name"},
+	UpdateSetLocation:               {"location"},
+	UpdateSetProperties:             {"updates"},
+	UpdateRemoveProperties:          {"removals"},
+	UpdateRemoveSpec:                {"spec-ids"},
+	UpdateRemoveSchemas:             {"schema-ids"},
+	UpdateSetStatistics:             {"snapshot-id", "statistics"},
+	UpdateRemoveStatistics:          {"snapshot-id"},
+	UpdateSetPartitionStatistics:    {"partition-statistics"},
+	UpdateRemovePartitionStatistics: {"snapshot-id"},
+	UpdateAddEncryptionKey:          {"encryption-key"},
+	UpdateRemoveEncryptionKey:       {"key-id"},
+}
+
+func validateRequiredUpdateFields(action string, raw json.RawMessage) error {
+	fields := requiredUpdateFields[action]
+	if len(fields) == 0 {
+		return nil
+	}
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return err
+	}
+
+	for _, field := range fields {
+		value, ok := object[field]
+		if !ok || bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return fmt.Errorf("%w: update %q requires field %q", iceberg.ErrInvalidArgument, action, field)
+		}
+	}
+
+	return nil
+}
 
 func (u *Updates) UnmarshalJSON(data []byte) error {
 	var rawUpdates []json.RawMessage
@@ -139,6 +187,9 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			upd = &removeEncryptionKeyUpdate{}
 		default:
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
+		}
+		if err := validateRequiredUpdateFields(base.ActionName, raw); err != nil {
+			return err
 		}
 
 		if err := json.Unmarshal(raw, upd); err != nil {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -370,10 +370,10 @@ func TestUnmarshalUpdates(t *testing.T) {
 				{"action": "set-properties", "updates": {"key1": "value1"}},
 				{"action": "remove-properties", "removals": ["key2"]},
 				{"action": "remove-schemas", "schema-ids": [1,2,3,4]},
-				{"action": "remove-partition-specs", "schema-ids": [1,2,3]},
+				{"action": "remove-partition-specs", "spec-ids": [1,2,3]},
 				{"action": "remove-snapshots", "snapshot-ids": [1,2]},
 				{"action": "remove-snapshot-ref", "ref-name": "main"},
-				{"action": "set-default-sort-order", "order-id": 1},
+				{"action": "set-default-sort-order", "sort-order-id": 1},
 				{"action": "set-default-spec", "spec-id": 1},
 				{"action": "set-snapshot-ref", "ref-name": "main", "type": "branch", "snapshot-id": 1}
 			]`),
@@ -562,6 +562,53 @@ func TestUnmarshalUpdatesReplacesExistingSlice(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`[]`), &updates))
 	assert.Empty(t, updates)
+}
+
+func TestUnmarshalUpdatesRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		action string
+		field  string
+	}{
+		{UpdateAssignUUID, "uuid"},
+		{UpdateUpgradeFormatVersion, "format-version"},
+		{UpdateAddSchema, "schema"},
+		{UpdateSetCurrentSchema, "schema-id"},
+		{UpdateAddSpec, "spec"},
+		{UpdateSetDefaultSpec, "spec-id"},
+		{UpdateAddSortOrder, "sort-order"},
+		{UpdateSetDefaultSortOrder, "sort-order-id"},
+		{UpdateAddSnapshot, "snapshot"},
+		{UpdateSetSnapshotRef, "ref-name"},
+		{UpdateRemoveSnapshots, "snapshot-ids"},
+		{UpdateRemoveSnapshotRef, "ref-name"},
+		{UpdateSetLocation, "location"},
+		{UpdateSetProperties, "updates"},
+		{UpdateRemoveProperties, "removals"},
+		{UpdateRemoveSpec, "spec-ids"},
+		{UpdateRemoveSchemas, "schema-ids"},
+		{UpdateSetStatistics, "snapshot-id"},
+		{UpdateRemoveStatistics, "snapshot-id"},
+		{UpdateSetPartitionStatistics, "partition-statistics"},
+		{UpdateRemovePartitionStatistics, "snapshot-id"},
+		{UpdateAddEncryptionKey, "encryption-key"},
+		{UpdateRemoveEncryptionKey, "key-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			var updates Updates
+			err := json.Unmarshal([]byte(fmt.Sprintf(`[{"action":%q}]`, tt.action)), &updates)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.field)
+		})
+	}
+}
+
+func TestUnmarshalUpdatesRejectsNullRequiredPayload(t *testing.T) {
+	var updates Updates
+	err := json.Unmarshal([]byte(`[{"action":"add-snapshot","snapshot":null}]`), &updates)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snapshot")
 }
 
 // baseMetaJSON is a minimal valid V2 metadata document used by the Apply tests below.

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -579,6 +579,8 @@ func TestUnmarshalUpdatesRejectsMissingRequiredFields(t *testing.T) {
 		{UpdateSetDefaultSortOrder, "sort-order-id"},
 		{UpdateAddSnapshot, "snapshot"},
 		{UpdateSetSnapshotRef, "ref-name"},
+		{UpdateSetSnapshotRef, "type"},
+		{UpdateSetSnapshotRef, "snapshot-id"},
 		{UpdateRemoveSnapshots, "snapshot-ids"},
 		{UpdateRemoveSnapshotRef, "ref-name"},
 		{UpdateSetLocation, "location"},
@@ -597,18 +599,125 @@ func TestUnmarshalUpdatesRejectsMissingRequiredFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.action, func(t *testing.T) {
 			var updates Updates
-			err := json.Unmarshal([]byte(fmt.Sprintf(`[{"action":%q}]`, tt.action)), &updates)
+			data := []byte(fmt.Sprintf(`[{"action":%q}]`, tt.action))
+			if tt.action == UpdateSetSnapshotRef {
+				data = snapshotRefPayload(tt.field, false)
+			}
+			err := json.Unmarshal(data, &updates)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.field)
 		})
 	}
 }
 
+func snapshotRefPayload(omittedField string, nullField bool) []byte {
+	fields := map[string]any{
+		"action":      UpdateSetSnapshotRef,
+		"ref-name":    "main",
+		"type":        "branch",
+		"snapshot-id": int64(1),
+	}
+	if nullField {
+		fields[omittedField] = nil
+	} else {
+		delete(fields, omittedField)
+	}
+
+	data, err := json.Marshal([]map[string]any{fields})
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
 func TestUnmarshalUpdatesRejectsNullRequiredPayload(t *testing.T) {
+	tests := []struct {
+		action string
+		field  string
+	}{
+		{UpdateAssignUUID, "uuid"},
+		{UpdateUpgradeFormatVersion, "format-version"},
+		{UpdateAddSchema, "schema"},
+		{UpdateSetCurrentSchema, "schema-id"},
+		{UpdateAddSpec, "spec"},
+		{UpdateSetDefaultSpec, "spec-id"},
+		{UpdateAddSortOrder, "sort-order"},
+		{UpdateSetDefaultSortOrder, "sort-order-id"},
+		{UpdateAddSnapshot, "snapshot"},
+		{UpdateSetSnapshotRef, "ref-name"},
+		{UpdateSetSnapshotRef, "type"},
+		{UpdateSetSnapshotRef, "snapshot-id"},
+		{UpdateRemoveSnapshots, "snapshot-ids"},
+		{UpdateRemoveSnapshotRef, "ref-name"},
+		{UpdateSetLocation, "location"},
+		{UpdateSetProperties, "updates"},
+		{UpdateRemoveProperties, "removals"},
+		{UpdateRemoveSpec, "spec-ids"},
+		{UpdateRemoveSchemas, "schema-ids"},
+		{UpdateSetStatistics, "statistics"},
+		{UpdateRemoveStatistics, "snapshot-id"},
+		{UpdateSetPartitionStatistics, "partition-statistics"},
+		{UpdateRemovePartitionStatistics, "snapshot-id"},
+		{UpdateAddEncryptionKey, "encryption-key"},
+		{UpdateRemoveEncryptionKey, "key-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action+"/"+tt.field, func(t *testing.T) {
+			var updates Updates
+			data := []byte(fmt.Sprintf(`[{"action":%q,%q:null}]`, tt.action, tt.field))
+			if tt.action == UpdateSetSnapshotRef {
+				data = snapshotRefPayload(tt.field, true)
+			}
+			err := json.Unmarshal(data, &updates)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.field)
+		})
+	}
+}
+
+func TestUnmarshalUpdatesRejectsMissingOrNullAction(t *testing.T) {
+	for _, data := range []string{`{}`, `{"action":null}`} {
+		t.Run(data, func(t *testing.T) {
+			var updates Updates
+			err := json.Unmarshal([]byte("["+data+"]"), &updates)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, "action")
+		})
+	}
+}
+
+func TestUnmarshalUpdatesAcceptsOptionalAndEmptyValues(t *testing.T) {
+	data := []byte(`[
+		{"action":"add-schema","schema":{"type":"struct","fields":[]}},
+		{"action":"set-snapshot-ref","ref-name":"main","type":"branch","snapshot-id":1},
+		{"action":"set-properties","updates":{}},
+		{"action":"remove-properties","removals":[]},
+		{"action":"remove-schemas","schema-ids":[]},
+		{"action":"remove-partition-specs","spec-ids":[]},
+		{"action":"remove-snapshots","snapshot-ids":[]}
+	]`)
+
 	var updates Updates
-	err := json.Unmarshal([]byte(`[{"action":"add-snapshot","snapshot":null}]`), &updates)
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 7)
+	assert.Equal(t, UpdateAddSchema, updates[0].Action())
+	assert.Equal(t, UpdateSetSnapshotRef, updates[1].Action())
+}
+
+func TestUnmarshalUpdatesPreservesReceiverAfterRequiredFieldFailure(t *testing.T) {
+	var updates Updates
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"action":"set-location","location":"s3://bucket/old-location"}
+	]`), &updates))
+	previous := append(Updates(nil), updates...)
+
+	err := json.Unmarshal([]byte(`[
+		{"action":"set-location"}
+	]`), &updates)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "snapshot")
+	assert.Equal(t, previous, updates)
 }
 
 // baseMetaJSON is a minimal valid V2 metadata document used by the Apply tests below.

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -586,7 +586,7 @@ func TestUnmarshalUpdatesRejectsMissingRequiredFields(t *testing.T) {
 		{UpdateRemoveProperties, "removals"},
 		{UpdateRemoveSpec, "spec-ids"},
 		{UpdateRemoveSchemas, "schema-ids"},
-		{UpdateSetStatistics, "snapshot-id"},
+		{UpdateSetStatistics, "statistics"},
 		{UpdateRemoveStatistics, "snapshot-id"},
 		{UpdateSetPartitionStatistics, "partition-statistics"},
 		{UpdateRemovePartitionStatistics, "snapshot-id"},
@@ -656,7 +656,6 @@ func TestAssignUUIDUpdate_ApplyRejectsNilUUID(t *testing.T) {
 func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {
 	data := []byte(`[{
 		"action": "set-statistics",
-		"snapshot-id": 42,
 		"statistics": {
 			"snapshot-id": 42,
 			"statistics-path": "s3://bucket/stats.puffin",
@@ -672,7 +671,7 @@ func TestSetStatisticsUpdate_Unmarshal(t *testing.T) {
 
 	u, ok := updates[0].(*setStatisticsUpdate)
 	require.True(t, ok)
-	assert.Equal(t, int64(42), u.SnapshotID)
+	assert.Zero(t, u.SnapshotID)
 	assert.Equal(t, "s3://bucket/stats.puffin", u.Statistics.StatisticsPath)
 }
 


### PR DESCRIPTION
## Summary

Require required wire fields when decoding metadata updates.

## Why

Missing payload fields could become Go zero values, nil objects, or empty no-op updates.

## What changed

Every update action now validates its required fields before decoding into the existing update types. Explicit empty collections remain valid where the format allows them.

## Tests

- go test ./table -count=1