### PR TITLE
fix(table): bound AllManifests concurrency

### DIFF
--- a/table/all_manifests_internal_test.go
+++ b/table/all_manifests_internal_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -68,10 +67,6 @@ func TestAllManifestsCompletesAfterErrorChannelCloses(t *testing.T) {
 
 func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
 	const snapshotCount = 64
-	const maxWorkers = 2
-
-	previousMaxProcs := runtime.GOMAXPROCS(maxWorkers)
-	defer runtime.GOMAXPROCS(previousMaxProcs)
 
 	var trackingFS *manifestTrackingIO
 	tbl, _ := tableWithManifestListsUsingIO(t, snapshotCount, func(memFS *iceio.MemFS) iceio.IO {
@@ -88,8 +83,26 @@ func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
 	trackingFS.mu.Lock()
 	maxOpen := trackingFS.maxOpen
 	trackingFS.mu.Unlock()
-	require.Greater(t, maxOpen, 1)
-	require.LessOrEqual(t, maxOpen, maxWorkers)
+	require.LessOrEqual(t, maxOpen, allManifestsMaxWorkers)
+}
+
+func TestAllManifestsWorkerCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		snapshotCount int
+		want          int
+	}{
+		{name: "empty", snapshotCount: 0, want: 1},
+		{name: "single snapshot", snapshotCount: 1, want: 1},
+		{name: "at limit", snapshotCount: allManifestsMaxWorkers, want: allManifestsMaxWorkers},
+		{name: "above limit", snapshotCount: allManifestsMaxWorkers + 1, want: allManifestsMaxWorkers},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, allManifestsWorkerCount(tt.snapshotCount))
+		})
+	}
 }
 
 type manifestTrackingIO struct {

--- a/table/all_manifests_internal_test.go
+++ b/table/all_manifests_internal_test.go
@@ -68,8 +68,9 @@ func TestAllManifestsCompletesAfterErrorChannelCloses(t *testing.T) {
 
 func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
 	const snapshotCount = 64
+	const maxWorkers = 2
 
-	previousMaxProcs := runtime.GOMAXPROCS(2)
+	previousMaxProcs := runtime.GOMAXPROCS(maxWorkers)
 	defer runtime.GOMAXPROCS(previousMaxProcs)
 
 	var trackingFS *manifestTrackingIO
@@ -88,7 +89,7 @@ func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
 	maxOpen := trackingFS.maxOpen
 	trackingFS.mu.Unlock()
 	require.Greater(t, maxOpen, 1)
-	require.LessOrEqual(t, maxOpen, 16)
+	require.LessOrEqual(t, maxOpen, maxWorkers)
 }
 
 type manifestTrackingIO struct {

--- a/table/all_manifests_internal_test.go
+++ b/table/all_manifests_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,10 +65,81 @@ func TestAllManifestsCompletesAfterErrorChannelCloses(t *testing.T) {
 	}
 }
 
+func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
+	const snapshotCount = 64
+
+	var trackingFS *manifestTrackingIO
+	tbl, _ := tableWithManifestListsUsingIO(t, snapshotCount, func(memFS *iceio.MemFS) iceio.IO {
+		trackingFS = &manifestTrackingIO{IO: memFS, delay: 5 * time.Millisecond}
+
+		return trackingFS
+	})
+
+	for mf, err := range tbl.AllManifests(context.Background()) {
+		require.NoError(t, err)
+		require.NotNil(t, mf)
+	}
+
+	trackingFS.mu.Lock()
+	maxOpen := trackingFS.maxOpen
+	trackingFS.mu.Unlock()
+	require.Greater(t, maxOpen, 1)
+	require.LessOrEqual(t, maxOpen, 16)
+}
+
+type manifestTrackingIO struct {
+	iceio.IO
+	mu      sync.Mutex
+	open    int
+	maxOpen int
+	delay   time.Duration
+}
+
+func (fs *manifestTrackingIO) Open(name string) (iceio.File, error) {
+	f, err := fs.IO.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	fs.mu.Lock()
+	fs.open++
+	if fs.open > fs.maxOpen {
+		fs.maxOpen = fs.open
+	}
+	fs.mu.Unlock()
+	time.Sleep(fs.delay)
+
+	return &manifestTrackingFile{File: f, onClose: func() {
+		fs.mu.Lock()
+		fs.open--
+		fs.mu.Unlock()
+	}}, nil
+}
+
+type manifestTrackingFile struct {
+	iceio.File
+	onClose func()
+	once    sync.Once
+}
+
+func (f *manifestTrackingFile) Close() error {
+	f.once.Do(f.onClose)
+
+	return f.File.Close()
+}
+
 func tableWithManifestLists(t *testing.T, snapshotCount int) (*Table, []string) {
+	return tableWithManifestListsUsingIO(t, snapshotCount, nil)
+}
+
+func tableWithManifestListsUsingIO(t *testing.T, snapshotCount int, readIOFn func(*iceio.MemFS) iceio.IO) (*Table, []string) {
 	t.Helper()
 
 	memFS := iceio.NewMemFS()
+	var readIO iceio.IO = memFS
+	if readIOFn != nil {
+		readIO = readIOFn(memFS)
+	}
 	schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
 	})
@@ -121,7 +193,7 @@ func tableWithManifestLists(t *testing.T, snapshotCount int) (*Table, []string) 
 
 	tbl := New(Identifier{"db", "all_manifests"}, built, tableLocation+"/metadata/metadata.json",
 		func(context.Context) (iceio.IO, error) {
-			return memFS, nil
+			return readIO, nil
 		}, nil)
 
 	return tbl, expectedPaths

--- a/table/all_manifests_internal_test.go
+++ b/table/all_manifests_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -67,6 +68,9 @@ func TestAllManifestsCompletesAfterErrorChannelCloses(t *testing.T) {
 
 func TestAllManifestsLimitsConcurrentReads(t *testing.T) {
 	const snapshotCount = 64
+
+	previousMaxProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(previousMaxProcs)
 
 	var trackingFS *manifestTrackingIO
 	tbl, _ := tableWithManifestListsUsingIO(t, snapshotCount, func(memFS *iceio.MemFS) iceio.IO {

--- a/table/table.go
+++ b/table/table.go
@@ -66,6 +66,12 @@ var ErrCommitFailed = errors.New("commit failed, refresh and try again")
 // WriteRecords behavior.
 var ErrWriteIORequired = fmt.Errorf("%w: file system does not implement WriteFileIO", iceberg.ErrNotImplemented)
 
+const allManifestsMaxWorkers = 16
+
+func allManifestsWorkerCount(snapshotCount int) int {
+	return max(1, min(snapshotCount, allManifestsMaxWorkers))
+}
+
 // requireWriteFileIO should run immediately after resolving the table FS and
 // before mutating transaction state such as automatic name mapping.
 func requireWriteFileIO(fs icebergio.IO) (icebergio.WriteFileIO, error) {
@@ -331,8 +337,11 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 	n := len(snapshots)
 	workCtx, cancel := context.WithCancel(ctx)
 	jobs := make(chan int)
-	ch := make(chan list, max(1, min(n, 16)))
-	workers := max(1, min(n, min(runtime.GOMAXPROCS(0), 16)))
+	// This buffer lets workers finish after an early consumer stop. The result
+	// channel created below still retains all snapshot results, so this is not a
+	// memory bound; all remote reads are bounded by allManifestsMaxWorkers.
+	ch := make(chan list, allManifestsWorkerCount(n))
+	workers := allManifestsWorkerCount(n)
 	g, groupCtx := errgroup.WithContext(workCtx)
 
 	for range workers {

--- a/table/table.go
+++ b/table/table.go
@@ -327,23 +327,50 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 	}
 
 	type list = tblutils.Enumerated[[]iceberg.ManifestFile]
-	g := errgroup.Group{}
+	snapshots := t.metadata.Snapshots()
+	n := len(snapshots)
+	workCtx, cancel := context.WithCancel(ctx)
+	jobs := make(chan int)
+	ch := make(chan list, max(1, min(n, 16)))
+	workers := max(1, min(n, min(runtime.GOMAXPROCS(0), 16)))
+	g, groupCtx := errgroup.WithContext(workCtx)
 
-	n := len(t.metadata.Snapshots())
-	ch := make(chan list, n)
-
-	for i, sn := range t.metadata.Snapshots() {
+	for range workers {
 		g.Go(func() error {
-			manifests, err := sn.Manifests(fs)
-			if err != nil {
-				return err
+			for {
+				select {
+				case <-groupCtx.Done():
+					return groupCtx.Err()
+				case i, ok := <-jobs:
+					if !ok {
+						return nil
+					}
+
+					manifests, err := snapshots[i].Manifests(fs)
+					if err != nil {
+						return err
+					}
+
+					select {
+					case ch <- list{Index: i, Value: manifests, Last: i == n-1}:
+					case <-groupCtx.Done():
+						return groupCtx.Err()
+					}
+				}
 			}
-
-			ch <- list{Index: i, Value: manifests, Last: i == n-1}
-
-			return nil
 		})
 	}
+
+	go func() {
+		defer close(jobs)
+		for i := range snapshots {
+			select {
+			case jobs <- i:
+			case <-groupCtx.Done():
+				return
+			}
+		}
+	}()
 
 	errch := make(chan error, 1)
 	go func() {
@@ -373,6 +400,7 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 		}, list{Index: -1})
 
 	return func(yield func(iceberg.ManifestFile, error) bool) {
+		defer cancel()
 		defer func() {
 			// drain channels if we exited early
 			go func() {


### PR DESCRIPTION
## Summary

Bound the remote work started by AllManifests.

## Why

The old implementation started one goroutine and one manifest-list read per snapshot. Long table histories could create a large burst of remote I/O even when the caller stopped early.

## What changed

AllManifests now uses a bounded worker pool, stops scheduling after cancellation, preserves snapshot order, and keeps the existing error behavior.

## Tests

- go test ./table -count=1