### PR TITLE
fix(table): require fields in requirement decoders

### DIFF
--- a/internal/requirements.go
+++ b/internal/requirements.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import "fmt"
+
+type RequirementWire struct {
+	Type *string `json:"type"`
+}
+
+func MissingRequiredField(sentinel error, name string) error {
+	return fmt.Errorf("%w: missing required field %q", sentinel, name)
+}

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -93,7 +93,11 @@ func TestParseRequirementBytes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := table.ParseRequirementBytes(tc.data)
 			assert.Equal(t, tc.expected, actual)
-			assert.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }
@@ -173,42 +177,76 @@ func TestParseRequirementListReplacesExistingSlice(t *testing.T) {
 
 func TestParseRequirementRejectsMissingRequiredFields(t *testing.T) {
 	tests := []struct {
-		name string
-		data string
+		name          string
+		data          string
+		expectedField string
 	}{
-		{name: "table uuid", data: `{"type":"assert-table-uuid"}`},
-		{name: "missing ref", data: `{"type":"assert-ref-snapshot-id"}`},
-		{name: "missing snapshot id", data: `{"type":"assert-ref-snapshot-id","ref":"main"}`},
-		{name: "default spec id", data: `{"type":"assert-default-spec-id"}`},
-		{name: "current schema id", data: `{"type":"assert-current-schema-id"}`},
-		{name: "default sort order id", data: `{"type":"assert-default-sort-order-id"}`},
-		{name: "last assigned field id", data: `{"type":"assert-last-assigned-field-id"}`},
-		{name: "last assigned partition id", data: `{"type":"assert-last-assigned-partition-id"}`},
-		{name: "null current schema id", data: `{"type":"assert-current-schema-id","current-schema-id":null}`},
+		{name: "missing type", data: `{}`, expectedField: "type"},
+		{name: "null type", data: `{"type":null}`, expectedField: "type"},
+		{name: "table uuid", data: `{"type":"assert-table-uuid"}`, expectedField: "uuid"},
+		{name: "null table uuid", data: `{"type":"assert-table-uuid","uuid":null}`, expectedField: "uuid"},
+		{name: "missing ref", data: `{"type":"assert-ref-snapshot-id"}`, expectedField: "ref"},
+		{name: "missing snapshot id", data: `{"type":"assert-ref-snapshot-id","ref":"main"}`, expectedField: "snapshot-id"},
+		{name: "default spec id", data: `{"type":"assert-default-spec-id"}`, expectedField: "default-spec-id"},
+		{name: "null default spec id", data: `{"type":"assert-default-spec-id","default-spec-id":null}`, expectedField: "default-spec-id"},
+		{name: "current schema id", data: `{"type":"assert-current-schema-id"}`, expectedField: "current-schema-id"},
+		{name: "null current schema id", data: `{"type":"assert-current-schema-id","current-schema-id":null}`, expectedField: "current-schema-id"},
+		{name: "default sort order id", data: `{"type":"assert-default-sort-order-id"}`, expectedField: "default-sort-order-id"},
+		{name: "null default sort order id", data: `{"type":"assert-default-sort-order-id","default-sort-order-id":null}`, expectedField: "default-sort-order-id"},
+		{name: "last assigned field id", data: `{"type":"assert-last-assigned-field-id"}`, expectedField: "last-assigned-field-id"},
+		{name: "null last assigned field id", data: `{"type":"assert-last-assigned-field-id","last-assigned-field-id":null}`, expectedField: "last-assigned-field-id"},
+		{name: "last assigned partition id", data: `{"type":"assert-last-assigned-partition-id"}`, expectedField: "last-assigned-partition-id"},
+		{name: "null last assigned partition id", data: `{"type":"assert-last-assigned-partition-id","last-assigned-partition-id":null}`, expectedField: "last-assigned-partition-id"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := table.ParseRequirementBytes([]byte(tt.data))
-			require.Error(t, err)
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, tt.expectedField)
 
 			var requirements table.Requirements
 			err = json.Unmarshal([]byte("["+tt.data+"]"), &requirements)
-			require.Error(t, err)
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, tt.expectedField)
 		})
 	}
 }
 
 func TestParseRequirementAcceptsExplicitZero(t *testing.T) {
-	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-current-schema-id","current-schema-id":0}`))
-	require.NoError(t, err)
-	assert.Equal(t, table.AssertCurrentSchemaID(0), actual)
+	tests := []struct {
+		name     string
+		data     string
+		expected table.Requirement
+	}{
+		{name: "default spec id", data: `{"type":"assert-default-spec-id","default-spec-id":0}`, expected: table.AssertDefaultSpecID(0)},
+		{name: "current schema id", data: `{"type":"assert-current-schema-id","current-schema-id":0}`, expected: table.AssertCurrentSchemaID(0)},
+		{name: "default sort order id", data: `{"type":"assert-default-sort-order-id","default-sort-order-id":0}`, expected: table.AssertDefaultSortOrderID(0)},
+		{name: "last assigned field id", data: `{"type":"assert-last-assigned-field-id","last-assigned-field-id":0}`, expected: table.AssertLastAssignedFieldID(0)},
+		{name: "last assigned partition id", data: `{"type":"assert-last-assigned-partition-id","last-assigned-partition-id":0}`, expected: table.AssertLastAssignedPartitionID(0)},
+		{name: "snapshot id", data: `{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":0}`, expected: table.AssertRefSnapshotID("main", ptr(int64(0)))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := table.ParseRequirementBytes([]byte(tt.data))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func TestParseRequirementRefRequiresRefButAllowsNullSnapshotID(t *testing.T) {
-	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null}`))
+	data := []byte(`{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null}`)
+
+	actual, err := table.ParseRequirementBytes(data)
 	require.NoError(t, err)
 	assert.Equal(t, table.AssertRefSnapshotID("main", nil), actual)
+
+	var requirements table.Requirements
+	require.NoError(t, json.Unmarshal([]byte("["+string(data)+"]"), &requirements))
+	require.Len(t, requirements, 1)
+	assert.Equal(t, table.AssertRefSnapshotID("main", nil), requirements[0])
 }
 
 func TestParseRequirementRefAcceptsNumericSnapshotID(t *testing.T) {

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -171,6 +171,45 @@ func TestParseRequirementListReplacesExistingSlice(t *testing.T) {
 	assert.Empty(t, requirements)
 }
 
+func TestParseRequirementRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "table uuid", data: `{"type":"assert-table-uuid"}`},
+		{name: "ref", data: `{"type":"assert-ref-snapshot-id"}`},
+		{name: "default spec id", data: `{"type":"assert-default-spec-id"}`},
+		{name: "current schema id", data: `{"type":"assert-current-schema-id"}`},
+		{name: "default sort order id", data: `{"type":"assert-default-sort-order-id"}`},
+		{name: "last assigned field id", data: `{"type":"assert-last-assigned-field-id"}`},
+		{name: "last assigned partition id", data: `{"type":"assert-last-assigned-partition-id"}`},
+		{name: "null current schema id", data: `{"type":"assert-current-schema-id","current-schema-id":null}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := table.ParseRequirementBytes([]byte(tt.data))
+			require.Error(t, err)
+
+			var requirements table.Requirements
+			err = json.Unmarshal([]byte("["+tt.data+"]"), &requirements)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseRequirementAcceptsExplicitZero(t *testing.T) {
+	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-current-schema-id","current-schema-id":0}`))
+	require.NoError(t, err)
+	assert.Equal(t, table.AssertCurrentSchemaID(0), actual)
+}
+
+func TestParseRequirementRefRequiresRefButAllowsNullSnapshotID(t *testing.T) {
+	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null}`))
+	require.NoError(t, err)
+	assert.Equal(t, table.AssertRefSnapshotID("main", nil), actual)
+}
+
 func TestAssertRefSnapshotIDValidate(t *testing.T) {
 	meta, err := table.ParseMetadataBytes([]byte(table.ExampleTableMetadataV2))
 	require.NoError(t, err)

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -236,6 +236,11 @@ func TestParseRequirementAcceptsExplicitZero(t *testing.T) {
 			actual, err := table.ParseRequirementBytes([]byte(tt.data))
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
+
+			var requirements table.Requirements
+			require.NoError(t, json.Unmarshal([]byte("["+tt.data+"]"), &requirements))
+			require.Len(t, requirements, 1)
+			assert.Equal(t, tt.expected, requirements[0])
 		})
 	}
 }

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -48,7 +48,7 @@ func TestParseRequirementBytes(t *testing.T) {
 		},
 		{
 			name:        "Should parse an assert ref snapshot id",
-			data:        []byte(`{"type": "assert-ref-snapshot-id", "ref": "branch"}`),
+			data:        []byte(`{"type": "assert-ref-snapshot-id", "ref": "branch", "snapshot-id": null}`),
 			expected:    table.AssertRefSnapshotID("branch", nil),
 			expectedErr: nil,
 		},
@@ -177,7 +177,8 @@ func TestParseRequirementRejectsMissingRequiredFields(t *testing.T) {
 		data string
 	}{
 		{name: "table uuid", data: `{"type":"assert-table-uuid"}`},
-		{name: "ref", data: `{"type":"assert-ref-snapshot-id"}`},
+		{name: "missing ref", data: `{"type":"assert-ref-snapshot-id"}`},
+		{name: "missing snapshot id", data: `{"type":"assert-ref-snapshot-id","ref":"main"}`},
 		{name: "default spec id", data: `{"type":"assert-default-spec-id"}`},
 		{name: "current schema id", data: `{"type":"assert-current-schema-id"}`},
 		{name: "default sort order id", data: `{"type":"assert-default-sort-order-id"}`},
@@ -208,6 +209,12 @@ func TestParseRequirementRefRequiresRefButAllowsNullSnapshotID(t *testing.T) {
 	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null}`))
 	require.NoError(t, err)
 	assert.Equal(t, table.AssertRefSnapshotID("main", nil), actual)
+}
+
+func TestParseRequirementRefAcceptsNumericSnapshotID(t *testing.T) {
+	actual, err := table.ParseRequirementBytes([]byte(`{"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":42}`))
+	require.NoError(t, err)
+	assert.Equal(t, table.AssertRefSnapshotID("main", ptr(int64(42))), actual)
 }
 
 func TestAssertRefSnapshotIDValidate(t *testing.T) {

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -19,6 +19,7 @@ package table_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/apache/iceberg-go/table"
@@ -94,7 +95,7 @@ func TestParseRequirementBytes(t *testing.T) {
 			actual, err := table.ParseRequirementBytes(tc.data)
 			assert.Equal(t, tc.expected, actual)
 			if tc.expectedErr != nil {
-				require.ErrorIs(t, err, tc.expectedErr)
+				require.Equal(t, tc.expectedErr, err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -202,14 +203,16 @@ func TestParseRequirementRejectsMissingRequiredFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expectedError := fmt.Sprintf("missing required field %q", tt.expectedField)
+
 			_, err := table.ParseRequirementBytes([]byte(tt.data))
 			require.ErrorIs(t, err, table.ErrInvalidRequirement)
-			require.ErrorContains(t, err, tt.expectedField)
+			require.ErrorContains(t, err, expectedError)
 
 			var requirements table.Requirements
 			err = json.Unmarshal([]byte("["+tt.data+"]"), &requirements)
 			require.ErrorIs(t, err, table.ErrInvalidRequirement)
-			require.ErrorContains(t, err, tt.expectedField)
+			require.ErrorContains(t, err, expectedError)
 		})
 	}
 }

--- a/table/requirement_test.go
+++ b/table/requirement_test.go
@@ -186,6 +186,7 @@ func TestParseRequirementRejectsMissingRequiredFields(t *testing.T) {
 		{name: "table uuid", data: `{"type":"assert-table-uuid"}`, expectedField: "uuid"},
 		{name: "null table uuid", data: `{"type":"assert-table-uuid","uuid":null}`, expectedField: "uuid"},
 		{name: "missing ref", data: `{"type":"assert-ref-snapshot-id"}`, expectedField: "ref"},
+		{name: "null ref", data: `{"type":"assert-ref-snapshot-id","ref":null}`, expectedField: "ref"},
 		{name: "missing snapshot id", data: `{"type":"assert-ref-snapshot-id","ref":"main"}`, expectedField: "snapshot-id"},
 		{name: "default spec id", data: `{"type":"assert-default-spec-id"}`, expectedField: "default-spec-id"},
 		{name: "null default spec id", data: `{"type":"assert-default-spec-id","default-spec-id":null}`, expectedField: "default-spec-id"},

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -89,9 +90,29 @@ type assertTableUUIDWire struct {
 	UUID *uuid.UUID `json:"uuid"`
 }
 
+type nullableInt64 struct {
+	Set   bool
+	Value *int64
+}
+
+func (n *nullableInt64) UnmarshalJSON(data []byte) error {
+	n.Set = true
+	n.Value = nil
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil
+	}
+
+	var value int64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	n.Value = &value
+	return nil
+}
+
 type assertRefSnapshotIDWire struct {
-	Ref        *string `json:"ref"`
-	SnapshotID *int64  `json:"snapshot-id"`
+	Ref        *string       `json:"ref"`
+	SnapshotID nullableInt64 `json:"snapshot-id"`
 }
 
 func requiredRequirementField(name string) error {
@@ -130,8 +151,11 @@ func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, e
 		if req.Ref == nil {
 			return nil, requiredRequirementField("ref")
 		}
+		if !req.SnapshotID.Set {
+			return nil, requiredRequirementField("snapshot-id")
+		}
 
-		return AssertRefSnapshotID(*req.Ref, req.SnapshotID), nil
+		return AssertRefSnapshotID(*req.Ref, req.SnapshotID.Value), nil
 
 	case reqAssertDefaultSpecID:
 		var req struct {

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -107,6 +107,7 @@ func (n *nullableInt64) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	n.Value = &value
+
 	return nil
 }
 

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -18,12 +18,12 @@
 package table
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
+	"github.com/apache/iceberg-go/internal"
 	"github.com/google/uuid"
 )
 
@@ -82,23 +82,19 @@ type baseRequirement struct {
 	Type string `json:"type"`
 }
 
-type requirementWire struct {
-	Type *string `json:"type"`
-}
-
 type assertTableUUIDWire struct {
 	UUID *uuid.UUID `json:"uuid"`
 }
 
 type nullableInt64 struct {
-	Set   bool
-	Value *int64
+	set   bool
+	value *int64
 }
 
 func (n *nullableInt64) UnmarshalJSON(data []byte) error {
-	n.Set = true
-	n.Value = nil
-	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+	n.set = true
+	n.value = nil
+	if string(data) == "null" {
 		return nil
 	}
 
@@ -106,7 +102,7 @@ func (n *nullableInt64) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	n.Value = &value
+	n.value = &value
 
 	return nil
 }
@@ -117,11 +113,11 @@ type assertRefSnapshotIDWire struct {
 }
 
 func requiredRequirementField(name string) error {
-	return fmt.Errorf("%w: missing required field %q", ErrInvalidRequirement, name)
+	return internal.MissingRequiredField(ErrInvalidRequirement, name)
 }
 
 func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, error) {
-	var base requirementWire
+	var base internal.RequirementWire
 	if err := json.Unmarshal(b, &base); err != nil {
 		return nil, err
 	}
@@ -152,11 +148,11 @@ func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, e
 		if req.Ref == nil {
 			return nil, requiredRequirementField("ref")
 		}
-		if !req.SnapshotID.Set {
+		if !req.SnapshotID.set {
 			return nil, requiredRequirementField("snapshot-id")
 		}
 
-		return AssertRefSnapshotID(*req.Ref, req.SnapshotID.Value), nil
+		return AssertRefSnapshotID(*req.Ref, req.SnapshotID.value), nil
 
 	case reqAssertDefaultSpecID:
 		var req struct {

--- a/table/requirements.go
+++ b/table/requirements.go
@@ -61,34 +61,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		requirements = make(Requirements, 0, len(rawRequirements))
 	}
 	for _, raw := range rawRequirements {
-		var base baseRequirement
-		if err := json.Unmarshal(raw, &base); err != nil {
-			return err
-		}
-
-		var req Requirement
-		switch base.Type {
-		case reqAssertCreate:
-			req = &assertCreate{}
-		case reqAssertTableUUID:
-			req = &assertTableUuid{}
-		case reqAssertRefSnapshotID:
-			req = &assertRefSnapshotID{}
-		case reqAssertDefaultSpecID:
-			req = &assertDefaultSpecId{}
-		case reqAssertCurrentSchemaID:
-			req = &assertCurrentSchemaId{}
-		case reqAssertDefaultSortOrderID:
-			req = &assertDefaultSortOrderId{}
-		case reqAssertLastAssignedFieldID:
-			req = &assertLastAssignedFieldId{}
-		case reqAssertLastAssignedPartitionID:
-			req = &assertLastAssignedPartitionId{}
-		default:
-			return fmt.Errorf("unknown requirement type: %s", base.Type)
-		}
-
-		if err := json.Unmarshal(raw, req); err != nil {
+		req, err := parseRequirementBytes(raw, func(reqType string) error {
+			return fmt.Errorf("unknown requirement type: %s", reqType)
+		})
+		if err != nil {
 			return err
 		}
 		requirements = append(requirements, req)
@@ -103,6 +79,127 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 // identify the type of the requirement.
 type baseRequirement struct {
 	Type string `json:"type"`
+}
+
+type requirementWire struct {
+	Type *string `json:"type"`
+}
+
+type assertTableUUIDWire struct {
+	UUID *uuid.UUID `json:"uuid"`
+}
+
+type assertRefSnapshotIDWire struct {
+	Ref        *string `json:"ref"`
+	SnapshotID *int64  `json:"snapshot-id"`
+}
+
+func requiredRequirementField(name string) error {
+	return fmt.Errorf("%w: missing required field %q", ErrInvalidRequirement, name)
+}
+
+func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, error) {
+	var base requirementWire
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
+	}
+	if base.Type == nil {
+		return nil, requiredRequirementField("type")
+	}
+
+	switch *base.Type {
+	case reqAssertCreate:
+		return AssertCreate(), nil
+
+	case reqAssertTableUUID:
+		var req assertTableUUIDWire
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.UUID == nil {
+			return nil, requiredRequirementField("uuid")
+		}
+
+		return AssertTableUUID(*req.UUID), nil
+
+	case reqAssertRefSnapshotID:
+		var req assertRefSnapshotIDWire
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.Ref == nil {
+			return nil, requiredRequirementField("ref")
+		}
+
+		return AssertRefSnapshotID(*req.Ref, req.SnapshotID), nil
+
+	case reqAssertDefaultSpecID:
+		var req struct {
+			DefaultSpecID *int `json:"default-spec-id"`
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.DefaultSpecID == nil {
+			return nil, requiredRequirementField("default-spec-id")
+		}
+
+		return AssertDefaultSpecID(*req.DefaultSpecID), nil
+
+	case reqAssertCurrentSchemaID:
+		var req struct {
+			CurrentSchemaID *int `json:"current-schema-id"`
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.CurrentSchemaID == nil {
+			return nil, requiredRequirementField("current-schema-id")
+		}
+
+		return AssertCurrentSchemaID(*req.CurrentSchemaID), nil
+
+	case reqAssertDefaultSortOrderID:
+		var req struct {
+			DefaultSortOrderID *int `json:"default-sort-order-id"`
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.DefaultSortOrderID == nil {
+			return nil, requiredRequirementField("default-sort-order-id")
+		}
+
+		return AssertDefaultSortOrderID(*req.DefaultSortOrderID), nil
+
+	case reqAssertLastAssignedFieldID:
+		var req struct {
+			LastAssignedFieldID *int `json:"last-assigned-field-id"`
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.LastAssignedFieldID == nil {
+			return nil, requiredRequirementField("last-assigned-field-id")
+		}
+
+		return AssertLastAssignedFieldID(*req.LastAssignedFieldID), nil
+
+	case reqAssertLastAssignedPartitionID:
+		var req struct {
+			LastAssignedPartitionID *int `json:"last-assigned-partition-id"`
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.LastAssignedPartitionID == nil {
+			return nil, requiredRequirementField("last-assigned-partition-id")
+		}
+
+		return AssertLastAssignedPartitionID(*req.LastAssignedPartitionID), nil
+	}
+
+	return nil, unknown(*base.Type)
 }
 
 func (b baseRequirement) GetType() string {
@@ -365,71 +462,5 @@ func ParseRequirementString(s string) (Requirement, error) {
 
 // ParseRequirementBytes parses json bytes into a Requirement
 func ParseRequirementBytes(b []byte) (Requirement, error) {
-	var base baseRequirement
-	if err := json.Unmarshal(b, &base); err != nil {
-		return nil, err
-	}
-
-	switch base.Type {
-	case reqAssertCreate:
-		return AssertCreate(), nil
-
-	case reqAssertTableUUID:
-		var req assertTableUuid
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertTableUUID(req.UUID), nil
-
-	case reqAssertRefSnapshotID:
-		var req assertRefSnapshotID
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertRefSnapshotID(req.Ref, req.SnapshotID), nil
-
-	case reqAssertDefaultSpecID:
-		var req assertDefaultSpecId
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertDefaultSpecID(req.DefaultSpecID), nil
-
-	case reqAssertCurrentSchemaID:
-		var req assertCurrentSchemaId
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertCurrentSchemaID(req.CurrentSchemaID), nil
-
-	case reqAssertDefaultSortOrderID:
-		var req assertDefaultSortOrderId
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertDefaultSortOrderID(req.DefaultSortOrderID), nil
-
-	case reqAssertLastAssignedFieldID:
-		var req assertLastAssignedFieldId
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertLastAssignedFieldID(req.LastAssignedFieldID), nil
-
-	case reqAssertLastAssignedPartitionID:
-		var req assertLastAssignedPartitionId
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertLastAssignedPartitionID(req.LastAssignedPartitionID), nil
-	}
-
-	return nil, ErrInvalidRequirement
+	return parseRequirementBytes(b, func(string) error { return ErrInvalidRequirement })
 }

--- a/view/requirements.go
+++ b/view/requirements.go
@@ -42,19 +42,6 @@ type Requirement interface {
 
 type Requirements []Requirement
 
-// requirementForType returns an instance of a requirement corresponding to a given type.
-func requirementForType(reqType string) (Requirement, error) {
-	var req Requirement
-	switch reqType {
-	case reqAssertViewUUID:
-		req = &assertViewUuid{}
-	default:
-		return nil, fmt.Errorf("unknown requirement type: %s", reqType)
-	}
-
-	return req, nil
-}
-
 func (r *Requirements) UnmarshalJSON(data []byte) error {
 	var rawRequirements []json.RawMessage
 	if err := json.Unmarshal(data, &rawRequirements); err != nil {
@@ -66,17 +53,10 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 		requirements = make(Requirements, 0, len(rawRequirements))
 	}
 	for _, raw := range rawRequirements {
-		var base baseRequirement
-		if err := json.Unmarshal(raw, &base); err != nil {
-			return err
-		}
-
-		req, err := requirementForType(base.Type)
+		req, err := parseRequirementBytes(raw, func(reqType string) error {
+			return fmt.Errorf("unknown requirement type: %s", reqType)
+		})
 		if err != nil {
-			return err
-		}
-
-		if err := json.Unmarshal(raw, req); err != nil {
 			return err
 		}
 		requirements = append(requirements, req)
@@ -91,6 +71,43 @@ func (r *Requirements) UnmarshalJSON(data []byte) error {
 // identify the type of the requirement.
 type baseRequirement struct {
 	Type string `json:"type"`
+}
+
+type requirementWire struct {
+	Type *string `json:"type"`
+}
+
+type assertViewUUIDWire struct {
+	UUID *uuid.UUID `json:"uuid"`
+}
+
+func requiredRequirementField(name string) error {
+	return fmt.Errorf("%w: missing required field %q", table.ErrInvalidRequirement, name)
+}
+
+func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, error) {
+	var base requirementWire
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
+	}
+	if base.Type == nil {
+		return nil, requiredRequirementField("type")
+	}
+
+	switch *base.Type {
+	case reqAssertViewUUID:
+		var req assertViewUUIDWire
+		if err := json.Unmarshal(b, &req); err != nil {
+			return nil, err
+		}
+		if req.UUID == nil {
+			return nil, requiredRequirementField("uuid")
+		}
+
+		return AssertViewUUID(*req.UUID), nil
+	default:
+		return nil, unknown(*base.Type)
+	}
 }
 
 func (b baseRequirement) GetType() string {
@@ -139,20 +156,5 @@ func ParseRequirementString(s string) (Requirement, error) {
 
 // ParseRequirementBytes parses json bytes into a Requirement
 func ParseRequirementBytes(b []byte) (Requirement, error) {
-	var base baseRequirement
-	if err := json.Unmarshal(b, &base); err != nil {
-		return nil, err
-	}
-
-	switch base.Type {
-	case reqAssertViewUUID:
-		var req assertViewUuid
-		if err := json.Unmarshal(b, &req); err != nil {
-			return nil, err
-		}
-
-		return AssertViewUUID(req.UUID), nil
-	}
-
-	return nil, table.ErrInvalidRequirement
+	return parseRequirementBytes(b, func(string) error { return table.ErrInvalidRequirement })
 }

--- a/view/requirements.go
+++ b/view/requirements.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/apache/iceberg-go/internal"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
 )
@@ -73,20 +74,16 @@ type baseRequirement struct {
 	Type string `json:"type"`
 }
 
-type requirementWire struct {
-	Type *string `json:"type"`
-}
-
 type assertViewUUIDWire struct {
 	UUID *uuid.UUID `json:"uuid"`
 }
 
 func requiredRequirementField(name string) error {
-	return fmt.Errorf("%w: missing required field %q", table.ErrInvalidRequirement, name)
+	return internal.MissingRequiredField(table.ErrInvalidRequirement, name)
 }
 
 func parseRequirementBytes(b []byte, unknown func(string) error) (Requirement, error) {
-	var base requirementWire
+	var base internal.RequirementWire
 	if err := json.Unmarshal(b, &base); err != nil {
 		return nil, err
 	}

--- a/view/requirements_test.go
+++ b/view/requirements_test.go
@@ -103,14 +103,16 @@ func TestParseRequirementRejectsMissingUUID(t *testing.T) {
 		`{"type":"assert-view-uuid"}`,
 		`{"type":"assert-view-uuid","uuid":null}`,
 	} {
-		_, err := view.ParseRequirementBytes([]byte(data))
-		require.ErrorIs(t, err, table.ErrInvalidRequirement)
-		require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
+		t.Run(data, func(t *testing.T) {
+			_, err := view.ParseRequirementBytes([]byte(data))
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
 
-		var requirements view.Requirements
-		err = json.Unmarshal([]byte("["+data+"]"), &requirements)
-		require.ErrorIs(t, err, table.ErrInvalidRequirement)
-		require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
+			var requirements view.Requirements
+			err = json.Unmarshal([]byte("["+data+"]"), &requirements)
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
+		})
 	}
 }
 

--- a/view/requirements_test.go
+++ b/view/requirements_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/apache/iceberg-go/table"
 	"github.com/apache/iceberg-go/view"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -102,9 +103,27 @@ func TestParseRequirementRejectsMissingUUID(t *testing.T) {
 		`{"type":"assert-view-uuid","uuid":null}`,
 	} {
 		_, err := view.ParseRequirementBytes([]byte(data))
-		require.Error(t, err)
+		require.ErrorIs(t, err, table.ErrInvalidRequirement)
+		require.ErrorContains(t, err, "uuid")
 
 		var requirements view.Requirements
-		require.Error(t, json.Unmarshal([]byte("["+data+"]"), &requirements))
+		err = json.Unmarshal([]byte("["+data+"]"), &requirements)
+		require.ErrorIs(t, err, table.ErrInvalidRequirement)
+		require.ErrorContains(t, err, "uuid")
+	}
+}
+
+func TestParseRequirementRejectsMissingOrNullType(t *testing.T) {
+	for _, data := range []string{`{}`, `{"type":null}`} {
+		t.Run(data, func(t *testing.T) {
+			_, err := view.ParseRequirementBytes([]byte(data))
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, "type")
+
+			var requirements view.Requirements
+			err = json.Unmarshal([]byte("["+data+"]"), &requirements)
+			require.ErrorIs(t, err, table.ErrInvalidRequirement)
+			require.ErrorContains(t, err, "type")
+		})
 	}
 }

--- a/view/requirements_test.go
+++ b/view/requirements_test.go
@@ -19,6 +19,7 @@ package view_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/apache/iceberg-go/table"
@@ -104,26 +105,28 @@ func TestParseRequirementRejectsMissingUUID(t *testing.T) {
 	} {
 		_, err := view.ParseRequirementBytes([]byte(data))
 		require.ErrorIs(t, err, table.ErrInvalidRequirement)
-		require.ErrorContains(t, err, "uuid")
+		require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
 
 		var requirements view.Requirements
 		err = json.Unmarshal([]byte("["+data+"]"), &requirements)
 		require.ErrorIs(t, err, table.ErrInvalidRequirement)
-		require.ErrorContains(t, err, "uuid")
+		require.ErrorContains(t, err, fmt.Sprintf("missing required field %q", "uuid"))
 	}
 }
 
 func TestParseRequirementRejectsMissingOrNullType(t *testing.T) {
 	for _, data := range []string{`{}`, `{"type":null}`} {
 		t.Run(data, func(t *testing.T) {
+			expectedError := fmt.Sprintf("missing required field %q", "type")
+
 			_, err := view.ParseRequirementBytes([]byte(data))
 			require.ErrorIs(t, err, table.ErrInvalidRequirement)
-			require.ErrorContains(t, err, "type")
+			require.ErrorContains(t, err, expectedError)
 
 			var requirements view.Requirements
 			err = json.Unmarshal([]byte("["+data+"]"), &requirements)
 			require.ErrorIs(t, err, table.ErrInvalidRequirement)
-			require.ErrorContains(t, err, "type")
+			require.ErrorContains(t, err, expectedError)
 		})
 	}
 }

--- a/view/requirements_test.go
+++ b/view/requirements_test.go
@@ -95,3 +95,16 @@ func TestParseRequirementListReplacesExistingSlice(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`[]`), &requirements))
 	assert.Empty(t, requirements)
 }
+
+func TestParseRequirementRejectsMissingUUID(t *testing.T) {
+	for _, data := range []string{
+		`{"type":"assert-view-uuid"}`,
+		`{"type":"assert-view-uuid","uuid":null}`,
+	} {
+		_, err := view.ParseRequirementBytes([]byte(data))
+		require.Error(t, err)
+
+		var requirements view.Requirements
+		require.Error(t, json.Unmarshal([]byte("["+data+"]"), &requirements))
+	}
+}


### PR DESCRIPTION
## Summary

Require required JSON fields when decoding table and view requirements.

## Why

The decoders used ordinary Go value fields, so omitted fields became zero values. A malformed requirement could pass when zero was a valid current ID.

## What changed

Required fields are now checked while explicit zero values remain valid. A nullable snapshot ID is still accepted for assert-ref-snapshot-id. Both JSON entry points use the same strict parsing path.

## Tests

- go test ./table ./view -count=1