### PR TITLE
fix(table): use data file metrics in conflict checks

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -367,7 +367,7 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 //     straddles the filter only triggers a conflict when at least
 //     one actual added file's partition value satisfies the filter.
 //  3. The surviving files are evaluated against their column metrics so
-//     unpartitioned files whose bounds cannot match the filter are ignored.
+//     files whose bounds cannot match the filter are ignored.
 func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.BooleanExpression) error {
 	if len(ctx.concurrent) == 0 {
 		return nil
@@ -392,6 +392,10 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 	partitionEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
 		return buildPartitionEvaluator(specID, ctx.current, ctx.current.CurrentSchema(), partitionFilters, ctx.caseSensitive)
 	})
+	// Eval copies each file's metrics into fresh evaluator state, so this
+	// evaluator can be reused across concurrent manifests.
+	// includeEmptyFiles=false is intentional: an empty file has no rows that
+	// can match the filter and must not create a conflict.
 	metricsEval, err := newInclusiveMetricsEvaluator(ctx.current.CurrentSchema(), filter, ctx.caseSensitive, false)
 	if err != nil {
 		return fmt.Errorf("failed to build metrics evaluator: %w", err)

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -358,7 +358,7 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 // predicate call this so that a concurrent append into the same
 // partition is rejected before the commit overwrites it.
 //
-// The check runs in two layers:
+// The check runs in three layers:
 //  1. A manifest-level partition-summary evaluator prunes manifests
 //     whose summaries cannot overlap the filter.
 //  2. Inside surviving manifests, every ADDED entry attributed to the
@@ -366,10 +366,8 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 //     evaluator on its partition tuple, so a manifest whose summary
 //     straddles the filter only triggers a conflict when at least
 //     one actual added file's partition value satisfies the filter.
-//
-// Per-file metric evaluation (a third pass in Java that refines
-// beyond partition for columns not in the spec) is TODO and tracked
-// under issue #830 follow-ups.
+//  3. The surviving files are evaluated against their column metrics so
+//     unpartitioned files whose bounds cannot match the filter are ignored.
 func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.BooleanExpression) error {
 	if len(ctx.concurrent) == 0 {
 		return nil
@@ -394,6 +392,10 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 	partitionEvals := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
 		return buildPartitionEvaluator(specID, ctx.current, ctx.current.CurrentSchema(), partitionFilters, ctx.caseSensitive)
 	})
+	metricsEval, err := newInclusiveMetricsEvaluator(ctx.current.CurrentSchema(), filter, ctx.caseSensitive, false)
+	if err != nil {
+		return fmt.Errorf("failed to build metrics evaluator: %w", err)
+	}
 
 	for _, snap := range ctx.concurrent {
 		manifests, err := snap.Manifests(ctx.fs)
@@ -431,6 +433,13 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 				matches, err := pEval(e.DataFile())
 				if err != nil {
 					return err
+				}
+				if !matches {
+					continue
+				}
+				matches, err = metricsEval(e.DataFile())
+				if err != nil {
+					return fmt.Errorf("evaluating metrics for data file %s: %w", e.DataFile().FilePath(), err)
 				}
 				if !matches {
 					continue

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -766,23 +766,60 @@ func TestValidateAddedDataFilesMatchingFilterUsesFileMetrics(t *testing.T) {
 	}
 }
 
+func TestValidateAddedDataFilesMatchingFilterWithMissingBounds(t *testing.T) {
+	dir := t.TempDir()
+	baseID := int64(1)
+	concID := int64(2)
+	base := newConflictTestMetadata(t, &baseID)
+	mf := writeTestMetricsManifestWithoutBounds(t, dir, base.CurrentSchema(), concID)
+	listPath := writeTestManifestList(t, dir, concID, []iceberg.ManifestFile{mf})
+	ctx := buildPartitionedContext(t, base, listPath, baseID, concID)
+
+	err := validateAddedDataFilesMatchingFilter(ctx,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(5)))
+	require.ErrorIs(t, err, ErrConflictingDataFiles,
+		"missing bounds must not make a data file look non-conflicting")
+}
+
 func writeTestMetricsManifest(t *testing.T, dir string, schema *iceberg.Schema, snapshotID, lower, upper int64) iceberg.ManifestFile {
 	t.Helper()
-	spec := *iceberg.UnpartitionedSpec
 	lowerBytes, err := iceberg.Int64Literal(lower).MarshalBinary()
 	require.NoError(t, err)
 	upperBytes, err := iceberg.Int64Literal(upper).MarshalBinary()
 	require.NoError(t, err)
+
+	return writeTestMetricsManifestWithValues(t, dir, schema, snapshotID,
+		map[int][]byte{1: lowerBytes}, map[int][]byte{1: upperBytes})
+}
+
+func writeTestMetricsManifestWithoutBounds(t *testing.T, dir string, schema *iceberg.Schema, snapshotID int64) iceberg.ManifestFile {
+	t.Helper()
+
+	return writeTestMetricsManifestWithValues(t, dir, schema, snapshotID, nil, nil)
+}
+
+func writeTestMetricsManifestWithValues(
+	t *testing.T,
+	dir string,
+	schema *iceberg.Schema,
+	snapshotID int64,
+	lowerBounds, upperBounds map[int][]byte,
+) iceberg.ManifestFile {
+	t.Helper()
+	spec := *iceberg.UnpartitionedSpec
 
 	builder, err := iceberg.NewDataFileBuilder(
 		spec, iceberg.EntryContentData, filepath.Join(dir, "data.parquet"), iceberg.ParquetFile,
 		nil, nil, nil, 10, 1024,
 	)
 	require.NoError(t, err)
-	df := builder.
-		LowerBoundValues(map[int][]byte{1: lowerBytes}).
-		UpperBoundValues(map[int][]byte{1: upperBytes}).
-		Build()
+	if lowerBounds != nil {
+		builder = builder.LowerBoundValues(lowerBounds)
+	}
+	if upperBounds != nil {
+		builder = builder.UpperBoundValues(upperBounds)
+	}
+	df := builder.Build()
 	entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID, df).
 		SequenceNum(1).
 		Build()

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -734,6 +734,73 @@ func TestValidateAddedDataFilesMatchingFilter_NoConcurrent(t *testing.T) {
 	require.NoError(t, validateAddedDataFilesMatchingFilter(ctx, nil))
 }
 
+func TestValidateAddedDataFilesMatchingFilterUsesFileMetrics(t *testing.T) {
+	tests := []struct {
+		name         string
+		lower, upper int64
+		wantConflict bool
+	}{
+		{name: "bounds cannot match", lower: 100, upper: 200, wantConflict: false},
+		{name: "bounds may match", lower: 1, upper: 10, wantConflict: true},
+		{name: "exact bound matches", lower: 5, upper: 5, wantConflict: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			baseID := int64(1)
+			concID := int64(2)
+			base := newConflictTestMetadata(t, &baseID)
+			mf := writeTestMetricsManifest(t, dir, base.CurrentSchema(), concID, tt.lower, tt.upper)
+			listPath := writeTestManifestList(t, dir, concID, []iceberg.ManifestFile{mf})
+			ctx := buildPartitionedContext(t, base, listPath, baseID, concID)
+
+			err := validateAddedDataFilesMatchingFilter(ctx,
+				iceberg.EqualTo(iceberg.Reference("id"), int64(5)))
+			if tt.wantConflict {
+				require.ErrorIs(t, err, ErrConflictingDataFiles)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func writeTestMetricsManifest(t *testing.T, dir string, schema *iceberg.Schema, snapshotID, lower, upper int64) iceberg.ManifestFile {
+	t.Helper()
+	spec := *iceberg.UnpartitionedSpec
+	lowerBytes, err := iceberg.Int64Literal(lower).MarshalBinary()
+	require.NoError(t, err)
+	upperBytes, err := iceberg.Int64Literal(upper).MarshalBinary()
+	require.NoError(t, err)
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentData, filepath.Join(dir, "data.parquet"), iceberg.ParquetFile,
+		nil, nil, nil, 10, 1024,
+	)
+	require.NoError(t, err)
+	df := builder.
+		LowerBoundValues(map[int][]byte{1: lowerBytes}).
+		UpperBoundValues(map[int][]byte{1: upperBytes}).
+		Build()
+	entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID, df).
+		SequenceNum(1).
+		Build()
+
+	manifestPath := filepath.Join(dir, "metrics-manifest.avro")
+	var buf bytes.Buffer
+	mf, err := iceberg.WriteManifest(manifestPath, &buf, 2, spec, schema, snapshotID, []iceberg.ManifestEntry{entry})
+	require.NoError(t, err)
+	fs := iceio.LocalFS{}
+	out, err := fs.Create(manifestPath)
+	require.NoError(t, err)
+	_, err = out.Write(buf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	return mf
+}
+
 func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
 	// Under snapshot isolation the validator is a no-op — it must not
 	// even attempt to enumerate concurrent snapshots.


### PR DESCRIPTION
## Summary

Use data file metrics to refine concurrent overwrite conflict checks.

## Why

Conflict validation already pruned manifest and partition data, but it did not use file-level bounds.

## What changed

For an unpartitioned table, a concurrent file whose bounds cannot match the overwrite filter is ignored. Missing or uncertain metrics remain conservative and still report a possible conflict.

## Tests

- go test ./table -count=1