### PR TITLE
fix(table): validate numeric Parquet writer properties

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -388,6 +388,13 @@ func ValidateParquetWriteProperties(props iceberg.Properties) error {
 		}
 	}
 
+	if value, ok := props[ParquetCompressionLevelKey]; ok {
+		if _, err := strconv.Atoi(value); err != nil {
+			return fmt.Errorf("%w: invalid %s value %q: %v", iceberg.ErrInvalidArgument,
+				ParquetCompressionLevelKey, value, err)
+		}
+	}
+
 	return nil
 }
 

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -73,6 +73,15 @@ const (
 	parquetBloomFilterMaxBytesMax            = 128 * 1024 * 1024
 	ParquetBloomFilterColumnEnabledKeyPrefix = "write.parquet.bloom-filter-enabled.column"
 
+	// These bounds mirror the compression libraries used by Arrow's Parquet
+	// writers. -1 is the shared default level and is included in each range.
+	parquetGzipCompressionLevelMin   = -3
+	parquetGzipCompressionLevelMax   = 9
+	parquetZstdCompressionLevelMin   = -5
+	parquetZstdCompressionLevelMax   = 22
+	parquetBrotliCompressionLevelMin = 0
+	parquetBrotliCompressionLevelMax = 11
+
 	// Deliberately not namespaced under write.parquet: this is the parquet-mr key
 	// Iceberg Java reads straight from the table properties, so a table carrying
 	// it gets the same dictionary behavior from either implementation.
@@ -358,6 +367,9 @@ func javaBool(val string) bool {
 }
 
 func ValidateParquetWriteProperties(props iceberg.Properties) error {
+	// A missing property uses the writer default, but an explicitly configured
+	// empty value is invalid. This keeps validation from silently accepting a
+	// value that GetInt would otherwise replace with its default.
 	for _, key := range []string{
 		ParquetRowGroupSizeBytesKey,
 		ParquetRowGroupLimitKey,
@@ -383,16 +395,54 @@ func ValidateParquetWriteProperties(props iceberg.Properties) error {
 			return fmt.Errorf("%w: %s must be between %d and %d bytes, got %d",
 				iceberg.ErrInvalidArgument, key, parquetBloomFilterMaxBytesMin, parquetBloomFilterMaxBytesMax, parsed)
 		}
-		if strconv.IntSize == 32 && parsed > int64(^uint(0)>>1) {
+		// Row-group size is kept as int64 all the way through the writer. The
+		// other values are passed to Arrow APIs that take int and therefore
+		// must fit the platform's int range.
+		if key != ParquetRowGroupSizeBytesKey && strconv.IntSize == 32 && parsed > int64(^uint(0)>>1) {
 			return fmt.Errorf("%w: %s value %d exceeds int range", iceberg.ErrInvalidArgument, key, parsed)
 		}
 	}
 
 	if value, ok := props[ParquetCompressionLevelKey]; ok {
-		if _, err := strconv.Atoi(value); err != nil {
+		level, err := strconv.Atoi(value)
+		if err != nil {
 			return fmt.Errorf("%w: invalid %s value %q: %v", iceberg.ErrInvalidArgument,
 				ParquetCompressionLevelKey, value, err)
 		}
+
+		compression := props.Get(ParquetCompressionKey, ParquetCompressionDefault)
+		if err := validateParquetCompressionLevel(compression, level); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateParquetCompressionLevel(compression string, level int) error {
+	min, max := 0, 0
+	switch compression {
+	case "gzip":
+		min, max = parquetGzipCompressionLevelMin, parquetGzipCompressionLevelMax
+	case "zstd":
+		min, max = parquetZstdCompressionLevelMin, parquetZstdCompressionLevelMax
+	case "brotli":
+		// Brotli uses -1 as the Iceberg default even though its underlying
+		// library accepts explicit qualities only in the 0..11 range.
+		if level == ParquetCompressionLevelDefault {
+			return nil
+		}
+		min, max = parquetBrotliCompressionLevelMin, parquetBrotliCompressionLevelMax
+	default:
+		// The remaining codecs do not expose a tunable level in Arrow's
+		// streaming writers, so the value is ignored after it is parsed.
+		return nil
+	}
+
+	if level < min || level > max {
+		return fmt.Errorf("%w: invalid %s value %d for %s; supported range is %d..%d (or %d for the default)",
+			iceberg.ErrInvalidArgument, ParquetCompressionLevelKey, level, compression, min, max,
+			ParquetCompressionLevelDefault)
 	}
 
 	return nil

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -354,6 +354,35 @@ func javaBool(val string) bool {
 	return strings.EqualFold(val, "true")
 }
 
+func ValidateParquetWriteProperties(props iceberg.Properties) error {
+	for _, key := range []string{
+		ParquetRowGroupSizeBytesKey,
+		ParquetRowGroupLimitKey,
+		ParquetPageSizeBytesKey,
+		ParquetPageRowLimitKey,
+		ParquetDictSizeBytesKey,
+		ParquetBloomFilterMaxBytesKey,
+	} {
+		value, ok := props[key]
+		if !ok {
+			continue
+		}
+
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("%w: invalid %s value %q: %v", iceberg.ErrInvalidArgument, key, value, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("%w: %s must be greater than 0, got %d", iceberg.ErrInvalidArgument, key, parsed)
+		}
+		if strconv.IntSize == 32 && parsed > int64(^uint(0)>>1) {
+			return fmt.Errorf("%w: %s value %d exceeds int range", iceberg.ErrInvalidArgument, key, parsed)
+		}
+	}
+
+	return nil
+}
+
 // ParquetRowGroupTargetSizeBytes returns the configured uncompressed row-group
 // size target. Iceberg Java rejects invalid and non-positive values rather than
 // silently falling back to the default.

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -50,24 +50,27 @@ import (
 )
 
 const (
-	ParquetRowGroupSizeBytesKey              = "write.parquet.row-group-size-bytes"
-	ParquetRowGroupSizeBytesDefault          = 128 * 1024 * 1024 // 128 MB
-	ParquetRowGroupLimitKey                  = "write.parquet.row-group-limit"
-	ParquetRowGroupLimitDefault              = 1048576
-	ParquetPageSizeBytesKey                  = "write.parquet.page-size-bytes"
-	ParquetPageSizeBytesDefault              = 1024 * 1024 // 1 MB
-	ParquetPageRowLimitKey                   = "write.parquet.page-row-limit"
-	ParquetPageRowLimitDefault               = 20000
-	ParquetDictSizeBytesKey                  = "write.parquet.dict-size-bytes"
-	ParquetDictSizeBytesDefault              = 2 * 1024 * 1024 // 2 MB
-	ParquetPageVersionKey                    = "write.parquet.page-version"
-	ParquetPageVersionDefault                = "2"
-	ParquetCompressionKey                    = "write.parquet.compression-codec"
-	ParquetCompressionDefault                = "zstd"
-	ParquetCompressionLevelKey               = "write.parquet.compression-level"
-	ParquetCompressionLevelDefault           = -1
-	ParquetBloomFilterMaxBytesKey            = "write.parquet.bloom-filter-max-bytes"
-	ParquetBloomFilterMaxBytesDefault        = 1024 * 1024
+	ParquetRowGroupSizeBytesKey       = "write.parquet.row-group-size-bytes"
+	ParquetRowGroupSizeBytesDefault   = 128 * 1024 * 1024 // 128 MB
+	ParquetRowGroupLimitKey           = "write.parquet.row-group-limit"
+	ParquetRowGroupLimitDefault       = 1048576
+	ParquetPageSizeBytesKey           = "write.parquet.page-size-bytes"
+	ParquetPageSizeBytesDefault       = 1024 * 1024 // 1 MB
+	ParquetPageRowLimitKey            = "write.parquet.page-row-limit"
+	ParquetPageRowLimitDefault        = 20000
+	ParquetDictSizeBytesKey           = "write.parquet.dict-size-bytes"
+	ParquetDictSizeBytesDefault       = 2 * 1024 * 1024 // 2 MB
+	ParquetPageVersionKey             = "write.parquet.page-version"
+	ParquetPageVersionDefault         = "2"
+	ParquetCompressionKey             = "write.parquet.compression-codec"
+	ParquetCompressionDefault         = "zstd"
+	ParquetCompressionLevelKey        = "write.parquet.compression-level"
+	ParquetCompressionLevelDefault    = -1
+	ParquetBloomFilterMaxBytesKey     = "write.parquet.bloom-filter-max-bytes"
+	ParquetBloomFilterMaxBytesDefault = 1024 * 1024
+	// These bounds mirror Arrow's public bloom-filter writer-property constraint.
+	parquetBloomFilterMaxBytesMin            = 32
+	parquetBloomFilterMaxBytesMax            = 128 * 1024 * 1024
 	ParquetBloomFilterColumnEnabledKeyPrefix = "write.parquet.bloom-filter-enabled.column"
 
 	// Deliberately not namespaced under write.parquet: this is the parquet-mr key
@@ -374,6 +377,11 @@ func ValidateParquetWriteProperties(props iceberg.Properties) error {
 		}
 		if parsed <= 0 {
 			return fmt.Errorf("%w: %s must be greater than 0, got %d", iceberg.ErrInvalidArgument, key, parsed)
+		}
+		if key == ParquetBloomFilterMaxBytesKey &&
+			(parsed < parquetBloomFilterMaxBytesMin || parsed > parquetBloomFilterMaxBytesMax) {
+			return fmt.Errorf("%w: %s must be between %d and %d bytes, got %d",
+				iceberg.ErrInvalidArgument, key, parquetBloomFilterMaxBytesMin, parquetBloomFilterMaxBytesMax, parsed)
 		}
 		if strconv.IntSize == 32 && parsed > int64(^uint(0)>>1) {
 			return fmt.Errorf("%w: %s value %d exceeds int range", iceberg.ErrInvalidArgument, key, parsed)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1557,6 +1557,25 @@ func TestValidateParquetWriteProperties(t *testing.T) {
 	}
 }
 
+func TestValidateParquetCompressionLevel(t *testing.T) {
+	for _, value := range []string{"nope", "", "9223372036854775808"} {
+		t.Run("invalid/"+value, func(t *testing.T) {
+			err := internal.ValidateParquetWriteProperties(iceberg.Properties{
+				internal.ParquetCompressionLevelKey: value,
+			})
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		})
+	}
+
+	for _, value := range []string{"-1", "0", "3"} {
+		t.Run("valid/"+value, func(t *testing.T) {
+			require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{
+				internal.ParquetCompressionLevelKey: value,
+			}))
+		})
+	}
+}
+
 func TestGetWritePropertiesBloomFilter(t *testing.T) {
 	format := internal.GetFileFormat(iceberg.ParquetFile)
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1513,7 +1513,6 @@ func TestValidateParquetWriteProperties(t *testing.T) {
 		internal.ParquetPageSizeBytesKey,
 		internal.ParquetPageRowLimitKey,
 		internal.ParquetDictSizeBytesKey,
-		internal.ParquetBloomFilterMaxBytesKey,
 	}
 
 	for _, key := range keys {
@@ -1526,6 +1525,27 @@ func TestValidateParquetWriteProperties(t *testing.T) {
 
 		t.Run(key+"/valid", func(t *testing.T) {
 			require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{key: "1"}))
+		})
+	}
+
+	for _, tt := range []struct {
+		value string
+		valid bool
+	}{
+		{value: "31", valid: false},
+		{value: "32", valid: true},
+		{value: "134217728", valid: true},
+		{value: "134217729", valid: false},
+	} {
+		t.Run(internal.ParquetBloomFilterMaxBytesKey+"/"+tt.value, func(t *testing.T) {
+			err := internal.ValidateParquetWriteProperties(iceberg.Properties{
+				internal.ParquetBloomFilterMaxBytesKey: tt.value,
+			})
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			}
 		})
 	}
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -28,6 +28,7 @@ import (
 	iofs "io/fs"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1503,6 +1504,37 @@ func writeDictTestColumn(t *testing.T, tableProps iceberg.Properties, values []p
 	require.NoError(t, pageRdr.Err())
 
 	return summary
+}
+
+func TestValidateParquetWriteProperties(t *testing.T) {
+	keys := []string{
+		internal.ParquetRowGroupSizeBytesKey,
+		internal.ParquetRowGroupLimitKey,
+		internal.ParquetPageSizeBytesKey,
+		internal.ParquetPageRowLimitKey,
+		internal.ParquetDictSizeBytesKey,
+		internal.ParquetBloomFilterMaxBytesKey,
+	}
+
+	for _, key := range keys {
+		for _, value := range []string{"nope", "0", "-1"} {
+			t.Run(key+"/"+value, func(t *testing.T) {
+				err := internal.ValidateParquetWriteProperties(iceberg.Properties{key: value})
+				require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			})
+		}
+
+		t.Run(key+"/valid", func(t *testing.T) {
+			require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{key: "1"}))
+		})
+	}
+
+	if strconv.IntSize == 32 {
+		err := internal.ValidateParquetWriteProperties(iceberg.Properties{
+			internal.ParquetPageSizeBytesKey: "2147483648",
+		})
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	}
 }
 
 func TestGetWritePropertiesBloomFilter(t *testing.T) {

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -1558,6 +1558,16 @@ func TestValidateParquetWriteProperties(t *testing.T) {
 }
 
 func TestValidateParquetCompressionLevel(t *testing.T) {
+	t.Run("absent uses the default", func(t *testing.T) {
+		require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{}))
+	})
+
+	t.Run("explicit default is valid", func(t *testing.T) {
+		require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{
+			internal.ParquetCompressionLevelKey: strconv.Itoa(internal.ParquetCompressionLevelDefault),
+		}))
+	})
+
 	for _, value := range []string{"nope", "", "9223372036854775808"} {
 		t.Run("invalid/"+value, func(t *testing.T) {
 			err := internal.ValidateParquetWriteProperties(iceberg.Properties{
@@ -1567,11 +1577,34 @@ func TestValidateParquetCompressionLevel(t *testing.T) {
 		})
 	}
 
-	for _, value := range []string{"-1", "0", "3"} {
-		t.Run("valid/"+value, func(t *testing.T) {
-			require.NoError(t, internal.ValidateParquetWriteProperties(iceberg.Properties{
-				internal.ParquetCompressionLevelKey: value,
-			}))
+	for _, tt := range []struct {
+		codec string
+		level int
+		valid bool
+	}{
+		{codec: "gzip", level: -3, valid: true},
+		{codec: "gzip", level: 9, valid: true},
+		{codec: "gzip", level: 10, valid: false},
+		{codec: "zstd", level: -5, valid: true},
+		{codec: "zstd", level: 22, valid: true},
+		{codec: "zstd", level: 23, valid: false},
+		{codec: "brotli", level: -1, valid: true},
+		{codec: "brotli", level: 0, valid: true},
+		{codec: "brotli", level: 11, valid: true},
+		{codec: "brotli", level: 12, valid: false},
+	} {
+		t.Run(fmt.Sprintf("%s/%d", tt.codec, tt.level), func(t *testing.T) {
+			err := internal.ValidateParquetWriteProperties(iceberg.Properties{
+				internal.ParquetCompressionKey:      tt.codec,
+				internal.ParquetCompressionLevelKey: strconv.Itoa(tt.level),
+			})
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+				require.Contains(t, err.Error(), internal.ParquetCompressionLevelKey)
+				require.Contains(t, err.Error(), tt.codec)
+			}
 		})
 	}
 }

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -152,6 +152,13 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 
 		return nil, err
 	}
+	if fileFormat == iceberg.ParquetFile {
+		if err := tblutils.ValidateParquetWriteProperties(meta.props); err != nil {
+			stopCount()
+
+			return nil, err
+		}
+	}
 
 	format := tblutils.GetFileFormat(fileFormat)
 

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -162,11 +162,14 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 
 	format := tblutils.GetFileFormat(fileFormat)
 
-	rowGroupTargetSizeBytes, err := tblutils.ParquetRowGroupTargetSizeBytes(meta.props)
-	if err != nil {
-		stopCount()
+	var rowGroupTargetSizeBytes int64
+	if fileFormat == iceberg.ParquetFile {
+		rowGroupTargetSizeBytes, err = tblutils.ParquetRowGroupTargetSizeBytes(meta.props)
+		if err != nil {
+			stopCount()
 
-		return nil, err
+			return nil, err
+		}
 	}
 
 	arrowSchema, err := SchemaToArrowSchemaWithOptions(fileSchema, ArrowSchemaOptions{

--- a/table/writer.go
+++ b/table/writer.go
@@ -95,6 +95,10 @@ func withEqualityFieldIDs(ids []int) dataFileWriterOption {
 }
 
 func newDataFileWriter(rootLocation string, fs io.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (*defaultDataFileWriter, error) {
+	if err := tblutils.ValidateParquetWriteProperties(props); err != nil {
+		return nil, err
+	}
+
 	locProvider, err := LoadLocationProvider(rootLocation, props)
 	if err != nil {
 		return nil, err

--- a/table/writer.go
+++ b/table/writer.go
@@ -95,10 +95,6 @@ func withEqualityFieldIDs(ids []int) dataFileWriterOption {
 }
 
 func newDataFileWriter(rootLocation string, fs io.WriteFileIO, meta *MetadataBuilder, props iceberg.Properties, opts ...dataFileWriterOption) (*defaultDataFileWriter, error) {
-	if err := tblutils.ValidateParquetWriteProperties(props); err != nil {
-		return nil, err
-	}
-
 	locProvider, err := LoadLocationProvider(rootLocation, props)
 	if err != nil {
 		return nil, err
@@ -108,6 +104,11 @@ func newDataFileWriter(rootLocation string, fs io.WriteFileIO, meta *MetadataBui
 		props.Get(WriteFormatDefaultKey, WriteFormatDefaultDefault))
 	if err != nil {
 		return nil, err
+	}
+	if fileFormat == iceberg.ParquetFile {
+		if err := tblutils.ValidateParquetWriteProperties(props); err != nil {
+			return nil, err
+		}
 	}
 
 	w := defaultDataFileWriter{
@@ -169,9 +170,12 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 		return nil, err
 	}
 
-	rowGroupTargetSizeBytes, err := tblutils.ParquetRowGroupTargetSizeBytes(w.props)
-	if err != nil {
-		return nil, err
+	var rowGroupTargetSizeBytes int64
+	if w.fileFormat == iceberg.ParquetFile {
+		rowGroupTargetSizeBytes, err = tblutils.ParquetRowGroupTargetSizeBytes(w.props)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return w.format.WriteDataFile(ctx, w.fs, partitionValues, tblutils.WriteFileInfo{


### PR DESCRIPTION
## Summary

Validate numeric Parquet writer properties before creating an output file.

## Why

Malformed, zero, negative, or out-of-range values were accepted by permissive parsing and then passed to Arrow.

## What changed

Row-group, page, dictionary, and bloom-filter sizes are checked before the writer is created. Existing defaults are unchanged.

## Tests

- go test ./table/internal -count=1