### PR TITLE
fix(table): close manifest lists before staging snapshots

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1153,23 +1153,55 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	return sp.commitManifests(newManifests, addedContent)
 }
 
-func closeManifestListOutput(
+func writeManifestListFile(
 	fs iceio.WriteFileIO,
 	path string,
-	out iceio.FileWriter,
-	writer *iceberg.ManifestListWriter,
-	removeOnError bool,
-) error {
-	var err error
-	if writer != nil {
-		err = errors.Join(err, writer.Close())
-	}
-	err = errors.Join(err, out.Close())
-	if removeOnError || err != nil {
-		err = errors.Join(err, fs.Remove(path))
+	version int,
+	snapshotID int64,
+	sequenceNumber int64,
+	firstRowID int64,
+	parentSnapshotID *int64,
+	manifests []iceberg.ManifestFile,
+) (addedRows int64, err error) {
+	out, err := fs.Create(path)
+	if err != nil {
+		return 0, err
 	}
 
-	return err
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, fs.Remove(path))
+		}
+	}()
+	defer internal.CheckedClose(out, &err)
+
+	var writer *iceberg.ManifestListWriter
+	switch version {
+	case 1:
+		writer, err = iceberg.NewManifestListWriterV1(out, snapshotID, parentSnapshotID)
+	case 2:
+		writer, err = iceberg.NewManifestListWriterV2(out, snapshotID, sequenceNumber, parentSnapshotID)
+	case 3:
+		writer, err = iceberg.NewManifestListWriterV3(out, snapshotID, sequenceNumber, firstRowID, parentSnapshotID)
+	default:
+		return 0, fmt.Errorf("unsupported manifest version: %d", version)
+	}
+
+	if writer != nil {
+		defer internal.CheckedClose(writer, &err)
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	if err = writer.AddManifests(manifests); err != nil {
+		return 0, err
+	}
+	if version == 3 && writer.NextRowID() != nil {
+		addedRows = *writer.NextRowID() - firstRowID
+	}
+
+	return addedRows, nil
 }
 
 // commitManifests stages the snapshot for an already-built manifest set.
@@ -1198,49 +1230,22 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 
 	firstRowID := int64(0)
 	var addedRows int64
-
-	out, err := sp.io.Create(manifestListFilePath)
+	if sp.txn.meta.formatVersion == 3 {
+		firstRowID = sp.txn.meta.NextRowID()
+	}
+	addedRows, err = writeManifestListFile(
+		sp.io,
+		manifestListFilePath,
+		sp.txn.meta.formatVersion,
+		sp.snapshotID,
+		nextSequence,
+		firstRowID,
+		parentSnapshot,
+		newManifests,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
-	var writer *iceberg.ManifestListWriter
-	closed := false
-	defer func() {
-		if !closed {
-			err = errors.Join(err, closeManifestListOutput(sp.io, manifestListFilePath, out, writer, true))
-		}
-	}()
-
-	if sp.txn.meta.formatVersion == 3 {
-		firstRowID = sp.txn.meta.NextRowID()
-		writer, err = iceberg.NewManifestListWriterV3(out, sp.snapshotID, nextSequence, firstRowID, parentSnapshot)
-		if err != nil {
-			return nil, nil, err
-		}
-		if err = writer.AddManifests(newManifests); err != nil {
-			return nil, nil, err
-		}
-		if writer.NextRowID() != nil {
-			// addedRows counts ALL rows in new manifests (existing + added), even
-			// for rewrites where survivors preserve old _row_id values. This
-			// "wastes" ID space but doesn't violate uniqueness: actual row IDs come
-			// from the explicit Parquet column, not the global counter. Java's
-			// ManifestListWriter.V3Writer uses the same accounting.
-			addedRows = *writer.NextRowID() - firstRowID
-		}
-	} else {
-		err = iceberg.WriteManifestList(sp.txn.meta.formatVersion, out,
-			sp.snapshotID, parentSnapshot, &nextSequence, firstRowID, newManifests)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	if err = closeManifestListOutput(sp.io, manifestListFilePath, out, writer, false); err != nil {
-		closed = true
-
-		return nil, nil, err
-	}
-	closed = true
 
 	snapshot := Snapshot{
 		SnapshotID:       sp.snapshotID,
@@ -1284,7 +1289,7 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 	commitUUID := sp.commitUuid
 	capturedSnapshot := snapshot // copy the value so the closure is self-contained
 
-	rebuildFn := func(rebuildCtx context.Context, freshMeta Metadata, freshParent *Snapshot, fio iceio.WriteFileIO, attempt int) (_ *Snapshot, retErr error) {
+	rebuildFn := func(rebuildCtx context.Context, freshMeta Metadata, freshParent *Snapshot, fio iceio.WriteFileIO, attempt int) (*Snapshot, error) {
 		// A concurrent writer may have already removed the files this producer
 		// intends to rewrite. Grafting our replacement on top of the fresh
 		// parent would duplicate rows, so abort terminally. The scan also
@@ -1314,6 +1319,21 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 			newSeq = freshMeta.LastSequenceNumber() + 1
 		}
 
+		var parentID *int64
+		if freshParent != nil {
+			id := freshParent.SnapshotID
+			parentID = &id
+		}
+
+		rebuiltSummary := capturedSnapshot.Summary
+		if freshParent != nil && freshParent.Summary != nil && capturedSnapshot.Summary != nil {
+			s, sumErr := sp.summaryOnRetry(sp.snapshotProps, freshParent, present)
+			if sumErr != nil {
+				return nil, fmt.Errorf("rebuild manifest list: recompute summary: %w", sumErr)
+			}
+			rebuiltSummary = &s
+		}
+
 		// Write the rebuilt manifest list to a path unique to this retry
 		// attempt. Each retry uses a different attempt counter in the filename
 		// (snap-{id}-{attempt}-{uuid}.avro) so that S3 conditional-write
@@ -1323,53 +1343,26 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 		fname := newManifestListFileName(snapshotID, attempt, commitUUID)
 		manifestListPath := locProvider.NewMetadataLocation(fname)
 
-		out, createErr := fio.Create(manifestListPath)
-		if createErr != nil {
-			return nil, fmt.Errorf("rebuild manifest list: create file: %w", createErr)
-		}
-		var writer *iceberg.ManifestListWriter
-		closed := false
-		defer func() {
-			if !closed {
-				retErr = errors.Join(retErr, closeManifestListOutput(fio, manifestListPath, out, writer, true))
-			}
-		}()
-
-		var parentID *int64
-		if freshParent != nil {
-			id := freshParent.SnapshotID
-			parentID = &id
-		}
-
 		firstRowID := int64(0)
-		var addedRows int64
 		if formatVersion == 3 {
 			// Derive firstRowID from the fresh metadata so the manifest-list
 			// first-row-id field is consistent with the catalog's nextRowID
 			// after concurrent writers have advanced it since attempt 0.
 			firstRowID = freshMeta.NextRowID()
-			var wrErr error
-			writer, wrErr = iceberg.NewManifestListWriterV3(out, snapshotID, newSeq, firstRowID, parentID)
-			if wrErr != nil {
-				return nil, fmt.Errorf("rebuild manifest list: create v3 writer: %w", wrErr)
-			}
-			if addErr := writer.AddManifests(combined); addErr != nil {
-				return nil, fmt.Errorf("rebuild manifest list: add manifests: %w", addErr)
-			}
-			if writer.NextRowID() != nil {
-				addedRows = *writer.NextRowID() - firstRowID
-			}
-		} else {
-			if wErr := iceberg.WriteManifestList(formatVersion, out, snapshotID, parentID, &newSeq, firstRowID, combined); wErr != nil {
-				return nil, fmt.Errorf("rebuild manifest list: write: %w", wErr)
-			}
 		}
-		if closeErr := closeManifestListOutput(fio, manifestListPath, out, writer, false); closeErr != nil {
-			closed = true
-
-			return nil, fmt.Errorf("rebuild manifest list: close: %w", closeErr)
+		addedRows, writeErr := writeManifestListFile(
+			fio,
+			manifestListPath,
+			formatVersion,
+			snapshotID,
+			newSeq,
+			firstRowID,
+			parentID,
+			combined,
+		)
+		if writeErr != nil {
+			return nil, fmt.Errorf("rebuild manifest list: write: %w", writeErr)
 		}
-		closed = true
 
 		rebuilt := capturedSnapshot
 		rebuilt.ManifestList = manifestListPath
@@ -1379,19 +1372,7 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 			rebuilt.FirstRowID = &firstRowID
 			rebuilt.AddedRows = &addedRows
 		}
-
-		// Recompute the snapshot summary against the fresh parent so totals are
-		// not regressed to the stale attempt-0 values. Removals of delete files
-		// / DVs are gated by present (see checkRemovedFiles) so a peer's prior
-		// removal is not subtracted twice, which would undercount
-		// total-delete-files.
-		if freshParent != nil && freshParent.Summary != nil && capturedSnapshot.Summary != nil {
-			s, sumErr := sp.summaryOnRetry(sp.snapshotProps, freshParent, present)
-			if sumErr != nil {
-				return nil, fmt.Errorf("rebuild manifest list: recompute summary: %w", sumErr)
-			}
-			rebuilt.Summary = &s
-		}
+		rebuilt.Summary = rebuiltSummary
 
 		return &rebuilt, nil
 	}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1153,6 +1153,25 @@ func (sp *snapshotProducer) commit(ctx context.Context) (_ []Update, _ []Require
 	return sp.commitManifests(newManifests, addedContent)
 }
 
+func closeManifestListOutput(
+	fs iceio.WriteFileIO,
+	path string,
+	out iceio.FileWriter,
+	writer *iceberg.ManifestListWriter,
+	removeOnError bool,
+) error {
+	var err error
+	if writer != nil {
+		err = errors.Join(err, writer.Close())
+	}
+	err = errors.Join(err, out.Close())
+	if removeOnError || err != nil {
+		err = errors.Join(err, fs.Remove(path))
+	}
+
+	return err
+}
+
 // commitManifests stages the snapshot for an already-built manifest set.
 // It is split out of commit so callers that must inspect the planned manifests
 // before anything is written (RewriteManifests detecting a no-op) can build the
@@ -1184,15 +1203,20 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 	if err != nil {
 		return nil, nil, err
 	}
-	defer internal.CheckedClose(out, &err)
+	closed := false
+	defer func() {
+		if !closed {
+			err = errors.Join(err, closeManifestListOutput(sp.io, manifestListFilePath, out, nil, true))
+		}
+	}()
 
+	var writer *iceberg.ManifestListWriter
 	if sp.txn.meta.formatVersion == 3 {
 		firstRowID = sp.txn.meta.NextRowID()
-		writer, err := iceberg.NewManifestListWriterV3(out, sp.snapshotID, nextSequence, firstRowID, parentSnapshot)
+		writer, err = iceberg.NewManifestListWriterV3(out, sp.snapshotID, nextSequence, firstRowID, parentSnapshot)
 		if err != nil {
 			return nil, nil, err
 		}
-		defer internal.CheckedClose(writer, &err)
 		if err = writer.AddManifests(newManifests); err != nil {
 			return nil, nil, err
 		}
@@ -1211,6 +1235,12 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 			return nil, nil, err
 		}
 	}
+	if err = closeManifestListOutput(sp.io, manifestListFilePath, out, writer, false); err != nil {
+		closed = true
+
+		return nil, nil, err
+	}
+	closed = true
 
 	snapshot := Snapshot{
 		SnapshotID:       sp.snapshotID,
@@ -1297,7 +1327,12 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 		if createErr != nil {
 			return nil, fmt.Errorf("rebuild manifest list: create file: %w", createErr)
 		}
-		defer internal.CheckedClose(out, &retErr)
+		closed := false
+		defer func() {
+			if !closed {
+				retErr = errors.Join(retErr, closeManifestListOutput(fio, manifestListPath, out, nil, true))
+			}
+		}()
 
 		var parentID *int64
 		if freshParent != nil {
@@ -1307,16 +1342,17 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 
 		firstRowID := int64(0)
 		var addedRows int64
+		var writer *iceberg.ManifestListWriter
 		if formatVersion == 3 {
 			// Derive firstRowID from the fresh metadata so the manifest-list
 			// first-row-id field is consistent with the catalog's nextRowID
 			// after concurrent writers have advanced it since attempt 0.
 			firstRowID = freshMeta.NextRowID()
-			writer, wrErr := iceberg.NewManifestListWriterV3(out, snapshotID, newSeq, firstRowID, parentID)
+			var wrErr error
+			writer, wrErr = iceberg.NewManifestListWriterV3(out, snapshotID, newSeq, firstRowID, parentID)
 			if wrErr != nil {
 				return nil, fmt.Errorf("rebuild manifest list: create v3 writer: %w", wrErr)
 			}
-			defer internal.CheckedClose(writer, &retErr)
 			if addErr := writer.AddManifests(combined); addErr != nil {
 				return nil, fmt.Errorf("rebuild manifest list: add manifests: %w", addErr)
 			}
@@ -1328,6 +1364,12 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 				return nil, fmt.Errorf("rebuild manifest list: write: %w", wErr)
 			}
 		}
+		if closeErr := closeManifestListOutput(fio, manifestListPath, out, writer, false); closeErr != nil {
+			closed = true
+
+			return nil, fmt.Errorf("rebuild manifest list: close: %w", closeErr)
+		}
+		closed = true
 
 		rebuilt := capturedSnapshot
 		rebuilt.ManifestList = manifestListPath

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1203,14 +1203,14 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 	if err != nil {
 		return nil, nil, err
 	}
+	var writer *iceberg.ManifestListWriter
 	closed := false
 	defer func() {
 		if !closed {
-			err = errors.Join(err, closeManifestListOutput(sp.io, manifestListFilePath, out, nil, true))
+			err = errors.Join(err, closeManifestListOutput(sp.io, manifestListFilePath, out, writer, true))
 		}
 	}()
 
-	var writer *iceberg.ManifestListWriter
 	if sp.txn.meta.formatVersion == 3 {
 		firstRowID = sp.txn.meta.NextRowID()
 		writer, err = iceberg.NewManifestListWriterV3(out, sp.snapshotID, nextSequence, firstRowID, parentSnapshot)
@@ -1327,10 +1327,11 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 		if createErr != nil {
 			return nil, fmt.Errorf("rebuild manifest list: create file: %w", createErr)
 		}
+		var writer *iceberg.ManifestListWriter
 		closed := false
 		defer func() {
 			if !closed {
-				retErr = errors.Join(retErr, closeManifestListOutput(fio, manifestListPath, out, nil, true))
+				retErr = errors.Join(retErr, closeManifestListOutput(fio, manifestListPath, out, writer, true))
 			}
 		}()
 
@@ -1342,7 +1343,6 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 
 		firstRowID := int64(0)
 		var addedRows int64
-		var writer *iceberg.ManifestListWriter
 		if formatVersion == 3 {
 			// Derive firstRowID from the fresh metadata so the manifest-list
 			// first-row-id field is consistent with the catalog's nextRowID

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1198,6 +1198,11 @@ func writeManifestListFile(
 		return 0, err
 	}
 	if version == 3 && writer.NextRowID() != nil {
+		// addedRows counts ALL rows in new manifests (existing + added), even
+		// for rewrites where survivors preserve old _row_id values. This
+		// "wastes" ID space but doesn't violate uniqueness: actual row IDs come
+		// from the explicit Parquet column, not the global counter. Java's
+		// ManifestListWriter.V3Writer uses the same accounting.
 		addedRows = *writer.NextRowID() - firstRowID
 	}
 

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -764,13 +764,27 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 			txn := createTestTransaction(t, fs, spec)
 			txn.meta.formatVersion = version
 			sp := newFastAppendFilesProducer(OpAppend, txn, fs, nil, nil)
+			manifest := writeTestManifestFile(t, fs, spec, simpleSchema(), sp.snapshotID, 1)
 
-			updates, requirements, err := sp.commitManifests(nil, nil)
+			updates, requirements, err := sp.commitManifests([]iceberg.ManifestFile{manifest}, nil)
 			require.ErrorIs(t, err, closeErr)
 			require.ErrorIs(t, err, removeErr)
 			require.Nil(t, updates)
 			require.Nil(t, requirements)
 			require.Len(t, fs.removes, 1)
+
+			if version == 3 {
+				fs.writersMu.Lock()
+				var output []byte
+				for _, writer := range fs.writers {
+					output = append([]byte(nil), writer.buf.Bytes()...)
+				}
+				fs.writersMu.Unlock()
+
+				writtenManifests, readErr := iceberg.ReadManifestList(bytes.NewReader(output))
+				require.NoError(t, readErr)
+				require.Len(t, writtenManifests, 1, "manifest-list writer must flush before the output is closed")
+			}
 		})
 	}
 }

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -633,10 +634,15 @@ func TestOverwriteFilesExistingManifestsClosesWriterOnError(t *testing.T) {
 
 // trackingWriteCloser wraps a bytes.Buffer and tracks if Close was called.
 type trackingWriteCloser struct {
-	buf      *bytes.Buffer
-	closed   bool
-	closeErr error
-	closeMu  sync.Mutex
+	buf         *bytes.Buffer
+	closed      bool
+	closeErr    error
+	closeCount  int
+	writeCount  int
+	failWriteAt int
+	writeErr    error
+	onClose     func([]byte)
+	closeMu     sync.Mutex
 }
 
 func newTrackingWriteCloser() *trackingWriteCloser {
@@ -644,6 +650,16 @@ func newTrackingWriteCloser() *trackingWriteCloser {
 }
 
 func (t *trackingWriteCloser) Write(p []byte) (int, error) {
+	t.closeMu.Lock()
+	defer t.closeMu.Unlock()
+	if t.closed {
+		return 0, errors.New("write after close")
+	}
+	t.writeCount++
+	if t.failWriteAt > 0 && t.writeCount == t.failWriteAt {
+		return 0, t.writeErr
+	}
+
 	return t.buf.Write(p)
 }
 
@@ -651,6 +667,10 @@ func (t *trackingWriteCloser) Close() error {
 	t.closeMu.Lock()
 	defer t.closeMu.Unlock()
 	t.closed = true
+	t.closeCount++
+	if t.onClose != nil && t.closeCount == 1 {
+		t.onClose(t.buf.Bytes())
+	}
 
 	return t.closeErr
 }
@@ -664,6 +684,13 @@ func (t *trackingWriteCloser) IsClosed() bool {
 	defer t.closeMu.Unlock()
 
 	return t.closed
+}
+
+func (t *trackingWriteCloser) CloseCount() int {
+	t.closeMu.Lock()
+	defer t.closeMu.Unlock()
+
+	return t.closeCount
 }
 
 // trackingIO is an IO implementation that tracks file writer closure.
@@ -734,9 +761,11 @@ func (t *trackingIO) GetWriterCount() int {
 
 type closeErrorIO struct {
 	*trackingIO
-	closeErr  error
-	removeErr error
-	removes   []string
+	closeErr    error
+	removeErr   error
+	failWriteAt int
+	writeErr    error
+	removes     []string
 }
 
 func newCloseErrorIO(closeErr, removeErr error) *closeErrorIO {
@@ -750,7 +779,13 @@ func newCloseErrorIO(closeErr, removeErr error) *closeErrorIO {
 func (c *closeErrorIO) Create(name string) (iceio.FileWriter, error) {
 	writer, err := c.trackingIO.Create(name)
 	if err == nil {
-		writer.(*trackingWriteCloser).closeErr = c.closeErr
+		tracked := writer.(*trackingWriteCloser)
+		tracked.closeErr = c.closeErr
+		tracked.failWriteAt = c.failWriteAt
+		tracked.writeErr = c.writeErr
+		tracked.onClose = func(data []byte) {
+			c.files[name] = append([]byte(nil), data...)
+		}
 	}
 
 	return writer, err
@@ -787,6 +822,8 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 			updates, requirements, err := sp.commitManifests([]iceberg.ManifestFile{manifest}, nil)
 			require.ErrorIs(t, err, closeErr)
 			require.ErrorIs(t, err, removeErr)
+			require.NotContains(t, err.Error(), "write after close",
+				"the manifest-list writer must flush before the outer file writer closes")
 			require.Nil(t, updates)
 			require.Nil(t, requirements)
 			require.Len(t, fs.removes, 1)
@@ -801,12 +838,23 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 				fs.writersMu.Unlock()
 
 				require.Equal(t, 1, writerCount)
+				for _, writer := range fs.writers {
+					require.Equal(t, 1, writer.CloseCount(), "each output writer must close exactly once")
+				}
 				writtenManifests, readErr := iceberg.ReadManifestList(bytes.NewReader(output))
 				require.NoError(t, readErr)
 				require.Len(t, writtenManifests, 1, "manifest-list writer must flush before the output is closed")
 			}
 		})
 	}
+}
+
+func newFlushErrorIO(writeErr error) *closeErrorIO {
+	fs := newCloseErrorIO(nil, nil)
+	fs.failWriteAt = 2 // header write succeeds; the OCF close-time block flush fails.
+	fs.writeErr = writeErr
+
+	return fs
 }
 
 func TestRebuildManifestListCloseFailureReturnsNoSnapshot(t *testing.T) {
@@ -851,7 +899,61 @@ func TestRebuildManifestListCloseFailureReturnsNoSnapshot(t *testing.T) {
 			require.Nil(t, rebuilt)
 			require.Len(t, retryFS.removes, 1)
 			require.Empty(t, retryFS.GetUnclosedWriters())
+			retryFS.writersMu.Lock()
+			retryWriters := make([]*trackingWriteCloser, 0, len(retryFS.writers))
+			for _, writer := range retryFS.writers {
+				retryWriters = append(retryWriters, writer)
+			}
+			retryFS.writersMu.Unlock()
+			for _, writer := range retryWriters {
+				require.Equal(t, 1, writer.CloseCount(), "each retry writer must close exactly once")
+			}
 		})
+	}
+}
+
+func TestCommitManifestsCloseFailureRemovesPartialOutput(t *testing.T) {
+	closeErr := errors.New("manifest list close failed")
+	fs := newCloseErrorIO(closeErr, nil)
+	spec := iceberg.NewPartitionSpec()
+	txn := createTestTransaction(t, fs, spec)
+	txn.meta.formatVersion = 2
+	sp := newFastAppendFilesProducer(OpAppend, txn, fs, nil, nil)
+	manifest := writeTestManifestFile(t, fs, spec, simpleSchema(), sp.snapshotID, 1)
+
+	_, _, err := sp.commitManifests([]iceberg.ManifestFile{manifest}, nil)
+	require.ErrorIs(t, err, closeErr)
+	require.Len(t, fs.removes, 1)
+	assert.NotContains(t, fs.files, fs.removes[0], "failed manifest-list output must be removed after close failure")
+
+	fs.writersMu.Lock()
+	defer fs.writersMu.Unlock()
+	for _, writer := range fs.writers {
+		require.Equal(t, 1, writer.CloseCount())
+	}
+}
+
+func TestCommitManifestsInnerCloseFailureReturnsNoUpdates(t *testing.T) {
+	flushErr := errors.New("manifest list flush failed")
+	fs := newFlushErrorIO(flushErr)
+	spec := iceberg.NewPartitionSpec()
+	txn := createTestTransaction(t, fs, spec)
+	txn.meta.formatVersion = 2
+	sp := newFastAppendFilesProducer(OpAppend, txn, fs, nil, nil)
+	manifest := writeTestManifestFile(t, fs, spec, simpleSchema(), sp.snapshotID, 1)
+
+	updates, requirements, err := sp.commitManifests([]iceberg.ManifestFile{manifest}, nil)
+	require.ErrorIs(t, err, flushErr)
+	require.NotContains(t, err.Error(), "write after close")
+	require.Nil(t, updates)
+	require.Nil(t, requirements)
+	require.Len(t, fs.removes, 1)
+	assert.NotContains(t, fs.files, fs.removes[0])
+
+	fs.writersMu.Lock()
+	defer fs.writersMu.Unlock()
+	for _, writer := range fs.writers {
+		require.Equal(t, 1, writer.CloseCount())
 	}
 }
 

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -228,6 +228,18 @@ func writeTestManifestFile(
 	snapshotID int64,
 	index int,
 ) iceberg.ManifestFile {
+	return writeTestManifestFileWithVersion(t, fs, spec, schema, snapshotID, index, 2)
+}
+
+func writeTestManifestFileWithVersion(
+	t *testing.T,
+	fs iceio.WriteFileIO,
+	spec iceberg.PartitionSpec,
+	schema *iceberg.Schema,
+	snapshotID int64,
+	index int,
+	version int,
+) iceberg.ManifestFile {
 	t.Helper()
 
 	df := newTestDataFile(t, spec, "file://data-"+strconv.Itoa(index)+".parquet", nil)
@@ -237,7 +249,7 @@ func writeTestManifestFile(
 
 	path := "table-location/metadata/source-" + strconv.Itoa(index) + ".avro"
 	var buf bytes.Buffer
-	manifestFile, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, snapshotID, entries)
+	manifestFile, err := iceberg.WriteManifest(path, &buf, version, spec, schema, snapshotID, entries)
 	require.NoError(t, err, "write manifest")
 	require.NoError(t, fs.WriteFile(path, buf.Bytes()))
 
@@ -757,14 +769,20 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 	closeErr := errors.New("manifest list close failed")
 	removeErr := errors.New("manifest list cleanup failed")
 
-	for _, version := range []int{2, 3} {
+	for _, version := range []int{1, 2, 3} {
 		t.Run(strconv.Itoa(version), func(t *testing.T) {
 			fs := newCloseErrorIO(closeErr, removeErr)
 			spec := iceberg.NewPartitionSpec()
 			txn := createTestTransaction(t, fs, spec)
 			txn.meta.formatVersion = version
 			sp := newFastAppendFilesProducer(OpAppend, txn, fs, nil, nil)
-			manifest := writeTestManifestFile(t, fs, spec, simpleSchema(), sp.snapshotID, 1)
+			manifestVersion := version
+			if manifestVersion == 3 {
+				manifestVersion = 2
+			}
+			manifest := writeTestManifestFileWithVersion(
+				t, fs, spec, simpleSchema(), sp.snapshotID, 1, manifestVersion,
+			)
 
 			updates, requirements, err := sp.commitManifests([]iceberg.ManifestFile{manifest}, nil)
 			require.ErrorIs(t, err, closeErr)
@@ -775,12 +793,14 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 
 			if version == 3 {
 				fs.writersMu.Lock()
+				writerCount := len(fs.writers)
 				var output []byte
 				for _, writer := range fs.writers {
 					output = append([]byte(nil), writer.buf.Bytes()...)
 				}
 				fs.writersMu.Unlock()
 
+				require.Equal(t, 1, writerCount)
 				writtenManifests, readErr := iceberg.ReadManifestList(bytes.NewReader(output))
 				require.NoError(t, readErr)
 				require.Len(t, writtenManifests, 1, "manifest-list writer must flush before the output is closed")
@@ -793,14 +813,20 @@ func TestRebuildManifestListCloseFailureReturnsNoSnapshot(t *testing.T) {
 	closeErr := errors.New("manifest list close failed")
 	removeErr := errors.New("manifest list cleanup failed")
 
-	for _, version := range []int{2, 3} {
+	for _, version := range []int{1, 2, 3} {
 		t.Run(strconv.Itoa(version), func(t *testing.T) {
 			initialIO := newTrackingIO()
 			spec := iceberg.NewPartitionSpec()
 			txn := createTestTransaction(t, initialIO, spec)
 			txn.meta.formatVersion = version
 			sp := newFastAppendFilesProducer(OpAppend, txn, initialIO, nil, nil)
-			manifest := writeTestManifestFile(t, initialIO, spec, simpleSchema(), sp.snapshotID, 1)
+			manifestVersion := version
+			if manifestVersion == 3 {
+				manifestVersion = 2
+			}
+			manifest := writeTestManifestFileWithVersion(
+				t, initialIO, spec, simpleSchema(), sp.snapshotID, 1, manifestVersion,
+			)
 
 			updates, _, err := sp.commitManifests(
 				[]iceberg.ManifestFile{manifest},

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -621,9 +621,10 @@ func TestOverwriteFilesExistingManifestsClosesWriterOnError(t *testing.T) {
 
 // trackingWriteCloser wraps a bytes.Buffer and tracks if Close was called.
 type trackingWriteCloser struct {
-	buf     *bytes.Buffer
-	closed  bool
-	closeMu sync.Mutex
+	buf      *bytes.Buffer
+	closed   bool
+	closeErr error
+	closeMu  sync.Mutex
 }
 
 func newTrackingWriteCloser() *trackingWriteCloser {
@@ -639,7 +640,7 @@ func (t *trackingWriteCloser) Close() error {
 	defer t.closeMu.Unlock()
 	t.closed = true
 
-	return nil
+	return t.closeErr
 }
 
 func (t *trackingWriteCloser) ReadFrom(r io.Reader) (int64, error) {
@@ -717,6 +718,61 @@ func (t *trackingIO) GetWriterCount() int {
 	defer t.writersMu.Unlock()
 
 	return len(t.writers)
+}
+
+type closeErrorIO struct {
+	*trackingIO
+	closeErr  error
+	removeErr error
+	removes   []string
+}
+
+func newCloseErrorIO(closeErr, removeErr error) *closeErrorIO {
+	return &closeErrorIO{
+		trackingIO: newTrackingIO(),
+		closeErr:   closeErr,
+		removeErr:  removeErr,
+	}
+}
+
+func (c *closeErrorIO) Create(name string) (iceio.FileWriter, error) {
+	writer, err := c.trackingIO.Create(name)
+	if err == nil {
+		writer.(*trackingWriteCloser).closeErr = c.closeErr
+	}
+
+	return writer, err
+}
+
+func (c *closeErrorIO) Remove(name string) error {
+	c.removes = append(c.removes, name)
+	if c.removeErr != nil {
+		return c.removeErr
+	}
+
+	return c.trackingIO.Remove(name)
+}
+
+func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
+	closeErr := errors.New("manifest list close failed")
+	removeErr := errors.New("manifest list cleanup failed")
+
+	for _, version := range []int{2, 3} {
+		t.Run(strconv.Itoa(version), func(t *testing.T) {
+			fs := newCloseErrorIO(closeErr, removeErr)
+			spec := iceberg.NewPartitionSpec()
+			txn := createTestTransaction(t, fs, spec)
+			txn.meta.formatVersion = version
+			sp := newFastAppendFilesProducer(OpAppend, txn, fs, nil, nil)
+
+			updates, requirements, err := sp.commitManifests(nil, nil)
+			require.ErrorIs(t, err, closeErr)
+			require.ErrorIs(t, err, removeErr)
+			require.Nil(t, updates)
+			require.Nil(t, requirements)
+			require.Len(t, fs.removes, 1)
+		})
+	}
 }
 
 // TestManifestWriterClosesUnderlyingFile tests that when using newManifestWriter,

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -789,6 +789,82 @@ func TestCommitManifestsCloseFailureReturnsNoUpdates(t *testing.T) {
 	}
 }
 
+func TestRebuildManifestListCloseFailureReturnsNoSnapshot(t *testing.T) {
+	closeErr := errors.New("manifest list close failed")
+	removeErr := errors.New("manifest list cleanup failed")
+
+	for _, version := range []int{2, 3} {
+		t.Run(strconv.Itoa(version), func(t *testing.T) {
+			initialIO := newTrackingIO()
+			spec := iceberg.NewPartitionSpec()
+			txn := createTestTransaction(t, initialIO, spec)
+			txn.meta.formatVersion = version
+			sp := newFastAppendFilesProducer(OpAppend, txn, initialIO, nil, nil)
+			manifest := writeTestManifestFile(t, initialIO, spec, simpleSchema(), sp.snapshotID, 1)
+
+			updates, _, err := sp.commitManifests(
+				[]iceberg.ManifestFile{manifest},
+				[]iceberg.ManifestFile{manifest},
+			)
+			require.NoError(t, err)
+			addSnap := updates[0].(*addSnapshotUpdate)
+
+			retryFS := newCloseErrorIO(closeErr, removeErr)
+			var freshMeta Metadata
+			if version == 3 {
+				freshMeta = newV3MetadataWithNextRowID(t, 0)
+			} else {
+				freshMeta = newMetadataWithLastSeqNum(t, 1)
+			}
+
+			rebuilt, err := addSnap.rebuildManifestList(
+				context.Background(), freshMeta, nil, retryFS, 1,
+			)
+			require.ErrorIs(t, err, closeErr)
+			require.ErrorIs(t, err, removeErr)
+			require.Nil(t, rebuilt)
+			require.Len(t, retryFS.removes, 1)
+			require.Empty(t, retryFS.GetUnclosedWriters())
+		})
+	}
+}
+
+func TestRebuildManifestListSummaryFailureCreatesNoOutput(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	txn.meta.formatVersion = 2
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+	manifest := writeTestManifestFile(t, wfs, spec, simpleSchema(), sp.snapshotID, 1)
+
+	updates, _, err := sp.commitManifests(
+		[]iceberg.ManifestFile{manifest},
+		[]iceberg.ManifestFile{manifest},
+	)
+	require.NoError(t, err)
+	addSnap := updates[0].(*addSnapshotUpdate)
+
+	parentManifestList := "mem://default/table-location/metadata/fresh-parent.avro"
+	out, err := wfs.Create(parentManifestList)
+	require.NoError(t, err)
+	require.NoError(t, iceberg.WriteManifestList(2, out, 77, nil, ptr(int64(0)), 0, nil))
+	require.NoError(t, out.Close())
+
+	sp.op = Operation("unsupported")
+	freshParent := &Snapshot{
+		SnapshotID:   77,
+		ManifestList: parentManifestList,
+		Summary:      &Summary{Operation: OpAppend},
+	}
+	retryFS := newTrackingIO()
+
+	rebuilt, err := addSnap.rebuildManifestList(
+		context.Background(), newMetadataWithLastSeqNum(t, 1), freshParent, retryFS, 1,
+	)
+	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+	require.Nil(t, rebuilt)
+	require.Zero(t, retryFS.GetWriterCount())
+}
+
 // TestManifestWriterClosesUnderlyingFile tests that when using newManifestWriter,
 // the underlying file writer is properly closed. This test is related to issue #644 and #681
 // where blob.Writer was never closed, causing table corruption.


### PR DESCRIPTION
## Summary

Close manifest-list writers before staging snapshot updates.

## Why

Manifest-list uploads can report their real failure from Close. The commit path built snapshot updates before that close ran, so a failed upload could leave a snapshot pointing at a missing manifest list.

## What changed

The manifest-list writer and underlying output are closed before snapshot updates are created. Close failures remove the incomplete object and return no updates or requirements. The retry rebuild path is covered too.

## Tests

- go test ./table -count=1

Fixes #1666