### PR TITLE
fix(partitions): reject redundant fields in the spec builder

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -226,6 +226,19 @@ func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
 			return PartitionSpec{}, fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 		}
 	}
+	// Validate the assembled field set rather than each field as it is added:
+	// the redundancy check needs every field in place, and routing the builder
+	// through the same validator as UnmarshalJSON keeps one definition of a
+	// redundant field, so a spec this constructor accepts is one this package's
+	// UnmarshalJSON can read back. NewPartitionSpec and NewPartitionSpecID do
+	// not validate, so that guarantee covers this constructor only.
+	//
+	// ErrInvalidPartitionSpec is attached exactly once per error, by whichever
+	// layer knows the sentinel: options return bare errors and the loop above
+	// wraps them, while validatePartitionFields wraps its own.
+	if err := validatePartitionFields(spec.fields); err != nil {
+		return PartitionSpec{}, err
+	}
 	spec.initialize()
 
 	return spec, nil
@@ -297,9 +310,6 @@ func (p *PartitionSpec) addSpecFieldInternal(targetName string, field NestedFiel
 	} else {
 		fieldIDValue = *fieldID
 	}
-	if err := p.checkForRedundantPartitions(field.ID, transform); err != nil {
-		return err
-	}
 	unboundField := PartitionField{
 		SourceIDs: []int{field.ID},
 		FieldID:   fieldIDValue,
@@ -324,21 +334,6 @@ func validateTransform(transform Transform) error {
 	default:
 		return nil
 	}
-}
-
-func (p *PartitionSpec) checkForRedundantPartitions(sourceID int, transform Transform) error {
-	if fields, ok := p.sourceIdToFields[sourceID]; ok {
-		for _, f := range fields {
-			if f.Transform.Equals(transform) {
-				return fmt.Errorf("cannot add redundant partition with source id %d and transform %s. A partition with the same source id and transform already exists with name: %s",
-					sourceID,
-					transform,
-					f.Name)
-			}
-		}
-	}
-
-	return nil
 }
 
 func (p *PartitionSpec) Len() int {
@@ -387,6 +382,10 @@ func (ps *PartitionSpec) assignPartitionFieldIds(lastAssignedFieldIDPtr *int) er
 // NewPartitionSpec creates a new PartitionSpec with the given fields.
 //
 // The fields are not verified against a schema, use NewPartitionSpecOpts if you have to ensure compatibility.
+//
+// The fields are not checked for redundancy either, so this accepts a spec that
+// UnmarshalJSON would reject, meaning the result may not survive a metadata
+// round trip. Use NewPartitionSpecOpts when the spec has to be readable back.
 func NewPartitionSpec(fields ...PartitionField) PartitionSpec {
 	return NewPartitionSpecID(InitialPartitionSpecID, fields...)
 }
@@ -394,6 +393,10 @@ func NewPartitionSpec(fields ...PartitionField) PartitionSpec {
 // NewPartitionSpecID creates a new PartitionSpec with the given fields and id.
 //
 // The fields are not verified against a schema, use NewPartitionSpecOpts if you have to ensure compatibility.
+//
+// The fields are not checked for redundancy either, so this accepts a spec that
+// UnmarshalJSON would reject, meaning the result may not survive a metadata
+// round trip. Use NewPartitionSpecOpts when the spec has to be readable back.
 func NewPartitionSpecID(id int, fields ...PartitionField) PartitionSpec {
 	fieldCopies := make([]PartitionField, len(fields))
 	for i, field := range fields {
@@ -498,24 +501,51 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// validatePartitionFields rejects duplicate partition names and redundant
+// fields (the same transform applied to the same source columns). It is the
+// single definition of a well-formed field set, shared by NewPartitionSpecOpts
+// and UnmarshalJSON so the builder cannot produce a spec the parser rejects.
+//
+// Repeated void fields are exempt: void is the tombstone written for a dropped
+// partition field, so a spec that has dropped several fields legitimately
+// carries more than one.
+//
+// TODO: this does not implement Java's dedupName rule, which collapses year,
+// month, day and hour to a single name per source column and so rejects
+// year(ts) alongside month(ts). We accept that pairing, which means a spec
+// built here can be refused by Java's PartitionSpec.Builder. UpdateSpec.addField
+// already carries an added-vs-added guard for time transforms, so the rule
+// exists in the codebase but not in this validator.
 func validatePartitionFields(fields []PartitionField) error {
 	names := make(map[string]struct{}, len(fields))
-	definitions := make(map[string]struct{}, len(fields))
+	// Keyed by source IDs only; the transforms behind each key are compared with
+	// Transform.Equals rather than their rendered names, so a transform whose
+	// String() is not injective cannot make two distinct transforms collide.
+	bySource := make(map[string][]Transform, len(fields))
 	for _, field := range fields {
 		if _, ok := names[field.Name]; ok {
 			return fmt.Errorf("%w: duplicate partition name: %s", ErrInvalidPartitionSpec, field.Name)
 		}
 		names[field.Name] = struct{}{}
+		// Reject a nil transform before the redundancy comparison below calls
+		// Equals on it. The option constructors accept any Transform and
+		// validateTransform's default branch passes nil through, so this is the
+		// first place a nil would be dereferenced.
+		if field.Transform == nil {
+			return fmt.Errorf("%w: partition field %s has no transform", ErrInvalidPartitionSpec, field.Name)
+		}
 		if _, isVoid := field.Transform.(VoidTransform); isVoid {
 			continue
 		}
 
-		definition := fmt.Sprintf("%v:%s", field.SourceIDs, field.Transform)
-		if _, ok := definitions[definition]; ok {
-			return fmt.Errorf("%w: redundant partition field for source IDs %v and transform %s",
-				ErrInvalidPartitionSpec, field.SourceIDs, field.Transform)
+		key := fmt.Sprint(field.SourceIDs)
+		for _, existing := range bySource[key] {
+			if existing.Equals(field.Transform) {
+				return fmt.Errorf("%w: redundant partition field for source IDs %v and transform %s",
+					ErrInvalidPartitionSpec, field.SourceIDs, field.Transform)
+			}
 		}
-		definitions[definition] = struct{}{}
+		bySource[key] = append(bySource[key], field.Transform)
 	}
 
 	return nil

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -725,3 +725,233 @@ func TestPartitionSpecUnmarshalAllowsRepeatedVoidTransforms(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &spec))
 	assert.Equal(t, 2, spec.NumFields())
 }
+
+// NewPartitionSpecOpts used to accept a redundant field and emit a spec that
+// UnmarshalJSON then rejected, so the builder could write table metadata this
+// library could not read back.
+func TestNewPartitionSpecOptsRejectsRedundantField(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	tests := []struct {
+		name      string
+		transform iceberg.Transform
+	}{
+		{name: "identity", transform: iceberg.IdentityTransform{}},
+		{name: "bucket", transform: iceberg.BucketTransform{NumBuckets: 16}},
+		{name: "truncate", transform: iceberg.TruncateTransform{Width: 4}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := iceberg.NewPartitionSpecOpts(
+				iceberg.WithSpecID(1),
+				iceberg.AddPartitionFieldByName("s", "first", tt.transform, schema, nil),
+				iceberg.AddPartitionFieldByName("s", "second", tt.transform, schema, nil),
+			)
+
+			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+			assert.ErrorContains(t, err, "redundant partition field")
+		})
+	}
+}
+
+// The builder and UnmarshalJSON must agree on what a redundant field is, so
+// anything the builder produces survives a metadata round trip.
+func TestNewPartitionSpecOptsOutputRoundTrips(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+
+	spec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("s", "s_bucket", iceberg.BucketTransform{NumBuckets: 16}, schema, nil),
+		iceberg.AddPartitionFieldByName("s", "s_trunc", iceberg.TruncateTransform{Width: 4}, schema, nil),
+		iceberg.AddPartitionFieldByName("ts", "ts_year", iceberg.YearTransform{}, schema, nil),
+	)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	var back iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal(data, &back))
+
+	// Compare field content, not just the count: a round trip that reordered
+	// the fields or dropped a transform parameter would keep the count.
+	require.Equal(t, spec.NumFields(), back.NumFields())
+	for i := range spec.NumFields() {
+		want, got := spec.Field(i), back.Field(i)
+		assert.Equal(t, want.Name, got.Name)
+		assert.Equal(t, want.SourceIDs, got.SourceIDs)
+		assert.True(t, want.Transform.Equals(got.Transform),
+			"field %s transform: want %s, got %s", want.Name, want.Transform, got.Transform)
+	}
+}
+
+// Differing parameters make two transforms distinct even though they share a
+// transform family, so both may partition the same source column.
+func TestNewPartitionSpecOptsAllowsDistinctTransformsOnSameSource(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	spec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("s", "s_b16", iceberg.BucketTransform{NumBuckets: 16}, schema, nil),
+		iceberg.AddPartitionFieldByName("s", "s_b32", iceberg.BucketTransform{NumBuckets: 32}, schema, nil),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, spec.NumFields())
+}
+
+// void is the tombstone for a dropped partition field, so a spec that dropped
+// several fields on one column carries several voids. BindToSchema replays such
+// a spec through the builder, which must not reject it.
+func TestBindToSchemaAllowsRepeatedVoidTransforms(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	data := `{"spec-id":0,"fields":[{"source-id":1,"field-id":1000,"name":"first","transform":"void"},{"source-id":1,"field-id":1001,"name":"second","transform":"void"}]}`
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal([]byte(data), &spec))
+
+	bound, err := spec.BindToSchema(schema, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, bound.NumFields())
+}
+
+// Redundancy is keyed on Transform.Equals rather than the rendered transform
+// name, so a transform whose String() is not injective cannot collide with a
+// distinct one. nonComparableTransform embeds IdentityTransform, so every
+// transform here renders as "identity" and only Equals separates them.
+func TestNewPartitionSpecOptsRedundancyUsesTransformEquals(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	same := nonComparableTransform{values: []int{1, 2}}
+	other := nonComparableTransform{values: []int{2, 3}}
+	require.Equal(t, same.String(), other.String(),
+		"the test is only meaningful while both transforms render identically")
+
+	_, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("s", "first", same, schema, nil),
+		iceberg.AddPartitionFieldByName("s", "second", same, schema, nil),
+	)
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
+
+	spec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("s", "first", same, schema, nil),
+		iceberg.AddPartitionFieldByName("s", "second", other, schema, nil),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, spec.NumFields())
+}
+
+// BindToSchema replays an existing spec through the builder, so it inherits the
+// same redundancy check. The specs are built with NewPartitionSpecID because
+// that constructor does not validate, which is the only way to get a redundant
+// spec into BindToSchema in the first place.
+func TestBindToSchemaRejectsRedundantField(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	redundant := iceberg.NewPartitionSpecID(1,
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "first",
+			Transform: iceberg.IdentityTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1001, Name: "second",
+			Transform: iceberg.IdentityTransform{},
+		},
+	)
+
+	_, err := redundant.BindToSchema(schema, nil, nil)
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
+}
+
+// A nil transform reaches the redundancy comparison once two fields share a
+// source column, so it has to be rejected rather than dereferenced.
+func TestNewPartitionSpecOptsRejectsNilTransform(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	require.NotPanics(t, func() {
+		_, err := iceberg.NewPartitionSpecOpts(
+			iceberg.WithSpecID(1),
+			iceberg.AddPartitionFieldByName("s", "first", nil, schema, nil),
+			iceberg.AddPartitionFieldByName("s", "second", nil, schema, nil),
+		)
+		require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+		assert.ErrorContains(t, err, "has no transform")
+	})
+}
+
+// Multi-argument transforms carry several source IDs, and redundancy is keyed on
+// the whole list, so neighbouring lists must not be conflated.
+func TestValidatePartitionFieldsMultiSourceRedundancy(t *testing.T) {
+	redundant := iceberg.NewPartitionSpecID(1,
+		iceberg.PartitionField{
+			SourceIDs: []int{1, 2}, FieldID: 1000, Name: "first",
+			Transform: iceberg.IdentityTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{1, 2}, FieldID: 1001, Name: "second",
+			Transform: iceberg.IdentityTransform{},
+		},
+	)
+	data, err := json.Marshal(redundant)
+	require.NoError(t, err)
+
+	var back iceberg.PartitionSpec
+	err = json.Unmarshal(data, &back)
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
+
+	// [1 2] and [1 23] must stay distinct rather than colliding on a shared prefix.
+	distinct := iceberg.NewPartitionSpecID(1,
+		iceberg.PartitionField{
+			SourceIDs: []int{1, 2}, FieldID: 1000, Name: "first",
+			Transform: iceberg.IdentityTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{1, 23}, FieldID: 1001, Name: "second",
+			Transform: iceberg.IdentityTransform{},
+		},
+	)
+	data, err = json.Marshal(distinct)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, 2, back.NumFields())
+}
+
+// Known divergence from Java: dedupName collapses the time transforms to one
+// name per source column, so Java rejects this pairing while we accept it. If
+// that rule ever lands here, this test should flip rather than silently break
+// callers building hierarchical time specs.
+func TestNewPartitionSpecOptsAllowsMultipleTimeTransforms(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+
+	spec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("ts", "ts_year", iceberg.YearTransform{}, schema, nil),
+		iceberg.AddPartitionFieldByName("ts", "ts_month", iceberg.MonthTransform{}, schema, nil),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, spec.NumFields())
+}


### PR DESCRIPTION
`checkForRedundantPartitions` used `PartitionSpec.sourceIdToFields`, but that map is only populated by `initialize()`. `NewPartitionSpecOpts` calls `initialize()` after all options have been applied, so during construction the map is nil and the check never runs. As a result, the builder accepted multiple partition fields with the same transform on the same source column.

`UnmarshalJSON` rejects the same spec through `validatePartitionFields`, which meant the builder could produce metadata that the library could not read back:

```text
build:    err=<nil> nfields=2
marshal:  {"spec-id":1,"fields":[{"source-id":1,...,"transform":"bucket[16]"},
                                 {"source-id":1,...,"transform":"bucket[16]"}]}
read back own output: err=invalid partition spec: redundant partition field for source IDs [1] and transform bucket[16]
```

This change validates the final field set in `NewPartitionSpecOpts` using `validatePartitionFields` instead of trying to catch duplicates as each field is added. That gives the constructor and parser a single definition of a redundant partition field. `BindToSchema` also goes through this constructor, so it gets the same validation.

`NewPartitionSpec` and `NewPartitionSpecID` remain unchanged because neither can return an error. Their doc comments now note that they may produce specs that do not survive a metadata round trip.

I also changed `validatePartitionFields` to compare transforms with `Transform.Equals` rather than using a string key based on `fmt.Sprintf`. This behaves the same for the eight transforms currently implemented, but avoids maintaining a separate definition of transform identity. Since this calls a method on the transform, nil transforms are now rejected explicitly instead of causing a dereference.

Repeated `void` fields remain allowed. `void` is used as a tombstone for dropped partition fields, and a v1 spec may legitimately contain several dropped fields for the same source column. `BindToSchema` reconstructs those specs through the builder, so rejecting repeated `void` fields would break that path. A test covers this case.

One intentional difference from Java remains. Java's `dedupName` treats year, month, day, and hour as one partition name per source column, so it rejects `year(ts)` together with `month(ts)`. Go currently accepts that combination. This PR does not change that behavior; the validator has a TODO, and a test records the current result.

This does make `NewPartitionSpecOpts` stricter. Callers that currently build redundant specs will start receiving an error. That is observable, but those specs could not be read back by the library anyway.

The review also uncovered a separate existing bug that is not included here: a source-less `void` tombstone fails `BindToSchema` with `cannot find source column with id: 0 in schema`. The behavior is the same on `main` and this branch. `UnmarshalJSON` accepts that shape intentionally, so `BindToSchema` should be able to replay it. I can file that separately.
