### PR TITLE
perf(table): prune row groups during row-lineage rewrites

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -685,6 +686,7 @@ type arrowScan struct {
 	// pruning. It lets callers keep boundRowFilter as AlwaysTrue while they
 	// must evaluate the real row filter after position-dependent enrichment.
 	rowGroupFilter iceberg.BooleanExpression
+	filterSchema   *iceberg.Schema
 	caseSensitive  bool
 	rowLimit       int64
 	options        iceberg.Properties
@@ -847,6 +849,81 @@ func (filterBindingVisitor) VisitBound(iceberg.BoundPredicate) filterBindingStat
 	return filterBindingState{hasBound: true}
 }
 
+type boundFilterSchemaVisitor struct {
+	schema *iceberg.Schema
+}
+
+func (boundFilterSchemaVisitor) VisitTrue() error  { return nil }
+func (boundFilterSchemaVisitor) VisitFalse() error { return nil }
+func (boundFilterSchemaVisitor) VisitNot(child error) error {
+	return child
+}
+
+func firstFilterValidationError(left, right error) error {
+	if left != nil {
+		return left
+	}
+
+	return right
+}
+
+func (boundFilterSchemaVisitor) VisitAnd(left, right error) error {
+	return firstFilterValidationError(left, right)
+}
+
+func (boundFilterSchemaVisitor) VisitOr(left, right error) error {
+	return firstFilterValidationError(left, right)
+}
+
+func (boundFilterSchemaVisitor) VisitUnbound(iceberg.UnboundPredicate) error {
+	return fmt.Errorf("%w: expected a fully bound scan task residual", iceberg.ErrInvalidArgument)
+}
+
+func (v boundFilterSchemaVisitor) VisitBound(pred iceberg.BoundPredicate) error {
+	boundRef := pred.Ref()
+	boundField := boundRef.Field()
+	effectiveField, ok := v.schema.FindFieldByID(boundField.ID)
+	if !ok {
+		return fmt.Errorf("%w: bound residual references field ID %d, which is not present in the scan schema",
+			iceberg.ErrInvalidArgument, boundField.ID)
+	}
+	if !effectiveField.Type.Equals(boundField.Type) {
+		return fmt.Errorf("%w: bound residual field ID %d has type %s, but the scan schema has type %s",
+			iceberg.ErrInvalidArgument, boundField.ID, boundField.Type, effectiveField.Type)
+	}
+
+	columnName, ok := v.schema.FindColumnName(boundField.ID)
+	if !ok {
+		return fmt.Errorf("%w: scan schema has no name for field ID %d",
+			iceberg.ErrInvalidArgument, boundField.ID)
+	}
+	rebound, err := iceberg.Reference(columnName).Bind(v.schema, true)
+	if err != nil {
+		return fmt.Errorf("%w: cannot validate field ID %d against the scan schema: %v",
+			iceberg.ErrInvalidArgument, boundField.ID, err)
+	}
+	if !slices.Equal(boundRef.PosPath(), rebound.Ref().PosPath()) {
+		return fmt.Errorf("%w: bound residual field ID %d has accessor path %v, but the scan schema uses %v",
+			iceberg.ErrInvalidArgument, boundField.ID, boundRef.PosPath(), rebound.Ref().PosPath())
+	}
+
+	return nil
+}
+
+func validateBoundFilter(schema *iceberg.Schema, filter iceberg.BooleanExpression) error {
+	if schema == nil {
+		return fmt.Errorf("%w: cannot validate a bound scan task residual against a nil schema",
+			iceberg.ErrInvalidArgument)
+	}
+
+	validationErr, visitErr := iceberg.VisitExpr(filter, boundFilterSchemaVisitor{schema: schema})
+	if visitErr != nil {
+		return visitErr
+	}
+
+	return validationErr
+}
+
 func bindTaskFilter(schema *iceberg.Schema, filter iceberg.BooleanExpression, caseSensitive bool) (iceberg.BooleanExpression, error) {
 	if filter == nil {
 		return nil, nil
@@ -860,6 +937,12 @@ func bindTaskFilter(schema *iceberg.Schema, filter iceberg.BooleanExpression, ca
 		return nil, fmt.Errorf("%w: scan task residual mixes bound and unbound predicates", iceberg.ErrInvalidArgument)
 	}
 	if !state.hasUnbound {
+		if state.hasBound {
+			if err := validateBoundFilter(schema, filter); err != nil {
+				return nil, err
+			}
+		}
+
 		return filter, nil
 	}
 
@@ -871,7 +954,12 @@ func (as *arrowScan) rowFilterForTask(task FileScanTask) (iceberg.BooleanExpress
 		return as.boundRowFilter, nil
 	}
 
-	return bindTaskFilter(as.scanSchema, task.Residual, as.caseSensitive)
+	filterSchema := as.scanSchema
+	if as.filterSchema != nil {
+		filterSchema = as.filterSchema
+	}
+
+	return bindTaskFilter(filterSchema, task.Residual, as.caseSensitive)
 }
 
 // fieldIndexByID returns the index of the field carrying fieldID in its Arrow

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -681,9 +681,13 @@ type arrowScan struct {
 	scanSchema      *iceberg.Schema
 	projectedSchema *iceberg.Schema
 	boundRowFilter  iceberg.BooleanExpression
-	caseSensitive   bool
-	rowLimit        int64
-	options         iceberg.Properties
+	// rowGroupFilter is used only for Parquet statistics and bloom-filter
+	// pruning. It lets callers keep boundRowFilter as AlwaysTrue while they
+	// must evaluate the real row filter after position-dependent enrichment.
+	rowGroupFilter iceberg.BooleanExpression
+	caseSensitive  bool
+	rowLimit       int64
+	options        iceberg.Properties
 
 	useLargeTypes bool
 	concurrency   int

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1063,8 +1063,12 @@ func (as *arrowScan) processRecords(
 		testRowGroups any
 		recRdr        array.RecordReader
 	)
-	if rowFilter == nil {
-		rowFilter = iceberg.AlwaysTrue{}
+	pruningFilter := rowFilter
+	if as.rowGroupFilter != nil {
+		pruningFilter = as.rowGroupFilter
+	}
+	if pruningFilter == nil {
+		pruningFilter = iceberg.AlwaysTrue{}
 	}
 
 	// Row-group stats/bloom pruning skips whole groups, so emitted batches no
@@ -1075,12 +1079,12 @@ func (as *arrowScan) processRecords(
 	// stays enabled.
 	switch {
 	case task.Value.File.FileFormat() == iceberg.ParquetFile:
-		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, rowFilter, false)
+		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, pruningFilter, false)
 		if err != nil {
 			return err
 		}
 
-		bloomPreds, err := newBloomFilterPredicates(rowFilter)
+		bloomPreds, err := newBloomFilterPredicates(pruningFilter)
 		if err != nil {
 			return err
 		}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1167,6 +1167,24 @@ func (as *arrowScan) processRecords(
 	// stays enabled.
 	switch {
 	case task.Value.File.FileFormat() == iceberg.ParquetFile:
+		logicalSchema := as.filterSchema
+		if logicalSchema == nil {
+			logicalSchema = as.projectedSchema
+		}
+
+		hasMissingDefault, err := pruningFilterHasMissingInitialDefault(
+			pruningFilter, logicalSchema, fileSchema)
+		if err != nil {
+			return err
+		}
+		if hasMissingDefault {
+			// TranslateColumnNames treats fields missing from the physical file
+			// as null. That is unsafe for fields added with a non-null
+			// initial-default because Iceberg materializes the default on read.
+			// Keep the actual row filter, but conservatively skip early pruning.
+			pruningFilter = iceberg.AlwaysTrue{}
+		}
+
 		filePruningFilter, err := iceberg.TranslateColumnNames(pruningFilter, fileSchema)
 		if err != nil {
 			return err
@@ -1252,6 +1270,33 @@ func (as *arrowScan) processRecords(
 	}
 
 	return err
+}
+
+func pruningFilterHasMissingInitialDefault(
+	filter iceberg.BooleanExpression,
+	logicalSchema, fileSchema *iceberg.Schema,
+) (bool, error) {
+	if logicalSchema == nil || fileSchema == nil {
+		return false, nil
+	}
+
+	fieldIDs, err := iceberg.ExtractFieldIDs(filter)
+	if err != nil {
+		return false, err
+	}
+
+	for _, fieldID := range fieldIDs {
+		if _, found := fileSchema.FindFieldByID(fieldID); found {
+			continue
+		}
+
+		field, found := logicalSchema.FindFieldByID(fieldID)
+		if found && field.InitialDefault != nil {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerated[FileScanTask], out chan<- enumeratedRecord, positionalDeletes positionDeletes, dvBitmap *dv.RoaringPositionBitmap, eqDeleteSets []*equalityDeleteSet) (err error) {

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1167,12 +1167,22 @@ func (as *arrowScan) processRecords(
 	// stays enabled.
 	switch {
 	case task.Value.File.FileFormat() == iceberg.ParquetFile:
-		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, pruningFilter, false)
+		filePruningFilter, err := iceberg.TranslateColumnNames(pruningFilter, fileSchema)
 		if err != nil {
 			return err
 		}
 
-		bloomPreds, err := newBloomFilterPredicates(pruningFilter)
+		filePruningFilter, err = iceberg.BindExpr(fileSchema, filePruningFilter, as.caseSensitive)
+		if err != nil {
+			return err
+		}
+
+		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, filePruningFilter, false)
+		if err != nil {
+			return err
+		}
+
+		bloomPreds, err := newBloomFilterPredicates(filePruningFilter)
 		if err != nil {
 			return err
 		}

--- a/table/arrow_scanner_pruning_internal_test.go
+++ b/table/arrow_scanner_pruning_internal_test.go
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	tblutils "github.com/apache/iceberg-go/table/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type pruningFilterTestReader struct {
+	schema *arrow.Schema
+	tester *tblutils.ParquetRowGroupTester
+}
+
+func (r *pruningFilterTestReader) Close() error { return nil }
+
+func (r *pruningFilterTestReader) Metadata() tblutils.Metadata { return nil }
+
+func (r *pruningFilterTestReader) SourceFileSize() int64 { return 1 }
+
+func (r *pruningFilterTestReader) Schema() (*arrow.Schema, error) {
+	return r.schema, nil
+}
+
+func (r *pruningFilterTestReader) PrunedSchema(map[int]struct{}, iceberg.NameMapping) (*arrow.Schema, []int, error) {
+	return r.schema, []int{0}, nil
+}
+
+func (r *pruningFilterTestReader) GetRecords(_ context.Context, _ []int, tester any) (array.RecordReader, error) {
+	r.tester = tester.(*tblutils.ParquetRowGroupTester)
+
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	values := builder.NewArray()
+	builder.Release()
+
+	record := array.NewRecordBatch(r.schema, []arrow.Array{values}, 1)
+	values.Release()
+	reader, err := array.NewRecordReader(r.schema, []arrow.RecordBatch{record})
+	record.Release()
+
+	return reader, err
+}
+
+func (r *pruningFilterTestReader) ReadTable(context.Context) (arrow.Table, error) {
+	return nil, nil
+}
+
+func TestProcessRecordsUsesRowGroupFilterForPruning(t *testing.T) {
+	ctx := context.Background()
+	fileSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	rowGroupFilter, err := iceberg.BindExpr(fileSchema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	dataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		"file:///test.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	reader := &pruningFilterTestReader{schema: arrowSchema}
+	out := make(chan enumeratedRecord, 1)
+	err = (&arrowScan{rowGroupFilter: rowGroupFilter, projectedSchema: fileSchema}).processRecords(
+		ctx,
+		tblutils.Enumerated[FileScanTask]{Value: FileScanTask{File: dataFileBuilder.Build()}},
+		fileSchema, iceberg.AlwaysTrue{}, reader, []int{0}, nil, nil, out)
+	require.NoError(t, err)
+
+	require.NotNil(t, reader.tester)
+	require.Len(t, reader.tester.BloomPreds, 1)
+	assert.Equal(t, 1, reader.tester.BloomPreds[0].FieldID)
+	assert.Len(t, reader.tester.BloomPreds[0].PhysBytes, 1)
+
+	result := <-out
+	result.Record.Value.Release()
+}

--- a/table/arrow_scanner_pruning_internal_test.go
+++ b/table/arrow_scanner_pruning_internal_test.go
@@ -188,6 +188,50 @@ func TestProcessRecordsRebindsRowGroupFilterToPromotedFileSchema(t *testing.T) {
 	result.Record.Value.Release()
 }
 
+func TestProcessRecordsDoesNotPruneMissingInitialDefault(t *testing.T) {
+	ctx := context.Background()
+	fileSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	currentSchema := iceberg.NewSchema(2,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{
+			ID: 2, Name: "flag", Type: iceberg.PrimitiveTypes.Int32,
+			InitialDefault: int32(1),
+		},
+	)
+	rowGroupFilter, err := iceberg.BindExpr(currentSchema, iceberg.NewAnd(
+		iceberg.GreaterThan(iceberg.Reference("id"), int64(5)),
+		iceberg.NotNull(iceberg.Reference("flag"))), true)
+	require.NoError(t, err)
+
+	dataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		"file:///test.parquet", iceberg.ParquetFile, nil, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	arrowSchema, err := SchemaToArrowSchema(fileSchema, nil, true, false)
+	require.NoError(t, err)
+	reader := &pruningFilterTestReader{schema: arrowSchema}
+	out := make(chan enumeratedRecord, 1)
+	err = (&arrowScan{
+		rowGroupFilter:  rowGroupFilter,
+		projectedSchema: currentSchema,
+		caseSensitive:   true,
+	}).processRecords(
+		ctx,
+		tblutils.Enumerated[FileScanTask]{Value: FileScanTask{File: dataFileBuilder.Build()}},
+		fileSchema, iceberg.AlwaysTrue{}, reader, []int{0}, nil, nil, out)
+	require.NoError(t, err)
+
+	require.NotNil(t, reader.tester)
+	assert.Empty(t, reader.tester.BloomPreds,
+		"a missing field with an initial-default must disable bloom pruning")
+
+	result := <-out
+	result.Record.Value.Release()
+}
+
 func TestBindTaskFilterValidatesBoundSchema(t *testing.T) {
 	int64Schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},

--- a/table/arrow_scanner_pruning_internal_test.go
+++ b/table/arrow_scanner_pruning_internal_test.go
@@ -18,12 +18,17 @@
 package table
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/assert"
@@ -31,8 +36,10 @@ import (
 )
 
 type pruningFilterTestReader struct {
-	schema *arrow.Schema
-	tester *tblutils.ParquetRowGroupTester
+	schema      *arrow.Schema
+	tester      *tblutils.ParquetRowGroupTester
+	rowGroup    *metadata.RowGroupMetaData
+	statsResult bool
 }
 
 func (r *pruningFilterTestReader) Close() error { return nil }
@@ -51,11 +58,29 @@ func (r *pruningFilterTestReader) PrunedSchema(map[int]struct{}, iceberg.NameMap
 
 func (r *pruningFilterTestReader) GetRecords(_ context.Context, _ []int, tester any) (array.RecordReader, error) {
 	r.tester = tester.(*tblutils.ParquetRowGroupTester)
+	if r.rowGroup != nil {
+		var err error
+		r.statsResult, err = r.tester.StatsFn(r.rowGroup, []int{0})
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	builder := array.NewInt64Builder(memory.DefaultAllocator)
-	builder.Append(1)
-	values := builder.NewArray()
-	builder.Release()
+	var values arrow.Array
+	switch r.schema.Field(0).Type.ID() {
+	case arrow.INT32:
+		builder := array.NewInt32Builder(memory.DefaultAllocator)
+		builder.Append(1)
+		values = builder.NewArray()
+		builder.Release()
+	case arrow.INT64:
+		builder := array.NewInt64Builder(memory.DefaultAllocator)
+		builder.Append(1)
+		values = builder.NewArray()
+		builder.Release()
+	default:
+		panic("unsupported pruning test type")
+	}
 
 	record := array.NewRecordBatch(r.schema, []arrow.Array{values}, 1)
 	values.Release()
@@ -96,6 +121,68 @@ func TestProcessRecordsUsesRowGroupFilterForPruning(t *testing.T) {
 	require.Len(t, reader.tester.BloomPreds, 1)
 	assert.Equal(t, 1, reader.tester.BloomPreds[0].FieldID)
 	assert.Len(t, reader.tester.BloomPreds[0].PhysBytes, 1)
+
+	result := <-out
+	result.Record.Value.Release()
+}
+
+func TestProcessRecordsRebindsRowGroupFilterToPromotedFileSchema(t *testing.T) {
+	ctx := context.Background()
+	fileSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	})
+	currentSchema := iceberg.NewSchema(2, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	rowGroupFilter, err := iceberg.BindExpr(currentSchema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	arrowSchema, err := SchemaToArrowSchema(fileSchema, nil, true, false)
+	require.NoError(t, err)
+	builder := array.NewInt32Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	values := builder.NewArray()
+	builder.Release()
+	record := array.NewRecordBatch(arrowSchema, []arrow.Array{values}, 1)
+	values.Release()
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	record.Release()
+	require.NoError(t, writer.Close())
+
+	parquetReader, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer parquetReader.Close()
+
+	dataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentData,
+		"file:///test.parquet", iceberg.ParquetFile, nil, nil, nil, 1, int64(buf.Len()))
+	require.NoError(t, err)
+
+	reader := &pruningFilterTestReader{
+		schema:   arrowSchema,
+		rowGroup: parquetReader.MetaData().RowGroup(0),
+	}
+	out := make(chan enumeratedRecord, 1)
+	err = (&arrowScan{
+		rowGroupFilter:  rowGroupFilter,
+		projectedSchema: currentSchema,
+		caseSensitive:   true,
+	}).processRecords(
+		ctx,
+		tblutils.Enumerated[FileScanTask]{Value: FileScanTask{File: dataFileBuilder.Build()}},
+		fileSchema, iceberg.AlwaysTrue{}, reader, []int{0}, nil, nil, out)
+	require.NoError(t, err)
+
+	assert.True(t, reader.statsResult, "matching INT32 row-group stats should be retained")
+	require.Len(t, reader.tester.BloomPreds, 1)
+	assert.Equal(t, []byte{1, 0, 0, 0}, reader.tester.BloomPreds[0].PhysBytes[0],
+		"the bloom predicate should use the INT32 file encoding")
 
 	result := <-out
 	result.Record.Value.Release()

--- a/table/arrow_scanner_pruning_internal_test.go
+++ b/table/arrow_scanner_pruning_internal_test.go
@@ -74,8 +74,8 @@ func TestProcessRecordsUsesRowGroupFilterForPruning(t *testing.T) {
 	fileSchema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
 	})
-	rowGroupFilter, err := iceberg.BindExpr(fileSchema,
-		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	rowGroupFilter, err := iceberg.BindExpr(fileSchema, iceberg.NewNot(
+		iceberg.NotEqualTo(iceberg.Reference("id"), int64(1))), true)
 	require.NoError(t, err)
 
 	dataFileBuilder, err := iceberg.NewDataFileBuilder(
@@ -99,4 +99,55 @@ func TestProcessRecordsUsesRowGroupFilterForPruning(t *testing.T) {
 
 	result := <-out
 	result.Record.Value.Release()
+}
+
+func TestBindTaskFilterValidatesBoundSchema(t *testing.T) {
+	int64Schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	bound, err := iceberg.BindExpr(int64Schema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	t.Run("matching schema is accepted", func(t *testing.T) {
+		got, err := bindTaskFilter(int64Schema, bound, true)
+		require.NoError(t, err)
+		require.Same(t, bound, got)
+	})
+
+	t.Run("missing field is rejected", func(t *testing.T) {
+		otherSchema := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 2, Name: "other", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		)
+		_, err := bindTaskFilter(otherSchema, bound, true)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "field ID 1")
+	})
+
+	t.Run("type mismatch is rejected", func(t *testing.T) {
+		otherSchema := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		)
+		_, err := bindTaskFilter(otherSchema, bound, true)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "type")
+	})
+
+	t.Run("accessor path mismatch is rejected", func(t *testing.T) {
+		field := iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}
+		originalSchema := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 10, Name: "payload", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{field}}},
+		)
+		boundNested, err := iceberg.BindExpr(originalSchema,
+			iceberg.EqualTo(iceberg.Reference("payload.id"), int64(1)), true)
+		require.NoError(t, err)
+		otherSchema := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 11, Name: "other", Type: iceberg.PrimitiveTypes.String, Required: true},
+			iceberg.NestedField{ID: 10, Name: "payload", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{field}}},
+		)
+
+		_, err = bindTaskFilter(otherSchema, boundNested, true)
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		require.ErrorContains(t, err, "accessor path")
+	})
 }

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -1859,5 +1859,14 @@ func (c *bloomPredicateCollector) VisitBBoxNotIntersects(_ iceberg.BoundTerm, _ 
 // predicates for row group pruning. Returns nil (no predicates) for
 // AlwaysTrue or any expression with no EqualTo/In conjuncts.
 func newBloomFilterPredicates(expr iceberg.BooleanExpression) ([]internal.RowGroupBloomPred, error) {
-	return iceberg.VisitExpr(expr, &bloomPredicateCollector{})
+	if expr == nil {
+		return nil, nil
+	}
+
+	rewritten, err := iceberg.RewriteNotExpr(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return iceberg.VisitExpr(rewritten, &bloomPredicateCollector{})
 }

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -3111,9 +3111,7 @@ func TestBloomPredicateCollector(t *testing.T) {
 	)
 
 	bind := func(expr iceberg.BooleanExpression) iceberg.BooleanExpression {
-		rewritten, err := iceberg.RewriteNotExpr(expr)
-		require.NoError(t, err)
-		bound, err := iceberg.BindExpr(sc, rewritten, true)
+		bound, err := iceberg.BindExpr(sc, expr, true)
 		require.NoError(t, err)
 
 		return bound
@@ -3152,6 +3150,34 @@ func TestBloomPredicateCollector(t *testing.T) {
 			iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
 			iceberg.EqualTo(iceberg.Reference("name"), "alice"),
 		))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		assert.Empty(t, preds)
+	})
+
+	t.Run("NOT(NotEqual) is normalized to Equal", func(t *testing.T) {
+		expr := bind(iceberg.NewNot(
+			iceberg.NotEqualTo(iceberg.Reference("id"), int64(42))))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+		assert.Equal(t, 1, preds[0].FieldID)
+		assert.Len(t, preds[0].PhysBytes, 1)
+	})
+
+	t.Run("NOT(NotIn) is normalized to In", func(t *testing.T) {
+		expr := bind(iceberg.NewNot(
+			iceberg.NotIn(iceberg.Reference("id"), int64(1), int64(2))))
+		preds, err := newBloomFilterPredicates(expr)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+		assert.Equal(t, 1, preds[0].FieldID)
+		assert.Len(t, preds[0].PhysBytes, 2)
+	})
+
+	t.Run("NOT(Equal) remains unsupported", func(t *testing.T) {
+		expr := bind(iceberg.NewNot(
+			iceberg.EqualTo(iceberg.Reference("id"), int64(42))))
 		preds, err := newBloomFilterPredicates(expr)
 		require.NoError(t, err)
 		assert.Empty(t, preds)

--- a/table/row_lineage_prune_delete_test.go
+++ b/table/row_lineage_prune_delete_test.go
@@ -131,6 +131,25 @@ func TestScanPruningSurvivingGroupSpansBatches(t *testing.T) {
 		"_row_id must stay contiguous as one surviving row group spans multiple batches")
 }
 
+func TestScanPruningAllRowGroupsCompletes(t *testing.T) {
+	ctx := context.Background()
+	tbl := buildTwoRowGroupV3Table(t)
+
+	_, itr, err := tbl.Scan(
+		table.WithRowLineage(),
+		table.WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), int64(999))),
+	).ToArrowRecords(ctx)
+	require.NoError(t, err)
+
+	count := 0
+	for rec, err := range itr {
+		require.NoError(t, err)
+		count += int(rec.NumRows())
+		rec.Release()
+	}
+	assert.Zero(t, count)
+}
+
 // TestReadTaskDeletionVectorSupersedesPositionalDeletes locks the spec contract
 // PlanFiles enforces (scanner.go) for hand-built tasks too: when a data file has
 // both a DV and a positional delete attached, the DV wins and positional deletes

--- a/table/row_lineage_rewrite_bench_test.go
+++ b/table/row_lineage_rewrite_bench_test.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+type rowLineageRewriteBenchmarkFixture struct {
+	tbl          *table.Table
+	catalog      *concurrentTestCatalog
+	fs           *iceio.MemFS
+	location     string
+	baseMetadata table.Metadata
+	initialFiles map[string]struct{}
+}
+
+func BenchmarkRowLineageRewriteRowGroupPruning(b *testing.B) {
+	const numRows = 1_000_000
+
+	for _, tc := range []struct {
+		name         string
+		deleteFilter iceberg.BooleanExpression
+	}{
+		{
+			name:         "keep-1-of-100",
+			deleteFilter: iceberg.LessThan(iceberg.Reference("id"), int64(numRows-10_000)),
+		},
+		{
+			name:         "keep-10-of-100",
+			deleteFilter: iceberg.LessThan(iceberg.Reference("id"), int64(numRows-100_000)),
+		},
+		{
+			name:         "keep-100-of-100",
+			deleteFilter: iceberg.EqualTo(iceberg.Reference("id"), int64(0)),
+		},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			fixture := newRowLineageRewriteBenchmarkFixture(b, numRows)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := fixture.tbl.Delete(ctx, tc.deleteFilter, nil, table.WithDeleteConcurrency(1)); err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+				fixture.reset(b)
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func newRowLineageRewriteBenchmarkFixture(b *testing.B, numRows int) *rowLineageRewriteBenchmarkFixture {
+	b.Helper()
+
+	fsys := iceio.NewMemFS()
+	location := "mem://row-lineage-rewrite-benchmark"
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec, table.UnsortedSortOrder, location,
+		iceberg.Properties{
+			table.PropertyFormatVersion:   "3",
+			table.ParquetRowGroupLimitKey: "10000",
+		})
+	require.NoError(b, err)
+
+	metaLoc := location + "/metadata/v1.metadata.json"
+	fsF := func(context.Context) (iceio.IO, error) { return fsys, nil }
+	catalog := &concurrentTestCatalog{metadata: meta, location: metaLoc, fsF: fsF}
+	tbl := table.New(table.Identifier{"db", "row_lineage_rewrite_benchmark"}, meta, metaLoc, fsF, catalog)
+
+	data := newRowLineageRewriteBenchmarkData(b, numRows)
+	defer data.Release()
+	tbl, err = tbl.Append(context.Background(), array.NewTableReader(data, -1), nil)
+	require.NoError(b, err)
+
+	return &rowLineageRewriteBenchmarkFixture{
+		tbl:          tbl,
+		catalog:      catalog,
+		fs:           fsys,
+		location:     location,
+		baseMetadata: tbl.Metadata(),
+		initialFiles: rowLineageRewriteBenchmarkFiles(b, fsys, location),
+	}
+}
+
+func newRowLineageRewriteBenchmarkData(b *testing.B, numRows int) arrow.Table {
+	b.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	idBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer idBuilder.Release()
+	dataBuilder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer dataBuilder.Release()
+	idBuilder.Reserve(numRows)
+	dataBuilder.Reserve(numRows)
+	for i := range numRows {
+		idBuilder.Append(int64(i))
+		dataBuilder.Append("payload")
+	}
+
+	id := idBuilder.NewArray()
+	defer id.Release()
+	data := dataBuilder.NewArray()
+	defer data.Release()
+	record := array.NewRecordBatch(schema, []arrow.Array{id, data}, int64(numRows))
+	defer record.Release()
+
+	return array.NewTableFromRecords(schema, []arrow.RecordBatch{record})
+}
+
+func (f *rowLineageRewriteBenchmarkFixture) reset(b *testing.B) {
+	b.Helper()
+	for path := range rowLineageRewriteBenchmarkFiles(b, f.fs, f.location) {
+		if _, ok := f.initialFiles[path]; ok {
+			continue
+		}
+		require.NoError(b, f.fs.Remove(path))
+	}
+	f.catalog.metadata = f.baseMetadata
+}
+
+func rowLineageRewriteBenchmarkFiles(b *testing.B, fsys *iceio.MemFS, location string) map[string]struct{} {
+	b.Helper()
+	files := make(map[string]struct{})
+	require.NoError(b, fsys.WalkDir(location, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			files[path] = struct{}{}
+		}
+
+		return nil
+	}))
+
+	return files
+}

--- a/table/row_lineage_rewrite_bench_test.go
+++ b/table/row_lineage_rewrite_bench_test.go
@@ -7,7 +7,6 @@
 // with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
-
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,26 +40,33 @@ type rowLineageRewriteBenchmarkFixture struct {
 }
 
 func BenchmarkRowLineageRewriteRowGroupPruning(b *testing.B) {
-	const numRows = 1_000_000
+	const (
+		rowGroups       = 100
+		rowsPerRowGroup = 10_000
+		numRows         = rowGroups * rowsPerRowGroup
+	)
 
 	for _, tc := range []struct {
-		name         string
-		deleteFilter iceberg.BooleanExpression
+		name              string
+		retainedRowGroups int
+		deleteFilter      iceberg.BooleanExpression
 	}{
 		{
-			name:         "keep-1-of-100",
-			deleteFilter: iceberg.LessThan(iceberg.Reference("id"), int64(numRows-10_000)),
+			name:              "keep-1-of-100",
+			retainedRowGroups: 1,
+			deleteFilter:      iceberg.LessThan(iceberg.Reference("id"), int64(numRows-rowsPerRowGroup)),
 		},
 		{
-			name:         "keep-10-of-100",
-			deleteFilter: iceberg.LessThan(iceberg.Reference("id"), int64(numRows-100_000)),
+			name:              "keep-10-of-100",
+			retainedRowGroups: 10,
+			deleteFilter:      iceberg.LessThan(iceberg.Reference("id"), int64(numRows-10*rowsPerRowGroup)),
 		},
 		{
-			name:         "keep-100-of-100",
-			deleteFilter: iceberg.EqualTo(iceberg.Reference("id"), int64(0)),
+			name:              "keep-100-of-100",
+			retainedRowGroups: rowGroups,
+			deleteFilter:      iceberg.EqualTo(iceberg.Reference("id"), int64(0)),
 		},
 	} {
-		tc := tc
 		b.Run(tc.name, func(b *testing.B) {
 			fixture := newRowLineageRewriteBenchmarkFixture(b, numRows)
 			ctx := context.Background()
@@ -76,6 +82,8 @@ func BenchmarkRowLineageRewriteRowGroupPruning(b *testing.B) {
 				fixture.reset(b)
 				b.StartTimer()
 			}
+			b.ReportMetric(float64(numRows), "rows/op")
+			b.ReportMetric(float64(tc.retainedRowGroups), "retained-row-groups/op")
 		})
 	}
 }

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -252,6 +252,54 @@ func TestCoWRewritePrunesRowGroupsBeforeLineageSynthesis(t *testing.T) {
 	}, readRowIDsByID(t, ctx, tbl))
 }
 
+func TestCoWRewriteDoesNotPruneMissingInitialDefault(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+
+	tbl := newV3RowLineageTestTable(t)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.SetProperties(iceberg.Properties{
+		table.ParquetRowGroupLimitKey: "5",
+	}))
+	tbl, err := tx.Commit(ctx)
+	require.NoError(t, err)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"},{"id":9,"data":"i"},{"id":10,"data":"j"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(data.Release)
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, parquetRowGroupCount(t, tbl), "fixture must have two row groups")
+
+	// The existing file has no flag column, but its rows logically read flag=1.
+	// The survivor complement is id > 5 AND flag IS NOT NULL, so pruning must
+	// not translate the missing physical column to false before projection.
+	tx = tbl.NewTransaction()
+	require.NoError(t, tx.UpdateSchema(true, false).
+		AddColumn([]string{"flag"}, iceberg.PrimitiveTypes.Int32, "", false, iceberg.Int32Literal(1)).
+		Commit())
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	deleteFilter := iceberg.NewOr(
+		iceberg.LessThanEqual(iceberg.Reference("id"), int64(5)),
+		iceberg.IsNull(iceberg.Reference("flag")),
+	)
+	tbl, err = tbl.Delete(ctx, deleteFilter, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[int64]int64{
+		6: 5, 7: 6, 8: 7, 9: 8, 10: 9,
+	}, readRowIDsByID(t, ctx, tbl))
+}
+
 func TestCoWRewriteNormalizesTheSurvivorComplement(t *testing.T) {
 	ctx := context.Background()
 	tbl := buildTwoRowGroupV3Table(t)

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -252,6 +252,19 @@ func TestCoWRewritePrunesRowGroupsBeforeLineageSynthesis(t *testing.T) {
 	}, readRowIDsByID(t, ctx, tbl))
 }
 
+func TestCoWRewriteNormalizesTheSurvivorComplement(t *testing.T) {
+	ctx := context.Background()
+	tbl := buildTwoRowGroupV3Table(t)
+
+	var err error
+	tbl, err = tbl.Delete(ctx,
+		iceberg.NotEqualTo(iceberg.Reference("id"), int64(7)), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[int64]int64{7: 6}, readRowIDsByID(t, ctx, tbl),
+		"the complement of id != 7 must retain only the original row at position 6")
+}
+
 // TestCoWRewriteRowIDNextRowIDAccounting verifies that row-id accounting remains
 // correct after a CoW rewrite. The overcounting (where next-row-id advances by
 // the full manifest row count including preserved survivors) is intentional and

--- a/table/row_lineage_rewrite_test.go
+++ b/table/row_lineage_rewrite_test.go
@@ -211,6 +211,47 @@ func TestCoWRewritePreservesRowID(t *testing.T) {
 		"_last_updated_sequence_number must report the original creation snapshot's sequence number, not the rewrite's")
 }
 
+// TestCoWRewritePrunesRowGroupsBeforeLineageSynthesis verifies that the
+// rewrite path can prune a non-matching row group without renumbering rows in
+// the group that survives. The row filter is still applied after lineage
+// synthesis, while Parquet statistics can skip the first group entirely.
+func TestCoWRewritePrunesRowGroupsBeforeLineageSynthesis(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.DefaultAllocator
+
+	tbl := newV3RowLineageTestTable(t)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.SetProperties(iceberg.Properties{
+		table.ParquetRowGroupLimitKey: "5",
+	}))
+	tbl, err := tx.Commit(ctx)
+	require.NoError(t, err)
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(mem, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"},{"id":9,"data":"i"},{"id":10,"data":"j"}]`,
+	})
+	require.NoError(t, err)
+	t.Cleanup(data.Release)
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, parquetRowGroupCount(t, tbl), "fixture must have two row groups")
+
+	// Delete ids 1..5, which occupy the first row group. The survivor filter
+	// can therefore skip that group by statistics while the second group's
+	// rows retain their original IDs.
+	tbl, err = tbl.Delete(ctx, iceberg.LessThanEqual(iceberg.Reference("id"), int64(5)), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[int64]int64{
+		6: 5, 7: 6, 8: 7, 9: 8, 10: 9,
+	}, readRowIDsByID(t, ctx, tbl))
+}
+
 // TestCoWRewriteRowIDNextRowIDAccounting verifies that row-id accounting remains
 // correct after a CoW rewrite. The overcounting (where next-row-id advances by
 // the full manifest row count including preserved survivors) is intentional and

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1207,6 +1207,7 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		scanSchema:      effectiveSchema,
 		projectedSchema: schema,
 		boundRowFilter:  boundFilter,
+		filterSchema:    effectiveSchema,
 		caseSensitive:   scan.caseSensitive,
 		rowLimit:        scan.limit,
 		options:         scan.options,

--- a/table/task_residual_test.go
+++ b/table/task_residual_test.go
@@ -72,6 +72,7 @@ func TestReadTasksUsesTaskResidual(t *testing.T) {
 
 	require.Equal(t, []int64{2, 3}, got)
 }
+
 func TestReadTasksAppliesDifferentResidualsPerTask(t *testing.T) {
 	ctx := context.Background()
 	tbl := newV3RowLineageTestTable(t)

--- a/table/task_residual_test.go
+++ b/table/task_residual_test.go
@@ -72,7 +72,6 @@ func TestReadTasksUsesTaskResidual(t *testing.T) {
 
 	require.Equal(t, []int64{2, 3}, got)
 }
-
 func TestReadTasksAppliesDifferentResidualsPerTask(t *testing.T) {
 	ctx := context.Background()
 	tbl := newV3RowLineageTestTable(t)

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2271,17 +2271,21 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 	// scanner because _row_id synthesis depends on original file position. The
 	// filter is applied post-synthesis in the record iterator instead.
 	//
-	// TODO(perf): disabling the scan-time row filter forfeits both manifest-
-	// and file-level pushdown for the rewrite read. For selective deletes on
-	// wide partitions this means re-reading every survivor candidate end-to-
-	// end. File-level skipping (against the bound filter's residual on file
-	// stats) could be re-enabled here without breaking _row_id synthesis,
-	// since synthesis depends only on within-file row positions.
+	// Keep the real filter available to Parquet row-group pruning while the
+	// scanner's row filter stays AlwaysTrue. Pruning happens before rows are
+	// materialized, so _row_id synthesis still sees the original positions of
+	// every surviving row group and the post-synthesis filter remains correct.
 	_, originalFirstRowID, _, _, _ := iceberginternal.BorrowedDataFilePointers(args.originalFile)
 	preserveRowLineage := meta.formatVersion >= 3 && originalFirstRowID != nil
 	projectedSchema := meta.CurrentSchema()
 	var factoryOpts []writerFactoryOption
+	var rowGroupFilter iceberg.BooleanExpression
 	if preserveRowLineage {
+		rowGroupFilter, err = iceberg.BindExpr(meta.CurrentSchema(), args.filter, args.caseSensitive)
+		if err != nil {
+			return nil, fmt.Errorf("failed to bind row-group filter: %w", err)
+		}
+
 		projectedSchema = iceberg.SchemaWithRowLineage(projectedSchema)
 		factoryOpts = append(factoryOpts, withFactoryFileSchema(projectedSchema))
 		scanTask.FirstRowID = args.originalFile.FirstRowID()
@@ -2316,6 +2320,7 @@ func (t *Transaction) rewriteSingleFile(ctx context.Context, args rewriteSingleF
 		scanSchema:      meta.CurrentSchema(),
 		projectedSchema: projectedSchema,
 		boundRowFilter:  scanFilter,
+		rowGroupFilter:  rowGroupFilter,
 		caseSensitive:   args.caseSensitive,
 		rowLimit:        -1, // No limit
 		concurrency:     args.concurrency,


### PR DESCRIPTION
## Summary

Restore Parquet row-group pruning during copy-on-write rewrites that preserve row lineage.

## Why

The rewrite scanner had to keep the row filter out of the main scan while it synthesized `_row_id`. That also disabled Parquet statistics and bloom-filter pruning.

## What changed

- Keep the post-lineage survivor filter separate from the Parquet pruning filter.
- Translate and bind pruning filters to each physical file schema.
- Preserve original row positions when row groups are skipped.
- Skip early pruning when a missing field has a non-null `initial-default`.
- Validate bound task residuals against the scan schema.
- Normalize negated filters before collecting bloom predicates.

## Benchmark

The benchmark is in `table/row_lineage_rewrite_bench_test.go`.

It covers 1M rows split into 100 Parquet row groups and measures the end-to-end copy-on-write delete path for 1/100, 10/100, and 100/100 retained groups.

## Tests

- `go test -vet=off ./... -count=1`
- `go test -vet=off -race ./table -run "Test(CoWRewritePrunesRowGroupsBeforeLineageSynthesis|CoWRewriteDoesNotPruneMissingInitialDefault|ProcessRecordsUsesRowGroupFilterForPruning|ProcessRecordsRebindsRowGroupFilterToPromotedFileSchema|ProcessRecordsDoesNotPruneMissingInitialDefault)$" -count=1`
- `go vet ./...`
- `go test -vet=off ./table -run "^$" -bench "^BenchmarkRowLineageRewriteRowGroupPruning$" -benchtime=1x -count=1`