### PR TITLE
feat(table): commit partial rewrites per group

### DIFF
--- a/cmd/iceberg/compact.go
+++ b/cmd/iceberg/compact.go
@@ -164,9 +164,11 @@ func compactRun(ctx context.Context, output Output, tbl *table.Table, plan compa
 		os.Exit(1)
 	}
 
-	if _, err := tx.Commit(ctx); err != nil {
-		output.Error(fmt.Errorf("commit failed: %w", err))
-		os.Exit(1)
+	if !cfg.partialProgress {
+		if _, err := tx.Commit(ctx); err != nil {
+			output.Error(fmt.Errorf("commit failed: %w", err))
+			os.Exit(1)
+		}
 	}
 
 	totalRemovedDeletes := result.RemovedPositionDeleteFiles + result.RemovedEqualityDeleteFiles

--- a/cmd/iceberg/compact.go
+++ b/cmd/iceberg/compact.go
@@ -165,8 +165,16 @@ func compactRun(ctx context.Context, output Output, tbl *table.Table, plan compa
 		os.Exit(1)
 	}
 
-	if _, err := tx.Commit(ctx); err != nil {
-		output.Error(fmt.Errorf("commit failed: %w", err))
+	if !cfg.partialProgress {
+		if _, err := tx.Commit(ctx); err != nil {
+			output.Error(fmt.Errorf("commit failed: %w", err))
+			os.Exit(1)
+		}
+	}
+	if len(result.FailedGroups) > 0 {
+		failure := result.FailedGroups[0]
+		output.Error(fmt.Errorf("compaction failed for %d group(s); first group %q: %w",
+			len(result.FailedGroups), failure.PartitionKey, failure.Err))
 		os.Exit(1)
 	}
 

--- a/table/compaction/pos_delete_collect.go
+++ b/table/compaction/pos_delete_collect.go
@@ -66,38 +66,9 @@ func CollectDeadPositionDeletes(
 	snap *table.Snapshot,
 	rewrittenPaths map[string]struct{},
 ) ([]iceberg.DataFile, error) {
-	if snap == nil || len(rewrittenPaths) == 0 {
-		return nil, nil
-	}
-
-	manifests, err := snap.Manifests(fs)
-	if err != nil {
-		return nil, err
-	}
-
-	// First pass: delete manifests, resolving each candidate's expunge scope.
-	candidates, hasPartitionScoped, err := collectPositionDeleteCandidates(ctx, fs, manifests)
-	if err != nil {
-		return nil, err
-	}
-
-	// Second pass runs only when a partition-scoped candidate needs a survivor
-	// check; file-scoped ones are decided from rewrittenPaths alone.
-	var minSurvivorSeq map[string]int64
-	if hasPartitionScoped {
-		minSurvivorSeq, err = minSurvivorSeqByPartition(ctx, fs, manifests, rewrittenPaths)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return decideDeadPositionDeletes(candidates, rewrittenPaths, minSurvivorSeq), nil
+	return table.CollectDeadPositionDeletes(ctx, fs, snap, rewrittenPaths)
 }
 
-// positionDeleteCandidate is a classic position-delete file resolved to its
-// expunge scope: fileScopedTarget is the single referenced data file for a
-// file-scoped delete, or "" for a partition-scoped one, which is then keyed by
-// partitionKey and gated by the delete's sequence number seq.
 type positionDeleteCandidate struct {
 	df               iceberg.DataFile
 	fileScopedTarget string

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -706,7 +706,7 @@ func validateNoNewDeletesForRewrittenFiles(ctx *conflictContext, rewrittenFiles 
 // can be determined), which callers must treat conservatively via a
 // partition-tuple match rather than skipping the delete.
 func referencedDataFilePath(df iceberg.DataFile) string {
-	if ref := iceberginternal.BorrowedDataFileReferencedDataFile(df); ref != nil {
+	if ref := iceberginternal.BorrowedDataFileReferencedDataFile(df); ref != nil && *ref != "" {
 		return *ref
 	}
 
@@ -721,8 +721,12 @@ func referencedDataFilePath(df iceberg.DataFile) string {
 	if err != nil {
 		return ""
 	}
+	value, ok := lit.(iceberg.TypedLiteral[string])
+	if !ok {
+		return ""
+	}
 
-	return lit.(iceberg.TypedLiteral[string]).Value()
+	return value.Value()
 }
 
 // filePathFieldID is the reserved field ID of the file_path column in a

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -61,11 +61,15 @@ func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 			groups, rewritten := planDVCompaction(t, tbl, dvTarget)
 
 			rtx := tbl.NewTransaction()
-			_, err := rtx.RewriteDataFiles(ctx, groups,
+			result, err := rtx.RewriteDataFiles(ctx, groups,
 				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
 			require.NoError(t, err)
-			tbl, err = rtx.Commit(ctx)
-			require.NoError(t, err)
+			if partialProgress {
+				tbl = result.Table
+			} else {
+				tbl, err = rtx.Commit(ctx)
+				require.NoError(t, err)
+			}
 
 			assertRowCount(t, tbl, 3) // DV applied during the rewrite; id=1 stays gone
 			assert.Empty(t, deleteEntriesReferencing(t, tbl, rewritten),
@@ -95,11 +99,15 @@ func TestRewriteDataFilesPreservesRowIDThroughDeletionVector(t *testing.T) {
 
 			groups, _ := planDVCompaction(t, tbl, dvTarget)
 			rtx := tbl.NewTransaction()
-			_, err := rtx.RewriteDataFiles(ctx, groups,
+			result, err := rtx.RewriteDataFiles(ctx, groups,
 				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
 			require.NoError(t, err)
-			tbl, err = rtx.Commit(ctx)
-			require.NoError(t, err)
+			if partialProgress {
+				tbl = result.Table
+			} else {
+				tbl, err = rtx.Commit(ctx)
+				require.NoError(t, err)
+			}
 
 			assert.Equal(t, before, rowIDByID(t, tbl),
 				"_row_id must be preserved for survivors when a deletion vector is applied during compaction")

--- a/table/dv_rewrite_test.go
+++ b/table/dv_rewrite_test.go
@@ -60,11 +60,15 @@ func TestRewriteDataFilesRemovesDeletionVectors(t *testing.T) {
 			groups, rewritten := planDVCompaction(t, tbl, dvTarget)
 
 			rtx := tbl.NewTransaction()
-			_, err := rtx.RewriteDataFiles(ctx, groups,
+			result, err := rtx.RewriteDataFiles(ctx, groups,
 				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
 			require.NoError(t, err)
-			tbl, err = rtx.Commit(ctx)
-			require.NoError(t, err)
+			if partialProgress {
+				tbl = result.Table
+			} else {
+				tbl, err = rtx.Commit(ctx)
+				require.NoError(t, err)
+			}
 
 			assertRowCount(t, tbl, 3) // DV applied during the rewrite; id=1 stays gone
 			assert.Empty(t, deleteEntriesReferencing(t, tbl, rewritten),
@@ -94,11 +98,15 @@ func TestRewriteDataFilesPreservesRowIDThroughDeletionVector(t *testing.T) {
 
 			groups, _ := planDVCompaction(t, tbl, dvTarget)
 			rtx := tbl.NewTransaction()
-			_, err := rtx.RewriteDataFiles(ctx, groups,
+			result, err := rtx.RewriteDataFiles(ctx, groups,
 				table.RewriteDataFilesOptions{PartialProgress: partialProgress})
 			require.NoError(t, err)
-			tbl, err = rtx.Commit(ctx)
-			require.NoError(t, err)
+			if partialProgress {
+				tbl = result.Table
+			} else {
+				tbl, err = rtx.Commit(ctx)
+				require.NoError(t, err)
+			}
 
 			assert.Equal(t, before, rowIDByID(t, tbl),
 				"_row_id must be preserved for survivors when a deletion vector is applied during compaction")

--- a/table/pos_delete_collect.go
+++ b/table/pos_delete_collect.go
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// CollectDeadPositionDeletes walks the given snapshot's manifests and returns
+// the classic position-delete files made dead by a rewrite that removes
+// rewrittenPaths. A returned delete references only data files the rewrite is
+// removing, so it is safe to expunge in the same commit.
+//
+// A file-scoped delete is resolved through referenced_data_file or equal
+// file_path bounds. A partition-scoped delete is retained when a surviving
+// data file in the same (specID, partition) has a sequence number to which the
+// delete still applies.
+//
+// Deletion vectors are intentionally excluded: they are one-to-one with their
+// referenced data file and are removed from a rewrite using the task result
+// that identified the rewritten file.
+func CollectDeadPositionDeletes(
+	ctx context.Context,
+	fs iceio.IO,
+	snap *Snapshot,
+	rewrittenPaths map[string]struct{},
+) ([]iceberg.DataFile, error) {
+	if snap == nil || len(rewrittenPaths) == 0 {
+		return nil, nil
+	}
+
+	manifests, err := snap.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates, hasPartitionScoped, err := collectPositionDeleteCandidates(ctx, fs, manifests)
+	if err != nil {
+		return nil, err
+	}
+
+	var minSurvivorSeq map[string]int64
+	if hasPartitionScoped {
+		minSurvivorSeq, err = minSurvivorSeqByPartition(ctx, fs, manifests, rewrittenPaths)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return decideDeadPositionDeletes(candidates, rewrittenPaths, minSurvivorSeq), nil
+}
+
+type positionDeleteCandidate struct {
+	df               iceberg.DataFile
+	fileScopedTarget string
+	partitionKey     string
+	seq              int64
+}
+
+func collectPositionDeleteCandidates(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile) (candidates []positionDeleteCandidate, hasPartitionScoped bool, err error) {
+	seen := make(map[string]struct{})
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, false, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		for e, err := range m.Entries(fs, true) {
+			if err != nil {
+				return nil, false, err
+			}
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentPosDeletes || IsDeletionVector(df) {
+				continue
+			}
+			path := df.FilePath()
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+
+			if target := referencedDataFilePath(df); target != "" {
+				candidates = append(candidates, positionDeleteCandidate{df: df, fileScopedTarget: target})
+
+				continue
+			}
+
+			// An unset delete sequence cannot be compared safely. Retain it.
+			if seq := e.SequenceNum(); seq >= 0 {
+				partitionKey, err := canonicalPartitionKey(df.SpecID(), dataFilePartition(df))
+				if err != nil {
+					return nil, false, fmt.Errorf("building partition key for position delete %s (spec %d): %w", df.FilePath(), df.SpecID(), err)
+				}
+				hasPartitionScoped = true
+				candidates = append(candidates, positionDeleteCandidate{
+					df:           df,
+					partitionKey: partitionKey,
+					seq:          seq,
+				})
+			}
+		}
+	}
+
+	return candidates, hasPartitionScoped, nil
+}
+
+func minSurvivorSeqByPartition(ctx context.Context, fs iceio.IO, manifests []iceberg.ManifestFile, rewrittenPaths map[string]struct{}) (map[string]int64, error) {
+	minSeq := make(map[string]int64)
+	for _, m := range manifests {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		if m.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		for e, err := range m.Entries(fs, true) {
+			if err != nil {
+				return nil, err
+			}
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentData {
+				continue
+			}
+			if _, rewritten := rewrittenPaths[df.FilePath()]; rewritten {
+				continue
+			}
+
+			// Unknown survivor sequence numbers are treated as old as possible,
+			// retaining every delete whose applicability is uncertain.
+			seq := max(e.SequenceNum(), 0)
+			key, err := canonicalPartitionKey(df.SpecID(), dataFilePartition(df))
+			if err != nil {
+				return nil, fmt.Errorf("building partition key for surviving data file %s (spec %d): %w", df.FilePath(), df.SpecID(), err)
+			}
+			if cur, ok := minSeq[key]; ok {
+				seq = min(seq, cur)
+			}
+			minSeq[key] = seq
+		}
+	}
+
+	return minSeq, nil
+}
+
+func decideDeadPositionDeletes(candidates []positionDeleteCandidate, rewrittenPaths map[string]struct{}, minSurvivorSeq map[string]int64) []iceberg.DataFile {
+	dead := make([]iceberg.DataFile, 0, len(candidates))
+	for _, c := range candidates {
+		if c.fileScopedTarget != "" {
+			if _, rewritten := rewrittenPaths[c.fileScopedTarget]; rewritten {
+				dead = append(dead, c.df)
+			}
+
+			continue
+		}
+		if cur, ok := minSurvivorSeq[c.partitionKey]; !ok || cur > c.seq {
+			dead = append(dead, c.df)
+		}
+	}
+
+	return dead
+}

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -446,7 +446,11 @@ func ExecuteCompactionGroup(ctx context.Context, tbl *Table, group CompactionTas
 	)
 	for df, err := range WriteRecords(ctx, tbl, arrowSchema, records, writeOpts...) {
 		if err != nil {
-			return CompactionGroupResult{}, fmt.Errorf("write compacted files for group %q: %w", group.PartitionKey, err)
+			return CompactionGroupResult{
+				PartitionKey: group.PartitionKey,
+				NewDataFiles: newFiles,
+				BytesAfter:   bytesAfter,
+			}, fmt.Errorf("write compacted files for group %q: %w", group.PartitionKey, err)
 		}
 		newFiles = append(newFiles, df)
 		bytesAfter += df.FileSizeBytes()
@@ -504,9 +508,6 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		return nil, errors.New("transaction has already been committed")
 	}
 	result := &RewriteResult{Table: t.tbl}
-	if len(groups) == 0 {
-		return result, nil
-	}
 	if len(meta.updates) > 0 || len(t.reqs) > 0 || len(t.validators) > 0 {
 		return nil, fmt.Errorf("%w: partial progress requires a fresh transaction",
 			ErrInvalidOperation)
@@ -519,6 +520,9 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		return nil, fmt.Errorf("%w: MaxCommits must be non-negative", ErrInvalidOperation)
 	}
 	maxFailedCommits := opts.MaxFailedCommits
+	if len(groups) == 0 {
+		return result, nil
+	}
 
 	pendingGroups := make([]CompactionTaskGroup, 0, len(groups))
 	for _, group := range groups {
@@ -548,15 +552,32 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		batchResults := make([]CompactionGroupResult, 0, len(batchGroups))
 		rewrittenPaths := make(map[string]struct{})
 		rewrittenFiles := make([]iceberg.DataFile, 0)
+		fs, err := current.fsF(ctx)
+		if err != nil {
+			return result, fmt.Errorf("open table IO for partial rewrite batch: %w", err)
+		}
+		cleanupBatch := func(cause error, extras ...CompactionGroupResult) error {
+			results := batchResults
+			if len(extras) > 0 {
+				results = make([]CompactionGroupResult, 0, len(batchResults)+len(extras))
+				results = append(results, batchResults...)
+				results = append(results, extras...)
+			}
+			if cleanupErr := cleanupCompactionOutputs(fs, results); cleanupErr != nil {
+				return errors.Join(cause, fmt.Errorf("clean up partial rewrite batch outputs: %w", cleanupErr))
+			}
+
+			return cause
+		}
 
 		for _, group := range batchGroups {
 			if err := ctx.Err(); err != nil {
-				return result, err
+				return result, cleanupBatch(err)
 			}
 
 			gr, err := ExecuteCompactionGroup(ctx, current, group, opts.GroupOptions...)
 			if err != nil {
-				return result, err
+				return result, cleanupBatch(err, gr)
 			}
 
 			if len(gr.OldDataFiles) == 0 && len(gr.NewDataFiles) == 0 {
@@ -576,14 +597,10 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 			continue
 		}
 
-		fs, err := current.fsF(ctx)
-		if err != nil {
-			return result, fmt.Errorf("open table IO for partial rewrite batch: %w", err)
-		}
 		deadPositionDeletes, err := CollectDeadPositionDeletes(
 			ctx, fs, latestSnapshotForBranch(current.Metadata(), t.branch), rewrittenPaths)
 		if err != nil {
-			return result, fmt.Errorf("collect dead position deletes for partial rewrite batch: %w", err)
+			return result, cleanupBatch(fmt.Errorf("collect dead position deletes for partial rewrite batch: %w", err))
 		}
 
 		// Deletion vectors are one-to-one with their referenced data file, so
@@ -608,7 +625,7 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 
 		groupTxn, err := current.NewTransactionOnBranchWithError(t.branch)
 		if err != nil {
-			return result, fmt.Errorf("create transaction for partial rewrite batch: %w", err)
+			return result, cleanupBatch(fmt.Errorf("create transaction for partial rewrite batch: %w", err))
 		}
 		newDataFiles := make([]iceberg.DataFile, 0)
 		oldDataFiles := make([]iceberg.DataFile, 0, len(rewrittenFiles))
@@ -618,7 +635,7 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		}
 		if err := groupTxn.ReplaceFiles(ctx, oldDataFiles, newDataFiles, deletesToRemove,
 			props, withRewriteSemantics()); err != nil {
-			return result, fmt.Errorf("stage partial rewrite batch: %w", err)
+			return result, cleanupBatch(fmt.Errorf("stage partial rewrite batch: %w", err))
 		}
 		groupTxn.addValidator(rewriteValidator(rewrittenFiles))
 

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -29,6 +29,10 @@ import (
 
 // RewriteResult summarizes a completed compaction.
 type RewriteResult struct {
+	// Table is the latest committed table when PartialProgress is enabled.
+	// It is nil for an atomic rewrite until the caller commits the transaction.
+	Table *Table
+
 	// RewrittenGroups is the number of compaction groups committed.
 	RewrittenGroups int
 
@@ -59,6 +63,21 @@ type RewriteResult struct {
 
 	// BytesAfter is the total size of output data files (measured from written files).
 	BytesAfter int64
+
+	// CompletedGroups contains the groups whose snapshots were committed in
+	// partial-progress mode.
+	CompletedGroups []CompactionGroupResult
+
+	// FailedGroups contains groups whose catalog commits failed. A partial
+	// rewrite can return both completed and failed groups.
+	FailedGroups []CompactionGroupFailure
+}
+
+// CompactionGroupFailure records a group that could not be committed during a
+// partial-progress rewrite.
+type CompactionGroupFailure struct {
+	PartitionKey string
+	Err          error
 }
 
 // CompactionTaskGroup is a set of scan tasks in the same partition that
@@ -127,16 +146,19 @@ type CompactionGroupResult struct {
 // RewriteDataFilesOptions bundles the per-rewrite knobs for
 // [Transaction.RewriteDataFiles].
 type RewriteDataFilesOptions struct {
-	// PartialProgress, when true, stages each group as its own
-	// rewrite snapshot and commits it before moving to the next group.
-	// A mid-loop failure therefore leaves already-completed groups durable.
-	// When false (the default), every group lands in a single atomic rewrite
-	// snapshot.
-	//
-	// The parent transaction remains usable as the final table handle: after
-	// partial progress has committed, [Transaction.Commit] returns the latest
-	// table and rejects additional staged work.
+	// PartialProgress, when true, commits each non-empty group in its own
+	// catalog snapshot. When false (the default), every group is staged in a
+	// single atomic rewrite snapshot.
 	PartialProgress bool
+
+	// MaxCommits bounds the number of catalog commits in partial-progress mode.
+	// Zero uses the default of 10. It has no effect for atomic rewrites.
+	MaxCommits int
+
+	// MaxFailedCommits bounds catalog commit failures in partial-progress mode.
+	// Zero (the default) allows all group commits to fail. A negative value also
+	// means unlimited failures.
+	MaxFailedCommits int
 
 	// SnapshotProps are added to the rewrite snapshot's summary.
 	// In partial-progress mode the same properties land on every
@@ -221,7 +243,12 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 		return nil, err
 	}
 	if len(groups) == 0 {
-		return &RewriteResult{}, nil
+		result := &RewriteResult{}
+		if opts.PartialProgress {
+			result.Table = t.tbl
+		}
+
+		return result, nil
 	}
 
 	if opts.PartialProgress {
@@ -432,7 +459,7 @@ func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 // transaction. This is the durable mode: a later group can fail without
 // rolling back snapshots already committed for earlier groups.
 func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
-	result := &RewriteResult{}
+	result := &RewriteResult{Table: t.tbl}
 	meta, err := t.txnMeta()
 	if err != nil {
 		return nil, err
@@ -441,9 +468,18 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		return nil, fmt.Errorf("%w: partial progress requires a fresh transaction",
 			ErrInvalidOperation)
 	}
+	maxCommits := opts.MaxCommits
+	if maxCommits == 0 {
+		maxCommits = 10
+	}
+	if maxCommits < 0 {
+		return nil, fmt.Errorf("%w: MaxCommits must be non-negative", ErrInvalidOperation)
+	}
+	maxFailedCommits := opts.MaxFailedCommits
 
 	props := maps.Clone(opts.SnapshotProps)
 	current := t.tbl
+	failedCommits := 0
 
 	for _, group := range groups {
 		if err := ctx.Err(); err != nil {
@@ -452,6 +488,10 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 
 		if len(group.Tasks) == 0 {
 			continue
+		}
+		if result.RewrittenGroups >= maxCommits {
+			return result, fmt.Errorf("%w: partial rewrite reached MaxCommits=%d",
+				ErrInvalidOperation, maxCommits)
 		}
 
 		gr, err := ExecuteCompactionGroup(ctx, current, group, opts.GroupOptions...)
@@ -480,18 +520,35 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 				current = next
 				t.tbl = next
 				t.committed = true
-				t.partialProgressCommitted = true
 				accumulateGroupMetrics(result, gr)
+				result.CompletedGroups = append(result.CompletedGroups, gr)
+				result.Table = next
+			} else {
+				failedCommits++
+				result.FailedGroups = append(result.FailedGroups, CompactionGroupFailure{
+					PartitionKey: group.PartitionKey,
+					Err:          err,
+				})
+				if maxFailedCommits > 0 && failedCommits >= maxFailedCommits {
+					return result, fmt.Errorf("commit compaction group %q: %w (maximum failed commits reached)",
+						group.PartitionKey, err)
+				}
 			}
 
-			return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
+			continue
 		}
 
 		current = next
 		t.tbl = next
 		t.committed = true
-		t.partialProgressCommitted = true
 		accumulateGroupMetrics(result, gr)
+		result.CompletedGroups = append(result.CompletedGroups, gr)
+		result.Table = next
+	}
+
+	if len(result.FailedGroups) > 0 {
+		return result, fmt.Errorf("partial rewrite completed %d groups with %d failed commits",
+			result.RewrittenGroups, len(result.FailedGroups))
 	}
 
 	return result, nil

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -128,18 +128,14 @@ type CompactionGroupResult struct {
 // [Transaction.RewriteDataFiles].
 type RewriteDataFilesOptions struct {
 	// PartialProgress, when true, stages each group as its own
-	// rewrite snapshot inside the loop so a mid-loop write failure
-	// leaves the already-completed groups staged on this transaction
-	// (the in-memory transaction can be discarded by group rather
-	// than wholesale). When false (the default), every group lands in
-	// a single atomic rewrite snapshot.
+	// rewrite snapshot and commits it before moving to the next group.
+	// A mid-loop failure therefore leaves already-completed groups durable.
+	// When false (the default), every group lands in a single atomic rewrite
+	// snapshot.
 	//
-	// In both modes the catalog commit happens once at
-	// [Transaction.Commit] time, so a process crash mid-loop loses
-	// every staged group regardless of this flag. Callers who need
-	// true per-group catalog durability (matching Java's behavior)
-	// should drive [Transaction.NewRewrite] themselves and commit a
-	// fresh transaction per group.
+	// The parent transaction remains usable as the final table handle: after
+	// partial progress has committed, [Transaction.Commit] returns the latest
+	// table and rejects additional staged work.
 	PartialProgress bool
 
 	// SnapshotProps are added to the rewrite snapshot's summary.
@@ -432,22 +428,22 @@ func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	return true
 }
 
-// rewriteDataFilesPartial stages each group as its own rewrite
-// snapshot via [Transaction.ReplaceFiles] directly. Per-group staging
-// lets a mid-loop write failure leave already-staged groups on the
-// transaction; the catalog still receives them at
-// [Transaction.Commit] time.
-//
-// Validator registration is coalesced: a single [rewriteValidator]
-// covering every rewritten path across all groups is registered once,
-// after the loop, instead of one per group. The transaction's
-// validator list otherwise grows linearly with the group count, and
-// each entry independently walks the concurrent-snapshot set on
-// refresh-replay — the union walk subsumes them.
+// rewriteDataFilesPartial commits each non-empty group in its own child
+// transaction. This is the durable mode: a later group can fail without
+// rolling back snapshots already committed for earlier groups.
 func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
 	result := &RewriteResult{}
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+	if len(meta.updates) > 0 || len(t.reqs) > 0 || len(t.validators) > 0 {
+		return nil, fmt.Errorf("%w: partial progress requires a fresh transaction",
+			ErrInvalidOperation)
+	}
+
 	props := maps.Clone(opts.SnapshotProps)
-	var allRewritten []iceberg.DataFile
+	current := t.tbl
 
 	for _, group := range groups {
 		if err := ctx.Err(); err != nil {
@@ -458,7 +454,7 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 			continue
 		}
 
-		gr, err := ExecuteCompactionGroup(ctx, t.tbl, group, opts.GroupOptions...)
+		gr, err := ExecuteCompactionGroup(ctx, current, group, opts.GroupOptions...)
 		if err != nil {
 			return result, err
 		}
@@ -468,17 +464,34 @@ func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []Comp
 		}
 
 		deletesToRemove := append(slices.Clone(gr.SafePosDeletes), gr.SafeDeletionVectors...)
-		if err := t.ReplaceFiles(ctx, gr.OldDataFiles, gr.NewDataFiles, deletesToRemove,
+		groupTxn, err := current.NewTransactionOnBranchWithError(t.branch)
+		if err != nil {
+			return result, fmt.Errorf("create transaction for compaction group %q: %w", group.PartitionKey, err)
+		}
+		if err := groupTxn.ReplaceFiles(ctx, gr.OldDataFiles, gr.NewDataFiles, deletesToRemove,
 			props, withRewriteSemantics()); err != nil {
+			return result, fmt.Errorf("stage compaction group %q: %w", group.PartitionKey, err)
+		}
+		groupTxn.addValidator(rewriteValidator(gr.OldDataFiles))
+
+		next, err := groupTxn.Commit(ctx)
+		if err != nil {
+			if next != nil {
+				current = next
+				t.tbl = next
+				t.committed = true
+				t.partialProgressCommitted = true
+				accumulateGroupMetrics(result, gr)
+			}
+
 			return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
 		}
 
-		allRewritten = append(allRewritten, gr.OldDataFiles...)
+		current = next
+		t.tbl = next
+		t.committed = true
+		t.partialProgressCommitted = true
 		accumulateGroupMetrics(result, gr)
-	}
-
-	if len(allRewritten) > 0 {
-		t.addValidator(rewriteValidator(allRewritten))
 	}
 
 	return result, nil

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -19,17 +19,23 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	iofs "io/fs"
 	"log/slog"
 	"maps"
-	"slices"
 
 	"github.com/apache/iceberg-go"
 	iceberginternal "github.com/apache/iceberg-go/internal"
+	iceio "github.com/apache/iceberg-go/io"
 )
 
 // RewriteResult summarizes a completed compaction.
 type RewriteResult struct {
+	// Table is the latest committed table when PartialProgress is enabled.
+	// It is nil for an atomic rewrite until the caller commits the transaction.
+	Table *Table
+
 	// RewrittenGroups is the number of compaction groups committed.
 	RewrittenGroups int
 
@@ -60,6 +66,49 @@ type RewriteResult struct {
 
 	// BytesAfter is the total size of output data files (measured from written files).
 	BytesAfter int64
+
+	// CompletedGroups contains the groups whose snapshots were committed in
+	// partial-progress mode.
+	CompletedGroups []CompactionGroupResult
+
+	// FailedGroups contains groups whose catalog commits failed. A partial
+	// rewrite can return both completed and failed groups.
+	FailedGroups []CompactionGroupFailure
+}
+
+// CompactionGroupFailure records a group that could not be committed during a
+// partial-progress rewrite.
+type CompactionGroupFailure struct {
+	PartitionKey string
+	Err          error
+}
+
+// RewriteDataFiles runs a compaction rewrite as a table-level action. Atomic
+// rewrites are committed before this method returns. Partial-progress rewrites
+// commit each group as they run and return the latest table through
+// [RewriteResult.Table].
+//
+// Use [Transaction.RewriteDataFiles] when the rewrite must be staged alongside
+// other updates in one transaction. Partial progress is terminal and should
+// normally be invoked through this action so callers do not accidentally try
+// to commit the parent transaction again.
+func (t Table) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
+	txn, err := t.NewTransactionOnBranchWithError(MainBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := txn.RewriteDataFiles(ctx, groups, opts)
+	if err != nil || opts.PartialProgress {
+		return result, err
+	}
+
+	committed, err := txn.Commit(ctx)
+	if result != nil && err == nil {
+		result.Table = committed
+	}
+
+	return result, err
 }
 
 // CompactionTaskGroup is a set of scan tasks in the same partition that
@@ -106,8 +155,9 @@ type CompactionGroupResult struct {
 
 	// SafePosDeletes are position-delete files referenced by tasks in
 	// this group whose target data file is being rewritten, computed
-	// via [CollectSafePositionDeletes]. They are safe to expunge in
-	// the rewrite snapshot.
+	// via [CollectSafePositionDeletes]. Partial-progress callers must
+	// re-check them against the complete commit batch before expunging
+	// them because one file can reference data files in multiple groups.
 	SafePosDeletes []iceberg.DataFile
 
 	// SafeDeletionVectors are deletion vectors attached to tasks in this
@@ -128,24 +178,26 @@ type CompactionGroupResult struct {
 // RewriteDataFilesOptions bundles the per-rewrite knobs for
 // [Transaction.RewriteDataFiles].
 type RewriteDataFilesOptions struct {
-	// PartialProgress, when true, stages each group as its own
-	// rewrite snapshot inside the loop so a mid-loop write failure
-	// leaves the already-completed groups staged on this transaction
-	// (the in-memory transaction can be discarded by group rather
-	// than wholesale). When false (the default), every group lands in
-	// a single atomic rewrite snapshot.
-	//
-	// In both modes the catalog commit happens once at
-	// [Transaction.Commit] time, so a process crash mid-loop loses
-	// every staged group regardless of this flag. Callers who need
-	// true per-group catalog durability (matching Java's behavior)
-	// should drive [Transaction.NewRewrite] themselves and commit a
-	// fresh transaction per group.
+	// PartialProgress, when true, commits non-empty groups in durable catalog
+	// batches. When false (the default), every group is staged in a single
+	// atomic rewrite snapshot.
 	PartialProgress bool
 
+	// MaxCommits bounds the number of catalog snapshots produced in
+	// partial-progress mode. Groups are batched so all groups are processed
+	// while staying within this bound. Zero uses the default of 10. It has no
+	// effect for atomic rewrites.
+	MaxCommits int
+
+	// MaxFailedCommits bounds catalog commit failures in partial-progress mode.
+	// Zero (the default) and negative values allow unlimited failures. Failures
+	// within the bound are returned in RewriteResult.FailedGroups without making
+	// the operation return an error.
+	MaxFailedCommits int
+
 	// SnapshotProps are added to the rewrite snapshot's summary.
-	// In partial-progress mode the same properties land on every
-	// per-group snapshot rather than being summed or split.
+	// In partial-progress mode the same properties land on every batch
+	// snapshot rather than being summed or split.
 	SnapshotProps iceberg.Properties
 
 	// ExtraDeleteFilesToRemove are delete files that are dead after
@@ -225,12 +277,11 @@ func (t *Transaction) RewriteDataFiles(ctx context.Context, groups []CompactionT
 	if _, err := t.txnMeta(); err != nil {
 		return nil, err
 	}
-	if len(groups) == 0 {
-		return &RewriteResult{}, nil
-	}
-
 	if opts.PartialProgress {
 		return t.rewriteDataFilesPartial(ctx, groups, opts)
+	}
+	if len(groups) == 0 {
+		return &RewriteResult{}, nil
 	}
 
 	result := &RewriteResult{}
@@ -433,64 +484,237 @@ func allTasksHaveRowLineage(tasks []FileScanTask) bool {
 	return true
 }
 
-// rewriteDataFilesPartial stages each group as its own rewrite
-// snapshot via [Transaction.ReplaceFiles] directly. Per-group staging
-// lets a mid-loop write failure leave already-staged groups on the
-// transaction; the catalog still receives them at
-// [Transaction.Commit] time.
-//
-// Validator registration is coalesced: a single [rewriteValidator]
-// covering every rewritten path across all groups is registered once,
-// after the loop, instead of one per group. The transaction's
-// validator list otherwise grows linearly with the group count, and
-// each entry independently walks the concurrent-snapshot set on
-// refresh-replay — the union walk subsumes them.
+// rewriteDataFilesPartial executes groups and commits them in durable batches.
+// A batch is the atomic unit for both the MaxCommits bound and delete cleanup:
+// classic position deletes are rechecked against the union of every old data
+// file in the batch before they are removed. A later batch can fail without
+// rolling back snapshots already committed for earlier batches.
 func (t *Transaction) rewriteDataFilesPartial(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
-	result := &RewriteResult{}
-	props := maps.Clone(opts.SnapshotProps)
-	var allRewritten []iceberg.DataFile
+	if err := t.checkNotNil(); err != nil {
+		return nil, err
+	}
+	t.mx.Lock()
+	defer t.mx.Unlock()
 
+	meta, err := t.txnMeta()
+	if err != nil {
+		return nil, err
+	}
+	if t.committed {
+		return nil, errors.New("transaction has already been committed")
+	}
+	result := &RewriteResult{Table: t.tbl}
+	if len(groups) == 0 {
+		return result, nil
+	}
+	if len(meta.updates) > 0 || len(t.reqs) > 0 || len(t.validators) > 0 {
+		return nil, fmt.Errorf("%w: partial progress requires a fresh transaction",
+			ErrInvalidOperation)
+	}
+	maxCommits := opts.MaxCommits
+	if maxCommits == 0 {
+		maxCommits = 10
+	}
+	if maxCommits < 0 {
+		return nil, fmt.Errorf("%w: MaxCommits must be non-negative", ErrInvalidOperation)
+	}
+	maxFailedCommits := opts.MaxFailedCommits
+
+	pendingGroups := make([]CompactionTaskGroup, 0, len(groups))
 	for _, group := range groups {
+		if len(group.Tasks) > 0 {
+			pendingGroups = append(pendingGroups, group)
+		}
+	}
+	if len(pendingGroups) == 0 {
+		return result, nil
+	}
+
+	// Match Iceberg's action semantics: MaxCommits is a bound on snapshots,
+	// not on the number of groups processed. Distribute all groups across at
+	// most MaxCommits batches.
+	groupsPerCommit := (len(pendingGroups)-1)/maxCommits + 1
+	props := maps.Clone(opts.SnapshotProps)
+	current := t.tbl
+	failedCommits := 0
+
+	for batchStart := 0; batchStart < len(pendingGroups); batchStart += groupsPerCommit {
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
 
-		if len(group.Tasks) == 0 {
+		batchEnd := min(batchStart+groupsPerCommit, len(pendingGroups))
+		batchGroups := pendingGroups[batchStart:batchEnd]
+		batchResults := make([]CompactionGroupResult, 0, len(batchGroups))
+		rewrittenPaths := make(map[string]struct{})
+		rewrittenFiles := make([]iceberg.DataFile, 0)
+
+		for _, group := range batchGroups {
+			if err := ctx.Err(); err != nil {
+				return result, err
+			}
+
+			gr, err := ExecuteCompactionGroup(ctx, current, group, opts.GroupOptions...)
+			if err != nil {
+				return result, err
+			}
+
+			if len(gr.OldDataFiles) == 0 && len(gr.NewDataFiles) == 0 {
+				continue
+			}
+			batchResults = append(batchResults, gr)
+			for _, df := range gr.OldDataFiles {
+				if _, ok := rewrittenPaths[df.FilePath()]; ok {
+					continue
+				}
+				rewrittenPaths[df.FilePath()] = struct{}{}
+				rewrittenFiles = append(rewrittenFiles, df)
+			}
+		}
+
+		if len(batchResults) == 0 {
 			continue
 		}
 
-		gr, err := ExecuteCompactionGroup(ctx, t.tbl, group, opts.GroupOptions...)
+		fs, err := current.fsF(ctx)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("open table IO for partial rewrite batch: %w", err)
+		}
+		deadPositionDeletes, err := CollectDeadPositionDeletes(
+			ctx, fs, latestSnapshotForBranch(current.Metadata(), t.branch), rewrittenPaths)
+		if err != nil {
+			return result, fmt.Errorf("collect dead position deletes for partial rewrite batch: %w", err)
 		}
 
-		if len(gr.OldDataFiles) == 0 && len(gr.NewDataFiles) == 0 {
+		// Deletion vectors are one-to-one with their referenced data file, so
+		// task-level results are sufficient. Deduplicate by reference because
+		// ReplaceFiles rejects multiple DVs for one data file.
+		safeDVs := make([]iceberg.DataFile, 0)
+		seenDVRefs := make(map[string]struct{})
+		for _, gr := range batchResults {
+			for _, dv := range gr.SafeDeletionVectors {
+				ref := dv.ReferencedDataFile()
+				if ref == nil {
+					continue
+				}
+				if _, ok := seenDVRefs[*ref]; ok {
+					continue
+				}
+				seenDVRefs[*ref] = struct{}{}
+				safeDVs = append(safeDVs, dv)
+			}
+		}
+		deletesToRemove := append(deadPositionDeletes, safeDVs...)
+
+		groupTxn, err := current.NewTransactionOnBranchWithError(t.branch)
+		if err != nil {
+			return result, fmt.Errorf("create transaction for partial rewrite batch: %w", err)
+		}
+		newDataFiles := make([]iceberg.DataFile, 0)
+		oldDataFiles := make([]iceberg.DataFile, 0, len(rewrittenFiles))
+		for _, gr := range batchResults {
+			oldDataFiles = append(oldDataFiles, gr.OldDataFiles...)
+			newDataFiles = append(newDataFiles, gr.NewDataFiles...)
+		}
+		if err := groupTxn.ReplaceFiles(ctx, oldDataFiles, newDataFiles, deletesToRemove,
+			props, withRewriteSemantics()); err != nil {
+			return result, fmt.Errorf("stage partial rewrite batch: %w", err)
+		}
+		groupTxn.addValidator(rewriteValidator(rewrittenFiles))
+
+		next, err := groupTxn.Commit(ctx)
+		if err != nil {
+			if next != nil {
+				// A non-nil table means the catalog commit succeeded even if a
+				// post-commit hook returned an error. Keep the committed state and
+				// stop before planning another batch from an error-bearing result.
+				recordCommittedRewriteBatch(result, next, batchResults, deadPositionDeletes, safeDVs, &current, t)
+
+				return result, err
+			}
+
+			// ErrCommitFailed is the only error that proves the catalog did not
+			// commit. Every other error leaves commit state unknown, so continuing
+			// with the old table could apply later batches on stale state.
+			if !errors.Is(err, ErrCommitFailed) {
+				t.committed = true
+
+				return result, err
+			}
+
+			failedCommits++
+			for _, gr := range batchResults {
+				result.FailedGroups = append(result.FailedGroups, CompactionGroupFailure{
+					PartitionKey: gr.PartitionKey,
+					Err:          err,
+				})
+			}
+			if cleanupErr := cleanupCompactionOutputs(fs, batchResults); cleanupErr != nil {
+				return result, errors.Join(err, fmt.Errorf("clean up failed partial rewrite batch outputs: %w", cleanupErr))
+			}
+			if maxFailedCommits > 0 && failedCommits > maxFailedCommits {
+				return result, fmt.Errorf("commit partial rewrite batch %d: %w (maximum failed commits reached)",
+					batchStart/groupsPerCommit+1, err)
+			}
+
 			continue
 		}
 
-		deletesToRemove := append(slices.Clone(gr.SafePosDeletes), gr.SafeDeletionVectors...)
-		if err := t.ReplaceFiles(ctx, gr.OldDataFiles, gr.NewDataFiles, deletesToRemove,
-			props, withRewriteSemantics()); err != nil {
-			return result, fmt.Errorf("commit compaction group %q: %w", group.PartitionKey, err)
-		}
-
-		allRewritten = append(allRewritten, gr.OldDataFiles...)
-		accumulateGroupMetrics(result, gr)
-	}
-
-	if len(allRewritten) > 0 {
-		t.addValidator(rewriteValidator(allRewritten))
+		recordCommittedRewriteBatch(result, next, batchResults, deadPositionDeletes, safeDVs, &current, t)
 	}
 
 	return result, nil
 }
 
+func recordCommittedRewriteBatch(
+	result *RewriteResult,
+	next *Table,
+	batchResults []CompactionGroupResult,
+	deadPositionDeletes []iceberg.DataFile,
+	safeDVs []iceberg.DataFile,
+	current **Table,
+	txn *Transaction,
+) {
+	*current = next
+	txn.tbl = next
+	txn.committed = true
+	for _, gr := range batchResults {
+		accumulateGroupMetricsWithDeletes(result, gr, 0, 0)
+		result.CompletedGroups = append(result.CompletedGroups, gr)
+	}
+	result.RemovedPositionDeleteFiles += len(deadPositionDeletes)
+	result.RemovedDeletionVectorFiles += len(safeDVs)
+	result.Table = next
+}
+
+func cleanupCompactionOutputs(fs iceio.IO, batchResults []CompactionGroupResult) error {
+	paths := make(map[string]struct{})
+	for _, result := range batchResults {
+		for _, file := range result.NewDataFiles {
+			paths[file.FilePath()] = struct{}{}
+		}
+	}
+
+	var cleanupErr error
+	for path := range paths {
+		if err := fs.Remove(path); err != nil && !errors.Is(err, iofs.ErrNotExist) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+
+	return cleanupErr
+}
+
 func accumulateGroupMetrics(r *RewriteResult, gr CompactionGroupResult) {
+	accumulateGroupMetricsWithDeletes(r, gr, len(gr.SafePosDeletes), len(gr.SafeDeletionVectors))
+}
+
+func accumulateGroupMetricsWithDeletes(r *RewriteResult, gr CompactionGroupResult, positionDeletes, deletionVectors int) {
 	r.RewrittenGroups++
 	r.AddedDataFiles += len(gr.NewDataFiles)
 	r.RemovedDataFiles += len(gr.OldDataFiles)
-	r.RemovedPositionDeleteFiles += len(gr.SafePosDeletes)
-	r.RemovedDeletionVectorFiles += len(gr.SafeDeletionVectors)
+	r.RemovedPositionDeleteFiles += positionDeletes
+	r.RemovedDeletionVectorFiles += deletionVectors
 	r.BytesBefore += gr.BytesBefore
 	r.BytesAfter += gr.BytesAfter
 }

--- a/table/rewrite_data_files.go
+++ b/table/rewrite_data_files.go
@@ -80,6 +80,34 @@ type CompactionGroupFailure struct {
 	Err          error
 }
 
+// RewriteDataFiles runs a compaction rewrite as a table-level action. Atomic
+// rewrites are committed before this method returns. Partial-progress rewrites
+// commit each group as they run and return the latest table through
+// [RewriteResult.Table].
+//
+// Use [Transaction.RewriteDataFiles] when the rewrite must be staged alongside
+// other updates in one transaction. Partial progress is terminal and should
+// normally be invoked through this action so callers do not accidentally try
+// to commit the parent transaction again.
+func (t Table) RewriteDataFiles(ctx context.Context, groups []CompactionTaskGroup, opts RewriteDataFilesOptions) (*RewriteResult, error) {
+	txn, err := t.NewTransactionOnBranchWithError(MainBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := txn.RewriteDataFiles(ctx, groups, opts)
+	if err != nil || opts.PartialProgress {
+		return result, err
+	}
+
+	committed, err := txn.Commit(ctx)
+	if result != nil && err == nil {
+		result.Table = committed
+	}
+
+	return result, err
+}
+
 // CompactionTaskGroup is a set of scan tasks in the same partition that
 // should be compacted together. This bridges the compaction planner
 // (table/compaction package) and the executor, avoiding a circular

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -715,7 +715,7 @@ func TestRewriteDataFiles_PartialProgressRetainsSharedPositionDeleteAfterFailure
 	assert.Greater(t, remainingPositionDeletes, 0,
 		"a shared position delete must remain while a referenced data file survives")
 
-	var expectedFiles = append([]string{}, beforeFiles...)
+	expectedFiles := append([]string{}, beforeFiles...)
 	for _, completed := range result.CompletedGroups {
 		for _, file := range completed.NewDataFiles {
 			expectedFiles = append(expectedFiles, file.FilePath())
@@ -750,6 +750,7 @@ func newPartialProgressPartitionedTable(t *testing.T) *table.Table {
 	require.NoError(t, err)
 
 	cat := &partialProgressCatalog{metadata: meta}
+
 	return table.New(
 		table.Identifier{"db", "partial_progress_branch_test"},
 		meta, location+"/metadata/v1.metadata.json",
@@ -832,6 +833,7 @@ func TestRewriteDataFiles_PartialProgressUsesTargetBranchSnapshot(t *testing.T) 
 	for _, task := range tasks {
 		if task.File.FilePath() == branchOnly[0] {
 			rewriteTask = task
+
 			break
 		}
 	}

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -725,6 +725,49 @@ func TestRewriteDataFiles_PartialProgressRetainsSharedPositionDeleteAfterFailure
 		"generated files from tolerated failed batches must be removed")
 }
 
+func TestRewriteDataFiles_PartialProgressCleansOutputsBeforeCommit(t *testing.T) {
+	tbl, _ := newPartialProgressTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/precommit-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc, fmt.Sprintf(
+			`[{"id": %d, "data": "row"}]`, i+1))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	groups := []table.CompactionTaskGroup{
+		{PartitionKey: "precommit-0", Tasks: []table.FileScanTask{tasks[0]}, TotalSizeBytes: tasks[0].File.FileSizeBytes()},
+		{PartitionKey: "precommit-1", Tasks: []table.FileScanTask{tasks[1]}, TotalSizeBytes: tasks[1].File.FileSizeBytes()},
+	}
+
+	// The first group writes an output before the second group fails while
+	// reading its source. Both groups are in one batch, so the output from the
+	// first group must be removed before the rewrite returns the read error.
+	missingPath := tasks[1].File.FilePath()
+	require.NoError(t, os.Remove(missingPath))
+	expectedFiles := parquetFiles(t, tbl.Location())
+
+	tx := tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+		MaxCommits:      1,
+	})
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.CompletedGroups)
+	assert.ElementsMatch(t, expectedFiles, parquetFiles(t, tbl.Location()),
+		"outputs from groups written before a pre-commit failure must be removed")
+}
+
 func parquetFiles(t *testing.T, location string) []string {
 	t.Helper()
 

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -103,6 +103,13 @@ func runRewriteWithCleanup(t *testing.T, tbl *table.Table, groups []table.Compac
 
 	result, err := tx.RewriteDataFiles(t.Context(), groups, rewriteOpts)
 	require.NoError(t, err)
+	if partialProgress {
+		require.NotNil(t, result.Table)
+		_, err := tx.Commit(t.Context())
+		require.Error(t, err, "partial progress is terminal and must not make the parent Commit idempotent")
+
+		return result, result.Table
+	}
 
 	out, err := tx.Commit(t.Context())
 	require.NoError(t, err)
@@ -241,6 +248,12 @@ func TestRewriteDataFiles_EmptyPlan(t *testing.T) {
 	assert.Equal(t, 0, result.AddedDataFiles)
 	assert.Equal(t, 0, result.RemovedDataFiles)
 	assert.Equal(t, int64(0), result.BytesBefore)
+
+	partialTx := tbl.NewTransaction()
+	partialResult, err := partialTx.RewriteDataFiles(t.Context(), nil,
+		table.RewriteDataFilesOptions{PartialProgress: true})
+	require.NoError(t, err)
+	assert.Same(t, tbl, partialResult.Table)
 }
 
 // TestExecuteCompactionGroup_TargetFileSizeForwarded verifies that
@@ -392,6 +405,14 @@ func TestRewriteDataFiles_EmptyGroupSkipped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.RewrittenGroups)
+
+	tx = tbl.NewTransaction()
+	_, err = tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+		MaxCommits:      -1,
+	})
+	require.ErrorIs(t, err, table.ErrInvalidOperation)
+	assert.Contains(t, err.Error(), "MaxCommits")
 }
 
 func TestRewriteDataFiles_PartialProgress(t *testing.T) {
@@ -436,6 +457,8 @@ func TestRewriteDataFiles_PartialProgress(t *testing.T) {
 
 	assertRowCount(t, tbl, 6)
 	assert.Greater(t, result.RewrittenGroups, 0)
+	assert.Len(t, result.CompletedGroups, result.RewrittenGroups)
+	assert.Same(t, tbl, result.Table)
 	assert.Equal(t, 6, result.RemovedDataFiles)
 	assert.Equal(t, beforeSnapshots+result.RewrittenGroups, len(tbl.Metadata().Snapshots()))
 }

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -253,7 +253,7 @@ func TestRewriteDataFiles_EmptyPlan(t *testing.T) {
 	partialResult, err := partialTx.RewriteDataFiles(t.Context(), nil,
 		table.RewriteDataFilesOptions{PartialProgress: true})
 	require.NoError(t, err)
-	assert.Same(t, tbl, partialResult.Table)
+	assert.Equal(t, tbl.Location(), partialResult.Table.Location())
 }
 
 // TestExecuteCompactionGroup_TargetFileSizeForwarded verifies that

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -19,7 +19,9 @@ package table_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,6 +36,59 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type partialProgressCatalog struct {
+	metadata  table.Metadata
+	failOn    int
+	unknownOn int
+	calls     int
+}
+
+func (c *partialProgressCatalog) LoadTable(context.Context, table.Identifier) (*table.Table, error) {
+	return nil, nil
+}
+
+func (c *partialProgressCatalog) CommitTable(_ context.Context, _ table.Identifier, _ []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	c.calls++
+	if c.failOn > 0 && c.calls == c.failOn {
+		return nil, "", fmt.Errorf("%w: injected partial progress commit failure", table.ErrCommitFailed)
+	}
+
+	meta, err := table.UpdateTableMetadata(c.metadata, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	c.metadata = meta
+	if c.unknownOn > 0 && c.calls == c.unknownOn {
+		return meta, "", errors.New("injected unknown commit state")
+	}
+
+	return meta, "", nil
+}
+
+func newPartialProgressTestTable(t *testing.T) (*table.Table, *partialProgressCatalog) {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	cat := &partialProgressCatalog{metadata: meta}
+	tbl := table.New(
+		table.Identifier{"db", "partial_progress_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		cat,
+	)
+
+	return tbl, cat
+}
 
 func newRewriteTestTable(t *testing.T) *table.Table {
 	t.Helper()
@@ -103,6 +158,13 @@ func runRewriteWithCleanup(t *testing.T, tbl *table.Table, groups []table.Compac
 
 	result, err := tx.RewriteDataFiles(t.Context(), groups, rewriteOpts)
 	require.NoError(t, err)
+	if partialProgress {
+		require.NotNil(t, result.Table)
+		_, err := tx.Commit(t.Context())
+		require.Error(t, err, "partial progress is terminal and must not make the parent Commit idempotent")
+
+		return result, result.Table
+	}
 
 	out, err := tx.Commit(t.Context())
 	require.NoError(t, err)
@@ -241,6 +303,12 @@ func TestRewriteDataFiles_EmptyPlan(t *testing.T) {
 	assert.Equal(t, 0, result.AddedDataFiles)
 	assert.Equal(t, 0, result.RemovedDataFiles)
 	assert.Equal(t, int64(0), result.BytesBefore)
+
+	partialTx := tbl.NewTransaction()
+	partialResult, err := partialTx.RewriteDataFiles(t.Context(), nil,
+		table.RewriteDataFilesOptions{PartialProgress: true})
+	require.NoError(t, err)
+	assert.Equal(t, tbl.Location(), partialResult.Table.Location())
 }
 
 // TestExecuteCompactionGroup_TargetFileSizeForwarded verifies that
@@ -392,6 +460,14 @@ func TestRewriteDataFiles_EmptyGroupSkipped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.RewrittenGroups)
+
+	tx = tbl.NewTransaction()
+	_, err = tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+		MaxCommits:      -1,
+	})
+	require.ErrorIs(t, err, table.ErrInvalidOperation)
+	assert.Contains(t, err.Error(), "MaxCommits")
 }
 
 func TestRewriteDataFiles_PartialProgress(t *testing.T) {
@@ -418,11 +494,371 @@ func TestRewriteDataFiles_PartialProgress(t *testing.T) {
 	plan, err := defaultTestCompactionCfg.PlanCompaction(tasks)
 	require.NoError(t, err)
 
-	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), true)
+	plannedGroups := toTaskGroups(plan.Groups)
+	require.NotEmpty(t, plannedGroups)
+	// Split the planned group so the test can distinguish one durable snapshot
+	// per group from one snapshot containing all staged rewrites.
+	first := plannedGroups[0]
+	require.GreaterOrEqual(t, len(first.Tasks), 2)
+	mid := len(first.Tasks) / 2
+	groups := []table.CompactionTaskGroup{
+		{PartitionKey: first.PartitionKey + "/a", Tasks: first.Tasks[:mid], TotalSizeBytes: first.TotalSizeBytes / 2},
+		{PartitionKey: first.PartitionKey + "/b", Tasks: first.Tasks[mid:], TotalSizeBytes: first.TotalSizeBytes - first.TotalSizeBytes/2},
+	}
+	groups = append(groups, plannedGroups[1:]...)
+	beforeSnapshots := len(tbl.Metadata().Snapshots())
+
+	result, tbl := runRewriteWithCleanup(t, tbl, groups, true)
 
 	assertRowCount(t, tbl, 6)
 	assert.Greater(t, result.RewrittenGroups, 0)
+	assert.Len(t, result.CompletedGroups, result.RewrittenGroups)
+	assert.Same(t, tbl, result.Table)
 	assert.Equal(t, 6, result.RemovedDataFiles)
+	assert.Equal(t, beforeSnapshots+result.RewrittenGroups, len(tbl.Metadata().Snapshots()))
+}
+
+func TestRewriteDataFiles_PartialProgressMaxCommitsProcessesAllGroups(t *testing.T) {
+	tbl := newRewriteTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/max-commit-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc,
+			fmt.Sprintf(`[{"id": %d, "data": "row"}]`, i+1))
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 3)
+	groups := make([]table.CompactionTaskGroup, 0, len(tasks))
+	for i, task := range tasks {
+		groups = append(groups, table.CompactionTaskGroup{
+			PartitionKey:   fmt.Sprintf("group-%d", i),
+			Tasks:          []table.FileScanTask{task},
+			TotalSizeBytes: task.File.FileSizeBytes(),
+		})
+	}
+
+	beforeSnapshots := len(tbl.Metadata().Snapshots())
+	tx := tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+		MaxCommits:      2,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.RewrittenGroups,
+		"MaxCommits limits durable snapshots, not the number of groups processed")
+	assert.Len(t, result.CompletedGroups, 3)
+	assert.Equal(t, beforeSnapshots+2, len(result.Table.Metadata().Snapshots()))
+	assertRowCount(t, result.Table, 3)
+}
+
+func TestRewriteDataFiles_PartialProgressRejectsCommittedParentReuse(t *testing.T) {
+	tbl, cat := newPartialProgressTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	dataPath := tbl.Location() + "/data/reuse.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "row"}]`)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	groups := []table.CompactionTaskGroup{{
+		PartitionKey:   "reuse",
+		Tasks:          []table.FileScanTask{tasks[0]},
+		TotalSizeBytes: tasks[0].File.FileSizeBytes(),
+	}}
+
+	tx = tbl.NewTransaction()
+	_, err = tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+	})
+	require.NoError(t, err)
+	calls := cat.calls
+
+	result, err := tx.RewriteDataFiles(t.Context(), nil, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+	})
+	require.ErrorContains(t, err, "transaction has already been committed")
+	assert.Nil(t, result)
+	assert.Equal(t, calls, cat.calls, "an empty reused parent must be rejected before another catalog commit")
+
+	result, err = tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+	})
+	require.ErrorContains(t, err, "transaction has already been committed")
+	assert.Nil(t, result)
+	assert.Equal(t, calls, cat.calls, "a reused parent must be rejected before another catalog commit")
+}
+
+func TestRewriteDataFiles_PartialProgressStopsOnUnknownCommitState(t *testing.T) {
+	tbl, cat := newPartialProgressTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/unknown-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc,
+			fmt.Sprintf(`[{"id": %d, "data": "row"}, {"id": %d, "data": "row"}]`, i*2+1, i*2+2))
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	groups := []table.CompactionTaskGroup{
+		{PartitionKey: "unknown-0", Tasks: []table.FileScanTask{tasks[0]}, TotalSizeBytes: tasks[0].File.FileSizeBytes()},
+		{PartitionKey: "unknown-1", Tasks: []table.FileScanTask{tasks[1]}, TotalSizeBytes: tasks[1].File.FileSizeBytes()},
+	}
+
+	cat.unknownOn = cat.calls + 1
+	tx := tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress: true,
+		MaxCommits:      2,
+	})
+	require.ErrorContains(t, err, "unknown commit state")
+	require.NotNil(t, result)
+	assert.Zero(t, result.RewrittenGroups)
+	assert.Equal(t, 1, len(cat.metadata.Snapshots())-len(tbl.Metadata().Snapshots()))
+	assert.Equal(t, cat.unknownOn, cat.calls, "later groups must not be planned after an unknown commit")
+	_, commitErr := tx.Commit(t.Context())
+	assert.Error(t, commitErr, "the parent transaction must remain terminal after an unknown commit")
+}
+
+func TestRewriteDataFiles_PartialProgressRetainsSharedPositionDeleteAfterFailure(t *testing.T) {
+	tbl, cat := newPartialProgressTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		dataPath := tbl.Location() + fmt.Sprintf("/data/shared-%d.parquet", i)
+		writeParquetFile(t, dataPath, arrowSc, fmt.Sprintf(
+			`[{"id": %d, "data": "a"}, {"id": %d, "data": "b"}]`, i*2+1, i*2+2))
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+		tbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+	}
+
+	// This partition-scoped position delete targets both data files. The first
+	// partial batch must not remove it while the second data file is still live.
+	posDelPath := tbl.Location() + "/data/shared-position-delete.parquet"
+	writeParquetFile(t, posDelPath, table.PositionalDeleteArrowSchema, fmt.Sprintf(
+		`[{"file_path": "%s", "pos": 0}, {"file_path": "%s", "pos": 0}]`,
+		tbl.Location()+"/data/shared-0.parquet", tbl.Location()+"/data/shared-1.parquet"))
+	posDelBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		posDelPath, iceberg.ParquetFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(posDelBuilder.Build()).Commit(t.Context()))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+	assertRowCount(t, tbl, 2)
+
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	groups := make([]table.CompactionTaskGroup, 0, len(tasks))
+	for i, task := range tasks {
+		groups = append(groups, table.CompactionTaskGroup{
+			PartitionKey:   fmt.Sprintf("shared-group-%d", i),
+			Tasks:          []table.FileScanTask{task},
+			TotalSizeBytes: task.File.FileSizeBytes(),
+		})
+	}
+
+	// The first batch commits; the second batch fails. One tolerated failure
+	// must still return a successful result and leave its old data plus delete
+	// file in the table.
+	beforeFiles := parquetFiles(t, tbl.Location())
+	cat.failOn = cat.calls + 2
+	tx = tbl.NewTransaction()
+	result, err := tx.RewriteDataFiles(t.Context(), groups, table.RewriteDataFilesOptions{
+		PartialProgress:  true,
+		MaxCommits:       2,
+		MaxFailedCommits: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.RewrittenGroups)
+	require.Len(t, result.CompletedGroups, 1)
+	require.Len(t, result.FailedGroups, 1)
+	assert.Equal(t, 1, len(result.Table.Metadata().Snapshots())-len(tbl.Metadata().Snapshots()))
+
+	// The row deleted from the failed group's data file must remain hidden.
+	// If the shared position delete were removed by the first batch, this would
+	// be three rows instead of two.
+	assertRowCount(t, result.Table, 2)
+	newTasks, err := result.Table.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	var remainingPositionDeletes int
+	for _, task := range newTasks {
+		remainingPositionDeletes += len(task.DeleteFiles)
+	}
+	assert.Greater(t, remainingPositionDeletes, 0,
+		"a shared position delete must remain while a referenced data file survives")
+
+	var expectedFiles = append([]string{}, beforeFiles...)
+	for _, completed := range result.CompletedGroups {
+		for _, file := range completed.NewDataFiles {
+			expectedFiles = append(expectedFiles, file.FilePath())
+		}
+	}
+	assert.ElementsMatch(t, expectedFiles, parquetFiles(t, tbl.Location()),
+		"generated files from tolerated failed batches must be removed")
+}
+
+func parquetFiles(t *testing.T, location string) []string {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(location, "data", "*.parquet"))
+	require.NoError(t, err)
+
+	return paths
+}
+
+func newPartialProgressPartitionedTable(t *testing.T) *table.Table {
+	t.Helper()
+
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "data",
+	})
+	meta, err := table.NewMetadata(schema, &spec, table.UnsortedSortOrder, location,
+		iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+
+	cat := &partialProgressCatalog{metadata: meta}
+	return table.New(
+		table.Identifier{"db", "partial_progress_branch_test"},
+		meta, location+"/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		cat,
+	)
+}
+
+func addPartitionedRowsOnRef(t *testing.T, tbl *table.Table, ref, name, partition string, ids ...int64) *table.Table {
+	t.Helper()
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+	rows := make([]string, len(ids))
+	for i, id := range ids {
+		rows[i] = fmt.Sprintf(`{"id": %d, "data": "%s"}`, id, partition)
+	}
+	dataPath := tbl.Location() + "/data/" + name + ".parquet"
+	writeParquetFile(t, dataPath, arrowSc, "["+strings.Join(rows, ",")+"]")
+	info, err := os.Stat(dataPath)
+	require.NoError(t, err)
+
+	txn, err := tbl.NewTransactionOnBranchWithError(ref)
+	require.NoError(t, err)
+	builder, err := iceberg.NewDataFileBuilder(
+		tbl.Spec(), iceberg.EntryContentData, dataPath, iceberg.ParquetFile,
+		map[int]any{1000: partition}, nil, nil, int64(len(ids)), info.Size())
+	require.NoError(t, err)
+	require.NoError(t, txn.AddDataFiles(t.Context(), []iceberg.DataFile{builder.Build()}, nil))
+	committed, err := txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	return committed
+}
+
+func TestRewriteDataFiles_PartialProgressUsesTargetBranchSnapshot(t *testing.T) {
+	const branch = "feature"
+	tbl := newPartialProgressPartitionedTable(t)
+	tbl = addPartitionedRowsOnRef(t, tbl, table.MainBranch, "main-0", "main", 1, 2)
+	tbl = addPartitionedRowsOnRef(t, tbl, branch, "branch-0", "branch", 3, 4)
+	tbl = addPartitionedRowsOnRef(t, tbl, table.MainBranch, "main-1", "main", 5, 6)
+	tbl = addPartitionedRowsOnRef(t, tbl, branch, "branch-1", "branch", 7, 8)
+
+	mainPaths, _ := liveFilesOnRef(t, tbl, table.MainBranch)
+	branchPaths, _ := liveFilesOnRef(t, tbl, branch)
+	mainPathSet := make(map[string]struct{}, len(mainPaths))
+	for _, path := range mainPaths {
+		mainPathSet[path] = struct{}{}
+	}
+	branchOnly := make([]string, 0, 2)
+	for _, path := range branchPaths {
+		if _, ok := mainPathSet[path]; !ok {
+			branchOnly = append(branchOnly, path)
+		}
+	}
+	require.Len(t, branchOnly, 2)
+
+	posDelPath := tbl.Location() + "/data/branch-position-delete.parquet"
+	writeParquetFile(t, posDelPath, table.PositionalDeleteArrowSchema, fmt.Sprintf(
+		`[{"file_path": %q, "pos": 0}, {"file_path": %q, "pos": 0}]`,
+		branchOnly[0], branchOnly[1]))
+	info, err := os.Stat(posDelPath)
+	require.NoError(t, err)
+	delBuilder, err := iceberg.NewDataFileBuilder(
+		tbl.Spec(), iceberg.EntryContentPosDeletes, posDelPath, iceberg.ParquetFile,
+		map[int]any{1000: "branch"}, nil, nil, 2, info.Size())
+	require.NoError(t, err)
+	txn, err := tbl.NewTransactionOnBranchWithError(branch)
+	require.NoError(t, err)
+	require.NoError(t, txn.NewRowDelta(nil).AddDeletes(delBuilder.Build()).Commit(t.Context()))
+	tbl, err = txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	scan := tbl.Scan()
+	scan, err = scan.UseRef(branch)
+	require.NoError(t, err)
+	tasks, err := scan.PlanFiles(t.Context())
+	require.NoError(t, err)
+	var rewriteTask table.FileScanTask
+	for _, task := range tasks {
+		if task.File.FilePath() == branchOnly[0] {
+			rewriteTask = task
+			break
+		}
+	}
+	require.NotNil(t, rewriteTask.File)
+
+	txn, err = tbl.NewTransactionOnBranchWithError(branch)
+	require.NoError(t, err)
+	result, err := txn.RewriteDataFiles(t.Context(), []table.CompactionTaskGroup{{
+		PartitionKey:   "branch",
+		Tasks:          []table.FileScanTask{rewriteTask},
+		TotalSizeBytes: rewriteTask.File.FileSizeBytes(),
+	}}, table.RewriteDataFilesOptions{PartialProgress: true})
+	require.NoError(t, err)
+	require.NotNil(t, result.Table)
+
+	assert.Equal(t, []int64{1, 2, 4, 8}, idsOnRef(t, result.Table, branch),
+		"a branch-only survivor must keep its partition-scoped delete after another branch file is rewritten")
+	branchScan := result.Table.Scan()
+	branchScan, err = branchScan.UseRef(branch)
+	require.NoError(t, err)
+	remainingTasks, err := branchScan.PlanFiles(t.Context())
+	require.NoError(t, err)
+	var remainingDeletes int
+	for _, task := range remainingTasks {
+		remainingDeletes += len(task.DeleteFiles)
+	}
+	assert.Greater(t, remainingDeletes, 0, "the branch position delete must remain live")
 }
 
 func TestRewriteDataFiles_ContextCancellation(t *testing.T) {

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -418,11 +418,26 @@ func TestRewriteDataFiles_PartialProgress(t *testing.T) {
 	plan, err := defaultTestCompactionCfg.PlanCompaction(tasks)
 	require.NoError(t, err)
 
-	result, tbl := runRewriteWithCleanup(t, tbl, toTaskGroups(plan.Groups), true)
+	plannedGroups := toTaskGroups(plan.Groups)
+	require.NotEmpty(t, plannedGroups)
+	// Split the planned group so the test can distinguish one durable snapshot
+	// per group from one snapshot containing all staged rewrites.
+	first := plannedGroups[0]
+	require.GreaterOrEqual(t, len(first.Tasks), 2)
+	mid := len(first.Tasks) / 2
+	groups := []table.CompactionTaskGroup{
+		{PartitionKey: first.PartitionKey + "/a", Tasks: first.Tasks[:mid], TotalSizeBytes: first.TotalSizeBytes / 2},
+		{PartitionKey: first.PartitionKey + "/b", Tasks: first.Tasks[mid:], TotalSizeBytes: first.TotalSizeBytes - first.TotalSizeBytes/2},
+	}
+	groups = append(groups, plannedGroups[1:]...)
+	beforeSnapshots := len(tbl.Metadata().Snapshots())
+
+	result, tbl := runRewriteWithCleanup(t, tbl, groups, true)
 
 	assertRowCount(t, tbl, 6)
 	assert.Greater(t, result.RewrittenGroups, 0)
 	assert.Equal(t, 6, result.RemovedDataFiles)
+	assert.Equal(t, beforeSnapshots+result.RewrittenGroups, len(tbl.Metadata().Snapshots()))
 }
 
 func TestRewriteDataFiles_ContextCancellation(t *testing.T) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -94,6 +94,11 @@ type Transaction struct {
 
 	mx        sync.Mutex
 	committed bool
+	// partialProgressCommitted means RewriteDataFiles(PartialProgress=true)
+	// already committed one or more groups through child transactions. The
+	// parent transaction remains the compatibility handle callers use to fetch
+	// the latest table with Commit, but cannot stage more work.
+	partialProgressCommitted bool
 }
 
 func (t *Transaction) ensureInitialized() error {
@@ -2369,6 +2374,10 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	}
 
 	if t.committed {
+		if t.partialProgressCommitted {
+			return t.tbl, nil
+		}
+
 		return nil, errors.New("transaction has already been committed")
 	}
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -94,11 +94,6 @@ type Transaction struct {
 
 	mx        sync.Mutex
 	committed bool
-	// partialProgressCommitted means RewriteDataFiles(PartialProgress=true)
-	// already committed one or more groups through child transactions. The
-	// parent transaction remains the compatibility handle callers use to fetch
-	// the latest table with Commit, but cannot stage more work.
-	partialProgressCommitted bool
 }
 
 func (t *Transaction) ensureInitialized() error {
@@ -2374,10 +2369,6 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	}
 
 	if t.committed {
-		if t.partialProgressCommitted {
-			return t.tbl, nil
-		}
-
 		return nil, errors.New("transaction has already been committed")
 	}
 


### PR DESCRIPTION
## Summary

Make partial compaction progress durable one group at a time.

## Why

PartialProgress previously staged separate updates in memory but sent them in one catalog commit. A process failure before that commit lost all completed groups.

## What changed

Commit each non-empty group through a fresh child transaction and keep the latest committed table on the parent transaction. The existing final Commit call returns that table, while additional work on the completed parent is rejected.

## Tests

- `go test ./table -run TestRewriteDataFiles_PartialProgress -count=1`
- `go test ./table -run TestRewriteDataFiles -count=1`