### PR TITLE
fix(table): close stale scan plan IO

### DIFF
--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -110,16 +110,19 @@ type ScanPlanningRequest struct {
 }
 
 // PlanIO lazily loads the FileIO used to read a planned scan and closes any
-// resources it holds (e.g. plan-scoped credentials) once reading is done. Nil
-// means the scan keeps using the table's normal FileIO. Remote planners may
-// return a PlanIO backed by plan-scoped storage credentials.
+// resources it holds (e.g. plan-scoped credentials) once the plan is replaced.
+// Nil means the scan keeps using the table's normal FileIO. Remote planners may
+// return a PlanIO backed by plan-scoped storage credentials. Implementations
+// must use a comparable dynamic type with stable identity, normally a pointer.
 //
 // Delivery contract (OQ1): a returned ScanPlanningResult.IO is stored on the
-// Scan that planned it; ReadTasks then loads from it instead of the table's
-// FileIO and closes it after the returned iterator finishes. This ties a
-// plan-scoped scan to the PlanFiles -> ReadTasks sequence on one Scan — tasks
-// from a remote plan must be read by the Scan that produced them, and a Scan
-// carrying plan-scoped IO is not safe for concurrent PlanFiles/ReadTasks.
+// Scan that planned it; every ReadTasks call loads from it instead of the
+// table's FileIO. Replacing the plan releases that Scan's ownership; the old IO
+// closes after its remaining scan owners and active record iterators finish.
+// This ties a plan-scoped scan to PlanFiles -> ReadTasks: tasks from a remote
+// plan must be read by the Scan that produced them or one of its derived scans.
+// A Scan carrying plan-scoped IO is not safe for concurrent PlanFiles or
+// ReadTasks calls, but consuming an existing iterator while replanning is safe.
 type PlanIO interface {
 	Load(context.Context) (icebergio.IO, error)
 	Close() error

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -93,6 +93,30 @@ func TestReadTasksClosesPlanIOWhenLoadFails(t *testing.T) {
 	assert.Nil(t, scan.planIO)
 }
 
+func TestReadTasksTransfersPlanIOOwnershipToIterator(t *testing.T) {
+	pio := &countingPlanIO{fs: icebergio.LocalFS{}}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = pio
+
+	_, records, err := scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, scan.planIO)
+
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, pio.closeCalls)
+
+	_, records, err = scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, pio.closeCalls, "the second read uses the table IO and must not close the transferred PlanIO again")
+}
+
 func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
 	t.Parallel()
 
@@ -201,11 +225,12 @@ func (fakePlanIO) Close() error                               { return nil }
 
 type countingPlanIO struct {
 	loadErr    error
+	fs         icebergio.IO
 	closeCalls int
 }
 
 func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
-	return nil, p.loadErr
+	return p.fs, p.loadErr
 }
 
 func (p *countingPlanIO) Close() error {

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -93,6 +93,30 @@ func TestReadTasksClosesPlanIOWhenLoadFails(t *testing.T) {
 	assert.Nil(t, scan.planIO)
 }
 
+func TestReadTasksTransfersPlanIOOwnershipToIterator(t *testing.T) {
+	pio := &countingPlanIO{fs: icebergio.LocalFS{}}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = pio
+
+	_, records, err := scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, scan.planIO)
+
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, pio.closeCalls)
+
+	_, records, err = scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, pio.closeCalls, "the second read uses the table IO and must not close the transferred PlanIO again")
+}
+
 func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
 	t.Parallel()
 
@@ -227,11 +251,12 @@ func (fakePlanIO) Close() error                               { return nil }
 
 type countingPlanIO struct {
 	loadErr    error
+	fs         icebergio.IO
 	closeCalls int
 }
 
 func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
-	return nil, p.loadErr
+	return p.fs, p.loadErr
 }
 
 func (p *countingPlanIO) Close() error {

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -40,7 +40,7 @@ func TestScanPlanningRemoteRequiresPlanner(t *testing.T) {
 func TestScanPlanningRemoteStoresPlanIO(t *testing.T) {
 	t.Parallel()
 
-	pio := fakePlanIO{}
+	pio := &fakePlanIO{}
 	planner := &fakeScanPlanner{
 		result:   ScanPlanningResult{IO: pio},
 		supports: true,
@@ -53,7 +53,7 @@ func TestScanPlanningRemoteStoresPlanIO(t *testing.T) {
 	tasks, err := scan.PlanFiles(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, tasks)
-	assert.Equal(t, pio, scan.planIO)
+	assert.Same(t, pio, scan.planIO.io)
 }
 
 func TestScanPlanningRemoteClosesPreviousPlanIO(t *testing.T) {
@@ -76,45 +76,207 @@ func TestScanPlanningRemoteClosesPreviousPlanIO(t *testing.T) {
 
 	assert.Equal(t, 1, first.closeCalls)
 	assert.Equal(t, 0, second.closeCalls)
-	assert.Same(t, second, scan.planIO)
+	assert.Same(t, second, scan.planIO.io)
 }
 
-func TestReadTasksClosesPlanIOWhenLoadFails(t *testing.T) {
+func TestRefinedScanRetainsPlanIOOwnership(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*Scan) (*Scan, error){
+		"row limit": func(scan *Scan) (*Scan, error) {
+			return scan.UseRowLimit(10), nil
+		},
+		"main ref": func(scan *Scan) (*Scan, error) {
+			return scan.UseRef(MainBranch)
+		},
+	}
+
+	for name, refine := range tests {
+		t.Run(name, func(t *testing.T) {
+			first := &countingPlanIO{}
+			second := &countingPlanIO{}
+			planner := &sequenceScanPlanner{
+				results: []ScanPlanningResult{{IO: first}, {IO: second}},
+			}
+			scan := &Scan{
+				planner:      planner,
+				planningMode: ScanPlanningRemote,
+			}
+
+			_, err := scan.PlanFiles(context.Background())
+			require.NoError(t, err)
+
+			refined, err := refine(scan)
+			require.NoError(t, err)
+			assert.Same(t, scan.planIO, refined.planIO)
+
+			_, err = refined.PlanFiles(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, 0, first.closeCalls)
+			assert.Same(t, first, scan.planIO.io)
+			assert.Same(t, second, refined.planIO.io)
+
+			scan.closePlanIO()
+			refined.closePlanIO()
+			assert.Equal(t, 1, first.closeCalls)
+			assert.Equal(t, 1, second.closeCalls)
+		})
+	}
+}
+
+func TestScanPlanningRemoteFailurePreservesPreviousPlanIO(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("replacement plan")
+	first := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: first}, {}},
+		errors:  []error{nil, want},
+	}
+	scan := &Scan{
+		planner:      planner,
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	_, err = scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, want)
+
+	assert.Equal(t, 0, first.closeCalls)
+	assert.Same(t, first, scan.planIO.io)
+}
+
+func TestScanPlanningRemoteKeepsSamePlanIO(t *testing.T) {
+	t.Parallel()
+
+	pio := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: pio}, {IO: pio}},
+	}
+	scan := &Scan{planner: planner, planningMode: ScanPlanningRemote}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	state := scan.planIO
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+
+	assert.Same(t, state, scan.planIO)
+	assert.Equal(t, 0, pio.closeCalls)
+}
+
+func TestScanPlanningRemoteRejectsNonComparablePlanIO(t *testing.T) {
+	t.Parallel()
+
+	pio := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: pio}, {IO: slicePlanIO{1, 2, 3}}},
+	}
+	scan := &Scan{planner: planner, planningMode: ScanPlanningRemote}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	state := scan.planIO
+	_, err = scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+	assert.Same(t, state, scan.planIO)
+	assert.Equal(t, 0, pio.closeCalls)
+}
+
+func TestReadTasksRetainsPlanIOWhenLoadFails(t *testing.T) {
 	want := errors.New("load plan io")
-	pio := &countingPlanIO{loadErr: want}
+	pio := &countingPlanIO{
+		loadErrs: []error{want, nil},
+		fs:       icebergio.LocalFS{},
+	}
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
 	scan, err := txn.Scan()
 	require.NoError(t, err)
-	scan.planIO = pio
+	scan.planIO = mustPlanIOState(t, pio)
+	scan.ioF = func(context.Context) (icebergio.IO, error) {
+		return nil, errors.New("table IO must not be used")
+	}
 
 	_, _, err = scan.ReadTasks(context.Background(), nil)
 	require.ErrorIs(t, err, want)
-	assert.Equal(t, 1, pio.closeCalls)
-	assert.Nil(t, scan.planIO)
+	assert.Equal(t, 0, pio.closeCalls)
+	assert.NotNil(t, scan.planIO)
+
+	_, records, err := scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, pio.loadCalls)
+	assert.Equal(t, 0, pio.closeCalls)
 }
 
-func TestReadTasksTransfersPlanIOOwnershipToIterator(t *testing.T) {
+func TestReadTasksReusesPlanIO(t *testing.T) {
 	pio := &countingPlanIO{fs: icebergio.LocalFS{}}
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
 	scan, err := txn.Scan()
 	require.NoError(t, err)
-	scan.planIO = pio
+	scan.planIO = mustPlanIOState(t, pio)
+	scan.ioF = func(context.Context) (icebergio.IO, error) {
+		return nil, errors.New("table IO must not be used")
+	}
 
-	_, records, err := scan.ReadTasks(context.Background(), nil)
+	for range 2 {
+		_, records, err := scan.ReadTasks(context.Background(), nil)
+		require.NoError(t, err)
+		for _, err := range records {
+			require.NoError(t, err)
+		}
+	}
+
+	assert.Equal(t, 2, pio.loadCalls)
+	assert.Equal(t, 0, pio.closeCalls)
+	assert.Same(t, pio, scan.planIO.io)
+}
+
+func TestReadTasksKeepsRetiredPlanIOAliveForIterator(t *testing.T) {
+	first := &countingPlanIO{fs: icebergio.LocalFS{}}
+	second := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: first}, {IO: second}},
+	}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan(WithScanPlanningMode(ScanPlanningRemote))
 	require.NoError(t, err)
+	scan.planner = planner
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	_, records, err := scan.ReadTasks(context.Background(), tasks)
+	require.NoError(t, err)
+	assert.Equal(t, 0, first.closeCalls)
+
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, first.closeCalls)
+	assert.Same(t, second, scan.planIO.io)
+
+	for _, err := range records {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, first.closeCalls)
+	assert.Equal(t, 0, second.closeCalls)
+}
+
+func TestScanPlanningLocalClosesPreviousPlanIOAfterSuccess(t *testing.T) {
+	pio := &countingPlanIO{}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = mustPlanIOState(t, pio)
+
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+
 	assert.Nil(t, scan.planIO)
-
-	for _, err := range records {
-		require.NoError(t, err)
-	}
 	assert.Equal(t, 1, pio.closeCalls)
-
-	_, records, err = scan.ReadTasks(context.Background(), nil)
-	require.NoError(t, err)
-	for _, err := range records {
-		require.NoError(t, err)
-	}
-	assert.Equal(t, 1, pio.closeCalls, "the second read uses the table IO and must not close the transferred PlanIO again")
 }
 
 func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
@@ -250,13 +412,19 @@ func (fakePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil 
 func (fakePlanIO) Close() error                               { return nil }
 
 type countingPlanIO struct {
-	loadErr    error
+	loadErrs   []error
 	fs         icebergio.IO
+	loadCalls  int
 	closeCalls int
 }
 
 func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
-	return p.fs, p.loadErr
+	p.loadCalls++
+	if p.loadCalls <= len(p.loadErrs) {
+		return p.fs, p.loadErrs[p.loadCalls-1]
+	}
+
+	return p.fs, nil
 }
 
 func (p *countingPlanIO) Close() error {
@@ -266,6 +434,7 @@ func (p *countingPlanIO) Close() error {
 
 type sequenceScanPlanner struct {
 	results []ScanPlanningResult
+	errors  []error
 	index   int
 }
 
@@ -273,6 +442,25 @@ func (p *sequenceScanPlanner) SupportsRemoteScanPlanning() bool { return true }
 
 func (p *sequenceScanPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
 	result := p.results[p.index]
+	var err error
+	if p.index < len(p.errors) {
+		err = p.errors[p.index]
+	}
 	p.index++
-	return result, nil
+
+	return result, err
+}
+
+type slicePlanIO []int
+
+func (slicePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil }
+func (slicePlanIO) Close() error                               { return nil }
+
+func mustPlanIOState(t *testing.T, planIO PlanIO) *planIOState {
+	t.Helper()
+
+	state, err := newPlanIOState(planIO)
+	require.NoError(t, err)
+
+	return state
 }

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -56,6 +56,43 @@ func TestScanPlanningRemoteStoresPlanIO(t *testing.T) {
 	assert.Equal(t, pio, scan.planIO)
 }
 
+func TestScanPlanningRemoteClosesPreviousPlanIO(t *testing.T) {
+	t.Parallel()
+
+	first := &countingPlanIO{}
+	second := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: first}, {IO: second}},
+	}
+	scan := &Scan{
+		planner:      planner,
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, first.closeCalls)
+	assert.Equal(t, 0, second.closeCalls)
+	assert.Same(t, second, scan.planIO)
+}
+
+func TestReadTasksClosesPlanIOWhenLoadFails(t *testing.T) {
+	want := errors.New("load plan io")
+	pio := &countingPlanIO{loadErr: want}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = pio
+
+	_, _, err = scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, want)
+	assert.Equal(t, 1, pio.closeCalls)
+	assert.Nil(t, scan.planIO)
+}
+
 func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
 	t.Parallel()
 
@@ -161,3 +198,30 @@ type fakePlanIO struct{}
 
 func (fakePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil }
 func (fakePlanIO) Close() error                               { return nil }
+
+type countingPlanIO struct {
+	loadErr    error
+	closeCalls int
+}
+
+func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
+	return nil, p.loadErr
+}
+
+func (p *countingPlanIO) Close() error {
+	p.closeCalls++
+	return nil
+}
+
+type sequenceScanPlanner struct {
+	results []ScanPlanningResult
+	index   int
+}
+
+func (p *sequenceScanPlanner) SupportsRemoteScanPlanning() bool { return true }
+
+func (p *sequenceScanPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+	result := p.results[p.index]
+	p.index++
+	return result, nil
+}

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -429,6 +429,7 @@ func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
 
 func (p *countingPlanIO) Close() error {
 	p.closeCalls++
+
 	return nil
 }
 

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -56,6 +56,43 @@ func TestScanPlanningRemoteStoresPlanIO(t *testing.T) {
 	assert.Equal(t, pio, scan.planIO)
 }
 
+func TestScanPlanningRemoteClosesPreviousPlanIO(t *testing.T) {
+	t.Parallel()
+
+	first := &countingPlanIO{}
+	second := &countingPlanIO{}
+	planner := &sequenceScanPlanner{
+		results: []ScanPlanningResult{{IO: first}, {IO: second}},
+	}
+	scan := &Scan{
+		planner:      planner,
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, first.closeCalls)
+	assert.Equal(t, 0, second.closeCalls)
+	assert.Same(t, second, scan.planIO)
+}
+
+func TestReadTasksClosesPlanIOWhenLoadFails(t *testing.T) {
+	want := errors.New("load plan io")
+	pio := &countingPlanIO{loadErr: want}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = pio
+
+	_, _, err = scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, want)
+	assert.Equal(t, 1, pio.closeCalls)
+	assert.Nil(t, scan.planIO)
+}
+
 func TestScanPlanningRemoteRejectsIncapablePlanner(t *testing.T) {
 	t.Parallel()
 
@@ -187,3 +224,30 @@ type fakePlanIO struct{}
 
 func (fakePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil }
 func (fakePlanIO) Close() error                               { return nil }
+
+type countingPlanIO struct {
+	loadErr    error
+	closeCalls int
+}
+
+func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
+	return nil, p.loadErr
+}
+
+func (p *countingPlanIO) Close() error {
+	p.closeCalls++
+	return nil
+}
+
+type sequenceScanPlanner struct {
+	results []ScanPlanningResult
+	index   int
+}
+
+func (p *sequenceScanPlanner) SupportsRemoteScanPlanning() bool { return true }
+
+func (p *sequenceScanPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+	result := p.results[p.index]
+	p.index++
+	return result, nil
+}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -230,10 +230,10 @@ type Scan struct {
 	ioF              FSysF
 	planner          ScanPlanner
 	planningMode     ScanPlanningMode
-	// planIO, when non-nil, is a plan-scoped FileIO loader set by remote scan
-	// planning; ReadTasks loads from it instead of ioF and closes it after the
-	// returned iterator finishes. See PlanIO.
-	planIO         PlanIO
+	// planIO, when non-nil, owns the plan-scoped FileIO loader set by remote
+	// planning. ReadTasks leases it instead of falling back to ioF, and replacing
+	// the plan retires it after all active readers finish. See PlanIO.
+	planIO         *planIOState
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool
@@ -250,11 +250,22 @@ type Scan struct {
 	reporter metrics.Reporter
 }
 
-func (scan *Scan) UseRowLimit(n int64) *Scan {
+// clone copies the scan configuration and gives the copy its own ownership
+// reference to any remote plan.
+func (scan *Scan) clone() *Scan {
 	out := *scan
-	out.limit = n
+	if out.planIO != nil {
+		out.planIO.retain()
+	}
 
 	return &out
+}
+
+func (scan *Scan) UseRowLimit(n int64) *Scan {
+	out := scan.clone()
+	out.limit = n
+
+	return out
 }
 
 // Reporter returns the metrics reporter for this scan, never nil. The
@@ -273,9 +284,7 @@ func (scan *Scan) Reporter() metrics.Reporter {
 // recorded by scan options are still surfaced by scan execution.
 func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if name == MainBranch {
-		out := *scan
-
-		return &out, nil
+		return scan.clone(), nil
 	}
 	if scan.selectorErr != nil {
 		return nil, scan.selectorErr
@@ -291,10 +300,10 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 	}
 
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {
-		out := *scan
+		out := scan.clone()
 		out.snapshotID = &snap.SnapshotID
 
-		return &out, nil
+		return out, nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot scan unknown ref=%s", iceberg.ErrInvalidArgument, name)
@@ -904,12 +913,16 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 
 // planFilesLocal performs local scan planning: it reads and filters the
 // snapshot's manifests using schema, builds the matching FileScanTasks, and
-// records planning metrics into acc for the caller to report. It resets the
-// plan-scoped scan.planIO to nil, since local planning reads through the
-// table's default FileIO. It returns a nil slice (not an empty one) when there
-// is no snapshot or every manifest is pruned.
-func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) ([]FileScanTask, error) {
-	scan.closePlanIO()
+// records planning metrics into acc for the caller to report. A successful
+// local plan retires any previous remote plan; a failed local plan leaves it
+// usable. It returns a nil slice (not an empty one) when there is no snapshot
+// or every manifest is pruned.
+func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) (results []FileScanTask, err error) {
+	defer func() {
+		if err == nil {
+			scan.closePlanIO()
+		}
+	}()
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
@@ -933,7 +946,7 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 		return nil, err
 	}
 
-	results := make([]FileScanTask, 0, len(entries.dataEntries))
+	results = make([]FileScanTask, 0, len(entries.dataEntries))
 	for _, e := range entries.dataEntries {
 		// Spec §Scan Planning: when a deletion vector applies to a data
 		// file, positional-delete files must NOT be applied. The DV is
@@ -1002,34 +1015,106 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, err
 	}
 
-	// Replace an unconsumed plan only after the new plan is available. A
-	// planner failure must not destroy a previously usable plan.
-	if scan.planIO != nil && !samePlanIO(scan.planIO, result.IO) {
-		_ = scan.planIO.Close()
+	planIO, err := newPlanIOState(result.IO)
+	if err != nil {
+		return nil, err
 	}
-	scan.planIO = result.IO
+
+	// Replace the current plan only after the new plan is available. A planner
+	// failure or invalid PlanIO must not destroy a previously usable plan.
+	if scan.planIO != nil && scan.planIO.matches(result.IO) {
+		return result.Tasks, nil
+	}
+
+	oldPlanIO := scan.planIO
+	scan.planIO = planIO
+	if oldPlanIO != nil {
+		oldPlanIO.releaseOwner()
+	}
 
 	return result.Tasks, nil
 }
 
-// samePlanIO compares plan-scoped IO handles without comparing interfaces
-// directly. PlanIO implementations are allowed to contain slices or maps and
-// therefore may be non-comparable interface values.
-func samePlanIO(left, right PlanIO) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
+type planIOState struct {
+	io PlanIO
+
+	mu        sync.Mutex
+	owners    int
+	readers   int
+	closeOnce sync.Once
+}
+
+func newPlanIOState(planIO PlanIO) (*planIOState, error) {
+	if planIO == nil {
+		return nil, nil
 	}
 
-	lv, rv := reflect.ValueOf(left), reflect.ValueOf(right)
-	if lv.Type() != rv.Type() {
-		return false
+	value := reflect.ValueOf(planIO)
+	if !value.Comparable() {
+		return nil, fmt.Errorf("%w: PlanIO type %T must be comparable", iceberg.ErrInvalidArgument, planIO)
+	}
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		if value.IsNil() {
+			return nil, fmt.Errorf("%w: PlanIO must not be nil", iceberg.ErrInvalidArgument)
+		}
 	}
 
-	if lv.Comparable() {
-		return lv.Interface() == rv.Interface()
+	return &planIOState{io: planIO, owners: 1}, nil
+}
+
+func (p *planIOState) matches(planIO PlanIO) bool {
+	return planIO != nil && p.io == planIO
+}
+
+func (p *planIOState) retain() {
+	p.mu.Lock()
+	p.owners++
+	p.mu.Unlock()
+}
+
+func (p *planIOState) acquire(ctx context.Context) (io.IO, func(), error) {
+	p.mu.Lock()
+	if p.owners == 0 {
+		p.mu.Unlock()
+
+		return nil, nil, fmt.Errorf("%w: remote scan plan is no longer current", ErrInvalidOperation)
+	}
+	p.readers++
+	p.mu.Unlock()
+
+	fs, err := p.io.Load(ctx)
+	if err != nil {
+		p.release()
+
+		return nil, nil, err
 	}
 
-	return false
+	var releaseOnce sync.Once
+
+	return fs, func() { releaseOnce.Do(p.release) }, nil
+}
+
+func (p *planIOState) release() {
+	p.mu.Lock()
+	p.readers--
+	closeNow := p.owners == 0 && p.readers == 0
+	p.mu.Unlock()
+
+	if closeNow {
+		p.closeOnce.Do(func() { _ = p.io.Close() })
+	}
+}
+
+func (p *planIOState) releaseOwner() {
+	p.mu.Lock()
+	p.owners--
+	closeNow := p.owners == 0 && p.readers == 0
+	p.mu.Unlock()
+
+	if closeNow {
+		p.closeOnce.Do(func() { _ = p.io.Close() })
+	}
 }
 
 type FileScanTask struct {
@@ -1102,16 +1187,14 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	}
 
 	// A plan-scoped FileIO (from remote planning) takes precedence over the
-	// table's default FileIO and is closed once the returned iterator finishes.
-	// Transfer ownership out of Scan before loading so replanning cannot close
-	// resources used by an active iterator.
+	// table's default FileIO. The iterator keeps a reader lease so replanning
+	// cannot close the old plan's resources while records are still being read.
 	planIO := scan.planIO
-	scan.planIO = nil
 	var fs io.IO
+	var releasePlanIO func()
 	if planIO != nil {
-		fs, err = planIO.Load(ctx)
+		fs, releasePlanIO, err = planIO.acquire(ctx)
 		if err != nil {
-			_ = planIO.Close()
 			return nil, nil, err
 		}
 	} else {
@@ -1132,16 +1215,16 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		concurrency:     scan.concurrency,
 	}).GetRecords(ctx, tasks)
 	if err != nil {
-		// No iterator to drive cleanup on a setup error, so close here.
-		if planIO != nil {
-			_ = planIO.Close()
+		// No iterator to drive cleanup on a setup error, so release here.
+		if releasePlanIO != nil {
+			releasePlanIO()
 		}
 
 		return nil, nil, err
 	}
 
-	if planIO != nil {
-		records = closePlanIOAfter(records, planIO)
+	if releasePlanIO != nil {
+		records = releasePlanIOAfter(records, releasePlanIO)
 	}
 
 	return outSchema, records, nil
@@ -1154,18 +1237,18 @@ func (scan *Scan) closePlanIO() {
 		return
 	}
 
-	_ = scan.planIO.Close()
+	planIO := scan.planIO
 	scan.planIO = nil
+	planIO.releaseOwner()
 }
 
-// closePlanIOAfter wraps an arrow record iterator so the plan-scoped IO is
-// closed once iteration ends — whether the consumer exhausts the iterator or
-// stops early. A caller that never ranges over the iterator does not trigger
-// the close; that is an accepted edge for an unread result.
-func closePlanIOAfter(seq iter.Seq2[arrow.RecordBatch, error], pio PlanIO) iter.Seq2[arrow.RecordBatch, error] {
-	var closeOnce sync.Once
+// releasePlanIOAfter wraps an arrow record iterator so its plan-scoped IO lease
+// is released once iteration ends, whether the consumer exhausts the iterator
+// or stops early. A caller that never ranges over the iterator does not release
+// the lease; that is an accepted edge for an unread result.
+func releasePlanIOAfter(seq iter.Seq2[arrow.RecordBatch, error], release func()) iter.Seq2[arrow.RecordBatch, error] {
 	return func(yield func(arrow.RecordBatch, error) bool) {
-		defer closeOnce.Do(func() { _ = pio.Close() })
+		defer release()
 		for rec, err := range seq {
 			if !yield(rec, err) {
 				return

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -957,11 +957,6 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
 
-	// A new remote plan supersedes any previous plan produced by this Scan.
-	// Release its scoped credentials before replacing the handle so repeated
-	// PlanFiles calls do not retain one PlanIO per plan.
-	scan.closePlanIO()
-
 	caseSensitive := scan.caseSensitive
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
 		Identifier:       slices.Clone(scan.identifier),
@@ -976,9 +971,34 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, err
 	}
 
+	// Replace an unconsumed plan only after the new plan is available. A
+	// planner failure must not destroy a previously usable plan.
+	if scan.planIO != nil && !samePlanIO(scan.planIO, result.IO) {
+		_ = scan.planIO.Close()
+	}
 	scan.planIO = result.IO
 
 	return result.Tasks, nil
+}
+
+// samePlanIO compares plan-scoped IO handles without comparing interfaces
+// directly. PlanIO implementations are allowed to contain slices or maps and
+// therefore may be non-comparable interface values.
+func samePlanIO(left, right PlanIO) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	lv, rv := reflect.ValueOf(left), reflect.ValueOf(right)
+	if lv.Type() != rv.Type() {
+		return false
+	}
+
+	if lv.Comparable() {
+		return lv.Interface() == rv.Interface()
+	}
+
+	return false
 }
 
 type FileScanTask struct {
@@ -1048,13 +1068,15 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 
 	// A plan-scoped FileIO (from remote planning) takes precedence over the
 	// table's default FileIO and is closed once the returned iterator finishes.
+	// Transfer ownership out of Scan before loading so replanning cannot close
+	// resources used by an active iterator.
+	planIO := scan.planIO
+	scan.planIO = nil
 	var fs io.IO
-	if scan.planIO != nil {
-		planIO := scan.planIO
+	if planIO != nil {
 		fs, err = planIO.Load(ctx)
 		if err != nil {
 			_ = planIO.Close()
-			scan.planIO = nil
 			return nil, nil, err
 		}
 	} else {
@@ -1076,16 +1098,15 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	}).GetRecords(ctx, tasks)
 	if err != nil {
 		// No iterator to drive cleanup on a setup error, so close here.
-		if scan.planIO != nil {
-			_ = scan.planIO.Close()
-			scan.planIO = nil
+		if planIO != nil {
+			_ = planIO.Close()
 		}
 
 		return nil, nil, err
 	}
 
-	if scan.planIO != nil {
-		records = closePlanIOAfter(records, scan.planIO)
+	if planIO != nil {
+		records = closePlanIOAfter(records, planIO)
 	}
 
 	return outSchema, records, nil
@@ -1107,8 +1128,9 @@ func (scan *Scan) closePlanIO() {
 // stops early. A caller that never ranges over the iterator does not trigger
 // the close; that is an accepted edge for an unread result.
 func closePlanIOAfter(seq iter.Seq2[arrow.RecordBatch, error], pio PlanIO) iter.Seq2[arrow.RecordBatch, error] {
+	var closeOnce sync.Once
 	return func(yield func(arrow.RecordBatch, error) bool) {
-		defer func() { _ = pio.Close() }()
+		defer closeOnce.Do(func() { _ = pio.Close() })
 		for rec, err := range seq {
 			if !yield(rec, err) {
 				return

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -878,7 +878,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 // table's default FileIO. It returns a nil slice (not an empty one) when there
 // is no snapshot or every manifest is pruned.
 func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) ([]FileScanTask, error) {
-	scan.planIO = nil
+	scan.closePlanIO()
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
@@ -956,6 +956,11 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	if scan.planner == nil || !scan.planner.SupportsRemoteScanPlanning() {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
+
+	// A new remote plan supersedes any previous plan produced by this Scan.
+	// Release its scoped credentials before replacing the handle so repeated
+	// PlanFiles calls do not retain one PlanIO per plan.
+	scan.closePlanIO()
 
 	caseSensitive := scan.caseSensitive
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
@@ -1045,7 +1050,13 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	// table's default FileIO and is closed once the returned iterator finishes.
 	var fs io.IO
 	if scan.planIO != nil {
-		fs, err = scan.planIO.Load(ctx)
+		planIO := scan.planIO
+		fs, err = planIO.Load(ctx)
+		if err != nil {
+			_ = planIO.Close()
+			scan.planIO = nil
+			return nil, nil, err
+		}
 	} else {
 		fs, err = scan.ioF(ctx)
 	}
@@ -1067,6 +1078,7 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		// No iterator to drive cleanup on a setup error, so close here.
 		if scan.planIO != nil {
 			_ = scan.planIO.Close()
+			scan.planIO = nil
 		}
 
 		return nil, nil, err
@@ -1077,6 +1089,17 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	}
 
 	return outSchema, records, nil
+}
+
+// closePlanIO releases the scoped resources associated with the current
+// remote plan. It is safe to call when no remote plan has been installed.
+func (scan *Scan) closePlanIO() {
+	if scan.planIO == nil {
+		return
+	}
+
+	_ = scan.planIO.Close()
+	scan.planIO = nil
 }
 
 // closePlanIOAfter wraps an arrow record iterator so the plan-scoped IO is

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -988,11 +988,6 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
 
-	// A new remote plan supersedes any previous plan produced by this Scan.
-	// Release its scoped credentials before replacing the handle so repeated
-	// PlanFiles calls do not retain one PlanIO per plan.
-	scan.closePlanIO()
-
 	caseSensitive := scan.caseSensitive
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
 		Identifier:       slices.Clone(scan.identifier),
@@ -1007,9 +1002,34 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, err
 	}
 
+	// Replace an unconsumed plan only after the new plan is available. A
+	// planner failure must not destroy a previously usable plan.
+	if scan.planIO != nil && !samePlanIO(scan.planIO, result.IO) {
+		_ = scan.planIO.Close()
+	}
 	scan.planIO = result.IO
 
 	return result.Tasks, nil
+}
+
+// samePlanIO compares plan-scoped IO handles without comparing interfaces
+// directly. PlanIO implementations are allowed to contain slices or maps and
+// therefore may be non-comparable interface values.
+func samePlanIO(left, right PlanIO) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	lv, rv := reflect.ValueOf(left), reflect.ValueOf(right)
+	if lv.Type() != rv.Type() {
+		return false
+	}
+
+	if lv.Comparable() {
+		return lv.Interface() == rv.Interface()
+	}
+
+	return false
 }
 
 type FileScanTask struct {
@@ -1083,13 +1103,15 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 
 	// A plan-scoped FileIO (from remote planning) takes precedence over the
 	// table's default FileIO and is closed once the returned iterator finishes.
+	// Transfer ownership out of Scan before loading so replanning cannot close
+	// resources used by an active iterator.
+	planIO := scan.planIO
+	scan.planIO = nil
 	var fs io.IO
-	if scan.planIO != nil {
-		planIO := scan.planIO
+	if planIO != nil {
 		fs, err = planIO.Load(ctx)
 		if err != nil {
 			_ = planIO.Close()
-			scan.planIO = nil
 			return nil, nil, err
 		}
 	} else {
@@ -1111,16 +1133,15 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	}).GetRecords(ctx, tasks)
 	if err != nil {
 		// No iterator to drive cleanup on a setup error, so close here.
-		if scan.planIO != nil {
-			_ = scan.planIO.Close()
-			scan.planIO = nil
+		if planIO != nil {
+			_ = planIO.Close()
 		}
 
 		return nil, nil, err
 	}
 
-	if scan.planIO != nil {
-		records = closePlanIOAfter(records, scan.planIO)
+	if planIO != nil {
+		records = closePlanIOAfter(records, planIO)
 	}
 
 	return outSchema, records, nil
@@ -1142,8 +1163,9 @@ func (scan *Scan) closePlanIO() {
 // stops early. A caller that never ranges over the iterator does not trigger
 // the close; that is an accepted edge for an unread result.
 func closePlanIOAfter(seq iter.Seq2[arrow.RecordBatch, error], pio PlanIO) iter.Seq2[arrow.RecordBatch, error] {
+	var closeOnce sync.Once
 	return func(yield func(arrow.RecordBatch, error) bool) {
-		defer func() { _ = pio.Close() }()
+		defer closeOnce.Do(func() { _ = pio.Close() })
 		for rec, err := range seq {
 			if !yield(rec, err) {
 				return

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -909,7 +909,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 // table's default FileIO. It returns a nil slice (not an empty one) when there
 // is no snapshot or every manifest is pruned.
 func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) ([]FileScanTask, error) {
-	scan.planIO = nil
+	scan.closePlanIO()
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
@@ -987,6 +987,11 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	if scan.planner == nil || !scan.planner.SupportsRemoteScanPlanning() {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
+
+	// A new remote plan supersedes any previous plan produced by this Scan.
+	// Release its scoped credentials before replacing the handle so repeated
+	// PlanFiles calls do not retain one PlanIO per plan.
+	scan.closePlanIO()
 
 	caseSensitive := scan.caseSensitive
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
@@ -1080,7 +1085,13 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	// table's default FileIO and is closed once the returned iterator finishes.
 	var fs io.IO
 	if scan.planIO != nil {
-		fs, err = scan.planIO.Load(ctx)
+		planIO := scan.planIO
+		fs, err = planIO.Load(ctx)
+		if err != nil {
+			_ = planIO.Close()
+			scan.planIO = nil
+			return nil, nil, err
+		}
 	} else {
 		fs, err = scan.ioF(ctx)
 	}
@@ -1102,6 +1113,7 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		// No iterator to drive cleanup on a setup error, so close here.
 		if scan.planIO != nil {
 			_ = scan.planIO.Close()
+			scan.planIO = nil
 		}
 
 		return nil, nil, err
@@ -1112,6 +1124,17 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	}
 
 	return outSchema, records, nil
+}
+
+// closePlanIO releases the scoped resources associated with the current
+// remote plan. It is safe to call when no remote plan has been installed.
+func (scan *Scan) closePlanIO() {
+	if scan.planIO == nil {
+		return
+	}
+
+	_ = scan.planIO.Close()
+	scan.planIO = nil
 }
 
 // closePlanIOAfter wraps an arrow record iterator so the plan-scoped IO is

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -343,6 +343,9 @@ func TestFetchPartitionSpecFilteredManifests_PropagatesEvalError(t *testing.T) {
 	}, nil)
 
 	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), int32(5))))
+	pio := &countingPlanIO{}
+	scan.planIO = mustPlanIOState(t, pio)
+	state := scan.planIO
 
 	_, err = scan.fetchPartitionSpecFilteredManifests(context.Background())
 	require.Error(t, err, "manifest eval errors must propagate instead of silently dropping manifests")
@@ -350,6 +353,8 @@ func TestFetchPartitionSpecFilteredManifests_PropagatesEvalError(t *testing.T) {
 
 	_, err = scan.PlanFiles(context.Background())
 	require.Error(t, err, "PlanFiles must fail when manifest filtering errors")
+	assert.Same(t, state, scan.planIO)
+	assert.Equal(t, 0, pio.closeCalls)
 }
 
 func TestFetchPartitionSpecFilteredManifests_InvalidSpecIDDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

Close plan-scoped IO when scan planning finishes or a plan is replaced.

## Why

Remote replanning and plan-loading errors could leave the previous plan IO open, which leaks resources during retries and failed reads.

## What changed

Close local plan IO after planning, close the previous remote plan before replacing it, and close plan IO when ReadTasks fails to load or initialize a plan.

## Tests

- `go test ./table -run TestScanPlanningRemote -count=1`
- `go test ./table -run TestReadTasksClosesPlanIOWhenLoadFails -count=1`