### PR TITLE
fix(catalog/sql): preserve close errors

### DIFF
--- a/catalog/sql/close_test.go
+++ b/catalog/sql/close_test.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/apache/iceberg-go/metrics"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+)
+
+const (
+	closeErrorDriverName   = "iceberg_go_sql_close_error"
+	closeErrorReporterName = "iceberg_go_sql_close_reporter"
+)
+
+var closeErrorDBErr error
+
+func init() {
+	sql.Register(closeErrorDriverName, closeErrorDriver{})
+}
+
+type closeErrorDriver struct{}
+
+func (closeErrorDriver) Open(string) (driver.Conn, error) {
+	return closeErrorConn{err: closeErrorDBErr}, nil
+}
+
+type closeErrorConn struct{ err error }
+
+func (c closeErrorConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c closeErrorConn) Close() error                        { return c.err }
+func (closeErrorConn) Begin() (driver.Tx, error)             { return nil, driver.ErrSkip }
+
+type closeErrorReporter struct{ err error }
+
+func (closeErrorReporter) Report(context.Context, metrics.MetricsReport) {}
+func (r closeErrorReporter) Close() error                                { return r.err }
+
+func TestCloseReturnsReporterAndDatabaseErrors(t *testing.T) {
+	dbErr := errors.New("database close")
+	reporterErr := errors.New("reporter close")
+
+	closeErrorDBErr = dbErr
+	metrics.Register(closeErrorReporterName, func(map[string]string) (metrics.Reporter, error) {
+		return closeErrorReporter{err: reporterErr}, nil
+	})
+	t.Cleanup(func() {
+		metrics.Deregister(closeErrorReporterName)
+	})
+
+	db, err := sql.Open(closeErrorDriverName, "")
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+
+	cat := &Catalog{
+		db:     bun.NewDB(db, sqlitedialect.New()),
+		props:  map[string]string{metrics.ReporterImplKey: closeErrorReporterName},
+		ownsDB: true,
+	}
+	_, err = cat.reporter.Get(cat.props)
+	require.NoError(t, err)
+
+	err = cat.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, reporterErr)
+	require.ErrorIs(t, err, dbErr)
+}

--- a/catalog/sql/close_test.go
+++ b/catalog/sql/close_test.go
@@ -35,16 +35,14 @@ const (
 	closeErrorReporterName = "iceberg_go_sql_close_reporter"
 )
 
-var closeErrorDBErr error
-
 func init() {
 	sql.Register(closeErrorDriverName, closeErrorDriver{})
 }
 
 type closeErrorDriver struct{}
 
-func (closeErrorDriver) Open(string) (driver.Conn, error) {
-	return closeErrorConn{err: closeErrorDBErr}, nil
+func (closeErrorDriver) Open(dsn string) (driver.Conn, error) {
+	return closeErrorConn{err: errors.New(dsn)}, nil
 }
 
 type closeErrorConn struct{ err error }
@@ -62,7 +60,6 @@ func TestCloseReturnsReporterAndDatabaseErrors(t *testing.T) {
 	dbErr := errors.New("database close")
 	reporterErr := errors.New("reporter close")
 
-	closeErrorDBErr = dbErr
 	metrics.Register(closeErrorReporterName, func(map[string]string) (metrics.Reporter, error) {
 		return closeErrorReporter{err: reporterErr}, nil
 	})
@@ -70,8 +67,9 @@ func TestCloseReturnsReporterAndDatabaseErrors(t *testing.T) {
 		metrics.Deregister(closeErrorReporterName)
 	})
 
-	db, err := sql.Open(closeErrorDriverName, "")
+	db, err := sql.Open(closeErrorDriverName, dbErr.Error())
 	require.NoError(t, err)
+	// Ping opens a connection so db.Close has a connection to drain.
 	require.NoError(t, db.Ping())
 
 	cat := &Catalog{
@@ -85,5 +83,5 @@ func TestCloseReturnsReporterAndDatabaseErrors(t *testing.T) {
 	err = cat.Close()
 	require.Error(t, err)
 	require.ErrorIs(t, err, reporterErr)
-	require.ErrorIs(t, err, dbErr)
+	require.ErrorContains(t, err, dbErr.Error())
 }

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -455,8 +455,8 @@ func (c *Catalog) CatalogType() catalog.Type {
 func (c *Catalog) Close() error {
 	err := c.reporter.Close()
 	if c.ownsDB {
-		if dbErr := c.db.Close(); dbErr != nil && err == nil {
-			err = dbErr
+		if dbErr := c.db.Close(); dbErr != nil {
+			err = errors.Join(err, dbErr)
 		}
 	}
 

--- a/catalog/sql/sql.go
+++ b/catalog/sql/sql.go
@@ -456,7 +456,11 @@ func (c *Catalog) Close() error {
 	err := c.reporter.Close()
 	if c.ownsDB {
 		if dbErr := c.db.Close(); dbErr != nil {
-			err = errors.Join(err, dbErr)
+			if err == nil {
+				err = dbErr
+			} else {
+				err = errors.Join(err, dbErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Preserve both reporter and database errors when closing a SQL catalog.

## Why

The close path returned only the first error, hiding a database close failure when the metrics reporter also failed.

## What changed

Join the database close error with the reporter close error and add a regression test using failures from both resources.

## Tests

- `go test ./catalog/sql -run TestCloseReturnsReporterAndDatabaseErrors -count=2`