### PR TITLE
fix(table): track parents of added columns so nested moves apply

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -357,6 +357,10 @@ func (u *UpdateSchema) addColumn(path []string, fieldType iceberg.Type, doc stri
 	}
 	u.adds[parentID] = append(u.adds[parentID], sch.Field(0))
 	u.addedNameToID[fullName] = sch.Field(0).ID
+	// Skipping TableRootID as findParentID already defaults unknown ids to it.
+	if parentID != TableRootID {
+		u.parentID[sch.Field(0).ID] = parentID
+	}
 
 	return nil
 }
@@ -785,6 +789,10 @@ func (u *UpdateSchema) unionAddColumn(path []string, newField iceberg.NestedFiel
 	}
 	u.adds[parentID] = append(u.adds[parentID], sch.Field(0))
 	u.addedNameToID[fullName] = sch.Field(0).ID
+	// Skipping TableRootID as findParentID already defaults unknown ids to it.
+	if parentID != TableRootID {
+		u.parentID[sch.Field(0).ID] = parentID
+	}
 
 	return nil
 }

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -742,6 +742,119 @@ func TestMoveColumn(t *testing.T) {
 	})
 }
 
+func addressFieldNames(t *testing.T, schema *iceberg.Schema) []string {
+	t.Helper()
+
+	address, ok := schema.FindFieldByName("address")
+	require.True(t, ok, "address field should exist")
+
+	st, ok := address.Type.(*iceberg.StructType)
+	require.True(t, ok, "address should be a struct")
+
+	names := make([]string, len(st.FieldList))
+	for i, f := range st.FieldList {
+		names[i] = f.Name
+	}
+
+	return names
+}
+
+func TestMoveAddedNestedColumn(t *testing.T) {
+	t.Run("move added nested column first", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			AddColumn([]string{"address", "code"}, iceberg.PrimitiveTypes.String, "", false, nil).
+			MoveFirst([]string{"address", "code"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		assert.Equal(t, []string{"code", "city", "zip"}, addressFieldNames(t, newSchema))
+	})
+
+	t.Run("move added nested column before sibling", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			AddColumn([]string{"address", "code"}, iceberg.PrimitiveTypes.String, "", false, nil).
+			MoveBefore([]string{"address", "code"}, []string{"address", "zip"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		assert.Equal(t, []string{"city", "code", "zip"}, addressFieldNames(t, newSchema))
+	})
+
+	t.Run("move added nested column after sibling", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			AddColumn([]string{"address", "code"}, iceberg.PrimitiveTypes.String, "", false, nil).
+			MoveAfter([]string{"address", "code"}, []string{"address", "city"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		assert.Equal(t, []string{"city", "code", "zip"}, addressFieldNames(t, newSchema))
+	})
+
+	t.Run("moving added nested column does not disturb top-level order", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			AddColumn([]string{"address", "code"}, iceberg.PrimitiveTypes.String, "", false, nil).
+			MoveFirst([]string{"address", "code"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		topLevel := make([]string, len(newSchema.Fields()))
+		for i, f := range newSchema.Fields() {
+			topLevel[i] = f.Name
+		}
+		assert.Equal(t, []string{"id", "name", "age", "address", "tags", "properties"}, topLevel)
+	})
+
+	t.Run("relative-to field in a different struct is rejected", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		_, err := NewUpdateSchema(txn, true, true).
+			AddColumn([]string{"address", "code"}, iceberg.PrimitiveTypes.String, "", false, nil).
+			MoveBefore([]string{"address", "code"}, []string{"name"}).
+			Apply()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not a child of the parent")
+	})
+
+	t.Run("move nested column added via union by name", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		incoming := iceberg.NewSchema(0,
+			iceberg.NestedField{Name: "address", Type: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{Name: "code", Type: iceberg.PrimitiveTypes.String, Required: false},
+				},
+			}, Required: false},
+		)
+
+		newSchema, err := NewUpdateSchema(txn, true, false).
+			UnionByNameWith(incoming).
+			MoveFirst([]string{"address", "code"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		assert.Equal(t, []string{"code", "city", "zip"}, addressFieldNames(t, newSchema))
+	})
+}
+
 func TestChainedOperations(t *testing.T) {
 	t.Run("test multiple operations in chain", func(t *testing.T) {
 		table := New([]string{"id"}, testMetadata, "", nil, nil)


### PR DESCRIPTION
## Description

Fixes #1685 

Record the parent id of freshly-added fields, so a nested column added and moved in the same transaction resolves to the correct parent struct instead of the table root.

## Testing

Added the regression test covering it : `TestMoveAddedNestedColumn`