### PR TITLE
fix(table): defer SetIdentifierField to preserve UpdateSchema chain ordering

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -624,11 +624,16 @@ func (u *UpdateSchema) moveColumn(op MoveOp, path []string, relativeTo []string)
 }
 
 func (u *UpdateSchema) SetIdentifierField(paths [][]string) *UpdateSchema {
-	identifierFieldNames := make(map[string]struct{})
-	for _, path := range paths {
-		identifierFieldNames[strings.Join(path, ".")] = struct{}{}
-	}
-	u.identifierFieldNames = identifierFieldNames
+	// Defer the mutation so it runs during Apply() in the order it was chained.
+	u.ops = append(u.ops, func() error {
+		identifierFieldNames := make(map[string]struct{})
+		for _, path := range paths {
+			identifierFieldNames[strings.Join(path, ".")] = struct{}{}
+		}
+		u.identifierFieldNames = identifierFieldNames
+
+		return nil
+	})
 
 	return u
 }

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -924,6 +924,49 @@ func TestSetIdentifierField(t *testing.T) {
 		assert.Len(t, newSchema.IdentifierFieldIDs, 1)
 		assert.Equal(t, 2, newSchema.IdentifierFieldIDs[0]) // name field has ID 2
 	})
+
+	t.Run("test rename then set identifier to old name fails", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		_, err := NewUpdateSchema(txn, true, true).
+			RenameColumn([]string{"id"}, "new_id").
+			SetIdentifierField([][]string{{"id"}}).
+			Apply()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "identifier field not found: id")
+	})
+
+	t.Run("test set identifier then rename tracks the new name", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			SetIdentifierField([][]string{{"id"}}).
+			RenameColumn([]string{"id"}, "new_id").
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		require.Len(t, newSchema.IdentifierFieldIDs, 1)
+		// Renamed field keeps ID 1
+		assert.Equal(t, 1, newSchema.IdentifierFieldIDs[0])
+		field, ok := newSchema.FindColumnName(1)
+		require.True(t, ok)
+		assert.Equal(t, "new_id", field)
+	})
+
+	t.Run("test delete then set identifier to deleted name fails", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		_, err := NewUpdateSchema(txn, true, true).
+			DeleteColumn([]string{"name"}).
+			SetIdentifierField([][]string{{"name"}}).
+			Apply()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "identifier field not found: name")
+	})
 }
 
 func TestErrorHandling(t *testing.T) {


### PR DESCRIPTION
### Description

Fixes #1689 

Earlier `UdateSchema.SetIdentifierField` mutated builder state eagerly, so it always applied before any deferred op regardless of chain position, diverging from every other builder method.

So, the fix is: Defer the mutation into `u.ops` so it runs in chain order during `Apply()`; `init()` now correctly seeds existing identifier fields first.

### Testing

Added the required regression test cases.