### PR TITLE
Catalog conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ integration-io:
 	go test -tags=integration -v ./io/...
 
 integration-rest:
-	go test -tags=integration -v -run="^TestRestIntegration$$" ./catalog/rest
+	go test -tags=integration -v -run="^(TestRestIntegration|TestRestCatalogConformance)$$" ./catalog/rest
 
 integration-spark:
 	go test -tags=integration -v -run="^TestSparkIntegration" ./table

--- a/catalog/catalogtest/catalogtest.go
+++ b/catalog/catalogtest/catalogtest.go
@@ -70,19 +70,12 @@ var TableSchema = iceberg.NewSchema(0,
 	iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
 )
 
-// Config describes the catalog under test and the optional behaviors it
-// supports. The zero value of each flag is the more permissive setting, so an
-// implementation only declares what it restricts.
+// Config describes the catalog under test.
 type Config struct {
 	// NewCatalog returns a fresh, empty catalog for a single test. It is called
 	// once per test; implementations should register any teardown with
 	// t.Cleanup rather than relying on the suite to release resources.
 	NewCatalog func(t *testing.T) catalog.Catalog
-
-	// RequiresNamespaceCreate reports whether a namespace must be created
-	// before a table can be created in it. Catalogs that derive namespaces
-	// from table paths leave this false.
-	RequiresNamespaceCreate bool
 }
 
 // RunCatalogTests runs the conformance suite against the catalog described by
@@ -105,10 +98,8 @@ func testBasicCreateTable(t *testing.T, cfg Config) {
 	require.NoError(t, err)
 	assert.False(t, exists, "table should not exist before create")
 
-	if cfg.RequiresNamespaceCreate {
-		require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
-		t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
-	}
+	require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
 
 	tbl, err := cat.CreateTable(ctx, ident, Schema)
 	require.NoError(t, err)

--- a/catalog/catalogtest/catalogtest.go
+++ b/catalog/catalogtest/catalogtest.go
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package catalogtest provides a conformance suite that every
+// [catalog.Catalog] implementation can run against itself, so that shared
+// behavior is specified once rather than re-derived in each implementation's
+// tests. It mirrors the role of CatalogTests in the Java implementation.
+//
+// An implementation opts in from its own test package by describing itself
+// with a [Config] and calling [RunCatalogTests]:
+//
+//	func TestCatalogConformance(t *testing.T) {
+//		catalogtest.RunCatalogTests(t, catalogtest.Config{
+//			NewCatalog: func(t *testing.T) catalog.Catalog { ... },
+//		})
+//	}
+//
+// Each test gets its own catalog from Config.NewCatalog, so tests never share
+// state and may run in any order.
+package catalogtest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newIdentifiers returns a namespace and a table within it, named uniquely per
+// call. Catalogs backed by a shared server (a REST fixture, a Hive metastore)
+// outlive a single test, so fixed names would collide between tests and
+// between runs.
+func newIdentifiers() (namespace, tbl table.Identifier) {
+	namespace = table.Identifier{"conformance_" + strings.ReplaceAll(uuid.NewString(), "-", "_")}
+
+	return namespace, table.Identifier{namespace[0], "tbl"}
+}
+
+// Schema is the schema the conformance tests create tables with. Its field IDs
+// are deliberately not 1 and 2: catalogs assign fresh IDs on create, and
+// [TableSchema] is what the created table is expected to report back.
+var Schema = iceberg.NewSchema(0,
+	iceberg.NestedField{ID: 3, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true, Doc: "unique ID 🤪"},
+	iceberg.NestedField{ID: 4, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
+)
+
+// TableSchema is [Schema] with the fresh field IDs a catalog assigns on create.
+var TableSchema = iceberg.NewSchema(0,
+	iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true, Doc: "unique ID 🤪"},
+	iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
+)
+
+// Config describes the catalog under test and the optional behaviors it
+// supports. The zero value of each flag is the more permissive setting, so an
+// implementation only declares what it restricts.
+type Config struct {
+	// NewCatalog returns a fresh, empty catalog for a single test. It is called
+	// once per test; implementations should register any teardown with
+	// t.Cleanup rather than relying on the suite to release resources.
+	NewCatalog func(t *testing.T) catalog.Catalog
+
+	// RequiresNamespaceCreate reports whether a namespace must be created
+	// before a table can be created in it. Catalogs that derive namespaces
+	// from table paths leave this false.
+	RequiresNamespaceCreate bool
+}
+
+// RunCatalogTests runs the conformance suite against the catalog described by
+// cfg. Each test runs as a subtest so a failure names the behavior that broke.
+func RunCatalogTests(t *testing.T, cfg Config) {
+	t.Helper()
+	require.NotNil(t, cfg.NewCatalog, "catalogtest.Config.NewCatalog must be set")
+
+	t.Run("BasicCreateTable", func(t *testing.T) { testBasicCreateTable(t, cfg) })
+}
+
+// testBasicCreateTable asserts that a newly created table is visible to the
+// catalog and reports the settings it was created with.
+func testBasicCreateTable(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, ident := newIdentifiers()
+
+	exists, err := cat.CheckTableExists(ctx, ident)
+	require.NoError(t, err)
+	assert.False(t, exists, "table should not exist before create")
+
+	if cfg.RequiresNamespaceCreate {
+		require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+		t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
+	}
+
+	tbl, err := cat.CreateTable(ctx, ident, Schema)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cat.DropTable(ctx, ident) })
+
+	exists, err = cat.CheckTableExists(ctx, ident)
+	require.NoError(t, err)
+	assert.True(t, exists, "table should exist after create")
+
+	assert.Equal(t, ident, tbl.Identifier(), "table should report the identifier it was created with")
+	assert.Equal(t, TableSchema.AsStruct(), tbl.Schema().AsStruct(), "schema should match expected ID assignment")
+	assert.NotEmpty(t, tbl.Location(), "table should have a location")
+	assert.True(t, tbl.Spec().IsUnpartitioned(), "table should be unpartitioned")
+	assert.True(t, tbl.SortOrder().IsUnsorted(), "table should be unsorted")
+	assert.NotNil(t, tbl.Properties(), "table should have properties")
+}

--- a/catalog/hadoop/conformance_test.go
+++ b/catalog/hadoop/conformance_test.go
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hadoop_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/catalogtest"
+	"github.com/apache/iceberg-go/catalog/hadoop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHadoopCatalogConformance(t *testing.T) {
+	catalogtest.RunCatalogTests(t, catalogtest.Config{
+		RequiresNamespaceCreate: true,
+		NewCatalog: func(t *testing.T) catalog.Catalog {
+			cat, err := hadoop.NewCatalog("test", t.TempDir(), nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cat.Close()) })
+
+			return cat
+		},
+	})
+}

--- a/catalog/hadoop/conformance_test.go
+++ b/catalog/hadoop/conformance_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestHadoopCatalogConformance(t *testing.T) {
 	catalogtest.RunCatalogTests(t, catalogtest.Config{
-		RequiresNamespaceCreate: true,
 		NewCatalog: func(t *testing.T) catalog.Catalog {
 			cat, err := hadoop.NewCatalog("test", t.TempDir(), nil)
 			require.NoError(t, err)

--- a/catalog/hive/conformance_test.go
+++ b/catalog/hive/conformance_test.go
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package hive
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/catalogtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHiveCatalogConformance(t *testing.T) {
+	catalogtest.RunCatalogTests(t, catalogtest.Config{
+		RequiresNamespaceCreate: true,
+		NewCatalog: func(t *testing.T) catalog.Catalog {
+			cat, err := NewCatalog(iceberg.Properties{
+				URI:       getTestHiveURI(),
+				Warehouse: getTestTableLocation(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cat.Close()) })
+
+			return cat
+		},
+	})
+}

--- a/catalog/hive/conformance_test.go
+++ b/catalog/hive/conformance_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestHiveCatalogConformance(t *testing.T) {
 	catalogtest.RunCatalogTests(t, catalogtest.Config{
-		RequiresNamespaceCreate: true,
 		NewCatalog: func(t *testing.T) catalog.Catalog {
 			cat, err := NewCatalog(iceberg.Properties{
 				URI:       getTestHiveURI(),

--- a/catalog/rest/conformance_test.go
+++ b/catalog/rest/conformance_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestRestCatalogConformance(t *testing.T) {
 	catalogtest.RunCatalogTests(t, catalogtest.Config{
-		RequiresNamespaceCreate: true,
 		NewCatalog: func(t *testing.T) catalog.Catalog {
 			cat, err := catalog.Load(context.Background(), "local", iceberg.Properties{
 				"type":               "rest",

--- a/catalog/rest/conformance_test.go
+++ b/catalog/rest/conformance_test.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package rest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/catalogtest"
+	"github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestCatalogConformance(t *testing.T) {
+	catalogtest.RunCatalogTests(t, catalogtest.Config{
+		RequiresNamespaceCreate: true,
+		NewCatalog: func(t *testing.T) catalog.Catalog {
+			cat, err := catalog.Load(context.Background(), "local", iceberg.Properties{
+				"type":               "rest",
+				"uri":                "http://localhost:8181",
+				io.S3Region:          "us-east-1",
+				io.S3AccessKeyID:     "admin",
+				io.S3SecretAccessKey: "password",
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if closer, ok := cat.(catalog.Closer); ok {
+					require.NoError(t, closer.Close())
+				}
+			})
+
+			return cat
+		},
+	})
+}

--- a/catalog/sql/conformance_test.go
+++ b/catalog/sql/conformance_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestSqlCatalogConformance(t *testing.T) {
 	catalogtest.RunCatalogTests(t, catalogtest.Config{
-		RequiresNamespaceCreate: true,
 		NewCatalog: func(t *testing.T) catalog.Catalog {
 			warehouse := t.TempDir()
 

--- a/catalog/sql/conformance_test.go
+++ b/catalog/sql/conformance_test.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sql_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/catalogtest"
+	sqlcat "github.com/apache/iceberg-go/catalog/sql"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func TestSqlCatalogConformance(t *testing.T) {
+	catalogtest.RunCatalogTests(t, catalogtest.Config{
+		RequiresNamespaceCreate: true,
+		NewCatalog: func(t *testing.T) catalog.Catalog {
+			warehouse := t.TempDir()
+
+			cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
+				"uri":             "file://" + filepath.Join(warehouse, "sql-catalog.db"),
+				sqlcat.DriverKey:  sqliteshim.ShimName,
+				sqlcat.DialectKey: string(sqlcat.SQLite),
+				"type":            "sql",
+				"warehouse":       "file://" + warehouse,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cat.(*sqlcat.Catalog).Close()) })
+
+			return cat
+		},
+	})
+}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1855,6 +1855,10 @@ func (c *commonMetadata) DefaultSortOrder() int {
 }
 
 func (c *commonMetadata) Properties() iceberg.Properties {
+	if c.Props == nil {
+		return iceberg.Properties{}
+	}
+
 	return maps.Clone(c.Props)
 }
 

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -2266,3 +2266,18 @@ func TestMetadataV3EmitsNullCurrentSnapshotID(t *testing.T) {
 		assert.Nil(t, v3.CurrentSnapshotID, "explicit null must parse back to nil")
 	})
 }
+
+func TestPropertiesRoundTripToEmptyMap(t *testing.T) {
+	meta, err := NewMetadata(iceberg.NewSchema(0), iceberg.UnpartitionedSpec,
+		UnsortedSortOrder, "s3://bucket/test/location", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, meta.Properties())
+
+	raw, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"properties"`)
+
+	parsed, err := ParseMetadataBytes(raw)
+	require.NoError(t, err)
+	assert.NotNil(t, parsed.Properties(), "omitted properties must parse back to an empty map, not nil")
+}


### PR DESCRIPTION
First part of #1691 

This creates an initial shared test suite for our catalogs to run against. There's a shared test suite and then runners for each catalog. There's an option for configuration in these runners, which will be useful in the future.

I've only added one test for now as a way to validate that the community finds this useful. We can add more tests in later PRs.