### PR TITLE
feat(table): add manifests metadata table

### DIFF
--- a/table/inspect.go
+++ b/table/inspect.go
@@ -290,39 +290,51 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			return nil, err
 		}
 
-		content.Append(int32(manifest.ManifestContent()))
+		manifestContent := manifest.ManifestContent()
+		switch manifestContent {
+		case iceberg.ManifestContentData, iceberg.ManifestContentDeletes:
+		default:
+			return nil, fmt.Errorf("manifest %s has unknown content %d", manifest.FilePath(), manifestContent)
+		}
+
+		content.Append(int32(manifestContent))
 		path.Append(manifest.FilePath())
 		length.Append(manifest.Length())
 		partitionSpecID.Append(manifest.PartitionSpecID())
 		addedSnapshotID.Append(manifest.SnapshotID())
 
-		if manifest.ManifestContent() == iceberg.ManifestContentData {
-			addedDataFiles.Append(manifest.AddedDataFiles())
-			existingDataFiles.Append(manifest.ExistingDataFiles())
-			deletedDataFiles.Append(manifest.DeletedDataFiles())
+		switch manifestContent {
+		case iceberg.ManifestContentData:
+			appendManifestCount(addedDataFiles, manifest.AddedDataFiles())
+			appendManifestCount(existingDataFiles, manifest.ExistingDataFiles())
+			appendManifestCount(deletedDataFiles, manifest.DeletedDataFiles())
 			addedDeleteFiles.Append(0)
 			existingDeleteFiles.Append(0)
 			deletedDeleteFiles.Append(0)
-		} else {
+		case iceberg.ManifestContentDeletes:
 			addedDataFiles.Append(0)
 			existingDataFiles.Append(0)
 			deletedDataFiles.Append(0)
-			addedDeleteFiles.Append(manifest.AddedDataFiles())
-			existingDeleteFiles.Append(manifest.ExistingDataFiles())
-			deletedDeleteFiles.Append(manifest.DeletedDataFiles())
+			appendManifestCount(addedDeleteFiles, manifest.AddedDataFiles())
+			appendManifestCount(existingDeleteFiles, manifest.ExistingDataFiles())
+			appendManifestCount(deletedDeleteFiles, manifest.DeletedDataFiles())
 		}
 
+		spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
+		if spec == nil {
+			return nil, fmt.Errorf("manifest %s references missing partition spec %d",
+				manifest.FilePath(), manifest.PartitionSpecID())
+		}
+		partType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
 		partitions := manifest.Partitions()
 		if partitions == nil {
 			partitionSummaries.AppendNull()
 
 			continue
 		}
-
-		spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
-		var partType *iceberg.StructType
-		if spec != nil {
-			partType = spec.PartitionType(i.tbl.metadata.CurrentSchema())
+		if len(partitions) > spec.NumFields() {
+			return nil, fmt.Errorf("manifest %s has %d partition summaries for partition spec %d with %d fields",
+				manifest.FilePath(), len(partitions), manifest.PartitionSpecID(), spec.NumFields())
 		}
 
 		partitionSummaries.Append(true)
@@ -335,19 +347,6 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 				summaryContainsNaN.Append(*summary.ContainsNaN)
 			}
 
-			if spec == nil || idx >= spec.NumFields() {
-				summaryLower.AppendNull()
-				summaryUpper.AppendNull()
-
-				continue
-			}
-
-			if idx >= len(partType.FieldList) {
-				summaryLower.AppendNull()
-				summaryUpper.AppendNull()
-
-				continue
-			}
 			fieldType := partType.FieldList[idx].Type
 			transform := spec.Field(idx).Transform
 			if err := appendManifestBound(summaryLower, fieldType, transform, summary.LowerBound); err != nil {
@@ -365,6 +364,16 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 	}
 
 	return rr, nil
+}
+
+func appendManifestCount(builder *array.Int32Builder, count int32) {
+	if count < 0 {
+		builder.AppendNull()
+
+		return
+	}
+
+	builder.Append(count)
 }
 
 func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.ManifestFile, error) {

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -345,8 +345,12 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			}
 			fieldType := partType.FieldList[idx].Type
 			transform := spec.Field(idx).Transform
-			appendManifestBound(summaryLower, fieldType, transform, summary.LowerBound)
-			appendManifestBound(summaryUpper, fieldType, transform, summary.UpperBound)
+			if err := appendManifestBound(summaryLower, fieldType, transform, summary.LowerBound); err != nil {
+				return nil, fmt.Errorf("manifest %s partition field %d lower bound: %w", manifest.FilePath(), idx, err)
+			}
+			if err := appendManifestBound(summaryUpper, fieldType, transform, summary.UpperBound); err != nil {
+				return nil, fmt.Errorf("manifest %s partition field %d upper bound: %w", manifest.FilePath(), idx, err)
+			}
 		}
 	}
 
@@ -375,20 +379,20 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 	return snapshot.Manifests(fs)
 }
 
-func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transform iceberg.Transform, bound *[]byte) {
+func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transform iceberg.Transform, bound *[]byte) error {
 	if bound == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
 
 	literal, err := iceberg.LiteralFromBytes(typ, *bound)
 	if err != nil {
-		builder.AppendNull()
-
-		return
+		return err
 	}
 	builder.Append(transform.ToHumanStrType(typ, literal.Any()))
+
+	return nil
 }
 
 // MetadataLogEntries returns one row for every metadata file in the table's
@@ -552,7 +556,7 @@ func ManifestsSchema() *iceberg.Schema {
 		iceberg.NestedField{ID: 15, Name: "added_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 		iceberg.NestedField{ID: 16, Name: "existing_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 		iceberg.NestedField{ID: 17, Name: "deleted_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 8, Name: "partition_summaries", Required: false, Type: &iceberg.ListType{
+		iceberg.NestedField{ID: 8, Name: "partition_summaries", Required: true, Type: &iceberg.ListType{
 			ElementID:       9,
 			ElementRequired: true,
 			Element: &iceberg.StructType{FieldList: []iceberg.NestedField{

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -396,9 +396,9 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 
 func appendManifestCount(builder *array.Int32Builder, version int, name string, count int32) error {
 	if count < 0 {
-		if version == 1 {
+		if version == 1 && count == -1 {
 			// V1 counts are optional, and an absent count means unknown rather
-			// than zero. Preserve that distinction in the metadata table.
+			// than zero. The V1 decoder represents that absent value as -1.
 			builder.AppendNull()
 
 			return nil

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -313,6 +314,7 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 
 		if manifest.Partitions() == nil {
 			partitionSummaries.AppendNull()
+
 			continue
 		}
 
@@ -330,6 +332,7 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			if spec == nil || idx >= spec.NumFields() {
 				summaryLower.AppendNull()
 				summaryUpper.AppendNull()
+
 				continue
 			}
 
@@ -337,6 +340,7 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			if idx >= len(partType.FieldList) {
 				summaryLower.AppendNull()
 				summaryUpper.AppendNull()
+
 				continue
 			}
 			fieldType := partType.FieldList[idx].Type
@@ -360,7 +364,7 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 		return nil, nil
 	}
 	if i.tbl.fsF == nil {
-		return nil, fmt.Errorf("table file IO is not configured")
+		return nil, errors.New("table file IO is not configured")
 	}
 
 	fs, err := i.tbl.fsF(ctx)
@@ -374,12 +378,14 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transform iceberg.Transform, bound *[]byte) {
 	if bound == nil {
 		builder.AppendNull()
+
 		return
 	}
 
 	literal, err := iceberg.LiteralFromBytes(typ, *bound)
 	if err != nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(transform.ToHumanStrType(typ, literal.Any()))

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -312,14 +312,21 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			deletedDeleteFiles.Append(manifest.DeletedDataFiles())
 		}
 
-		if manifest.Partitions() == nil {
+		partitions := manifest.Partitions()
+		if partitions == nil {
 			partitionSummaries.AppendNull()
 
 			continue
 		}
 
+		spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
+		var partType *iceberg.StructType
+		if spec != nil {
+			partType = spec.PartitionType(i.tbl.metadata.CurrentSchema())
+		}
+
 		partitionSummaries.Append(true)
-		for idx, summary := range manifest.Partitions() {
+		for idx, summary := range partitions {
 			summaryStruct.Append(true)
 			summaryContainsNull.Append(summary.ContainsNull)
 			if summary.ContainsNaN == nil {
@@ -328,7 +335,6 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 				summaryContainsNaN.Append(*summary.ContainsNaN)
 			}
 
-			spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
 			if spec == nil || idx >= spec.NumFields() {
 				summaryLower.AppendNull()
 				summaryUpper.AppendNull()
@@ -336,7 +342,6 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 				continue
 			}
 
-			partType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
 			if idx >= len(partType.FieldList) {
 				summaryLower.AppendNull()
 				summaryUpper.AppendNull()

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -296,17 +296,16 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 		default:
 			return nil, fmt.Errorf("manifest %s has unknown content %d", manifest.FilePath(), manifestContent)
 		}
+		snapshotID := manifest.SnapshotID()
+		if snapshotID < 0 {
+			return nil, fmt.Errorf("manifest %s has negative added_snapshot_id %d", manifest.FilePath(), snapshotID)
+		}
 
 		content.Append(int32(manifestContent))
 		path.Append(manifest.FilePath())
 		length.Append(manifest.Length())
 		partitionSpecID.Append(manifest.PartitionSpecID())
-		snapshotID := manifest.SnapshotID()
-		if snapshotID == -1 {
-			addedSnapshotID.AppendNull()
-		} else {
-			addedSnapshotID.Append(snapshotID)
-		}
+		addedSnapshotID.Append(snapshotID)
 		appendCount := func(builder *array.Int32Builder, name string, count int32) error {
 			if err := appendManifestCount(builder, manifest.Version(), name, count); err != nil {
 				return fmt.Errorf("manifest %s: %w", manifest.FilePath(), err)
@@ -398,9 +397,9 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 func appendManifestCount(builder *array.Int32Builder, version int, name string, count int32) error {
 	if count < 0 {
 		if version == 1 {
-			// V1 counts are optional. Normalize an absent count to zero so the
-			// metadata table's required count columns remain non-nullable.
-			builder.Append(0)
+			// V1 counts are optional, and an absent count means unknown rather
+			// than zero. Preserve that distinction in the metadata table.
+			builder.AppendNull()
 
 			return nil
 		}
@@ -633,13 +632,13 @@ func ManifestsSchema() *iceberg.Schema {
 		iceberg.NestedField{ID: 1, Name: "path", Type: iceberg.PrimitiveTypes.String, Required: true},
 		iceberg.NestedField{ID: 2, Name: "length", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 3, Name: "partition_spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 4, Name: "added_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
-		iceberg.NestedField{ID: 5, Name: "added_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 6, Name: "existing_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 7, Name: "deleted_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 15, Name: "added_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 16, Name: "existing_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 17, Name: "deleted_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 4, Name: "added_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 5, Name: "added_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 6, Name: "existing_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 7, Name: "deleted_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 15, Name: "added_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 16, Name: "existing_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 17, Name: "deleted_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 		iceberg.NestedField{ID: 8, Name: "partition_summaries", Required: true, Type: &iceberg.ListType{
 			ElementID:       9,
 			ElementRequired: true,

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -248,6 +248,143 @@ func (i InspectTable) Snapshots(ctx context.Context) (array.RecordReader, error)
 	return rr, nil
 }
 
+// Manifests returns one row for each manifest in the current snapshot.
+// Partition summaries are exposed as the human-readable values used by the
+// other Iceberg clients.
+func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error) {
+	schema := ManifestsSchema()
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect manifests: build arrow schema: %w", err)
+	}
+
+	manifests, err := i.currentSnapshotManifests(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("inspect manifests: %w", err)
+	}
+
+	bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
+	defer bldr.Release()
+
+	content := bldr.Field(0).(*array.Int32Builder)
+	path := bldr.Field(1).(*array.StringBuilder)
+	length := bldr.Field(2).(*array.Int64Builder)
+	partitionSpecID := bldr.Field(3).(*array.Int32Builder)
+	addedSnapshotID := bldr.Field(4).(*array.Int64Builder)
+	addedDataFiles := bldr.Field(5).(*array.Int32Builder)
+	existingDataFiles := bldr.Field(6).(*array.Int32Builder)
+	deletedDataFiles := bldr.Field(7).(*array.Int32Builder)
+	addedDeleteFiles := bldr.Field(8).(*array.Int32Builder)
+	existingDeleteFiles := bldr.Field(9).(*array.Int32Builder)
+	deletedDeleteFiles := bldr.Field(10).(*array.Int32Builder)
+	partitionSummaries := bldr.Field(11).(*array.ListBuilder)
+	summaryStruct := partitionSummaries.ValueBuilder().(*array.StructBuilder)
+	summaryContainsNull := summaryStruct.FieldBuilder(0).(*array.BooleanBuilder)
+	summaryContainsNaN := summaryStruct.FieldBuilder(1).(*array.BooleanBuilder)
+	summaryLower := summaryStruct.FieldBuilder(2).(*array.StringBuilder)
+	summaryUpper := summaryStruct.FieldBuilder(3).(*array.StringBuilder)
+
+	for _, manifest := range manifests {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		content.Append(int32(manifest.ManifestContent()))
+		path.Append(manifest.FilePath())
+		length.Append(manifest.Length())
+		partitionSpecID.Append(manifest.PartitionSpecID())
+		addedSnapshotID.Append(manifest.SnapshotID())
+
+		if manifest.ManifestContent() == iceberg.ManifestContentData {
+			addedDataFiles.Append(manifest.AddedDataFiles())
+			existingDataFiles.Append(manifest.ExistingDataFiles())
+			deletedDataFiles.Append(manifest.DeletedDataFiles())
+			addedDeleteFiles.Append(0)
+			existingDeleteFiles.Append(0)
+			deletedDeleteFiles.Append(0)
+		} else {
+			addedDataFiles.Append(0)
+			existingDataFiles.Append(0)
+			deletedDataFiles.Append(0)
+			addedDeleteFiles.Append(manifest.AddedDataFiles())
+			existingDeleteFiles.Append(manifest.ExistingDataFiles())
+			deletedDeleteFiles.Append(manifest.DeletedDataFiles())
+		}
+
+		if manifest.Partitions() == nil {
+			partitionSummaries.AppendNull()
+			continue
+		}
+
+		partitionSummaries.Append(true)
+		for idx, summary := range manifest.Partitions() {
+			summaryStruct.Append(true)
+			summaryContainsNull.Append(summary.ContainsNull)
+			if summary.ContainsNaN == nil {
+				summaryContainsNaN.AppendNull()
+			} else {
+				summaryContainsNaN.Append(*summary.ContainsNaN)
+			}
+
+			spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
+			if spec == nil || idx >= spec.NumFields() {
+				summaryLower.AppendNull()
+				summaryUpper.AppendNull()
+				continue
+			}
+
+			partType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
+			if idx >= len(partType.FieldList) {
+				summaryLower.AppendNull()
+				summaryUpper.AppendNull()
+				continue
+			}
+			fieldType := partType.FieldList[idx].Type
+			transform := spec.Field(idx).Transform
+			appendManifestBound(summaryLower, fieldType, transform, summary.LowerBound)
+			appendManifestBound(summaryUpper, fieldType, transform, summary.UpperBound)
+		}
+	}
+
+	rr, err := singleBatchReader(arrowSchema, bldr)
+	if err != nil {
+		return nil, fmt.Errorf("inspect manifests: %w", err)
+	}
+
+	return rr, nil
+}
+
+func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.ManifestFile, error) {
+	snapshot := i.tbl.metadata.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil
+	}
+	if i.tbl.fsF == nil {
+		return nil, fmt.Errorf("table file IO is not configured")
+	}
+
+	fs, err := i.tbl.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot.Manifests(fs)
+}
+
+func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transform iceberg.Transform, bound *[]byte) {
+	if bound == nil {
+		builder.AppendNull()
+		return
+	}
+
+	literal, err := iceberg.LiteralFromBytes(typ, *bound)
+	if err != nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(transform.ToHumanStrType(typ, literal.Any()))
+}
+
 // MetadataLogEntries returns one row for every metadata file in the table's
 // metadata log, plus the current metadata file when its location is set.
 // Snapshot information is resolved from the snapshot log at each metadata
@@ -392,5 +529,32 @@ func MetadataLogEntriesSchema() *iceberg.Schema {
 		iceberg.NestedField{ID: 3, Name: "latest_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 		iceberg.NestedField{ID: 4, Name: "latest_schema_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 		iceberg.NestedField{ID: 5, Name: "latest_sequence_number", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+}
+
+// ManifestsSchema returns the Iceberg schema of the manifests metadata table.
+func ManifestsSchema() *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 14, Name: "content", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 1, Name: "path", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "length", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 3, Name: "partition_spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 4, Name: "added_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 5, Name: "added_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 6, Name: "existing_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 7, Name: "deleted_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 15, Name: "added_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 16, Name: "existing_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 17, Name: "deleted_delete_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 8, Name: "partition_summaries", Required: false, Type: &iceberg.ListType{
+			ElementID:       9,
+			ElementRequired: true,
+			Element: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 10, Name: "contains_null", Type: iceberg.PrimitiveTypes.Bool, Required: true},
+				{ID: 11, Name: "contains_nan", Type: iceberg.PrimitiveTypes.Bool, Required: false},
+				{ID: 12, Name: "lower_bound", Type: iceberg.PrimitiveTypes.String, Required: false},
+				{ID: 13, Name: "upper_bound", Type: iceberg.PrimitiveTypes.String, Required: false},
+			}},
+		}},
 	)
 }

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -400,10 +400,16 @@ func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transfo
 		return nil
 	}
 
-	literal, err := iceberg.LiteralFromBytes(typ, *bound)
+	literal, err := manifestBoundLiteral(typ, *bound)
 	if err != nil {
 		return err
 	}
+	if literal == nil {
+		builder.AppendNull()
+
+		return nil
+	}
+
 	builder.Append(transform.ToHumanStrType(typ, literal.Any()))
 
 	return nil
@@ -502,6 +508,33 @@ func latestSnapshotAt(metadata Metadata, timestampMs int64) (int64, *Snapshot, b
 	}
 
 	return entry.SnapshotID, metadata.SnapshotByID(entry.SnapshotID), true
+}
+
+func manifestBoundLiteral(typ iceberg.Type, bound []byte) (iceberg.Literal, error) {
+	switch t := typ.(type) {
+	case iceberg.UnknownType:
+		return nil, nil
+	case iceberg.Int64Type:
+		if len(bound) == 4 {
+			literal, err := iceberg.LiteralFromBytes(iceberg.PrimitiveTypes.Int32, bound)
+			if err != nil {
+				return nil, err
+			}
+
+			return literal.To(t)
+		}
+	case iceberg.Float64Type:
+		if len(bound) == 4 {
+			literal, err := iceberg.LiteralFromBytes(iceberg.PrimitiveTypes.Float32, bound)
+			if err != nil {
+				return nil, err
+			}
+
+			return literal.To(t)
+		}
+	}
+
+	return iceberg.LiteralFromBytes(typ, bound)
 }
 
 // HistorySchema returns the Iceberg schema of the history metadata table. The

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -301,7 +301,12 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 		path.Append(manifest.FilePath())
 		length.Append(manifest.Length())
 		partitionSpecID.Append(manifest.PartitionSpecID())
-		addedSnapshotID.Append(manifest.SnapshotID())
+		snapshotID := manifest.SnapshotID()
+		if snapshotID == -1 {
+			addedSnapshotID.AppendNull()
+		} else {
+			addedSnapshotID.Append(snapshotID)
+		}
 		appendCount := func(builder *array.Int32Builder, name string, count int32) error {
 			if err := appendManifestCount(builder, manifest.Version(), name, count); err != nil {
 				return fmt.Errorf("manifest %s: %w", manifest.FilePath(), err)
@@ -328,6 +333,8 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			addedDataFiles.Append(0)
 			existingDataFiles.Append(0)
 			deletedDataFiles.Append(0)
+			// ManifestFile's data-file accessors expose the generic manifest-list
+			// file counts, which represent delete files for delete manifests.
 			if err := appendCount(addedDeleteFiles, "added_delete_files", manifest.AddedDataFiles()); err != nil {
 				return nil, err
 			}
@@ -339,18 +346,19 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			}
 		}
 
+		partitions := manifest.Partitions()
+		if partitions == nil {
+			partitionSummaries.Append(true)
+
+			continue
+		}
+
 		spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
 		if spec == nil {
 			return nil, fmt.Errorf("manifest %s references missing partition spec %d",
 				manifest.FilePath(), manifest.PartitionSpecID())
 		}
 		partType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
-		partitions := manifest.Partitions()
-		if partitions == nil {
-			partitionSummaries.AppendNull()
-
-			continue
-		}
 		if len(partitions) > spec.NumFields() {
 			return nil, fmt.Errorf("manifest %s has %d partition summaries for partition spec %d with %d fields",
 				manifest.FilePath(), len(partitions), manifest.PartitionSpecID(), spec.NumFields())
@@ -369,10 +377,12 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			fieldType := partType.FieldList[idx].Type
 			transform := spec.Field(idx).Transform
 			if err := appendManifestBound(summaryLower, fieldType, transform, summary.LowerBound); err != nil {
-				return nil, fmt.Errorf("manifest %s partition field %d lower bound: %w", manifest.FilePath(), idx, err)
+				return nil, fmt.Errorf("manifest %s partition field %q lower bound: %w",
+					manifest.FilePath(), partType.FieldList[idx].Name, err)
 			}
 			if err := appendManifestBound(summaryUpper, fieldType, transform, summary.UpperBound); err != nil {
-				return nil, fmt.Errorf("manifest %s partition field %d upper bound: %w", manifest.FilePath(), idx, err)
+				return nil, fmt.Errorf("manifest %s partition field %q upper bound: %w",
+					manifest.FilePath(), partType.FieldList[idx].Name, err)
 			}
 		}
 	}
@@ -388,7 +398,9 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 func appendManifestCount(builder *array.Int32Builder, version int, name string, count int32) error {
 	if count < 0 {
 		if version == 1 {
-			builder.AppendNull()
+			// V1 counts are optional. Normalize an absent count to zero so the
+			// metadata table's required count columns remain non-nullable.
+			builder.Append(0)
 
 			return nil
 		}
@@ -412,7 +424,7 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 
 	fs, err := i.tbl.fsF(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get file IO: %w", err)
 	}
 
 	return snapshot.Manifests(fs)
@@ -621,7 +633,7 @@ func ManifestsSchema() *iceberg.Schema {
 		iceberg.NestedField{ID: 1, Name: "path", Type: iceberg.PrimitiveTypes.String, Required: true},
 		iceberg.NestedField{ID: 2, Name: "length", Type: iceberg.PrimitiveTypes.Int64, Required: true},
 		iceberg.NestedField{ID: 3, Name: "partition_spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
-		iceberg.NestedField{ID: 4, Name: "added_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 4, Name: "added_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 		iceberg.NestedField{ID: 5, Name: "added_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 		iceberg.NestedField{ID: 6, Name: "existing_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 		iceberg.NestedField{ID: 7, Name: "deleted_data_files_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -302,12 +302,25 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 		length.Append(manifest.Length())
 		partitionSpecID.Append(manifest.PartitionSpecID())
 		addedSnapshotID.Append(manifest.SnapshotID())
+		appendCount := func(builder *array.Int32Builder, name string, count int32) error {
+			if err := appendManifestCount(builder, manifest.Version(), name, count); err != nil {
+				return fmt.Errorf("manifest %s: %w", manifest.FilePath(), err)
+			}
+
+			return nil
+		}
 
 		switch manifestContent {
 		case iceberg.ManifestContentData:
-			appendManifestCount(addedDataFiles, manifest.AddedDataFiles())
-			appendManifestCount(existingDataFiles, manifest.ExistingDataFiles())
-			appendManifestCount(deletedDataFiles, manifest.DeletedDataFiles())
+			if err := appendCount(addedDataFiles, "added_data_files", manifest.AddedDataFiles()); err != nil {
+				return nil, err
+			}
+			if err := appendCount(existingDataFiles, "existing_data_files", manifest.ExistingDataFiles()); err != nil {
+				return nil, err
+			}
+			if err := appendCount(deletedDataFiles, "deleted_data_files", manifest.DeletedDataFiles()); err != nil {
+				return nil, err
+			}
 			addedDeleteFiles.Append(0)
 			existingDeleteFiles.Append(0)
 			deletedDeleteFiles.Append(0)
@@ -315,9 +328,15 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 			addedDataFiles.Append(0)
 			existingDataFiles.Append(0)
 			deletedDataFiles.Append(0)
-			appendManifestCount(addedDeleteFiles, manifest.AddedDataFiles())
-			appendManifestCount(existingDeleteFiles, manifest.ExistingDataFiles())
-			appendManifestCount(deletedDeleteFiles, manifest.DeletedDataFiles())
+			if err := appendCount(addedDeleteFiles, "added_delete_files", manifest.AddedDataFiles()); err != nil {
+				return nil, err
+			}
+			if err := appendCount(existingDeleteFiles, "existing_delete_files", manifest.ExistingDataFiles()); err != nil {
+				return nil, err
+			}
+			if err := appendCount(deletedDeleteFiles, "deleted_delete_files", manifest.DeletedDataFiles()); err != nil {
+				return nil, err
+			}
 		}
 
 		spec := i.tbl.metadata.PartitionSpecByID(int(manifest.PartitionSpecID()))
@@ -366,14 +385,20 @@ func (i InspectTable) Manifests(ctx context.Context) (array.RecordReader, error)
 	return rr, nil
 }
 
-func appendManifestCount(builder *array.Int32Builder, count int32) {
+func appendManifestCount(builder *array.Int32Builder, version int, name string, count int32) error {
 	if count < 0 {
-		builder.AppendNull()
+		if version == 1 {
+			builder.AppendNull()
 
-		return
+			return nil
+		}
+
+		return fmt.Errorf("negative %s count %d in manifest list version %d", name, count, version)
 	}
 
 	builder.Append(count)
+
+	return nil
 }
 
 func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.ManifestFile, error) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -985,6 +985,46 @@ func TestInspectManifestsV1UnknownCounts(t *testing.T) {
 	require.EqualValues(t, 0, end-start)
 }
 
+func TestAppendManifestCountValidatesNegativeSentinels(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  int
+		count    int32
+		wantNull bool
+		wantErr  bool
+	}{
+		{name: "v1 absent count", version: 1, count: -1, wantNull: true},
+		{name: "v1 invalid negative count", version: 1, count: -2, wantErr: true},
+		{name: "v2 negative count", version: 2, count: -1, wantErr: true},
+		{name: "v3 negative count", version: 3, count: -1, wantErr: true},
+		{name: "non-negative count", version: 2, count: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := array.NewInt32Builder(memory.DefaultAllocator)
+			defer builder.Release()
+
+			err := appendManifestCount(builder, tt.version, "added_data_files", tt.count)
+			if tt.wantErr {
+				require.ErrorContains(t, err, fmt.Sprintf("negative added_data_files count %d", tt.count))
+				require.ErrorContains(t, err, fmt.Sprintf("manifest list version %d", tt.version))
+				require.Zero(t, builder.Len())
+
+				return
+			}
+
+			require.NoError(t, err)
+			values := builder.NewInt32Array()
+			defer values.Release()
+			require.Equal(t, tt.wantNull, values.IsNull(0))
+			if !tt.wantNull {
+				require.Equal(t, tt.count, values.Value(0))
+			}
+		})
+	}
+}
+
 func TestInspectManifestsRejectsNegativeAddedSnapshotID(t *testing.T) {
 	spec := partitionedSpec()
 	manifest := iceberg.NewManifestFile(1, "mem://default/table-location/metadata/v1-manifest.avro",

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -103,7 +103,8 @@ func inspectTableWithManifestList(t *testing.T, spec iceberg.PartitionSpec, vers
 }
 
 func inspectTableWithManifestListAndSchemas(t *testing.T, initialSchema, currentSchema *iceberg.Schema,
-	spec iceberg.PartitionSpec, version int, manifests []iceberg.ManifestFile) *Table {
+	spec iceberg.PartitionSpec, version int, manifests []iceberg.ManifestFile,
+) *Table {
 	t.Helper()
 
 	const snapshotID = int64(1)

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -673,6 +673,7 @@ func TestInspectManifestsSchema(t *testing.T) {
 	require.Equal(t, 1, fields[1].ID)
 	require.Equal(t, 17, fields[10].ID)
 	require.Equal(t, 8, fields[11].ID)
+	require.True(t, fields[11].Required)
 	require.True(t, fields[11].Type.(*iceberg.ListType).ElementRequired)
 	require.Equal(t, 9, fields[11].Type.(*iceberg.ListType).ElementID)
 

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -727,19 +727,21 @@ func TestInspectManifestsSchema(t *testing.T) {
 	require.Equal(t, 1, fields[1].ID)
 	require.Equal(t, 17, fields[10].ID)
 	require.Equal(t, 8, fields[11].ID)
-	require.False(t, fields[4].Required)
-	for _, idx := range []int{5, 6, 7, 8, 9, 10, 11} {
-		require.True(t, fields[idx].Required)
+	require.True(t, fields[4].Required)
+	for _, idx := range []int{5, 6, 7, 8, 9, 10} {
+		require.False(t, fields[idx].Required)
 	}
+	require.True(t, fields[11].Required)
 	require.True(t, fields[11].Type.(*iceberg.ListType).ElementRequired)
 	require.Equal(t, 9, fields[11].Type.(*iceberg.ListType).ElementID)
 
 	arrowSchema, err := SchemaToArrowSchema(sc, nil, true, false)
 	require.NoError(t, err)
-	require.True(t, arrowSchema.Field(4).Nullable)
-	for _, idx := range []int{5, 6, 7, 8, 9, 10, 11} {
-		require.False(t, arrowSchema.Field(idx).Nullable)
+	require.False(t, arrowSchema.Field(4).Nullable)
+	for _, idx := range []int{5, 6, 7, 8, 9, 10} {
+		require.True(t, arrowSchema.Field(idx).Nullable)
 	}
+	require.False(t, arrowSchema.Field(11).Nullable)
 
 	partitionSummary := fields[11].Type.(*iceberg.ListType).Element.(*iceberg.StructType)
 	require.Equal(t,
@@ -970,11 +972,12 @@ func TestInspectManifestsV1UnknownCounts(t *testing.T) {
 	defer record.Release()
 
 	for _, col := range []int{5, 6, 7} {
-		require.False(t, record.Column(col).(*array.Int32).IsNull(0))
-		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
+		require.True(t, record.Column(col).(*array.Int32).IsNull(0))
 	}
 	for _, col := range []int{8, 9, 10} {
-		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
+		values := record.Column(col).(*array.Int32)
+		require.False(t, values.IsNull(0))
+		require.EqualValues(t, 0, values.Value(0))
 	}
 	summaries := record.Column(11).(*array.List)
 	require.False(t, summaries.IsNull(0))
@@ -982,20 +985,15 @@ func TestInspectManifestsV1UnknownCounts(t *testing.T) {
 	require.EqualValues(t, 0, end-start)
 }
 
-func TestInspectManifestsMissingAddedSnapshotID(t *testing.T) {
+func TestInspectManifestsRejectsNegativeAddedSnapshotID(t *testing.T) {
 	spec := partitionedSpec()
 	manifest := iceberg.NewManifestFile(1, "mem://default/table-location/metadata/v1-manifest.avro",
 		100, int32(spec.ID()), -1).
 		Build()
 	tbl := inspectTableWithManifestList(t, spec, 1, []iceberg.ManifestFile{manifest})
 
-	rr, err := tbl.Inspect().Manifests(context.Background())
-	require.NoError(t, err)
-	defer rr.Release()
-	record := collectRecord(t, rr)
-	defer record.Release()
-
-	require.True(t, record.Column(4).(*array.Int64).IsNull(0))
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.ErrorContains(t, err, "negative added_snapshot_id -1")
 }
 
 func TestInspectManifestsRejectsNegativeCountsForV2AndV3(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -933,6 +934,40 @@ func TestInspectManifestsV1UnknownCounts(t *testing.T) {
 		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
 	}
 	require.True(t, record.Column(11).(*array.List).IsNull(0))
+}
+
+func TestInspectManifestsRejectsNegativeCountsForV2AndV3(t *testing.T) {
+	tests := []struct {
+		name                     string
+		version                  int
+		added, existing, deleted int32
+		invalidCountName         string
+	}{
+		{name: "v2 added data files", version: 2, added: -123, existing: 1, deleted: 1, invalidCountName: "added_data_files"},
+		{name: "v2 existing data files", version: 2, added: 1, existing: -123, deleted: 1, invalidCountName: "existing_data_files"},
+		{name: "v2 deleted data files", version: 2, added: 1, existing: 1, deleted: -123, invalidCountName: "deleted_data_files"},
+		{name: "v3 added data files", version: 3, added: -123, existing: 1, deleted: 1, invalidCountName: "added_data_files"},
+		{name: "v3 existing data files", version: 3, added: 1, existing: -123, deleted: 1, invalidCountName: "existing_data_files"},
+		{name: "v3 deleted data files", version: 3, added: 1, existing: 1, deleted: -123, invalidCountName: "deleted_data_files"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := partitionedSpec()
+			manifest := iceberg.NewManifestFile(tt.version, "mem://default/table-location/metadata/negative-count.avro",
+				100, int32(spec.ID()), 1).
+				SequenceNum(1, 1).
+				AddedFiles(tt.added).
+				ExistingFiles(tt.existing).
+				DeletedFiles(tt.deleted).
+				Build()
+			tbl := inspectTableWithManifestList(t, spec, tt.version, []iceberg.ManifestFile{manifest})
+
+			_, err := tbl.Inspect().Manifests(context.Background())
+			require.ErrorContains(t, err, fmt.Sprintf("negative %s count -123", tt.invalidCountName))
+			require.ErrorContains(t, err, fmt.Sprintf("manifest list version %d", tt.version))
+		})
+	}
 }
 
 func TestInspectManifestsRejectsMissingPartitionSpec(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -660,10 +660,12 @@ func TestInspectManifestsSchema(t *testing.T) {
 	sc := ManifestsSchema()
 
 	require.Equal(t,
-		[]string{"content", "path", "length", "partition_spec_id", "added_snapshot_id",
+		[]string{
+			"content", "path", "length", "partition_spec_id", "added_snapshot_id",
 			"added_data_files_count", "existing_data_files_count", "deleted_data_files_count",
 			"added_delete_files_count", "existing_delete_files_count", "deleted_delete_files_count",
-			"partition_summaries"},
+			"partition_summaries",
+		},
 		testFieldNames(sc))
 
 	fields := sc.Fields()

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -99,10 +99,28 @@ func collectRecord(t *testing.T, rr array.RecordReader) arrow.RecordBatch {
 }
 
 func inspectTableWithManifestList(t *testing.T, spec iceberg.PartitionSpec, version int, manifests []iceberg.ManifestFile) *Table {
+	return inspectTableWithManifestListAndSchemas(t, simpleSchema(), nil, spec, version, manifests)
+}
+
+func inspectTableWithManifestListAndSchemas(t *testing.T, initialSchema, currentSchema *iceberg.Schema,
+	spec iceberg.PartitionSpec, version int, manifests []iceberg.ManifestFile) *Table {
 	t.Helper()
 
 	const snapshotID = int64(1)
-	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	ctx := context.Background()
+	fs, err := iceio.LoadFS(ctx, nil, "mem://default/table-location")
+	require.NoError(t, err)
+	memIO := fs.(iceio.WriteFileIO)
+	meta, err := NewMetadata(initialSchema, &spec, UnsortedSortOrder, "mem://default/table-location", nil)
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "tbl"}, meta, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+	txn := tbl.NewTransaction()
+	if currentSchema != nil {
+		require.NoError(t, txn.meta.AddSchema(currentSchema))
+		require.NoError(t, txn.meta.SetCurrentSchemaID(currentSchema.ID))
+	}
+
 	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
 	sequenceNumber := int64(1)
 	var listSequenceNumber *int64
@@ -775,6 +793,93 @@ func TestInspectManifests(t *testing.T) {
 	require.False(t, summary.Field(0).(*array.Boolean).Value(0))
 	require.Equal(t, "7", summary.Field(2).(*array.String).Value(0))
 	require.Equal(t, "7", summary.Field(3).(*array.String).Value(0))
+}
+
+func TestInspectManifestsPromotedPartitionSummaryBounds(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialType iceberg.Type
+		currentType iceberg.Type
+		literal     iceberg.Literal
+		expected    string
+	}{
+		{
+			name:        "int to long",
+			initialType: iceberg.PrimitiveTypes.Int32,
+			currentType: iceberg.PrimitiveTypes.Int64,
+			literal:     iceberg.Int32Literal(7),
+			expected:    "7",
+		},
+		{
+			name:        "float to double",
+			initialType: iceberg.PrimitiveTypes.Float32,
+			currentType: iceberg.PrimitiveTypes.Float64,
+			literal:     iceberg.Float32Literal(1.5),
+			expected:    "1.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := partitionedSpec()
+			initialSchema := iceberg.NewSchema(0, iceberg.NestedField{
+				ID: 1, Name: "id", Type: tt.initialType, Required: true,
+			})
+			currentSchema := iceberg.NewSchema(1, iceberg.NestedField{
+				ID: 1, Name: "id", Type: tt.currentType, Required: true,
+			})
+			bound, err := tt.literal.MarshalBinary()
+			require.NoError(t, err)
+			manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/promoted.avro",
+				100, int32(spec.ID()), 1).
+				SequenceNum(1, 1).
+				Partitions([]iceberg.FieldSummary{{LowerBound: &bound, UpperBound: &bound}}).
+				Build()
+			tbl := inspectTableWithManifestListAndSchemas(t, initialSchema, currentSchema,
+				spec, 2, []iceberg.ManifestFile{manifest})
+
+			rr, err := tbl.Inspect().Manifests(context.Background())
+			require.NoError(t, err)
+			defer rr.Release()
+			record := collectRecord(t, rr)
+			defer record.Release()
+
+			summaries := record.Column(11).(*array.List)
+			start, end := summaries.ValueOffsets(0)
+			require.EqualValues(t, 1, end-start)
+			summary := summaries.ListValues().(*array.Struct)
+			require.Equal(t, tt.expected, summary.Field(2).(*array.String).Value(0))
+			require.Equal(t, tt.expected, summary.Field(3).(*array.String).Value(0))
+		})
+	}
+}
+
+func TestInspectManifestsDroppedPartitionSource(t *testing.T) {
+	spec := partitionedSpec()
+	initialSchema := simpleSchema()
+	currentSchema := iceberg.NewSchema(1)
+	bound, err := iceberg.Int32Literal(7).MarshalBinary()
+	require.NoError(t, err)
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/dropped-source.avro",
+		100, int32(spec.ID()), 1).
+		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{LowerBound: &bound, UpperBound: &bound}}).
+		Build()
+	tbl := inspectTableWithManifestListAndSchemas(t, initialSchema, currentSchema,
+		spec, 2, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	summaries := record.Column(11).(*array.List)
+	start, end := summaries.ValueOffsets(0)
+	require.EqualValues(t, 1, end-start)
+	summary := summaries.ListValues().(*array.Struct)
+	require.True(t, summary.Field(2).(*array.String).IsNull(0))
+	require.True(t, summary.Field(3).(*array.String).IsNull(0))
 }
 
 func TestInspectManifestsDeleteCounts(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -98,6 +98,37 @@ func collectRecord(t *testing.T, rr array.RecordReader) arrow.RecordBatch {
 	return rec
 }
 
+func inspectTableWithManifestList(t *testing.T, spec iceberg.PartitionSpec, version int, manifests []iceberg.ManifestFile) *Table {
+	t.Helper()
+
+	const snapshotID = int64(1)
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	sequenceNumber := int64(1)
+	var listSequenceNumber *int64
+	if version > 1 {
+		listSequenceNumber = &sequenceNumber
+	}
+
+	var listBuf bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(version, &listBuf, snapshotID, nil,
+		listSequenceNumber, 0, manifests))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: sequenceNumber,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	return New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+}
+
 func TestInspectHistorySchema(t *testing.T) {
 	sc := HistorySchema()
 
@@ -744,6 +775,99 @@ func TestInspectManifests(t *testing.T) {
 	require.False(t, summary.Field(0).(*array.Boolean).Value(0))
 	require.Equal(t, "7", summary.Field(2).(*array.String).Value(0))
 	require.Equal(t, "7", summary.Field(3).(*array.String).Value(0))
+}
+
+func TestInspectManifestsDeleteCounts(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/delete-manifest.avro",
+		100, int32(spec.ID()), 1).
+		Content(iceberg.ManifestContentDeletes).
+		SequenceNum(1, 1).
+		AddedFiles(2).
+		ExistingFiles(3).
+		DeletedFiles(4).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, iceberg.ManifestContentDeletes, record.Column(0).(*array.Int32).Value(0))
+	for _, col := range []int{5, 6, 7} {
+		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
+	}
+	require.EqualValues(t, 2, record.Column(8).(*array.Int32).Value(0))
+	require.EqualValues(t, 3, record.Column(9).(*array.Int32).Value(0))
+	require.EqualValues(t, 4, record.Column(10).(*array.Int32).Value(0))
+}
+
+func TestInspectManifestsV1UnknownCounts(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(1, "mem://default/table-location/metadata/v1-manifest.avro",
+		100, int32(spec.ID()), 1).
+		AddedFiles(-1).
+		ExistingFiles(-1).
+		DeletedFiles(-1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 1, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	for _, col := range []int{5, 6, 7} {
+		require.True(t, record.Column(col).(*array.Int32).IsNull(0))
+	}
+	for _, col := range []int{8, 9, 10} {
+		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
+	}
+	require.True(t, record.Column(11).(*array.List).IsNull(0))
+}
+
+func TestInspectManifestsRejectsMissingPartitionSpec(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/missing-spec.avro",
+		100, 999, 1).
+		SequenceNum(1, 1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "references missing partition spec 999")
+}
+
+func TestInspectManifestsRejectsExtraPartitionSummaries(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/extra-summary.avro",
+		100, int32(spec.ID()), 1).
+		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{}, {}}).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "has 2 partition summaries")
+}
+
+func TestInspectManifestsRejectsUnknownContent(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/unknown-content.avro",
+		100, int32(spec.ID()), 1).
+		Content(iceberg.ManifestContent(2)).
+		SequenceNum(1, 1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "has unknown content 2")
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -656,6 +656,34 @@ func TestInspectMetadataLogEntriesSkipsEmptyCurrentMetadataLocation(t *testing.T
 	require.EqualValues(t, 5, rec.NumCols())
 }
 
+func TestInspectManifestsSchema(t *testing.T) {
+	sc := ManifestsSchema()
+
+	require.Equal(t,
+		[]string{"content", "path", "length", "partition_spec_id", "added_snapshot_id",
+			"added_data_files_count", "existing_data_files_count", "deleted_data_files_count",
+			"added_delete_files_count", "existing_delete_files_count", "deleted_delete_files_count",
+			"partition_summaries"},
+		testFieldNames(sc))
+
+	fields := sc.Fields()
+	require.Equal(t, 14, fields[0].ID)
+	require.Equal(t, 1, fields[1].ID)
+	require.Equal(t, 17, fields[10].ID)
+	require.Equal(t, 8, fields[11].ID)
+	require.True(t, fields[11].Type.(*iceberg.ListType).ElementRequired)
+	require.Equal(t, 9, fields[11].Type.(*iceberg.ListType).ElementID)
+
+	partitionSummary := fields[11].Type.(*iceberg.ListType).Element.(*iceberg.StructType)
+	require.Equal(t,
+		[]string{"contains_null", "contains_nan", "lower_bound", "upper_bound"},
+		testFieldNames(iceberg.NewSchema(0, partitionSummary.FieldList...)))
+	require.Equal(t, 10, partitionSummary.FieldList[0].ID)
+	require.Equal(t, 11, partitionSummary.FieldList[1].ID)
+	require.Equal(t, 12, partitionSummary.FieldList[2].ID)
+	require.Equal(t, 13, partitionSummary.FieldList[3].ID)
+}
+
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations
 // through the supplied allocator, and that all buffers are released.
 func TestInspectAllocatorOption(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -726,9 +727,19 @@ func TestInspectManifestsSchema(t *testing.T) {
 	require.Equal(t, 1, fields[1].ID)
 	require.Equal(t, 17, fields[10].ID)
 	require.Equal(t, 8, fields[11].ID)
-	require.True(t, fields[11].Required)
+	require.False(t, fields[4].Required)
+	for _, idx := range []int{5, 6, 7, 8, 9, 10, 11} {
+		require.True(t, fields[idx].Required)
+	}
 	require.True(t, fields[11].Type.(*iceberg.ListType).ElementRequired)
 	require.Equal(t, 9, fields[11].Type.(*iceberg.ListType).ElementID)
+
+	arrowSchema, err := SchemaToArrowSchema(sc, nil, true, false)
+	require.NoError(t, err)
+	require.True(t, arrowSchema.Field(4).Nullable)
+	for _, idx := range []int{5, 6, 7, 8, 9, 10, 11} {
+		require.False(t, arrowSchema.Field(idx).Nullable)
+	}
 
 	partitionSummary := fields[11].Type.(*iceberg.ListType).Element.(*iceberg.StructType)
 	require.Equal(t,
@@ -793,8 +804,39 @@ func TestInspectManifests(t *testing.T) {
 	require.EqualValues(t, 1, end-start)
 	summary := summaries.ListValues().(*array.Struct)
 	require.False(t, summary.Field(0).(*array.Boolean).Value(0))
+	require.False(t, summary.Field(1).(*array.Boolean).IsNull(0))
+	require.False(t, summary.Field(1).(*array.Boolean).Value(0))
 	require.Equal(t, "7", summary.Field(2).(*array.String).Value(0))
 	require.Equal(t, "7", summary.Field(3).(*array.String).Value(0))
+}
+
+func TestInspectManifestsContainsNaN(t *testing.T) {
+	spec := partitionedSpec()
+	containsNaN := true
+	bound, err := iceberg.Int32Literal(7).MarshalBinary()
+	require.NoError(t, err)
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/contains-nan.avro",
+		100, int32(spec.ID()), 1).
+		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{
+			ContainsNaN: &containsNaN,
+			LowerBound:  &bound,
+			UpperBound:  &bound,
+		}}).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	summaries := record.Column(11).(*array.List)
+	summary := summaries.ListValues().(*array.Struct)
+	containsNaNValues := summary.Field(1).(*array.Boolean)
+	require.False(t, containsNaNValues.IsNull(0))
+	require.True(t, containsNaNValues.Value(0))
 }
 
 func TestInspectManifestsPromotedPartitionSummaryBounds(t *testing.T) {
@@ -928,18 +970,39 @@ func TestInspectManifestsV1UnknownCounts(t *testing.T) {
 	defer record.Release()
 
 	for _, col := range []int{5, 6, 7} {
-		require.True(t, record.Column(col).(*array.Int32).IsNull(0))
+		require.False(t, record.Column(col).(*array.Int32).IsNull(0))
+		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
 	}
 	for _, col := range []int{8, 9, 10} {
 		require.EqualValues(t, 0, record.Column(col).(*array.Int32).Value(0))
 	}
-	require.True(t, record.Column(11).(*array.List).IsNull(0))
+	summaries := record.Column(11).(*array.List)
+	require.False(t, summaries.IsNull(0))
+	start, end := summaries.ValueOffsets(0)
+	require.EqualValues(t, 0, end-start)
+}
+
+func TestInspectManifestsMissingAddedSnapshotID(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(1, "mem://default/table-location/metadata/v1-manifest.avro",
+		100, int32(spec.ID()), -1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 1, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.True(t, record.Column(4).(*array.Int64).IsNull(0))
 }
 
 func TestInspectManifestsRejectsNegativeCountsForV2AndV3(t *testing.T) {
 	tests := []struct {
 		name                     string
 		version                  int
+		content                  iceberg.ManifestContent
 		added, existing, deleted int32
 		invalidCountName         string
 	}{
@@ -949,6 +1012,12 @@ func TestInspectManifestsRejectsNegativeCountsForV2AndV3(t *testing.T) {
 		{name: "v3 added data files", version: 3, added: -123, existing: 1, deleted: 1, invalidCountName: "added_data_files"},
 		{name: "v3 existing data files", version: 3, added: 1, existing: -123, deleted: 1, invalidCountName: "existing_data_files"},
 		{name: "v3 deleted data files", version: 3, added: 1, existing: 1, deleted: -123, invalidCountName: "deleted_data_files"},
+		{name: "v2 added delete files", version: 2, content: iceberg.ManifestContentDeletes, added: -123, existing: 1, deleted: 1, invalidCountName: "added_delete_files"},
+		{name: "v2 existing delete files", version: 2, content: iceberg.ManifestContentDeletes, added: 1, existing: -123, deleted: 1, invalidCountName: "existing_delete_files"},
+		{name: "v2 deleted delete files", version: 2, content: iceberg.ManifestContentDeletes, added: 1, existing: 1, deleted: -123, invalidCountName: "deleted_delete_files"},
+		{name: "v3 added delete files", version: 3, content: iceberg.ManifestContentDeletes, added: -123, existing: 1, deleted: 1, invalidCountName: "added_delete_files"},
+		{name: "v3 existing delete files", version: 3, content: iceberg.ManifestContentDeletes, added: 1, existing: -123, deleted: 1, invalidCountName: "existing_delete_files"},
+		{name: "v3 deleted delete files", version: 3, content: iceberg.ManifestContentDeletes, added: 1, existing: 1, deleted: -123, invalidCountName: "deleted_delete_files"},
 	}
 
 	for _, tt := range tests {
@@ -956,6 +1025,7 @@ func TestInspectManifestsRejectsNegativeCountsForV2AndV3(t *testing.T) {
 			spec := partitionedSpec()
 			manifest := iceberg.NewManifestFile(tt.version, "mem://default/table-location/metadata/negative-count.avro",
 				100, int32(spec.ID()), 1).
+				Content(tt.content).
 				SequenceNum(1, 1).
 				AddedFiles(tt.added).
 				ExistingFiles(tt.existing).
@@ -975,12 +1045,78 @@ func TestInspectManifestsRejectsMissingPartitionSpec(t *testing.T) {
 	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/missing-spec.avro",
 		100, 999, 1).
 		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{}}).
 		Build()
 	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
 
 	_, err := tbl.Inspect().Manifests(context.Background())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "references missing partition spec 999")
+}
+
+func TestInspectManifestsAllowsMissingPartitionSpecWithoutSummaries(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/missing-spec.avro",
+		100, 999, 1).
+		SequenceNum(1, 1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	summaries := record.Column(11).(*array.List)
+	require.False(t, summaries.IsNull(0))
+	start, end := summaries.ValueOffsets(0)
+	require.EqualValues(t, 0, end-start)
+}
+
+func TestInspectManifestsReportsPartitionFieldNameInBoundErrors(t *testing.T) {
+	spec := partitionedSpec()
+	invalidBound := []byte{0x01}
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/invalid-bound.avro",
+		100, int32(spec.ID()), 1).
+		SequenceNum(1, 1).
+		Partitions([]iceberg.FieldSummary{{LowerBound: &invalidBound}}).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.ErrorContains(t, err, "partition field \"id\" lower bound")
+}
+
+func TestInspectManifestsWrapsFileIOFactoryError(t *testing.T) {
+	spec := partitionedSpec()
+	manifest := iceberg.NewManifestFile(2, "mem://default/table-location/metadata/manifest.avro",
+		100, int32(spec.ID()), 1).
+		SequenceNum(1, 1).
+		Build()
+	tbl := inspectTableWithManifestList(t, spec, 2, []iceberg.ManifestFile{manifest})
+	factoryErr := errors.New("factory failed")
+	tbl.fsF = func(context.Context) (iceio.IO, error) { return nil, factoryErr }
+
+	_, err := tbl.Inspect().Manifests(context.Background())
+	require.ErrorIs(t, err, factoryErr)
+	require.ErrorContains(t, err, "inspect manifests: get file IO")
+}
+
+func TestInspectManifestsNoCurrentSnapshot(t *testing.T) {
+	spec := partitionedSpec()
+	meta, err := NewMetadata(simpleSchema(), &spec, UnsortedSortOrder, "mem://default/table-location", nil)
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "tbl"}, meta, "metadata.json", nil, nil)
+
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 0, record.NumRows())
+	require.EqualValues(t, 12, record.NumCols())
 }
 
 func TestInspectManifestsRejectsExtraPartitionSummaries(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -685,6 +687,63 @@ func TestInspectManifestsSchema(t *testing.T) {
 	require.Equal(t, 11, partitionSummary.FieldList[1].ID)
 	require.Equal(t, 12, partitionSummary.FieldList[2].ID)
 	require.Equal(t, 13, partitionSummary.FieldList[3].ID)
+}
+
+func TestInspectManifests(t *testing.T) {
+	const snapshotID = int64(1)
+	spec := partitionedSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+	file := newTestDataFileWithCount(t, spec,
+		"mem://default/table-location/data/data.parquet", map[int]any{1000: int32(7)}, 3)
+	sequenceNumber := int64(1)
+	entry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, int64Ptr(snapshotID), &sequenceNumber, &sequenceNumber, file)
+
+	manifestPath := "mem://default/table-location/metadata/data-manifest.avro"
+	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	var manifestBuf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, snapshotID,
+		[]iceberg.ManifestEntry{entry})
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
+
+	var listBuf bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{manifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: sequenceNumber,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+	rr, err := tbl.Inspect().Manifests(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+	require.EqualValues(t, 1, record.NumRows())
+	require.EqualValues(t, 1, record.Column(5).(*array.Int32).Value(0))
+	require.EqualValues(t, 0, record.Column(8).(*array.Int32).Value(0))
+	require.Equal(t, manifestPath, record.Column(1).(*array.String).Value(0))
+
+	summaries := record.Column(11).(*array.List)
+	require.False(t, summaries.IsNull(0))
+	start, end := summaries.ValueOffsets(0)
+	require.EqualValues(t, 1, end-start)
+	summary := summaries.ListValues().(*array.Struct)
+	require.False(t, summary.Field(0).(*array.Boolean).Value(0))
+	require.Equal(t, "7", summary.Field(2).(*array.String).Value(0))
+	require.Equal(t, "7", summary.Field(3).(*array.String).Value(0))
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations


### PR DESCRIPTION
## Summary

Adds the current-snapshot `manifests` metadata table to `Table.Inspect`.

- Exposes manifest content, paths, lengths, counts, and partition specification IDs.
- Converts partition summaries to the human-readable values used by Iceberg clients.
- Represents missing partition summaries as a non-null empty list and preserves unknown legacy V1 file counts as null.
- Keeps `added_snapshot_id` required and rejects malformed negative values.
- Rejects missing partition specs when partition summaries require decoding, excess partition summaries, and unknown manifest content.

## Tests

- `go test -race ./table`
- `go test ./...`
- `golangci-lint run --timeout=10m`
- Covers data and delete manifests, V1 unknown and invalid negative counts, invalid snapshot IDs, invalid partition metadata, field IDs, and partition-summary conversion.

## Scope

This adds current-snapshot metadata inspection only. It does not change manifest reading or writing.