### PR TITLE
feat(table): add data files metadata table

### DIFF
--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -334,6 +334,15 @@ func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (
 		if value, ok := value.(uuid.UUID); ok {
 			return scalar.MakeScalarParam(value[:], arrowType)
 		}
+	case iceberg.DecimalType:
+		switch value := value.(type) {
+		case iceberg.DecimalLiteral:
+			return scalar.NewDecimal128Scalar(value.Val, arrowType), nil
+		case iceberg.Decimal:
+			return scalar.NewDecimal128Scalar(value.Val, arrowType), nil
+		default:
+			return nil, fmt.Errorf("unsupported decimal partition value %T", value)
+		}
 	}
 
 	return scalar.MakeScalarParam(value, arrowType)

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -21,10 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"sort"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
 	"github.com/google/uuid"
@@ -40,23 +42,13 @@ func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error)
 		return nil, fmt.Errorf("inspect data files: build arrow schema: %w", err)
 	}
 
-	files, err := i.currentContentFiles(ctx, iceberg.ManifestContentData)
-	if err != nil {
-		return nil, fmt.Errorf("inspect data files: %w", err)
-	}
-
-	bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
-	defer bldr.Release()
-	for _, file := range files {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := appendContentFileRecord(bldr, partitionType, file); err != nil {
-			return nil, fmt.Errorf("inspect data files: append %s: %w", file.FilePath(), err)
-		}
-	}
-
-	rr, err := singleBatchReader(arrowSchema, bldr)
+	rr, err := i.manifestEntryReader(ctx, arrowSchema, true,
+		func(manifest iceberg.ManifestFile) bool {
+			return manifest.ManifestContent() == iceberg.ManifestContentData
+		},
+		func(bldr *array.RecordBuilder, entry iceberg.ManifestEntry) error {
+			return appendContentFileRecord(bldr, partitionType, entry.DataFile())
+		})
 	if err != nil {
 		return nil, fmt.Errorf("inspect data files: %w", err)
 	}
@@ -64,10 +56,21 @@ func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error)
 	return rr, nil
 }
 
-func (i InspectTable) currentContentFiles(ctx context.Context, content iceberg.ManifestContent) ([]iceberg.DataFile, error) {
+const inspectRecordBatchSize = 4096
+
+// manifestEntryReader streams manifest entries into bounded Arrow record
+// batches. It keeps only the current batch and manifest decoder state in
+// memory instead of materializing every entry before returning a reader.
+func (i InspectTable) manifestEntryReader(
+	ctx context.Context,
+	arrowSchema *arrow.Schema,
+	discardDeleted bool,
+	includeManifest func(iceberg.ManifestFile) bool,
+	appendEntry func(*array.RecordBuilder, iceberg.ManifestEntry) error,
+) (array.RecordReader, error) {
 	snapshot := i.tbl.metadata.CurrentSnapshot()
 	if snapshot == nil {
-		return nil, nil
+		return array.ReaderFromIter(arrowSchema, emptyInspectRecordBatch(i.alloc, arrowSchema)), nil
 	}
 	if i.tbl.fsF == nil {
 		return nil, errors.New("table file IO is not configured")
@@ -82,26 +85,90 @@ func (i InspectTable) currentContentFiles(ctx context.Context, content iceberg.M
 		return nil, err
 	}
 
-	files := make([]iceberg.DataFile, 0)
-	for _, manifest := range manifests {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if manifest.ManifestContent() != content {
-			continue
-		}
-		for entry, err := range manifest.Entries(fs, true) {
-			if err != nil {
-				return nil, err
+	return array.ReaderFromIter(arrowSchema, func(yield func(arrow.RecordBatch, error) bool) {
+		bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
+		defer bldr.Release()
+
+		rows := 0
+		emitted := false
+		emit := func() bool {
+			if rows == 0 {
+				return true
 			}
+
+			batch := bldr.NewRecordBatch()
+			rows = 0
+			emitted = true
+			if yield(batch, nil) {
+				return true
+			}
+
+			batch.Release()
+
+			return false
+		}
+		emitEmpty := func() {
+			batch := bldr.NewRecordBatch()
+			emitted = true
+			if !yield(batch, nil) {
+				batch.Release()
+			}
+		}
+		yieldError := func(err error) {
+			_ = yield(nil, err)
+		}
+
+		for _, manifest := range manifests {
 			if err := ctx.Err(); err != nil {
-				return nil, err
+				yieldError(err)
+
+				return
 			}
-			files = append(files, entry.DataFile())
+			if includeManifest != nil && !includeManifest(manifest) {
+				continue
+			}
+
+			for entry, err := range manifest.Entries(fs, discardDeleted) {
+				if err != nil {
+					yieldError(fmt.Errorf("read manifest %s: %w", manifest.FilePath(), err))
+
+					return
+				}
+				if err := ctx.Err(); err != nil {
+					yieldError(err)
+
+					return
+				}
+				if err := appendEntry(bldr, entry); err != nil {
+					yieldError(fmt.Errorf("append manifest entry from %s: %w", manifest.FilePath(), err))
+
+					return
+				}
+				rows++
+				if rows == inspectRecordBatchSize && !emit() {
+					return
+				}
+			}
+		}
+
+		if rows > 0 {
+			_ = emit()
+		} else if !emitted {
+			emitEmpty()
+		}
+	}), nil
+}
+
+func emptyInspectRecordBatch(alloc memory.Allocator, schema *arrow.Schema) iter.Seq2[arrow.RecordBatch, error] {
+	return func(yield func(arrow.RecordBatch, error) bool) {
+		bldr := array.NewRecordBuilder(alloc, schema)
+		defer bldr.Release()
+
+		batch := bldr.NewRecordBatch()
+		if !yield(batch, nil) {
+			batch.Release()
 		}
 	}
-
-	return files, nil
 }
 
 // inspectPartitionType returns the table-wide partition type. It contains the

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -70,7 +71,7 @@ func (i InspectTable) currentContentFiles(ctx context.Context, content iceberg.M
 		return nil, nil
 	}
 	if i.tbl.fsF == nil {
-		return nil, fmt.Errorf("table file IO is not configured")
+		return nil, errors.New("table file IO is not configured")
 	}
 
 	fs, err := i.tbl.fsF(ctx)
@@ -208,6 +209,7 @@ func appendPartitionStruct(builder *array.StructBuilder, partitionType *iceberg.
 		value := values[field.ID]
 		if value == nil {
 			builder.FieldBuilder(idx).AppendNull()
+
 			continue
 		}
 		sc, err := inspectValueScalar(value, field.Type, arrowType.Field(idx).Type)
@@ -255,6 +257,7 @@ func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (
 func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) {
 	if values == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(true)
@@ -274,6 +277,7 @@ func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) {
 func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) {
 	if values == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(true)
@@ -293,6 +297,7 @@ func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) {
 func appendInspectBytes(builder array.Builder, value []byte) {
 	if value == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.(*array.BinaryBuilder).Append(value)
@@ -301,6 +306,7 @@ func appendInspectBytes(builder array.Builder, value []byte) {
 func appendInspectInt64List(builder *array.ListBuilder, values []int64) {
 	if values == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(true)
@@ -310,6 +316,7 @@ func appendInspectInt64List(builder *array.ListBuilder, values []int64) {
 func appendInspectInt32List(builder *array.ListBuilder, values []int) {
 	if values == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(true)
@@ -322,6 +329,7 @@ func appendInspectInt32List(builder *array.ListBuilder, values []int) {
 func appendInspectOptionalInt32(builder *array.Int32Builder, value *int) {
 	if value == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(int32(*value))
@@ -330,6 +338,7 @@ func appendInspectOptionalInt32(builder *array.Int32Builder, value *int) {
 func appendInspectOptionalInt64(builder *array.Int64Builder, value *int64) {
 	if value == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(*value)
@@ -338,6 +347,7 @@ func appendInspectOptionalInt64(builder *array.Int64Builder, value *int64) {
 func appendInspectOptionalString(builder *array.StringBuilder, value *string) {
 	if value == nil {
 		builder.AppendNull()
+
 		return
 	}
 	builder.Append(*value)

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 	"slices"
 	"sort"
 
@@ -46,12 +47,13 @@ func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error)
 		return nil, fmt.Errorf("inspect data files: build arrow schema: %w", err)
 	}
 
+	appendFile := newInspectContentFileAppender(partitionType)
 	rr, err := i.manifestEntryReader(ctx, arrowSchema, true,
 		func(manifest iceberg.ManifestFile) bool {
 			return manifest.ManifestContent() == iceberg.ManifestContentData
 		},
 		func(bldr *array.RecordBuilder, entry iceberg.ManifestEntry) error {
-			return appendContentFileRecord(bldr, partitionType, entry.DataFile())
+			return appendFile(bldr, entry.DataFile())
 		})
 	if err != nil {
 		return nil, fmt.Errorf("inspect data files: %w", err)
@@ -250,7 +252,7 @@ func inspectPartitionType(metadata Metadata) (*iceberg.StructType, error) {
 
 func isInspectVoidTransform(transform iceberg.Transform) bool {
 	switch transform.(type) {
-	case iceberg.VoidTransform, *iceberg.VoidTransform:
+	case iceberg.VoidTransform:
 		return true
 	default:
 		return false
@@ -264,37 +266,61 @@ func DataFilesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
 	return iceberg.NewSchema(0, inspectContentFileFields(partitionType)...)
 }
 
-func inspectContentFileType(partitionType *iceberg.StructType) *iceberg.StructType {
-	return &iceberg.StructType{FieldList: inspectContentFileFields(partitionType)}
-}
+const (
+	inspectContentFieldIDContent             = 134
+	inspectContentFieldIDFilePath            = 100
+	inspectContentFieldIDFileFormat          = 101
+	inspectContentFieldIDSpecID              = 141
+	inspectContentFieldIDPartition           = 102
+	inspectContentFieldIDRecordCount         = 103
+	inspectContentFieldIDFileSize            = 104
+	inspectContentFieldIDColumnSizes         = 108
+	inspectContentFieldIDValueCounts         = 109
+	inspectContentFieldIDNullValueCounts     = 110
+	inspectContentFieldIDDistinctValueCounts = 111
+	inspectContentFieldIDNaNValueCounts      = 137
+	inspectContentFieldIDLowerBounds         = 125
+	inspectContentFieldIDUpperBounds         = 128
+	inspectContentFieldIDKeyMetadata         = 131
+	inspectContentFieldIDSplitOffsets        = 132
+	inspectContentFieldIDEqualityIDs         = 135
+	inspectContentFieldIDSortOrderID         = 140
+	inspectContentFieldIDFirstRowID          = 142
+	inspectContentFieldIDReferencedDataFile  = 143
+	inspectContentFieldIDContentOffset       = 144
+	inspectContentFieldIDContentSize         = 145
+)
 
 func inspectContentFileFields(partitionType *iceberg.StructType) []iceberg.NestedField {
 	fields := []iceberg.NestedField{
-		{ID: 134, Name: "content", Type: iceberg.PrimitiveTypes.Int32, Required: false},
-		{ID: 100, Name: "file_path", Type: iceberg.PrimitiveTypes.String, Required: true},
-		{ID: 101, Name: "file_format", Type: iceberg.PrimitiveTypes.String, Required: true},
-		{ID: 141, Name: "spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		{ID: inspectContentFieldIDContent, Name: "content", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		{ID: inspectContentFieldIDFilePath, Name: "file_path", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: inspectContentFieldIDFileFormat, Name: "file_format", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: inspectContentFieldIDSpecID, Name: "spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 	}
 	if partitionType != nil && len(partitionType.FieldList) > 0 {
-		fields = append(fields, iceberg.NestedField{ID: 102, Name: "partition", Type: partitionType, Required: true})
+		fields = append(fields, iceberg.NestedField{
+			ID: inspectContentFieldIDPartition, Name: "partition", Type: partitionType, Required: true,
+		})
 	}
 	fields = append(fields,
-		iceberg.NestedField{ID: 103, Name: "record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
-		iceberg.NestedField{ID: 104, Name: "file_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: true},
-		iceberg.NestedField{ID: 108, Name: "column_sizes", Type: inspectInt64MapType(117, 118), Required: false},
-		iceberg.NestedField{ID: 109, Name: "value_counts", Type: inspectInt64MapType(119, 120), Required: false},
-		iceberg.NestedField{ID: 110, Name: "null_value_counts", Type: inspectInt64MapType(121, 122), Required: false},
-		iceberg.NestedField{ID: 137, Name: "nan_value_counts", Type: inspectInt64MapType(138, 139), Required: false},
-		iceberg.NestedField{ID: 125, Name: "lower_bounds", Type: inspectBinaryMapType(126, 127), Required: false},
-		iceberg.NestedField{ID: 128, Name: "upper_bounds", Type: inspectBinaryMapType(129, 130), Required: false},
-		iceberg.NestedField{ID: 131, Name: "key_metadata", Type: iceberg.PrimitiveTypes.Binary, Required: false},
-		iceberg.NestedField{ID: 132, Name: "split_offsets", Type: &iceberg.ListType{ElementID: 133, Element: iceberg.PrimitiveTypes.Int64, ElementRequired: true}, Required: false},
-		iceberg.NestedField{ID: 135, Name: "equality_ids", Type: &iceberg.ListType{ElementID: 136, Element: iceberg.PrimitiveTypes.Int32, ElementRequired: true}, Required: false},
-		iceberg.NestedField{ID: 140, Name: "sort_order_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
-		iceberg.NestedField{ID: 142, Name: "first_row_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
-		iceberg.NestedField{ID: 143, Name: "referenced_data_file", Type: iceberg.PrimitiveTypes.String, Required: false},
-		iceberg.NestedField{ID: 144, Name: "content_offset", Type: iceberg.PrimitiveTypes.Int64, Required: false},
-		iceberg.NestedField{ID: 145, Name: "content_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDRecordCount, Name: "record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: inspectContentFieldIDFileSize, Name: "file_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: inspectContentFieldIDColumnSizes, Name: "column_sizes", Type: inspectInt64MapType(117, 118), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDValueCounts, Name: "value_counts", Type: inspectInt64MapType(119, 120), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDNullValueCounts, Name: "null_value_counts", Type: inspectInt64MapType(121, 122), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDDistinctValueCounts, Name: "distinct_value_counts", Type: inspectInt64MapType(112, 113), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDNaNValueCounts, Name: "nan_value_counts", Type: inspectInt64MapType(138, 139), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDLowerBounds, Name: "lower_bounds", Type: inspectBinaryMapType(126, 127), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDUpperBounds, Name: "upper_bounds", Type: inspectBinaryMapType(129, 130), Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDKeyMetadata, Name: "key_metadata", Type: iceberg.PrimitiveTypes.Binary, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDSplitOffsets, Name: "split_offsets", Type: &iceberg.ListType{ElementID: 133, Element: iceberg.PrimitiveTypes.Int64, ElementRequired: true}, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDEqualityIDs, Name: "equality_ids", Type: &iceberg.ListType{ElementID: 136, Element: iceberg.PrimitiveTypes.Int32, ElementRequired: true}, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDSortOrderID, Name: "sort_order_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDFirstRowID, Name: "first_row_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDReferencedDataFile, Name: "referenced_data_file", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDContentOffset, Name: "content_offset", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: inspectContentFieldIDContentSize, Name: "content_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 	)
 
 	return fields
@@ -309,84 +335,223 @@ func inspectBinaryMapType(keyID, valueID int) *iceberg.MapType {
 }
 
 func appendContentFileRecord(bldr *array.RecordBuilder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
-	return appendContentFileFields(bldr.Field, partitionType, file)
-}
-
-func appendContentFile(builder *array.StructBuilder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
-	builder.Append(true)
-
-	return appendContentFileFields(builder.FieldBuilder, partitionType, file)
-}
-
-func appendContentFileFields(fieldBuilder func(int) array.Builder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
-	idx := 0
-	fieldBuilder(idx).(*array.Int32Builder).Append(int32(file.ContentType()))
-	idx++
-	fieldBuilder(idx).(*array.StringBuilder).Append(file.FilePath())
-	idx++
-	fieldBuilder(idx).(*array.StringBuilder).Append(string(file.FileFormat()))
-	idx++
-	fieldBuilder(idx).(*array.Int32Builder).Append(file.SpecID())
-	idx++
-
-	if partitionType != nil && len(partitionType.FieldList) > 0 {
-		partition := fieldBuilder(idx).(*array.StructBuilder)
-		if err := appendInspectPartition(partition, partitionType, file.Partition()); err != nil {
-			return err
-		}
-		idx++
+	contentFileBuilder, err := newInspectContentFileBuilder(bldr, partitionType)
+	if err != nil {
+		return err
 	}
 
-	fieldBuilder(idx).(*array.Int64Builder).Append(file.Count())
-	idx++
-	fieldBuilder(idx).(*array.Int64Builder).Append(file.FileSizeBytes())
-	idx++
-	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.ColumnSizes())
-	idx++
-	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.ValueCounts())
-	idx++
-	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.NullValueCounts())
-	idx++
-	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.NaNValueCounts())
-	idx++
-	appendInspectBinaryMap(fieldBuilder(idx).(*array.MapBuilder), file.LowerBoundValues())
-	idx++
-	appendInspectBinaryMap(fieldBuilder(idx).(*array.MapBuilder), file.UpperBoundValues())
-	idx++
-	appendInspectBytes(fieldBuilder(idx), file.KeyMetadata())
-	idx++
-	appendInspectInt64List(fieldBuilder(idx).(*array.ListBuilder), file.SplitOffsets())
-	idx++
-	appendInspectInt32List(fieldBuilder(idx).(*array.ListBuilder), file.EqualityFieldIDs())
-	idx++
-	appendInspectOptionalInt32(fieldBuilder(idx).(*array.Int32Builder), file.SortOrderID())
-	idx++
-	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.FirstRowID())
-	idx++
-	appendInspectOptionalString(fieldBuilder(idx).(*array.StringBuilder), file.ReferencedDataFile())
-	idx++
-	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.ContentOffset())
-	idx++
-	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.ContentSizeInBytes())
+	return contentFileBuilder.append(partitionType, file)
+}
+
+func newInspectContentFileAppender(partitionType *iceberg.StructType) func(*array.RecordBuilder, iceberg.DataFile) error {
+	var current *array.RecordBuilder
+	var contentFileBuilder inspectContentFileBuilder
+	var bindErr error
+
+	return func(bldr *array.RecordBuilder, file iceberg.DataFile) error {
+		if bldr != current {
+			contentFileBuilder, bindErr = newInspectContentFileBuilder(bldr, partitionType)
+			current = bldr
+		}
+		if bindErr != nil {
+			return bindErr
+		}
+
+		return contentFileBuilder.append(partitionType, file)
+	}
+}
+
+type inspectContentFileBuilder struct {
+	content             *array.Int32Builder
+	filePath            *array.StringBuilder
+	fileFormat          *array.StringBuilder
+	specID              *array.Int32Builder
+	partition           *array.StructBuilder
+	recordCount         *array.Int64Builder
+	fileSize            *array.Int64Builder
+	columnSizes         *array.MapBuilder
+	valueCounts         *array.MapBuilder
+	nullValueCounts     *array.MapBuilder
+	distinctValueCounts *array.MapBuilder
+	nanValueCounts      *array.MapBuilder
+	lowerBounds         *array.MapBuilder
+	upperBounds         *array.MapBuilder
+	keyMetadata         *array.BinaryBuilder
+	splitOffsets        *array.ListBuilder
+	equalityIDs         *array.ListBuilder
+	sortOrderID         *array.Int32Builder
+	firstRowID          *array.Int64Builder
+	referencedDataFile  *array.StringBuilder
+	contentOffset       *array.Int64Builder
+	contentSize         *array.Int64Builder
+}
+
+func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceberg.StructType) (inspectContentFileBuilder, error) {
+	lookup, err := newInspectBuilderLookup("content-file", bldr.Schema().Fields(), bldr.Field)
+	if err != nil {
+		return inspectContentFileBuilder{}, err
+	}
+	if err := validateInspectBuilderLookup("content-file", lookup, inspectContentFileFieldIDs(partitionType)); err != nil {
+		return inspectContentFileBuilder{}, err
+	}
+
+	var out inspectContentFileBuilder
+	if out.content, err = inspectBuilderAs[*array.Int32Builder](lookup, inspectContentFieldIDContent, "content"); err != nil {
+		return out, err
+	}
+	if out.filePath, err = inspectBuilderAs[*array.StringBuilder](lookup, inspectContentFieldIDFilePath, "file_path"); err != nil {
+		return out, err
+	}
+	if out.fileFormat, err = inspectBuilderAs[*array.StringBuilder](lookup, inspectContentFieldIDFileFormat, "file_format"); err != nil {
+		return out, err
+	}
+	if out.specID, err = inspectBuilderAs[*array.Int32Builder](lookup, inspectContentFieldIDSpecID, "spec_id"); err != nil {
+		return out, err
+	}
+	if partitionType != nil && len(partitionType.FieldList) > 0 {
+		if out.partition, err = inspectBuilderAs[*array.StructBuilder](lookup, inspectContentFieldIDPartition, "partition"); err != nil {
+			return out, err
+		}
+	}
+	if out.recordCount, err = inspectBuilderAs[*array.Int64Builder](lookup, inspectContentFieldIDRecordCount, "record_count"); err != nil {
+		return out, err
+	}
+	if out.fileSize, err = inspectBuilderAs[*array.Int64Builder](lookup, inspectContentFieldIDFileSize, "file_size_in_bytes"); err != nil {
+		return out, err
+	}
+	if out.columnSizes, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDColumnSizes, "column_sizes"); err != nil {
+		return out, err
+	}
+	if out.valueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDValueCounts, "value_counts"); err != nil {
+		return out, err
+	}
+	if out.nullValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDNullValueCounts, "null_value_counts"); err != nil {
+		return out, err
+	}
+	if out.distinctValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDDistinctValueCounts, "distinct_value_counts"); err != nil {
+		return out, err
+	}
+	if out.nanValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDNaNValueCounts, "nan_value_counts"); err != nil {
+		return out, err
+	}
+	if out.lowerBounds, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDLowerBounds, "lower_bounds"); err != nil {
+		return out, err
+	}
+	if out.upperBounds, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDUpperBounds, "upper_bounds"); err != nil {
+		return out, err
+	}
+	if out.keyMetadata, err = inspectBuilderAs[*array.BinaryBuilder](lookup, inspectContentFieldIDKeyMetadata, "key_metadata"); err != nil {
+		return out, err
+	}
+	if out.splitOffsets, err = inspectBuilderAs[*array.ListBuilder](lookup, inspectContentFieldIDSplitOffsets, "split_offsets"); err != nil {
+		return out, err
+	}
+	if out.equalityIDs, err = inspectBuilderAs[*array.ListBuilder](lookup, inspectContentFieldIDEqualityIDs, "equality_ids"); err != nil {
+		return out, err
+	}
+	if out.sortOrderID, err = inspectBuilderAs[*array.Int32Builder](lookup, inspectContentFieldIDSortOrderID, "sort_order_id"); err != nil {
+		return out, err
+	}
+	if out.firstRowID, err = inspectBuilderAs[*array.Int64Builder](lookup, inspectContentFieldIDFirstRowID, "first_row_id"); err != nil {
+		return out, err
+	}
+	if out.referencedDataFile, err = inspectBuilderAs[*array.StringBuilder](lookup, inspectContentFieldIDReferencedDataFile, "referenced_data_file"); err != nil {
+		return out, err
+	}
+	if out.contentOffset, err = inspectBuilderAs[*array.Int64Builder](lookup, inspectContentFieldIDContentOffset, "content_offset"); err != nil {
+		return out, err
+	}
+	if out.contentSize, err = inspectBuilderAs[*array.Int64Builder](lookup, inspectContentFieldIDContentSize, "content_size_in_bytes"); err != nil {
+		return out, err
+	}
+
+	return out, nil
+}
+
+func (b inspectContentFileBuilder) append(partitionType *iceberg.StructType, file iceberg.DataFile) error {
+	b.content.Append(int32(file.ContentType()))
+	b.filePath.Append(file.FilePath())
+	b.fileFormat.Append(string(file.FileFormat()))
+	b.specID.Append(file.SpecID())
+
+	if b.partition != nil {
+		if err := appendInspectPartition(b.partition, partitionType, file.Partition()); err != nil {
+			return err
+		}
+	}
+
+	b.recordCount.Append(file.Count())
+	b.fileSize.Append(file.FileSizeBytes())
+	if err := appendInspectInt64Map(b.columnSizes, file.ColumnSizes()); err != nil {
+		return err
+	}
+	if err := appendInspectInt64Map(b.valueCounts, file.ValueCounts()); err != nil {
+		return err
+	}
+	if err := appendInspectInt64Map(b.nullValueCounts, file.NullValueCounts()); err != nil {
+		return err
+	}
+	if err := appendInspectInt64Map(b.distinctValueCounts, file.DistinctValueCounts()); err != nil {
+		return err
+	}
+	if err := appendInspectInt64Map(b.nanValueCounts, file.NaNValueCounts()); err != nil {
+		return err
+	}
+	if err := appendInspectBinaryMap(b.lowerBounds, file.LowerBoundValues()); err != nil {
+		return err
+	}
+	if err := appendInspectBinaryMap(b.upperBounds, file.UpperBoundValues()); err != nil {
+		return err
+	}
+	appendInspectBytes(b.keyMetadata, file.KeyMetadata())
+	if err := appendInspectInt64List(b.splitOffsets, file.SplitOffsets()); err != nil {
+		return err
+	}
+	if err := appendInspectInt32List(b.equalityIDs, file.EqualityFieldIDs()); err != nil {
+		return err
+	}
+	if err := appendInspectOptionalInt32(b.sortOrderID, file.SortOrderID()); err != nil {
+		return err
+	}
+	appendInspectOptionalInt64(b.firstRowID, file.FirstRowID())
+	appendInspectOptionalString(b.referencedDataFile, file.ReferencedDataFile())
+	appendInspectOptionalInt64(b.contentOffset, file.ContentOffset())
+	appendInspectOptionalInt64(b.contentSize, file.ContentSizeInBytes())
 
 	return nil
 }
 
 func appendInspectPartition(builder *array.StructBuilder, partitionType *iceberg.StructType, values map[int]any) error {
-	arrowType := builder.Type().(*arrow.StructType)
+	arrowType, ok := builder.Type().(*arrow.StructType)
+	if !ok {
+		return fmt.Errorf("partition builder has type %T, want struct", builder.Type())
+	}
+	lookup, err := newInspectBuilderLookup("partition", arrowType.Fields(), builder.FieldBuilder)
+	if err != nil {
+		return err
+	}
+	expected := make(map[int]struct{}, len(partitionType.FieldList))
+	for _, field := range partitionType.FieldList {
+		expected[field.ID] = struct{}{}
+	}
+	if err := validateInspectBuilderLookup("partition", lookup, expected); err != nil {
+		return err
+	}
+
 	builder.Append(true)
-	for idx, field := range partitionType.FieldList {
+	for _, field := range partitionType.FieldList {
 		value := values[field.ID]
+		fieldBuilder := lookup[field.ID]
 		if value == nil {
-			builder.FieldBuilder(idx).AppendNull()
+			fieldBuilder.AppendNull()
 
 			continue
 		}
-		sc, err := inspectValueScalar(value, field.Type, arrowType.Field(idx).Type)
+		sc, err := inspectValueScalar(value, field.Type, fieldBuilder.Type())
 		if err != nil {
 			return fmt.Errorf("partition field %q: %w", field.Name, err)
 		}
-		if err := scalar.Append(builder.FieldBuilder(idx), sc); err != nil {
+		if err := scalar.Append(fieldBuilder, sc); err != nil {
 			return err
 		}
 	}
@@ -402,23 +567,33 @@ func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (
 			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
 		case int32:
 			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
+		default:
+			return nil, fmt.Errorf("unsupported date partition value %T", value)
 		}
 	case iceberg.TimeType:
 		if value, ok := value.(iceberg.Time); ok {
 			return scalar.NewTime64Scalar(arrow.Time64(value), arrowType), nil
 		}
+
+		return nil, fmt.Errorf("unsupported time partition value %T", value)
 	case iceberg.TimestampType, iceberg.TimestampTzType:
 		if value, ok := value.(iceberg.Timestamp); ok {
 			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
 		}
+
+		return nil, fmt.Errorf("unsupported timestamp partition value %T", value)
 	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
 		if value, ok := value.(iceberg.TimestampNano); ok {
 			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
 		}
+
+		return nil, fmt.Errorf("unsupported nanosecond timestamp partition value %T", value)
 	case iceberg.UUIDType:
 		if value, ok := value.(uuid.UUID); ok {
 			return scalar.MakeScalarParam(value[:], arrowType)
 		}
+
+		return nil, fmt.Errorf("unsupported UUID partition value %T", value)
 	case iceberg.DecimalType:
 		switch value := value.(type) {
 		case iceberg.DecimalLiteral:
@@ -433,85 +608,217 @@ func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (
 	return scalar.MakeScalarParam(value, arrowType)
 }
 
-func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) {
+func inspectContentFileFieldIDs(partitionType *iceberg.StructType) map[int]struct{} {
+	ids := map[int]struct{}{
+		inspectContentFieldIDContent:             {},
+		inspectContentFieldIDFilePath:            {},
+		inspectContentFieldIDFileFormat:          {},
+		inspectContentFieldIDSpecID:              {},
+		inspectContentFieldIDRecordCount:         {},
+		inspectContentFieldIDFileSize:            {},
+		inspectContentFieldIDColumnSizes:         {},
+		inspectContentFieldIDValueCounts:         {},
+		inspectContentFieldIDNullValueCounts:     {},
+		inspectContentFieldIDDistinctValueCounts: {},
+		inspectContentFieldIDNaNValueCounts:      {},
+		inspectContentFieldIDLowerBounds:         {},
+		inspectContentFieldIDUpperBounds:         {},
+		inspectContentFieldIDKeyMetadata:         {},
+		inspectContentFieldIDSplitOffsets:        {},
+		inspectContentFieldIDEqualityIDs:         {},
+		inspectContentFieldIDSortOrderID:         {},
+		inspectContentFieldIDFirstRowID:          {},
+		inspectContentFieldIDReferencedDataFile:  {},
+		inspectContentFieldIDContentOffset:       {},
+		inspectContentFieldIDContentSize:         {},
+	}
+	if partitionType != nil && len(partitionType.FieldList) > 0 {
+		ids[inspectContentFieldIDPartition] = struct{}{}
+	}
+
+	return ids
+}
+
+func newInspectBuilderLookup(scope string, fields []arrow.Field, builder func(int) array.Builder) (map[int]array.Builder, error) {
+	lookup := make(map[int]array.Builder, len(fields))
+	for idx, field := range fields {
+		id := getFieldID(field)
+		if id == nil {
+			return nil, fmt.Errorf("%s field %q is missing a valid field ID", scope, field.Name)
+		}
+		if _, exists := lookup[*id]; exists {
+			return nil, fmt.Errorf("%s schema contains duplicate field ID %d", scope, *id)
+		}
+		lookup[*id] = builder(idx)
+	}
+
+	return lookup, nil
+}
+
+func validateInspectBuilderLookup(scope string, lookup map[int]array.Builder, expected map[int]struct{}) error {
+	if len(lookup) != len(expected) {
+		return fmt.Errorf("%s schema has %d fields, want %d", scope, len(lookup), len(expected))
+	}
+	for id := range lookup {
+		if _, ok := expected[id]; !ok {
+			return fmt.Errorf("%s schema contains unexpected field ID %d", scope, id)
+		}
+	}
+	for id := range expected {
+		if _, ok := lookup[id]; !ok {
+			return fmt.Errorf("%s schema is missing field ID %d", scope, id)
+		}
+	}
+
+	return nil
+}
+
+func inspectBuilderAs[T any](lookup map[int]array.Builder, id int, name string) (T, error) {
+	var zero T
+	builder, ok := lookup[id]
+	if !ok {
+		return zero, fmt.Errorf("content-file schema is missing field %q (ID %d)", name, id)
+	}
+	typed, ok := builder.(T)
+	if !ok {
+		return zero, fmt.Errorf("content-file field %q (ID %d) has builder type %T", name, id, builder)
+	}
+
+	return typed, nil
+}
+
+func inspectInt32Value(value int, name string) (int32, error) {
+	if value < math.MinInt32 || value > math.MaxInt32 {
+		return 0, fmt.Errorf("%s %d does not fit in int32", name, value)
+	}
+
+	return int32(value), nil
+}
+
+func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) error {
 	if values == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
 	builder.Append(true)
-	keys := builder.KeyBuilder().(*array.Int32Builder)
-	items := builder.ItemBuilder().(*array.Int64Builder)
+	keys, ok := builder.KeyBuilder().(*array.Int32Builder)
+	if !ok {
+		return fmt.Errorf("map key builder has type %T, want int32", builder.KeyBuilder())
+	}
+	items, ok := builder.ItemBuilder().(*array.Int64Builder)
+	if !ok {
+		return fmt.Errorf("map item builder has type %T, want int64", builder.ItemBuilder())
+	}
 	ids := make([]int, 0, len(values))
 	for id := range values {
 		ids = append(ids, id)
 	}
 	sort.Ints(ids)
 	for _, id := range ids {
-		keys.Append(int32(id))
+		key, err := inspectInt32Value(id, "field ID")
+		if err != nil {
+			return err
+		}
+		keys.Append(key)
 		items.Append(values[id])
 	}
+
+	return nil
 }
 
-func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) {
+func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) error {
 	if values == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
 	builder.Append(true)
-	keys := builder.KeyBuilder().(*array.Int32Builder)
-	items := builder.ItemBuilder().(*array.BinaryBuilder)
+	keys, ok := builder.KeyBuilder().(*array.Int32Builder)
+	if !ok {
+		return fmt.Errorf("map key builder has type %T, want int32", builder.KeyBuilder())
+	}
+	items, ok := builder.ItemBuilder().(*array.BinaryBuilder)
+	if !ok {
+		return fmt.Errorf("map item builder has type %T, want binary", builder.ItemBuilder())
+	}
 	ids := make([]int, 0, len(values))
 	for id := range values {
 		ids = append(ids, id)
 	}
 	sort.Ints(ids)
 	for _, id := range ids {
-		keys.Append(int32(id))
+		key, err := inspectInt32Value(id, "field ID")
+		if err != nil {
+			return err
+		}
+		keys.Append(key)
 		items.Append(values[id])
 	}
+
+	return nil
 }
 
-func appendInspectBytes(builder array.Builder, value []byte) {
+func appendInspectBytes(builder *array.BinaryBuilder, value []byte) {
 	if value == nil {
 		builder.AppendNull()
 
 		return
 	}
-	builder.(*array.BinaryBuilder).Append(value)
+	builder.Append(value)
 }
 
-func appendInspectInt64List(builder *array.ListBuilder, values []int64) {
+func appendInspectInt64List(builder *array.ListBuilder, values []int64) error {
 	if values == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
 	builder.Append(true)
-	builder.ValueBuilder().(*array.Int64Builder).AppendValues(values, nil)
+	items, ok := builder.ValueBuilder().(*array.Int64Builder)
+	if !ok {
+		return fmt.Errorf("list item builder has type %T, want int64", builder.ValueBuilder())
+	}
+	items.AppendValues(values, nil)
+
+	return nil
 }
 
-func appendInspectInt32List(builder *array.ListBuilder, values []int) {
+func appendInspectInt32List(builder *array.ListBuilder, values []int) error {
 	if values == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
 	builder.Append(true)
-	items := builder.ValueBuilder().(*array.Int32Builder)
+	items, ok := builder.ValueBuilder().(*array.Int32Builder)
+	if !ok {
+		return fmt.Errorf("list item builder has type %T, want int32", builder.ValueBuilder())
+	}
 	for _, value := range values {
-		items.Append(int32(value))
+		converted, err := inspectInt32Value(value, "equality field ID")
+		if err != nil {
+			return err
+		}
+		items.Append(converted)
 	}
+
+	return nil
 }
 
-func appendInspectOptionalInt32(builder *array.Int32Builder, value *int) {
+func appendInspectOptionalInt32(builder *array.Int32Builder, value *int) error {
 	if value == nil {
 		builder.AppendNull()
 
-		return
+		return nil
 	}
-	builder.Append(int32(*value))
+	converted, err := inspectInt32Value(*value, "sort order ID")
+	if err != nil {
+		return err
+	}
+	builder.Append(converted)
+
+	return nil
 }
 
 func appendInspectOptionalInt64(builder *array.Int64Builder, value *int64) {

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -105,20 +105,13 @@ func (i InspectTable) manifestEntryReader(
 			batch := bldr.NewRecordBatch()
 			rows = 0
 			emitted = true
-			if yield(batch, nil) {
-				return true
-			}
 
-			batch.Release()
-
-			return false
+			return yield(batch, nil)
 		}
 		emitEmpty := func() {
 			batch := bldr.NewRecordBatch()
 			emitted = true
-			if !yield(batch, nil) {
-				batch.Release()
-			}
+			_ = yield(batch, nil)
 		}
 		yieldError := func(err error) {
 			_ = yield(nil, err)
@@ -171,9 +164,7 @@ func emptyInspectRecordBatch(alloc memory.Allocator, schema *arrow.Schema) iter.
 		defer bldr.Release()
 
 		batch := bldr.NewRecordBatch()
-		if !yield(batch, nil) {
-			batch.Release()
-		}
+		_ = yield(batch, nil)
 	}
 }
 

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -33,8 +33,7 @@ import (
 // DataFiles returns the live data files in the current snapshot. Deleted
 // manifest entries are omitted, matching the data_files metadata table.
 func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error) {
-	spec := i.tbl.metadata.PartitionSpec()
-	partitionType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
+	partitionType := inspectPartitionType(i.tbl.metadata)
 	schema := DataFilesSchema(partitionType)
 	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
 	if err != nil {
@@ -105,10 +104,84 @@ func (i InspectTable) currentContentFiles(ctx context.Context, content iceberg.M
 	return files, nil
 }
 
+// inspectPartitionType returns the table-wide partition type. It contains the
+// union of partition fields from every spec, which lets metadata tables
+// represent live files written before partition evolution.
+func inspectPartitionType(metadata Metadata) *iceberg.StructType {
+	currentSchema := metadata.CurrentSchema()
+	specs := metadata.PartitionSpecs()
+	sort.Slice(specs, func(left, right int) bool {
+		return specs[left].ID() > specs[right].ID()
+	})
+
+	selected := make(map[int]iceberg.PartitionField)
+	fieldsByID := make(map[int]iceberg.NestedField)
+	for _, spec := range specs {
+		partitionType := spec.PartitionType(currentSchema)
+		for idx, field := range spec.Fields() {
+			active := true
+			for _, sourceID := range field.SourceIDs {
+				if _, ok := currentSchema.FindTypeByID(sourceID); !ok {
+					active = false
+					break
+				}
+			}
+			if !active || idx >= len(partitionType.FieldList) {
+				continue
+			}
+
+			if previous, exists := selected[field.FieldID]; exists {
+				// A v1 partition-field drop is represented by a void transform.
+				// Keep the newest field name, but use the older non-void type when
+				// that is the only concrete type available.
+				if isInspectVoidTransform(previous.Transform) && !isInspectVoidTransform(field.Transform) {
+					old := fieldsByID[field.FieldID]
+					old.Type = partitionType.FieldList[idx].Type
+					fieldsByID[field.FieldID] = old
+				}
+				continue
+			}
+
+			selected[field.FieldID] = field
+			fieldsByID[field.FieldID] = iceberg.NestedField{
+				ID:       field.FieldID,
+				Name:     field.Name,
+				Type:     partitionType.FieldList[idx].Type,
+				Required: false,
+			}
+		}
+	}
+
+	fields := make([]iceberg.NestedField, 0, len(fieldsByID))
+	for _, field := range fieldsByID {
+		fields = append(fields, field)
+	}
+	sort.Slice(fields, func(left, right int) bool { return fields[left].ID < fields[right].ID })
+
+	return &iceberg.StructType{FieldList: fields}
+}
+
+func isInspectVoidTransform(transform iceberg.Transform) bool {
+	switch transform.(type) {
+	case iceberg.VoidTransform, *iceberg.VoidTransform:
+		return true
+	default:
+		return false
+	}
+}
+
 // DataFilesSchema returns the common content-file schema used by the data_files
 // and delete_files metadata tables. The partition field is omitted for an
 // unpartitioned table, as required by the Iceberg metadata-table spec.
 func DataFilesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
+	return iceberg.NewSchema(0, inspectContentFileFields(partitionType)...)
+}
+
+func inspectContentFileType(partitionType *iceberg.StructType) *iceberg.StructType {
+	return &iceberg.StructType{FieldList: inspectContentFileFields(partitionType)}
+}
+
+func inspectContentFileFields(partitionType *iceberg.StructType) []iceberg.NestedField {
 	fields := []iceberg.NestedField{
 		{ID: 134, Name: "content", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 		{ID: 100, Name: "file_path", Type: iceberg.PrimitiveTypes.String, Required: true},
@@ -137,7 +210,7 @@ func DataFilesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
 		iceberg.NestedField{ID: 145, Name: "content_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 	)
 
-	return iceberg.NewSchema(0, fields...)
+	return fields
 }
 
 func inspectInt64MapType(keyID, valueID int) *iceberg.MapType {
@@ -149,60 +222,70 @@ func inspectBinaryMapType(keyID, valueID int) *iceberg.MapType {
 }
 
 func appendContentFileRecord(bldr *array.RecordBuilder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
+	return appendContentFileFields(bldr.Field, partitionType, file)
+}
+
+func appendContentFile(builder *array.StructBuilder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
+	builder.Append(true)
+
+	return appendContentFileFields(builder.FieldBuilder, partitionType, file)
+}
+
+func appendContentFileFields(fieldBuilder func(int) array.Builder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
 	idx := 0
-	bldr.Field(idx).(*array.Int32Builder).Append(int32(file.ContentType()))
+	fieldBuilder(idx).(*array.Int32Builder).Append(int32(file.ContentType()))
 	idx++
-	bldr.Field(idx).(*array.StringBuilder).Append(file.FilePath())
+	fieldBuilder(idx).(*array.StringBuilder).Append(file.FilePath())
 	idx++
-	bldr.Field(idx).(*array.StringBuilder).Append(string(file.FileFormat()))
+	fieldBuilder(idx).(*array.StringBuilder).Append(string(file.FileFormat()))
 	idx++
-	bldr.Field(idx).(*array.Int32Builder).Append(file.SpecID())
+	fieldBuilder(idx).(*array.Int32Builder).Append(file.SpecID())
 	idx++
 
 	if partitionType != nil && len(partitionType.FieldList) > 0 {
-		partition := bldr.Field(idx).(*array.StructBuilder)
-		if err := appendPartitionStruct(partition, partitionType, file.Partition()); err != nil {
+		partition := fieldBuilder(idx).(*array.StructBuilder)
+		if err := appendInspectPartition(partition, partitionType, file.Partition()); err != nil {
 			return err
 		}
 		idx++
 	}
 
-	bldr.Field(idx).(*array.Int64Builder).Append(file.Count())
+	fieldBuilder(idx).(*array.Int64Builder).Append(file.Count())
 	idx++
-	bldr.Field(idx).(*array.Int64Builder).Append(file.FileSizeBytes())
+	fieldBuilder(idx).(*array.Int64Builder).Append(file.FileSizeBytes())
 	idx++
-	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.ColumnSizes())
+	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.ColumnSizes())
 	idx++
-	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.ValueCounts())
+	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.ValueCounts())
 	idx++
-	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.NullValueCounts())
+	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.NullValueCounts())
 	idx++
-	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.NaNValueCounts())
+	appendInspectInt64Map(fieldBuilder(idx).(*array.MapBuilder), file.NaNValueCounts())
 	idx++
-	appendInspectBinaryMap(bldr.Field(idx).(*array.MapBuilder), file.LowerBoundValues())
+	appendInspectBinaryMap(fieldBuilder(idx).(*array.MapBuilder), file.LowerBoundValues())
 	idx++
-	appendInspectBinaryMap(bldr.Field(idx).(*array.MapBuilder), file.UpperBoundValues())
+	appendInspectBinaryMap(fieldBuilder(idx).(*array.MapBuilder), file.UpperBoundValues())
 	idx++
-	appendInspectBytes(bldr.Field(idx), file.KeyMetadata())
+	appendInspectBytes(fieldBuilder(idx), file.KeyMetadata())
 	idx++
-	appendInspectInt64List(bldr.Field(idx).(*array.ListBuilder), file.SplitOffsets())
+	appendInspectInt64List(fieldBuilder(idx).(*array.ListBuilder), file.SplitOffsets())
 	idx++
-	appendInspectInt32List(bldr.Field(idx).(*array.ListBuilder), file.EqualityFieldIDs())
+	appendInspectInt32List(fieldBuilder(idx).(*array.ListBuilder), file.EqualityFieldIDs())
 	idx++
-	appendInspectOptionalInt32(bldr.Field(idx).(*array.Int32Builder), file.SortOrderID())
+	appendInspectOptionalInt32(fieldBuilder(idx).(*array.Int32Builder), file.SortOrderID())
 	idx++
-	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.FirstRowID())
+	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.FirstRowID())
 	idx++
-	appendInspectOptionalString(bldr.Field(idx).(*array.StringBuilder), file.ReferencedDataFile())
+	appendInspectOptionalString(fieldBuilder(idx).(*array.StringBuilder), file.ReferencedDataFile())
 	idx++
-	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.ContentOffset())
+	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.ContentOffset())
 	idx++
-	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.ContentSizeInBytes())
+	appendInspectOptionalInt64(fieldBuilder(idx).(*array.Int64Builder), file.ContentSizeInBytes())
 
 	return nil
 }
 
-func appendPartitionStruct(builder *array.StructBuilder, partitionType *iceberg.StructType, values map[int]any) error {
+func appendInspectPartition(builder *array.StructBuilder, partitionType *iceberg.StructType, values map[int]any) error {
 	arrowType := builder.Type().(*arrow.StructType)
 	builder.Append(true)
 	for idx, field := range partitionType.FieldList {

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 	"sort"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -35,7 +36,10 @@ import (
 // DataFiles returns the live data files in the current snapshot. Deleted
 // manifest entries are omitted, matching the data_files metadata table.
 func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error) {
-	partitionType := inspectPartitionType(i.tbl.metadata)
+	partitionType, err := inspectPartitionType(i.tbl.metadata)
+	if err != nil {
+		return nil, fmt.Errorf("inspect data files: %w", err)
+	}
 	schema := DataFilesSchema(partitionType)
 	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
 	if err != nil {
@@ -174,7 +178,7 @@ func emptyInspectRecordBatch(alloc memory.Allocator, schema *arrow.Schema) iter.
 // inspectPartitionType returns the table-wide partition type. It contains the
 // union of partition fields from every spec, which lets metadata tables
 // represent live files written before partition evolution.
-func inspectPartitionType(metadata Metadata) *iceberg.StructType {
+func inspectPartitionType(metadata Metadata) (*iceberg.StructType, error) {
 	currentSchema := metadata.CurrentSchema()
 	specs := metadata.PartitionSpecs()
 	sort.Slice(specs, func(left, right int) bool {
@@ -199,13 +203,27 @@ func inspectPartitionType(metadata Metadata) *iceberg.StructType {
 			}
 
 			if previous, exists := selected[field.FieldID]; exists {
-				// A v1 partition-field drop is represented by a void transform.
-				// Keep the newest field name, but use the older non-void type when
-				// that is the only concrete type available.
-				if isInspectVoidTransform(previous.Transform) && !isInspectVoidTransform(field.Transform) {
-					old := fieldsByID[field.FieldID]
-					old.Type = partitionType.FieldList[idx].Type
-					fieldsByID[field.FieldID] = old
+				if !slices.Equal(previous.SourceIDs, field.SourceIDs) {
+					return nil, fmt.Errorf("%w: partition field ID %d has incompatible source IDs %v and %v",
+						iceberg.ErrInvalidPartitionSpec, field.FieldID, previous.SourceIDs, field.SourceIDs)
+				}
+
+				previousVoid := isInspectVoidTransform(previous.Transform)
+				fieldVoid := isInspectVoidTransform(field.Transform)
+				if previousVoid || fieldVoid {
+					if previousVoid && !fieldVoid {
+						selected[field.FieldID] = field
+						old := fieldsByID[field.FieldID]
+						old.Type = partitionType.FieldList[idx].Type
+						fieldsByID[field.FieldID] = old
+					}
+
+					continue
+				}
+
+				if !previous.Transform.Equals(field.Transform) {
+					return nil, fmt.Errorf("%w: partition field ID %d has incompatible transforms %q and %q",
+						iceberg.ErrInvalidPartitionSpec, field.FieldID, previous.Transform, field.Transform)
 				}
 
 				continue
@@ -227,7 +245,7 @@ func inspectPartitionType(metadata Metadata) *iceberg.StructType {
 	}
 	sort.Slice(fields, func(left, right int) bool { return fields[left].ID < fields[right].ID })
 
-	return &iceberg.StructType{FieldList: fields}
+	return &iceberg.StructType{FieldList: fields}, nil
 }
 
 func isInspectVoidTransform(transform iceberg.Transform) bool {

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -190,6 +190,13 @@ func inspectPartitionType(metadata Metadata) (*iceberg.StructType, error) {
 	selected := make(map[int]iceberg.PartitionField)
 	fieldsByID := make(map[int]iceberg.NestedField)
 	for _, spec := range specs {
+		for _, field := range spec.Fields() {
+			if isInspectUnknownTransform(field.Transform) {
+				return nil, fmt.Errorf("%w: cannot build metadata partition type for field %d with unknown transform %s",
+					iceberg.ErrInvalidPartitionSpec, field.FieldID, field.Transform)
+			}
+		}
+
 		partitionType := spec.PartitionType(currentSchema)
 		for idx, field := range spec.Fields() {
 			active := true
@@ -252,7 +259,16 @@ func inspectPartitionType(metadata Metadata) (*iceberg.StructType, error) {
 
 func isInspectVoidTransform(transform iceberg.Transform) bool {
 	switch transform.(type) {
-	case iceberg.VoidTransform:
+	case iceberg.VoidTransform, *iceberg.VoidTransform:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInspectUnknownTransform(transform iceberg.Transform) bool {
+	switch transform.(type) {
+	case iceberg.UnknownTransform, *iceberg.UnknownTransform:
 		return true
 	default:
 		return false

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -1,0 +1,344 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+)
+
+// DataFiles returns the live data files in the current snapshot. Deleted
+// manifest entries are omitted, matching the data_files metadata table.
+func (i InspectTable) DataFiles(ctx context.Context) (array.RecordReader, error) {
+	spec := i.tbl.metadata.PartitionSpec()
+	partitionType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
+	schema := DataFilesSchema(partitionType)
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect data files: build arrow schema: %w", err)
+	}
+
+	files, err := i.currentContentFiles(ctx, iceberg.ManifestContentData)
+	if err != nil {
+		return nil, fmt.Errorf("inspect data files: %w", err)
+	}
+
+	bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
+	defer bldr.Release()
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := appendContentFileRecord(bldr, partitionType, file); err != nil {
+			return nil, fmt.Errorf("inspect data files: append %s: %w", file.FilePath(), err)
+		}
+	}
+
+	rr, err := singleBatchReader(arrowSchema, bldr)
+	if err != nil {
+		return nil, fmt.Errorf("inspect data files: %w", err)
+	}
+
+	return rr, nil
+}
+
+func (i InspectTable) currentContentFiles(ctx context.Context, content iceberg.ManifestContent) ([]iceberg.DataFile, error) {
+	snapshot := i.tbl.metadata.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil
+	}
+	if i.tbl.fsF == nil {
+		return nil, fmt.Errorf("table file IO is not configured")
+	}
+
+	fs, err := i.tbl.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := snapshot.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]iceberg.DataFile, 0)
+	for _, manifest := range manifests {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if manifest.ManifestContent() != content {
+			continue
+		}
+		for entry, err := range manifest.Entries(fs, true) {
+			if err != nil {
+				return nil, err
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			files = append(files, entry.DataFile())
+		}
+	}
+
+	return files, nil
+}
+
+// DataFilesSchema returns the common content-file schema used by the data_files
+// and delete_files metadata tables. The partition field is omitted for an
+// unpartitioned table, as required by the Iceberg metadata-table spec.
+func DataFilesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
+	fields := []iceberg.NestedField{
+		{ID: 134, Name: "content", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		{ID: 100, Name: "file_path", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: 101, Name: "file_format", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: 141, Name: "spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+	}
+	if partitionType != nil && len(partitionType.FieldList) > 0 {
+		fields = append(fields, iceberg.NestedField{ID: 102, Name: "partition", Type: partitionType, Required: true})
+	}
+	fields = append(fields,
+		iceberg.NestedField{ID: 103, Name: "record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 104, Name: "file_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 108, Name: "column_sizes", Type: inspectInt64MapType(117, 118), Required: false},
+		iceberg.NestedField{ID: 109, Name: "value_counts", Type: inspectInt64MapType(119, 120), Required: false},
+		iceberg.NestedField{ID: 110, Name: "null_value_counts", Type: inspectInt64MapType(121, 122), Required: false},
+		iceberg.NestedField{ID: 137, Name: "nan_value_counts", Type: inspectInt64MapType(138, 139), Required: false},
+		iceberg.NestedField{ID: 125, Name: "lower_bounds", Type: inspectBinaryMapType(126, 127), Required: false},
+		iceberg.NestedField{ID: 128, Name: "upper_bounds", Type: inspectBinaryMapType(129, 130), Required: false},
+		iceberg.NestedField{ID: 131, Name: "key_metadata", Type: iceberg.PrimitiveTypes.Binary, Required: false},
+		iceberg.NestedField{ID: 132, Name: "split_offsets", Type: &iceberg.ListType{ElementID: 133, Element: iceberg.PrimitiveTypes.Int64, ElementRequired: true}, Required: false},
+		iceberg.NestedField{ID: 135, Name: "equality_ids", Type: &iceberg.ListType{ElementID: 136, Element: iceberg.PrimitiveTypes.Int32, ElementRequired: true}, Required: false},
+		iceberg.NestedField{ID: 140, Name: "sort_order_id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 142, Name: "first_row_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 143, Name: "referenced_data_file", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 144, Name: "content_offset", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 145, Name: "content_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	return iceberg.NewSchema(0, fields...)
+}
+
+func inspectInt64MapType(keyID, valueID int) *iceberg.MapType {
+	return &iceberg.MapType{KeyID: keyID, KeyType: iceberg.PrimitiveTypes.Int32, ValueID: valueID, ValueType: iceberg.PrimitiveTypes.Int64, ValueRequired: true}
+}
+
+func inspectBinaryMapType(keyID, valueID int) *iceberg.MapType {
+	return &iceberg.MapType{KeyID: keyID, KeyType: iceberg.PrimitiveTypes.Int32, ValueID: valueID, ValueType: iceberg.PrimitiveTypes.Binary, ValueRequired: true}
+}
+
+func appendContentFileRecord(bldr *array.RecordBuilder, partitionType *iceberg.StructType, file iceberg.DataFile) error {
+	idx := 0
+	bldr.Field(idx).(*array.Int32Builder).Append(int32(file.ContentType()))
+	idx++
+	bldr.Field(idx).(*array.StringBuilder).Append(file.FilePath())
+	idx++
+	bldr.Field(idx).(*array.StringBuilder).Append(string(file.FileFormat()))
+	idx++
+	bldr.Field(idx).(*array.Int32Builder).Append(file.SpecID())
+	idx++
+
+	if partitionType != nil && len(partitionType.FieldList) > 0 {
+		partition := bldr.Field(idx).(*array.StructBuilder)
+		if err := appendPartitionStruct(partition, partitionType, file.Partition()); err != nil {
+			return err
+		}
+		idx++
+	}
+
+	bldr.Field(idx).(*array.Int64Builder).Append(file.Count())
+	idx++
+	bldr.Field(idx).(*array.Int64Builder).Append(file.FileSizeBytes())
+	idx++
+	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.ColumnSizes())
+	idx++
+	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.ValueCounts())
+	idx++
+	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.NullValueCounts())
+	idx++
+	appendInspectInt64Map(bldr.Field(idx).(*array.MapBuilder), file.NaNValueCounts())
+	idx++
+	appendInspectBinaryMap(bldr.Field(idx).(*array.MapBuilder), file.LowerBoundValues())
+	idx++
+	appendInspectBinaryMap(bldr.Field(idx).(*array.MapBuilder), file.UpperBoundValues())
+	idx++
+	appendInspectBytes(bldr.Field(idx), file.KeyMetadata())
+	idx++
+	appendInspectInt64List(bldr.Field(idx).(*array.ListBuilder), file.SplitOffsets())
+	idx++
+	appendInspectInt32List(bldr.Field(idx).(*array.ListBuilder), file.EqualityFieldIDs())
+	idx++
+	appendInspectOptionalInt32(bldr.Field(idx).(*array.Int32Builder), file.SortOrderID())
+	idx++
+	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.FirstRowID())
+	idx++
+	appendInspectOptionalString(bldr.Field(idx).(*array.StringBuilder), file.ReferencedDataFile())
+	idx++
+	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.ContentOffset())
+	idx++
+	appendInspectOptionalInt64(bldr.Field(idx).(*array.Int64Builder), file.ContentSizeInBytes())
+
+	return nil
+}
+
+func appendPartitionStruct(builder *array.StructBuilder, partitionType *iceberg.StructType, values map[int]any) error {
+	arrowType := builder.Type().(*arrow.StructType)
+	builder.Append(true)
+	for idx, field := range partitionType.FieldList {
+		value := values[field.ID]
+		if value == nil {
+			builder.FieldBuilder(idx).AppendNull()
+			continue
+		}
+		sc, err := inspectValueScalar(value, field.Type, arrowType.Field(idx).Type)
+		if err != nil {
+			return fmt.Errorf("partition field %q: %w", field.Name, err)
+		}
+		if err := scalar.Append(builder.FieldBuilder(idx), sc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (scalar.Scalar, error) {
+	switch typ.(type) {
+	case iceberg.DateType:
+		switch value := value.(type) {
+		case iceberg.Date:
+			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
+		case int32:
+			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
+		}
+	case iceberg.TimeType:
+		if value, ok := value.(iceberg.Time); ok {
+			return scalar.NewTime64Scalar(arrow.Time64(value), arrowType), nil
+		}
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		if value, ok := value.(iceberg.Timestamp); ok {
+			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
+		}
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		if value, ok := value.(iceberg.TimestampNano); ok {
+			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
+		}
+	case iceberg.UUIDType:
+		if value, ok := value.(uuid.UUID); ok {
+			return scalar.MakeScalarParam(value[:], arrowType)
+		}
+	}
+
+	return scalar.MakeScalarParam(value, arrowType)
+}
+
+func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) {
+	if values == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(true)
+	keys := builder.KeyBuilder().(*array.Int32Builder)
+	items := builder.ItemBuilder().(*array.Int64Builder)
+	ids := make([]int, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	for _, id := range ids {
+		keys.Append(int32(id))
+		items.Append(values[id])
+	}
+}
+
+func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) {
+	if values == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(true)
+	keys := builder.KeyBuilder().(*array.Int32Builder)
+	items := builder.ItemBuilder().(*array.BinaryBuilder)
+	ids := make([]int, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	for _, id := range ids {
+		keys.Append(int32(id))
+		items.Append(values[id])
+	}
+}
+
+func appendInspectBytes(builder array.Builder, value []byte) {
+	if value == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.(*array.BinaryBuilder).Append(value)
+}
+
+func appendInspectInt64List(builder *array.ListBuilder, values []int64) {
+	if values == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(true)
+	builder.ValueBuilder().(*array.Int64Builder).AppendValues(values, nil)
+}
+
+func appendInspectInt32List(builder *array.ListBuilder, values []int) {
+	if values == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(true)
+	items := builder.ValueBuilder().(*array.Int32Builder)
+	for _, value := range values {
+		items.Append(int32(value))
+	}
+}
+
+func appendInspectOptionalInt32(builder *array.Int32Builder, value *int) {
+	if value == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(int32(*value))
+}
+
+func appendInspectOptionalInt64(builder *array.Int64Builder, value *int64) {
+	if value == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(*value)
+}
+
+func appendInspectOptionalString(builder *array.StringBuilder, value *string) {
+	if value == nil {
+		builder.AppendNull()
+		return
+	}
+	builder.Append(*value)
+}

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -267,28 +267,27 @@ func DataFilesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
 }
 
 const (
-	inspectContentFieldIDContent             = 134
-	inspectContentFieldIDFilePath            = 100
-	inspectContentFieldIDFileFormat          = 101
-	inspectContentFieldIDSpecID              = 141
-	inspectContentFieldIDPartition           = 102
-	inspectContentFieldIDRecordCount         = 103
-	inspectContentFieldIDFileSize            = 104
-	inspectContentFieldIDColumnSizes         = 108
-	inspectContentFieldIDValueCounts         = 109
-	inspectContentFieldIDNullValueCounts     = 110
-	inspectContentFieldIDDistinctValueCounts = 111
-	inspectContentFieldIDNaNValueCounts      = 137
-	inspectContentFieldIDLowerBounds         = 125
-	inspectContentFieldIDUpperBounds         = 128
-	inspectContentFieldIDKeyMetadata         = 131
-	inspectContentFieldIDSplitOffsets        = 132
-	inspectContentFieldIDEqualityIDs         = 135
-	inspectContentFieldIDSortOrderID         = 140
-	inspectContentFieldIDFirstRowID          = 142
-	inspectContentFieldIDReferencedDataFile  = 143
-	inspectContentFieldIDContentOffset       = 144
-	inspectContentFieldIDContentSize         = 145
+	inspectContentFieldIDContent            = 134
+	inspectContentFieldIDFilePath           = 100
+	inspectContentFieldIDFileFormat         = 101
+	inspectContentFieldIDSpecID             = 141
+	inspectContentFieldIDPartition          = 102
+	inspectContentFieldIDRecordCount        = 103
+	inspectContentFieldIDFileSize           = 104
+	inspectContentFieldIDColumnSizes        = 108
+	inspectContentFieldIDValueCounts        = 109
+	inspectContentFieldIDNullValueCounts    = 110
+	inspectContentFieldIDNaNValueCounts     = 137
+	inspectContentFieldIDLowerBounds        = 125
+	inspectContentFieldIDUpperBounds        = 128
+	inspectContentFieldIDKeyMetadata        = 131
+	inspectContentFieldIDSplitOffsets       = 132
+	inspectContentFieldIDEqualityIDs        = 135
+	inspectContentFieldIDSortOrderID        = 140
+	inspectContentFieldIDFirstRowID         = 142
+	inspectContentFieldIDReferencedDataFile = 143
+	inspectContentFieldIDContentOffset      = 144
+	inspectContentFieldIDContentSize        = 145
 )
 
 func inspectContentFileFields(partitionType *iceberg.StructType) []iceberg.NestedField {
@@ -309,7 +308,6 @@ func inspectContentFileFields(partitionType *iceberg.StructType) []iceberg.Neste
 		iceberg.NestedField{ID: inspectContentFieldIDColumnSizes, Name: "column_sizes", Type: inspectInt64MapType(117, 118), Required: false},
 		iceberg.NestedField{ID: inspectContentFieldIDValueCounts, Name: "value_counts", Type: inspectInt64MapType(119, 120), Required: false},
 		iceberg.NestedField{ID: inspectContentFieldIDNullValueCounts, Name: "null_value_counts", Type: inspectInt64MapType(121, 122), Required: false},
-		iceberg.NestedField{ID: inspectContentFieldIDDistinctValueCounts, Name: "distinct_value_counts", Type: inspectInt64MapType(112, 113), Required: false},
 		iceberg.NestedField{ID: inspectContentFieldIDNaNValueCounts, Name: "nan_value_counts", Type: inspectInt64MapType(138, 139), Required: false},
 		iceberg.NestedField{ID: inspectContentFieldIDLowerBounds, Name: "lower_bounds", Type: inspectBinaryMapType(126, 127), Required: false},
 		iceberg.NestedField{ID: inspectContentFieldIDUpperBounds, Name: "upper_bounds", Type: inspectBinaryMapType(129, 130), Required: false},
@@ -362,28 +360,27 @@ func newInspectContentFileAppender(partitionType *iceberg.StructType) func(*arra
 }
 
 type inspectContentFileBuilder struct {
-	content             *array.Int32Builder
-	filePath            *array.StringBuilder
-	fileFormat          *array.StringBuilder
-	specID              *array.Int32Builder
-	partition           *array.StructBuilder
-	recordCount         *array.Int64Builder
-	fileSize            *array.Int64Builder
-	columnSizes         *array.MapBuilder
-	valueCounts         *array.MapBuilder
-	nullValueCounts     *array.MapBuilder
-	distinctValueCounts *array.MapBuilder
-	nanValueCounts      *array.MapBuilder
-	lowerBounds         *array.MapBuilder
-	upperBounds         *array.MapBuilder
-	keyMetadata         *array.BinaryBuilder
-	splitOffsets        *array.ListBuilder
-	equalityIDs         *array.ListBuilder
-	sortOrderID         *array.Int32Builder
-	firstRowID          *array.Int64Builder
-	referencedDataFile  *array.StringBuilder
-	contentOffset       *array.Int64Builder
-	contentSize         *array.Int64Builder
+	content            *array.Int32Builder
+	filePath           *array.StringBuilder
+	fileFormat         *array.StringBuilder
+	specID             *array.Int32Builder
+	partition          *array.StructBuilder
+	recordCount        *array.Int64Builder
+	fileSize           *array.Int64Builder
+	columnSizes        *array.MapBuilder
+	valueCounts        *array.MapBuilder
+	nullValueCounts    *array.MapBuilder
+	nanValueCounts     *array.MapBuilder
+	lowerBounds        *array.MapBuilder
+	upperBounds        *array.MapBuilder
+	keyMetadata        *array.BinaryBuilder
+	splitOffsets       *array.ListBuilder
+	equalityIDs        *array.ListBuilder
+	sortOrderID        *array.Int32Builder
+	firstRowID         *array.Int64Builder
+	referencedDataFile *array.StringBuilder
+	contentOffset      *array.Int64Builder
+	contentSize        *array.Int64Builder
 }
 
 func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceberg.StructType) (inspectContentFileBuilder, error) {
@@ -426,9 +423,6 @@ func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceb
 		return out, err
 	}
 	if out.nullValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDNullValueCounts, "null_value_counts"); err != nil {
-		return out, err
-	}
-	if out.distinctValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDDistinctValueCounts, "distinct_value_counts"); err != nil {
 		return out, err
 	}
 	if out.nanValueCounts, err = inspectBuilderAs[*array.MapBuilder](lookup, inspectContentFieldIDNaNValueCounts, "nan_value_counts"); err != nil {
@@ -489,9 +483,6 @@ func (b inspectContentFileBuilder) append(partitionType *iceberg.StructType, fil
 		return err
 	}
 	if err := appendInspectInt64Map(b.nullValueCounts, file.NullValueCounts()); err != nil {
-		return err
-	}
-	if err := appendInspectInt64Map(b.distinctValueCounts, file.DistinctValueCounts()); err != nil {
 		return err
 	}
 	if err := appendInspectInt64Map(b.nanValueCounts, file.NaNValueCounts()); err != nil {
@@ -610,27 +601,26 @@ func inspectValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (
 
 func inspectContentFileFieldIDs(partitionType *iceberg.StructType) map[int]struct{} {
 	ids := map[int]struct{}{
-		inspectContentFieldIDContent:             {},
-		inspectContentFieldIDFilePath:            {},
-		inspectContentFieldIDFileFormat:          {},
-		inspectContentFieldIDSpecID:              {},
-		inspectContentFieldIDRecordCount:         {},
-		inspectContentFieldIDFileSize:            {},
-		inspectContentFieldIDColumnSizes:         {},
-		inspectContentFieldIDValueCounts:         {},
-		inspectContentFieldIDNullValueCounts:     {},
-		inspectContentFieldIDDistinctValueCounts: {},
-		inspectContentFieldIDNaNValueCounts:      {},
-		inspectContentFieldIDLowerBounds:         {},
-		inspectContentFieldIDUpperBounds:         {},
-		inspectContentFieldIDKeyMetadata:         {},
-		inspectContentFieldIDSplitOffsets:        {},
-		inspectContentFieldIDEqualityIDs:         {},
-		inspectContentFieldIDSortOrderID:         {},
-		inspectContentFieldIDFirstRowID:          {},
-		inspectContentFieldIDReferencedDataFile:  {},
-		inspectContentFieldIDContentOffset:       {},
-		inspectContentFieldIDContentSize:         {},
+		inspectContentFieldIDContent:            {},
+		inspectContentFieldIDFilePath:           {},
+		inspectContentFieldIDFileFormat:         {},
+		inspectContentFieldIDSpecID:             {},
+		inspectContentFieldIDRecordCount:        {},
+		inspectContentFieldIDFileSize:           {},
+		inspectContentFieldIDColumnSizes:        {},
+		inspectContentFieldIDValueCounts:        {},
+		inspectContentFieldIDNullValueCounts:    {},
+		inspectContentFieldIDNaNValueCounts:     {},
+		inspectContentFieldIDLowerBounds:        {},
+		inspectContentFieldIDUpperBounds:        {},
+		inspectContentFieldIDKeyMetadata:        {},
+		inspectContentFieldIDSplitOffsets:       {},
+		inspectContentFieldIDEqualityIDs:        {},
+		inspectContentFieldIDSortOrderID:        {},
+		inspectContentFieldIDFirstRowID:         {},
+		inspectContentFieldIDReferencedDataFile: {},
+		inspectContentFieldIDContentOffset:      {},
+		inspectContentFieldIDContentSize:        {},
 	}
 	if partitionType != nil && len(partitionType.FieldList) > 0 {
 		ids[inspectContentFieldIDPartition] = struct{}{}

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -123,6 +123,7 @@ func inspectPartitionType(metadata Metadata) *iceberg.StructType {
 			for _, sourceID := range field.SourceIDs {
 				if _, ok := currentSchema.FindTypeByID(sourceID); !ok {
 					active = false
+
 					break
 				}
 			}
@@ -139,6 +140,7 @@ func inspectPartitionType(metadata Metadata) *iceberg.StructType {
 					old.Type = partitionType.FieldList[idx].Type
 					fieldsByID[field.FieldID] = old
 				}
+
 				continue
 			}
 

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1196,17 +1196,18 @@ func TestDataFilesSchema(t *testing.T) {
 	require.Equal(t, []string{
 		"content", "file_path", "file_format", "spec_id", "partition",
 		"record_count", "file_size_in_bytes", "column_sizes", "value_counts", "null_value_counts",
-		"distinct_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
+		"nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
 		"equality_ids", "sort_order_id", "first_row_id", "referenced_data_file", "content_offset",
 		"content_size_in_bytes",
 	}, testFieldNames(sc))
+	require.NotContains(t, testFieldNames(sc), "distinct_value_counts")
 
 	fields := sc.Fields()
 	require.Equal(t, 134, fields[0].ID)
 	require.Equal(t, 100, fields[1].ID)
 	require.Equal(t, 141, fields[3].ID)
 	require.Equal(t, 102, fields[4].ID)
-	require.Equal(t, 111, fields[10].ID)
+	require.Equal(t, 137, fields[10].ID)
 	require.Equal(t, 145, fields[len(fields)-1].ID)
 
 	unpartitioned := DataFilesSchema(&iceberg.StructType{})

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1185,6 +1185,28 @@ func TestInspectManifestsRejectsUnknownContent(t *testing.T) {
 	require.ErrorContains(t, err, "has unknown content 2")
 }
 
+func TestDataFilesSchema(t *testing.T) {
+	sc := DataFilesSchema(&iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	}})
+
+	require.Equal(t, []string{"content", "file_path", "file_format", "spec_id", "partition",
+		"record_count", "file_size_in_bytes", "column_sizes", "value_counts", "null_value_counts",
+		"nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
+		"equality_ids", "sort_order_id", "first_row_id", "referenced_data_file", "content_offset",
+		"content_size_in_bytes"}, testFieldNames(sc))
+
+	fields := sc.Fields()
+	require.Equal(t, 134, fields[0].ID)
+	require.Equal(t, 100, fields[1].ID)
+	require.Equal(t, 141, fields[3].ID)
+	require.Equal(t, 102, fields[4].ID)
+	require.Equal(t, 145, fields[len(fields)-1].ID)
+
+	unpartitioned := DataFilesSchema(&iceberg.StructType{})
+	require.NotContains(t, testFieldNames(unpartitioned), "partition")
+}
+
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations
 // through the supplied allocator, and that all buffers are released.
 func TestInspectAllocatorOption(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -1209,6 +1210,71 @@ func TestDataFilesSchema(t *testing.T) {
 
 	unpartitioned := DataFilesSchema(&iceberg.StructType{})
 	require.NotContains(t, testFieldNames(unpartitioned), "partition")
+}
+
+func TestInspectDataFilesStreamsBatchesAndSkipsDeleted(t *testing.T) {
+	const snapshotID = int64(1)
+	spec := *iceberg.UnpartitionedSpec
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+
+	entries := make([]iceberg.ManifestEntry, 0, inspectRecordBatchSize+2)
+	for index := 0; index < inspectRecordBatchSize+1; index++ {
+		file := newTestDataFile(t, spec,
+			"mem://default/table-location/data/live-"+strconv.Itoa(index)+".parquet", nil)
+		sequenceNumber := int64(1)
+		entries = append(entries, iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, int64Ptr(snapshotID), &sequenceNumber, &sequenceNumber, file))
+	}
+	deletedPath := "mem://default/table-location/data/deleted.parquet"
+	deleted := newTestDataFile(t, spec, deletedPath, nil)
+	deletedSequenceNumber := int64(1)
+	entries = append(entries, iceberg.NewManifestEntry(
+		iceberg.EntryStatusDELETED, int64Ptr(snapshotID), &deletedSequenceNumber, &deletedSequenceNumber, deleted))
+
+	manifestPath := "mem://default/table-location/metadata/data-manifest.avro"
+	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	var manifestBuf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
+
+	var listBuf bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{manifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: sequenceNumber,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+	rr, err := tbl.Inspect().DataFiles(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	var batchRows []int
+	var paths []string
+	for rr.Next() {
+		record := rr.RecordBatch()
+		batchRows = append(batchRows, int(record.NumRows()))
+		filePaths := record.Column(1).(*array.String)
+		for row := 0; row < filePaths.Len(); row++ {
+			paths = append(paths, filePaths.Value(row))
+		}
+	}
+	require.NoError(t, rr.Err())
+	require.Equal(t, []int{inspectRecordBatchSize, 1}, batchRows)
+	require.Len(t, paths, inspectRecordBatchSize+1)
+	require.NotContains(t, paths, deletedPath)
 }
 
 func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1190,11 +1190,13 @@ func TestDataFilesSchema(t *testing.T) {
 		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 	}})
 
-	require.Equal(t, []string{"content", "file_path", "file_format", "spec_id", "partition",
+	require.Equal(t, []string{
+		"content", "file_path", "file_format", "spec_id", "partition",
 		"record_count", "file_size_in_bytes", "column_sizes", "value_counts", "null_value_counts",
 		"nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
 		"equality_ids", "sort_order_id", "first_row_id", "referenced_data_file", "content_offset",
-		"content_size_in_bytes"}, testFieldNames(sc))
+		"content_size_in_bytes",
+	}, testFieldNames(sc))
 
 	fields := sc.Fields()
 	require.Equal(t, 134, fields[0].ID)

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1500,6 +1500,11 @@ func TestInspectPartitionTypeRejectsIncompatibleFieldReuse(t *testing.T) {
 			valid: true,
 		},
 		{
+			name:  "pointer void transition is compatible",
+			specs: []iceberg.PartitionSpec{field(0, 1, iceberg.IdentityTransform{}), field(1, 1, &iceberg.VoidTransform{})},
+			valid: true,
+		},
+		{
 			name:  "different source ids",
 			specs: []iceberg.PartitionSpec{field(0, 1, iceberg.IdentityTransform{}), field(1, 2, iceberg.IdentityTransform{})},
 		},
@@ -1528,6 +1533,11 @@ func TestInspectPartitionTypeRejectsIncompatibleFieldReuse(t *testing.T) {
 			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 		})
 	}
+
+	unknown, err := iceberg.ParseTransform("future_transform")
+	require.NoError(t, err)
+	_, err = inspectPartitionType(metadataFor([]iceberg.PartitionSpec{field(0, 1, unknown)}))
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1196,7 +1196,7 @@ func TestDataFilesSchema(t *testing.T) {
 	require.Equal(t, []string{
 		"content", "file_path", "file_format", "spec_id", "partition",
 		"record_count", "file_size_in_bytes", "column_sizes", "value_counts", "null_value_counts",
-		"nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
+		"distinct_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds", "key_metadata", "split_offsets",
 		"equality_ids", "sort_order_id", "first_row_id", "referenced_data_file", "content_offset",
 		"content_size_in_bytes",
 	}, testFieldNames(sc))
@@ -1206,10 +1206,61 @@ func TestDataFilesSchema(t *testing.T) {
 	require.Equal(t, 100, fields[1].ID)
 	require.Equal(t, 141, fields[3].ID)
 	require.Equal(t, 102, fields[4].ID)
+	require.Equal(t, 111, fields[10].ID)
 	require.Equal(t, 145, fields[len(fields)-1].ID)
 
 	unpartitioned := DataFilesSchema(&iceberg.StructType{})
 	require.NotContains(t, testFieldNames(unpartitioned), "partition")
+}
+
+func inspectDataFilesTable(t *testing.T, spec iceberg.PartitionSpec, entries []iceberg.ManifestEntry) *Table {
+	t.Helper()
+	const snapshotID = int64(1)
+
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+	manifestPath := "mem://default/table-location/metadata/data-manifest.avro"
+	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+
+	var manifestBuf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
+
+	var listBuf bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{manifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snapID := snapshotID
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: sequenceNumber,
+	}}
+	txn.meta.currentSnapshotID = &snapID
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	return New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+}
+
+func inspectDataFileEntries(t *testing.T, spec iceberg.PartitionSpec, count int) []iceberg.ManifestEntry {
+	t.Helper()
+	const snapshotID = int64(1)
+
+	entries := make([]iceberg.ManifestEntry, 0, count)
+	for index := 0; index < count; index++ {
+		path := "mem://default/table-location/data/live-" + strconv.Itoa(index) + ".parquet"
+		file := newTestDataFile(t, spec, path, nil)
+		sequenceNumber := int64(1)
+		entries = append(entries, iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, int64Ptr(snapshotID), &sequenceNumber, &sequenceNumber, file))
+	}
+
+	return entries
 }
 
 func TestInspectDataFilesStreamsBatchesAndSkipsDeleted(t *testing.T) {
@@ -1275,6 +1326,105 @@ func TestInspectDataFilesStreamsBatchesAndSkipsDeleted(t *testing.T) {
 	require.Equal(t, []int{inspectRecordBatchSize, 1}, batchRows)
 	require.Len(t, paths, inspectRecordBatchSize+1)
 	require.NotContains(t, paths, deletedPath)
+}
+
+func TestInspectDataFilesReturnsPartitionValues(t *testing.T) {
+	const snapshotID = int64(1)
+	spec := partitionedSpec()
+	file := newTestDataFile(t, spec,
+		"mem://default/table-location/data/partitioned.parquet", map[int]any{1000: int32(7)})
+	sequenceNumber := int64(1)
+	entry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, int64Ptr(snapshotID), &sequenceNumber, &sequenceNumber, file)
+	tbl := inspectDataFilesTable(t, spec, []iceberg.ManifestEntry{entry})
+
+	rr, err := tbl.Inspect().DataFiles(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 1, record.NumRows())
+	partition := record.Column(4).(*array.Struct)
+	values := partition.Field(0).(*array.Int32)
+	require.EqualValues(t, 7, values.Value(0))
+}
+
+func TestInspectDataFilesEmitsEmptyBatchWhenAllEntriesAreDeleted(t *testing.T) {
+	const snapshotID = int64(1)
+	spec := *iceberg.UnpartitionedSpec
+	file := newTestDataFile(t, spec,
+		"mem://default/table-location/data/deleted.parquet", nil)
+	sequenceNumber := int64(1)
+	entry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusDELETED, int64Ptr(snapshotID), &sequenceNumber, &sequenceNumber, file)
+	tbl := inspectDataFilesTable(t, spec, []iceberg.ManifestEntry{entry})
+
+	rr, err := tbl.Inspect().DataFiles(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+	require.EqualValues(t, 0, record.NumRows())
+}
+
+func TestInspectDataFilesAllocator(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		abandon bool
+	}{
+		{name: "drains reader"},
+		{name: "abandons reader after first batch", abandon: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			checked := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			t.Cleanup(func() { checked.AssertSize(t, 0) })
+
+			spec := *iceberg.UnpartitionedSpec
+			tbl := inspectDataFilesTable(t, spec, inspectDataFileEntries(t, spec, inspectRecordBatchSize+1))
+			rr, err := tbl.Inspect(WithInspectAllocator(checked)).DataFiles(context.Background())
+			require.NoError(t, err)
+
+			if tt.abandon {
+				require.True(t, rr.Next())
+				rr.Release()
+
+				return
+			}
+
+			for rr.Next() {
+				// The reader owns the current batch until the next call to Next or
+				// Release, so no extra retain is needed here.
+			}
+			require.NoError(t, rr.Err())
+			rr.Release()
+		})
+	}
+}
+
+func TestAppendContentFileRecordUsesFieldIDs(t *testing.T) {
+	fields := inspectContentFileFields(&iceberg.StructType{})
+	reordered := make([]iceberg.NestedField, 0, len(fields))
+	reordered = append(reordered, fields[1:]...)
+	reordered = append(reordered, fields[0])
+	schema := iceberg.NewSchema(0, reordered...)
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	require.NoError(t, err)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer bldr.Release()
+	file := newTestDataFile(t, *iceberg.UnpartitionedSpec,
+		"mem://default/table-location/data/reordered.parquet", nil)
+	require.NoError(t, appendContentFileRecord(bldr, &iceberg.StructType{}, file))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	pathIndex := record.Schema().FieldIndices("file_path")[0]
+	countIndex := record.Schema().FieldIndices("record_count")[0]
+	require.Equal(t, file.FilePath(), record.Column(pathIndex).(*array.String).Value(0))
+	require.EqualValues(t, file.Count(), record.Column(countIndex).(*array.Int64).Value(0))
 }
 
 func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {
@@ -1454,4 +1604,36 @@ func TestInspectValueScalarDecimal(t *testing.T) {
 	got, err := inspectValueScalar(value, typ, arrowType)
 	require.NoError(t, err)
 	require.Equal(t, value.Val, got.(*scalar.Decimal128).Value)
+}
+
+func TestInspectValueScalarRejectsMismatchedPartitionValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     any
+		typ       iceberg.Type
+		arrowType arrow.DataType
+		want      string
+	}{
+		{name: "date", value: int64(1), typ: iceberg.PrimitiveTypes.Date, arrowType: arrow.FixedWidthTypes.Date32, want: "unsupported date"},
+		{name: "time", value: int64(1), typ: iceberg.PrimitiveTypes.Time, arrowType: arrow.FixedWidthTypes.Time64us, want: "unsupported time"},
+		{name: "timestamp", value: int64(1), typ: iceberg.PrimitiveTypes.Timestamp, arrowType: arrow.FixedWidthTypes.Timestamp_us, want: "unsupported timestamp"},
+		{name: "timestamp nanos", value: int64(1), typ: iceberg.PrimitiveTypes.TimestampNs, arrowType: arrow.FixedWidthTypes.Timestamp_ns, want: "unsupported nanosecond timestamp"},
+		{name: "UUID", value: []byte("not-a-UUID"), typ: iceberg.PrimitiveTypes.UUID, arrowType: &arrow.FixedSizeBinaryType{ByteWidth: 16}, want: "unsupported UUID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inspectValueScalar(tt.value, tt.typ, tt.arrowType)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestInspectInt32ValueRejectsOverflow(t *testing.T) {
+	if strconv.IntSize == 32 {
+		t.Skip("int32 is the native int width")
+	}
+
+	_, err := inspectInt32Value(int(^uint32(0)>>1)+1, "field ID")
+	require.ErrorContains(t, err, "does not fit in int32")
 }

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/google/uuid"
@@ -1309,4 +1311,14 @@ func testFieldNames(sc *iceberg.Schema) []string {
 	}
 
 	return names
+}
+
+func TestInspectValueScalarDecimal(t *testing.T) {
+	typ := iceberg.DecimalTypeOf(10, 2)
+	arrowType := &arrow.Decimal128Type{Precision: 10, Scale: 2}
+	value := iceberg.DecimalLiteral{Val: decimal128.FromI64(123), Scale: 2}
+
+	got, err := inspectValueScalar(value, typ, arrowType)
+	require.NoError(t, err)
+	require.Equal(t, value.Val, got.(*scalar.Decimal128).Value)
 }

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1209,6 +1209,41 @@ func TestDataFilesSchema(t *testing.T) {
 	require.NotContains(t, testFieldNames(unpartitioned), "partition")
 }
 
+func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "region", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	oldSpec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "region", Transform: iceberg.IdentityTransform{},
+	})
+	newSpec := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1001, Name: "category", Transform: iceberg.IdentityTransform{},
+	})
+	lastPartitionID := 1001
+	meta := &metadataV2{commonMetadata: commonMetadata{
+		FormatVersion:   2,
+		UUID:            uuid.New(),
+		LastColumnId:    2,
+		SchemaList:      []*iceberg.Schema{schema},
+		CurrentSchemaID: 0,
+		Specs:           []iceberg.PartitionSpec{oldSpec, newSpec},
+		DefaultSpecID:   1,
+		LastPartitionID: &lastPartitionID,
+		SnapshotRefs:    map[string]SnapshotRef{},
+	}}
+
+	partitionType := inspectPartitionType(meta)
+	require.Equal(t, []int{1000, 1001}, []int{
+		partitionType.FieldList[0].ID,
+		partitionType.FieldList[1].ID,
+	})
+	require.Equal(t, []string{"region", "category"}, []string{
+		partitionType.FieldList[0].Name,
+		partitionType.FieldList[1].Name,
+	})
+}
+
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations
 // through the supplied allocator, and that all buffers are released.
 func TestInspectAllocatorOption(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1320,6 +1320,7 @@ func TestInspectPartitionTypeRejectsIncompatibleFieldReuse(t *testing.T) {
 	)
 	metadataFor := func(specs []iceberg.PartitionSpec) Metadata {
 		lastPartitionID := 1000
+
 		return &metadataV2{commonMetadata: commonMetadata{
 			FormatVersion:   2,
 			UUID:            uuid.New(),

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1301,7 +1301,8 @@ func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {
 		SnapshotRefs:    map[string]SnapshotRef{},
 	}}
 
-	partitionType := inspectPartitionType(meta)
+	partitionType, err := inspectPartitionType(meta)
+	require.NoError(t, err)
 	require.Equal(t, []int{1000, 1001}, []int{
 		partitionType.FieldList[0].ID,
 		partitionType.FieldList[1].ID,
@@ -1310,6 +1311,71 @@ func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {
 		partitionType.FieldList[0].Name,
 		partitionType.FieldList[1].Name,
 	})
+}
+
+func TestInspectPartitionTypeRejectsIncompatibleFieldReuse(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "first", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 2, Name: "second", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+	metadataFor := func(specs []iceberg.PartitionSpec) Metadata {
+		lastPartitionID := 1000
+		return &metadataV2{commonMetadata: commonMetadata{
+			FormatVersion:   2,
+			UUID:            uuid.New(),
+			LastColumnId:    2,
+			SchemaList:      []*iceberg.Schema{schema},
+			CurrentSchemaID: 0,
+			Specs:           specs,
+			DefaultSpecID:   specs[len(specs)-1].ID(),
+			LastPartitionID: &lastPartitionID,
+		}}
+	}
+	field := func(specID, sourceID int, transform iceberg.Transform) iceberg.PartitionSpec {
+		return iceberg.NewPartitionSpecID(specID, iceberg.PartitionField{
+			SourceIDs: []int{sourceID}, FieldID: 1000, Name: "part", Transform: transform,
+		})
+	}
+
+	tests := []struct {
+		name  string
+		specs []iceberg.PartitionSpec
+		valid bool
+	}{
+		{
+			name:  "void transition is compatible",
+			specs: []iceberg.PartitionSpec{field(0, 1, iceberg.IdentityTransform{}), field(1, 1, iceberg.VoidTransform{})},
+			valid: true,
+		},
+		{
+			name:  "different source ids",
+			specs: []iceberg.PartitionSpec{field(0, 1, iceberg.IdentityTransform{}), field(1, 2, iceberg.IdentityTransform{})},
+		},
+		{
+			name:  "different transforms",
+			specs: []iceberg.PartitionSpec{field(0, 1, iceberg.IdentityTransform{}), field(1, 1, iceberg.BucketTransform{NumBuckets: 16})},
+		},
+		{
+			name: "void cannot hide incompatible history",
+			specs: []iceberg.PartitionSpec{
+				field(0, 1, iceberg.BucketTransform{NumBuckets: 16}),
+				field(1, 1, iceberg.IdentityTransform{}),
+				field(2, 1, iceberg.VoidTransform{}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inspectPartitionType(metadataFor(tt.specs))
+			if tt.valid {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+		})
+	}
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations


### PR DESCRIPTION
## Summary

Adds the current live `data_files` metadata table to `Table.Inspect`.

- Exposes content-file metrics, partition values, bounds, delete metadata, and row-lineage fields.
- Uses the Iceberg content-file field IDs and a table-wide partition type for evolved partition specs.
- Provides shared content-file schema and conversion helpers for the related metadata tables.

## Tests

- `go test ./table`
- Covers the content-file schema, decimal partition values, and active partition specs.

## Scope

This reports live data-file metadata for the current snapshot. It does not change data-file reads, writes, or scan behavior.

## Related

The shared content-file foundation is used by #1699, #1700, and #1701.