### PR TITLE
feat(table): add partitions metadata table

### DIFF
--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1997,19 +1997,23 @@ func TestPartitionsSchema(t *testing.T) {
 		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 	}}
 	sc := PartitionsSchema(partitionType)
-	require.Equal(t, []string{"partition", "spec_id", "record_count", "file_count",
+	require.Equal(t, []string{
+		"partition", "spec_id", "record_count", "file_count",
 		"total_data_file_size_in_bytes", "position_delete_record_count", "position_delete_file_count",
 		"equality_delete_record_count", "equality_delete_file_count", "last_updated_at",
-		"last_updated_snapshot_id"}, testFieldNames(sc))
+		"last_updated_snapshot_id",
+	}, testFieldNames(sc))
 	require.Equal(t, 1, sc.Fields()[0].ID)
 	require.Equal(t, 4, sc.Fields()[1].ID)
 	require.Equal(t, 11, sc.Fields()[4].ID)
 	require.Equal(t, 10, sc.Fields()[10].ID)
 
 	unpartitioned := PartitionsSchema(&iceberg.StructType{})
-	require.Equal(t, []string{"record_count", "file_count", "total_data_file_size_in_bytes",
+	require.Equal(t, []string{
+		"record_count", "file_count", "total_data_file_size_in_bytes",
 		"position_delete_record_count", "position_delete_file_count", "equality_delete_record_count",
-		"equality_delete_file_count", "last_updated_at", "last_updated_snapshot_id"}, testFieldNames(unpartitioned))
+		"equality_delete_file_count", "last_updated_at", "last_updated_snapshot_id",
+	}, testFieldNames(unpartitioned))
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2016,6 +2016,155 @@ func TestPartitionsSchema(t *testing.T) {
 	}, testFieldNames(unpartitioned))
 }
 
+func TestInspectPartitionAggregateTreeHandlesBinaryAndNaNValues(t *testing.T) {
+	tree := newInspectPartitionAggregateTree()
+	aggregate := &inspectPartitionAggregate{specID: 1}
+	record := partitionRecord{[]byte{1, 2, 3}, math.NaN()}
+	tree.insert(record, aggregate)
+
+	require.Same(t, aggregate, tree.lookup(partitionRecord{[]byte{1, 2, 3}, math.NaN()}))
+	require.Nil(t, tree.lookup(partitionRecord{[]byte{1, 2, 4}, math.NaN()}))
+}
+
+func TestInspectPartitionsAggregatesDataAndDeletes(t *testing.T) {
+	const snapshotID = int64(1)
+	spec := partitionedSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+	partition := map[int]any{1000: int32(7)}
+	dataSequenceNumber := int64(1)
+	dataFiles := []iceberg.DataFile{
+		newTestDataFileWithCount(t, spec,
+			"mem://default/table-location/data/first.parquet", partition, 3),
+		newTestDataFileWithCount(t, spec,
+			"mem://default/table-location/data/second.parquet", partition, 2),
+	}
+	dataEntries := make([]iceberg.ManifestEntry, 0, len(dataFiles))
+	for _, file := range dataFiles {
+		dataEntries = append(dataEntries, iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, int64Ptr(snapshotID), &dataSequenceNumber, &dataSequenceNumber, file))
+	}
+
+	dataManifestPath := "mem://default/table-location/metadata/data-manifest.avro"
+	var dataManifestBuf bytes.Buffer
+	dataManifest, err := iceberg.WriteManifest(dataManifestPath, &dataManifestBuf, 2, spec, schema, snapshotID, dataEntries)
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(dataManifestPath, dataManifestBuf.Bytes()))
+
+	deleteFile := newTestPosDeleteFileForSpec(t, spec,
+		"mem://default/table-location/delete/positions.parquet", partition,
+		dataFiles[0].FilePath())
+	deleteManifestPath := "mem://default/table-location/metadata/delete-manifest.avro"
+	var deleteManifestBuf bytes.Buffer
+	deleteWriter, err := iceberg.NewManifestWriter(2, &deleteManifestBuf, spec, schema, snapshotID,
+		iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+	require.NoError(t, deleteWriter.Add(iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, int64Ptr(snapshotID), &dataSequenceNumber, &dataSequenceNumber, deleteFile)))
+	require.NoError(t, deleteWriter.Close())
+	deleteManifest, err := deleteWriter.ToManifestFile(deleteManifestPath, int64(deleteManifestBuf.Len()),
+		iceberg.WithManifestFileContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(deleteManifestPath, deleteManifestBuf.Bytes()))
+
+	manifestListPath := "mem://default/table-location/metadata/snap-1-manifest-list.avro"
+	var listBuf bytes.Buffer
+	manifestListSequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil,
+		&manifestListSequenceNumber, 0, []iceberg.ManifestFile{dataManifest, deleteManifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     snapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: manifestListSequenceNumber,
+		TimestampMs:    2000,
+	}}
+	txn.meta.currentSnapshotID = int64Ptr(snapshotID)
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+	rr, err := tbl.Inspect().Partitions(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+	require.EqualValues(t, 1, record.NumRows())
+
+	partitionValues := record.Column(0).(*array.Struct)
+	require.EqualValues(t, 7, partitionValues.Field(0).(*array.Int32).Value(0))
+	require.EqualValues(t, spec.ID(), record.Column(1).(*array.Int32).Value(0))
+	require.EqualValues(t, 5, record.Column(2).(*array.Int64).Value(0))
+	require.EqualValues(t, 2, record.Column(3).(*array.Int32).Value(0))
+	require.EqualValues(t, 5, record.Column(4).(*array.Int64).Value(0))
+	require.EqualValues(t, 1, record.Column(5).(*array.Int64).Value(0))
+	require.EqualValues(t, 1, record.Column(6).(*array.Int32).Value(0))
+	require.EqualValues(t, 0, record.Column(7).(*array.Int64).Value(0))
+	require.EqualValues(t, 0, record.Column(8).(*array.Int32).Value(0))
+	require.EqualValues(t, 2000*1000, record.Column(9).(*array.Timestamp).Value(0))
+	require.EqualValues(t, snapshotID, record.Column(10).(*array.Int64).Value(0))
+}
+
+func TestInspectPartitionsLeavesSpecIDUnsetForExpiredSnapshot(t *testing.T) {
+	const (
+		expiredSnapshotID = int64(1)
+		currentSnapshotID = int64(2)
+	)
+	spec := iceberg.NewPartitionSpecID(7, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+	file := newTestDataFile(t, spec,
+		"mem://default/table-location/data/expired.parquet", map[int]any{1000: int32(7)})
+	sequenceNumber := int64(1)
+	manifestPath := "mem://default/table-location/metadata/expired-manifest.avro"
+	var manifestBuf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, expiredSnapshotID,
+		[]iceberg.ManifestEntry{iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, int64Ptr(expiredSnapshotID), &sequenceNumber, &sequenceNumber, file)})
+	require.NoError(t, err)
+	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
+	manifest = iceberg.NewManifestFile(2, manifestPath, int64(manifestBuf.Len()), int32(spec.ID()), expiredSnapshotID).
+		SequenceNum(sequenceNumber, sequenceNumber).
+		AddedFiles(1).
+		AddedRows(1).
+		Build()
+
+	manifestListPath := "mem://default/table-location/metadata/snap-2-manifest-list.avro"
+	var listBuf bytes.Buffer
+	currentSequenceNumber := int64(2)
+	require.NoError(t, iceberg.WriteManifestList(2, &listBuf, currentSnapshotID, nil,
+		&currentSequenceNumber, 0, []iceberg.ManifestFile{manifest}))
+	require.NoError(t, memIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	txn.meta.snapshotList = []Snapshot{{
+		SnapshotID:     currentSnapshotID,
+		ManifestList:   manifestListPath,
+		SequenceNumber: currentSequenceNumber,
+		TimestampMs:    2000,
+	}}
+	txn.meta.currentSnapshotID = int64Ptr(currentSnapshotID)
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+	rr, err := tbl.Inspect().Partitions(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+	require.EqualValues(t, 1, record.NumRows())
+	require.EqualValues(t, 0, record.Column(1).(*array.Int32).Value(0))
+	require.True(t, record.Column(9).IsNull(0))
+	require.True(t, record.Column(10).IsNull(0))
+}
+
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations
 // through the supplied allocator, and that all buffers are released.
 func TestInspectAllocatorOption(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2123,12 +2123,12 @@ func TestInspectPartitionsLeavesSpecIDUnsetForExpiredSnapshot(t *testing.T) {
 	sequenceNumber := int64(1)
 	manifestPath := "mem://default/table-location/metadata/expired-manifest.avro"
 	var manifestBuf bytes.Buffer
-	manifest, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, expiredSnapshotID,
+	_, err := iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, expiredSnapshotID,
 		[]iceberg.ManifestEntry{iceberg.NewManifestEntry(
 			iceberg.EntryStatusADDED, int64Ptr(expiredSnapshotID), &sequenceNumber, &sequenceNumber, file)})
 	require.NoError(t, err)
 	require.NoError(t, memIO.WriteFile(manifestPath, manifestBuf.Bytes()))
-	manifest = iceberg.NewManifestFile(2, manifestPath, int64(manifestBuf.Len()), int32(spec.ID()), expiredSnapshotID).
+	manifest := iceberg.NewManifestFile(2, manifestPath, int64(manifestBuf.Len()), int32(spec.ID()), expiredSnapshotID).
 		SequenceNum(sequenceNumber, sequenceNumber).
 		AddedFiles(1).
 		AddedRows(1).

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1992,6 +1992,26 @@ func TestInspectPartitionTypeRejectsIncompatibleFieldReuse(t *testing.T) {
 	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 }
 
+func TestPartitionsSchema(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	}}
+	sc := PartitionsSchema(partitionType)
+	require.Equal(t, []string{"partition", "spec_id", "record_count", "file_count",
+		"total_data_file_size_in_bytes", "position_delete_record_count", "position_delete_file_count",
+		"equality_delete_record_count", "equality_delete_file_count", "last_updated_at",
+		"last_updated_snapshot_id"}, testFieldNames(sc))
+	require.Equal(t, 1, sc.Fields()[0].ID)
+	require.Equal(t, 4, sc.Fields()[1].ID)
+	require.Equal(t, 11, sc.Fields()[4].ID)
+	require.Equal(t, 10, sc.Fields()[10].ID)
+
+	unpartitioned := PartitionsSchema(&iceberg.StructType{})
+	require.Equal(t, []string{"record_count", "file_count", "total_data_file_size_in_bytes",
+		"position_delete_record_count", "position_delete_file_count", "equality_delete_record_count",
+		"equality_delete_file_count", "last_updated_at", "last_updated_snapshot_id"}, testFieldNames(unpartitioned))
+}
+
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations
 // through the supplied allocator, and that all buffers are released.
 func TestInspectAllocatorOption(t *testing.T) {

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+)
+
+type inspectPartitionAggregate struct {
+	specID              int32
+	partition           map[int]any
+	dataRecordCount     int64
+	dataFileCount       int32
+	dataFileSize        int64
+	positionDeleteCount int64
+	positionDeleteFiles int32
+	equalityDeleteCount int64
+	equalityDeleteFiles int32
+	lastUpdatedAt       *int64
+	lastUpdatedSnapshot *int64
+	orderingKey         string
+}
+
+// Partitions returns one row per live partition, aggregating data and delete
+// files from the current snapshot. Different partition specs remain separate
+// groups so files from evolved specs are never combined by raw map equality.
+func (i InspectTable) Partitions(ctx context.Context) (array.RecordReader, error) {
+	spec := i.tbl.metadata.PartitionSpec()
+	partitionType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
+	schema := PartitionsSchema(partitionType)
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect partitions: build arrow schema: %w", err)
+	}
+
+	aggregates, err := i.partitionAggregates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("inspect partitions: %w", err)
+	}
+
+	bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
+	defer bldr.Release()
+	for _, aggregate := range aggregates {
+		if err := appendPartitionAggregate(bldr, partitionType, aggregate); err != nil {
+			return nil, fmt.Errorf("inspect partitions: append partition: %w", err)
+		}
+	}
+
+	rr, err := singleBatchReader(arrowSchema, bldr)
+	if err != nil {
+		return nil, fmt.Errorf("inspect partitions: %w", err)
+	}
+
+	return rr, nil
+}
+
+func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartitionAggregate, error) {
+	snapshot := i.tbl.metadata.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil
+	}
+	if i.tbl.fsF == nil {
+		return nil, fmt.Errorf("table file IO is not configured")
+	}
+	fs, err := i.tbl.fsF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := snapshot.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregates := make(map[string]*inspectPartitionAggregate)
+	for _, manifest := range manifests {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for entry, err := range manifest.Entries(fs, true) {
+			if err != nil {
+				return nil, err
+			}
+			file := entry.DataFile()
+			partition := file.Partition()
+			key := fmt.Sprintf("%d:%s", file.SpecID(), inspectPartitionKey(partition))
+			aggregate := aggregates[key]
+			if aggregate == nil {
+				aggregate = &inspectPartitionAggregate{
+					specID:      file.SpecID(),
+					partition:   cloneInspectPartition(partition),
+					orderingKey: key,
+				}
+				aggregates[key] = aggregate
+			}
+
+			switch file.ContentType() {
+			case iceberg.EntryContentData:
+				aggregate.dataRecordCount += file.Count()
+				aggregate.dataFileCount++
+				aggregate.dataFileSize += file.FileSizeBytes()
+			case iceberg.EntryContentPosDeletes:
+				aggregate.positionDeleteCount += file.Count()
+				aggregate.positionDeleteFiles++
+			case iceberg.EntryContentEqDeletes:
+				aggregate.equalityDeleteCount += file.Count()
+				aggregate.equalityDeleteFiles++
+			}
+
+			if file.ContentType() == iceberg.EntryContentData ||
+				file.ContentType() == iceberg.EntryContentPosDeletes ||
+				file.ContentType() == iceberg.EntryContentEqDeletes {
+				i.updatePartitionTimestamp(aggregate, entry.SnapshotID())
+			}
+		}
+	}
+
+	result := make([]inspectPartitionAggregate, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		result = append(result, *aggregate)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left].orderingKey < result[right].orderingKey })
+
+	return result, nil
+}
+
+func (i InspectTable) updatePartitionTimestamp(aggregate *inspectPartitionAggregate, snapshotID int64) {
+	if snapshotID < 0 {
+		return
+	}
+	snapshot := i.tbl.metadata.SnapshotByID(snapshotID)
+	if snapshot == nil {
+		return
+	}
+	timestamp := snapshot.TimestampMs * 1000
+	if aggregate.lastUpdatedAt != nil && timestamp <= *aggregate.lastUpdatedAt {
+		return
+	}
+	aggregate.lastUpdatedAt = &timestamp
+	id := snapshot.SnapshotID
+	aggregate.lastUpdatedSnapshot = &id
+}
+
+func inspectPartitionKey(partition map[int]any) string {
+	ids := make([]int, 0, len(partition))
+	for id := range partition {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	key := ""
+	for _, id := range ids {
+		key += fmt.Sprintf("%d:%T:%v;", id, partition[id], partition[id])
+	}
+	return key
+}
+
+func cloneInspectPartition(partition map[int]any) map[int]any {
+	if partition == nil {
+		return nil
+	}
+	returnMap := make(map[int]any, len(partition))
+	for id, value := range partition {
+		returnMap[id] = value
+	}
+	return returnMap
+}
+
+// PartitionsSchema returns the partition metadata-table schema. For an
+// unpartitioned table the partition and spec_id columns are omitted, matching
+// Java's PartitionsTable behavior.
+func PartitionsSchema(partitionType *iceberg.StructType) *iceberg.Schema {
+	if partitionType == nil || len(partitionType.FieldList) == 0 {
+		return iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 2, Name: "record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 3, Name: "file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 11, Name: "total_data_file_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 5, Name: "position_delete_record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 6, Name: "position_delete_file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 7, Name: "equality_delete_record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 8, Name: "equality_delete_file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+			iceberg.NestedField{ID: 9, Name: "last_updated_at", Type: iceberg.PrimitiveTypes.TimestampTz, Required: false},
+			iceberg.NestedField{ID: 10, Name: "last_updated_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		)
+	}
+
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "partition", Type: partitionType, Required: true},
+		iceberg.NestedField{ID: 4, Name: "spec_id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 2, Name: "record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 3, Name: "file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 11, Name: "total_data_file_size_in_bytes", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 5, Name: "position_delete_record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 6, Name: "position_delete_file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 7, Name: "equality_delete_record_count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 8, Name: "equality_delete_file_count", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 9, Name: "last_updated_at", Type: iceberg.PrimitiveTypes.TimestampTz, Required: false},
+		iceberg.NestedField{ID: 10, Name: "last_updated_snapshot_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+}
+
+func appendPartitionAggregate(bldr *array.RecordBuilder, partitionType *iceberg.StructType, aggregate inspectPartitionAggregate) error {
+	idx := 0
+	if partitionType != nil && len(partitionType.FieldList) > 0 {
+		partition := bldr.Field(idx).(*array.StructBuilder)
+		arrowType := partition.Type().(*arrow.StructType)
+		partition.Append(true)
+		for fieldIndex, field := range partitionType.FieldList {
+			value := aggregate.partition[field.ID]
+			if value == nil {
+				partition.FieldBuilder(fieldIndex).AppendNull()
+				continue
+			}
+			valueScalar, err := inspectPartitionValueScalar(value, field.Type, arrowType.Field(fieldIndex).Type)
+			if err != nil {
+				return fmt.Errorf("partition field %q: %w", field.Name, err)
+			}
+			if err := scalar.Append(partition.FieldBuilder(fieldIndex), valueScalar); err != nil {
+				return err
+			}
+		}
+		idx++
+		bldr.Field(idx).(*array.Int32Builder).Append(aggregate.specID)
+		idx++
+	}
+	bldr.Field(idx).(*array.Int64Builder).Append(aggregate.dataRecordCount)
+	idx++
+	bldr.Field(idx).(*array.Int32Builder).Append(aggregate.dataFileCount)
+	idx++
+	bldr.Field(idx).(*array.Int64Builder).Append(aggregate.dataFileSize)
+	idx++
+	bldr.Field(idx).(*array.Int64Builder).Append(aggregate.positionDeleteCount)
+	idx++
+	bldr.Field(idx).(*array.Int32Builder).Append(aggregate.positionDeleteFiles)
+	idx++
+	bldr.Field(idx).(*array.Int64Builder).Append(aggregate.equalityDeleteCount)
+	idx++
+	bldr.Field(idx).(*array.Int32Builder).Append(aggregate.equalityDeleteFiles)
+	idx++
+	if aggregate.lastUpdatedAt == nil {
+		bldr.Field(idx).(*array.TimestampBuilder).AppendNull()
+	} else {
+		bldr.Field(idx).(*array.TimestampBuilder).Append(arrow.Timestamp(*aggregate.lastUpdatedAt))
+	}
+	idx++
+	if aggregate.lastUpdatedSnapshot == nil {
+		bldr.Field(idx).(*array.Int64Builder).AppendNull()
+	} else {
+		bldr.Field(idx).(*array.Int64Builder).Append(*aggregate.lastUpdatedSnapshot)
+	}
+
+	return nil
+}
+
+func inspectPartitionValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (scalar.Scalar, error) {
+	switch typ.(type) {
+	case iceberg.DateType:
+		switch value := value.(type) {
+		case iceberg.Date:
+			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
+		case int32:
+			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
+		}
+	case iceberg.TimeType:
+		if value, ok := value.(iceberg.Time); ok {
+			return scalar.NewTime64Scalar(arrow.Time64(value), arrowType), nil
+		}
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		if value, ok := value.(iceberg.Timestamp); ok {
+			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
+		}
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		if value, ok := value.(iceberg.TimestampNano); ok {
+			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
+		}
+	case iceberg.UUIDType:
+		if value, ok := value.(uuid.UUID); ok {
+			return scalar.MakeScalarParam(value[:], arrowType)
+		}
+	}
+	return scalar.MakeScalarParam(value, arrowType)
+}

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -46,6 +46,44 @@ type inspectPartitionAggregate struct {
 	orderingKey         string
 }
 
+type inspectPartitionAggregateTree struct {
+	children  map[any]*inspectPartitionAggregateTree
+	aggregate *inspectPartitionAggregate
+}
+
+func newInspectPartitionAggregateTree() *inspectPartitionAggregateTree {
+	return &inspectPartitionAggregateTree{
+		children: make(map[any]*inspectPartitionAggregateTree),
+	}
+}
+
+func (t *inspectPartitionAggregateTree) lookup(record partitionRecord) *inspectPartitionAggregate {
+	node := t
+	for _, value := range record {
+		child, ok := node.children[comparablePartitionKey(value)]
+		if !ok {
+			return nil
+		}
+		node = child
+	}
+
+	return node.aggregate
+}
+
+func (t *inspectPartitionAggregateTree) insert(record partitionRecord, aggregate *inspectPartitionAggregate) {
+	node := t
+	for _, value := range record {
+		key := comparablePartitionKey(value)
+		child, ok := node.children[key]
+		if !ok {
+			child = newInspectPartitionAggregateTree()
+			node.children[key] = child
+		}
+		node = child
+	}
+	node.aggregate = aggregate
+}
+
 // Partitions returns one row per live partition, aggregating data and delete
 // files from the current snapshot. Files from evolved specs are coerced into
 // the table-wide partition type before grouping.
@@ -95,7 +133,13 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 		return nil, err
 	}
 
+	snapshotTimes := make(map[int64]int64, len(i.tbl.metadata.Snapshots()))
+	for _, snapshot := range i.tbl.metadata.Snapshots() {
+		snapshotTimes[snapshot.SnapshotID] = snapshot.TimestampMs
+	}
+
 	aggregates := make([]*inspectPartitionAggregate, 0)
+	aggregateTree := newInspectPartitionAggregateTree()
 	for _, manifest := range manifests {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -107,14 +151,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 			file := entry.DataFile()
 			partition := inspectCoercePartition(file.Partition(), partitionType)
 			record := newPartitionRecord(partition, partitionType)
-			var aggregate *inspectPartitionAggregate
-			for _, candidate := range aggregates {
-				if partitionRecordsEqual(candidate.partitionRecord, record) {
-					aggregate = candidate
-
-					break
-				}
-			}
+			aggregate := aggregateTree.lookup(record)
 			if aggregate == nil {
 				aggregate = &inspectPartitionAggregate{
 					specID:          file.SpecID(),
@@ -123,6 +160,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 					orderingKey:     inspectPartitionKey(partition),
 				}
 				aggregates = append(aggregates, aggregate)
+				aggregateTree.insert(record, aggregate)
 			}
 
 			switch file.ContentType() {
@@ -141,7 +179,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 			if file.ContentType() == iceberg.EntryContentData ||
 				file.ContentType() == iceberg.EntryContentPosDeletes ||
 				file.ContentType() == iceberg.EntryContentEqDeletes {
-				i.updatePartitionTimestamp(aggregate, entry.SnapshotID(), file.SpecID())
+				i.updatePartitionTimestamp(aggregate, snapshotTimes, entry.SnapshotID(), file.SpecID())
 			}
 		}
 	}
@@ -155,20 +193,25 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 	return result, nil
 }
 
-func (i InspectTable) updatePartitionTimestamp(aggregate *inspectPartitionAggregate, snapshotID int64, specID int32) {
+func (i InspectTable) updatePartitionTimestamp(
+	aggregate *inspectPartitionAggregate,
+	snapshotTimes map[int64]int64,
+	snapshotID int64,
+	specID int32,
+) {
 	if snapshotID < 0 {
 		return
 	}
-	snapshot := i.tbl.metadata.SnapshotByID(snapshotID)
-	if snapshot == nil {
+	timestampMs, ok := snapshotTimes[snapshotID]
+	if !ok {
 		return
 	}
-	timestamp := snapshot.TimestampMs * 1000
+	timestamp := timestampMs * 1000
 	if aggregate.lastUpdatedAt != nil && timestamp <= *aggregate.lastUpdatedAt {
 		return
 	}
 	aggregate.lastUpdatedAt = &timestamp
-	id := snapshot.SnapshotID
+	id := snapshotID
 	aggregate.lastUpdatedSnapshot = &id
 	aggregate.specID = specID
 }

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -28,7 +28,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
-	"github.com/google/uuid"
 )
 
 type inspectPartitionAggregate struct {
@@ -43,22 +42,22 @@ type inspectPartitionAggregate struct {
 	equalityDeleteFiles int32
 	lastUpdatedAt       *int64
 	lastUpdatedSnapshot *int64
+	partitionRecord     partitionRecord
 	orderingKey         string
 }
 
 // Partitions returns one row per live partition, aggregating data and delete
-// files from the current snapshot. Different partition specs remain separate
-// groups so files from evolved specs are never combined by raw map equality.
+// files from the current snapshot. Files from evolved specs are coerced into
+// the table-wide partition type before grouping.
 func (i InspectTable) Partitions(ctx context.Context) (array.RecordReader, error) {
-	spec := i.tbl.metadata.PartitionSpec()
-	partitionType := spec.PartitionType(i.tbl.metadata.CurrentSchema())
+	partitionType := inspectPartitionType(i.tbl.metadata)
 	schema := PartitionsSchema(partitionType)
 	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
 	if err != nil {
 		return nil, fmt.Errorf("inspect partitions: build arrow schema: %w", err)
 	}
 
-	aggregates, err := i.partitionAggregates(ctx)
+	aggregates, err := i.partitionAggregates(ctx, partitionType)
 	if err != nil {
 		return nil, fmt.Errorf("inspect partitions: %w", err)
 	}
@@ -79,7 +78,7 @@ func (i InspectTable) Partitions(ctx context.Context) (array.RecordReader, error
 	return rr, nil
 }
 
-func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartitionAggregate, error) {
+func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *iceberg.StructType) ([]inspectPartitionAggregate, error) {
 	snapshot := i.tbl.metadata.CurrentSnapshot()
 	if snapshot == nil {
 		return nil, nil
@@ -96,7 +95,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartiti
 		return nil, err
 	}
 
-	aggregates := make(map[string]*inspectPartitionAggregate)
+	aggregates := make([]*inspectPartitionAggregate, 0)
 	for _, manifest := range manifests {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -106,16 +105,24 @@ func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartiti
 				return nil, err
 			}
 			file := entry.DataFile()
-			partition := file.Partition()
-			key := fmt.Sprintf("%d:%s", file.SpecID(), inspectPartitionKey(partition))
-			aggregate := aggregates[key]
+			partition := inspectCoercePartition(file.Partition(), partitionType)
+			record := newPartitionRecord(partition, partitionType)
+			var aggregate *inspectPartitionAggregate
+			for _, candidate := range aggregates {
+				if partitionRecordsEqual(candidate.partitionRecord, record) {
+					aggregate = candidate
+
+					break
+				}
+			}
 			if aggregate == nil {
 				aggregate = &inspectPartitionAggregate{
-					specID:      file.SpecID(),
-					partition:   cloneInspectPartition(partition),
-					orderingKey: key,
+					specID:          file.SpecID(),
+					partition:       cloneInspectPartition(partition),
+					partitionRecord: record,
+					orderingKey:     inspectPartitionKey(partition),
 				}
-				aggregates[key] = aggregate
+				aggregates = append(aggregates, aggregate)
 			}
 
 			switch file.ContentType() {
@@ -134,7 +141,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartiti
 			if file.ContentType() == iceberg.EntryContentData ||
 				file.ContentType() == iceberg.EntryContentPosDeletes ||
 				file.ContentType() == iceberg.EntryContentEqDeletes {
-				i.updatePartitionTimestamp(aggregate, entry.SnapshotID())
+				i.updatePartitionTimestamp(aggregate, entry.SnapshotID(), file.SpecID())
 			}
 		}
 	}
@@ -148,7 +155,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartiti
 	return result, nil
 }
 
-func (i InspectTable) updatePartitionTimestamp(aggregate *inspectPartitionAggregate, snapshotID int64) {
+func (i InspectTable) updatePartitionTimestamp(aggregate *inspectPartitionAggregate, snapshotID int64, specID int32) {
 	if snapshotID < 0 {
 		return
 	}
@@ -163,6 +170,22 @@ func (i InspectTable) updatePartitionTimestamp(aggregate *inspectPartitionAggreg
 	aggregate.lastUpdatedAt = &timestamp
 	id := snapshot.SnapshotID
 	aggregate.lastUpdatedSnapshot = &id
+	aggregate.specID = specID
+}
+
+func inspectCoercePartition(values map[int]any, partitionType *iceberg.StructType) map[int]any {
+	if partitionType == nil || len(partitionType.FieldList) == 0 {
+		return nil
+	}
+
+	coerced := make(map[int]any, len(partitionType.FieldList))
+	for _, field := range partitionType.FieldList {
+		if value, ok := values[field.ID]; ok {
+			coerced[field.ID] = value
+		}
+	}
+
+	return coerced
 }
 
 func inspectPartitionKey(partition map[int]any) string {
@@ -237,7 +260,7 @@ func appendPartitionAggregate(bldr *array.RecordBuilder, partitionType *iceberg.
 
 				continue
 			}
-			valueScalar, err := inspectPartitionValueScalar(value, field.Type, arrowType.Field(fieldIndex).Type)
+			valueScalar, err := inspectValueScalar(value, field.Type, arrowType.Field(fieldIndex).Type)
 			if err != nil {
 				return fmt.Errorf("partition field %q: %w", field.Name, err)
 			}
@@ -276,34 +299,4 @@ func appendPartitionAggregate(bldr *array.RecordBuilder, partitionType *iceberg.
 	}
 
 	return nil
-}
-
-func inspectPartitionValueScalar(value any, typ iceberg.Type, arrowType arrow.DataType) (scalar.Scalar, error) {
-	switch typ.(type) {
-	case iceberg.DateType:
-		switch value := value.(type) {
-		case iceberg.Date:
-			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
-		case int32:
-			return scalar.NewDate32Scalar(arrow.Date32(value)), nil
-		}
-	case iceberg.TimeType:
-		if value, ok := value.(iceberg.Time); ok {
-			return scalar.NewTime64Scalar(arrow.Time64(value), arrowType), nil
-		}
-	case iceberg.TimestampType, iceberg.TimestampTzType:
-		if value, ok := value.(iceberg.Timestamp); ok {
-			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
-		}
-	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
-		if value, ok := value.(iceberg.TimestampNano); ok {
-			return scalar.NewTimestampScalar(arrow.Timestamp(value), arrowType), nil
-		}
-	case iceberg.UUIDType:
-		if value, ok := value.(uuid.UUID); ok {
-			return scalar.MakeScalarParam(value[:], arrowType)
-		}
-	}
-
-	return scalar.MakeScalarParam(value, arrowType)
 }

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -154,7 +154,6 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 			aggregate := aggregateTree.lookup(record)
 			if aggregate == nil {
 				aggregate = &inspectPartitionAggregate{
-					specID:          file.SpecID(),
 					partition:       cloneInspectPartition(partition),
 					partitionRecord: record,
 					orderingKey:     inspectPartitionKey(partition),

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -88,7 +88,10 @@ func (t *inspectPartitionAggregateTree) insert(record partitionRecord, aggregate
 // files from the current snapshot. Files from evolved specs are coerced into
 // the table-wide partition type before grouping.
 func (i InspectTable) Partitions(ctx context.Context) (array.RecordReader, error) {
-	partitionType := inspectPartitionType(i.tbl.metadata)
+	partitionType, err := inspectPartitionType(i.tbl.metadata)
+	if err != nil {
+		return nil, fmt.Errorf("inspect partitions: %w", err)
+	}
 	schema := PartitionsSchema(partitionType)
 	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
 	if err != nil {

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -19,8 +19,10 @@ package table
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -83,7 +85,7 @@ func (i InspectTable) partitionAggregates(ctx context.Context) ([]inspectPartiti
 		return nil, nil
 	}
 	if i.tbl.fsF == nil {
-		return nil, fmt.Errorf("table file IO is not configured")
+		return nil, errors.New("table file IO is not configured")
 	}
 	fs, err := i.tbl.fsF(ctx)
 	if err != nil {
@@ -169,11 +171,12 @@ func inspectPartitionKey(partition map[int]any) string {
 		ids = append(ids, id)
 	}
 	sort.Ints(ids)
-	key := ""
+	var key strings.Builder
 	for _, id := range ids {
-		key += fmt.Sprintf("%d:%T:%v;", id, partition[id], partition[id])
+		fmt.Fprintf(&key, "%d:%T:%v;", id, partition[id], partition[id])
 	}
-	return key
+
+	return key.String()
 }
 
 func cloneInspectPartition(partition map[int]any) map[int]any {
@@ -184,6 +187,7 @@ func cloneInspectPartition(partition map[int]any) map[int]any {
 	for id, value := range partition {
 		returnMap[id] = value
 	}
+
 	return returnMap
 }
 
@@ -230,6 +234,7 @@ func appendPartitionAggregate(bldr *array.RecordBuilder, partitionType *iceberg.
 			value := aggregate.partition[field.ID]
 			if value == nil {
 				partition.FieldBuilder(fieldIndex).AppendNull()
+
 				continue
 			}
 			valueScalar, err := inspectPartitionValueScalar(value, field.Type, arrowType.Field(fieldIndex).Type)
@@ -299,5 +304,6 @@ func inspectPartitionValueScalar(value any, typ iceberg.Type, arrowType arrow.Da
 			return scalar.MakeScalarParam(value[:], arrowType)
 		}
 	}
+
 	return scalar.MakeScalarParam(value, arrowType)
 }


### PR DESCRIPTION
## Summary

Adds the current-snapshot `partitions` metadata table to `Table.Inspect`.

- Aggregates data-file, position-delete, and equality-delete counts by partition.
- Preserves the latest update timestamp, snapshot ID, and partition specification ID.
- Coerces compatible evolved partition specs into a table-wide partition value.

## Tests

- `go test ./table`
- Covers the partition schema, unified partition fields, and evolved partition specs.

## Scope

This reports partition-level metadata for the current snapshot. It does not change file writing, delete application, or scan behavior.

## Related

Builds on the shared content-file and partition representation in #1698.