### PR TITLE
test(table): expand geometry write-path coverage

### DIFF
--- a/table/geo_write_test.go
+++ b/table/geo_write_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/io"
@@ -33,6 +34,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twpayne/go-geom/encoding/wkb"
 	"github.com/twpayne/go-geom/encoding/wkt"
+)
+
+const (
+	geoTestIDFieldID   = 1
+	geoTestGeomFieldID = 2
+	geoTestGeogFieldID = 3
 )
 
 // wktToWKB converts Well-Known Text into little-endian (NDR) Well-Known Binary,
@@ -46,6 +53,45 @@ func wktToWKB(t *testing.T, s string) geoarrow.WKBBytes {
 	require.NoError(t, err)
 
 	return geoarrow.WKBBytes(b)
+}
+
+// newGeoTestWriter builds an unpartitioned v3 table with an id/geom/geog schema
+// and returns a data file writer over it. props feed the metrics-mode
+// configuration (e.g. write.metadata.metrics.column.geom=none) so tests can
+// exercise the stats-plan dispatch that decides whether geo bounds are recorded.
+func newGeoTestWriter(t *testing.T, dir string, props iceberg.Properties) (*defaultDataFileWriter, *iceberg.Schema, *arrow.Schema) {
+	t.Helper()
+
+	geogType, err := iceberg.GeographyTypeOf("OGC:CRS84", "spherical")
+	require.NoError(t, err)
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: geoTestIDFieldID, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: geoTestGeomFieldID, Name: "geom", Type: iceberg.GeometryType{}, Required: false},
+		iceberg.NestedField{ID: geoTestGeogFieldID, Name: "geog", Type: geogType, Required: false},
+	)
+
+	// Geometry/geography are v3 types.
+	mb, err := NewMetadataBuilder(3)
+	require.NoError(t, err)
+	require.NoError(t, mb.AddSchema(schema))
+	require.NoError(t, mb.SetCurrentSchemaID(0))
+	unpartitioned := *iceberg.UnpartitionedSpec
+	require.NoError(t, mb.AddPartitionSpec(&unpartitioned, true))
+	require.NoError(t, mb.SetDefaultSpecID(0))
+	// The stats plan is computed from the table properties on the builder (see
+	// defaultDataFileWriter.writeFile), so metrics-mode config must live here.
+	if len(props) > 0 {
+		require.NoError(t, mb.SetProperties(props))
+	}
+
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	require.NoError(t, err)
+
+	writer, err := newDataFileWriter(dir, &io.LocalFS{}, mb, props)
+	require.NoError(t, err)
+
+	return writer, schema, arrowSchema
 }
 
 // TestWriteGeometryColumnPopulatesBounds writes a geometry and a geography
@@ -64,46 +110,24 @@ func wktToWKB(t *testing.T, s string) geoarrow.WKBBytes {
 func TestWriteGeometryColumnPopulatesBounds(t *testing.T) {
 	t.Parallel()
 
-	const (
-		geomFieldID = 2
-		geogFieldID = 3
-	)
-
-	geogType, err := iceberg.GeographyTypeOf("OGC:CRS84", "spherical")
-	require.NoError(t, err)
-
-	schema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
-		iceberg.NestedField{ID: geomFieldID, Name: "geom", Type: iceberg.GeometryType{}, Required: false},
-		iceberg.NestedField{ID: geogFieldID, Name: "geog", Type: geogType, Required: false},
-	)
-
-	// Geometry/geography are v3 types.
-	mb, err := NewMetadataBuilder(3)
-	require.NoError(t, err)
-	require.NoError(t, mb.AddSchema(schema))
-	require.NoError(t, mb.SetCurrentSchemaID(0))
-	unpartitioned := *iceberg.UnpartitionedSpec
-	require.NoError(t, mb.AddPartitionSpec(&unpartitioned, true))
-	require.NoError(t, mb.SetDefaultSpecID(0))
-
-	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
-	require.NoError(t, err)
+	writer, schema, arrowSchema := newGeoTestWriter(t, t.TempDir(), iceberg.Properties{})
 
 	// Two geometry points spanning X in [0, 30] and Y in [-5, 10].
 	geomLo := wktToWKB(t, "POINT (0 -5)")
 	geomHi := wktToWKB(t, "POINT (30 10)")
 	geog := wktToWKB(t, "POINT (12 4)")
 
+	// The records below feed geoarrow's JSON parser the lowercase-hex WKB from
+	// WKBBytes.String() and rely on it round-tripping back into WKB; if that ever
+	// stopped, the accumulator would see no values and the geometry bound
+	// assertions below would fail confusingly. parquet_files_test.go leans on the
+	// same .String() hex pattern.
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
 		{"id": 1, "geom": "`+geomLo.String()+`", "geog": "`+geog.String()+`"},
 		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
 	]`))
 	require.NoError(t, err)
 	defer rec.Release()
-
-	writer, err := newDataFileWriter(t.TempDir(), &io.LocalFS{}, mb, iceberg.Properties{})
-	require.NoError(t, err)
 
 	df, err := writer.writeFile(t.Context(), nil, WriteTask{
 		Uuid:      uuid.New(),
@@ -118,17 +142,145 @@ func TestWriteGeometryColumnPopulatesBounds(t *testing.T) {
 	// Geometry column carries a planar XY bounding box in the manifest bounds.
 	lower := df.LowerBoundValues()
 	upper := df.UpperBoundValues()
-	require.Contains(t, lower, geomFieldID, "geometry column must record a lower bound")
-	require.Contains(t, upper, geomFieldID, "geometry column must record an upper bound")
+	require.Contains(t, lower, geoTestGeomFieldID, "geometry column must record a lower bound")
+	require.Contains(t, upper, geoTestGeomFieldID, "geometry column must record an upper bound")
 
-	minX, minY, maxX, maxY, ok := tblutils.GeoBoundsXY(lower[geomFieldID], upper[geomFieldID])
+	minX, minY, maxX, maxY, ok := tblutils.GeoBoundsXY(lower[geoTestGeomFieldID], upper[geoTestGeomFieldID])
 	require.True(t, ok, "geometry bounds must decode to a planar XY box")
 	assert.Equal(t, 0.0, minX)
 	assert.Equal(t, -5.0, minY)
 	assert.Equal(t, 30.0, maxX)
 	assert.Equal(t, 10.0, maxY)
 
-	// Geography stays unbounded: a planar box over geodesic edges is unsafe.
-	assert.NotContains(t, lower, geogFieldID, "geography column must not record bounds")
-	assert.NotContains(t, upper, geogFieldID, "geography column must not record bounds")
+	// The non-geo id column still gets ordinary min/max bounds. The geo-type guard
+	// in DataFileStatsFromMeta suppresses generic Parquet stats for geo columns;
+	// pinning id here catches a regression that over-suppresses an adjacent
+	// non-geo column.
+	require.Contains(t, lower, geoTestIDFieldID, "non-geo id column must still record a lower bound")
+	require.Contains(t, upper, geoTestIDFieldID, "non-geo id column must still record an upper bound")
+
+	// Geography does not record bounds in the current implementation: the V3 spec
+	// permits geography bounds (with the xmin > xmax antimeridian-wrapping
+	// convention), but iceberg-go leaves them unbounded as a deliberate
+	// conservative choice until geodesic/antimeridian-aware computation lands (see
+	// geoBoundsAccumulator). This assertion should flip when that computation is
+	// added.
+	assert.NotContains(t, lower, geoTestGeogFieldID, "geography column does not record bounds in the current implementation")
+	assert.NotContains(t, upper, geoTestGeogFieldID, "geography column does not record bounds in the current implementation")
+}
+
+// TestWriteGeometryColumnAllNull writes a geometry column whose values are all
+// null and asserts the field drops out of the manifest bounds map through the
+// full write path. With no WKB values to accumulate, geoBoundsAccumulator has
+// nothing to encode, so no bound must be emitted.
+func TestWriteGeometryColumnAllNull(t *testing.T) {
+	t.Parallel()
+
+	writer, schema, arrowSchema := newGeoTestWriter(t, t.TempDir(), iceberg.Properties{})
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
+		{"id": 1, "geom": null, "geog": null},
+		{"id": 2, "geom": null, "geog": null}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	df, err := writer.writeFile(t.Context(), nil, WriteTask{
+		Uuid:      uuid.New(),
+		ID:        0,
+		FileCount: 1,
+		Schema:    schema,
+		Batches:   []arrow.RecordBatch{rec},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, df.Count())
+
+	lower := df.LowerBoundValues()
+	upper := df.UpperBoundValues()
+	assert.NotContains(t, lower, geoTestGeomFieldID, "all-null geometry column must not record a lower bound")
+	assert.NotContains(t, upper, geoTestGeomFieldID, "all-null geometry column must not record an upper bound")
+
+	// The non-geo id column is unaffected by the geometry column being all null.
+	require.Contains(t, lower, geoTestIDFieldID, "non-geo id column must still record a lower bound")
+	require.Contains(t, upper, geoTestIDFieldID, "non-geo id column must still record an upper bound")
+}
+
+// TestWriteGeometryColumnMetricsNone sets write.metadata.metrics.column.geom=none
+// and asserts computeStatsPlan actually suppresses the geometry bounds. This
+// exercises the stats-plan dispatch (arrowStatsCollector -> applyGeoBounds) that
+// internal.TestWriteDataFileGeoBounds cannot reach, since that test feeds
+// hand-built StatsCols straight to WriteDataFile. The adjacent non-geo id column
+// keeps its ordinary bounds so the suppression is scoped to the geometry column.
+func TestWriteGeometryColumnMetricsNone(t *testing.T) {
+	t.Parallel()
+
+	props := iceberg.Properties{
+		MetricsModeColumnConfPrefix + ".geom": string(tblutils.MetricModeNone),
+	}
+	writer, schema, arrowSchema := newGeoTestWriter(t, t.TempDir(), props)
+
+	geomLo := wktToWKB(t, "POINT (0 -5)")
+	geomHi := wktToWKB(t, "POINT (30 10)")
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
+		{"id": 1, "geom": "`+geomLo.String()+`", "geog": null},
+		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	df, err := writer.writeFile(t.Context(), nil, WriteTask{
+		Uuid:      uuid.New(),
+		ID:        0,
+		FileCount: 1,
+		Schema:    schema,
+		Batches:   []arrow.RecordBatch{rec},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, df.Count())
+
+	lower := df.LowerBoundValues()
+	upper := df.UpperBoundValues()
+	assert.NotContains(t, lower, geoTestGeomFieldID, "geometry column bounds must be suppressed under metrics mode none")
+	assert.NotContains(t, upper, geoTestGeomFieldID, "geometry column bounds must be suppressed under metrics mode none")
+
+	// Suppression is scoped to the geom column: id still gets ordinary bounds.
+	require.Contains(t, lower, geoTestIDFieldID, "non-geo id column must keep bounds when only geom is set to none")
+	require.Contains(t, upper, geoTestIDFieldID, "non-geo id column must keep bounds when only geom is set to none")
+}
+
+// TestWriteGeometryColumnCheckedAllocator runs the geometry write path on a
+// checked allocator and asserts zero residual once the writer is done, catching
+// a silent allocation escape in the geo-bounds accumulator wiring. This mirrors
+// the memory.NewCheckedAllocator/AssertSize pattern the writer suites use.
+func TestWriteGeometryColumnCheckedAllocator(t *testing.T) {
+	t.Parallel()
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	ctx := compute.WithAllocator(t.Context(), mem)
+
+	writer, schema, arrowSchema := newGeoTestWriter(t, t.TempDir(), iceberg.Properties{})
+
+	geomLo := wktToWKB(t, "POINT (0 -5)")
+	geomHi := wktToWKB(t, "POINT (30 10)")
+	geog := wktToWKB(t, "POINT (12 4)")
+
+	rec, _, err := array.RecordFromJSON(mem, arrowSchema, strings.NewReader(`[
+		{"id": 1, "geom": "`+geomLo.String()+`", "geog": "`+geog.String()+`"},
+		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	df, err := writer.writeFile(ctx, nil, WriteTask{
+		Uuid:      uuid.New(),
+		ID:        0,
+		FileCount: 1,
+		Schema:    schema,
+		Batches:   []arrow.RecordBatch{rec},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, df.Count())
+	require.Contains(t, df.LowerBoundValues(), geoTestGeomFieldID, "geometry column must record a lower bound")
 }

--- a/table/geo_write_test.go
+++ b/table/geo_write_test.go
@@ -59,6 +59,10 @@ func wktToWKB(t *testing.T, s string) geoarrow.WKBBytes {
 // and returns a data file writer over it. props feed the metrics-mode
 // configuration (e.g. write.metadata.metrics.column.geom=none) so tests can
 // exercise the stats-plan dispatch that decides whether geo bounds are recorded.
+//
+// The geo columns are all top-level; nested geo columns are still unhandled in
+// the writer (see the TODO(#992) in parquet_files.go), so nothing here covers
+// them.
 func newGeoTestWriter(t *testing.T, dir string, props iceberg.Properties) (*defaultDataFileWriter, *iceberg.Schema, *arrow.Schema) {
 	t.Helper()
 
@@ -127,7 +131,6 @@ func TestWriteGeometryColumnPopulatesBounds(t *testing.T) {
 		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
 	]`))
 	require.NoError(t, err)
-	defer rec.Release()
 
 	df, err := writer.writeFile(t.Context(), nil, WriteTask{
 		Uuid:      uuid.New(),
@@ -165,6 +168,11 @@ func TestWriteGeometryColumnPopulatesBounds(t *testing.T) {
 	// conservative choice until geodesic/antimeridian-aware computation lands (see
 	// geoBoundsAccumulator). This assertion should flip when that computation is
 	// added.
+	//
+	// Note for whoever adds it: geography needs its own decode, not a reuse of
+	// GeoBoundsXY. That helper rejects xmin > xmax as inverted (correct for planar
+	// geometry), which would silently drop the valid antimeridian-crossing bounds
+	// Java/PyIceberg emit for geography.
 	assert.NotContains(t, lower, geoTestGeogFieldID, "geography column does not record bounds in the current implementation")
 	assert.NotContains(t, upper, geoTestGeogFieldID, "geography column does not record bounds in the current implementation")
 }
@@ -183,7 +191,6 @@ func TestWriteGeometryColumnAllNull(t *testing.T) {
 		{"id": 2, "geom": null, "geog": null}
 	]`))
 	require.NoError(t, err)
-	defer rec.Release()
 
 	df, err := writer.writeFile(t.Context(), nil, WriteTask{
 		Uuid:      uuid.New(),
@@ -197,6 +204,10 @@ func TestWriteGeometryColumnAllNull(t *testing.T) {
 
 	lower := df.LowerBoundValues()
 	upper := df.UpperBoundValues()
+	// This asserts absence, which also holds if the accumulator were never wired
+	// up at all (e.g. collectGeoColumns stopped registering geo columns).
+	// TestWriteGeometryColumnPopulatesBounds is the positive guard against that
+	// bypass; this test pins the all-null case on top of it.
 	assert.NotContains(t, lower, geoTestGeomFieldID, "all-null geometry column must not record a lower bound")
 	assert.NotContains(t, upper, geoTestGeomFieldID, "all-null geometry column must not record an upper bound")
 
@@ -227,7 +238,6 @@ func TestWriteGeometryColumnMetricsNone(t *testing.T) {
 		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
 	]`))
 	require.NoError(t, err)
-	defer rec.Release()
 
 	df, err := writer.writeFile(t.Context(), nil, WriteTask{
 		Uuid:      uuid.New(),
@@ -250,9 +260,11 @@ func TestWriteGeometryColumnMetricsNone(t *testing.T) {
 }
 
 // TestWriteGeometryColumnCheckedAllocator runs the geometry write path on a
-// checked allocator and asserts zero residual once the writer is done, catching
-// a silent allocation escape in the geo-bounds accumulator wiring. This mirrors
-// the memory.NewCheckedAllocator/AssertSize pattern the writer suites use.
+// checked allocator and asserts zero residual once the writer is done. The
+// geo-bounds accumulator works on plain Go fields and returns []byte, so the
+// checked allocator cannot see it; what this pins is that the Arrow write
+// pipeline (ToRequestedSchema, the pqarrow writer) releases every buffer it
+// allocates on the geo write path.
 func TestWriteGeometryColumnCheckedAllocator(t *testing.T) {
 	t.Parallel()
 
@@ -271,7 +283,6 @@ func TestWriteGeometryColumnCheckedAllocator(t *testing.T) {
 		{"id": 2, "geom": "`+geomHi.String()+`", "geog": null}
 	]`))
 	require.NoError(t, err)
-	defer rec.Release()
 
 	df, err := writer.writeFile(ctx, nil, WriteTask{
 		Uuid:      uuid.New(),
@@ -283,4 +294,5 @@ func TestWriteGeometryColumnCheckedAllocator(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 2, df.Count())
 	require.Contains(t, df.LowerBoundValues(), geoTestGeomFieldID, "geometry column must record a lower bound")
+	require.Contains(t, df.UpperBoundValues(), geoTestGeomFieldID, "geometry column must record an upper bound")
 }


### PR DESCRIPTION
Add end-to-end sub-tests around the geometry write path that exercise dispatch the internal TestWriteDataFileGeoBounds cannot reach (it feeds hand-built StatsCols straight to WriteDataFile):

- non-geo id column keeps ordinary min/max bounds, so an over-eager geo stats suppression on an adjacent column cannot pass unnoticed
- all-null geometry column drops out of the manifest bounds map
- write.metadata.metrics.column.geom=none suppresses geo bounds via the stats-plan dispatch, scoped to the geom column
- checked allocator asserts zero residual to catch allocation escapes in the geo-bounds accumulator wiring

Also reword the geography assertion: leaving bounds unbounded is the current conservative implementation, not a spec mandate, and note the .String() hex round-trip the JSON parser depends on.