### PR TITLE
fix(cli): support SQL catalog and validate DynamoDB type

### DIFF
--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -414,6 +414,11 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 
 	hadoopWarehouse := t.TempDir()
 
+	sqlWarehouse := t.TempDir()
+	sqlDB := filepath.Join(t.TempDir(), "catalog.db")
+	sqlURI := "file:" + sqlDB
+	sqlWarehouseURI := "file://" + sqlWarehouse
+
 	// A raw TCP listener stands in for a Hive metastore: the CLI only needs to
 	// get far enough to open a connection to prove "HIVE"/"Hive" were recognized
 	// as the Hive catalog type. It has no Thrift handshake, so the command still
@@ -444,6 +449,9 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 		// rejected outright, to keep that failure mode distinguishable from
 		// wantErr above.
 		wantUnrecognized bool
+		// wantContains, when set with wantErr, asserts a substring of stderr/stdout
+		// so "not implemented" failures stay distinguishable from other errors.
+		wantContains string
 	}{
 		{
 			name: "rest lowercase",
@@ -496,6 +504,48 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "sql lowercase",
+			args: []string{
+				"list", "--catalog", "sql",
+				"--uri", sqlURI,
+				"--sql-driver", "sqliteshim",
+				"--sql-dialect", "sqlite",
+				"--warehouse", sqlWarehouseURI,
+			},
+		},
+		{
+			name: "sql uppercase",
+			args: []string{
+				"list", "--catalog", "SQL",
+				"--uri", sqlURI,
+				"--sql-driver", "sqliteshim",
+				"--sql-dialect", "sqlite",
+				"--warehouse", sqlWarehouseURI,
+			},
+		},
+		{
+			name: "sql mixed case",
+			args: []string{
+				"list", "--catalog", "Sql",
+				"--uri", sqlURI,
+				"--sql-driver", "sqliteshim",
+				"--sql-dialect", "sqlite",
+				"--warehouse", sqlWarehouseURI,
+			},
+		},
+		{
+			name:         "dynamodb is recognized but not implemented",
+			args:         []string{"list", "--catalog", "dynamodb"},
+			wantErr:      true,
+			wantContains: "dynamodb catalog is not implemented",
+		},
+		{
+			name:         "dynamodb uppercase is recognized but not implemented",
+			args:         []string{"list", "--catalog", "DYNAMODB"},
+			wantErr:      true,
+			wantContains: "dynamodb catalog is not implemented",
+		},
+		{
 			name:             "unknown catalog type is still rejected",
 			args:             []string{"list", "--catalog", "RESTX", "--uri", restSrv.URL},
 			wantUnrecognized: true,
@@ -519,6 +569,9 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err, "output: %s", out)
 				require.NotContains(t, string(out), "unrecognized catalog type")
+				if tt.wantContains != "" {
+					require.Contains(t, string(out), tt.wantContains)
+				}
 
 				return
 			}
@@ -526,6 +579,27 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 			require.NoError(t, err, "output: %s", out)
 		})
 	}
+}
+
+func TestMergeConfSQLOptions(t *testing.T) {
+	fileCfg := &config.CatalogConfig{
+		SQLDriver:  "sqliteshim",
+		SQLDialect: "sqlite",
+	}
+
+	t.Run("file values applied when flags absent", func(t *testing.T) {
+		var a Args
+		mergeConf(fileCfg, &a, map[string]bool{})
+		assert.Equal(t, "sqliteshim", a.SQLDriver)
+		assert.Equal(t, "sqlite", a.SQLDialect)
+	})
+
+	t.Run("explicit flags win over file", func(t *testing.T) {
+		a := Args{SQLDriver: "mysql", SQLDialect: "mysql"}
+		mergeConf(fileCfg, &a, map[string]bool{"sql-driver": true, "sql-dialect": true})
+		assert.Equal(t, "mysql", a.SQLDriver)
+		assert.Equal(t, "mysql", a.SQLDialect)
+	})
 }
 
 func TestMergeConfAwsProfile(t *testing.T) {

--- a/cmd/iceberg/args_test.go
+++ b/cmd/iceberg/args_test.go
@@ -534,6 +534,19 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 			},
 		},
 		{
+			// Missing --sql-driver must reach the SQL registrar (catalog.Load),
+			// not fail as an unrecognized catalog type.
+			name: "sql without sql-driver reaches registrar",
+			args: []string{
+				"list", "--catalog", "sql",
+				"--uri", sqlURI,
+				"--sql-dialect", "sqlite",
+				"--warehouse", sqlWarehouseURI,
+			},
+			wantErr:      true,
+			wantContains: "must provide driver",
+		},
+		{
 			name:         "dynamodb is recognized but not implemented",
 			args:         []string{"list", "--catalog", "dynamodb"},
 			wantErr:      true,
@@ -583,20 +596,42 @@ func TestCLIAcceptsMixedCaseCatalogType(t *testing.T) {
 
 func TestMergeConfSQLOptions(t *testing.T) {
 	fileCfg := &config.CatalogConfig{
-		SQLDriver:  "sqliteshim",
-		SQLDialect: "sqlite",
+		CatalogType: "sql",
+		URI:         "file:from-config.db",
+		Warehouse:   "file:///tmp/from-config-wh",
+		Credential:  "config-credential",
+		SQLDriver:   "sqliteshim",
+		SQLDialect:  "sqlite",
 	}
 
 	t.Run("file values applied when flags absent", func(t *testing.T) {
 		var a Args
 		mergeConf(fileCfg, &a, map[string]bool{})
+		assert.Equal(t, "sql", a.Catalog)
+		assert.Equal(t, "file:from-config.db", a.URI)
+		assert.Equal(t, "file:///tmp/from-config-wh", a.Warehouse)
+		assert.Equal(t, "config-credential", a.Credential)
 		assert.Equal(t, "sqliteshim", a.SQLDriver)
 		assert.Equal(t, "sqlite", a.SQLDialect)
 	})
 
 	t.Run("explicit flags win over file", func(t *testing.T) {
-		a := Args{SQLDriver: "mysql", SQLDialect: "mysql"}
-		mergeConf(fileCfg, &a, map[string]bool{"sql-driver": true, "sql-dialect": true})
+		a := Args{
+			Catalog:    "rest",
+			URI:        "file:cli.db",
+			Warehouse:  "file:///tmp/cli-wh",
+			Credential: "cli-credential",
+			SQLDriver:  "mysql",
+			SQLDialect: "mysql",
+		}
+		mergeConf(fileCfg, &a, map[string]bool{
+			"catalog": true, "uri": true, "warehouse": true, "credential": true,
+			"sql-driver": true, "sql-dialect": true,
+		})
+		assert.Equal(t, "rest", a.Catalog)
+		assert.Equal(t, "file:cli.db", a.URI)
+		assert.Equal(t, "file:///tmp/cli-wh", a.Warehouse)
+		assert.Equal(t, "cli-credential", a.Credential)
 		assert.Equal(t, "mysql", a.SQLDriver)
 		assert.Equal(t, "mysql", a.SQLDialect)
 	})

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -42,6 +42,8 @@ import (
 	"github.com/apache/iceberg-go/table"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	// The default CLI binary only compiles in sqliteshim. Other database/sql
+	// drivers (postgres, mysql, mssql, oracle) require a custom build.
 	_ "github.com/uptrace/bun/driver/sqliteshim"
 )
 
@@ -202,7 +204,7 @@ type Args struct {
 	Upgrade          *UpgradeCmd          `arg:"subcommand:upgrade" help:"upgrade table format version"`
 	Rollback         *RollbackCmd         `arg:"subcommand:rollback" help:"roll back to a previous snapshot"`
 
-	Catalog     string `arg:"--catalog" default:"rest" help:"catalog type (rest, glue, hive, hadoop, sql)"`
+	Catalog     string `arg:"--catalog" default:"rest" help:"catalog type (rest, glue, hive, hadoop, sql; dynamodb recognized but not implemented)"`
 	CatalogName string `arg:"--catalog-name" default:"default" help:"catalog name from config"`
 	URI         string `arg:"--uri" help:"catalog URI"`
 	Output      string `arg:"--output" default:"text" help:"output type (json/text)"`
@@ -212,8 +214,8 @@ type Args struct {
 	Scope       string `arg:"--scope" default:"catalog" help:"OAuth scope"`
 	Config      string `arg:"--config" help:"path to configuration file"`
 	AwsProfile  string `arg:"--aws-profile" help:"AWS profile to use (Glue catalog)"`
-	SQLDriver   string `arg:"--sql-driver" help:"database/sql driver name (SQL catalog; e.g. sqliteshim)"`
-	SQLDialect  string `arg:"--sql-dialect" help:"SQL dialect (SQL catalog: postgres, mysql, sqlite, mssql, oracle)"`
+	SQLDriver   string `arg:"--sql-driver" help:"database/sql driver name (SQL catalog; default binary includes sqliteshim only)"`
+	SQLDialect  string `arg:"--sql-dialect" help:"SQL dialect (SQL catalog; default binary includes sqlite via sqliteshim; other dialects need a custom build with their drivers)"`
 
 	RestOptions *config.RestOptions `arg:"-"`
 }
@@ -292,6 +294,13 @@ func main() {
 			output.Error(err)
 			os.Exit(1)
 		}
+	}
+
+	// Reject known-but-unimplemented catalog types through the same output path
+	// as other user-facing errors (respects --output).
+	if catalog.Type(strings.ToLower(args.Catalog)) == catalog.DynamoDB {
+		output.Error(errors.New("dynamodb catalog is not implemented"))
+		os.Exit(1)
 	}
 
 	cat := initCatalog(ctx, args)
@@ -427,12 +436,15 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 			log.Fatal(err)
 		}
 	case catalog.SQL:
-		// Always set uri/warehouse keys (even when empty) so catalog.Load does not
-		// fill them from EnvConfig for a differently typed catalog of the same name.
+		// Always set uri/warehouse/credential keys (even when empty) so
+		// catalog.Load does not fill them from EnvConfig for a differently typed
+		// catalog of the same name. mergeConf populates these from the config
+		// file before initCatalog runs when the flags were omitted.
 		props := iceberg.Properties{
-			"type":      string(catalog.SQL),
-			"uri":       args.URI,
-			"warehouse": args.Warehouse,
+			"type":       string(catalog.SQL),
+			"uri":        args.URI,
+			"warehouse":  args.Warehouse,
+			"credential": args.Credential,
 		}
 		if len(args.SQLDriver) > 0 {
 			props[sqlcat.DriverKey] = args.SQLDriver
@@ -444,8 +456,6 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 		if cat, err = catalog.Load(ctx, args.CatalogName, props); err != nil {
 			log.Fatal(err)
 		}
-	case catalog.DynamoDB:
-		log.Fatal("dynamodb catalog is not implemented")
 	default:
 		log.Fatal("unrecognized catalog type")
 	}

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -427,14 +427,12 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 			log.Fatal(err)
 		}
 	case catalog.SQL:
+		// Always set uri/warehouse keys (even when empty) so catalog.Load does not
+		// fill them from EnvConfig for a differently typed catalog of the same name.
 		props := iceberg.Properties{
-			"type": string(catalog.SQL),
-		}
-		if len(args.URI) > 0 {
-			props["uri"] = args.URI
-		}
-		if len(args.Warehouse) > 0 {
-			props["warehouse"] = args.Warehouse
+			"type":      string(catalog.SQL),
+			"uri":       args.URI,
+			"warehouse": args.Warehouse,
 		}
 		if len(args.SQLDriver) > 0 {
 			props[sqlcat.DriverKey] = args.SQLDriver

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -36,11 +36,13 @@ import (
 	"github.com/apache/iceberg-go/catalog/hadoop"
 	"github.com/apache/iceberg-go/catalog/hive"
 	"github.com/apache/iceberg-go/catalog/rest"
+	sqlcat "github.com/apache/iceberg-go/catalog/sql"
 	"github.com/apache/iceberg-go/config"
 	_ "github.com/apache/iceberg-go/io/gocloud"
 	"github.com/apache/iceberg-go/table"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	_ "github.com/uptrace/bun/driver/sqliteshim"
 )
 
 // Subcommand structs
@@ -200,7 +202,7 @@ type Args struct {
 	Upgrade          *UpgradeCmd          `arg:"subcommand:upgrade" help:"upgrade table format version"`
 	Rollback         *RollbackCmd         `arg:"subcommand:rollback" help:"roll back to a previous snapshot"`
 
-	Catalog     string `arg:"--catalog" default:"rest" help:"catalog type"`
+	Catalog     string `arg:"--catalog" default:"rest" help:"catalog type (rest, glue, hive, hadoop, sql)"`
 	CatalogName string `arg:"--catalog-name" default:"default" help:"catalog name from config"`
 	URI         string `arg:"--uri" help:"catalog URI"`
 	Output      string `arg:"--output" default:"text" help:"output type (json/text)"`
@@ -210,6 +212,8 @@ type Args struct {
 	Scope       string `arg:"--scope" default:"catalog" help:"OAuth scope"`
 	Config      string `arg:"--config" help:"path to configuration file"`
 	AwsProfile  string `arg:"--aws-profile" help:"AWS profile to use (Glue catalog)"`
+	SQLDriver   string `arg:"--sql-driver" help:"database/sql driver name (SQL catalog; e.g. sqliteshim)"`
+	SQLDialect  string `arg:"--sql-dialect" help:"SQL dialect (SQL catalog: postgres, mysql, sqlite, mssql, oracle)"`
 
 	RestOptions *config.RestOptions `arg:"-"`
 }
@@ -422,6 +426,28 @@ func initCatalog(ctx context.Context, args Args) catalog.Catalog {
 		}); err != nil {
 			log.Fatal(err)
 		}
+	case catalog.SQL:
+		props := iceberg.Properties{
+			"type": string(catalog.SQL),
+		}
+		if len(args.URI) > 0 {
+			props["uri"] = args.URI
+		}
+		if len(args.Warehouse) > 0 {
+			props["warehouse"] = args.Warehouse
+		}
+		if len(args.SQLDriver) > 0 {
+			props[sqlcat.DriverKey] = args.SQLDriver
+		}
+		if len(args.SQLDialect) > 0 {
+			props[sqlcat.DialectKey] = args.SQLDialect
+		}
+
+		if cat, err = catalog.Load(ctx, args.CatalogName, props); err != nil {
+			log.Fatal(err)
+		}
+	case catalog.DynamoDB:
+		log.Fatal("dynamodb catalog is not implemented")
 	default:
 		log.Fatal("unrecognized catalog type")
 	}
@@ -902,6 +928,14 @@ func mergeConf(fileConf *config.CatalogConfig, args *Args, explicitFlags map[str
 
 	if !explicitFlags["aws-profile"] && len(fileConf.AwsProfile) > 0 {
 		args.AwsProfile = fileConf.AwsProfile
+	}
+
+	if !explicitFlags["sql-driver"] && len(fileConf.SQLDriver) > 0 {
+		args.SQLDriver = fileConf.SQLDriver
+	}
+
+	if !explicitFlags["sql-dialect"] && len(fileConf.SQLDialect) > 0 {
+		args.SQLDialect = fileConf.SQLDialect
 	}
 
 	if fileConf.RestOptions != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,8 @@ type CatalogConfig struct {
 	Credential  string       `yaml:"credential"`
 	Warehouse   string       `yaml:"warehouse"`
 	AwsProfile  string       `yaml:"aws-profile"`
+	SQLDriver   string       `yaml:"sql-driver"`
+	SQLDialect  string       `yaml:"sql-dialect"`
 	RestOptions *RestOptions `yaml:"rest,omitempty"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,6 +142,25 @@ catalog:
 			AwsProfile:  "my-aws-profile",
 		},
 	},
+	// sql catalog with driver/dialect
+	{
+		[]byte(`
+catalog:
+  default:
+    type: sql
+    uri: file:iceberg-catalog.db
+    warehouse: file:///tmp/warehouse
+    sql-driver: sqliteshim
+    sql-dialect: sqlite
+`), "default",
+		&CatalogConfig{
+			CatalogType: "sql",
+			URI:         "file:iceberg-catalog.db",
+			Warehouse:   "file:///tmp/warehouse",
+			SQLDriver:   "sqliteshim",
+			SQLDialect:  "sqlite",
+		},
+	},
 	// empty name resolves via the file's default-catalog field
 	{
 		[]byte(`

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -53,8 +53,8 @@ Catalog connection flags are global and apply to every subcommand:
 | `--catalog-name` | Catalog name to load from config file (default `default`) |
 | `--config` | Path to a config file |
 | `--aws-profile` | AWS named profile to use (Glue catalog); overrides `aws-profile` in the config file |
-| `--sql-driver` | `database/sql` driver name for the SQL catalog (e.g. `sqliteshim`) |
-| `--sql-dialect` | SQL dialect for the SQL catalog: `postgres`, `mysql`, `sqlite`, `mssql`, `oracle` |
+| `--sql-driver` | `database/sql` driver name for the SQL catalog. The default CLI binary only compiles in `sqliteshim`; other drivers require a custom build. |
+| `--sql-dialect` | SQL dialect for the SQL catalog. The SQL catalog library supports `postgres`, `mysql`, `sqlite`, `mssql`, and `oracle`, but the default CLI binary only ships the `sqlite` dialect via `sqliteshim`. Other dialects need a custom build that blank-imports their `database/sql` drivers. |
 
 To avoid passing flags every time, define a config file at `~/.iceberg-go.yaml`:
 ```yaml

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -44,8 +44,8 @@ Catalog connection flags are global and apply to every subcommand:
 
 | Flag | Description |
 | ---- | ----------- |
-| `--catalog` | Catalog type: `rest` (default), `glue`, `hive`, `hadoop` |
-| `--uri` | Catalog URI (REST/Hive) |
+| `--catalog` | Catalog type: `rest` (default), `glue`, `hive`, `hadoop`, `sql`. `dynamodb` is recognized but not implemented yet. |
+| `--uri` | Catalog URI (REST/Hive) or SQL DSN |
 | `--warehouse` | Warehouse location |
 | `--credential` | Credentials for the catalog |
 | `--token` | OAuth token (skips OAuth flow) |
@@ -53,6 +53,8 @@ Catalog connection flags are global and apply to every subcommand:
 | `--catalog-name` | Catalog name to load from config file (default `default`) |
 | `--config` | Path to a config file |
 | `--aws-profile` | AWS named profile to use (Glue catalog); overrides `aws-profile` in the config file |
+| `--sql-driver` | `database/sql` driver name for the SQL catalog (e.g. `sqliteshim`) |
+| `--sql-dialect` | SQL dialect for the SQL catalog: `postgres`, `mysql`, `sqlite`, `mssql`, `oracle` |
 
 To avoid passing flags every time, define a config file at `~/.iceberg-go.yaml`:
 ```yaml
@@ -63,6 +65,18 @@ catalog:
     uri: http://localhost:8181
     warehouse: s3://my-warehouse
 ```
+
+SQL catalog example:
+```yaml
+catalog:
+  local:
+    type: sql
+    uri: file:iceberg-catalog.db
+    warehouse: file:///tmp/warehouse
+    sql-driver: sqliteshim
+    sql-dialect: sqlite
+```
+
 Flags on the command line override values from the config file.
 
 ## Output format

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -54,6 +54,8 @@ catalog:
 | `catalog.<name>.credential` | Credential string passed through to the catalog's auth handler. |
 | `catalog.<name>.output` | CLI output format (e.g. `text`, `json`). |
 | `catalog.<name>.aws-profile` | AWS named profile for the Glue catalog. When unset, the AWS SDK default credential chain is used. |
+| `catalog.<name>.sql-driver` | `database/sql` driver name for the SQL catalog (e.g. `sqliteshim`). Maps to the `sql.driver` property. |
+| `catalog.<name>.sql-dialect` | SQL dialect for the SQL catalog (`postgres`, `mysql`, `sqlite`, `mssql`, `oracle`). Maps to the `sql.dialect` property. |
 | `catalog.<name>.rest.sigv4-enabled` | Enable AWS SigV4 signing for REST. |
 | `catalog.<name>.rest.signing-name` | SigV4 service name. |
 | `catalog.<name>.rest.signing-region` | SigV4 region. |

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -48,14 +48,14 @@ catalog:
 |---|---|
 | `default-catalog` | Name used when `--catalog-name` is not passed on the CLI. |
 | `max-workers` | Worker pool size for concurrent operations. Default `5`. |
-| `catalog.<name>.type` | One of `rest`, `hive`, `glue`, `sql`, `hadoop`. |
+| `catalog.<name>.type` | One of `rest`, `hive`, `glue`, `sql`, `hadoop`. `dynamodb` is recognized by the CLI but not implemented yet. |
 | `catalog.<name>.uri` | Catalog endpoint or DSN. |
 | `catalog.<name>.warehouse` | Warehouse identifier (REST/Glue) or location (Hive/SQL). |
 | `catalog.<name>.credential` | Credential string passed through to the catalog's auth handler. |
 | `catalog.<name>.output` | CLI output format (e.g. `text`, `json`). |
 | `catalog.<name>.aws-profile` | AWS named profile for the Glue catalog. When unset, the AWS SDK default credential chain is used. |
-| `catalog.<name>.sql-driver` | `database/sql` driver name for the SQL catalog (e.g. `sqliteshim`). Maps to the `sql.driver` property. |
-| `catalog.<name>.sql-dialect` | SQL dialect for the SQL catalog (`postgres`, `mysql`, `sqlite`, `mssql`, `oracle`). Maps to the `sql.dialect` property. |
+| `catalog.<name>.sql-driver` | `database/sql` driver name for the SQL catalog. Maps to the `sql.driver` property. The default CLI binary only compiles in `sqliteshim`; other drivers require a custom build. |
+| `catalog.<name>.sql-dialect` | SQL dialect for the SQL catalog (`postgres`, `mysql`, `sqlite`, `mssql`, `oracle`). Maps to the `sql.dialect` property. The default CLI binary only ships `sqlite` via `sqliteshim`; other dialects need a custom build with their drivers. |
 | `catalog.<name>.rest.sigv4-enabled` | Enable AWS SigV4 signing for REST. |
 | `catalog.<name>.rest.signing-name` | SigV4 service name. |
 | `catalog.<name>.rest.signing-region` | SigV4 region. |


### PR DESCRIPTION
## Summary
- Wire `--catalog sql` through `catalog.Load` so the CLI uses the registered SQL catalog instead of failing with `unrecognized catalog type`.
- Add `--sql-driver` / `--sql-dialect` flags and matching `sql-driver` / `sql-dialect` config keys.
- Recognize `--catalog dynamodb` with a clear `not implemented` error (type exists; catalog package does not yet).
- Document the new flags/config and cover mixed-case SQL plus DynamoDB validation in CLI tests.

Fixes #1692

## Testing
- `go test ./config/ ./cmd/iceberg/ -count=1`
- `gofmt` clean on touched Go files