### PR TITLE
fix(types): reject decimal scales above precision

### DIFF
--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -60,7 +60,7 @@ func TestArrowToIceberg(t *testing.T) {
 		{&arrow.FixedSizeBinaryType{ByteWidth: 0}, iceberg.FixedTypeOf(0), true, ""},
 		{&arrow.FixedSizeBinaryType{ByteWidth: 23}, iceberg.FixedTypeOf(23), true, ""},
 		{&arrow.Decimal32Type{Precision: 8, Scale: 2}, iceberg.DecimalTypeOf(8, 2), false, ""},
-		{&arrow.Decimal32Type{Precision: 8, Scale: 9}, iceberg.DecimalTypeOf(8, 9), false, ""},
+		{&arrow.Decimal32Type{Precision: 8, Scale: 9}, nil, false, "invalid scale 9: must be less than or equal to precision 8"},
 		{&arrow.Decimal64Type{Precision: 15, Scale: 14}, iceberg.DecimalTypeOf(15, 14), false, ""},
 		{&arrow.Decimal128Type{Precision: 26, Scale: 20}, iceberg.DecimalTypeOf(26, 20), true, ""},
 		{&arrow.Decimal256Type{Precision: 8, Scale: 9}, nil, false, "unsupported arrow type for conversion - decimal256(8, 9)"},

--- a/types.go
+++ b/types.go
@@ -634,6 +634,9 @@ func validateDecimalPrecisionScale(precision, scale int) error {
 	if scale < 0 {
 		return fmt.Errorf("invalid scale %d: must be greater than or equal to 0", scale)
 	}
+	if scale > precision {
+		return fmt.Errorf("invalid scale %d: must be less than or equal to precision %d", scale, precision)
+	}
 
 	return nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -50,7 +50,7 @@ func TestTypesBasic(t *testing.T) {
 		{"fixed[0]", iceberg.FixedTypeOf(0)},
 		{"fixed[5]", iceberg.FixedTypeOf(5)},
 		{"decimal(9, 4)", iceberg.DecimalTypeOf(9, 4)},
-		{"decimal(5, 7)", iceberg.DecimalTypeOf(5, 7)},
+		{"decimal(5, 5)", iceberg.DecimalTypeOf(5, 5)},
 	}
 
 	for _, tt := range tests {
@@ -139,9 +139,12 @@ func TestDecimalType(t *testing.T) {
 		assert.PanicsWithError(t, "invalid argument: invalid precision 39: must be less than or equal to 38", func() {
 			iceberg.DecimalTypeOf(39, 0)
 		})
-		assert.Equal(t, "decimal(10, 11)", iceberg.DecimalTypeOf(10, 11).String())
+		assert.Equal(t, "decimal(10, 10)", iceberg.DecimalTypeOf(10, 10).String())
 		assert.PanicsWithError(t, "invalid argument: invalid scale -1: must be greater than or equal to 0", func() {
 			iceberg.DecimalTypeOf(10, -1)
+		})
+		assert.PanicsWithError(t, "invalid argument: invalid scale 6: must be less than or equal to precision 5", func() {
+			iceberg.DecimalTypeOf(5, 6)
 		})
 	})
 }
@@ -166,6 +169,10 @@ func TestDecimalTypeInvalidParse(t *testing.T) {
 		{
 			name: "precision too large",
 			data: `{"id": 1, "name": "d", "type": "decimal(39,2)", "required": true}`,
+		},
+		{
+			name: "scale greater than precision",
+			data: `{"id": 1, "name": "d", "type": "decimal(5,6)", "required": true}`,
 		},
 	}
 


### PR DESCRIPTION
## Description

validateDecimalPrecisionScale checked positive precision, maximum precision, and non-negative scale, but it did not check that scale is less than or equal to precision. As a result, decimal(5,6) was accepted even though the type is invalid.

Add the missing check. decimal(5,5) remains valid, while decimal(5,6) is rejected by both DecimalTypeOf and JSON decoding.

## Testing

- go test ./... -count=1