### PR TITLE
fix(types): reject malformed fixed type names

### DIFF
--- a/types.go
+++ b/types.go
@@ -33,10 +33,10 @@ import (
 )
 
 var (
-	regexFromBrackets = regexp.MustCompile(`^\w+\[(\d+)\]$`)
-	decimalRegex      = regexp.MustCompile(`^decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
-	geometryRegex     = regexp.MustCompile(`(?i)^geometry\s*(?:\(\s*([^),]+?)\s*\))?$`)
-	geographyRegex    = regexp.MustCompile(`(?i)^geography\s*(?:\(\s*([^\s,)]+)\s*(?:,\s*(\w+)\s*)?\))?$`)
+	fixedRegex     = regexp.MustCompile(`^fixed\[(\d+)\]$`)
+	decimalRegex   = regexp.MustCompile(`^decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
+	geometryRegex  = regexp.MustCompile(`(?i)^geometry\s*(?:\(\s*([^),]+?)\s*\))?$`)
+	geographyRegex = regexp.MustCompile(`(?i)^geography\s*(?:\(\s*([^\s,)]+)\s*(?:,\s*(\w+)\s*)?\))?$`)
 )
 
 type Properties map[string]string
@@ -196,7 +196,7 @@ func (t *typeIFace) UnmarshalJSON(b []byte) error {
 		default:
 			switch {
 			case strings.HasPrefix(typename, "fixed"):
-				matches := regexFromBrackets.FindStringSubmatch(typename)
+				matches := fixedRegex.FindStringSubmatch(typename)
 				if len(matches) != 2 {
 					return fmt.Errorf("%w: %s", ErrInvalidTypeString, typename)
 				}

--- a/types_test.go
+++ b/types_test.go
@@ -96,6 +96,14 @@ func TestFixedTypeInvalidParse(t *testing.T) {
 			data: `{"id": 1, "name": "f", "type": "fixed[0]junk", "required": true}`,
 		},
 		{
+			name: "malformed prefix",
+			data: `{"id": 1, "name": "f", "type": "fixedfoo[16]", "required": true}`,
+		},
+		{
+			name: "malformed short prefix",
+			data: `{"id": 1, "name": "f", "type": "fixedx[5]", "required": true}`,
+		},
+		{
 			name: "overflow",
 			data: `{"id": 1, "name": "f", "type": "fixed[99999999999999999999]", "required": true}`,
 		},


### PR DESCRIPTION
## Description

The fixed type parser used strings.HasPrefix(typename, "fixed") together with a generic bracket regex. This allowed fixedfoo[16] to be decoded as FixedType{16}.

Use a fixed-specific regex so only the fixed[N] spelling is accepted. Add regression coverage for fixedfoo[16] and fixedx[5].

## Testing

- go test ./... -count=1