### PR TITLE
fix(types): require list element type during JSON decoding

### DIFF
--- a/types.go
+++ b/types.go
@@ -481,6 +481,9 @@ func (l *ListType) UnmarshalJSON(b []byte) error {
 	if aux.ID == nil {
 		return fmt.Errorf("%w: field is missing required 'element-id' key in JSON", ErrInvalidSchema)
 	}
+	if aux.Elem.Type == nil {
+		return fmt.Errorf("%w: field is missing required 'element' key in JSON", ErrInvalidSchema)
+	}
 
 	l.ElementID = *aux.ID
 	l.Element = aux.Elem.Type

--- a/types_test.go
+++ b/types_test.go
@@ -235,6 +235,14 @@ func TestListType(t *testing.T) {
 	assert.True(t, typ.Equals(&actual))
 }
 
+func TestListTypeUnmarshalRequiresElement(t *testing.T) {
+	var typ iceberg.ListType
+	err := json.Unmarshal([]byte(`{"element-id": 1, "element-required": false}`), &typ)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'element' key")
+}
+
 func TestMapType(t *testing.T) {
 	typ := &iceberg.MapType{
 		KeyID:         1,


### PR DESCRIPTION
## Description

ListType.UnmarshalJSON checked element-id but did not require the element type. Missing element data therefore left Element nil and allowed malformed list metadata to be constructed.

Return ErrInvalidSchema at the JSON boundary when the required element field is missing.

## Testing

- go test ./... -count=1