### PR TITLE
fix(types): require map key type during JSON decoding

### DIFF
--- a/types.go
+++ b/types.go
@@ -567,6 +567,9 @@ func (m *MapType) UnmarshalJSON(b []byte) error {
 	if aux.KeyID == nil {
 		return fmt.Errorf("%w: field is missing required 'key-id' key in JSON", ErrInvalidSchema)
 	}
+	if aux.Key.Type == nil {
+		return fmt.Errorf("%w: field is missing required 'key' key in JSON", ErrInvalidSchema)
+	}
 
 	if aux.ValueID == nil {
 		return fmt.Errorf("%w: field is missing required 'value-id' key in JSON", ErrInvalidSchema)

--- a/types_test.go
+++ b/types_test.go
@@ -265,6 +265,14 @@ func TestMapType(t *testing.T) {
 	assert.True(t, typ.Equals(&actual))
 }
 
+func TestMapTypeUnmarshalRequiresKey(t *testing.T) {
+	var typ iceberg.MapType
+	err := json.Unmarshal([]byte(`{"key-id": 1, "value-id": 2, "value": "string"}`), &typ)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'key' key")
+}
+
 var NonParameterizedTypes = []iceberg.Type{
 	iceberg.PrimitiveTypes.Bool,
 	iceberg.PrimitiveTypes.Int32,


### PR DESCRIPTION
## Description

MapType.UnmarshalJSON checked key-id but did not require the key type. Missing key data therefore left KeyType nil and allowed malformed map metadata to be constructed.

Return ErrInvalidSchema at the JSON boundary when the required key field is missing.

## Testing

- go test ./... -count=1