### PR TITLE
fix(types): require map value type during JSON decoding

### DIFF
--- a/types.go
+++ b/types.go
@@ -577,6 +577,9 @@ func (m *MapType) UnmarshalJSON(b []byte) error {
 	if aux.ValueID == nil {
 		return fmt.Errorf("%w: field is missing required 'value-id' key in JSON", ErrInvalidSchema)
 	}
+	if aux.Value.Type == nil {
+		return fmt.Errorf("%w: field is missing required 'value' key in JSON", ErrInvalidSchema)
+	}
 
 	m.KeyID, m.KeyType = *aux.KeyID, aux.Key.Type
 	m.ValueID, m.ValueType = *aux.ValueID, aux.Value.Type

--- a/types_test.go
+++ b/types_test.go
@@ -296,6 +296,14 @@ func TestMapTypeUnmarshalRequiresKey(t *testing.T) {
 	assert.ErrorContains(t, err, "missing required 'key' key")
 }
 
+func TestMapTypeUnmarshalRequiresValue(t *testing.T) {
+	var typ iceberg.MapType
+	err := json.Unmarshal([]byte(`{"key-id": 1, "key": "string", "value-id": 2}`), &typ)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'value' key")
+}
+
 var NonParameterizedTypes = []iceberg.Type{
 	iceberg.PrimitiveTypes.Bool,
 	iceberg.PrimitiveTypes.Int32,


### PR DESCRIPTION
## Description

MapType.UnmarshalJSON checked value-id but did not require the value type. Missing value data therefore left ValueType nil and allowed malformed map metadata to be constructed.

Return ErrInvalidSchema at the JSON boundary when the required value field is missing.

## Testing

- go test ./... -count=1