### PR TITLE
fix(literals): correct below-min marshal error

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -321,7 +321,7 @@ type belowMinLiteral[T int32 | int64 | float32 | float64] struct {
 }
 
 func (bm belowMinLiteral[T]) MarshalBinary() (data []byte, err error) {
-	return nil, fmt.Errorf("%w: cannot marshal above max literal",
+	return nil, fmt.Errorf("%w: cannot marshal below min literal",
 		ErrInvalidBinSerialization)
 }
 

--- a/literals_test.go
+++ b/literals_test.go
@@ -347,6 +347,12 @@ func TestInt64ToInt32OutsideBound(t *testing.T) {
 	assert.Equal(t, iceberg.PrimitiveTypes.Int32, belowMin.Type())
 }
 
+func TestBelowMinLiteralMarshalBinary(t *testing.T) {
+	_, err := iceberg.Int32BelowMinLiteral().MarshalBinary()
+	require.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)
+	assert.EqualError(t, err, "invalid binary serialization: cannot marshal below min literal")
+}
+
 func TestFloatConversions(t *testing.T) {
 	n1, _ := decimal128.FromFloat32(34.56, 9, 1)
 	n2, _ := decimal128.FromFloat32(34.56, 9, 2)


### PR DESCRIPTION
## Description

BelowMinLiteral.MarshalBinary returned an error saying "cannot marshal above max literal". This is a copy-paste typo and makes the error misleading.

Correct the message to say "cannot marshal below min literal" and add regression coverage for Int32BelowMinLiteral.

## Testing

- go test ./... -count=1