### PR TITLE
fix(hive): tighten the lock-jitter docs and tests from post-merge review

### DIFF
--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -178,7 +178,18 @@ func calculateBackoff(attempt int, minWait, maxWait time.Duration) time.Duration
 //     downward instead, floored at the last interval the sequence produced before
 //     it saturated — a bound the schedule has already cleared, which stops a later
 //     attempt from being allowed to wait less than an earlier one;
-//   - the result never exceeds maxWait and never falls below minWait.
+//   - the result never exceeds maxWait, and never falls below minWait when
+//     minWait <= maxWait. When minWait > maxWait the configuration is
+//     self-contradictory, calculateBackoff resolves it to maxWait, and this
+//     returns exactly maxWait — below the configured minimum, because there is no
+//     value that honours both bounds.
+//
+// The spread below the cap is wider than the Java implementation's. Java's
+// Tasks.exponentialBackoff jitters by roughly 10% of the current delay, whereas
+// this draws from [d, 2d]. The wider window is deliberate — it decorrelates a
+// contended fleet faster — but it does mean Go and Java clients polling the same
+// metastore spread differently, so do not assume the two are interchangeable when
+// reasoning about load.
 func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 	if d <= 0 {
 		return d
@@ -200,9 +211,22 @@ func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 		return d + time.Duration(rand.Int64N(int64(extra)+1))
 	}
 
+	// Everything below this point is unreachable under the default configuration.
+	// lock-check-min-wait-time=100ms, lock-check-max-wait-time=1m and
+	// lock-check-retries=4 top the sequence out at 800ms, so it never saturates and
+	// the branch above always wins. Getting here needs a lowered maximum or a raised
+	// retry count. Stated plainly because this is the most intricate part of the
+	// helper and the least exercised in practice.
+	//
 	// Replay the doubling sequence and keep the largest interval that still fitted
 	// under the cap. The guard on scheduled keeps a non-positive or overflowing
 	// minWait from spinning here.
+	//
+	// The replay is what a flat max(minWait, d/2) floor cannot do, and the gap is
+	// not hypothetical: at minWait=300ms, maxWait=1s the sequence runs 300ms, 600ms,
+	// then saturates. The last uncapped interval is 600ms, but d/2 is 500ms, so a
+	// flat floor would let the first capped attempt wait less than the one before it.
+	// The divergence appears whenever the ratio is not a clean power of two.
 	//
 	// minWait is applied before the replay rather than relying on it. When minWait
 	// is itself >= maxWait the loop cannot run at all, and options.go accepts that

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -431,11 +431,14 @@ func TestApplyJitterAtCapStaysWithinBoundsAndVaries(t *testing.T) {
 	minWait := 100 * time.Millisecond
 	maxWait := time.Second
 
+	// 800ms is the last interval the sequence produced before saturating, which is
+	// the floor the code actually guarantees. Asserting maxWait/2 here would pass a
+	// regression that let the spread dip to 600ms.
 	seen := make(map[time.Duration]struct{})
 	for i := 0; i < 500; i++ {
 		got := applyJitter(maxWait, minWait, maxWait)
-		assert.GreaterOrEqual(t, got, maxWait/2,
-			"the spread at the cap must not exceed one half interval")
+		assert.GreaterOrEqual(t, got, 800*time.Millisecond,
+			"the spread at the cap must be at least the last uncapped interval")
 		assert.LessOrEqual(t, got, maxWait,
 			"the wait must never exceed the configured maximum")
 		seen[got] = struct{}{}
@@ -508,6 +511,29 @@ func TestApplyJitterAtCapFloorsAtTheLastUncappedInterval(t *testing.T) {
 	}
 }
 
+// The case above uses a clean power-of-two ratio, where d/2 and the last uncapped
+// interval happen to be close. This one separates them: at 300ms/1s the sequence
+// runs 300ms, 600ms, then saturates, so the floor must be 600ms while d/2 is only
+// 500ms. It is the case that distinguishes the replay from a flat max(minWait, d/2)
+// floor, and the only place the arithmetic could quietly go wrong.
+func TestApplyJitterAtCapFloorsCorrectlyForNonPowerOfTwoRatios(t *testing.T) {
+	minWait := 300 * time.Millisecond
+	maxWait := time.Second
+
+	require.Equal(t, 600*time.Millisecond, calculateBackoff(1, minWait, maxWait),
+		"the last interval before the cap")
+	require.Equal(t, maxWait, calculateBackoff(2, minWait, maxWait),
+		"the first interval at the cap")
+
+	for i := 0; i < 2000; i++ {
+		got := applyJitter(maxWait, minWait, maxWait)
+		assert.GreaterOrEqual(t, got, 600*time.Millisecond,
+			"a flat d/2 floor would allow 500ms here, below what the previous attempt guaranteed")
+		assert.LessOrEqual(t, got, maxWait,
+			"the wait must never exceed the configured maximum")
+	}
+}
+
 // A caller may configure minWait above maxWait; options.go accepts it, and
 // calculateBackoff resolves it by returning maxWait. The downward spread must not
 // then draw below the configured minimum. Flooring at half the interval would
@@ -533,7 +559,7 @@ func TestApplyJitterHonoursMinWaitAboveMaxWait(t *testing.T) {
 // the lower bound is asserted tightly; the ceiling is loose because a busy CI box
 // can add arbitrary scheduling delay on top, and a flaky timing test is worse than
 // no timing test.
-func TestAcquireLocksAggregateRetryDelayStaysWithinBound(t *testing.T) {
+func TestAcquireLocksRunsTheFullRetrySchedule(t *testing.T) {
 	mockClient := new(mockHiveClient)
 	ctx := context.Background()
 	opts := NewHiveOptions()
@@ -553,20 +579,18 @@ func TestAcquireLocksAggregateRetryDelayStaysWithinBound(t *testing.T) {
 		}, nil)
 	mockClient.On("Unlock", mock.Anything, int64(901)).Return(nil)
 
-	start := time.Now()
 	lock, err := acquireLocks(ctx, mockClient,
 		[]tableLockIdentifier{{database: "testdb", table: "testtable"}}, opts)
-	elapsed := time.Since(start)
 
 	require.Error(t, err)
 	require.Nil(t, lock)
 	assert.ErrorIs(t, err, ErrLockAcquisitionFailed)
 
-	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond,
-		"the jittered waits must never sum to less than the unjittered schedule")
-	assert.Less(t, elapsed, 5*time.Second,
-		"the jittered waits must stay bounded by roughly twice the schedule")
-
+	// Counting calls rather than measuring elapsed time. The additive
+	// never-shorter property is already covered by
+	// TestApplyJitterBelowCapNeverShorterThanInput without touching the clock, and a
+	// wall-clock bound is the kind of assertion that flakes on a loaded CI runner.
+	mockClient.AssertNumberOfCalls(t, "CheckLock", opts.LockRetries)
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Follow-up to #1640, addressing the review @laskoviymishka left alongside the approval. Docs and tests only — no behaviour change.

## The open question: is the downward-spread branch worth its complexity?

Keeping it, and the reason is now a test rather than an argument.

The concern was fair: under the defaults (`100ms` / `1m` / `4 retries`) the sequence tops out at 800ms and never saturates, so that branch is unreachable in a normal deployment, and it is the most intricate part of the helper. The previously pinned case (`100ms`/`1s`) also could not distinguish it from a flat floor, because a clean power-of-two ratio puts `d/2` and the last uncapped interval close together.

A non-power-of-two ratio separates them. At `minWait=300ms`, `maxWait=1s` the sequence runs 300ms, 600ms, then saturates:

- last uncapped interval = **600ms**
- `d/2` = **500ms**

So `max(minWait, d/2)` would let the first capped attempt draw as low as 500ms, below what the attempt *before* it already guaranteed. That is the inversion the replay exists to prevent. `TestApplyJitterAtCapFloorsCorrectlyForNonPowerOfTwoRatios` pins it; deleting the replay loop makes it fail with draws around 560–590ms against the 600ms floor.

The branch is still unreachable on defaults, so that is now stated plainly at the top of it instead of being left for the next reader to derive.

## Doc corrections

**The invariant list was wrong.** It claimed the result never falls below `minWait`. That does not hold when `minWait > maxWait` — `calculateBackoff` resolves that configuration to `maxWait` and `applyJitter` returns exactly `maxWait`, which is below the configured minimum. `TestApplyJitterHonoursMinWaitAboveMaxWait` already pinned that behaviour, so the comment contradicted the test. Now qualified: never below `minWait` when `minWait <= maxWait`, otherwise exactly `maxWait`, because no value honours both bounds.

**Divergence from Java is now recorded.** `Tasks.exponentialBackoff` jitters by roughly 10% of the current delay; this draws from `[d, 2d]`. The wider window is deliberate, but it means Go and Java clients polling the same metastore spread differently, and that should not be discovered by surprise.

## Test corrections

- `TestApplyJitterAtCapStaysWithinBoundsAndVaries` asserted `>= maxWait/2` (500ms) when the guaranteed floor is 800ms, so a regression letting the spread dip to 600–700ms would have passed. Tightened to 800ms so it agrees with the pinned test. Its message was also upper-bound wording on a `GreaterOrEqual` check, which would have made a failure dump confusing.
- `TestAcquireLocksAggregateRetryDelayStaysWithinBound` asserted real elapsed wall-clock time. It slept on every run and the lower bound could flake on a loaded runner. It is now `TestAcquireLocksRunsTheFullRetrySchedule` and counts `CheckLock` calls instead — the additive never-shorter property is already covered by `TestApplyJitterBelowCapNeverShorterThanInput` without touching the clock.

## Not included

The two Java-compat gaps — backoff scale 2.0 vs Java's 1.5, and the lock-check config keys not matching Java's names and defaults — are behaviour changes rather than documentation, so they are filed separately rather than folded in here.

## Testing

`gofmt` and `go vet` clean. `go test ./catalog/hive/ -count=3` passes. The new non-power-of-two test was checked against the change it guards: with the replay loop removed it fails, and it passes with it restored.
