### PR TITLE
fix(catalog): normalize registered catalog types

### DIFF
--- a/catalog/registry.go
+++ b/catalog/registry.go
@@ -81,12 +81,12 @@ func Register(catalogType string, reg Registrar) {
 	if reg == nil {
 		panic("catalog: RegisterCatalog catalog factory is nil")
 	}
-	defaultRegistry.set(catalogType, reg)
+	defaultRegistry.set(strings.ToLower(catalogType), reg)
 }
 
 // Unregister removes the requested catalog factory from the registry.
 func Unregister(catalogType string) {
-	defaultRegistry.remove(catalogType)
+	defaultRegistry.remove(strings.ToLower(catalogType))
 }
 
 // GetRegisteredCatalogs returns the list of registered catalog names that can

--- a/catalog/registry_test.go
+++ b/catalog/registry_test.go
@@ -115,6 +115,22 @@ func TestCatalogRegistry(t *testing.T) {
 	}, catalog.GetRegisteredCatalogs())
 }
 
+func TestCatalogRegistryNormalizesType(t *testing.T) {
+	ctx := context.Background()
+	catalog.Register("MyCatalog", catalog.RegistrarFunc(func(context.Context, string, iceberg.Properties) (catalog.Catalog, error) {
+		return nil, nil
+	}))
+	t.Cleanup(func() { catalog.Unregister("MyCatalog") })
+
+	c, err := catalog.Load(ctx, "test", iceberg.Properties{"type": "MYCATALOG"})
+	assert.NoError(t, err)
+	assert.Nil(t, c)
+
+	catalog.Unregister("MYCATALOG")
+	_, err = catalog.Load(ctx, "test", iceberg.Properties{"type": "mycatalog"})
+	assert.ErrorIs(t, err, catalog.ErrCatalogNotFound)
+}
+
 func TestRegistryPanic(t *testing.T) {
 	assert.PanicsWithValue(t, "catalog: RegisterCatalog catalog factory is nil", func() { catalog.Register("foobar", nil) })
 }

--- a/catalog/registry_test.go
+++ b/catalog/registry_test.go
@@ -121,6 +121,8 @@ func TestCatalogRegistryNormalizesType(t *testing.T) {
 		return nil, nil
 	}))
 	t.Cleanup(func() { catalog.Unregister("MyCatalog") })
+	assert.Contains(t, catalog.GetRegisteredCatalogs(), "mycatalog")
+	assert.NotContains(t, catalog.GetRegisteredCatalogs(), "MyCatalog")
 
 	c, err := catalog.Load(ctx, "test", iceberg.Properties{"type": "MYCATALOG"})
 	assert.NoError(t, err)


### PR DESCRIPTION
## What changed

- Normalize catalog type names when registering and unregistering custom catalogs.
- Keep registry keys aligned with the case-insensitive lookup in Load.

## Why

Load already lowercases the requested type. A registration such as MyCatalog was stored with mixed-case keys, so it could not be loaded by type.

## Tests

- `go test ./catalog -count=1`
- `go test ./... -count=1`