### PR TITLE
fix(catalog): reject trailing junk in metadata filenames

### DIFF
--- a/catalog/internal/metadata_filename_test.go
+++ b/catalog/internal/metadata_filename_test.go
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMetadataVersionRejectsTrailingJunk(t *testing.T) {
+	for _, name := range []string{
+		"00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json.tmp",
+		"00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json.garbage",
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, -1, ParseMetadataVersion(name))
+		})
+	}
+}

--- a/catalog/internal/metadata_filename_test.go
+++ b/catalog/internal/metadata_filename_test.go
@@ -27,6 +27,7 @@ func TestParseMetadataVersionRejectsTrailingJunk(t *testing.T) {
 	for _, name := range []string{
 		"00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json.tmp",
 		"00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json.garbage",
+		"00001-a1b2c3d4-e5f6-7890-abcd-ef1234567890.metadata.json/",
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.Equal(t, -1, ParseMetadataVersion(name))

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -229,7 +229,7 @@ func getDefaultWarehouseLocation(namespaceKey, tablename string, nsprops, catpro
 // ([\w-]{36})      -> UUID (36 characters, including hyphens)
 // (?:\.\w+)?       -> optional codec name
 // \.metadata\.json -> file extension
-var tableMetadataFileNameRegex = regexp.MustCompile(`^(\d+)-([\w-]{36})(?:\.\w+)?\.metadata\.json`)
+var tableMetadataFileNameRegex = regexp.MustCompile(`^(\d+)-([\w-]{36})(?:\.\w+)?\.metadata\.json$`)
 
 func ParseMetadataVersion(location string) int {
 	fileName := path.Base(location)

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -228,10 +228,14 @@ func getDefaultWarehouseLocation(namespaceKey, tablename string, nsprops, catpro
 // -                -> separator
 // ([\w-]{36})      -> UUID (36 characters, including hyphens)
 // (?:\.\w+)?       -> optional codec name
-// \.metadata\.json -> file extension
+// \.metadata\.json -> file extension at the end of the filename
 var tableMetadataFileNameRegex = regexp.MustCompile(`^(\d+)-([\w-]{36})(?:\.\w+)?\.metadata\.json$`)
 
 func ParseMetadataVersion(location string) int {
+	if strings.HasSuffix(location, "/") {
+		return -1
+	}
+
 	fileName := path.Base(location)
 	matches := tableMetadataFileNameRegex.FindStringSubmatch(fileName)
 


### PR DESCRIPTION
## What changed

- Anchor the modern table metadata filename regex at the end.
- Make ParseMetadataVersion ignore trailing suffixes and trailing path separators.

## Why

The old regex matched valid prefixes. A path ending in .metadata.json.tmp could be mistaken for a metadata file when choosing the next version.

The follow-up in #1719 rejects invalid current locations before staging and keeps legacy vN names working.

## Tests

- `go test ./catalog/internal -count=1`
- `go test ./... -count=1`