### PR TITLE
fix(hive): reject metastore URIs without a host

### DIFF
--- a/catalog/hive/client.go
+++ b/catalog/hive/client.go
@@ -58,6 +58,9 @@ func newHiveClient(uri string, opts *HiveOptions) (HiveClient, error) {
 	}
 
 	host := parsed.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("invalid URI: host is required")
+	}
 	portStr := parsed.Port()
 	if portStr == "" {
 		portStr = "9083"

--- a/catalog/hive/client.go
+++ b/catalog/hive/client.go
@@ -19,6 +19,7 @@ package hive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -59,7 +60,7 @@ func newHiveClient(uri string, opts *HiveOptions) (HiveClient, error) {
 
 	host := parsed.Hostname()
 	if host == "" {
-		return nil, fmt.Errorf("invalid URI: host is required")
+		return nil, errors.New("invalid URI: host is required")
 	}
 	portStr := parsed.Port()
 	if portStr == "" {

--- a/catalog/hive/client_host_test.go
+++ b/catalog/hive/client_host_test.go
@@ -3,7 +3,8 @@
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
-// "License"); you may obtain a copy of the License at
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/catalog/hive/client_test.go
+++ b/catalog/hive/client_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestNewHiveClientRejectsMissingHost(t *testing.T) {
-	for _, uri := range []string{"thrift://:9083", "localhost:9083"} {
+	for _, uri := range []string{"thrift://", "thrift://:9083", "localhost:9083"} {
 		t.Run(uri, func(t *testing.T) {
 			client, err := newHiveClient(uri, nil)
 			require.Error(t, err)
 			require.Nil(t, client)
-			require.Contains(t, err.Error(), "host is required")
+			require.ErrorContains(t, err, "host is required")
 		})
 	}
 }

--- a/catalog/hive/client_test.go
+++ b/catalog/hive/client_test.go
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHiveClientRejectsMissingHost(t *testing.T) {
+	for _, uri := range []string{"thrift://:9083", "localhost:9083"} {
+		t.Run(uri, func(t *testing.T) {
+			client, err := newHiveClient(uri, nil)
+			require.Error(t, err)
+			require.Nil(t, client)
+			require.Contains(t, err.Error(), "host is required")
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Require a hostname before creating a Hive metastore client.
- Reject authority-less URIs and URIs with an empty host.
- Keep the default port at 9083 when the URI has no port.

## Why

url.Parse accepts values such as thrift://:9083 and localhost:9083 without providing a host for the metastore connection. These values now fail before the client is created.

## Tests

- `go test ./catalog/hive -count=1`
- `go test ./... -count=1`