### PR TITLE
fix(table): compare sort order IDs by value

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -637,9 +637,10 @@ func (b *MetadataBuilder) AddSortOrder(sortOrder *SortOrder) error {
 
 	newOrderID := b.reuseOrCreateNewSortOrderID(sortOrder)
 	if _, err := b.GetSortOrderByID(newOrderID); err == nil {
-		if b.lastAddedSortOrderID != &newOrderID {
+		sortOrder.orderID = newOrderID
+
+		if b.lastAddedSortOrderID == nil || *b.lastAddedSortOrderID != newOrderID {
 			b.lastAddedSortOrderID = &newOrderID
-			sortOrder.orderID = newOrderID
 			b.updates = append(b.updates, NewAddSortOrderUpdate(sortOrder))
 		}
 

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -446,6 +446,20 @@ func TestSetSortOrder(t *testing.T) {
 	require.True(t, builder.updates[0].(*addSortOrderUpdate).SortOrder.Equals(expected), "expected sort order to match added sort order")
 }
 
+func TestAddSortOrderDoesNotAddDuplicateUpdate(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	first := sortOrder()
+	first.orderID = 10
+	second := sortOrder()
+	second.orderID = 20
+
+	require.NoError(t, builder.AddSortOrder(&first))
+	require.NoError(t, builder.AddSortOrder(&second))
+	require.Len(t, builder.updates, 1)
+	require.Equal(t, 1, first.OrderID())
+	require.Equal(t, 1, second.OrderID())
+}
+
 func TestSetRef(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	schemaID := 0


### PR DESCRIPTION
## What

`MetadataBuilder.AddSortOrder` compared `lastAddedSortOrderID` with the address of a fresh local variable. Re-adding an equivalent sort order could therefore append duplicate add-sort-order updates. This compares the stored ID by value instead.

## Testing

- `go test ./table -count=1`
