### PR TITLE
fix(literals): return independent bool marshal bytes

### DIFF
--- a/literals.go
+++ b/literals.go
@@ -424,15 +424,13 @@ func (b BoolLiteral) Equals(l Literal) bool {
 	return literalEq(b, l)
 }
 
-var falseBin, trueBin = [1]byte{0x0}, [1]byte{0x1}
-
 func (b BoolLiteral) MarshalBinary() (data []byte, err error) {
 	// stored as 0x00 for false, and anything non-zero for True
 	if b {
-		return trueBin[:], nil
+		return []byte{0x1}, nil
 	}
 
-	return falseBin[:], nil
+	return []byte{0x0}, nil
 }
 
 func (b *BoolLiteral) UnmarshalBinary(data []byte) error {

--- a/literals_test.go
+++ b/literals_test.go
@@ -939,6 +939,31 @@ func TestBoolLiteralComparator(t *testing.T) {
 	}
 }
 
+func TestBoolLiteralMarshalBinaryReturnsIndependentBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		value iceberg.BoolLiteral
+		want  byte
+	}{
+		{name: "false", value: iceberg.BoolLiteral(false), want: 0x0},
+		{name: "true", value: iceberg.BoolLiteral(true), want: 0x1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.value.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, []byte{tt.want}, data)
+
+			data[0] ^= 0x1
+
+			again, err := tt.value.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, []byte{tt.want}, again)
+		})
+	}
+}
+
 func TestInvalidNumericConversions(t *testing.T) {
 	testInvalidLiteralConversions(t, iceberg.NewLiteral(int32(34)), []iceberg.Type{
 		iceberg.PrimitiveTypes.Bool,


### PR DESCRIPTION
## Summary

BoolLiteral.MarshalBinary currently returns a slice backed by a package-level buffer. Since the returned []byte is mutable, changing it also changes the result of later calls.

Return a new one-byte slice for each call instead. The regression test covers both true and false, mutates the first result, and checks that later calls still return the correct value.

## Testing

- go test . -run TestBoolLiteralMarshalBinaryReturnsIndependentBytes -count=1
- go list ./... | rg -v io/gocloud | xargs go test -count=1
- go test ./io/gocloud -run ^$ -count=1