### PR TITLE
fix(table): preserve unknown snapshot operation values

### DIFF
--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -233,9 +233,10 @@ func (s *Summary) UnmarshalJSON(b []byte) (err error) {
 		return nil
 	}
 
-	if s.Operation, err = ValidOperation(op); err != nil {
-		return err
+	if op == "" {
+		return fmt.Errorf("%w: found empty operation", ErrInvalidOperation)
 	}
+	s.Operation = Operation(op)
 
 	delete(alias, operationKey)
 	s.Properties = alias

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -109,11 +109,21 @@ func TestEmptySummary(t *testing.T) {
 	assert.Empty(t, summary.Properties)
 }
 
-func TestInvalidOperation(t *testing.T) {
+func TestUnknownOperationIsPreserved(t *testing.T) {
 	var summary table.Summary
-	err := json.Unmarshal([]byte(`{"operation": "foobar"}`), &summary)
+	require.NoError(t, json.Unmarshal([]byte(`{"operation":"merge","foo":"bar"}`), &summary))
+	assert.Equal(t, table.Operation("merge"), summary.Operation)
+	assert.Equal(t, iceberg.Properties{"foo": "bar"}, summary.Properties)
+
+	encoded, err := json.Marshal(&summary)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"operation":"merge","foo":"bar"}`, string(encoded))
+}
+
+func TestEmptyOperationIsInvalid(t *testing.T) {
+	var summary table.Summary
+	err := json.Unmarshal([]byte(`{"operation":""}`), &summary)
 	assert.ErrorIs(t, err, table.ErrInvalidOperation)
-	assert.ErrorContains(t, err, "found 'foobar'")
 }
 
 func TestSummaryEqualsHandlesNil(t *testing.T) {

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -126,6 +126,12 @@ func TestEmptyOperationIsInvalid(t *testing.T) {
 	assert.ErrorIs(t, err, table.ErrInvalidOperation)
 }
 
+func TestNullOperationIsInvalid(t *testing.T) {
+	var summary table.Summary
+	err := json.Unmarshal([]byte(`{"operation":null}`), &summary)
+	assert.ErrorIs(t, err, table.ErrInvalidOperation)
+}
+
 func TestSummaryEqualsHandlesNil(t *testing.T) {
 	var nilSummary *table.Summary
 	summary := &table.Summary{Operation: table.OpAppend}


### PR DESCRIPTION
## What

Preserve unknown non-empty `summary.operation` values when reading snapshots. This keeps readers forward-compatible with newer operation values.

Explicitly empty operation values are still rejected, and known operation validation for write/update paths is unchanged.

## Tests

- `go test ./table -count=1`
- `go test ./...`