### PR TITLE
fix(table): preserve embedded v1 snapshot manifests

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2064,7 +2064,10 @@ func cloneSnapshotRef(ref SnapshotRef) SnapshotRef {
 
 func cloneSnapshot(snapshot Snapshot) Snapshot {
 	clone := snapshot
-	clone.ManifestLocations = slices.Clone(snapshot.ManifestLocations)
+	if snapshot.ManifestLocations != nil {
+		clone.ManifestLocations = make([]string, len(snapshot.ManifestLocations))
+		copy(clone.ManifestLocations, snapshot.ManifestLocations)
+	}
 	if snapshot.ParentSnapshotID != nil {
 		value := *snapshot.ParentSnapshotID
 		clone.ParentSnapshotID = &value

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2064,6 +2064,7 @@ func cloneSnapshotRef(ref SnapshotRef) SnapshotRef {
 
 func cloneSnapshot(snapshot Snapshot) Snapshot {
 	clone := snapshot
+	clone.ManifestLocations = slices.Clone(snapshot.ManifestLocations)
 	if snapshot.ParentSnapshotID != nil {
 		value := *snapshot.ParentSnapshotID
 		clone.ParentSnapshotID = &value

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -300,8 +300,8 @@ func (s Snapshot) MarshalJSON() ([]byte, error) {
 	}
 
 	// A non-nil slice represents the V1 embedded-manifest form, including an
-	// explicitly empty manifests array. V1 snapshots do not serialize a
-	// sequence number.
+	// explicitly empty manifests array. Match Java by omitting the default
+	// sequence number while preserving any positive value accepted on read.
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return nil, err
@@ -311,7 +311,9 @@ func (s Snapshot) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	fields["manifests"] = locations
-	delete(fields, "sequence-number")
+	if s.SequenceNumber <= 0 {
+		delete(fields, "sequence-number")
+	}
 
 	return json.Marshal(fields)
 }

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -268,6 +268,18 @@ type Snapshot struct {
 	AddedRows         *int64   `json:"added-rows,omitempty"`   // V3: Number of rows added by this snapshot
 }
 
+func (s *Snapshot) UnmarshalJSON(data []byte) error {
+	type Alias Snapshot
+	var next Alias
+	if err := json.Unmarshal(data, &next); err != nil {
+		return err
+	}
+
+	*s = Snapshot(next)
+
+	return nil
+}
+
 func (s Snapshot) MarshalJSON() ([]byte, error) {
 	type Alias Snapshot
 	if s.ManifestList != "" {

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -276,7 +276,29 @@ func (s Snapshot) MarshalJSON() ([]byte, error) {
 		s.ManifestLocations = nil
 	}
 
-	return json.Marshal((*Alias)(&s))
+	data, err := json.Marshal((*Alias)(&s))
+	if err != nil {
+		return nil, err
+	}
+	if s.ManifestLocations == nil {
+		return data, nil
+	}
+
+	// A non-nil slice represents the V1 embedded-manifest form, including an
+	// explicitly empty manifests array. V1 snapshots do not serialize a
+	// sequence number.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	locations, err := json.Marshal(s.ManifestLocations)
+	if err != nil {
+		return nil, err
+	}
+	fields["manifests"] = locations
+	delete(fields, "sequence-number")
+
+	return json.Marshal(fields)
 }
 
 func (s Snapshot) String() string {
@@ -297,6 +319,9 @@ func (s Snapshot) String() string {
 }
 
 func (s Snapshot) Equals(other Snapshot) bool {
+	manifestLocationsEqual := (s.ManifestLocations == nil) == (other.ManifestLocations == nil) &&
+		slices.Equal(s.ManifestLocations, other.ManifestLocations)
+
 	switch {
 	case s.ParentSnapshotID == nil && other.ParentSnapshotID != nil:
 		fallthrough
@@ -324,7 +349,7 @@ func (s Snapshot) Equals(other Snapshot) bool {
 		s.SequenceNumber == other.SequenceNumber &&
 		s.TimestampMs == other.TimestampMs &&
 		s.ManifestList == other.ManifestList &&
-		slices.Equal(s.ManifestLocations, other.ManifestLocations) &&
+		manifestLocationsEqual &&
 		s.Summary.Equals(other.Summary)
 }
 
@@ -352,10 +377,15 @@ func (s Snapshot) Manifests(fio iceio.IO) (_ []iceberg.ManifestFile, err error) 
 
 		return iceberg.ReadManifestList(f)
 	}
-	if len(s.ManifestLocations) > 0 {
+	if s.ManifestLocations != nil {
 		manifests := make([]iceberg.ManifestFile, len(s.ManifestLocations))
 		for i, path := range s.ManifestLocations {
-			manifests[i] = iceberg.NewManifestFile(1, path, -1, 0, s.SnapshotID).
+			length, err := embeddedManifestLength(fio, path)
+			if err != nil {
+				return nil, err
+			}
+
+			manifests[i] = iceberg.NewManifestFile(1, path, length, 0, s.SnapshotID).
 				AddedFiles(-1).
 				ExistingFiles(-1).
 				DeletedFiles(-1).
@@ -369,6 +399,34 @@ func (s Snapshot) Manifests(fio iceio.IO) (_ []iceberg.ManifestFile, err error) 
 	}
 
 	return nil, nil
+}
+
+func embeddedManifestLength(fio iceio.IO, path string) (_ int64, err error) {
+	if fio == nil {
+		return 0, fmt.Errorf("cannot stat embedded manifest %q without IO", path)
+	}
+
+	if statIO, ok := fio.(iceio.StatIO); ok {
+		info, err := statIO.Stat(path)
+		if err != nil {
+			return 0, fmt.Errorf("could not stat embedded manifest %q: %w", path, err)
+		}
+
+		return info.Size(), nil
+	}
+
+	f, err := fio.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("could not open embedded manifest %q: %w", path, err)
+	}
+	defer internal.CheckedClose(f, &err)
+
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("could not stat embedded manifest %q: %w", path, err)
+	}
+
+	return info.Size(), nil
 }
 
 func (s Snapshot) dataFiles(fio iceio.IO, fileFilter set[iceberg.ManifestEntryContent]) iter.Seq2[iceberg.DataFile, error] {

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -274,6 +274,9 @@ func (s *Snapshot) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &next); err != nil {
 		return err
 	}
+	if next.ManifestList != "" {
+		next.ManifestLocations = nil
+	}
 
 	*s = Snapshot(next)
 

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -256,15 +256,27 @@ func (s *Summary) MarshalJSON() ([]byte, error) {
 }
 
 type Snapshot struct {
-	SnapshotID       int64    `json:"snapshot-id"`
-	ParentSnapshotID *int64   `json:"parent-snapshot-id,omitempty"`
-	SequenceNumber   int64    `json:"sequence-number"`
-	TimestampMs      int64    `json:"timestamp-ms"`
-	ManifestList     string   `json:"manifest-list,omitempty"`
-	Summary          *Summary `json:"summary,omitempty"`
-	SchemaID         *int     `json:"schema-id,omitempty"`
-	FirstRowID       *int64   `json:"first-row-id,omitempty"` // V3: Starting row ID for this snapshot
-	AddedRows        *int64   `json:"added-rows,omitempty"`   // V3: Number of rows added by this snapshot
+	SnapshotID        int64    `json:"snapshot-id"`
+	ParentSnapshotID  *int64   `json:"parent-snapshot-id,omitempty"`
+	SequenceNumber    int64    `json:"sequence-number"`
+	TimestampMs       int64    `json:"timestamp-ms"`
+	ManifestList      string   `json:"manifest-list,omitempty"`
+	ManifestLocations []string `json:"manifests,omitempty"` // V1: Embedded manifest locations
+	Summary           *Summary `json:"summary,omitempty"`
+	SchemaID          *int     `json:"schema-id,omitempty"`
+	FirstRowID        *int64   `json:"first-row-id,omitempty"` // V3: Starting row ID for this snapshot
+	AddedRows         *int64   `json:"added-rows,omitempty"`   // V3: Number of rows added by this snapshot
+}
+
+func (s Snapshot) MarshalJSON() ([]byte, error) {
+	type Alias Snapshot
+	if s.ManifestList != "" {
+		// The manifest list is authoritative when both legacy and current
+		// representations are present. Do not write the V1 fallback alongside it.
+		s.ManifestLocations = nil
+	}
+
+	return json.Marshal((*Alias)(&s))
 }
 
 func (s Snapshot) String() string {
@@ -312,6 +324,7 @@ func (s Snapshot) Equals(other Snapshot) bool {
 		s.SequenceNumber == other.SequenceNumber &&
 		s.TimestampMs == other.TimestampMs &&
 		s.ManifestList == other.ManifestList &&
+		slices.Equal(s.ManifestLocations, other.ManifestLocations) &&
 		s.Summary.Equals(other.Summary)
 }
 
@@ -338,6 +351,21 @@ func (s Snapshot) Manifests(fio iceio.IO) (_ []iceberg.ManifestFile, err error) 
 		defer internal.CheckedClose(f, &err)
 
 		return iceberg.ReadManifestList(f)
+	}
+	if len(s.ManifestLocations) > 0 {
+		manifests := make([]iceberg.ManifestFile, len(s.ManifestLocations))
+		for i, path := range s.ManifestLocations {
+			manifests[i] = iceberg.NewManifestFile(1, path, -1, 0, s.SnapshotID).
+				AddedFiles(-1).
+				ExistingFiles(-1).
+				DeletedFiles(-1).
+				AddedRows(-1).
+				ExistingRows(-1).
+				DeletedRows(-1).
+				Build()
+		}
+
+		return manifests, nil
 	}
 
 	return nil, nil

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -94,6 +94,64 @@ func TestSerializeSnapshotWithProps(t *testing.T) {
 	}`, string(data))
 }
 
+func TestSerializeSnapshotWithEmbeddedManifestLocations(t *testing.T) {
+	snapshot := table.Snapshot{
+		SnapshotID:        25,
+		TimestampMs:       1602638573590,
+		ManifestLocations: []string{"s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"},
+	}
+
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"snapshot-id": 25,
+		"sequence-number": 0,
+		"timestamp-ms": 1602638573590,
+		"manifests": ["s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"]
+	}`, string(data))
+}
+
+func TestDeserializeSnapshotWithEmbeddedManifestLocations(t *testing.T) {
+	var snapshot table.Snapshot
+	err := json.Unmarshal([]byte(`{
+		"snapshot-id": 25,
+		"timestamp-ms": 1602638573590,
+		"manifests": ["s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"]
+	}`), &snapshot)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"}, snapshot.ManifestLocations)
+	manifests, err := snapshot.Manifests(nil)
+	require.NoError(t, err)
+	require.Len(t, manifests, 2)
+	assert.Equal(t, "s3:/a/b/manifest-1.avro", manifests[0].FilePath())
+	assert.Equal(t, "s3:/a/b/manifest-2.avro", manifests[1].FilePath())
+	assert.Equal(t, 1, manifests[0].Version())
+	assert.Equal(t, int32(0), manifests[0].PartitionSpecID())
+	assert.Equal(t, int64(25), manifests[0].SnapshotID())
+	assert.Equal(t, int32(-1), manifests[0].AddedDataFiles())
+}
+
+func TestSerializeSnapshotPrefersManifestListOverEmbeddedManifestLocations(t *testing.T) {
+	snapshot := table.Snapshot{
+		SnapshotID:        25,
+		TimestampMs:       1602638573590,
+		ManifestList:      "s3:/a/b/manifest-list.avro",
+		ManifestLocations: []string{"s3:/a/b/manifest.avro"},
+	}
+
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"snapshot-id": 25,
+		"sequence-number": 0,
+		"timestamp-ms": 1602638573590,
+		"manifest-list": "s3:/a/b/manifest-list.avro"
+	}`, string(data))
+}
+
 func TestMissingOperationDefaultsToOverwrite(t *testing.T) {
 	var summary table.Summary
 	err := json.Unmarshal([]byte(`{"foo": "bar"}`), &summary)

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -195,6 +195,20 @@ func TestSnapshotUnmarshalManifestListReplacesEmbeddedManifests(t *testing.T) {
 	assert.Nil(t, snapshot.ManifestLocations)
 }
 
+func TestSnapshotUnmarshalPrefersManifestListOverEmbeddedManifests(t *testing.T) {
+	var snapshot table.Snapshot
+
+	err := json.Unmarshal([]byte(`{
+		"snapshot-id": 25,
+		"timestamp-ms": 1602638573590,
+		"manifest-list": "new-manifest-list.avro",
+		"manifests": ["old-manifest.avro"]
+	}`), &snapshot)
+	require.NoError(t, err)
+	assert.Equal(t, "new-manifest-list.avro", snapshot.ManifestList)
+	assert.Nil(t, snapshot.ManifestLocations)
+}
+
 func TestSerializeSnapshotPrefersManifestListOverEmbeddedManifestLocations(t *testing.T) {
 	snapshot := table.Snapshot{
 		SnapshotID:        25,

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -168,6 +168,33 @@ func TestDeserializeSnapshotWithEmbeddedManifestLocations(t *testing.T) {
 	assert.Equal(t, manifests[1].Length(), writtenManifests[1].Length())
 }
 
+func TestSnapshotUnmarshalEmbeddedManifestsReplacesManifestList(t *testing.T) {
+	snapshot := table.Snapshot{ManifestList: "old-manifest-list.avro"}
+
+	err := json.Unmarshal([]byte(`{
+		"snapshot-id": 25,
+		"timestamp-ms": 1602638573590,
+		"manifests": ["new-manifest.avro"]
+	}`), &snapshot)
+	require.NoError(t, err)
+	assert.Empty(t, snapshot.ManifestList)
+	assert.Equal(t, []string{"new-manifest.avro"}, snapshot.ManifestLocations)
+}
+
+func TestSnapshotUnmarshalManifestListReplacesEmbeddedManifests(t *testing.T) {
+	snapshot := table.Snapshot{ManifestLocations: []string{"old-manifest.avro"}}
+
+	err := json.Unmarshal([]byte(`{
+		"snapshot-id": 25,
+		"sequence-number": 1,
+		"timestamp-ms": 1602638573590,
+		"manifest-list": "new-manifest-list.avro"
+	}`), &snapshot)
+	require.NoError(t, err)
+	assert.Equal(t, "new-manifest-list.avro", snapshot.ManifestList)
+	assert.Nil(t, snapshot.ManifestLocations)
+}
+
 func TestSerializeSnapshotPrefersManifestListOverEmbeddedManifestLocations(t *testing.T) {
 	snapshot := table.Snapshot{
 		SnapshotID:        25,

--- a/table/snapshots_test.go
+++ b/table/snapshots_test.go
@@ -18,10 +18,12 @@
 package table_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,31 +108,64 @@ func TestSerializeSnapshotWithEmbeddedManifestLocations(t *testing.T) {
 
 	assert.JSONEq(t, `{
 		"snapshot-id": 25,
-		"sequence-number": 0,
 		"timestamp-ms": 1602638573590,
 		"manifests": ["s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"]
 	}`, string(data))
 }
 
+func TestSerializeSnapshotWithEmptyEmbeddedManifestLocations(t *testing.T) {
+	var snapshot table.Snapshot
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"snapshot-id": 25,
+		"timestamp-ms": 1602638573590,
+		"manifests": []
+	}`), &snapshot))
+	require.NotNil(t, snapshot.ManifestLocations)
+
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"snapshot-id": 25,
+		"timestamp-ms": 1602638573590,
+		"manifests": []
+	}`, string(data))
+}
+
 func TestDeserializeSnapshotWithEmbeddedManifestLocations(t *testing.T) {
+	paths := []string{"mem://bucket/manifest-1.avro", "mem://bucket/manifest-2.avro"}
 	var snapshot table.Snapshot
 	err := json.Unmarshal([]byte(`{
 		"snapshot-id": 25,
 		"timestamp-ms": 1602638573590,
-		"manifests": ["s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"]
+		"manifests": ["mem://bucket/manifest-1.avro", "mem://bucket/manifest-2.avro"]
 	}`), &snapshot)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"s3:/a/b/manifest-1.avro", "s3:/a/b/manifest-2.avro"}, snapshot.ManifestLocations)
-	manifests, err := snapshot.Manifests(nil)
+	assert.Equal(t, paths, snapshot.ManifestLocations)
+	fs := iceio.NewMemFS()
+	require.NoError(t, fs.WriteFile(paths[0], []byte("manifest-one")))
+	require.NoError(t, fs.WriteFile(paths[1], []byte("manifest-two-longer")))
+
+	manifests, err := snapshot.Manifests(fs)
 	require.NoError(t, err)
 	require.Len(t, manifests, 2)
-	assert.Equal(t, "s3:/a/b/manifest-1.avro", manifests[0].FilePath())
-	assert.Equal(t, "s3:/a/b/manifest-2.avro", manifests[1].FilePath())
+	assert.Equal(t, paths[0], manifests[0].FilePath())
+	assert.Equal(t, paths[1], manifests[1].FilePath())
 	assert.Equal(t, 1, manifests[0].Version())
 	assert.Equal(t, int32(0), manifests[0].PartitionSpecID())
 	assert.Equal(t, int64(25), manifests[0].SnapshotID())
 	assert.Equal(t, int32(-1), manifests[0].AddedDataFiles())
+	assert.Equal(t, int64(len("manifest-one")), manifests[0].Length())
+	assert.Equal(t, int64(len("manifest-two-longer")), manifests[1].Length())
+
+	var manifestList bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(1, &manifestList, snapshot.SnapshotID, nil, nil, 0, manifests))
+	writtenManifests, err := iceberg.ReadManifestList(bytes.NewReader(manifestList.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, writtenManifests, 2)
+	assert.Equal(t, manifests[0].Length(), writtenManifests[0].Length())
+	assert.Equal(t, manifests[1].Length(), writtenManifests[1].Length())
 }
 
 func TestSerializeSnapshotPrefersManifestListOverEmbeddedManifestLocations(t *testing.T) {

--- a/table/snapshots_v1_inheritance_test.go
+++ b/table/snapshots_v1_inheritance_test.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastAppendInheritsEmbeddedV1ManifestWithLength(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	txn.meta.formatVersion = 1
+
+	const parentSnapshotID int64 = 101
+	inherited := writeTestManifestFileWithVersion(
+		t, memIO, spec, simpleSchema(), parentSnapshotID, 1, 1,
+	)
+	parent := Snapshot{
+		SnapshotID:        parentSnapshotID,
+		TimestampMs:       time.Now().UnixMilli(),
+		ManifestLocations: []string{inherited.FilePath()},
+		Summary:           &Summary{Operation: OpAppend},
+	}
+	require.NoError(t, txn.meta.AddSnapshot(&parent))
+	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, parentSnapshotID, BranchRef))
+
+	producer := newFastAppendFilesProducer(OpAppend, txn, memIO, nil, nil)
+	producer.appendDataFile(newTestDataFile(t, spec, "file://new-data.parquet", nil))
+
+	updates, _, err := producer.commit(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, updates)
+
+	addSnapshot, ok := updates[0].(*addSnapshotUpdate)
+	require.True(t, ok, "first update must add the new snapshot")
+	manifests := readManifestListFromPath(t, memIO, addSnapshot.Snapshot.ManifestList)
+	require.Len(t, manifests, 2)
+
+	for _, manifest := range manifests {
+		if manifest.FilePath() == inherited.FilePath() {
+			require.Equal(t, inherited.Length(), manifest.Length())
+			require.Positive(t, manifest.Length())
+
+			return
+		}
+	}
+
+	require.Failf(t, "missing inherited manifest", "path=%s", inherited.FilePath())
+}

--- a/table/snapshots_v1_sequence_test.go
+++ b/table/snapshots_v1_sequence_test.go
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeEmbeddedSnapshotPreservesNonzeroSequenceNumber(t *testing.T) {
+	snapshot := table.Snapshot{
+		SnapshotID:        25,
+		SequenceNumber:    7,
+		TimestampMs:       1602638573590,
+		ManifestLocations: []string{"s3:/a/b/manifest.avro"},
+	}
+
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"snapshot-id": 25,
+		"sequence-number": 7,
+		"timestamp-ms": 1602638573590,
+		"manifests": ["s3:/a/b/manifest.avro"]
+	}`, string(data))
+}


### PR DESCRIPTION
## Summary

Preserve the V1 `manifests` array when reading and writing snapshot metadata.

- Keep embedded manifest locations during JSON decoding.
- Decode snapshots into a fresh value so stale `manifest-list` and `manifests` state cannot survive receiver reuse.
- Normalize dual-field input to the `manifest-list` representation.
- Preserve an explicitly empty `manifests` array.
- Resolve each embedded manifest length through the supplied IO before creating a manifest-list entry.
- Omit V1 snapshot sequence numbers when serializing the embedded representation.
- Prefer `manifest-list` when both representations are present.

Previously, the `manifests` array was ignored and synthetic entries used `-1` for the required manifest length. That value could be carried into a later manifest list when a snapshot inherited the V1 manifests.

## Testing

- `go test ./table -count=1`