### PR TITLE
fix(schema): reject missing requiredness flags

### DIFF
--- a/types.go
+++ b/types.go
@@ -376,8 +376,9 @@ func defaultValueToJSON(typ Type, value any) any {
 func (n *NestedField) UnmarshalJSON(b []byte) error {
 	type Alias NestedField
 	aux := struct {
-		ID   *int      `json:"id"`
-		Type typeIFace `json:"type"`
+		ID       *int      `json:"id"`
+		Required *bool     `json:"required"`
+		Type     typeIFace `json:"type"`
 		*Alias
 	}{
 		Alias: (*Alias)(n),
@@ -401,6 +402,11 @@ func (n *NestedField) UnmarshalJSON(b []byte) error {
 	if n.Type == nil {
 		return fmt.Errorf("%w: field %q is missing required 'type' key in JSON", ErrInvalidSchema, n.Name)
 	}
+
+	if aux.Required == nil {
+		return fmt.Errorf("%w: field is missing required 'required' key in JSON", ErrInvalidSchema)
+	}
+	n.Required = *aux.Required
 
 	return nil
 }
@@ -505,7 +511,7 @@ func (l *ListType) UnmarshalJSON(b []byte) error {
 	aux := struct {
 		ID   *int      `json:"element-id"`
 		Elem typeIFace `json:"element"`
-		Req  bool      `json:"element-required"`
+		Req  *bool     `json:"element-required"`
 	}{}
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
@@ -517,10 +523,13 @@ func (l *ListType) UnmarshalJSON(b []byte) error {
 	if aux.Elem.Type == nil {
 		return fmt.Errorf("%w: field is missing required 'element' key in JSON", ErrInvalidSchema)
 	}
+	if aux.Req == nil {
+		return fmt.Errorf("%w: field is missing required 'element-required' key in JSON", ErrInvalidSchema)
+	}
 
 	l.ElementID = *aux.ID
 	l.Element = aux.Elem.Type
-	l.ElementRequired = aux.Req
+	l.ElementRequired = *aux.Req
 
 	return nil
 }
@@ -613,14 +622,13 @@ func (m *MapType) UnmarshalJSON(b []byte) error {
 	if aux.Value.Type == nil {
 		return fmt.Errorf("%w: field is missing required 'value' key in JSON", ErrInvalidSchema)
 	}
+	if aux.ValueReq == nil {
+		return fmt.Errorf("%w: field is missing required 'value-required' key in JSON", ErrInvalidSchema)
+	}
 
 	m.KeyID, m.KeyType = *aux.KeyID, aux.Key.Type
 	m.ValueID, m.ValueType = *aux.ValueID, aux.Value.Type
-	if aux.ValueReq == nil {
-		m.ValueRequired = true
-	} else {
-		m.ValueRequired = *aux.ValueReq
-	}
+	m.ValueRequired = *aux.ValueReq
 
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -375,38 +375,41 @@ func defaultValueToJSON(typ Type, value any) any {
 
 func (n *NestedField) UnmarshalJSON(b []byte) error {
 	type Alias NestedField
+	var next NestedField
 	aux := struct {
 		ID       *int      `json:"id"`
 		Required *bool     `json:"required"`
 		Type     typeIFace `json:"type"`
 		*Alias
 	}{
-		Alias: (*Alias)(n),
+		Alias: (*Alias)(&next),
 	}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
-	n.Type = aux.Type.Type
+	next.Type = aux.Type.Type
 
 	if aux.ID == nil {
 		return fmt.Errorf("%w: field is missing required 'id' key in JSON", ErrInvalidSchema)
 	}
-	n.ID = *aux.ID
+	next.ID = *aux.ID
 
-	if n.Name == "" {
+	if next.Name == "" {
 		return fmt.Errorf("%w: field is missing required 'name' key in JSON", ErrInvalidSchema)
 	}
 
-	if n.Type == nil {
-		return fmt.Errorf("%w: field %q is missing required 'type' key in JSON", ErrInvalidSchema, n.Name)
+	if next.Type == nil {
+		return fmt.Errorf("%w: field %q is missing required 'type' key in JSON", ErrInvalidSchema, next.Name)
 	}
 
 	if aux.Required == nil {
 		return fmt.Errorf("%w: field is missing required 'required' key in JSON", ErrInvalidSchema)
 	}
-	n.Required = *aux.Required
+	next.Required = *aux.Required
+
+	*n = next
 
 	return nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -651,6 +651,33 @@ func TestNestedFieldUnmarshalMissingName(t *testing.T) {
 	assert.ErrorContains(t, err, "missing required 'name'")
 }
 
+func TestNestedFieldUnmarshalMissingRequired(t *testing.T) {
+	data := []byte(`{"id":1,"name":"col","type":"string"}`)
+
+	var f iceberg.NestedField
+	err := json.Unmarshal(data, &f)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'required'")
+}
+
+func TestListTypeUnmarshalMissingElementRequired(t *testing.T) {
+	data := []byte(`{"type":"list","element-id":1,"element":"string"}`)
+
+	var list iceberg.ListType
+	err := json.Unmarshal(data, &list)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'element-required'")
+}
+
+func TestMapTypeUnmarshalMissingValueRequired(t *testing.T) {
+	data := []byte(`{"type":"map","key-id":1,"key":"string","value-id":2,"value":"string"}`)
+
+	var m iceberg.MapType
+	err := json.Unmarshal(data, &m)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.ErrorContains(t, err, "missing required 'value-required'")
+}
+
 func TestNestedFieldUnmarshalZeroIDIsValid(t *testing.T) {
 	// id:0 is a valid field ID — should NOT be treated as a missing key
 	data := []byte(`{"id":0,"name":"col","type":"string","required":false}`)

--- a/types_test.go
+++ b/types_test.go
@@ -660,6 +660,23 @@ func TestNestedFieldUnmarshalMissingRequired(t *testing.T) {
 	assert.ErrorContains(t, err, "missing required 'required'")
 }
 
+func TestNestedFieldUnmarshalMissingRequiredPreservesState(t *testing.T) {
+	field := iceberg.NestedField{
+		ID:             7,
+		Name:           "old",
+		Type:           iceberg.PrimitiveTypes.Int32,
+		Required:       true,
+		Doc:            "old doc",
+		InitialDefault: "old initial default",
+		WriteDefault:   "old write default",
+	}
+	original := field
+
+	err := json.Unmarshal([]byte(`{"id":1,"name":"new","type":"string"}`), &field)
+	assert.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Equal(t, original, field)
+}
+
 func TestListTypeUnmarshalMissingElementRequired(t *testing.T) {
 	data := []byte(`{"type":"list","element-id":1,"element":"string"}`)
 


### PR DESCRIPTION
## Summary

Reject schema JSON when requiredness flags are missing for:

- Struct fields: `required`
- List elements: `element-required`
- Map values: `value-required`

The nested-field decoder now validates a temporary value and updates the receiver only after decoding succeeds.

Previously, missing flags were decoded as Go zero values or defaults. A failed nested-field decode could also leave a partially updated receiver.

## Testing

- `go test . -run 'TestNestedFieldUnmarshal|TestListTypeUnmarshalMissingElementRequired|TestMapTypeUnmarshalMissingValueRequired' -count=1`