### PR TITLE
fix(table): require order-id and fields in sort order JSON

### DIFF
--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -2564,7 +2564,12 @@ func TestDefaultSortOrder(t *testing.T) {
 	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")
 	require.NoError(t, err)
 	meta.(*metadataV2).DefaultSortOrderID = orderID
-	sortOrder, err := NewSortOrder(orderID, nil)
+	sortOrder, err := NewSortOrder(orderID, []SortField{{
+		SourceIDs: []int{2},
+		Transform: iceberg.IdentityTransform{},
+		Direction: SortASC,
+		NullOrder: NullsFirst,
+	}})
 	require.NoError(t, err)
 
 	meta.(*metadataV2).SortOrderList = append(meta.(*metadataV2).SortOrderList, sortOrder)

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -319,30 +319,30 @@ func (s *SortOrder) UnmarshalJSON(b []byte) error {
 
 func (s *SortOrder) unmarshal(b []byte, binding orderBinding) error {
 	aux := struct {
-		OrderID int               `json:"order-id"`
-		Fields  []json.RawMessage `json:"fields"`
-	}{OrderID: -1}
+		OrderID *int         `json:"order-id"`
+		Fields  *[]json.RawMessage `json:"fields"`
+	}{}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
 	}
 
-	fields := make([]SortField, len(aux.Fields))
-	for i, rawField := range aux.Fields {
+	fields := make([]SortField, len(*aux.Fields))
+	for i, rawField := range *aux.Fields {
 		if err := fields[i].unmarshal(rawField, binding); err != nil {
 			return err
 		}
 	}
 
-	if len(fields) == 0 && aux.OrderID == -1 {
-		aux.OrderID = 0
+	if aux.OrderID == nil {
+		return fmt.Errorf("%w: sort order is missing required 'order-id' key in JSON", iceberg.ErrInvalidArgument)
 	}
 
-	if aux.OrderID == -1 {
-		aux.OrderID = InitialSortOrderID
+	if aux.Fields == nil {
+		return fmt.Errorf("%w: sort order is missing required 'fields' key in JSON", iceberg.ErrInvalidArgument)
 	}
 
-	newOrder, err := newSortOrder(aux.OrderID, fields, false)
+	newOrder, err := newSortOrder(*aux.OrderID, *aux.Fields, false)
 	if err != nil {
 		return err
 	}

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -319,19 +319,12 @@ func (s *SortOrder) UnmarshalJSON(b []byte) error {
 
 func (s *SortOrder) unmarshal(b []byte, binding orderBinding) error {
 	aux := struct {
-		OrderID *int         `json:"order-id"`
+		OrderID *int               `json:"order-id"`
 		Fields  *[]json.RawMessage `json:"fields"`
 	}{}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
 		return err
-	}
-
-	fields := make([]SortField, len(*aux.Fields))
-	for i, rawField := range *aux.Fields {
-		if err := fields[i].unmarshal(rawField, binding); err != nil {
-			return err
-		}
 	}
 
 	if aux.OrderID == nil {
@@ -342,7 +335,14 @@ func (s *SortOrder) unmarshal(b []byte, binding orderBinding) error {
 		return fmt.Errorf("%w: sort order is missing required 'fields' key in JSON", iceberg.ErrInvalidArgument)
 	}
 
-	newOrder, err := newSortOrder(*aux.OrderID, *aux.Fields, false)
+	fields := make([]SortField, len(*aux.Fields))
+	for i, rawField := range *aux.Fields {
+		if err := fields[i].unmarshal(rawField, binding); err != nil {
+			return err
+		}
+	}
+
+	newOrder, err := newSortOrder(*aux.OrderID, fields, false)
 	if err != nil {
 		return err
 	}
@@ -356,6 +356,7 @@ func (s *SortOrder) unmarshal(b []byte, binding orderBinding) error {
 //
 // The orderID must be greater than or equal to 0.
 // If orderID is 0, no fields can be passed, this is equal to UnsortedSortOrder.
+// If fields is empty, orderID must be 0.
 // Fields need to have non-nil Transform, valid Direction and NullOrder values,
 // and non-empty source IDs.
 func NewSortOrder(orderID int, fields []SortField) (SortOrder, error) {
@@ -370,6 +371,10 @@ func newSortOrder(orderID int, fields []SortField, validateSourceIDs bool) (Sort
 
 	if orderID == 0 && len(fields) != 0 {
 		return SortOrder{}, fmt.Errorf("%w: sort order ID 0 is reserved for unsorted order", ErrInvalidSortOrderID)
+	}
+
+	if orderID != UnsortedSortOrderID && len(fields) == 0 {
+		return SortOrder{}, fmt.Errorf("%w: sort order ID %d requires at least one sort field", ErrInvalidSortOrderID, orderID)
 	}
 
 	if fields == nil {

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -315,6 +315,21 @@ func TestUnmarshalSortOrderAcceptsExplicitUnsortedOrder(t *testing.T) {
 	assert.Equal(t, table.UnsortedSortOrder, order)
 }
 
+func TestUnmarshalSortOrderRejectsNonzeroIDForEmptyFields(t *testing.T) {
+	var order table.SortOrder
+	err := json.Unmarshal([]byte(`{"order-id": 1, "fields": []}`), &order)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, table.ErrInvalidSortOrderID)
+	assert.ErrorContains(t, err, "requires at least one sort field")
+}
+
+func TestNewSortOrderRejectsNonzeroIDForEmptyFields(t *testing.T) {
+	_, err := table.NewSortOrder(1, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, table.ErrInvalidSortOrderID)
+	assert.ErrorContains(t, err, "requires at least one sort field")
+}
+
 func TestUnmarshalSortOrderRejectsInvalidSourceIDs(t *testing.T) {
 	for _, tt := range []struct {
 		name     string

--- a/table/sorting_test.go
+++ b/table/sorting_test.go
@@ -273,13 +273,46 @@ func TestSortOrderCheckCompatibilityRejectsMissingSourceIDInSchema(t *testing.T)
 	assert.ErrorContains(t, err, "sort field with source id 999 not found in schema")
 }
 
-func TestUnmarshalSortOrderDefaults(t *testing.T) {
-	var order table.SortOrder
-	require.NoError(t, json.Unmarshal([]byte(`{"fields": []}`), &order))
-	assert.Equal(t, table.UnsortedSortOrder, order)
+func TestUnmarshalSortOrderRequiresOrderID(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		jsonData string
+	}{
+		{name: "missing", jsonData: `{"fields": []}`},
+		{name: "null", jsonData: `{"order-id": null, "fields": []}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var order table.SortOrder
+			err := json.Unmarshal([]byte(tt.jsonData), &order)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			assert.ErrorContains(t, err, "missing required 'order-id' key in JSON")
+		})
+	}
+}
 
-	require.NoError(t, json.Unmarshal([]byte(`{"fields": [{"source-id": 19, "transform": "identity", "direction": "asc", "null-order": "nulls-first"}]}`), &order))
-	assert.Equal(t, table.InitialSortOrderID, order.OrderID())
+func TestUnmarshalSortOrderRequiresFields(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		jsonData string
+	}{
+		{name: "missing", jsonData: `{"order-id": 0}`},
+		{name: "null", jsonData: `{"order-id": 0, "fields": null}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var order table.SortOrder
+			err := json.Unmarshal([]byte(tt.jsonData), &order)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			assert.ErrorContains(t, err, "missing required 'fields' key in JSON")
+		})
+	}
+}
+
+func TestUnmarshalSortOrderAcceptsExplicitUnsortedOrder(t *testing.T) {
+	var order table.SortOrder
+	require.NoError(t, json.Unmarshal([]byte(`{"order-id": 0, "fields": []}`), &order))
+	assert.Equal(t, table.UnsortedSortOrder, order)
 }
 
 func TestUnmarshalSortOrderRejectsInvalidSourceIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

Require valid sort order JSON and construction invariants.

- Reject missing or null `order-id`.
- Reject missing or null `fields`.
- Keep explicit `{"order-id": 0, "fields": []}` valid for the unsorted order.
- Reject nonzero order IDs with no sort fields.

The empty-fields invariant is enforced in `NewSortOrder` as well as JSON decoding, so all construction paths follow the same rules.

## Testing

- `go test ./table -count=1`