### PR TITLE
fix(table): preserve AllManifests read errors

### DIFF
--- a/table/all_manifests_internal_test.go
+++ b/table/all_manifests_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -27,8 +28,28 @@ import (
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	tblutils "github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/require"
 )
+
+func TestYieldAllManifestsReturnsErrorAfterResultsClose(t *testing.T) {
+	results := make(chan tblutils.Enumerated[[]iceberg.ManifestFile])
+	close(results)
+
+	manifestErr := errors.New("manifest list read failed")
+	errch := make(chan error, 1)
+	errch <- manifestErr
+	close(errch)
+
+	var got error
+	yieldAllManifests(results, errch, func(_ iceberg.ManifestFile, err error) bool {
+		got = err
+
+		return true
+	})
+
+	require.ErrorIs(t, got, manifestErr)
+}
 
 func TestAllManifestsCompletesAfterErrorChannelCloses(t *testing.T) {
 	const snapshotCount = 8

--- a/table/table.go
+++ b/table/table.go
@@ -449,29 +449,42 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 			}()
 		}()
 
-		for {
-			select {
-			case err, ok := <-errch:
-				if !ok {
-					errch = nil
+		yieldAllManifests(results, errch, yield)
+	}
+}
 
-					continue
-				}
-				if err != nil {
-					yield(nil, err)
+func yieldAllManifests(
+	results <-chan tblutils.Enumerated[[]iceberg.ManifestFile],
+	errch <-chan error,
+	yield func(iceberg.ManifestFile, error) bool,
+) {
+	for results != nil || errch != nil {
+		select {
+		case err, ok := <-errch:
+			if !ok {
+				errch = nil
 
+				continue
+			}
+			if err != nil {
+				yield(nil, err)
+
+				return
+			}
+		case next, ok := <-results:
+			if !ok {
+				results = nil
+
+				continue
+			}
+			for _, mf := range next.Value {
+				if !yield(mf, nil) {
 					return
 				}
-			case next, ok := <-results:
-				for _, mf := range next.Value {
-					if !yield(mf, nil) {
-						return
-					}
-				}
+			}
 
-				if next.Last || !ok {
-					return
-				}
+			if next.Last {
+				return
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Preserve manifest-list read errors from `Table.AllManifests` when concurrent result delivery finishes before the error channel is consumed.

## Problem

`AllManifests` reads snapshot manifest lists concurrently and sequences the results. If a worker fails, the error is sent on `errch`, while the sequenced results channel can close without emitting a final value for that snapshot. The consumer could select the closed results channel first, treat iteration as complete, and return without reading the buffered error. Callers then saw successful completion instead of the manifest read failure.

## What changed

- Extract result and error consumption into `yieldAllManifests`.
- Treat a closed results channel as no more results, not successful completion.
- Continue consuming terminal events when results close before `errch`.
- Surface the non-nil manifest read error to the iterator consumer.
- Preserve ordered yields, normal `Last` termination, early consumer stop, and channel draining.

This fixes the error path without changing the concurrent read limit or the order in which manifest files are yielded.

## Tests

- Added a regression test where results are closed while a manifest read error remains buffered.
- `go test ./table -count=1`
- `go test -race ./table -run "Test(YieldAllManifests|AllManifests)" -count=1`

## Reference

Apache Iceberg loads a snapshot manifest list as one operation and propagates failures from that read in [`BaseSnapshot`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseSnapshot.java). This change is specific to the Go concurrent iterator, where results and errors arrive on separate channels.