### PR TITLE
fix(table): align float partition equality

### DIFF
--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -42,40 +42,56 @@ import (
 func TestClusteredPartitionTrackingUsesComparableKeys(t *testing.T) {
 	t.Parallel()
 
-	records := []partitionRecord{
-		{[]byte{1, 2, 3}},
-		{math.NaN()},
-		{math.Float64frombits(0x7ff8000000000001)},
-	}
-	completed := make(closedPartitionSet)
-	for _, record := range records {
-		completed.add(record)
-		require.True(t, completed.contains(record))
-		require.True(t, partitionRecordsEqual(record, record))
+	tests := []struct {
+		name       string
+		record     partitionRecord
+		equivalent partitionRecord
+	}{
+		{
+			name:       "binary values",
+			record:     partitionRecord{[]byte{1, 2, 3}},
+			equivalent: partitionRecord{[]byte{1, 2, 3}},
+		},
+		{
+			name:       "float64 NaN payloads",
+			record:     partitionRecord{math.Float64frombits(0x7ff8000000000001)},
+			equivalent: partitionRecord{math.Float64frombits(0x7ff8000000000002)},
+		},
+		{
+			name:       "float32 NaN payloads",
+			record:     partitionRecord{math.Float32frombits(0xffc00001)},
+			equivalent: partitionRecord{math.Float32frombits(0x7fc00002)},
+		},
 	}
 
-	require.True(t, completed.contains(partitionRecord{[]byte{1, 2, 3}}))
-	require.True(t, completed.contains(partitionRecord{math.NaN()}))
-	require.True(t, completed.contains(partitionRecord{math.Float64frombits(0x7ff8000000000002)}))
-	signedZeros := make(closedPartitionSet)
-	signedZeros.add(partitionRecord{math.Copysign(0, -1)})
-	require.True(t, signedZeros.contains(partitionRecord{math.Copysign(0, -1)}))
-	require.False(t, signedZeros.contains(partitionRecord{float64(0)}))
-	require.True(t, partitionRecordsEqual(partitionRecord{[]byte{1, 2, 3}}, partitionRecord{[]byte{1, 2, 3}}))
-	require.True(t, partitionRecordsEqual(partitionRecord{math.NaN()}, partitionRecord{math.NaN()}))
-	require.True(t, partitionRecordsEqual(
-		partitionRecord{math.Float64frombits(0x7ff8000000000001)},
-		partitionRecord{math.Float64frombits(0x7ff8000000000002)},
-	))
-	require.True(t, partitionRecordsEqual(
-		partitionRecord{math.Float32frombits(0xffc00001)},
-		partitionRecord{math.Float32frombits(0x7fc00002)},
-	))
-	require.False(t, partitionRecordsEqual(
-		partitionRecord{math.Float32frombits(0x7fc00001)},
-		partitionRecord{math.Float64frombits(0x7ff8000000000001)},
-	))
-	require.False(t, partitionRecordsEqual(partitionRecord{math.Copysign(0, -1)}, partitionRecord{float64(0)}))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			completed := make(closedPartitionSet)
+			completed.add(tt.record)
+			require.True(t, completed.contains(tt.record))
+			require.True(t, completed.contains(tt.equivalent))
+			require.True(t, partitionRecordsEqual(tt.record, tt.record))
+			require.True(t, partitionRecordsEqual(tt.record, tt.equivalent))
+		})
+	}
+
+	t.Run("float widths stay distinct", func(t *testing.T) {
+		require.False(t, partitionRecordsEqual(
+			partitionRecord{math.Float32frombits(0x7fc00001)},
+			partitionRecord{math.Float64frombits(0x7ff8000000000001)},
+		))
+	})
+
+	t.Run("signed zero stays distinct", func(t *testing.T) {
+		signedZeros := make(closedPartitionSet)
+		signedZeros.add(partitionRecord{math.Copysign(0, -1)})
+		require.True(t, signedZeros.contains(partitionRecord{math.Copysign(0, -1)}))
+		require.False(t, signedZeros.contains(partitionRecord{float64(0)}))
+		require.False(t, partitionRecordsEqual(
+			partitionRecord{math.Copysign(0, -1)},
+			partitionRecord{float64(0)},
+		))
+	})
 }
 
 type ClusteredWriterTestSuite struct {

--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -45,6 +45,7 @@ func TestClusteredPartitionTrackingUsesComparableKeys(t *testing.T) {
 	records := []partitionRecord{
 		{[]byte{1, 2, 3}},
 		{math.NaN()},
+		{math.Float64frombits(0x7ff8000000000001)},
 	}
 	completed := make(closedPartitionSet)
 	for _, record := range records {
@@ -55,8 +56,18 @@ func TestClusteredPartitionTrackingUsesComparableKeys(t *testing.T) {
 
 	require.True(t, completed.contains(partitionRecord{[]byte{1, 2, 3}}))
 	require.True(t, completed.contains(partitionRecord{math.NaN()}))
+	require.True(t, completed.contains(partitionRecord{math.Float64frombits(0x7ff8000000000002)}))
+	signedZeros := make(closedPartitionSet)
+	signedZeros.add(partitionRecord{math.Copysign(0, -1)})
+	require.True(t, signedZeros.contains(partitionRecord{math.Copysign(0, -1)}))
+	require.False(t, signedZeros.contains(partitionRecord{float64(0)}))
 	require.True(t, partitionRecordsEqual(partitionRecord{[]byte{1, 2, 3}}, partitionRecord{[]byte{1, 2, 3}}))
 	require.True(t, partitionRecordsEqual(partitionRecord{math.NaN()}, partitionRecord{math.NaN()}))
+	require.True(t, partitionRecordsEqual(
+		partitionRecord{math.Float64frombits(0x7ff8000000000001)},
+		partitionRecord{math.Float64frombits(0x7ff8000000000002)},
+	))
+	require.False(t, partitionRecordsEqual(partitionRecord{math.Copysign(0, -1)}, partitionRecord{float64(0)}))
 }
 
 type ClusteredWriterTestSuite struct {

--- a/table/clustered_writer_test.go
+++ b/table/clustered_writer_test.go
@@ -67,6 +67,14 @@ func TestClusteredPartitionTrackingUsesComparableKeys(t *testing.T) {
 		partitionRecord{math.Float64frombits(0x7ff8000000000001)},
 		partitionRecord{math.Float64frombits(0x7ff8000000000002)},
 	))
+	require.True(t, partitionRecordsEqual(
+		partitionRecord{math.Float32frombits(0xffc00001)},
+		partitionRecord{math.Float32frombits(0x7fc00002)},
+	))
+	require.False(t, partitionRecordsEqual(
+		partitionRecord{math.Float32frombits(0x7fc00001)},
+		partitionRecord{math.Float64frombits(0x7ff8000000000001)},
+	))
 	require.False(t, partitionRecordsEqual(partitionRecord{math.Copysign(0, -1)}, partitionRecord{float64(0)}))
 }
 

--- a/table/equality_delete_index.go
+++ b/table/equality_delete_index.go
@@ -20,7 +20,6 @@ package table
 import (
 	"cmp"
 	"fmt"
-	"math"
 	"slices"
 	"sort"
 
@@ -50,11 +49,9 @@ type equalityDeletePartitionKey struct {
 
 type (
 	equalityDeleteIntegerPartitionValue int64
-	equalityDeleteFloatPartitionValue   uint64
 	equalityDeleteStringPartitionValue  string
 	equalityDeleteEncodedPartitionValue string
 	equalityDeleteBinaryPartitionValue  string
-	equalityDeleteNaNPartitionValue     struct{}
 	equalityDeleteNilPartitionValue     struct{}
 )
 
@@ -106,19 +103,10 @@ func comparableEqualityDeletePartitionValue(value any) (any, error) {
 		return equalityDeleteIntegerPartitionValue(value), nil
 	case iceberg.TimestampNano:
 		return equalityDeleteIntegerPartitionValue(value), nil
-	case float32:
-		value64 := float64(value)
-		if math.IsNaN(value64) {
-			return equalityDeleteNaNPartitionValue{}, nil
-		}
-
-		return equalityDeleteFloatPartitionValue(math.Float64bits(value64)), nil
-	case float64:
-		if math.IsNaN(value) {
-			return equalityDeleteNaNPartitionValue{}, nil
-		}
-
-		return equalityDeleteFloatPartitionValue(math.Float64bits(value)), nil
+	case float32, float64:
+		// Keep equality-delete indexing aligned with writer partition keys:
+		// canonicalize NaNs within each width and preserve signed zero.
+		return comparablePartitionKey(value), nil
 	case string:
 		return equalityDeleteStringPartitionValue(value), nil
 	case []byte:

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2617,6 +2617,21 @@ func TestInspectPartitionAggregateTreeHandlesBinaryAndNaNValues(t *testing.T) {
 	require.Nil(t, tree.lookup(partitionRecord{[]byte{1, 2, 4}, math.NaN()}))
 }
 
+func TestInspectPartitionAggregateTreeDistinguishesFloatWidthsAndSignedZero(t *testing.T) {
+	tree := newInspectPartitionAggregateTree()
+	float32Aggregate := &inspectPartitionAggregate{specID: 1}
+	float32Record := partitionRecord{math.Float32frombits(0xffc00001)}
+	tree.insert(float32Record, float32Aggregate)
+
+	require.Same(t, float32Aggregate, tree.lookup(partitionRecord{math.Float32frombits(0x7fc00002)}))
+	require.Nil(t, tree.lookup(partitionRecord{math.Float64frombits(0x7ff8000000000001)}))
+
+	negativeZeroAggregate := &inspectPartitionAggregate{specID: 2}
+	tree.insert(partitionRecord{math.Copysign(0, -1)}, negativeZeroAggregate)
+	require.Same(t, negativeZeroAggregate, tree.lookup(partitionRecord{math.Copysign(0, -1)}))
+	require.Nil(t, tree.lookup(partitionRecord{float64(0)}))
+}
+
 func TestInspectPartitionsAggregatesDataAndDeletes(t *testing.T) {
 	const snapshotID = int64(1)
 	spec := partitionedSpec()

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -24,7 +24,6 @@ import (
 	"iter"
 	"math"
 	"math/bits"
-	"reflect"
 	"slices"
 	"sync"
 
@@ -85,6 +84,8 @@ type (
 )
 
 const (
+	// Canonical NaN payloads make all NaNs of the same width compare equal.
+	// The width-specific key types and raw bits preserve float width and signed zero.
 	canonicalFloat32NaNBits uint32 = 0x7fc00000
 	canonicalFloat64NaNBits uint64 = 0x7ff8000000000000
 )
@@ -113,7 +114,9 @@ func comparablePartitionKey(value any) any {
 }
 
 func partitionValuesEqual(left, right any) bool {
-	return reflect.DeepEqual(comparablePartitionKey(left), comparablePartitionKey(right))
+	// Partition values are primitive literals; []byte is converted to a string key
+	// and float values are converted to comparable width-aware keys above.
+	return comparablePartitionKey(left) == comparablePartitionKey(right)
 }
 
 func partitionRecordsEqual(left, right partitionRecord) bool {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -195,6 +195,7 @@ func startRecordFeeder(ctx context.Context, itr iter.Seq2[arrow.RecordBatch, err
 			case inputRecordsCh <- record:
 			}
 		}
+
 		return nil
 	})
 }

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -85,7 +85,8 @@ type (
 
 const (
 	// Canonical NaN payloads make all NaNs of the same width compare equal.
-	// The width-specific key types and raw bits preserve float width and signed zero.
+	// The width-specific key types preserve float width, while using raw bits
+	// intentionally keeps -0.0 and +0.0 distinct.
 	canonicalFloat32NaNBits uint32 = 0x7fc00000
 	canonicalFloat64NaNBits uint64 = 0x7ff8000000000000
 )
@@ -95,27 +96,28 @@ func comparablePartitionKey(value any) any {
 	case []byte:
 		return binaryPartitionKey(value)
 	case float32:
-		bits := math.Float32bits(value)
+		rawBits := math.Float32bits(value)
 		if math.IsNaN(float64(value)) {
-			bits = canonicalFloat32NaNBits
+			rawBits = canonicalFloat32NaNBits
 		}
 
-		return float32PartitionKey(bits)
+		return float32PartitionKey(rawBits)
 	case float64:
-		bits := math.Float64bits(value)
+		rawBits := math.Float64bits(value)
 		if math.IsNaN(value) {
-			bits = canonicalFloat64NaNBits
+			rawBits = canonicalFloat64NaNBits
 		}
 
-		return float64PartitionKey(bits)
+		return float64PartitionKey(rawBits)
 	}
 
 	return value
 }
 
 func partitionValuesEqual(left, right any) bool {
-	// Partition values are primitive literals; []byte is converted to a string key
-	// and float values are converted to comparable width-aware keys above.
+	// Supported partition values are primitive literals; []byte is converted to
+	// a string key and float values are converted to comparable width-aware keys
+	// above. The default branch preserves comparable scalar values.
 	return comparablePartitionKey(left) == comparablePartitionKey(right)
 }
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -78,10 +78,11 @@ type partitionExtractionPlan struct {
 	fields       []partitionFieldInfo
 }
 
-type binaryPartitionKey string
-
-type float32PartitionKey uint32
-type float64PartitionKey uint64
+type (
+	binaryPartitionKey  string
+	float32PartitionKey uint32
+	float64PartitionKey uint64
+)
 
 const (
 	canonicalFloat32NaNBits uint32 = 0x7fc00000
@@ -194,7 +195,6 @@ func startRecordFeeder(ctx context.Context, itr iter.Seq2[arrow.RecordBatch, err
 			case inputRecordsCh <- record:
 			}
 		}
-
 		return nil
 	})
 }

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -24,6 +24,7 @@ import (
 	"iter"
 	"math"
 	"math/bits"
+	"reflect"
 	"slices"
 	"sync"
 
@@ -79,25 +80,39 @@ type partitionExtractionPlan struct {
 
 type binaryPartitionKey string
 
-type nanPartitionKey struct {
-	bits int
-}
+type float32PartitionKey uint32
+type float64PartitionKey uint64
+
+const (
+	canonicalFloat32NaNBits uint32 = 0x7fc00000
+	canonicalFloat64NaNBits uint64 = 0x7ff8000000000000
+)
 
 func comparablePartitionKey(value any) any {
 	switch value := value.(type) {
 	case []byte:
 		return binaryPartitionKey(value)
 	case float32:
+		bits := math.Float32bits(value)
 		if math.IsNaN(float64(value)) {
-			return nanPartitionKey{bits: 32}
+			bits = canonicalFloat32NaNBits
 		}
+
+		return float32PartitionKey(bits)
 	case float64:
+		bits := math.Float64bits(value)
 		if math.IsNaN(value) {
-			return nanPartitionKey{bits: 64}
+			bits = canonicalFloat64NaNBits
 		}
+
+		return float64PartitionKey(bits)
 	}
 
 	return value
+}
+
+func partitionValuesEqual(left, right any) bool {
+	return reflect.DeepEqual(comparablePartitionKey(left), comparablePartitionKey(right))
 }
 
 func partitionRecordsEqual(left, right partitionRecord) bool {
@@ -105,7 +120,7 @@ func partitionRecordsEqual(left, right partitionRecord) bool {
 		return false
 	}
 	for i := range left {
-		if comparablePartitionKey(left[i]) != comparablePartitionKey(right[i]) {
+		if !partitionValuesEqual(left[i], right[i]) {
 			return false
 		}
 	}

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -397,6 +397,69 @@ func (s *FanoutWriterTestSuite) TestFloatPartitionValuesUseIcebergKeys() {
 	s.Equal(2, rowsByBits[math.Float64bits(math.Float64frombits(0x7ff8000000000001))])
 }
 
+func (s *FanoutWriterTestSuite) TestFloat32PartitionValuesUseIcebergKeys() {
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: arrow.PrimitiveTypes.Float32}}, nil)
+	record := s.createCustomTestRecord(arrowSchema, [][]any{
+		{math.Float32frombits(0x80000000)},
+		{float32(0)},
+		{math.Float32frombits(0xffc00001)},
+		{math.Float32frombits(0x7fc00002)},
+	})
+	defer record.Release()
+
+	icebergSchema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Float32})
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "part", Transform: iceberg.IdentityTransform{},
+	})
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 3)
+
+	rowsByBits := make(map[uint32]int)
+	for _, partition := range partitions {
+		value := partition.partitionRec[0].(float32)
+		rowsByBits[math.Float32bits(value)] = len(partition.rows)
+	}
+	s.Equal(1, rowsByBits[0x80000000])
+	s.Equal(1, rowsByBits[0])
+	s.Equal(2, rowsByBits[0xffc00001])
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionMapUsesComparableKeysAtEveryLevel() {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "first", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "second", Type: arrow.PrimitiveTypes.Float64},
+	}, nil)
+	record := s.createCustomTestRecord(arrowSchema, [][]any{
+		{math.Float64frombits(0x7ff8000000000001), math.Copysign(0, -1)},
+		{math.Float64frombits(0xfff8000000000001), math.Copysign(0, -1)},
+		{math.Float64frombits(0x7ff8000000000001), float64(0)},
+		{float64(0), math.Float64frombits(0x7ff8000000000001)},
+		{float64(0), math.Float64frombits(0xfff8000000000001)},
+	})
+	defer record.Release()
+
+	icebergSchema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "first", Type: iceberg.PrimitiveTypes.Float64},
+		iceberg.NestedField{ID: 2, Name: "second", Type: iceberg.PrimitiveTypes.Float64},
+	)
+	spec := iceberg.NewPartitionSpec(
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "first", Transform: iceberg.IdentityTransform{}},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1001, Name: "second", Transform: iceberg.IdentityTransform{}},
+	)
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 3)
+
+	rowsByPartition := make([][]int64, 0, len(partitions))
+	for _, partition := range partitions {
+		rowsByPartition = append(rowsByPartition, partition.rows)
+	}
+	s.ElementsMatch([][]int64{{0, 1}, {2}, {3, 4}}, rowsByPartition)
+}
+
 func (s *FanoutWriterTestSuite) TestBucketTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -368,6 +368,35 @@ func (s *FanoutWriterTestSuite) TestNaNPartitionValuesUseStableKeys() {
 	s.True(math.IsNaN(partitions[0].partitionRec[0].(float64)))
 }
 
+func (s *FanoutWriterTestSuite) TestFloatPartitionValuesUseIcebergKeys() {
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: arrow.PrimitiveTypes.Float64}}, nil)
+	record := s.createCustomTestRecord(arrowSchema, [][]any{
+		{math.Copysign(0, -1)},
+		{0.0},
+		{math.Float64frombits(0x7ff8000000000001)},
+		{math.Float64frombits(0x7ff8000000000002)},
+	})
+	defer record.Release()
+
+	icebergSchema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Float64})
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "part", Transform: iceberg.IdentityTransform{},
+	})
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 3)
+
+	rowsByBits := make(map[uint64]int)
+	for _, partition := range partitions {
+		value := partition.partitionRec[0].(float64)
+		rowsByBits[math.Float64bits(value)] = len(partition.rows)
+	}
+	s.Equal(1, rowsByBits[math.Float64bits(math.Copysign(0, -1))])
+	s.Equal(1, rowsByBits[math.Float64bits(0)])
+	s.Equal(2, rowsByBits[math.Float64bits(math.Float64frombits(0x7ff8000000000001))])
+}
+
 func (s *FanoutWriterTestSuite) TestBucketTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -642,7 +642,7 @@ func matchEqualityDeletesToData(dataEntry iceberg.ManifestEntry, eqDeleteEntries
 }
 
 func partitionsMatch(a, b map[int]any) bool {
-	return maps.EqualFunc(a, b, reflect.DeepEqual)
+	return maps.EqualFunc(a, b, partitionValuesEqual)
 }
 
 // buildDVIndex indexes deletion vectors by the data file path they reference.

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -439,30 +439,54 @@ func TestMatchEqualityDeletesToDataHandlesBinaryPartitions(t *testing.T) {
 }
 
 func TestMatchEqualityDeletesToDataHandlesFloatPartitions(t *testing.T) {
-	dataSeqNum := int64(1)
-	deleteSeqNum := int64(2)
-	dataFile := &mockDataFile{
-		path:      "data.parquet",
-		partition: map[int]any{1000: math.Float64frombits(0x7ff8000000000001)},
-	}
-	matchingDelete := &mockDataFile{
-		path:      "matching-delete.parquet",
-		partition: map[int]any{1000: math.Float64frombits(0x7ff8000000000002)},
-	}
-	nonMatchingDelete := &mockDataFile{
-		path:      "non-matching-delete.parquet",
-		partition: map[int]any{1000: math.Copysign(0, -1)},
-	}
-
-	dataEntry := iceberg.NewManifestEntry(
-		iceberg.EntryStatusADDED, nil, &dataSeqNum, nil, dataFile)
-	deleteEntries := []iceberg.ManifestEntry{
-		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, nonMatchingDelete),
-		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, matchingDelete),
+	tests := []struct {
+		name                    string
+		dataPartition           any
+		matchingDeletePartition any
+		nonMatchingPartition    any
+	}{
+		{
+			name:                    "float32",
+			dataPartition:           math.Float32frombits(0xffc00001),
+			matchingDeletePartition: math.Float32frombits(0x7fc00002),
+			nonMatchingPartition:    float32(math.Copysign(0, -1)),
+		},
+		{
+			name:                    "float64",
+			dataPartition:           math.Float64frombits(0xfff8000000000001),
+			matchingDeletePartition: math.Float64frombits(0x7ff8000000000002),
+			nonMatchingPartition:    math.Copysign(0, -1),
+		},
 	}
 
-	assert.Equal(t, []iceberg.DataFile{matchingDelete},
-		matchEqualityDeletesToData(dataEntry, deleteEntries))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataSeqNum := int64(1)
+			deleteSeqNum := int64(2)
+			dataFile := &mockDataFile{
+				path:      "data.parquet",
+				partition: map[int]any{1000: tt.dataPartition},
+			}
+			matchingDelete := &mockDataFile{
+				path:      "matching-delete.parquet",
+				partition: map[int]any{1000: tt.matchingDeletePartition},
+			}
+			nonMatchingDelete := &mockDataFile{
+				path:      "non-matching-delete.parquet",
+				partition: map[int]any{1000: tt.nonMatchingPartition},
+			}
+
+			dataEntry := iceberg.NewManifestEntry(
+				iceberg.EntryStatusADDED, nil, &dataSeqNum, nil, dataFile)
+			deleteEntries := []iceberg.ManifestEntry{
+				iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, nonMatchingDelete),
+				iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, matchingDelete),
+			}
+
+			assert.Equal(t, []iceberg.DataFile{matchingDelete},
+				matchEqualityDeletesToData(dataEntry, deleteEntries))
+		})
+	}
 }
 
 func TestMinSequenceNum(t *testing.T) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -47,7 +47,7 @@ func newDataManifest(minSeqNum int64) iceberg.ManifestFile {
 		Content(iceberg.ManifestContentData).
 		SequenceNum(minSeqNum, minSeqNum).
 		Build()
-		}
+}
 
 func newDeleteManifest(minSeqNum int64) iceberg.ManifestFile {
 	return iceberg.NewManifestFile(2, "/path/to/manifest.avro", 1000, 0, 1).

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -47,7 +47,7 @@ func newDataManifest(minSeqNum int64) iceberg.ManifestFile {
 		Content(iceberg.ManifestContentData).
 		SequenceNum(minSeqNum, minSeqNum).
 		Build()
-}
+		}
 
 func newDeleteManifest(minSeqNum int64) iceberg.ManifestFile {
 	return iceberg.NewManifestFile(2, "/path/to/manifest.avro", 1000, 0, 1).
@@ -276,7 +276,6 @@ func TestEqualityDeletePartitionKeyNormalizesValues(t *testing.T) {
 
 func TestEqualityDeletePartitionKeyDistinguishesSignedZero(t *testing.T) {
 	negativeZero := math.Copysign(0, -1)
-
 	negative, err := newEqualityDeletePartitionKey(1, map[int]any{1000: negativeZero})
 	require.NoError(t, err)
 	positive, err := newEqualityDeletePartitionKey(1, map[int]any{1000: float64(0)})
@@ -383,6 +382,87 @@ func TestOpenManifestShortCircuitsMetricsEvaluation(t *testing.T) {
 			assert.Len(t, entries, tt.wantEntries)
 		})
 	}
+}
+
+func TestPartitionsMatchUsesFloatSemantics(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  any
+		right any
+		match bool
+	}{
+		{name: "float32 NaN values", left: float32(math.NaN()), right: float32(math.NaN()), match: true},
+		{name: "float64 NaN values", left: math.NaN(), right: math.NaN(), match: true},
+		{name: "float32 NaN payloads", left: math.Float32frombits(0x7fc00001), right: math.Float32frombits(0x7fc00002), match: true},
+		{name: "float64 NaN payloads", left: math.Float64frombits(0x7ff8000000000001), right: math.Float64frombits(0x7ff8000000000002), match: true},
+		{name: "float32 signed zero", left: float32(math.Copysign(0, -1)), right: float32(0), match: false},
+		{name: "float64 signed zero", left: math.Copysign(0, -1), right: float64(0), match: false},
+		{name: "float widths differ", left: float32(1), right: float64(1), match: false},
+		{name: "pass-through integer", left: int64(42), right: int64(42), match: true},
+		{name: "pass-through strings differ", left: "a", right: "b", match: false},
+		{name: "nil values", left: nil, right: nil, match: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match,
+				partitionsMatch(map[int]any{1000: tt.left}, map[int]any{1000: tt.right}))
+		})
+	}
+}
+
+func TestMatchEqualityDeletesToDataHandlesBinaryPartitions(t *testing.T) {
+	dataSeqNum := int64(1)
+	deleteSeqNum := int64(2)
+	dataFile := &mockDataFile{
+		path:      "data.parquet",
+		partition: map[int]any{1000: []byte{0xde, 0xad}},
+	}
+	matchingDelete := &mockDataFile{
+		path:      "matching-delete.parquet",
+		partition: map[int]any{1000: []byte{0xde, 0xad}},
+	}
+	nonMatchingDelete := &mockDataFile{
+		path:      "non-matching-delete.parquet",
+		partition: map[int]any{1000: []byte{0xbe, 0xef}},
+	}
+
+	dataEntry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, nil, &dataSeqNum, nil, dataFile)
+	deleteEntries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, nonMatchingDelete),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, matchingDelete),
+	}
+
+	assert.Equal(t, []iceberg.DataFile{matchingDelete},
+		matchEqualityDeletesToData(dataEntry, deleteEntries))
+}
+
+func TestMatchEqualityDeletesToDataHandlesFloatPartitions(t *testing.T) {
+	dataSeqNum := int64(1)
+	deleteSeqNum := int64(2)
+	dataFile := &mockDataFile{
+		path:      "data.parquet",
+		partition: map[int]any{1000: math.Float64frombits(0x7ff8000000000001)},
+	}
+	matchingDelete := &mockDataFile{
+		path:      "matching-delete.parquet",
+		partition: map[int]any{1000: math.Float64frombits(0x7ff8000000000002)},
+	}
+	nonMatchingDelete := &mockDataFile{
+		path:      "non-matching-delete.parquet",
+		partition: map[int]any{1000: math.Copysign(0, -1)},
+	}
+
+	dataEntry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, nil, &dataSeqNum, nil, dataFile)
+	deleteEntries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, nonMatchingDelete),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, nil, &deleteSeqNum, nil, matchingDelete),
+	}
+
+	assert.Equal(t, []iceberg.DataFile{matchingDelete},
+		matchEqualityDeletesToData(dataEntry, deleteEntries))
 }
 
 func TestMinSequenceNum(t *testing.T) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -232,12 +232,39 @@ func TestEqualityDeletePartitionKeyNormalizesValues(t *testing.T) {
 		name  string
 		left  any
 		right any
+		equal bool
 	}{
-		{name: "integer widths", left: int32(7), right: int64(7)},
-		{name: "date and integer", left: iceberg.Date(7), right: int32(7)},
+		{name: "integer widths", left: int32(7), right: int64(7), equal: true},
+		{name: "date and integer", left: iceberg.Date(7), right: int32(7), equal: true},
 		{name: "float widths", left: float32(1.5), right: float64(1.5)},
-		{name: "NaN", left: math.Float32frombits(0x7fc00000), right: math.NaN()},
-		{name: "UUID and bytes", left: sampleUUID, right: sampleUUID[:]},
+		{
+			name:  "float32 NaN payloads",
+			left:  math.Float32frombits(0x7fc00001),
+			right: math.Float32frombits(0x7fc00002),
+			equal: true,
+		},
+		{
+			name:  "float64 NaN payloads",
+			left:  math.Float64frombits(0x7ff8000000000001),
+			right: math.Float64frombits(0x7ff8000000000002),
+			equal: true,
+		},
+		{
+			name:  "float widths keep NaNs distinct",
+			left:  math.Float32frombits(0x7fc00001),
+			right: math.Float64frombits(0x7ff8000000000001),
+		},
+		{
+			name:  "float32 signed zero",
+			left:  float32(math.Copysign(0, -1)),
+			right: float32(0),
+		},
+		{
+			name:  "float64 signed zero",
+			left:  math.Copysign(0, -1),
+			right: float64(0),
+		},
+		{name: "UUID and bytes", left: sampleUUID, right: sampleUUID[:], equal: true},
 	}
 
 	for _, tt := range tests {
@@ -246,7 +273,7 @@ func TestEqualityDeletePartitionKeyNormalizesValues(t *testing.T) {
 			require.NoError(t, err)
 			right, err := newEqualityDeletePartitionKey(1, map[int]any{1000: tt.right})
 			require.NoError(t, err)
-			assert.Equal(t, left, right)
+			assert.Equal(t, tt.equal, left == right)
 		})
 	}
 
@@ -272,6 +299,65 @@ func TestEqualityDeletePartitionKeyNormalizesValues(t *testing.T) {
 
 	_, err = newEqualityDeletePartitionKey(1, map[int]any{1000: struct{}{}})
 	assert.ErrorContains(t, err, "unsupported partition value type struct {}")
+}
+
+func TestEqualityDeleteIndexUsesFloatSemantics(t *testing.T) {
+	tests := []struct {
+		name            string
+		dataPartition   any
+		deletePartition any
+		match           bool
+	}{
+		{
+			name:            "float32 NaN payloads match",
+			dataPartition:   math.Float32frombits(0xffc00001),
+			deletePartition: math.Float32frombits(0x7fc00002),
+			match:           true,
+		},
+		{
+			name:            "float64 NaN payloads match",
+			dataPartition:   math.Float64frombits(0xfff8000000000001),
+			deletePartition: math.Float64frombits(0x7ff8000000000002),
+			match:           true,
+		},
+		{
+			name:            "float widths stay distinct",
+			dataPartition:   float32(1.5),
+			deletePartition: float64(1.5),
+		},
+		{
+			name:            "float32 signed zero stays distinct",
+			dataPartition:   float32(math.Copysign(0, -1)),
+			deletePartition: float32(0),
+		},
+		{
+			name:            "float64 signed zero stays distinct",
+			dataPartition:   math.Copysign(0, -1),
+			deletePartition: float64(0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deleteEntry := newEqualityDeleteIndexTestEntry(
+				"delete.parquet", 1, map[int]any{1000: tt.deletePartition}, 2)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs())
+			require.NoError(t, err)
+
+			dataEntry := newEqualityDeleteIndexTestEntry(
+				"data.parquet", 1, map[int]any{1000: tt.dataPartition}, 1)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			if tt.match {
+				require.Len(t, matched, 1)
+				assert.Equal(t, "delete.parquet", matched[0].FilePath())
+
+				return
+			}
+			assert.Empty(t, matched)
+		})
+	}
 }
 
 func TestEqualityDeletePartitionKeyDistinguishesSignedZero(t *testing.T) {


### PR DESCRIPTION
## Summary

Use one Iceberg-compatible equality path for partition values in equality-delete matching, partitioned fanout grouping, and clustered partition tracking.

## Problem

The old writer path used raw float values as Go map keys, while scanner matching used `reflect.DeepEqual`. Those paths did not have the same floating-point behavior:

- NaN values did not match themselves in equality-delete partition matching.
- Different NaN payloads were not treated as the same value by scanner matching.
- `-0.0` and `+0.0` could be grouped together by Go map equality even though their float bit patterns are different.
- The same partition could therefore be handled differently by delete matching and by the writers.

## What changed

- Convert float32 and float64 partition values to width-specific bit-pattern keys.
- Canonicalize NaNs separately for float32 and float64.
- Preserve signed zero.
- Keep float32 and float64 values as distinct partition types.
- Keep binary partition values compared by byte content.
- Reuse the normalized comparator for scanner partition matching and writer key generation.

This keeps equality-delete matching, fanout grouping, and clustered partition tracking consistent. The behavior is aligned with Java Iceberg type-aware partition comparators in [`PartitionMap`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/util/PartitionMap.java), [`StructLikeMap`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/util/StructLikeMap.java), and [`Comparators`](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/types/Comparators.java).

## Tests

- Added coverage for float32 and float64 NaNs and NaN payloads, signed zero, binary values, float widths, equality-delete matching, fanout grouping, and clustered tracking.
- `go test ./table -count=1`
- `go test -race ./table -run "Test(ClusteredWriter|FanoutWriter|PartitionsMatchUsesFloatSemantics|MatchEqualityDeletesToDataHandlesFloatPartitions)" -count=1`