### PR TITLE
fix(manifest): reject unknown legacy row counts

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1648,6 +1648,7 @@ type ManifestListWriter struct {
 	sequenceNumber   int64
 	writer           *ocf.Writer
 	nextRowID        *int64
+	failure          error
 }
 
 func NewManifestListWriterV1(out io.Writer, snapshotID int64, parentSnapshot *int64) (*ManifestListWriter, error) {
@@ -1722,7 +1723,7 @@ func advanceRowID(firstRowID, existingRows, addedRows int64) (int64, error) {
 		return 0, fmt.Errorf("%w: first row ID must be non-negative: %d", ErrInvalidArgument, firstRowID)
 	}
 	if existingRows == -1 || addedRows == -1 {
-		return 0, fmt.Errorf("%w: cannot assign row-lineage IDs with unknown row counts: existing=%d added=%d",
+		return 0, fmt.Errorf("%w: cannot assign row-lineage IDs because at least one row count is unknown (existing=%d added=%d); rewrite or compact the legacy manifest before upgrading to v3",
 			ErrInvalidArgument, existingRows, addedRows)
 	}
 	if existingRows < 0 || addedRows < 0 {
@@ -1768,18 +1769,29 @@ func (m *ManifestListWriter) NextRowID() *int64 {
 	return m.nextRowID
 }
 
+// AddManifests appends manifest files to the list. If it returns an error, the
+// writer is poisoned: callers must close and discard it, and subsequent calls
+// return the original error.
 func (m *ManifestListWriter) AddManifests(files []ManifestFile) (err error) {
+	if m.failure != nil {
+		return m.failure
+	}
 	if len(files) == 0 {
 		return nil
 	}
-	if m.version == 3 && m.nextRowID != nil {
-		batchStartRowID := *m.nextRowID
-		defer func() {
-			if err != nil {
+	hasRowID := m.version == 3 && m.nextRowID != nil
+	var batchStartRowID int64
+	if hasRowID {
+		batchStartRowID = *m.nextRowID
+	}
+	defer func() {
+		if err != nil {
+			if hasRowID {
 				*m.nextRowID = batchStartRowID
 			}
-		}()
-	}
+			m.failure = err
+		}
+	}()
 
 	switch m.version {
 	case 1:

--- a/manifest.go
+++ b/manifest.go
@@ -1721,11 +1721,9 @@ func advanceRowID(firstRowID, existingRows, addedRows int64) (int64, error) {
 	if firstRowID < 0 {
 		return 0, fmt.Errorf("%w: first row ID must be non-negative: %d", ErrInvalidArgument, firstRowID)
 	}
-	if existingRows == -1 {
-		existingRows = 0
-	}
-	if addedRows == -1 {
-		addedRows = 0
+	if existingRows == -1 || addedRows == -1 {
+		return 0, fmt.Errorf("%w: cannot assign row-lineage IDs with unknown row counts: existing=%d added=%d",
+			ErrInvalidArgument, existingRows, addedRows)
 	}
 	if existingRows < 0 || addedRows < 0 {
 		return 0, fmt.Errorf("%w: row counts must be non-negative: existing=%d added=%d",

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -22,6 +22,7 @@ import (
 	"compress/flate"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"math"
@@ -3853,15 +3854,15 @@ func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCou
 		existingRows int64
 	}{
 		{name: "both row counts unknown", addedRows: -1, existingRows: -1},
-		{name: "existing row count unknown", addedRows: 1, existingRows: -1},
-		{name: "added row count unknown", addedRows: -1, existingRows: 1},
+		{name: "only existing row count unknown", addedRows: 1, existingRows: -1},
+		{name: "only added row count unknown", addedRows: -1, existingRows: 1},
 	}
 
-	for _, test := range tests {
-		m.Run(test.name, func() {
+	for _, tt := range tests {
+		m.Run(tt.name, func() {
 			legacy := *(manifestFileRecordsV1[0].(*manifestFile))
-			legacy.AddedRowsCount = test.addedRows
-			legacy.ExistingRowsCount = test.existingRows
+			legacy.AddedRowsCount = tt.addedRows
+			legacy.ExistingRowsCount = tt.existingRows
 
 			var v1Buf bytes.Buffer
 			m.Require().NoError(
@@ -3875,12 +3876,45 @@ func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCou
 			m.Require().NoError(err)
 			err = writer.AddManifests(manifests)
 			m.Require().ErrorIs(err, ErrInvalidArgument)
-			m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
+			m.Require().ErrorContains(err, "cannot assign row-lineage IDs because at least one row count is unknown")
+			m.Require().ErrorContains(err, fmt.Sprintf("existing=%d added=%d", tt.existingRows, tt.addedRows))
 			m.Require().ErrorContains(err, legacy.Path)
-			m.EqualValues(1000, *writer.NextRowID())
+			m.Require().EqualValues(1000, *writer.NextRowID())
 			m.Require().NoError(writer.Close())
 		})
 	}
+
+	m.Run("mixed batch failure poisons writer", func() {
+		valid := *(manifestFileRecordsV1[0].(*manifestFile))
+		valid.Path = "valid.avro"
+		unknown := valid
+		unknown.Path = "unknown-counts.avro"
+		unknown.AddedRowsCount = -1
+		unknown.ExistingRowsCount = -1
+		manifests := []ManifestFile{&valid, &unknown}
+
+		var buf bytes.Buffer
+		writer, err := NewManifestListWriterV3(&buf, snapshotID, 1, 1000, nil)
+		m.Require().NoError(err)
+
+		err = writer.AddManifests(manifests)
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.Require().ErrorContains(err, unknown.Path)
+		m.Require().EqualValues(1000, *writer.NextRowID())
+
+		retryErr := writer.AddManifests([]ManifestFile{&valid})
+		m.Require().ErrorIs(retryErr, err)
+		m.Require().EqualValues(1000, *writer.NextRowID())
+		// Close flushes the partial OCF so we can verify that retrying did not
+		// append a colliding row ID. The failed writer output must be discarded.
+		m.Require().NoError(writer.Close())
+
+		written, readErr := ReadManifestList(bytes.NewReader(buf.Bytes()))
+		m.Require().NoError(readErr)
+		m.Require().Len(written, 1, "the failed batch must not be reusable")
+		m.Require().NotNil(written[0].FirstRowID())
+		m.Require().EqualValues(1000, *written[0].FirstRowID())
+	})
 }
 
 // TestV2ManifestListRejectsV3Manifests confirms that a v2 manifest list still

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -3846,7 +3846,7 @@ func (m *ManifestTestSuite) TestV3ManifestListAcceptsV1AndV2Manifests() {
 	m.Nil(v2Entry.FirstRowID(), "delete manifests must not be assigned first_row_id")
 }
 
-func (m *ManifestTestSuite) TestV3ManifestListAssignsZeroForV1ManifestWithUnknownRowCounts() {
+func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCounts() {
 	legacy := *(manifestFileRecordsV1[0].(*manifestFile))
 	legacy.AddedRowsCount = -1
 	legacy.ExistingRowsCount = -1
@@ -3860,7 +3860,10 @@ func (m *ManifestTestSuite) TestV3ManifestListAssignsZeroForV1ManifestWithUnknow
 	var v3Buf bytes.Buffer
 	writer, err := NewManifestListWriterV3(&v3Buf, snapshotID, 1, 1000, nil)
 	m.Require().NoError(err)
-	m.Require().NoError(writer.AddManifests(manifests))
+	err = writer.AddManifests(manifests)
+	m.Require().ErrorIs(err, ErrInvalidArgument)
+	m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
+	m.Require().ErrorContains(err, legacy.Path)
 	m.EqualValues(1000, *writer.NextRowID())
 	m.Require().NoError(writer.Close())
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -3847,25 +3847,40 @@ func (m *ManifestTestSuite) TestV3ManifestListAcceptsV1AndV2Manifests() {
 }
 
 func (m *ManifestTestSuite) TestV3ManifestListRejectsV1ManifestWithUnknownRowCounts() {
-	legacy := *(manifestFileRecordsV1[0].(*manifestFile))
-	legacy.AddedRowsCount = -1
-	legacy.ExistingRowsCount = -1
+	tests := []struct {
+		name         string
+		addedRows    int64
+		existingRows int64
+	}{
+		{name: "both row counts unknown", addedRows: -1, existingRows: -1},
+		{name: "existing row count unknown", addedRows: 1, existingRows: -1},
+		{name: "added row count unknown", addedRows: -1, existingRows: 1},
+	}
 
-	var v1Buf bytes.Buffer
-	m.Require().NoError(WriteManifestList(1, &v1Buf, snapshotID, nil, nil, 0, []ManifestFile{&legacy}))
-	manifests, err := ReadManifestList(&v1Buf)
-	m.Require().NoError(err)
-	m.Require().Len(manifests, 1)
+	for _, test := range tests {
+		m.Run(test.name, func() {
+			legacy := *(manifestFileRecordsV1[0].(*manifestFile))
+			legacy.AddedRowsCount = test.addedRows
+			legacy.ExistingRowsCount = test.existingRows
 
-	var v3Buf bytes.Buffer
-	writer, err := NewManifestListWriterV3(&v3Buf, snapshotID, 1, 1000, nil)
-	m.Require().NoError(err)
-	err = writer.AddManifests(manifests)
-	m.Require().ErrorIs(err, ErrInvalidArgument)
-	m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
-	m.Require().ErrorContains(err, legacy.Path)
-	m.EqualValues(1000, *writer.NextRowID())
-	m.Require().NoError(writer.Close())
+			var v1Buf bytes.Buffer
+			m.Require().NoError(
+				WriteManifestList(1, &v1Buf, snapshotID, nil, nil, 0, []ManifestFile{&legacy}))
+			manifests, err := ReadManifestList(&v1Buf)
+			m.Require().NoError(err)
+			m.Require().Len(manifests, 1)
+
+			var v3Buf bytes.Buffer
+			writer, err := NewManifestListWriterV3(&v3Buf, snapshotID, 1, 1000, nil)
+			m.Require().NoError(err)
+			err = writer.AddManifests(manifests)
+			m.Require().ErrorIs(err, ErrInvalidArgument)
+			m.Require().ErrorContains(err, "cannot assign row-lineage IDs with unknown row counts")
+			m.Require().ErrorContains(err, legacy.Path)
+			m.EqualValues(1000, *writer.NextRowID())
+			m.Require().NoError(writer.Close())
+		})
+	}
 }
 
 // TestV2ManifestListRejectsV3Manifests confirms that a v2 manifest list still


### PR DESCRIPTION
## Summary

V1 manifest lists can omit added_rows_count and existing_rows_count. The [First Row ID Assignment](https://iceberg.apache.org/spec/#first-row-id-assignment) section of the Iceberg specification says missing row counts are assumed to be non-zero. During v3 first_row_id assignment, converting the legacy -1 sentinel to zero can leave no space for rows that readers later assign from record_count.

For upgraded tables, the specification also requires post-upgrade snapshots to assign row IDs to existing and added files. See [Row Lineage for Upgraded Tables](https://iceberg.apache.org/spec/#row-lineage-for-upgraded-tables).

This is the follow-up to [#1627](https://github.com/apache/iceberg-go/pull/1627).

## Changes

- reject unknown legacy row counts during v3 first_row_id assignment
- keep the row ID cursor unchanged when validation fails
- cover both unknown counts and each asymmetric case in the regression test

## Testing

- go test . -run TestManifests/TestV3ManifestList(RejectsV1ManifestWithUnknownRowCounts|WriterRejectsInvalidRowIDRanges) -count=1 -v
- go test ./... -count=1