### PR TITLE
fix(table): align snapshot expiration retention semantics

### DIFF
--- a/table/properties.go
+++ b/table/properties.go
@@ -99,14 +99,18 @@ const (
 	ParquetVariantBufferSizeKey     = internal.ParquetVariantBufferSizeKey
 	ParquetVariantBufferSizeDefault = internal.ParquetVariantBufferSizeDefault
 
-	MinSnapshotsToKeepKey     = "min-snapshots-to-keep"
-	MinSnapshotsToKeepDefault = math.MaxInt
+	MinSnapshotsToKeepKey     = "history.expire.min-snapshots-to-keep"
+	MinSnapshotsToKeepDefault = 1
 
-	MaxSnapshotAgeMsKey     = "max-snapshot-age-ms"
-	MaxSnapshotAgeMsDefault = int64(math.MaxInt64)
+	MaxSnapshotAgeMsKey     = "history.expire.max-snapshot-age-ms"
+	MaxSnapshotAgeMsDefault = int64(5 * 24 * 60 * 60 * 1000)
 
-	MaxRefAgeMsKey     = "max-ref-age-ms"
+	MaxRefAgeMsKey     = "history.expire.max-ref-age-ms"
 	MaxRefAgeMsDefault = int64(math.MaxInt64)
+
+	legacyMinSnapshotsToKeepKey = "min-snapshots-to-keep"
+	legacyMaxSnapshotAgeMsKey   = "max-snapshot-age-ms"
+	legacyMaxRefAgeMsKey        = "max-ref-age-ms"
 
 	// CommitNumRetriesKey is the number of commit retry attempts before
 	// giving up on ErrCommitFailed from the catalog.

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1952,8 +1952,8 @@ func (t *TableWritingTestSuite) TestExpireSnapshotsNoOpWhenNothingToExpire() {
 }
 
 // TestExpireSnapshotsUsesTableProperties verifies that ExpireSnapshots reads
-// min-snapshots-to-keep and max-snapshot-age-ms from table properties when
-// no explicit options are provided by the caller (mirrors Java behaviour).
+// the standard history.expire.* properties when no explicit options are
+// provided by the caller (mirrors Java behaviour).
 func (t *TableWritingTestSuite) TestExpireSnapshotsUsesTableProperties() {
 	fs := iceio.LocalFS{}
 
@@ -1973,7 +1973,7 @@ func (t *TableWritingTestSuite) TestExpireSnapshotsUsesTableProperties() {
 			table.MinSnapshotsToKeepKey: "2",
 			table.MaxSnapshotAgeMsKey:   "0", // expire everything older than "now"
 			// max-ref-age-ms is intentionally absent to prove that a missing
-			// property correctly falls back to the math.MaxInt default.
+			// property correctly falls back to the standard forever default.
 		})
 	t.Require().NoError(err)
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -418,6 +418,22 @@ func WithPostCommit(postCommit bool) ExpireSnapshotsOpt {
 	}
 }
 
+func getRetentionInt(props iceberg.Properties, standardKey, legacyKey string, defaultValue int) int {
+	if _, ok := props[standardKey]; ok {
+		return props.GetInt(standardKey, defaultValue)
+	}
+
+	return props.GetInt(legacyKey, defaultValue)
+}
+
+func getRetentionInt64(props iceberg.Properties, standardKey, legacyKey string, defaultValue int64) int64 {
+	if _, ok := props[standardKey]; ok {
+		return props.GetInt64(standardKey, defaultValue)
+	}
+
+	return props.GetInt64(legacyKey, defaultValue)
+}
+
 // ExpireSnapshots removes expired snapshots from the table metadata, staging
 // the changes on the transaction. Call [Transaction.Commit] to persist them.
 //
@@ -468,29 +484,27 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	// mirroring the Java implementation. The unprefixed property names are
 	// retained as compatibility fallbacks for tables created by older Go
 	// versions.
-	propMaxRefAgeMs := meta.props.GetInt64(
-		MaxRefAgeMsKey,
-		meta.props.GetInt64(legacyMaxRefAgeMsKey, MaxRefAgeMsDefault),
+	propMaxRefAgeMs := getRetentionInt64(
+		meta.props, MaxRefAgeMsKey, legacyMaxRefAgeMsKey, MaxRefAgeMsDefault,
 	)
-	propMinSnapshotsToKeep := meta.props.GetInt(
-		MinSnapshotsToKeepKey,
-		meta.props.GetInt(legacyMinSnapshotsToKeepKey, MinSnapshotsToKeepDefault),
+	propMinSnapshotsToKeep := getRetentionInt(
+		meta.props, MinSnapshotsToKeepKey, legacyMinSnapshotsToKeepKey, MinSnapshotsToKeepDefault,
 	)
-	propMaxSnapshotAgeMs := meta.props.GetInt64(
-		MaxSnapshotAgeMsKey,
-		meta.props.GetInt64(legacyMaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault),
+	propMaxSnapshotAgeMs := getRetentionInt64(
+		meta.props, MaxSnapshotAgeMsKey, legacyMaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault,
 	)
+	defaultMaxSnapshotAgeMs := propMaxSnapshotAgeMs
+	if cfg.maxSnapshotAgeMs != nil {
+		defaultMaxSnapshotAgeMs = *cfg.maxSnapshotAgeMs
+	}
 
+	retainedRefs := make(map[string]SnapshotRef, len(meta.refs))
 	for refName, ref := range meta.refs {
 		// Assert that this ref's snapshot ID hasn't changed concurrently.
 		// This ensures we don't accidentally expire snapshots that are now
 		// referenced by updated refs.
 		snapshotID := ref.SnapshotID
 		reqs = append(reqs, AssertRefSnapshotID(refName, &snapshotID))
-
-		if refName == MainBranch {
-			snapsToKeep[ref.SnapshotID] = struct{}{}
-		}
 
 		snap, err := meta.SnapshotByID(ref.SnapshotID)
 		if err != nil {
@@ -504,6 +518,11 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 			updates = append(updates, NewRemoveSnapshotRefUpdate(refName))
 
 			continue
+		}
+		retainedRefs[refName] = ref
+
+		if refName == MainBranch {
+			snapsToKeep[ref.SnapshotID] = struct{}{}
 		}
 
 		var (
@@ -543,6 +562,41 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 
 			snapId = *snap.ParentSnapshotID
 			numSnapshots++
+		}
+	}
+
+	referencedSnapshots := make(map[int64]struct{})
+	for _, ref := range retainedRefs {
+		if ref.SnapshotRefType != BranchRef {
+			referencedSnapshots[ref.SnapshotID] = struct{}{}
+
+			continue
+		}
+
+		snapshotID := ref.SnapshotID
+		for {
+			snap, err := meta.SnapshotByID(snapshotID)
+			if err != nil {
+				break
+			}
+
+			referencedSnapshots[snap.SnapshotID] = struct{}{}
+			if snap.ParentSnapshotID == nil {
+				break
+			}
+
+			snapshotID = *snap.ParentSnapshotID
+		}
+	}
+
+	unreferencedSnapshotCutoff := nowMs - defaultMaxSnapshotAgeMs
+	for _, snap := range meta.snapshotList {
+		if _, referenced := referencedSnapshots[snap.SnapshotID]; referenced {
+			continue
+		}
+
+		if snap.TimestampMs >= unreferencedSnapshotCutoff {
+			snapsToKeep[snap.SnapshotID] = struct{}{}
 		}
 	}
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -381,10 +381,9 @@ type expireSnapshotsCfg struct {
 type ExpireSnapshotsOpt func(*expireSnapshotsCfg)
 
 // WithRetainLast sets the minimum number of snapshots to keep per branch,
-// regardless of age. It overrides the MinSnapshotsToKeepKey
-// ("min-snapshots-to-keep") table property for this call. Snapshots beyond this
-// count become eligible for expiry only once they are also older than the
-// configured age (see WithOlderThan).
+// regardless of age. It overrides the MinSnapshotsToKeepKey table property for
+// this call. Snapshots beyond this count become eligible for expiry only once
+// they are also older than the configured age (see WithOlderThan).
 func WithRetainLast(n int) ExpireSnapshotsOpt {
 	return func(cfg *expireSnapshotsCfg) {
 		cfg.minSnapshotsToKeep = &n
@@ -395,10 +394,10 @@ func WithRetainLast(n int) ExpireSnapshotsOpt {
 }
 
 // WithOlderThan expires snapshots older than the given duration, measured from
-// the current time. It overrides the MaxSnapshotAgeMsKey ("max-snapshot-age-ms")
-// table property for this call. The most recent snapshots are still retained up
-// to the count set by WithRetainLast. This option does not expire branches or
-// tags based on their age; configure max-ref-age-ms on the ref or table for that.
+// the current time. It overrides the MaxSnapshotAgeMsKey table property for this
+// call. The most recent snapshots are still retained up to the count set by
+// WithRetainLast. This option does not expire branches or tags based on their
+// age; configure MaxRefAgeMsKey on the ref or table for that.
 func WithOlderThan(t time.Duration) ExpireSnapshotsOpt {
 	return func(cfg *expireSnapshotsCfg) {
 		n := t.Milliseconds()
@@ -466,13 +465,21 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	}
 
 	// Read table-level retention properties as the last-resort defaults,
-	// mirroring the Java implementation. When neither the ref nor the
-	// caller provides a value, fall back to the table property; when the
-	// table property is also absent use the constant default (math.MaxInt64,
-	// meaning "keep everything").
-	propMaxRefAgeMs := meta.props.GetInt64(MaxRefAgeMsKey, MaxRefAgeMsDefault)
-	propMinSnapshotsToKeep := meta.props.GetInt(MinSnapshotsToKeepKey, MinSnapshotsToKeepDefault)
-	propMaxSnapshotAgeMs := meta.props.GetInt64(MaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault)
+	// mirroring the Java implementation. The unprefixed property names are
+	// retained as compatibility fallbacks for tables created by older Go
+	// versions.
+	propMaxRefAgeMs := meta.props.GetInt64(
+		MaxRefAgeMsKey,
+		meta.props.GetInt64(legacyMaxRefAgeMsKey, MaxRefAgeMsDefault),
+	)
+	propMinSnapshotsToKeep := meta.props.GetInt(
+		MinSnapshotsToKeepKey,
+		meta.props.GetInt(legacyMinSnapshotsToKeepKey, MinSnapshotsToKeepDefault),
+	)
+	propMaxSnapshotAgeMs := meta.props.GetInt64(
+		MaxSnapshotAgeMsKey,
+		meta.props.GetInt64(legacyMaxSnapshotAgeMsKey, MaxSnapshotAgeMsDefault),
+	)
 
 	for refName, ref := range meta.refs {
 		// Assert that this ref's snapshot ID hasn't changed concurrently.

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -64,6 +64,122 @@ func TestExpireSnapshotsWithOlderThanDoesNotExpireSnapshotRefs(t *testing.T) {
 	require.True(t, tagExists, "WithOlderThan must not expire a tag without max-ref-age-ms")
 }
 
+func TestExpireSnapshotsUsesStandardRetentionPropertyNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		props           iceberg.Properties
+		oldSnapshotKept bool
+	}{
+		{
+			name: "standard properties",
+			props: iceberg.Properties{
+				MinSnapshotsToKeepKey: "1",
+				MaxSnapshotAgeMsKey:   "0",
+			},
+		},
+		{
+			name: "legacy properties",
+			props: iceberg.Properties{
+				legacyMinSnapshotsToKeepKey: "1",
+				legacyMaxSnapshotAgeMsKey:   "0",
+			},
+		},
+		{
+			name: "standard max age takes precedence",
+			props: iceberg.Properties{
+				MinSnapshotsToKeepKey:       "1",
+				MaxSnapshotAgeMsKey:         "0",
+				legacyMinSnapshotsToKeepKey: "1",
+				legacyMaxSnapshotAgeMsKey:   "1000000000000000000",
+			},
+		},
+		{
+			name:            "standard minimum takes precedence",
+			oldSnapshotKept: true,
+			props: iceberg.Properties{
+				MinSnapshotsToKeepKey:       "2",
+				MaxSnapshotAgeMsKey:         "0",
+				legacyMinSnapshotsToKeepKey: "1",
+				legacyMaxSnapshotAgeMsKey:   "0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txn := newTransactionWithSnapshotRefs(t)
+			txn.meta.props = tt.props
+			txn.meta.snapshotList[0].TimestampMs = time.Now().Add(-time.Hour).UnixMilli()
+			require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 20, BranchRef))
+
+			require.NoError(t, txn.ExpireSnapshots())
+			_, err := txn.meta.SnapshotByID(10)
+			if tt.oldSnapshotKept {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestExpireSnapshotsUsesStandardRetentionDefaults(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	txn.meta.snapshotList[0].TimestampMs = time.Now().Add(-6 * 24 * time.Hour).UnixMilli()
+	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 20, BranchRef))
+
+	require.NoError(t, txn.ExpireSnapshots())
+	_, err := txn.meta.SnapshotByID(10)
+	require.Error(t, err)
+}
+
+func TestExpireSnapshotsUsesStandardMaxRefAgeProperty(t *testing.T) {
+	tests := []struct {
+		name    string
+		props   iceberg.Properties
+		refKept bool
+	}{
+		{
+			name: "standard property",
+			props: iceberg.Properties{
+				MaxRefAgeMsKey: "0",
+			},
+		},
+		{
+			name: "legacy property",
+			props: iceberg.Properties{
+				legacyMaxRefAgeMsKey: "0",
+			},
+		},
+		{
+			name:    "standard property takes precedence",
+			refKept: true,
+			props: iceberg.Properties{
+				MaxRefAgeMsKey:       "1000000000000000000",
+				legacyMaxRefAgeMsKey: "0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txn := newTransactionWithSnapshotRefs(t)
+			txn.meta.props = tt.props
+			require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 20, BranchRef))
+			require.NoError(t, txn.meta.SetSnapshotRef("old-branch", 10, BranchRef))
+			txn.meta.snapshotList[0].TimestampMs = time.Now().Add(-time.Hour).UnixMilli()
+
+			require.NoError(t, txn.ExpireSnapshots())
+			_, refKept := txn.meta.refs["old-branch"]
+			if tt.refKept {
+				require.True(t, refKept)
+			} else {
+				require.False(t, refKept)
+			}
+		})
+	}
+}
+
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {
 	txn := newTransactionWithSnapshotRefs(t)
 

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -103,6 +103,16 @@ func TestExpireSnapshotsUsesStandardRetentionPropertyNames(t *testing.T) {
 				legacyMaxSnapshotAgeMsKey:   "0",
 			},
 		},
+		{
+			name:            "malformed standard max age does not use legacy value",
+			oldSnapshotKept: true,
+			props: iceberg.Properties{
+				MinSnapshotsToKeepKey:       "1",
+				MaxSnapshotAgeMsKey:         "not-a-number",
+				legacyMinSnapshotsToKeepKey: "1",
+				legacyMaxSnapshotAgeMsKey:   "0",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,13 +152,13 @@ func TestExpireSnapshotsUsesStandardMaxRefAgeProperty(t *testing.T) {
 		{
 			name: "standard property",
 			props: iceberg.Properties{
-				MaxRefAgeMsKey: "0",
+				MaxRefAgeMsKey: "60000",
 			},
 		},
 		{
 			name: "legacy property",
 			props: iceberg.Properties{
-				legacyMaxRefAgeMsKey: "0",
+				legacyMaxRefAgeMsKey: "60000",
 			},
 		},
 		{
@@ -156,7 +166,7 @@ func TestExpireSnapshotsUsesStandardMaxRefAgeProperty(t *testing.T) {
 			refKept: true,
 			props: iceberg.Properties{
 				MaxRefAgeMsKey:       "1000000000000000000",
-				legacyMaxRefAgeMsKey: "0",
+				legacyMaxRefAgeMsKey: "60000",
 			},
 		},
 	}
@@ -175,6 +185,53 @@ func TestExpireSnapshotsUsesStandardMaxRefAgeProperty(t *testing.T) {
 				require.True(t, refKept)
 			} else {
 				require.False(t, refKept)
+			}
+		})
+	}
+}
+
+func TestExpireSnapshotsRetainsYoungUnreferencedSnapshots(t *testing.T) {
+	tests := []struct {
+		name         string
+		age          time.Duration
+		snapshotKept bool
+	}{
+		{name: "younger than default age", age: time.Hour, snapshotKept: true},
+		{name: "older than default age", age: 6 * 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txn := newTransactionWithSnapshotRefs(t)
+			now := time.Now().UnixMilli()
+			require.NoError(t, txn.meta.AddSnapshot(&Snapshot{
+				SnapshotID:       30,
+				ParentSnapshotID: transactionTestPtr(int64(10)),
+				SequenceNumber:   3,
+				ManifestList:     "mem://default/table-location/metadata/manifest-30.avro",
+				Summary:          &Summary{Operation: OpAppend},
+				TimestampMs:      now,
+			}))
+			txn.meta.props = iceberg.Properties{MaxRefAgeMsKey: "60000"}
+			require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 20, BranchRef))
+			require.NoError(t, txn.meta.SetSnapshotRef("old-branch", 30, BranchRef))
+			require.NoError(t, txn.meta.RemoveSnapshotRef("feature"))
+			for i := range txn.meta.snapshotList {
+				if txn.meta.snapshotList[i].SnapshotID == 30 {
+					txn.meta.snapshotList[i].TimestampMs = time.Now().Add(-tt.age).UnixMilli()
+
+					break
+				}
+			}
+
+			require.NoError(t, txn.ExpireSnapshots())
+			_, refKept := txn.meta.refs["old-branch"]
+			require.False(t, refKept)
+			_, snapshotErr := txn.meta.SnapshotByID(30)
+			if tt.snapshotKept {
+				require.NoError(t, snapshotErr)
+			} else {
+				require.Error(t, snapshotErr)
 			}
 		})
 	}

--- a/website/src/api.md
+++ b/website/src/api.md
@@ -474,7 +474,7 @@ err := txn.ExpireSnapshots(/* options */)
 err = txn.RollbackToSnapshot(targetSnapshotID)
 ```
 
-Tune retention with the `min-snapshots-to-keep`, `max-snapshot-age-ms`, and `max-ref-age-ms` table properties (see [Configuration](./configuration.md)).
+Tune retention with the `history.expire.min-snapshots-to-keep`, `history.expire.max-snapshot-age-ms`, and `history.expire.max-ref-age-ms` table properties (see [Configuration](./configuration.md)).
 
 ## Maintenance
 

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -295,10 +295,12 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 
 | Key | Description |
 |---|---|
-| `min-snapshots-to-keep` | Minimum snapshots to retain when expiring. |
-| `max-snapshot-age-ms` | Maximum age of retained snapshots. |
-| `max-ref-age-ms` | Maximum age of branch/tag refs that are not the main branch. |
+| `history.expire.min-snapshots-to-keep` | Minimum snapshots to retain when expiring. Default `1`. |
+| `history.expire.max-snapshot-age-ms` | Maximum age of retained snapshots. Default `432000000` (5 days). |
+| `history.expire.max-ref-age-ms` | Maximum age of branch/tag refs that are not the main branch. Default `Long.MAX_VALUE` (forever). |
 | `gc.enabled` | Gate for orphan-file cleanup. |
+
+The unprefixed retention property names are accepted as compatibility fallbacks. The `history.expire.*` properties take precedence when both forms are set.
 
 ### Delete mode
 


### PR DESCRIPTION
## Summary

`ExpireSnapshots` was using non-standard table-property names and defaults, and it expired young snapshots that were no longer referenced by a branch or tag.

This change:
- uses the standard `history.expire.*` property names
- matches the standard defaults: 1 snapshot, 5 days, and no ref-age limit
- retains young unreferenced snapshots according to the expiration age
- accepts the old unprefixed names as compatibility fallbacks
- gives the standard names precedence when both forms are set
- updates the retention documentation and adds regression coverage

## Test plan

- `go test ./... -count=1`
- CI checks on the pull request