### PR TITLE
fix(table): respect gc.enabled during snapshot expiration

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -1238,7 +1238,7 @@ func pathPrefix(path string) (scheme, authority string, ok bool) {
 // catalog drop operation should typically proceed so the catalog does not
 // get out of sync with storage.
 func (t Table) PurgeFiles(ctx context.Context) error {
-	gcEnabled := t.Metadata().Properties().GetBool(GCEnabledKey, GCEnabledDefault)
+	gcEnabled := isGCEnabled(t.Metadata().Properties())
 
 	fs, err := t.FS(ctx)
 	if err != nil {

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -1238,7 +1238,7 @@ func pathPrefix(path string) (scheme, authority string, ok bool) {
 // catalog drop operation should typically proceed so the catalog does not
 // get out of sync with storage.
 func (t Table) PurgeFiles(ctx context.Context) error {
-	gcEnabled := t.Metadata().Properties().GetBool("gc.enabled", true)
+	gcEnabled := t.Metadata().Properties().GetBool(GCEnabledKey, GCEnabledDefault)
 
 	fs, err := t.FS(ctx)
 	if err != nil {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -1616,6 +1616,38 @@ func (m mockFileInfo) ModTime() time.Time   { return m.modTime }
 func (m mockFileInfo) IsDir() bool          { return m.mode.IsDir() }
 func (m mockFileInfo) Sys() any             { return nil }
 
+func TestPurgeFilesSkipsDataFilesForMalformedGCEnabled(t *testing.T) {
+	const orphanDataPath = "s3://bucket/table/data/orphan.parquet"
+
+	for _, gcValue := range []string{"1", "garbage", "false ", "true "} {
+		t.Run(gcValue, func(t *testing.T) {
+			meta, err := NewMetadata(
+				iceberg.NewSchema(0),
+				iceberg.UnpartitionedSpec,
+				UnsortedSortOrder,
+				"s3://bucket/table",
+				iceberg.Properties{GCEnabledKey: gcValue},
+			)
+			require.NoError(t, err)
+
+			fsys := &mockListableIO{entries: []mockWalkEntry{{
+				path: orphanDataPath,
+				info: mockFileInfo{name: "orphan.parquet"},
+			}}}
+			tbl := New(
+				Identifier{"db", "tbl"},
+				meta,
+				"s3://bucket/table/metadata/v1.metadata.json",
+				func(context.Context) (io.IO, error) { return fsys, nil },
+				nil,
+			)
+
+			require.NoError(t, tbl.PurgeFiles(context.Background()))
+			assert.NotContains(t, fsys.removed, orphanDataPath)
+		})
+	}
+}
+
 func TestDeleteOrphanFilesPrefixMismatchModes(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/table/properties.go
+++ b/table/properties.go
@@ -99,6 +99,9 @@ const (
 	ParquetVariantBufferSizeKey     = internal.ParquetVariantBufferSizeKey
 	ParquetVariantBufferSizeDefault = internal.ParquetVariantBufferSizeDefault
 
+	GCEnabledKey     = "gc.enabled"
+	GCEnabledDefault = true
+
 	MinSnapshotsToKeepKey     = "history.expire.min-snapshots-to-keep"
 	MinSnapshotsToKeepDefault = 1
 

--- a/table/properties.go
+++ b/table/properties.go
@@ -19,7 +19,9 @@ package table
 
 import (
 	"math"
+	"strings"
 
+	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table/internal"
 )
 
@@ -153,6 +155,15 @@ const (
 	CommitTotalRetryTimeoutMsKey     = "commit.retry.total-timeout-ms"
 	CommitTotalRetryTimeoutMsDefault = 30 * 60 * 1000
 )
+
+func isGCEnabled(props iceberg.Properties) bool {
+	value, ok := props[GCEnabledKey]
+	if !ok {
+		return GCEnabledDefault
+	}
+
+	return strings.EqualFold(value, "true")
+}
 
 // Reserved properties
 const (

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3274,7 +3274,7 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 }
 
 func validateGCEnabledForSnapshotExpiration(props iceberg.Properties) error {
-	if !props.GetBool(GCEnabledKey, GCEnabledDefault) {
+	if !isGCEnabled(props) {
 		return errors.New("cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
 	}
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -705,7 +705,7 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 		return err
 	}
 	if !meta.props.GetBool(GCEnabledKey, GCEnabledDefault) {
-		return errors.New("Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
+		return errors.New("cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
 	}
 
 	// Read table-level retention properties as the last-resort defaults,

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3233,9 +3233,6 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	if t.committed {
 		return nil, errors.New("transaction has already been committed")
 	}
-	if err := validateSnapshotExpirationGC(meta); err != nil {
-		return nil, err
-	}
 
 	if len(meta.updates) > 0 {
 		reqs := append(transactionRequirements(t.reqs, t.branch, t.tbl.metadata), AssertTableUUID(meta.uuid))
@@ -3279,16 +3276,6 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 func validateGCEnabledForSnapshotExpiration(props iceberg.Properties) error {
 	if !props.GetBool(GCEnabledKey, GCEnabledDefault) {
 		return errors.New("cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
-	}
-
-	return nil
-}
-
-func validateSnapshotExpirationGC(meta *MetadataBuilder) error {
-	for _, update := range meta.updates {
-		if _, ok := update.(*removeSnapshotsUpdate); ok {
-			return validateGCEnabledForSnapshotExpiration(meta.props)
-		}
 	}
 
 	return nil

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -704,6 +704,9 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	if err != nil {
 		return err
 	}
+	if !meta.props.GetBool(GCEnabledKey, GCEnabledDefault) {
+		return errors.New("Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
+	}
 
 	// Read table-level retention properties as the last-resort defaults,
 	// mirroring the Java implementation. The unprefixed property names are

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -704,8 +704,8 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 	if err != nil {
 		return err
 	}
-	if !meta.props.GetBool(GCEnabledKey, GCEnabledDefault) {
-		return errors.New("cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
+	if err := validateGCEnabledForSnapshotExpiration(meta.props); err != nil {
+		return err
 	}
 
 	// Read table-level retention properties as the last-resort defaults,
@@ -3233,6 +3233,9 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	if t.committed {
 		return nil, errors.New("transaction has already been committed")
 	}
+	if err := validateSnapshotExpirationGC(meta); err != nil {
+		return nil, err
+	}
 
 	if len(meta.updates) > 0 {
 		reqs := append(transactionRequirements(t.reqs, t.branch, t.tbl.metadata), AssertTableUUID(meta.uuid))
@@ -3271,6 +3274,24 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	t.committed = true
 
 	return t.tbl, nil
+}
+
+func validateGCEnabledForSnapshotExpiration(props iceberg.Properties) error {
+	if !props.GetBool(GCEnabledKey, GCEnabledDefault) {
+		return errors.New("cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)")
+	}
+
+	return nil
+}
+
+func validateSnapshotExpirationGC(meta *MetadataBuilder) error {
+	for _, update := range meta.updates {
+		if _, ok := update.(*removeSnapshotsUpdate); ok {
+			return validateGCEnabledForSnapshotExpiration(meta.props)
+		}
+	}
+
+	return nil
 }
 
 type StagedTable struct {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -852,6 +852,17 @@ func expireSnapshotsSnapshot(t *testing.T, txn *Transaction, snapshotID int64) *
 	return nil
 }
 
+func TestExpireSnapshotsRejectsWhenGCDisabled(t *testing.T) {
+	txn := newTransactionWithSnapshotRefs(t)
+	txn.meta.props = iceberg.Properties{GCEnabledKey: "false"}
+
+	err := txn.ExpireSnapshots(WithPostCommit(false))
+	require.ErrorContains(t, err, "GC is disabled")
+	require.Empty(t, txn.reqs)
+	_, err = txn.meta.SnapshotByID(10)
+	require.NoError(t, err)
+}
+
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {
 	txn := newTransactionWithSnapshotRefs(t)
 

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -856,11 +856,38 @@ func TestExpireSnapshotsRejectsWhenGCDisabled(t *testing.T) {
 	txn := newTransactionWithSnapshotRefs(t)
 	txn.meta.props = iceberg.Properties{GCEnabledKey: "false"}
 
-	err := txn.ExpireSnapshots(WithPostCommit(false))
+	err := txn.ExpireSnapshots()
 	require.ErrorContains(t, err, "GC is disabled")
 	require.Empty(t, txn.reqs)
 	_, err = txn.meta.SnapshotByID(10)
 	require.NoError(t, err)
+}
+
+func TestExpireSnapshotsRejectsWhenGCDisabledBeforeCommit(t *testing.T) {
+	tbl, cat := newValidationTestTable(t, nil)
+
+	builder, err := MetadataBuilderFromBase(tbl.Metadata(), "")
+	require.NoError(t, err)
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     99,
+		SequenceNumber: 2,
+		ManifestList:   "file:///tmp/validation-test/metadata/manifest-99.avro",
+		TimestampMs:    time.Now().UnixMilli(),
+		Summary:        &Summary{Operation: OpAppend},
+	}))
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	cat.metadata = meta
+	tbl = New(Identifier{"db", "validation"}, meta, "file:///tmp/validation-test/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.ExpireSnapshots(WithOlderThan(time.Hour), WithRetainLast(1)))
+	require.NoError(t, txn.SetProperties(iceberg.Properties{GCEnabledKey: "false"}))
+
+	_, err = txn.Commit(context.Background())
+	require.ErrorContains(t, err, "GC is disabled")
+	require.Equal(t, int32(0), cat.attempts.Load(), "GC-disabled snapshot expiration must not commit")
 }
 
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -853,41 +853,26 @@ func expireSnapshotsSnapshot(t *testing.T, txn *Transaction, snapshotID int64) *
 }
 
 func TestExpireSnapshotsRejectsWhenGCDisabled(t *testing.T) {
-	txn := newTransactionWithSnapshotRefs(t)
-	txn.meta.props = iceberg.Properties{GCEnabledKey: "false"}
+	tests := []struct {
+		name string
+		opts []ExpireSnapshotsOpt
+	}{
+		{name: "with post-commit cleanup"},
+		{name: "without post-commit cleanup", opts: []ExpireSnapshotsOpt{WithPostCommit(false)}},
+	}
 
-	err := txn.ExpireSnapshots()
-	require.ErrorContains(t, err, "GC is disabled")
-	require.Empty(t, txn.reqs)
-	_, err = txn.meta.SnapshotByID(10)
-	require.NoError(t, err)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txn := newTransactionWithSnapshotRefs(t)
+			txn.meta.props = iceberg.Properties{GCEnabledKey: "false"}
 
-func TestExpireSnapshotsRejectsWhenGCDisabledBeforeCommit(t *testing.T) {
-	tbl, cat := newValidationTestTable(t, nil)
-
-	builder, err := MetadataBuilderFromBase(tbl.Metadata(), "")
-	require.NoError(t, err)
-	require.NoError(t, builder.AddSnapshot(&Snapshot{
-		SnapshotID:     99,
-		SequenceNumber: 2,
-		ManifestList:   "file:///tmp/validation-test/metadata/manifest-99.avro",
-		TimestampMs:    time.Now().UnixMilli(),
-		Summary:        &Summary{Operation: OpAppend},
-	}))
-	meta, err := builder.Build()
-	require.NoError(t, err)
-	cat.metadata = meta
-	tbl = New(Identifier{"db", "validation"}, meta, "file:///tmp/validation-test/metadata/v1.metadata.json",
-		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
-
-	txn := tbl.NewTransaction()
-	require.NoError(t, txn.ExpireSnapshots(WithOlderThan(time.Hour), WithRetainLast(1)))
-	require.NoError(t, txn.SetProperties(iceberg.Properties{GCEnabledKey: "false"}))
-
-	_, err = txn.Commit(context.Background())
-	require.ErrorContains(t, err, "GC is disabled")
-	require.Equal(t, int32(0), cat.attempts.Load(), "GC-disabled snapshot expiration must not commit")
+			err := txn.ExpireSnapshots(tt.opts...)
+			require.ErrorContains(t, err, "GC is disabled")
+			require.Empty(t, txn.reqs)
+			_, err = txn.meta.SnapshotByID(10)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestTransactionApplyDedupesEquivalentRequirementsWithinAndAcrossCalls(t *testing.T) {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -854,23 +854,51 @@ func expireSnapshotsSnapshot(t *testing.T, txn *Transaction, snapshotID int64) *
 
 func TestExpireSnapshotsRejectsWhenGCDisabled(t *testing.T) {
 	tests := []struct {
-		name string
-		opts []ExpireSnapshotsOpt
+		name    string
+		gcValue string
+		opts    []ExpireSnapshotsOpt
 	}{
-		{name: "with post-commit cleanup"},
-		{name: "without post-commit cleanup", opts: []ExpireSnapshotsOpt{WithPostCommit(false)}},
+		{name: "false with post-commit cleanup", gcValue: "false"},
+		{name: "false without post-commit cleanup", gcValue: "false", opts: []ExpireSnapshotsOpt{WithPostCommit(false)}},
+		{name: "one", gcValue: "1"},
+		{name: "garbage", gcValue: "garbage"},
+		{name: "false with trailing space", gcValue: "false "},
+		{name: "true with trailing space", gcValue: "true "},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			txn := newTransactionWithSnapshotRefs(t)
-			txn.meta.props = iceberg.Properties{GCEnabledKey: "false"}
+			txn.meta.props = iceberg.Properties{GCEnabledKey: tt.gcValue}
 
 			err := txn.ExpireSnapshots(tt.opts...)
 			require.ErrorContains(t, err, "GC is disabled")
 			require.Empty(t, txn.reqs)
 			_, err = txn.meta.SnapshotByID(10)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsGCEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		props iceberg.Properties
+		want  bool
+	}{
+		{name: "missing", want: true},
+		{name: "true", props: iceberg.Properties{GCEnabledKey: "true"}, want: true},
+		{name: "mixed case true", props: iceberg.Properties{GCEnabledKey: "TrUe"}, want: true},
+		{name: "false", props: iceberg.Properties{GCEnabledKey: "false"}},
+		{name: "one", props: iceberg.Properties{GCEnabledKey: "1"}},
+		{name: "garbage", props: iceberg.Properties{GCEnabledKey: "garbage"}},
+		{name: "false with trailing space", props: iceberg.Properties{GCEnabledKey: "false "}},
+		{name: "true with trailing space", props: iceberg.Properties{GCEnabledKey: "true "}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isGCEnabled(tt.props))
 		})
 	}
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -632,7 +632,7 @@ func (u *removeSnapshotsUpdate) Apply(builder *MetadataBuilder) error {
 }
 
 func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table, postTable *Table) error {
-	if !u.postCommit || postTable == nil || !postTable.Properties().GetBool(GCEnabledKey, GCEnabledDefault) {
+	if !u.postCommit || postTable == nil || !isGCEnabled(postTable.Properties()) {
 		return nil
 	}
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -632,7 +632,7 @@ func (u *removeSnapshotsUpdate) Apply(builder *MetadataBuilder) error {
 }
 
 func (u *removeSnapshotsUpdate) PostCommit(ctx context.Context, preTable *Table, postTable *Table) error {
-	if !u.postCommit {
+	if !u.postCommit || postTable == nil || !postTable.Properties().GetBool(GCEnabledKey, GCEnabledDefault) {
 		return nil
 	}
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -146,33 +146,48 @@ func TestRemoveSnapshotsPostCommitSkipped(t *testing.T) {
 }
 
 func TestRemoveSnapshotsPostCommitSkippedWhenGCDisabled(t *testing.T) {
-	preMeta := buildMetaJSON(metaJSONOpts{
-		snapshots:  `{"snapshot-id":1,"timestamp-ms":1000}`,
-		statistics: `{"snapshot-id":1,"statistics-path":"s3://bucket/stats/snap1.puffin","file-size-in-bytes":100,"file-footer-size-in-bytes":10,"blob-metadata":[]}`,
-	})
-	postMeta := buildMetaJSON(metaJSONOpts{})
+	tests := []struct {
+		name    string
+		gcValue string
+	}{
+		{name: "false", gcValue: "false"},
+		{name: "one", gcValue: "1"},
+		{name: "garbage", gcValue: "garbage"},
+		{name: "false with trailing space", gcValue: "false "},
+		{name: "true with trailing space", gcValue: "true "},
+	}
 
-	pre, err := ParseMetadataString(preMeta)
-	require.NoError(t, err)
-	post, err := ParseMetadataString(postMeta)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preMeta := buildMetaJSON(metaJSONOpts{
+				snapshots:  `{"snapshot-id":1,"timestamp-ms":1000}`,
+				statistics: `{"snapshot-id":1,"statistics-path":"s3://bucket/stats/snap1.puffin","file-size-in-bytes":100,"file-footer-size-in-bytes":10,"blob-metadata":[]}`,
+			})
+			postMeta := buildMetaJSON(metaJSONOpts{})
 
-	postBuilder, err := MetadataBuilderFromBase(post, "")
-	require.NoError(t, err)
-	require.NoError(t, postBuilder.SetProperties(iceberg.Properties{GCEnabledKey: "false"}))
-	post, err = postBuilder.Build()
-	require.NoError(t, err)
+			pre, err := ParseMetadataString(preMeta)
+			require.NoError(t, err)
+			post, err := ParseMetadataString(postMeta)
+			require.NoError(t, err)
 
-	tio := newTrackingCallsIO()
-	tio.files["s3://bucket/stats/snap1.puffin"] = []byte("puffin")
-	fsF := testFSF(tio)
-	preTable := New(Identifier{"ns", "tbl"}, pre, "metadata.json", fsF, nil)
-	postTable := New(Identifier{"ns", "tbl"}, post, "metadata.json", fsF, nil)
+			postBuilder, err := MetadataBuilderFromBase(post, "")
+			require.NoError(t, err)
+			require.NoError(t, postBuilder.SetProperties(iceberg.Properties{GCEnabledKey: tt.gcValue}))
+			post, err = postBuilder.Build()
+			require.NoError(t, err)
 
-	update := NewRemoveSnapshotsUpdate([]int64{1}, true)
-	require.NoError(t, update.PostCommit(context.Background(), preTable, postTable))
-	require.Contains(t, tio.files, "s3://bucket/stats/snap1.puffin")
-	require.Zero(t, tio.removeCount["s3://bucket/stats/snap1.puffin"])
+			tio := newTrackingCallsIO()
+			tio.files["s3://bucket/stats/snap1.puffin"] = []byte("puffin")
+			fsF := testFSF(tio)
+			preTable := New(Identifier{"ns", "tbl"}, pre, "metadata.json", fsF, nil)
+			postTable := New(Identifier{"ns", "tbl"}, post, "metadata.json", fsF, nil)
+
+			update := NewRemoveSnapshotsUpdate([]int64{1}, true)
+			require.NoError(t, update.PostCommit(context.Background(), preTable, postTable))
+			require.Contains(t, tio.files, "s3://bucket/stats/snap1.puffin")
+			require.Zero(t, tio.removeCount["s3://bucket/stats/snap1.puffin"])
+		})
+	}
 }
 
 func TestRemoveSnapshotsPostCommitDeletesStatisticsFiles(t *testing.T) {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -145,6 +145,36 @@ func TestRemoveSnapshotsPostCommitSkipped(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRemoveSnapshotsPostCommitSkippedWhenGCDisabled(t *testing.T) {
+	preMeta := buildMetaJSON(metaJSONOpts{
+		snapshots:  `{"snapshot-id":1,"timestamp-ms":1000}`,
+		statistics: `{"snapshot-id":1,"statistics-path":"s3://bucket/stats/snap1.puffin","file-size-in-bytes":100,"file-footer-size-in-bytes":10,"blob-metadata":[]}`,
+	})
+	postMeta := buildMetaJSON(metaJSONOpts{})
+
+	pre, err := ParseMetadataString(preMeta)
+	require.NoError(t, err)
+	post, err := ParseMetadataString(postMeta)
+	require.NoError(t, err)
+
+	postBuilder, err := MetadataBuilderFromBase(post, "")
+	require.NoError(t, err)
+	require.NoError(t, postBuilder.SetProperties(iceberg.Properties{GCEnabledKey: "false"}))
+	post, err = postBuilder.Build()
+	require.NoError(t, err)
+
+	tio := newTrackingCallsIO()
+	tio.files["s3://bucket/stats/snap1.puffin"] = []byte("puffin")
+	fsF := testFSF(tio)
+	preTable := New(Identifier{"ns", "tbl"}, pre, "metadata.json", fsF, nil)
+	postTable := New(Identifier{"ns", "tbl"}, post, "metadata.json", fsF, nil)
+
+	update := NewRemoveSnapshotsUpdate([]int64{1}, true)
+	require.NoError(t, update.PostCommit(context.Background(), preTable, postTable))
+	require.Contains(t, tio.files, "s3://bucket/stats/snap1.puffin")
+	require.Zero(t, tio.removeCount["s3://bucket/stats/snap1.puffin"])
+}
+
 func TestRemoveSnapshotsPostCommitDeletesStatisticsFiles(t *testing.T) {
 	// preTable has snapshot 1 with associated statistics and partition statistics files.
 	// postTable has no snapshots and no statistics (snapshot 1 has been expired).

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -335,7 +335,7 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 | `history.expire.min-snapshots-to-keep` | Minimum snapshots to retain when expiring. Default `1`. |
 | `history.expire.max-snapshot-age-ms` | Maximum age of retained snapshots. Default `432000000` (5 days). |
 | `history.expire.max-ref-age-ms` | Maximum age of branch/tag refs that are not the main branch. Default `Long.MAX_VALUE` (forever). |
-| `gc.enabled` | Gate for orphan-file cleanup. |
+| `gc.enabled` | Controls physical garbage collection. Snapshot expiration is rejected when `false`, and data-file cleanup skips deletion. |
 
 The unprefixed retention property names are accepted as compatibility fallbacks. The `history.expire.*` properties take precedence when both forms are set.
 


### PR DESCRIPTION
## Summary

`ExpireSnapshots` could remove snapshots and later garbage-collect their files even when the table property `gc.enabled=false`.

This change:
- rejects snapshot expiration when garbage collection is disabled
- applies the guard before staging metadata requirements
- keeps the behavior independent of `WithPostCommit(false)`
- exposes the shared `gc.enabled` property constant and default
- updates the cleanup documentation

The diagnostic follows the current Iceberg Java implementation, using Go's lowercase error-string convention.

## Test plan

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./codec/... ./table/...`