### PR TITLE
feat(table,rest): complete server-side scan delegation (Phase 5)

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1116,7 +1116,15 @@ func (r *Catalog) checkValidNamespace(ident table.Identifier) error {
 	return nil
 }
 
-func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {
+func (r *Catalog) tableFromResponse(
+	_ context.Context,
+	identifier []string,
+	metadata table.Metadata,
+	loc string,
+	config iceberg.Properties,
+	scanPlanningConfig iceberg.Properties,
+	credsVended bool,
+) (*table.Table, error) {
 	var fsF func(context.Context) (iceio.IO, error)
 	if credsVended {
 		refresher := &vendedCredentialRefresher{
@@ -1151,7 +1159,7 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF,
 		r,
 		table.WithMetricsReporter(reporter),
-		table.WithScanPlanningIOProperties(config),
+		table.WithScanPlanningIOProperties(scanPlanningConfig),
 	), nil
 }
 
@@ -1387,10 +1395,11 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 // commitStagedCreate performs the second phase of a staged table
@@ -1602,10 +1611,11 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*table.Table, error) {
@@ -1632,10 +1642,11 @@ func (r *Catalog) LoadTable(ctx context.Context, identifier table.Identifier) (*
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requirements []table.Requirement, updates []table.Update) (*table.Table, error) {
@@ -1679,7 +1690,7 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 
-	return r.tableFromResponse(ctx, ident, ret.Metadata, ret.MetadataLoc, config, false)
+	return r.tableFromResponse(ctx, ident, ret.Metadata, ret.MetadataLoc, config, config, false)
 }
 
 func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1151,6 +1151,7 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF,
 		r,
 		table.WithMetricsReporter(reporter),
+		table.WithScanPlanningIOProperties(config),
 	), nil
 }
 

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -206,6 +206,11 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 	if resp.PlanID != nil {
 		planID = *resp.PlanID
 	}
+	cleanup := func() {
+		if planID != "" {
+			r.abandonPlan(ctx, req.Identifier, planID, DefaultWaitForPlanOptions.CancelGracePeriod)
+		}
+	}
 
 	// Resolve to a completed plan: use an inline result as-is, or poll a
 	// submitted one to completion. PlanTableScan maps failed to an error and
@@ -229,22 +234,25 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 
 	envelopes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
 	if err != nil {
-		if planID != "" {
-			r.abandonPlan(ctx, req.Identifier, planID, DefaultWaitForPlanOptions.CancelGracePeriod)
-		}
+		cleanup()
 
 		return table.ScanPlanningResult{}, err
 	}
 
 	tasks, err := remoteScanTasks(envelopes, req)
 	if err != nil {
+		cleanup()
+
 		return table.ScanPlanningResult{}, err
 	}
 
-	return table.ScanPlanningResult{
+	result := table.ScanPlanningResult{
 		Tasks: tasks,
 		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req.Metadata)),
-	}, nil
+	}
+	cleanup()
+
+	return result, nil
 }
 
 // planIOBaseProps rebuilds the props the table's own FileIO was built with, so a
@@ -301,7 +309,7 @@ func remoteScanTasks(envelopes []ScanTasks, req table.ScanPlanningRequest) ([]ta
 			continue
 		}
 
-		tasks, err := DecodeScanTasks(envelope, req.Metadata, nil, req.RowFilter)
+		tasks, err := DecodeScanTasks(envelope, req.Metadata, req.Schema, req.RowFilter)
 		if err != nil {
 			return nil, fmt.Errorf("decoding remote scan task envelope %d: %w", i, err)
 		}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -145,20 +145,15 @@ const headerIdempotencyKey = "Idempotency-Key"
 // --- Capability gating -------------------------------------------------------
 //
 // Capability is split into two predicates. SupportsPlanTableScan is the narrow
-// "server can plan inline" check (plan endpoint only). SupportsFullRemoteScanPlanning
-// is the endpoint-level execution check: an
-// end-to-end plan can come back `submitted` or with `plan-tasks` that need the
-// poll/fetch endpoints to finish, and auto mode has no second chance to fall
-// back to local once it commits to remote, so a plan-only server must not count
-// as end-to-end capable. The cancel endpoint is best-effort cleanup rather than
-// an execution dependency.
-//
-// SupportsRemoteScanPlanning is the table.ScanPlanner-facing predicate that
-// table.Scan's auto mode routes on. It requires the execution endpoints because
-// an accepted plan may be asynchronous or return opaque plan-task handles.
+// "server can plan" check (plan endpoint only). SupportsFullRemoteScanPlanning
+// reports whether every continuation endpoint is also advertised. A plan-only
+// server can still complete a remote scan synchronously with inline file tasks,
+// so table.Scan routes on the narrow predicate and PlanFiles checks continuation
+// endpoints only when the response requires polling or task expansion. The
+// cancel endpoint is best-effort cleanup rather than an execution dependency.
 
-// SupportsPlanTableScan reports whether the server advertised the synchronous
-// plan endpoint.
+// SupportsPlanTableScan reports whether the server advertised the plan
+// submission endpoint.
 func (r *Catalog) SupportsPlanTableScan() bool {
 	return r.endpoints.contains(endpointPlanTableScan)
 }
@@ -175,11 +170,11 @@ func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 
 // --- table.ScanPlanner implementation ---------------------------------------
 
-// SupportsRemoteScanPlanning reports whether this catalog can complete a remote
-// plan end-to-end. table.Scan's auto mode routes on it, calling PlanFiles when it
-// is true.
+// SupportsRemoteScanPlanning reports whether this catalog can submit a remote
+// plan. Any continuation capability is validated against the response returned
+// by the server.
 func (r *Catalog) SupportsRemoteScanPlanning() bool {
-	return r.SupportsFullRemoteScanPlanning()
+	return r.SupportsPlanTableScan()
 }
 
 // PlanFiles plans a scan server-side and returns tasks (and, optionally, a
@@ -260,13 +255,10 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 		return table.ScanPlanningResult{}, err
 	}
 
-	result := table.ScanPlanningResult{
+	return table.ScanPlanningResult{
 		Tasks: tasks,
 		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req)),
-	}
-	cleanup()
-
-	return result, nil
+	}, nil
 }
 
 // planIOBaseProps rebuilds the props the table's own FileIO was built with, so

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -225,6 +225,20 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 	case PlanStatusSubmitted:
 		completed, err = r.WaitForPlan(ctx, req.Identifier, *resp.PlanID, WaitForPlanOptions{})
 		if err != nil {
+			// WaitForPlan already abandons plans when its retry budget or the
+			// caller's context is exhausted. Other terminal client/transport
+			// errors can leave a submitted plan active, so release it here.
+			if !errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) &&
+				!errors.Is(err, ErrPlanPollExhausted) &&
+				!errors.Is(err, ErrPlanFailed) &&
+				!errors.Is(err, ErrPlanCancelled) &&
+				!errors.Is(err, ErrPlanExpired) &&
+				!errors.Is(err, catalog.ErrNoSuchTable) &&
+				!errors.Is(err, catalog.ErrNoSuchNamespace) {
+				cleanup()
+			}
+
 			return table.ScanPlanningResult{}, err
 		}
 	default:
@@ -248,22 +262,24 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 
 	result := table.ScanPlanningResult{
 		Tasks: tasks,
-		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req.Metadata)),
+		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req)),
 	}
 	cleanup()
 
 	return result, nil
 }
 
-// planIOBaseProps rebuilds the props the table's own FileIO was built with, so a
-// plan-scoped IO keeps settings like a custom S3 endpoint or region. loadTable's
-// config block never reaches the planner seam, so it isn't included.
-func (r *Catalog) planIOBaseProps(meta table.ScanPlanningMetadata) iceberg.Properties {
+// planIOBaseProps rebuilds the props the table's own FileIO was built with, so
+// a plan-scoped IO keeps settings like a custom S3 endpoint or region. The
+// table-scoped properties take precedence over catalog and metadata defaults;
+// this mirrors the merge order used by LoadTable.
+func (r *Catalog) planIOBaseProps(req table.ScanPlanningRequest) iceberg.Properties {
 	props := make(iceberg.Properties, len(r.props))
 	maps.Copy(props, r.props)
-	if meta != nil {
-		maps.Copy(props, meta.Properties())
+	if req.Metadata != nil {
+		maps.Copy(props, req.Metadata.Properties())
 	}
+	maps.Copy(props, req.FileIOProperties)
 
 	return props
 }

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -255,10 +255,13 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 		return table.ScanPlanningResult{}, err
 	}
 
-	return table.ScanPlanningResult{
+	result := table.ScanPlanningResult{
 		Tasks: tasks,
 		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req)),
-	}, nil
+	}
+	cleanup()
+
+	return result, nil
 }
 
 // planIOBaseProps rebuilds the props the table's own FileIO was built with, so

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -16,9 +16,8 @@
 // under the License.
 
 // This file contains the REST server-side scan planning client surface for
-// apache/iceberg-go#1178. Low-level client methods and endpoint capability
-// checks are implemented here; higher-level orchestration, scanner delegation,
-// expression wrappers, and scan-task content decoding land in follow-up phases.
+// apache/iceberg-go#1178. It includes the low-level endpoint methods and the
+// end-to-end planner implementation used by table.Scan.
 
 package rest
 
@@ -153,10 +152,8 @@ const headerIdempotencyKey = "Idempotency-Key"
 // count as end-to-end capable.
 //
 // SupportsRemoteScanPlanning is the table.ScanPlanner-facing predicate that
-// table.Scan's auto mode routes on. It is deliberately gated to false while
-// PlanFiles is an unimplemented stub: routing on endpoint capability alone would
-// send an auto-mode scan into PlanFiles and surface ErrNotImplemented instead of
-// falling back to local planning. It flips on with the PlanFiles phase.
+// table.Scan's auto mode routes on. It requires all four endpoints because an
+// accepted plan may be asynchronous or return opaque plan-task handles.
 
 // SupportsPlanTableScan reports whether the server advertised the synchronous
 // plan endpoint.
@@ -178,15 +175,9 @@ func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 
 // SupportsRemoteScanPlanning reports whether this catalog can complete a remote
 // plan end-to-end. table.Scan's auto mode routes on it, calling PlanFiles when it
-// is true, so it must stay false until PlanFiles is implemented — otherwise an
-// auto-mode scan against a server advertising all four endpoints would fail with
-// ErrNotImplemented instead of falling back to local planning.
-//
-// TODO(#1178): return SupportsFullRemoteScanPlanning() once PlanFiles is wired
-// end-to-end. Until then, callers probing endpoint capability should use
-// SupportsFullRemoteScanPlanning / SupportsPlanTableScan directly.
+// is true.
 func (r *Catalog) SupportsRemoteScanPlanning() bool {
-	return false
+	return r.SupportsFullRemoteScanPlanning()
 }
 
 // PlanFiles plans a scan server-side and returns tasks (and, optionally, a
@@ -194,11 +185,10 @@ func (r *Catalog) SupportsRemoteScanPlanning() bool {
 // submitted plan to completion, and expands any plan-task handles into their
 // tasks before returning.
 //
-// Decoding the returned tasks into table.FileScanTask is the one piece still
-// stubbed: RESTFileScanTask/RESTDeleteFile are empty pending the scan-task
-// decoder phase, so a plan that yields any task surfaces ErrNotImplemented (see
-// remoteScanTasks). SupportsRemoteScanPlanning therefore stays false until that
-// lands, so auto-mode scans keep planning locally rather than routing here.
+// Each response is decoded as its own ScanTasks envelope before the results are
+// combined. Delete-file references are scoped to the envelope that returned
+// them, so flattening all responses first would attach deletes to the wrong
+// data files when the server uses plan-task fanout.
 func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
 	wire, err := planTableScanRequestFrom(req)
 	if err != nil {
@@ -230,12 +220,12 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 			"%w: unexpected plan status %q from planTableScan", ErrRESTError, resp.Status)
 	}
 
-	files, deletes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
+	envelopes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
 	if err != nil {
 		return table.ScanPlanningResult{}, err
 	}
 
-	tasks, err := remoteScanTasks(files, deletes)
+	tasks, err := remoteScanTasks(envelopes, req)
 	if err != nil {
 		return table.ScanPlanningResult{}, err
 	}
@@ -259,14 +249,13 @@ func (r *Catalog) planIOBaseProps(meta table.ScanPlanningMetadata) iceberg.Prope
 	return props
 }
 
-// collectScanTasks expands plan-task handles into their tasks, walking the
-// fanout: a fetchScanTasks response can itself return more plan-tasks. It
-// accumulates the file-scan-tasks and delete-files reachable from the initial
-// set. A handle is fetched at most once; a server that re-issues one would
-// otherwise loop forever.
-func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]RESTFileScanTask, []RESTDeleteFile, error) {
-	files := append([]RESTFileScanTask(nil), tasks.FileScanTasks...)
-	deletes := append([]RESTDeleteFile(nil), tasks.DeleteFiles...)
+// collectScanTasks expands plan-task handles into their task envelopes, walking
+// the fanout: a fetchScanTasks response can itself return more plan-tasks. A
+// handle is fetched at most once; a server that re-issues one would otherwise
+// loop forever. The envelope boundaries are retained because delete-file
+// references are local to each response.
+func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]ScanTasks, error) {
+	envelopes := []ScanTasks{tasks}
 
 	queue := append([]string(nil), tasks.PlanTasks...)
 	seen := make(map[string]bool, len(queue))
@@ -280,26 +269,35 @@ func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, 
 
 		resp, err := r.FetchScanTasks(ctx, ident, FetchScanTasksRequest{PlanTask: handle})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		files = append(files, resp.FileScanTasks...)
-		deletes = append(deletes, resp.DeleteFiles...)
+		envelopes = append(envelopes, resp.ScanTasks)
 		queue = append(queue, resp.PlanTasks...)
 	}
 
-	return files, deletes, nil
+	return envelopes, nil
 }
 
-// remoteScanTasks decodes the server's task payload into domain FileScanTasks.
-// Blocked for now: RESTFileScanTask/RESTDeleteFile are empty pending the
-// scan-task decoder phase, so an empty plan decodes to no tasks while any actual
-// task surfaces ErrNotImplemented. The decoder phase replaces this body.
-func remoteScanTasks(files []RESTFileScanTask, deletes []RESTDeleteFile) ([]table.FileScanTask, error) {
-	if len(files) == 0 && len(deletes) == 0 {
-		return nil, nil
+// remoteScanTasks decodes each server task envelope into domain FileScanTasks.
+// The decoder must run before envelopes are combined because delete-file
+// references are indexes into the envelope-local delete-files array.
+func remoteScanTasks(envelopes []ScanTasks, req table.ScanPlanningRequest) ([]table.FileScanTask, error) {
+	var result []table.FileScanTask
+	for i, envelope := range envelopes {
+		// Keep empty completed plans cheap and allow the low-level planner method
+		// to return no tasks even when a caller did not provide metadata.
+		if len(envelope.FileScanTasks) == 0 && len(envelope.DeleteFiles) == 0 {
+			continue
+		}
+
+		tasks, err := DecodeScanTasks(envelope, req.Metadata, nil, req.RowFilter)
+		if err != nil {
+			return nil, fmt.Errorf("decoding remote scan task envelope %d: %w", i, err)
+		}
+		result = append(result, tasks...)
 	}
 
-	return nil, fmt.Errorf("%w: decoding remote scan tasks", iceberg.ErrNotImplemented)
+	return result, nil
 }
 
 // planIOFromCredentials wraps a plan's vended storage credentials in a lazy

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -30,6 +30,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -145,15 +146,16 @@ const headerIdempotencyKey = "Idempotency-Key"
 //
 // Capability is split into two predicates. SupportsPlanTableScan is the narrow
 // "server can plan inline" check (plan endpoint only). SupportsFullRemoteScanPlanning
-// is the endpoint-level "server advertises all four endpoints" check: an
+// is the endpoint-level execution check: an
 // end-to-end plan can come back `submitted` or with `plan-tasks` that need the
-// poll/cancel/fetch endpoints to finish, and auto mode has no second chance to
-// fall back to local once it commits to remote, so a plan-only server must not
-// count as end-to-end capable.
+// poll/fetch endpoints to finish, and auto mode has no second chance to fall
+// back to local once it commits to remote, so a plan-only server must not count
+// as end-to-end capable. The cancel endpoint is best-effort cleanup rather than
+// an execution dependency.
 //
 // SupportsRemoteScanPlanning is the table.ScanPlanner-facing predicate that
-// table.Scan's auto mode routes on. It requires all four endpoints because an
-// accepted plan may be asynchronous or return opaque plan-task handles.
+// table.Scan's auto mode routes on. It requires the execution endpoints because
+// an accepted plan may be asynchronous or return opaque plan-task handles.
 
 // SupportsPlanTableScan reports whether the server advertised the synchronous
 // plan endpoint.
@@ -161,13 +163,13 @@ func (r *Catalog) SupportsPlanTableScan() bool {
 	return r.endpoints.contains(endpointPlanTableScan)
 }
 
-// SupportsFullRemoteScanPlanning reports whether the server advertised all four
-// scan-planning endpoints (plan, fetch-result, cancel, fetch-tasks), i.e. it can
-// drive the async/fanout path, not just sync inline planning.
+// SupportsFullRemoteScanPlanning reports whether the server advertised the
+// execution endpoints (plan, fetch-result, fetch-tasks), i.e. it can drive the
+// async/fanout path, not just sync inline planning. Cancellation is optional
+// cleanup and does not prevent a plan from producing tasks.
 func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 	return r.SupportsPlanTableScan() &&
 		r.endpoints.contains(endpointFetchPlanResult) &&
-		r.endpoints.contains(endpointCancelPlanning) &&
 		r.endpoints.contains(endpointFetchScanTasks)
 }
 
@@ -200,6 +202,11 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 		return table.ScanPlanningResult{}, err
 	}
 
+	planID := ""
+	if resp.PlanID != nil {
+		planID = *resp.PlanID
+	}
+
 	// Resolve to a completed plan: use an inline result as-is, or poll a
 	// submitted one to completion. PlanTableScan maps failed to an error and
 	// rejects other statuses, so only completed/submitted reach here.
@@ -222,6 +229,10 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 
 	envelopes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
 	if err != nil {
+		if planID != "" {
+			r.abandonPlan(ctx, req.Identifier, planID, DefaultWaitForPlanOptions.CancelGracePeriod)
+		}
+
 		return table.ScanPlanningResult{}, err
 	}
 
@@ -300,27 +311,21 @@ func remoteScanTasks(envelopes []ScanTasks, req table.ScanPlanningRequest) ([]ta
 	return result, nil
 }
 
-// planIOFromCredentials wraps a plan's vended storage credentials in a lazy
-// PlanIO, overlaid on the table's base IO props so vended keys win on collision.
-// With none vended it returns a nil PlanIO, and the scan falls back to the
-// table's own FileIO.
+// planIOFromCredentials wraps a plan's prefix-scoped storage credentials in a
+// lazy PlanIO. The returned IO resolves the longest matching credential prefix
+// for each data or delete file it opens, overlaid on the table's base IO props
+// so vended keys win on collision. With none vended it returns a nil PlanIO,
+// and the scan falls back to the table's own FileIO.
 func planIOFromCredentials(creds []StorageCredential, location string, baseProps iceberg.Properties) table.PlanIO {
 	if len(creds) == 0 {
 		return nil
 	}
 
-	// TODO(#1178): plan.storage-credentials is prefix-scoped, but this builds one
-	// IO from the metadata location — wrong cred if data/delete files sit under a
-	// different prefix. The scan-task decoder settles the PlanIO shape.
-	resolved := resolveStorageCredentials(creds, location)
-	props := make(iceberg.Properties, len(baseProps)+len(resolved))
-	maps.Copy(props, baseProps)
-	maps.Copy(props, resolved)
-
 	return &planScopedIO{refresher: &vendedCredentialRefresher{
-		mu:       semaphore.NewWeighted(1),
-		location: location,
-		props:    props,
+		mu:          semaphore.NewWeighted(1),
+		location:    location,
+		props:       maps.Clone(baseProps),
+		credentials: slices.Clone(creds),
 		// fetchCreds stays nil: a plan's creds can't be renewed via the
 		// table-credentials endpoint, so an expiry is fatal, not a re-fetch.
 	}}
@@ -346,11 +351,16 @@ func (p *planScopedIO) Close() error {
 func planTableScanRequestFrom(req table.ScanPlanningRequest) (PlanTableScanRequest, error) {
 	out := PlanTableScanRequest{
 		SnapshotID:        req.SnapshotID,
-		Select:            req.SelectedFields,
 		MinRowsRequested:  req.MinRowsRequested,
 		CaseSensitive:     req.CaseSensitive,
 		UseSnapshotSchema: req.UseSnapshotSchema,
 		StatsFields:       req.StatsFields,
+	}
+	// `*` is table.Scan's local sentinel, not a REST FieldName. A planner
+	// normally expands it to schema field names before reaching this function;
+	// omitting it here is the safe fallback for direct callers without a schema.
+	if len(req.SelectedFields) > 0 && !slices.Contains(req.SelectedFields, "*") {
+		out.Select = slices.Clone(req.SelectedFields)
 	}
 
 	if req.RowFilter != nil && !req.RowFilter.Equals(iceberg.AlwaysTrue{}) {
@@ -378,8 +388,18 @@ func marshalScanFilter(req table.ScanPlanningRequest) ([]byte, error) {
 		caseSensitive = *req.CaseSensitive
 	}
 
-	// Snapshot-schema selection (UseSnapshotSchema) is OQ4, deferred; bind current.
-	bound, err := iceberg.BindExpr(req.Metadata.CurrentSchema(), req.RowFilter, caseSensitive)
+	schema := req.Schema
+	if schema == nil {
+		if req.Metadata == nil {
+			return nil, fmt.Errorf("%w: cannot encode scan filter without table metadata", iceberg.ErrInvalidArgument)
+		}
+		schema = req.Metadata.CurrentSchema()
+	}
+	if schema == nil {
+		return nil, fmt.Errorf("%w: cannot encode scan filter without a scan schema", iceberg.ErrInvalidArgument)
+	}
+
+	bound, err := iceberg.BindExpr(schema, req.RowFilter, caseSensitive)
 	if err != nil {
 		return nil, fmt.Errorf("%w: binding scan filter: %s", iceberg.ErrInvalidArgument, err)
 	}

--- a/catalog/rest/scan_planning_fake_test.go
+++ b/catalog/rest/scan_planning_fake_test.go
@@ -121,6 +121,7 @@ func TestPlanFakeCapabilityDiscovery(t *testing.T) {
 
 			assert.Equal(t, test.wantPlan, catalog.SupportsPlanTableScan())
 			assert.Equal(t, test.wantFullPlanning, catalog.SupportsFullRemoteScanPlanning())
+			assert.Equal(t, test.wantPlan, catalog.SupportsRemoteScanPlanning())
 
 			requests := srv.Requests()
 			require.Len(t, requests, 1)

--- a/catalog/rest/scan_planning_fake_test.go
+++ b/catalog/rest/scan_planning_fake_test.go
@@ -89,7 +89,7 @@ func TestPlanFakeCapabilityDiscovery(t *testing.T) {
 				planfake.FetchScanTasksEndpoint,
 			},
 			wantPlan:         true,
-			wantFullPlanning: false,
+			wantFullPlanning: true,
 		},
 		{
 			name: "missing task fetch",

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1214,6 +1214,37 @@ func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {
 	assert.Equal(t, int32(1), cancels.Load())
 }
 
+func TestPlanFilesCancelsAfterTerminalPollError(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchPlanResult,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"submitted","plan-id":"plan-1"}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			switch req.Method {
+			case http.MethodGet:
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			case http.MethodDelete:
+				cancels.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			}
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
 func TestRemoteScanTasksUsesResolvedSchemaForResiduals(t *testing.T) {
 	t.Parallel()
 
@@ -1298,7 +1329,7 @@ func TestPlanFilesDecodesFanoutTaskEnvelopes(t *testing.T) {
 }
 
 // TestPlanFilesSurfacesVendedCredentials checks a plan that vends storage
-// credentials yields a plan-scoped IO that keeps the catalog's IO props (the
+// credentials yields a plan-scoped IO that keeps the table's IO props (the
 // custom endpoint here) rather than running on the vended creds alone, with the
 // vended values winning where they overlap.
 func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
@@ -1310,11 +1341,15 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 			require.NoError(t, err)
 		})
 	})
-	cat.props["s3.endpoint"] = "https://minio.local"
-	cat.props["s3.access-key-id"] = "static"
+	cat.props["s3.endpoint"] = "https://catalog.local"
+	cat.props["s3.access-key-id"] = "catalog-static"
 
 	req := planFilesReq()
 	req.MetadataLocation = "s3://bucket/db/tbl/metadata/v1.json"
+	req.FileIOProperties = iceberg.Properties{
+		"s3.endpoint":      "https://table.local",
+		"s3.access-key-id": "table-static",
+	}
 
 	result, err := cat.PlanFiles(context.Background(), req)
 	require.NoError(t, err)
@@ -1322,7 +1357,8 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 
 	planIO, ok := result.IO.(*planScopedIO)
 	require.True(t, ok)
-	assert.Equal(t, "https://minio.local", planIO.refresher.props["s3.endpoint"])
+	assert.Equal(t, "https://table.local", planIO.refresher.props["s3.endpoint"])
+	assert.Equal(t, "table-static", planIO.refresher.props["s3.access-key-id"])
 	require.Len(t, planIO.refresher.credentials, 1)
 	assert.Equal(t, "vended", planIO.refresher.credentials[0].Config["s3.access-key-id"])
 }

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -956,6 +956,15 @@ func (m scanTestMetadata) CurrentSnapshot() *table.Snapshot             { return
 func (m scanTestMetadata) SnapshotByID(int64) *table.Snapshot           { return nil }
 func (m scanTestMetadata) Properties() iceberg.Properties               { return nil }
 
+type scanPlanningSchemaMetadata struct {
+	*scanTaskDecoderMetadata
+	current *iceberg.Schema
+	schemas []*iceberg.Schema
+}
+
+func (m scanPlanningSchemaMetadata) CurrentSchema() *iceberg.Schema { return m.current }
+func (m scanPlanningSchemaMetadata) Schemas() []*iceberg.Schema     { return m.schemas }
+
 // planFilesReq is a minimal planner request naming the test table.
 func planFilesReq() table.ScanPlanningRequest {
 	return table.ScanPlanningRequest{
@@ -1138,6 +1147,103 @@ func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
 	_, err := cat.PlanFiles(context.Background(), planFilesReq())
 	require.ErrorIs(t, err, ErrServiceUnavailable)
 	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, "h1", body.PlanTask)
+			_, err := w.Write([]byte(`{"file-scan-tasks":[]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	result, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.NoError(t, err)
+	assert.Empty(t, result.Tasks)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, "h1", body.PlanTask)
+			_, err := w.Write([]byte(`{"file-scan-tasks":[{}]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.ErrorIs(t, err, ErrRESTError)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestRemoteScanTasksUsesResolvedSchemaForResiduals(t *testing.T) {
+	t.Parallel()
+
+	decoderMetadata := newScanTaskDecoderMetadata()
+	oldSchema := decoderMetadata.schema
+	currentFields := append([]iceberg.NestedField(nil), oldSchema.Fields()...)
+	currentFields[1].Name = "new_category"
+	currentSchema := iceberg.NewSchema(11, currentFields...)
+	metadata := scanPlanningSchemaMetadata{
+		scanTaskDecoderMetadata: decoderMetadata,
+		current:                 currentSchema,
+		schemas:                 []*iceberg.Schema{currentSchema, oldSchema},
+	}
+	req := table.ScanPlanningRequest{
+		Metadata: metadata,
+		Schema:   oldSchema,
+		RowFilter: iceberg.GreaterThan(
+			iceberg.Reference("category"),
+			"old",
+		),
+	}
+	wireReq, err := planTableScanRequestFrom(req)
+	require.NoError(t, err)
+
+	wire := validScanTasksWire()
+	wire.FileScanTasks[0].ResidualFilter = wireReq.Filter
+	tasks, err := remoteScanTasks([]ScanTasks{wire}, req)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.True(t, tasks[0].Residual.Equals(req.RowFilter))
 }
 
 // TestPlanFilesDecodesFanoutTaskEnvelopes exercises the Phase 5 boundary from

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1208,7 +1208,7 @@ func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
 	assert.Equal(t, int32(1), cancels.Load())
 }
 
-func TestPlanFilesDoesNotCancelAfterSuccessfulMaterialization(t *testing.T) {
+func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
 	t.Parallel()
 
 	var cancels atomic.Int32
@@ -1238,7 +1238,7 @@ func TestPlanFilesDoesNotCancelAfterSuccessfulMaterialization(t *testing.T) {
 	result, err := cat.PlanFiles(context.Background(), planFilesReq())
 	require.NoError(t, err)
 	assert.Empty(t, result.Tasks)
-	assert.Zero(t, cancels.Load())
+	assert.Equal(t, int32(1), cancels.Load())
 }
 
 func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {
@@ -1423,7 +1423,8 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 }
 
 // TestPlanScopedIOExpiredCredentials checks a plan whose creds state an expiry
-// fails loudly once past it, since plan creds can't be renewed.
+// fails loudly for a matching location once past it, since plan creds can't be
+// renewed.
 func TestPlanScopedIOExpiredCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -1444,20 +1445,26 @@ func TestPlanScopedIOExpiredCredentials(t *testing.T) {
 	require.True(t, ok)
 	p.refresher.nowFunc = func() time.Time { return now }
 
-	// The first load caches an IO and picks up the stated expiry.
+	// The first load caches the prefix resolver rather than treating the plan's
+	// location-specific credentials as one global credential set.
 	fs, err := p.Load(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, fs)
-	assert.Equal(t, now.Add(time.Hour).UnixMilli(), p.refresher.expiresAt.UnixMilli())
+	assert.True(t, p.refresher.expiresAt.IsZero())
+	prefixIO, ok := fs.(*prefixScopedIO)
+	require.True(t, ok)
+	_, err = prefixIO.filesystemFor("file:///bucket/data.parquet")
+	require.NoError(t, err)
 
-	// Past the expiry, with no endpoint to renew from, the load fails.
+	// Past the expiry, access under the credential's prefix fails even though
+	// its filesystem was already cached.
 	p.refresher.nowFunc = func() time.Time { return now.Add(2 * time.Hour) }
-	_, err = p.Load(context.Background())
+	_, err = prefixIO.filesystemFor("file:///bucket/data.parquet")
 	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
 }
 
 // TestPlanScopedIOAlreadyExpiredCredentials checks creds that are already past
-// their expiry on the very first load fail loudly instead of yielding an IO.
+// their expiry fail loudly when a matching location is first opened.
 func TestPlanScopedIOAlreadyExpiredCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -1474,7 +1481,43 @@ func TestPlanScopedIOAlreadyExpiredCredentials(t *testing.T) {
 	require.True(t, ok)
 	p.refresher.nowFunc = func() time.Time { return now }
 
-	_, err := p.Load(context.Background())
+	fs, err := p.Load(context.Background())
+	require.NoError(t, err)
+	_, err = fs.Open("file:///bucket/data.parquet")
+	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
+}
+
+func TestPlanScopedIOIgnoresExpiredCredentialForUnrelatedPrefix(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	creds := []StorageCredential{
+		{
+			Prefix: "file:///archive/",
+			Config: iceberg.Properties{
+				keyS3TokenExpiresAtMs: strconv.FormatInt(now.Add(-time.Hour).UnixMilli(), 10),
+			},
+		},
+		{
+			Prefix: "file:///current/",
+			Config: iceberg.Properties{
+				keyS3TokenExpiresAtMs: strconv.FormatInt(now.Add(time.Hour).UnixMilli(), 10),
+			},
+		},
+	}
+
+	p, ok := planIOFromCredentials(creds, "file:///metadata/v1.json", nil).(*planScopedIO)
+	require.True(t, ok)
+	p.refresher.nowFunc = func() time.Time { return now }
+
+	fs, err := p.Load(context.Background())
+	require.NoError(t, err)
+	prefixIO, ok := fs.(*prefixScopedIO)
+	require.True(t, ok)
+	_, err = prefixIO.filesystemFor("file:///current/data.parquet")
+	require.NoError(t, err)
+
+	_, err = prefixIO.filesystemFor("file:///archive/data.parquet")
 	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
 }
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -120,12 +120,12 @@ func TestScanPlanningCapabilities(t *testing.T) {
 	t.Run("plan only", func(t *testing.T) {
 		t.Parallel()
 
-		// A plan-only server can plan inline, but a `submitted` reply could not
-		// be polled, so it is not full-remote capable.
+		// A plan-only server can plan inline even though it cannot handle response
+		// shapes that require polling or task expansion.
 		cat := &Catalog{endpoints: newEndpointSet([]endpoint{endpointPlanTableScan})}
 		assert.True(t, cat.SupportsPlanTableScan())
 		assert.False(t, cat.SupportsFullRemoteScanPlanning())
-		assert.False(t, cat.SupportsRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
 	})
 
 	t.Run("full remote planning", func(t *testing.T) {
@@ -992,6 +992,65 @@ func TestPlanFilesCompletedEmpty(t *testing.T) {
 	assert.Nil(t, result.IO)
 }
 
+func TestScanPlanningRemoteSupportsSynchronousPlanOnlyServer(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			planID := "plan-1"
+			require.NoError(t, json.NewEncoder(w).Encode(PlanTableScanResponse{
+				Status:    PlanStatusCompleted,
+				PlanID:    &planID,
+				ScanTasks: validScanTasksWire(),
+			}))
+		})
+	})
+
+	assert.True(t, cat.SupportsRemoteScanPlanning())
+	assert.False(t, cat.SupportsFullRemoteScanPlanning())
+
+	req := planFilesReq()
+	req.Metadata = metadata
+	req.Schema = metadata.schema
+	result, err := cat.PlanFiles(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 1)
+	assert.Equal(t, "s3://bucket/table/data.parquet", result.Tasks[0].File.FilePath())
+}
+
+func TestPlanFilesRequiresAdvertisedResponseContinuation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "submitted plan requires result fetch",
+			response: `{"status":"submitted","plan-id":"plan-1"}`,
+		},
+		{
+			name:     "plan task requires task fetch",
+			response: `{"status":"completed","plan-id":"plan-1","plan-tasks":["task-1"]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
+				mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+					_, err := w.Write([]byte(test.response))
+					require.NoError(t, err)
+				})
+			})
+
+			_, err := cat.PlanFiles(context.Background(), planFilesReq())
+			require.ErrorIs(t, err, ErrEndpointNotSupported)
+		})
+	}
+}
+
 // TestPlanFilesEncodesFilter checks the row filter reaches the plan request body
 // as ExpressionParser JSON.
 func TestPlanFilesEncodesFilter(t *testing.T) {
@@ -1149,7 +1208,7 @@ func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
 	assert.Equal(t, int32(1), cancels.Load())
 }
 
-func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
+func TestPlanFilesDoesNotCancelAfterSuccessfulMaterialization(t *testing.T) {
 	t.Parallel()
 
 	var cancels atomic.Int32
@@ -1179,7 +1238,7 @@ func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
 	result, err := cat.PlanFiles(context.Background(), planFilesReq())
 	require.NoError(t, err)
 	assert.Empty(t, result.Tasks)
-	assert.Equal(t, int32(1), cancels.Load())
+	assert.Zero(t, cancels.Load())
 }
 
 func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -121,8 +121,7 @@ func TestScanPlanningCapabilities(t *testing.T) {
 		t.Parallel()
 
 		// A plan-only server can plan inline, but a `submitted` reply could not
-		// be polled, so it is not full-remote capable. SupportsRemoteScanPlanning
-		// is false here too (gated off while PlanFiles is a stub).
+		// be polled, so it is not full-remote capable.
 		cat := &Catalog{endpoints: newEndpointSet([]endpoint{endpointPlanTableScan})}
 		assert.True(t, cat.SupportsPlanTableScan())
 		assert.False(t, cat.SupportsFullRemoteScanPlanning())
@@ -140,11 +139,7 @@ func TestScanPlanningCapabilities(t *testing.T) {
 		})}
 		assert.True(t, cat.SupportsPlanTableScan())
 		assert.True(t, cat.SupportsFullRemoteScanPlanning())
-		// SupportsRemoteScanPlanning stays false while PlanFiles is a stub, even
-		// when all four endpoints are advertised, so auto mode falls back to
-		// local instead of routing into ErrNotImplemented. Flips on with the
-		// PlanFiles phase.
-		assert.False(t, cat.SupportsRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
 	})
 
 	t.Run("default fallback does not advertise scan planning", func(t *testing.T) {
@@ -997,10 +992,9 @@ func TestPlanFilesEncodesFilter(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestPlanFilesTasksNotYetDecodable documents the one stubbed boundary: a plan
-// that returns actual file-scan-tasks surfaces ErrNotImplemented until the
-// scan-task decoder phase fills in RESTFileScanTask.
-func TestPlanFilesTasksNotYetDecodable(t *testing.T) {
+// TestPlanFilesRejectsMalformedScanTasks makes sure remote planning validates
+// the task payload instead of returning partially decoded tasks.
+func TestPlanFilesRejectsMalformedScanTasks(t *testing.T) {
 	t.Parallel()
 
 	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
@@ -1011,7 +1005,7 @@ func TestPlanFilesTasksNotYetDecodable(t *testing.T) {
 	})
 
 	_, err := cat.PlanFiles(context.Background(), planFilesReq())
-	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+	require.ErrorIs(t, err, ErrRESTError)
 }
 
 // TestPlanFilesPollsSubmittedPlan covers the async arm: a submitted plan is
@@ -1091,6 +1085,57 @@ func TestPlanFilesFanoutCycleTerminates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Tasks)
 	assert.Equal(t, int32(1), calls.Load())
+}
+
+// TestPlanFilesDecodesFanoutTaskEnvelopes exercises the Phase 5 boundary from
+// REST wire tasks to table.FileScanTask. In particular, each fetchScanTasks
+// response has its own delete-file reference namespace; decoding after
+// flattening the responses would attach the second task to the first delete.
+func TestPlanFilesDecodesFanoutTaskEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	first := validScanTasksWire()
+	first.FileScanTasks[0].DataFile.FilePath = "s3://bucket/table/first-data.parquet"
+	first.DeleteFiles[0].FilePath = "s3://bucket/table/first-delete.parquet"
+	first.PlanTasks = []string{"h1"}
+
+	second := validScanTasksWire()
+	second.FileScanTasks[0].DataFile.FilePath = "s3://bucket/table/second-data.parquet"
+	second.DeleteFiles[0].FilePath = "s3://bucket/table/second-delete.parquet"
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan, endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			response := struct {
+				Status PlanStatus `json:"status"`
+				PlanID string     `json:"plan-id"`
+				ScanTasks
+			}{
+				Status:    PlanStatusCompleted,
+				PlanID:    "plan-1",
+				ScanTasks: first,
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var got FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&got))
+			require.Equal(t, "h1", got.PlanTask)
+			require.NoError(t, json.NewEncoder(w).Encode(FetchScanTasksResponse{ScanTasks: second}))
+		})
+	})
+
+	req := planFilesReq()
+	req.Metadata = newScanTaskDecoderMetadata()
+	req.RowFilter = iceberg.GreaterThan(iceberg.Reference("id"), int64(10))
+
+	result, err := cat.PlanFiles(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 2)
+	assert.Equal(t, "s3://bucket/table/first-data.parquet", result.Tasks[0].File.FilePath())
+	assert.Equal(t, "s3://bucket/table/first-delete.parquet", result.Tasks[0].DeleteFiles[0].FilePath())
+	assert.Equal(t, "s3://bucket/table/second-data.parquet", result.Tasks[1].File.FilePath())
+	assert.Equal(t, "s3://bucket/table/second-delete.parquet", result.Tasks[1].DeleteFiles[0].FilePath())
+	assert.Same(t, req.RowFilter, result.Tasks[0].Residual)
 }
 
 // TestPlanFilesSurfacesVendedCredentials checks a plan that vends storage

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -142,6 +142,18 @@ func TestScanPlanningCapabilities(t *testing.T) {
 		assert.True(t, cat.SupportsRemoteScanPlanning())
 	})
 
+	t.Run("execution endpoints without optional cancel", func(t *testing.T) {
+		t.Parallel()
+
+		cat := &Catalog{endpoints: newEndpointSet([]endpoint{
+			endpointPlanTableScan,
+			endpointFetchPlanResult,
+			endpointFetchScanTasks,
+		})}
+		assert.True(t, cat.SupportsFullRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
+	})
+
 	t.Run("default fallback does not advertise scan planning", func(t *testing.T) {
 		t.Parallel()
 
@@ -918,6 +930,10 @@ func TestPlanTableScanRequestFromPassesFields(t *testing.T) {
 	assert.Equal(t, &caseSensitive, wire.CaseSensitive)
 	assert.Equal(t, []string{"a"}, wire.StatsFields)
 	assert.Nil(t, wire.Filter)
+
+	wire, err = planTableScanRequestFrom(table.ScanPlanningRequest{SelectedFields: []string{"*"}})
+	require.NoError(t, err)
+	assert.Nil(t, wire.Select, "the local wildcard sentinel is not a REST FieldName")
 }
 
 // scanFilterSchema is the schema filter-binding tests resolve references against.
@@ -1087,6 +1103,43 @@ func TestPlanFilesFanoutCycleTerminates(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load())
 }
 
+func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1","h2"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			if body.PlanTask == "h1" {
+				_, err := w.Write([]byte(`{}`))
+				require.NoError(t, err)
+
+				return
+			}
+
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.ErrorIs(t, err, ErrServiceUnavailable)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
 // TestPlanFilesDecodesFanoutTaskEnvelopes exercises the Phase 5 boundary from
 // REST wire tasks to table.FileScanTask. In particular, each fetchScanTasks
 // response has its own delete-file reference namespace; decoding after
@@ -1164,7 +1217,8 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 	planIO, ok := result.IO.(*planScopedIO)
 	require.True(t, ok)
 	assert.Equal(t, "https://minio.local", planIO.refresher.props["s3.endpoint"])
-	assert.Equal(t, "vended", planIO.refresher.props["s3.access-key-id"])
+	require.Len(t, planIO.refresher.credentials, 1)
+	assert.Equal(t, "vended", planIO.refresher.credentials[0].Config["s3.access-key-id"])
 }
 
 // TestPlanScopedIOExpiredCredentials checks a plan whose creds state an expiry

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -102,20 +102,6 @@ func parseCredentialExpiry(config iceberg.Properties) (time.Time, bool) {
 	return earliest, found
 }
 
-func earliestCredentialExpiry(creds []StorageCredential) (time.Time, bool) {
-	var earliest time.Time
-	found := false
-	for _, credential := range creds {
-		expiresAt, ok := parseCredentialExpiry(credential.Config)
-		if ok && (!found || expiresAt.Before(earliest)) {
-			earliest = expiresAt
-			found = true
-		}
-	}
-
-	return earliest, found
-}
-
 type vendedCredentialRefresher struct {
 	// Use a weighted semaphore with a single unit to use as an exclusive lock
 	// but cancellation (via context) is supported. This is important as we do IO
@@ -159,13 +145,12 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	switch {
 	case v.cachedIO == nil:
 		config = v.props
-		// Plan creds can already be past their expiry by the time we first use
-		// them, so check before building an IO we'd only hand back 403s from.
-		if v.fetchCreds == nil {
+		// A single resolved credential can already be past its expiry by the
+		// time we first use it, so check before building an IO we'd only hand
+		// back 403s from. Plan credentials are resolved later, per location, by
+		// prefixScopedIO and must not be rejected as one global credential set.
+		if v.fetchCreds == nil && len(v.credentials) == 0 {
 			expiresAt, ok := parseCredentialExpiry(config)
-			if len(v.credentials) > 0 {
-				expiresAt, ok = earliestCredentialExpiry(v.credentials)
-			}
 			if ok && v.now().After(expiresAt) {
 				return nil, v.expiredError(expiresAt)
 			}
@@ -185,8 +170,12 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	}
 
 	if len(v.credentials) > 0 {
-		v.cachedIO = newPrefixScopedIO(ctx, v.props, v.credentials)
-		v.expiresAt = v.expiresAtFromConfig(config)
+		prefixIO := newPrefixScopedIO(ctx, v.props, v.credentials)
+		prefixIO.nowFunc = v.now
+		v.cachedIO = prefixIO
+		// Expiry is enforced by prefixScopedIO against only the credential
+		// selected for each object location.
+		v.expiresAt = time.Time{}
 
 		return v.cachedIO, nil
 	}
@@ -219,10 +208,6 @@ func (v *vendedCredentialRefresher) expired() bool {
 
 func (v *vendedCredentialRefresher) expiresAtFromConfig(config iceberg.Properties) time.Time {
 	if len(v.credentials) > 0 {
-		if exp, ok := earliestCredentialExpiry(v.credentials); ok {
-			return exp
-		}
-
 		return time.Time{}
 	}
 
@@ -266,6 +251,7 @@ type prefixScopedIO struct {
 	mu          sync.Mutex
 	filesystems map[string]iceio.IO
 	closed      bool
+	nowFunc     func() time.Time
 }
 
 func newPrefixScopedIO(ctx context.Context, baseProps iceberg.Properties, credentials []StorageCredential) *prefixScopedIO {
@@ -297,6 +283,14 @@ func (p *prefixScopedIO) Remove(name string) error {
 
 func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
 	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	if credentialIndex >= 0 {
+		if expiresAt, ok := parseCredentialExpiry(p.credentials[credentialIndex].Config); ok &&
+			p.now().After(expiresAt) {
+			return nil, fmt.Errorf("%w: %s expired at %s",
+				ErrVendedCredentialsExpired, name, expiresAt.Format(time.RFC3339))
+		}
+	}
+
 	key := scopedFilesystemKey(credentialIndex, name)
 
 	p.mu.Lock()
@@ -319,6 +313,14 @@ func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
 	p.filesystems[key] = fs
 
 	return fs, nil
+}
+
+func (p *prefixScopedIO) now() time.Time {
+	if p.nowFunc != nil {
+		return p.nowFunc()
+	}
+
+	return time.Now()
 }
 
 func (p *prefixScopedIO) propertiesForLocation(name string) iceberg.Properties {

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -75,22 +75,31 @@ func matchingStorageCredentialIndex(creds []StorageCredential, location string) 
 
 var credentialExpiryKeys = []string{
 	keyS3TokenExpiresAtMs,
-	keyAdlsSasExpiresAtMs,
 	keyGcsOAuthExpiresAt,
 	keyExpirationTime,
 }
 
 func parseCredentialExpiry(config iceberg.Properties) (time.Time, bool) {
-	for _, key := range credentialExpiryKeys {
-		if v, ok := config[key]; ok {
-			ms, err := strconv.ParseInt(v, 10, 64)
-			if err == nil && ms > 0 {
-				return time.UnixMilli(ms), true
+	var earliest time.Time
+	found := false
+	for key, value := range config {
+		if !slices.Contains(credentialExpiryKeys, key) &&
+			key != keyAdlsSasExpiresAtMs &&
+			!strings.HasPrefix(key, keyAdlsSasExpiresAtMs+".") {
+			continue
+		}
+
+		ms, err := strconv.ParseInt(value, 10, 64)
+		if err == nil && ms > 0 {
+			expiresAt := time.UnixMilli(ms)
+			if !found || expiresAt.Before(earliest) {
+				earliest = expiresAt
+				found = true
 			}
 		}
 	}
 
-	return time.Time{}, false
+	return earliest, found
 }
 
 func earliestCredentialExpiry(creds []StorageCredential) (time.Time, bool) {
@@ -317,10 +326,48 @@ func (p *prefixScopedIO) propertiesForLocation(name string) iceberg.Properties {
 	props := make(iceberg.Properties, len(p.baseProps))
 	maps.Copy(props, p.baseProps)
 	if credentialIndex >= 0 {
-		maps.Copy(props, p.credentials[credentialIndex].Config)
+		credentialConfig := p.credentials[credentialIndex].Config
+		clearOverriddenCredentialProperties(props, credentialConfig)
+		maps.Copy(props, credentialConfig)
 	}
 
 	return props
+}
+
+// clearOverriddenCredentialProperties prevents a matched credential from being
+// combined with optional fields from another credential. In particular, an S3
+// access/secret pair without a session token must not inherit a stale token
+// from the table or catalog configuration.
+func clearOverriddenCredentialProperties(props, credentialConfig iceberg.Properties) {
+	_, hasS3AccessKey := credentialConfig[iceio.S3AccessKeyID]
+	_, hasS3SecretKey := credentialConfig[iceio.S3SecretAccessKey]
+	_, hasS3SessionToken := credentialConfig[iceio.S3SessionToken]
+	if hasS3AccessKey || hasS3SecretKey || hasS3SessionToken {
+		delete(props, iceio.S3AccessKeyID)
+		delete(props, iceio.S3SecretAccessKey)
+		delete(props, iceio.S3SessionToken)
+		delete(props, keyS3TokenExpiresAtMs)
+	}
+
+	_, hasGCSOAuthToken := credentialConfig[iceio.GCSOAuthToken]
+	_, hasGCSOAuthExpiry := credentialConfig[iceio.GCSOAuthExpiresAt]
+	if hasGCSOAuthToken || hasGCSOAuthExpiry {
+		delete(props, iceio.GCSOAuthToken)
+		delete(props, iceio.GCSOAuthExpiresAt)
+	}
+
+	for key := range credentialConfig {
+		switch {
+		case strings.HasPrefix(key, iceio.ADLSSasTokenPrefix):
+			suffix := strings.TrimPrefix(key, iceio.ADLSSasTokenPrefix)
+			delete(props, iceio.ADLSSasTokenPrefix+suffix)
+			delete(props, keyAdlsSasExpiresAtMs+"."+suffix)
+		case strings.HasPrefix(key, keyAdlsSasExpiresAtMs+"."):
+			suffix := strings.TrimPrefix(key, keyAdlsSasExpiresAtMs+".")
+			delete(props, iceio.ADLSSasTokenPrefix+suffix)
+			delete(props, keyAdlsSasExpiresAtMs+"."+suffix)
+		}
+	}
 }
 
 func scopedFilesystemKey(credentialIndex int, location string) string {

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -261,7 +261,7 @@ type prefixScopedIO struct {
 
 func newPrefixScopedIO(ctx context.Context, baseProps iceberg.Properties, credentials []StorageCredential) *prefixScopedIO {
 	return &prefixScopedIO{
-		ctx:         context.WithoutCancel(ctx),
+		ctx:         ctx,
 		baseProps:   maps.Clone(baseProps),
 		credentials: slices.Clone(credentials),
 		filesystems: make(map[string]iceio.IO),

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -19,10 +19,14 @@ package rest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"net/url"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -47,20 +51,26 @@ const (
 // resolveStorageCredentials finds the best-matching credential for the given
 // location using longest-prefix match, mirroring the Java and Python implementations.
 func resolveStorageCredentials(creds []StorageCredential, location string) iceberg.Properties {
-	var best *StorageCredential
-	for i := range creds {
-		c := &creds[i]
-		if strings.HasPrefix(location, c.Prefix) {
-			if best == nil || len(c.Prefix) > len(best.Prefix) {
-				best = c
-			}
-		}
-	}
-	if best == nil {
+	index := matchingStorageCredentialIndex(creds, location)
+	if index < 0 {
 		return nil
 	}
 
-	return best.Config
+	return creds[index].Config
+}
+
+func matchingStorageCredentialIndex(creds []StorageCredential, location string) int {
+	best := -1
+	for i := range creds {
+		if !strings.HasPrefix(location, creds[i].Prefix) {
+			continue
+		}
+		if best == -1 || len(creds[i].Prefix) > len(creds[best].Prefix) {
+			best = i
+		}
+	}
+
+	return best
 }
 
 var credentialExpiryKeys = []string{
@@ -83,6 +93,20 @@ func parseCredentialExpiry(config iceberg.Properties) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+func earliestCredentialExpiry(creds []StorageCredential) (time.Time, bool) {
+	var earliest time.Time
+	found := false
+	for _, credential := range creds {
+		expiresAt, ok := parseCredentialExpiry(credential.Config)
+		if ok && (!found || expiresAt.Before(earliest)) {
+			earliest = expiresAt
+			found = true
+		}
+	}
+
+	return earliest, found
+}
+
 type vendedCredentialRefresher struct {
 	// Use a weighted semaphore with a single unit to use as an exclusive lock
 	// but cancellation (via context) is supported. This is important as we do IO
@@ -94,6 +118,10 @@ type vendedCredentialRefresher struct {
 	identifier []string
 	location   string
 	props      iceberg.Properties
+	// credentials is populated only for scan-plan IO. Unlike table-load
+	// credentials, which are already resolved against the metadata location,
+	// plan credentials must be selected against every file path opened later.
+	credentials []StorageCredential
 
 	fetchCreds func(ctx context.Context, ident []string) (iceberg.Properties, error)
 
@@ -125,8 +153,12 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 		// Plan creds can already be past their expiry by the time we first use
 		// them, so check before building an IO we'd only hand back 403s from.
 		if v.fetchCreds == nil {
-			if exp, ok := parseCredentialExpiry(config); ok && v.now().After(exp) {
-				return nil, v.expiredError(exp)
+			expiresAt, ok := parseCredentialExpiry(config)
+			if len(v.credentials) > 0 {
+				expiresAt, ok = earliestCredentialExpiry(v.credentials)
+			}
+			if ok && v.now().After(expiresAt) {
+				return nil, v.expiredError(expiresAt)
 			}
 		}
 	case v.fetchCreds == nil:
@@ -141,6 +173,13 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 
 		config = maps.Clone(v.props)
 		maps.Copy(config, freshCreds)
+	}
+
+	if len(v.credentials) > 0 {
+		v.cachedIO = newPrefixScopedIO(ctx, v.props, v.credentials)
+		v.expiresAt = v.expiresAtFromConfig(config)
+
+		return v.cachedIO, nil
 	}
 
 	newIO, err := iceio.LoadFS(ctx, config, v.location)
@@ -170,6 +209,14 @@ func (v *vendedCredentialRefresher) expired() bool {
 }
 
 func (v *vendedCredentialRefresher) expiresAtFromConfig(config iceberg.Properties) time.Time {
+	if len(v.credentials) > 0 {
+		if exp, ok := earliestCredentialExpiry(v.credentials); ok {
+			return exp
+		}
+
+		return time.Time{}
+	}
+
 	if exp, ok := parseCredentialExpiry(config); ok {
 		return exp
 	}
@@ -196,4 +243,111 @@ func (v *vendedCredentialRefresher) close() error {
 	}
 
 	return nil
+}
+
+// prefixScopedIO selects a plan credential using the actual object location
+// passed to Open/Remove. A single plan may cover metadata, data, and delete
+// files in different storage prefixes, so resolving credentials once at plan
+// creation would be incorrect.
+type prefixScopedIO struct {
+	ctx         context.Context
+	baseProps   iceberg.Properties
+	credentials []StorageCredential
+
+	mu          sync.Mutex
+	filesystems map[string]iceio.IO
+	closed      bool
+}
+
+func newPrefixScopedIO(ctx context.Context, baseProps iceberg.Properties, credentials []StorageCredential) *prefixScopedIO {
+	return &prefixScopedIO{
+		ctx:         context.WithoutCancel(ctx),
+		baseProps:   maps.Clone(baseProps),
+		credentials: slices.Clone(credentials),
+		filesystems: make(map[string]iceio.IO),
+	}
+}
+
+func (p *prefixScopedIO) Open(name string) (iceio.File, error) {
+	fs, err := p.filesystemFor(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fs.Open(name)
+}
+
+func (p *prefixScopedIO) Remove(name string) error {
+	fs, err := p.filesystemFor(name)
+	if err != nil {
+		return err
+	}
+
+	return fs.Remove(name)
+}
+
+func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
+	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	key := scopedFilesystemKey(credentialIndex, name)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, errors.New("prefix-scoped IO is closed")
+	}
+	if fs, ok := p.filesystems[key]; ok {
+		return fs, nil
+	}
+
+	props := p.propertiesForLocation(name)
+
+	fs, err := iceio.LoadFS(p.ctx, props, name)
+	if err != nil {
+		return nil, err
+	}
+
+	p.filesystems[key] = fs
+
+	return fs, nil
+}
+
+func (p *prefixScopedIO) propertiesForLocation(name string) iceberg.Properties {
+	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	props := make(iceberg.Properties, len(p.baseProps))
+	maps.Copy(props, p.baseProps)
+	if credentialIndex >= 0 {
+		maps.Copy(props, p.credentials[credentialIndex].Config)
+	}
+
+	return props
+}
+
+func scopedFilesystemKey(credentialIndex int, location string) string {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return fmt.Sprintf("%d:%s", credentialIndex, location)
+	}
+
+	return fmt.Sprintf("%d:%s://%s", credentialIndex, parsed.Scheme, parsed.Host)
+}
+
+func (p *prefixScopedIO) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	var closeErr error
+	for _, fs := range p.filesystems {
+		if closer, ok := fs.(interface{ Close() error }); ok {
+			closeErr = errors.Join(closeErr, closer.Close())
+		}
+	}
+	p.filesystems = nil
+
+	return closeErr
 }

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -434,3 +434,13 @@ func TestPrefixScopedIOUsesLongestCredentialPerLocation(t *testing.T) {
 	assert.Equal(t, "private", p.propertiesForLocation("s3://data/table/private/file.parquet")["credential"])
 	assert.Equal(t, "yes", p.propertiesForLocation("s3://other/table/file.parquet")["base"])
 }
+
+func TestPrefixScopedIOPreservesReadContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := newPrefixScopedIO(ctx, nil, nil)
+
+	cancel()
+	require.ErrorIs(t, p.ctx.Err(), context.Canceled)
+}

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -419,3 +419,18 @@ func TestResolveStorageCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestPrefixScopedIOUsesLongestCredentialPerLocation(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{"base": "yes"}, []StorageCredential{
+		{Prefix: "s3://metadata/table/", Config: iceberg.Properties{"credential": "metadata"}},
+		{Prefix: "s3://data/table/", Config: iceberg.Properties{"credential": "data"}},
+		{Prefix: "s3://data/table/private/", Config: iceberg.Properties{"credential": "private"}},
+	})
+
+	assert.Equal(t, "metadata", p.propertiesForLocation("s3://metadata/table/metadata.json")["credential"])
+	assert.Equal(t, "data", p.propertiesForLocation("s3://data/table/file.parquet")["credential"])
+	assert.Equal(t, "private", p.propertiesForLocation("s3://data/table/private/file.parquet")["credential"])
+	assert.Equal(t, "yes", p.propertiesForLocation("s3://other/table/file.parquet")["base"])
+}

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -357,6 +357,18 @@ func TestVendedCredsServerExpiryUsedOnRefresh(t *testing.T) {
 	assert.Equal(t, serverExpiry.UnixMilli(), r.expiresAt.UnixMilli())
 }
 
+func TestParseCredentialExpirySupportsAccountScopedADLSKey(t *testing.T) {
+	t.Parallel()
+
+	want := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+	got, ok := parseCredentialExpiry(iceberg.Properties{
+		keyAdlsSasExpiresAtMs + ".account.dfs.core.windows.net": strconv.FormatInt(want.UnixMilli(), 10),
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
 func TestResolveStorageCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -433,6 +445,50 @@ func TestPrefixScopedIOUsesLongestCredentialPerLocation(t *testing.T) {
 	assert.Equal(t, "data", p.propertiesForLocation("s3://data/table/file.parquet")["credential"])
 	assert.Equal(t, "private", p.propertiesForLocation("s3://data/table/private/file.parquet")["credential"])
 	assert.Equal(t, "yes", p.propertiesForLocation("s3://other/table/file.parquet")["base"])
+}
+
+func TestPrefixScopedIOReplacesS3CredentialAtomically(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{
+		iceio.S3EndpointURL:     "https://s3.local",
+		iceio.S3AccessKeyID:     "load-access",
+		iceio.S3SecretAccessKey: "load-secret",
+		iceio.S3SessionToken:    "load-token",
+		keyS3TokenExpiresAtMs:   "1000",
+	}, []StorageCredential{{
+		Prefix: "s3://bucket/data/",
+		Config: iceberg.Properties{
+			iceio.S3AccessKeyID:     "plan-access",
+			iceio.S3SecretAccessKey: "plan-secret",
+		},
+	}})
+
+	props := p.propertiesForLocation("s3://bucket/data/file.parquet")
+	assert.Equal(t, "https://s3.local", props[iceio.S3EndpointURL])
+	assert.Equal(t, "plan-access", props[iceio.S3AccessKeyID])
+	assert.Equal(t, "plan-secret", props[iceio.S3SecretAccessKey])
+	assert.NotContains(t, props, iceio.S3SessionToken)
+	assert.NotContains(t, props, keyS3TokenExpiresAtMs)
+}
+
+func TestPrefixScopedIODoesNotApplyCredentialOutsidePrefix(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{
+		iceio.S3EndpointURL: "https://s3.local",
+	}, []StorageCredential{{
+		Prefix: "s3://bucket/data/",
+		Config: iceberg.Properties{
+			iceio.S3AccessKeyID:     "plan-access",
+			iceio.S3SecretAccessKey: "plan-secret",
+		},
+	}})
+
+	props := p.propertiesForLocation("s3://other-bucket/data/file.parquet")
+	assert.Equal(t, "https://s3.local", props[iceio.S3EndpointURL])
+	assert.NotContains(t, props, iceio.S3AccessKeyID)
+	assert.NotContains(t, props, iceio.S3SecretAccessKey)
 }
 
 func TestPrefixScopedIOPreservesReadContextCancellation(t *testing.T) {

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -427,7 +427,8 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
 	require.NoError(t, metadataBuilder.AddPartitionSpec(&partitionSpec, true))
 	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
-	require.NoError(t, metadataBuilder.AddSortOrder(&UnsortedSortOrder))
+	unsortedSortOrder := UnsortedSortOrder
+	require.NoError(t, metadataBuilder.AddSortOrder(&unsortedSortOrder))
 	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(0))
 	latestMeta, err := metadataBuilder.Build()
 	require.NoError(t, err)

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -80,16 +80,16 @@ var _ ScanPlanningMetadata = (Metadata)(nil)
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
 // the resolved scan state a planner needs without depending on catalog/rest.
 //
-// Open question (epic OQ4): when the table has evolved, UseSnapshotSchema must
-// pin which schema binds a returned residual and the partition decode: the
-// snapshot's schema (via schema-id), kept separate from each file's partition
-// spec-id. Incremental scans (start/end snapshot) are deferred to a later
-// phase; point-in-time SnapshotID lands first.
+// Schema is the schema resolved for this scan. It is kept separate from
+// Metadata.CurrentSchema because a historical/tag scan may use a snapshot
+// schema while a branch scan uses the table schema. Planners should use this
+// same schema for filter binding and returned residual decoding.
 type ScanPlanningRequest struct {
 	Identifier Identifier
 	// Metadata is the narrowed planner view of table metadata (see
 	// ScanPlanningMetadata); MetadataLocation is kept separate.
 	Metadata         ScanPlanningMetadata
+	Schema           *iceberg.Schema
 	MetadataLocation string
 	SnapshotID       *int64
 	SelectedFields   []string

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -15,13 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// This file is a PROPOSED public API surface for REST server-side scan
-// planning (apache/iceberg-go#1178). It defines the table-side seam — the
-// option, request/result types, and the ScanPlanner interface (implemented by
-// catalog/rest) — so it can be reviewed as Go rather than prose.
-// WithScanPlanningMode records the requested mode on the Scan; the delegation
-// skeleton rejects unavailable remote planning so the exported option is not a
-// silent no-op if this surface is released before the full implementation lands.
+// This file contains the table-side seam for REST server-side scan planning
+// (apache/iceberg-go#1178): the scan option, request/result types, and the
+// ScanPlanner interface implemented by catalog/rest.
 
 package table
 
@@ -51,13 +47,13 @@ const (
 	// ScanPlanningRemote requires a planner that advertises remote capability
 	// and fails loudly if remote planning is unavailable.
 	ScanPlanningRemote ScanPlanningMode = "remote"
-	// ScanPlanningAuto uses remote planning when available and allowed by the
-	// table config, otherwise falls back to local.
+	// ScanPlanningAuto uses remote planning when available, otherwise it falls
+	// back to local.
 	ScanPlanningAuto ScanPlanningMode = "auto"
 )
 
 // WithScanPlanningMode sets the scan-planning mode for a scan. The default is
-// ScanPlanningLocal unless the REST table config requires server planning.
+// ScanPlanningLocal.
 func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
 	return func(scan *Scan) { scan.planningMode = mode }
 }
@@ -141,8 +137,7 @@ type ScanPlanner interface {
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
 }
 
-// Scan integration, added here as a delegation skeleton and completed in the
-// scanner-delegation phase:
+// Scan integration:
 //
 //	type Scan struct {
 //		// ...existing fields...

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -120,7 +120,9 @@ type ScanPlanningRequest struct {
 // FileIO and closes it after the returned iterator finishes. This ties a
 // plan-scoped scan to the PlanFiles -> ReadTasks sequence on one Scan — tasks
 // from a remote plan must be read by the Scan that produced them, and a Scan
-// carrying plan-scoped IO is not safe for concurrent PlanFiles/ReadTasks.
+// carrying plan-scoped IO is not safe for concurrent PlanFiles/ReadTasks. Scan
+// refinements such as UseRowLimit transfer this single-owner lease to the
+// returned Scan rather than sharing it.
 type PlanIO interface {
 	Load(context.Context) (icebergio.IO, error)
 	Close() error

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -91,6 +91,11 @@ type ScanPlanningRequest struct {
 	Metadata         ScanPlanningMetadata
 	Schema           *iceberg.Schema
 	MetadataLocation string
+	// FileIOProperties are the table-scoped properties used to build the
+	// table's normal FileIO. A remote planner can overlay plan-scoped
+	// credentials on these properties without serializing them into the plan
+	// request.
+	FileIOProperties iceberg.Properties
 	SnapshotID       *int64
 	SelectedFields   []string
 	RowFilter        iceberg.BooleanExpression

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -134,21 +134,45 @@ func TestScanPlanningRemoteOmitsNegativeRowLimit(t *testing.T) {
 func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	t.Parallel()
 
+	snapshotTime := time.Now().UnixMilli()
 	schemaID := 0
 	metadata, err := createTestMetadata([]Snapshot{{
 		SnapshotID:  10,
-		TimestampMs: time.Now().Add(time.Hour).UnixMilli(),
+		TimestampMs: snapshotTime,
 		SchemaID:    &schemaID,
-	}}, nil)
+	}}, []SnapshotLogEntry{{SnapshotID: 10, TimestampMs: snapshotTime}})
 	require.NoError(t, err)
 	builder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
+	currentSchema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String},
+	)
+	require.NoError(t, builder.AddSchema(currentSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(-1))
 	require.NoError(t, builder.SetSnapshotRef("branch", 10, BranchRef))
 	require.NoError(t, builder.SetSnapshotRef("tag", 10, TagRef))
 	metadata, err = builder.Build()
 	require.NoError(t, err)
 
+	var snapshotSchema *iceberg.Schema
+	for _, schema := range metadata.Schemas() {
+		if schema.ID == schemaID {
+			snapshotSchema = schema
+
+			break
+		}
+	}
+	require.NotNil(t, snapshotSchema)
+	require.False(t, snapshotSchema.Equals(metadata.CurrentSchema()))
+
 	base := (&Table{metadata: metadata}).Scan(WithScanPlanningMode(ScanPlanningRemote))
+	livePlanner := &fakeScanPlanner{supports: true}
+	base.planner = livePlanner
+	_, err = base.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.True(t, livePlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	assert.Equal(t, []string{"id", "category"}, livePlanner.receivedRequest.SelectedFields)
 
 	branch, err := base.UseRef("branch")
 	require.NoError(t, err)
@@ -159,6 +183,7 @@ func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	require.NotNil(t, branchPlanner.receivedRequest.UseSnapshotSchema)
 	assert.False(t, *branchPlanner.receivedRequest.UseSnapshotSchema)
 	assert.True(t, branchPlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	assert.Equal(t, []string{"id", "category"}, branchPlanner.receivedRequest.SelectedFields)
 
 	tag, err := base.UseRef("tag")
 	require.NoError(t, err)
@@ -168,7 +193,8 @@ func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tagPlanner.receivedRequest.UseSnapshotSchema)
 	assert.True(t, *tagPlanner.receivedRequest.UseSnapshotSchema)
-	assert.True(t, tagPlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	assert.True(t, tagPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, tagPlanner.receivedRequest.SelectedFields)
 
 	historical := (&Table{metadata: metadata}).Scan(
 		WithScanPlanningMode(ScanPlanningRemote),
@@ -181,8 +207,23 @@ func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, historicalPlanner.receivedRequest.UseSnapshotSchema)
 	assert.True(t, *historicalPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, historicalPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, historicalPlanner.receivedRequest.SelectedFields)
 	require.NotNil(t, historicalPlanner.receivedRequest.MinRowsRequested)
 	assert.Equal(t, int64(25), *historicalPlanner.receivedRequest.MinRowsRequested)
+
+	asOf := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+		WithSnapshotAsOf(snapshotTime),
+	)
+	asOfPlanner := &fakeScanPlanner{supports: true}
+	asOf.planner = asOfPlanner
+	_, err = asOf.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, asOfPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *asOfPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, asOfPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, asOfPlanner.receivedRequest.SelectedFields)
 }
 
 func TestScanPlanningRemoteRejectsLastUpdatedSequenceNumber(t *testing.T) {
@@ -327,8 +368,66 @@ func TestUseRowLimitTransfersPlanIOOwnership(t *testing.T) {
 	refined := scan.UseRowLimit(10)
 
 	assert.Nil(t, scan.planIO)
+	assert.True(t, scan.planIOConsumed)
 	assert.Same(t, planIO, refined.planIO)
+	assert.False(t, refined.planIOConsumed)
 	assert.Equal(t, int64(10), refined.limit)
+
+	_, _, err := scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestRepeatedReadTasksAfterRemotePlan(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	planIO := &trackingPlanIO{fs: icebergio.NewMemFS()}
+	fallbackCalls := 0
+	scan := (&Table{
+		metadata: metadata,
+		fsF: func(context.Context) (icebergio.IO, error) {
+			fallbackCalls++
+
+			return icebergio.NewMemFS(), nil
+		},
+	}).Scan()
+	scan.planIO = planIO
+
+	_, records, err := scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	for _, recordErr := range records {
+		require.NoError(t, recordErr)
+	}
+
+	_, _, err = scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, ErrInvalidOperation)
+	assert.Equal(t, 1, planIO.loadCount)
+	assert.True(t, planIO.closed)
+	assert.Zero(t, fallbackCalls)
+}
+
+func TestFailedReplanningKeepsPlanIOConsumed(t *testing.T) {
+	t.Parallel()
+
+	plannerErr := errors.New("planning failed")
+	fallbackCalls := 0
+	scan := &Scan{
+		planner:        &fakeScanPlanner{supports: true, err: plannerErr},
+		planningMode:   ScanPlanningRemote,
+		planIOConsumed: true,
+		ioF: func(context.Context) (icebergio.IO, error) {
+			fallbackCalls++
+
+			return icebergio.NewMemFS(), nil
+		},
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, plannerErr)
+	_, _, err = scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, ErrInvalidOperation)
+	assert.Zero(t, fallbackCalls)
 }
 
 func TestRepeatedScanPlanningClosesPreviousPlanIO(t *testing.T) {
@@ -386,6 +485,24 @@ func (fakePlanIO) Close() error                               { return nil }
 type failingPlanIO struct {
 	loadErr error
 	closed  bool
+}
+
+type trackingPlanIO struct {
+	fs        icebergio.IO
+	loadCount int
+	closed    bool
+}
+
+func (p *trackingPlanIO) Load(context.Context) (icebergio.IO, error) {
+	p.loadCount++
+
+	return p.fs, nil
+}
+
+func (p *trackingPlanIO) Close() error {
+	p.closed = true
+
+	return nil
 }
 
 func (f *failingPlanIO) Load(context.Context) (icebergio.IO, error) { return nil, f.loadErr }

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -203,6 +203,31 @@ func TestScanPlanningAutoFallsBackForLastUpdatedSequenceNumber(t *testing.T) {
 	assert.Empty(t, planner.receivedIdentifier)
 }
 
+func TestScanPlanningRemotePassesFileIOProperties(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	props := iceberg.Properties{"s3.endpoint": "https://table.local"}
+	planner := &fakeScanPlanner{supports: true}
+	tbl := New(
+		Identifier{"db", "tbl"},
+		metadata,
+		"s3://bucket/db/tbl/metadata/v1.json",
+		nil,
+		nil,
+		WithScanPlanningIOProperties(props),
+	)
+	tbl.planner = planner
+
+	_, err = tbl.Scan(WithScanPlanningMode(ScanPlanningRemote)).PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, props, planner.receivedRequest.FileIOProperties)
+
+	planner.receivedRequest.FileIOProperties["s3.endpoint"] = "https://mutated.local"
+	assert.Equal(t, "https://table.local", props["s3.endpoint"])
+}
+
 func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 	t.Parallel()
 
@@ -227,18 +252,64 @@ func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 
 func TestTransactionScanCopiesIdentifier(t *testing.T) {
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
-	txn.tbl.planner = &fakeScanPlanner{
+
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.identifier[0] = "corrupt"
+	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
+}
+
+func TestTransactionScanKeepsStagedMetadataLocal(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	planner := &fakeScanPlanner{
 		result:   ScanPlanningResult{Tasks: []FileScanTask{{}}},
 		supports: true,
 	}
+	txn.tbl.planner = planner
+	dataFile := newTestDataFile(
+		t,
+		*iceberg.UnpartitionedSpec,
+		"mem://default/table-location/data.parquet",
+		nil,
+	)
+	require.NoError(t, txn.AddDataFiles(context.Background(), []iceberg.DataFile{dataFile}, nil))
 
 	scan, err := txn.Scan(WithScanPlanningMode(ScanPlanningAuto))
 	require.NoError(t, err)
-	_, err = scan.PlanFiles(context.Background())
+	tasks, err := scan.PlanFiles(context.Background())
 	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, dataFile.FilePath(), tasks[0].File.FilePath())
+	assert.Empty(t, planner.receivedIdentifier)
 
-	scan.identifier[0] = "corrupt"
-	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
+	remote, err := txn.Scan(WithScanPlanningMode(ScanPlanningRemote))
+	require.NoError(t, err)
+	_, err = remote.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+
+	staged, err := txn.StagedTable()
+	require.NoError(t, err)
+	stagedTasks, err := staged.Scan(WithScanPlanningMode(ScanPlanningAuto)).PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, stagedTasks, 1)
+	assert.Equal(t, dataFile.FilePath(), stagedTasks[0].File.FilePath())
+
+	_, err = staged.Scan(WithScanPlanningMode(ScanPlanningRemote)).PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestReadTasksClosesPlanIOIfLoadFails(t *testing.T) {
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	loadErr := errors.New("load failed")
+	planIO := &failingPlanIO{loadErr: loadErr}
+	scan := (&Table{metadata: metadata}).Scan()
+	scan.planIO = planIO
+
+	_, _, err = scan.ReadTasks(context.Background(), nil)
+	require.ErrorIs(t, err, loadErr)
+	assert.True(t, planIO.closed)
+	assert.Nil(t, scan.planIO)
 }
 
 func TestScanPlanningUnknownModeErrors(t *testing.T) {
@@ -272,3 +343,15 @@ type fakePlanIO struct{}
 
 func (fakePlanIO) Load(context.Context) (icebergio.IO, error) { return nil, nil }
 func (fakePlanIO) Close() error                               { return nil }
+
+type failingPlanIO struct {
+	loadErr error
+	closed  bool
+}
+
+func (f *failingPlanIO) Load(context.Context) (icebergio.IO, error) { return nil, f.loadErr }
+func (f *failingPlanIO) Close() error {
+	f.closed = true
+
+	return nil
+}

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go"
 	icebergio "github.com/apache/iceberg-go/io"
@@ -94,6 +95,80 @@ func TestScanPlanningAutoUsesCapablePlanner(t *testing.T) {
 	assert.Len(t, tasks, 1)
 }
 
+func TestScanPlanningRemoteResolvesDefaultProjectionAndSchema(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	planner := &fakeScanPlanner{supports: true}
+	scan := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+	)
+	scan.planner = planner
+
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, planner.receivedRequest.SelectedFields)
+	assert.True(t, planner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	require.NotNil(t, planner.receivedRequest.UseSnapshotSchema)
+	assert.False(t, *planner.receivedRequest.UseSnapshotSchema)
+	assert.Nil(t, planner.receivedRequest.MinRowsRequested)
+}
+
+func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
+	t.Parallel()
+
+	schemaID := 0
+	metadata, err := createTestMetadata([]Snapshot{{
+		SnapshotID:  10,
+		TimestampMs: time.Now().Add(time.Hour).UnixMilli(),
+		SchemaID:    &schemaID,
+	}}, nil)
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.SetSnapshotRef("branch", 10, BranchRef))
+	require.NoError(t, builder.SetSnapshotRef("tag", 10, TagRef))
+	metadata, err = builder.Build()
+	require.NoError(t, err)
+
+	base := (&Table{metadata: metadata}).Scan(WithScanPlanningMode(ScanPlanningRemote))
+
+	branch, err := base.UseRef("branch")
+	require.NoError(t, err)
+	branchPlanner := &fakeScanPlanner{supports: true}
+	branch.planner = branchPlanner
+	_, err = branch.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, branchPlanner.receivedRequest.UseSnapshotSchema)
+	assert.False(t, *branchPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, branchPlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+
+	tag, err := base.UseRef("tag")
+	require.NoError(t, err)
+	tagPlanner := &fakeScanPlanner{supports: true}
+	tag.planner = tagPlanner
+	_, err = tag.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, tagPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *tagPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, tagPlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+
+	historical := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+		WithSnapshotID(10),
+		WithLimit(25),
+	)
+	historicalPlanner := &fakeScanPlanner{supports: true}
+	historical.planner = historicalPlanner
+	_, err = historical.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, historicalPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *historicalPlanner.receivedRequest.UseSnapshotSchema)
+	require.NotNil(t, historicalPlanner.receivedRequest.MinRowsRequested)
+	assert.Equal(t, int64(25), *historicalPlanner.receivedRequest.MinRowsRequested)
+}
+
 func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 	t.Parallel()
 
@@ -147,12 +222,14 @@ type fakeScanPlanner struct {
 	err      error
 	// captured after PlanFiles receives it
 	receivedIdentifier Identifier
+	receivedRequest    ScanPlanningRequest
 }
 
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
 	f.receivedIdentifier = req.Identifier
+	f.receivedRequest = req
 
 	return f.result, f.err
 }

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -115,6 +115,22 @@ func TestScanPlanningRemoteResolvesDefaultProjectionAndSchema(t *testing.T) {
 	assert.Nil(t, planner.receivedRequest.MinRowsRequested)
 }
 
+func TestScanPlanningRemoteOmitsNegativeRowLimit(t *testing.T) {
+	t.Parallel()
+
+	planner := &fakeScanPlanner{supports: true}
+	scan := &Scan{
+		planner:        planner,
+		planningMode:   ScanPlanningRemote,
+		selectedFields: []string{"*"},
+		limit:          -2,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, planner.receivedRequest.MinRowsRequested)
+}
+
 func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	t.Parallel()
 
@@ -300,6 +316,39 @@ func TestReadTasksClosesPlanIOIfLoadFails(t *testing.T) {
 	require.ErrorIs(t, err, loadErr)
 	assert.True(t, planIO.closed)
 	assert.Nil(t, scan.planIO)
+}
+
+func TestUseRowLimitTransfersPlanIOOwnership(t *testing.T) {
+	t.Parallel()
+
+	planIO := &failingPlanIO{}
+	scan := &Scan{planIO: planIO}
+
+	refined := scan.UseRowLimit(10)
+
+	assert.Nil(t, scan.planIO)
+	assert.Same(t, planIO, refined.planIO)
+	assert.Equal(t, int64(10), refined.limit)
+}
+
+func TestRepeatedScanPlanningClosesPreviousPlanIO(t *testing.T) {
+	t.Parallel()
+
+	previousPlanIO := &failingPlanIO{}
+	currentPlanIO := &failingPlanIO{}
+	scan := &Scan{
+		planner: &fakeScanPlanner{
+			result:   ScanPlanningResult{IO: currentPlanIO},
+			supports: true,
+		},
+		planningMode: ScanPlanningRemote,
+		planIO:       previousPlanIO,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.True(t, previousPlanIO.closed)
+	assert.Same(t, currentPlanIO, scan.planIO)
 }
 
 func TestScanPlanningUnknownModeErrors(t *testing.T) {

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -286,16 +286,6 @@ func TestTransactionScanKeepsStagedMetadataLocal(t *testing.T) {
 	require.NoError(t, err)
 	_, err = remote.PlanFiles(context.Background())
 	require.ErrorIs(t, err, ErrInvalidOperation)
-
-	staged, err := txn.StagedTable()
-	require.NoError(t, err)
-	stagedTasks, err := staged.Scan(WithScanPlanningMode(ScanPlanningAuto)).PlanFiles(context.Background())
-	require.NoError(t, err)
-	require.Len(t, stagedTasks, 1)
-	assert.Equal(t, dataFile.FilePath(), stagedTasks[0].File.FilePath())
-
-	_, err = staged.Scan(WithScanPlanningMode(ScanPlanningRemote)).PlanFiles(context.Background())
-	require.ErrorIs(t, err, ErrInvalidOperation)
 }
 
 func TestReadTasksClosesPlanIOIfLoadFails(t *testing.T) {

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -169,6 +169,40 @@ func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
 	assert.Equal(t, int64(25), *historicalPlanner.receivedRequest.MinRowsRequested)
 }
 
+func TestScanPlanningRemoteRejectsLastUpdatedSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	planner := &fakeScanPlanner{supports: true}
+	scan := &Scan{
+		planner:        planner,
+		planningMode:   ScanPlanningRemote,
+		selectedFields: []string{iceberg.LastUpdatedSequenceNumberColumnName},
+		caseSensitive:  true,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+	assert.Empty(t, planner.receivedIdentifier)
+}
+
+func TestScanPlanningAutoFallsBackForLastUpdatedSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	planner := &fakeScanPlanner{supports: true}
+	scan := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningAuto),
+		WithRowLineage(),
+	)
+	scan.planner = planner
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+	assert.Empty(t, planner.receivedIdentifier)
+}
+
 func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 	t.Parallel()
 

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -239,8 +239,13 @@ type Scan struct {
 	caseSensitive  bool
 	snapshotID     *int64
 	asOfTimestamp  *int64
-	options        iceberg.Properties
-	limit          int64
+	// useSnapshotSchema is set for explicit snapshot/time-travel and tag
+	// scans. A branch ref deliberately keeps the table's current schema. A nil
+	// value preserves the historical behavior for scans assembled directly in
+	// package tests with snapshotID/asOfTimestamp fields set.
+	useSnapshotSchema *bool
+	options           iceberg.Properties
+	limit             int64
 
 	includeRowLineage bool
 
@@ -275,6 +280,15 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {
 		out := *scan
 		out.snapshotID = &snap.SnapshotID
+		out.asOfTimestamp = nil
+		useSnapshotSchema := true
+		for refName, ref := range scan.metadata.Refs() {
+			if refName == name {
+				useSnapshotSchema = ref.SnapshotRefType == TagRef
+				break
+			}
+		}
+		out.useSnapshotSchema = &useSnapshotSchema
 
 		return &out, nil
 	}
@@ -377,10 +391,11 @@ func (scan *Scan) Projection() (*iceberg.Schema, error) {
 
 func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 	curSchema := scan.metadata.CurrentSchema()
-	if scan.snapshotID == nil && scan.asOfTimestamp == nil {
+	if !scan.snapshotSchemaEnabled() {
 		// Live scans intentionally use the table's current schema. A schema-only
 		// metadata update can advance CurrentSchema without creating a snapshot,
-		// while explicit snapshot/as-of scans use the snapshot schema below.
+		// and branch refs intentionally use the table schema even though they
+		// resolve to a snapshot.
 		return curSchema, nil
 	}
 
@@ -401,6 +416,14 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 
 	return nil, fmt.Errorf("%w: snapshot %d references unknown schema id %d",
 		ErrInvalidMetadata, snap.SnapshotID, *snap.SchemaID)
+}
+
+func (scan *Scan) snapshotSchemaEnabled() bool {
+	if scan.useSnapshotSchema != nil {
+		return *scan.useSnapshotSchema
+	}
+
+	return scan.snapshotID != nil || scan.asOfTimestamp != nil
 }
 
 // splitLineageMetadataFields partitions selectedFields into user fields and
@@ -954,15 +977,34 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
 
+	var schema *iceberg.Schema
+	if scan.metadata != nil {
+		var err error
+		schema, err = scan.effectiveSchema()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	caseSensitive := scan.caseSensitive
+	useSnapshotSchema := scan.snapshotSchemaEnabled()
+	var minRowsRequested *int64
+	if scan.limit != ScanNoLimit {
+		minRows := scan.limit
+		minRowsRequested = &minRows
+	}
+
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
-		Identifier:       slices.Clone(scan.identifier),
-		Metadata:         scan.metadata,
-		MetadataLocation: scan.metadataLocation,
-		SnapshotID:       scan.snapshotID,
-		SelectedFields:   scan.selectedFields,
-		RowFilter:        scan.rowFilter,
-		CaseSensitive:    &caseSensitive,
+		Identifier:        slices.Clone(scan.identifier),
+		Metadata:          scan.metadata,
+		Schema:            schema,
+		MetadataLocation:  scan.metadataLocation,
+		SnapshotID:        scan.snapshotID,
+		SelectedFields:    scan.remoteSelectedFields(schema),
+		RowFilter:         scan.rowFilter,
+		MinRowsRequested:  minRowsRequested,
+		CaseSensitive:     &caseSensitive,
+		UseSnapshotSchema: &useSnapshotSchema,
 	})
 	if err != nil {
 		return nil, err
@@ -971,6 +1013,23 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	scan.planIO = result.IO
 
 	return result.Tasks, nil
+}
+
+func (scan *Scan) remoteSelectedFields(schema *iceberg.Schema) []string {
+	if !slices.Contains(scan.selectedFields, "*") {
+		return slices.Clone(scan.selectedFields)
+	}
+	if schema == nil {
+		return nil
+	}
+
+	fields := schema.Fields()
+	selected := make([]string, 0, len(fields))
+	for _, field := range fields {
+		selected = append(selected, field.Name)
+	}
+
+	return selected
 }
 
 type FileScanTask struct {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -256,8 +256,19 @@ type Scan struct {
 }
 
 func (scan *Scan) UseRowLimit(n int64) *Scan {
-	out := *scan
+	out := scan.refinedCopy()
 	out.limit = n
+
+	return out
+}
+
+// refinedCopy returns a shallow scan refinement while transferring ownership
+// of any plan-scoped IO to the returned scan. PlanIO is a single-owner lease:
+// copying it would let either scan close the filesystem while the other is
+// still reading.
+func (scan *Scan) refinedCopy() *Scan {
+	out := *scan
+	scan.planIO = nil
 
 	return &out
 }
@@ -279,7 +290,7 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 	}
 
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {
-		out := *scan
+		out := scan.refinedCopy()
 		out.snapshotID = &snap.SnapshotID
 		out.asOfTimestamp = nil
 		useSnapshotSchema := true
@@ -292,7 +303,7 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 		}
 		out.useSnapshotSchema = &useSnapshotSchema
 
-		return &out, nil
+		return out, nil
 	}
 
 	return nil, fmt.Errorf("%w: cannot scan unknown ref=%s", iceberg.ErrInvalidArgument, name)
@@ -832,6 +843,10 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 // scan's reporter on success; remote (server-side) planning reports its own
 // metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
+	// Starting a new plan abandons any prior plan whose IO was not handed to
+	// ReadTasks. Close that single-owner lease before replacing it.
+	scan.discardPlanIO()
+
 	if scan.asOfTimestamp != nil {
 		snapshot, err := scan.ResolveSnapshot()
 		if err != nil {
@@ -901,7 +916,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 // table's default FileIO. It returns a nil slice (not an empty one) when there
 // is no snapshot or every manifest is pruned.
 func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) ([]FileScanTask, error) {
-	scan.planIO = nil
+	scan.discardPlanIO()
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
@@ -975,6 +990,15 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	return results, nil
 }
 
+func (scan *Scan) discardPlanIO() {
+	if scan.planIO == nil {
+		return
+	}
+
+	_ = scan.planIO.Close()
+	scan.planIO = nil
+}
+
 func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	if scan.requiresLastUpdatedSequenceNumber() {
 		return nil, fmt.Errorf(
@@ -1000,7 +1024,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	caseSensitive := scan.caseSensitive
 	useSnapshotSchema := scan.snapshotSchemaEnabled()
 	var minRowsRequested *int64
-	if scan.limit != ScanNoLimit {
+	if scan.limit >= 0 {
 		minRows := scan.limit
 		minRowsRequested = &minRows
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -234,7 +234,10 @@ type Scan struct {
 	// planIO, when non-nil, is a plan-scoped FileIO loader set by remote scan
 	// planning; ReadTasks loads from it instead of ioF and closes it after the
 	// returned iterator finishes. See PlanIO.
-	planIO         PlanIO
+	planIO PlanIO
+	// planIOConsumed prevents a second ReadTasks call from silently falling back
+	// to table credentials after the plan-scoped IO lease has been handed off.
+	planIOConsumed bool
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool
@@ -268,7 +271,10 @@ func (scan *Scan) UseRowLimit(n int64) *Scan {
 // still reading.
 func (scan *Scan) refinedCopy() *Scan {
 	out := *scan
-	scan.planIO = nil
+	if scan.planIO != nil {
+		scan.planIO = nil
+		scan.planIOConsumed = true
+	}
 
 	return &out
 }
@@ -883,6 +889,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	if err != nil {
 		return nil, err
 	}
+	scan.planIOConsumed = false
 	// Snap the elapsed time right after planning so total-planning-duration
 	// reflects planning alone, not the report assembly below.
 	planningDuration := time.Since(start)
@@ -991,12 +998,11 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 }
 
 func (scan *Scan) discardPlanIO() {
-	if scan.planIO == nil {
-		return
+	if scan.planIO != nil {
+		_ = scan.planIO.Close()
+		scan.planIO = nil
+		scan.planIOConsumed = true
 	}
-
-	_ = scan.planIO.Close()
-	scan.planIO = nil
 }
 
 func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
@@ -1047,6 +1053,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	}
 
 	scan.planIO = result.IO
+	scan.planIOConsumed = false
 
 	return result.Tasks, nil
 }
@@ -1133,12 +1140,21 @@ func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[
 
 // ReadTasks reads Arrow records from a specific set of FileScanTasks, applying the
 // scan's projection, row filters, and positional delete handling. This is useful when
-// the caller has already planned or selected specific tasks to read.
+// the caller has already planned or selected specific tasks to read. When the most
+// recent remote plan returned plan-scoped IO, ReadTasks may be called once for that
+// plan; callers must plan again before reading another task subset.
 func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
+	if scan.planIO == nil && scan.planIOConsumed {
+		return nil, nil, fmt.Errorf("%w: remote plan IO has already been consumed", ErrInvalidOperation)
+	}
+
 	// Transfer ownership out of the Scan before setup. Every error below closes
 	// the plan-scoped IO; a successful return hands it to the record iterator.
 	planIO := scan.planIO
-	scan.planIO = nil
+	if planIO != nil {
+		scan.planIO = nil
+		scan.planIOConsumed = true
+	}
 	planIOHandedOff := false
 	defer func() {
 		if planIO != nil && !planIOHandedOff {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -285,6 +285,7 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 		for refName, ref := range scan.metadata.Refs() {
 			if refName == name {
 				useSnapshotSchema = ref.SnapshotRefType == TagRef
+
 				break
 			}
 		}
@@ -843,7 +844,8 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	case ScanPlanningRemote:
 		return scan.planFilesRemote(ctx)
 	case ScanPlanningAuto:
-		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() {
+		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() &&
+			!scan.requiresLastUpdatedSequenceNumber() {
 			return scan.planFilesRemote(ctx)
 		}
 	case ScanPlanningLocal:
@@ -973,6 +975,14 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 }
 
 func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
+	if scan.requiresLastUpdatedSequenceNumber() {
+		return nil, fmt.Errorf(
+			"%w: remote scan planning cannot populate %s",
+			ErrInvalidOperation,
+			iceberg.LastUpdatedSequenceNumberColumnName,
+		)
+	}
+
 	if scan.planner == nil || !scan.planner.SupportsRemoteScanPlanning() {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
@@ -1013,6 +1023,30 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	scan.planIO = result.IO
 
 	return result.Tasks, nil
+}
+
+// requiresLastUpdatedSequenceNumber reports whether the scan projection needs
+// the manifest-entry data sequence number. The REST FileScanTask payload does
+// not carry that value, so remote planning cannot safely synthesize the
+// _last_updated_sequence_number metadata column for files that do not store it
+// physically. Auto mode falls back to local planning; explicit remote mode
+// fails before making a request rather than returning silently incomplete data.
+func (scan *Scan) requiresLastUpdatedSequenceNumber() bool {
+	if scan.includeRowLineage {
+		return true
+	}
+
+	for _, field := range scan.selectedFields {
+		if scan.caseSensitive {
+			if field == iceberg.LastUpdatedSequenceNumberColumnName {
+				return true
+			}
+		} else if strings.EqualFold(field, iceberg.LastUpdatedSequenceNumberColumnName) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (scan *Scan) remoteSelectedFields(schema *iceberg.Schema) []string {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -224,12 +224,13 @@ func IsDeletionVector(df iceberg.DataFile) bool {
 }
 
 type Scan struct {
-	identifier       Identifier
-	metadata         Metadata
-	metadataLocation string
-	ioF              FSysF
-	planner          ScanPlanner
-	planningMode     ScanPlanningMode
+	identifier          Identifier
+	metadata            Metadata
+	metadataLocation    string
+	ioF                 FSysF
+	planner             ScanPlanner
+	scanPlanningIOProps iceberg.Properties
+	planningMode        ScanPlanningMode
 	// planIO, when non-nil, is a plan-scoped FileIO loader set by remote scan
 	// planning; ReadTasks loads from it instead of ioF and closes it after the
 	// returned iterator finishes. See PlanIO.
@@ -1009,6 +1010,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		Metadata:          scan.metadata,
 		Schema:            schema,
 		MetadataLocation:  scan.metadataLocation,
+		FileIOProperties:  maps.Clone(scan.scanPlanningIOProps),
 		SnapshotID:        scan.snapshotID,
 		SelectedFields:    scan.remoteSelectedFields(schema),
 		RowFilter:         scan.rowFilter,
@@ -1109,6 +1111,17 @@ func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[
 // scan's projection, row filters, and positional delete handling. This is useful when
 // the caller has already planned or selected specific tasks to read.
 func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
+	// Transfer ownership out of the Scan before setup. Every error below closes
+	// the plan-scoped IO; a successful return hands it to the record iterator.
+	planIO := scan.planIO
+	scan.planIO = nil
+	planIOHandedOff := false
+	defer func() {
+		if planIO != nil && !planIOHandedOff {
+			_ = planIO.Close()
+		}
+	}()
+
 	var (
 		boundFilter iceberg.BooleanExpression
 		err         error
@@ -1134,8 +1147,8 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	// A plan-scoped FileIO (from remote planning) takes precedence over the
 	// table's default FileIO and is closed once the returned iterator finishes.
 	var fs io.IO
-	if scan.planIO != nil {
-		fs, err = scan.planIO.Load(ctx)
+	if planIO != nil {
+		fs, err = planIO.Load(ctx)
 	} else {
 		fs, err = scan.ioF(ctx)
 	}
@@ -1154,16 +1167,12 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 		concurrency:     scan.concurrency,
 	}).GetRecords(ctx, tasks)
 	if err != nil {
-		// No iterator to drive cleanup on a setup error, so close here.
-		if scan.planIO != nil {
-			_ = scan.planIO.Close()
-		}
-
 		return nil, nil, err
 	}
 
-	if scan.planIO != nil {
-		records = closePlanIOAfter(records, scan.planIO)
+	if planIO != nil {
+		records = closePlanIOAfter(records, planIO)
+		planIOHandedOff = true
 	}
 
 	return outSchema, records, nil

--- a/table/table.go
+++ b/table/table.go
@@ -105,7 +105,12 @@ type Table struct {
 	cat              CatalogIO
 	fsF              FSysF
 	planner          ScanPlanner
-	reporter         metrics.Reporter
+	// scanPlanningIOProps are the table-scoped FileIO properties supplied by a
+	// catalog load response. They are separate from metadata properties because
+	// REST catalogs can return FileIO configuration in the response's config
+	// block.
+	scanPlanningIOProps iceberg.Properties
+	reporter            metrics.Reporter
 	// reporterSet records whether a caller injected a reporter via
 	// WithMetricsReporter. It distinguishes an explicit reporter (including an
 	// explicit NopReporter opt-out) from the construction-time default, so
@@ -231,6 +236,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
 	t.planner = fresh.planner
+	t.scanPlanningIOProps = maps.Clone(fresh.scanPlanningIOProps)
 	// Only inherit the catalog-derived reporter when the caller hasn't set one
 	// of their own. Refresh runs inside commit retry loops, so unconditionally
 	// copying fresh.reporter would silently revert a WithMetricsReporter-injected
@@ -747,7 +753,15 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		}
 	}
 
-	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat, withReporterState(t.reporter, t.reporterSet)), nil
+	return New(
+		t.identifier,
+		newMeta,
+		newLoc,
+		t.fsF,
+		t.cat,
+		withReporterState(t.reporter, t.reporterSet),
+		WithScanPlanningIOProperties(t.scanPlanningIOProps),
+	), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every
@@ -1140,11 +1154,12 @@ func WithRowLineage() ScanOption {
 
 func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
-		identifier:       slices.Clone(t.identifier),
-		metadata:         t.metadata,
-		metadataLocation: t.metadataLocation,
-		ioF:              t.fsF,
-		planner:          t.planner,
+		identifier:          slices.Clone(t.identifier),
+		metadata:            t.metadata,
+		metadataLocation:    t.metadataLocation,
+		ioF:                 t.fsF,
+		planner:             t.planner,
+		scanPlanningIOProps: maps.Clone(t.scanPlanningIOProps),
 		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
@@ -1182,6 +1197,20 @@ func WithMetricsReporter(r metrics.Reporter) Option {
 	return func(t *Table) {
 		t.reporter = r
 		t.reporterSet = true
+	}
+}
+
+// WithScanPlanningIOProperties supplies the table-scoped FileIO properties
+// that a remote scan planner needs when it builds a plan-scoped FileIO. This
+// is intended for catalog implementations whose table-load response carries
+// FileIO configuration separately from table metadata properties.
+func WithScanPlanningIOProperties(props iceberg.Properties) Option {
+	if props == nil {
+		return noopTableOption
+	}
+
+	return func(t *Table) {
+		t.scanPlanningIOProps = maps.Clone(props)
 	}
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -1054,6 +1054,8 @@ func WithSnapshotID(n int64) ScanOption {
 	return func(scan *Scan) {
 		scan.snapshotID = &n
 		scan.asOfTimestamp = nil
+		useSnapshotSchema := true
+		scan.useSnapshotSchema = &useSnapshotSchema
 	}
 }
 
@@ -1061,6 +1063,8 @@ func WithSnapshotAsOf(timeStampMs int64) ScanOption {
 	return func(scan *Scan) {
 		scan.asOfTimestamp = &timeStampMs
 		scan.snapshotID = nil
+		useSnapshotSchema := true
+		scan.useSnapshotSchema = &useSnapshotSchema
 	}
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2383,20 +2383,17 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 		return nil, err
 	}
 
-	staged := New(
-		t.tbl.identifier,
-		updatedMeta,
-		updatedMeta.Location(),
-		t.tbl.fsF,
-		t.tbl.cat,
-		withReporterState(t.tbl.reporter, t.tbl.reporterSet),
-		WithScanPlanningIOProperties(t.tbl.scanPlanningIOProps),
-	)
-	// Like Transaction.Scan, this table contains metadata the catalog cannot
-	// see until commit. Do not let auto mode delegate it to a catalog planner.
-	staged.planner = nil
-
-	return &StagedTable{Table: staged}, nil
+	return &StagedTable{
+		Table: New(
+			t.tbl.identifier,
+			updatedMeta,
+			updatedMeta.Location(),
+			t.tbl.fsF,
+			t.tbl.cat,
+			withReporterState(t.tbl.reporter, t.tbl.reporterSet),
+			WithScanPlanningIOProperties(t.tbl.scanPlanningIOProps),
+		),
+	}, nil
 }
 
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2352,7 +2352,10 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,
-		planner:          t.tbl.planner,
+		// Catalog planners can only see committed table state, not metadata
+		// staged inside this transaction. Keep transaction scans local so auto
+		// mode cannot silently return stale tasks.
+		planner: nil,
 		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
@@ -2380,16 +2383,20 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 		return nil, err
 	}
 
-	return &StagedTable{
-		Table: New(
-			t.tbl.identifier,
-			updatedMeta,
-			updatedMeta.Location(),
-			t.tbl.fsF,
-			t.tbl.cat,
-			withReporterState(t.tbl.reporter, t.tbl.reporterSet),
-		),
-	}, nil
+	staged := New(
+		t.tbl.identifier,
+		updatedMeta,
+		updatedMeta.Location(),
+		t.tbl.fsF,
+		t.tbl.cat,
+		withReporterState(t.tbl.reporter, t.tbl.reporterSet),
+		WithScanPlanningIOProperties(t.tbl.scanPlanningIOProps),
+	)
+	// Like Transaction.Scan, this table contains metadata the catalog cannot
+	// see until commit. Do not let auto mode delegate it to a catalog planner.
+	staged.planner = nil
+
+	return &StagedTable{Table: staged}, nil
 }
 
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {


### PR DESCRIPTION
## Summary

- enable REST catalogs advertising all four scan-planning endpoints as scan planners
- decode inline and fetched ScanTasks envelopes into table.FileScanTask values
- preserve envelope-local delete-file references and residual filters
- keep local planning as the default while remote and auto modes use the planner seam

## Test plan

- go test ./table ./catalog/rest
- go vet ./table ./catalog/rest

Part of #1178. Opening as draft for feedback on the Phase 5 behavior and API boundary.