### PR TITLE
fix(manifest): keep writer content consistent

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1427,6 +1427,9 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 	for _, apply := range opts {
 		apply(w)
 	}
+	if w.content != ManifestContentData && w.content != ManifestContentDeletes {
+		return nil, fmt.Errorf("%w: invalid manifest content: %d", ErrInvalidArgument, w.content)
+	}
 	if version < 2 && w.content != ManifestContentData {
 		return nil, fmt.Errorf("unsupported content '%s' for format version '%d'", w.content, version)
 	}
@@ -1517,7 +1520,6 @@ func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...M
 	for _, apply := range opts {
 		apply(&mf)
 	}
-
 	// The writer already stamped w.content into the manifest's own avro metadata,
 	// so a different content here would contradict the file it describes.
 	if mf.Content != w.content {
@@ -1569,6 +1571,21 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	case EntryStatusADDED, EntryStatusEXISTING, EntryStatusDELETED:
 	default:
 		return fmt.Errorf("unknown entry status: %v", status)
+	}
+	if w.version > 1 {
+		entryContent := entry.DataFile().ContentType()
+		switch entryContent {
+		case EntryContentData:
+			if w.content != ManifestContentData {
+				return fmt.Errorf("%w: data file cannot be written to a delete manifest", ErrInvalidArgument)
+			}
+		case EntryContentPosDeletes, EntryContentEqDeletes:
+			if w.content != ManifestContentDeletes {
+				return fmt.Errorf("%w: delete file cannot be written to a data manifest", ErrInvalidArgument)
+			}
+		default:
+			return fmt.Errorf("%w: invalid manifest entry content: %d", ErrInvalidArgument, entryContent)
+		}
 	}
 	count := entry.DataFile().Count()
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2356,6 +2356,50 @@ func (m *ManifestTestSuite) TestManifestWriterMeta() {
 	m.Equal("[]", string(md["partition-spec"]))
 }
 
+func (m *ManifestTestSuite) TestManifestWriterContentConsistency() {
+	deleteEntry := *manifestEntryV2Records[0]
+	deleteFile := cloneDataFileAvroFields(deleteEntry.Data.(*dataFile))
+	deleteFile.Content = EntryContentEqDeletes
+	deleteEntry.Data = deleteFile
+
+	m.Run("manifest file inherits writer content", func() {
+		var out bytes.Buffer
+		writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID,
+			WithManifestWriterContent(ManifestContentDeletes))
+		m.Require().NoError(err)
+		m.Require().NoError(writer.Add(&deleteEntry))
+
+		manifest, err := writer.ToManifestFile("manifest.avro", int64(out.Len()))
+		m.Require().NoError(err)
+		m.Equal(ManifestContentDeletes, manifest.ManifestContent())
+	})
+
+	m.Run("rejects conflicting manifest file content", func() {
+		var out bytes.Buffer
+		writer, err := NewManifestWriter(2, &out, *UnpartitionedSpec, testSchema, snapshotID,
+			WithManifestWriterContent(ManifestContentDeletes))
+		m.Require().NoError(err)
+		m.Require().NoError(writer.Add(&deleteEntry))
+
+		_, err = writer.ToManifestFile("manifest.avro", int64(out.Len()),
+			WithManifestFileContent(ManifestContentData))
+		m.ErrorIs(err, ErrInvalidArgument)
+	})
+
+	m.Run("rejects data file in delete manifest", func() {
+		writer, err := NewManifestWriter(2, io.Discard, *UnpartitionedSpec, testSchema, snapshotID,
+			WithManifestWriterContent(ManifestContentDeletes))
+		m.Require().NoError(err)
+		m.ErrorIs(writer.Add(manifestEntryV2Records[0]), ErrInvalidArgument)
+	})
+
+	m.Run("rejects delete file in data manifest", func() {
+		writer, err := NewManifestWriter(2, io.Discard, *UnpartitionedSpec, testSchema, snapshotID)
+		m.Require().NoError(err)
+		m.ErrorIs(writer.Add(&deleteEntry), ErrInvalidArgument)
+	})
+}
+
 func (m *ManifestTestSuite) TestEmptyManifestWriterCloseIsTerminal() {
 	for _, version := range []int{1, 2, 3} {
 		m.Run("v"+strconv.Itoa(version), func() {
@@ -3785,12 +3829,14 @@ func (m *ManifestTestSuite) TestManifestWriterPreservesMinSequenceNumberZero() {
 	oldSnapshot := int64(999)
 	entries := make([]ManifestEntry, len(manifestEntryV1Records))
 	for i, rec := range manifestEntryV1Records {
+		dataFile := cloneDataFileAvroFields(rec.DataFile().(*dataFile))
+		dataFile.Content = EntryContentData
 		entries[i] = NewManifestEntry(
 			EntryStatusEXISTING,
 			&oldSnapshot,
 			&seqZero,
 			&seqZero,
-			rec.DataFile(),
+			dataFile,
 		)
 	}
 


### PR DESCRIPTION
## What changed

- use the writer content as the default content of the returned manifest file
- reject data files in delete manifests and delete files in data manifests
- reject a conflicting manifest file content override
- keep V1 behavior unchanged because V1 does not encode file content

## Why

A delete manifest writer currently writes `content=deletes` into the Avro metadata, but `ToManifestFile` defaults the returned manifest descriptor to data. The writer also accepts entries with the wrong file content. This can produce a manifest list entry that contradicts the manifest it references.

## Testing

- added coverage for content inheritance and mismatches
- `go test ./...`
- `go vet ./...`