### PR TITLE
fix(transforms): handle truncate projection bounds

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -1319,14 +1319,22 @@ func truncateNumber[T LiteralType](name string, pred BoundLiteralPredicate, fn f
 
 	switch pred.Op() {
 	case OpLT:
+		adjusted := boundary.Decrement()
+		if _, ok := adjusted.(BelowMinLiteral); ok {
+			return nil, nil
+		}
 		return LiteralPredicate(OpLTEQ, Reference(name),
-			transformLiteral(fn, boundary.Decrement())), nil
+			transformLiteral(fn, adjusted)), nil
 	case OpLTEQ:
 		return LiteralPredicate(OpLTEQ, Reference(name),
 			transformLiteral(fn, boundary)), nil
 	case OpGT:
+		adjusted := boundary.Increment()
+		if _, ok := adjusted.(AboveMaxLiteral); ok {
+			return nil, nil
+		}
 		return LiteralPredicate(OpGTEQ, Reference(name),
-			transformLiteral(fn, boundary.Increment())), nil
+			transformLiteral(fn, adjusted)), nil
 	case OpGTEQ:
 		return LiteralPredicate(OpGTEQ, Reference(name),
 			transformLiteral(fn, boundary)), nil

--- a/transforms.go
+++ b/transforms.go
@@ -1323,6 +1323,7 @@ func truncateNumber[T LiteralType](name string, pred BoundLiteralPredicate, fn f
 		if _, ok := adjusted.(BelowMinLiteral); ok {
 			return nil, nil
 		}
+
 		return LiteralPredicate(OpLTEQ, Reference(name),
 			transformLiteral(fn, adjusted)), nil
 	case OpLTEQ:
@@ -1333,6 +1334,7 @@ func truncateNumber[T LiteralType](name string, pred BoundLiteralPredicate, fn f
 		if _, ok := adjusted.(AboveMaxLiteral); ok {
 			return nil, nil
 		}
+
 		return LiteralPredicate(OpGTEQ, Reference(name),
 			transformLiteral(fn, adjusted)), nil
 	case OpGTEQ:

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -20,6 +20,7 @@ package iceberg_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -1123,6 +1124,48 @@ func TestTruncateTransform(t *testing.T) {
 			result := transform.Apply(iceberg.Optional[iceberg.Literal]{Val: tt.value, Valid: true})
 			require.True(t, result.Valid)
 			assert.Equal(t, tt.expected, result.Val)
+		})
+	}
+}
+
+func TestTruncateTransformProjectStrictNumericBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType iceberg.Type
+		predicate iceberg.UnboundPredicate
+	}{
+		{
+			name:      "int32 above maximum",
+			fieldType: iceberg.PrimitiveTypes.Int32,
+			predicate: iceberg.GreaterThan(iceberg.Reference("id"), int32(math.MaxInt32)),
+		},
+		{
+			name:      "int32 below minimum",
+			fieldType: iceberg.PrimitiveTypes.Int32,
+			predicate: iceberg.LessThan(iceberg.Reference("id"), int32(math.MinInt32)),
+		},
+		{
+			name:      "int64 above maximum",
+			fieldType: iceberg.PrimitiveTypes.Int64,
+			predicate: iceberg.GreaterThan(iceberg.Reference("id"), int64(math.MaxInt64)),
+		},
+		{
+			name:      "int64 below minimum",
+			fieldType: iceberg.PrimitiveTypes.Int64,
+			predicate: iceberg.LessThan(iceberg.Reference("id"), int64(math.MinInt64)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "id", Type: tt.fieldType})
+			bound, err := tt.predicate.Bind(schema, true)
+			require.NoError(t, err)
+
+			projected, err := (iceberg.TruncateTransform{Width: 10}).Project(
+				"id_trunc", bound.(iceberg.BoundPredicate))
+			require.NoError(t, err)
+			assert.Nil(t, projected)
 		})
 	}
 }


### PR DESCRIPTION
## What changed

Handle strict truncate projections at the minimum and maximum integer bounds without passing sentinel literals into the transform.

## Why

Projecting predicates such as `id > math.MaxInt32` currently increments the boundary to an above-max literal. The truncate transform does not support that literal and panics with `invalid literal type`.

The projection API cannot return an always-false unbound predicate, so this uses no partition projection for these cases. That is conservative and leaves the exact row predicate in place.

## Testing

- added cases for strict predicates at both int32 bounds
- added cases for strict predicates at both int64 bounds
- `go test ./...`
- `go vet ./...`