### PR TITLE
fix(manifest): reject invalid manifest entries

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -924,11 +924,11 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	switch entryContent {
 	case EntryContentData:
 		if c.content != ManifestContentData {
-			return nil, fmt.Errorf("data file found in delete manifest")
+			return nil, errors.New("data file found in delete manifest")
 		}
 	case EntryContentPosDeletes, EntryContentEqDeletes:
 		if c.content != ManifestContentDeletes {
-			return nil, fmt.Errorf("delete file found in data manifest")
+			return nil, errors.New("delete file found in data manifest")
 		}
 	default:
 		return nil, fmt.Errorf("manifest entry has invalid content: %d", entryContent)

--- a/manifest.go
+++ b/manifest.go
@@ -914,6 +914,25 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	if c.isFallback {
 		tmp = tmp.(*fallbackManifestEntry).toEntry()
 	}
+	switch tmp.Status() {
+	case EntryStatusEXISTING, EntryStatusADDED, EntryStatusDELETED:
+	default:
+		return nil, fmt.Errorf("manifest entry has invalid status: %d", tmp.Status())
+	}
+
+	entryContent := tmp.DataFile().ContentType()
+	switch entryContent {
+	case EntryContentData:
+		if c.content != ManifestContentData {
+			return nil, fmt.Errorf("data file found in delete manifest")
+		}
+	case EntryContentPosDeletes, EntryContentEqDeletes:
+		if c.content != ManifestContentDeletes {
+			return nil, fmt.Errorf("delete file found in data manifest")
+		}
+	default:
+		return nil, fmt.Errorf("manifest entry has invalid content: %d", entryContent)
+	}
 	tmp.inherit(c.file)
 	// First Row ID Inheritance (spec): assign the manifest's first_row_id to data
 	// files that lack one, advancing by record_count only on the files actually

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2126,6 +2126,84 @@ func (m *ManifestTestSuite) TestNewManifestReaderZstdManifestEntriesV2() {
 	m.Require().ErrorIs(err, io.EOF)
 }
 
+func (m *ManifestTestSuite) TestManifestReaderRejectsInvalidEntries() {
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
+	m.Require().NoError(err)
+	entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 2)
+	m.Require().NoError(err)
+	deleteEntry := *manifestEntryV2Records[0]
+	deleteFile := cloneDataFileAvroFields(deleteEntry.Data.(*dataFile))
+	deleteFile.Content = EntryContentEqDeletes
+	deleteEntry.Data = deleteFile
+	invalidContentEntry := deleteEntry
+	invalidContentFile := cloneDataFileAvroFields(deleteFile)
+	invalidContentFile.Content = ManifestEntryContent(3)
+	invalidContentEntry.Data = invalidContentFile
+
+	tests := []struct {
+		name            string
+		manifestContent ManifestContent
+		entry           *manifestEntry
+		errorContains   string
+	}{
+		{
+			name:            "unknown status",
+			manifestContent: ManifestContentData,
+			entry: func() *manifestEntry {
+				entry := *manifestEntryV2Records[0]
+				entry.EntryStatus = ManifestEntryStatus(3)
+
+				return &entry
+			}(),
+			errorContains: "invalid status",
+		},
+		{
+			name:            "data file in delete manifest",
+			manifestContent: ManifestContentDeletes,
+			entry:           manifestEntryV2Records[0],
+			errorContains:   "data file found in delete manifest",
+		},
+		{
+			name:            "delete file in data manifest",
+			manifestContent: ManifestContentData,
+			entry:           &deleteEntry,
+			errorContains:   "delete file found in data manifest",
+		},
+		{
+			name:            "unknown content",
+			manifestContent: ManifestContentDeletes,
+			entry:           &invalidContentEntry,
+			errorContains:   "invalid content",
+		},
+	}
+
+	for _, tt := range tests {
+		m.Run(tt.name, func() {
+			mw := ManifestWriter{version: 2, spec: partitionSpec, schema: testSchema, content: tt.manifestContent}
+			metadata, err := mw.meta()
+			m.Require().NoError(err)
+
+			var buf bytes.Buffer
+			writer, err := ocf.NewWriter(&buf, entrySchema,
+				ocf.WithSchema(entrySchema.String()), ocf.WithMetadata(metadata))
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Encode(tt.entry))
+			m.Require().NoError(writer.Close())
+
+			manifest := &manifestFile{version: 2, SpecID: 1, Content: tt.manifestContent}
+			reader, err := NewManifestReader(manifest, bytes.NewReader(buf.Bytes()))
+			m.Require().NoError(err)
+			defer reader.Close()
+
+			_, err = reader.ReadEntry()
+			m.ErrorContains(err, tt.errorContains)
+		})
+	}
+}
+
 func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	dataFileBuilder, err := NewDataFileBuilder(
 		NewPartitionSpec(),


### PR DESCRIPTION
## What changed

Validate decoded manifest entries before inheritance or filtering:

- reject unknown entry status values
- reject data files in delete manifests
- reject delete files in data manifests
- reject unknown file content values

## Why

The writer validates entry status, but the reader currently accepts any decoded status. An unknown status is not treated as deleted, so it can continue through scan planning as a live entry. Content mismatches are accepted in the same path.

## Testing

- added low-level Avro fixtures for each invalid status and content case
- `go test ./...`
- `go vet ./...`