### PR TITLE
fix(manifest): reject inherited row ID overflow

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -807,6 +807,10 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 	var nextFirstRowID int64
 	if inheritRowIDs {
 		nextFirstRowID = *file.FirstRowID()
+		if nextFirstRowID < 0 {
+			return nil, fmt.Errorf("%w: first row ID must be non-negative: %d",
+				ErrInvalidArgument, nextFirstRowID)
+		}
 	}
 
 	return &ManifestReader{

--- a/manifest.go
+++ b/manifest.go
@@ -925,8 +925,17 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	if c.inheritRowIDs && tmp.Status() != EntryStatusDELETED {
 		if df, ok := tmp.DataFile().(*dataFile); ok && df.FirstRowIDField == nil {
 			id := c.nextFirstRowID
+			count := df.Count()
+			if count < 0 {
+				return nil, fmt.Errorf("cannot inherit first row ID for data file %q: %w: record count must be non-negative: %d",
+					df.FilePath(), ErrInvalidArgument, count)
+			}
+			nextFirstRowID, err := advanceRowID(id, 0, count)
+			if err != nil {
+				return nil, fmt.Errorf("cannot inherit first row ID for data file %q: %w", df.FilePath(), err)
+			}
 			df.FirstRowIDField = &id
-			c.nextFirstRowID += df.Count()
+			c.nextFirstRowID = nextFirstRowID
 		}
 	}
 	if fieldToIDMap, ok := tmp.DataFile().(hasFieldToIDMap); ok {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1386,6 +1386,52 @@ func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritance() {
 	m.EqualValues(1000+firstCount, *entries[1].DataFile().FirstRowID())
 }
 
+func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritanceRejectsInvalidRange() {
+	tests := []struct {
+		name          string
+		firstRowID    int64
+		recordCount   int64
+		errorContains string
+	}{
+		{name: "overflow", firstRowID: math.MaxInt64, recordCount: 1, errorContains: "overflows int64"},
+		{name: "negative record count", firstRowID: 0, recordCount: -1, errorContains: "record count must be non-negative"},
+	}
+
+	for _, tt := range tests {
+		m.Run(tt.name, func() {
+			partitionSpec := NewPartitionSpecID(1,
+				PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
+			entry := &manifestEntry{
+				EntryStatus: EntryStatusADDED,
+				Snapshot:    &entrySnapshotID,
+				Data: &dataFile{
+					Content:          EntryContentData,
+					Path:             "/data/file.parquet",
+					Format:           ParquetFile,
+					PartitionData:    map[string]any{"x": int(1)},
+					RecordCount:      tt.recordCount,
+					FileSize:         1000,
+					BlockSizeInBytes: 64 * 1024,
+				},
+			}
+			var manifestBuf bytes.Buffer
+			_, err := WriteManifest("/manifest.avro", &manifestBuf, 3, partitionSpec, testSchema,
+				entrySnapshotID, []ManifestEntry{entry})
+			m.Require().NoError(err)
+
+			file := &manifestFile{
+				version:         3,
+				Path:            "/manifest.avro",
+				Content:         ManifestContentData,
+				FirstRowIDValue: &tt.firstRowID,
+			}
+			_, err = ReadManifest(file, bytes.NewReader(manifestBuf.Bytes()), false)
+			m.Require().ErrorIs(err, ErrInvalidArgument)
+			m.ErrorContains(err, tt.errorContains)
+		})
+	}
+}
+
 // TestV3DataManifestFirstRowIDInheritanceSkipsDeletedEntries verifies that a
 // DELETED entry consumes no row IDs during inheritance, matching the
 // manifest-list writer, which reserves a manifest's id range as added+existing

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1430,6 +1430,41 @@ func (m *ManifestTestSuite) TestV3DataManifestFirstRowIDInheritanceRejectsInvali
 			m.ErrorContains(err, tt.errorContains)
 		})
 	}
+
+	m.Run("negative manifest first row ID with explicit entry ID", func() {
+		partitionSpec := NewPartitionSpecID(1,
+			PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "x", Transform: IdentityTransform{}})
+		entryFirstRowID := int64(0)
+		entry := &manifestEntry{
+			EntryStatus: EntryStatusADDED,
+			Snapshot:    &entrySnapshotID,
+			Data: &dataFile{
+				Content:          EntryContentData,
+				Path:             "/data/file.parquet",
+				Format:           ParquetFile,
+				PartitionData:    map[string]any{"x": int(1)},
+				RecordCount:      1,
+				FileSize:         1000,
+				BlockSizeInBytes: 64 * 1024,
+				FirstRowIDField:  &entryFirstRowID,
+			},
+		}
+		var manifestBuf bytes.Buffer
+		_, err := WriteManifest("/manifest.avro", &manifestBuf, 3, partitionSpec, testSchema,
+			entrySnapshotID, []ManifestEntry{entry})
+		m.Require().NoError(err)
+
+		negativeManifestFirstRowID := int64(-1)
+		file := &manifestFile{
+			version:         3,
+			Path:            "/manifest.avro",
+			Content:         ManifestContentData,
+			FirstRowIDValue: &negativeManifestFirstRowID,
+		}
+		_, err = ReadManifest(file, bytes.NewReader(manifestBuf.Bytes()), false)
+		m.Require().ErrorIs(err, ErrInvalidArgument)
+		m.ErrorContains(err, "first row ID must be non-negative")
+	})
 }
 
 // TestV3DataManifestFirstRowIDInheritanceSkipsDeletedEntries verifies that a


### PR DESCRIPTION
## What changed

Use checked arithmetic when a manifest reader inherits `first_row_id` for V3 data files. The reader now rejects:

- a row ID range that exceeds int64
- a negative data-file record count
- a negative inherited starting row ID

The next row ID is only updated after validation succeeds.

## Why

The reader currently advances its row ID cursor with unchecked addition. A range near `math.MaxInt64` can wrap to a negative row ID and assign invalid lineage to later files.

## Testing

- added overflow coverage at `math.MaxInt64`
- added negative record-count coverage
- `go test ./...`
- `go vet ./...`