### PR TITLE
fix(rest): reject trailing JSON responses

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -583,13 +583,21 @@ func decodeJSONResponse(body io.Reader, dst any) error {
 		return fmt.Errorf("%w: error decoding json payload: `%s`", ErrRESTError, err.Error())
 	}
 
+	if err := rejectTrailingJSON(decoder); err != nil {
+		return fmt.Errorf("%w: %s", ErrRESTError, err)
+	}
+
+	return nil
+}
+
+func rejectTrailingJSON(decoder *json.Decoder) error {
 	var trailing json.RawMessage
 	if err := decoder.Decode(&trailing); err != io.EOF {
 		if err == nil {
-			return fmt.Errorf("%w: response contains multiple JSON values", ErrRESTError)
+			return errors.New("response contains multiple JSON values")
 		}
 
-		return fmt.Errorf("%w: error decoding trailing json payload: `%s`", ErrRESTError, err.Error())
+		return fmt.Errorf("error decoding trailing json payload: `%s`", err.Error())
 	}
 
 	return nil
@@ -618,7 +626,11 @@ func handleNon200(rsp *http.Response, override map[int]error, typeOverride map[s
 			Error: &e,
 		}
 
-		decErr := json.NewDecoder(rsp.Body).Decode(&payload)
+		decoder := json.NewDecoder(rsp.Body)
+		decErr := decoder.Decode(&payload)
+		if decErr == nil {
+			decErr = rejectTrailingJSON(decoder)
+		}
 		if decErr != nil && decErr != io.EOF {
 			// Preserve the HTTP metadata even when the server returned a non-JSON
 			// error page. Callers such as WaitForPlan still need the status to apply

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -502,8 +502,8 @@ func do[T any](ctx context.Context, method string, baseURI *url.URL, path []stri
 		return ret, err
 	}
 
-	if err = json.NewDecoder(rsp.Body).Decode(&ret); err != nil {
-		return ret, fmt.Errorf("%w: error decoding json payload: `%s`", ErrRESTError, err.Error())
+	if err = decodeJSONResponse(rsp.Body, &ret); err != nil {
+		return ret, err
 	}
 
 	return ret, err
@@ -570,11 +570,29 @@ func doPost[Payload, Result any](ctx context.Context, baseURI *url.URL, path []s
 		return ret, err
 	}
 
-	if err = json.NewDecoder(rsp.Body).Decode(&ret); err != nil {
-		return ret, fmt.Errorf("%w: error decoding json payload: `%s`", ErrRESTError, err.Error())
+	if err = decodeJSONResponse(rsp.Body, &ret); err != nil {
+		return ret, err
 	}
 
 	return ret, err
+}
+
+func decodeJSONResponse(body io.Reader, dst any) error {
+	decoder := json.NewDecoder(body)
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("%w: error decoding json payload: `%s`", ErrRESTError, err.Error())
+	}
+
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("%w: response contains multiple JSON values", ErrRESTError)
+		}
+
+		return fmt.Errorf("%w: error decoding trailing json payload: `%s`", ErrRESTError, err.Error())
+	}
+
+	return nil
 }
 
 func setRequestHeaders(req *http.Request, headers map[string]string) {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1368,6 +1368,19 @@ func TestHandleNon200_DecodeCanonicalErrorRendersExpectedMessage(t *testing.T) {
 	require.True(t, errors.Is(err, ErrForbidden))
 }
 
+func TestHandleNon200_RejectsTrailingJSON(t *testing.T) {
+	body := `{"message":"bad request"} {}`
+	rsp := &http.Response{
+		StatusCode:    http.StatusBadRequest,
+		ContentLength: int64(len(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := handleNon200(rsp, nil, nil)
+	require.ErrorIs(t, err, ErrRESTError)
+	require.ErrorContains(t, err, "multiple JSON values")
+}
+
 func TestHandleNon200_EmptyBodyFallback(t *testing.T) {
 	rsp := &http.Response{
 		StatusCode:    http.StatusBadRequest,

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -91,6 +91,43 @@ func (r *RestCatalogSuite) TearDownTest() {
 	r.configVals = nil
 }
 
+func TestRESTRejectsTrailingJSONInGetResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"defaults":{},"overrides":{},"endpoints":[]} {}`))
+		require.NoError(t, err)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
+	require.ErrorIs(t, err, rest.ErrRESTError)
+	require.ErrorContains(t, err, "multiple JSON values")
+}
+
+func TestRESTRejectsTrailingJSONInPostResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"defaults":  map[string]any{},
+			"overrides": map[string]any{},
+			"endpoints": rest.AllEndpointStrings,
+		}))
+	})
+	mux.HandleFunc("/v1/namespaces/fokko/tables", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(createTableRestExample + `{}`))
+		require.NoError(t, err)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", srv.URL, rest.WithOAuthToken(TestToken))
+	require.NoError(t, err)
+	_, err = cat.CreateTable(context.Background(), catalog.ToIdentifier("fokko", "fokko2"), tableSchemaSimple)
+	require.ErrorIs(t, err, rest.ErrRESTError)
+	require.ErrorContains(t, err, "multiple JSON values")
+}
+
 func (r *RestCatalogSuite) TestToken200() {
 	const scope = "myscope"
 	r.mux.HandleFunc("/v1/oauth/tokens", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## What changed

Use one response decoder for successful GET and POST requests, and require EOF after the first JSON value.

## Why

The REST client currently decodes one value and ignores the rest of the response body. A response containing a valid object followed by another JSON value is accepted as successful even though it is not a single JSON document.

Whitespace after the response remains valid.

## Testing

- added a trailing JSON test for GET responses
- added a trailing JSON test for POST responses
- `go test ./...`
- `go vet ./...`