### PR TITLE
feat(table): add all entries metadata table

### DIFF
--- a/table/inspect_all_entries.go
+++ b/table/inspect_all_entries.go
@@ -18,7 +18,6 @@ package table
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/iceberg-go"
@@ -28,22 +27,7 @@ import (
 // snapshot currently tracked by the table. Shared manifests are scanned once,
 // and deleted entries remain visible.
 func (i InspectTable) AllEntries(ctx context.Context) (array.RecordReader, error) {
-	partitionType, err := inspectPartitionType(i.tbl.metadata)
-	if err != nil {
-		return nil, fmt.Errorf("inspect all entries: %w", err)
-	}
-	arrowSchema, err := SchemaToArrowSchema(AllEntriesSchema(partitionType), nil, true, false)
-	if err != nil {
-		return nil, fmt.Errorf("inspect all entries: build arrow schema: %w", err)
-	}
-
-	rr, err := i.allManifestEntryReader(ctx, arrowSchema, false, nil,
-		newInspectEntryAppender(partitionType))
-	if err != nil {
-		return nil, fmt.Errorf("inspect all entries: %w", err)
-	}
-
-	return rr, nil
+	return i.inspectEntries(ctx, "all entries", true, AllEntriesSchema)
 }
 
 // AllEntriesSchema returns the schema of the all_entries metadata table.

--- a/table/inspect_all_entries.go
+++ b/table/inspect_all_entries.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/iceberg-go"
+)
+
+// AllEntries returns every entry from each manifest reachable from any
+// snapshot currently tracked by the table. Shared manifests are scanned once,
+// and deleted entries remain visible.
+func (i InspectTable) AllEntries(ctx context.Context) (array.RecordReader, error) {
+	partitionType, err := inspectPartitionType(i.tbl.metadata)
+	if err != nil {
+		return nil, fmt.Errorf("inspect all entries: %w", err)
+	}
+	arrowSchema, err := SchemaToArrowSchema(AllEntriesSchema(partitionType), nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect all entries: build arrow schema: %w", err)
+	}
+
+	rr, err := i.allManifestEntryReader(ctx, arrowSchema, false, nil,
+		newInspectEntryAppender(partitionType))
+	if err != nil {
+		return nil, fmt.Errorf("inspect all entries: %w", err)
+	}
+
+	return rr, nil
+}
+
+// AllEntriesSchema returns the schema of the all_entries metadata table.
+func AllEntriesSchema(partitionType *iceberg.StructType) *iceberg.Schema {
+	return EntriesSchema(partitionType)
+}

--- a/table/inspect_entries.go
+++ b/table/inspect_entries.go
@@ -39,34 +39,41 @@ func (i InspectTable) Entries(ctx context.Context) (array.RecordReader, error) {
 		return nil, fmt.Errorf("inspect entries: build arrow schema: %w", err)
 	}
 
-	var current *array.RecordBuilder
-	var contentFileBuilder inspectContentFileBuilder
-	var bindErr error
+	appendEntry := newInspectEntryAppender(partitionType)
 	rr, err := i.manifestEntryReader(ctx, arrowSchema, false, nil,
-		func(bldr *array.RecordBuilder, entry iceberg.ManifestEntry) error {
-			dataFileBuilder := bldr.Field(4).(*array.StructBuilder)
-			if bldr != current {
-				contentFileBuilder, bindErr = newInspectContentFileStructBuilder(dataFileBuilder, partitionType)
-				current = bldr
-			}
-			if bindErr != nil {
-				return bindErr
-			}
-
-			bldr.Field(0).(*array.Int32Builder).Append(int32(entry.Status()))
-			appendEntriesOptionalInt64(bldr.Field(1).(*array.Int64Builder), entry.SnapshotID())
-			appendEntriesOptionalInt64(bldr.Field(2).(*array.Int64Builder), entry.SequenceNum())
-			appendInspectOptionalInt64(bldr.Field(3).(*array.Int64Builder), entry.FileSequenceNum())
-
-			dataFileBuilder.Append(true)
-
-			return contentFileBuilder.append(entry.DataFile())
-		})
+		appendEntry)
 	if err != nil {
 		return nil, fmt.Errorf("inspect entries: %w", err)
 	}
 
 	return rr, nil
+}
+
+func newInspectEntryAppender(
+	partitionType *iceberg.StructType,
+) func(*array.RecordBuilder, iceberg.ManifestEntry) error {
+	var current *array.RecordBuilder
+	var contentFileBuilder inspectContentFileBuilder
+	var bindErr error
+
+	return func(bldr *array.RecordBuilder, entry iceberg.ManifestEntry) error {
+		dataFileBuilder := bldr.Field(4).(*array.StructBuilder)
+		if bldr != current {
+			contentFileBuilder, bindErr = newInspectContentFileStructBuilder(dataFileBuilder, partitionType)
+			current = bldr
+		}
+		if bindErr != nil {
+			return bindErr
+		}
+
+		bldr.Field(0).(*array.Int32Builder).Append(int32(entry.Status()))
+		appendEntriesOptionalInt64(bldr.Field(1).(*array.Int64Builder), entry.SnapshotID())
+		appendEntriesOptionalInt64(bldr.Field(2).(*array.Int64Builder), entry.SequenceNum())
+		appendInspectOptionalInt64(bldr.Field(3).(*array.Int64Builder), entry.FileSequenceNum())
+		dataFileBuilder.Append(true)
+
+		return contentFileBuilder.append(entry.DataFile())
+	}
 }
 
 // EntriesSchema returns the schema of the entries metadata table.

--- a/table/inspect_entries.go
+++ b/table/inspect_entries.go
@@ -29,21 +29,33 @@ import (
 // entries marked deleted. This exposes commit history that data_files and
 // delete_files intentionally hide.
 func (i InspectTable) Entries(ctx context.Context) (array.RecordReader, error) {
+	return i.inspectEntries(ctx, "entries", false, EntriesSchema)
+}
+
+func (i InspectTable) inspectEntries(
+	ctx context.Context,
+	name string,
+	allSnapshots bool,
+	schemaFn func(*iceberg.StructType) *iceberg.Schema,
+) (array.RecordReader, error) {
 	partitionType, err := inspectPartitionType(i.tbl.metadata)
 	if err != nil {
-		return nil, fmt.Errorf("inspect entries: %w", err)
+		return nil, fmt.Errorf("inspect %s: %w", name, err)
 	}
-	schema := EntriesSchema(partitionType)
-	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	arrowSchema, err := SchemaToArrowSchema(schemaFn(partitionType), nil, true, false)
 	if err != nil {
-		return nil, fmt.Errorf("inspect entries: build arrow schema: %w", err)
+		return nil, fmt.Errorf("inspect %s: build arrow schema: %w", name, err)
 	}
 
 	appendEntry := newInspectEntryAppender(partitionType)
-	rr, err := i.manifestEntryReader(ctx, arrowSchema, false, nil,
-		appendEntry)
+	var rr array.RecordReader
+	if allSnapshots {
+		rr, err = i.allManifestEntryReader(ctx, arrowSchema, false, nil, appendEntry)
+	} else {
+		rr, err = i.manifestEntryReader(ctx, arrowSchema, false, nil, appendEntry)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("inspect entries: %w", err)
+		return nil, fmt.Errorf("inspect %s: %w", name, err)
 	}
 
 	return rr, nil

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1820,6 +1820,64 @@ func TestInspectAllEntriesDeduplicatesSharedManifests(t *testing.T) {
 	}, []string{paths.Value(0), paths.Value(1), paths.Value(2)})
 }
 
+func TestInspectAllEntriesIncludesDeleteManifests(t *testing.T) {
+	tbl := inspectAllFilesTable(t)
+
+	rr, err := tbl.Inspect().AllEntries(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	record := collectRecord(t, rr)
+	defer record.Release()
+	require.EqualValues(t, 5, record.NumRows())
+
+	statuses := record.Column(0).(*array.Int32)
+	require.Equal(t, []int32{
+		int32(iceberg.EntryStatusADDED),
+		int32(iceberg.EntryStatusDELETED),
+		int32(iceberg.EntryStatusADDED),
+		int32(iceberg.EntryStatusADDED),
+		int32(iceberg.EntryStatusADDED),
+	}, statuses.Int32Values())
+
+	dataFiles := record.Column(4).(*array.Struct)
+	contents := dataFiles.Field(0).(*array.Int32)
+	paths := dataFiles.Field(1).(*array.String)
+	require.Equal(t, []int32{
+		int32(iceberg.EntryContentData),
+		int32(iceberg.EntryContentData),
+		int32(iceberg.EntryContentData),
+		int32(iceberg.EntryContentData),
+		int32(iceberg.EntryContentPosDeletes),
+	}, contents.Int32Values())
+	require.Equal(t, []string{
+		"mem://default/table-location/data/shared.parquet",
+		"mem://default/table-location/data/deleted.parquet",
+		"mem://default/table-location/data/shared.parquet",
+		"mem://default/table-location/data/new.parquet",
+		"mem://default/table-location/data/delete.parquet",
+	}, []string{
+		paths.Value(0), paths.Value(1), paths.Value(2), paths.Value(3), paths.Value(4),
+	})
+}
+
+func TestInspectAllEntriesStreamsBatches(t *testing.T) {
+	spec := *iceberg.UnpartitionedSpec
+	tbl := inspectDataFilesTable(t, spec,
+		inspectDataFileEntries(t, spec, inspectRecordBatchSize+1))
+
+	rr, err := tbl.Inspect().AllEntries(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	var batchRows []int
+	for rr.Next() {
+		batchRows = append(batchRows, int(rr.RecordBatch().NumRows()))
+	}
+	require.NoError(t, rr.Err())
+	require.Equal(t, []int{inspectRecordBatchSize, 1}, batchRows)
+}
+
 func TestDataFilesSchema(t *testing.T) {
 	sc := DataFilesSchema(&iceberg.StructType{FieldList: []iceberg.NestedField{
 		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
@@ -2127,6 +2185,7 @@ func TestInspectFilesTablesEarlyRelease(t *testing.T) {
 		{name: "all files", read: tbl.Inspect(WithInspectAllocator(checked)).AllFiles},
 		{name: "all data files", read: tbl.Inspect(WithInspectAllocator(checked)).AllDataFiles},
 		{name: "all delete files", read: tbl.Inspect(WithInspectAllocator(checked)).AllDeleteFiles},
+		{name: "all entries", read: tbl.Inspect(WithInspectAllocator(checked)).AllEntries},
 	}
 
 	for _, tt := range reads {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1878,6 +1878,38 @@ func TestInspectAllEntriesStreamsBatches(t *testing.T) {
 	require.Equal(t, []int{inspectRecordBatchSize, 1}, batchRows)
 }
 
+func TestInspectAllEntriesEmptyTableEarlyRelease(t *testing.T) {
+	checked := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	t.Cleanup(func() { checked.AssertSize(t, 0) })
+	meta := &metadataV2{commonMetadata: commonMetadata{
+		SchemaList:      []*iceberg.Schema{simpleSchema()},
+		CurrentSchemaID: 0,
+		Specs:           []iceberg.PartitionSpec{*iceberg.UnpartitionedSpec},
+		DefaultSpecID:   0,
+	}}
+	tbl := New(Identifier{"empty-all-entries"}, meta, "metadata.json", nil, nil)
+
+	rr, err := tbl.Inspect(WithInspectAllocator(checked)).AllEntries(context.Background())
+	require.NoError(t, err)
+	require.True(t, rr.Next())
+	require.EqualValues(t, 0, rr.RecordBatch().NumRows())
+	rr.Release()
+}
+
+func TestInspectAllEntriesStopsOnContextCancellation(t *testing.T) {
+	tbl := inspectAllFilesTable(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rr, err := tbl.Inspect().AllEntries(ctx)
+	require.NoError(t, err)
+	cancel()
+
+	require.False(t, rr.Next())
+	require.ErrorIs(t, rr.Err(), context.Canceled)
+	rr.Release()
+}
+
 func TestDataFilesSchema(t *testing.T) {
 	sc := DataFilesSchema(&iceberg.StructType{FieldList: []iceberg.NestedField{
 		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1729,6 +1729,97 @@ func TestInspectManifestsRejectsUnknownContent(t *testing.T) {
 	require.ErrorContains(t, err, "has unknown content 2")
 }
 
+func TestInspectAllEntriesDeduplicatesSharedManifests(t *testing.T) {
+	spec := *iceberg.UnpartitionedSpec
+	txn, memIO := createTestTransactionWithMemIO(t, spec)
+	schema := simpleSchema()
+	snapshotOne, snapshotTwo := int64(1), int64(2)
+	sequenceOne, sequenceTwo := int64(1), int64(2)
+
+	sharedAdded := newTestDataFile(t, spec,
+		"mem://default/table-location/data/shared-added.parquet", nil)
+	sharedDeleted := newTestDataFile(t, spec,
+		"mem://default/table-location/data/shared-deleted.parquet", nil)
+	newFile := newTestDataFile(t, spec,
+		"mem://default/table-location/data/new.parquet", nil)
+	sharedEntries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotOne,
+			&sequenceOne, &sequenceOne, sharedAdded),
+		iceberg.NewManifestEntry(iceberg.EntryStatusDELETED, &snapshotOne,
+			&sequenceOne, &sequenceOne, sharedDeleted),
+	}
+	newEntries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotTwo,
+			&sequenceTwo, &sequenceTwo, newFile),
+	}
+
+	writeManifest := func(path string, snapshotID int64, entries []iceberg.ManifestEntry) iceberg.ManifestFile {
+		var buf bytes.Buffer
+		manifest, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, snapshotID, entries)
+		require.NoError(t, err)
+		require.NoError(t, memIO.WriteFile(path, buf.Bytes()))
+
+		return manifest
+	}
+	sharedManifest := writeManifest(
+		"mem://default/table-location/metadata/shared.avro", snapshotOne, sharedEntries)
+	newManifest := writeManifest(
+		"mem://default/table-location/metadata/new.avro", snapshotTwo, newEntries)
+
+	writeList := func(path string, snapshotID int64, parent *int64, sequenceNumber int64,
+		manifests []iceberg.ManifestFile,
+	) []iceberg.ManifestFile {
+		var buf bytes.Buffer
+		require.NoError(t, iceberg.WriteManifestList(2, &buf, snapshotID, parent,
+			&sequenceNumber, 0, manifests))
+		require.NoError(t, memIO.WriteFile(path, buf.Bytes()))
+		written, err := iceberg.ReadManifestList(bytes.NewReader(buf.Bytes()))
+		require.NoError(t, err)
+
+		return written
+	}
+	listOne := "mem://default/table-location/metadata/snap-1.avro"
+	listTwo := "mem://default/table-location/metadata/snap-2.avro"
+	writtenOne := writeList(listOne, snapshotOne, nil, sequenceOne,
+		[]iceberg.ManifestFile{sharedManifest})
+	writeList(listTwo, snapshotTwo, &snapshotOne, sequenceTwo,
+		[]iceberg.ManifestFile{writtenOne[0], newManifest})
+
+	txn.meta.snapshotList = []Snapshot{
+		{SnapshotID: snapshotOne, ManifestList: listOne, SequenceNumber: sequenceOne},
+		{
+			SnapshotID: snapshotTwo, ParentSnapshotID: &snapshotOne,
+			ManifestList: listTwo, SequenceNumber: sequenceTwo,
+		},
+	}
+	txn.meta.currentSnapshotID = &snapshotTwo
+	built, err := txn.meta.Build()
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "tbl"}, built, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memIO, nil }, nil)
+
+	rr, err := tbl.Inspect().AllEntries(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 3, record.NumRows())
+	status := record.Column(0).(*array.Int32)
+	require.Equal(t, []int32{
+		int32(iceberg.EntryStatusADDED),
+		int32(iceberg.EntryStatusDELETED),
+		int32(iceberg.EntryStatusADDED),
+	}, status.Int32Values())
+	dataFiles := record.Column(4).(*array.Struct)
+	paths := dataFiles.Field(1).(*array.String)
+	require.Equal(t, []string{
+		sharedAdded.FilePath(),
+		sharedDeleted.FilePath(),
+		newFile.FilePath(),
+	}, []string{paths.Value(0), paths.Value(1), paths.Value(2)})
+}
+
 func TestDataFilesSchema(t *testing.T) {
 	sc := DataFilesSchema(&iceberg.StructType{FieldList: []iceberg.NestedField{
 		{ID: 1000, Name: "bucket", Type: iceberg.PrimitiveTypes.Int32, Required: true},
@@ -2677,6 +2768,13 @@ func TestInspectEntriesIncludesDeletedEntries(t *testing.T) {
 	paths := dataFiles.Field(1).(*array.String)
 	require.Equal(t, addedFile.FilePath(), paths.Value(0))
 	require.Equal(t, deletedFile.FilePath(), paths.Value(1))
+}
+
+func TestAllEntriesSchemaMatchesEntries(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "part", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+	}}
+	require.True(t, EntriesSchema(partitionType).Equals(AllEntriesSchema(partitionType)))
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations


### PR DESCRIPTION
## Summary

- add all_entries to Table.Inspect
- read each reachable manifest once across tracked snapshots
- keep deleted manifest entries visible and reuse the entries row appender

## Dependency

Built on #1700, which currently depends on #1698. I will rebase as the parent PRs land.

## Testing

- go test ./...
- golangci-lint run --timeout=10m

Refs #1703