### PR TITLE
feat(table): add position deletes metadata table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 	go test -v ./...
 
 test-assert:
-	go test -tags=assert -v -run='^(TestInspectFilesTablesEarlyRelease|TestInspectDataFilesEmitsEmptyBatchWhenAllEntriesAreDeleted|TestInspectDataFilesEmptyTableEarlyRelease)$$' ./table
+	go test -tags=assert -v -run='^(TestInspectFilesTablesEarlyRelease|TestInspectDataFilesEmitsEmptyBatchWhenAllEntriesAreDeleted|TestInspectDataFilesEmptyTableEarlyRelease|TestInspectPositionDeletesEarlyRelease)$$' ./table
 
 # Race detector is opt-in per package/test.
 test-race:

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -479,6 +479,13 @@ func collectPosDeletePositions(positionalDeletes positionDeletes) (set[int64], e
 				return nil, fmt.Errorf("%w: unsupported pos chunk array type %T in position delete file",
 					iceberg.ErrInvalidSchema, arr)
 			}
+			if posArr.NullN() > 0 {
+				return nil, fmt.Errorf("%w: null pos in position delete file",
+					iceberg.ErrInvalidSchema)
+			}
+			if err := validatePositionDeletePositions(posArr); err != nil {
+				return nil, err
+			}
 			for _, v := range posArr.Int64Values() {
 				deletes[v] = struct{}{}
 			}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -320,6 +320,17 @@ type posDeleteCursor struct {
 	offset     int
 }
 
+func validatePositionDeletePositions(positions *array.Int64) error {
+	for row := range positions.Len() {
+		if position := positions.Value(row); position < 0 {
+			return fmt.Errorf("%w: negative pos %d in position delete file",
+				iceberg.ErrInvalidSchema, position)
+		}
+	}
+
+	return nil
+}
+
 func newPosDeleteCursor(posCol *arrow.Chunked) (posDeleteCursor, error) {
 	chunks := posCol.Chunks()
 	arrays := make([]*array.Int64, len(chunks))
@@ -328,6 +339,9 @@ func newPosDeleteCursor(posCol *arrow.Chunked) (posDeleteCursor, error) {
 		if !ok {
 			return posDeleteCursor{}, fmt.Errorf("%w: unsupported pos chunk array type %T in position delete file",
 				iceberg.ErrInvalidSchema, chunk)
+		}
+		if err := validatePositionDeletePositions(posArr); err != nil {
+			return posDeleteCursor{}, err
 		}
 		arrays[i] = posArr
 	}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -340,9 +340,6 @@ func newPosDeleteCursor(posCol *arrow.Chunked) (posDeleteCursor, error) {
 			return posDeleteCursor{}, fmt.Errorf("%w: unsupported pos chunk array type %T in position delete file",
 				iceberg.ErrInvalidSchema, chunk)
 		}
-		if err := validatePositionDeletePositions(posArr); err != nil {
-			return posDeleteCursor{}, err
-		}
 		arrays[i] = posArr
 	}
 
@@ -431,6 +428,10 @@ func groupPosDeletesByFilePath(ctx context.Context, filePathCol, posCol *arrow.C
 				return nil, fmt.Errorf("%w: position delete columns ended before file_path column",
 					iceberg.ErrInvalidSchema)
 			}
+			if pos < 0 {
+				return nil, fmt.Errorf("%w: negative pos %d in position delete file",
+					iceberg.ErrInvalidSchema, pos)
+			}
 			if dictionary != nil && dictionary.IsNull(indices.GetValueIndex(i)) {
 				return nil, fmt.Errorf("%w: null file_path dictionary value in position delete file",
 					iceberg.ErrInvalidSchema)
@@ -483,10 +484,11 @@ func collectPosDeletePositions(positionalDeletes positionDeletes) (set[int64], e
 				return nil, fmt.Errorf("%w: null pos in position delete file",
 					iceberg.ErrInvalidSchema)
 			}
-			if err := validatePositionDeletePositions(posArr); err != nil {
-				return nil, err
-			}
 			for _, v := range posArr.Int64Values() {
+				if v < 0 {
+					return nil, fmt.Errorf("%w: negative pos %d in position delete file",
+						iceberg.ErrInvalidSchema, v)
+				}
 				deletes[v] = struct{}{}
 			}
 		}

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -603,6 +603,39 @@ func TestCollectPosDeletePositionsRejectsUnsupportedPosType(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported pos column type")
 }
 
+func TestCollectPosDeletePositionsRejectsNegativePositions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	posArr := int64Array(mem, -1)
+	defer posArr.Release()
+
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	defer posCol.Release()
+
+	_, err := collectPosDeletePositions(positionDeletes{posCol})
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "negative pos -1")
+}
+
+func TestCollectPosDeletePositionsRejectsNullPositions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewInt64Builder(mem)
+	bldr.AppendNull()
+	posArr := bldr.NewInt64Array()
+	bldr.Release()
+	defer posArr.Release()
+
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	defer posCol.Release()
+
+	_, err := collectPosDeletePositions(positionDeletes{posCol})
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "null pos in position delete file")
+}
+
 func TestReadDeletesRejectsNullPos(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	ctx := compute.WithAllocator(t.Context(), mem)

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -308,6 +308,25 @@ func TestGroupPosDeletesByFilePathRejectsMismatchedLengths(t *testing.T) {
 	assert.Contains(t, err.Error(), "file_path and pos columns have different lengths: 2 and 1")
 }
 
+func TestGroupPosDeletesByFilePathRejectsNegativePositions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	ctx := compute.WithAllocator(t.Context(), mem)
+
+	filePathArr := stringArray(mem, "file-a.parquet")
+	defer filePathArr.Release()
+	filePathCol := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{filePathArr})
+	defer filePathCol.Release()
+	posArr := int64Array(mem, -1)
+	defer posArr.Release()
+	posCol := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{posArr})
+	defer posCol.Release()
+
+	_, err := groupPosDeletesByFilePath(ctx, filePathCol, posCol)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	assert.Contains(t, err.Error(), "negative pos -1")
+}
+
 func TestGroupPosDeletesByFilePathOwnsResults(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1050,6 +1050,7 @@ type arrowProjectionVisitor struct {
 	ctx                 context.Context
 	fileSchema          *iceberg.Schema
 	tableProperties     iceberg.Properties
+	formatVersion       int
 	includeFieldIDs     bool
 	downcastNsTimestamp bool
 	useLargeTypes       bool
@@ -1079,8 +1080,13 @@ func (a *arrowProjectionVisitor) castIfNeeded(field iceberg.NestedField, vals ar
 
 	if !field.Type.Equals(typ) {
 		if !canDowncastTimestampPrecision(fileField.Type, field.Type, a.downcastNsTimestamp) {
-			promoted := retOrPanic(iceberg.PromoteType(fileField.Type, field.Type))
-			targetType := a.typeToArrowType(promoted)
+			var targetType arrow.DataType
+			if a.formatVersion >= 3 && canPromoteDateToTimestamp(fileField.Type, field.Type) {
+				targetType = a.typeToArrowType(field.Type)
+			} else {
+				promoted := retOrPanic(iceberg.PromoteType(fileField.Type, field.Type))
+				targetType = a.typeToArrowType(promoted)
+			}
 			if !a.useLargeTypes {
 				targetType = retOrPanic(ensureSmallArrowTypes(targetType))
 			}
@@ -1184,6 +1190,19 @@ func canDowncastTimestampPrecision(fileType, readType iceberg.Type, enabled bool
 		_, ok := readType.(iceberg.TimestampTzType)
 
 		return ok
+	default:
+		return false
+	}
+}
+
+func canPromoteDateToTimestamp(fileType, readType iceberg.Type) bool {
+	if _, ok := fileType.(iceberg.DateType); !ok {
+		return false
+	}
+
+	switch readType.(type) {
+	case iceberg.TimestampType, iceberg.TimestampNsType:
+		return true
 	default:
 		return false
 	}
@@ -1425,10 +1444,12 @@ func (a *arrowProjectionVisitor) Variant(_ iceberg.VariantType, arr arrow.Array)
 // SchemaOptions controls the behaviour of ToRequestedSchema.
 type SchemaOptions struct {
 	DowncastTimestamp bool
-	IncludeFieldIDs   bool
-	UseLargeTypes     bool
-	UseWriteDefault   bool
-	TableProperties   iceberg.Properties
+	// FormatVersion enables format-version-specific read promotions.
+	FormatVersion   int
+	IncludeFieldIDs bool
+	UseLargeTypes   bool
+	UseWriteDefault bool
+	TableProperties iceberg.Properties
 }
 
 // ToRequestedSchema will construct a new record batch matching the requested iceberg schema
@@ -1442,6 +1463,7 @@ func ToRequestedSchema(ctx context.Context, requested, fileSchema *iceberg.Schem
 			ctx:                 ctx,
 			fileSchema:          fileSchema,
 			tableProperties:     opts.TableProperties,
+			formatVersion:       opts.FormatVersion,
 			includeFieldIDs:     opts.IncludeFieldIDs,
 			downcastNsTimestamp: opts.DowncastTimestamp,
 			useLargeTypes:       opts.UseLargeTypes,

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1047,14 +1047,15 @@ func defaultToArray(v any, t iceberg.Type, dt arrow.DataType, n int, alloc memor
 }
 
 type arrowProjectionVisitor struct {
-	ctx                 context.Context
-	fileSchema          *iceberg.Schema
-	tableProperties     iceberg.Properties
-	formatVersion       int
-	includeFieldIDs     bool
-	downcastNsTimestamp bool
-	useLargeTypes       bool
-	useWriteDefault     bool
+	ctx                  context.Context
+	fileSchema           *iceberg.Schema
+	tableProperties      iceberg.Properties
+	formatVersion        int
+	includeFieldIDs      bool
+	downcastNsTimestamp  bool
+	useLargeTypes        bool
+	useWriteDefault      bool
+	allowMissingRequired bool
 }
 
 func (a *arrowProjectionVisitor) typeToArrowType(t iceberg.Type) arrow.DataType {
@@ -1288,7 +1289,7 @@ func (a *arrowProjectionVisitor) Struct(st iceberg.StructType, structArr arrow.A
 				arr = defaultToArray(field.WriteDefault, field.Type, dt, structArr.Len(), alloc)
 			case field.InitialDefault != nil && !a.useWriteDefault:
 				arr = defaultToArray(field.InitialDefault, field.Type, dt, structArr.Len(), alloc)
-			case !field.Required:
+			case !field.Required || a.allowMissingRequired:
 				arr = array.MakeArrayOfNull(alloc, dt, structArr.Len())
 			default:
 				panic(fmt.Errorf("%w: required field is missing and has no default value: %s",
@@ -1445,11 +1446,12 @@ func (a *arrowProjectionVisitor) Variant(_ iceberg.VariantType, arr arrow.Array)
 type SchemaOptions struct {
 	DowncastTimestamp bool
 	// FormatVersion enables format-version-specific read promotions.
-	FormatVersion   int
-	IncludeFieldIDs bool
-	UseLargeTypes   bool
-	UseWriteDefault bool
-	TableProperties iceberg.Properties
+	FormatVersion        int
+	IncludeFieldIDs      bool
+	UseLargeTypes        bool
+	UseWriteDefault      bool
+	AllowMissingRequired bool
+	TableProperties      iceberg.Properties
 }
 
 // ToRequestedSchema will construct a new record batch matching the requested iceberg schema
@@ -1460,14 +1462,15 @@ func ToRequestedSchema(ctx context.Context, requested, fileSchema *iceberg.Schem
 
 	result, err := iceberg.VisitSchemaWithPartner[arrow.Array, arrow.Array](requested, st,
 		&arrowProjectionVisitor{
-			ctx:                 ctx,
-			fileSchema:          fileSchema,
-			tableProperties:     opts.TableProperties,
-			formatVersion:       opts.FormatVersion,
-			includeFieldIDs:     opts.IncludeFieldIDs,
-			downcastNsTimestamp: opts.DowncastTimestamp,
-			useLargeTypes:       opts.UseLargeTypes,
-			useWriteDefault:     opts.UseWriteDefault,
+			ctx:                  ctx,
+			fileSchema:           fileSchema,
+			tableProperties:      opts.TableProperties,
+			formatVersion:        opts.FormatVersion,
+			includeFieldIDs:      opts.IncludeFieldIDs,
+			downcastNsTimestamp:  opts.DowncastTimestamp,
+			useLargeTypes:        opts.UseLargeTypes,
+			useWriteDefault:      opts.UseWriteDefault,
+			allowMissingRequired: opts.AllowMissingRequired,
 		}, arrowAccessor{fileSchema: fileSchema})
 	if err != nil {
 		return nil, err

--- a/table/dv/roaring_bitmap_test.go
+++ b/table/dv/roaring_bitmap_test.go
@@ -74,6 +74,22 @@ func TestDeserializeRoaringBitmapJava32BitValues(t *testing.T) {
 	assert.False(t, bm.Contains(10))
 }
 
+// Why: metadata-table readers need deterministic expansion of deletion vectors.
+// Condition: positions span multiple high-bit buckets and were inserted out of order.
+// Assertion: Positions yields every value once in ascending order.
+func TestRoaringPositionBitmapPositions(t *testing.T) {
+	bm := NewRoaringPositionBitmap()
+	for _, position := range []uint64{(uint64(2) << 32) | 4, 9, 1, (uint64(1) << 32) | 3} {
+		bm.Set(position)
+	}
+
+	var actual []uint64
+	for position := range bm.Positions() {
+		actual = append(actual, position)
+	}
+	assert.Equal(t, []uint64{1, 9, (uint64(1) << 32) | 3, (uint64(2) << 32) | 4}, actual)
+}
+
 // Why: the deserializer must fail cleanly when the outer bitmap count cannot be read.
 // Condition: empty input stream.
 // Assertion: returns an error containing "read bitmap count".

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -3006,7 +3007,7 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
-func TestInspectPositionDeletesV3ParquetUsesFileSize(t *testing.T) {
+func TestInspectPositionDeletesV3ParquetLeavesDVMetadataNull(t *testing.T) {
 	ctx := context.Background()
 	memFS := iceio.NewMemFS()
 	deletePath := "mem://position-deletes/table/data/delete-v3.parquet"
@@ -3035,8 +3036,7 @@ func TestInspectPositionDeletesV3ParquetUsesFileSize(t *testing.T) {
 	require.EqualValues(t, 2, record.NumRows())
 	require.EqualValues(t, 7, record.NumCols())
 	require.EqualValues(t, 2, record.Column(5).NullN())
-	require.Equal(t, []int64{fileSize, fileSize},
-		record.Column(6).(*array.Int64).Int64Values())
+	require.EqualValues(t, 2, record.Column(6).NullN())
 }
 
 func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
@@ -3050,7 +3050,7 @@ func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 
 			return true, nil
@@ -3095,7 +3095,7 @@ func TestAppendParquetPositionDeleteRowsRejectsNullRow(t *testing.T) {
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 
 			return true, nil
@@ -3205,6 +3205,107 @@ func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
 	require.Equal(t, int32(18), amount.DataType().(*arrow.Decimal128Type).Precision)
 }
 
+func TestInspectPositionDeletesParquetUsesNameMappingAndInitialDefault(t *testing.T) {
+	const (
+		deletePath = "mem://position-deletes/table/data/delete-renamed.parquet"
+		dataPath   = "mem://position-deletes/table/data/data.parquet"
+	)
+	memFS := iceio.NewMemFS()
+	intPtr := func(value int) *int { return &value }
+
+	tablePayloadType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 2, Name: "new_name", Type: iceberg.PrimitiveTypes.String, Required: true},
+	}}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "payload", Type: tablePayloadType, Required: true},
+		iceberg.NestedField{ID: 4, Name: "status", Type: iceberg.PrimitiveTypes.String, Required: false, InitialDefault: "active"},
+	)
+	mapping := iceberg.NameMapping{
+		{FieldID: intPtr(1), Names: []string{"payload", "old_payload"}, Fields: []iceberg.MappedField{
+			{FieldID: intPtr(2), Names: []string{"new_name", "old_name"}},
+		}},
+		{FieldID: intPtr(4), Names: []string{"status"}},
+	}
+	metadata := newInspectPositionDeletesMetadataWithSchema(t, 3, tableSchema)
+	mappingJSON, err := json.Marshal(mapping)
+	require.NoError(t, err)
+	require.NoError(t, metadata.SetProperties(iceberg.Properties{
+		DefaultNameMappingKey: string(mappingJSON),
+	}))
+
+	sourcePayloadType := arrow.StructOf(arrow.Field{
+		Name:     "old_name",
+		Type:     arrow.BinaryTypes.String,
+		Nullable: false,
+	})
+	sourceRowType := arrow.StructOf(arrow.Field{
+		Name:     "old_payload",
+		Type:     sourcePayloadType,
+		Nullable: false,
+	})
+	sourceSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "row", Type: sourceRowType, Nullable: false},
+	}, nil)
+	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, sourceSchema)
+	recordBuilder.Field(0).(*array.StringBuilder).Append(dataPath)
+	recordBuilder.Field(1).(*array.Int64Builder).Append(7)
+	rowBuilder := recordBuilder.Field(2).(*array.StructBuilder)
+	rowBuilder.Append(true)
+	payloadBuilder := rowBuilder.FieldBuilder(0).(*array.StructBuilder)
+	payloadBuilder.Append(true)
+	payloadBuilder.FieldBuilder(0).(*array.StringBuilder).Append("deleted")
+	record := recordBuilder.NewRecordBatch()
+	defer record.Release()
+	defer recordBuilder.Release()
+
+	arrowTable := array.NewTableFromRecords(sourceSchema, []arrow.RecordBatch{record})
+	defer arrowTable.Release()
+	file, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(
+		arrowTable, file, record.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	require.NoError(t, file.Close())
+
+	tbl := inspectPositionDeletesTableWithSchema(
+		t, 3, metadata, tableSchema, memFS,
+		[]iceberg.DataFile{newPosDeleteFile(t, deletePath, 1, 128)},
+	)
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	result := collectRecord(t, rr)
+	defer result.Release()
+
+	projectedRow := result.Column(2).(*array.Struct)
+	payload := projectedRow.Field(0).(*array.Struct)
+	require.Equal(t, "deleted", payload.Field(0).(*array.String).Value(0))
+	require.Equal(t, "active", projectedRow.Field(1).(*array.String).Value(0))
+}
+
+func TestInspectPositionDeletesRejectsUnsupportedFileFormat(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete.avro"
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		deletePath, iceberg.AvroFile, nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+
+	tbl := inspectPositionDeletesTable(
+		t, 2, newInspectPositionDeletesMetadata(t, 2), memFS,
+		[]iceberg.DataFile{builder.Build()},
+	)
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+
+	require.False(t, rr.Next())
+	require.ErrorIs(t, rr.Err(), iceberg.ErrNotImplemented)
+	require.ErrorContains(t, rr.Err(), "unsupported position delete file format AVRO")
+}
+
 func TestInspectPositionDeletesParquetProjectsDateToTimestampsV3(t *testing.T) {
 	const (
 		deletePath = "mem://position-deletes/table/data/delete-date.parquet"
@@ -3289,7 +3390,7 @@ func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T)
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		ctx, memFS, newPosDeleteFile(t, deletePath, 2, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 			cancel()
 
@@ -3303,7 +3404,7 @@ func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T)
 
 func TestPositionDeleteRowProjection(t *testing.T) {
 	tableSchema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
 	)
 	outputSchema, err := SchemaToArrowSchema(
@@ -3452,21 +3553,14 @@ func TestPositionDeleteRowProjectionPromotesDateInV3(t *testing.T) {
 		arrow.Timestamp(int64(dateValue)*int64(24*time.Hour/time.Nanosecond)), dateNanos.Value(0))
 }
 
-func TestPositionDeleteDatePromotionRequiresV3(t *testing.T) {
-	timestamp := &arrow.TimestampType{Unit: arrow.Microsecond}
-	date := arrow.FixedWidthTypes.Date32
-
-	require.False(t, canPromotePositionDeleteValue(date, timestamp, 2))
-	require.True(t, canPromotePositionDeleteValue(date, timestamp, 3))
-	require.True(t, canPromotePositionDeleteValue(
-		date, &arrow.TimestampType{Unit: arrow.Nanosecond}, 3))
-	require.False(t, canPromotePositionDeleteValue(date, arrow.FixedWidthTypes.Timestamp_us, 3),
+func TestPositionDeleteDatePromotion(t *testing.T) {
+	require.True(t, canPromoteDateToTimestamp(
+		iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.Timestamp))
+	require.True(t, canPromoteDateToTimestamp(
+		iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.TimestampNs))
+	require.False(t, canPromoteDateToTimestamp(
+		iceberg.PrimitiveTypes.Date, iceberg.PrimitiveTypes.TimestampTz),
 		"date promotion must not target a timezone-aware timestamp")
-
-	_, ok := convertPositionDeleteDate32(arrow.Date32(20_000), arrow.Nanosecond)
-	require.True(t, ok)
-	_, ok = convertPositionDeleteDate32(arrow.Date32(math.MaxInt32), arrow.Nanosecond)
-	require.False(t, ok, "out-of-range dates must fail timestamp conversion")
 }
 
 func TestPositionDeleteRowProjectionRejectsDatePromotionBeforeV3(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2985,6 +2985,37 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
+func TestPositionDeleteRowProjection(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	sourceType := arrow.StructOf(arrow.Field{
+		Name:     "data",
+		Type:     arrow.BinaryTypes.String,
+		Nullable: true,
+		Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
+	})
+	row := scalar.NewStructScalar([]scalar.Scalar{scalar.NewStringScalar("deleted")}, sourceType)
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	projected := record.Column(2).(*array.Struct)
+	require.False(t, projected.IsNull(0))
+	require.True(t, projected.Field(0).IsNull(0), "missing row fields should be null")
+	require.Equal(t, "deleted", projected.Field(1).(*array.String).Value(0))
+}
+
 func TestInspectPositionDeletesEarlyRelease(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3340,6 +3340,41 @@ func TestPositionDeleteRowProjectionPromotesTypes(t *testing.T) {
 	require.Equal(t, 1.25, projected.Field(1).(*array.Float64).Value(0))
 }
 
+func TestPositionDeleteRowProjectionPromotesLargeBinaryToBinary(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "payload", Type: iceberg.PrimitiveTypes.Binary, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	fieldID := arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})
+	sourceType := arrow.StructOf(arrow.Field{
+		Name:     "payload",
+		Type:     arrow.BinaryTypes.LargeBinary,
+		Nullable: true,
+		Metadata: fieldID,
+	})
+	buf := memory.NewBufferBytes([]byte("deleted"))
+	value := scalar.NewLargeBinaryScalar(buf)
+	buf.Release()
+	row := scalar.NewStructScalar([]scalar.Scalar{value}, sourceType)
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(
+		deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	payload := record.Column(2).(*array.Struct).Field(0).(*array.Binary)
+	require.Equal(t, []byte("deleted"), payload.Value(0))
+}
+
 func TestPositionDeleteRowProjectionPromotesDateInV3(t *testing.T) {
 	tableSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "created_at", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3019,12 +3019,58 @@ func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
 		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
 		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
 			rows++
+
 			return true, nil
 		},
 	)
 	require.False(t, keepGoing)
 	require.ErrorContains(t, err, "negative pos -1")
 	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	require.Zero(t, rows)
+}
+
+func TestAppendParquetPositionDeleteRowsRejectsNullRow(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete-null-row.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "row", Type: arrow.StructOf(arrow.Field{
+			Name:     "id",
+			Type:     arrow.PrimitiveTypes.Int32,
+			Nullable: false,
+		}), Nullable: true},
+	}, nil)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	bldr.Field(0).(*array.StringBuilder).Append(dataPath)
+	bldr.Field(1).(*array.Int64Builder).Append(1)
+	bldr.Field(2).(*array.StructBuilder).Append(false)
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	defer bldr.Release()
+
+	tbl := array.NewTableFromRecords(schema, []arrow.RecordBatch{record})
+	defer tbl.Release()
+	file, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(
+		tbl, file, record.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	require.NoError(t, file.Close())
+
+	rows := 0
+	keepGoing, err := appendParquetPositionDeleteRows(
+		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
+		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+			rows++
+
+			return true, nil
+		},
+	)
+	require.False(t, keepGoing)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	require.ErrorContains(t, err, "null row")
 	require.Zero(t, rows)
 }
 

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table/dv"
@@ -2871,11 +2873,19 @@ func TestAllEntriesSchemaMatchesEntries(t *testing.T) {
 }
 
 func newInspectPositionDeletesMetadata(t *testing.T, formatVersion int) *MetadataBuilder {
+	return newInspectPositionDeletesMetadataWithSchema(t, formatVersion, simpleSchema())
+}
+
+func newInspectPositionDeletesMetadataWithSchema(
+	t *testing.T,
+	formatVersion int,
+	tableSchema *iceberg.Schema,
+) *MetadataBuilder {
 	t.Helper()
 
 	mb, err := NewMetadataBuilder(formatVersion)
 	require.NoError(t, err)
-	require.NoError(t, mb.AddSchema(simpleSchema()))
+	require.NoError(t, mb.AddSchema(tableSchema))
 	require.NoError(t, mb.SetCurrentSchemaID(0))
 	require.NoError(t, mb.AddPartitionSpec(iceberg.UnpartitionedSpec, true))
 	require.NoError(t, mb.SetDefaultSpecID(0))
@@ -2896,6 +2906,17 @@ func inspectPositionDeletesTable(
 	fs iceio.WriteFileIO,
 	files []iceberg.DataFile,
 ) *Table {
+	return inspectPositionDeletesTableWithSchema(t, formatVersion, mb, simpleSchema(), fs, files)
+}
+
+func inspectPositionDeletesTableWithSchema(
+	t *testing.T,
+	formatVersion int,
+	mb *MetadataBuilder,
+	tableSchema *iceberg.Schema,
+	fs iceio.WriteFileIO,
+	files []iceberg.DataFile,
+) *Table {
 	t.Helper()
 
 	snapshotID := int64(1)
@@ -2904,7 +2925,7 @@ func inspectPositionDeletesTable(
 	manifestBuffer := &bytes.Buffer{}
 	writer, err := iceberg.NewManifestWriter(
 		formatVersion, manifestBuffer, *iceberg.UnpartitionedSpec,
-		simpleSchema(), snapshotID,
+		tableSchema, snapshotID,
 		iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes),
 	)
 	require.NoError(t, err)
@@ -2927,7 +2948,7 @@ func inspectPositionDeletesTable(
 	))
 	require.NoError(t, fs.WriteFile(manifestListPath, manifestListBuffer.Bytes()))
 
-	schemaID := 0
+	schemaID := tableSchema.ID
 	snapshot := &Snapshot{
 		SnapshotID:     snapshotID,
 		SequenceNumber: sequenceNumber,
@@ -2983,6 +3004,104 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	deleteFilePaths := rec.Column(4).(*array.String)
 	require.Equal(t, deletePath, deleteFilePaths.Value(0))
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
+}
+
+func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
+	const (
+		deletePath = "mem://position-deletes/table/data/delete-evolved.parquet"
+		dataPath   = "mem://position-deletes/table/data/data.parquet"
+	)
+	memFS := iceio.NewMemFS()
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+
+	tableListType := &iceberg.ListType{
+		ElementID:       3,
+		Element:         iceberg.PrimitiveTypes.Int64,
+		ElementRequired: true,
+	}
+	tableMapType := &iceberg.MapType{
+		KeyID:         4,
+		KeyType:       iceberg.PrimitiveTypes.String,
+		ValueID:       5,
+		ValueType:     iceberg.PrimitiveTypes.Int64,
+		ValueRequired: false,
+	}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "values", Type: tableListType, Required: true},
+		iceberg.NestedField{ID: 2, Name: "attributes", Type: tableMapType, Required: true},
+		iceberg.NestedField{ID: 6, Name: "amount", Type: iceberg.DecimalTypeOf(18, 2), Required: true},
+	)
+
+	sourceListType := arrow.ListOfField(arrow.Field{
+		Name:     "element",
+		Type:     arrow.PrimitiveTypes.Int32,
+		Nullable: false,
+		Metadata: fieldID(3),
+	})
+	sourceMapType := arrow.MapOfFields(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String, Nullable: false, Metadata: fieldID(4)},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: true, Metadata: fieldID(5)},
+	)
+	sourceDecimalType := &arrow.Decimal128Type{Precision: 9, Scale: 2}
+	sourceRowType := arrow.StructOf(
+		arrow.Field{Name: "values", Type: sourceListType, Nullable: true, Metadata: fieldID(1)},
+		arrow.Field{Name: "attributes", Type: sourceMapType, Nullable: true, Metadata: fieldID(2)},
+		arrow.Field{Name: "amount", Type: sourceDecimalType, Nullable: true, Metadata: fieldID(6)},
+	)
+	sourceSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "row", Type: sourceRowType, Nullable: true},
+	}, nil)
+
+	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, sourceSchema)
+	recordBuilder.Field(0).(*array.StringBuilder).Append(dataPath)
+	recordBuilder.Field(1).(*array.Int64Builder).Append(7)
+	rowBuilder := recordBuilder.Field(2).(*array.StructBuilder)
+	rowBuilder.Append(true)
+	valuesBuilder := rowBuilder.FieldBuilder(0).(*array.ListBuilder)
+	valuesBuilder.Append(true)
+	valuesBuilder.ValueBuilder().(*array.Int32Builder).AppendValues([]int32{7, 9}, nil)
+	attributesBuilder := rowBuilder.FieldBuilder(1).(*array.MapBuilder)
+	attributesBuilder.Append(true)
+	attributesBuilder.KeyBuilder().(*array.StringBuilder).Append("first")
+	attributesBuilder.ItemBuilder().(*array.Int32Builder).Append(11)
+	attributesBuilder.KeyBuilder().(*array.StringBuilder).Append("second")
+	attributesBuilder.ItemBuilder().(*array.Int32Builder).Append(13)
+	rowBuilder.FieldBuilder(2).(*array.Decimal128Builder).Append(decimal128.FromI64(12345))
+	record := recordBuilder.NewRecordBatch()
+	defer record.Release()
+	defer recordBuilder.Release()
+
+	arrowTable := array.NewTableFromRecords(sourceSchema, []arrow.RecordBatch{record})
+	defer arrowTable.Release()
+	file, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(
+		arrowTable, file, record.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	require.NoError(t, file.Close())
+
+	deleteFile := newPosDeleteFile(t, deletePath, 1, 128)
+	tbl := inspectPositionDeletesTableWithSchema(
+		t, 2, newInspectPositionDeletesMetadataWithSchema(t, 2, tableSchema),
+		tableSchema, memFS, []iceberg.DataFile{deleteFile})
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record = collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 1, record.NumRows())
+	projectedRow := record.Column(2).(*array.Struct)
+	require.False(t, projectedRow.IsNull(0))
+	require.Equal(t, []int64{7, 9}, projectedRow.Field(0).(*array.List).ListValues().(*array.Int64).Int64Values())
+	require.Equal(t, []int64{11, 13}, projectedRow.Field(1).(*array.Map).Items().(*array.Int64).Int64Values())
+	amount := projectedRow.Field(2).(*array.Decimal128)
+	require.Equal(t, decimal128.FromI64(12345), amount.Value(0))
+	require.Equal(t, int32(18), amount.DataType().(*arrow.Decimal128Type).Precision)
 }
 
 func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T) {
@@ -3233,6 +3352,55 @@ func TestPositionDeleteRowProjectionPromotesNestedStructValues(t *testing.T) {
 	items := record.Column(2).(*array.Struct).Field(0).(*array.List).ListValues().(*array.Struct)
 	require.EqualValues(t, 17, items.Field(0).(*array.Int64).Value(0))
 	require.Equal(t, "nested", items.Field(1).(*array.String).Value(0))
+}
+
+func TestPositionDeleteRowProjectionRejectsNullMapKey(t *testing.T) {
+	tableMapType := &iceberg.MapType{
+		KeyID:         2,
+		KeyType:       iceberg.PrimitiveTypes.String,
+		ValueID:       3,
+		ValueType:     iceberg.PrimitiveTypes.Int64,
+		ValueRequired: false,
+	}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "attributes", Type: tableMapType, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	sourceEntryType := arrow.StructOf(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String, Nullable: true, Metadata: fieldID(2)},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: true, Metadata: fieldID(3)},
+	)
+	entryBuilder := array.NewStructBuilder(memory.DefaultAllocator, sourceEntryType)
+	entryBuilder.Append(true)
+	entryBuilder.FieldBuilder(0).(*array.StringBuilder).AppendNull()
+	entryBuilder.FieldBuilder(1).(*array.Int32Builder).Append(11)
+	entries := entryBuilder.NewArray()
+	entryBuilder.Release()
+	mapValue := scalar.NewMapScalar(entries)
+	entries.Release()
+	sourceMapType := arrow.MapOfFields(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String, Nullable: false, Metadata: fieldID(2)},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: true, Metadata: fieldID(3)},
+	)
+	row := scalar.NewStructScalar([]scalar.Scalar{mapValue}, arrow.StructOf(
+		arrow.Field{Name: "attributes", Type: sourceMapType, Nullable: true, Metadata: fieldID(1)},
+	))
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	err = appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row)
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	require.ErrorContains(t, err, "null key")
 }
 
 func TestInspectPositionDeletesStopsOnContextCancellation(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3006,6 +3006,35 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
+func TestInspectPositionDeletesV3ParquetUsesFileSize(t *testing.T) {
+	ctx := context.Background()
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete-v3.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	writePosDeleteParquetToMemFS(t, memFS, deletePath, `[
+		{"file_path": "`+dataPath+`", "pos": 1},
+		{"file_path": "`+dataPath+`", "pos": 3}
+	]`)
+	const fileSize int64 = 128
+	deleteFile := newPosDeleteFile(t, deletePath, 2, fileSize)
+	tbl := inspectPositionDeletesTable(
+		t, 3, newInspectPositionDeletesMetadata(t, 3), memFS,
+		[]iceberg.DataFile{deleteFile},
+	)
+
+	rr, err := tbl.Inspect().PositionDeletes(ctx)
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 2, record.NumRows())
+	require.EqualValues(t, 7, record.NumCols())
+	require.EqualValues(t, 2, record.Column(5).NullN())
+	require.Equal(t, []int64{fileSize, fileSize},
+		record.Column(6).(*array.Int64).Int64Values())
+}
+
 func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
 	memFS := iceio.NewMemFS()
 	deletePath := "mem://position-deletes/table/data/delete-negative.parquet"

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3461,7 +3461,7 @@ func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T)
 
 func TestPositionDeleteRowProjection(t *testing.T) {
 	tableSchema := iceberg.NewSchema(0,
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
 		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: true},
 	)
 	outputSchema, err := SchemaToArrowSchema(
@@ -3488,6 +3488,52 @@ func TestPositionDeleteRowProjection(t *testing.T) {
 	require.False(t, projected.IsNull(0))
 	require.True(t, projected.Field(0).IsNull(0), "missing row fields should be null")
 	require.Equal(t, "deleted", projected.Field(1).(*array.String).Value(0))
+}
+
+func TestPositionDeleteRowProjectionAllowsMissingRequiredNestedField(t *testing.T) {
+	tableDetailsType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 2, Name: "present", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: 3, Name: "missing", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	}}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "details", Type: tableDetailsType, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	sourceDetailsType := arrow.StructOf(arrow.Field{
+		Name:     "present",
+		Type:     arrow.BinaryTypes.String,
+		Nullable: true,
+		Metadata: fieldID(2),
+	})
+	sourceType := arrow.StructOf(arrow.Field{
+		Name:     "details",
+		Type:     sourceDetailsType,
+		Nullable: true,
+		Metadata: fieldID(1),
+	})
+	row := scalar.NewStructScalar([]scalar.Scalar{
+		scalar.NewStructScalar([]scalar.Scalar{scalar.NewStringScalar("kept")}, sourceDetailsType),
+	}, sourceType)
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	details := record.Column(2).(*array.Struct).Field(0).(*array.Struct)
+	require.Equal(t, "kept", details.Field(0).(*array.String).Value(0))
+	require.True(t, details.Field(1).IsNull(0), "missing nested row fields should be null")
 }
 
 func TestPositionDeleteRowProjectionPromotesTypes(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3165,6 +3165,9 @@ func TestAppendParquetPositionDeleteRowsRejectsNullRow(t *testing.T) {
 }
 
 func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
+	checked := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	t.Cleanup(func() { checked.AssertSize(t, 0) })
+
 	const (
 		deletePath = "mem://position-deletes/table/data/delete-evolved.parquet"
 		dataPath   = "mem://position-deletes/table/data/data.parquet"
@@ -3246,7 +3249,7 @@ func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
 	tbl := inspectPositionDeletesTableWithSchema(
 		t, 2, newInspectPositionDeletesMetadataWithSchema(t, 2, tableSchema),
 		tableSchema, memFS, []iceberg.DataFile{deleteFile})
-	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	rr, err := tbl.Inspect(WithInspectAllocator(checked)).PositionDeletes(context.Background())
 	require.NoError(t, err)
 	defer rr.Release()
 	record = collectRecord(t, rr)

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2941,11 +2941,27 @@ func inspectPositionDeletesTableWithSchema(
 	require.NoError(t, err)
 	require.NoError(t, fs.WriteFile(manifestPath, manifestBuffer.Bytes()))
 
+	return inspectPositionDeletesTableWithManifests(
+		t, formatVersion, mb, tableSchema, fs, []iceberg.ManifestFile{manifest})
+}
+
+func inspectPositionDeletesTableWithManifests(
+	t *testing.T,
+	formatVersion int,
+	mb *MetadataBuilder,
+	tableSchema *iceberg.Schema,
+	fs iceio.WriteFileIO,
+	manifests []iceberg.ManifestFile,
+) *Table {
+	t.Helper()
+
+	snapshotID := int64(1)
+	sequenceNumber := int64(1)
 	manifestListPath := "mem://position-deletes/table/metadata/snap.avro"
 	manifestListBuffer := &bytes.Buffer{}
 	require.NoError(t, iceberg.WriteManifestList(
 		formatVersion, manifestListBuffer, snapshotID, nil, &sequenceNumber, 0,
-		[]iceberg.ManifestFile{manifest},
+		manifests,
 	))
 	require.NoError(t, fs.WriteFile(manifestListPath, manifestListBuffer.Bytes()))
 
@@ -3060,6 +3076,47 @@ func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
 	require.ErrorContains(t, err, "negative pos -1")
 	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 	require.Zero(t, rows)
+}
+
+func TestInspectPositionDeletesDefersLaterManifestReads(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	tableSchema := simpleSchema()
+	deletePath := "mem://position-deletes/table/data/delete-first.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	var deleteRows bytes.Buffer
+	deleteRows.WriteByte('[')
+	for pos := range inspectRecordBatchSize {
+		if pos > 0 {
+			deleteRows.WriteByte(',')
+		}
+		fmt.Fprintf(&deleteRows, `{"file_path": %q, "pos": %d}`, dataPath, pos)
+	}
+	deleteRows.WriteByte(']')
+	writePosDeleteParquetToMemFS(t, memFS, deletePath, deleteRows.String())
+
+	snapshotID := int64(1)
+	sequenceNumber := int64(1)
+	firstManifest := writeInspectManifest(
+		t, memFS, "mem://position-deletes/table/metadata/first-deletes.avro",
+		*iceberg.UnpartitionedSpec, tableSchema, snapshotID, iceberg.ManifestContentDeletes,
+		[]iceberg.ManifestEntry{iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, &sequenceNumber, &sequenceNumber,
+			newPosDeleteFile(t, deletePath, inspectRecordBatchSize, 128),
+		)},
+	)
+	missingManifest := iceberg.NewManifestFile(
+		2, "mem://position-deletes/table/metadata/not-opened.avro", 1, 0, snapshotID,
+	).Content(iceberg.ManifestContentDeletes).AddedFiles(1).ExistingFiles(0).DeletedFiles(0).Build()
+	tbl := inspectPositionDeletesTableWithManifests(
+		t, 2, newInspectPositionDeletesMetadataWithSchema(t, 2, tableSchema), tableSchema,
+		memFS, []iceberg.ManifestFile{firstManifest, missingManifest},
+	)
+
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	require.True(t, rr.Next(), "reader error: %v", rr.Err())
+	require.EqualValues(t, inspectRecordBatchSize, rr.RecordBatch().NumRows())
 }
 
 func TestAppendParquetPositionDeleteRowsRejectsNullRow(t *testing.T) {
@@ -3788,6 +3845,17 @@ func TestPositionDeleteRowProjectionRejectsNullMapKey(t *testing.T) {
 	err = appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row)
 	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
 	require.ErrorContains(t, err, "null key")
+}
+
+func TestAppendPositionDeleteProjectedScalarRejectsNonStruct(t *testing.T) {
+	builder := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	))
+	defer builder.Release()
+
+	err := appendPositionDeleteProjectedScalar(builder, scalar.NewInt32Scalar(7))
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	require.ErrorContains(t, err, "want struct")
 }
 
 func TestInspectPositionDeletesStopsOnContextCancellation(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3016,7 +3016,11 @@ func TestInspectPositionDeletesV3ParquetUsesFileSize(t *testing.T) {
 		{"file_path": "`+dataPath+`", "pos": 3}
 	]`)
 	const fileSize int64 = 128
-	deleteFile := newPosDeleteFile(t, deletePath, 2, fileSize)
+	deleteFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, 2, fileSize)
+	require.NoError(t, err)
+	deleteFile := deleteFileBuilder.ContentSizeInBytes(fileSize / 2).Build()
 	tbl := inspectPositionDeletesTable(
 		t, 3, newInspectPositionDeletesMetadata(t, 3), memFS,
 		[]iceberg.DataFile{deleteFile},

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3006,6 +3006,28 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
+func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete-negative.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	writePosDeleteParquetToMemFS(t, memFS, deletePath, `[
+		{"file_path": "`+dataPath+`", "pos": -1}
+	]`)
+
+	rows := 0
+	keepGoing, err := appendParquetPositionDeleteRows(
+		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
+		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+			rows++
+			return true, nil
+		},
+	)
+	require.False(t, keepGoing)
+	require.ErrorContains(t, err, "negative pos -1")
+	require.ErrorIs(t, err, iceberg.ErrInvalidSchema)
+	require.Zero(t, rows)
+}
+
 func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
 	const (
 		deletePath = "mem://position-deletes/table/data/delete-evolved.parquet"

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3016,6 +3016,47 @@ func TestPositionDeleteRowProjection(t *testing.T) {
 	require.Equal(t, "deleted", projected.Field(1).(*array.String).Value(0))
 }
 
+func TestPositionDeleteRowProjectionPromotesTypes(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "ratio", Type: iceberg.PrimitiveTypes.Float64, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	sourceType := arrow.StructOf(
+		arrow.Field{
+			Name:     "id",
+			Type:     arrow.PrimitiveTypes.Int32,
+			Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"}),
+		},
+		arrow.Field{
+			Name:     "ratio",
+			Type:     arrow.PrimitiveTypes.Float32,
+			Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "2"}),
+		},
+	)
+	row := scalar.NewStructScalar([]scalar.Scalar{
+		scalar.NewInt32Scalar(7),
+		scalar.NewFloat32Scalar(1.25),
+	}, sourceType)
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	projected := record.Column(2).(*array.Struct)
+	require.EqualValues(t, 7, projected.Field(0).(*array.Int64).Value(0))
+	require.Equal(t, 1.25, projected.Field(1).(*array.Float64).Value(0))
+}
+
 func TestInspectPositionDeletesStopsOnContextCancellation(t *testing.T) {
 	metadata, err := newInspectPositionDeletesMetadata(t, 2).Build()
 	require.NoError(t, err)

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3016,6 +3016,25 @@ func TestPositionDeleteRowProjection(t *testing.T) {
 	require.Equal(t, "deleted", projected.Field(1).(*array.String).Value(0))
 }
 
+func TestInspectPositionDeletesStopsOnContextCancellation(t *testing.T) {
+	metadata, err := newInspectPositionDeletesMetadata(t, 2).Build()
+	require.NoError(t, err)
+	memFS := iceio.NewMemFS()
+	tbl := New(
+		Identifier{"db", "position_deletes"}, metadata, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memFS, nil }, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rr, err := tbl.Inspect().PositionDeletes(ctx)
+	require.NoError(t, err)
+	cancel()
+
+	require.False(t, rr.Next())
+	require.ErrorIs(t, rr.Err(), context.Canceled)
+	rr.Release()
+}
+
 func TestInspectPositionDeletesEarlyRelease(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -33,6 +34,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/dv"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -2866,6 +2868,208 @@ func TestAllEntriesSchemaMatchesEntries(t *testing.T) {
 		{ID: 1000, Name: "part", Type: iceberg.PrimitiveTypes.Int32, Required: false},
 	}}
 	require.True(t, EntriesSchema(partitionType).Equals(AllEntriesSchema(partitionType)))
+}
+
+func newInspectPositionDeletesMetadata(t *testing.T, formatVersion int) *MetadataBuilder {
+	t.Helper()
+
+	mb, err := NewMetadataBuilder(formatVersion)
+	require.NoError(t, err)
+	require.NoError(t, mb.AddSchema(simpleSchema()))
+	require.NoError(t, mb.SetCurrentSchemaID(0))
+	require.NoError(t, mb.AddPartitionSpec(iceberg.UnpartitionedSpec, true))
+	require.NoError(t, mb.SetDefaultSpecID(0))
+	require.NoError(t, mb.SetLoc("mem://position-deletes/table"))
+	addUnsortedSortOrder(t, mb)
+	metadata, err := mb.Build()
+	require.NoError(t, err)
+	mb, err = MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+
+	return mb
+}
+
+func inspectPositionDeletesTable(
+	t *testing.T,
+	formatVersion int,
+	mb *MetadataBuilder,
+	fs iceio.WriteFileIO,
+	files []iceberg.DataFile,
+) *Table {
+	t.Helper()
+
+	snapshotID := int64(1)
+	sequenceNumber := int64(1)
+	manifestPath := "mem://position-deletes/table/metadata/deletes.avro"
+	manifestBuffer := &bytes.Buffer{}
+	writer, err := iceberg.NewManifestWriter(
+		formatVersion, manifestBuffer, *iceberg.UnpartitionedSpec,
+		simpleSchema(), snapshotID,
+		iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes),
+	)
+	require.NoError(t, err)
+	for _, file := range files {
+		require.NoError(t, writer.Add(iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, &sequenceNumber, &sequenceNumber, file)))
+	}
+	manifest, err := writer.ToManifestFile(
+		manifestPath, int64(manifestBuffer.Len()),
+		iceberg.WithManifestFileContent(iceberg.ManifestContentDeletes),
+	)
+	require.NoError(t, err)
+	require.NoError(t, fs.WriteFile(manifestPath, manifestBuffer.Bytes()))
+
+	manifestListPath := "mem://position-deletes/table/metadata/snap.avro"
+	manifestListBuffer := &bytes.Buffer{}
+	require.NoError(t, iceberg.WriteManifestList(
+		formatVersion, manifestListBuffer, snapshotID, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{manifest},
+	))
+	require.NoError(t, fs.WriteFile(manifestListPath, manifestListBuffer.Bytes()))
+
+	schemaID := 0
+	snapshot := &Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: sequenceNumber,
+		TimestampMs:    time.Now().UnixMilli(),
+		ManifestList:   manifestListPath,
+		SchemaID:       &schemaID,
+	}
+	if formatVersion >= 3 {
+		firstRowID, addedRows := int64(0), int64(0)
+		snapshot.FirstRowID = &firstRowID
+		snapshot.AddedRows = &addedRows
+	}
+	require.NoError(t, mb.AddSnapshot(snapshot))
+	require.NoError(t, mb.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	metadata, err := mb.Build()
+	require.NoError(t, err)
+
+	return New(
+		Identifier{"db", "position_deletes"}, metadata, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return fs, nil }, nil,
+	)
+}
+
+func TestInspectPositionDeletesParquet(t *testing.T) {
+	ctx := context.Background()
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	writePosDeleteParquetToMemFS(t, memFS, deletePath, `[
+		{"file_path": "`+dataPath+`", "pos": 1},
+		{"file_path": "`+dataPath+`", "pos": 3}
+	]`)
+	deleteFile := newPosDeleteFile(t, deletePath, 2, 128)
+	tbl := inspectPositionDeletesTable(
+		t, 2, newInspectPositionDeletesMetadata(t, 2), memFS,
+		[]iceberg.DataFile{deleteFile},
+	)
+
+	rr, err := tbl.Inspect().PositionDeletes(ctx)
+	require.NoError(t, err)
+	defer rr.Release()
+	rec := collectRecord(t, rr)
+	defer rec.Release()
+
+	require.EqualValues(t, 2, rec.NumRows())
+	require.EqualValues(t, 5, rec.NumCols())
+	filePaths := rec.Column(0).(*array.String)
+	require.Equal(t, dataPath, filePaths.Value(0))
+	require.Equal(t, dataPath, filePaths.Value(1))
+	require.Equal(t, []int64{1, 3}, rec.Column(1).(*array.Int64).Int64Values())
+	require.EqualValues(t, 2, rec.Column(2).NullN())
+	require.Equal(t, []int32{0, 0}, rec.Column(3).(*array.Int32).Int32Values())
+	deleteFilePaths := rec.Column(4).(*array.String)
+	require.Equal(t, deletePath, deleteFilePaths.Value(0))
+	require.Equal(t, deletePath, deleteFilePaths.Value(1))
+}
+
+func TestInspectPositionDeletesDeletionVector(t *testing.T) {
+	ctx := context.Background()
+	memFS := iceio.NewMemFS()
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	dvPath := "mem://position-deletes/table/metadata/deletes.puffin"
+	dvWriter := dv.NewDVWriter(memFS, func(id int32) *iceberg.PartitionSpec {
+		if id == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	})
+	require.NoError(t, dvWriter.Add(dataPath, []int64{1, 3}, 0, nil))
+	deleteFiles, err := dvWriter.Flush(ctx, dvPath)
+	require.NoError(t, err)
+	require.Len(t, deleteFiles, 1)
+	tbl := inspectPositionDeletesTable(
+		t, 3, newInspectPositionDeletesMetadata(t, 3), memFS, deleteFiles,
+	)
+
+	rr, err := tbl.Inspect().PositionDeletes(ctx)
+	require.NoError(t, err)
+	defer rr.Release()
+	rec := collectRecord(t, rr)
+	defer rec.Release()
+
+	require.EqualValues(t, 2, rec.NumRows())
+	require.EqualValues(t, 7, rec.NumCols())
+	filePaths := rec.Column(0).(*array.String)
+	require.Equal(t, dataPath, filePaths.Value(0))
+	require.Equal(t, dataPath, filePaths.Value(1))
+	require.Equal(t, []int64{1, 3}, rec.Column(1).(*array.Int64).Int64Values())
+	deleteFilePaths := rec.Column(4).(*array.String)
+	require.Equal(t, dvPath, deleteFilePaths.Value(0))
+	require.Equal(t, dvPath, deleteFilePaths.Value(1))
+	offset := *deleteFiles[0].ContentOffset()
+	size := *deleteFiles[0].ContentSizeInBytes()
+	require.Equal(t, []int64{offset, offset}, rec.Column(5).(*array.Int64).Int64Values())
+	require.Equal(t, []int64{size, size}, rec.Column(6).(*array.Int64).Int64Values())
+}
+
+func TestPositionDeletesSchema(t *testing.T) {
+	v2 := PositionDeletesSchema(simpleSchema(), &iceberg.StructType{}, 2)
+	v2Fields := v2.Fields()
+	require.Equal(t,
+		[]string{"file_path", "pos", "row", "spec_id", "delete_file_path"},
+		testFieldNames(v2),
+	)
+	require.Equal(t, []int{
+		positionDeleteFilePathID,
+		positionDeletePosID,
+		positionDeleteRowID,
+		positionDeleteSpecID,
+		positionDeletePhysicalPathID,
+	}, []int{
+		v2Fields[0].ID,
+		v2Fields[1].ID,
+		v2Fields[2].ID,
+		v2Fields[3].ID,
+		v2Fields[4].ID,
+	})
+
+	v3 := PositionDeletesSchema(simpleSchema(), &iceberg.StructType{}, 3)
+	v3Fields := v3.Fields()
+	require.Equal(t,
+		[]string{"file_path", "pos", "row", "spec_id", "delete_file_path", "content_offset", "content_size_in_bytes"},
+		testFieldNames(v3),
+	)
+	require.Equal(t, positionDeleteContentOffsetID, v3Fields[5].ID)
+	require.Equal(t, positionDeleteContentSizeID, v3Fields[6].ID)
+
+	spec := partitionedSpec()
+	metadata, err := NewMetadata(
+		simpleSchema(), &spec, UnsortedSortOrder, "mem://position-deletes/table", nil,
+	)
+	require.NoError(t, err)
+	partitionType, partitionIDs, err := positionDeletesPartitionType(metadata)
+	require.NoError(t, err)
+	require.Equal(t, map[int]int{1000: 2}, partitionIDs)
+	require.Equal(t, 2, partitionType.FieldList[0].ID)
+	partitioned := PositionDeletesSchema(simpleSchema(), partitionType, 2)
+	require.Equal(t,
+		[]string{"file_path", "pos", "row", "partition", "spec_id", "delete_file_path"},
+		testFieldNames(partitioned),
+	)
 }
 
 // TestInspectAllocatorOption verifies WithInspectAllocator routes allocations

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2985,6 +2985,59 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
+func TestInspectPositionDeletesEarlyRelease(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		populated bool
+	}{
+		{name: "populated", populated: true},
+		{name: "empty"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			checked := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			t.Cleanup(func() { checked.AssertSize(t, 0) })
+
+			memFS := iceio.NewMemFS()
+			deletePath := "mem://position-deletes/table/data/delete.parquet"
+			dataPath := "mem://position-deletes/table/data/data.parquet"
+			var tbl *Table
+			if tt.populated {
+				writePosDeleteParquetToMemFS(t, memFS, deletePath,
+					`[{"file_path": "`+dataPath+`", "pos": 1}]`)
+				tbl = inspectPositionDeletesTable(
+					t, 2, newInspectPositionDeletesMetadata(t, 2), memFS,
+					[]iceberg.DataFile{newPosDeleteFile(t, deletePath, 1, 128)},
+				)
+			} else {
+				metadata, buildErr := newInspectPositionDeletesMetadata(t, 2).Build()
+				require.NoError(t, buildErr)
+				tbl = New(
+					Identifier{"db", "position_deletes"}, metadata, "metadata.json",
+					func(context.Context) (iceio.IO, error) { return memFS, nil }, nil,
+				)
+			}
+			inspect := tbl.Inspect(WithInspectAllocator(checked))
+
+			var rr array.RecordReader
+			var err error
+			if tt.populated {
+				rr, err = inspect.PositionDeletes(context.Background())
+			} else {
+				partitionType, partitionIDs, partitionErr := positionDeletesPartitionType(tbl.metadata)
+				require.NoError(t, partitionErr)
+				schema := PositionDeletesSchema(tbl.metadata.CurrentSchema(), partitionType, tbl.metadata.Version())
+				arrowSchema, schemaErr := SchemaToArrowSchema(schema, nil, true, false)
+				require.NoError(t, schemaErr)
+				rr = inspect.positionDeleteRecordReader(
+					context.Background(), arrowSchema, nil, nil, partitionType, partitionIDs, tbl.metadata.Version())
+			}
+			require.NoError(t, err)
+			require.True(t, rr.Next())
+			rr.Release()
+		})
+	}
+}
+
 func TestInspectPositionDeletesDeletionVector(t *testing.T) {
 	ctx := context.Background()
 	memFS := iceio.NewMemFS()

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2985,6 +2985,32 @@ func TestInspectPositionDeletesParquet(t *testing.T) {
 	require.Equal(t, deletePath, deleteFilePaths.Value(1))
 }
 
+func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	deletePath := "mem://position-deletes/table/data/delete.parquet"
+	dataPath := "mem://position-deletes/table/data/data.parquet"
+	writePosDeleteParquetToMemFS(t, memFS, deletePath, `[
+		{"file_path": "`+dataPath+`", "pos": 1},
+		{"file_path": "`+dataPath+`", "pos": 2}
+	]`)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	rows := 0
+	keepGoing, err := appendParquetPositionDeleteRows(
+		ctx, memFS, newPosDeleteFile(t, deletePath, 2, 128),
+		func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error) {
+			rows++
+			cancel()
+
+			return true, nil
+		},
+	)
+	require.False(t, keepGoing)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, rows)
+}
+
 func TestPositionDeleteRowProjection(t *testing.T) {
 	tableSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3104,6 +3104,76 @@ func TestInspectPositionDeletesParquetProjectsEvolvedNestedRow(t *testing.T) {
 	require.Equal(t, int32(18), amount.DataType().(*arrow.Decimal128Type).Precision)
 }
 
+func TestInspectPositionDeletesParquetProjectsDateToTimestampsV3(t *testing.T) {
+	const (
+		deletePath = "mem://position-deletes/table/data/delete-date.parquet"
+		dataPath   = "mem://position-deletes/table/data/data.parquet"
+	)
+	const dateValue = arrow.Date32(20_000)
+	memFS := iceio.NewMemFS()
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "created_at", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 2, Name: "created_at_ns", Type: iceberg.PrimitiveTypes.TimestampNs, Required: true},
+	)
+	sourceRowType := arrow.StructOf(
+		arrow.Field{Name: "created_at", Type: arrow.FixedWidthTypes.Date32, Nullable: true, Metadata: fieldID(1)},
+		arrow.Field{Name: "created_at_ns", Type: arrow.FixedWidthTypes.Date32, Nullable: true, Metadata: fieldID(2)},
+	)
+	sourceSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "row", Type: sourceRowType, Nullable: true},
+	}, nil)
+
+	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, sourceSchema)
+	recordBuilder.Field(0).(*array.StringBuilder).Append(dataPath)
+	recordBuilder.Field(1).(*array.Int64Builder).Append(7)
+	rowBuilder := recordBuilder.Field(2).(*array.StructBuilder)
+	rowBuilder.Append(true)
+	rowBuilder.FieldBuilder(0).(*array.Date32Builder).Append(dateValue)
+	rowBuilder.FieldBuilder(1).(*array.Date32Builder).Append(dateValue)
+	record := recordBuilder.NewRecordBatch()
+	defer record.Release()
+	defer recordBuilder.Release()
+
+	arrowTable := array.NewTableFromRecords(sourceSchema, []arrow.RecordBatch{record})
+	defer arrowTable.Release()
+	file, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(
+		arrowTable, file, record.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+	require.NoError(t, file.Close())
+
+	deleteFile := newPosDeleteFile(t, deletePath, 1, 128)
+	tbl := inspectPositionDeletesTableWithSchema(
+		t, 3, newInspectPositionDeletesMetadataWithSchema(t, 3, tableSchema),
+		tableSchema, memFS, []iceberg.DataFile{deleteFile})
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record = collectRecord(t, rr)
+	defer record.Release()
+
+	projectedRow := record.Column(2).(*array.Struct)
+	require.False(t, projectedRow.IsNull(0))
+	micros := projectedRow.Field(0).(*array.Timestamp)
+	microsType := micros.DataType().(*arrow.TimestampType)
+	require.Equal(t, arrow.Microsecond, microsType.Unit)
+	nanos := projectedRow.Field(1).(*array.Timestamp)
+	nanosType := nanos.DataType().(*arrow.TimestampType)
+	require.Equal(t, arrow.Nanosecond, nanosType.Unit)
+
+	unitsPerDayMicros := int64(24 * time.Hour / time.Microsecond)
+	unitsPerDayNanos := int64(24 * time.Hour / time.Nanosecond)
+	require.Equal(t, arrow.Timestamp(int64(dateValue)*unitsPerDayMicros), micros.Value(0))
+	require.Equal(t, arrow.Timestamp(int64(dateValue)*unitsPerDayNanos), nanos.Value(0))
+}
+
 func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T) {
 	memFS := iceio.NewMemFS()
 	deletePath := "mem://position-deletes/table/data/delete.parquet"
@@ -3200,6 +3270,93 @@ func TestPositionDeleteRowProjectionPromotesTypes(t *testing.T) {
 	projected := record.Column(2).(*array.Struct)
 	require.EqualValues(t, 7, projected.Field(0).(*array.Int64).Value(0))
 	require.Equal(t, 1.25, projected.Field(1).(*array.Float64).Value(0))
+}
+
+func TestPositionDeleteRowProjectionPromotesDateInV3(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "created_at", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 2, Name: "created_at_ns", Type: iceberg.PrimitiveTypes.TimestampNs, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 3), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 3)
+	require.NoError(t, err)
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	dateValue := arrow.Date32(20_000)
+	sourceType := arrow.StructOf(
+		arrow.Field{Name: "created_at", Type: arrow.FixedWidthTypes.Date32, Nullable: true, Metadata: fieldID(1)},
+		arrow.Field{Name: "created_at_ns", Type: arrow.FixedWidthTypes.Date32, Nullable: true, Metadata: fieldID(2)},
+	)
+	row := scalar.NewStructScalar([]scalar.Scalar{
+		scalar.NewDate32Scalar(dateValue),
+		scalar.NewDate32Scalar(dateValue),
+	}, sourceType)
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(
+		deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	projected := record.Column(2).(*array.Struct)
+	dateMicros := projected.Field(0).(*array.Timestamp)
+	dateNanos := projected.Field(1).(*array.Timestamp)
+	require.Equal(t, arrow.Microsecond, dateMicros.DataType().(*arrow.TimestampType).Unit)
+	require.Equal(t, arrow.Nanosecond, dateNanos.DataType().(*arrow.TimestampType).Unit)
+	require.Equal(t,
+		arrow.Timestamp(int64(dateValue)*int64(24*time.Hour/time.Microsecond)), dateMicros.Value(0))
+	require.Equal(t,
+		arrow.Timestamp(int64(dateValue)*int64(24*time.Hour/time.Nanosecond)), dateNanos.Value(0))
+}
+
+func TestPositionDeleteDatePromotionRequiresV3(t *testing.T) {
+	timestamp := &arrow.TimestampType{Unit: arrow.Microsecond}
+	date := arrow.FixedWidthTypes.Date32
+
+	require.False(t, canPromotePositionDeleteValue(date, timestamp, 2))
+	require.True(t, canPromotePositionDeleteValue(date, timestamp, 3))
+	require.True(t, canPromotePositionDeleteValue(
+		date, &arrow.TimestampType{Unit: arrow.Nanosecond}, 3))
+	require.False(t, canPromotePositionDeleteValue(date, arrow.FixedWidthTypes.Timestamp_us, 3),
+		"date promotion must not target a timezone-aware timestamp")
+
+	_, ok := convertPositionDeleteDate32(arrow.Date32(20_000), arrow.Nanosecond)
+	require.True(t, ok)
+	_, ok = convertPositionDeleteDate32(arrow.Date32(math.MaxInt32), arrow.Nanosecond)
+	require.False(t, ok, "out-of-range dates must fail timestamp conversion")
+}
+
+func TestPositionDeleteRowProjectionRejectsDatePromotionBeforeV3(t *testing.T) {
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "created_at", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	row := scalar.NewStructScalar([]scalar.Scalar{scalar.NewDate32Scalar(arrow.Date32(20_000))},
+		arrow.StructOf(arrow.Field{
+			Name:     "created_at",
+			Type:     arrow.FixedWidthTypes.Date32,
+			Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"}),
+		}))
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	err = appender.append(deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row)
+	require.Error(t, err)
 }
 
 func TestPositionDeleteRowProjectionPromotesNestedValues(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3083,6 +3083,158 @@ func TestPositionDeleteRowProjectionPromotesTypes(t *testing.T) {
 	require.Equal(t, 1.25, projected.Field(1).(*array.Float64).Value(0))
 }
 
+func TestPositionDeleteRowProjectionPromotesNestedValues(t *testing.T) {
+	tableListType := &iceberg.ListType{
+		ElementID:       3,
+		Element:         iceberg.PrimitiveTypes.Int64,
+		ElementRequired: true,
+	}
+	tableMapType := &iceberg.MapType{
+		KeyID:         4,
+		KeyType:       iceberg.PrimitiveTypes.String,
+		ValueID:       5,
+		ValueType:     iceberg.PrimitiveTypes.Int64,
+		ValueRequired: false,
+	}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "values", Type: tableListType, Required: true},
+		iceberg.NestedField{ID: 2, Name: "attributes", Type: tableMapType, Required: true},
+		iceberg.NestedField{ID: 6, Name: "amount", Type: iceberg.DecimalTypeOf(18, 2), Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	sourceListType := arrow.ListOfField(arrow.Field{
+		Name:     "element",
+		Type:     arrow.PrimitiveTypes.Int32,
+		Nullable: false,
+		Metadata: fieldID(3),
+	})
+	listBuilder := array.NewListBuilderWithField(memory.DefaultAllocator, sourceListType.ElemField())
+	defer listBuilder.Release()
+	listBuilder.Append(true)
+	listValues := listBuilder.ValueBuilder().(*array.Int32Builder)
+	listValues.Append(7)
+	listValues.Append(9)
+	listArray := listBuilder.NewListArray()
+	defer listArray.Release()
+	listValue := scalar.NewListScalar(listArray.ListValues())
+	defer listValue.Release()
+
+	sourceMapType := arrow.MapOfFields(
+		arrow.Field{Name: "key", Type: arrow.BinaryTypes.String, Nullable: false, Metadata: fieldID(4)},
+		arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32, Nullable: true, Metadata: fieldID(5)},
+	)
+	mapBuilder := array.NewMapBuilderWithType(memory.DefaultAllocator, sourceMapType)
+	defer mapBuilder.Release()
+	mapBuilder.Append(true)
+	mapBuilder.KeyBuilder().(*array.StringBuilder).Append("first")
+	mapBuilder.ItemBuilder().(*array.Int32Builder).Append(11)
+	mapBuilder.KeyBuilder().(*array.StringBuilder).Append("second")
+	mapBuilder.ItemBuilder().(*array.Int32Builder).Append(13)
+	mapArray := mapBuilder.NewMapArray()
+	defer mapArray.Release()
+	mapValue := scalar.NewMapScalar(mapArray.ListValues())
+	defer mapValue.Release()
+
+	sourceDecimalType := &arrow.Decimal128Type{Precision: 9, Scale: 2}
+	row := scalar.NewStructScalar([]scalar.Scalar{
+		listValue,
+		mapValue,
+		scalar.NewDecimal128Scalar(decimal128.FromI64(12345), sourceDecimalType),
+	}, arrow.StructOf(
+		arrow.Field{Name: "values", Type: sourceListType, Nullable: true, Metadata: fieldID(1)},
+		arrow.Field{Name: "attributes", Type: sourceMapType, Nullable: true, Metadata: fieldID(2)},
+		arrow.Field{Name: "amount", Type: sourceDecimalType, Nullable: true, Metadata: fieldID(6)},
+	))
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(
+		deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	projected := record.Column(2).(*array.Struct)
+	values := projected.Field(0).(*array.List)
+	require.Equal(t, []int64{7, 9}, values.ListValues().(*array.Int64).Int64Values())
+	attributes := projected.Field(1).(*array.Map)
+	require.Equal(t, []int64{11, 13}, attributes.Items().(*array.Int64).Int64Values())
+	amount := projected.Field(2).(*array.Decimal128)
+	require.Equal(t, decimal128.FromI64(12345), amount.Value(0))
+	require.Equal(t, int32(18), amount.DataType().(*arrow.Decimal128Type).Precision)
+}
+
+func TestPositionDeleteRowProjectionPromotesNestedStructValues(t *testing.T) {
+	tableElementType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 8, Name: "count", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		{ID: 9, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: true},
+	}}
+	tableListType := &iceberg.ListType{
+		ElementID:       7,
+		Element:         tableElementType,
+		ElementRequired: true,
+	}
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "items", Type: tableListType, Required: true},
+	)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	fieldID := func(id int) arrow.Metadata {
+		return arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: strconv.Itoa(id)})
+	}
+	sourceElementType := arrow.StructOf(
+		arrow.Field{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true, Metadata: fieldID(9)},
+		arrow.Field{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true, Metadata: fieldID(8)},
+	)
+	sourceListType := arrow.ListOfField(arrow.Field{
+		Name:     "element",
+		Type:     sourceElementType,
+		Nullable: false,
+		Metadata: fieldID(7),
+	})
+	listBuilder := array.NewListBuilderWithField(memory.DefaultAllocator, sourceListType.ElemField())
+	defer listBuilder.Release()
+	listBuilder.Append(true)
+	elementBuilder := listBuilder.ValueBuilder().(*array.StructBuilder)
+	elementBuilder.Append(true)
+	elementBuilder.FieldBuilder(0).(*array.StringBuilder).Append("nested")
+	elementBuilder.FieldBuilder(1).(*array.Int32Builder).Append(17)
+	listArray := listBuilder.NewListArray()
+	defer listArray.Release()
+	listValue := scalar.NewListScalar(listArray.ListValues())
+	defer listValue.Release()
+
+	row := scalar.NewStructScalar([]scalar.Scalar{listValue}, arrow.StructOf(
+		arrow.Field{Name: "items", Type: sourceListType, Nullable: true, Metadata: fieldID(1)},
+	))
+	defer row.Release()
+
+	deleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/delete.parquet", 1, 128)
+	require.NoError(t, appender.append(
+		deleteFile, "mem://position-deletes/table/data/data.parquet", 7, row))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	items := record.Column(2).(*array.Struct).Field(0).(*array.List).ListValues().(*array.Struct)
+	require.EqualValues(t, 17, items.Field(0).(*array.Int64).Value(0))
+	require.Equal(t, "nested", items.Field(1).(*array.String).Value(0))
+}
+
 func TestInspectPositionDeletesStopsOnContextCancellation(t *testing.T) {
 	metadata, err := newInspectPositionDeletesMetadata(t, 2).Build()
 	require.NoError(t, err)

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -1,0 +1,526 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/dv"
+	tblutils "github.com/apache/iceberg-go/table/internal"
+)
+
+const (
+	positionDeleteFilePathID       = math.MaxInt32 - 101
+	positionDeletePosID            = math.MaxInt32 - 102
+	positionDeleteRowID            = math.MaxInt32 - 103
+	positionDeletePartitionID      = math.MaxInt32 - 5
+	positionDeleteSpecID           = math.MaxInt32 - 4
+	positionDeletePhysicalPathID   = math.MaxInt32 - 1
+	positionDeleteContentOffsetID  = math.MaxInt32 - 6
+	positionDeleteContentSizeID    = math.MaxInt32 - 7
+	positionDeletePhysicalPathName = "delete_file_path"
+)
+
+// PositionDeletes returns the individual position-delete records referenced
+// by the current snapshot. Parquet position-delete files and V3 deletion
+// vectors are exposed through the same schema.
+func (i InspectTable) PositionDeletes(ctx context.Context) (array.RecordReader, error) {
+	partitionType, partitionIDs, err := positionDeletesPartitionType(i.tbl.metadata)
+	if err != nil {
+		return nil, fmt.Errorf("inspect position deletes: %w", err)
+	}
+	schema := PositionDeletesSchema(i.tbl.metadata.CurrentSchema(), partitionType, i.tbl.metadata.Version())
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("inspect position deletes: build arrow schema: %w", err)
+	}
+
+	fs, files, err := i.currentPositionDeleteFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("inspect position deletes: %w", err)
+	}
+	if len(files) == 0 {
+		return array.ReaderFromIter(arrowSchema, emptyInspectRecordBatch(i.alloc, arrowSchema)), nil
+	}
+
+	ctx = compute.WithAllocator(ctx, i.alloc)
+
+	return i.positionDeleteRecordReader(
+		ctx, arrowSchema, fs, files, partitionType, partitionIDs, i.tbl.metadata.Version()), nil
+}
+
+func (i InspectTable) currentPositionDeleteFiles(
+	ctx context.Context,
+) (iceio.IO, []iceberg.DataFile, error) {
+	snapshot := i.tbl.metadata.CurrentSnapshot()
+	if snapshot == nil {
+		return nil, nil, nil
+	}
+	if i.tbl.fsF == nil {
+		return nil, nil, errors.New("table file IO is not configured")
+	}
+	fs, err := i.tbl.fsF(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifests, err := snapshot.Manifests(fs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	files := make([]iceberg.DataFile, 0)
+	for _, manifest := range manifests {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		if manifest.ManifestContent() != iceberg.ManifestContentDeletes {
+			continue
+		}
+		for entry, err := range manifest.Entries(fs, true) {
+			if err != nil {
+				return nil, nil, fmt.Errorf("read manifest %s: %w", manifest.FilePath(), err)
+			}
+			if entry.DataFile().ContentType() == iceberg.EntryContentPosDeletes {
+				files = append(files, entry.DataFile())
+			}
+		}
+	}
+
+	return fs, files, nil
+}
+
+type positionDeleteRecordAppender struct {
+	filePath         *array.StringBuilder
+	pos              *array.Int64Builder
+	row              *array.StructBuilder
+	partition        *inspectPartitionBuilder
+	specID           *array.Int32Builder
+	deleteFilePath   *array.StringBuilder
+	contentOffset    *array.Int64Builder
+	contentSize      *array.Int64Builder
+	partitionType    *iceberg.StructType
+	partitionIDByOld map[int]int
+	formatVersion    int
+}
+
+func newPositionDeleteRecordAppender(
+	bldr *array.RecordBuilder,
+	partitionType *iceberg.StructType,
+	partitionIDByOld map[int]int,
+	formatVersion int,
+) (positionDeleteRecordAppender, error) {
+	nextField := 3
+	out := positionDeleteRecordAppender{
+		filePath:         bldr.Field(0).(*array.StringBuilder),
+		pos:              bldr.Field(1).(*array.Int64Builder),
+		row:              bldr.Field(2).(*array.StructBuilder),
+		partitionType:    partitionType,
+		partitionIDByOld: partitionIDByOld,
+		formatVersion:    formatVersion,
+	}
+	if len(partitionType.FieldList) > 0 {
+		partitionBuilder, err := newInspectPartitionBuilder(
+			bldr.Field(nextField).(*array.StructBuilder), partitionType)
+		if err != nil {
+			return out, err
+		}
+		out.partition = partitionBuilder
+		nextField++
+	}
+	out.specID = bldr.Field(nextField).(*array.Int32Builder)
+	out.deleteFilePath = bldr.Field(nextField + 1).(*array.StringBuilder)
+	if formatVersion >= 3 {
+		out.contentOffset = bldr.Field(nextField + 2).(*array.Int64Builder)
+		out.contentSize = bldr.Field(nextField + 3).(*array.Int64Builder)
+	}
+
+	return out, nil
+}
+
+func (a positionDeleteRecordAppender) append(
+	file iceberg.DataFile,
+	dataFilePath string,
+	pos int64,
+	deletedRow scalar.Scalar,
+) error {
+	a.filePath.Append(dataFilePath)
+	a.pos.Append(pos)
+	if deletedRow == nil || !deletedRow.IsValid() {
+		a.row.AppendNull()
+	} else if err := scalar.Append(a.row, deletedRow); err != nil {
+		return fmt.Errorf("append deleted row: %w", err)
+	}
+
+	if a.partition != nil {
+		partition := make(map[int]any, len(file.Partition()))
+		for oldID, value := range file.Partition() {
+			if newID, ok := a.partitionIDByOld[oldID]; ok {
+				partition[newID] = value
+			}
+		}
+		if err := a.partition.append(partition); err != nil {
+			return err
+		}
+	}
+	a.specID.Append(file.SpecID())
+	a.deleteFilePath.Append(file.FilePath())
+	if a.formatVersion >= 3 {
+		appendInspectOptionalInt64(a.contentOffset, file.ContentOffset())
+		appendInspectOptionalInt64(a.contentSize, file.ContentSizeInBytes())
+	}
+
+	return nil
+}
+
+func (i InspectTable) positionDeleteRecordReader(
+	ctx context.Context,
+	arrowSchema *arrow.Schema,
+	fs iceio.IO,
+	files []iceberg.DataFile,
+	partitionType *iceberg.StructType,
+	partitionIDByOld map[int]int,
+	formatVersion int,
+) array.RecordReader {
+	return array.ReaderFromIter(arrowSchema, func(yield func(arrow.RecordBatch, error) bool) {
+		bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
+		defer bldr.Release()
+		appender, err := newPositionDeleteRecordAppender(bldr, partitionType, partitionIDByOld, formatVersion)
+		if err != nil {
+			_ = yield(nil, err)
+
+			return
+		}
+
+		rows := 0
+		emitted := false
+		emit := func() bool {
+			if rows == 0 {
+				return true
+			}
+			batch := bldr.NewRecordBatch()
+			rows = 0
+			emitted = true
+			if yield(batch, nil) {
+				return true
+			}
+			batch.Release()
+
+			return false
+		}
+		yieldError := func(err error) {
+			_ = yield(nil, err)
+		}
+		appendRow := func(file iceberg.DataFile, path string, pos int64, deletedRow scalar.Scalar) (bool, error) {
+			if err := appender.append(file, path, pos, deletedRow); err != nil {
+				return false, err
+			}
+			rows++
+			if rows == inspectRecordBatchSize {
+				return emit(), nil
+			}
+
+			return true, nil
+		}
+
+		for _, file := range files {
+			if err := ctx.Err(); err != nil {
+				yieldError(err)
+
+				return
+			}
+			var keepGoing bool
+			var err error
+			switch file.FileFormat() {
+			case iceberg.PuffinFile:
+				keepGoing, err = appendDeletionVectorRows(ctx, fs, file, appendRow)
+			default:
+				keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow)
+			}
+			if err != nil {
+				yieldError(fmt.Errorf("read position delete file %s: %w", file.FilePath(), err))
+
+				return
+			}
+			if !keepGoing {
+				return
+			}
+		}
+
+		if rows > 0 {
+			_ = emit()
+		} else if !emitted {
+			batch := bldr.NewRecordBatch()
+			if !yield(batch, nil) {
+				batch.Release()
+			}
+		}
+	})
+}
+
+type appendPositionDeleteRow func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error)
+
+func appendDeletionVectorRows(
+	ctx context.Context,
+	fs iceio.IO,
+	file iceberg.DataFile,
+	appendRow appendPositionDeleteRow,
+) (bool, error) {
+	referencedDataFile := file.ReferencedDataFile()
+	if referencedDataFile == nil {
+		return false, fmt.Errorf("%w: deletion vector is missing referenced_data_file",
+			iceberg.ErrInvalidSchema)
+	}
+	if file.ContentOffset() == nil || file.ContentSizeInBytes() == nil {
+		return false, fmt.Errorf("%w: deletion vector is missing content_offset/content_size_in_bytes",
+			iceberg.ErrInvalidSchema)
+	}
+	bitmap, err := dv.ReadDV(fs, file)
+	if err != nil {
+		return false, err
+	}
+	for position := range bitmap.Positions() {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if position > math.MaxInt64 {
+			return false, fmt.Errorf("%w: deletion position %d exceeds int64", iceberg.ErrInvalidSchema, position)
+		}
+		keepGoing, err := appendRow(file, *referencedDataFile, int64(position), nil)
+		if err != nil || !keepGoing {
+			return keepGoing, err
+		}
+	}
+
+	return true, nil
+}
+
+func appendParquetPositionDeleteRows(
+	ctx context.Context,
+	fs iceio.IO,
+	file iceberg.DataFile,
+	appendRow appendPositionDeleteRow,
+) (keepGoing bool, err error) {
+	source, err := tblutils.GetFile(ctx, fs, file, true)
+	if err != nil {
+		return false, err
+	}
+	reader, err := source.GetReader(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if closeErr := reader.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	records, err := reader.GetRecords(ctx, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	defer records.Release()
+
+	for records.Next() {
+		record := records.RecordBatch()
+		filePathIndex, posIndex, err := positionDeleteColumnIndices(record.Schema())
+		if err != nil {
+			return false, err
+		}
+		filePaths, err := filePathValues(record.Column(filePathIndex))
+		if err != nil {
+			return false, err
+		}
+		if err := validatePositionDeleteFilePathValues(filePaths, record.Column(filePathIndex)); err != nil {
+			return false, err
+		}
+		positions, ok := record.Column(posIndex).(*array.Int64)
+		if !ok {
+			return false, fmt.Errorf("%w: pos column has type %s, want int64",
+				iceberg.ErrInvalidSchema, record.Column(posIndex).DataType())
+		}
+		if positions.NullN() > 0 {
+			return false, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
+		}
+
+		rowIndex := -1
+		if indices := record.Schema().FieldIndices("row"); len(indices) > 1 {
+			return false, fmt.Errorf("%w: position delete file contains multiple row columns",
+				iceberg.ErrInvalidSchema)
+		} else if len(indices) == 1 {
+			rowIndex = indices[0]
+		}
+		for row := range int(record.NumRows()) {
+			var deletedRow scalar.Scalar
+			if rowIndex >= 0 && !record.Column(rowIndex).IsNull(row) {
+				deletedRow, err = scalar.GetScalar(record.Column(rowIndex), row)
+				if err != nil {
+					return false, err
+				}
+			}
+			continueReading, appendErr := appendRow(
+				file, filePaths.Value(row), positions.Value(row), deletedRow)
+			if releasable, ok := deletedRow.(scalar.Releasable); ok {
+				releasable.Release()
+			}
+			if appendErr != nil || !continueReading {
+				return continueReading, appendErr
+			}
+		}
+	}
+	if err := records.Err(); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func validatePositionDeleteFilePathValues(values arrow.TypedArray[string], arr arrow.Array) error {
+	var dictionary arrow.Array
+	var indices *array.Dictionary
+	if dict, ok := arr.(*array.Dictionary); ok {
+		dictionary = dict.Dictionary()
+		indices = dict
+	}
+
+	for index := range values.Len() {
+		if values.IsNull(index) {
+			return fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
+		}
+		if dictionary != nil && dictionary.IsNull(indices.GetValueIndex(index)) {
+			return fmt.Errorf("%w: null file_path dictionary value in position delete file", iceberg.ErrInvalidSchema)
+		}
+	}
+
+	return nil
+}
+
+func positionDeletesPartitionType(
+	metadata Metadata,
+) (*iceberg.StructType, map[int]int, error) {
+	base, err := inspectPartitionType(metadata)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	used := map[int]struct{}{
+		positionDeleteFilePathID:      {},
+		positionDeletePosID:           {},
+		positionDeleteRowID:           {},
+		positionDeletePartitionID:     {},
+		positionDeleteSpecID:          {},
+		positionDeletePhysicalPathID:  {},
+		positionDeleteContentOffsetID: {},
+		positionDeleteContentSizeID:   {},
+	}
+	for _, schema := range metadata.Schemas() {
+		fields, err := iceberg.IndexByID(schema)
+		if err != nil {
+			return nil, nil, err
+		}
+		for id := range fields {
+			used[id] = struct{}{}
+		}
+	}
+	for _, field := range base.FieldList {
+		used[field.ID] = struct{}{}
+	}
+
+	fields := make([]iceberg.NestedField, len(base.FieldList))
+	idByOld := make(map[int]int, len(base.FieldList))
+	nextID := 1
+	for index, field := range base.FieldList {
+		for {
+			if _, exists := used[nextID]; !exists {
+				break
+			}
+			nextID++
+		}
+		idByOld[field.ID] = nextID
+		field.ID = nextID
+		fields[index] = field
+		used[nextID] = struct{}{}
+		nextID++
+	}
+
+	return &iceberg.StructType{FieldList: fields}, idByOld, nil
+}
+
+// PositionDeletesSchema returns the schema of the position_deletes metadata table.
+func PositionDeletesSchema(
+	tableSchema *iceberg.Schema,
+	partitionType *iceberg.StructType,
+	formatVersion int,
+) *iceberg.Schema {
+	rowType := iceberg.StructType{}
+	if tableSchema != nil {
+		rowType = tableSchema.AsStruct()
+	}
+	fields := []iceberg.NestedField{
+		{ID: positionDeleteFilePathID, Name: "file_path", Type: iceberg.PrimitiveTypes.String, Required: true},
+		{ID: positionDeletePosID, Name: "pos", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		{ID: positionDeleteRowID, Name: "row", Type: &rowType, Required: false},
+	}
+	if len(partitionType.FieldList) > 0 {
+		fields = append(fields, iceberg.NestedField{
+			ID:       positionDeletePartitionID,
+			Name:     "partition",
+			Type:     partitionType,
+			Required: true,
+		})
+	}
+	fields = append(fields,
+		iceberg.NestedField{
+			ID:       positionDeleteSpecID,
+			Name:     "spec_id",
+			Type:     iceberg.PrimitiveTypes.Int32,
+			Required: true,
+		},
+		iceberg.NestedField{
+			ID:       positionDeletePhysicalPathID,
+			Name:     positionDeletePhysicalPathName,
+			Type:     iceberg.PrimitiveTypes.String,
+			Required: true,
+		},
+	)
+	if formatVersion >= 3 {
+		fields = append(fields,
+			iceberg.NestedField{
+				ID:       positionDeleteContentOffsetID,
+				Name:     "content_offset",
+				Type:     iceberg.PrimitiveTypes.Int64,
+				Required: false,
+			},
+			iceberg.NestedField{
+				ID:       positionDeleteContentSizeID,
+				Name:     "content_size_in_bytes",
+				Type:     iceberg.PrimitiveTypes.Int64,
+				Required: false,
+			},
+		)
+	}
+
+	return iceberg.NewSchema(0, fields...)
+}

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -167,7 +167,7 @@ func (a positionDeleteRecordAppender) append(
 ) error {
 	a.filePath.Append(dataFilePath)
 	a.pos.Append(pos)
-	if err := appendProjectedPositionDeleteRow(a.row, deletedRow); err != nil {
+	if err := appendProjectedPositionDeleteRow(a.row, deletedRow, a.formatVersion); err != nil {
 		return fmt.Errorf("append deleted row: %w", err)
 	}
 
@@ -197,7 +197,11 @@ func (a positionDeleteRecordAppender) append(
 // of the table fields, so matching by Arrow field position or exact type is
 // not sufficient. Field IDs are authoritative when the source schema carries
 // them; names are used only for readers that do not preserve Parquet metadata.
-func appendProjectedPositionDeleteRow(builder *array.StructBuilder, deletedRow scalar.Scalar) error {
+func appendProjectedPositionDeleteRow(
+	builder *array.StructBuilder,
+	deletedRow scalar.Scalar,
+	formatVersion int,
+) error {
 	if deletedRow == nil || !deletedRow.IsValid() {
 		builder.AppendNull()
 
@@ -209,10 +213,14 @@ func appendProjectedPositionDeleteRow(builder *array.StructBuilder, deletedRow s
 		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, deletedRow.DataType())
 	}
 
-	return appendPositionDeleteStruct(builder, row)
+	return appendPositionDeleteStruct(builder, row, formatVersion)
 }
 
-func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Struct) error {
+func appendPositionDeleteStruct(
+	builder *array.StructBuilder,
+	source *scalar.Struct,
+	formatVersion int,
+) error {
 	sourceType, ok := source.DataType().(*arrow.StructType)
 	if !ok {
 		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, source.DataType())
@@ -254,7 +262,7 @@ func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Str
 		}
 
 		fieldBuilder := builder.FieldBuilder(index)
-		if err := appendPositionDeleteValue(fieldBuilder, value); err != nil {
+		if err := appendPositionDeleteValue(fieldBuilder, value, formatVersion); err != nil {
 			return fmt.Errorf("field %q: %w", destinationField.Name, err)
 		}
 	}
@@ -262,7 +270,7 @@ func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Str
 	return nil
 }
 
-func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error {
+func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar, formatVersion int) error {
 	if value == nil || !value.IsValid() {
 		builder.AppendNull()
 
@@ -277,7 +285,7 @@ func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error
 				iceberg.ErrInvalidSchema, value.DataType())
 		}
 
-		return appendPositionDeleteStruct(builder, source)
+		return appendPositionDeleteStruct(builder, source, formatVersion)
 	case *array.MapBuilder:
 		source, ok := value.(*scalar.Map)
 		if !ok {
@@ -285,7 +293,7 @@ func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error
 				iceberg.ErrInvalidSchema, value.DataType())
 		}
 
-		return appendPositionDeleteMap(builder, source)
+		return appendPositionDeleteMap(builder, source, formatVersion)
 	case array.ListLikeBuilder:
 		source, ok := value.(scalar.ListScalar)
 		if !ok {
@@ -293,13 +301,13 @@ func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error
 				iceberg.ErrInvalidSchema, value.DataType())
 		}
 
-		return appendPositionDeleteList(builder, source)
+		return appendPositionDeleteList(builder, source, formatVersion)
 	}
 
 	if arrow.TypeEqual(builder.Type(), value.DataType()) {
 		return scalar.Append(builder, value)
 	}
-	if !canPromotePositionDeleteValue(value.DataType(), builder.Type()) {
+	if !canPromotePositionDeleteValue(value.DataType(), builder.Type(), formatVersion) {
 		return scalar.Append(builder, value)
 	}
 
@@ -328,6 +336,7 @@ type positionDeleteStorageBuilder interface {
 func appendPositionDeleteList(
 	builder array.ListLikeBuilder,
 	source scalar.ListScalar,
+	formatVersion int,
 ) error {
 	if !isPositionDeleteListType(source.DataType()) {
 		return fmt.Errorf("%w: value has type %s, want list",
@@ -352,7 +361,7 @@ func appendPositionDeleteList(
 		if err != nil {
 			return err
 		}
-		appendErr := appendPositionDeleteValue(valueBuilder, child)
+		appendErr := appendPositionDeleteValue(valueBuilder, child, formatVersion)
 		if releasable, ok := child.(scalar.Releasable); ok {
 			releasable.Release()
 		}
@@ -364,7 +373,11 @@ func appendPositionDeleteList(
 	return nil
 }
 
-func appendPositionDeleteMap(builder *array.MapBuilder, source *scalar.Map) error {
+func appendPositionDeleteMap(
+	builder *array.MapBuilder,
+	source *scalar.Map,
+	formatVersion int,
+) error {
 	if source.DataType().ID() != arrow.MAP {
 		return fmt.Errorf("%w: value has type %s, want map",
 			iceberg.ErrInvalidSchema, source.DataType())
@@ -430,7 +443,7 @@ func appendPositionDeleteMap(builder *array.MapBuilder, source *scalar.Map) erro
 			return fmt.Errorf("%w: map entry %d has a null key",
 				iceberg.ErrInvalidSchema, index)
 		}
-		appendErr := appendPositionDeleteValue(entryBuilder, entry)
+		appendErr := appendPositionDeleteValue(entryBuilder, entry, formatVersion)
 		if releasable, ok := entry.(scalar.Releasable); ok {
 			releasable.Release()
 		}
@@ -452,6 +465,17 @@ func isPositionDeleteListType(typ arrow.DataType) bool {
 }
 
 func castPositionDeleteValue(value scalar.Scalar, destination arrow.DataType) (scalar.Scalar, error) {
+	if date, ok := value.(*scalar.Date32); ok {
+		if timestamp, ok := destination.(*arrow.TimestampType); ok {
+			converted, ok := convertPositionDeleteDate32(date.Value, timestamp.Unit)
+			if !ok {
+				return nil, fmt.Errorf("date %d is outside %s range", date.Value, timestamp)
+			}
+
+			return scalar.NewTimestampScalar(converted, timestamp), nil
+		}
+	}
+
 	if destination.ID() == arrow.LARGE_BINARY {
 		if binary, ok := value.(scalar.BinaryScalar); ok {
 			return scalar.NewLargeBinaryScalar(binary.Buffer()), nil
@@ -466,12 +490,43 @@ func castPositionDeleteValue(value scalar.Scalar, destination arrow.DataType) (s
 	return value.CastTo(destination)
 }
 
-func canPromotePositionDeleteValue(source, destination arrow.DataType) bool {
+func convertPositionDeleteDate32(value arrow.Date32, unit arrow.TimeUnit) (arrow.Timestamp, bool) {
+	var unitsPerDay int64
+	switch unit {
+	case arrow.Second:
+		unitsPerDay = 86_400
+	case arrow.Millisecond:
+		unitsPerDay = 86_400_000
+	case arrow.Microsecond:
+		unitsPerDay = 86_400_000_000
+	case arrow.Nanosecond:
+		unitsPerDay = 86_400_000_000_000
+	default:
+		return 0, false
+	}
+
+	days := int64(value)
+	if days > math.MaxInt64/unitsPerDay || days < math.MinInt64/unitsPerDay {
+		return 0, false
+	}
+
+	return arrow.Timestamp(days * unitsPerDay), true
+}
+
+func canPromotePositionDeleteValue(source, destination arrow.DataType, formatVersion int) bool {
 	switch source.ID() {
 	case arrow.INT32:
 		return destination.ID() == arrow.INT64
 	case arrow.FLOAT32:
 		return destination.ID() == arrow.FLOAT64
+	case arrow.DATE32:
+		if formatVersion < 3 {
+			return false
+		}
+
+		timestamp, ok := destination.(*arrow.TimestampType)
+		return ok && timestamp.TimeZone == "" &&
+			(timestamp.Unit == arrow.Microsecond || timestamp.Unit == arrow.Nanosecond)
 	case arrow.DECIMAL128:
 		sourceDecimal, sourceOK := source.(*arrow.Decimal128Type)
 		destinationDecimal, destinationOK := destination.(*arrow.Decimal128Type)

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -781,6 +781,12 @@ func appendParquetPositionDeleteRows(
 		if positions.NullN() > 0 {
 			return false, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
 		}
+		for row := 0; row < positions.Len(); row++ {
+			if position := positions.Value(row); position < 0 {
+				return false, fmt.Errorf("%w: negative pos %d in position delete file",
+					iceberg.ErrInvalidSchema, position)
+			}
+		}
 
 		rowIndex := -1
 		if indices := record.Schema().FieldIndices("row"); len(indices) > 1 {

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -263,12 +263,39 @@ func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Str
 
 			continue
 		}
-		if err := scalar.Append(fieldBuilder, value); err != nil {
+		if err := appendPositionDeleteValue(fieldBuilder, value); err != nil {
 			return fmt.Errorf("field %q: %w", destinationField.Name, err)
 		}
 	}
 
 	return nil
+}
+
+func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error {
+	if arrow.TypeEqual(builder.Type(), value.DataType()) {
+		return scalar.Append(builder, value)
+	}
+	if !canPromotePositionDeleteValue(value.DataType(), builder.Type()) {
+		return scalar.Append(builder, value)
+	}
+
+	casted, err := value.CastTo(builder.Type())
+	if err != nil {
+		return fmt.Errorf("promote %s to %s: %w", value.DataType(), builder.Type(), err)
+	}
+
+	return scalar.Append(builder, casted)
+}
+
+func canPromotePositionDeleteValue(source, destination arrow.DataType) bool {
+	switch source.ID() {
+	case arrow.INT32:
+		return destination.ID() == arrow.INT64
+	case arrow.FLOAT32:
+		return destination.ID() == arrow.FLOAT64
+	default:
+		return false
+	}
 }
 
 type positionDeleteFieldLookup struct {

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -62,10 +62,6 @@ func (i InspectTable) PositionDeletes(ctx context.Context) (array.RecordReader, 
 	if err != nil {
 		return nil, fmt.Errorf("inspect position deletes: %w", err)
 	}
-	if len(files) == 0 {
-		return array.ReaderFromIter(arrowSchema, emptyInspectRecordBatch(i.alloc, arrowSchema)), nil
-	}
-
 	ctx = compute.WithAllocator(ctx, i.alloc)
 
 	return i.positionDeleteRecordReader(
@@ -344,6 +340,12 @@ func (i InspectTable) positionDeleteRecordReader(
 	formatVersion int,
 ) array.RecordReader {
 	return array.ReaderFromIter(arrowSchema, func(yield func(arrow.RecordBatch, error) bool) {
+		if err := ctx.Err(); err != nil {
+			_ = yield(nil, err)
+
+			return
+		}
+
 		bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
 		defer bldr.Release()
 		appender, err := newPositionDeleteRecordAppender(bldr, partitionType, partitionIDByOld, formatVersion)

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -281,11 +281,15 @@ func appendProjectedPositionDeleteRow(
 	if err != nil {
 		return err
 	}
-	if releasable, ok := projectedRow.(scalar.Releasable); ok {
-		defer releasable.Release()
-	}
+	defer releasePositionDeleteScalar(projectedRow)
 
 	return appendPositionDeleteProjectedScalar(builder, projectedRow)
+}
+
+func releasePositionDeleteScalar(value scalar.Scalar) {
+	if releasable, ok := value.(interface{ Release() }); ok {
+		releasable.Release()
+	}
 }
 
 func appendPositionDeleteProjectedScalar(builder array.Builder, value scalar.Scalar) error {
@@ -333,39 +337,28 @@ func appendPositionDeleteProjectedScalar(builder array.Builder, value scalar.Sca
 			if err != nil {
 				return err
 			}
-			entryStruct, ok := entry.(*scalar.Struct)
-			if !ok || len(entryStruct.Value) != 2 {
-				if releasable, ok := entry.(scalar.Releasable); ok {
-					releasable.Release()
+			appendErr := func() error {
+				defer releasePositionDeleteScalar(entry)
+				entryStruct, ok := entry.(*scalar.Struct)
+				if !ok || len(entryStruct.Value) != 2 {
+					return fmt.Errorf("%w: projected map entry %d is not a two-field struct",
+						iceberg.ErrInvalidSchema, index)
+				}
+				if entryStruct.Value[0] == nil || !entryStruct.Value[0].IsValid() {
+					return fmt.Errorf("%w: projected map entry %d has a null key",
+						iceberg.ErrInvalidSchema, index)
+				}
+				if err := appendPositionDeleteProjectedScalar(builder.KeyBuilder(), entryStruct.Value[0]); err != nil {
+					return fmt.Errorf("map entry %d key: %w", index, err)
+				}
+				if err := appendPositionDeleteProjectedScalar(builder.ItemBuilder(), entryStruct.Value[1]); err != nil {
+					return fmt.Errorf("map entry %d value: %w", index, err)
 				}
 
-				return fmt.Errorf("%w: projected map entry %d is not a two-field struct",
-					iceberg.ErrInvalidSchema, index)
-			}
-			if entryStruct.Value[0] == nil || !entryStruct.Value[0].IsValid() {
-				if releasable, ok := entry.(scalar.Releasable); ok {
-					releasable.Release()
-				}
-
-				return fmt.Errorf("%w: projected map entry %d has a null key",
-					iceberg.ErrInvalidSchema, index)
-			}
-			if err := appendPositionDeleteProjectedScalar(builder.KeyBuilder(), entryStruct.Value[0]); err != nil {
-				if releasable, ok := entry.(scalar.Releasable); ok {
-					releasable.Release()
-				}
-
-				return fmt.Errorf("map entry %d key: %w", index, err)
-			}
-			if err := appendPositionDeleteProjectedScalar(builder.ItemBuilder(), entryStruct.Value[1]); err != nil {
-				if releasable, ok := entry.(scalar.Releasable); ok {
-					releasable.Release()
-				}
-
-				return fmt.Errorf("map entry %d value: %w", index, err)
-			}
-			if releasable, ok := entry.(scalar.Releasable); ok {
-				releasable.Release()
+				return nil
+			}()
+			if appendErr != nil {
+				return appendErr
 			}
 		}
 
@@ -391,9 +384,7 @@ func appendPositionDeleteProjectedScalar(builder array.Builder, value scalar.Sca
 				return err
 			}
 			appendErr := appendPositionDeleteProjectedScalar(builder.ValueBuilder(), child)
-			if releasable, ok := child.(scalar.Releasable); ok {
-				releasable.Release()
-			}
+			releasePositionDeleteScalar(child)
 			if appendErr != nil {
 				return fmt.Errorf("list element %d: %w", index, appendErr)
 			}
@@ -725,9 +716,7 @@ func appendPositionDeleteRecord(
 		}
 		continueReading, appendErr := appendRow(
 			file, filePaths.Value(row), positions.Value(row), deletedRow, projected)
-		if releasable, ok := deletedRow.(scalar.Releasable); ok {
-			releasable.Release()
-		}
+		releasePositionDeleteScalar(deletedRow)
 		if appendErr != nil || !continueReading {
 			return continueReading, appendErr
 		}

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -168,9 +168,7 @@ func (a positionDeleteRecordAppender) append(
 ) error {
 	a.filePath.Append(dataFilePath)
 	a.pos.Append(pos)
-	if deletedRow == nil || !deletedRow.IsValid() {
-		a.row.AppendNull()
-	} else if err := scalar.Append(a.row, deletedRow); err != nil {
+	if err := appendProjectedPositionDeleteRow(a.row, deletedRow); err != nil {
 		return fmt.Errorf("append deleted row: %w", err)
 	}
 
@@ -193,6 +191,147 @@ func (a positionDeleteRecordAppender) append(
 	}
 
 	return nil
+}
+
+// appendPositionDeleteRow projects a row from a position-delete file onto the
+// current table schema. Position-delete row structs may contain only a subset
+// of the table fields, so matching by Arrow field position or exact type is
+// not sufficient. Field IDs are authoritative when the source schema carries
+// them; names are used only for readers that do not preserve Parquet metadata.
+func appendProjectedPositionDeleteRow(builder *array.StructBuilder, deletedRow scalar.Scalar) error {
+	if deletedRow == nil || !deletedRow.IsValid() {
+		builder.AppendNull()
+
+		return nil
+	}
+
+	row, ok := deletedRow.(*scalar.Struct)
+	if !ok {
+		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, deletedRow.DataType())
+	}
+
+	return appendPositionDeleteStruct(builder, row)
+}
+
+func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Struct) error {
+	sourceType, ok := source.DataType().(*arrow.StructType)
+	if !ok {
+		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, source.DataType())
+	}
+	if len(source.Value) != sourceType.NumFields() {
+		return fmt.Errorf("%w: row has %d values for %d fields",
+			iceberg.ErrInvalidSchema, len(source.Value), sourceType.NumFields())
+	}
+
+	sourceFields, err := newPositionDeleteFieldLookup(sourceType)
+	if err != nil {
+		return err
+	}
+	destinationType, ok := builder.Type().(*arrow.StructType)
+	if !ok {
+		return fmt.Errorf("%w: destination row has type %s, want struct", iceberg.ErrInvalidSchema, builder.Type())
+	}
+
+	if !source.IsValid() {
+		builder.AppendNull()
+
+		return nil
+	}
+	builder.Append(true)
+
+	for index, destinationField := range destinationType.Fields() {
+		sourceIndex, found := sourceFields.index(destinationField)
+		if !found {
+			builder.FieldBuilder(index).AppendNull()
+
+			continue
+		}
+
+		value := source.Value[sourceIndex]
+		if value == nil || !value.IsValid() {
+			builder.FieldBuilder(index).AppendNull()
+
+			continue
+		}
+
+		fieldBuilder := builder.FieldBuilder(index)
+		if nestedBuilder, ok := fieldBuilder.(*array.StructBuilder); ok {
+			nestedValue, ok := value.(*scalar.Struct)
+			if !ok {
+				return fmt.Errorf("%w: field %q has type %s, want struct",
+					iceberg.ErrInvalidSchema, destinationField.Name, value.DataType())
+			}
+			if err := appendPositionDeleteStruct(nestedBuilder, nestedValue); err != nil {
+				return fmt.Errorf("field %q: %w", destinationField.Name, err)
+			}
+
+			continue
+		}
+		if err := scalar.Append(fieldBuilder, value); err != nil {
+			return fmt.Errorf("field %q: %w", destinationField.Name, err)
+		}
+	}
+
+	return nil
+}
+
+type positionDeleteFieldLookup struct {
+	byID   map[int]int
+	byName map[string]int
+	byIDs  bool
+}
+
+func newPositionDeleteFieldLookup(sourceType *arrow.StructType) (positionDeleteFieldLookup, error) {
+	fields := positionDeleteFieldLookup{
+		byID:   make(map[int]int, sourceType.NumFields()),
+		byName: make(map[string]int, sourceType.NumFields()),
+	}
+	missingIDs := 0
+	for index, field := range sourceType.Fields() {
+		if _, exists := fields.byName[field.Name]; exists {
+			return fields, fmt.Errorf("%w: row contains duplicate field %q",
+				iceberg.ErrInvalidSchema, field.Name)
+		}
+		fields.byName[field.Name] = index
+
+		id := getFieldID(field)
+		if id == nil {
+			missingIDs++
+
+			continue
+		}
+		if _, exists := fields.byID[*id]; exists {
+			return fields, fmt.Errorf("%w: row contains duplicate field ID %d",
+				iceberg.ErrInvalidSchema, *id)
+		}
+		fields.byID[*id] = index
+	}
+	if len(fields.byID) > 0 {
+		if missingIDs > 0 {
+			return fields, fmt.Errorf("%w: row schema has fields with and without field IDs",
+				iceberg.ErrInvalidSchema)
+		}
+		fields.byIDs = true
+	}
+
+	return fields, nil
+}
+
+func (f positionDeleteFieldLookup) index(destination arrow.Field) (int, bool) {
+	if f.byIDs {
+		id := getFieldID(destination)
+		if id == nil {
+			return 0, false
+		}
+
+		index, ok := f.byID[*id]
+
+		return index, ok
+	}
+
+	index, ok := f.byName[destination.Name]
+
+	return index, ok
 }
 
 func (i InspectTable) positionDeleteRecordReader(

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -223,12 +223,8 @@ func (i InspectTable) positionDeleteRecordReader(
 			batch := bldr.NewRecordBatch()
 			rows = 0
 			emitted = true
-			if yield(batch, nil) {
-				return true
-			}
-			batch.Release()
 
-			return false
+			return yield(batch, nil)
 		}
 		yieldError := func(err error) {
 			_ = yield(nil, err)
@@ -273,9 +269,7 @@ func (i InspectTable) positionDeleteRecordReader(
 			_ = emit()
 		} else if !emitted {
 			batch := bldr.NewRecordBatch()
-			if !yield(batch, nil) {
-				batch.Release()
-			}
+			_ = yield(batch, nil)
 		}
 	})
 }

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -384,6 +384,20 @@ func appendPositionDeleteMap(builder *array.MapBuilder, source *scalar.Map) erro
 		return fmt.Errorf("%w: map builder has entry builder of type %T, want struct",
 			iceberg.ErrInvalidSchema, builder.ValueBuilder())
 	}
+	destinationEntryType, ok := entryBuilder.Type().(*arrow.StructType)
+	if !ok || destinationEntryType.NumFields() != 2 {
+		return fmt.Errorf("%w: map builder has entry type %s, want a two-field struct",
+			iceberg.ErrInvalidSchema, entryBuilder.Type())
+	}
+	sourceFields, err := newPositionDeleteFieldLookup(entryType)
+	if err != nil {
+		return err
+	}
+	keySourceIndex, found := sourceFields.index(destinationEntryType.Field(0))
+	if !found {
+		return fmt.Errorf("%w: map entry is missing the key field",
+			iceberg.ErrInvalidSchema)
+	}
 
 	builder.Append(true)
 	for index := range entries.Len() {
@@ -397,6 +411,24 @@ func appendPositionDeleteMap(builder *array.MapBuilder, source *scalar.Map) erro
 			}
 
 			return fmt.Errorf("%w: map entry %d is null", iceberg.ErrInvalidSchema, index)
+		}
+		entryStruct, ok := entry.(*scalar.Struct)
+		if !ok || len(entryStruct.Value) != entryType.NumFields() {
+			if releasable, ok := entry.(scalar.Releasable); ok {
+				releasable.Release()
+			}
+
+			return fmt.Errorf("%w: map entry %d is not a valid struct",
+				iceberg.ErrInvalidSchema, index)
+		}
+		key := entryStruct.Value[keySourceIndex]
+		if key == nil || !key.IsValid() {
+			if releasable, ok := entry.(scalar.Releasable); ok {
+				releasable.Release()
+			}
+
+			return fmt.Errorf("%w: map entry %d has a null key",
+				iceberg.ErrInvalidSchema, index)
 		}
 		appendErr := appendPositionDeleteValue(entryBuilder, entry)
 		if releasable, ok := entry.(scalar.Releasable); ok {

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -186,10 +186,20 @@ func (a positionDeleteRecordAppender) append(
 	a.deleteFilePath.Append(file.FilePath())
 	if a.formatVersion >= 3 {
 		appendInspectOptionalInt64(a.contentOffset, file.ContentOffset())
-		appendInspectOptionalInt64(a.contentSize, file.ContentSizeInBytes())
+		appendInspectOptionalInt64(a.contentSize, positionDeleteContentSize(file))
 	}
 
 	return nil
+}
+
+func positionDeleteContentSize(file iceberg.DataFile) *int64 {
+	if file.FileFormat() == iceberg.PuffinFile {
+		return file.ContentSizeInBytes()
+	}
+
+	fileSize := file.FileSizeBytes()
+
+	return &fileSize
 }
 
 // appendPositionDeleteRow projects a row from a position-delete file onto the

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -435,9 +435,10 @@ func projectPositionDeleteRows(
 	defer sourceBatch.Release()
 
 	return ToRequestedSchema(ctx, projection.tableSchema, fileSchema, sourceBatch, SchemaOptions{
-		FormatVersion:   projection.formatVersion,
-		IncludeFieldIDs: true,
-		TableProperties: projection.tableProperties,
+		FormatVersion:        projection.formatVersion,
+		IncludeFieldIDs:      true,
+		AllowMissingRequired: true,
+		TableProperties:      projection.tableProperties,
 	})
 }
 

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -123,6 +123,15 @@ type positionDeleteRecordAppender struct {
 	partitionType    *iceberg.StructType
 	partitionIDByOld map[int]int
 	formatVersion    int
+	projection       positionDeleteProjectionOptions
+}
+
+type positionDeleteProjectionOptions struct {
+	ctx             context.Context
+	formatVersion   int
+	tableSchema     *iceberg.Schema
+	nameMapping     iceberg.NameMapping
+	tableProperties iceberg.Properties
 }
 
 func newPositionDeleteRecordAppender(
@@ -130,8 +139,42 @@ func newPositionDeleteRecordAppender(
 	partitionType *iceberg.StructType,
 	partitionIDByOld map[int]int,
 	formatVersion int,
+	options ...positionDeleteProjectionOptions,
 ) (positionDeleteRecordAppender, error) {
 	nextField := 3
+	projection := positionDeleteProjectionOptions{
+		ctx:           context.Background(),
+		formatVersion: formatVersion,
+	}
+	if len(options) > 1 {
+		return positionDeleteRecordAppender{}, fmt.Errorf("%w: expected at most one position delete projection option", iceberg.ErrInvalidArgument)
+	}
+	if len(options) == 1 {
+		projection = options[0]
+		if projection.ctx == nil {
+			projection.ctx = context.Background()
+		}
+		if projection.formatVersion == 0 {
+			projection.formatVersion = formatVersion
+		}
+	}
+	if projection.tableSchema == nil {
+		rowType, ok := bldr.Field(2).Type().(*arrow.StructType)
+		if !ok {
+			return positionDeleteRecordAppender{}, fmt.Errorf("%w: destination row has type %s, want struct", iceberg.ErrInvalidSchema, bldr.Field(2).Type())
+		}
+		rowSchema, err := ArrowSchemaToIcebergWithOptions(
+			arrow.NewSchema(rowType.Fields(), nil),
+			ArrowToIcebergOptions{TableProperties: projection.tableProperties},
+		)
+		if err != nil {
+			return positionDeleteRecordAppender{}, fmt.Errorf("%w: resolve destination row schema: %v", iceberg.ErrInvalidSchema, err)
+		}
+		projection.tableSchema = rowSchema
+	}
+	if projection.nameMapping == nil && projection.tableSchema != nil {
+		projection.nameMapping = projection.tableSchema.NameMapping()
+	}
 	out := positionDeleteRecordAppender{
 		filePath:         bldr.Field(0).(*array.StringBuilder),
 		pos:              bldr.Field(1).(*array.Int64Builder),
@@ -139,6 +182,7 @@ func newPositionDeleteRecordAppender(
 		partitionType:    partitionType,
 		partitionIDByOld: partitionIDByOld,
 		formatVersion:    formatVersion,
+		projection:       projection,
 	}
 	if len(partitionType.FieldList) > 0 {
 		partitionBuilder, err := newInspectPartitionBuilder(
@@ -164,10 +208,21 @@ func (a positionDeleteRecordAppender) append(
 	dataFilePath string,
 	pos int64,
 	deletedRow scalar.Scalar,
+	projected ...bool,
 ) error {
 	a.filePath.Append(dataFilePath)
 	a.pos.Append(pos)
-	if err := appendProjectedPositionDeleteRow(a.row, deletedRow, a.formatVersion); err != nil {
+	var err error
+	if len(projected) > 0 && projected[0] {
+		if deletedRow == nil || !deletedRow.IsValid() {
+			a.row.AppendNull()
+		} else {
+			err = appendPositionDeleteProjectedScalar(a.row, deletedRow)
+		}
+	} else {
+		err = appendProjectedPositionDeleteRow(a.row, deletedRow, a.projection)
+	}
+	if err != nil {
 		return fmt.Errorf("append deleted row: %w", err)
 	}
 
@@ -193,24 +248,21 @@ func (a positionDeleteRecordAppender) append(
 }
 
 func positionDeleteContentSize(file iceberg.DataFile) *int64 {
-	if file.FileFormat() == iceberg.PuffinFile {
-		return file.ContentSizeInBytes()
+	if file.FileFormat() != iceberg.PuffinFile {
+		return nil
 	}
 
-	fileSize := file.FileSizeBytes()
-
-	return &fileSize
+	return file.ContentSizeInBytes()
 }
 
 // appendPositionDeleteRow projects a row from a position-delete file onto the
-// current table schema. Position-delete row structs may contain only a subset
-// of the table fields, so matching by Arrow field position or exact type is
-// not sufficient. Field IDs are authoritative when the source schema carries
-// them; names are used only for readers that do not preserve Parquet metadata.
+// current table schema. The shared Arrow projection path resolves field IDs,
+// name mappings, nested types, promotions, and initial defaults consistently
+// with normal table scans.
 func appendProjectedPositionDeleteRow(
 	builder *array.StructBuilder,
 	deletedRow scalar.Scalar,
-	formatVersion int,
+	projection positionDeleteProjectionOptions,
 ) error {
 	if deletedRow == nil || !deletedRow.IsValid() {
 		builder.AppendNull()
@@ -222,65 +274,42 @@ func appendProjectedPositionDeleteRow(
 	if !ok {
 		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, deletedRow.DataType())
 	}
-
-	return appendPositionDeleteStruct(builder, row, formatVersion)
-}
-
-func appendPositionDeleteStruct(
-	builder *array.StructBuilder,
-	source *scalar.Struct,
-	formatVersion int,
-) error {
-	sourceType, ok := source.DataType().(*arrow.StructType)
+	rowType, ok := row.DataType().(*arrow.StructType)
 	if !ok {
-		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, source.DataType())
+		return fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, row.DataType())
 	}
-	if len(source.Value) != sourceType.NumFields() {
-		return fmt.Errorf("%w: row has %d values for %d fields",
-			iceberg.ErrInvalidSchema, len(source.Value), sourceType.NumFields())
+	rowBuilder := array.NewStructBuilder(compute.GetAllocator(projection.ctx), rowType)
+	defer rowBuilder.Release()
+	if err := appendPositionDeleteProjectedScalar(rowBuilder, row); err != nil {
+		return fmt.Errorf("make row array: %w", err)
 	}
+	rowArray := rowBuilder.NewArray()
+	defer rowArray.Release()
 
-	sourceFields, err := newPositionDeleteFieldLookup(sourceType)
+	rowStruct, ok := rowArray.(*array.Struct)
+	if !ok {
+		return fmt.Errorf("%w: row array has type %s, want struct", iceberg.ErrInvalidSchema, rowArray.DataType())
+	}
+	projected, err := projectPositionDeleteRows(projection.ctx, rowStruct, projection)
 	if err != nil {
 		return err
 	}
-	destinationType, ok := builder.Type().(*arrow.StructType)
-	if !ok {
-		return fmt.Errorf("%w: destination row has type %s, want struct", iceberg.ErrInvalidSchema, builder.Type())
+	defer projected.Release()
+
+	projectedStruct := array.RecordToStructArray(projected)
+	defer projectedStruct.Release()
+	projectedRow, err := scalar.GetScalar(projectedStruct, 0)
+	if err != nil {
+		return err
+	}
+	if releasable, ok := projectedRow.(scalar.Releasable); ok {
+		defer releasable.Release()
 	}
 
-	if !source.IsValid() {
-		builder.AppendNull()
-
-		return nil
-	}
-	builder.Append(true)
-
-	for index, destinationField := range destinationType.Fields() {
-		sourceIndex, found := sourceFields.index(destinationField)
-		if !found {
-			builder.FieldBuilder(index).AppendNull()
-
-			continue
-		}
-
-		value := source.Value[sourceIndex]
-		if value == nil || !value.IsValid() {
-			builder.FieldBuilder(index).AppendNull()
-
-			continue
-		}
-
-		fieldBuilder := builder.FieldBuilder(index)
-		if err := appendPositionDeleteValue(fieldBuilder, value, formatVersion); err != nil {
-			return fmt.Errorf("field %q: %w", destinationField.Name, err)
-		}
-	}
-
-	return nil
+	return appendPositionDeleteProjectedScalar(builder, projectedRow)
 }
 
-func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar, formatVersion int) error {
+func appendPositionDeleteProjectedScalar(builder array.Builder, value scalar.Scalar) error {
 	if value == nil || !value.IsValid() {
 		builder.AppendNull()
 
@@ -290,349 +319,143 @@ func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar, forma
 	switch builder := builder.(type) {
 	case *array.StructBuilder:
 		source, ok := value.(*scalar.Struct)
-		if !ok {
-			return fmt.Errorf("%w: value has type %s, want struct",
-				iceberg.ErrInvalidSchema, value.DataType())
+		if !ok || len(source.Value) != builder.NumField() {
+			return fmt.Errorf("%w: projected struct has %d fields, want %d",
+				iceberg.ErrInvalidSchema, len(source.Value), builder.NumField())
+		}
+		builder.Append(true)
+		for index, child := range source.Value {
+			if err := appendPositionDeleteProjectedScalar(builder.FieldBuilder(index), child); err != nil {
+				return fmt.Errorf("projected struct field %d: %w", index, err)
+			}
 		}
 
-		return appendPositionDeleteStruct(builder, source, formatVersion)
+		return nil
 	case *array.MapBuilder:
 		source, ok := value.(*scalar.Map)
 		if !ok {
-			return fmt.Errorf("%w: value has type %s, want map",
-				iceberg.ErrInvalidSchema, value.DataType())
+			return fmt.Errorf("%w: projected map has type %s", iceberg.ErrInvalidSchema, value.DataType())
+		}
+		entries := source.GetList()
+		if entries == nil {
+			return fmt.Errorf("%w: projected map has no entries", iceberg.ErrInvalidSchema)
+		}
+		entryType, ok := entries.DataType().(*arrow.StructType)
+		if !ok || entryType.NumFields() != 2 {
+			return fmt.Errorf("%w: projected map entries have type %s", iceberg.ErrInvalidSchema, entries.DataType())
+		}
+		builder.Append(true)
+		for index := range entries.Len() {
+			entry, err := scalar.GetScalar(entries, index)
+			if err != nil {
+				return err
+			}
+			entryStruct, ok := entry.(*scalar.Struct)
+			if !ok || len(entryStruct.Value) != 2 {
+				if releasable, ok := entry.(scalar.Releasable); ok {
+					releasable.Release()
+				}
+
+				return fmt.Errorf("%w: projected map entry %d is not a two-field struct",
+					iceberg.ErrInvalidSchema, index)
+			}
+			if entryStruct.Value[0] == nil || !entryStruct.Value[0].IsValid() {
+				if releasable, ok := entry.(scalar.Releasable); ok {
+					releasable.Release()
+				}
+
+				return fmt.Errorf("%w: projected map entry %d has a null key",
+					iceberg.ErrInvalidSchema, index)
+			}
+			if err := appendPositionDeleteProjectedScalar(builder.KeyBuilder(), entryStruct.Value[0]); err != nil {
+				if releasable, ok := entry.(scalar.Releasable); ok {
+					releasable.Release()
+				}
+
+				return fmt.Errorf("map entry %d key: %w", index, err)
+			}
+			if err := appendPositionDeleteProjectedScalar(builder.ItemBuilder(), entryStruct.Value[1]); err != nil {
+				if releasable, ok := entry.(scalar.Releasable); ok {
+					releasable.Release()
+				}
+
+				return fmt.Errorf("map entry %d value: %w", index, err)
+			}
+			if releasable, ok := entry.(scalar.Releasable); ok {
+				releasable.Release()
+			}
 		}
 
-		return appendPositionDeleteMap(builder, source, formatVersion)
+		return nil
 	case array.ListLikeBuilder:
 		source, ok := value.(scalar.ListScalar)
 		if !ok {
-			return fmt.Errorf("%w: value has type %s, want list",
-				iceberg.ErrInvalidSchema, value.DataType())
+			return fmt.Errorf("%w: projected list has type %s", iceberg.ErrInvalidSchema, value.DataType())
+		}
+		values := source.GetList()
+		if values == nil {
+			return fmt.Errorf("%w: projected list has no values", iceberg.ErrInvalidSchema)
+		}
+		if destination, ok := builder.Type().(*arrow.FixedSizeListType); ok &&
+			values.Len() != int(destination.Len()) {
+			return fmt.Errorf("%w: projected list has %d elements, want %d",
+				iceberg.ErrInvalidSchema, values.Len(), destination.Len())
+		}
+		builder.Append(true)
+		for index := range values.Len() {
+			child, err := scalar.GetScalar(values, index)
+			if err != nil {
+				return err
+			}
+			appendErr := appendPositionDeleteProjectedScalar(builder.ValueBuilder(), child)
+			if releasable, ok := child.(scalar.Releasable); ok {
+				releasable.Release()
+			}
+			if appendErr != nil {
+				return fmt.Errorf("list element %d: %w", index, appendErr)
+			}
 		}
 
-		return appendPositionDeleteList(builder, source, formatVersion)
-	}
-
-	if arrow.TypeEqual(builder.Type(), value.DataType()) {
+		return nil
+	default:
 		return scalar.Append(builder, value)
 	}
-	if !canPromotePositionDeleteValue(value.DataType(), builder.Type(), formatVersion) {
-		return scalar.Append(builder, value)
-	}
-
-	appendBuilder := builder
-	castType := builder.Type()
-	if storageBuilder, ok := builder.(positionDeleteStorageBuilder); ok {
-		appendBuilder = storageBuilder.StorageBuilder()
-		castType = appendBuilder.Type()
-	}
-	casted, err := castPositionDeleteValue(value, castType)
-	if err != nil {
-		return fmt.Errorf("promote %s to %s: %w", value.DataType(), builder.Type(), err)
-	}
-	if releasable, ok := casted.(scalar.Releasable); ok {
-		defer releasable.Release()
-	}
-
-	return scalar.Append(appendBuilder, casted)
 }
 
-type positionDeleteStorageBuilder interface {
-	array.Builder
-	StorageBuilder() array.Builder
-}
-
-func appendPositionDeleteList(
-	builder array.ListLikeBuilder,
-	source scalar.ListScalar,
-	formatVersion int,
-) error {
-	if !isPositionDeleteListType(source.DataType()) {
-		return fmt.Errorf("%w: value has type %s, want list",
-			iceberg.ErrInvalidSchema, source.DataType())
+func projectPositionDeleteRows(
+	ctx context.Context,
+	rows *array.Struct,
+	projection positionDeleteProjectionOptions,
+) (arrow.RecordBatch, error) {
+	if projection.tableSchema == nil {
+		return nil, fmt.Errorf("%w: position delete projection has no table schema", iceberg.ErrInvalidSchema)
 	}
-	values := source.GetList()
-	if values == nil {
-		return fmt.Errorf("%w: valid list value has no child array",
-			iceberg.ErrInvalidSchema)
+	if rows == nil {
+		return nil, fmt.Errorf("%w: position delete row array is nil", iceberg.ErrInvalidSchema)
 	}
-
-	if destination, ok := builder.Type().(*arrow.FixedSizeListType); ok &&
-		values.Len() != int(destination.Len()) {
-		return fmt.Errorf("%w: list value has %d elements, want %d",
-			iceberg.ErrInvalidSchema, values.Len(), destination.Len())
-	}
-
-	builder.Append(true)
-	valueBuilder := builder.ValueBuilder()
-	for index := range values.Len() {
-		child, err := scalar.GetScalar(values, index)
-		if err != nil {
-			return err
-		}
-		appendErr := appendPositionDeleteValue(valueBuilder, child, formatVersion)
-		if releasable, ok := child.(scalar.Releasable); ok {
-			releasable.Release()
-		}
-		if appendErr != nil {
-			return fmt.Errorf("list element %d: %w", index, appendErr)
-		}
-	}
-
-	return nil
-}
-
-func appendPositionDeleteMap(
-	builder *array.MapBuilder,
-	source *scalar.Map,
-	formatVersion int,
-) error {
-	if source.DataType().ID() != arrow.MAP {
-		return fmt.Errorf("%w: value has type %s, want map",
-			iceberg.ErrInvalidSchema, source.DataType())
-	}
-	entries := source.GetList()
-	if entries == nil {
-		return fmt.Errorf("%w: valid map value has no entry array",
-			iceberg.ErrInvalidSchema)
-	}
-	entryType, ok := entries.DataType().(*arrow.StructType)
-	if !ok || entryType.NumFields() != 2 {
-		return fmt.Errorf("%w: map entries have type %s, want a two-field struct",
-			iceberg.ErrInvalidSchema, entries.DataType())
-	}
-	entryBuilder, ok := builder.ValueBuilder().(*array.StructBuilder)
+	rowType, ok := rows.DataType().(*arrow.StructType)
 	if !ok {
-		return fmt.Errorf("%w: map builder has entry builder of type %T, want struct",
-			iceberg.ErrInvalidSchema, builder.ValueBuilder())
+		return nil, fmt.Errorf("%w: row has type %s, want struct", iceberg.ErrInvalidSchema, rows.DataType())
 	}
-	destinationEntryType, ok := entryBuilder.Type().(*arrow.StructType)
-	if !ok || destinationEntryType.NumFields() != 2 {
-		return fmt.Errorf("%w: map builder has entry type %s, want a two-field struct",
-			iceberg.ErrInvalidSchema, entryBuilder.Type())
-	}
-	sourceFields, err := newPositionDeleteFieldLookup(entryType)
+
+	sourceArrowSchema := arrow.NewSchema(rowType.Fields(), nil)
+	fileSchema, err := ArrowSchemaToIcebergWithOptions(sourceArrowSchema, ArrowToIcebergOptions{
+		NameMapping:     projection.nameMapping,
+		TableSchema:     projection.tableSchema,
+		TableProperties: projection.tableProperties,
+	})
 	if err != nil {
-		return err
-	}
-	keySourceIndex, found := sourceFields.index(destinationEntryType.Field(0))
-	if !found {
-		return fmt.Errorf("%w: map entry is missing the key field",
-			iceberg.ErrInvalidSchema)
+		return nil, fmt.Errorf("resolve position delete row schema: %w", err)
 	}
 
-	builder.Append(true)
-	for index := range entries.Len() {
-		entry, err := scalar.GetScalar(entries, index)
-		if err != nil {
-			return err
-		}
-		if !entry.IsValid() {
-			if releasable, ok := entry.(scalar.Releasable); ok {
-				releasable.Release()
-			}
+	sourceBatch := array.RecordFromStructArray(rows, sourceArrowSchema)
+	defer sourceBatch.Release()
 
-			return fmt.Errorf("%w: map entry %d is null", iceberg.ErrInvalidSchema, index)
-		}
-		entryStruct, ok := entry.(*scalar.Struct)
-		if !ok || len(entryStruct.Value) != entryType.NumFields() {
-			if releasable, ok := entry.(scalar.Releasable); ok {
-				releasable.Release()
-			}
-
-			return fmt.Errorf("%w: map entry %d is not a valid struct",
-				iceberg.ErrInvalidSchema, index)
-		}
-		key := entryStruct.Value[keySourceIndex]
-		if key == nil || !key.IsValid() {
-			if releasable, ok := entry.(scalar.Releasable); ok {
-				releasable.Release()
-			}
-
-			return fmt.Errorf("%w: map entry %d has a null key",
-				iceberg.ErrInvalidSchema, index)
-		}
-		appendErr := appendPositionDeleteValue(entryBuilder, entry, formatVersion)
-		if releasable, ok := entry.(scalar.Releasable); ok {
-			releasable.Release()
-		}
-		if appendErr != nil {
-			return fmt.Errorf("map entry %d: %w", index, appendErr)
-		}
-	}
-
-	return nil
-}
-
-func isPositionDeleteListType(typ arrow.DataType) bool {
-	switch typ.ID() {
-	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST:
-		return true
-	default:
-		return false
-	}
-}
-
-func castPositionDeleteValue(value scalar.Scalar, destination arrow.DataType) (scalar.Scalar, error) {
-	if date, ok := value.(*scalar.Date32); ok {
-		if timestamp, ok := destination.(*arrow.TimestampType); ok {
-			converted, ok := convertPositionDeleteDate32(date.Value, timestamp.Unit)
-			if !ok {
-				return nil, fmt.Errorf("date %d is outside %s range", date.Value, timestamp)
-			}
-
-			return scalar.NewTimestampScalar(converted, timestamp), nil
-		}
-	}
-
-	if binary, ok := value.(scalar.BinaryScalar); ok {
-		switch destination.ID() {
-		case arrow.BINARY:
-			return scalar.NewBinaryScalar(binary.Buffer(), destination), nil
-		case arrow.LARGE_BINARY:
-			return scalar.NewLargeBinaryScalar(binary.Buffer()), nil
-		case arrow.STRING:
-			return scalar.NewStringScalarFromBuffer(binary.Buffer()), nil
-		case arrow.LARGE_STRING:
-			return scalar.NewLargeStringScalarFromBuffer(binary.Buffer()), nil
-		}
-	}
-
-	return value.CastTo(destination)
-}
-
-func convertPositionDeleteDate32(value arrow.Date32, unit arrow.TimeUnit) (arrow.Timestamp, bool) {
-	var unitsPerDay int64
-	switch unit {
-	case arrow.Second:
-		unitsPerDay = 86_400
-	case arrow.Millisecond:
-		unitsPerDay = 86_400_000
-	case arrow.Microsecond:
-		unitsPerDay = 86_400_000_000
-	case arrow.Nanosecond:
-		unitsPerDay = 86_400_000_000_000
-	default:
-		return 0, false
-	}
-
-	days := int64(value)
-	if days > math.MaxInt64/unitsPerDay || days < math.MinInt64/unitsPerDay {
-		return 0, false
-	}
-
-	return arrow.Timestamp(days * unitsPerDay), true
-}
-
-func canPromotePositionDeleteValue(source, destination arrow.DataType, formatVersion int) bool {
-	switch source.ID() {
-	case arrow.INT32:
-		return destination.ID() == arrow.INT64
-	case arrow.FLOAT32:
-		return destination.ID() == arrow.FLOAT64
-	case arrow.DATE32:
-		if formatVersion < 3 {
-			return false
-		}
-
-		timestamp, ok := destination.(*arrow.TimestampType)
-
-		return ok && timestamp.TimeZone == "" &&
-			(timestamp.Unit == arrow.Microsecond || timestamp.Unit == arrow.Nanosecond)
-	case arrow.DECIMAL128:
-		sourceDecimal, sourceOK := source.(*arrow.Decimal128Type)
-		destinationDecimal, destinationOK := destination.(*arrow.Decimal128Type)
-
-		return sourceOK && destinationOK &&
-			sourceDecimal.Scale == destinationDecimal.Scale &&
-			sourceDecimal.Precision <= destinationDecimal.Precision
-	case arrow.STRING, arrow.LARGE_STRING:
-		switch destination.ID() {
-		case arrow.STRING, arrow.LARGE_STRING, arrow.BINARY, arrow.LARGE_BINARY:
-			return true
-		default:
-			return false
-		}
-	case arrow.BINARY, arrow.LARGE_BINARY:
-		switch destination.ID() {
-		case arrow.BINARY, arrow.LARGE_BINARY, arrow.STRING, arrow.LARGE_STRING:
-			return true
-		default:
-			return false
-		}
-	case arrow.FIXED_SIZE_BINARY:
-		sourceFixed, sourceOK := source.(*arrow.FixedSizeBinaryType)
-		destinationExtension, destinationOK := destination.(arrow.ExtensionType)
-		if !sourceOK || !destinationOK || sourceFixed.ByteWidth != 16 ||
-			destinationExtension.ExtensionName() != "arrow.uuid" {
-			return false
-		}
-		destinationFixed, destinationOK := destinationExtension.StorageType().(*arrow.FixedSizeBinaryType)
-
-		return destinationOK && destinationFixed.ByteWidth == 16
-	default:
-		return false
-	}
-}
-
-type positionDeleteFieldLookup struct {
-	byID   map[int]int
-	byName map[string]int
-	byIDs  bool
-}
-
-func newPositionDeleteFieldLookup(sourceType *arrow.StructType) (positionDeleteFieldLookup, error) {
-	fields := positionDeleteFieldLookup{
-		byID:   make(map[int]int, sourceType.NumFields()),
-		byName: make(map[string]int, sourceType.NumFields()),
-	}
-	missingIDs := 0
-	for index, field := range sourceType.Fields() {
-		if _, exists := fields.byName[field.Name]; exists {
-			return fields, fmt.Errorf("%w: row contains duplicate field %q",
-				iceberg.ErrInvalidSchema, field.Name)
-		}
-		fields.byName[field.Name] = index
-
-		id := getFieldID(field)
-		if id == nil {
-			missingIDs++
-
-			continue
-		}
-		if _, exists := fields.byID[*id]; exists {
-			return fields, fmt.Errorf("%w: row contains duplicate field ID %d",
-				iceberg.ErrInvalidSchema, *id)
-		}
-		fields.byID[*id] = index
-	}
-	if len(fields.byID) > 0 {
-		if missingIDs > 0 {
-			return fields, fmt.Errorf("%w: row schema has fields with and without field IDs",
-				iceberg.ErrInvalidSchema)
-		}
-		fields.byIDs = true
-	}
-
-	return fields, nil
-}
-
-func (f positionDeleteFieldLookup) index(destination arrow.Field) (int, bool) {
-	if f.byIDs {
-		id := getFieldID(destination)
-		if id == nil {
-			return 0, false
-		}
-
-		index, ok := f.byID[*id]
-
-		return index, ok
-	}
-
-	index, ok := f.byName[destination.Name]
-
-	return index, ok
+	return ToRequestedSchema(ctx, projection.tableSchema, fileSchema, sourceBatch, SchemaOptions{
+		FormatVersion:   projection.formatVersion,
+		IncludeFieldIDs: true,
+		TableProperties: projection.tableProperties,
+	})
 }
 
 func (i InspectTable) positionDeleteRecordReader(
@@ -653,7 +476,16 @@ func (i InspectTable) positionDeleteRecordReader(
 
 		bldr := array.NewRecordBuilder(i.alloc, arrowSchema)
 		defer bldr.Release()
-		appender, err := newPositionDeleteRecordAppender(bldr, partitionType, partitionIDByOld, formatVersion)
+		appender, err := newPositionDeleteRecordAppender(
+			bldr, partitionType, partitionIDByOld, formatVersion,
+			positionDeleteProjectionOptions{
+				ctx:             ctx,
+				formatVersion:   formatVersion,
+				tableSchema:     i.tbl.metadata.CurrentSchema(),
+				nameMapping:     i.tbl.metadata.NameMapping(),
+				tableProperties: i.tbl.metadata.Properties(),
+			},
+		)
 		if err != nil {
 			_ = yield(nil, err)
 
@@ -675,8 +507,8 @@ func (i InspectTable) positionDeleteRecordReader(
 		yieldError := func(err error) {
 			_ = yield(nil, err)
 		}
-		appendRow := func(file iceberg.DataFile, path string, pos int64, deletedRow scalar.Scalar) (bool, error) {
-			if err := appender.append(file, path, pos, deletedRow); err != nil {
+		appendRow := func(file iceberg.DataFile, path string, pos int64, deletedRow scalar.Scalar, projected bool) (bool, error) {
+			if err := appender.append(file, path, pos, deletedRow, projected); err != nil {
 				return false, err
 			}
 			rows++
@@ -698,8 +530,12 @@ func (i InspectTable) positionDeleteRecordReader(
 			switch file.FileFormat() {
 			case iceberg.PuffinFile:
 				keepGoing, err = appendDeletionVectorRows(ctx, fs, file, appendRow)
+			case iceberg.ParquetFile:
+				keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow, appender.projection)
 			default:
-				keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow)
+				keepGoing = false
+				err = fmt.Errorf("%w: unsupported position delete file format %s",
+					iceberg.ErrNotImplemented, file.FileFormat())
 			}
 			if err != nil {
 				yieldError(fmt.Errorf("read position delete file %s: %w", file.FilePath(), err))
@@ -720,7 +556,7 @@ func (i InspectTable) positionDeleteRecordReader(
 	})
 }
 
-type appendPositionDeleteRow func(iceberg.DataFile, string, int64, scalar.Scalar) (bool, error)
+type appendPositionDeleteRow func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error)
 
 func appendDeletionVectorRows(
 	ctx context.Context,
@@ -748,7 +584,7 @@ func appendDeletionVectorRows(
 		if position > math.MaxInt64 {
 			return false, fmt.Errorf("%w: deletion position %d exceeds int64", iceberg.ErrInvalidSchema, position)
 		}
-		keepGoing, err := appendRow(file, *referencedDataFile, int64(position), nil)
+		keepGoing, err := appendRow(file, *referencedDataFile, int64(position), nil, false)
 		if err != nil || !keepGoing {
 			return keepGoing, err
 		}
@@ -762,7 +598,18 @@ func appendParquetPositionDeleteRows(
 	fs iceio.IO,
 	file iceberg.DataFile,
 	appendRow appendPositionDeleteRow,
+	options ...positionDeleteProjectionOptions,
 ) (keepGoing bool, err error) {
+	projection := positionDeleteProjectionOptions{ctx: ctx}
+	if len(options) > 1 {
+		return false, fmt.Errorf("%w: expected at most one position delete projection option", iceberg.ErrInvalidArgument)
+	}
+	if len(options) == 1 {
+		projection = options[0]
+		if projection.ctx == nil {
+			projection.ctx = ctx
+		}
+	}
 	source, err := tblutils.GetFile(ctx, fs, file, true)
 	if err != nil {
 		return false, err
@@ -784,63 +631,102 @@ func appendParquetPositionDeleteRows(
 	defer records.Release()
 
 	for records.Next() {
-		record := records.RecordBatch()
-		filePathIndex, posIndex, err := positionDeleteColumnIndices(record.Schema())
-		if err != nil {
-			return false, err
-		}
-		filePaths, err := filePathValues(record.Column(filePathIndex))
-		if err != nil {
-			return false, err
-		}
-		if err := validatePositionDeleteFilePathValues(filePaths, record.Column(filePathIndex)); err != nil {
-			return false, err
-		}
-		positions, ok := record.Column(posIndex).(*array.Int64)
-		if !ok {
-			return false, fmt.Errorf("%w: pos column has type %s, want int64",
-				iceberg.ErrInvalidSchema, record.Column(posIndex).DataType())
-		}
-		if positions.NullN() > 0 {
-			return false, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
-		}
-		if err := validatePositionDeletePositions(positions); err != nil {
-			return false, err
-		}
-
-		rowIndex := -1
-		if indices := record.Schema().FieldIndices("row"); len(indices) > 1 {
-			return false, fmt.Errorf("%w: position delete file contains multiple row columns",
-				iceberg.ErrInvalidSchema)
-		} else if len(indices) == 1 {
-			rowIndex = indices[0]
-		}
-		if rowIndex >= 0 && record.Column(rowIndex).NullN() > 0 {
-			return false, fmt.Errorf("%w: null row in position delete file", iceberg.ErrInvalidSchema)
-		}
-		for row := range int(record.NumRows()) {
-			if err := ctx.Err(); err != nil {
-				return false, err
-			}
-			var deletedRow scalar.Scalar
-			if rowIndex >= 0 && !record.Column(rowIndex).IsNull(row) {
-				deletedRow, err = scalar.GetScalar(record.Column(rowIndex), row)
-				if err != nil {
-					return false, err
-				}
-			}
-			continueReading, appendErr := appendRow(
-				file, filePaths.Value(row), positions.Value(row), deletedRow)
-			if releasable, ok := deletedRow.(scalar.Releasable); ok {
-				releasable.Release()
-			}
-			if appendErr != nil || !continueReading {
-				return continueReading, appendErr
-			}
+		continueReading, appendErr := appendPositionDeleteRecord(
+			ctx, file, records.RecordBatch(), appendRow, projection)
+		if appendErr != nil || !continueReading {
+			return continueReading, appendErr
 		}
 	}
 	if err := records.Err(); err != nil {
 		return false, err
+	}
+
+	return true, nil
+}
+
+func appendPositionDeleteRecord(
+	ctx context.Context,
+	file iceberg.DataFile,
+	record arrow.RecordBatch,
+	appendRow appendPositionDeleteRow,
+	projection positionDeleteProjectionOptions,
+) (bool, error) {
+	filePathIndex, posIndex, err := positionDeleteColumnIndices(record.Schema())
+	if err != nil {
+		return false, err
+	}
+	filePaths, err := filePathValues(record.Column(filePathIndex))
+	if err != nil {
+		return false, err
+	}
+	if err := validatePositionDeleteFilePathValues(filePaths, record.Column(filePathIndex)); err != nil {
+		return false, err
+	}
+	positions, ok := record.Column(posIndex).(*array.Int64)
+	if !ok {
+		return false, fmt.Errorf("%w: pos column has type %s, want int64",
+			iceberg.ErrInvalidSchema, record.Column(posIndex).DataType())
+	}
+	if positions.NullN() > 0 {
+		return false, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
+	}
+	if err := validatePositionDeletePositions(positions); err != nil {
+		return false, err
+	}
+
+	rowIndex := -1
+	if indices := record.Schema().FieldIndices("row"); len(indices) > 1 {
+		return false, fmt.Errorf("%w: position delete file contains multiple row columns",
+			iceberg.ErrInvalidSchema)
+	} else if len(indices) == 1 {
+		rowIndex = indices[0]
+	}
+	if rowIndex >= 0 && record.Column(rowIndex).NullN() > 0 {
+		return false, fmt.Errorf("%w: null row in position delete file", iceberg.ErrInvalidSchema)
+	}
+
+	var projectedRecord arrow.RecordBatch
+	var projectedRows *array.Struct
+	if rowIndex >= 0 && projection.tableSchema != nil {
+		rowArray, ok := record.Column(rowIndex).(*array.Struct)
+		if !ok {
+			return false, fmt.Errorf("%w: row column has type %s, want struct",
+				iceberg.ErrInvalidSchema, record.Column(rowIndex).DataType())
+		}
+		projectedRecord, err = projectPositionDeleteRows(ctx, rowArray, projection)
+		if err != nil {
+			return false, err
+		}
+		projectedRows = array.RecordToStructArray(projectedRecord)
+		defer projectedRecord.Release()
+		defer projectedRows.Release()
+	}
+
+	for row := range int(record.NumRows()) {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		var deletedRow scalar.Scalar
+		projected := false
+		if rowIndex >= 0 {
+			if projectedRows != nil {
+				deletedRow, err = scalar.GetScalar(projectedRows, row)
+				projected = true
+			} else if !record.Column(rowIndex).IsNull(row) {
+				deletedRow, err = scalar.GetScalar(record.Column(rowIndex), row)
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+		continueReading, appendErr := appendRow(
+			file, filePaths.Value(row), positions.Value(row), deletedRow, projected)
+		if releasable, ok := deletedRow.(scalar.Releasable); ok {
+			releasable.Release()
+		}
+		if appendErr != nil || !continueReading {
+			return continueReading, appendErr
+		}
 	}
 
 	return true, nil

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -58,19 +58,19 @@ func (i InspectTable) PositionDeletes(ctx context.Context) (array.RecordReader, 
 		return nil, fmt.Errorf("inspect position deletes: build arrow schema: %w", err)
 	}
 
-	fs, files, err := i.currentPositionDeleteFiles(ctx)
+	fs, manifests, err := i.currentPositionDeleteManifests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("inspect position deletes: %w", err)
 	}
 	ctx = compute.WithAllocator(ctx, i.alloc)
 
 	return i.positionDeleteRecordReader(
-		ctx, arrowSchema, fs, files, partitionType, partitionIDs, i.tbl.metadata.Version()), nil
+		ctx, arrowSchema, fs, manifests, partitionType, partitionIDs, i.tbl.metadata.Version()), nil
 }
 
-func (i InspectTable) currentPositionDeleteFiles(
+func (i InspectTable) currentPositionDeleteManifests(
 	ctx context.Context,
-) (iceio.IO, []iceberg.DataFile, error) {
+) (iceio.IO, []iceberg.ManifestFile, error) {
 	snapshot := i.tbl.metadata.CurrentSnapshot()
 	if snapshot == nil {
 		return nil, nil, nil
@@ -87,28 +87,7 @@ func (i InspectTable) currentPositionDeleteFiles(
 		return nil, nil, err
 	}
 
-	files := make([]iceberg.DataFile, 0)
-	for _, manifest := range manifests {
-		if err := ctx.Err(); err != nil {
-			return nil, nil, err
-		}
-		if manifest.ManifestContent() != iceberg.ManifestContentDeletes {
-			continue
-		}
-		for entry, err := range manifest.Entries(fs, true) {
-			if err != nil {
-				return nil, nil, fmt.Errorf("read manifest %s: %w", manifest.FilePath(), err)
-			}
-			if err := ctx.Err(); err != nil {
-				return nil, nil, err
-			}
-			if entry.DataFile().ContentType() == iceberg.EntryContentPosDeletes {
-				files = append(files, entry.DataFile())
-			}
-		}
-	}
-
-	return fs, files, nil
+	return fs, manifests, nil
 }
 
 type positionDeleteRecordAppender struct {
@@ -319,7 +298,11 @@ func appendPositionDeleteProjectedScalar(builder array.Builder, value scalar.Sca
 	switch builder := builder.(type) {
 	case *array.StructBuilder:
 		source, ok := value.(*scalar.Struct)
-		if !ok || len(source.Value) != builder.NumField() {
+		if !ok {
+			return fmt.Errorf("%w: projected struct has type %s, want struct",
+				iceberg.ErrInvalidSchema, value.DataType())
+		}
+		if len(source.Value) != builder.NumField() {
 			return fmt.Errorf("%w: projected struct has %d fields, want %d",
 				iceberg.ErrInvalidSchema, len(source.Value), builder.NumField())
 		}
@@ -462,7 +445,7 @@ func (i InspectTable) positionDeleteRecordReader(
 	ctx context.Context,
 	arrowSchema *arrow.Schema,
 	fs iceio.IO,
-	files []iceberg.DataFile,
+	manifests []iceberg.ManifestFile,
 	partitionType *iceberg.StructType,
 	partitionIDByOld map[int]int,
 	formatVersion int,
@@ -519,31 +502,51 @@ func (i InspectTable) positionDeleteRecordReader(
 			return true, nil
 		}
 
-		for _, file := range files {
+		for _, manifest := range manifests {
 			if err := ctx.Err(); err != nil {
 				yieldError(err)
 
 				return
 			}
-			var keepGoing bool
-			var err error
-			switch file.FileFormat() {
-			case iceberg.PuffinFile:
-				keepGoing, err = appendDeletionVectorRows(ctx, fs, file, appendRow)
-			case iceberg.ParquetFile:
-				keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow, appender.projection)
-			default:
-				keepGoing = false
-				err = fmt.Errorf("%w: unsupported position delete file format %s",
-					iceberg.ErrNotImplemented, file.FileFormat())
+			if manifest.ManifestContent() != iceberg.ManifestContentDeletes {
+				continue
 			}
-			if err != nil {
-				yieldError(fmt.Errorf("read position delete file %s: %w", file.FilePath(), err))
 
-				return
-			}
-			if !keepGoing {
-				return
+			for entry, err := range manifest.Entries(fs, true) {
+				if err != nil {
+					yieldError(fmt.Errorf("read manifest %s: %w", manifest.FilePath(), err))
+
+					return
+				}
+				if err := ctx.Err(); err != nil {
+					yieldError(err)
+
+					return
+				}
+				file := entry.DataFile()
+				if file.ContentType() != iceberg.EntryContentPosDeletes {
+					continue
+				}
+
+				var keepGoing bool
+				switch file.FileFormat() {
+				case iceberg.PuffinFile:
+					keepGoing, err = appendDeletionVectorRows(ctx, fs, file, appendRow)
+				case iceberg.ParquetFile:
+					keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow, appender.projection)
+				default:
+					keepGoing = false
+					err = fmt.Errorf("%w: unsupported position delete file format %s",
+						iceberg.ErrNotImplemented, file.FileFormat())
+				}
+				if err != nil {
+					yieldError(fmt.Errorf("read position delete file %s: %w", file.FilePath(), err))
+
+					return
+				}
+				if !keepGoing {
+					return
+				}
 			}
 		}
 

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -525,6 +525,7 @@ func canPromotePositionDeleteValue(source, destination arrow.DataType, formatVer
 		}
 
 		timestamp, ok := destination.(*arrow.TimestampType)
+
 		return ok && timestamp.TimeZone == "" &&
 			(timestamp.Unit == arrow.Microsecond || timestamp.Unit == arrow.Nanosecond)
 	case arrow.DECIMAL128:
@@ -781,11 +782,8 @@ func appendParquetPositionDeleteRows(
 		if positions.NullN() > 0 {
 			return false, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
 		}
-		for row := 0; row < positions.Len(); row++ {
-			if position := positions.Value(row); position < 0 {
-				return false, fmt.Errorf("%w: negative pos %d in position delete file",
-					iceberg.ErrInvalidSchema, position)
-			}
+		if err := validatePositionDeletePositions(positions); err != nil {
+			return false, err
 		}
 
 		rowIndex := -1
@@ -794,6 +792,9 @@ func appendParquetPositionDeleteRows(
 				iceberg.ErrInvalidSchema)
 		} else if len(indices) == 1 {
 			rowIndex = indices[0]
+		}
+		if rowIndex >= 0 && record.Column(rowIndex).NullN() > 0 {
+			return false, fmt.Errorf("%w: null row in position delete file", iceberg.ErrInvalidSchema)
 		}
 		for row := range int(record.NumRows()) {
 			if err := ctx.Err(); err != nil {

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -99,6 +99,9 @@ func (i InspectTable) currentPositionDeleteFiles(
 			if err != nil {
 				return nil, nil, fmt.Errorf("read manifest %s: %w", manifest.FilePath(), err)
 			}
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			if entry.DataFile().ContentType() == iceberg.EntryContentPosDeletes {
 				files = append(files, entry.DataFile())
 			}
@@ -535,6 +538,9 @@ func appendParquetPositionDeleteRows(
 			rowIndex = indices[0]
 		}
 		for row := range int(record.NumRows()) {
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
 			var deletedRow scalar.Scalar
 			if rowIndex >= 0 && !record.Column(rowIndex).IsNull(row) {
 				deletedRow, err = scalar.GetScalar(record.Column(rowIndex), row)

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -254,18 +254,6 @@ func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Str
 		}
 
 		fieldBuilder := builder.FieldBuilder(index)
-		if nestedBuilder, ok := fieldBuilder.(*array.StructBuilder); ok {
-			nestedValue, ok := value.(*scalar.Struct)
-			if !ok {
-				return fmt.Errorf("%w: field %q has type %s, want struct",
-					iceberg.ErrInvalidSchema, destinationField.Name, value.DataType())
-			}
-			if err := appendPositionDeleteStruct(nestedBuilder, nestedValue); err != nil {
-				return fmt.Errorf("field %q: %w", destinationField.Name, err)
-			}
-
-			continue
-		}
 		if err := appendPositionDeleteValue(fieldBuilder, value); err != nil {
 			return fmt.Errorf("field %q: %w", destinationField.Name, err)
 		}
@@ -275,6 +263,39 @@ func appendPositionDeleteStruct(builder *array.StructBuilder, source *scalar.Str
 }
 
 func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error {
+	if value == nil || !value.IsValid() {
+		builder.AppendNull()
+
+		return nil
+	}
+
+	switch builder := builder.(type) {
+	case *array.StructBuilder:
+		source, ok := value.(*scalar.Struct)
+		if !ok {
+			return fmt.Errorf("%w: value has type %s, want struct",
+				iceberg.ErrInvalidSchema, value.DataType())
+		}
+
+		return appendPositionDeleteStruct(builder, source)
+	case *array.MapBuilder:
+		source, ok := value.(*scalar.Map)
+		if !ok {
+			return fmt.Errorf("%w: value has type %s, want map",
+				iceberg.ErrInvalidSchema, value.DataType())
+		}
+
+		return appendPositionDeleteMap(builder, source)
+	case array.ListLikeBuilder:
+		source, ok := value.(scalar.ListScalar)
+		if !ok {
+			return fmt.Errorf("%w: value has type %s, want list",
+				iceberg.ErrInvalidSchema, value.DataType())
+		}
+
+		return appendPositionDeleteList(builder, source)
+	}
+
 	if arrow.TypeEqual(builder.Type(), value.DataType()) {
 		return scalar.Append(builder, value)
 	}
@@ -282,12 +303,135 @@ func appendPositionDeleteValue(builder array.Builder, value scalar.Scalar) error
 		return scalar.Append(builder, value)
 	}
 
-	casted, err := value.CastTo(builder.Type())
+	appendBuilder := builder
+	castType := builder.Type()
+	if storageBuilder, ok := builder.(positionDeleteStorageBuilder); ok {
+		appendBuilder = storageBuilder.StorageBuilder()
+		castType = appendBuilder.Type()
+	}
+	casted, err := castPositionDeleteValue(value, castType)
 	if err != nil {
 		return fmt.Errorf("promote %s to %s: %w", value.DataType(), builder.Type(), err)
 	}
+	if releasable, ok := casted.(scalar.Releasable); ok {
+		defer releasable.Release()
+	}
 
-	return scalar.Append(builder, casted)
+	return scalar.Append(appendBuilder, casted)
+}
+
+type positionDeleteStorageBuilder interface {
+	array.Builder
+	StorageBuilder() array.Builder
+}
+
+func appendPositionDeleteList(
+	builder array.ListLikeBuilder,
+	source scalar.ListScalar,
+) error {
+	if !isPositionDeleteListType(source.DataType()) {
+		return fmt.Errorf("%w: value has type %s, want list",
+			iceberg.ErrInvalidSchema, source.DataType())
+	}
+	values := source.GetList()
+	if values == nil {
+		return fmt.Errorf("%w: valid list value has no child array",
+			iceberg.ErrInvalidSchema)
+	}
+
+	if destination, ok := builder.Type().(*arrow.FixedSizeListType); ok &&
+		values.Len() != int(destination.Len()) {
+		return fmt.Errorf("%w: list value has %d elements, want %d",
+			iceberg.ErrInvalidSchema, values.Len(), destination.Len())
+	}
+
+	builder.Append(true)
+	valueBuilder := builder.ValueBuilder()
+	for index := range values.Len() {
+		child, err := scalar.GetScalar(values, index)
+		if err != nil {
+			return err
+		}
+		appendErr := appendPositionDeleteValue(valueBuilder, child)
+		if releasable, ok := child.(scalar.Releasable); ok {
+			releasable.Release()
+		}
+		if appendErr != nil {
+			return fmt.Errorf("list element %d: %w", index, appendErr)
+		}
+	}
+
+	return nil
+}
+
+func appendPositionDeleteMap(builder *array.MapBuilder, source *scalar.Map) error {
+	if source.DataType().ID() != arrow.MAP {
+		return fmt.Errorf("%w: value has type %s, want map",
+			iceberg.ErrInvalidSchema, source.DataType())
+	}
+	entries := source.GetList()
+	if entries == nil {
+		return fmt.Errorf("%w: valid map value has no entry array",
+			iceberg.ErrInvalidSchema)
+	}
+	entryType, ok := entries.DataType().(*arrow.StructType)
+	if !ok || entryType.NumFields() != 2 {
+		return fmt.Errorf("%w: map entries have type %s, want a two-field struct",
+			iceberg.ErrInvalidSchema, entries.DataType())
+	}
+	entryBuilder, ok := builder.ValueBuilder().(*array.StructBuilder)
+	if !ok {
+		return fmt.Errorf("%w: map builder has entry builder of type %T, want struct",
+			iceberg.ErrInvalidSchema, builder.ValueBuilder())
+	}
+
+	builder.Append(true)
+	for index := range entries.Len() {
+		entry, err := scalar.GetScalar(entries, index)
+		if err != nil {
+			return err
+		}
+		if !entry.IsValid() {
+			if releasable, ok := entry.(scalar.Releasable); ok {
+				releasable.Release()
+			}
+
+			return fmt.Errorf("%w: map entry %d is null", iceberg.ErrInvalidSchema, index)
+		}
+		appendErr := appendPositionDeleteValue(entryBuilder, entry)
+		if releasable, ok := entry.(scalar.Releasable); ok {
+			releasable.Release()
+		}
+		if appendErr != nil {
+			return fmt.Errorf("map entry %d: %w", index, appendErr)
+		}
+	}
+
+	return nil
+}
+
+func isPositionDeleteListType(typ arrow.DataType) bool {
+	switch typ.ID() {
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST:
+		return true
+	default:
+		return false
+	}
+}
+
+func castPositionDeleteValue(value scalar.Scalar, destination arrow.DataType) (scalar.Scalar, error) {
+	if destination.ID() == arrow.LARGE_BINARY {
+		if binary, ok := value.(scalar.BinaryScalar); ok {
+			return scalar.NewLargeBinaryScalar(binary.Buffer()), nil
+		}
+	}
+	if destination.ID() == arrow.LARGE_STRING {
+		if binary, ok := value.(scalar.BinaryScalar); ok {
+			return scalar.NewLargeStringScalarFromBuffer(binary.Buffer()), nil
+		}
+	}
+
+	return value.CastTo(destination)
 }
 
 func canPromotePositionDeleteValue(source, destination arrow.DataType) bool {
@@ -296,6 +440,27 @@ func canPromotePositionDeleteValue(source, destination arrow.DataType) bool {
 		return destination.ID() == arrow.INT64
 	case arrow.FLOAT32:
 		return destination.ID() == arrow.FLOAT64
+	case arrow.DECIMAL128:
+		sourceDecimal, sourceOK := source.(*arrow.Decimal128Type)
+		destinationDecimal, destinationOK := destination.(*arrow.Decimal128Type)
+
+		return sourceOK && destinationOK &&
+			sourceDecimal.Scale == destinationDecimal.Scale &&
+			sourceDecimal.Precision <= destinationDecimal.Precision
+	case arrow.STRING, arrow.LARGE_STRING:
+		return destination.ID() == arrow.BINARY || destination.ID() == arrow.LARGE_BINARY
+	case arrow.BINARY, arrow.LARGE_BINARY:
+		return destination.ID() == arrow.STRING || destination.ID() == arrow.LARGE_STRING
+	case arrow.FIXED_SIZE_BINARY:
+		sourceFixed, sourceOK := source.(*arrow.FixedSizeBinaryType)
+		destinationExtension, destinationOK := destination.(arrow.ExtensionType)
+		if !sourceOK || !destinationOK || sourceFixed.ByteWidth != 16 ||
+			destinationExtension.ExtensionName() != "arrow.uuid" {
+			return false
+		}
+		destinationFixed, destinationOK := destinationExtension.StorageType().(*arrow.FixedSizeBinaryType)
+
+		return destinationOK && destinationFixed.ByteWidth == 16
 	default:
 		return false
 	}

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -476,13 +476,15 @@ func castPositionDeleteValue(value scalar.Scalar, destination arrow.DataType) (s
 		}
 	}
 
-	if destination.ID() == arrow.LARGE_BINARY {
-		if binary, ok := value.(scalar.BinaryScalar); ok {
+	if binary, ok := value.(scalar.BinaryScalar); ok {
+		switch destination.ID() {
+		case arrow.BINARY:
+			return scalar.NewBinaryScalar(binary.Buffer(), destination), nil
+		case arrow.LARGE_BINARY:
 			return scalar.NewLargeBinaryScalar(binary.Buffer()), nil
-		}
-	}
-	if destination.ID() == arrow.LARGE_STRING {
-		if binary, ok := value.(scalar.BinaryScalar); ok {
+		case arrow.STRING:
+			return scalar.NewStringScalarFromBuffer(binary.Buffer()), nil
+		case arrow.LARGE_STRING:
 			return scalar.NewLargeStringScalarFromBuffer(binary.Buffer()), nil
 		}
 	}
@@ -536,9 +538,19 @@ func canPromotePositionDeleteValue(source, destination arrow.DataType, formatVer
 			sourceDecimal.Scale == destinationDecimal.Scale &&
 			sourceDecimal.Precision <= destinationDecimal.Precision
 	case arrow.STRING, arrow.LARGE_STRING:
-		return destination.ID() == arrow.BINARY || destination.ID() == arrow.LARGE_BINARY
+		switch destination.ID() {
+		case arrow.STRING, arrow.LARGE_STRING, arrow.BINARY, arrow.LARGE_BINARY:
+			return true
+		default:
+			return false
+		}
 	case arrow.BINARY, arrow.LARGE_BINARY:
-		return destination.ID() == arrow.STRING || destination.ID() == arrow.LARGE_STRING
+		switch destination.ID() {
+		case arrow.BINARY, arrow.LARGE_BINARY, arrow.STRING, arrow.LARGE_STRING:
+			return true
+		default:
+			return false
+		}
 	case arrow.FIXED_SIZE_BINARY:
 		sourceFixed, sourceOK := source.(*arrow.FixedSizeBinaryType)
 		destinationExtension, destinationOK := destination.(arrow.ExtensionType)

--- a/table/inspect_position_deletes_regression_test.go
+++ b/table/inspect_position_deletes_regression_test.go
@@ -1,0 +1,224 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/dv"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func writePositionDeleteManifestList(
+	t *testing.T,
+	fs iceio.WriteFileIO,
+	path string,
+	snapshotID int64,
+	parentSnapshotID *int64,
+	sequenceNumber int64,
+	manifests []iceberg.ManifestFile,
+) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(
+		2, &buf, snapshotID, parentSnapshotID, &sequenceNumber, 0, manifests))
+	require.NoError(t, fs.WriteFile(path, buf.Bytes()))
+}
+
+func TestInspectPositionDeletesV3MixesParquetAndDeletionVector(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	parquetDeletePath := "mem://position-deletes/table/data/delete.parquet"
+	parquetDataPath := "mem://position-deletes/table/data/parquet-data.parquet"
+	dvDataPath := "mem://position-deletes/table/data/dv-data.parquet"
+	dvPath := "mem://position-deletes/table/data/deletes.puffin"
+
+	writePosDeleteParquetToMemFS(t, memFS, parquetDeletePath, `[
+		{"file_path": "`+parquetDataPath+`", "pos": 2},
+		{"file_path": "`+parquetDataPath+`", "pos": 4}
+	]`)
+	parquetFile := newPosDeleteFile(t, parquetDeletePath, 2, 128)
+
+	dvWriter := dv.NewDVWriter(memFS, func(id int32) *iceberg.PartitionSpec {
+		if id == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	})
+	require.NoError(t, dvWriter.Add(dvDataPath, []int64{1, 3}, 0, nil))
+	dvFiles, err := dvWriter.Flush(context.Background(), dvPath)
+	require.NoError(t, err)
+	require.Len(t, dvFiles, 1)
+
+	tbl := inspectPositionDeletesTable(
+		t, 3, newInspectPositionDeletesMetadata(t, 3), memFS,
+		[]iceberg.DataFile{parquetFile, dvFiles[0]},
+	)
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 4, record.NumRows())
+	filePaths := record.Column(0).(*array.String)
+	require.Equal(t, parquetDataPath, filePaths.Value(0))
+	require.Equal(t, parquetDataPath, filePaths.Value(1))
+	require.Equal(t, dvDataPath, filePaths.Value(2))
+	require.Equal(t, dvDataPath, filePaths.Value(3))
+	require.Equal(t, []int64{2, 4, 1, 3}, record.Column(1).(*array.Int64).Int64Values())
+	require.EqualValues(t, 4, record.Column(2).NullN())
+
+	deleteFilePaths := record.Column(4).(*array.String)
+	require.Equal(t, parquetDeletePath, deleteFilePaths.Value(0))
+	require.Equal(t, parquetDeletePath, deleteFilePaths.Value(1))
+	require.Equal(t, dvPath, deleteFilePaths.Value(2))
+	require.Equal(t, dvPath, deleteFilePaths.Value(3))
+
+	offsets := record.Column(5).(*array.Int64)
+	require.True(t, offsets.IsNull(0))
+	require.True(t, offsets.IsNull(1))
+	require.Equal(t, *dvFiles[0].ContentOffset(), offsets.Value(2))
+	require.Equal(t, *dvFiles[0].ContentOffset(), offsets.Value(3))
+	sizes := record.Column(6).(*array.Int64)
+	require.True(t, sizes.IsNull(0))
+	require.True(t, sizes.IsNull(1))
+	require.Equal(t, *dvFiles[0].ContentSizeInBytes(), sizes.Value(2))
+	require.Equal(t, *dvFiles[0].ContentSizeInBytes(), sizes.Value(3))
+}
+
+func TestInspectPositionDeletesUsesLiveEntriesFromCurrentSnapshot(t *testing.T) {
+	memFS := iceio.NewMemFS()
+	tableSchema := simpleSchema()
+	oldSnapshotID := int64(1)
+	currentSnapshotID := int64(2)
+	oldSequenceNumber := int64(1)
+	currentSequenceNumber := int64(2)
+	oldDeletePath := "mem://position-deletes/table/data/expired.parquet"
+	currentDeletePath := "mem://position-deletes/table/data/current.parquet"
+	currentDataPath := "mem://position-deletes/table/data/current-data.parquet"
+
+	writePosDeleteParquetToMemFS(t, memFS, currentDeletePath, `[
+		{"file_path": "`+currentDataPath+`", "pos": 7}
+	]`)
+	oldDeleteFile := newPosDeleteFile(t, oldDeletePath, 1, 128)
+	currentDeleteFile := newPosDeleteFile(t, currentDeletePath, 1, 128)
+	deletedDeleteFile := newPosDeleteFile(t, "mem://position-deletes/table/data/removed.parquet", 1, 128)
+	equalityDeleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		"mem://position-deletes/table/data/equality.parquet", iceberg.ParquetFile,
+		nil, nil, nil, 1, 128)
+	require.NoError(t, err)
+	equalityDeleteFile := equalityDeleteBuilder.EqualityFieldIDs([]int{1}).Build()
+
+	entry := func(status iceberg.ManifestEntryStatus, snapshotID, sequenceNumber int64, file iceberg.DataFile) iceberg.ManifestEntry {
+		return iceberg.NewManifestEntry(status, &snapshotID, &sequenceNumber, &sequenceNumber, file)
+	}
+	oldManifest := writeInspectManifest(
+		t, memFS, "mem://position-deletes/table/metadata/expired.avro",
+		*iceberg.UnpartitionedSpec, tableSchema, oldSnapshotID, iceberg.ManifestContentDeletes,
+		[]iceberg.ManifestEntry{entry(iceberg.EntryStatusADDED, oldSnapshotID, oldSequenceNumber, oldDeleteFile)},
+	)
+	currentDeleteManifest := writeInspectManifest(
+		t, memFS, "mem://position-deletes/table/metadata/current-deletes.avro",
+		*iceberg.UnpartitionedSpec, tableSchema, currentSnapshotID, iceberg.ManifestContentDeletes,
+		[]iceberg.ManifestEntry{
+			entry(iceberg.EntryStatusADDED, currentSnapshotID, currentSequenceNumber, currentDeleteFile),
+			entry(iceberg.EntryStatusDELETED, currentSnapshotID, currentSequenceNumber, deletedDeleteFile),
+			entry(iceberg.EntryStatusADDED, currentSnapshotID, currentSequenceNumber, equalityDeleteFile),
+		},
+	)
+	dataFile := newTestDataFile(t, *iceberg.UnpartitionedSpec,
+		"mem://position-deletes/table/data/data-file.parquet", nil)
+	dataManifest := writeInspectManifest(
+		t, memFS, "mem://position-deletes/table/metadata/data.avro",
+		*iceberg.UnpartitionedSpec, tableSchema, currentSnapshotID, iceberg.ManifestContentData,
+		[]iceberg.ManifestEntry{entry(iceberg.EntryStatusADDED, currentSnapshotID, currentSequenceNumber, dataFile)},
+	)
+
+	oldManifestListPath := "mem://position-deletes/table/metadata/snap-1.avro"
+	currentManifestListPath := "mem://position-deletes/table/metadata/snap-2.avro"
+	writePositionDeleteManifestList(
+		t, memFS, oldManifestListPath, oldSnapshotID, nil, oldSequenceNumber,
+		[]iceberg.ManifestFile{oldManifest})
+	writePositionDeleteManifestList(
+		t, memFS, currentManifestListPath, currentSnapshotID, &oldSnapshotID, currentSequenceNumber,
+		[]iceberg.ManifestFile{currentDeleteManifest, dataManifest})
+
+	mb := newInspectPositionDeletesMetadataWithSchema(t, 2, tableSchema)
+	schemaID := tableSchema.ID
+	timestamp := time.Now().UnixMilli()
+	require.NoError(t, mb.AddSnapshot(&Snapshot{
+		SnapshotID: oldSnapshotID, SequenceNumber: oldSequenceNumber,
+		TimestampMs: timestamp, ManifestList: oldManifestListPath, SchemaID: &schemaID,
+	}))
+	require.NoError(t, mb.AddSnapshot(&Snapshot{
+		SnapshotID: currentSnapshotID, ParentSnapshotID: &oldSnapshotID,
+		SequenceNumber: currentSequenceNumber, TimestampMs: timestamp + 1,
+		ManifestList: currentManifestListPath, SchemaID: &schemaID,
+	}))
+	require.NoError(t, mb.SetSnapshotRef(MainBranch, currentSnapshotID, BranchRef))
+	metadata, err := mb.Build()
+	require.NoError(t, err)
+	tbl := New(
+		Identifier{"db", "position_deletes"}, metadata, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return memFS, nil }, nil,
+	)
+
+	rr, err := tbl.Inspect().PositionDeletes(context.Background())
+	require.NoError(t, err)
+	defer rr.Release()
+	record := collectRecord(t, rr)
+	defer record.Release()
+
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, currentDataPath, record.Column(0).(*array.String).Value(0))
+	require.EqualValues(t, 7, record.Column(1).(*array.Int64).Value(0))
+}
+
+func TestPositionDeletesPartitionTypeAvoidsHistoricalSchemaFieldIDs(t *testing.T) {
+	currentSchema := simpleSchema()
+	historicalSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 2, Name: "historical", Type: iceberg.PrimitiveTypes.String, Required: true,
+	})
+	spec := partitionedSpec()
+	lastPartitionID := 1000
+	metadata := &metadataV2{commonMetadata: commonMetadata{
+		FormatVersion:   2,
+		UUID:            uuid.New(),
+		LastColumnId:    2,
+		SchemaList:      []*iceberg.Schema{currentSchema, historicalSchema},
+		CurrentSchemaID: 0,
+		Specs:           []iceberg.PartitionSpec{spec},
+		DefaultSpecID:   0,
+		LastPartitionID: &lastPartitionID,
+	}}
+
+	partitionType, partitionIDs, err := positionDeletesPartitionType(metadata)
+	require.NoError(t, err)
+	require.Equal(t, map[int]int{1000: 3}, partitionIDs)
+	require.Equal(t, 3, partitionType.FieldList[0].ID)
+}


### PR DESCRIPTION
## Summary

- add position_deletes to Table.Inspect
- expose records from Parquet position delete files and v3 Puffin deletion vectors
- include partition/spec metadata, physical delete file paths, and v3 DV offsets
- omit the empty partition struct for unpartitioned tables and deconflict partition field IDs

## Dependency

Built on #1699, which currently depends on #1698. I will rebase as the parent PRs land.

## Testing

- go test ./...
- golangci-lint run --timeout=10m

Refs #1703