### PR TITLE
Add Transaction.RemoveProperties

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -3218,6 +3218,35 @@ func (t *TableTestSuite) TestRefresh() {
 	t.Equal(originalSpec, tbl.Spec())
 }
 
+func (t *TableTestSuite) TestTransactionRemoveProperties() {
+	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
+		"uri":          ":memory:",
+		"type":         "sql",
+		sql.DriverKey:  sqliteshim.ShimName,
+		sql.DialectKey: string(sql.SQLite),
+		"warehouse":    "file://" + t.T().TempDir(),
+	})
+	t.Require().NoError(err)
+
+	ident := table.Identifier{"test", "remove_properties_table"}
+	t.Require().NoError(cat.CreateNamespace(context.Background(), catalog.NamespaceFromIdent(ident), nil))
+
+	tbl, err := cat.CreateTable(context.Background(), ident, t.tbl.Schema(),
+		catalog.WithProperties(iceberg.Properties{"keep": "true", "drop": "true"}))
+	t.Require().NoError(err)
+	t.Require().NotNil(tbl)
+
+	txn := tbl.NewTransaction()
+	t.Require().NoError(txn.RemoveProperties([]string{"drop", "absent"}))
+
+	updated, err := txn.Commit(context.Background())
+	t.Require().NoError(err)
+
+	t.Equal("true", updated.Properties()["keep"])
+	_, ok := updated.Properties()["drop"]
+	t.False(ok)
+}
+
 func (t *TableTestSuite) TestMetadataCompressionRoundTrip() {
 	cat, err := catalog.Load(context.Background(), "default", iceberg.Properties{
 		"uri":          ":memory:",

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -313,6 +313,19 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 	return nil
 }
 
+// RemoveProperties removes the given property keys from the table. Keys that
+// are not currently set are ignored.
+func (t *Transaction) RemoveProperties(keys []string) error {
+	if _, err := t.txnMeta(); err != nil {
+		return err
+	}
+	if len(keys) > 0 {
+		return t.apply([]Update{NewRemovePropertiesUpdate(keys)}, nil)
+	}
+
+	return nil
+}
+
 // UpgradeFormatVersion upgrades the table to the given format version. Downgrading
 // is not allowed. If the table is already at the given version, this is a no-op.
 func (t *Transaction) UpgradeFormatVersion(version int) error {


### PR DESCRIPTION
## Key changes
- Adds `Transaction.RemoveProperties(keys []string) error`, mirroring the existing `SetProperties`.

## Motivation
`Transaction` currently supports setting table properties but has no way to remove them.