### PR TITLE
perf(table): reuse equality-delete key sets across scan tasks

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -19,10 +19,13 @@ package table
 
 import (
 	"bytes"
+	"cmp"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -42,7 +45,8 @@ var ErrAmbiguousEqualityColumn = errors.New("equality delete column is ambiguous
 // equalityDeleteSet holds the set of delete keys and the column names
 // used to look them up in data records. Each set corresponds to one
 // group of equality field IDs — delete files with different field IDs
-// produce separate sets.
+// produce separate sets. The set is immutable after construction so it
+// can be shared by tasks with the same delete files.
 type equalityDeleteSet struct {
 	keys     set[string]
 	fieldIDs []int
@@ -178,12 +182,18 @@ func makeArrowFieldEncoder(record arrow.RecordBatch, ref arrowFieldRef, fieldID 
 	}, nil
 }
 
+type equalityDeleteFileSet struct {
+	id int
+	*equalityDeleteSet
+}
+
 // readAllEqualityDeleteFiles reads all unique equality delete files from
 // the tasks and builds per-task delete key sets. Returns nil if there are
 // no equality deletes. Delete files with different equality field IDs are
 // kept as separate sets (not merged).
 func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceberg.Schema, nameMapping iceberg.NameMapping, tasks []FileScanTask, concurrency int) (map[int][]*equalityDeleteSet, error) {
 	type deleteFileInfo struct {
+		id       int
 		file     iceberg.DataFile
 		fieldIDs []int
 	}
@@ -204,6 +214,7 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 			hasAny = true
 			if _, ok := uniqueDeletes[d.FilePath()]; !ok {
 				uniqueDeletes[d.FilePath()] = deleteFileInfo{
+					id:       len(uniqueDeletes),
 					file:     d,
 					fieldIDs: d.EqualityFieldIDs(),
 				}
@@ -216,6 +227,7 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 	}
 
 	type deleteFileResult struct {
+		id       int
 		path     string
 		fieldIDs []int
 		colNames []string
@@ -238,6 +250,7 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 				}
 
 				resultCh <- deleteFileResult{
+					id:       info.id,
 					path:     info.file.FilePath(),
 					fieldIDs: info.fieldIDs,
 					colNames: colNames,
@@ -251,18 +264,15 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 		_ = g.Wait()
 	}()
 
-	type perFileDeleteKeys struct {
-		fieldIDs []int
-		colNames []string
-		keys     set[string]
-	}
-
-	perFile := make(map[string]*perFileDeleteKeys)
+	perFile := make(map[string]*equalityDeleteFileSet)
 	for result := range resultCh {
-		perFile[result.path] = &perFileDeleteKeys{
-			fieldIDs: result.fieldIDs,
-			colNames: result.colNames,
-			keys:     result.keys,
+		perFile[result.path] = &equalityDeleteFileSet{
+			id: result.id,
+			equalityDeleteSet: &equalityDeleteSet{
+				fieldIDs: result.fieldIDs,
+				colNames: result.colNames,
+				keys:     result.keys,
+			},
 		}
 	}
 
@@ -270,16 +280,26 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 		return nil, err
 	}
 
-	// Build per-task delete sets. Group by field IDs so delete files with
-	// different equality field sets are applied independently.
+	return buildEqualityDeleteSetsPerTask(tasks, perFile), nil
+}
+
+// buildEqualityDeleteSetsPerTask groups delete files by field IDs and merges
+// their keys into the sets used by each scan task.
+func buildEqualityDeleteSetsPerTask(
+	tasks []FileScanTask,
+	perFile map[string]*equalityDeleteFileSet,
+) map[int][]*equalityDeleteSet {
 	perTask := make(map[int][]*equalityDeleteSet)
+	// File IDs are sufficient as the cache key because each ID identifies one
+	// immutable delete set with a fixed equality-field group for this call.
+	sharedSets := make(map[string]*equalityDeleteSet)
 	for i, t := range tasks {
 		if len(t.EqualityDeleteFiles) == 0 {
 			continue
 		}
 
 		// Group delete files by their field IDs key.
-		groups := make(map[string]*equalityDeleteSet)
+		groups := make(map[string][]*equalityDeleteFileSet)
 		for _, d := range t.EqualityDeleteFiles {
 			dk, ok := perFile[d.FilePath()]
 			if !ok {
@@ -287,25 +307,14 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 			}
 
 			groupKey := fmt.Sprint(dk.fieldIDs)
-			g, exists := groups[groupKey]
-			if !exists {
-				g = &equalityDeleteSet{
-					keys:     make(set[string]),
-					fieldIDs: dk.fieldIDs,
-					colNames: dk.colNames,
-				}
-				groups[groupKey] = g
-			}
-
-			for k := range dk.keys {
-				g.keys[k] = struct{}{}
-			}
+			groups[groupKey] = append(groups[groupKey], dk)
 		}
 
 		sets := make([]*equalityDeleteSet, 0, len(groups))
-		for _, g := range groups {
-			if len(g.keys) > 0 {
-				sets = append(sets, g)
+		for _, files := range groups {
+			deleteSet := equalityDeleteSetForFiles(files, sharedSets)
+			if len(deleteSet.keys) > 0 {
+				sets = append(sets, deleteSet)
 			}
 		}
 
@@ -314,7 +323,47 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 		}
 	}
 
-	return perTask, nil
+	return perTask
+}
+
+func equalityDeleteSetForFiles(
+	files []*equalityDeleteFileSet,
+	sharedSets map[string]*equalityDeleteSet,
+) *equalityDeleteSet {
+	slices.SortFunc(files, func(a, b *equalityDeleteFileSet) int {
+		return cmp.Compare(a.id, b.id)
+	})
+	files = slices.CompactFunc(files, func(a, b *equalityDeleteFileSet) bool {
+		return a.id == b.id
+	})
+
+	if len(files) == 1 {
+		return files[0].equalityDeleteSet
+	}
+
+	combinationKey := make([]byte, 0, len(files)*8)
+	for _, file := range files {
+		combinationKey = binary.LittleEndian.AppendUint64(combinationKey, uint64(file.id))
+	}
+	key := string(combinationKey)
+	if deleteSet, ok := sharedSets[key]; ok {
+		return deleteSet
+	}
+
+	deleteSet := &equalityDeleteSet{
+		keys:     make(set[string]),
+		fieldIDs: files[0].fieldIDs,
+		colNames: files[0].colNames,
+	}
+	for _, file := range files {
+		for key := range file.keys {
+			deleteSet.keys[key] = struct{}{}
+		}
+	}
+
+	sharedSets[key] = deleteSet
+
+	return deleteSet
 }
 
 // readEqualityDeleteFile reads a single equality delete file and returns

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -362,3 +362,115 @@ func TestResolveArrowFieldRejectsDuplicateMetadataIDs(t *testing.T) {
 	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
 	require.ErrorContains(t, err, "data.parquet")
 }
+
+func TestBuildEqualityDeleteSetsPerTaskSharesIdenticalSets(t *testing.T) {
+	deleteA := newEqualityDeleteSetAssemblyTestFile(t, "delete-a.parquet", []int{1})
+	deleteB := newEqualityDeleteSetAssemblyTestFile(t, "delete-b.parquet", []int{1})
+	deleteC := newEqualityDeleteSetAssemblyTestFile(t, "delete-c.parquet", []int{1})
+
+	perFile := map[string]*equalityDeleteFileSet{
+		deleteA.FilePath(): {
+			id: 0,
+			equalityDeleteSet: &equalityDeleteSet{
+				keys:     set[string]{"a": {}},
+				fieldIDs: []int{1},
+				colNames: []string{"id"},
+			},
+		},
+		deleteB.FilePath(): {
+			id: 1,
+			equalityDeleteSet: &equalityDeleteSet{
+				keys:     set[string]{"b": {}},
+				fieldIDs: []int{1},
+				colNames: []string{"id"},
+			},
+		},
+		deleteC.FilePath(): {
+			id: 2,
+			equalityDeleteSet: &equalityDeleteSet{
+				keys:     set[string]{"c": {}},
+				fieldIDs: []int{1},
+				colNames: []string{"id"},
+			},
+		},
+	}
+
+	tasks := []FileScanTask{
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteA}},
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteA}},
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteA, deleteB}},
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteB, deleteA}},
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteA, deleteB, deleteA}},
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteA, deleteC}},
+	}
+
+	perTask := buildEqualityDeleteSetsPerTask(tasks, perFile)
+	require.Len(t, perTask, len(tasks))
+
+	assert.Same(t, perFile[deleteA.FilePath()].equalityDeleteSet, perTask[0][0])
+	assert.Same(t, perTask[0][0], perTask[1][0])
+	assert.Same(t, perTask[2][0], perTask[3][0])
+	assert.Same(t, perTask[2][0], perTask[4][0])
+	assert.NotSame(t, perTask[2][0], perTask[5][0])
+	assert.Equal(t, set[string]{"a": {}, "b": {}}, perTask[2][0].keys)
+	assert.Equal(t, set[string]{"a": {}, "c": {}}, perTask[5][0].keys)
+}
+
+func TestBuildEqualityDeleteSetsPerTaskKeepsFieldGroupsSeparate(t *testing.T) {
+	deleteID := newEqualityDeleteSetAssemblyTestFile(t, "delete-id.parquet", []int{1})
+	deleteCategory := newEqualityDeleteSetAssemblyTestFile(t, "delete-category.parquet", []int{2})
+
+	perFile := map[string]*equalityDeleteFileSet{
+		deleteID.FilePath(): {
+			id: 0,
+			equalityDeleteSet: &equalityDeleteSet{
+				keys:     set[string]{"id": {}},
+				fieldIDs: []int{1},
+				colNames: []string{"id"},
+			},
+		},
+		deleteCategory.FilePath(): {
+			id: 1,
+			equalityDeleteSet: &equalityDeleteSet{
+				keys:     set[string]{"category": {}},
+				fieldIDs: []int{2},
+				colNames: []string{"category"},
+			},
+		},
+	}
+
+	perTask := buildEqualityDeleteSetsPerTask([]FileScanTask{{
+		EqualityDeleteFiles: []iceberg.DataFile{deleteID, deleteCategory},
+	}}, perFile)
+	require.Len(t, perTask[0], 2)
+
+	setsByFieldID := make(map[int]*equalityDeleteSet)
+	for _, deleteSet := range perTask[0] {
+		setsByFieldID[deleteSet.fieldIDs[0]] = deleteSet
+	}
+	assert.Same(t, perFile[deleteID.FilePath()].equalityDeleteSet, setsByFieldID[1])
+	assert.Same(t, perFile[deleteCategory.FilePath()].equalityDeleteSet, setsByFieldID[2])
+}
+
+func newEqualityDeleteSetAssemblyTestFile(
+	t *testing.T,
+	path string,
+	fieldIDs []int,
+) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentEqDeletes,
+		path,
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		128,
+	)
+	require.NoError(t, err)
+
+	return builder.EqualityFieldIDs(fieldIDs).Build()
+}

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -144,6 +144,80 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows with id=2 and id=4 deleted")
 }
 
+func TestEqualityDeleteReadSharesMultiFileUnionAcrossConcurrentTasks(t *testing.T) {
+	ctx := t.Context()
+	tbl := newEqDeleteReadTestTable(t)
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, false, false)
+	require.NoError(t, err)
+
+	dataPaths := []string{
+		tbl.Location() + "/data/data-001.parquet",
+		tbl.Location() + "/data/data-002.parquet",
+	}
+	writeParquetFile(t, dataPaths[0], arrowSc, `[
+		{"id": 1, "data": "one"},
+		{"id": 2, "data": "two"}
+	]`)
+	writeParquetFile(t, dataPaths[1], arrowSc, `[
+		{"id": 3, "data": "three"},
+		{"id": 4, "data": "four"}
+	]`)
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(ctx, dataPaths, nil, false))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	deleteSchema, err := table.SchemaToArrowSchema(
+		iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		), nil, true, false)
+	require.NoError(t, err)
+	deleteTwoRecords, releaseTwo := makeEqDeleteRecords(t, deleteSchema, `[{"id": 2}]`)
+	defer releaseTwo()
+	deleteThreeRecords, releaseThree := makeEqDeleteRecords(t, deleteSchema, `[{"id": 3}]`)
+	defer releaseThree()
+
+	tx = tbl.NewTransaction()
+	deleteTwoFiles, err := tx.WriteEqualityDeletes(ctx, []int{1}, deleteTwoRecords)
+	require.NoError(t, err)
+	deleteThreeFiles, err := tx.WriteEqualityDeletes(ctx, []int{1}, deleteThreeRecords)
+	require.NoError(t, err)
+	require.Len(t, deleteTwoFiles, 1)
+	require.Len(t, deleteThreeFiles, 1)
+	require.NotEqual(t, deleteTwoFiles[0].FilePath(), deleteThreeFiles[0].FilePath())
+
+	rowDelta := tx.NewRowDelta(nil)
+	rowDelta.AddDeletes(deleteTwoFiles...)
+	rowDelta.AddDeletes(deleteThreeFiles...)
+	require.NoError(t, rowDelta.Commit(ctx))
+	tbl, err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	scan := tbl.Scan(table.WithMaxConcurrency(4), table.WithSelectedFields("id"))
+	tasks, err := scan.PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	for _, task := range tasks {
+		require.Len(t, task.EqualityDeleteFiles, 2,
+			"each task must use the same multi-file equality-delete union")
+	}
+
+	_, records, err := scan.ReadTasks(ctx, tasks)
+	require.NoError(t, err)
+	var ids []int64
+	for record, err := range records {
+		require.NoError(t, err)
+		column := record.Column(0).(*array.Int64)
+		for i := 0; i < column.Len(); i++ {
+			ids = append(ids, column.Value(i))
+		}
+		record.Release()
+	}
+
+	assert.ElementsMatch(t, []int64{1, 4}, ids)
+}
+
 func TestEqualityDeleteReadResolvesRenamedDataColumnByFieldID(t *testing.T) {
 	tbl := newEqDeleteReadTestTable(t)
 

--- a/table/equality_delete_set_assembly_bench_test.go
+++ b/table/equality_delete_set_assembly_bench_test.go
@@ -1,0 +1,202 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var equalityDeleteAssemblyBenchmarkSink map[int][]*equalityDeleteSet
+
+func BenchmarkEqualityDeleteSetAssembly(b *testing.B) {
+	benchmarks := []struct {
+		name                string
+		combinations        int
+		tasksPerCombination int
+		filesPerCombination int
+		keysPerFile         int
+	}{
+		{
+			name:                "shared-single-file",
+			combinations:        1,
+			tasksPerCombination: 1_000,
+			filesPerCombination: 1,
+			keysPerFile:         1_000,
+		},
+		{
+			name:                "shared-four-file-union",
+			combinations:        1,
+			tasksPerCombination: 1_000,
+			filesPerCombination: 4,
+			keysPerFile:         250,
+		},
+		{
+			name:                "partitioned-four-file-unions",
+			combinations:        100,
+			tasksPerCombination: 10,
+			filesPerCombination: 4,
+			keysPerFile:         250,
+		},
+		{
+			name:                "unique-two-file-unions",
+			combinations:        1_000,
+			tasksPerCombination: 1,
+			filesPerCombination: 2,
+			keysPerFile:         100,
+		},
+	}
+
+	for _, benchmark := range benchmarks {
+		tasks, perFile := equalityDeleteAssemblyBenchmarkInput(
+			b,
+			benchmark.combinations,
+			benchmark.tasksPerCombination,
+			benchmark.filesPerCombination,
+			benchmark.keysPerFile,
+		)
+
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.Run("shared", func(b *testing.B) {
+				benchmarkEqualityDeleteSetAssembly(b, tasks, func() map[int][]*equalityDeleteSet {
+					return buildEqualityDeleteSetsPerTask(tasks, perFile)
+				})
+			})
+			b.Run("copy-per-task", func(b *testing.B) {
+				benchmarkEqualityDeleteSetAssembly(b, tasks, func() map[int][]*equalityDeleteSet {
+					return buildEqualityDeleteSetsPerTaskWithCopies(tasks, perFile)
+				})
+			})
+		})
+	}
+}
+
+func benchmarkEqualityDeleteSetAssembly(
+	b *testing.B,
+	tasks []FileScanTask,
+	build func() map[int][]*equalityDeleteSet,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(tasks)), "tasks")
+	b.ResetTimer()
+	for range b.N {
+		equalityDeleteAssemblyBenchmarkSink = build()
+	}
+	if len(equalityDeleteAssemblyBenchmarkSink) != len(tasks) {
+		b.Fatalf("expected sets for %d tasks, got %d", len(tasks), len(equalityDeleteAssemblyBenchmarkSink))
+	}
+}
+
+func buildEqualityDeleteSetsPerTaskWithCopies(
+	tasks []FileScanTask,
+	perFile map[string]*equalityDeleteFileSet,
+) map[int][]*equalityDeleteSet {
+	perTask := make(map[int][]*equalityDeleteSet)
+	for taskIndex, task := range tasks {
+		groups := make(map[string]*equalityDeleteSet)
+		for _, deleteFile := range task.EqualityDeleteFiles {
+			fileSet, ok := perFile[deleteFile.FilePath()]
+			if !ok {
+				continue
+			}
+
+			groupKey := fmt.Sprint(fileSet.fieldIDs)
+			deleteSet, exists := groups[groupKey]
+			if !exists {
+				deleteSet = &equalityDeleteSet{
+					keys:     make(set[string]),
+					fieldIDs: fileSet.fieldIDs,
+					colNames: fileSet.colNames,
+				}
+				groups[groupKey] = deleteSet
+			}
+
+			for key := range fileSet.keys {
+				deleteSet.keys[key] = struct{}{}
+			}
+		}
+
+		sets := make([]*equalityDeleteSet, 0, len(groups))
+		for _, deleteSet := range groups {
+			if len(deleteSet.keys) > 0 {
+				sets = append(sets, deleteSet)
+			}
+		}
+		if len(sets) > 0 {
+			perTask[taskIndex] = sets
+		}
+	}
+
+	return perTask
+}
+
+func equalityDeleteAssemblyBenchmarkInput(
+	b *testing.B,
+	combinations, tasksPerCombination, filesPerCombination, keysPerFile int,
+) ([]FileScanTask, map[string]*equalityDeleteFileSet) {
+	b.Helper()
+
+	tasks := make([]FileScanTask, 0, combinations*tasksPerCombination)
+	perFile := make(map[string]*equalityDeleteFileSet, combinations*filesPerCombination)
+	fileID := 0
+
+	for combination := range combinations {
+		deleteFiles := make([]iceberg.DataFile, filesPerCombination)
+		for fileIndex := range filesPerCombination {
+			path := fmt.Sprintf("delete-%d-%d.parquet", combination, fileIndex)
+			builder, err := iceberg.NewDataFileBuilder(
+				*iceberg.UnpartitionedSpec,
+				iceberg.EntryContentEqDeletes,
+				path,
+				iceberg.ParquetFile,
+				nil,
+				nil,
+				nil,
+				int64(keysPerFile),
+				128,
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			deleteFiles[fileIndex] = builder.EqualityFieldIDs([]int{1}).Build()
+
+			keys := make(set[string], keysPerFile)
+			for keyIndex := range keysPerFile {
+				keys[fmt.Sprintf("key-%d-%d", fileID, keyIndex)] = struct{}{}
+			}
+			perFile[path] = &equalityDeleteFileSet{
+				id: fileID,
+				equalityDeleteSet: &equalityDeleteSet{
+					keys:     keys,
+					fieldIDs: []int{1},
+					colNames: []string{"id"},
+				},
+			}
+			fileID++
+		}
+
+		for range tasksPerCombination {
+			tasks = append(tasks, FileScanTask{EqualityDeleteFiles: deleteFiles})
+		}
+	}
+
+	return tasks, perFile
+}


### PR DESCRIPTION
## Summary

Equality delete files are already deduplicated and read once, but their decoded key maps are copied into a fresh union for every scan task. When many tasks share the same delete files, setup time and memory therefore grow with the number of tasks rather than the number of distinct delete-file combinations.

This change reuses the decoded key sets during per-task assembly:

* a group backed by one delete file points directly at that file's key set
* multi-file groups are canonicalized by delete-file ID and identical combinations share one merged set
* duplicate references to the same delete file are removed before building a union
* delete files with different equality field IDs remain separate, as before

The branch is based on the current equality-delete reader. Name mapping, structural field-ID resolution, nested fields, ambiguous-column validation, and per-data-file field resolution all happen unchanged. Sharing begins only after each delete file has been decoded.

The shared sets are immutable during record filtering, so the scan hot path still performs one lookup per equality-field group. It does not add a chain of underlying maps or change row filtering behavior.

This is independent of #1752. That PR speeds up deciding which equality delete files apply during planning; this change avoids repeatedly materializing their decoded key unions before reading rows.

## Benchmarks

Representative medians from five runs with three iterations each on an Apple M1 Pro:

| Workload | Copy per task | Shared | Speedup | Memory before | Memory after |
|---|---:|---:|---:|---:|---:|
| 1 file, 1 combination | 68.27 ms | 0.31 ms | 219x | 109.3 MB | 0.22 MB |
| 4 files, 1 combination | 71.98 ms | 0.87 ms | 83x | 109.4 MB | 0.49 MB |
| 4 files, 100 combinations | 71.24 ms | 8.57 ms | 8.3x | 109.4 MB | 11.30 MB |
| 2 files, 1,000 unique combinations | 10.97 ms | 10.78 ms | 1.0x | 13.8 MB | 13.97 MB |

Each workload has 1,000 tasks. The shared cases model global or partition-level deletes used by multiple data files. The fully unique case is included as a control and remains effectively neutral.

Command:

    go test ./table -run '^$' -bench '^BenchmarkEqualityDeleteSetAssembly$' -benchmem -benchtime=3x -count=5

## Testing

* full repository test suite
* focused equality-delete tests under the race detector
* golangci-lint
* scan-level regression with two data tasks sharing the same two-file delete union and four reader workers
* helper coverage for singleton sharing, order-independent combinations, duplicate references, distinct combinations, and separate field-ID groups