### PR TITLE
perf(table): batch concurrent manifest entry collection

### DIFF
--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -152,6 +152,20 @@ func TestManifestEntries_ConcurrentMerge(t *testing.T) {
 			path:        "s3://bucket/data/pos-del-001.parquet",
 			contentType: iceberg.EntryContentPosDeletes,
 		}),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+			path:        "s3://bucket/data/eq-del-001.parquet",
+			contentType: iceberg.EntryContentEqDeletes,
+		}),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &dvMockDataFile{
+			mockDataFile: mockDataFile{
+				path:        "s3://bucket/data/dv-001.puffin",
+				contentType: iceberg.EntryContentPosDeletes,
+				format:      iceberg.PuffinFile,
+			},
+			referencedDataFile: strPtr("s3://bucket/data/data-001.parquet"),
+			contentOffset:      int64Ptr(0),
+			contentSizeInBytes: int64Ptr(128),
+		}),
 	}
 
 	const manifestCount = 64
@@ -168,6 +182,8 @@ func TestManifestEntries_ConcurrentMerge(t *testing.T) {
 
 	assert.Len(t, entries.dataEntries, manifestCount)
 	assert.Len(t, entries.positionalDeleteEntries, manifestCount)
+	assert.Len(t, entries.equalityDeleteEntries, manifestCount)
+	assert.Len(t, entries.dvEntries, manifestCount)
 }
 
 func TestDVMatchingToDataFiles(t *testing.T) {

--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -94,7 +95,6 @@ func TestIsDeletionVector(t *testing.T) {
 }
 
 func TestManifestEntries_DVClassification(t *testing.T) {
-	entries := newManifestEntries()
 	snapshotID := int64(1)
 
 	// Data entry
@@ -102,16 +102,12 @@ func TestManifestEntries_DVClassification(t *testing.T) {
 		path:        "s3://bucket/data/data-001.parquet",
 		contentType: iceberg.EntryContentData,
 	}
-	entries.addDataEntry(iceberg.NewManifestEntry(
-		iceberg.EntryStatusADDED, &snapshotID, nil, nil, dataFile))
 
 	// Regular position delete entry
 	posDelFile := &mockDataFile{
 		path:        "s3://bucket/data/pos-del-001.parquet",
 		contentType: iceberg.EntryContentPosDeletes,
 	}
-	entries.addPositionalDeleteEntry(iceberg.NewManifestEntry(
-		iceberg.EntryStatusADDED, &snapshotID, nil, nil, posDelFile))
 
 	// DV entry
 	dvFile := &dvMockDataFile{
@@ -124,21 +120,54 @@ func TestManifestEntries_DVClassification(t *testing.T) {
 		contentOffset:      int64Ptr(0),
 		contentSizeInBytes: int64Ptr(128),
 	}
-	entries.addDVEntry(iceberg.NewManifestEntry(
-		iceberg.EntryStatusADDED, &snapshotID, nil, nil, dvFile))
 
 	// Equality delete entry
 	eqDelFile := &mockDataFile{
 		path:        "s3://bucket/data/eq-del-001.parquet",
 		contentType: iceberg.EntryContentEqDeletes,
 	}
-	entries.addEqualityDeleteEntry(iceberg.NewManifestEntry(
-		iceberg.EntryStatusADDED, &snapshotID, nil, nil, eqDelFile))
+
+	entries := newManifestEntries()
+	assert.NoError(t, entries.merge([]iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, dataFile),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, posDelFile),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, dvFile),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, eqDelFile),
+	}))
 
 	assert.Len(t, entries.dataEntries, 1)
 	assert.Len(t, entries.positionalDeleteEntries, 1)
 	assert.Len(t, entries.dvEntries, 1)
 	assert.Len(t, entries.equalityDeleteEntries, 1)
+}
+
+func TestManifestEntries_ConcurrentMerge(t *testing.T) {
+	snapshotID := int64(1)
+	batch := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+			path:        "s3://bucket/data/data-001.parquet",
+			contentType: iceberg.EntryContentData,
+		}),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+			path:        "s3://bucket/data/pos-del-001.parquet",
+			contentType: iceberg.EntryContentPosDeletes,
+		}),
+	}
+
+	const manifestCount = 64
+	entries := newManifestEntries()
+	var wg sync.WaitGroup
+	for range manifestCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, entries.merge(batch))
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, entries.dataEntries, manifestCount)
+	assert.Len(t, entries.positionalDeleteEntries, manifestCount)
 }
 
 func TestDVMatchingToDataFiles(t *testing.T) {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -146,28 +146,30 @@ func newManifestEntries() *manifestEntries {
 	}
 }
 
-func (m *manifestEntries) addDataEntry(e iceberg.ManifestEntry) {
+func (m *manifestEntries) merge(entries []iceberg.ManifestEntry) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.dataEntries = append(m.dataEntries, e)
-}
 
-func (m *manifestEntries) addPositionalDeleteEntry(e iceberg.ManifestEntry) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.positionalDeleteEntries = append(m.positionalDeleteEntries, e)
-}
+	for _, entry := range entries {
+		dataFile := entry.DataFile()
+		switch dataFile.ContentType() {
+		case iceberg.EntryContentData:
+			m.dataEntries = append(m.dataEntries, entry)
+		case iceberg.EntryContentPosDeletes:
+			if IsDeletionVector(dataFile) {
+				m.dvEntries = append(m.dvEntries, entry)
+			} else {
+				m.positionalDeleteEntries = append(m.positionalDeleteEntries, entry)
+			}
+		case iceberg.EntryContentEqDeletes:
+			m.equalityDeleteEntries = append(m.equalityDeleteEntries, entry)
+		default:
+			return fmt.Errorf("%w: unknown DataFileContent type (%s): %s",
+				ErrInvalidMetadata, dataFile.ContentType(), entry)
+		}
+	}
 
-func (m *manifestEntries) addEqualityDeleteEntry(e iceberg.ManifestEntry) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.equalityDeleteEntries = append(m.equalityDeleteEntries, e)
-}
-
-func (m *manifestEntries) addDVEntry(e iceberg.ManifestEntry) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.dvEntries = append(m.dvEntries, e)
+	return nil
 }
 
 func newPartitionRecord(partitionData map[int]any, partitionType *iceberg.StructType) partitionRecord {
@@ -770,24 +772,8 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 			if err != nil {
 				return err
 			}
-
-			for _, e := range manifestEntries {
-				df := e.DataFile()
-				switch df.ContentType() {
-				case iceberg.EntryContentData:
-					entries.addDataEntry(e)
-				case iceberg.EntryContentPosDeletes:
-					if IsDeletionVector(e.DataFile()) {
-						entries.addDVEntry(e)
-					} else {
-						entries.addPositionalDeleteEntry(e)
-					}
-				case iceberg.EntryContentEqDeletes:
-					entries.addEqualityDeleteEntry(e)
-				default:
-					return fmt.Errorf("%w: unknown DataFileContent type (%s): %s",
-						ErrInvalidMetadata, df.ContentType(), e)
-				}
+			if err := entries.merge(manifestEntries); err != nil {
+				return err
 			}
 
 			return nil

--- a/table/scanner_manifest_entries_bench_test.go
+++ b/table/scanner_manifest_entries_bench_test.go
@@ -20,10 +20,10 @@ package table
 import (
 	"fmt"
 	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"golang.org/x/sync/errgroup"
 )
 
 func BenchmarkManifestEntryCollection(b *testing.B) {
@@ -34,49 +34,48 @@ func BenchmarkManifestEntryCollection(b *testing.B) {
 		{name: "data", content: iceberg.ManifestContentData},
 		{name: "deletes", content: iceberg.ManifestContentDeletes},
 	} {
-		for _, manifestCount := range []int{1, 8, 64} {
-			const entryCount = 1_000
-			name := fmt.Sprintf("content=%s/manifests=%d/entries=%d", workload.name, manifestCount, entryCount)
-			b.Run(name, func(b *testing.B) {
-				entries := benchmarkManifestEntries(entryCount, workload.content)
-				b.ReportAllocs()
-				b.SetBytes(int64(manifestCount * entryCount))
-				b.ResetTimer()
+		for _, manifestCount := range []int{8, 64} {
+			for _, concurrency := range []int{1, 4, 16} {
+				const entryCount = 1_000
+				name := fmt.Sprintf("content=%s/manifests=%d/concurrency=%d/entries=%d",
+					workload.name, manifestCount, concurrency, entryCount)
+				b.Run(name, func(b *testing.B) {
+					entries := benchmarkManifestEntries(entryCount, workload.content)
+					b.ReportAllocs()
+					b.ResetTimer()
+					b.ReportMetric(float64(manifestCount*entryCount), "entries/op")
 
-				var result *manifestEntries
-				for range b.N {
-					result = collectManifestEntryBatches(entries, manifestCount)
-				}
+					var result *manifestEntries
+					for range b.N {
+						result = collectManifestEntryBatches(entries, manifestCount, concurrency)
+					}
 
-				if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
-					len(result.equalityDeleteEntries)+len(result.dvEntries), manifestCount*entryCount; got != want {
-					b.Fatalf("collected %d entries, want %d", got, want)
-				}
-				runtime.KeepAlive(result)
-			})
+					if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
+						len(result.equalityDeleteEntries)+len(result.dvEntries), manifestCount*entryCount; got != want {
+						b.Fatalf("collected %d entries, want %d", got, want)
+					}
+					runtime.KeepAlive(result)
+				})
+			}
 		}
 	}
 }
 
-func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount int) *manifestEntries {
+func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount, concurrency int) *manifestEntries {
 	collected := newManifestEntries()
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(manifestCount)
+	var g errgroup.Group
+	g.SetLimit(min(concurrency, manifestCount))
 	for range manifestCount {
-		go func() {
-			defer wg.Done()
-			<-start
-
+		g.Go(func() error {
 			manifestEntries := append(make([]iceberg.ManifestEntry, 0, len(entries)), entries...)
-			if err := collected.merge(manifestEntries); err != nil {
-				panic(err)
-			}
-		}()
+
+			return collected.merge(manifestEntries)
+		})
 	}
 
-	close(start)
-	wg.Wait()
+	if err := g.Wait(); err != nil {
+		panic(err)
+	}
 
 	return collected
 }

--- a/table/scanner_manifest_entries_bench_test.go
+++ b/table/scanner_manifest_entries_bench_test.go
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+func BenchmarkManifestEntryCollection(b *testing.B) {
+	for _, workload := range []struct {
+		name    string
+		content iceberg.ManifestContent
+	}{
+		{name: "data", content: iceberg.ManifestContentData},
+		{name: "deletes", content: iceberg.ManifestContentDeletes},
+	} {
+		for _, manifestCount := range []int{1, 8, 64} {
+			const entryCount = 1_000
+			name := fmt.Sprintf("content=%s/manifests=%d/entries=%d", workload.name, manifestCount, entryCount)
+			b.Run(name, func(b *testing.B) {
+				entries := benchmarkManifestEntries(entryCount, workload.content)
+				b.ReportAllocs()
+				b.SetBytes(int64(manifestCount * entryCount))
+				b.ResetTimer()
+
+				var result *manifestEntries
+				for range b.N {
+					result = collectManifestEntryBatches(entries, manifestCount)
+				}
+
+				if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
+					len(result.equalityDeleteEntries)+len(result.dvEntries), manifestCount*entryCount; got != want {
+					b.Fatalf("collected %d entries, want %d", got, want)
+				}
+				runtime.KeepAlive(result)
+			})
+		}
+	}
+}
+
+func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount int) *manifestEntries {
+	collected := newManifestEntries()
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(manifestCount)
+	for range manifestCount {
+		go func() {
+			defer wg.Done()
+			<-start
+
+			manifestEntries := append(make([]iceberg.ManifestEntry, 0, len(entries)), entries...)
+			if err := collected.merge(manifestEntries); err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	return collected
+}
+
+func benchmarkManifestEntries(count int, content iceberg.ManifestContent) []iceberg.ManifestEntry {
+	snapshotID := int64(1)
+	dataFiles := []iceberg.DataFile{&mockDataFile{
+		path: "data.parquet", contentType: iceberg.EntryContentData,
+	}}
+	if content == iceberg.ManifestContentDeletes {
+		dataFiles = []iceberg.DataFile{
+			&mockDataFile{path: "pos-delete.parquet", contentType: iceberg.EntryContentPosDeletes},
+			&mockDataFile{path: "eq-delete.parquet", contentType: iceberg.EntryContentEqDeletes},
+			&dvMockDataFile{
+				mockDataFile:       mockDataFile{path: "dv.puffin", contentType: iceberg.EntryContentPosDeletes, format: iceberg.PuffinFile},
+				referencedDataFile: strPtr("data.parquet"),
+				contentOffset:      int64Ptr(0),
+				contentSizeInBytes: int64Ptr(128),
+			},
+		}
+	}
+
+	entries := make([]iceberg.ManifestEntry, count)
+	for i := range entries {
+		entries[i] = iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, nil, nil, dataFiles[i%len(dataFiles)])
+	}
+
+	return entries
+}

--- a/table/scanner_manifest_entries_bench_test.go
+++ b/table/scanner_manifest_entries_bench_test.go
@@ -27,6 +27,32 @@ import (
 )
 
 func BenchmarkManifestEntryCollection(b *testing.B) {
+	benchmarkCases := []struct {
+		manifestCount int
+		concurrency   int
+		entryCount    int
+	}{
+		{manifestCount: 8, concurrency: 1, entryCount: 1_000},
+		{manifestCount: 8, concurrency: 4, entryCount: 1_000},
+		{manifestCount: 8, concurrency: 16, entryCount: 1_000},
+		{manifestCount: 64, concurrency: 1, entryCount: 1_000},
+		{manifestCount: 64, concurrency: 4, entryCount: 1_000},
+		{manifestCount: 64, concurrency: 16, entryCount: 1_000},
+		{manifestCount: 8, concurrency: 1, entryCount: 10_000},
+		{manifestCount: 8, concurrency: 4, entryCount: 10_000},
+		{manifestCount: 8, concurrency: 16, entryCount: 10_000},
+		{manifestCount: 16, concurrency: 1, entryCount: 10_000},
+		{manifestCount: 16, concurrency: 4, entryCount: 10_000},
+		{manifestCount: 16, concurrency: 16, entryCount: 10_000},
+		{manifestCount: 64, concurrency: 1, entryCount: 10_000},
+		{manifestCount: 64, concurrency: 4, entryCount: 10_000},
+		{manifestCount: 64, concurrency: 16, entryCount: 10_000},
+		{manifestCount: 8, concurrency: 4, entryCount: 100_000},
+		{manifestCount: 8, concurrency: 16, entryCount: 100_000},
+		{manifestCount: 16, concurrency: 4, entryCount: 100_000},
+		{manifestCount: 16, concurrency: 16, entryCount: 100_000},
+	}
+
 	for _, workload := range []struct {
 		name    string
 		content iceberg.ManifestContent
@@ -34,29 +60,26 @@ func BenchmarkManifestEntryCollection(b *testing.B) {
 		{name: "data", content: iceberg.ManifestContentData},
 		{name: "deletes", content: iceberg.ManifestContentDeletes},
 	} {
-		for _, manifestCount := range []int{8, 64} {
-			for _, concurrency := range []int{1, 4, 16} {
-				const entryCount = 1_000
-				name := fmt.Sprintf("content=%s/manifests=%d/concurrency=%d/entries=%d",
-					workload.name, manifestCount, concurrency, entryCount)
-				b.Run(name, func(b *testing.B) {
-					entries := benchmarkManifestEntries(entryCount, workload.content)
-					b.ReportAllocs()
-					b.ResetTimer()
-					b.ReportMetric(float64(manifestCount*entryCount), "entries/op")
+		for _, benchmarkCase := range benchmarkCases {
+			name := fmt.Sprintf("content=%s/manifests=%d/concurrency=%d/entries=%d",
+				workload.name, benchmarkCase.manifestCount, benchmarkCase.concurrency, benchmarkCase.entryCount)
+			b.Run(name, func(b *testing.B) {
+				entries := benchmarkManifestEntries(benchmarkCase.entryCount, workload.content)
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportMetric(float64(benchmarkCase.manifestCount*benchmarkCase.entryCount), "entries/op")
 
-					var result *manifestEntries
-					for range b.N {
-						result = collectManifestEntryBatches(entries, manifestCount, concurrency)
-					}
+				var result *manifestEntries
+				for range b.N {
+					result = collectManifestEntryBatches(entries, benchmarkCase.manifestCount, benchmarkCase.concurrency)
+				}
 
-					if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
-						len(result.equalityDeleteEntries)+len(result.dvEntries), manifestCount*entryCount; got != want {
-						b.Fatalf("collected %d entries, want %d", got, want)
-					}
-					runtime.KeepAlive(result)
-				})
-			}
+				if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
+					len(result.equalityDeleteEntries)+len(result.dvEntries), benchmarkCase.manifestCount*benchmarkCase.entryCount; got != want {
+					b.Fatalf("collected %d entries, want %d", got, want)
+				}
+				runtime.KeepAlive(result)
+			})
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- collect each manifest batch under one mutex acquisition
- reduce synchronization from once per accepted entry to once per manifest
- preserve the existing data, delete, equality delete, and deletion vector classification

## Benchmarks

`go test ./table -run "^$" -bench "^BenchmarkManifestEntryCollection$" -benchmem -benchtime=2s -count=6 -cpu=4`

The benchmark now models manifest count and scanner concurrency separately. `-cpu=4` sets GOMAXPROCS, while `concurrency=4` applies the same active manifest limit as the scanner.

With 1,000 entries per manifest on an Apple M1 Pro:

| Workload | Manifest concurrency | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 64 data manifests | 4 | 7.484 ms | 2.761 ms | 2.7x |
| 64 delete manifests | 4 | 7.616 ms | 1.803 ms | 4.2x |

For example, the 64-delete-manifest workload is about 4x faster with the production-style concurrency limit. `B/op` and `allocs/op` are unchanged in both cases.

The benchmark also covers larger manifests:

- 10,000 entries per manifest at 8, 16, and 64 manifests, with concurrency 1, 4, and 16
- 100,000 entries per manifest at 8 and 16 manifests, with concurrency 4 and 16
- 38 total subbenchmarks across data and delete workloads

A one-iteration run of all 38 subbenchmarks completed successfully on an Apple M1 Pro.

## Validation

- `go test ./...`
- `go test ./table -count=1`
- `go test -race ./table -run "TestManifestEntries_(DVClassification|ConcurrentMerge)$" -count=1`
- `go test ./table -run "^$" -bench "^BenchmarkManifestEntryCollection$" -benchmem -benchtime=1x -count=1`
- `golangci-lint run --timeout=10m`