### PR TITLE
feat(dv): add SetRange and RunLengthEncode to RoaringPositionBitmap

### DIFF
--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -114,7 +114,12 @@ func DeserializeDV(data []byte, expectedCardinality int64) (*RoaringPositionBitm
 //   - Magic  (4 bytes, little-endian): DVMagicNumber
 //   - Bitmap (variable): roaring bitmap in Iceberg portable format
 //   - CRC-32 (4 bytes, big-endian): checksum over magic + bitmap
+//
+// The bitmap is run-length encoded in place before it is written, matching
+// Java's BitmapPositionDeleteIndex.serialize.
 func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
+	bitmap.RunLengthEncode()
+
 	var bitmapBuf bytes.Buffer
 	if err := bitmap.Serialize(&bitmapBuf); err != nil {
 		return nil, fmt.Errorf("serialize roaring bitmap: %w", err)

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -220,6 +220,69 @@ type failingOpenFS struct {
 func (f failingOpenFS) Open(string) (iceio.File, error) { return nil, f.err }
 func (f failingOpenFS) Remove(string) error             { return nil }
 
+// Why: SerializeDV run-length encodes before emitting bytes, so a caller that
+// records contiguous deletes one position at a time still gets a compact blob
+// rather than dense containers. Without that step the envelope carries a full
+// 8 KiB word block per container.
+// Condition: 100,000 contiguous positions recorded with individual Set calls,
+// measured against what the bare bitmap encoder would have produced.
+// Assertion: the envelope is two orders of magnitude smaller and still decodes
+// to the same positions and cardinality.
+func TestSerializeDVRunLengthEncodesContiguousPositions(t *testing.T) {
+	const positions = 100_000
+
+	bm := NewRoaringPositionBitmap()
+	for pos := uint64(0); pos < positions; pos++ {
+		bm.Set(pos)
+	}
+
+	var unencoded bytes.Buffer
+	require.NoError(t, bm.Serialize(&unencoded))
+
+	data, err := SerializeDV(bm)
+	require.NoError(t, err)
+	t.Logf("%d contiguous positions: %d bytes unencoded, %d bytes in the DV envelope",
+		positions, unencoded.Len(), len(data))
+
+	assert.Less(t, len(data), unencoded.Len()/100, "run encoding must dominate the envelope size")
+
+	got, err := DeserializeDV(data, positions)
+	require.NoError(t, err)
+	assert.Equal(t, int64(positions), got.Cardinality())
+	assert.True(t, got.Contains(0))
+	assert.True(t, got.Contains(positions-1))
+	assert.False(t, got.Contains(positions))
+}
+
+// Why: SetRange is the cheap way to record a block-granular delete, and its
+// output has to survive the envelope it was built for.
+// Condition: two disjoint ranges in one bucket plus one in a higher bucket,
+// round-tripped through SerializeDV and DeserializeDV.
+// Assertion: cardinality and membership at both ends of every range survive,
+// and the gaps between ranges stay undeleted.
+func TestSerializeDVRoundTripsRanges(t *testing.T) {
+	const bucket = uint64(1) << 32
+
+	bm := NewRoaringPositionBitmap()
+	bm.SetRange(0, 1000)
+	bm.SetRange(5000, 5010)
+	bm.SetRange(bucket-5, bucket+5)
+
+	data, err := SerializeDV(bm)
+	require.NoError(t, err)
+
+	got, err := DeserializeDV(data, bm.Cardinality())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1020), got.Cardinality())
+	for _, pos := range []uint64{0, 999, 5000, 5009, bucket - 5, bucket - 1, bucket, bucket + 4} {
+		assert.Truef(t, got.Contains(pos), "position %d should survive the round trip", pos)
+	}
+	for _, pos := range []uint64{1000, 4999, 5010, bucket - 6, bucket + 5} {
+		assert.Falsef(t, got.Contains(pos), "position %d was never deleted", pos)
+	}
+}
+
 // Why: proves the DV envelope can successfully decode a representative valid blob.
 // Condition: Java-produced DV with deleted positions [1, 3, 5, 7, 9] and cardinality validation disabled.
 // Assertion: no error, cardinality is 5, expected positions are present, and an adjacent unset position is absent.

--- a/table/dv/dv_cross_client_test.go
+++ b/table/dv/dv_cross_client_test.go
@@ -101,15 +101,11 @@ func TestCrossClientReadJavaMultiBlobDV(t *testing.T) {
 }
 
 // TestCrossClientGoSerializeMatchesJavaSingleArrayContainer asserts byte-equal
-// envelope output for the narrow case it actually covers: scattered
-// low-cardinality positions [1, 3, 5, 7, 9] that fit in a single roaring
-// array container. Byte equality is *not* a general cross-client guarantee:
-// Java's BitmapPositionDeleteIndex.serialize() runs runLengthEncode() before
-// emitting bytes, while Go's RoaringPositionBitmap.Serialize() does not, so
-// for range-style deletes (or any input that hits the array→bitmap or
-// run-encoded thresholds) the two outputs diverge at the byte level while
-// both remaining spec-compliant. End-to-end interop for those cases is
-// covered by TestCrossClientReadJavaSingleBlobDV / ...MultiBlobDV.
+// envelope output for scattered low-cardinality positions [1, 3, 5, 7, 9] that
+// fit in a single roaring array container — the shape run encoding leaves
+// alone, since five single-value runs cost more than five array entries.
+// Together with ...AllContainerTypes it pins both sides of the run-encoding
+// decision against Java's own output.
 func TestCrossClientGoSerializeMatchesJavaSingleArrayContainer(t *testing.T) {
 	javaBytes := readDVTestData(t, "small-alternating-values-position-index.bin")
 
@@ -125,6 +121,58 @@ func TestCrossClientGoSerializeMatchesJavaSingleArrayContainer(t *testing.T) {
 
 	assert.Equal(t, javaBytes, goBytes,
 		"Go-serialized envelope must match Java byte-for-byte for a single-array-container fixture")
+}
+
+// TestCrossClientGoSerializeMatchesJavaAllContainerTypes rebuilds the position
+// set behind Java's all-container-types fixture with SetRange and Set, then
+// asserts the Go envelope is byte-identical to Java's. The fixture is the
+// strongest available parity check for range writes: Java built it from
+// PositionDeleteIndex.delete(posStart, posEnd) calls — setRange under the hood —
+// and emitted it through BitmapPositionDeleteIndex.serialize, which
+// run-length encodes first. It therefore pins three things at once: SetRange
+// splits a range across buckets and containers exactly as Java does, Go's
+// roaring library run-encodes to the same bytes, and SerializeDV run-encodes at
+// all. Drop the run encoding and 132,561 positions balloon from 94 bytes to
+// tens of kilobytes of dense containers, and this assertion fails.
+func TestCrossClientGoSerializeMatchesJavaAllContainerTypes(t *testing.T) {
+	const (
+		bucketOffset    = uint64(1) << 32 // one 32-bit roaring bitmap per key
+		containerOffset = uint64(1) << 16 // one roaring container per 65,536 positions
+	)
+	// position mirrors the fixture generator's helper in Java's
+	// TestBitmapPositionDeleteIndex, addressing a position by which bucket and
+	// which container within that bucket it lands in.
+	position := func(bucket, container int, value uint64) uint64 {
+		return uint64(bucket)*bucketOffset + uint64(container)*containerOffset + value
+	}
+
+	bm := NewRoaringPositionBitmap()
+	for _, bucket := range []int{0, 1} {
+		// Container 0: two scattered positions, which stay an array container.
+		// Container 1: a range short enough that roaring keeps it as a
+		// run-encoded array. Container 2: a range covering all but the first
+		// and last position of the container, which starts as a dense bitmap.
+		switch bucket {
+		case 0:
+			bm.Set(position(bucket, 0, 5))
+			bm.Set(position(bucket, 0, 7))
+			bm.SetRange(position(bucket, 1, 1), position(bucket, 1, 1000))
+		case 1:
+			bm.Set(position(bucket, 0, 10))
+			bm.Set(position(bucket, 0, 20))
+			bm.SetRange(position(bucket, 1, 10), position(bucket, 1, 500))
+		}
+		bm.SetRange(position(bucket, 2, 1), position(bucket, 2, containerOffset-1))
+	}
+	require.Equal(t, int64(132561), bm.Cardinality(), "reconstructed fixture cardinality")
+
+	javaBytes := readDVTestData(t, "all-container-types-position-index.bin")
+	goBytes, err := SerializeDV(bm)
+	require.NoError(t, err)
+	t.Logf("%d positions serialize to %d bytes", bm.Cardinality(), len(goBytes))
+
+	assert.Equal(t, javaBytes, goBytes,
+		"Go-serialized envelope must match Java byte-for-byte for range-built deletes across all container types")
 }
 
 // TestCrossClientHighKeyFixtureRejected asserts Go rejects the same

--- a/table/dv/roaring_bitmap.go
+++ b/table/dv/roaring_bitmap.go
@@ -54,14 +54,56 @@ func NewRoaringPositionBitmap() *RoaringPositionBitmap {
 
 // Set marks a position in the bitmap.
 func (b *RoaringPositionBitmap) Set(pos uint64) {
-	key := uint32(pos >> 32)
-	low := uint32(pos)
+	b.bucket(uint32(pos >> 32)).Add(uint32(pos))
+}
+
+// SetRange marks every position in [startInclusive, endExclusive), like Java's
+// setRange. An empty or inverted range is a no-op (no mutator on this type
+// panics or reports errors).
+func (b *RoaringPositionBitmap) SetRange(startInclusive, endExclusive uint64) {
+	if startInclusive >= endExclusive {
+		return
+	}
+
+	// Bucket off the last included position: a range ending exactly on a
+	// bucket boundary must not allocate an empty bitmap for the bucket above.
+	lastPos := endExclusive - 1
+	startKey, endKey := uint32(startInclusive>>32), uint32(lastPos>>32)
+
+	// roaring's AddRange is [start, end) over 32-bit values but takes uint64
+	// bounds so that a whole bucket can be expressed as [0, 1<<32).
+	if startKey == endKey {
+		b.bucket(startKey).AddRange(uint64(uint32(startInclusive)), uint64(uint32(lastPos))+1)
+
+		return
+	}
+
+	b.bucket(startKey).AddRange(uint64(uint32(startInclusive)), 1<<32)
+	for key := startKey + 1; key < endKey; key++ {
+		b.bucket(key).AddRange(0, 1<<32)
+	}
+	b.bucket(endKey).AddRange(0, uint64(uint32(lastPos))+1)
+}
+
+// RunLengthEncode re-encodes each bucket's containers as runs wherever runs
+// are more compact, like Java's runLengthEncode. Membership and cardinality
+// are unchanged.
+func (b *RoaringPositionBitmap) RunLengthEncode() {
+	for _, bm := range b.bitmaps {
+		bm.RunOptimize()
+	}
+}
+
+// bucket returns the 32-bit bitmap holding the low bits for key, allocating it
+// on first use.
+func (b *RoaringPositionBitmap) bucket(key uint32) *roaring.Bitmap {
 	bm, ok := b.bitmaps[key]
 	if !ok {
 		bm = roaring.New()
 		b.bitmaps[key] = bm
 	}
-	bm.Add(low)
+
+	return bm
 }
 
 // Or merges every position set in other into b. Buckets present only in

--- a/table/dv/roaring_bitmap_test.go
+++ b/table/dv/roaring_bitmap_test.go
@@ -20,6 +20,8 @@ package dv
 import (
 	"bytes"
 	"encoding/binary"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -349,6 +351,225 @@ func TestRoaringBitmapSetContainsAndCardinality(t *testing.T) {
 	assert.False(t, bm.Contains((uint64(1)<<32)|6))
 	assert.False(t, bm.Contains((uint64(2)<<32)|1))
 	assert.False(t, bm.Contains(uint64(100)<<32))
+}
+
+// Why: SetRange has to split a 64-bit range across 32-bit buckets, and every
+// boundary in that split is a place an off-by-one silently deletes the wrong
+// rows. Condition: ranges wholly inside a bucket, ending and starting exactly
+// on a bucket boundary, spanning two and three buckets, plus the degenerate
+// empty and inverted cases. Assertion: exactly the in-range positions are set,
+// the neighbours on both sides are not, and no bucket is allocated for a range
+// that does not reach it.
+func TestRoaringBitmapSetRange(t *testing.T) {
+	const bucket = uint64(1) << 32
+
+	for _, tt := range []struct {
+		name        string
+		start, end  uint64
+		cardinality int64
+		set         []uint64
+		unset       []uint64
+		buckets     []uint32
+	}{
+		{
+			name: "within one bucket", start: 10, end: 15, cardinality: 5,
+			set: []uint64{10, 11, 14}, unset: []uint64{9, 15}, buckets: []uint32{0},
+		},
+		{
+			name: "single position", start: 7, end: 8, cardinality: 1,
+			set: []uint64{7}, unset: []uint64{6, 8}, buckets: []uint32{0},
+		},
+		{
+			name: "crossing a roaring container boundary", start: 65530, end: 65540, cardinality: 10,
+			set: []uint64{65530, 65535, 65536, 65539}, unset: []uint64{65529, 65540}, buckets: []uint32{0},
+		},
+		{
+			// The last included position is bucket 0's highest, so bucket 1
+			// must not be allocated at all — bucketing endExclusive instead of
+			// endExclusive-1 would create an empty bucket 1 and change the
+			// serialized bitmap count.
+			name: "ending exactly on a bucket boundary", start: bucket - 4, end: bucket, cardinality: 4,
+			set: []uint64{bucket - 4, bucket - 1}, unset: []uint64{bucket - 5, bucket}, buckets: []uint32{0},
+		},
+		{
+			name: "starting exactly on a bucket boundary", start: bucket, end: bucket + 3, cardinality: 3,
+			set: []uint64{bucket, bucket + 2}, unset: []uint64{bucket - 1, bucket + 3}, buckets: []uint32{1},
+		},
+		{
+			name: "spanning a bucket boundary", start: bucket - 3, end: bucket + 4, cardinality: 7,
+			set:   []uint64{bucket - 3, bucket - 1, bucket, bucket + 3},
+			unset: []uint64{bucket - 4, bucket + 4}, buckets: []uint32{0, 1},
+		},
+		{
+			// Three buckets exercises the middle-bucket loop, where every
+			// position of bucket 1 must be set without any range arithmetic
+			// derived from the caller's start or end.
+			name: "spanning three buckets", start: 2*bucket - 1, end: 3*bucket + 1,
+			cardinality: int64(bucket) + 2,
+			set:         []uint64{2*bucket - 1, 2 * bucket, 3*bucket - 1, 3 * bucket},
+			unset:       []uint64{2*bucket - 2, 3*bucket + 1}, buckets: []uint32{1, 2, 3},
+		},
+		{
+			name: "empty range", start: 5, end: 5,
+			unset: []uint64{4, 5, 6},
+		},
+		{
+			// Java's setRange throws on an inverted range; the Go port has no
+			// error channel here, so the documented behaviour is a no-op.
+			name: "inverted range", start: 9, end: 5,
+			unset: []uint64{4, 5, 8, 9, 10},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bm := NewRoaringPositionBitmap()
+			bm.SetRange(tt.start, tt.end)
+
+			assert.Equal(t, tt.cardinality, bm.Cardinality())
+			for _, pos := range tt.set {
+				assert.Truef(t, bm.Contains(pos), "position %d should be set", pos)
+			}
+			for _, pos := range tt.unset {
+				assert.Falsef(t, bm.Contains(pos), "position %d should not be set", pos)
+			}
+			assert.ElementsMatch(t, tt.buckets, slices.Collect(maps.Keys(bm.bitmaps)),
+				"allocated buckets")
+		})
+	}
+}
+
+// Why: SetRange is only a shortcut if it produces exactly what the per-position
+// Set loop it replaces would have produced; a divergence would delete or spare
+// rows depending on which API the writer happened to use.
+// Condition: ranges inside one bucket, across a bucket boundary, and appended to
+// an already-populated bitmap, each mirrored by a Set loop over every position.
+// Assertion: identical membership and cardinality (container encoding may
+// differ — SetRange yields runs where Set yields arrays).
+func TestRoaringBitmapSetRangeMatchesPerPositionSet(t *testing.T) {
+	const bucket = uint64(1) << 32
+
+	for _, tt := range []struct {
+		name       string
+		seed       []uint64
+		start, end uint64
+	}{
+		{name: "within one bucket", start: 1000, end: 5000},
+		{name: "spanning a bucket boundary", start: bucket - 100, end: bucket + 100},
+		{name: "merged into existing positions", seed: []uint64{0, 2500, 999999}, start: 1000, end: 5000},
+		{name: "overlapping itself", seed: []uint64{1000, 1001, 1002}, start: 1000, end: 1003},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ranged, looped := NewRoaringPositionBitmap(), NewRoaringPositionBitmap()
+			for _, pos := range tt.seed {
+				ranged.Set(pos)
+				looped.Set(pos)
+			}
+
+			ranged.SetRange(tt.start, tt.end)
+			for pos := tt.start; pos < tt.end; pos++ {
+				looped.Set(pos)
+			}
+
+			assertSamePositions(t, looped, ranged)
+		})
+	}
+}
+
+// Why: KeepMaskBytes reads each bucket through roaring's dense conversion, a
+// path that until SetRange existed only ever saw array and bitmap containers in
+// Go-built bitmaps. A range write installs run containers instead, so the mask
+// has to be correct for those too — otherwise a reader would keep rows the
+// writer deleted.
+// Condition: a range that stops mid-word, alongside a scattered position.
+// Assertion: exactly the in-range positions are dropped from the keep mask.
+func TestKeepMaskBytesAfterSetRange(t *testing.T) {
+	bitAt := func(mask []byte, i int64) bool {
+		return mask[i>>3]&(1<<uint(i&7)) != 0
+	}
+
+	bm := NewRoaringPositionBitmap()
+	bm.SetRange(10, 70)
+	bm.Set(100)
+
+	mask := bm.KeepMaskBytes(128)
+	require.Len(t, mask, 16)
+	for i := int64(0); i < 128; i++ {
+		deleted := (i >= 10 && i < 70) || i == 100
+		assert.Equalf(t, !deleted, bitAt(mask, i), "position %d: deleted=%v", i, deleted)
+	}
+}
+
+// Why: run-length encoding is the whole reason a range-shaped deletion set is
+// cheap on the wire, and it must not disturb the positions it re-encodes.
+// Condition: a bitmap built one position at a time over a 100,000-position
+// contiguous stretch — two dense bitmap containers — serialized before and
+// after RunLengthEncode.
+// Assertion: the encoded bitmap shrinks, membership and cardinality survive,
+// and the shrunken bytes still round-trip through the deserializer.
+func TestRoaringBitmapRunLengthEncode(t *testing.T) {
+	const positions = 100_000
+
+	bm := NewRoaringPositionBitmap()
+	for pos := uint64(0); pos < positions; pos++ {
+		bm.Set(pos)
+	}
+
+	var before bytes.Buffer
+	require.NoError(t, bm.Serialize(&before))
+
+	bm.RunLengthEncode()
+
+	var after bytes.Buffer
+	require.NoError(t, bm.Serialize(&after))
+	t.Logf("bare bitmap serialization: %d bytes before RunLengthEncode, %d after", before.Len(), after.Len())
+
+	assert.Less(t, after.Len(), before.Len(), "run encoding must shrink a contiguous stretch")
+	assert.Equal(t, int64(positions), bm.Cardinality())
+
+	got, err := DeserializeRoaringPositionBitmap(after.Bytes())
+	require.NoError(t, err)
+	assertSamePositions(t, bm, got)
+	assert.False(t, got.Contains(positions))
+}
+
+// Why: run encoding must be a no-op, not a corruption, for the scattered
+// low-cardinality bitmaps that make up most deletion vectors.
+// Condition: alternating positions that roaring keeps as an array container.
+// Assertion: membership and cardinality are unchanged and the bitmap still
+// serializes and round-trips.
+func TestRoaringBitmapRunLengthEncodeScatteredPositions(t *testing.T) {
+	bm := NewRoaringPositionBitmap()
+	positions := []uint64{1, 3, 5, 7, 9, (uint64(1) << 32) | 11}
+	for _, pos := range positions {
+		bm.Set(pos)
+	}
+
+	bm.RunLengthEncode()
+
+	assert.Equal(t, int64(len(positions)), bm.Cardinality())
+	for _, pos := range positions {
+		assert.Truef(t, bm.Contains(pos), "position %d should survive run encoding", pos)
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, bm.Serialize(&buf))
+	got, err := DeserializeRoaringPositionBitmap(buf.Bytes())
+	require.NoError(t, err)
+	assertSamePositions(t, bm, got)
+}
+
+// assertSamePositions asserts two bitmaps hold the same positions. It compares
+// buckets with roaring's Equals, which tests membership rather than container
+// encoding, so a run-encoded bucket matches an array-encoded bucket holding the
+// same positions.
+func assertSamePositions(t *testing.T, want, got *RoaringPositionBitmap) {
+	t.Helper()
+
+	require.Equal(t, want.Cardinality(), got.Cardinality(), "cardinality")
+	require.ElementsMatch(t, slices.Collect(maps.Keys(want.bitmaps)), slices.Collect(maps.Keys(got.bitmaps)),
+		"allocated buckets")
+	for key, wantBucket := range want.bitmaps {
+		assert.Truef(t, wantBucket.Equals(got.bitmaps[key]), "bucket %d holds different positions", key)
+	}
 }
 
 // Why: Serialize and DeserializeRoaringPositionBitmap together define the Go encoding contract for non-empty bitmaps.


### PR DESCRIPTION
Fixes #1757.

`Set` was the only mutator on `RoaringPositionBitmap`, so range-shaped deletes (dead blocks or row groups) cost one call per position and serialized as array or dense bitmap containers. This adds, mirroring Java's `RoaringPositionBitmap`:

- **`SetRange(startInclusive, endExclusive uint64)`** — marks `[start, end)` with one roaring `AddRange` per 2^32-position bucket (Java: `setRange`).
- **`RunLengthEncode()`** — re-encodes each bucket's containers as runs where smaller (Java: `runLengthEncode`).
- **`SerializeDV`** now run-length encodes before emitting bytes, matching `BitmapPositionDeleteIndex.serialize`. For 100,000 contiguous positions the DV envelope drops from 8,235 to 49 bytes; output remains spec-valid (run containers are flagged in the portable format's cookie header).

Two deliberate deviations from Java, documented in the code: an inverted range is a no-op rather than an exception (no mutator on this type panics or errors, and uint64 already excludes Java's negative-position case), and `RunLengthEncode` returns nothing (roaring's `RunOptimize` doesn't report whether it changed anything).

## Testing

- New unit tests: range within/spanning/ending-on bucket boundaries, empty and inverted ranges, `SetRange`≡`Set`-loop equivalence, serialized-size reduction with round-trip membership/cardinality equality.
- New cross-client test rebuilds Java's `all-container-types-position-index.bin` fixture (132,561 positions across array/run/dense containers in two buckets) via `SetRange`/`Set` and asserts the Go envelope is byte-identical to Java's 94 bytes — it passes only with serialize-time run encoding, pinning the parity decision.
- Existing Java golden fixtures still match byte-for-byte; the comment on `TestCrossClientGoSerializeMatchesJavaSingleArrayContainer` that described the old serialize-time divergence from Java is corrected to match.
- `go test ./...`, `gofmt`, `golangci-lint run` all clean locally.
