### PR TITLE
fix(cli): validate refs type before loading table

### DIFF
--- a/cmd/iceberg/snapshots.go
+++ b/cmd/iceberg/snapshots.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -35,8 +36,25 @@ func runSnapshots(ctx context.Context, output Output, cat catalog.Catalog, cmd *
 }
 
 func runRefs(ctx context.Context, output Output, cat catalog.Catalog, cmd *RefsCmd) {
+	if err := validateRefType(cmd.Type); err != nil {
+		output.Error(err)
+		osExit(1)
+
+		return
+	}
+
 	tbl := loadTable(ctx, output, cat, cmd.TableID)
 	output.Refs(tbl, cmd.Type)
+}
+
+func validateRefType(refType string) error {
+	switch refType {
+	case "", string(table.BranchRef), string(table.TagRef):
+		return nil
+	default:
+		return fmt.Errorf("invalid --type %q: expected %q or %q",
+			refType, table.BranchRef, table.TagRef)
+	}
 }
 
 func buildSnapshotEntries(tbl *table.Table) []SnapshotEntry {

--- a/cmd/iceberg/snapshots_test.go
+++ b/cmd/iceberg/snapshots_test.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -148,6 +149,23 @@ func TestBuildRefEntries(t *testing.T) {
 	assert.Equal(t, "v1.0", tags[0].Name)
 	require.NotNil(t, tags[0].MaxRefAgeMs)
 	assert.Equal(t, int64(86400000), *tags[0].MaxRefAgeMs)
+}
+
+func TestRunRefsRejectsInvalidTypeBeforeLoad(t *testing.T) {
+	cat := &loadTrackingCatalog{}
+	var out errCapture
+
+	exitCode := captureExit(func() {
+		runRefs(context.Background(), &out, cat, &RefsCmd{
+			TableID: "db.evnets",
+			Type:    "foo",
+		})
+	})
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, out.lastErr)
+	assert.Contains(t, out.lastErr.Error(), "invalid --type")
+	assert.Zero(t, cat.loadCount)
 }
 
 func TestTextOutputSnapshots(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reject invalid `refs --type` values before loading table metadata
- Allow only `branch`, `tag`, or an omitted type filter.

## Testing
- `go test ./cmd/iceberg -run TestRunRefsRejectsInvalidTypeBeforeLoad -v`
- `go test ./cmd/iceberg`
