### PR TITLE
test(catalog): add namespace lifecycle conformance tests

### DIFF
--- a/catalog/catalogtest/catalogtest.go
+++ b/catalog/catalogtest/catalogtest.go
@@ -94,6 +94,13 @@ func RunCatalogTests(t *testing.T, cfg Config) {
 	t.Run("BasicCreateTableThatAlreadyExists", func(t *testing.T) { testBasicCreateTableThatAlreadyExists(t, cfg) })
 	t.Run("LoadMissingTable", func(t *testing.T) { testLoadMissingTable(t, cfg) })
 	t.Run("LoadTableWithNonExistingNamespace", func(t *testing.T) { testLoadTableWithNonExistingNamespace(t, cfg) })
+
+	t.Run("CreateNamespace", func(t *testing.T) { testCreateNamespace(t, cfg) })
+	t.Run("CreateNamespaceThatAlreadyExists", func(t *testing.T) { testCreateNamespaceThatAlreadyExists(t, cfg) })
+	t.Run("DropNamespace", func(t *testing.T) { testDropNamespace(t, cfg) })
+	t.Run("DropMissingNamespace", func(t *testing.T) { testDropMissingNamespace(t, cfg) })
+	t.Run("DropNamespaceNotEmpty", func(t *testing.T) { testDropNamespaceNotEmpty(t, cfg) })
+	t.Run("ListNamespaces", func(t *testing.T) { testListNamespaces(t, cfg) })
 }
 
 // testBasicCreateTable asserts that a newly created table is visible to the

--- a/catalog/catalogtest/namespaces.go
+++ b/catalog/catalogtest/namespaces.go
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package catalogtest
+
+// This file covers the structural namespace lifecycle: create, exists, list,
+// and drop. Namespace *properties* conformance — CreateNamespace with non-nil
+// properties, LoadNamespaceProperties, and UpdateNamespaceProperties — is
+// deferred to a later slice of #1691, together with the Config capability flags
+// (e.g. SupportsNamespaceProperties, SupportsNestedNamespaces) that gate tests
+// for backends which do not support those features.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCreateNamespace asserts that a created namespace is reported as existing.
+// Listing behavior is covered by testListNamespaces.
+func testCreateNamespace(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, _ := newIdentifiers()
+
+	exists, err := cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.False(t, exists, "namespace should not exist before create")
+
+	require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
+
+	exists, err = cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.True(t, exists, "namespace should exist after create")
+}
+
+// testCreateNamespaceThatAlreadyExists asserts that creating a namespace that
+// already exists is rejected and leaves the original namespace intact.
+func testCreateNamespaceThatAlreadyExists(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, _ := newIdentifiers()
+
+	exists, err := cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.False(t, exists, "namespace should not exist before create")
+
+	require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
+
+	err = cat.CreateNamespace(ctx, namespace, nil)
+	assert.ErrorIs(t, err, catalog.ErrNamespaceAlreadyExists)
+
+	exists, err = cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.True(t, exists, "original namespace should still exist after a rejected duplicate create")
+}
+
+// testDropNamespace asserts that a dropped namespace no longer exists.
+func testDropNamespace(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, _ := newIdentifiers()
+
+	require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, namespace) })
+
+	exists, err := cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.True(t, exists, "namespace should exist after create")
+
+	require.NoError(t, cat.DropNamespace(ctx, namespace))
+
+	exists, err = cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.False(t, exists, "namespace should not exist after drop")
+}
+
+// testDropMissingNamespace asserts that dropping a namespace that was never
+// created reports that the namespace does not exist. This is a deliberate
+// Go-idiom divergence from Java's SupportsNamespaces.dropNamespace, which
+// returns false (and no error) for a missing namespace; the Go catalog
+// interface returns catalog.ErrNoSuchNamespace instead.
+func testDropMissingNamespace(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, _ := newIdentifiers()
+
+	err := cat.DropNamespace(ctx, namespace)
+	assert.ErrorIs(t, err, catalog.ErrNoSuchNamespace)
+}
+
+// testDropNamespaceNotEmpty asserts that a namespace containing a table cannot
+// be dropped.
+func testDropNamespaceNotEmpty(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	namespace, ident := newIdentifiers()
+
+	require.NoError(t, cat.CreateNamespace(ctx, namespace, nil))
+	t.Cleanup(func() {
+		_ = cat.DropTable(ctx, ident)
+		_ = cat.DropNamespace(ctx, namespace)
+	})
+
+	_, err := cat.CreateTable(ctx, ident, Schema)
+	require.NoError(t, err)
+
+	err = cat.DropNamespace(ctx, namespace)
+	assert.ErrorIs(t, err, catalog.ErrNamespaceNotEmpty)
+
+	// A rejected drop must leave the namespace and its table intact.
+	nsExists, err := cat.CheckNamespaceExists(ctx, namespace)
+	require.NoError(t, err)
+	assert.True(t, nsExists, "namespace should still exist after a rejected non-empty drop")
+
+	tableExists, err := cat.CheckTableExists(ctx, ident)
+	require.NoError(t, err)
+	assert.True(t, tableExists, "table should still exist after a rejected namespace drop")
+}
+
+// testListNamespaces asserts that created namespaces appear in the top-level
+// listing and that a dropped namespace disappears from it while the others
+// remain.
+func testListNamespaces(t *testing.T, cfg Config) {
+	ctx := context.Background()
+	cat := cfg.NewCatalog(t)
+	first, _ := newIdentifiers()
+	second, _ := newIdentifiers()
+
+	require.NoError(t, cat.CreateNamespace(ctx, first, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, first) })
+	require.NoError(t, cat.CreateNamespace(ctx, second, nil))
+	t.Cleanup(func() { _ = cat.DropNamespace(ctx, second) })
+
+	namespaces, err := cat.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	assert.Contains(t, namespaces, first, "first created namespace should be listed")
+	assert.Contains(t, namespaces, second, "second created namespace should be listed")
+
+	require.NoError(t, cat.DropNamespace(ctx, first))
+
+	namespaces, err = cat.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, namespaces, first, "dropped namespace should no longer be listed")
+	assert.Contains(t, namespaces, second, "remaining namespace should still be listed")
+}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1808,7 +1808,10 @@ func (r *Catalog) DropNamespace(ctx context.Context, namespace table.Identifier)
 	}
 
 	_, err = doDelete[struct{}](ctx, r.baseURI, path,
-		r.cl, map[int]error{http.StatusNotFound: catalog.ErrNoSuchNamespace})
+		r.cl, map[int]error{
+			http.StatusNotFound: catalog.ErrNoSuchNamespace,
+			http.StatusConflict: catalog.ErrNamespaceNotEmpty,
+		})
 
 	return err
 }

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -1115,6 +1115,32 @@ func (r *RestCatalogSuite) TestDropNamespace404() {
 	r.ErrorContains(err, "examples in warehouse")
 }
 
+func (r *RestCatalogSuite) TestDropNamespace409() {
+	r.mux.HandleFunc("/v1/namespaces/examples", func(w http.ResponseWriter, req *http.Request) {
+		r.Require().Equal(http.MethodDelete, req.Method)
+
+		for k, v := range TestHeaders {
+			r.Equal(v, req.Header.Values(k))
+		}
+
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "Namespace examples is not empty. Contains 1 table(s).",
+				"type":    "NamespaceNotEmptyException",
+				"code":    409,
+			},
+		})
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL, rest.WithOAuthToken(TestToken))
+	r.Require().NoError(err)
+
+	err = cat.DropNamespace(context.Background(), catalog.ToIdentifier("examples"))
+	r.ErrorIs(err, catalog.ErrNamespaceNotEmpty)
+	r.ErrorContains(err, "is not empty")
+}
+
 func (r *RestCatalogSuite) TestLoadNamespaceProps200() {
 	r.mux.HandleFunc("/v1/namespaces/leden", func(w http.ResponseWriter, req *http.Request) {
 		r.Require().Equal(http.MethodGet, req.Method)


### PR DESCRIPTION
Follows up on #1694, which stood up the shared catalog conformance suite as the
first part of #1691. That one landed the harness plus a few table tests and left
room for more, so this adds the namespace side: create, list, and drop, along
with the error cases (create-already-exists, drop-missing, drop-not-empty).

Adding the not-empty-drop test surfaced a real bug in the REST catalog: its
DropNamespace mapped only 404, so a 409 on a non-empty namespace came back as a
generic REST error instead of catalog.ErrNamespaceNotEmpty. Fixed that here (with
a unit test), which is exactly the kind of divergence the shared suite is meant
to catch.

The suite runs against the SQL and REST catalogs today. Each test takes a fresh
catalog and unique identifiers so it stays isolated on shared-server backends too.

I kept this focused on the structural lifecycle. Namespace properties
(LoadNamespaceProperties / UpdateNamespaceProperties) and the Config capability
flags to gate them per backend are the obvious next step, and I'll send those in
a separate PR so this one stays easy to review.
