### PR TITLE
fix(hive): align lock-check config keys and defaults with Java

### DIFF
--- a/catalog/hive/lock.go
+++ b/catalog/hive/lock.go
@@ -222,11 +222,11 @@ func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 	}
 
 	// Everything below this point is unreachable under the default configuration.
-	// lock-check-min-wait-time=100ms, lock-check-max-wait-time=1m and
-	// lock-check-retries=4 top the sequence out at 337.5ms, so it never saturates and
-	// the branch above always wins. Getting here needs a lowered maximum or a raised
-	// retry count. Stated plainly because this is the most intricate part of the
-	// helper and the least exercised in practice.
+	// iceberg.hive.lock-check-min-wait-ms=50, iceberg.hive.lock-check-max-wait-ms=5000
+	// and lock-check-retries=4 top the sequence out at 168.75ms (50×1.5³), so it never
+	// saturates and the branch above always wins. Getting here needs a lowered
+	// maximum or a raised retry count. Stated plainly because this is the most
+	// intricate part of the helper and the least exercised in practice.
 	//
 	// Replay the 1.5× backoff sequence and keep the largest interval that still
 	// fitted under the cap. The guard on scheduled keeps a non-positive or
@@ -239,9 +239,9 @@ func applyJitter(d, minWait, maxWait time.Duration) time.Duration {
 	// than the one before it.
 	//
 	// minWait is applied before the replay rather than relying on it. When minWait
-	// is itself >= maxWait the loop cannot run at all, and options.go accepts that
-	// configuration, so leaving the floor at d/scale there would allow a wait below
-	// the configured minimum.
+	// is itself >= maxWait the loop cannot run at all. ApplyProperties ignores that
+	// configuration, but direct callers can still pass it, so leaving the floor at
+	// d/scale there would allow a wait below the configured minimum.
 	floor := max(minWait, time.Duration(float64(d)/lockCheckBackoffScale))
 	for scheduled := float64(minWait); scheduled > 0 && scheduled < float64(maxWait); {
 		if s := time.Duration(scheduled); s > floor {

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -384,26 +384,108 @@ func TestCalculateBackoff(t *testing.T) {
 }
 
 func TestLockConfigurationParsing(t *testing.T) {
-	props := map[string]string{
-		LockCheckMinWaitTime: "200ms",
-		LockCheckMaxWaitTime: "30s",
-		LockCheckRetries:     "5",
-	}
+	t.Run("legacy go duration keys", func(t *testing.T) {
+		props := map[string]string{
+			LockCheckMinWaitTime: "200ms",
+			LockCheckMaxWaitTime: "30s",
+			LockCheckRetries:     "5",
+		}
 
-	opts := NewHiveOptions()
-	opts.ApplyProperties(props)
+		opts := NewHiveOptions()
+		opts.ApplyProperties(props)
 
-	assert.Equal(t, 200*time.Millisecond, opts.LockMinWaitTime)
-	assert.Equal(t, 30*time.Second, opts.LockMaxWaitTime)
-	assert.Equal(t, 5, opts.LockRetries)
+		assert.Equal(t, 200*time.Millisecond, opts.LockMinWaitTime)
+		assert.Equal(t, 30*time.Second, opts.LockMaxWaitTime)
+		assert.Equal(t, 5, opts.LockRetries)
+	})
+
+	t.Run("java millisecond keys", func(t *testing.T) {
+		props := map[string]string{
+			LockCheckMinWaitMs: "75",
+			LockCheckMaxWaitMs: "2500",
+			LockCheckRetries:   "6",
+		}
+
+		opts := NewHiveOptions()
+		opts.ApplyProperties(props)
+
+		assert.Equal(t, 75*time.Millisecond, opts.LockMinWaitTime)
+		assert.Equal(t, 2500*time.Millisecond, opts.LockMaxWaitTime)
+		assert.Equal(t, 6, opts.LockRetries)
+	})
+
+	t.Run("java keys win over legacy aliases", func(t *testing.T) {
+		props := map[string]string{
+			LockCheckMinWaitMs:   "80",
+			LockCheckMaxWaitMs:   "4000",
+			LockCheckMinWaitTime: "200ms",
+			LockCheckMaxWaitTime: "30s",
+		}
+
+		opts := NewHiveOptions()
+		opts.ApplyProperties(props)
+
+		assert.Equal(t, 80*time.Millisecond, opts.LockMinWaitTime)
+		assert.Equal(t, 4*time.Second, opts.LockMaxWaitTime)
+	})
 }
 
 func TestLockConfigurationDefaults(t *testing.T) {
 	opts := NewHiveOptions()
 
+	assert.Equal(t, 50*time.Millisecond, DefaultLockCheckMinWaitTime)
+	assert.Equal(t, 5*time.Second, DefaultLockCheckMaxWaitTime)
 	assert.Equal(t, DefaultLockCheckMinWaitTime, opts.LockMinWaitTime)
 	assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
 	assert.Equal(t, DefaultLockCheckRetries, opts.LockRetries)
+}
+
+func TestLockConfigurationValidation(t *testing.T) {
+	t.Run("negative and zero waits keep defaults", func(t *testing.T) {
+		opts := NewHiveOptions()
+		opts.ApplyProperties(map[string]string{
+			LockCheckMinWaitMs: "0",
+			LockCheckMaxWaitMs: "-1",
+			LockCheckRetries:   "0",
+		})
+
+		assert.Equal(t, DefaultLockCheckMinWaitTime, opts.LockMinWaitTime)
+		assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
+		assert.Equal(t, DefaultLockCheckRetries, opts.LockRetries)
+	})
+
+	t.Run("min greater than or equal to max keeps defaults", func(t *testing.T) {
+		opts := NewHiveOptions()
+		opts.ApplyProperties(map[string]string{
+			LockCheckMinWaitMs: "5000",
+			LockCheckMaxWaitMs: "50",
+		})
+
+		assert.Equal(t, DefaultLockCheckMinWaitTime, opts.LockMinWaitTime)
+		assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
+
+		opts = NewHiveOptions()
+		opts.ApplyProperties(map[string]string{
+			LockCheckMinWaitTime: "5s",
+			LockCheckMaxWaitTime: "5s",
+		})
+
+		assert.Equal(t, DefaultLockCheckMinWaitTime, opts.LockMinWaitTime)
+		assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
+	})
+
+	t.Run("invalid legacy duration keeps defaults", func(t *testing.T) {
+		opts := NewHiveOptions()
+		opts.ApplyProperties(map[string]string{
+			LockCheckMinWaitTime: "not-a-duration",
+			LockCheckMaxWaitTime: "also-bad",
+			LockCheckRetries:     "nope",
+		})
+
+		assert.Equal(t, DefaultLockCheckMinWaitTime, opts.LockMinWaitTime)
+		assert.Equal(t, DefaultLockCheckMaxWaitTime, opts.LockMaxWaitTime)
+		assert.Equal(t, DefaultLockCheckRetries, opts.LockRetries)
+	})
 }
 
 func TestApplyJitterBelowCapNeverShorterThanInput(t *testing.T) {
@@ -469,7 +551,7 @@ func TestApplyJitterAtCapNeverPollsSoonerThanMinWait(t *testing.T) {
 // grows.
 //
 // Reaching the cap takes a lowered lock-check-max-wait-time or a raised retry
-// count; the defaults (100ms, 1 minute, 4 retries) top out at 337.5ms and never
+// count; the defaults (50ms, 5s, 4 retries) top out at 168.75ms and never
 // saturate. The values below are the smallest that put the boundary in range.
 func TestApplyJitterMinimumIsMonotonicAcrossTheCap(t *testing.T) {
 	minWait := 100 * time.Millisecond

--- a/catalog/hive/lock_test.go
+++ b/catalog/hive/lock_test.go
@@ -625,11 +625,11 @@ func TestApplyJitterAtCapFloorsCorrectlyVersusFlatScaleFloor(t *testing.T) {
 	}
 }
 
-// A caller may configure minWait above maxWait; options.go accepts it, and
-// calculateBackoff resolves it by returning maxWait. The downward spread must not
-// then draw below the configured minimum. Flooring at half the interval would
-// permit a third of it, because the replay loop cannot run when minWait is already
-// past the cap.
+// A caller may pass minWait above maxWait directly; ApplyProperties ignores that
+// configuration, but calculateBackoff still resolves it by returning maxWait. The
+// downward spread must not then draw below the configured minimum. Flooring at
+// half the interval would permit a third of it, because the replay loop cannot
+// run when minWait is already past the cap.
 func TestApplyJitterHonoursMinWaitAboveMaxWait(t *testing.T) {
 	minWait := 90 * time.Second
 	maxWait := 60 * time.Second

--- a/catalog/hive/options.go
+++ b/catalog/hive/options.go
@@ -46,14 +46,25 @@ const (
 	GCEnabledKey                = "gc.enabled"
 	ExternalTablePurgeKey       = "external.table.purge"
 
-	// Lock configuration property keys
+	// Lock configuration property keys.
+	//
+	// Primary names match the Java Hive catalog properties (integer milliseconds).
+	// Legacy Go keys remain accepted as aliases so existing configs keep working;
+	// when both forms are set, the Java key wins.
+	// Ref: https://iceberg.apache.org/docs/nightly/catalog-properties/#hive-metastore-configuration
+	LockCheckMinWaitMs = "iceberg.hive.lock-check-min-wait-ms"
+	LockCheckMaxWaitMs = "iceberg.hive.lock-check-max-wait-ms"
+
+	// Legacy Go-specific aliases (Go duration strings, e.g. "100ms", "5s").
 	LockCheckMinWaitTime = "lock-check-min-wait-time"
 	LockCheckMaxWaitTime = "lock-check-max-wait-time"
-	LockCheckRetries     = "lock-check-retries"
+	// LockCheckRetries is Go-specific. Java bounds acquisition with
+	// iceberg.hive.lock-timeout-ms instead of a retry count.
+	LockCheckRetries = "lock-check-retries"
 
-	// Default lock configuration values
-	DefaultLockCheckMinWaitTime = 100 * time.Millisecond // 100ms
-	DefaultLockCheckMaxWaitTime = 60 * time.Second       // 1 minute
+	// Default lock configuration values match the Java Hive catalog.
+	DefaultLockCheckMinWaitTime = 50 * time.Millisecond // Java: 50ms
+	DefaultLockCheckMaxWaitTime = 5 * time.Second       // Java: 5000ms
 	DefaultLockCheckRetries     = 4
 
 	// lockCheckBackoffScale matches the Java MetastoreLock lock-check path, which
@@ -91,22 +102,47 @@ func (o *HiveOptions) ApplyProperties(props iceberg.Properties) {
 		o.Warehouse = warehouse
 	}
 
-	// Parse lock configuration
-	if val, ok := props[LockCheckMinWaitTime]; ok {
-		if d, err := time.ParseDuration(val); err == nil {
-			o.LockMinWaitTime = d
-		}
+	minWait := o.LockMinWaitTime
+	maxWait := o.LockMaxWaitTime
+
+	if d, ok := durationFromProps(props, LockCheckMinWaitMs, LockCheckMinWaitTime); ok {
+		minWait = d
 	}
-	if val, ok := props[LockCheckMaxWaitTime]; ok {
-		if d, err := time.ParseDuration(val); err == nil {
-			o.LockMaxWaitTime = d
-		}
+	if d, ok := durationFromProps(props, LockCheckMaxWaitMs, LockCheckMaxWaitTime); ok {
+		maxWait = d
 	}
+
+	// Only apply a consistent positive wait window. Invalid values (non-positive
+	// or min >= max) are ignored so callers keep the previous/default settings
+	// instead of relying on calculateBackoff/applyJitter to paper over bad config.
+	if minWait > 0 && maxWait > 0 && minWait < maxWait {
+		o.LockMinWaitTime = minWait
+		o.LockMaxWaitTime = maxWait
+	}
+
 	if val, ok := props[LockCheckRetries]; ok {
-		if i, err := strconv.Atoi(val); err == nil {
+		if i, err := strconv.Atoi(val); err == nil && i > 0 {
 			o.LockRetries = i
 		}
 	}
+}
+
+// durationFromProps resolves a lock wait duration from properties. The Java
+// millisecond key is preferred when present and valid; otherwise the legacy Go
+// duration-string alias is used.
+func durationFromProps(props iceberg.Properties, javaMsKey, legacyDurationKey string) (time.Duration, bool) {
+	if val, ok := props[javaMsKey]; ok {
+		if ms, err := strconv.ParseInt(val, 10, 64); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond, true
+		}
+	}
+	if val, ok := props[legacyDurationKey]; ok {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d, true
+		}
+	}
+
+	return 0, false
 }
 
 type Option func(*HiveOptions)

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -106,6 +106,17 @@ Source: [`catalog/hive/options.go`](https://github.com/apache/iceberg-go/blob/ma
 - `WithWarehouse(warehouse string)`
 - `WithProperties(props iceberg.Properties)`
 
+Lock-check catalog properties (passed via `WithProperties` / `catalog.Load` props):
+
+| Property | Default | Description |
+|---|---|---|
+| `iceberg.hive.lock-check-min-wait-ms` | `50` | Minimum wait between lock-status checks, in milliseconds. Matches the Java Hive catalog key. |
+| `iceberg.hive.lock-check-max-wait-ms` | `5000` | Maximum wait between lock-status checks, in milliseconds. Matches the Java Hive catalog key. |
+| `lock-check-min-wait-time` / `lock-check-max-wait-time` | same defaults | Legacy Go aliases that accept Go duration strings (e.g. `100ms`, `5s`). Ignored when the corresponding Java key is set. |
+| `lock-check-retries` | `4` | Go-specific upper bound on check attempts. Java instead uses `iceberg.hive.lock-timeout-ms` (not wired in Go yet). |
+
+Invalid values (non-positive waits/retries, or min ≥ max) are ignored and the previous/default settings are kept.
+
 ### Glue (`catalog/glue`)
 
 Source: [`catalog/glue/options.go`](https://github.com/apache/iceberg-go/blob/main/catalog/glue/options.go).


### PR DESCRIPTION
## Summary
- Accept Java's `iceberg.hive.lock-check-min-wait-ms` / `iceberg.hive.lock-check-max-wait-ms` as the primary Hive lock-check property keys (integer milliseconds).
- Keep the existing Go duration-string keys as aliases; Java keys win when both are set.
- Match Java defaults (`50ms` / `5s`) and ignore invalid values (non-positive waits/retries, or min ≥ max) at parse time.
- Document the remaining Go-specific `lock-check-retries` vs Java `iceberg.hive.lock-timeout-ms` gap as follow-up.

Fixes #1716

## Test plan
- [x] `go test ./catalog/hive/ -count=1`
- [x] Cover Java keys, legacy aliases, precedence, defaults, and invalid-value handling
- [ ] CI green
