### PR TITLE
perf(table): reuse partition extraction plans

### DIFF
--- a/table/clustered_writer.go
+++ b/table/clustered_writer.go
@@ -65,6 +65,7 @@ func clusteredPartitionedWrite(
 			currentRec          partitionRecord
 			currentWriter       *RollingDataWriter
 			completedPartitions = make(closedPartitionSet)
+			extractionPlan      *partitionExtractionPlan
 		)
 
 		closeCurrentWriter := func() error {
@@ -144,7 +145,16 @@ func clusteredPartitionedWrite(
 				return
 			}
 
-			partitions, err := getRecordPartitions(spec, schema, rec)
+			if extractionPlan == nil {
+				extractionPlan, err = newPartitionExtractionPlan(spec, schema, rec.Schema())
+				if err != nil {
+					fail(err)
+
+					return
+				}
+			}
+
+			partitions, err := extractionPlan.getRecordPartitions(rec)
 			if err != nil {
 				fail(err)
 

--- a/table/partition_extraction_bench_test.go
+++ b/table/partition_extraction_bench_test.go
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+)
+
+func BenchmarkPartitionExtraction(b *testing.B) {
+	const partitionFields = 4
+
+	arrowFields := make([]arrow.Field, partitionFields)
+	icebergFields := make([]iceberg.NestedField, partitionFields)
+	specFields := make([]iceberg.PartitionField, partitionFields)
+	for i := range partitionFields {
+		name := fmt.Sprintf("part_%d", i)
+		arrowFields[i] = arrow.Field{Name: name, Type: arrow.PrimitiveTypes.Int32}
+		icebergFields[i] = iceberg.NestedField{ID: i + 1, Name: name, Type: iceberg.PrimitiveTypes.Int32}
+		specFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{i + 1},
+			FieldID:   1000 + i,
+			Name:      name,
+			Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	arrowSchema := arrow.NewSchema(arrowFields, nil)
+	icebergSchema := iceberg.NewSchema(0, icebergFields...)
+	spec := iceberg.NewPartitionSpec(specFields...)
+
+	for _, rows := range []int{0, 1, 16, 1024} {
+		b.Run(fmt.Sprintf("rows_%d", rows), func(b *testing.B) {
+			columns := make([]arrow.Array, partitionFields)
+			for i := range columns {
+				builder := array.NewInt32Builder(memory.DefaultAllocator)
+				for row := range rows {
+					builder.Append(int32(row % 8))
+				}
+				columns[i] = builder.NewArray()
+				builder.Release()
+			}
+
+			record := array.NewRecordBatch(arrowSchema, columns, int64(rows))
+			for _, column := range columns {
+				column.Release()
+			}
+			defer record.Release()
+			writer := newPartitionedFanoutWriter(spec, icebergSchema, nil, nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := writer.getPartitions(record); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -375,7 +375,7 @@ func newPartitionExtractionPlan(spec iceberg.PartitionSpec, schema *iceberg.Sche
 func (p *partitionExtractionPlan) getRecordPartitions(record arrow.RecordBatch) ([]*partitionInfo, error) {
 	// Preserve support for iterators whose batch schema changes. The usual path compares
 	// schema pointers; equivalent independently-built schemas also reuse the plan.
-	if record.Schema() != p.recordSchema && !record.Schema().Equal(p.recordSchema) {
+	if !p.matchesSchema(record.Schema()) {
 		plan, err := newPartitionExtractionPlan(p.spec, p.schema, record.Schema())
 		if err != nil {
 			return nil, err
@@ -427,6 +427,10 @@ func (p *partitionExtractionPlan) getRecordPartitions(record arrow.RecordBatch) 
 	}
 
 	return partitionMap.collectPartitions(), nil
+}
+
+func (p *partitionExtractionPlan) matchesSchema(recordSchema *arrow.Schema) bool {
+	return recordSchema == p.recordSchema || recordSchema.Equal(p.recordSchema)
 }
 
 // partitionMapNode represents a simple tree structure for storing partitionInfo.

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -24,6 +24,7 @@ import (
 	"iter"
 	"math"
 	"slices"
+	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -43,6 +44,11 @@ type partitionedFanoutWriter struct {
 	schema        *iceberg.Schema
 	itr           iter.Seq2[arrow.RecordBatch, error]
 	writerFactory *writerFactory
+	// Equality-delete inputs may contain partition columns omitted from the output schema,
+	// so compile from the first actual batch and share the immutable plan across workers.
+	planOnce sync.Once
+	plan     *partitionExtractionPlan
+	planErr  error
 }
 
 // PartitionInfo holds the row indices and partition values for a specific partition,
@@ -58,6 +64,14 @@ type partitionFieldInfo struct {
 	sourceName  string
 	fieldID     int
 	sourceType  iceberg.Type
+	columnIndex int
+}
+
+type partitionExtractionPlan struct {
+	spec         iceberg.PartitionSpec
+	schema       *iceberg.Schema
+	recordSchema *arrow.Schema
+	fields       []partitionFieldInfo
 }
 
 type binaryPartitionKey string
@@ -295,15 +309,27 @@ func yieldDataFiles(
 }
 
 func (p *partitionedFanoutWriter) getPartitions(record arrow.RecordBatch) ([]*partitionInfo, error) {
-	return getRecordPartitions(p.partitionSpec, p.schema, record)
+	p.planOnce.Do(func() {
+		p.plan, p.planErr = newPartitionExtractionPlan(p.partitionSpec, p.schema, record.Schema())
+	})
+	if p.planErr != nil {
+		return nil, p.planErr
+	}
+
+	return p.plan.getRecordPartitions(record)
 }
 
 func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, record arrow.RecordBatch) ([]*partitionInfo, error) {
-	partitionMap := newPartitionMapNode()
-	partitionFields := spec.PartitionType(schema).FieldList
-	partitionRec := make(partitionRecord, len(partitionFields))
+	plan, err := newPartitionExtractionPlan(spec, schema, record.Schema())
+	if err != nil {
+		return nil, err
+	}
 
-	partitionColumns := make([]arrow.Array, len(partitionFields))
+	return plan.getRecordPartitions(record)
+}
+
+func newPartitionExtractionPlan(spec iceberg.PartitionSpec, schema *iceberg.Schema, recordSchema *arrow.Schema) (*partitionExtractionPlan, error) {
+	partitionFields := spec.PartitionType(schema).FieldList
 	partitionFieldsInfo := make([]partitionFieldInfo, len(partitionFields))
 	specFieldsByID := make(map[int]iceberg.PartitionField, spec.NumFields())
 	for _, field := range spec.Fields() {
@@ -311,6 +337,7 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 	}
 
 	for i, partitionField := range partitionFields {
+		partitionFieldsInfo[i].columnIndex = -1
 		sourceField, ok := specFieldsByID[partitionField.ID]
 		if !ok {
 			return nil, fmt.Errorf("failed to find partition field ID %d in spec", partitionField.ID)
@@ -320,7 +347,7 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 		if !ok {
 			continue
 		}
-		colIndices := record.Schema().FieldIndices(colName)
+		colIndices := recordSchema.FieldIndices(colName)
 		if len(colIndices) == 0 {
 			return nil, fmt.Errorf("failed to find source column %q in record schema", colName)
 		}
@@ -328,20 +355,48 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 		if !ok {
 			return nil, fmt.Errorf("failed to find type for source field ID %d in schema", sourceField.SourceID())
 		}
-		partitionColumns[i] = record.Column(colIndices[0])
 		partitionFieldsInfo[i] = partitionFieldInfo{
 			sourceField: sourceField,
 			sourceName:  colName,
 			fieldID:     sourceField.FieldID,
 			sourceType:  sourceType,
+			columnIndex: colIndices[0],
+		}
+	}
+
+	return &partitionExtractionPlan{
+		spec:         spec,
+		schema:       schema,
+		recordSchema: recordSchema,
+		fields:       partitionFieldsInfo,
+	}, nil
+}
+
+func (p *partitionExtractionPlan) getRecordPartitions(record arrow.RecordBatch) ([]*partitionInfo, error) {
+	// Preserve support for iterators whose batch schema changes. The usual path compares
+	// schema pointers; equivalent independently-built schemas also reuse the plan.
+	if record.Schema() != p.recordSchema && !record.Schema().Equal(p.recordSchema) {
+		plan, err := newPartitionExtractionPlan(p.spec, p.schema, record.Schema())
+		if err != nil {
+			return nil, err
+		}
+
+		return plan.getRecordPartitions(record)
+	}
+
+	partitionMap := newPartitionMapNode()
+	partitionRec := make(partitionRecord, len(p.fields))
+	partitionColumns := make([]arrow.Array, len(p.fields))
+	for i, fieldInfo := range p.fields {
+		if fieldInfo.columnIndex >= 0 {
+			partitionColumns[i] = record.Column(fieldInfo.columnIndex)
 		}
 	}
 
 	for row := range record.NumRows() {
-		for i := range partitionFields {
+		for i, fieldInfo := range p.fields {
 			col := partitionColumns[i]
 			if col != nil && !col.IsNull(int(row)) {
-				fieldInfo := partitionFieldsInfo[i]
 				sourceField := fieldInfo.sourceField
 				val, err := getArrowValueAsIcebergLiteral(col, int(row), fieldInfo.sourceType)
 				if err != nil {
@@ -367,7 +422,7 @@ func getRecordPartitions(spec iceberg.PartitionSpec, schema *iceberg.Schema, rec
 		}
 
 		// Get or create partition info for this partition key
-		partVal := partitionMap.getOrCreate(partitionRec, partitionFieldsInfo)
+		partVal := partitionMap.getOrCreate(partitionRec, p.fields)
 		partVal.rows = append(partVal.rows, row)
 	}
 

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -683,6 +683,75 @@ func (s *FanoutWriterTestSuite) TestGetRecordPartitionsWithDroppedLeadingSourceC
 	s.Equal("foo=null/bar=7/baz=true", spec.PartitionToPath(partitions[0].partitionRec, icebergSchema))
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionedWriterReusesExtractionPlan() {
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 2, Name: "value", Type: iceberg.PrimitiveTypes.String},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "part",
+	})
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "value", Type: arrow.BinaryTypes.String},
+	}, nil)
+	firstRecord := s.createCustomTestRecord(arrowSchema, [][]any{{int32(7), "a"}})
+	defer firstRecord.Release()
+
+	writer := newPartitionedFanoutWriter(spec, icebergSchema, nil, nil)
+	partitions, err := writer.getPartitions(firstRecord)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Equal(int32(7), partitions[0].partitionRec.Get(0))
+	firstPlan := writer.plan
+	s.Require().NotNil(firstPlan)
+
+	equivalentSchema := arrow.NewSchema(arrowSchema.Fields(), nil)
+	secondRecord := s.createCustomTestRecord(equivalentSchema, [][]any{{int32(8), "b"}})
+	defer secondRecord.Release()
+
+	partitions, err = writer.getPartitions(secondRecord)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Equal(int32(8), partitions[0].partitionRec.Get(0))
+	s.Same(firstPlan, writer.plan)
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionExtractionPlanHandlesReorderedRecordSchema() {
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 2, Name: "value", Type: iceberg.PrimitiveTypes.String},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "part",
+	})
+
+	originalSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "value", Type: arrow.BinaryTypes.String},
+	}, nil)
+	plan, err := newPartitionExtractionPlan(spec, icebergSchema, originalSchema)
+	s.Require().NoError(err)
+	s.Equal(0, plan.fields[0].columnIndex)
+
+	reorderedSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "value", Type: arrow.BinaryTypes.String},
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+	}, nil)
+	record := s.createCustomTestRecord(reorderedSchema, [][]any{{"a", int32(7)}, {"b", int32(8)}})
+	defer record.Release()
+
+	partitions, err := plan.getRecordPartitions(record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 2)
+	values := []int32{
+		partitions[0].partitionRec.Get(0).(int32),
+		partitions[1].partitionRec.Get(0).(int32),
+	}
+	s.ElementsMatch([]int32{7, 8}, values)
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -718,6 +718,63 @@ func (s *FanoutWriterTestSuite) TestPartitionedWriterReusesExtractionPlan() {
 	s.Same(firstPlan, writer.plan)
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionExtractionPlanMatchesSchema() {
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 2, Name: "value", Type: iceberg.PrimitiveTypes.String},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "part",
+	})
+
+	originalSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "value", Type: arrow.BinaryTypes.String},
+	}, nil)
+	plan, err := newPartitionExtractionPlan(spec, icebergSchema, originalSchema)
+	s.Require().NoError(err)
+
+	tests := []struct {
+		name   string
+		schema *arrow.Schema
+		match  bool
+	}{
+		{name: "same schema pointer", schema: originalSchema, match: true},
+		{name: "equivalent schema", schema: arrow.NewSchema(originalSchema.Fields(), nil), match: true},
+		{
+			name: "reordered fields",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "value", Type: arrow.BinaryTypes.String},
+				{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+			}, nil),
+			match: false,
+		},
+		{
+			name: "added field",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+				{Name: "value", Type: arrow.BinaryTypes.String},
+				{Name: "extra", Type: arrow.FixedWidthTypes.Boolean},
+			}, nil),
+			match: false,
+		},
+		{
+			name: "changed field type",
+			schema: arrow.NewSchema([]arrow.Field{
+				{Name: "part", Type: arrow.PrimitiveTypes.Int64},
+				{Name: "value", Type: arrow.BinaryTypes.String},
+			}, nil),
+			match: false,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.Equal(test.match, plan.matchesSchema(test.schema))
+		})
+	}
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionExtractionPlanHandlesReorderedRecordSchema() {
 	icebergSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},


### PR DESCRIPTION
## What changed

- Build partition extraction descriptors once from the first record batch.
- Share the immutable plan across fanout workers.
- Reuse the same plan in clustered writes.
- Rebuild for a batch only if its Arrow schema actually changes.
- Keep the existing literal conversion and transform behavior unchanged.

## Why

Partition routing rebuilt the partition type, field lookup map, source names, source types, and Arrow column indexes for every batch. This fixed setup cost is noticeable for streams with many small batches.

The plan is built from the first real batch because partitioned equality-delete input may include routing columns that are omitted from the output file schema.

## Benchmark

Apple M1 Pro, median of 3 runs:

    go test ./table -run ^$ -bench ^BenchmarkPartitionExtraction$ -benchmem -benchtime=1s -count=3 -cpu=1

| Rows per batch | main | this PR | main allocations | this PR allocations |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 1695 ns | 197 ns | 1432 B, 10 allocs | 128 B, 2 allocs |
| 1 | 3926 ns | 2412 ns | 3928 B, 28 allocs | 2624 B, 20 allocs |
| 16 | 20558 ns | 18070 ns | 21456 B, 150 allocs | 20152 B, 142 allocs |
| 1024 | 184282 ns | 156782 ns | 21456 B, 150 allocs | 20152 B, 142 allocs |

## Tests

- go test ./...
- go test -race ./table with the fanout, clustered, equality-delete, and shredded-variant writer tests
- go vet ./...
- git diff --check