### PR TITLE
perf(table): avoid copying contiguous partition batches

### DIFF
--- a/table/partition_batch_bench_test.go
+++ b/table/partition_batch_bench_test.go
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func BenchmarkPartitionBatchByKey(b *testing.B) {
+	const rows = 65_536
+
+	full := make([]int64, rows)
+	contiguous := make([]int64, rows/2)
+	scattered := make([]int64, rows/2)
+	for row := range rows {
+		full[row] = int64(row)
+		if row < rows/2 {
+			contiguous[row] = int64(rows/4 + row)
+			scattered[row] = int64(row * 2)
+		}
+	}
+
+	for _, columns := range []int{1, 8} {
+		record := newPartitionBatchBenchmarkRecord(columns, rows)
+		b.Run(fmt.Sprintf("%d_columns", columns), func(b *testing.B) {
+			for _, test := range []struct {
+				name    string
+				indices []int64
+			}{
+				{name: "full", indices: full},
+				{name: "contiguous_half", indices: contiguous},
+				{name: "scattered_half", indices: scattered},
+			} {
+				b.Run(test.name, func(b *testing.B) {
+					partitionBatch := partitionBatchByKey(context.Background())
+					b.ReportAllocs()
+					b.ResetTimer()
+
+					for b.Loop() {
+						batch, err := partitionBatch(record, test.indices)
+						if err != nil {
+							b.Fatal(err)
+						}
+						batch.Release()
+					}
+				})
+			}
+		})
+		record.Release()
+	}
+}
+
+func newPartitionBatchBenchmarkRecord(columns, rows int) arrow.RecordBatch {
+	fields := make([]arrow.Field, columns)
+	arrays := make([]arrow.Array, columns)
+	for column := range columns {
+		fields[column] = arrow.Field{Name: fmt.Sprintf("value_%d", column), Type: arrow.PrimitiveTypes.Int64}
+		builder := array.NewInt64Builder(memory.DefaultAllocator)
+		builder.Reserve(rows)
+		for row := range rows {
+			builder.Append(int64(row + column))
+		}
+		arrays[column] = builder.NewArray()
+		builder.Release()
+	}
+
+	record := array.NewRecordBatch(arrow.NewSchema(fields, nil), arrays, int64(rows))
+	for _, values := range arrays {
+		values.Release()
+	}
+
+	return record
+}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -557,7 +557,7 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 				return record, nil
 			}
 
-			if recordHasRowBoundedStorage(record) && contiguousSliceHasBoundedRetention(start, end, record.NumRows()) {
+			if contiguousSliceHasBoundedRetention(start, end, record.NumRows()) && recordHasRowBoundedStorage(record) {
 				return record.NewSlice(start, end), nil
 			}
 		}

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -569,6 +569,11 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 		rowIndicesArr := bldr.NewInt64Array()
 		defer rowIndicesArr.Release()
 
+		recordMetadata := arrow.Metadata{}
+		if recordWithMetadata, ok := record.(arrow.RecordBatchWithMetadata); ok {
+			recordMetadata = recordWithMetadata.Metadata()
+		}
+
 		partitionedRecord, err := compute.Take(
 			ctx,
 			*compute.DefaultTakeOptions(),
@@ -579,8 +584,52 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 			return nil, err
 		}
 
-		return partitionedRecord.(*compute.RecordDatum).Value, nil
+		return materializeDictionaryColumns(ctx, partitionedRecord.(*compute.RecordDatum).Value, recordMetadata)
 	}
+}
+
+// materializeDictionaryColumns removes dictionary values that are not referenced
+// by a partial result. Arrow's Take kernel copies dictionary indices but reuses
+// the complete dictionary, which can otherwise retain a large variable-width
+// buffer in a rolling writer queue.
+func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch, recordMetadata arrow.Metadata) (arrow.RecordBatch, error) {
+	columns := slices.Clone(record.Columns())
+	fields := record.Schema().Fields()
+	materialized := make([]arrow.Array, 0)
+
+	for i, column := range columns {
+		dictionary, ok := column.(*array.Dictionary)
+		if !ok {
+			continue
+		}
+
+		values, err := compute.TakeArray(ctx, dictionary.Dictionary(), dictionary.Indices())
+		if err != nil {
+			for _, materializedColumn := range materialized {
+				materializedColumn.Release()
+			}
+			record.Release()
+
+			return nil, err
+		}
+
+		columns[i] = values
+		fields[i].Type = values.DataType()
+		materialized = append(materialized, values)
+	}
+
+	if len(materialized) == 0 {
+		return record, nil
+	}
+
+	metadata := record.Schema().Metadata()
+	result := array.NewRecordBatchWithMetadata(arrow.NewSchema(fields, &metadata), columns, record.NumRows(), recordMetadata)
+	for _, materializedColumn := range materialized {
+		materializedColumn.Release()
+	}
+	record.Release()
+
+	return result, nil
 }
 
 // recordHasRowBoundedStorage reports whether a partial zero-copy slice retains

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -557,7 +557,7 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 				return record, nil
 			}
 
-			if recordHasRowBoundedStorage(record) {
+			if recordHasRowBoundedStorage(record) && contiguousSliceHasBoundedRetention(start, end, record.NumRows()) {
 				return record.NewSlice(start, end), nil
 			}
 		}
@@ -599,6 +599,15 @@ func recordHasRowBoundedStorage(record arrow.RecordBatch) bool {
 	}
 
 	return true
+}
+
+// contiguousSliceHasBoundedRetention reports whether a partial zero-copy slice
+// retains no more than twice as many input rows as it returns. This bound is
+// meaningful only for records whose storage is row-bounded.
+func contiguousSliceHasBoundedRetention(start, end, numRows int64) bool {
+	selectedRows := end - start
+
+	return selectedRows >= numRows-selectedRows
 }
 
 func contiguousRowRange(rowIndices []int64, numRows int64) (start, end int64, ok bool) {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -598,12 +598,7 @@ func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch,
 	materialized := make([]arrow.Array, 0)
 
 	for i, column := range columns {
-		dictionary, ok := column.(*array.Dictionary)
-		if !ok {
-			continue
-		}
-
-		values, err := compute.TakeArray(ctx, dictionary.Dictionary(), dictionary.Indices())
+		values, changed, err := materializeDictionaryArray(ctx, column)
 		if err != nil {
 			for _, materializedColumn := range materialized {
 				materializedColumn.Release()
@@ -611,6 +606,9 @@ func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch,
 			record.Release()
 
 			return nil, err
+		}
+		if !changed {
+			continue
 		}
 
 		columns[i] = values
@@ -630,6 +628,149 @@ func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch,
 	record.Release()
 
 	return result, nil
+}
+
+// materializeDictionaryArray removes dictionaries recursively from the nested
+// array types used by Iceberg schemas. A dictionary array is decoded by taking
+// its selected logical values, while nested arrays are rebuilt only when one of
+// their children changes.
+func materializeDictionaryArray(ctx context.Context, input arrow.Array) (arrow.Array, bool, error) {
+	if input.DataType().ID() == arrow.DICTIONARY {
+		dictionary := input.(*array.Dictionary)
+		values, err := compute.TakeArray(ctx, dictionary.Dictionary(), dictionary.Indices())
+		if err != nil {
+			return nil, false, err
+		}
+
+		materializedValues, _, err := materializeDictionaryArray(ctx, values)
+		if err != nil {
+			values.Release()
+
+			return nil, false, err
+		}
+		if materializedValues != values {
+			values.Release()
+			values = materializedValues
+		}
+
+		return values, true, nil
+	}
+
+	dataType := input.DataType()
+	switch dataType.ID() {
+	case arrow.STRUCT, arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST, arrow.MAP:
+	default:
+		return input, false, nil
+	}
+
+	data := input.Data()
+	children := make([]arrow.Array, len(data.Children()))
+	changed := false
+	for i, childData := range data.Children() {
+		child := array.MakeFromData(childData)
+		materializedChild, childChanged, err := materializeDictionaryArray(ctx, child)
+		if err != nil {
+			child.Release()
+			for _, materializedChild := range children {
+				if materializedChild != nil {
+					materializedChild.Release()
+				}
+			}
+
+			return nil, false, err
+		}
+
+		if childChanged {
+			child.Release()
+			child = materializedChild
+			changed = true
+		}
+		children[i] = child
+	}
+
+	if !changed {
+		for _, child := range children {
+			child.Release()
+		}
+
+		return input, false, nil
+	}
+
+	newType, err := nestedArrayTypeWithChildren(dataType, children)
+	if err != nil {
+		for _, child := range children {
+			child.Release()
+		}
+
+		return nil, false, err
+	}
+
+	childData := make([]arrow.ArrayData, len(children))
+	for i, child := range children {
+		childData[i] = child.Data()
+	}
+	newData := array.NewData(newType, data.Len(), data.Buffers(), childData, data.NullN(), data.Offset())
+	result := array.MakeFromData(newData)
+	newData.Release()
+	for _, child := range children {
+		child.Release()
+	}
+
+	return result, true, nil
+}
+
+func nestedArrayTypeWithChildren(dataType arrow.DataType, children []arrow.Array) (arrow.DataType, error) {
+	switch dataType := dataType.(type) {
+	case *arrow.StructType:
+		fields := dataType.Fields()
+		if len(fields) != len(children) {
+			return nil, fmt.Errorf("struct has %d fields but %d children", len(fields), len(children))
+		}
+		for i, child := range children {
+			fields[i].Type = child.DataType()
+		}
+
+		return arrow.StructOf(fields...), nil
+	case *arrow.ListType:
+		if len(children) != 1 {
+			return nil, fmt.Errorf("list has %d children", len(children))
+		}
+		field := dataType.ElemField()
+		field.Type = children[0].DataType()
+
+		return arrow.ListOfField(field), nil
+	case *arrow.LargeListType:
+		if len(children) != 1 {
+			return nil, fmt.Errorf("large list has %d children", len(children))
+		}
+		field := dataType.ElemField()
+		field.Type = children[0].DataType()
+
+		return arrow.LargeListOfField(field), nil
+	case *arrow.FixedSizeListType:
+		if len(children) != 1 {
+			return nil, fmt.Errorf("fixed-size list has %d children", len(children))
+		}
+		field := dataType.ElemField()
+		field.Type = children[0].DataType()
+
+		return arrow.FixedSizeListOfField(dataType.Len(), field), nil
+	case *arrow.MapType:
+		if len(children) != 1 {
+			return nil, fmt.Errorf("map has %d children", len(children))
+		}
+		entryType, ok := children[0].DataType().(*arrow.StructType)
+		if !ok || entryType.NumFields() != 2 {
+			return nil, fmt.Errorf("map child has type %s, want a two-field struct", children[0].DataType())
+		}
+
+		result := arrow.MapOfFields(entryType.Field(0), entryType.Field(1))
+		result.KeysSorted = dataType.KeysSorted
+
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unsupported nested array type %s", dataType)
+	}
 }
 
 // recordHasRowBoundedStorage reports whether a partial zero-copy slice retains

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -557,7 +557,13 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 				return record, nil
 			}
 
-			return record.NewSlice(start, end), nil
+			// A partial slice retains the complete input buffers. Keep it only
+			// when those buffers are no more than twice the selected range;
+			// smaller partitions must be copied before they enter a writer queue.
+			selectedRows := end - start
+			if selectedRows >= record.NumRows()-selectedRows {
+				return record.NewSlice(start, end), nil
+			}
 		}
 
 		bldr := array.NewInt64Builder(mem)

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -557,7 +557,7 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 				return record, nil
 			}
 
-			if contiguousSliceHasBoundedRetention(start, end, record.NumRows()) {
+			if recordHasRowBoundedStorage(record) {
 				return record.NewSlice(start, end), nil
 			}
 		}
@@ -583,13 +583,22 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 	}
 }
 
-// contiguousSliceHasBoundedRetention reports whether a partial zero-copy slice
-// retains no more than twice as many input rows as it returns. The range must
-// already have been validated by contiguousRowRange.
-func contiguousSliceHasBoundedRetention(start, end, numRows int64) bool {
-	selectedRows := end - start
+// recordHasRowBoundedStorage reports whether a partial zero-copy slice retains
+// buffers whose size is bounded by the number of rows. Fixed-width arrays have
+// row-bounded value and validity buffers. Dictionary arrays are excluded even
+// though their indices are fixed-width because their dictionary values are not.
+func recordHasRowBoundedStorage(record arrow.RecordBatch) bool {
+	for _, column := range record.Columns() {
+		dataType := column.Data().DataType()
+		if dataType.ID() == arrow.DICTIONARY {
+			return false
+		}
+		if _, ok := dataType.(arrow.FixedWidthDataType); !ok {
+			return false
+		}
+	}
 
-	return selectedRows >= numRows-selectedRows
+	return true
 }
 
 func contiguousRowRange(rowIndices []int64, numRows int64) (start, end int64, ok bool) {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -557,11 +557,7 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 				return record, nil
 			}
 
-			// A partial slice retains the complete input buffers. Keep it only
-			// when those buffers are no more than twice the selected range;
-			// smaller partitions must be copied before they enter a writer queue.
-			selectedRows := end - start
-			if selectedRows >= record.NumRows()-selectedRows {
+			if contiguousSliceHasBoundedRetention(start, end, record.NumRows()) {
 				return record.NewSlice(start, end), nil
 			}
 		}
@@ -585,6 +581,15 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 
 		return partitionedRecord.(*compute.RecordDatum).Value, nil
 	}
+}
+
+// contiguousSliceHasBoundedRetention reports whether a partial zero-copy slice
+// retains no more than twice as many input rows as it returns. The range must
+// already have been validated by contiguousRowRange.
+func contiguousSliceHasBoundedRetention(start, end, numRows int64) bool {
+	selectedRows := end - start
+
+	return selectedRows >= numRows-selectedRows
 }
 
 func contiguousRowRange(rowIndices []int64, numRows int64) (start, end int64, ok bool) {

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -544,6 +544,22 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 	mem := compute.GetAllocator(ctx)
 
 	return func(record arrow.RecordBatch, rowIndices []int64) (arrow.RecordBatch, error) {
+		if len(rowIndices) == 0 && record.NumRows() == 0 {
+			record.Retain()
+
+			return record, nil
+		}
+
+		if start, end, ok := contiguousRowRange(rowIndices, record.NumRows()); ok {
+			if start == 0 && end == record.NumRows() {
+				record.Retain()
+
+				return record, nil
+			}
+
+			return record.NewSlice(start, end), nil
+		}
+
 		bldr := array.NewInt64Builder(mem)
 		defer bldr.Release()
 
@@ -563,6 +579,26 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 
 		return partitionedRecord.(*compute.RecordDatum).Value, nil
 	}
+}
+
+func contiguousRowRange(rowIndices []int64, numRows int64) (start, end int64, ok bool) {
+	if len(rowIndices) == 0 {
+		return 0, 0, false
+	}
+
+	start = rowIndices[0]
+	length := int64(len(rowIndices))
+	if start < 0 || length > numRows || start > numRows-length {
+		return 0, 0, false
+	}
+
+	for offset, row := range rowIndices[1:] {
+		if row != start+int64(offset)+1 {
+			return 0, 0, false
+		}
+	}
+
+	return start, start + length, true
 }
 
 func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType iceberg.Type) (iceberg.Literal, error) {

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -825,6 +825,30 @@ func (s *FanoutWriterTestSuite) TestRecordHasRowBoundedStorage() {
 	stringRecord := s.createCustomTestRecord(stringSchema, [][]any{{"value"}})
 	defer stringRecord.Release()
 	s.False(recordHasRowBoundedStorage(stringRecord))
+
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	indexBuilder := array.NewInt8Builder(s.mem)
+	indexBuilder.Append(0)
+	indices := indexBuilder.NewInt8Array()
+	indexBuilder.Release()
+
+	dictBuilder := array.NewStringBuilder(s.mem)
+	dictBuilder.Append("dictionary value")
+	dictionary := dictBuilder.NewStringArray()
+	dictBuilder.Release()
+
+	dict := array.NewDictionaryArray(dictType, indices, dictionary)
+	indices.Release()
+	dictionary.Release()
+	defer dict.Release()
+
+	dictSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: dictType}}, nil)
+	dictRecord := array.NewRecordBatch(dictSchema, []arrow.Array{dict}, 1)
+	defer dictRecord.Release()
+	s.False(recordHasRowBoundedStorage(dictRecord))
 }
 
 func (s *FanoutWriterTestSuite) TestContiguousSliceHasBoundedRetention() {
@@ -861,6 +885,7 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyCopiesVariableWidthPartia
 	s.Require().NoError(err)
 	defer partitioned.Release()
 
+	s.NotSame(record.Column(0).Data().Buffers()[1], partitioned.Column(0).Data().Buffers()[1])
 	s.NotSame(record.Column(1).Data().Buffers()[2], partitioned.Column(1).Data().Buffers()[2])
 	values := partitioned.Column(1).(*array.String)
 	s.Equal([]string{"s", "s"}, []string{values.Value(0), values.Value(1)})

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -1038,6 +1038,27 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemory(
 	s.Less(peakBytes, fullBatchBytes*4, "queued partial batches should not retain complete input batches")
 }
 
+func (s *FanoutWriterTestSuite) TestContiguousSliceHasBoundedRetention() {
+	tests := []struct {
+		name        string
+		start       int64
+		end         int64
+		numRows     int64
+		wantBounded bool
+	}{
+		{name: "small partial range", start: 1, end: 2, numRows: 5},
+		{name: "just below half", start: 1, end: 3, numRows: 5},
+		{name: "half", start: 1, end: 3, numRows: 4, wantBounded: true},
+		{name: "more than half", start: 1, end: 4, numRows: 5, wantBounded: true},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.Equal(test.wantBounded, contiguousSliceHasBoundedRetention(test.start, test.end, test.numRows))
+		})
+	}
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -827,6 +827,27 @@ func (s *FanoutWriterTestSuite) TestRecordHasRowBoundedStorage() {
 	s.False(recordHasRowBoundedStorage(stringRecord))
 }
 
+func (s *FanoutWriterTestSuite) TestContiguousSliceHasBoundedRetention() {
+	tests := []struct {
+		name        string
+		start       int64
+		end         int64
+		numRows     int64
+		wantBounded bool
+	}{
+		{name: "small partial range", start: 1, end: 2, numRows: 5},
+		{name: "just below half", start: 1, end: 3, numRows: 5},
+		{name: "half", start: 1, end: 3, numRows: 4, wantBounded: true},
+		{name: "more than half", start: 1, end: 4, numRows: 5, wantBounded: true},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.Equal(test.wantBounded, contiguousSliceHasBoundedRetention(test.start, test.end, test.numRows))
+		})
+	}
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyCopiesVariableWidthPartialSlices() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
@@ -1043,6 +1064,15 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyFastPaths() {
 	s.Equal([]int64{1, 2, 3}, []int64{
 		contiguousValues.Value(0), contiguousValues.Value(1), contiguousValues.Value(2),
 	})
+
+	narrow, err := partitionBatch(record, []int64{1})
+	s.Require().NoError(err)
+	defer narrow.Release()
+	s.NotSame(record.Column(0).Data().Buffers()[1], narrow.Column(0).Data().Buffers()[1])
+
+	s.Equal(int64(1), narrow.NumRows())
+	narrowValues := narrow.Column(0).(*array.Int64)
+	s.Equal(int64(1), narrowValues.Value(0))
 
 	scattered, err := partitionBatch(record, []int64{0, 2, 4})
 	s.Require().NoError(err)

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -113,6 +113,24 @@ func (s *FanoutWriterTestSuite) createLargeTestRecord(arrSchema *arrow.Schema, r
 	return bldr.NewRecordBatch()
 }
 
+func (s *FanoutWriterTestSuite) createSkewedTestRecord(arrSchema *arrow.Schema, rows int, idOffset int64, largePayloadRows, largePayloadSize, smallPayloadSize int) arrow.RecordBatch {
+	bldr := array.NewRecordBuilder(s.mem, arrSchema)
+	defer bldr.Release()
+
+	largePayload := strings.Repeat("l", largePayloadSize)
+	smallPayload := strings.Repeat("s", smallPayloadSize)
+	for i := range rows {
+		bldr.Field(0).(*array.Int64Builder).Append(idOffset + int64(i))
+		payload := smallPayload
+		if i < largePayloadRows {
+			payload = largePayload
+		}
+		bldr.Field(1).(*array.StringBuilder).Append(payload)
+	}
+
+	return bldr.NewRecordBatch()
+}
+
 func (s *FanoutWriterTestSuite) TestCloseAllFlushesAfterFanoutSuccessContextCancel() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
@@ -797,6 +815,87 @@ func (s *FanoutWriterTestSuite) TestPartitionRowCapacityLateDiscoveryIsGrowthSaf
 	}
 }
 
+func (s *FanoutWriterTestSuite) TestRecordHasRowBoundedStorage() {
+	intSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	intRecord := s.createCustomTestRecord(intSchema, [][]any{{int64(1)}})
+	defer intRecord.Release()
+	s.True(recordHasRowBoundedStorage(intRecord))
+
+	stringSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.BinaryTypes.String}}, nil)
+	stringRecord := s.createCustomTestRecord(stringSchema, [][]any{{"value"}})
+	defer stringRecord.Release()
+	s.False(recordHasRowBoundedStorage(stringRecord))
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyCopiesVariableWidthPartialSlices() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "payload", Type: arrow.BinaryTypes.String},
+	}, nil)
+	record := s.createSkewedTestRecord(arrSchema, 4, 0, 2, 1024, 1)
+	defer record.Release()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+	partitioned, err := partitionBatch(record, []int64{2, 3})
+	s.Require().NoError(err)
+	defer partitioned.Release()
+
+	s.NotSame(record.Column(1).Data().Buffers()[2], partitioned.Column(1).Data().Buffers()[2])
+	values := partitioned.Column(1).(*array.String)
+	s.Equal([]string{"s", "s"}, []string{values.Value(0), values.Value(1)})
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemoryForSkewedPayload() {
+	const (
+		inputRows         = 256
+		largePayloadRows  = inputRows / 2
+		largePayloadSize  = 16 * 1024
+		smallPayloadSize  = 1
+		selectedRowsCount = inputRows / 2
+	)
+
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "payload", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	probe := s.createSkewedTestRecord(arrSchema, inputRows, 0, largePayloadRows, largePayloadSize, smallPayloadSize)
+	fullBatchBytes := s.mem.CurrentAlloc()
+	probe.Release()
+
+	writer := &RollingDataWriter{
+		recordCh: make(chan arrow.RecordBatch, rollingDataWriterQueueCapacity),
+		errorCh:  make(chan error, 1),
+		ctx:      s.ctx,
+	}
+	defer func() {
+		for len(writer.recordCh) > 0 {
+			(<-writer.recordCh).Release()
+		}
+	}()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+	selectedRows := make([]int64, selectedRowsCount)
+	for i := range selectedRows {
+		selectedRows[i] = int64(largePayloadRows + i)
+	}
+
+	peakBytes := 0
+	for batch := range rollingDataWriterQueueCapacity {
+		record := s.createSkewedTestRecord(arrSchema, inputRows, int64(batch*inputRows), largePayloadRows, largePayloadSize, smallPayloadSize)
+		partitioned, err := partitionBatch(record, selectedRows)
+		s.Require().NoError(err)
+
+		s.Require().NoError(writer.Add(partitioned))
+		partitioned.Release()
+		record.Release()
+
+		peakBytes = max(peakBytes, s.mem.CurrentAlloc())
+	}
+
+	s.Less(peakBytes, fullBatchBytes*4, "queued partial batches should not retain complete input batches")
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionedWriterReusesExtractionPlan() {
 	icebergSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
@@ -938,6 +1037,7 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyFastPaths() {
 	contiguous, err := partitionBatch(record, []int64{1, 2, 3})
 	s.Require().NoError(err)
 	defer contiguous.Release()
+	s.Same(record.Column(0).Data().Buffers()[1], contiguous.Column(0).Data().Buffers()[1])
 	s.Equal(int64(3), contiguous.NumRows())
 	contiguousValues := contiguous.Column(0).(*array.Int64)
 	s.Equal([]int64{1, 2, 3}, []int64{
@@ -1036,27 +1136,6 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemory(
 	}
 
 	s.Less(peakBytes, fullBatchBytes*4, "queued partial batches should not retain complete input batches")
-}
-
-func (s *FanoutWriterTestSuite) TestContiguousSliceHasBoundedRetention() {
-	tests := []struct {
-		name        string
-		start       int64
-		end         int64
-		numRows     int64
-		wantBounded bool
-	}{
-		{name: "small partial range", start: 1, end: 2, numRows: 5},
-		{name: "just below half", start: 1, end: 3, numRows: 5},
-		{name: "half", start: 1, end: 3, numRows: 4, wantBounded: true},
-		{name: "more than half", start: 1, end: 4, numRows: 5, wantBounded: true},
-	}
-
-	for _, test := range tests {
-		s.Run(test.name, func() {
-			s.Equal(test.wantBounded, contiguousSliceHasBoundedRetention(test.start, test.end, test.numRows))
-		})
-	}
 }
 
 func (s *FanoutWriterTestSuite) TestVoidTransform() {

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -891,6 +891,51 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyCopiesVariableWidthPartia
 	s.Equal([]string{"s", "s"}, []string{values.Value(0), values.Value(1)})
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesDictionaryPartialSlices() {
+	largeValue := strings.Repeat("l", 16*1024)
+
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	indexBuilder := array.NewInt8Builder(s.mem)
+	indexBuilder.AppendValues([]int8{0, 1, 1, 1}, nil)
+	indices := indexBuilder.NewInt8Array()
+	indexBuilder.Release()
+
+	dictBuilder := array.NewStringBuilder(s.mem)
+	dictBuilder.Append(largeValue)
+	dictBuilder.Append("small dictionary value")
+	dictionary := dictBuilder.NewStringArray()
+	dictBuilder.Release()
+	originalValuesBuffer := dictionary.Data().Buffers()[2]
+
+	dict := array.NewDictionaryArray(dictType, indices, dictionary)
+	indices.Release()
+	dictionary.Release()
+
+	arrSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: dictType}}, nil)
+	recordMetadata := arrow.MetadataFrom(map[string]string{"record": "metadata"})
+	record := array.NewRecordBatchWithMetadata(arrSchema, []arrow.Array{dict}, 4, recordMetadata)
+	dict.Release()
+	defer record.Release()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+	partitioned, err := partitionBatch(record, []int64{2, 3})
+	s.Require().NoError(err)
+	defer partitioned.Release()
+
+	s.Equal(arrow.STRING, partitioned.Column(0).DataType().ID())
+	s.NotSame(originalValuesBuffer, partitioned.Column(0).Data().Buffers()[2])
+	metadataRecord, ok := partitioned.(arrow.RecordBatchWithMetadata)
+	s.Require().True(ok)
+	recordMetadataValue, ok := metadataRecord.Metadata().GetValue("record")
+	s.Require().True(ok)
+	s.Equal("metadata", recordMetadataValue)
+	values := partitioned.Column(0).(*array.String)
+	s.Equal([]string{"small dictionary value", "small dictionary value"}, []string{values.Value(0), values.Value(1)})
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemoryForSkewedPayload() {
 	const (
 		inputRows         = 256

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -923,6 +923,80 @@ func (s *FanoutWriterTestSuite) TestPartitionExtractionPlanHandlesReorderedRecor
 	s.ElementsMatch([]int32{7, 8}, values)
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyFastPaths() {
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	record := s.createCustomTestRecord(arrowSchema, [][]any{{int64(0)}, {int64(1)}, {int64(2)}, {int64(3)}, {int64(4)}})
+	defer record.Release()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+
+	full, err := partitionBatch(record, []int64{0, 1, 2, 3, 4})
+	s.Require().NoError(err)
+	s.Same(record, full)
+	full.Release()
+
+	contiguous, err := partitionBatch(record, []int64{1, 2, 3})
+	s.Require().NoError(err)
+	defer contiguous.Release()
+	s.Equal(int64(3), contiguous.NumRows())
+	contiguousValues := contiguous.Column(0).(*array.Int64)
+	s.Equal([]int64{1, 2, 3}, []int64{
+		contiguousValues.Value(0), contiguousValues.Value(1), contiguousValues.Value(2),
+	})
+
+	scattered, err := partitionBatch(record, []int64{0, 2, 4})
+	s.Require().NoError(err)
+	defer scattered.Release()
+	s.Equal(int64(3), scattered.NumRows())
+	scatteredValues := scattered.Column(0).(*array.Int64)
+	s.Equal([]int64{0, 2, 4}, []int64{
+		scatteredValues.Value(0), scatteredValues.Value(1), scatteredValues.Value(2),
+	})
+
+	empty, err := partitionBatch(record, nil)
+	s.Require().NoError(err)
+	defer empty.Release()
+	s.Zero(empty.NumRows())
+
+	emptyRecord := s.createCustomTestRecord(arrowSchema, nil)
+	defer emptyRecord.Release()
+	emptyFull, err := partitionBatch(emptyRecord, nil)
+	s.Require().NoError(err)
+	s.Same(emptyRecord, emptyFull)
+	emptyFull.Release()
+
+	_, err = partitionBatch(record, []int64{4, 5})
+	s.Error(err)
+}
+
+func (s *FanoutWriterTestSuite) TestContiguousRowRangeRejectsInvalidRanges() {
+	tests := []struct {
+		name    string
+		indices []int64
+		rows    int64
+		start   int64
+		end     int64
+		ok      bool
+	}{
+		{name: "empty", rows: 5},
+		{name: "single", indices: []int64{2}, rows: 5, start: 2, end: 3, ok: true},
+		{name: "full", indices: []int64{0, 1, 2, 3, 4}, rows: 5, start: 0, end: 5, ok: true},
+		{name: "gap", indices: []int64{1, 3}, rows: 5},
+		{name: "descending", indices: []int64{2, 1}, rows: 5},
+		{name: "negative", indices: []int64{-1}, rows: 5},
+		{name: "past end", indices: []int64{4, 5}, rows: 5},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			start, end, ok := contiguousRowRange(test.indices, test.rows)
+			s.Equal(test.ok, ok)
+			s.Equal(test.start, start)
+			s.Equal(test.end, end)
+		})
+	}
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -936,6 +936,148 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesDictionaryPar
 	s.Equal([]string{"small dictionary value", "small dictionary value"}, []string{values.Value(0), values.Value(1)})
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesNestedDictionaryPartialSlices() {
+	largeValue := strings.Repeat("l", 16*1024)
+
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	indexBuilder := array.NewInt8Builder(s.mem)
+	indexBuilder.AppendValues([]int8{0, 1, 1, 1}, nil)
+	indices := indexBuilder.NewInt8Array()
+	indexBuilder.Release()
+
+	dictBuilder := array.NewStringBuilder(s.mem)
+	dictBuilder.Append(largeValue)
+	dictBuilder.Append("small nested dictionary value")
+	dictionary := dictBuilder.NewStringArray()
+	dictBuilder.Release()
+	originalValuesBuffer := dictionary.Data().Buffers()[2]
+
+	dict := array.NewDictionaryArray(dictType, indices, dictionary)
+	indices.Release()
+	dictionary.Release()
+
+	structFields := []arrow.Field{{Name: "value", Type: dictType}}
+	nested, err := array.NewStructArrayWithFields([]arrow.Array{dict}, structFields)
+	s.Require().NoError(err)
+	dict.Release()
+
+	arrSchema := arrow.NewSchema([]arrow.Field{{Name: "nested", Type: nested.DataType()}}, nil)
+	record := array.NewRecordBatch(arrSchema, []arrow.Array{nested}, 4)
+	nested.Release()
+	defer record.Release()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+	partitioned, err := partitionBatch(record, []int64{2, 3})
+	s.Require().NoError(err)
+	defer partitioned.Release()
+
+	values := partitioned.Column(0).(*array.Struct).Field(0).(*array.String)
+	s.Equal(arrow.STRING, values.DataType().ID())
+	s.NotSame(originalValuesBuffer, values.Data().Buffers()[2])
+	s.Equal([]string{"small nested dictionary value", "small nested dictionary value"}, []string{values.Value(0), values.Value(1)})
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesNestedDictionaryContainers() {
+	const rowCount = 4
+
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	newDictionary := func() (*array.Dictionary, *memory.Buffer) {
+		indexBuilder := array.NewInt8Builder(s.mem)
+		indexBuilder.AppendValues([]int8{0, 1, 1, 1}, nil)
+		indices := indexBuilder.NewInt8Array()
+		indexBuilder.Release()
+
+		dictBuilder := array.NewStringBuilder(s.mem)
+		dictBuilder.Append(strings.Repeat("l", 16*1024))
+		dictBuilder.Append("small container dictionary value")
+		dictionary := dictBuilder.NewStringArray()
+		dictBuilder.Release()
+		originalValuesBuffer := dictionary.Data().Buffers()[2]
+
+		dict := array.NewDictionaryArray(dictType, indices, dictionary)
+		indices.Release()
+		dictionary.Release()
+
+		return dict, originalValuesBuffer
+	}
+	newOffsets := func() *array.Int32 {
+		offsetBuilder := array.NewInt32Builder(s.mem)
+		offsetBuilder.AppendValues([]int32{0, 1, 2, 3, 4}, nil)
+		offsets := offsetBuilder.NewInt32Array()
+		offsetBuilder.Release()
+
+		return offsets
+	}
+
+	s.Run("list", func() {
+		dict, originalValuesBuffer := newDictionary()
+		offsets := newOffsets()
+		listType := arrow.ListOf(dictType)
+		listData := array.NewData(listType, rowCount, []*memory.Buffer{nil, offsets.Data().Buffers()[1]}, []arrow.ArrayData{dict.Data()}, 0, 0)
+		list := array.NewListData(listData)
+		listData.Release()
+		offsets.Release()
+		dict.Release()
+
+		record := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "values", Type: listType}}, nil), []arrow.Array{list}, rowCount)
+		list.Release()
+		defer record.Release()
+
+		partitioned, err := partitionBatchByKey(s.ctx)(record, []int64{2, 3})
+		s.Require().NoError(err)
+		defer partitioned.Release()
+
+		values := partitioned.Column(0).(*array.List).ListValues().(*array.String)
+		s.Equal(arrow.STRING, values.DataType().ID())
+		s.NotSame(originalValuesBuffer, values.Data().Buffers()[2])
+		s.Equal([]string{"small container dictionary value", "small container dictionary value"}, []string{values.Value(0), values.Value(1)})
+	})
+
+	s.Run("map", func() {
+		dict, originalValuesBuffer := newDictionary()
+		keysBuilder := array.NewStringBuilder(s.mem)
+		keysBuilder.AppendValues([]string{"a", "b", "c", "d"}, nil)
+		keys := keysBuilder.NewStringArray()
+		keysBuilder.Release()
+
+		entryFields := []arrow.Field{
+			{Name: "key", Type: arrow.BinaryTypes.String},
+			{Name: "value", Type: dictType, Nullable: true},
+		}
+		entries, err := array.NewStructArrayWithFields([]arrow.Array{keys, dict}, entryFields)
+		s.Require().NoError(err)
+		keys.Release()
+		dict.Release()
+
+		offsets := newOffsets()
+		mapType := arrow.MapOfFields(entryFields[0], entryFields[1])
+		mapData := array.NewData(mapType, rowCount, []*memory.Buffer{nil, offsets.Data().Buffers()[1]}, []arrow.ArrayData{entries.Data()}, 0, 0)
+		mapArray := array.NewMapData(mapData)
+		mapData.Release()
+		offsets.Release()
+		entries.Release()
+
+		record := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "values", Type: mapType}}, nil), []arrow.Array{mapArray}, rowCount)
+		mapArray.Release()
+		defer record.Release()
+
+		partitioned, err := partitionBatchByKey(s.ctx)(record, []int64{2, 3})
+		s.Require().NoError(err)
+		defer partitioned.Release()
+
+		values := partitioned.Column(0).(*array.Map).Items().(*array.String)
+		s.Equal(arrow.STRING, values.DataType().ID())
+		s.NotSame(originalValuesBuffer, values.Data().Buffers()[2])
+		s.Equal([]string{"small container dictionary value", "small container dictionary value"}, []string{values.Value(0), values.Value(1)})
+	})
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemoryForSkewedPayload() {
 	const (
 		inputRows         = 256

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -997,6 +997,47 @@ func (s *FanoutWriterTestSuite) TestContiguousRowRangeRejectsInvalidRanges() {
 	}
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemory() {
+	const inputRows = 4096
+	const payloadSize = 128
+
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "payload", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	probe := s.createLargeTestRecord(arrSchema, inputRows, 0, payloadSize)
+	fullBatchBytes := s.mem.CurrentAlloc()
+	probe.Release()
+
+	writer := &RollingDataWriter{
+		recordCh: make(chan arrow.RecordBatch, rollingDataWriterQueueCapacity),
+		errorCh:  make(chan error, 1),
+		ctx:      s.ctx,
+	}
+	defer func() {
+		for len(writer.recordCh) > 0 {
+			(<-writer.recordCh).Release()
+		}
+	}()
+
+	partitionBatch := partitionBatchByKey(s.ctx)
+	peakBytes := 0
+	for batch := range rollingDataWriterQueueCapacity {
+		record := s.createLargeTestRecord(arrSchema, inputRows, int64(batch*inputRows), payloadSize)
+		partitioned, err := partitionBatch(record, []int64{inputRows / 2})
+		s.Require().NoError(err)
+
+		s.Require().NoError(writer.Add(partitioned))
+		partitioned.Release()
+		record.Release()
+
+		peakBytes = max(peakBytes, s.mem.CurrentAlloc())
+	}
+
+	s.Less(peakBytes, fullBatchBytes*4, "queued partial batches should not retain complete input batches")
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -43,6 +43,8 @@ import (
 // streaming goroutine has already stopped.
 var ErrWriterClosed = errors.New("writer is closed")
 
+const rollingDataWriterQueueCapacity = 64
+
 // writerFactory manages the creation and lifecycle of RollingDataWriter instances
 // for different partitions, providing shared configuration and coordination
 // across all writers in a partitioned write operation.
@@ -334,7 +336,7 @@ func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition stri
 	writer := &RollingDataWriter{
 		partitionKey:    partition,
 		partitionID:     partitionID,
-		recordCh:        make(chan arrow.RecordBatch, 64),
+		recordCh:        make(chan arrow.RecordBatch, rollingDataWriterQueueCapacity),
 		errorCh:         make(chan error, 1),
 		factory:         w,
 		partitionValues: partitionValues,


### PR DESCRIPTION
## What changed

- Reuse the input record when a partition contains the full batch.
- Use Arrow slices when the selected rows are one contiguous range.
- Check the complete row range and bounds before taking the fast path.
- Keep the existing `compute.Take` path for scattered rows.

## Why

`partitionBatchByKey` always built an Int64 index array and ran `Take`. This copied every selected column even when the result was the full batch or one contiguous range.

## Benchmark

Apple M1 Pro, 65,536 rows, median of 3 runs:

```
go test ./table -run '^$' -bench '^BenchmarkPartitionBatchByKey$' -benchmem -benchtime=1s -count=3 -cpu=1
```

| Case | main | this PR |
| --- | ---: | ---: |
| 1 column, full | 649,907 ns/op, 1,610,469 B/op, 47 allocs/op | 49,908 ns/op, 0 B/op, 0 allocs/op |
| 1 column, contiguous half | 319,600 ns/op, 815,066 B/op, 47 allocs/op | 18,402 ns/op, 288 B/op, 4 allocs/op |
| 8 columns, full | 2,360,602 ns/op, 5,351,519 B/op, 236 allocs/op | 35,814 ns/op, 0 B/op, 0 allocs/op |
| 8 columns, contiguous half | 1,217,218 ns/op, 2,721,096 B/op, 236 allocs/op | 18,282 ns/op, 1,760 B/op, 19 allocs/op |

Scattered selections still use `Take`. Their allocation counts are unchanged and runtime stayed within normal benchmark variance.

## Tests

- `go test ./...`
- `go test -race ./table -run 'TestFanoutWriter|TestClusteredWriter|TestWriteEqualityDeleteFilesPartitioned|TestShreddedVariantPartitioned' -count=1`
- `go vet ./...`
- `git diff --check`
