### PR TITLE
perf(table): bind partition transforms once

### DIFF
--- a/table/partition_extraction_bench_test.go
+++ b/table/partition_extraction_bench_test.go
@@ -78,3 +78,120 @@ func BenchmarkPartitionExtraction(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkPartitionTransforms(b *testing.B) {
+	const rows = 65_536
+
+	tests := []struct {
+		name        string
+		arrowType   arrow.DataType
+		icebergType iceberg.Type
+		transform   iceberg.Transform
+		appendRows  func(int) arrow.Array
+	}{
+		{
+			name:        "identity_int64",
+			arrowType:   arrow.PrimitiveTypes.Int64,
+			icebergType: iceberg.PrimitiveTypes.Int64,
+			transform:   iceberg.IdentityTransform{},
+			appendRows: func(count int) arrow.Array {
+				builder := array.NewInt64Builder(memory.DefaultAllocator)
+				defer builder.Release()
+				for row := range count {
+					builder.Append(int64(row % 128))
+				}
+
+				return builder.NewArray()
+			},
+		},
+		{
+			name:        "bucket_string",
+			arrowType:   arrow.BinaryTypes.String,
+			icebergType: iceberg.PrimitiveTypes.String,
+			transform:   iceberg.BucketTransform{NumBuckets: 64},
+			appendRows: func(count int) arrow.Array {
+				builder := array.NewStringBuilder(memory.DefaultAllocator)
+				defer builder.Release()
+				for row := range count {
+					builder.Append(fmt.Sprintf("partition-value-%03d", row%128))
+				}
+
+				return builder.NewArray()
+			},
+		},
+		{
+			name:        "truncate_string",
+			arrowType:   arrow.BinaryTypes.String,
+			icebergType: iceberg.PrimitiveTypes.String,
+			transform:   iceberg.TruncateTransform{Width: 19},
+			appendRows: func(count int) arrow.Array {
+				builder := array.NewStringBuilder(memory.DefaultAllocator)
+				defer builder.Release()
+				for row := range count {
+					builder.Append(fmt.Sprintf("partition-value-%03d", row%128))
+				}
+
+				return builder.NewArray()
+			},
+		},
+		{
+			name:        "day_timestamp",
+			arrowType:   &arrow.TimestampType{Unit: arrow.Microsecond},
+			icebergType: iceberg.PrimitiveTypes.Timestamp,
+			transform:   iceberg.DayTransform{},
+			appendRows: func(count int) arrow.Array {
+				builder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Microsecond})
+				defer builder.Release()
+				for row := range count {
+					builder.Append(arrow.Timestamp(int64(row%128) * 86_400_000_000))
+				}
+
+				return builder.NewArray()
+			},
+		},
+		{
+			name:        "hour_timestamp_ns",
+			arrowType:   &arrow.TimestampType{Unit: arrow.Nanosecond},
+			icebergType: iceberg.PrimitiveTypes.TimestampNs,
+			transform:   iceberg.HourTransform{},
+			appendRows: func(count int) arrow.Array {
+				builder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Nanosecond})
+				defer builder.Release()
+				for row := range count {
+					builder.Append(arrow.Timestamp(int64(row%128) * 3_600_000_000_000))
+				}
+
+				return builder.NewArray()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: test.arrowType}}, nil)
+			icebergSchema := iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "part", Type: test.icebergType},
+			)
+			spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+				SourceIDs: []int{1}, FieldID: 1000, Name: "part", Transform: test.transform,
+			})
+			column := test.appendRows(rows)
+			record := array.NewRecordBatch(arrowSchema, []arrow.Array{column}, rows)
+			column.Release()
+			defer record.Release()
+
+			writer := newPartitionedFanoutWriter(spec, icebergSchema, nil, nil)
+			if _, err := writer.getPartitions(record); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := writer.getPartitions(record); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/table/partition_extraction_bench_test.go
+++ b/table/partition_extraction_bench_test.go
@@ -67,6 +67,9 @@ func BenchmarkPartitionExtraction(b *testing.B) {
 			}
 			defer record.Release()
 			writer := newPartitionedFanoutWriter(spec, icebergSchema, nil, nil)
+			if _, err := writer.getPartitions(record); err != nil {
+				b.Fatal(err)
+			}
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -984,7 +984,7 @@ func getArrowValueAsIcebergValue(column arrow.Array, row int, sourceType iceberg
 	case *array.Decimal32:
 		val := arr.Value(row)
 		dec := iceberg.Decimal{
-			Val:   decimal128.FromU64(uint64(val)),
+			Val:   decimal128.FromI64(int64(val)),
 			Scale: int(arr.DataType().(*arrow.Decimal32Type).Scale),
 		}
 
@@ -992,7 +992,7 @@ func getArrowValueAsIcebergValue(column arrow.Array, row int, sourceType iceberg
 	case *array.Decimal64:
 		val := arr.Value(row)
 		dec := iceberg.Decimal{
-			Val:   decimal128.FromU64(uint64(val)),
+			Val:   decimal128.FromI64(int64(val)),
 			Scale: int(arr.DataType().(*arrow.Decimal64Type).Scale),
 		}
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -439,6 +439,9 @@ func bindPartitionValue(transform iceberg.Transform, sourceType iceberg.Type) fu
 			if err != nil {
 				return nil, err
 			}
+			if value == nil {
+				return nil, nil
+			}
 
 			transformed := transform.Apply(iceberg.Optional[iceberg.Literal]{Valid: true, Val: value})
 			if !transformed.Valid {
@@ -453,6 +456,9 @@ func bindPartitionValue(transform iceberg.Transform, sourceType iceberg.Type) fu
 		value, err := getArrowValueAsIcebergValue(column, row, sourceType)
 		if err != nil {
 			return nil, err
+		}
+		if value == nil {
+			return nil, nil
 		}
 
 		return bound(value), nil
@@ -487,6 +493,10 @@ func bindPartitionTransform(transform iceberg.Transform, sourceType iceberg.Type
 	case iceberg.VoidTransform:
 		return func(any) any { return nil }, true
 	case iceberg.BucketTransform:
+		if !typed.CanTransform(sourceType) {
+			break
+		}
+
 		return optionalInt(typed.Transformer(sourceType)), true
 	case iceberg.TruncateTransform:
 		transformer, err := typed.Transformer(sourceType)

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/internal"
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -66,6 +67,7 @@ type partitionFieldInfo struct {
 	fieldID     int
 	sourceType  iceberg.Type
 	columnIndex int
+	valueAt     func(arrow.Array, int) (any, error)
 }
 
 type partitionExtractionPlan struct {
@@ -362,6 +364,7 @@ func newPartitionExtractionPlan(spec iceberg.PartitionSpec, schema *iceberg.Sche
 			fieldID:     sourceField.FieldID,
 			sourceType:  sourceType,
 			columnIndex: colIndices[0],
+			valueAt:     bindPartitionValue(sourceField.Transform, sourceType),
 		}
 	}
 
@@ -398,25 +401,19 @@ func (p *partitionExtractionPlan) getRecordPartitions(record arrow.RecordBatch) 
 		for i, fieldInfo := range p.fields {
 			col := partitionColumns[i]
 			if col != nil && !col.IsNull(int(row)) {
-				sourceField := fieldInfo.sourceField
-				val, err := getArrowValueAsIcebergLiteral(col, int(row), fieldInfo.sourceType)
+				value, err := fieldInfo.valueAt(col, int(row))
 				if err != nil {
 					return nil, fmt.Errorf(
 						"failed to convert source column %q (field ID %d) from Arrow type %s to Iceberg type %s: %w",
 						fieldInfo.sourceName,
-						sourceField.SourceID(),
+						fieldInfo.sourceField.SourceID(),
 						col.DataType(),
 						fieldInfo.sourceType,
 						err,
 					)
 				}
 
-				transformedLiteral := sourceField.Transform.Apply(iceberg.Optional[iceberg.Literal]{Valid: true, Val: val})
-				if transformedLiteral.Valid {
-					partitionRec[i] = transformedLiteral.Val.Any()
-				} else {
-					partitionRec[i] = nil
-				}
+				partitionRec[i] = value
 			} else {
 				partitionRec[i] = nil
 			}
@@ -432,6 +429,87 @@ func (p *partitionExtractionPlan) getRecordPartitions(record arrow.RecordBatch) 
 
 func (p *partitionExtractionPlan) matchesSchema(recordSchema *arrow.Schema) bool {
 	return recordSchema == p.recordSchema || recordSchema.Equal(p.recordSchema)
+}
+
+func bindPartitionValue(transform iceberg.Transform, sourceType iceberg.Type) func(arrow.Array, int) (any, error) {
+	bound, ok := bindPartitionTransform(transform, sourceType)
+	if !ok {
+		return func(column arrow.Array, row int) (any, error) {
+			value, err := getArrowValueAsIcebergLiteral(column, row, sourceType)
+			if err != nil {
+				return nil, err
+			}
+
+			transformed := transform.Apply(iceberg.Optional[iceberg.Literal]{Valid: true, Val: value})
+			if !transformed.Valid {
+				return nil, nil
+			}
+
+			return transformed.Val.Any(), nil
+		}
+	}
+
+	return func(column arrow.Array, row int) (any, error) {
+		value, err := getArrowValueAsIcebergValue(column, row, sourceType)
+		if err != nil {
+			return nil, err
+		}
+
+		return bound(value), nil
+	}
+}
+
+func bindPartitionTransform(transform iceberg.Transform, sourceType iceberg.Type) (func(any) any, bool) {
+	optionalInt := func(transformer func(any) iceberg.Optional[int32]) func(any) any {
+		return func(value any) any {
+			transformed := transformer(value)
+			if !transformed.Valid {
+				return nil
+			}
+
+			return transformed.Val
+		}
+	}
+	optionalDate := func(transformer func(any) iceberg.Optional[int32]) func(any) any {
+		return func(value any) any {
+			transformed := transformer(value)
+			if !transformed.Valid {
+				return nil
+			}
+
+			return iceberg.Date(transformed.Val)
+		}
+	}
+
+	switch typed := transform.(type) {
+	case iceberg.IdentityTransform:
+		return func(value any) any { return value }, true
+	case iceberg.VoidTransform:
+		return func(any) any { return nil }, true
+	case iceberg.BucketTransform:
+		return optionalInt(typed.Transformer(sourceType)), true
+	case iceberg.TruncateTransform:
+		transformer, err := typed.Transformer(sourceType)
+		if err == nil {
+			return transformer, true
+		}
+	case iceberg.UnknownTransform:
+		return func(any) any { return nil }, true
+	}
+
+	// Year, month, and hour transforms bind through TimeTransform.
+	if typed, ok := transform.(iceberg.TimeTransform); ok {
+		transformer, err := typed.Transformer(sourceType)
+		if err == nil {
+			if _, ok := transform.(iceberg.DayTransform); ok {
+				return optionalDate(transformer), true
+			}
+
+			return optionalInt(transformer), true
+		}
+	}
+
+	return nil, false
 }
 
 // partitionMapNode represents a simple tree structure for storing partitionInfo.
@@ -821,6 +899,60 @@ func contiguousRowRange(rowIndices []int64, numRows int64) (start, end int64, ok
 }
 
 func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType iceberg.Type) (iceberg.Literal, error) {
+	value, err := getArrowValueAsIcebergValue(column, row, sourceType)
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return nil, nil
+	}
+
+	literal, err := partitionLiteralFromValue(value)
+	if err != nil {
+		return nil, err
+	}
+	switch sourceType.(type) {
+	case iceberg.BinaryType, iceberg.FixedType, iceberg.UUIDType:
+		return literal.To(sourceType)
+	default:
+		return literal, nil
+	}
+}
+
+func partitionLiteralFromValue(value any) (iceberg.Literal, error) {
+	switch value := value.(type) {
+	case bool:
+		return iceberg.NewLiteral(value), nil
+	case int32:
+		return iceberg.NewLiteral(value), nil
+	case int64:
+		return iceberg.NewLiteral(value), nil
+	case float32:
+		return iceberg.NewLiteral(value), nil
+	case float64:
+		return iceberg.NewLiteral(value), nil
+	case iceberg.Date:
+		return iceberg.NewLiteral(value), nil
+	case iceberg.Time:
+		return iceberg.NewLiteral(value), nil
+	case iceberg.Timestamp:
+		return iceberg.NewLiteral(value), nil
+	case iceberg.TimestampNano:
+		return iceberg.NewLiteral(value), nil
+	case string:
+		return iceberg.NewLiteral(value), nil
+	case []byte:
+		return iceberg.NewLiteral(value), nil
+	case uuid.UUID:
+		return iceberg.NewLiteral(value), nil
+	case iceberg.Decimal:
+		return iceberg.NewLiteral(value), nil
+	default:
+		return nil, fmt.Errorf("unsupported Iceberg literal value type: %T", value)
+	}
+}
+
+func getArrowValueAsIcebergValue(column arrow.Array, row int, sourceType iceberg.Type) (any, error) {
 	if column.IsNull(row) {
 		return nil, nil
 	}
@@ -828,17 +960,17 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 	switch arr := column.(type) {
 	case *array.Date32:
 
-		return iceberg.NewLiteral(iceberg.Date(arr.Value(row))), nil
+		return iceberg.Date(arr.Value(row)), nil
 	case *array.Time64:
 		dt, ok := arr.DataType().(*arrow.Time64Type)
 		if !ok || dt.Unit != arrow.Microsecond {
 			return nil, fmt.Errorf("%w: unsupported arrow type for conversion - %s", iceberg.ErrInvalidSchema, arr.DataType())
 		}
 
-		return iceberg.NewLiteral(iceberg.Time(arr.Value(row))), nil
+		return iceberg.Time(arr.Value(row)), nil
 	case *array.Timestamp:
 
-		return timestampLiteralFromArrow(arr, row, sourceType)
+		return timestampValueFromArrow(arr, row, sourceType)
 	case *array.Decimal32:
 		val := arr.Value(row)
 		dec := iceberg.Decimal{
@@ -846,7 +978,7 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 			Scale: int(arr.DataType().(*arrow.Decimal32Type).Scale),
 		}
 
-		return iceberg.NewLiteral(dec), nil
+		return dec, nil
 	case *array.Decimal64:
 		val := arr.Value(row)
 		dec := iceberg.Decimal{
@@ -854,7 +986,7 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 			Scale: int(arr.DataType().(*arrow.Decimal64Type).Scale),
 		}
 
-		return iceberg.NewLiteral(dec), nil
+		return dec, nil
 	case *array.Decimal128:
 		val := arr.Value(row)
 		dec := iceberg.Decimal{
@@ -862,56 +994,56 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 			Scale: int(arr.DataType().(*arrow.Decimal128Type).Scale),
 		}
 
-		return iceberg.NewLiteral(dec), nil
+		return dec, nil
 	case *extensions.UUIDArray:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 
 	case *array.String:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.LargeString:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Int64:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Int32:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Int16:
 
-		return iceberg.NewLiteral(int32(arr.Value(row))), nil
+		return int32(arr.Value(row)), nil
 	case *array.Int8:
 
-		return iceberg.NewLiteral(int32(arr.Value(row))), nil
+		return int32(arr.Value(row)), nil
 	case *array.Uint64:
 
-		return iceberg.NewLiteral(int64(arr.Value(row))), nil
+		return int64(arr.Value(row)), nil
 	case *array.Uint32:
 
-		return iceberg.NewLiteral(int32(arr.Value(row))), nil
+		return int32(arr.Value(row)), nil
 	case *array.Uint16:
 
-		return iceberg.NewLiteral(int32(arr.Value(row))), nil
+		return int32(arr.Value(row)), nil
 	case *array.Uint8:
 
-		return iceberg.NewLiteral(int32(arr.Value(row))), nil
+		return int32(arr.Value(row)), nil
 	case *array.Float32:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Float64:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Boolean:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.Binary:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.LargeBinary:
 
-		return iceberg.NewLiteral(arr.Value(row)), nil
+		return arr.Value(row), nil
 	case *array.FixedSizeBinary:
 		switch sourceType.(type) {
 		case iceberg.BinaryType, iceberg.FixedType, iceberg.UUIDType:
@@ -919,7 +1051,12 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 			return nil, fmt.Errorf("%w: cannot convert Arrow %s to Iceberg type %v", iceberg.ErrInvalidSchema, arr.DataType(), sourceType)
 		}
 
-		return iceberg.NewLiteral(arr.Value(row)).To(sourceType)
+		literal, err := iceberg.NewLiteral(arr.Value(row)).To(sourceType)
+		if err != nil {
+			return nil, err
+		}
+
+		return literal.Any(), nil
 
 	default:
 		val := column.GetOneForMarshal(row)
@@ -928,7 +1065,7 @@ func getArrowValueAsIcebergLiteral(column arrow.Array, row int, sourceType icebe
 	}
 }
 
-func timestampLiteralFromArrow(arr *array.Timestamp, row int, sourceType iceberg.Type) (iceberg.Literal, error) {
+func timestampValueFromArrow(arr *array.Timestamp, row int, sourceType iceberg.Type) (any, error) {
 	timestampType := arr.DataType().(*arrow.TimestampType)
 	value := int64(arr.Value(row))
 
@@ -939,14 +1076,14 @@ func timestampLiteralFromArrow(arr *array.Timestamp, row int, sourceType iceberg
 			return nil, err
 		}
 
-		return iceberg.NewLiteral(iceberg.Timestamp(micros)), nil
+		return iceberg.Timestamp(micros), nil
 	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
 		nanos, err := arrowTimestampToNanos(value, timestampType.Unit)
 		if err != nil {
 			return nil, err
 		}
 
-		return iceberg.NewLiteral(iceberg.TimestampNano(nanos)), nil
+		return iceberg.TimestampNano(nanos), nil
 	default:
 		return nil, fmt.Errorf("cannot convert arrow timestamp to iceberg literal for source type %v", sourceType)
 	}

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -1380,6 +1380,99 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyBoundsQueuedWriterMemory(
 	s.Less(peakBytes, fullBatchBytes*4, "queued partial batches should not retain complete input batches")
 }
 
+func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchGenericApply() {
+	unknown, err := iceberg.ParseTransform("custom-transform")
+	s.Require().NoError(err)
+
+	tests := []struct {
+		name       string
+		transform  iceberg.Transform
+		sourceType iceberg.Type
+		value      iceberg.Literal
+		fallback   bool
+	}{
+		{
+			name: "identity", transform: iceberg.IdentityTransform{},
+			sourceType: iceberg.PrimitiveTypes.Int64, value: iceberg.Int64Literal(34),
+		},
+		{
+			name: "void", transform: iceberg.VoidTransform{},
+			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"),
+		},
+		{
+			name: "bucket", transform: iceberg.BucketTransform{NumBuckets: 16},
+			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"),
+		},
+		{
+			name: "truncate", transform: iceberg.TruncateTransform{Width: 3},
+			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abcdef"),
+		},
+		{
+			name: "year", transform: iceberg.YearTransform{},
+			sourceType: iceberg.PrimitiveTypes.Date, value: iceberg.DateLiteral(19_358),
+		},
+		{
+			name: "month", transform: iceberg.MonthTransform{},
+			sourceType: iceberg.PrimitiveTypes.Timestamp, value: iceberg.TimestampLiteral(1_672_531_200_000_000),
+		},
+		{
+			name: "day nanoseconds", transform: iceberg.DayTransform{},
+			sourceType: iceberg.PrimitiveTypes.TimestampNs, value: iceberg.TimestampNsLiteral(1_672_531_200_000_000_000),
+		},
+		{
+			name: "hour", transform: iceberg.HourTransform{},
+			sourceType: iceberg.PrimitiveTypes.Timestamp, value: iceberg.TimestampLiteral(1_672_531_200_000_000),
+		},
+		{
+			name: "invalid truncate fallback", transform: iceberg.TruncateTransform{Width: 0},
+			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"), fallback: true,
+		},
+		{
+			name: "unknown fallback", transform: unknown,
+			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"),
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			expected := test.transform.Apply(iceberg.Optional[iceberg.Literal]{Valid: true, Val: test.value})
+			var expectedValue any
+			if expected.Valid {
+				expectedValue = expected.Val.Any()
+			}
+
+			bound, ok := bindPartitionTransform(test.transform, test.sourceType)
+			if test.fallback {
+				s.False(ok)
+
+				return
+			}
+
+			s.Require().True(ok)
+			s.Equal(expectedValue, bound(test.value.Any()))
+		})
+	}
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionTransformBindingFallsBackForInvalidTransform() {
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: arrow.BinaryTypes.String}}, nil)
+	record := s.createCustomTestRecord(arrowSchema, [][]any{{"abc"}})
+	defer record.Release()
+
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.String},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "part",
+		Transform: iceberg.TruncateTransform{Width: 0},
+	})
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Nil(partitions[0].partitionRec.Get(0))
+}
+
 func (s *FanoutWriterTestSuite) TestVoidTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	arrowdecimal "github.com/apache/arrow-go/v18/arrow/decimal"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
@@ -1617,6 +1618,54 @@ func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchArrowValues() {
 
 				s.Equal(expectedValue, bound(nativeValue), "row %d", row)
 			}
+		})
+	}
+}
+
+func (s *FanoutWriterTestSuite) TestArrowDecimalValuesPreserveSign() {
+	tests := []struct {
+		name       string
+		sourceType iceberg.Type
+		build      func() arrow.Array
+		want       iceberg.Decimal
+	}{
+		{
+			name:       "decimal32",
+			sourceType: iceberg.DecimalTypeOf(8, 2),
+			build: func() arrow.Array {
+				builder := array.NewDecimal32Builder(s.mem, &arrow.Decimal32Type{Precision: 8, Scale: 2})
+				builder.Append(arrowdecimal.Decimal32(-1234))
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+			want: iceberg.Decimal{Val: decimal128.FromI64(-1234), Scale: 2},
+		},
+		{
+			name:       "decimal64",
+			sourceType: iceberg.DecimalTypeOf(18, 2),
+			build: func() arrow.Array {
+				builder := array.NewDecimal64Builder(s.mem, &arrow.Decimal64Type{Precision: 18, Scale: 2})
+				builder.Append(arrowdecimal.Decimal64(-1234))
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+			want: iceberg.Decimal{Val: decimal128.FromI64(-1234), Scale: 2},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		s.Run(test.name, func() {
+			column := test.build()
+			defer column.Release()
+
+			value, err := getArrowValueAsIcebergValue(column, 0, test.sourceType)
+			s.Require().NoError(err)
+			s.Equal(test.want, value)
 		})
 	}
 }

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -1164,6 +1164,41 @@ func (s *FanoutWriterTestSuite) TestPartitionedWriterReusesExtractionPlan() {
 	s.Same(firstPlan, writer.plan)
 }
 
+func (s *FanoutWriterTestSuite) TestPartitionedWriterRebuildsPlanForDivergentSchemas() {
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
+		iceberg.NestedField{ID: 2, Name: "value", Type: iceberg.PrimitiveTypes.String},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "part",
+	})
+
+	firstSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "value", Type: arrow.BinaryTypes.String},
+	}, nil)
+	firstRecord := s.createCustomTestRecord(firstSchema, [][]any{{int32(7), "first"}})
+	defer firstRecord.Release()
+
+	writer := newPartitionedFanoutWriter(spec, icebergSchema, nil, nil)
+	partitions, err := writer.getPartitions(firstRecord)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Equal(int32(7), partitions[0].partitionRec.Get(0))
+
+	secondSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "value", Type: arrow.BinaryTypes.String},
+		{Name: "part", Type: arrow.PrimitiveTypes.Int32},
+	}, nil)
+	secondRecord := s.createCustomTestRecord(secondSchema, [][]any{{"second", int32(8)}})
+	defer secondRecord.Release()
+
+	partitions, err = writer.getPartitions(secondRecord)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Equal(int32(8), partitions[0].partitionRec.Get(0))
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionExtractionPlanMatchesSchema() {
 	icebergSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Int32},
@@ -1428,8 +1463,12 @@ func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchGenericApply() 
 			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"), fallback: true,
 		},
 		{
-			name: "unknown fallback", transform: unknown,
+			name: "unknown_transform", transform: unknown,
 			sourceType: iceberg.PrimitiveTypes.String, value: iceberg.StringLiteral("abc"),
+		},
+		{
+			name: "unsupported bucket source fallback", transform: iceberg.BucketTransform{NumBuckets: 16},
+			sourceType: iceberg.PrimitiveTypes.Bool, value: iceberg.BoolLiteral(true), fallback: true,
 		},
 	}
 
@@ -1454,6 +1493,147 @@ func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchGenericApply() 
 	}
 }
 
+func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchArrowValues() {
+	buildDecimal := func() arrow.Array {
+		builder := array.NewDecimal128Builder(s.mem, &arrow.Decimal128Type{Precision: 10, Scale: 2})
+		for _, value := range []string{"-123.45", "67.89"} {
+			decimal, err := arrowdecimal.Decimal128FromString(value, 10, 2)
+			s.Require().NoError(err)
+			builder.Append(decimal)
+		}
+		result := builder.NewArray()
+		builder.Release()
+
+		return result
+	}
+
+	tests := []struct {
+		name       string
+		sourceType iceberg.Type
+		transform  iceberg.Transform
+		build      func() arrow.Array
+	}{
+		{
+			name:       "bucket int32",
+			sourceType: iceberg.PrimitiveTypes.Int32,
+			transform:  iceberg.BucketTransform{NumBuckets: 16},
+			build: func() arrow.Array {
+				builder := array.NewInt32Builder(s.mem)
+				builder.AppendValues([]int32{-7, 34}, nil)
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+		},
+		{
+			name:       "bucket date",
+			sourceType: iceberg.PrimitiveTypes.Date,
+			transform:  iceberg.BucketTransform{NumBuckets: 16},
+			build: func() arrow.Array {
+				builder := array.NewDate32Builder(s.mem)
+				builder.AppendValues([]arrow.Date32{-7, 19_358}, nil)
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+		},
+		{
+			name:       "bucket decimal",
+			sourceType: iceberg.DecimalTypeOf(10, 2),
+			transform:  iceberg.BucketTransform{NumBuckets: 16},
+			build:      buildDecimal,
+		},
+		{
+			name:       "truncate decimal",
+			sourceType: iceberg.DecimalTypeOf(10, 2),
+			transform:  iceberg.TruncateTransform{Width: 10},
+			build:      buildDecimal,
+		},
+		{
+			name:       "bucket uuid",
+			sourceType: iceberg.PrimitiveTypes.UUID,
+			transform:  iceberg.BucketTransform{NumBuckets: 16},
+			build: func() arrow.Array {
+				builder := extensions.NewUUIDBuilder(s.mem)
+				builder.Append(uuid.MustParse("12345678-9abc-def0-1234-56789abcdef0"))
+				builder.Append(uuid.MustParse("fedcba98-7654-3210-fedc-ba9876543210"))
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+		},
+		{
+			name:       "bucket fixed",
+			sourceType: iceberg.FixedTypeOf(4),
+			transform:  iceberg.BucketTransform{NumBuckets: 16},
+			build: func() arrow.Array {
+				builder := array.NewFixedSizeBinaryBuilder(s.mem, &arrow.FixedSizeBinaryType{ByteWidth: 4})
+				builder.Append([]byte{1, 2, 3, 4})
+				builder.Append([]byte{5, 6, 7, 8})
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+		},
+		{
+			name:       "truncate binary",
+			sourceType: iceberg.PrimitiveTypes.Binary,
+			transform:  iceberg.TruncateTransform{Width: 3},
+			build: func() arrow.Array {
+				builder := array.NewBinaryBuilder(s.mem, arrow.BinaryTypes.Binary)
+				builder.Append([]byte{1, 2, 3, 4})
+				builder.Append([]byte{5, 6})
+				result := builder.NewArray()
+				builder.Release()
+
+				return result
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		s.Run(test.name, func() {
+			column := test.build()
+			defer column.Release()
+
+			bound, ok := bindPartitionTransform(test.transform, test.sourceType)
+			s.Require().True(ok)
+			for row := 0; row < column.Len(); row++ {
+				nativeValue, err := getArrowValueAsIcebergValue(column, row, test.sourceType)
+				s.Require().NoError(err)
+				literalValue, err := getArrowValueAsIcebergLiteral(column, row, test.sourceType)
+				s.Require().NoError(err)
+
+				expected := test.transform.Apply(iceberg.Optional[iceberg.Literal]{Valid: true, Val: literalValue})
+				var expectedValue any
+				if expected.Valid {
+					expectedValue = expected.Val.Any()
+				}
+
+				s.Equal(expectedValue, bound(nativeValue), "row %d", row)
+			}
+		})
+	}
+}
+
+func (s *FanoutWriterTestSuite) TestBoundPartitionValueHandlesNull() {
+	builder := array.NewInt32Builder(s.mem)
+	builder.AppendNull()
+	column := builder.NewArray()
+	builder.Release()
+	defer column.Release()
+
+	valueAt := bindPartitionValue(iceberg.BucketTransform{NumBuckets: 16}, iceberg.PrimitiveTypes.Int32)
+	value, err := valueAt(column, 0)
+	s.Require().NoError(err)
+	s.Nil(value)
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionTransformBindingFallsBackForInvalidTransform() {
 	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: arrow.BinaryTypes.String}}, nil)
 	record := s.createCustomTestRecord(arrowSchema, [][]any{{"abc"}})
@@ -1465,6 +1645,25 @@ func (s *FanoutWriterTestSuite) TestPartitionTransformBindingFallsBackForInvalid
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 		SourceIDs: []int{1}, FieldID: 1000, Name: "part",
 		Transform: iceberg.TruncateTransform{Width: 0},
+	})
+
+	partitions, err := getRecordPartitions(spec, icebergSchema, record)
+	s.Require().NoError(err)
+	s.Require().Len(partitions, 1)
+	s.Nil(partitions[0].partitionRec.Get(0))
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionTransformBindingFallsBackForUnsupportedSource() {
+	arrSchema := arrow.NewSchema([]arrow.Field{{Name: "part", Type: arrow.FixedWidthTypes.Boolean}}, nil)
+	record := s.createCustomTestRecord(arrSchema, [][]any{{true}})
+	defer record.Release()
+
+	icebergSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "part", Type: iceberg.PrimitiveTypes.Bool},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "part",
+		Transform: iceberg.BucketTransform{NumBuckets: 16},
 	})
 
 	partitions, err := getRecordPartitions(spec, icebergSchema, record)

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -1597,14 +1597,13 @@ func (s *FanoutWriterTestSuite) TestBoundPartitionTransformsMatchArrowValues() {
 	}
 
 	for _, test := range tests {
-		test := test
 		s.Run(test.name, func() {
 			column := test.build()
 			defer column.Release()
 
 			bound, ok := bindPartitionTransform(test.transform, test.sourceType)
 			s.Require().True(ok)
-			for row := 0; row < column.Len(); row++ {
+			for row := range column.Len() {
 				nativeValue, err := getArrowValueAsIcebergValue(column, row, test.sourceType)
 				s.Require().NoError(err)
 				literalValue, err := getArrowValueAsIcebergLiteral(column, row, test.sourceType)
@@ -1658,7 +1657,6 @@ func (s *FanoutWriterTestSuite) TestArrowDecimalValuesPreserveSign() {
 	}
 
 	for _, test := range tests {
-		test := test
 		s.Run(test.name, func() {
 			column := test.build()
 			defer column.Release()


### PR DESCRIPTION
Depends on #1765. This is stacked on top of it, so only the second commit is new here.

## What changed

- Bind built-in partition transform functions when the extraction plan is created.
- Feed native Iceberg values directly into identity, bucket, truncate, and time transforms.
- Keep the generic literal path for custom or unsupported transforms.
- Keep unknown and void transforms producing null partition values.

## Why

The row loop currently converts each Arrow value into a literal and calls `Transform.Apply`. Some transforms do more setup there. For example, `TruncateTransform.Apply` rebuilds its transformer for every value.

The extraction plan has the source type already, so it can bind the transform once and reuse the function for every batch. Java's `StructTransform` uses the same bind-once shape.

## Benchmark

Apple M1 Pro, 65,536 rows, median of 3 runs. The baseline is #1765.

```
go test ./table -run '^$' -bench '^BenchmarkPartitionTransforms$' -benchmem -benchtime=1s -count=3 -cpu=1
```

| Transform | #1765 | this PR |
| --- | ---: | ---: |
| identity int64 | 2,648,326 ns/op | 2,531,346 ns/op |
| bucket string | 5,862,667 ns/op | 5,710,295 ns/op |
| truncate string | 15,767,652 ns/op, 7,271,656 B/op, 394,124 allocs/op | 7,205,658 ns/op, 3,077,352 B/op, 131,980 allocs/op |
| day timestamp | 3,898,547 ns/op | 3,468,050 ns/op |
| hour timestamp_ns | 3,812,458 ns/op | 3,621,065 ns/op |

The largest change is `truncate[string]`, which is about 2.2x faster with 67% fewer allocations.

## Tests

- `go test ./...`
- `go test -race ./table -run '^TestFanoutWriter$' -count=1`
- `go vet ./...`
- `git diff --check`
