### PR TITLE
perf(manifest): update partition summaries incrementally

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1168,14 +1168,6 @@ type partitionFieldStats[T LiteralType] struct {
 	cmp Comparator[T]
 }
 
-func clonePartitionStatValue[T LiteralType](value T) T {
-	if data, ok := any(value).([]byte); ok {
-		return any(slices.Clone(data)).(T)
-	}
-
-	return value
-}
-
 // unknownPartitionFieldStats records null presence but omits bounds because
 // the dropped source type needed to encode and compare non-null values is lost.
 type unknownPartitionFieldStats struct {
@@ -1274,6 +1266,9 @@ func (p *partitionFieldStats[T]) update(value any) (err error) {
 	}
 
 	actualVal = v.Convert(reflect.TypeOf(actualVal)).Interface().(T)
+	if data, ok := any(actualVal).([]byte); ok {
+		actualVal = any(slices.Clone(data)).(T)
+	}
 
 	switch f := any(actualVal).(type) {
 	case float32:
@@ -1291,18 +1286,15 @@ func (p *partitionFieldStats[T]) update(value any) (err error) {
 	}
 
 	if p.min == nil {
-		actualVal = clonePartitionStatValue(actualVal)
 		p.min = &actualVal
 		p.max = &actualVal
 	} else {
 		if p.cmp(actualVal, *p.min) < 0 {
-			min := clonePartitionStatValue(actualVal)
-			p.min = &min
+			p.min = &actualVal
 		}
 
 		if p.cmp(actualVal, *p.max) > 0 {
-			max := clonePartitionStatValue(actualVal)
-			p.max = &max
+			p.max = &actualVal
 		}
 	}
 

--- a/manifest.go
+++ b/manifest.go
@@ -1298,36 +1298,47 @@ func (p *partitionFieldStats[T]) update(value any) (err error) {
 	return nil
 }
 
-func constructPartitionSummaries(spec PartitionSpec, schema *Schema, partitions []map[int]any) ([]FieldSummary, error) {
-	partType := spec.PartitionType(schema)
-	fieldStats := make([]fieldStats, len(partType.FieldList))
+type partitionSummaryStats struct {
+	fields []NestedField
+	stats  []fieldStats
+}
+
+func newPartitionSummaryStats(spec PartitionSpec, schema *Schema) (*partitionSummaryStats, error) {
+	fields := spec.PartitionType(schema).FieldList
+	stats := make([]fieldStats, len(fields))
 	var err error
-	for i, field := range partType.FieldList {
+	for i, field := range fields {
 		pt, ok := field.Type.(PrimitiveType)
 		if !ok {
 			return nil, fmt.Errorf("expected primitive type for partition field, got %s", field.Type)
 		}
 
-		fieldStats[i], err = newPartitionFieldStat(pt)
+		stats[i], err = newPartitionFieldStat(pt)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing field stats for partition %d: %s: %s", i, field.Name, err)
 		}
 	}
 
-	for _, part := range partitions {
-		for i, field := range partType.FieldList {
-			if err := fieldStats[i].update(part[field.ID]); err != nil {
-				return nil, fmt.Errorf("error updating field stats for partition %d: %s: %s", i, field.Name, err)
-			}
+	return &partitionSummaryStats{fields: fields, stats: stats}, nil
+}
+
+func (p *partitionSummaryStats) update(partition map[int]any) error {
+	for i, field := range p.fields {
+		if err := p.stats[i].update(partition[field.ID]); err != nil {
+			return fmt.Errorf("error updating field stats for partition %d: %s: %s", i, field.Name, err)
 		}
 	}
 
-	summaries := make([]FieldSummary, len(fieldStats))
-	for i, stat := range fieldStats {
+	return nil
+}
+
+func (p *partitionSummaryStats) summaries() []FieldSummary {
+	summaries := make([]FieldSummary, len(p.stats))
+	for i, stat := range p.stats {
 		summaries[i] = stat.toSummary()
 	}
 
-	return summaries, nil
+	return summaries
 }
 
 type ManifestWriter struct {
@@ -1353,9 +1364,10 @@ type ManifestWriter struct {
 	deletedFiles  int32
 	deletedRows   int64
 
-	partitions  []map[int]any
-	minSeqNum   int64
-	reusedEntry manifestEntry
+	partitionStats    *partitionSummaryStats
+	partitionStatsErr error
+	minSeqNum         int64
+	reusedEntry       manifestEntry
 }
 
 type ManifestWriterOption func(w *ManifestWriter)
@@ -1391,18 +1403,20 @@ func NewManifestWriter(version int, out io.Writer, spec PartitionSpec, schema *S
 	}
 
 	fieldMaps := getFieldIDMap(fileSchema)
+	partitionStats, partitionStatsErr := newPartitionSummaryStats(spec, schema)
 
 	w := &ManifestWriter{
-		impl:          impl,
-		version:       version,
-		output:        out,
-		spec:          spec,
-		content:       ManifestContentData,
-		schema:        schema,
-		partFieldMaps: fieldMaps,
-		snapshotID:    snapshotID,
-		minSeqNum:     -1,
-		partitions:    make([]map[int]any, 0),
+		impl:              impl,
+		version:           version,
+		output:            out,
+		spec:              spec,
+		content:           ManifestContentData,
+		schema:            schema,
+		partFieldMaps:     fieldMaps,
+		snapshotID:        snapshotID,
+		partitionStats:    partitionStats,
+		partitionStatsErr: partitionStatsErr,
+		minSeqNum:         -1,
 	}
 
 	for _, apply := range opts {
@@ -1470,10 +1484,10 @@ func (w *ManifestWriter) ToManifestFile(location string, length int64, opts ...M
 		return nil, err
 	}
 
-	partitions, err := constructPartitionSummaries(w.spec, w.schema, w.partitions)
-	if err != nil {
-		return nil, err
+	if w.partitionStatsErr != nil {
+		return nil, w.partitionStatsErr
 	}
+	partitions := w.partitionStats.summaries()
 
 	mf := manifestFile{
 		version:            w.version,
@@ -1568,7 +1582,6 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	if err := w.writer.Encode(toEncode); err != nil {
 		return err
 	}
-	w.partitions = append(w.partitions, clonePartitionMap(partition))
 
 	switch status {
 	case EntryStatusADDED:
@@ -1580,6 +1593,10 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	case EntryStatusDELETED:
 		w.deletedFiles++
 		w.deletedRows += count
+	}
+
+	if w.partitionStatsErr == nil {
+		w.partitionStatsErr = w.partitionStats.update(partition)
 	}
 
 	if status == EntryStatusADDED || status == EntryStatusEXISTING {

--- a/manifest.go
+++ b/manifest.go
@@ -1168,6 +1168,14 @@ type partitionFieldStats[T LiteralType] struct {
 	cmp Comparator[T]
 }
 
+func clonePartitionStatValue[T LiteralType](value T) T {
+	if data, ok := any(value).([]byte); ok {
+		return any(slices.Clone(data)).(T)
+	}
+
+	return value
+}
+
 // unknownPartitionFieldStats records null presence but omits bounds because
 // the dropped source type needed to encode and compare non-null values is lost.
 type unknownPartitionFieldStats struct {
@@ -1283,15 +1291,18 @@ func (p *partitionFieldStats[T]) update(value any) (err error) {
 	}
 
 	if p.min == nil {
+		actualVal = clonePartitionStatValue(actualVal)
 		p.min = &actualVal
 		p.max = &actualVal
 	} else {
 		if p.cmp(actualVal, *p.min) < 0 {
-			p.min = &actualVal
+			min := clonePartitionStatValue(actualVal)
+			p.min = &min
 		}
 
 		if p.cmp(actualVal, *p.max) > 0 {
-			p.max = &actualVal
+			max := clonePartitionStatValue(actualVal)
+			p.max = &max
 		}
 	}
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -601,6 +601,73 @@ func TestManifestWriterUpdatesPartitionSummariesIncrementally(t *testing.T) {
 	assertSummary(2, false, false, NewLiteral([]byte{1}), NewLiteral([]byte{3}))
 }
 
+func TestManifestWriterCopiesBinaryPartitionSummaryBounds(t *testing.T) {
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "shard", Type: PrimitiveTypes.Binary},
+	)
+	spec := NewPartitionSpec(
+		PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "shard", Transform: IdentityTransform{}},
+	)
+	snapshotID := int64(1234)
+	sequenceNumber := int64(1)
+	low := []byte{1}
+	high := []byte{2}
+
+	newEntry := func(path string, partition []byte) ManifestEntry {
+		builder, err := NewDataFileBuilder(
+			spec,
+			EntryContentData,
+			path,
+			ParquetFile,
+			map[int]any{1000: partition},
+			nil,
+			nil,
+			1,
+			1,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return NewManifestEntry(
+			EntryStatusADDED,
+			&snapshotID,
+			&sequenceNumber,
+			&sequenceNumber,
+			builder.Build(),
+		)
+	}
+
+	writer, err := NewManifestWriter(2, io.Discard, spec, schema, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Add(newEntry("low.parquet", low)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Add(newEntry("high.parquet", high)); err != nil {
+		t.Fatal(err)
+	}
+
+	low[0] = 3
+
+	manifest, err := writer.ToManifestFile("manifest.avro", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summaries := manifest.Partitions()
+	if len(summaries) != 1 {
+		t.Fatalf("expected one partition summary, got %d", len(summaries))
+	}
+	summary := summaries[0]
+	if summary.LowerBound == nil || !bytes.Equal(*summary.LowerBound, []byte{1}) {
+		t.Fatalf("lower bound = %v, want [1]", summary.LowerBound)
+	}
+	if summary.UpperBound == nil || !bytes.Equal(*summary.UpperBound, []byte{2}) {
+		t.Fatalf("upper bound = %v, want [2]", summary.UpperBound)
+	}
+}
+
 type ManifestTestSuite struct {
 	suite.Suite
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -486,10 +486,14 @@ func TestConstructPartitionSummariesWithDroppedSource(t *testing.T) {
 	})
 	schema := NewSchema(0)
 
-	summaries, err := constructPartitionSummaries(spec, schema, []map[int]any{{1000: "historical-value"}})
+	stats, err := newPartitionSummaryStats(spec, schema)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := stats.update(map[int]any{1000: "historical-value"}); err != nil {
+		t.Fatal(err)
+	}
+	summaries := stats.summaries()
 	if len(summaries) != 1 {
 		t.Fatalf("expected one partition summary, got %d", len(summaries))
 	}
@@ -499,6 +503,102 @@ func TestConstructPartitionSummariesWithDroppedSource(t *testing.T) {
 	if summaries[0].LowerBound != nil || summaries[0].UpperBound != nil {
 		t.Fatal("expected the unknown partition field summary to omit bounds")
 	}
+}
+
+func TestManifestWriterUpdatesPartitionSummariesIncrementally(t *testing.T) {
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "region", Type: PrimitiveTypes.String},
+		NestedField{ID: 2, Name: "temperature", Type: PrimitiveTypes.Float64},
+		NestedField{ID: 3, Name: "shard", Type: PrimitiveTypes.Binary},
+	)
+	spec := NewPartitionSpec(
+		PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "region", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{2}, FieldID: 1001, Name: "temperature", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{3}, FieldID: 1002, Name: "shard", Transform: IdentityTransform{}},
+	)
+	snapshotID := int64(1234)
+	sequenceNumber := int64(1)
+
+	newEntry := func(path string, partition map[int]any) ManifestEntry {
+		builder, err := NewDataFileBuilder(
+			spec,
+			EntryContentData,
+			path,
+			ParquetFile,
+			partition,
+			nil,
+			nil,
+			1,
+			1,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return NewManifestEntry(
+			EntryStatusADDED,
+			&snapshotID,
+			&sequenceNumber,
+			&sequenceNumber,
+			builder.Build(),
+		)
+	}
+
+	writer, err := NewManifestWriter(2, io.Discard, spec, schema, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []ManifestEntry{
+		newEntry("east.parquet", map[int]any{1000: "east", 1001: 1.0, 1002: []byte{2}}),
+		newEntry("null.parquet", map[int]any{1000: nil, 1001: math.NaN(), 1002: []byte{1}}),
+		newEntry("west.parquet", map[int]any{1000: "west", 1001: 3.0, 1002: []byte{3}}),
+	}
+	if err := writer.Add(entries[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Existing(entries[1]); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Delete(entries[2]); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := writer.ToManifestFile("manifest.avro", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summaries := manifest.Partitions()
+	if len(summaries) != 3 {
+		t.Fatalf("expected three partition summaries, got %d", len(summaries))
+	}
+
+	assertSummary := func(index int, containsNull, containsNaN bool, lower, upper Literal) {
+		t.Helper()
+		lowerBytes, err := lower.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		upperBytes, err := upper.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		summary := summaries[index]
+		if summary.ContainsNull != containsNull || summary.ContainsNaN == nil || *summary.ContainsNaN != containsNaN {
+			t.Fatalf("summary %d flags = (%v, %v), want (%v, %v)", index, summary.ContainsNull, summary.ContainsNaN, containsNull, containsNaN)
+		}
+		if summary.LowerBound == nil || !bytes.Equal(*summary.LowerBound, lowerBytes) {
+			t.Fatalf("summary %d lower bound = %v, want %v", index, summary.LowerBound, lowerBytes)
+		}
+		if summary.UpperBound == nil || !bytes.Equal(*summary.UpperBound, upperBytes) {
+			t.Fatalf("summary %d upper bound = %v, want %v", index, summary.UpperBound, upperBytes)
+		}
+	}
+
+	assertSummary(0, true, false, NewLiteral("east"), NewLiteral("west"))
+	assertSummary(1, false, true, NewLiteral(1.0), NewLiteral(3.0))
+	assertSummary(2, false, false, NewLiteral([]byte{1}), NewLiteral([]byte{3}))
 }
 
 type ManifestTestSuite struct {
@@ -3015,12 +3115,13 @@ func (m *ManifestTestSuite) TestManifestWriterDoesNotCommitStateOnEncodeError() 
 	m.Zero(writer.existingRows)
 	m.Zero(writer.deletedFiles)
 	m.Zero(writer.deletedRows)
-	m.Empty(writer.partitions)
+	m.NoError(writer.partitionStatsErr)
+	m.Equal([]FieldSummary{{ContainsNaN: &falseBool}}, writer.partitionStats.summaries())
 	m.Equal(int64(-1), writer.minSeqNum)
 	m.Equal(originalPartitionData, dataFile.PartitionData)
 }
 
-func (m *ManifestTestSuite) TestManifestWriterCopiesBorrowedPartitionBeforeRetaining() {
+func (m *ManifestTestSuite) TestManifestWriterCopiesBorrowedPartitionSummaryBounds() {
 	schema := NewSchema(1, NestedField{ID: 1, Name: "part", Type: PrimitiveTypes.Binary})
 	partitionSpec := NewPartitionSpecID(
 		1,
@@ -3050,7 +3151,14 @@ func (m *ManifestTestSuite) TestManifestWriterCopiesBorrowedPartitionBeforeRetai
 	borrowed[1000].([]byte)[0] = 0xff
 	borrowed[1000] = []byte{0xff, 0xff}
 
-	m.Equal([]byte{0x01, 0x02}, writer.partitions[0][1000])
+	manifest, err := writer.ToManifestFile("manifest.avro", 0)
+	m.Require().NoError(err)
+	summaries := manifest.Partitions()
+	m.Require().Len(summaries, 1)
+	m.Require().NotNil(summaries[0].LowerBound)
+	m.Require().NotNil(summaries[0].UpperBound)
+	m.Equal([]byte{0x01, 0x02}, *summaries[0].LowerBound)
+	m.Equal([]byte{0x01, 0x02}, *summaries[0].UpperBound)
 }
 
 func newDatePartitionManifestEntry(t *testing.T, partitionSpec PartitionSpec, snapshotID int64, partitionValue any) ManifestEntry {

--- a/manifest_writer_bench_test.go
+++ b/manifest_writer_bench_test.go
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+func BenchmarkManifestWriterPartitionSummaries(b *testing.B) {
+	for _, entryCount := range []int{100, 1_000, 10_000} {
+		schema, spec, snapshotID, entries := manifestWriterBenchmarkData(b, entryCount)
+
+		b.Run(fmt.Sprintf("entries_%d", entryCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				writer, err := NewManifestWriter(2, io.Discard, spec, schema, snapshotID)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for _, entry := range entries {
+					if err := writer.Add(entry); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if _, err := writer.ToManifestFile("manifest.avro", 0); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkManifestWriterPartitionSummaryFinalization(b *testing.B) {
+	for _, entryCount := range []int{100, 1_000, 10_000} {
+		schema, spec, snapshotID, entries := manifestWriterBenchmarkData(b, entryCount)
+
+		b.Run(fmt.Sprintf("entries_%d", entryCount), func(b *testing.B) {
+			writer, err := NewManifestWriter(2, io.Discard, spec, schema, snapshotID)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for _, entry := range entries {
+				if err := writer.Add(entry); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := writer.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := writer.ToManifestFile("manifest.avro", 0); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func manifestWriterBenchmarkData(b *testing.B, entryCount int) (*Schema, PartitionSpec, int64, []ManifestEntry) {
+	b.Helper()
+
+	schema := NewSchema(0,
+		NestedField{ID: 1, Name: "region", Type: PrimitiveTypes.String},
+		NestedField{ID: 2, Name: "day", Type: PrimitiveTypes.Date},
+		NestedField{ID: 3, Name: "bucket", Type: PrimitiveTypes.Int32},
+		NestedField{ID: 4, Name: "shard", Type: PrimitiveTypes.Binary},
+	)
+	spec := NewPartitionSpec(
+		PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "region", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{2}, FieldID: 1001, Name: "day", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{3}, FieldID: 1002, Name: "bucket", Transform: IdentityTransform{}},
+		PartitionField{SourceIDs: []int{4}, FieldID: 1003, Name: "shard", Transform: IdentityTransform{}},
+	)
+	snapshotID := int64(1234)
+	sequenceNumber := int64(1)
+	entries := make([]ManifestEntry, entryCount)
+	for i := range entries {
+		builder, err := NewDataFileBuilder(
+			spec,
+			EntryContentData,
+			fmt.Sprintf("s3://bucket/data/%05d.parquet", i),
+			ParquetFile,
+			map[int]any{
+				1000: fmt.Sprintf("region-%02d", i%32),
+				1001: Date(i % 365),
+				1002: int32(i % 128),
+				1003: []byte{byte(i >> 8), byte(i)},
+			},
+			nil,
+			nil,
+			1_000,
+			1_000_000,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entries[i] = NewManifestEntry(
+			EntryStatusADDED,
+			&snapshotID,
+			&sequenceNumber,
+			&sequenceNumber,
+			builder.Build(),
+		)
+	}
+
+	return schema, spec, snapshotID, entries
+}


### PR DESCRIPTION
## What

- update partition field stats as manifest entries are written
- stop retaining every entry's partition map until finalization
- keep summary errors reported from `ToManifestFile`, like before
- add coverage for null, NaN, binary bounds, and failed entry encoding
- add writer and finalization benchmarks

## Why

`ManifestWriter` currently keeps one partition map per entry. `ToManifestFile` then walks all of them again to build partition summaries.

This makes retained state and finalization work grow with the number of manifest entries. The Java writer already keeps one `PartitionSummary` accumulator and updates it for each entry.

The summary values are unchanged. They still follow the spec rules for nulls, NaNs, and lower/upper bounds.

## Benchmark

```text
go test . -run '^$' -bench '^BenchmarkManifestWriterPartitionSummaryFinalization$' -benchmem -benchtime=1s -count=5 -cpu=1
```

Median results on an Apple M1 Pro:

| Entries | main | this PR | main B/op | this PR B/op | main allocs/op | this PR allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100 | 31.9 us | 0.92 us | 7,152 | 568 | 627 | 19 |
| 1,000 | 265.6 us | 0.71 us | 57,556 | 572 | 6,028 | 20 |
| 10,000 | 3.31 ms | 0.66 us | 561,556 | 572 | 60,028 | 20 |

This benchmark isolates `ToManifestFile` after entries have already been written. End-to-end manifest writing is still mostly Avro encoding. At 10,000 entries, the end-to-end benchmark also reduced allocations from about 23.02 MB/op to 22.71 MB/op.

## Testing

- `go test ./...`
- `go test -race . -run '^(TestManifestWriterUpdatesPartitionSummariesIncrementally|TestConstructPartitionSummariesWithDroppedSource|TestManifests)$' -count=1`
- `go vet ./...`
