### PR TITLE
perf(table): skip metrics after partition rejection

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -215,7 +215,7 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 			return nil, err
 		}
 
-		if p && m {
+		if m {
 			out = append(out, entry)
 		}
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -206,6 +206,9 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 		if err != nil {
 			return nil, err
 		}
+		if !p {
+			continue
+		}
 
 		m, err := metricsEval(entry.DataFile())
 		if err != nil {

--- a/table/scanner_bench_test.go
+++ b/table/scanner_bench_test.go
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+func BenchmarkOpenManifestPartitionRejectsMostEntries(b *testing.B) {
+	const (
+		entryCount    = 1_000
+		rejectThrough = 950
+	)
+
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	snapshotID := int64(1)
+	entries := make([]iceberg.ManifestEntry, entryCount)
+	for i := range entries {
+		value := int32(i)
+		builder, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentData,
+			fmt.Sprintf("mem://default/table/data/file-%d.parquet", i),
+			iceberg.ParquetFile,
+			map[int]any{1000: value},
+			nil,
+			nil,
+			1,
+			100,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		bound := make([]byte, 4)
+		binary.LittleEndian.PutUint32(bound, uint32(value))
+		entries[i] = iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED,
+			&snapshotID,
+			nil,
+			nil,
+			builder.
+				LowerBoundValues(map[int][]byte{1: bound}).
+				UpperBoundValues(map[int][]byte{1: bound}).
+				Build(),
+		)
+	}
+
+	manifestPath := "mem://default/table/metadata/manifest.avro"
+	var manifestBytes bytes.Buffer
+	manifest, err := iceberg.WriteManifest(
+		manifestPath,
+		&manifestBytes,
+		2,
+		spec,
+		schema,
+		snapshotID,
+		entries,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	fs := iceio.NewMemFS()
+	if err := fs.WriteFile(manifestPath, manifestBytes.Bytes()); err != nil {
+		b.Fatal(err)
+	}
+
+	partitionFilter := func(df iceberg.DataFile) (bool, error) {
+		return df.Partition()[1000].(int32) >= rejectThrough, nil
+	}
+	metricsEval, err := newInclusiveMetricsEvaluator(
+		schema,
+		iceberg.EqualTo(iceberg.Reference("id"), int32(entryCount-1)),
+		true,
+		false,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		matched, err := openManifest(fs, manifest, partitionFilter, metricsEval)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(matched) != 1 {
+			b.Fatalf("openManifest returned %d entries, want 1", len(matched))
+		}
+	}
+}

--- a/table/scanner_bench_test.go
+++ b/table/scanner_bench_test.go
@@ -88,6 +88,8 @@ func BenchmarkOpenManifestPartitionRejectsMostEntries(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	// This simplified filter isolates skipped metrics evaluation; production
+	// scans build the evaluator through buildPartitionEvaluator.
 	partitionFilter := func(df iceberg.DataFile) (bool, error) {
 		return df.Partition()[1000].(int32) >= rejectThrough, nil
 	}

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -285,6 +285,99 @@ func TestEqualityDeletePartitionKeyDistinguishesSignedZero(t *testing.T) {
 	assert.NotEqual(t, negative, positive)
 }
 
+func TestOpenManifestShortCircuitsMetricsEvaluation(t *testing.T) {
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	snapshotID := int64(1)
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"mem://default/table/data/file.parquet",
+		iceberg.ParquetFile,
+		map[int]any{1000: int32(7)},
+		nil,
+		nil,
+		1,
+		100,
+	)
+	require.NoError(t, err)
+
+	entry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED,
+		&snapshotID,
+		nil,
+		nil,
+		builder.Build(),
+	)
+	manifestPath := "mem://default/table/metadata/manifest.avro"
+	var manifestBytes bytes.Buffer
+	manifest, err := iceberg.WriteManifest(
+		manifestPath,
+		&manifestBytes,
+		2,
+		spec,
+		schema,
+		snapshotID,
+		[]iceberg.ManifestEntry{entry},
+	)
+	require.NoError(t, err)
+
+	fs := iceio.NewMemFS()
+	require.NoError(t, fs.WriteFile(manifestPath, manifestBytes.Bytes()))
+
+	tests := []struct {
+		name             string
+		partitionMatches bool
+		metricsMatches   bool
+		wantEvaluations  []string
+		wantEntries      int
+	}{
+		{
+			name:             "partition rejection skips metrics",
+			partitionMatches: false,
+			metricsMatches:   true,
+			wantEvaluations:  []string{"partition"},
+		},
+		{
+			name:             "partition acceptance evaluates metrics",
+			partitionMatches: true,
+			metricsMatches:   true,
+			wantEvaluations:  []string{"partition", "metrics"},
+			wantEntries:      1,
+		},
+		{
+			name:             "metrics rejection still prunes accepted partition",
+			partitionMatches: true,
+			metricsMatches:   false,
+			wantEvaluations:  []string{"partition", "metrics"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluations := make([]string, 0, 2)
+			entries, err := openManifest(
+				fs,
+				manifest,
+				func(iceberg.DataFile) (bool, error) {
+					evaluations = append(evaluations, "partition")
+
+					return tt.partitionMatches, nil
+				},
+				func(iceberg.DataFile) (bool, error) {
+					evaluations = append(evaluations, "metrics")
+
+					return tt.metricsMatches, nil
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEvaluations, evaluations)
+			assert.Len(t, entries, tt.wantEntries)
+		})
+	}
+}
+
 func TestMinSequenceNum(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -330,6 +330,7 @@ func TestOpenManifestShortCircuitsMetricsEvaluation(t *testing.T) {
 		name             string
 		partitionMatches bool
 		metricsMatches   bool
+		metricsErr       error
 		wantEvaluations  []string
 		wantEntries      int
 	}{
@@ -337,6 +338,12 @@ func TestOpenManifestShortCircuitsMetricsEvaluation(t *testing.T) {
 			name:             "partition rejection skips metrics",
 			partitionMatches: false,
 			metricsMatches:   true,
+			wantEvaluations:  []string{"partition"},
+		},
+		{
+			name:             "partition rejection skips metrics errors",
+			partitionMatches: false,
+			metricsErr:       errors.New("metrics evaluation should be skipped"),
 			wantEvaluations:  []string{"partition"},
 		},
 		{
@@ -368,7 +375,7 @@ func TestOpenManifestShortCircuitsMetricsEvaluation(t *testing.T) {
 				func(iceberg.DataFile) (bool, error) {
 					evaluations = append(evaluations, "metrics")
 
-					return tt.metricsMatches, nil
+					return tt.metricsMatches, tt.metricsErr
 				},
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
## What changed

- Short-circuit manifest entry filtering when the partition evaluator rejects an entry.
- Keep partition evaluation first.
- Run the existing inclusive metrics evaluator for entries accepted by the partition filter.
- Add regression coverage for the evaluation order and all three outcomes.
- Add a rejection-heavy benchmark with unique data-file paths.

## Why

Partition filtering can reject files before their column metrics are needed. Skipping metrics evaluation for those files avoids unnecessary work during scan planning. The candidate file results remain the same.

There are no API changes.

## Validation

- `go test ./... -count=1`
- `go test -race ./table -run TestOpenManifestShortCircuitsMetricsEvaluation -count=1`
- `go vet ./...`

## Benchmark

Local run on an Apple M1 Pro. The benchmark scans 1,000 entries, rejects 95% with the partition filter, and runs five samples.

| branch | time/op | bytes/op | allocs/op |
| --- | ---: | ---: | ---: |
| `origin/main` | 2.527 ms | 2.666 MB | 30,521 |
| `this branch` | 2.117 ms | 1.914 MB | 22,479 |
| change | **-16.2%** | **-28.2%** | **-26.3%** |

Command:

```text
go test ./table -run ^$ -bench ^BenchmarkOpenManifestPartitionRejectsMostEntries$ -benchtime=2s -count=5
```

Results will vary by machine, but this shows the expected benefit when partition rejection is common.