### PR TITLE
perf(table): skip clean positional delete batches

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -564,7 +564,7 @@ func combinePositionalDeletes(mem memory.Allocator, deletes set[int64], cursor *
 		if _, deleted := deletes[cursor.next()]; deleted {
 			if bldr == nil {
 				bldr = array.NewInt64Builder(mem)
-				bldr.Reserve(int(nrows))
+				bldr.Reserve(int(i))
 				for j := range i {
 					bldr.Append(j)
 				}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -553,15 +553,35 @@ type set[T comparable] map[T]struct{}
 // batch handed to compute.Take, not into the whole file. Without batch-local
 // indices, the second and later batches of a file would pass indices >= the batch
 // length and compute.Take would fail with "index error: N out of bounds".
+//
+// A nil result means that no row in the batch was deleted. The index builder is
+// allocated lazily after the first deleted row so clean batches can pass through
+// without reconstructing their columns.
 func combinePositionalDeletes(mem memory.Allocator, deletes set[int64], cursor *rowPositionCursor, nrows int64) arrow.Array {
-	bldr := array.NewInt64Builder(mem)
-	defer bldr.Release()
+	var bldr *array.Int64Builder
 
 	for i := range nrows {
-		if _, ok := deletes[cursor.next()]; !ok {
+		if _, deleted := deletes[cursor.next()]; deleted {
+			if bldr == nil {
+				bldr = array.NewInt64Builder(mem)
+				bldr.Reserve(int(nrows))
+				for j := int64(0); j < i; j++ {
+					bldr.Append(j)
+				}
+			}
+
+			continue
+		}
+
+		if bldr != nil {
 			bldr.Append(i)
 		}
 	}
+
+	if bldr == nil {
+		return nil
+	}
+	defer bldr.Release()
 
 	return bldr.NewArray()
 }
@@ -575,6 +595,11 @@ func processPositionalDeletes(ctx context.Context, deletes set[int64], cursor *r
 		defer r.Release()
 
 		indices := combinePositionalDeletes(mem, deletes, cursor, r.NumRows())
+		if indices == nil {
+			r.Retain()
+
+			return r, nil
+		}
 		defer indices.Release()
 
 		out, err := compute.Take(ctx, *compute.DefaultTakeOptions(),

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -565,7 +565,7 @@ func combinePositionalDeletes(mem memory.Allocator, deletes set[int64], cursor *
 			if bldr == nil {
 				bldr = array.NewInt64Builder(mem)
 				bldr.Reserve(int(nrows))
-				for j := int64(0); j < i; j++ {
+				for j := range i {
 					bldr.Append(j)
 				}
 			}

--- a/table/arrow_scanner_posdelete_bench_test.go
+++ b/table/arrow_scanner_posdelete_bench_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
@@ -208,4 +209,53 @@ func benchmarkChunkBoundaries(length, numChunks int) []int {
 	}
 
 	return boundaries
+}
+
+func BenchmarkProcessPositionalDeletes(b *testing.B) {
+	const numRows = 64 * 1024
+
+	for _, tc := range []struct {
+		name    string
+		deletes set[int64]
+	}{
+		{name: "clean", deletes: set[int64]{numRows: {}}},
+		{name: "partial", deletes: set[int64]{numRows / 2: {}}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			batch := benchmarkPositionalDeleteBatch(memory.DefaultAllocator, numRows)
+			defer batch.Release()
+
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				process := processPositionalDeletes(ctx, tc.deletes, (&rowPositionSource{}).cursor())
+				batch.Retain()
+				out, err := process(batch)
+				if err != nil {
+					b.Fatal(err)
+				}
+				out.Release()
+			}
+		})
+	}
+}
+
+func benchmarkPositionalDeleteBatch(mem memory.Allocator, numRows int64) arrow.RecordBatch {
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.Reserve(int(numRows))
+	for i := range numRows {
+		bldr.Append(i)
+	}
+
+	values := bldr.NewArray()
+	defer values.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: false,
+	}}, nil)
+
+	return array.NewRecordBatch(schema, []arrow.Array{values}, numRows)
 }

--- a/table/arrow_scanner_posdelete_bench_test.go
+++ b/table/arrow_scanner_posdelete_bench_test.go
@@ -213,6 +213,8 @@ func benchmarkChunkBoundaries(length, numChunks int) []int {
 
 func BenchmarkProcessPositionalDeletes(b *testing.B) {
 	const numRows = 64 * 1024
+	deleteHeavy := benchmarkPositionalDeleteSet(numRows, numRows-1)
+	allDeleted := benchmarkPositionalDeleteSet(numRows)
 
 	for _, tc := range []struct {
 		name    string
@@ -220,6 +222,8 @@ func BenchmarkProcessPositionalDeletes(b *testing.B) {
 	}{
 		{name: "clean", deletes: set[int64]{numRows: {}}},
 		{name: "partial", deletes: set[int64]{numRows / 2: {}}},
+		{name: "delete-heavy", deletes: deleteHeavy},
+		{name: "all-deleted", deletes: allDeleted},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			batch := benchmarkPositionalDeleteBatch(memory.DefaultAllocator, numRows)
@@ -240,6 +244,18 @@ func BenchmarkProcessPositionalDeletes(b *testing.B) {
 			}
 		})
 	}
+}
+
+func benchmarkPositionalDeleteSet(numRows int64, survivors ...int64) set[int64] {
+	deletes := make(set[int64], int(numRows))
+	for i := range numRows {
+		deletes[i] = struct{}{}
+	}
+	for _, pos := range survivors {
+		delete(deletes, pos)
+	}
+
+	return deletes
 }
 
 func benchmarkPositionalDeleteBatch(mem memory.Allocator, numRows int64) arrow.RecordBatch {

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -711,6 +711,12 @@ func TestProcessPositionalDeletes(t *testing.T) {
 			expecteds: [][]int64{{0, 1, 2}},
 		},
 		{
+			name:      "all but last row deleted",
+			deletes:   set[int64]{0: {}, 1: {}, 2: {}},
+			batches:   [][]int64{{0, 1, 2, 3}},
+			expecteds: [][]int64{{3}},
+		},
+		{
 			name:      "batch boundary deletion",
 			deletes:   set[int64]{4: {}},
 			batches:   [][]int64{{0, 1, 2, 3}, {4, 5, 6}},

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -661,6 +662,112 @@ func TestProcessPositionalDeletesAcrossBatches(t *testing.T) {
 
 		out.Release()
 	}
+}
+
+func TestProcessPositionalDeletesNoOpRetainsBatch(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	ctx := compute.WithAllocator(t.Context(), mem)
+	batch := checkedInt64RecordBatch(mem, 0, 1, 2)
+
+	process := processPositionalDeletes(ctx, set[int64]{99: {}}, (&rowPositionSource{}).cursor())
+	out, err := process(batch)
+	require.NoError(t, err)
+	assert.Same(t, batch, out)
+	out.Release()
+}
+
+func TestProcessPositionalDeletes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		deletes   set[int64]
+		spans     []internal.RowGroupSpan
+		batches   [][]int64
+		expecteds [][]int64
+	}{
+		{
+			name:      "zero deletes",
+			deletes:   set[int64]{},
+			batches:   [][]int64{{0, 1, 2}},
+			expecteds: [][]int64{{0, 1, 2}},
+		},
+		{
+			name:      "first deletion",
+			deletes:   set[int64]{0: {}},
+			batches:   [][]int64{{0, 1, 2, 3}},
+			expecteds: [][]int64{{1, 2, 3}},
+		},
+		{
+			name:      "middle deletion",
+			deletes:   set[int64]{2: {}},
+			batches:   [][]int64{{0, 1, 2, 3}},
+			expecteds: [][]int64{{0, 1, 3}},
+		},
+		{
+			name:      "last deletion",
+			deletes:   set[int64]{3: {}},
+			batches:   [][]int64{{0, 1, 2, 3}},
+			expecteds: [][]int64{{0, 1, 2}},
+		},
+		{
+			name:      "batch boundary deletion",
+			deletes:   set[int64]{4: {}},
+			batches:   [][]int64{{0, 1, 2, 3}, {4, 5, 6}},
+			expecteds: [][]int64{{0, 1, 2, 3}, {5, 6}},
+		},
+		{
+			name:      "all rows deleted",
+			deletes:   set[int64]{0: {}, 1: {}, 2: {}},
+			batches:   [][]int64{{0, 1}, {2}},
+			expecteds: [][]int64{{}, {}},
+		},
+		{
+			name:    "pruned row group positions",
+			deletes: set[int64]{4: {}},
+			spans: []internal.RowGroupSpan{
+				{FirstRowPos: 0, NumRows: 2},
+				{FirstRowPos: 4, NumRows: 2},
+			},
+			batches:   [][]int64{{0, 1}, {4, 5}},
+			expecteds: [][]int64{{0, 1}, {5}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+			ctx := compute.WithAllocator(t.Context(), mem)
+			process := processPositionalDeletes(ctx, tc.deletes, (&rowPositionSource{spans: tc.spans}).cursor())
+
+			for i, values := range tc.batches {
+				batch := checkedInt64RecordBatch(mem, values...)
+				out, err := process(batch)
+				require.NoErrorf(t, err, "batch %d", i)
+				got := out.Column(0).(*array.Int64).Int64Values()
+				if len(tc.expecteds[i]) == 0 {
+					assert.Empty(t, got)
+				} else {
+					assert.Equal(t, tc.expecteds[i], got)
+				}
+				out.Release()
+			}
+		})
+	}
+}
+
+func checkedInt64RecordBatch(mem memory.Allocator, values ...int64) arrow.RecordBatch {
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+
+	col := bldr.NewArray()
+	defer col.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: false,
+	}}, nil)
+
+	return array.NewRecordBatch(schema, []arrow.Array{col}, int64(len(values)))
 }
 
 func stringArray(mem memory.Allocator, values ...string) *array.String {


### PR DESCRIPTION
## What changed

When a data file has positional deletes, the scanner currently builds a survivor index and calls `compute.Take` for every record batch. Most batches may not contain a deleted row, so this does extra work and rebuilds batches that could be passed through unchanged.

This PR:

- returns the original Arrow record batch when no positional delete applies;
- creates the survivor index only after the first deleted row in a batch;
- keeps the existing batch-local index behavior for later batches;
- keeps row-position tracking correct across batches and pruned row groups.

The no-op path retains the input batch before returning it, so ownership stays compatible with the scanner pipeline.

## Tests

- `go test ./table -count=1`
- `go test -race ./table -run '^TestProcessPositionalDeletes' -count=1`
- Coverage for zero deletes, first/middle/last row deletes, batch boundaries, all rows deleted, pruned row groups, and allocator cleanup.

## Benchmarks

Apple M1 Pro, 64K-row batch:

- Clean batch: `189,498 ns/op`, `112 B/op`, `3 allocs/op`
- Partially deleted batch: `859,138 ns/op`, `1,610,925 B/op`, `51 allocs/op`

The partial-delete path keeps the existing reconstruction behavior.