### PR TITLE
perf(table): stream projected equality deletes

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -368,7 +368,7 @@ func equalityDeleteSetForFiles(
 
 // readEqualityDeleteFile reads a single equality delete file and returns
 // the set of encoded delete keys and the column names used.
-func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *iceberg.Schema, nameMapping iceberg.NameMapping, dataFile iceberg.DataFile, fieldIDs []int) (set[string], []string, error) {
+func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *iceberg.Schema, nameMapping iceberg.NameMapping, dataFile iceberg.DataFile, fieldIDs []int) (keys set[string], colNames []string, err error) {
 	src, err := internal.GetFile(ctx, fs, dataFile, true)
 	if err != nil {
 		return nil, nil, err
@@ -380,24 +380,28 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 	}
 	defer iceinternal.CheckedClose(rdr, &err)
 
-	tbl, err := rdr.ReadTable(ctx)
+	if nameMapping == nil {
+		nameMapping = tableSchema.NameMapping()
+	}
+
+	projectedIDs := make(map[int]struct{}, len(fieldIDs))
+	for _, fieldID := range fieldIDs {
+		projectedIDs[fieldID] = struct{}{}
+	}
+
+	projectedSchema, colIndices, err := rdr.PrunedSchema(projectedIDs, nameMapping)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer tbl.Release()
 
-	hasFieldIDs, err := VisitArrowSchema(tbl.Schema(), hasIDs{})
+	hasFieldIDs, err := VisitArrowSchema(projectedSchema, hasIDs{})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var fileSchema *iceberg.Schema
 	if !hasFieldIDs {
-		if nameMapping == nil {
-			nameMapping = tableSchema.NameMapping()
-		}
-
-		fileSchema, err = ArrowSchemaToIcebergWithOptions(tbl.Schema(), ArrowToIcebergOptions{
+		fileSchema, err = ArrowSchemaToIcebergWithOptions(projectedSchema, ArrowToIcebergOptions{
 			NameMapping: nameMapping,
 			TableSchema: tableSchema,
 		})
@@ -408,13 +412,13 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 	var fieldRefsByID arrowFieldRefsByID
 	if hasFieldIDs {
-		fieldRefsByID = indexArrowFieldsByMetadata(tbl.Schema())
+		fieldRefsByID = indexArrowFieldsByMetadata(projectedSchema)
 	} else {
 		fieldRefsByID = indexArrowFields(fileSchema)
 	}
 
-	// Resolve column names from field IDs.
-	colNames := make([]string, len(fieldIDs))
+	// Resolve projected field paths from field IDs.
+	colNames = make([]string, len(fieldIDs))
 	fieldRefs := make([]arrowFieldRef, len(fieldIDs))
 
 	for i, fid := range fieldIDs {
@@ -432,16 +436,23 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 		fieldRefs[i] = ref
 	}
 
-	// Build the set of encoded delete keys by iterating aligned batches.
-	keys := make(set[string])
+	// Stream projected batches directly into the encoded key set. The reader
+	// owns the current record and releases it before producing the next one.
+	recRdr, err := rdr.GetRecords(ctx, colIndices, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer recRdr.Release()
 
+	keys = make(set[string])
 	var keyBuf bytes.Buffer
 
-	tr := array.NewTableReader(tbl, tbl.NumRows())
-	defer tr.Release()
+	for recRdr.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 
-	for tr.Next() {
-		rec := tr.RecordBatch()
+		rec := recRdr.RecordBatch()
 		encoders := make([]colEncoder, len(fieldRefs))
 		for i, ref := range fieldRefs {
 			encoders[i], err = makeArrowFieldEncoder(rec, ref, fieldIDs[i], colNames[i], dataFile.FilePath())
@@ -452,6 +463,12 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 		numRows := int(rec.NumRows())
 		for row := range numRows {
+			if row&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return nil, nil, err
+				}
+			}
+
 			keyBuf.Reset()
 			for _, enc := range encoders {
 				enc(&keyBuf, row)
@@ -459,6 +476,12 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 			keys[keyBuf.String()] = struct{}{}
 		}
+	}
+	if err := recRdr.Err(); err != nil {
+		return nil, nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 
 	return keys, colNames, nil

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -22,14 +22,98 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 )
+
+func BenchmarkReadEqualityDeleteFile(b *testing.B) {
+	for _, numRows := range []int{10_000, 100_000} {
+		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+			tableSchema := iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+				iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+				iceberg.NestedField{ID: 3, Name: "payload", Type: iceberg.PrimitiveTypes.String},
+			)
+			arrowSchema, err := SchemaToArrowSchema(tableSchema, nil, true, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			path := filepath.Join(b.TempDir(), "equality-delete.parquet")
+			mem := memory.DefaultAllocator
+			builder := array.NewRecordBuilder(mem, arrowSchema)
+			idBuilder := builder.Field(0).(*array.Int64Builder)
+			nameBuilder := builder.Field(1).(*array.StringBuilder)
+			payloadBuilder := builder.Field(2).(*array.StringBuilder)
+			payload := strings.Repeat("payload-", 64)
+			for i := 0; i < numRows; i++ {
+				idBuilder.Append(int64(i))
+				nameBuilder.Append(fmt.Sprintf("user-%08d", i))
+				payloadBuilder.Append(payload)
+			}
+			rec := builder.NewRecordBatch()
+			builder.Release()
+			defer rec.Release()
+
+			tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+			defer tbl.Release()
+			file, err := (iceio.LocalFS{}).Create(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := pqarrow.WriteTable(tbl, file, 16_384,
+				parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()); err != nil {
+				b.Fatal(err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			dataFileBuilder, err := iceberg.NewDataFileBuilder(
+				*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+				path, iceberg.ParquetFile, nil, nil, nil, int64(numRows), info.Size())
+			if err != nil {
+				b.Fatal(err)
+			}
+			dataFileBuilder.EqualityFieldIDs([]int{1, 2})
+			dataFile := dataFileBuilder.Build()
+
+			for _, benchmark := range []struct {
+				name string
+				read func(context.Context, iceio.IO, *iceberg.Schema, iceberg.NameMapping, iceberg.DataFile, []int) (set[string], []string, error)
+			}{
+				{name: "streamed-projection", read: readEqualityDeleteFile},
+				{name: "materialized-table", read: readEqualityDeleteFileMaterialized},
+			} {
+				b.Run(benchmark.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						keys, _, err := benchmark.read(context.Background(), iceio.LocalFS{}, tableSchema, nil, dataFile, []int{1, 2})
+						if err != nil {
+							b.Fatal(err)
+						}
+						if len(keys) != numRows {
+							b.Fatalf("got %d keys, want %d", len(keys), numRows)
+						}
+					}
+				})
+			}
+		})
+	}
+}
 
 func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.RecordBatch, buildDel func(int) *equalityDeleteSet) {
 	b.Helper()

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -57,7 +57,7 @@ func BenchmarkReadEqualityDeleteFile(b *testing.B) {
 			nameBuilder := builder.Field(1).(*array.StringBuilder)
 			payloadBuilder := builder.Field(2).(*array.StringBuilder)
 			payload := strings.Repeat("payload-", 64)
-			for i := 0; i < numRows; i++ {
+			for i := range numRows {
 				idBuilder.Append(int64(i))
 				nameBuilder.Append(fmt.Sprintf("user-%08d", i))
 				payloadBuilder.Append(payload)

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -21,13 +21,22 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
+	iceinternal "github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -230,6 +239,158 @@ func TestReadAllEqualityDeleteFilesRejectsEmptyEqualityFieldIDs(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrEmptyEqualityFieldIDs)
 	require.ErrorContains(t, err, "empty-equality-fields.parquet")
+}
+
+func TestReadEqualityDeleteFileMatchesMaterializedRead(t *testing.T) {
+	t.Parallel()
+
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 3, Name: "ignored", Type: iceberg.PrimitiveTypes.String},
+	)
+	arrowSchema, err := SchemaToArrowSchema(tableSchema, nil, true, false)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "equality-delete.parquet")
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
+		{"id": 7, "name": "alice", "ignored": "a very large value that is not part of the equality key"},
+		{"id": null, "name": "bob", "ignored": "another value that should not be read"},
+		{"id": 7, "name": null, "ignored": "yet another value that should not be read"}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	f, err := (iceio.LocalFS{}).Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(tbl, f, 2,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, 3, info.Size())
+	require.NoError(t, err)
+	builder.EqualityFieldIDs([]int{1, 2})
+	dataFile := builder.Build()
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	defer mem.AssertSize(t, 0)
+
+	gotKeys, gotNames, err := readEqualityDeleteFile(
+		ctx, iceio.LocalFS{}, tableSchema, nil, dataFile, []int{1, 2})
+	require.NoError(t, err)
+
+	wantKeys, wantNames, err := readEqualityDeleteFileMaterialized(
+		ctx, iceio.LocalFS{}, tableSchema, nil, dataFile, []int{1, 2})
+	require.NoError(t, err)
+
+	assert.Equal(t, wantNames, gotNames)
+	assert.Equal(t, wantKeys, gotKeys)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, _, err = readEqualityDeleteFile(
+		canceledCtx, iceio.LocalFS{}, tableSchema, nil, dataFile, []int{1, 2})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func readEqualityDeleteFileMaterialized(
+	ctx context.Context,
+	fs iceio.IO,
+	tableSchema *iceberg.Schema,
+	nameMapping iceberg.NameMapping,
+	dataFile iceberg.DataFile,
+	fieldIDs []int,
+) (set[string], []string, error) {
+	src, err := internal.GetFile(ctx, fs, dataFile, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rdr, err := src.GetReader(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer iceinternal.CheckedClose(rdr, &err)
+
+	tbl, err := rdr.ReadTable(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tbl.Release()
+
+	if nameMapping == nil {
+		nameMapping = tableSchema.NameMapping()
+	}
+	hasFieldIDs, err := VisitArrowSchema(tbl.Schema(), hasIDs{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var fileSchema *iceberg.Schema
+	if !hasFieldIDs {
+		fileSchema, err = ArrowSchemaToIcebergWithOptions(tbl.Schema(), ArrowToIcebergOptions{
+			NameMapping: nameMapping,
+			TableSchema: tableSchema,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var fieldRefsByID arrowFieldRefsByID
+	if hasFieldIDs {
+		fieldRefsByID = indexArrowFieldsByMetadata(tbl.Schema())
+	} else {
+		fieldRefsByID = indexArrowFields(fileSchema)
+	}
+
+	colNames := make([]string, len(fieldIDs))
+	fieldRefs := make([]arrowFieldRef, len(fieldIDs))
+	for i, fieldID := range fieldIDs {
+		name, ok := tableSchema.FindColumnName(fieldID)
+		if !ok {
+			return nil, nil, fmt.Errorf("equality delete field ID %d not found in table schema for %s", fieldID, dataFile.FilePath())
+		}
+
+		ref, err := resolveArrowField(fieldRefsByID, fieldID, name, dataFile.FilePath())
+		if err != nil {
+			return nil, nil, err
+		}
+		colNames[i] = name
+		fieldRefs[i] = ref
+	}
+
+	keys := make(set[string])
+	var keyBuf bytes.Buffer
+	tr := array.NewTableReader(tbl, tbl.NumRows())
+	defer tr.Release()
+	for tr.Next() {
+		rec := tr.RecordBatch()
+		encoders := make([]colEncoder, len(fieldRefs))
+		for i, ref := range fieldRefs {
+			encoders[i], err = makeArrowFieldEncoder(rec, ref, fieldIDs[i], colNames[i], dataFile.FilePath())
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		for row := 0; row < int(rec.NumRows()); row++ {
+			keyBuf.Reset()
+			for _, enc := range encoders {
+				enc(&keyBuf, row)
+			}
+			keys[keyBuf.String()] = struct{}{}
+		}
+	}
+
+	return keys, colNames, nil
 }
 
 func TestProcessEqualityDeletesUsesStructuralFieldPaths(t *testing.T) {

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -300,6 +300,59 @@ func TestReadEqualityDeleteFileMatchesMaterializedRead(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestReadEqualityDeleteFilePreservesEmbeddedFieldIDsWhenNamesAreReused(t *testing.T) {
+	t.Parallel()
+
+	oldSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "old_name", Type: iceberg.PrimitiveTypes.Int64},
+	)
+	tableSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "new_name", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "old_name", Type: iceberg.PrimitiveTypes.Int64},
+	)
+	arrowSchema, err := SchemaToArrowSchema(oldSchema, nil, true, false)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "equality-delete-rename-reuse.parquet")
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSchema, strings.NewReader(`[
+		{"old_name": 7}
+	]`))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	f, err := (iceio.LocalFS{}).Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(tbl, f, 1,
+		parquet.NewWriterProperties(parquet.WithStats(true)), pqarrow.DefaultWriterProps()))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentEqDeletes,
+		path, iceberg.ParquetFile, nil, nil, nil, 1, info.Size())
+	require.NoError(t, err)
+	builder.EqualityFieldIDs([]int{1})
+	dataFile := builder.Build()
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	defer mem.AssertSize(t, 0)
+
+	wantKeys, wantNames, err := readEqualityDeleteFileMaterialized(
+		ctx, iceio.LocalFS{}, tableSchema, tableSchema.NameMapping(), dataFile, []int{1})
+	require.NoError(t, err)
+
+	gotKeys, gotNames, err := readEqualityDeleteFile(
+		ctx, iceio.LocalFS{}, tableSchema, tableSchema.NameMapping(), dataFile, []int{1})
+	require.NoError(t, err)
+
+	assert.Equal(t, wantNames, gotNames)
+	assert.Equal(t, wantKeys, gotKeys)
+}
+
 func readEqualityDeleteFileMaterialized(
 	ctx context.Context,
 	fs iceio.IO,

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -381,7 +381,7 @@ func readEqualityDeleteFileMaterialized(
 			}
 		}
 
-		for row := 0; row < int(rec.NumRows()); row++ {
+		for row := range int(rec.NumRows()) {
 			keyBuf.Reset()
 			for _, enc := range encoders {
 				enc(&keyBuf, row)

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -2116,7 +2116,7 @@ func getFieldID(f arrow.Field) *int {
 	}
 
 	id, err := strconv.Atoi(fieldIDStr)
-	if err != nil {
+	if err != nil || id <= 0 {
 		return nil
 	}
 
@@ -2132,14 +2132,16 @@ type pruneParquetSchema struct {
 }
 
 func (p *pruneParquetSchema) fieldID(field arrow.Field, mapping *iceberg.MappedField) int {
+	// Embedded Parquet field IDs are authoritative. Name mappings are only a
+	// fallback for files and fields that do not carry their own IDs.
+	if id := getFieldID(field); id != nil {
+		return *id
+	}
+
 	if mapping != nil {
 		if mapping.FieldID != nil {
 			return *mapping.FieldID
 		}
-	}
-
-	if id := getFieldID(field); id != nil {
-		return *id
 	}
 
 	panic(fmt.Errorf("%w: cannot convert %s to Iceberg field, missing field_id",


### PR DESCRIPTION
## Summary

- Read equality delete files with only the fields used by the delete key.
- Build encoded delete keys while record batches are being read.
- Keep the existing field ID and name mapping behavior.
- Preserve null handling, type encoding, cancellation, and the current worker limit.
- Add an equivalence test against the old materialized path.

## Why

`ReadTable` loaded the full equality delete file before the keys were built. This also loaded columns that were not part of the equality key. Streaming the projected columns lowers peak memory use and avoids that extra work.

## Checks

- `go test ./table -count=1`
- `go test -race ./table -run "EqualityDelete|ReadEqualityDeleteFile" -count=1`
- `go vet ./table`

## Benchmark

For a 100k-row equality delete file on an Apple M1 Pro:

- Streamed projection: 30.6 MB/op, 11.6 ms/op
- Materialized table: 161.2 MB/op, 25.0 ms/op