### PR TITLE
fix(table): sort identifier field IDs for deterministic schema updates

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -1136,10 +1136,10 @@ func (u *UpdateSchema) Apply() (*iceberg.Schema, error) {
 		identifierFieldIDs = append(identifierFieldIDs, field.ID)
 	}
 
-	// u.identifierFieldNames is a map, so the iteration above yields the ids in a 
+	// u.identifierFieldNames is a map, so the iteration above yields the ids in a
 	// non-deterministic order. Thus, sorting them to produce a canonical ordering:
 	// Schema.Equals compares IdentifierFieldIDs positionally, so,
-	// an unsorted slice would make otherwise-identical schemas compare unequal at random. 
+	// an unsorted slice would make otherwise-identical schemas compare unequal at random.
 	slices.Sort(identifierFieldIDs)
 
 	meta, err := u.txn.txnMeta()

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -1136,6 +1136,12 @@ func (u *UpdateSchema) Apply() (*iceberg.Schema, error) {
 		identifierFieldIDs = append(identifierFieldIDs, field.ID)
 	}
 
+	// u.identifierFieldNames is a map, so the iteration above yields the ids in a 
+	// non-deterministic order. Thus, sorting them to produce a canonical ordering:
+	// Schema.Equals compares IdentifierFieldIDs positionally, so,
+	// an unsorted slice would make otherwise-identical schemas compare unequal at random. 
+	slices.Sort(identifierFieldIDs)
+
 	meta, err := u.txn.txnMeta()
 	if err != nil {
 		return nil, err

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -969,6 +969,35 @@ func TestSetIdentifierField(t *testing.T) {
 	})
 }
 
+func TestSetIdentifierFieldDeterministicOrder(t *testing.T) {
+	t.Run("apply returns identifier field ids in sorted order", func(t *testing.T) {
+		const iterations = 50
+
+		var first *iceberg.Schema
+		for range iterations {
+			table := New([]string{"id"}, testMetadata, "", nil, nil)
+			txn := table.NewTransaction()
+
+			newSchema, err := NewUpdateSchema(txn, true, true).
+				SetIdentifierField([][]string{{"age"}, {"id"}, {"name"}}).
+				Apply()
+			require.NoError(t, err)
+			require.NotNil(t, newSchema)
+
+			assert.Equal(t, []int{1, 2, 3}, newSchema.IdentifierFieldIDs)
+
+			// Every independently-produced schema must compare equal, which is
+			// exactly the invariant the ordering bug breaks.
+			if first == nil {
+				first = newSchema
+			} else {
+				assert.True(t, first.Equals(newSchema),
+					"schemas produced by separate Apply() calls must be equal")
+			}
+		}
+	})
+}
+
 func TestErrorHandling(t *testing.T) {
 	t.Run("test incompatible changes without allowIncompatibleChanges", func(t *testing.T) {
 		table := New([]string{"id"}, testMetadata, "", nil, nil)


### PR DESCRIPTION
### Description

Fixes #1776

As said in the issue, `UpdateSchema.Apply()` derived `IdentifierFieldIDs` by iterating a Go map, yielding non-deterministic order. `Schema.Equals` compares these ids positionally, so identical schemas compared unequal at random, producing spurious duplicate schema versions in `BuildUpdates()`.

Sorting `identifierFieldIDs` in `Apply()` to produce a deterministic, canonical order fixes this problem.

### Testing

Added `TestSetIdentifierFieldDeterministicOrder` as a regression test. (across multiple iterations, asserts sorted output and cross-run equals)