### PR TITLE
fix(table): delete column should check the column's own pending update

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -380,8 +380,13 @@ func (u *UpdateSchema) deleteColumn(path []string) error {
 		return fmt.Errorf("field that has additions cannot be deleted: %s", fullName)
 	}
 
-	if _, ok := u.updates[field.ID]; ok {
-		return fmt.Errorf("field that has updates cannot be deleted: %s", fullName)
+	// u.updates is keyed by parent ID, then by the field's own ID, so a
+	// field's own pending update lives under its parent's map
+	parentID := u.findParentID(field.ID)
+	if upds, ok := u.updates[parentID]; ok {
+		if _, ok := upds[field.ID]; ok {
+			return fmt.Errorf("field that has updates cannot be deleted: %s", fullName)
+		}
 	}
 
 	delete(u.identifierFieldNames, fullName)

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -539,6 +539,79 @@ func TestDeleteColumn(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "field not found")
 	})
+
+	t.Run("test delete top level column with own update fails", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		_, err := NewUpdateSchema(txn, true, true).
+			UpdateColumn([]string{"age"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Valid: true, Val: "the age"},
+			}).
+			DeleteColumn([]string{"age"}).
+			Apply()
+		require.ErrorContains(t, err, "field that has updates cannot be deleted: age")
+	})
+
+	t.Run("test delete nested column with own update fails", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		_, err := NewUpdateSchema(txn, true, true).
+			UpdateColumn([]string{"address", "city"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Valid: true, Val: "the city"},
+			}).
+			DeleteColumn([]string{"address", "city"}).
+			Apply()
+		require.ErrorContains(t, err, "field that has updates cannot be deleted: address.city")
+	})
+
+	t.Run("test delete parent struct with updated child succeeds", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			UpdateColumn([]string{"address", "city"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Valid: true, Val: "the city"},
+			}).
+			DeleteColumn([]string{"address"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		_, ok := newSchema.FindFieldByName("address")
+		assert.False(t, ok, "address struct should be deleted")
+
+		// The staged child update is discarded with its parent; every other
+		// top-level column must survive untouched.
+		for _, name := range []string{"id", "name", "age", "tags", "properties"} {
+			_, ok := newSchema.FindFieldByName(name)
+			assert.True(t, ok, "field %s should remain", name)
+		}
+	})
+
+	// deleting a column while an unrelated column has a pending update must still succeed,
+	// and that update must be applied to the surviving column.
+	t.Run("test delete column with unrelated pending update succeeds", func(t *testing.T) {
+		table := New([]string{"id"}, testMetadata, "", nil, nil)
+		txn := table.NewTransaction()
+
+		newSchema, err := NewUpdateSchema(txn, true, true).
+			UpdateColumn([]string{"age"}, ColumnUpdate{
+				Doc: iceberg.Optional[string]{Valid: true, Val: "the age"},
+			}).
+			DeleteColumn([]string{"name"}).
+			Apply()
+		require.NoError(t, err)
+		require.NotNil(t, newSchema)
+
+		_, ok := newSchema.FindFieldByName("name")
+		assert.False(t, ok, "name column should be deleted")
+
+		ageField, ok := newSchema.FindFieldByName("age")
+		require.True(t, ok, "age column should remain")
+		assert.Equal(t, "the age", ageField.Doc, "unrelated update should still apply")
+	})
 }
 
 func TestUpdateColumn(t *testing.T) {


### PR DESCRIPTION
### Description

Fixes #1778 

Fixed `UpdateSchema.deleteColumn` to correctly check for pending updates using the field's own ID under its parent's update map.

### Testing

Added the required regression tests for it.