### PR TITLE
perf(table): reuse scan invariants across Arrow reads

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -717,8 +717,16 @@ type arrowScan struct {
 
 	useLargeTypes bool
 	concurrency   int
+}
 
-	nameMapping iceberg.NameMapping
+// arrowScanInvariants holds metadata-derived values that cannot change during
+// a scan. The snapshots returned by Metadata are owned by the scan and are
+// safe to share read-only across file workers.
+type arrowScanInvariants struct {
+	tableSchema     *iceberg.Schema
+	tableProperties iceberg.Properties
+	projectedIDs    set[int]
+	nameMapping     iceberg.NameMapping
 }
 
 // collectLeafIDs recursively collects leaf field IDs from a type
@@ -742,6 +750,23 @@ func collectLeafIDs(typ iceberg.Type, fieldID int, idset set[int]) {
 	}
 }
 
+func addFilterFieldIDs(idset set[int], rowFilter iceberg.BooleanExpression) error {
+	if rowFilter == nil {
+		return nil
+	}
+
+	extracted, err := iceberg.ExtractFieldIDs(rowFilter)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range extracted {
+		idset[id] = struct{}{}
+	}
+
+	return nil
+}
+
 func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression, equalityDeletes []*equalityDeleteSet) (set[int], error) {
 	idset := set[int]{}
 	// Collect leaf field IDs for column pruning.
@@ -751,15 +776,8 @@ func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression, equa
 		collectLeafIDs(field.Type, field.ID, idset)
 	}
 
-	if rowFilter != nil {
-		extracted, err := iceberg.ExtractFieldIDs(rowFilter)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, id := range extracted {
-			idset[id] = struct{}{}
-		}
+	if err := addFilterFieldIDs(idset, rowFilter); err != nil {
+		return nil, err
 	}
 	for _, deletes := range equalityDeletes {
 		for _, id := range deletes.fieldIDs {
@@ -770,18 +788,52 @@ func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression, equa
 	return idset, nil
 }
 
+func (as *arrowScan) scanInvariants(tableProperties iceberg.Properties) (*arrowScanInvariants, error) {
+	projectedIDs, err := as.projectedFieldIDs(as.boundRowFilter, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &arrowScanInvariants{
+		tableSchema:     as.metadata.CurrentSchema(),
+		tableProperties: tableProperties,
+		projectedIDs:    projectedIDs,
+		nameMapping:     as.metadata.NameMapping(),
+	}, nil
+}
+
+func (as *arrowScan) addTaskProjectedFieldIDs(invariants *arrowScanInvariants, tasks []FileScanTask) error {
+	for _, task := range tasks {
+		rowFilter, err := as.rowFilterForTask(task)
+		if err != nil {
+			return err
+		}
+
+		if err := addFilterFieldIDs(invariants.projectedIDs, rowFilter); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addEqualityDeleteFieldIDs(invariants *arrowScanInvariants, eqDeleteSets map[int][]*equalityDeleteSet) {
+	for _, deleteSets := range eqDeleteSets {
+		for _, deleteSet := range deleteSets {
+			for _, id := range deleteSet.fieldIDs {
+				invariants.projectedIDs[id] = struct{}{}
+			}
+		}
+	}
+}
+
 type enumeratedRecord struct {
 	Record tblutils.Enumerated[arrow.RecordBatch]
 	Task   tblutils.Enumerated[FileScanTask]
 	Err    error
 }
 
-func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, rowFilter iceberg.BooleanExpression, equalityDeletes []*equalityDeleteSet) (*iceberg.Schema, []int, tblutils.FileReader, error) {
-	ids, err := as.projectedFieldIDs(rowFilter, equalityDeletes)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, invariants *arrowScanInvariants) (*iceberg.Schema, []int, tblutils.FileReader, error) {
 	src, err := tblutils.GetFile(ctx, as.fs, file, false)
 	if err != nil {
 		return nil, nil, nil, err
@@ -792,7 +844,7 @@ func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, r
 		return nil, nil, nil, err
 	}
 
-	fileSchema, colIndices, err := rdr.PrunedSchema(ids, as.nameMapping)
+	fileSchema, colIndices, err := rdr.PrunedSchema(invariants.projectedIDs, invariants.nameMapping)
 	if err != nil {
 		rdr.Close()
 
@@ -800,9 +852,9 @@ func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, r
 	}
 
 	iceSchema, err := ArrowSchemaToIcebergWithOptions(fileSchema, ArrowToIcebergOptions{
-		NameMapping:     as.nameMapping,
-		TableSchema:     as.metadata.CurrentSchema(),
-		TableProperties: as.metadata.Properties(),
+		NameMapping:     invariants.nameMapping,
+		TableSchema:     invariants.tableSchema,
+		TableProperties: invariants.tableProperties,
 	})
 	if err != nil {
 		rdr.Close()
@@ -1328,7 +1380,7 @@ func pruningFilterHasMissingInitialDefault(
 	return false, nil
 }
 
-func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerated[FileScanTask], out chan<- enumeratedRecord, positionalDeletes positionDeletes, dvBitmap *dv.RoaringPositionBitmap, eqDeleteSets []*equalityDeleteSet) (err error) {
+func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerated[FileScanTask], out chan<- enumeratedRecord, positionalDeletes positionDeletes, dvBitmap *dv.RoaringPositionBitmap, eqDeleteSets []*equalityDeleteSet, invariants *arrowScanInvariants) (err error) {
 	defer func() {
 		if err != nil {
 			out <- enumeratedRecord{Task: task, Err: err}
@@ -1349,7 +1401,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 		return err
 	}
 
-	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, rowFilter, eqDeleteSets)
+	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, invariants)
 	if err != nil {
 		return err
 	}
@@ -1453,7 +1505,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 
 		return ToRequestedSchema(ctx, as.projectedSchema, readSchema, r, SchemaOptions{
 			UseLargeTypes:   as.useLargeTypes,
-			TableProperties: as.metadata.Properties(),
+			TableProperties: invariants.tableProperties,
 		})
 	})
 
@@ -1462,7 +1514,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 	return err
 }
 
-func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutils.Enumerated[FileScanTask], positionalDeletes positionDeletes, out chan<- enumeratedRecord) (err error) {
+func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutils.Enumerated[FileScanTask], positionalDeletes positionDeletes, out chan<- enumeratedRecord, invariants *arrowScanInvariants) (err error) {
 	defer func() {
 		if err != nil {
 			out <- enumeratedRecord{Task: task, Err: err}
@@ -1477,7 +1529,7 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 		dropFile   bool
 	)
 
-	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, as.boundRowFilter, nil)
+	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, invariants)
 	if err != nil {
 		return err
 	}
@@ -1634,9 +1686,8 @@ func createIterator(ctx context.Context, numWorkers uint, records <-chan enumera
 	}
 }
 
-func (as *arrowScan) recordBatchesFromTasksAndDeletes(ctx context.Context, tasks []FileScanTask, deletesPerFile perFilePosDeletes, dvBitmaps perFileDVBitmaps, eqDeleteSets map[int][]*equalityDeleteSet) iter.Seq2[arrow.RecordBatch, error] {
+func (as *arrowScan) recordBatchesFromTasksAndDeletes(ctx context.Context, tasks []FileScanTask, deletesPerFile perFilePosDeletes, dvBitmaps perFileDVBitmaps, eqDeleteSets map[int][]*equalityDeleteSet, invariants *arrowScanInvariants) iter.Seq2[arrow.RecordBatch, error] {
 	extSet := substrait.NewExtensionSet()
-	as.nameMapping = as.metadata.NameMapping()
 
 	ctx, cancel := context.WithCancelCause(exprs.WithExtensionIDSet(ctx, extSet))
 	taskChan := make(chan tblutils.Enumerated[FileScanTask], len(tasks))
@@ -1663,7 +1714,8 @@ func (as *arrowScan) recordBatchesFromTasksAndDeletes(ctx context.Context, tasks
 					if err := as.recordsFromTask(ctx, task, records,
 						deletesPerFile[filePath],
 						dvBitmaps[filePath],
-						eqDeleteSets[task.Index]); err != nil {
+						eqDeleteSets[task.Index],
+						invariants); err != nil {
 						cancel(err)
 
 						return
@@ -1696,11 +1748,12 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 		as.useLargeTypes = false
 	}
 
-	ctx = tblutils.WithTableProperties(ctx, as.metadata.Properties())
+	tableProperties := as.metadata.Properties()
+	ctx = tblutils.WithTableProperties(ctx, tableProperties)
 
 	resultSchema, err := SchemaToArrowSchemaWithOptions(as.projectedSchema, ArrowSchemaOptions{
 		UseLargeTypes:   as.useLargeTypes,
-		TableProperties: as.metadata.Properties(),
+		TableProperties: tableProperties,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -1708,6 +1761,14 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 
 	if as.rowLimit == 0 {
 		return resultSchema, func(yield func(arrow.RecordBatch, error) bool) {}, nil
+	}
+
+	invariants, err := as.scanInvariants(tableProperties)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := as.addTaskProjectedFieldIDs(invariants, tasks); err != nil {
+		return nil, nil, err
 	}
 
 	deletesPerFile, err := readAllDeleteFiles(ctx, as.fs, tasks, as.concurrency)
@@ -1732,13 +1793,14 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 	}
 
 	eqDeleteSets, err := readAllEqualityDeleteFiles(ctx, as.fs,
-		as.metadata.CurrentSchema(), as.metadata.NameMapping(), tasks, as.concurrency)
+		invariants.tableSchema, invariants.nameMapping, tasks, as.concurrency)
 	if err != nil {
 		// Positional deletes were fully loaded; release them before aborting.
 		releasePerFilePosDeletes(deletesPerFile)
 
 		return nil, nil, err
 	}
+	addEqualityDeleteFieldIDs(invariants, eqDeleteSets)
 
-	return resultSchema, as.recordBatchesFromTasksAndDeletes(ctx, tasks, deletesPerFile, dvBitmaps, eqDeleteSets), nil
+	return resultSchema, as.recordBatchesFromTasksAndDeletes(ctx, tasks, deletesPerFile, dvBitmaps, eqDeleteSets, invariants), nil
 }

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+func benchmarkScanSchema(fieldCount int) *iceberg.Schema {
+	fields := make([]iceberg.NestedField, fieldCount)
+	for i := range fields {
+		baseID := i*3 + 1
+		fields[i] = iceberg.NestedField{
+			ID:   baseID,
+			Name: fmt.Sprintf("field_%d", i),
+			Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: baseID + 1, Name: "value", Type: iceberg.PrimitiveTypes.String},
+				{ID: baseID + 2, Name: "count", Type: iceberg.PrimitiveTypes.Int64},
+			}},
+		}
+	}
+
+	return iceberg.NewSchema(1, fields...)
+}
+
+func benchmarkScanMetadata(b *testing.B, fieldCount, propertyCount int) Metadata {
+	b.Helper()
+
+	props := make(iceberg.Properties, propertyCount)
+	for i := range propertyCount {
+		props[fmt.Sprintf("property_%d", i)] = fmt.Sprintf("value_%d", i)
+	}
+
+	metadata, err := NewMetadata(
+		benchmarkScanSchema(fieldCount),
+		iceberg.UnpartitionedSpec,
+		UnsortedSortOrder,
+		"mem://benchmark/table",
+		props,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return metadata
+}
+
+func benchmarkScanJSON(rowCount, fieldCount int) string {
+	var result strings.Builder
+	result.WriteByte('[')
+	for row := range rowCount {
+		if row > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteByte('{')
+		for field := range fieldCount {
+			if field > 0 {
+				result.WriteByte(',')
+			}
+			fmt.Fprintf(&result, `"field_%d":{"value":"value_%d","count":%d}`,
+				field, field, row)
+		}
+		result.WriteByte('}')
+	}
+	result.WriteByte(']')
+
+	return result.String()
+}
+
+func BenchmarkArrowScanManyFilesAndBatches(b *testing.B) {
+	const (
+		fieldCount = 16
+		fileCount  = 32
+		batchCount = 32
+	)
+
+	for _, propertyCount := range []int{0, 16, 64} {
+		b.Run(fmt.Sprintf("extra_properties_%d", propertyCount), func(b *testing.B) {
+			metadata := benchmarkScanMetadata(b, fieldCount, propertyCount)
+			properties := metadata.Properties()
+			properties[ParquetBatchSizeKey] = "1"
+			metadata, err := NewMetadata(
+				metadata.CurrentSchema(),
+				iceberg.UnpartitionedSpec,
+				UnsortedSortOrder,
+				"mem://benchmark/table",
+				properties,
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			projectedSchema := metadata.CurrentSchema()
+			arrowSchema, err := SchemaToArrowSchemaWithOptions(projectedSchema, ArrowSchemaOptions{IncludeFieldIDs: true})
+			if err != nil {
+				b.Fatal(err)
+			}
+			record := mustLoadRecordBatchFromJSON(arrowSchema, benchmarkScanJSON(batchCount, fieldCount))
+			defer record.Release()
+			table := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{record})
+			defer table.Release()
+
+			const dataPath = "mem://benchmark/table/data.parquet"
+			fs := iceio.NewMemFS()
+			writer, err := fs.Create(dataPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := pqarrow.WriteTable(table, writer, record.NumRows(),
+				parquet.NewWriterProperties(parquet.WithStats(true)),
+				pqarrow.DefaultWriterProps()); err != nil {
+				b.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			dataFile, err := iceberg.NewDataFileBuilder(
+				*iceberg.UnpartitionedSpec,
+				iceberg.EntryContentData,
+				dataPath,
+				iceberg.ParquetFile,
+				nil,
+				nil,
+				nil,
+				record.NumRows(),
+				1,
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tasks := make([]FileScanTask, fileCount)
+			for i := range tasks {
+				tasks[i].File = dataFile.Build()
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				scan := &arrowScan{
+					metadata:        metadata,
+					fs:              fs,
+					projectedSchema: projectedSchema,
+					boundRowFilter:  iceberg.AlwaysTrue{},
+					rowLimit:        -1,
+					concurrency:     4,
+				}
+				_, records, err := scan.GetRecords(b.Context(), tasks)
+				if err != nil {
+					b.Fatal(err)
+				}
+				batches := 0
+				for record, err := range records {
+					if err != nil {
+						b.Fatal(err)
+					}
+					record.Release()
+					batches++
+				}
+				if batches != fileCount*batchCount {
+					b.Fatalf("unexpected batch count: %d", batches)
+				}
+			}
+			b.ReportMetric(fileCount, "files/op")
+			b.ReportMetric(fileCount*batchCount, "batches/op")
+		})
+	}
+}

--- a/table/arrow_scanner_test.go
+++ b/table/arrow_scanner_test.go
@@ -94,6 +94,61 @@ func (f *closeSignalFile) Close() error {
 	return err
 }
 
+type countingScanMetadata struct {
+	Metadata
+	currentSchemaCalls int
+	propertiesCalls    int
+	nameMappingCalls   int
+}
+
+func (m *countingScanMetadata) CurrentSchema() *iceberg.Schema {
+	m.currentSchemaCalls++
+
+	return m.Metadata.CurrentSchema()
+}
+
+func (m *countingScanMetadata) Properties() iceberg.Properties {
+	m.propertiesCalls++
+
+	return m.Metadata.Properties()
+}
+
+func (m *countingScanMetadata) NameMapping() iceberg.NameMapping {
+	m.nameMappingCalls++
+
+	return m.Metadata.NameMapping()
+}
+
+func TestArrowScanSnapshotsInvariants(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "value", Type: iceberg.PrimitiveTypes.String,
+	})
+	base, err := NewMetadata(
+		schema,
+		iceberg.UnpartitionedSpec,
+		UnsortedSortOrder,
+		"mem://test/table",
+		iceberg.Properties{"test-property": "test-value"},
+	)
+	require.NoError(t, err)
+
+	metadata := &countingScanMetadata{Metadata: base}
+	scan := &arrowScan{
+		metadata:        metadata,
+		projectedSchema: schema,
+	}
+
+	tableProperties := metadata.Properties()
+	invariants, err := scan.scanInvariants(tableProperties)
+	require.NoError(t, err)
+	assert.Equal(t, set[int]{1: {}}, invariants.projectedIDs)
+	assert.True(t, schema.Equals(invariants.tableSchema))
+	assert.Equal(t, tableProperties, invariants.tableProperties)
+	assert.Equal(t, 1, metadata.currentSchemaCalls)
+	assert.Equal(t, 1, metadata.propertiesCalls)
+	assert.Equal(t, 1, metadata.nameMappingCalls)
+}
+
 func TestEnrichRecordsWithPosDeleteFields(t *testing.T) {
 	testSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "first_name", Type: &arrow.StringType{}, Nullable: false},

--- a/table/projjson_roundtrip_internal_test.go
+++ b/table/projjson_roundtrip_internal_test.go
@@ -85,14 +85,16 @@ func TestWriteRecordsRecoversExactProjJSONCRSOnRead(t *testing.T) {
 	fs, err := tbl.fsF(ctx)
 	require.NoError(t, err)
 
-	readSchema, _, rdr, err := (&arrowScan{
+	scanner := &arrowScan{
 		metadata:        tbl.Metadata(),
 		fs:              fs,
 		scanSchema:      tbl.Schema(),
 		projectedSchema: tbl.Schema(),
 		concurrency:     1,
-		nameMapping:     tbl.Metadata().NameMapping(),
-	}).prepareToRead(ctx, dataFiles[0], nil, nil)
+	}
+	invariants, err := scanner.scanInvariants(tbl.Metadata().Properties())
+	require.NoError(t, err)
+	readSchema, _, rdr, err := scanner.prepareToRead(ctx, dataFiles[0], invariants)
 	require.NoError(t, err)
 	defer rdr.Close()
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3096,6 +3096,10 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 		rowLimit:        -1, // No limit
 		concurrency:     concurrency,
 	}
+	invariants, err := scanner.scanInvariants(builtMeta.Properties())
+	if err != nil {
+		return nil, err
+	}
 
 	deletesPerFile, err := readAllDeleteFiles(ctx, fs, tasks, concurrency)
 	if err != nil {
@@ -3128,7 +3132,7 @@ func (t *Transaction) makePositionDeleteRecordsForFilter(ctx context.Context, fs
 						return
 					}
 
-					if err := scanner.producePosDeletesFromTask(ctx, task, deletesPerFile[task.Value.File.FilePath()], records); err != nil {
+					if err := scanner.producePosDeletesFromTask(ctx, task, deletesPerFile[task.Value.File.FilePath()], records, invariants); err != nil {
 						cancel(err)
 
 						return


### PR DESCRIPTION
## Summary

- snapshot the current schema, table properties, and name mapping once per Arrow scan
- build projected read field IDs once before file workers start
- reuse the scan-owned values across file reads and record batch projection
- keep the defensive metadata getter behavior unchanged

## Benchmark

`BenchmarkArrowScanManyFilesAndBatches` scans 32 logical files with 32 one-row batches per file, 16 nested struct fields, and 4 workers. These are medians from five local runs on an Apple M1 Pro.

| Extra properties | Before | After | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: | ---: |
| 0 | 110.5 ms | 94.1 ms | 259.0 MB -> 257.9 MB | 2,077,360 -> 2,071,319 |
| 16 | 103.1 ms | 89.2 ms | 259.9 MB -> 257.9 MB | 2,079,328 -> 2,071,319 |
| 64 | 92.6 ms | 86.7 ms | 263.8 MB -> 257.9 MB | 2,079,395 -> 2,071,143 |

The timing is noisier than the allocation measurements. The 64-property case removes about 5.9 MB and 8.2k allocations per scan operation.

## Tests

- `go test ./... -count=1`
- `go test -race ./table -run TestArrowScanSnapshotsInvariants\|TestWriteRecordsRecoversExactProjJSONCRSOnRead -count=1`
- `go vet ./table/...`
- `golangci-lint run --timeout=10m ./table/...`