### PR TITLE
perf(table): reuse FileIO during local scan planning

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -346,8 +346,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2292,4 +2293,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -159,7 +159,7 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 	if s.scan.ioF == nil {
 		return nil, fmt.Errorf("%w: table file IO is not configured", ErrInvalidOperation)
 	}
-	fs, err := s.scan.ioF(ctx)
+	manifestListFS, err := s.scan.ioF(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		manifests, err := snapshot.Manifests(fs)
+		manifests, err := snapshot.Manifests(manifestListFS)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,10 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 	if len(manifestList) == 0 {
 		return finish(nil)
 	}
-	entries, err := planningScan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
+	// The IO above is scoped to reading manifest lists. Manifest workers must
+	// reacquire through the factory so long-running incremental plans can renew
+	// vended credentials between reads.
+	entries, err := planningScan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -204,9 +204,10 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 	if len(manifestList) == 0 {
 		return finish(nil)
 	}
-	// The IO above is scoped to reading manifest lists. Manifest workers must
-	// reacquire through the factory so long-running incremental plans can renew
-	// vended credentials between reads.
+	// The IO above is scoped to reading manifest lists. Manifest workers reuse
+	// one factory result per concurrent batch, then reacquire through the factory
+	// so long-running incremental plans can renew vended credentials between
+	// batches.
 	entries, err := planningScan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 	if err != nil {
 		return nil, err

--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -204,7 +204,7 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 	if len(manifestList) == 0 {
 		return finish(nil)
 	}
-	entries, err := planningScan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
+	entries, err := planningScan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1001,7 +1001,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	manifestIO := newManifestIOBatch(scan.ioF, concurrencyLimit)
 
 	entries := newManifestEntries()
-	g, _ := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrencyLimit)
 
 	partitionFilters := scan.partitionFiltersForSchema(schema)
@@ -1015,7 +1015,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		}
 
 		g.Go(func() error {
-			fs, err := manifestIO.acquire(ctx)
+			fs, err := manifestIO.acquire(gctx)
 			if err != nil {
 				return err
 			}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -941,6 +941,7 @@ func (scan *Scan) collectManifestEntries(
 	if err != nil {
 		return nil, err
 	}
+
 	return scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 }
 

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -941,20 +941,11 @@ func (scan *Scan) collectManifestEntries(
 	if err != nil {
 		return nil, err
 	}
-	var fs io.IO
-	if len(manifestList) > 0 {
-		fs, err = scan.ioF(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return scan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
+	return scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 }
 
 func (scan *Scan) collectManifestEntriesWithSchema(
 	ctx context.Context,
-	fs io.IO,
 	manifestList []iceberg.ManifestFile,
 	schema *iceberg.Schema,
 ) (*manifestEntries, error) {
@@ -986,6 +977,13 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		}
 
 		g.Go(func() error {
+			// FileIO factories may renew credentials between manifest reads. Keep
+			// this load at the worker boundary instead of retaining the IO used for
+			// the manifest list across the whole plan.
+			fs, err := scan.ioF(ctx)
+			if err != nil {
+				return err
+			}
 			partEval, err := partitionEvaluators.Get(int(mf.PartitionSpecID()))
 			if err != nil {
 				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
@@ -1124,7 +1122,7 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	}
 
 	// Step 2: Read manifest entries concurrently, accumulating data and positional deletes.
-	entries, err := scan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
+	entries, err := scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -952,6 +952,10 @@ func (b *manifestIOBatch) acquire(ctx context.Context) (io.IO, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if b.remaining == 0 {
 		fs, err := b.factory(ctx)
 		if err != nil {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -931,6 +931,42 @@ func (scan *Scan) filterManifestsWithSchema(
 	return filtered, nil
 }
 
+// manifestIOBatch shares a FileIO within a concurrency-sized batch. A new
+// batch loads through the factory again so factories that renew credentials
+// still get regular checkpoints without rebuilding the backend for every
+// manifest.
+type manifestIOBatch struct {
+	factory FSysF
+	limit   int
+
+	mu        sync.Mutex
+	fs        io.IO
+	remaining int
+}
+
+func newManifestIOBatch(factory FSysF, limit int) *manifestIOBatch {
+	return &manifestIOBatch{factory: factory, limit: max(limit, 1)}
+}
+
+func (b *manifestIOBatch) acquire(ctx context.Context) (io.IO, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.remaining == 0 {
+		fs, err := b.factory(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		b.fs = fs
+		b.remaining = b.limit
+	}
+
+	b.remaining--
+
+	return b.fs, nil
+}
+
 // collectManifestEntries concurrently opens manifests, applies partition and metrics
 // filters, and accumulates both data entries and positional-delete entries.
 func (scan *Scan) collectManifestEntries(
@@ -962,6 +998,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 
 	minSeqNum := minSequenceNum(manifestList)
 	concurrencyLimit := min(scan.concurrency, len(manifestList))
+	manifestIO := newManifestIOBatch(scan.ioF, concurrencyLimit)
 
 	entries := newManifestEntries()
 	g, _ := errgroup.WithContext(ctx)
@@ -978,10 +1015,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		}
 
 		g.Go(func() error {
-			// FileIO factories may renew credentials between manifest reads. Keep
-			// this load at the worker boundary instead of retaining the IO used for
-			// the manifest list across the whole plan.
-			fs, err := scan.ioF(ctx)
+			fs, err := manifestIO.acquire(ctx)
 			if err != nil {
 				return err
 			}
@@ -1105,9 +1139,9 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	if err != nil {
 		return nil, err
 	}
-	// Share one FileIO for this planning operation between the manifest list
-	// and all manifest workers. Other concurrent table reads use the same
-	// ownership.
+	// Keep the manifest-list load separate from manifest workers. Workers reuse
+	// one FileIO within each concurrent batch, while the next batch loads again
+	// so credential-renewing factories retain their checkpoints.
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(snap, fs, schema, acc)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -855,32 +855,28 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 	if err != nil {
 		return nil, err
 	}
+	snap, err := scan.ResolveSnapshot()
+	if err != nil || snap == nil {
+		return nil, err
+	}
+	fs, err := scan.ioF(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// This path has no reporter behind it, so the manifest counts recorded into
 	// this accumulator are intentionally discarded. A future caller that needs
 	// those counts should use fetchPartitionSpecFilteredManifestsWithSchema and
 	// pass in an accumulator it actually reads.
-	return scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, &scanMetricsAccumulator{})
+	return scan.fetchPartitionSpecFilteredManifestsWithSchema(snap, fs, schema, &scanMetricsAccumulator{})
 }
 
-// fetchPartitionSpecFilteredManifestsWithSchema filters the snapshot's manifests
-// using the given schema. It records total/scanned/skipped manifest counts
-// (split by data vs delete content) into acc.
-func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(ctx context.Context, schema *iceberg.Schema, acc *scanMetricsAccumulator) ([]iceberg.ManifestFile, error) {
-	snap, err := scan.ResolveSnapshot()
-	if err != nil {
-		return nil, err
-	}
-	if snap == nil {
-		return nil, nil
-	}
-
-	afs, err := scan.ioF(ctx)
-	if err != nil {
-		return nil, err
-	}
+// fetchPartitionSpecFilteredManifestsWithSchema loads the snapshot's manifests
+// with fs and filters them using the given schema. It records
+// total/scanned/skipped manifest counts (split by data vs delete content) into acc.
+func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(snap *Snapshot, fs io.IO, schema *iceberg.Schema, acc *scanMetricsAccumulator) ([]iceberg.ManifestFile, error) {
 	// Fetch all manifests for the current snapshot.
-	manifestList, err := snap.Manifests(afs)
+	manifestList, err := snap.Manifests(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -945,12 +941,20 @@ func (scan *Scan) collectManifestEntries(
 	if err != nil {
 		return nil, err
 	}
+	var fs io.IO
+	if len(manifestList) > 0 {
+		fs, err = scan.ioF(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	return scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
+	return scan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
 }
 
 func (scan *Scan) collectManifestEntriesWithSchema(
 	ctx context.Context,
+	fs io.IO,
 	manifestList []iceberg.ManifestFile,
 	schema *iceberg.Schema,
 ) (*manifestEntries, error) {
@@ -982,10 +986,6 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		}
 
 		g.Go(func() error {
-			fs, err := scan.ioF(ctx)
-			if err != nil {
-				return err
-			}
 			partEval, err := partitionEvaluators.Get(int(mf.PartitionSpecID()))
 			if err != nil {
 				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
@@ -1098,8 +1098,20 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 		}
 	}()
 
+	snap, err := scan.ResolveSnapshot()
+	if err != nil || snap == nil {
+		return nil, err
+	}
+	fs, err := scan.ioF(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Share one FileIO for this planning operation between the manifest list
+	// and all manifest workers. Other concurrent table reads use the same
+	// ownership.
+
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
-	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(ctx, schema, acc)
+	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(snap, fs, schema, acc)
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}
@@ -1112,7 +1124,7 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	}
 
 	// Step 2: Read manifest entries concurrently, accumulating data and positional deletes.
-	entries, err := scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
+	entries, err := scan.collectManifestEntriesWithSchema(ctx, fs, manifestList, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -102,12 +102,15 @@ func (fs *expiringManifestIO) Remove(name string) error {
 type failingManifestIO struct {
 	base        *iceio.MemFS
 	failingPath string
+	laterOpens  atomic.Int64
 }
 
 func (fs *failingManifestIO) Open(name string) (iceio.File, error) {
 	if name == fs.failingPath {
 		return nil, errors.New("manifest failed")
 	}
+
+	fs.laterOpens.Add(1)
 
 	return fs.base.Open(name)
 }
@@ -139,30 +142,51 @@ func TestPlanFilesRefreshesFileIODuringManifestPlanning(t *testing.T) {
 func TestPlanFilesStopsLoadingManifestIOAfterWorkerError(t *testing.T) {
 	scan, fs := scanWithManifestCount(t, 2)
 	scan.concurrency = 1
+	failing := &failingManifestIO{
+		base:        fs,
+		failingPath: "mem://planning/table/metadata/manifest-0.avro",
+	}
 
 	var factoryCalls atomic.Int64
-	var canceledFactoryCalls atomic.Int64
-	scan.ioF = func(ctx context.Context) (iceio.IO, error) {
-		if ctx.Err() != nil {
-			canceledFactoryCalls.Add(1)
-
-			return nil, ctx.Err()
-		}
-
+	scan.ioF = func(context.Context) (iceio.IO, error) {
 		if factoryCalls.Add(1) == 1 {
 			return fs, nil
 		}
 
-		return &failingManifestIO{
-			base:        fs,
-			failingPath: "mem://planning/table/metadata/manifest-0.avro",
-		}, nil
+		return failing, nil
 	}
 
 	_, err := scan.PlanFiles(t.Context())
 	require.ErrorContains(t, err, "manifest failed")
-	assert.Equal(t, int64(1), canceledFactoryCalls.Load(),
-		"a later manifest worker should observe cancellation before loading FileIO")
+	assert.Equal(t, int64(2), factoryCalls.Load(),
+		"a later manifest worker must not load FileIO after cancellation")
+	assert.Zero(t, failing.laterOpens.Load())
+}
+
+func TestManifestIOBatchRejectsCanceledContext(t *testing.T) {
+	for _, cached := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cached=%t", cached), func(t *testing.T) {
+			fs := iceio.NewMemFS()
+			var calls int
+			batch := newManifestIOBatch(func(context.Context) (iceio.IO, error) {
+				calls++
+
+				return fs, nil
+			}, 2)
+			if cached {
+				_, err := batch.acquire(t.Context())
+				require.NoError(t, err)
+			}
+			priorCalls := calls
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			got, err := batch.acquire(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+			assert.Nil(t, got)
+			assert.Equal(t, priorCalls, calls)
+		})
+	}
 }
 
 func BenchmarkPlanFilesFileIOFactory(b *testing.B) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -99,6 +99,23 @@ func (fs *expiringManifestIO) Remove(name string) error {
 	return fs.base.Remove(name)
 }
 
+type failingManifestIO struct {
+	base        *iceio.MemFS
+	failingPath string
+}
+
+func (fs *failingManifestIO) Open(name string) (iceio.File, error) {
+	if name == fs.failingPath {
+		return nil, errors.New("manifest failed")
+	}
+
+	return fs.base.Open(name)
+}
+
+func (fs *failingManifestIO) Remove(name string) error {
+	return fs.base.Remove(name)
+}
+
 func TestPlanFilesRefreshesFileIODuringManifestPlanning(t *testing.T) {
 	scan, fs := scanWithManifestCount(t, 1)
 	const manifestListPath = "mem://planning/table/metadata/snap-1.avro"
@@ -117,6 +134,35 @@ func TestPlanFilesRefreshesFileIODuringManifestPlanning(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, tasks, 1)
 	assert.Equal(t, int64(2), calls.Load(), "manifest workers must reacquire FileIO after the manifest list read")
+}
+
+func TestPlanFilesStopsLoadingManifestIOAfterWorkerError(t *testing.T) {
+	scan, fs := scanWithManifestCount(t, 2)
+	scan.concurrency = 1
+
+	var factoryCalls atomic.Int64
+	var canceledFactoryCalls atomic.Int64
+	scan.ioF = func(ctx context.Context) (iceio.IO, error) {
+		if ctx.Err() != nil {
+			canceledFactoryCalls.Add(1)
+
+			return nil, ctx.Err()
+		}
+
+		if factoryCalls.Add(1) == 1 {
+			return fs, nil
+		}
+
+		return &failingManifestIO{
+			base:        fs,
+			failingPath: "mem://planning/table/metadata/manifest-0.avro",
+		}, nil
+	}
+
+	_, err := scan.PlanFiles(t.Context())
+	require.ErrorContains(t, err, "manifest failed")
+	assert.Equal(t, int64(1), canceledFactoryCalls.Load(),
+		"a later manifest worker should observe cancellation before loading FileIO")
 }
 
 func BenchmarkPlanFilesFileIOFactory(b *testing.B) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -57,6 +57,94 @@ func newDeleteManifest(minSeqNum int64) iceberg.ManifestFile {
 		Build()
 }
 
+func TestPlanFilesChecksFileIOForEachManifestWorker(t *testing.T) {
+	const manifestCount = 8
+
+	scan, fs := scanWithManifestCount(t, manifestCount)
+	var calls atomic.Int64
+	scan.ioF = func(context.Context) (iceio.IO, error) {
+		calls.Add(1)
+
+		return fs, nil
+	}
+
+	tasks, err := scan.PlanFiles(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, tasks, manifestCount)
+	assert.Equal(t, int64(manifestCount+1), calls.Load(),
+		"the manifest list and each manifest worker need a FileIO renewal checkpoint")
+}
+
+type expiringManifestIO struct {
+	base         *iceio.MemFS
+	manifestList string
+	expired      atomic.Bool
+}
+
+func (fs *expiringManifestIO) Open(name string) (iceio.File, error) {
+	if name != fs.manifestList && fs.expired.Load() {
+		return nil, fmt.Errorf("credentials expired")
+	}
+
+	file, err := fs.base.Open(name)
+	if err == nil && name == fs.manifestList {
+		fs.expired.Store(true)
+	}
+
+	return file, err
+}
+
+func (fs *expiringManifestIO) Remove(name string) error {
+	return fs.base.Remove(name)
+}
+
+func TestPlanFilesRefreshesFileIODuringManifestPlanning(t *testing.T) {
+	scan, fs := scanWithManifestCount(t, 1)
+	const manifestListPath = "mem://planning/table/metadata/snap-1.avro"
+
+	expiring := &expiringManifestIO{base: fs, manifestList: manifestListPath}
+	var calls atomic.Int64
+	scan.ioF = func(context.Context) (iceio.IO, error) {
+		if calls.Add(1) == 1 {
+			return expiring, nil
+		}
+
+		return fs, nil
+	}
+
+	tasks, err := scan.PlanFiles(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, int64(2), calls.Load(), "manifest workers must reacquire FileIO after the manifest list read")
+}
+
+func BenchmarkPlanFilesFileIOFactory(b *testing.B) {
+	for _, manifestCount := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("manifests_%d", manifestCount), func(b *testing.B) {
+			scan, fs := scanWithManifestCount(b, manifestCount)
+			var calls atomic.Int64
+			scan.ioF = func(context.Context) (iceio.IO, error) {
+				calls.Add(1)
+
+				return fs, nil
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				tasks, err := scan.PlanFiles(b.Context())
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(tasks) != manifestCount {
+					b.Fatalf("unexpected task count: %d", len(tasks))
+				}
+			}
+			b.ReportMetric(float64(calls.Load())/float64(b.N), "fileio-factory-calls/op")
+		})
+	}
+}
+
 func TestArrowScanBindsTaskResidualAgainstScanSchema(t *testing.T) {
 	const historicalFieldID = 7
 	scanSchema := iceberg.NewSchema(1, iceberg.NestedField{
@@ -454,50 +542,6 @@ func scanWithManifestCount(tb testing.TB, manifestCount int) (*Scan, *iceio.MemF
 		limit:          ScanNoLimit,
 		concurrency:    8,
 	}, fs
-}
-
-func TestPlanFilesReusesFileIO(t *testing.T) {
-	const manifestCount = 8
-
-	scan, fs := scanWithManifestCount(t, manifestCount)
-	var calls atomic.Int64
-	scan.ioF = func(context.Context) (iceio.IO, error) {
-		calls.Add(1)
-
-		return fs, nil
-	}
-
-	tasks, err := scan.PlanFiles(t.Context())
-	require.NoError(t, err)
-	assert.Len(t, tasks, manifestCount)
-	assert.Equal(t, int64(1), calls.Load())
-}
-
-func BenchmarkPlanFilesFileIOReuse(b *testing.B) {
-	for _, manifestCount := range []int{1, 10, 100} {
-		b.Run(fmt.Sprintf("manifests_%d", manifestCount), func(b *testing.B) {
-			scan, fs := scanWithManifestCount(b, manifestCount)
-			var calls atomic.Int64
-			scan.ioF = func(context.Context) (iceio.IO, error) {
-				calls.Add(1)
-
-				return fs, nil
-			}
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				tasks, err := scan.PlanFiles(b.Context())
-				if err != nil {
-					b.Fatal(err)
-				}
-				if len(tasks) != manifestCount {
-					b.Fatalf("unexpected task count: %d", len(tasks))
-				}
-			}
-			b.ReportMetric(float64(calls.Load())/float64(b.N), "fileio-loads/op")
-		})
-	}
 }
 
 func TestEqualityDeletePartitionKeyDistinguishesSignedZero(t *testing.T) {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -83,7 +83,7 @@ type expiringManifestIO struct {
 
 func (fs *expiringManifestIO) Open(name string) (iceio.File, error) {
 	if name != fs.manifestList && fs.expired.Load() {
-		return nil, fmt.Errorf("credentials expired")
+		return nil, errors.New("credentials expired")
 	}
 
 	file, err := fs.base.Open(name)

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -57,8 +57,8 @@ func newDeleteManifest(minSeqNum int64) iceberg.ManifestFile {
 		Build()
 }
 
-func TestPlanFilesChecksFileIOForEachManifestWorker(t *testing.T) {
-	const manifestCount = 8
+func TestPlanFilesReusesFileIOWithinManifestBatches(t *testing.T) {
+	const manifestCount = 17
 
 	scan, fs := scanWithManifestCount(t, manifestCount)
 	var calls atomic.Int64
@@ -71,8 +71,9 @@ func TestPlanFilesChecksFileIOForEachManifestWorker(t *testing.T) {
 	tasks, err := scan.PlanFiles(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, tasks, manifestCount)
-	assert.Equal(t, int64(manifestCount+1), calls.Load(),
-		"the manifest list and each manifest worker need a FileIO renewal checkpoint")
+	expectedCalls := int64(1 + (manifestCount+scan.concurrency-1)/scan.concurrency)
+	assert.Equal(t, expectedCalls, calls.Load(),
+		"manifest batches should share FileIO while retaining factory renewal checkpoints")
 }
 
 type expiringManifestIO struct {

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"runtime"
 	"strconv"
@@ -356,6 +357,145 @@ func TestEqualityDeleteIndexUsesFloatSemantics(t *testing.T) {
 				return
 			}
 			assert.Empty(t, matched)
+		})
+	}
+}
+
+func scanWithManifestCount(tb testing.TB, manifestCount int) (*Scan, *iceio.MemFS) {
+	tb.Helper()
+
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	spec := iceberg.NewPartitionSpec()
+	metadata, err := NewMetadata(
+		schema,
+		&spec,
+		UnsortedSortOrder,
+		"mem://planning/table",
+		iceberg.Properties{PropertyFormatVersion: "2"},
+	)
+	require.NoError(tb, err)
+
+	snapshotID := int64(1)
+	fs := iceio.NewMemFS()
+	manifests := make([]iceberg.ManifestFile, manifestCount)
+	for i := range manifestCount {
+		dataFile, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentData,
+			fmt.Sprintf("mem://planning/table/data/file-%d.parquet", i),
+			iceberg.ParquetFile,
+			nil,
+			nil,
+			nil,
+			1,
+			128,
+		)
+		require.NoError(tb, err)
+
+		entry := iceberg.NewManifestEntryBuilder(
+			iceberg.EntryStatusADDED,
+			&snapshotID,
+			dataFile.Build(),
+		).SequenceNum(1).Build()
+		manifestPath := fmt.Sprintf("mem://planning/table/metadata/manifest-%d.avro", i)
+		var manifestData bytes.Buffer
+		manifests[i], err = iceberg.WriteManifest(
+			manifestPath,
+			&manifestData,
+			2,
+			spec,
+			schema,
+			snapshotID,
+			[]iceberg.ManifestEntry{entry},
+		)
+		require.NoError(tb, err)
+		require.NoError(tb, fs.WriteFile(manifestPath, manifestData.Bytes()))
+	}
+
+	const manifestListPath = "mem://planning/table/metadata/snap-1.avro"
+	sequenceNumber := int64(1)
+	var manifestListData bytes.Buffer
+	require.NoError(tb, iceberg.WriteManifestList(
+		2,
+		&manifestListData,
+		snapshotID,
+		nil,
+		&sequenceNumber,
+		0,
+		manifests,
+	))
+	require.NoError(tb, fs.WriteFile(manifestListPath, manifestListData.Bytes()))
+
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(tb, err)
+	schemaID := schema.ID
+	require.NoError(tb, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: sequenceNumber,
+		TimestampMs:    metadata.LastUpdatedMillis() + 1,
+		ManifestList:   manifestListPath,
+		Summary:        &Summary{Operation: OpAppend},
+		SchemaID:       &schemaID,
+	}))
+	require.NoError(tb, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	metadata, err = builder.Build()
+	require.NoError(tb, err)
+
+	return &Scan{
+		metadata:       metadata,
+		ioF:            func(context.Context) (iceio.IO, error) { return fs, nil },
+		planningMode:   ScanPlanningLocal,
+		rowFilter:      iceberg.AlwaysTrue{},
+		selectedFields: []string{"*"},
+		caseSensitive:  true,
+		options:        iceberg.Properties{},
+		limit:          ScanNoLimit,
+		concurrency:    8,
+	}, fs
+}
+
+func TestPlanFilesReusesFileIO(t *testing.T) {
+	const manifestCount = 8
+
+	scan, fs := scanWithManifestCount(t, manifestCount)
+	var calls atomic.Int64
+	scan.ioF = func(context.Context) (iceio.IO, error) {
+		calls.Add(1)
+
+		return fs, nil
+	}
+
+	tasks, err := scan.PlanFiles(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, tasks, manifestCount)
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func BenchmarkPlanFilesFileIOReuse(b *testing.B) {
+	for _, manifestCount := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("manifests_%d", manifestCount), func(b *testing.B) {
+			scan, fs := scanWithManifestCount(b, manifestCount)
+			var calls atomic.Int64
+			scan.ioF = func(context.Context) (iceio.IO, error) {
+				calls.Add(1)
+
+				return fs, nil
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				tasks, err := scan.PlanFiles(b.Context())
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(tasks) != manifestCount {
+					b.Fatalf("unexpected task count: %d", len(tasks))
+				}
+			}
+			b.ReportMetric(float64(calls.Load())/float64(b.N), "fileio-loads/op")
 		})
 	}
 }
@@ -916,7 +1056,9 @@ func TestFetchManifestCountersWithRealSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	var acc scanMetricsAccumulator
-	filtered, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(context.Background(), schema, &acc)
+	snapshot, err := scan.ResolveSnapshot()
+	require.NoError(t, err)
+	filtered, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(snapshot, memIO, schema, &acc)
 	require.NoError(t, err)
 
 	// Two data manifests, one delete manifest.


### PR DESCRIPTION
## Summary

- Reuse one `FileIO` across each concurrent manifest-worker batch.
- Load through the factory again at every batch boundary so credential-renewing factories keep their checkpoints.
- Stop loading later manifest batches after a worker error.
- Keep empty-table planning lazy.
- Leave remote planning and its plan-scoped IO lifecycle unchanged.

## Benchmark

Run with:

`go test ./table -run ^$ -bench BenchmarkPlanFilesFileIOFactory -benchmem -benchtime=1s -count=3`

Results below are from a macOS arm64 machine with max concurrency 8. The factory-call count is the important metric; wall time includes in-memory Avro planning and varies by machine.

| Manifests | Before factory calls/op | After factory calls/op | After ns/op |
| ---: | ---: | ---: | ---: |
| 1 | 2 | 2 | 393,944 |
| 10 | 11 | 3 | 1,130,422 |
| 100 | 101 | 14 | 9,499,501 |

This keeps the renewal checkpoints while reducing backend-factory calls by 73% for 10 manifests and 86% for 100 manifests.

## Tests

- `go test ./table/...`
- `go test -race ./table -run ^TestPlanFiles(ReusesFileIOWithinManifestBatches|RefreshesFileIODuringManifestPlanning|StopsLoadingManifestIOAfterWorkerError)$ -count=1`
- `go vet ./table/...`
- `golangci-lint run --timeout=10m ./table/...`