### PR TITLE
perf(table): avoid writer-factory lock on cache hits

### DIFF
--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -349,9 +349,19 @@ func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition stri
 }
 
 func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) (*RollingDataWriter, error) {
+	if existing, ok := w.writers.Load(partition); ok {
+		if writer, ok := existing.(*RollingDataWriter); ok {
+			return writer, nil
+		}
+
+		return nil, fmt.Errorf("invalid writer type for partition: %s", partition)
+	}
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	// Recheck after acquiring the lock in case another goroutine created the
+	// writer while this goroutine was waiting.
 	if existing, ok := w.writers.Load(partition); ok {
 		if writer, ok := existing.(*RollingDataWriter); ok {
 			return writer, nil

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -64,6 +66,32 @@ func (s *RollingDataWriterTestSuite) SetupTest() {
 
 func TestRollingDataWriter(t *testing.T) {
 	suite.Run(t, new(RollingDataWriterTestSuite))
+}
+
+func BenchmarkWriterFactoryCacheHit(b *testing.B) {
+	for _, partitionCount := range []int{1, 8, 128} {
+		b.Run(strconv.Itoa(partitionCount)+"_partitions", func(b *testing.B) {
+			factory := &writerFactory{}
+			partitions := make([]string, partitionCount)
+			for i := range partitionCount {
+				partitions[i] = strconv.Itoa(i)
+				factory.writers.Store(partitions[i], &RollingDataWriter{})
+			}
+
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				var i int
+				for pb.Next() {
+					writer, err := factory.getOrCreateRollingDataWriter(
+						context.Background(), partitions[i%partitionCount], nil, nil)
+					if err != nil || writer == nil {
+						b.Fatalf("get existing writer: writer=%v, err=%v", writer, err)
+					}
+					i++
+				}
+			})
+		})
+	}
 }
 
 func (s *RollingDataWriterTestSuite) createWriterFactory(loc string, arrSchema *arrow.Schema, targetFileSize int64) (*writerFactory, *iceberg.Schema) {
@@ -269,6 +297,49 @@ func (s *RollingDataWriterTestSuite) TestCloseAllFinishesQueuedRecordsWithoutCan
 	}
 
 	s.Equal(expectedRows, actualRows, "all queued records should be flushed when closeAll is used")
+}
+
+func (s *RollingDataWriterTestSuite) TestConcurrentGetOrCreateCreatesOneWriter() {
+	const goroutineCount = 32
+
+	factory := &writerFactory{}
+	outputCh := make(chan iceberg.DataFile)
+	start := make(chan struct{})
+	results := make(chan struct {
+		writer *RollingDataWriter
+		err    error
+	}, goroutineCount)
+
+	var wg sync.WaitGroup
+	for range goroutineCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			writer, err := factory.getOrCreateRollingDataWriter(s.ctx, "partition", nil, outputCh)
+			results <- struct {
+				writer *RollingDataWriter
+				err    error
+			}{writer, err}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var expected *RollingDataWriter
+	for result := range results {
+		s.Require().NoError(result.err)
+		if expected == nil {
+			expected = result.writer
+		}
+		s.Same(expected, result.writer)
+	}
+
+	s.EqualValues(1, factory.partitionIDCounter.Load())
+	s.Require().NotNil(expected)
+	s.Require().NoError(expected.closeAndWait())
 }
 
 func (s *RollingDataWriterTestSuite) TestAbortAndWaitCancelsContext() {


### PR DESCRIPTION
## What changed

- Return cached partition writers before taking the factory mutex.
- Keep the locked recheck so concurrent cache misses still create one writer.
- Add a concurrent creation regression test and a focused cache-hit benchmark.

## Benchmark

Apple M1 Pro, Go 1.26.3, 8 benchmark workers:

```text
                                 before       after
1 partition                     139.5 ns/op   2.6 ns/op
8 partitions                    146.7 ns/op   3.1 ns/op
128 partitions                  152.3 ns/op   3.8 ns/op
```

All cases remain at 0 allocs/op.

## Testing

- `go test ./table`
- `go test -race ./table -run TestRollingDataWriter/TestConcurrentGetOrCreateCreatesOneWriter -count=20`
- `go vet ./table`
- `golangci-lint run --timeout=10m ./table/...`