### PR TITLE
fix(table): skip DELETED manifest entries in Snapshot.dataFiles

### DIFF
--- a/table/rewrite_files_test.go
+++ b/table/rewrite_files_test.go
@@ -343,6 +343,47 @@ func TestRewriteFiles_DeleteFile_RoutesByContentType(t *testing.T) {
 	assert.NotContains(t, err.Error(), dataSliceMiss)
 }
 
+// TestAddFiles_ReAddsPathDeletedByRewrite pins the duplicate check's
+// tombstone handling: a rewrite that removes a data file leaves a
+// DELETED manifest entry for its path on the branch head. That entry
+// records a removal — the path is no longer referenced by the table —
+// so a subsequent AddFiles for the same path must not report a false
+// "already referenced" conflict.
+func TestAddFiles_ReAddsPathDeletedByRewrite(t *testing.T) {
+	tbl := newRewriteTestTable(t)
+
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+	dataPath := tbl.Location() + "/data/seed.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "seed"}]`)
+	seedTx := tbl.NewTransaction()
+	require.NoError(t, seedTx.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = seedTx.Commit(t.Context())
+	require.NoError(t, err)
+
+	// A rewrite removes the file, leaving a DELETED tombstone on the head.
+	// The physical parquet file stays on disk (Iceberg deletes are
+	// metadata-only), so it can be legitimately re-added.
+	tasks, err := tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	rewriteTx := tbl.NewTransaction()
+	require.NoError(t, rewriteTx.NewRewrite(nil).DeleteFile(tasks[0].File).Commit(t.Context()))
+	tbl, err = rewriteTx.Commit(t.Context())
+	require.NoError(t, err)
+
+	readdTx := tbl.NewTransaction()
+	require.NoError(t, readdTx.AddFiles(t.Context(), []string{dataPath}, nil, false),
+		"a path whose only head entry is a DELETED tombstone is not referenced by the table")
+	tbl, err = readdTx.Commit(t.Context())
+	require.NoError(t, err)
+
+	tasks, err = tbl.Scan().PlanFiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, dataPath, tasks[0].File.FilePath())
+}
+
 // TestRewriteFiles_RejectsAddsWithoutDataDeletes proves that staging
 // new data files with no data files to delete is rejected up front —
 // otherwise the chain would slip through ReplaceFiles →

--- a/table/snapshots.go
+++ b/table/snapshots.go
@@ -354,7 +354,11 @@ func (s Snapshot) dataFiles(fio iceio.IO, fileFilter set[iceberg.ManifestEntryCo
 		}
 
 		for _, m := range manifests {
-			for entry, err := range m.Entries(fio, false) {
+			// Discard DELETED entries: they are tombstones recording a
+			// removal, not files reachable from this snapshot. Yielding
+			// them would make existence and duplicate checks treat a
+			// file deleted by this snapshot as still live.
+			for entry, err := range m.Entries(fio, true) {
 				if err != nil {
 					yield(nil, err)
 

--- a/table/snapshots_datafiles_internal_test.go
+++ b/table/snapshots_datafiles_internal_test.go
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildSnapshotTestDataFile(t *testing.T, path string, content iceberg.ManifestEntryContent) iceberg.DataFile {
+	t.Helper()
+
+	b, err := iceberg.NewDataFileBuilder(*iceberg.UnpartitionedSpec,
+		content, path, iceberg.ParquetFile, nil, nil, nil, 10, 1024)
+	require.NoError(t, err)
+
+	return b.Build()
+}
+
+// writeSnapshotTestManifest writes a manifest containing the given files
+// with status ADDED, existingFiles with status EXISTING (live files
+// carried over from a prior snapshot), and deletedFiles with status
+// DELETED (tombstones for files removed by the snapshot).
+func writeSnapshotTestManifest(t *testing.T, fs iceio.WriteFileIO, path string, content iceberg.ManifestContent, files, existingFiles, deletedFiles []iceberg.DataFile) iceberg.ManifestFile {
+	t.Helper()
+
+	var buf bytes.Buffer
+	wr, err := iceberg.NewManifestWriter(2, &buf, *iceberg.UnpartitionedSpec,
+		tableSchemaSimple, 1, iceberg.WithManifestWriterContent(content))
+	require.NoError(t, err)
+
+	snapshotID := int64(1)
+	for _, df := range files {
+		require.NoError(t, wr.Add(iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, nil, nil, df)))
+	}
+	// Non-ADDED entries must carry explicit sequence numbers.
+	seq := int64(1)
+	for _, df := range existingFiles {
+		require.NoError(t, wr.Existing(iceberg.NewManifestEntry(
+			iceberg.EntryStatusEXISTING, &snapshotID, &seq, &seq, df)))
+	}
+	for _, df := range deletedFiles {
+		require.NoError(t, wr.Delete(iceberg.NewManifestEntry(
+			iceberg.EntryStatusDELETED, &snapshotID, &seq, &seq, df)))
+	}
+	require.NoError(t, wr.Close())
+	require.NoError(t, fs.WriteFile(path, buf.Bytes()))
+
+	mf, err := wr.ToManifestFile(path, int64(buf.Len()), iceberg.WithManifestFileContent(content))
+	require.NoError(t, err)
+
+	return mf
+}
+
+// writeSnapshotTestManifestList writes a manifest list referencing the
+// given manifests in order and returns its path.
+func writeSnapshotTestManifestList(t *testing.T, fs iceio.WriteFileIO, dir string, manifests []iceberg.ManifestFile) string {
+	t.Helper()
+
+	listPath := dir + "/metadata/manifest-list.avro"
+	out, err := fs.Create(listPath)
+	require.NoError(t, err)
+	seq := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, out, 1, nil, &seq, 0, manifests))
+	require.NoError(t, out.Close())
+
+	return listPath
+}
+
+// Why: a manifest entry with status DELETED is a tombstone recording a
+// removal, not a file reachable from the snapshot. Yielding it would make
+// existence and duplicate checks (ReplaceFiles' belong-to-table check,
+// AddFiles' duplicate walk, classifyFilesForDeletions) treat a file
+// deleted by the snapshot as still live. ADDED and EXISTING entries are
+// both live and must keep flowing through.
+// Condition: a snapshot whose data and delete manifests each carry one
+// ADDED, one EXISTING, and one DELETED entry.
+// Assertion: the ADDED and EXISTING entries are yielded; the DELETED
+// ones are not.
+func TestSnapshotDataFilesSkipsDeletedEntries(t *testing.T) {
+	fs := iceio.LocalFS{}
+	dir := filepath.ToSlash(t.TempDir())
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "metadata"), 0o755))
+
+	addedData := dir + "/data/added.parquet"
+	existingData := dir + "/data/existing.parquet"
+	goneData := dir + "/data/gone.parquet"
+	addedDel := dir + "/data/added-del.parquet"
+	existingDel := dir + "/data/existing-del.parquet"
+	goneDel := dir + "/data/gone-del.parquet"
+
+	manifests := []iceberg.ManifestFile{
+		writeSnapshotTestManifest(t, fs, dir+"/metadata/manifest-0.avro",
+			iceberg.ManifestContentData,
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, addedData, iceberg.EntryContentData)},
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, existingData, iceberg.EntryContentData)},
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, goneData, iceberg.EntryContentData)}),
+		writeSnapshotTestManifest(t, fs, dir+"/metadata/manifest-1.avro",
+			iceberg.ManifestContentDeletes,
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, addedDel, iceberg.EntryContentPosDeletes)},
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, existingDel, iceberg.EntryContentPosDeletes)},
+			[]iceberg.DataFile{buildSnapshotTestDataFile(t, goneDel, iceberg.EntryContentPosDeletes)}),
+	}
+	snap := Snapshot{
+		SnapshotID:     1,
+		SequenceNumber: 1,
+		ManifestList:   writeSnapshotTestManifestList(t, fs, dir, manifests),
+	}
+
+	var got []string
+	for df, err := range snap.dataFiles(fs, nil) {
+		require.NoError(t, err)
+		got = append(got, df.FilePath())
+	}
+
+	assert.Equal(t, []string{addedData, existingData, addedDel, existingDel}, got,
+		"ADDED and EXISTING entries must be yielded; DELETED tombstones must not")
+}


### PR DESCRIPTION
## What

`Snapshot.dataFiles` read manifest entries with `discardDeleted=false` and applied no status filter, so DELETED entries — tombstones recording that a file was removed — were yielded as if the files were still reachable. This PR flips that one flag to `true` (the manifest reader's existing `discardDeleted` support) and adds regression tests.

## Why

Every caller of `dataFiles` wants live files only, so the leak made each one subtly wrong:

- `AddFiles` / `AddDataFiles` duplicate walks reported false "already referenced" errors for a path whose previous incarnation was deleted (e.g. by a compaction), blocking a legitimate re-add.
- The `ReplaceFiles`-family belong-to-table checks matched already-removed files, silently staging a redundant re-delete of a file the table no longer references.
- `classifyFilesForDeletions`' full-table branch collected tombstoned files as deletion candidates.

I audited every call site to make sure no caller wants tombstones (all are in `transaction.go`):

| Call site | Wants |
|---|---|
| `ReplaceDataFiles` belong-to-table / already-referenced | live only |
| `AddDataFiles` duplicate check | live only |
| `ReplaceDataFilesWithDataFiles` belong-to-table | live only |
| `ReplaceFiles` belong-to-table | live only |
| `AddFiles` duplicate walk | live only |
| `classifyFilesForDeletions` full-table branch | live only |

Code that genuinely needs tombstones (conflict validation, `collectExistingDVs`) already uses the separate `Snapshot.entries` iterator and filters by status itself, so it's untouched. Scan planning already discards DELETED entries — this brings the transaction-side walks in line.

This also matches Java, where the transaction/validation walks go through `ManifestReader.liveEntries()` / `ManifestGroup`, which filter DELETED entries by default.

## Behavior changes

Both are bug-fix-shaped, but worth stating plainly:

- Re-adding a path whose only head entry is a tombstone now succeeds instead of failing with a false "already referenced" error.
- Asking the `ReplaceFiles` family to delete such a path now correctly fails with "cannot delete files that do not belong to the table" instead of silently staging a redundant re-delete. This matches Java's `BaseReplaceFiles` validation.

## Tests

- `TestSnapshotDataFilesSkipsDeletedEntries` (new internal test): a snapshot whose data and delete manifests each carry ADDED, EXISTING, and DELETED entries yields only the live ones.
- `TestAddFiles_ReAddsPathDeletedByRewrite`: a rewrite removes a file leaving a tombstone; re-adding the same path succeeds and the file is scannable again.

Both fail on the pre-fix code. `go test ./...` and `golangci-lint run` are clean.

Made with [Cursor](https://cursor.com)