### PR TITLE
feat(table): add Transaction.AssertRefSnapshotID (Java UpdateRequirements parity)

### DIFF
--- a/table/commit_refresh_replay_test.go
+++ b/table/commit_refresh_replay_test.go
@@ -294,7 +294,7 @@ func TestRewriteRefSnapshotRequirements(t *testing.T) {
 	newHead := int64(99)
 	fresh := newConflictTestMetadata(t, &newHead)
 
-	out := rewriteRefSnapshotRequirements(reqs, MainBranch, fresh)
+	out := rewriteRefSnapshotRequirements(reqs, MainBranch, fresh, nil)
 	require.Len(t, out, 3)
 
 	a, ok := out[0].(*assertRefSnapshotID)
@@ -307,14 +307,21 @@ func TestRewriteRefSnapshotRequirements(t *testing.T) {
 	assert.Same(t, otherAssert, out[1])
 	assert.Same(t, uuidAssert, out[2])
 
+	// A pinned branch carries an explicit compare-and-swap requirement:
+	// its assertion must survive the rewrite untouched.
+	pinnedOut := rewriteRefSnapshotRequirements(reqs, MainBranch, fresh,
+		map[string]struct{}{MainBranch: {}})
+	assert.Same(t, mainAssert, pinnedOut[0],
+		"a pinned assertion must not be rewritten to the fresh head")
+
 	// Edge cases: empty branch / nil fresh / branch missing on fresh
 	// return the slice unchanged.
-	noBranchOut := rewriteRefSnapshotRequirements(reqs, "", fresh)
+	noBranchOut := rewriteRefSnapshotRequirements(reqs, "", fresh, nil)
 	assert.Equal(t, reqs, noBranchOut)
 
-	nilFreshOut := rewriteRefSnapshotRequirements(reqs, MainBranch, nil)
+	nilFreshOut := rewriteRefSnapshotRequirements(reqs, MainBranch, nil, nil)
 	assert.Equal(t, reqs, nilFreshOut)
 
-	missingBranchOut := rewriteRefSnapshotRequirements(reqs, "non-existent", fresh)
+	missingBranchOut := rewriteRefSnapshotRequirements(reqs, "non-existent", fresh, nil)
 	assert.Equal(t, reqs, missingBranchOut)
 }

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1431,6 +1431,13 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 		addSnap.supersededSource = acc
 	}
 
+	// Build the assertion from the base table's branch head, not the
+	// staged metadata's current snapshot: a staged intermediate snapshot
+	// never exists on the catalog, so requiring it could never hold. A
+	// nil id requires that the branch not exist yet (this commit
+	// creates it).
+	baseHeadID := sp.txn.baseRefSnapshotID(branch)
+
 	return []Update{
 			addSnap,
 			// Carry over the branch's existing retention settings so advancing
@@ -1441,6 +1448,6 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 			// determines the resulting ref rather than merging with the old one.
 			sp.txn.meta.NewRetainingSnapshotRefUpdate(branch, sp.snapshotID, BranchRef),
 		}, []Requirement{
-			AssertRefSnapshotID(branch, sp.txn.meta.currentSnapshotID),
+			AssertRefSnapshotID(branch, baseHeadID),
 		}, nil
 }

--- a/table/table.go
+++ b/table/table.go
@@ -503,6 +503,12 @@ type commitOpts struct {
 	// Set for commits carrying delete-file removals; see the flag site
 	// in snapshotProducer.commitManifests for the rationale.
 	noReplay bool
+
+	// pinnedRefs names branches with an explicit requirement from
+	// Transaction.AssertRefSnapshotID, whose assertions must not be
+	// rewritten to the fresh branch head between retries (see
+	// Transaction.pinnedRefs).
+	pinnedRefs map[string]struct{}
 }
 
 type commitOption func(*commitOpts)
@@ -525,6 +531,10 @@ func withCommitValidators(vs ...conflictValidatorFunc) commitOption {
 
 func withCommitNoReplay(noReplay bool) commitOption {
 	return func(o *commitOpts) { o.noReplay = noReplay }
+}
+
+func withCommitPinnedRefs(refs map[string]struct{}) commitOption {
+	return func(o *commitOpts) { o.pinnedRefs = refs }
 }
 
 func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requirement, opts ...commitOption) (*Table, error) {
@@ -633,7 +643,14 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 				}
 			}
 			current = fresh.metadata
-			reqs = rewriteRefSnapshotRequirements(reqs, co.branch, current)
+			reqs = rewriteRefSnapshotRequirements(reqs, co.branch, current, co.pinnedRefs)
+
+			// A pinned assertion the fresh catalog state violates can
+			// never succeed — fail now instead of burning the remaining
+			// retries on it.
+			if err := validatePinnedRefRequirements(reqs, co.pinnedRefs, current); err != nil {
+				return nil, fmt.Errorf("%w: explicit ref requirement failed: %w", ErrCommitFailed, err)
+			}
 			if err := validateBranchRequirement(reqs, co.branch, current); err != nil {
 				return nil, err
 			}
@@ -783,7 +800,12 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 // the branch is empty or the new head cannot be resolved (branch
 // deleted underneath us), reqs is returned unchanged — newConflict-
 // Context will surface the divergence on the next pre-flight pass.
-func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Metadata) []Requirement {
+//
+// Assertions on branches in pinned were registered explicitly by the
+// committer (Transaction.AssertRefSnapshotID) for compare-and-swap
+// semantics and are never rewritten: a branch that has changed must
+// fail the commit, not be replayed against the new head.
+func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Metadata, pinned map[string]struct{}) []Requirement {
 	if branch == "" || fresh == nil {
 		return reqs
 	}
@@ -795,19 +817,46 @@ func rewriteRefSnapshotRequirements(reqs []Requirement, branch string, fresh Met
 	out := make([]Requirement, len(reqs))
 	for i, r := range reqs {
 		if a, ok := r.(*assertRefSnapshotID); ok && a.Ref == branch {
-			newID := head.SnapshotID
-			if a.requireBranch {
-				out[i] = assertBranchRefSnapshotID(branch, &newID)
-			} else {
-				out[i] = AssertRefSnapshotID(branch, &newID)
-			}
+			if _, isPinned := pinned[a.Ref]; !isPinned {
+				newID := head.SnapshotID
+				if a.requireBranch {
+					out[i] = assertBranchRefSnapshotID(branch, &newID)
+				} else {
+					out[i] = AssertRefSnapshotID(branch, &newID)
+				}
 
-			continue
+				continue
+			}
 		}
 		out[i] = r
 	}
 
 	return out
+}
+
+// validatePinnedRefRequirements validates every assert-ref-snapshot-id
+// requirement on a pinned branch against the freshly refreshed catalog
+// metadata. A failure means the branch has changed from the required
+// snapshot: the assertion is never rewritten, so it can never hold and
+// the commit must fail instead of retrying.
+func validatePinnedRefRequirements(reqs []Requirement, pinned map[string]struct{}, fresh Metadata) error {
+	if len(pinned) == 0 {
+		return nil
+	}
+	for _, r := range reqs {
+		a, ok := r.(*assertRefSnapshotID)
+		if !ok {
+			continue
+		}
+		if _, isPinned := pinned[a.Ref]; !isPinned {
+			continue
+		}
+		if err := a.Validate(fresh); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func validateBranchRequirement(reqs []Requirement, branch string, meta Metadata) error {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"runtime"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -167,13 +168,13 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 		return err
 	}
 
-	for _, r := range reqs {
-		if err := r.Validate(current); err != nil {
-			return err
-		}
-	}
-
-	existing := map[string]struct{}{}
+	// Deduplicate requirements by semantic key, rejecting pairs that
+	// share a key but cannot both hold (see checkRequirementConflict).
+	// Only requirements actually appended are validated against the
+	// staged metadata: a deduplicated twin re-asserts base state the
+	// staged metadata has intentionally moved past, and its kept twin
+	// was validated when first added.
+	existing := make(map[string]Requirement, len(t.reqs))
 	stagedReqs := make([]Requirement, 0, len(t.reqs)+len(reqs))
 	for _, r := range t.reqs {
 		key, err := requirementSemanticKey(r)
@@ -181,7 +182,7 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 			return err
 		}
 
-		existing[key] = struct{}{}
+		existing[key] = r
 		stagedReqs = append(stagedReqs, r)
 	}
 
@@ -191,10 +192,18 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 			return err
 		}
 
-		if _, ok := existing[key]; !ok {
-			stagedReqs = append(stagedReqs, r)
-			existing[key] = struct{}{}
+		if prev, ok := existing[key]; ok {
+			if err := checkRequirementConflict(prev, r); err != nil {
+				return err
+			}
+
+			continue
 		}
+		if err := r.Validate(current); err != nil {
+			return err
+		}
+		existing[key] = r
+		stagedReqs = append(stagedReqs, r)
 	}
 
 	prevUpdates, prevLastUpdated := len(stagedMeta.updates), stagedMeta.lastUpdatedMS
@@ -226,13 +235,13 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 // from collapsing into one another.
 //
 // assert-ref-snapshot-id is special-cased to key by requirement type + ref name
-// only, deliberately ignoring the asserted snapshot id. Within a single
-// transaction the builder mutates its own ref state across operations (e.g. the
-// first append asserts main == nil, a later append asserts main == snapshot-1),
-// which would otherwise produce multiple, mutually contradictory base-state
-// assertions for the same ref against the pre-transaction metadata. Keying by
-// ref name keeps only the first assertion for each ref while still letting
-// assertions for different refs survive dedupe.
+// only, deliberately ignoring the asserted snapshot id. Producers build their
+// assertion from the BASE table's branch head, so repeated producer commits
+// (and explicit AssertRefSnapshotID calls) for the same ref produce identical
+// assertions that collapse to one, while assertions for different refs
+// survive dedupe. Two assertions for the same ref requiring different
+// snapshot ids share a key but cannot be collapsed —
+// checkRequirementConflict rejects them at apply time.
 func requirementSemanticKey(r Requirement) (string, error) {
 	if ref, ok := r.(*assertRefSnapshotID); ok {
 		return fmt.Sprintf("%s\x00%s", reqAssertRefSnapshotID, ref.Ref), nil
@@ -244,6 +253,59 @@ func requirementSemanticKey(r Requirement) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+// checkRequirementConflict reports whether two requirements sharing a
+// semantic key can be collapsed into one. Identical ref assertions dedupe
+// to the first; two assert-ref-snapshot-id for the same ref requiring
+// different snapshot ids can never both hold, so keeping either one
+// would silently drop a check the caller registered — reject instead.
+func checkRequirementConflict(prev, next Requirement) error {
+	a, aok := prev.(*assertRefSnapshotID)
+	b, bok := next.(*assertRefSnapshotID)
+	if !aok || !bok {
+		return nil
+	}
+
+	if (a.SnapshotID == nil) != (b.SnapshotID == nil) ||
+		(a.SnapshotID != nil && *a.SnapshotID != *b.SnapshotID) {
+		return fmt.Errorf("conflicting snapshot-id assertions for ref %q: %s vs %s",
+			a.Ref, formatSnapshotID(a.SnapshotID), formatSnapshotID(b.SnapshotID))
+	}
+
+	return nil
+}
+
+// formatSnapshotID renders a required snapshot id for error messages; a
+// nil id asserts the ref's absence.
+func formatSnapshotID(id *int64) string {
+	if id == nil {
+		return "<ref absent>"
+	}
+
+	return strconv.FormatInt(*id, 10)
+}
+
+// baseRefSnapshotID returns the snapshot id the transaction's BASE
+// table metadata records for branch, or nil when the branch does not
+// exist on the base. Ref requirements must be built from this state —
+// the catalog state the writer actually read, as in Java's
+// UpdateRequirements — rather than the staged builder's refs, which
+// move past it as producer commits stage intermediate snapshots the
+// catalog has never seen.
+func (t *Transaction) baseRefSnapshotID(branch string) *int64 {
+	if t.tbl == nil || t.tbl.metadata == nil {
+		return nil
+	}
+	for name, ref := range t.tbl.metadata.Refs() {
+		if name == branch {
+			id := ref.SnapshotID
+
+			return &id
+		}
+	}
+
+	return nil
 }
 
 func transactionRequirements(reqs []Requirement, branch string, base Metadata) []Requirement {
@@ -364,9 +426,17 @@ func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
 	}
 
 	update := meta.NewRetainingSnapshotRefUpdate(MainBranch, snapshotID, BranchRef)
-	req := AssertRefSnapshotID(MainBranch, &cs.SnapshotID)
 
-	return t.apply([]Update{update}, []Requirement{req})
+	// Assert the base branch head so a concurrent head move fails the
+	// commit instead of the rollback clobbering it. When main was
+	// staged by this transaction (absent on the base), the update that
+	// created it already carries its own base-state requirement.
+	var reqs []Requirement
+	if id := t.baseRefSnapshotID(MainBranch); id != nil {
+		reqs = append(reqs, AssertRefSnapshotID(MainBranch, id))
+	}
+
+	return t.apply([]Update{update}, reqs)
 }
 
 func (t *Transaction) UpdateSpec(caseSensitive bool) *UpdateSpec {
@@ -519,11 +589,14 @@ func (t *Transaction) ExpireSnapshots(opts ...ExpireSnapshotsOpt) error {
 
 	retainedRefs := make(map[string]SnapshotRef, len(meta.refs))
 	for refName, ref := range meta.refs {
-		// Assert that this ref's snapshot ID hasn't changed concurrently.
-		// This ensures we don't accidentally expire snapshots that are now
-		// referenced by updated refs.
-		snapshotID := ref.SnapshotID
-		reqs = append(reqs, AssertRefSnapshotID(refName, &snapshotID))
+		// Assert the ref's base snapshot id so we don't accidentally
+		// expire snapshots that are now referenced by concurrently
+		// updated refs. Refs the transaction itself staged (absent on
+		// the base) get no assertion here: the update that created
+		// them carries its own base-state requirement.
+		if id := t.baseRefSnapshotID(refName); id != nil {
+			reqs = append(reqs, AssertRefSnapshotID(refName, id))
+		}
 
 		snap, err := meta.SnapshotByID(ref.SnapshotID)
 		if err != nil {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -99,6 +99,13 @@ type Transaction struct {
 	// removals; see the flag site in commitManifests.
 	noReplay bool
 
+	// pinnedRefs names branches with an explicit AssertRefSnapshotID
+	// requirement. doCommit's refresh-and-replay must not rewrite their
+	// assertions to the fresh branch head between retries: the caller
+	// opted into compare-and-swap semantics, so a branch that has
+	// changed fails the commit.
+	pinnedRefs map[string]struct{}
+
 	mx        sync.Mutex
 	committed bool
 }
@@ -376,6 +383,63 @@ func (t *Transaction) SetProperties(props iceberg.Properties) error {
 	}
 	if len(props) > 0 {
 		return t.apply([]Update{NewSetPropertiesUpdate(props)}, nil)
+	}
+
+	return nil
+}
+
+// AssertRefSnapshotID records a requirement that the given branch is
+// unchanged from the transaction's base table metadata — the catalog
+// state this transaction read: the branch must still reference the
+// same snapshot id, or still not exist when the base has none. An
+// empty branch means the transaction's target branch (main unless the
+// transaction was created with NewTransactionOnBranch).
+//
+// It provides optimistic concurrency for metadata-only commits, such
+// as SetProperties used for exactly-once bookkeeping. Commit normally
+// retries against the fresh branch head; with this requirement it
+// instead fails with ErrCommitFailed if any snapshot was committed to
+// the branch after the transaction's read. Snapshot producers
+// targeting the branch in the same transaction fail the same way
+// rather than retry.
+//
+// The requirement is submitted together with the transaction's
+// updates; a transaction with no updates never contacts the catalog,
+// so the requirement alone does not force a commit.
+func (t *Transaction) AssertRefSnapshotID(branch string) error {
+	if _, err := t.txnMeta(); err != nil {
+		return err
+	}
+	if branch == "" {
+		branch = t.branch
+	}
+	if branch == "" {
+		branch = MainBranch
+	}
+
+	id := t.baseRefSnapshotID(branch)
+
+	// Record the pin before the requirement can become visible to a
+	// concurrent Commit, which would otherwise rewrite the requirement
+	// to the fresh head on retry and silently void the
+	// compare-and-swap. The transient pin is harmless on its own and
+	// is rolled back if the requirement fails to apply.
+	t.mx.Lock()
+	if t.pinnedRefs == nil {
+		t.pinnedRefs = make(map[string]struct{})
+	}
+	_, alreadyPinned := t.pinnedRefs[branch]
+	t.pinnedRefs[branch] = struct{}{}
+	t.mx.Unlock()
+
+	if err := t.apply(nil, []Requirement{AssertRefSnapshotID(branch, id)}); err != nil {
+		if !alreadyPinned {
+			t.mx.Lock()
+			delete(t.pinnedRefs, branch)
+			t.mx.Unlock()
+		}
+
+		return err
 	}
 
 	return nil
@@ -2570,6 +2634,7 @@ func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 			withCommitBranch(t.branch),
 			withCommitValidators(t.validators...),
 			withCommitNoReplay(t.noReplay),
+			withCommitPinnedRefs(t.pinnedRefs),
 		)
 		if err != nil {
 			// A clean conflict (ErrCommitFailed) committed nothing and stays

--- a/table/transaction_assert_ref_test.go
+++ b/table/transaction_assert_ref_test.go
@@ -1,0 +1,274 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var assertRefRetryProps = iceberg.Properties{
+	CommitNumRetriesKey:     "2",
+	CommitMinRetryWaitMsKey: "1",
+	CommitMaxRetryWaitMsKey: "2",
+}
+
+// newAssertRefTestTable builds a writer-side table over the given base
+// metadata, backed by a headTrackingCatalog seeded with catalogMeta —
+// the catalog state at commit time, which may differ from the writer's
+// view to simulate an interleaved commit.
+func newAssertRefTestTable(t *testing.T, base, catalogMeta Metadata) (*Table, *headTrackingCatalog) {
+	t.Helper()
+
+	cat := &headTrackingCatalog{metadata: catalogMeta}
+	tbl := New(Identifier{"db", "assert-ref-test"}, base, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, cat)
+
+	return tbl, cat
+}
+
+// newProducerAssertRefTable builds an empty v2 table over a temp dir so
+// subtests combining an explicit ref requirement with a producer can
+// run a real fast-append commit.
+func newProducerAssertRefTable(t *testing.T) (*Table, *headTrackingCatalog, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	props := iceberg.Properties{PropertyFormatVersion: "2"}
+	for k, v := range assertRefRetryProps {
+		props[k] = v
+	}
+	base, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, dir, props)
+	require.NoError(t, err)
+	tbl, cat := newAssertRefTestTable(t, base, base)
+
+	return tbl, cat, dir
+}
+
+// commitPropsWithAssertedRef runs the motivating flow on tx: stage a
+// bookkeeping property, require branch unchanged, and commit, returning
+// the commit error.
+func commitPropsWithAssertedRef(t *testing.T, tx *Transaction, branch string) error {
+	t.Helper()
+
+	require.NoError(t, tx.SetProperties(iceberg.Properties{"offsets": "42"}))
+	require.NoError(t, tx.AssertRefSnapshotID(branch))
+	_, err := tx.Commit(t.Context())
+
+	return err
+}
+
+// Why: a transaction carrying only metadata updates (e.g. SetProperties
+// used for exactly-once bookkeeping) has its implicit branch assertion
+// rewritten to the fresh head between retries and replayed, so the
+// writer cannot detect that the branch changed between its read and the
+// commit; callers need an explicit requirement — and the retry loop's
+// refresh-and-replay must not rewrite it to the new head, which would
+// silently void the compare-and-swap.
+// Condition: a properties-only transaction with AssertRefSnapshotID,
+// committed against a catalog whose branch head did or did not change
+// in between.
+// Assertion: the commit succeeds when the branch is unchanged and fails
+// with ErrCommitFailed — with the properties left uncommitted — when it
+// changed.
+func TestTransactionAssertRefSnapshotID(t *testing.T) {
+	head := int64(100)
+
+	t.Run("succeeds when the branch is unchanged", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+		tbl, cat := newAssertRefTestTable(t, base, base)
+
+		require.NoError(t, commitPropsWithAssertedRef(t, tbl.NewTransaction(), MainBranch))
+		assert.Equal(t, int32(1), cat.attempts.Load())
+		assert.Equal(t, "42", cat.metadata.Properties()["offsets"])
+	})
+
+	t.Run("fails when a concurrent commit changed the branch", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+		changed := graftSnapshotOnto(t, base, MainBranch, 200)
+		tbl, cat := newAssertRefTestTable(t, base, changed)
+
+		err := commitPropsWithAssertedRef(t, tbl.NewTransaction(), MainBranch)
+		assert.ErrorIs(t, err, ErrCommitFailed)
+		assert.NotContains(t, cat.metadata.Properties(), "offsets",
+			"a failed compare-and-swap must not apply the properties")
+		assert.Equal(t, int32(1), cat.attempts.Load(),
+			"the retry's pre-flight must fail the pinned assertion fast instead of rewriting it or re-submitting it")
+	})
+
+	t.Run("requires branch absence when the branch does not exist", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, nil, assertRefRetryProps)
+
+		// Catalog state: a peer created the branch after the writer's read.
+		builder, err := MetadataBuilderFromBase(base, "")
+		require.NoError(t, err)
+		require.NoError(t, builder.AddSnapshot(&Snapshot{
+			SnapshotID:     head,
+			SequenceNumber: 1,
+			TimestampMs:    base.LastUpdatedMillis() + 1,
+			Summary:        &Summary{Operation: OpAppend},
+		}))
+		require.NoError(t, builder.SetSnapshotRef(MainBranch, head, BranchRef))
+		created, err := builder.Build()
+		require.NoError(t, err)
+
+		tbl, cat := newAssertRefTestTable(t, base, created)
+
+		err = commitPropsWithAssertedRef(t, tbl.NewTransaction(), MainBranch)
+		assert.ErrorIs(t, err, ErrCommitFailed,
+			"a branch created concurrently must fail a requirement asserting its absence")
+		assert.NotContains(t, cat.metadata.Properties(), "offsets")
+		assert.Equal(t, int32(1), cat.attempts.Load())
+	})
+
+	t.Run("empty branch defaults to the transaction's target branch", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+		changed := graftSnapshotOnto(t, base, MainBranch, 200)
+		tbl, _ := newAssertRefTestTable(t, base, changed)
+
+		// NewTransaction targets main, so the empty-branch requirement
+		// asserts main.
+		err := commitPropsWithAssertedRef(t, tbl.NewTransaction(), "")
+		assert.ErrorIs(t, err, ErrCommitFailed)
+	})
+
+	t.Run("empty branch on a branch transaction asserts that branch", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+
+		// The writer's base has a "feature" branch alongside main.
+		builder, err := MetadataBuilderFromBase(base, "")
+		require.NoError(t, err)
+		require.NoError(t, builder.SetSnapshotRef("feature", head, BranchRef))
+		withFeature, err := builder.Build()
+		require.NoError(t, err)
+
+		// Catalog state: feature changed, main unchanged — only a
+		// requirement on feature can catch it.
+		changed := graftSnapshotOnto(t, withFeature, "feature", 200)
+		tbl, cat := newAssertRefTestTable(t, withFeature, changed)
+
+		err = commitPropsWithAssertedRef(t, tbl.NewTransactionOnBranch("feature"), "")
+		assert.ErrorIs(t, err, ErrCommitFailed)
+		assert.NotContains(t, cat.metadata.Properties(), "offsets")
+	})
+}
+
+// Why: ref assertions are deduplicated by (type, ref), so assertions
+// for distinct branches must both be enforced, an explicit requirement
+// and a producer assertion requiring the same snapshot must collapse to
+// one, and two assertions for the same ref requiring different snapshot
+// ids must be rejected as conflicting rather than silently collapsed.
+// Condition/Assertion: per subtest.
+func TestTransactionRequirementDedup(t *testing.T) {
+	head := int64(100)
+
+	t.Run("independent branches are both enforced", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+
+		// Catalog state: main unmoved, but a peer created the "audit"
+		// branch in between — only the audit assertion can catch it.
+		builder, err := MetadataBuilderFromBase(base, "")
+		require.NoError(t, err)
+		require.NoError(t, builder.SetSnapshotRef("audit", head, BranchRef))
+		withAudit, err := builder.Build()
+		require.NoError(t, err)
+
+		tbl, cat := newAssertRefTestTable(t, base, withAudit)
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.SetProperties(iceberg.Properties{"offsets": "42"}))
+		require.NoError(t, tx.AssertRefSnapshotID(MainBranch))
+		require.NoError(t, tx.AssertRefSnapshotID("audit")) // requires absence
+		assert.Len(t, refAssertions(tx), 2,
+			"assertions for distinct branches must both be kept")
+
+		_, err = tx.Commit(t.Context())
+		assert.ErrorIs(t, err, ErrCommitFailed)
+		assert.NotContains(t, cat.metadata.Properties(), "offsets")
+	})
+
+	t.Run("same ref with the same required id dedupes to one", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+		tbl, _ := newAssertRefTestTable(t, base, base)
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AssertRefSnapshotID(MainBranch))
+		// A producer-built assertion for the same branch requires the
+		// same base head; it must coexist with the explicit requirement
+		// as one assertion.
+		require.NoError(t, tx.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &head)}))
+		assert.Len(t, refAssertions(tx), 1)
+	})
+
+	t.Run("same ref with conflicting ids errors", func(t *testing.T) {
+		base := newConflictTestMetadataWithProps(t, &head, assertRefRetryProps)
+		tbl, _ := newAssertRefTestTable(t, base, base)
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AssertRefSnapshotID(MainBranch))
+
+		other := int64(200)
+		err := tx.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &other)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting snapshot-id assertions")
+
+		err = tx.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, nil)})
+		require.Error(t, err, "required id vs required absence must also conflict")
+		assert.Contains(t, err.Error(), "conflicting snapshot-id assertions")
+	})
+
+	// The explicit requirement and a fast-append producer assert the
+	// same base state (main's absence on this empty table), so they must
+	// collapse to one requirement no matter which registers first.
+	t.Run("explicit requirement coexists with a producer commit", func(t *testing.T) {
+		tbl, cat, dir := newProducerAssertRefTable(t)
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AssertRefSnapshotID(MainBranch))
+		require.NoError(t, tx.AddDataFiles(t.Context(),
+			[]iceberg.DataFile{newTestDataFile(t, *iceberg.UnpartitionedSpec, dir+"/data/f1.parquet", nil)}, nil))
+		assert.Len(t, refAssertions(tx), 1)
+
+		_, err := tx.Commit(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, cat.metadata.CurrentSnapshot(),
+			"the producer commit must still create the branch")
+	})
+
+	t.Run("explicit requirement after a producer commit asserts the same base state", func(t *testing.T) {
+		tbl, cat, dir := newProducerAssertRefTable(t)
+
+		tx := tbl.NewTransaction()
+		require.NoError(t, tx.AddDataFiles(t.Context(),
+			[]iceberg.DataFile{newTestDataFile(t, *iceberg.UnpartitionedSpec, dir+"/data/f1.parquet", nil)}, nil))
+		require.NoError(t, tx.AssertRefSnapshotID(MainBranch))
+		assert.Len(t, refAssertions(tx), 1,
+			"a requirement registered after the producer must dedupe, not assert the staged snapshot")
+
+		_, err := tx.Commit(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, cat.metadata.CurrentSnapshot())
+	})
+}

--- a/table/transaction_empty_append_test.go
+++ b/table/transaction_empty_append_test.go
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Why: Java's newFastAppend().commit() with zero files is legal and
+// produces an empty snapshot that moves the branch head. Writers use
+// such commits for metadata-only bookkeeping (e.g. recording ingestion
+// progress in snapshot or table properties) that must still serialize
+// through the producer's AssertRefSnapshotID requirement, which only
+// engages when a snapshot moves the head. AddFiles with an empty path
+// list must keep committing an empty append rather than degrading to a
+// silent no-op.
+// Condition: AddFiles with no paths on an empty table, then again on
+// the resulting table after real data was added.
+// Assertion: each commit creates a new "append" snapshot chained to its
+// parent, the branch head moves, and existing data files stay reachable.
+func TestAddFilesEmptyCommitsEmptySnapshot(t *testing.T) {
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(schema, iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, location, iceberg.Properties{table.PropertyFormatVersion: "3"})
+	require.NoError(t, err)
+
+	fsF := func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }
+	cat := &concurrentTestCatalog{
+		metadata: meta,
+		location: location + "/metadata/v1.metadata.json",
+		fsF:      fsF,
+	}
+	tbl := table.New(table.Identifier{"db", "empty_append"},
+		meta, location+"/metadata/v1.metadata.json", fsF, cat)
+
+	// Empty append on an empty table creates the branch head.
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.AddFiles(t.Context(), nil, nil, false))
+	tbl, err = tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	first := tbl.CurrentSnapshot()
+	require.NotNil(t, first, "an empty append must still commit a snapshot")
+	assert.Equal(t, table.OpAppend, first.Summary.Operation)
+	assert.Equal(t, "0", first.Summary.Properties["total-data-files"])
+	assert.Nil(t, first.ParentSnapshotID)
+
+	// Add real data, then another empty append: the head must move
+	// again and the data must remain reachable from the new snapshot.
+	arrowSc, err := table.SchemaToArrowSchema(tbl.Schema(), nil, false, false)
+	require.NoError(t, err)
+	dataPath := location + "/data/data-001.parquet"
+	writeParquetFile(t, dataPath, arrowSc, `[{"id": 1, "data": "alpha"}]`)
+
+	txData := tbl.NewTransaction()
+	require.NoError(t, txData.AddFiles(t.Context(), []string{dataPath}, nil, false))
+	tbl, err = txData.Commit(t.Context())
+	require.NoError(t, err)
+	withData := tbl.CurrentSnapshot()
+	require.NotNil(t, withData)
+
+	txEmpty := tbl.NewTransaction()
+	require.NoError(t, txEmpty.AddFiles(t.Context(), nil, nil, false))
+	tbl, err = txEmpty.Commit(t.Context())
+	require.NoError(t, err)
+
+	head := tbl.CurrentSnapshot()
+	require.NotNil(t, head)
+	assert.NotEqual(t, withData.SnapshotID, head.SnapshotID, "the branch head must move")
+	require.NotNil(t, head.ParentSnapshotID)
+	assert.Equal(t, withData.SnapshotID, *head.ParentSnapshotID)
+	assert.Equal(t, "1", head.Summary.Properties["total-data-files"],
+		"existing data files must stay reachable from the empty snapshot")
+}

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -599,12 +599,14 @@ func TestTransactionApplyKeepsRequirementsUnchangedOnUpdateFailure(t *testing.T)
 	require.Equal(t, AssertTableUUID(baseMeta.TableUUID()), txn.reqs[0])
 }
 
-// TestTransactionApplyDedupesSameRefAssertionsNewTable covers two appends in a
-// single new-table transaction: the first asserts main must not exist, and the
-// second (after the builder has created main) asserts main == the new snapshot.
-// Only the first main == nil assertion, which reflects the pre-transaction base
-// state, must be retained.
-func TestTransactionApplyDedupesSameRefAssertionsNewTable(t *testing.T) {
+// TestTransactionApplyDedupesIdenticalSameRefAssertions covers repeated
+// producer commits in one transaction: producers build their assertion from
+// the BASE table's branch head, so a second commit re-asserts exactly the
+// base state the first one required. The identical twin must collapse to a
+// single requirement — and it
+// must dedupe WITHOUT being re-validated against the staged metadata, which
+// has intentionally moved past the base state it re-asserts.
+func TestTransactionApplyDedupesIdenticalSameRefAssertions(t *testing.T) {
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
 
 	// First append: main does not exist yet in the pre-transaction metadata.
@@ -623,20 +625,21 @@ func TestTransactionApplyDedupesSameRefAssertionsNewTable(t *testing.T) {
 	}))
 	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 10, BranchRef))
 
-	// Second append asserts main == 10; it must dedupe against the first
-	// assertion for main rather than adding a contradictory base-state check.
-	newHead := int64(10)
-	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &newHead)})
+	// Second append re-asserts the same base state (main absent). The staged
+	// metadata now has main -> 10, so validating this twin would fail —
+	// dedup must skip it instead of re-validating.
+	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, nil)})
 	require.NoError(t, err)
 	require.Len(t, txn.reqs, 1)
 	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, nil)
 }
 
-// TestTransactionApplyDedupesSameRefAssertionsExistingTable covers two appends
-// on an existing table: the first asserts the original base head, and the second
-// (after the builder has advanced main) asserts the new head. Only the original
-// base-head assertion must be retained.
-func TestTransactionApplyDedupesSameRefAssertionsExistingTable(t *testing.T) {
+// TestTransactionApplyRejectsConflictingSameRefAssertions covers two
+// assertions for the same ref requiring different snapshot ids (or an id vs
+// absence): both can never hold against the catalog, so collapsing them
+// would silently drop a check the caller registered. apply must fail with
+// a named error and leave the accumulated requirements unchanged.
+func TestTransactionApplyRejectsConflictingSameRefAssertions(t *testing.T) {
 	txn := newTransactionWithSnapshotRefs(t) // main -> 10, feature -> 20
 
 	base := int64(10)
@@ -645,24 +648,83 @@ func TestTransactionApplyDedupesSameRefAssertionsExistingTable(t *testing.T) {
 	require.Len(t, txn.reqs, 1)
 	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &base)
 
-	// Simulate the first append advancing main -> 30.
-	require.NoError(t, txn.meta.AddSnapshot(&Snapshot{
-		SnapshotID:       30,
-		ParentSnapshotID: transactionTestPtr(base),
-		SequenceNumber:   3,
-		ManifestList:     "mem://default/table-location/metadata/manifest-30.avro",
-		Summary:          &Summary{Operation: OpAppend},
-		TimestampMs:      time.Now().UnixMilli(),
-	}))
-	require.NoError(t, txn.meta.SetSnapshotRef(MainBranch, 30, BranchRef))
+	other := int64(30)
+	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &other)})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicting snapshot-id assertions")
 
-	// Second append asserts main == 30; it must dedupe against the original
-	// base-head assertion, which is the only one kept.
-	newHead := int64(30)
-	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, &newHead)})
-	require.NoError(t, err)
+	err = txn.apply(nil, []Requirement{AssertRefSnapshotID(MainBranch, nil)})
+	require.Error(t, err, "required id vs required absence must also conflict")
+	require.Contains(t, err.Error(), "conflicting snapshot-id assertions")
+
 	require.Len(t, txn.reqs, 1)
 	requireContainsRefSnapshotRequirement(t, txn.reqs, MainBranch, &base)
+}
+
+// refAssertions returns the assert-ref-snapshot-id requirements the
+// transaction has accumulated, in registration order.
+func refAssertions(txn *Transaction) []*assertRefSnapshotID {
+	var out []*assertRefSnapshotID
+	for _, r := range txn.reqs {
+		if a, ok := r.(*assertRefSnapshotID); ok {
+			out = append(out, a)
+		}
+	}
+
+	return out
+}
+
+// requireSingleBaseMainAssertion asserts the transaction holds exactly
+// one ref assertion: main required to be absent, the base state of the
+// fresh test table (not a staged intermediate snapshot, which the
+// catalog has never seen).
+func requireSingleBaseMainAssertion(t *testing.T, txn *Transaction, msg string) {
+	t.Helper()
+
+	asserts := refAssertions(txn)
+	require.Len(t, asserts, 1, msg)
+	require.Equal(t, MainBranch, asserts[0].Ref)
+	require.Nil(t, asserts[0].SnapshotID, msg)
+}
+
+func addOneTestDataFile(t *testing.T, txn *Transaction, path string) {
+	t.Helper()
+
+	require.NoError(t, txn.AddDataFiles(t.Context(), []iceberg.DataFile{
+		newTestDataFile(t, *iceberg.UnpartitionedSpec, path, nil),
+	}, nil))
+}
+
+// TestTransactionSecondProducerCommitAssertsBaseHead runs two real producer
+// commits (AddDataFiles) in one transaction on a new table. Each producer
+// must assert the base table's branch head — absent here — rather than the
+// staged metadata's current snapshot: the staged intermediate snapshot
+// never exists on the catalog, and the conflict check would reject it as
+// contradicting the first producer's base assertion.
+func TestTransactionSecondProducerCommitAssertsBaseHead(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+
+	addOneTestDataFile(t, txn, "mem://default/table-location/data/f1.parquet")
+	addOneTestDataFile(t, txn, "mem://default/table-location/data/f2.parquet")
+
+	requireSingleBaseMainAssertion(t, txn,
+		"producer assertions must be built from the base branch head and collapse to one")
+}
+
+// TestTransactionExpireAfterProducerDoesNotConflict pins the interaction
+// between a producer commit and ExpireSnapshots inside one transaction:
+// expire's per-ref assertions are built from the base table's state, so a
+// ref the producer just created must not produce a staged-head assertion
+// that conflicts with the producer's own.
+func TestTransactionExpireAfterProducerDoesNotConflict(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+
+	addOneTestDataFile(t, txn, "mem://default/table-location/data/f1.parquet")
+	require.NoError(t, txn.ExpireSnapshots(WithOlderThan(7*24*time.Hour)),
+		"expire after a producer in the same transaction must not register a conflicting staged-head assertion")
+
+	requireSingleBaseMainAssertion(t, txn,
+		"only the producer's base-state assertion must remain for the branch it created")
 }
 
 // TestTransactionApplyKeepsRefAssertionsForDistinctRefs confirms that dedupe by


### PR DESCRIPTION
Adds `Transaction.AssertRefSnapshotID(branch)`: the same `assert-ref-snapshot-id` requirement Java's `UpdateRequirements` builds for a changed ref, exposed so metadata-only commits can use it too. A transaction that only sets properties (e.g. exactly-once bookkeeping that records ingestion offsets) can require that the branch is unchanged from the state it read; if another writer committed in between, the commit fails with `ErrCommitFailed` instead of being silently replayed onto the new head.

Two commits:

1. **Align ref requirement accumulation with Java.** `UpdateRequirements` accumulates one assertion per ref, built from the base table state. Our producers built theirs from the staged metadata's current snapshot instead — an id the catalog has never seen when a transaction carries multiple operations. Producers, `RollbackToSnapshot`, and `ExpireSnapshots` now assert the base state, and two same-ref assertions requiring different snapshot ids are rejected at apply time rather than one being silently dropped.

2. **Expose the requirement on `Transaction`.** Matches Java semantics: an explicit requirement and a producer-built one for the same branch collapse to one. The one Go-specific wrinkle is the commit retry loop, which rewrites ref assertions to the fresh head between retries; explicitly registered assertions are exempt, since rewriting would void the compare-and-swap the caller asked for.

Without this, Go writers have to commit an empty `AddFiles` append per metadata-only write to serialize through a producer's requirement (an included test documents that workaround, which also matches Java's zero-file `newFastAppend().commit()` behavior).

Made with [Cursor](https://cursor.com)