### PR TITLE
fix(table): repair task residual CI failures

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -821,18 +821,22 @@ func (filterBindingVisitor) VisitFalse() filterBindingState { return filterBindi
 func (filterBindingVisitor) VisitNot(child filterBindingState) filterBindingState {
 	return child
 }
+
 func (filterBindingVisitor) VisitAnd(left, right filterBindingState) filterBindingState {
 	return filterBindingState{
 		hasBound:   left.hasBound || right.hasBound,
 		hasUnbound: left.hasUnbound || right.hasUnbound,
 	}
 }
+
 func (filterBindingVisitor) VisitOr(left, right filterBindingState) filterBindingState {
 	return filterBindingVisitor{}.VisitAnd(left, right)
 }
+
 func (filterBindingVisitor) VisitUnbound(iceberg.UnboundPredicate) filterBindingState {
 	return filterBindingState{hasUnbound: true}
 }
+
 func (filterBindingVisitor) VisitBound(iceberg.BoundPredicate) filterBindingState {
 	return filterBindingState{hasBound: true}
 }
@@ -1150,12 +1154,11 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 	)
 
 	rowFilter := as.boundRowFilter
-	rowFilter, err = bindTaskFilter(as.metadata.CurrentSchema(), task.Value.Residual, as.caseSensitive)
-	if task.Value.Residual == nil {
-		rowFilter = as.boundRowFilter
-	}
-	if err != nil {
-		return err
+	if task.Value.Residual != nil {
+		rowFilter, err = bindTaskFilter(as.metadata.CurrentSchema(), task.Value.Residual, as.caseSensitive)
+		if err != nil {
+			return err
+		}
 	}
 
 	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, rowFilter)

--- a/table/scanner_test.go
+++ b/table/scanner_test.go
@@ -114,39 +114,6 @@ func (s *ScannerSuite) TestScanner() {
 		})
 	}
 
-	s.Run("task residual", func() {
-		ctx := compute.WithAllocator(s.ctx, mem)
-		scan := tbl.Scan(table.WithRowFilter(iceberg.AlwaysTrue{}),
-			table.WithSelectedFields("number"))
-		tasks, err := scan.PlanFiles(ctx)
-		s.Require().NoError(err)
-		s.Require().Len(tasks, 1)
-
-		// A remote planner can return a residual that is narrower than the
-		// original scan filter. ReadTasks must apply it even when the caller
-		// supplies the planned tasks directly.
-		tasks[0].Residual = iceberg.GreaterThanEqual(ref, "i")
-		_, itr, err := scan.ReadTasks(ctx, tasks)
-		s.Require().NoError(err)
-
-		next, stop := iter.Pull2(itr)
-		defer stop()
-		rec, err, valid := next()
-		s.Require().True(valid)
-		s.Require().NoError(err)
-		defer rec.Release()
-
-		arr, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[10, 11, 12]`))
-		s.Require().NoError(err)
-		defer arr.Release()
-		expected := array.NewRecord(expectedSchema, []arrow.Array{arr}, int64(arr.Len()))
-		defer expected.Release()
-		s.True(array.RecordEqual(expected, rec), "task residual must filter the planned task")
-
-		_, err, valid = next()
-		s.Require().NoError(err)
-		s.Require().False(valid)
-	})
 }
 
 func (s *ScannerSuite) TestScannerWithDeletes() {
@@ -431,6 +398,40 @@ func (s *ScannerSuite) TestReadTasks() {
 			s.Require().False(valid)
 		})
 	}
+
+	s.Run("task residual", func() {
+		ctx := compute.WithAllocator(s.ctx, mem)
+		scan := tbl.Scan(table.WithRowFilter(iceberg.AlwaysTrue{}),
+			table.WithSelectedFields("number"))
+		tasks, err := scan.PlanFiles(ctx)
+		s.Require().NoError(err)
+		s.Require().Len(tasks, 1)
+
+		// A remote planner can return a residual that is narrower than the
+		// original scan filter. ReadTasks must apply it even when the caller
+		// supplies the planned tasks directly.
+		tasks[0].Residual = iceberg.GreaterThanEqual(ref, "i")
+		_, itr, err := scan.ReadTasks(ctx, tasks)
+		s.Require().NoError(err)
+
+		next, stop := iter.Pull2(itr)
+		defer stop()
+		rec, err, valid := next()
+		s.Require().True(valid)
+		s.Require().NoError(err)
+		defer rec.Release()
+
+		arr, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[10, 11, 12]`))
+		s.Require().NoError(err)
+		defer arr.Release()
+		expected := array.NewRecord(expectedSchema, []arrow.Array{arr}, int64(arr.Len()))
+		defer expected.Release()
+		s.True(array.RecordEqual(expected, rec), "task residual must filter the planned task")
+
+		_, err, valid = next()
+		s.Require().NoError(err)
+		s.Require().False(valid)
+	})
 }
 
 func (s *ScannerSuite) TestScannerRecordsDoubleDeletes() {


### PR DESCRIPTION
## Summary

- move the task-residual integration assertion into `TestReadTasks`, where its table, allocator, schema, and reference fixtures are defined
- only bind task residuals when they are present, avoiding the overwritten assignment reported by staticcheck
- apply `gofumpt` formatting required by CI

## Testing

- `go test -tags=integration -run "^$" ./table`
- `go test ./table`
- `golangci-lint run --timeout=10m ./table/...`
- `git diff --check`
