### PR TITLE
fix(partitions): preserve source-less void tombstones

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -80,6 +80,15 @@ func (p *PartitionField) EscapedName() string {
 }
 
 func (p PartitionField) MarshalJSON() ([]byte, error) {
+	if len(p.SourceIDs) == 1 && p.SourceIDs[0] == 0 {
+		if _, isVoid := p.Transform.(VoidTransform); isVoid {
+			return json.Marshal(struct {
+				FieldID   int       `json:"field-id"`
+				Name      string    `json:"name"`
+				Transform Transform `json:"transform"`
+			}{p.FieldID, p.Name, p.Transform})
+		}
+	}
 	if len(p.SourceIDs) > 1 {
 		return json.Marshal(struct {
 			SourceIDs []int     `json:"source-ids"`
@@ -208,6 +217,17 @@ func (p *PartitionSpec) BindToSchema(schema *Schema, lastPartitionID *int, newSp
 	}
 
 	for _, field := range p.Fields() {
+		if len(field.SourceIDs) == 1 && field.SourceIDs[0] == 0 {
+			if _, isVoid := field.Transform.(VoidTransform); isVoid {
+				opts = append(opts, func(spec *PartitionSpec) error {
+					spec.fields = append(spec.fields, clonePartitionField(field))
+
+					return nil
+				})
+
+				continue
+			}
+		}
 		opts = append(opts, AddPartitionFieldBySourceID(field.SourceID(), field.Name, field.Transform, schema, &field.FieldID))
 	}
 

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -943,6 +943,34 @@ func TestBindToSchemaAllowsRepeatedVoidTransforms(t *testing.T) {
 	assert.Equal(t, 2, bound.NumFields())
 }
 
+func TestBindToSchemaPreservesSourceLessVoidTombstone(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+
+	data := `{"spec-id":0,"fields":[{"field-id":1000,"name":"old_partition","transform":"void"}]}`
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal([]byte(data), &spec))
+
+	newSpecID := 2
+	bound, err := spec.BindToSchema(schema, nil, &newSpecID)
+	require.NoError(t, err)
+	assert.Equal(t, newSpecID, bound.ID())
+	require.Equal(t, 1, bound.NumFields())
+	assert.Equal(t, []int{0}, bound.Field(0).SourceIDs)
+	assert.Equal(t, 1000, bound.Field(0).FieldID)
+	assert.Equal(t, "old_partition", bound.Field(0).Name)
+	assert.Equal(t, iceberg.VoidTransform{}, bound.Field(0).Transform)
+
+	roundTripped, err := json.Marshal(bound)
+	require.NoError(t, err)
+	assert.NotContains(t, string(roundTripped), `"source-id"`)
+
+	var decoded iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal(roundTripped, &decoded))
+	assert.True(t, bound.Equals(decoded))
+}
+
 // Redundancy is keyed on Transform.Equals rather than the rendered transform
 // name, so a transform whose String() is not injective cannot collide with a
 // distinct one. nonComparableTransform embeds IdentityTransform, so every

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -207,12 +207,8 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 	}
 
 	partitionFields = append(partitionFields, us.adds...)
-	opts := make([]iceberg.PartitionOption, len(partitionFields))
-	for i, field := range partitionFields {
-		opts[i] = iceberg.AddPartitionFieldBySourceID(field.SourceID(), field.Name, field.Transform, us.txn.tbl.Schema(), &field.FieldID)
-	}
-
-	newSpec, err := iceberg.NewPartitionSpecOpts(opts...)
+	candidate := iceberg.NewPartitionSpec(partitionFields...)
+	newSpec, err := candidate.BindToSchema(us.txn.tbl.Schema(), nil, nil)
 	if err != nil {
 		return iceberg.PartitionSpec{}, err
 	}

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -427,9 +427,10 @@ func (us *UpdateSpec) isDuplicatePartition(transform iceberg.Transform, partitio
 	return !deleted && transform.Equals(partitionField.Transform)
 }
 
-func (us *UpdateSpec) checkAndAddPartitionName(schema *iceberg.Schema, name string, sourceId int, partitionNames map[string]bool) error {
+func (us *UpdateSpec) checkAndAddPartitionName(schema *iceberg.Schema, name string, sourceId int, transform iceberg.Transform, partitionNames map[string]bool) error {
 	field, found := schema.FindFieldByName(name)
-	if found && field.ID != sourceId {
+	_, isVoid := transform.(iceberg.VoidTransform)
+	if found && field.ID != sourceId && (sourceId != 0 || !isVoid) {
 		return fmt.Errorf("cannot create partition from name that exists in schema %s", name)
 	}
 	if _, exists := partitionNames[name]; exists {
@@ -441,7 +442,7 @@ func (us *UpdateSpec) checkAndAddPartitionName(schema *iceberg.Schema, name stri
 }
 
 func (us *UpdateSpec) addNewField(schema *iceberg.Schema, sourceId int, fieldId int, name string, transform iceberg.Transform, partitionNames map[string]bool) (iceberg.PartitionField, error) {
-	err := us.checkAndAddPartitionName(schema, name, sourceId, partitionNames)
+	err := us.checkAndAddPartitionName(schema, name, sourceId, transform, partitionNames)
 	if err != nil {
 		return iceberg.PartitionField{}, err
 	}

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -92,7 +92,7 @@ func TestNewUpdateSpecWithNilTransactionReturnsError(t *testing.T) {
 
 func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
-		SourceIDs: []int{5}, FieldID: 1000, Name: "old_partition",
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id",
 		Transform: iceberg.VoidTransform{},
 	})
 	meta, err := table.NewMetadata(testSchema, &spec, table.UnsortedSortOrder, "", nil)
@@ -100,7 +100,7 @@ func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
 
 	metadataJSON, err := json.Marshal(meta)
 	require.NoError(t, err)
-	source := []byte(`"source-id":5,`)
+	source := []byte(`"source-id":1,`)
 	metadataJSON = bytes.ReplaceAll(metadataJSON, source, nil)
 	require.NotContains(t, string(metadataJSON), string(source))
 	meta, err = table.ParseMetadataBytes(metadataJSON)
@@ -116,7 +116,7 @@ func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
 	require.Equal(t, 2, newSpec.NumFields())
 	assert.Equal(t, []int{0}, newSpec.Field(0).SourceIDs)
 	assert.Equal(t, 1000, newSpec.Field(0).FieldID)
-	assert.Equal(t, "old_partition", newSpec.Field(0).Name)
+	assert.Equal(t, "id", newSpec.Field(0).Name)
 	assert.Equal(t, iceberg.VoidTransform{}, newSpec.Field(0).Transform)
 	assert.Equal(t, 2, newSpec.Field(1).SourceID())
 	assert.Equal(t, "name_identity", newSpec.Field(1).Name)

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -18,6 +18,8 @@
 package table_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -86,6 +88,38 @@ func TestNewUpdateSpecWithNilTransactionReturnsError(t *testing.T) {
 	err := table.NewUpdateSpec(nil, false).Commit()
 	require.ErrorIs(t, err, table.ErrInvalidMetadata)
 	assert.ErrorContains(t, err, "transaction is nil")
+}
+
+func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{5}, FieldID: 1000, Name: "old_partition",
+		Transform: iceberg.VoidTransform{},
+	})
+	meta, err := table.NewMetadata(testSchema, &spec, table.UnsortedSortOrder, "", nil)
+	require.NoError(t, err)
+
+	metadataJSON, err := json.Marshal(meta)
+	require.NoError(t, err)
+	source := []byte(`"source-id":5,`)
+	metadataJSON = bytes.ReplaceAll(metadataJSON, source, nil)
+	require.NotContains(t, string(metadataJSON), string(source))
+	meta, err = table.ParseMetadataBytes(metadataJSON)
+	require.NoError(t, err)
+	tbl := table.New([]string{"source_less_void"}, meta, "", nil, nil)
+
+	update := table.NewUpdateSpec(tbl.NewTransaction(), false).
+		AddField("name", iceberg.IdentityTransform{}, "name_identity")
+	_, _, err = update.BuildUpdates()
+	require.NoError(t, err)
+	newSpec, err := update.Apply()
+	require.NoError(t, err)
+	require.Equal(t, 2, newSpec.NumFields())
+	assert.Equal(t, []int{0}, newSpec.Field(0).SourceIDs)
+	assert.Equal(t, 1000, newSpec.Field(0).FieldID)
+	assert.Equal(t, "old_partition", newSpec.Field(0).Name)
+	assert.Equal(t, iceberg.VoidTransform{}, newSpec.Field(0).Transform)
+	assert.Equal(t, 2, newSpec.Field(1).SourceID())
+	assert.Equal(t, "name_identity", newSpec.Field(1).Name)
 }
 
 func TestUpdateSpecAddField(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve historical source-less `void` partition tombstones when binding a partition spec to a schema
- keep those tombstones source-less when marshaling JSON, so accepted metadata round-trips without inventing `source-id: 0`
- allow partition evolution to retain source-less tombstones even when their historical partition name matches a live schema column
- route partition-spec updates through the shared binding path and cover both direct binding and table evolution with regressions

## Problem

`PartitionField.UnmarshalJSON` intentionally accepts historical `void` fields that omit both `source-id` and `source-ids`, representing them internally with the compatibility sentinel `[]int{0}`. `PartitionSpec.BindToSchema` and `UpdateSpec.Apply` then treated that sentinel as a real schema field ID and failed with `field id 0 not found`, preventing otherwise valid metadata from being rebound or evolved. `UpdateSpec.Apply` could also reject a retained tombstone before binding when its historical partition name matched a live schema column.

The fix recognizes only the exact source-less `void` sentinel, preserves it without a schema lookup, and exempts that same compatibility case from the schema-name collision check. Every sourced field, and every non-`void` field, continues through the existing validation. JSON marshaling omits the synthetic sentinel so the accepted historical representation remains round-trippable.

Fixes #1791

## Testing

- `go test . ./table -run 'TestBindToSchemaPreservesSourceLessVoidTombstone|TestUpdateSpecPreservesSourceLessVoidTombstone' -count=2 -v`
- `go test ./... -count=1`
- `go test -race -v ./codec/... ./table/... -count=1`
- `golangci-lint run --timeout=10m` (v2.11.4, 0 issues)
- `go vet ./...`
- `GOOS=linux GOARCH=s390x CGO_ENABLED=0 go build ./...`
- `dev/check-license`
- `git diff --check origin/main...HEAD`
