### PR TITLE
fix(partitions): reject redundant time transforms on the same source column

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -551,26 +551,26 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 }
 
 // validatePartitionFields rejects duplicate partition names and redundant
-// fields (the same transform applied to the same source columns). It is the
-// single definition of a well-formed field set, shared by NewPartitionSpecOpts
-// and UnmarshalJSON so the builder cannot produce a spec the parser rejects.
+// fields (transforms that overlap when applied to the same source columns). It
+// is the single definition of a well-formed field set, shared by
+// NewPartitionSpecOpts and UnmarshalJSON so the builder cannot produce a spec
+// the parser rejects.
 //
 // Repeated void fields are exempt: void is the tombstone written for a dropped
 // partition field, so a spec that has dropped several fields legitimately
 // carries more than one.
 //
-// TODO: this does not implement Java's dedupName rule, which collapses year,
-// month, day and hour to a single name per source column and so rejects
-// year(ts) alongside month(ts). We accept that pairing, which means a spec
-// built here can be refused by Java's PartitionSpec.Builder. UpdateSpec.addField
-// already carries an added-vs-added guard for time transforms, so the rule
-// exists in the codebase but not in this validator.
+// Every time transform (year, month, day, hour) collapses to
+// a single "time" key per source column. Any two time transforms are additionally redundant
+// regardless of granularity: year, month, day and hour on one source column
+// produce overlapping partitions, so permit at most one.
 func validatePartitionFields(fields []PartitionField) error {
 	names := make(map[string]struct{}, len(fields))
 	// Keyed by source IDs only; the transforms behind each key are compared with
-	// Transform.Equals rather than their rendered names, so a transform whose
-	// String() is not injective cannot make two distinct transforms collide.
-	bySource := make(map[string][]Transform, len(fields))
+	// partitionFieldsRedundant rather than their rendered names, so a transform
+	// whose String() is not injective cannot make two distinct transforms
+	// collide.
+	bySource := make(map[string][]PartitionField, len(fields))
 	for _, field := range fields {
 		if _, ok := names[field.Name]; ok {
 			return fmt.Errorf("%w: duplicate partition name: %s", ErrInvalidPartitionSpec, field.Name)
@@ -589,15 +589,25 @@ func validatePartitionFields(fields []PartitionField) error {
 
 		key := fmt.Sprint(field.SourceIDs)
 		for _, existing := range bySource[key] {
-			if existing.Equals(field.Transform) {
-				return fmt.Errorf("%w: redundant partition field for source IDs %v and transform %s",
-					ErrInvalidPartitionSpec, field.SourceIDs, field.Transform)
+			if partitionFieldsRedundant(existing.Transform, field.Transform) {
+				return fmt.Errorf("%w: redundant partition field for source IDs %v: %s (%s) conflicts with %s (%s)",
+					ErrInvalidPartitionSpec, field.SourceIDs, field.Name, field.Transform, existing.Name, existing.Transform)
 			}
 		}
-		bySource[key] = append(bySource[key], field.Transform)
+		bySource[key] = append(bySource[key], field)
 	}
 
 	return nil
+}
+
+func partitionFieldsRedundant(a, b Transform) bool {
+	if a.Equals(b) {
+		return true
+	}
+	_, aTime := a.(TimeTransform)
+	_, bTime := b.(TimeTransform)
+
+	return aTime && bTime
 }
 
 func (ps *PartitionSpec) initialize() {

--- a/partitions.go
+++ b/partitions.go
@@ -231,7 +231,9 @@ func (p *PartitionSpec) BindToSchema(schema *Schema, lastPartitionID *int, newSp
 		opts = append(opts, AddPartitionFieldBySourceID(field.SourceID(), field.Name, field.Transform, schema, &field.FieldID))
 	}
 
-	freshSpec, err := NewPartitionSpecOpts(opts...)
+	// Replay, not authoring: the spec may come from another client, so it only
+	// has to satisfy what every spec must. See validateReplayedFields.
+	freshSpec, err := newPartitionSpec(validateReplayedFields, opts...)
 	if err != nil {
 		return PartitionSpec{}, err
 	}
@@ -242,7 +244,16 @@ func (p *PartitionSpec) BindToSchema(schema *Schema, lastPartitionID *int, newSp
 	return freshSpec, err
 }
 
+// NewPartitionSpecOpts assembles a brand new spec and validates it as authored,
+// so it permits at most one time transform per source column.
+// That rule is narrower than the replay rule, so anything it accepts still parses back.
 func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
+	return newPartitionSpec(validateAuthoredFields, opts...)
+}
+
+// newPartitionSpec validates the assembled set rather than each field as it is
+// added, so the outcome does not depend on the order of opts.
+func newPartitionSpec(validate func([]PartitionField) error, opts ...PartitionOption) (PartitionSpec, error) {
 	spec := PartitionSpec{
 		id: 0,
 	}
@@ -251,17 +262,7 @@ func NewPartitionSpecOpts(opts ...PartitionOption) (PartitionSpec, error) {
 			return PartitionSpec{}, fmt.Errorf("%w: %w", ErrInvalidPartitionSpec, err)
 		}
 	}
-	// Validate the assembled field set rather than each field as it is added:
-	// the redundancy check needs every field in place, and routing the builder
-	// through the same validator as UnmarshalJSON keeps one definition of a
-	// redundant field, so a spec this constructor accepts is one this package's
-	// UnmarshalJSON can read back. NewPartitionSpec and NewPartitionSpecID do
-	// not validate, so that guarantee covers this constructor only.
-	//
-	// ErrInvalidPartitionSpec is attached exactly once per error, by whichever
-	// layer knows the sentinel: options return bare errors and the loop above
-	// wraps them, while validatePartitionFields wraps its own.
-	if err := validatePartitionFields(spec.fields); err != nil {
+	if err := validate(spec.fields); err != nil {
 		return PartitionSpec{}, err
 	}
 	spec.initialize()
@@ -536,7 +537,7 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("%w: invalid partition field: %w", ErrInvalidPartitionSpec, err)
 		}
 	}
-	if err := validatePartitionFields(fields); err != nil {
+	if err := validateReplayedFields(fields); err != nil {
 		return err
 	}
 
@@ -550,34 +551,32 @@ func (ps *PartitionSpec) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// validatePartitionFields rejects duplicate partition names and redundant
-// fields (transforms that overlap when applied to the same source columns). It
-// is the single definition of a well-formed field set, shared by
-// NewPartitionSpecOpts and UnmarshalJSON so the builder cannot produce a spec
-// the parser rejects.
-//
-// Repeated void fields are exempt: void is the tombstone written for a dropped
-// partition field, so a spec that has dropped several fields legitimately
-// carries more than one.
-//
-// Every time transform (year, month, day, hour) collapses to
-// a single "time" key per source column. Any two time transforms are additionally redundant
-// regardless of granularity: year, month, day and hour on one source column
-// produce overlapping partitions, so permit at most one.
-func validatePartitionFields(fields []PartitionField) error {
+// validateReplayedFields checks a spec that already exists, from metadata JSON
+// or BindToSchema; "partition-specs" retains every old spec.
+func validateReplayedFields(fields []PartitionField) error {
+	return validatePartitionFields(fields, Transform.Equals)
+}
+
+// validateAuthoredFields checks a spec this process is building from scratch.
+// Refusing to author a bad spec is cheap; refusing to read one costs the table,
+// so only this side gets the one-time-transform-per-source rule.
+func validateAuthoredFields(fields []PartitionField) error {
+	return validatePartitionFields(fields, transformsRedundant)
+}
+
+// validatePartitionFields is the single definition of a well-formed field set;
+// its two callers differ only in which transform pairs count as redundant.
+func validatePartitionFields(fields []PartitionField, redundant func(a, b Transform) bool) error {
 	names := make(map[string]struct{}, len(fields))
-	// Keyed by source IDs only; the transforms behind each key are compared with
-	// partitionFieldsRedundant rather than their rendered names, so a transform
-	// whose String() is not injective cannot make two distinct transforms
-	// collide.
+	// Keyed by source IDs only, with transforms compared by the redundant
+	// predicate rather than by name, so a transform whose String() is not
+	// injective cannot make two distinct transforms collide.
 	bySource := make(map[string][]PartitionField, len(fields))
 	for _, field := range fields {
 		if _, ok := names[field.Name]; ok {
 			return fmt.Errorf("%w: duplicate partition name: %s", ErrInvalidPartitionSpec, field.Name)
 		}
 		names[field.Name] = struct{}{}
-		// Reject a nil transform before the redundancy comparison below calls
-		// Equals on it. The option constructors accept any Transform and
 		// validateTransform's default branch passes nil through, so this is the
 		// first place a nil would be dereferenced.
 		if field.Transform == nil {
@@ -589,7 +588,7 @@ func validatePartitionFields(fields []PartitionField) error {
 
 		key := fmt.Sprint(field.SourceIDs)
 		for _, existing := range bySource[key] {
-			if partitionFieldsRedundant(existing.Transform, field.Transform) {
+			if redundant(existing.Transform, field.Transform) {
 				return fmt.Errorf("%w: redundant partition field for source IDs %v: %s (%s) conflicts with %s (%s)",
 					ErrInvalidPartitionSpec, field.SourceIDs, field.Name, field.Transform, existing.Name, existing.Transform)
 			}
@@ -600,7 +599,10 @@ func validatePartitionFields(fields []PartitionField) error {
 	return nil
 }
 
-func partitionFieldsRedundant(a, b Transform) bool {
+// transformsRedundant widens Transform.Equals to collide any two time
+// transforms regardless of granularity: time partitions nest, so day(ts) prunes
+// nothing hour(ts) has not already pruned.
+func transformsRedundant(a, b Transform) bool {
 	if a.Equals(b) {
 		return true
 	}

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -926,6 +926,83 @@ func TestNewPartitionSpecOptsAllowsDistinctTransformsOnSameSource(t *testing.T) 
 	assert.Equal(t, 2, spec.NumFields())
 }
 
+func TestNewPartitionSpecOptsRejectsRedundantTimeTransforms(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+
+	tests := []struct {
+		name  string
+		first iceberg.Transform
+		last  iceberg.Transform
+	}{
+		{name: "year_month", first: iceberg.YearTransform{}, last: iceberg.MonthTransform{}},
+		{name: "year_day", first: iceberg.YearTransform{}, last: iceberg.DayTransform{}},
+		{name: "year_hour", first: iceberg.YearTransform{}, last: iceberg.HourTransform{}},
+		{name: "month_day", first: iceberg.MonthTransform{}, last: iceberg.DayTransform{}},
+		{name: "month_hour", first: iceberg.MonthTransform{}, last: iceberg.HourTransform{}},
+		{name: "day_hour", first: iceberg.DayTransform{}, last: iceberg.HourTransform{}},
+		// order must not matter
+		{name: "hour_day", first: iceberg.HourTransform{}, last: iceberg.DayTransform{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := iceberg.NewPartitionSpecOpts(
+				iceberg.WithSpecID(1),
+				iceberg.AddPartitionFieldByName("ts", "first", tt.first, schema, nil),
+				iceberg.AddPartitionFieldByName("ts", "second", tt.last, schema, nil),
+			)
+
+			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+			assert.ErrorContains(t, err, "redundant partition field")
+		})
+	}
+}
+
+func TestNewPartitionSpecOptsAllowsTimeAndNonTimeOnSameSource(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+
+	tests := []struct {
+		name  string
+		other iceberg.Transform
+	}{
+		{name: "identity", other: iceberg.IdentityTransform{}},
+		{name: "bucket", other: iceberg.BucketTransform{NumBuckets: 16}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := iceberg.NewPartitionSpecOpts(
+				iceberg.WithSpecID(1),
+				iceberg.AddPartitionFieldByName("ts", "ts_day", iceberg.DayTransform{}, schema, nil),
+				iceberg.AddPartitionFieldByName("ts", "ts_other", tt.other, schema, nil),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, 2, spec.NumFields())
+		})
+	}
+}
+
+func TestNewPartitionSpecOptsAllowsTimeTransformsOnDistinctSources(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "ts1", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 2, Name: "ts2", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+	)
+
+	spec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldByName("ts1", "ts1_day", iceberg.DayTransform{}, schema, nil),
+		iceberg.AddPartitionFieldByName("ts2", "ts2_hour", iceberg.HourTransform{}, schema, nil),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, spec.NumFields())
+}
+
 // void is the tombstone for a dropped partition field, so a spec that dropped
 // several fields on one column carries several voids. BindToSchema replays such
 // a spec through the builder, which must not reject it.
@@ -1083,21 +1160,19 @@ func TestValidatePartitionFieldsMultiSourceRedundancy(t *testing.T) {
 	assert.Equal(t, 2, back.NumFields())
 }
 
-// Known divergence from Java: dedupName collapses the time transforms to one
-// name per source column, so Java rejects this pairing while we accept it. If
-// that rule ever lands here, this test should flip rather than silently break
-// callers building hierarchical time specs.
-func TestNewPartitionSpecOptsAllowsMultipleTimeTransforms(t *testing.T) {
+// dedupName collapses the time transforms to one name per source column, so
+// year(ts) alongside month(ts) is redundant and rejected.
+func TestNewPartitionSpecOptsRejectsMultipleTimeTransforms(t *testing.T) {
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
 	)
 
-	spec, err := iceberg.NewPartitionSpecOpts(
+	_, err := iceberg.NewPartitionSpecOpts(
 		iceberg.WithSpecID(1),
 		iceberg.AddPartitionFieldByName("ts", "ts_year", iceberg.YearTransform{}, schema, nil),
 		iceberg.AddPartitionFieldByName("ts", "ts_month", iceberg.MonthTransform{}, schema, nil),
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, 2, spec.NumFields())
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
 }

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -19,6 +19,7 @@ package iceberg_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 	"testing"
 
@@ -956,6 +957,10 @@ func TestNewPartitionSpecOptsRejectsRedundantTimeTransforms(t *testing.T) {
 
 			require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
 			assert.ErrorContains(t, err, "redundant partition field")
+			// Both offending fields must be named, or a wide spec leaves the
+			// caller nothing to act on.
+			assert.ErrorContains(t, err,
+				fmt.Sprintf("second (%s) conflicts with first (%s)", tt.last, tt.first))
 		})
 	}
 }
@@ -1079,10 +1084,10 @@ func TestNewPartitionSpecOptsRedundancyUsesTransformEquals(t *testing.T) {
 	assert.Equal(t, 2, spec.NumFields())
 }
 
-// BindToSchema replays an existing spec through the builder, so it inherits the
-// same redundancy check. The specs are built with NewPartitionSpecID because
-// that constructor does not validate, which is the only way to get a redundant
-// spec into BindToSchema in the first place.
+// BindToSchema uses the replay rule, which still rejects two fields applying the
+// same transform to one column. The spec is built with NewPartitionSpecID
+// because that constructor does not validate, the only way to get a redundant
+// spec into BindToSchema at all.
 func TestBindToSchemaRejectsRedundantField(t *testing.T) {
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "s", Type: iceberg.PrimitiveTypes.String, Required: true},
@@ -1160,19 +1165,67 @@ func TestValidatePartitionFieldsMultiSourceRedundancy(t *testing.T) {
 	assert.Equal(t, 2, back.NumFields())
 }
 
-// dedupName collapses the time transforms to one name per source column, so
-// year(ts) alongside month(ts) is redundant and rejected.
-func TestNewPartitionSpecOptsRejectsMultipleTimeTransforms(t *testing.T) {
+func TestUnmarshalPartitionSpecAllowsTimeGranularityOverlap(t *testing.T) {
+	data := `{"spec-id":0,"fields":[` +
+		`{"source-id":1,"field-id":1000,"name":"ts_day","transform":"day"},` +
+		`{"source-id":1,"field-id":1001,"name":"ts_hour","transform":"hour"}]}`
+
+	var spec iceberg.PartitionSpec
+	require.NoError(t, json.Unmarshal([]byte(data), &spec))
+	require.Equal(t, 2, spec.NumFields())
+	assert.Equal(t, iceberg.DayTransform{}, spec.Field(0).Transform)
+	assert.Equal(t, iceberg.HourTransform{}, spec.Field(1).Transform)
+
+	duplicate := `{"spec-id":0,"fields":[` +
+		`{"source-id":1,"field-id":1000,"name":"first","transform":"day"},` +
+		`{"source-id":1,"field-id":1001,"name":"second","transform":"day"}]}`
+	err := json.Unmarshal([]byte(duplicate), &spec)
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
+}
+
+func TestBindToSchemaAllowsTimeGranularityOverlap(t *testing.T) {
 	schema := iceberg.NewSchema(1,
 		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
 	)
 
-	_, err := iceberg.NewPartitionSpecOpts(
-		iceberg.WithSpecID(1),
-		iceberg.AddPartitionFieldByName("ts", "ts_year", iceberg.YearTransform{}, schema, nil),
-		iceberg.AddPartitionFieldByName("ts", "ts_month", iceberg.MonthTransform{}, schema, nil),
+	overlapping := iceberg.NewPartitionSpecID(1,
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1000, Name: "ts_day",
+			Transform: iceberg.DayTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{1}, FieldID: 1001, Name: "ts_hour",
+			Transform: iceberg.HourTransform{},
+		},
 	)
 
-	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
-	assert.ErrorContains(t, err, "redundant partition field")
+	bound, err := overlapping.BindToSchema(schema, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, bound.NumFields())
+}
+
+func TestTimeTransformMembership(t *testing.T) {
+	tests := []struct {
+		name     string
+		trans    iceberg.Transform
+		wantTime bool
+	}{
+		{name: "year", trans: iceberg.YearTransform{}, wantTime: true},
+		{name: "month", trans: iceberg.MonthTransform{}, wantTime: true},
+		{name: "day", trans: iceberg.DayTransform{}, wantTime: true},
+		{name: "hour", trans: iceberg.HourTransform{}, wantTime: true},
+		{name: "identity", trans: iceberg.IdentityTransform{}, wantTime: false},
+		{name: "void", trans: iceberg.VoidTransform{}, wantTime: false},
+		{name: "bucket", trans: iceberg.BucketTransform{NumBuckets: 16}, wantTime: false},
+		{name: "truncate", trans: iceberg.TruncateTransform{Width: 4}, wantTime: false},
+		{name: "unknown", trans: iceberg.UnknownTransform{}, wantTime: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, isTime := tt.trans.(iceberg.TimeTransform)
+			assert.Equal(t, tt.wantTime, isTime)
+		})
+	}
 }

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -41,7 +41,6 @@ type UpdateSpec struct {
 	transformToField      map[transformKey]iceberg.PartitionField
 	transformToAddedField map[transformKey]iceberg.PartitionField
 	renames               map[string]string
-	addedTimeFields       map[int]iceberg.PartitionField
 	caseSensitive         bool
 	adds                  []iceberg.PartitionField
 	deletes               map[int]bool
@@ -69,7 +68,6 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 		transformToField:      make(map[transformKey]iceberg.PartitionField),
 		transformToAddedField: make(map[transformKey]iceberg.PartitionField),
 		renames:               make(map[string]string),
-		addedTimeFields:       make(map[int]iceberg.PartitionField),
 		caseSensitive:         caseSensitive,
 		adds:                  make([]iceberg.PartitionField, 0),
 		deletes:               make(map[int]bool),
@@ -207,6 +205,9 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 	}
 
 	partitionFields = append(partitionFields, us.adds...)
+	if err := validateNoRedundantTimeFields(partitionFields); err != nil {
+		return iceberg.PartitionSpec{}, err
+	}
 	candidate := iceberg.NewPartitionSpec(partitionFields...)
 	newSpec, err := candidate.BindToSchema(us.txn.tbl.Schema(), nil, nil)
 	if err != nil {
@@ -224,6 +225,29 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 	}
 
 	return iceberg.NewPartitionSpecID(newSpecId, partitionFields...), nil
+}
+
+// validateNoRedundantTimeFields rejects hour(ts) alongside day(ts).
+// Taking the assembled set is load bearing: only it knows which fields survive
+// the deletes, so AddField(month) -> RemoveField(year) works in either order.
+func validateNoRedundantTimeFields(fields []iceberg.PartitionField) error {
+	timeFields := make(map[int]iceberg.PartitionField, len(fields))
+	for _, field := range fields {
+		// Void is not a TimeTransform, so a v1 tombstone left by a removed
+		// year(ts) does not block adding month(ts) on the same column.
+		if _, isTime := field.Transform.(iceberg.TimeTransform); !isTime {
+			continue
+		}
+		source := field.SourceID()
+		if existing, exists := timeFields[source]; exists {
+			return fmt.Errorf("%w: redundant partition field for source ID %d: %s (%s) conflicts with %s (%s)",
+				iceberg.ErrInvalidPartitionSpec, source,
+				field.Name, field.Transform, existing.Name, existing.Transform)
+		}
+		timeFields[source] = field
+	}
+
+	return nil
 }
 
 func (us *UpdateSpec) Commit() error {
@@ -287,13 +311,9 @@ func (us *UpdateSpec) addField(sourceColName string, transform iceberg.Transform
 			return fmt.Errorf("already added partition field with name: %s", newField.Name)
 		}
 
-		// Handle special case for time transforms
-		if _, isTimeTransform := newField.Transform.(iceberg.TimeTransform); isTimeTransform {
-			if existingTimeField, exists := us.addedTimeFields[newField.SourceID()]; exists {
-				return fmt.Errorf("cannot add time partition field: %s conflicts with %s", newField.Name, existingTimeField.Name)
-			}
-			us.addedTimeFields[newField.SourceID()] = newField
-		}
+		// Time conflicts are not checked here: they depend on which existing
+		// fields survive this update's deletes, so validateNoRedundantTimeFields
+		// checks the set Apply assembles once every operation has run.
 		us.transformToAddedField[key] = newField
 
 		// If name matches an existing field, rename it if it's VOID transform

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -122,6 +122,71 @@ func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
 	assert.Equal(t, "name_identity", newSpec.Field(1).Name)
 }
 
+func TestUpdateSpecRejectsTimeTransformConflictWithExistingField(t *testing.T) {
+	baseSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{3},
+		FieldID:   iceberg.PartitionDataIDStart,
+		Name:      "ts_hour",
+		Transform: iceberg.HourTransform{},
+	})
+	meta, err := table.NewMetadata(testSchema, &baseSpec, table.UnsortedSortOrder, "", nil)
+	require.NoError(t, err)
+	tbl := table.New([]string{"hour_partitioned"}, meta, "", nil, nil)
+
+	updates, reqs, err := table.NewUpdateSpec(tbl.NewTransaction(), false).
+		AddField("ts", iceberg.DayTransform{}, "ts_day").
+		BuildUpdates()
+
+	require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	assert.ErrorContains(t, err, "redundant partition field")
+	assert.Nil(t, updates)
+	assert.Nil(t, reqs)
+}
+
+func TestUpdateSpecAllowsReplacingTimeTransformOnSameSource(t *testing.T) {
+	newYearPartitionedTable := func() *table.Table {
+		baseSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+			SourceIDs: []int{3},
+			FieldID:   iceberg.PartitionDataIDStart,
+			Name:      "ts_year",
+			Transform: iceberg.YearTransform{},
+		})
+		meta, err := table.NewMetadata(testSchema, &baseSpec, table.UnsortedSortOrder, "", nil)
+		require.NoError(t, err)
+
+		return table.New([]string{"year_partitioned"}, meta, "", nil, nil)
+	}
+
+	assertReplaced := func(t *testing.T, specUpdate *table.UpdateSpec) {
+		t.Helper()
+		updates, reqs, err := specUpdate.BuildUpdates()
+		require.NoError(t, err)
+		assert.NotNil(t, updates)
+		assert.NotNil(t, reqs)
+
+		newSpec, err := specUpdate.Apply()
+		require.NoError(t, err)
+		require.Equal(t, 1, newSpec.NumFields())
+		assert.Equal(t, "ts_month", newSpec.Field(0).Name)
+		assert.Equal(t, iceberg.MonthTransform{}, newSpec.Field(0).Transform)
+		assert.Equal(t, 3, newSpec.Field(0).SourceID())
+	}
+
+	t.Run("remove then add", func(t *testing.T) {
+		tbl := newYearPartitionedTable()
+		assertReplaced(t, table.NewUpdateSpec(tbl.NewTransaction(), false).
+			RemoveField("ts_year").
+			AddField("ts", iceberg.MonthTransform{}, "ts_month"))
+	})
+
+	t.Run("add then remove", func(t *testing.T) {
+		tbl := newYearPartitionedTable()
+		assertReplaced(t, table.NewUpdateSpec(tbl.NewTransaction(), false).
+			AddField("ts", iceberg.MonthTransform{}, "ts_month").
+			RemoveField("ts_year"))
+	})
+}
+
 func TestUpdateSpecAddField(t *testing.T) {
 	var txn *table.Transaction
 

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -187,6 +187,121 @@ func TestUpdateSpecAllowsReplacingTimeTransformOnSameSource(t *testing.T) {
 	})
 }
 
+func TestUpdateSpecReplacesTimeTransformOverV1VoidTombstone(t *testing.T) {
+	baseSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{3},
+		FieldID:   iceberg.PartitionDataIDStart,
+		Name:      "ts_year",
+		Transform: iceberg.YearTransform{},
+	})
+	meta, err := table.NewMetadata(testSchema, &baseSpec, table.UnsortedSortOrder, "",
+		iceberg.Properties{"format-version": "1"})
+	require.NoError(t, err)
+	require.Equal(t, 1, meta.Version())
+	tbl := table.New([]string{"v1_year_partitioned"}, meta, "", nil, nil)
+
+	specUpdate := table.NewUpdateSpec(tbl.NewTransaction(), false).
+		RemoveField("ts_year").
+		AddField("ts", iceberg.MonthTransform{}, "ts_month")
+	_, _, err = specUpdate.BuildUpdates()
+	require.NoError(t, err)
+
+	newSpec, err := specUpdate.Apply()
+	require.NoError(t, err)
+	require.Equal(t, 2, newSpec.NumFields())
+	assert.Equal(t, "ts_year", newSpec.Field(0).Name)
+	assert.Equal(t, iceberg.VoidTransform{}, newSpec.Field(0).Transform)
+	assert.Equal(t, 3, newSpec.Field(0).SourceID())
+	assert.Equal(t, "ts_month", newSpec.Field(1).Name)
+	assert.Equal(t, iceberg.MonthTransform{}, newSpec.Field(1).Transform)
+	assert.Equal(t, 3, newSpec.Field(1).SourceID())
+}
+
+// Iceberg-Java writes this metadata today, so loading it has to keep working: the
+// redundancy rule is a write-side rule.
+// Metadata carrying day(ts) and hour(ts) on one column, the shape both Iceberg-Java and
+// iceberg-go before at some point could write.
+const timeOverlapMetadataJSON = `{
+	"format-version": 2,
+	"table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+	"location": "s3://bucket/table",
+	"last-sequence-number": 0,
+	"last-updated-ms": 1602638573874,
+	"last-column-id": 3,
+	"current-schema-id": 0,
+	"schemas": [{"type":"struct","schema-id":0,"fields":[
+		{"id":1,"name":"id","required":true,"type":"long"},
+		{"id":3,"name":"ts","required":false,"type":"timestamp"}]}],
+	"default-spec-id": 0,
+	"partition-specs": [{"spec-id":0,"fields":[
+		{"source-id":3,"field-id":1000,"name":"ts_day","transform":"day"},
+		{"source-id":3,"field-id":1001,"name":"ts_hour","transform":"hour"}]}],
+	"last-partition-id": 1001,
+	"default-sort-order-id": 0,
+	"sort-orders": [{"order-id":0,"fields":[]}],
+	"properties": {},
+	"current-snapshot-id": -1,
+	"snapshots": [],
+	"snapshot-log": [],
+	"metadata-log": []
+}`
+
+func newTimeOverlapTable(t *testing.T) *table.Table {
+	t.Helper()
+	meta, err := table.ParseMetadataString(timeOverlapMetadataJSON)
+	require.NoError(t, err)
+
+	return table.New([]string{"time_overlap"}, meta, "", nil, nil)
+}
+
+func TestParseMetadataAllowsTimeGranularityOverlapInSpec(t *testing.T) {
+	tbl := newTimeOverlapTable(t)
+
+	spec := tbl.Metadata().PartitionSpec()
+	require.Equal(t, 2, spec.NumFields())
+	assert.Equal(t, iceberg.DayTransform{}, spec.Field(0).Transform)
+	assert.Equal(t, iceberg.HourTransform{}, spec.Field(1).Transform)
+}
+
+// Inherited redundancy is checked on the spec the update produces, not on what
+// the update touches, so it blocks unrelated evolution until it is cleaned up.
+// Deliberate: rewriting the spec unchanged would carry the redundancy forward.
+func TestUpdateSpecOnInheritedTimeOverlap(t *testing.T) {
+	t.Run("unrelated add is blocked", func(t *testing.T) {
+		tbl := newTimeOverlapTable(t)
+		_, _, err := table.NewUpdateSpec(tbl.NewTransaction(), false).
+			AddField("id", iceberg.BucketTransform{NumBuckets: 8}, "id_bucket").
+			BuildUpdates()
+		require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+		assert.ErrorContains(t, err, "ts_hour (hour) conflicts with ts_day (day)")
+	})
+
+	t.Run("unrelated rename is blocked", func(t *testing.T) {
+		tbl := newTimeOverlapTable(t)
+		_, _, err := table.NewUpdateSpec(tbl.NewTransaction(), false).
+			RenameField("ts_day", "ts_daily").
+			BuildUpdates()
+		require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+	})
+
+	// The escape hatch: dropping the redundant field is always allowed, and may
+	// be staged alongside the change that was blocked.
+	t.Run("removing the redundant field unblocks the rest", func(t *testing.T) {
+		tbl := newTimeOverlapTable(t)
+		specUpdate := table.NewUpdateSpec(tbl.NewTransaction(), false).
+			RemoveField("ts_day").
+			AddField("id", iceberg.BucketTransform{NumBuckets: 8}, "id_bucket")
+		_, _, err := specUpdate.BuildUpdates()
+		require.NoError(t, err)
+
+		newSpec, err := specUpdate.Apply()
+		require.NoError(t, err)
+		require.Equal(t, 2, newSpec.NumFields())
+		assert.Equal(t, "ts_hour", newSpec.Field(0).Name)
+		assert.Equal(t, "id_bucket", newSpec.Field(1).Name)
+	})
+}
+
 func TestUpdateSpecAddField(t *testing.T) {
 	var txn *table.Transaction
 
@@ -330,8 +445,11 @@ func TestUpdateSpecAddField(t *testing.T) {
 			AddField("ts", iceberg.MonthTransform{}, "ts_month").
 			BuildUpdates()
 
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "cannot add time partition field")
+		// Added-vs-added, and it reports the same sentinel and wording as the
+		// existing-vs-added case
+		require.ErrorIs(t, err, iceberg.ErrInvalidPartitionSpec)
+		assert.ErrorContains(t, err, "redundant partition field")
+		assert.ErrorContains(t, err, "ts_month (month) conflicts with ts_year (year)")
 		assert.Nil(t, updates)
 		assert.Nil(t, reqs)
 	})


### PR DESCRIPTION
### Description

Fixes #1796 

Extends the function `validatePartitionFields` with `partitionFieldsRedundant` folding _year_, _month_, _day_ and _hour_ into one slot per source column.

Other families keep equality-only conflict and stay legal.

### Testing

Added the necessary regression tests for it.