### PR TITLE
fix(table): guard nil base in snapshot timestamp check

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -519,7 +519,11 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 				snapshot.TimestampMs, last.TimestampMs)
 		}
 	}
-	maxTS := max(b.lastUpdatedMS, b.base.LastUpdatedMillis())
+	var baseLastUpdated int64
+	if b.base != nil {
+		baseLastUpdated = b.base.LastUpdatedMillis()
+	}
+	maxTS := max(b.lastUpdatedMS, baseLastUpdated)
 	if snapshot.TimestampMs-maxTS < -oneMinuteInMs {
 		return fmt.Errorf("invalid snapshot timestamp %d: before last updated timestamp %d",
 			snapshot.TimestampMs, maxTS)

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -42,6 +42,7 @@ const (
 	supportedTableFormatVersion = 3
 	minFormatVersionRowLineage  = 3
 	initialRowID                = int64(0)
+	initialSequenceNumber       = int64(0)
 	oneMinuteInMs               = int64(60_000)
 )
 
@@ -499,6 +500,7 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 		return nil
 	}
 
+	lastSeqNum := b.currentLastSequenceNumber()
 	if len(b.schemaList) == 0 {
 		return errors.New("can't add snapshot with no added schemas")
 	} else if len(b.specs) == 0 {
@@ -507,9 +509,9 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 		return fmt.Errorf("can't add snapshot with id %d, already exists", snapshot.SnapshotID)
 	} else if b.formatVersion >= 2 &&
 		snapshot.ParentSnapshotID != nil &&
-		snapshot.SequenceNumber <= *b.lastSequenceNumber {
+		snapshot.SequenceNumber <= lastSeqNum {
 		return fmt.Errorf("can't add snapshot with sequence number %d, must be > than last sequence number %d",
-			snapshot.SequenceNumber, *b.lastSequenceNumber)
+			snapshot.SequenceNumber, lastSeqNum)
 	}
 
 	if len(b.snapshotLog) > 0 {
@@ -519,6 +521,10 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 				snapshot.TimestampMs, last.TimestampMs)
 		}
 	}
+
+	// b.base is nil for builders created by NewMetadataBuilder (the create-table path);
+	// only MetadataBuilderFromBase populates it. Treat the missing base as "no previous update"
+	// instead of dereferencing it, mirroring the fallback in currentNextRowID.
 	var baseLastUpdated int64
 	if b.base != nil {
 		baseLastUpdated = b.base.LastUpdatedMillis()
@@ -581,6 +587,18 @@ func (b *MetadataBuilder) validateAndUpdateRowLineage(snapshot *Snapshot) error 
 	b.nextRowID = &newNextRowID
 
 	return nil
+}
+
+// currentLastSequenceNumber returns the last sequence number assigned to a
+// snapshot. b.lastSequenceNumber is nil for v1 tables and for builders created
+// by NewMetadataBuilder that have not added a snapshot yet, in which case the
+// spec's initial sequence number is the correct floor.
+func (b *MetadataBuilder) currentLastSequenceNumber() int64 {
+	if b.lastSequenceNumber != nil {
+		return *b.lastSequenceNumber
+	}
+
+	return initialSequenceNumber
 }
 
 func (b *MetadataBuilder) currentNextRowID() int64 {

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -118,6 +118,41 @@ func builderWithoutChanges(formatVersion int) MetadataBuilder {
 	return *builder
 }
 
+func freshMetadataBuilder(t *testing.T, formatVersion int) *MetadataBuilder {
+	t.Helper()
+
+	tableSchema := schema()
+	partitionSpec := partitionSpec()
+	sortOrder := sortOrder()
+
+	builder, err := NewMetadataBuilder(formatVersion)
+	require.NoError(t, err)
+	require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
+	require.NoError(t, builder.AddSchema(&tableSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(-1))
+	require.NoError(t, builder.AddSortOrder(&sortOrder))
+	require.NoError(t, builder.SetDefaultSortOrderID(-1))
+	require.NoError(t, builder.AddPartitionSpec(&partitionSpec, true))
+	require.NoError(t, builder.SetDefaultSpecID(-1))
+	require.Nil(t, builder.base, "builder from NewMetadataBuilder must have no base metadata")
+
+	return builder
+}
+
+func freshBuilderSnapshot(snapshotID int64, parentSnapshotID *int64, sequenceNumber, timestampMs int64) Snapshot {
+	schemaID := 0
+
+	return Snapshot{
+		SnapshotID:       snapshotID,
+		ParentSnapshotID: parentSnapshotID,
+		SequenceNumber:   sequenceNumber,
+		TimestampMs:      timestampMs,
+		ManifestList:     fmt.Sprintf("/snap-%d.avro", snapshotID),
+		Summary:          &Summary{Operation: OpAppend, Properties: map[string]string{}},
+		SchemaID:         &schemaID,
+	}
+}
+
 func TestBuildUnpartitionedUnsorted(t *testing.T) {
 	TestLocation := "file:///tmp/iceberg-test"
 	tableSchema := schema()
@@ -1301,77 +1336,102 @@ func TestAddSnapshotRejectsInvalidTimestamp(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAddSnapshotOnFreshBuilderDoesNotPanic(t *testing.T) {
-	tableSchema := schema()
-	spec := partitionSpec()
-	order := sortOrder()
+func TestAddSnapshotOnBuilderWithoutBase(t *testing.T) {
+	t.Run("parentless snapshot", func(t *testing.T) {
+		builder := freshMetadataBuilder(t, 2)
+		snapshot := freshBuilderSnapshot(1, nil, 0, time.Now().UnixMilli())
 
-	builder, err := NewMetadataBuilder(2)
-	require.NoError(t, err)
-	require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
-	require.NoError(t, builder.AddSchema(&tableSchema))
-	require.NoError(t, builder.SetCurrentSchemaID(-1))
-	require.NoError(t, builder.AddSortOrder(&order))
-	require.NoError(t, builder.SetDefaultSortOrderID(-1))
-	require.NoError(t, builder.AddPartitionSpec(&spec, true))
-	require.NoError(t, builder.SetDefaultSpecID(-1))
+		require.NoError(t, builder.AddSnapshot(&snapshot))
 
-	schemaID := 0
-	snapshot := Snapshot{
-		SnapshotID:       1,
-		ParentSnapshotID: nil,
-		SequenceNumber:   0,
-		TimestampMs:      time.Now().UnixMilli(),
-		ManifestList:     "/snap-1.avro",
-		Summary:          &Summary{Operation: OpAppend, Properties: map[string]string{}},
-		SchemaID:         &schemaID,
-	}
-
-	require.NotPanics(t, func() {
-		err = builder.AddSnapshot(&snapshot)
+		meta, err := builder.Build()
+		require.NoError(t, err)
+		require.Len(t, meta.Snapshots(), 1)
+		require.Equal(t, snapshot.TimestampMs, meta.LastUpdatedMillis())
 	})
-	require.NoError(t, err)
 
-	meta, err := builder.Build()
-	require.NoError(t, err)
-	require.Len(t, meta.Snapshots(), 1)
+	t.Run("snapshot with parent", func(t *testing.T) {
+		builder := freshMetadataBuilder(t, 2)
+		parentSnapshotID := int64(1)
+		snapshot := freshBuilderSnapshot(2, &parentSnapshotID, 1, time.Now().UnixMilli())
+
+		require.NoError(t, builder.AddSnapshot(&snapshot))
+
+		meta, err := builder.Build()
+		require.NoError(t, err)
+		require.Len(t, meta.Snapshots(), 1)
+		require.Equal(t, int64(1), meta.LastSequenceNumber())
+	})
+
+	t.Run("rejects sequence number at the initial value", func(t *testing.T) {
+		builder := freshMetadataBuilder(t, 2)
+		parentSnapshotID := int64(1)
+		snapshot := freshBuilderSnapshot(2, &parentSnapshotID, 0, time.Now().UnixMilli())
+
+		err := builder.AddSnapshot(&snapshot)
+		require.ErrorContains(t, err, "can't add snapshot with sequence number 0, must be > than last sequence number 0")
+	})
+
+	t.Run("rejects timestamp before last update", func(t *testing.T) {
+		builder := freshMetadataBuilder(t, 2)
+		now := time.Now().UnixMilli()
+		first := freshBuilderSnapshot(1, nil, 0, now)
+		require.NoError(t, builder.AddSnapshot(&first))
+
+		// No ref has been set, so the snapshot log is empty and this exercises the
+		// last-updated bound rather than the last-snapshot bound.
+		require.Empty(t, builder.snapshotLog)
+		second := freshBuilderSnapshot(2, nil, 1, now-(2*oneMinuteInMs))
+
+		err := builder.AddSnapshot(&second)
+		require.ErrorContains(t, err, "before last updated timestamp")
+	})
 }
 
-func TestAddSnapshotUpdateOnFreshBuilderDoesNotPanic(t *testing.T) {
-	tableSchema := schema()
-	spec := partitionSpec()
-	order := sortOrder()
+func TestAddSnapshotOnBuilderWithoutBaseV3(t *testing.T) {
+	// v3 row lineage validation only became reachable for a builder without base
+	// metadata once AddSnapshot stopped panicking before it.
+	builder := freshMetadataBuilder(t, 3)
+	firstRowID, addedRows := int64(0), int64(10)
+	snapshot := freshBuilderSnapshot(1, nil, 0, time.Now().UnixMilli())
+	snapshot.FirstRowID, snapshot.AddedRows = &firstRowID, &addedRows
 
-	builder, err := NewMetadataBuilder(2)
-	require.NoError(t, err)
-	require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
-	require.NoError(t, builder.AddSchema(&tableSchema))
-	require.NoError(t, builder.SetCurrentSchemaID(-1))
-	require.NoError(t, builder.AddSortOrder(&order))
-	require.NoError(t, builder.SetDefaultSortOrderID(-1))
-	require.NoError(t, builder.AddPartitionSpec(&spec, true))
-	require.NoError(t, builder.SetDefaultSpecID(-1))
+	require.NoError(t, builder.AddSnapshot(&snapshot))
+	require.Equal(t, addedRows, builder.NextRowID())
 
-	schemaID := 0
-	snapshot := &Snapshot{
-		SnapshotID:       1,
-		ParentSnapshotID: nil,
-		SequenceNumber:   0,
-		TimestampMs:      time.Now().UnixMilli(),
-		ManifestList:     "/snap-1.avro",
-		Summary:          &Summary{Operation: OpAppend, Properties: map[string]string{}},
-		SchemaID:         &schemaID,
-	}
-	update := NewAddSnapshotUpdate(snapshot)
+	behindFirstRowID := int64(5)
+	parentSnapshotID := int64(1)
+	stale := freshBuilderSnapshot(2, &parentSnapshotID, 1, time.Now().UnixMilli())
+	stale.FirstRowID, stale.AddedRows = &behindFirstRowID, &addedRows
 
-	require.NotPanics(t, func() {
-		err = builder.AddSnapshotUpdate(update)
-	})
-	require.NoError(t, err)
+	err := builder.AddSnapshot(&stale)
+	require.ErrorIs(t, err, ErrInvalidRowLineage)
+	require.ErrorContains(t, err, "first-row-id 5 is behind table next-row-id 10")
 
 	meta, err := builder.Build()
 	require.NoError(t, err)
 	require.Len(t, meta.Snapshots(), 1)
+	require.Equal(t, addedRows, meta.NextRowID())
+}
+
+func TestAddSnapshotUpdateOnBuilderWithoutBase(t *testing.T) {
+	builder := freshMetadataBuilder(t, 2)
+	parentSnapshotID := int64(1)
+	snapshot := freshBuilderSnapshot(2, &parentSnapshotID, 1, time.Now().UnixMilli())
+	update := NewAddSnapshotUpdate(&snapshot)
+
+	require.NoError(t, builder.AddSnapshotUpdate(update))
+
+	// AddSnapshotUpdate must store the caller's update verbatim rather than
+	// rebuilding it, so runtime-only fields survive the OCC retry path.
+	require.NotEmpty(t, builder.updates)
+	stored, ok := builder.updates[len(builder.updates)-1].(*addSnapshotUpdate)
+	require.True(t, ok, "expected last update to be *addSnapshotUpdate, got %T", builder.updates[len(builder.updates)-1])
+	require.Same(t, update, stored)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	require.Len(t, meta.Snapshots(), 1)
+	require.Equal(t, int64(1), meta.LastSequenceNumber())
 }
 
 func TestConstructDefaultMainBranch(t *testing.T) {

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -1301,6 +1301,79 @@ func TestAddSnapshotRejectsInvalidTimestamp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAddSnapshotOnFreshBuilderDoesNotPanic(t *testing.T) {
+	tableSchema := schema()
+	spec := partitionSpec()
+	order := sortOrder()
+
+	builder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
+	require.NoError(t, builder.AddSchema(&tableSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(-1))
+	require.NoError(t, builder.AddSortOrder(&order))
+	require.NoError(t, builder.SetDefaultSortOrderID(-1))
+	require.NoError(t, builder.AddPartitionSpec(&spec, true))
+	require.NoError(t, builder.SetDefaultSpecID(-1))
+
+	schemaID := 0
+	snapshot := Snapshot{
+		SnapshotID:       1,
+		ParentSnapshotID: nil,
+		SequenceNumber:   0,
+		TimestampMs:      time.Now().UnixMilli(),
+		ManifestList:     "/snap-1.avro",
+		Summary:          &Summary{Operation: OpAppend, Properties: map[string]string{}},
+		SchemaID:         &schemaID,
+	}
+
+	require.NotPanics(t, func() {
+		err = builder.AddSnapshot(&snapshot)
+	})
+	require.NoError(t, err)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	require.Len(t, meta.Snapshots(), 1)
+}
+
+func TestAddSnapshotUpdateOnFreshBuilderDoesNotPanic(t *testing.T) {
+	tableSchema := schema()
+	spec := partitionSpec()
+	order := sortOrder()
+
+	builder, err := NewMetadataBuilder(2)
+	require.NoError(t, err)
+	require.NoError(t, builder.SetLoc("s3://bucket/test/location"))
+	require.NoError(t, builder.AddSchema(&tableSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(-1))
+	require.NoError(t, builder.AddSortOrder(&order))
+	require.NoError(t, builder.SetDefaultSortOrderID(-1))
+	require.NoError(t, builder.AddPartitionSpec(&spec, true))
+	require.NoError(t, builder.SetDefaultSpecID(-1))
+
+	schemaID := 0
+	snapshot := &Snapshot{
+		SnapshotID:       1,
+		ParentSnapshotID: nil,
+		SequenceNumber:   0,
+		TimestampMs:      time.Now().UnixMilli(),
+		ManifestList:     "/snap-1.avro",
+		Summary:          &Summary{Operation: OpAppend, Properties: map[string]string{}},
+		SchemaID:         &schemaID,
+	}
+	update := NewAddSnapshotUpdate(snapshot)
+
+	require.NotPanics(t, func() {
+		err = builder.AddSnapshotUpdate(update)
+	})
+	require.NoError(t, err)
+
+	meta, err := builder.Build()
+	require.NoError(t, err)
+	require.Len(t, meta.Snapshots(), 1)
+}
+
 func TestConstructDefaultMainBranch(t *testing.T) {
 	// TODO: Not sure what this test is supposed to do Rust: `test_construct_default_main_branch`
 	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")


### PR DESCRIPTION
### Description

Fixes #1798 

Two nil derefs in `addSnapshotInternal` on a create-path `MetadataBuilder` (`base` is nil until `MetadataBuilderFromBase` is used):

1. `*b.lastSequenceNumber` panicked for parented snapshots. Added `currentLastSequenceNumber()`, falling back to 0, matching `nextSequenceNumber()`/`Build()`.
2. `b.base.LastUpdatedMillis()` panicked on nil `base`. Guarded it like `currentNextRowID()`, treating a missing base as 0.

### Testing

Added the necessary tests required for it.