### PR TITLE
perf(schema): index name-mapping lookups

### DIFF
--- a/name_mapping.go
+++ b/name_mapping.go
@@ -262,12 +262,50 @@ func (u *updateNameMappingVisitor) addNewFields(mappedFields []MappedField, pare
 	return append(fields, newFields...)
 }
 
-type NameMappingAccessor struct {
+type NameMappingAccessor struct{}
+
+func (NameMappingAccessor) SchemaPartner(partner *MappedField) *MappedField {
+	return partner
+}
+
+func (NameMappingAccessor) FieldPartner(partnerStruct *MappedField, _ int, fieldName string) *MappedField {
+	if partnerStruct == nil {
+		return nil
+	}
+
+	return partnerStruct.GetField(fieldName)
+}
+
+func (NameMappingAccessor) ListElementPartner(partnerList *MappedField) *MappedField {
+	if partnerList == nil {
+		return nil
+	}
+
+	return partnerList.GetField("element")
+}
+
+func (NameMappingAccessor) MapKeyPartner(partnerMap *MappedField) *MappedField {
+	if partnerMap == nil {
+		return nil
+	}
+
+	return partnerMap.GetField("key")
+}
+
+func (NameMappingAccessor) MapValuePartner(partnerMap *MappedField) *MappedField {
+	if partnerMap == nil {
+		return nil
+	}
+
+	return partnerMap.GetField("value")
+}
+
+type indexedNameMappingAccessor struct {
 	fieldsByName map[*MappedField]map[string]*MappedField
 }
 
-func newNameMappingAccessor(root *MappedField) NameMappingAccessor {
-	accessor := NameMappingAccessor{
+func newIndexedNameMappingAccessor(root *MappedField) indexedNameMappingAccessor {
+	accessor := indexedNameMappingAccessor{
 		fieldsByName: make(map[*MappedField]map[string]*MappedField),
 	}
 	accessor.indexFields(root)
@@ -275,7 +313,7 @@ func newNameMappingAccessor(root *MappedField) NameMappingAccessor {
 	return accessor
 }
 
-func (n NameMappingAccessor) indexFields(field *MappedField) {
+func (n indexedNameMappingAccessor) indexFields(field *MappedField) {
 	if field == nil || len(field.Fields) == 0 {
 		return
 	}
@@ -295,7 +333,7 @@ func (n NameMappingAccessor) indexFields(field *MappedField) {
 	}
 }
 
-func (n NameMappingAccessor) getField(partnerStruct *MappedField, fieldName string) *MappedField {
+func (n indexedNameMappingAccessor) getField(partnerStruct *MappedField, fieldName string) *MappedField {
 	if partnerStruct == nil {
 		return nil
 	}
@@ -307,29 +345,29 @@ func (n NameMappingAccessor) getField(partnerStruct *MappedField, fieldName stri
 	return partnerStruct.GetField(fieldName)
 }
 
-func (NameMappingAccessor) SchemaPartner(partner *MappedField) *MappedField {
+func (n indexedNameMappingAccessor) SchemaPartner(partner *MappedField) *MappedField {
 	return partner
 }
 
-func (n NameMappingAccessor) FieldPartner(partnerStruct *MappedField, _ int, fieldName string) *MappedField {
+func (n indexedNameMappingAccessor) FieldPartner(partnerStruct *MappedField, _ int, fieldName string) *MappedField {
 	return n.getField(partnerStruct, fieldName)
 }
 
-func (n NameMappingAccessor) ListElementPartner(partnerList *MappedField) *MappedField {
+func (n indexedNameMappingAccessor) ListElementPartner(partnerList *MappedField) *MappedField {
 	return n.getField(partnerList, "element")
 }
 
-func (n NameMappingAccessor) MapKeyPartner(partnerMap *MappedField) *MappedField {
+func (n indexedNameMappingAccessor) MapKeyPartner(partnerMap *MappedField) *MappedField {
 	return n.getField(partnerMap, "key")
 }
 
-func (n NameMappingAccessor) MapValuePartner(partnerMap *MappedField) *MappedField {
+func (n indexedNameMappingAccessor) MapValuePartner(partnerMap *MappedField) *MappedField {
 	return n.getField(partnerMap, "value")
 }
 
 type nameMapProjectVisitor struct {
 	currentPath []string
-	accessor    NameMappingAccessor
+	accessor    indexedNameMappingAccessor
 }
 
 func (n *nameMapProjectVisitor) popPath() {
@@ -461,7 +499,7 @@ func (n *nameMapProjectVisitor) Variant(v VariantType, variantPartner *MappedFie
 
 func ApplyNameMapping(schemaWithoutIDs *Schema, nameMapping NameMapping) (*Schema, error) {
 	partner := &MappedField{Fields: nameMapping}
-	accessor := newNameMappingAccessor(partner)
+	accessor := newIndexedNameMappingAccessor(partner)
 	top, err := VisitSchemaWithPartner(schemaWithoutIDs,
 		partner,
 		&nameMapProjectVisitor{

--- a/name_mapping.go
+++ b/name_mapping.go
@@ -262,46 +262,74 @@ func (u *updateNameMappingVisitor) addNewFields(mappedFields []MappedField, pare
 	return append(fields, newFields...)
 }
 
-type NameMappingAccessor struct{}
+type NameMappingAccessor struct {
+	fieldsByName map[*MappedField]map[string]*MappedField
+}
+
+func newNameMappingAccessor(root *MappedField) NameMappingAccessor {
+	accessor := NameMappingAccessor{
+		fieldsByName: make(map[*MappedField]map[string]*MappedField),
+	}
+	accessor.indexFields(root)
+
+	return accessor
+}
+
+func (n NameMappingAccessor) indexFields(field *MappedField) {
+	if field == nil || len(field.Fields) == 0 {
+		return
+	}
+
+	fieldsByName := make(map[string]*MappedField, len(field.Fields))
+	n.fieldsByName[field] = fieldsByName
+
+	for i := range field.Fields {
+		mappedField := &field.Fields[i]
+		for _, name := range mappedField.Names {
+			if _, exists := fieldsByName[name]; !exists {
+				fieldsByName[name] = mappedField
+			}
+		}
+
+		n.indexFields(mappedField)
+	}
+}
+
+func (n NameMappingAccessor) getField(partnerStruct *MappedField, fieldName string) *MappedField {
+	if partnerStruct == nil {
+		return nil
+	}
+
+	if fieldsByName, ok := n.fieldsByName[partnerStruct]; ok {
+		return fieldsByName[fieldName]
+	}
+
+	return partnerStruct.GetField(fieldName)
+}
 
 func (NameMappingAccessor) SchemaPartner(partner *MappedField) *MappedField {
 	return partner
 }
 
 func (n NameMappingAccessor) FieldPartner(partnerStruct *MappedField, _ int, fieldName string) *MappedField {
-	if partnerStruct == nil {
-		return nil
-	}
-
-	return partnerStruct.GetField(fieldName)
+	return n.getField(partnerStruct, fieldName)
 }
 
 func (n NameMappingAccessor) ListElementPartner(partnerList *MappedField) *MappedField {
-	if partnerList == nil {
-		return nil
-	}
-
-	return partnerList.GetField("element")
+	return n.getField(partnerList, "element")
 }
 
 func (n NameMappingAccessor) MapKeyPartner(partnerMap *MappedField) *MappedField {
-	if partnerMap == nil {
-		return nil
-	}
-
-	return partnerMap.GetField("key")
+	return n.getField(partnerMap, "key")
 }
 
 func (n NameMappingAccessor) MapValuePartner(partnerMap *MappedField) *MappedField {
-	if partnerMap == nil {
-		return nil
-	}
-
-	return partnerMap.GetField("value")
+	return n.getField(partnerMap, "value")
 }
 
 type nameMapProjectVisitor struct {
 	currentPath []string
+	accessor    NameMappingAccessor
 }
 
 func (n *nameMapProjectVisitor) popPath() {
@@ -367,15 +395,10 @@ func (n *nameMapProjectVisitor) Field(field NestedField, fieldPartner *MappedFie
 	}
 }
 
-func (nameMapProjectVisitor) mappedFieldID(mapped *MappedField, name string) int {
-	for _, f := range mapped.Fields {
-		if slices.Contains(f.Names, name) {
-			if f.FieldID != nil {
-				return *f.FieldID
-			}
-
-			return -1
-		}
+func (n nameMapProjectVisitor) mappedFieldID(mapped *MappedField, name string) int {
+	field := n.accessor.getField(mapped, name)
+	if field != nil && field.FieldID != nil {
+		return *field.FieldID
 	}
 
 	return -1
@@ -437,10 +460,15 @@ func (n *nameMapProjectVisitor) Variant(v VariantType, variantPartner *MappedFie
 }
 
 func ApplyNameMapping(schemaWithoutIDs *Schema, nameMapping NameMapping) (*Schema, error) {
+	partner := &MappedField{Fields: nameMapping}
+	accessor := newNameMappingAccessor(partner)
 	top, err := VisitSchemaWithPartner(schemaWithoutIDs,
-		&MappedField{Fields: nameMapping},
-		&nameMapProjectVisitor{currentPath: make([]string, 0, 1)},
-		NameMappingAccessor{})
+		partner,
+		&nameMapProjectVisitor{
+			currentPath: make([]string, 0, 1),
+			accessor:    accessor,
+		},
+		accessor)
 	if err != nil {
 		return nil, err
 	}

--- a/name_mapping_bench_test.go
+++ b/name_mapping_bench_test.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+func BenchmarkApplyNameMappingWideSchema(b *testing.B) {
+	const fieldCount = 256
+
+	fields := make([]iceberg.NestedField, fieldCount)
+	mapping := make(iceberg.NameMapping, fieldCount)
+	for i := range fieldCount {
+		name := fmt.Sprintf("field_%d", i)
+		fieldID := i + 1
+		fields[i] = iceberg.NestedField{
+			ID:   fieldID,
+			Name: name,
+			Type: iceberg.PrimitiveTypes.Int32,
+		}
+		mapping[i] = iceberg.MappedField{
+			FieldID: &fieldID,
+			Names:   []string{name},
+		}
+	}
+	schema := iceberg.NewSchema(0, fields...)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := iceberg.ApplyNameMapping(schema, mapping); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -106,18 +106,26 @@ func TestNameMappingFromJson(t *testing.T) {
 	})
 }
 
-func TestApplyNameMappingUsesFirstMatchingName(t *testing.T) {
+func TestApplyNameMappingUsesAlias(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 100, Name: "renamed", Type: iceberg.PrimitiveTypes.String},
 	)
 	mapping := iceberg.NameMapping{
-		{FieldID: makeID(1), Names: []string{"renamed", "legacy"}},
-		{FieldID: makeID(2), Names: []string{"renamed"}},
+		{FieldID: makeID(1), Names: []string{"legacy", "renamed"}},
 	}
 
 	result, err := iceberg.ApplyNameMapping(schema, mapping)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Field(0).ID)
+}
+
+func TestNameMappingAccessorRemainsComparable(t *testing.T) {
+	first := iceberg.NameMappingAccessor{}
+	second := iceberg.NameMappingAccessor{}
+	accessors := map[iceberg.NameMappingAccessor]struct{}{first: {}}
+
+	_, ok := accessors[second]
+	assert.True(t, ok)
 }
 
 func TestNameMappingToJson(t *testing.T) {

--- a/name_mapping_test.go
+++ b/name_mapping_test.go
@@ -106,6 +106,20 @@ func TestNameMappingFromJson(t *testing.T) {
 	})
 }
 
+func TestApplyNameMappingUsesFirstMatchingName(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 100, Name: "renamed", Type: iceberg.PrimitiveTypes.String},
+	)
+	mapping := iceberg.NameMapping{
+		{FieldID: makeID(1), Names: []string{"renamed", "legacy"}},
+		{FieldID: makeID(2), Names: []string{"renamed"}},
+	}
+
+	result, err := iceberg.ApplyNameMapping(schema, mapping)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Field(0).ID)
+}
+
 func TestNameMappingToJson(t *testing.T) {
 	result, err := json.Marshal(tableNameMappingNested)
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- Build one name lookup index for each `ApplyNameMapping` call.
- Reuse it for regular fields and list/map `element`, `key`, and `value` lookups.
- Keep aliases scoped to their parent mapping field, so nested fields with the same name still resolve correctly.
- Keep the exported `NameMappingAccessor` as the original empty, comparable type. The index is held by a private accessor used only by `ApplyNameMapping`.
- Add alias and API-compatibility regression tests.
- Add a wide-schema benchmark.

## Why

Name mapping lookup previously scanned sibling fields for every schema field. On wide schemas, that repeated the same work and caused many allocations.

The new per-operation index builds the lookup once, then uses map lookups during traversal. It is private to each call and read-only after construction.

## Benchmark

`BenchmarkApplyNameMappingWideSchema` with a 256-field schema on an Apple M1 Pro:

| Metric | Before | After | Result |
| --- | ---: | ---: | --- |
| Time/op | 0.90 ms | 37 us | ~24x faster |
| Memory/op | 2.16 MB | 68 KB | ~97% less |
| Allocs/op | 32,921 | 31 | ~99.9% fewer |

## Validation

- `go test ./...`
- `go vet .`
- Wide-schema benchmark with `-benchmem`