### PR TITLE
perf(table): index snapshots by ID

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2062,12 +2062,12 @@ func (c *commonMetadata) Snapshots() []Snapshot {
 }
 
 func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
-	if snapshotIndexNeedsRebuild(c.snapshotIndex, c.SnapshotList) {
-		c.snapshotIndex = buildSnapshotIndex(c.SnapshotList)
+	index := c.snapshotIndex
+	if snapshotIndexNeedsRebuild(index, c.SnapshotList) {
+		index = buildSnapshotIndex(c.SnapshotList)
 	}
 
-	i, ok, index := snapshotIndexPosition(c.snapshotIndex, c.SnapshotList, id)
-	c.snapshotIndex = index
+	i, ok, _ := snapshotIndexPosition(index, c.SnapshotList, id)
 	if ok {
 		return cloneSnapshotPtr(&c.SnapshotList[i])
 	}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -63,9 +63,21 @@ func snapshotIDFromUUID(id uuid.UUID) int64 {
 
 type snapshotIndexData struct {
 	positions map[int64]int
+	// firstSnapshot identifies the snapshot slice used to build positions.
+	// It lets read-only lookups distinguish a complete index from an index
+	// left behind by an in-package fixture that replaced the slice.
+	firstSnapshot *Snapshot
 	// shared means positions is owned by more than one builder or metadata
 	// value and must be copied before a builder mutates it.
 	shared bool
+}
+
+func snapshotListFirst(snapshots []Snapshot) *Snapshot {
+	if len(snapshots) == 0 {
+		return nil
+	}
+
+	return &snapshots[0]
 }
 
 func buildSnapshotIndex(snapshots []Snapshot) *snapshotIndexData {
@@ -76,7 +88,7 @@ func buildSnapshotIndex(snapshots []Snapshot) *snapshotIndexData {
 		}
 	}
 
-	return &snapshotIndexData{positions: positions}
+	return &snapshotIndexData{positions: positions, firstSnapshot: snapshotListFirst(snapshots)}
 }
 
 func cloneSnapshotIndex(index *snapshotIndexData) *snapshotIndexData {
@@ -84,11 +96,18 @@ func cloneSnapshotIndex(index *snapshotIndexData) *snapshotIndexData {
 		return nil
 	}
 
-	return &snapshotIndexData{positions: maps.Clone(index.positions)}
+	return &snapshotIndexData{
+		positions:     maps.Clone(index.positions),
+		firstSnapshot: index.firstSnapshot,
+	}
 }
 
 func snapshotIndexNeedsRebuild(index *snapshotIndexData, snapshots []Snapshot) bool {
-	return index == nil || len(index.positions) != len(snapshots)
+	if index == nil || len(index.positions) != len(snapshots) {
+		return true
+	}
+
+	return len(snapshots) > 0 && index.firstSnapshot != &snapshots[0]
 }
 
 // snapshotIndexPosition returns the position for id. Metadata loaded or built
@@ -106,6 +125,10 @@ func snapshotIndexPosition(index *snapshotIndexData, snapshots []Snapshot, id in
 				return i, true
 			}
 
+			return 0, false
+		}
+
+		if !snapshotIndexNeedsRebuild(index, snapshots) {
 			return 0, false
 		}
 	}
@@ -380,7 +403,6 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 		lastPartitionID:      clonePtr(b.lastPartitionID),
 		props:                maps.Clone(b.props),
 		snapshotList:         slices.Clone(b.snapshotList),
-		snapshotIndex:        b.snapshotIndex,
 		currentSnapshotID:    clonePtr(b.currentSnapshotID),
 		snapshotLog:          slices.Clone(b.snapshotLog),
 		metadataLog:          slices.Clone(b.metadataLog),
@@ -396,6 +418,13 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 		lastAddedSchemaID:    clonePtr(b.lastAddedSchemaID),
 		lastAddedPartitionID: clonePtr(b.lastAddedPartitionID),
 		lastAddedSortOrderID: clonePtr(b.lastAddedSortOrderID),
+	}
+	if b.snapshotIndex != nil {
+		cloned.snapshotIndex = &snapshotIndexData{
+			positions:     b.snapshotIndex.positions,
+			firstSnapshot: snapshotListFirst(cloned.snapshotList),
+			shared:        true,
+		}
 	}
 	if b.snapshotIndex != nil {
 		b.snapshotIndex.shared = true
@@ -655,6 +684,7 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 	b.ensureSnapshotIndexMutable()
 	b.snapshotList = append(b.snapshotList, *snapshot)
 	b.snapshotIndex.positions[snapshot.SnapshotID] = len(b.snapshotList) - 1
+	b.snapshotIndex.firstSnapshot = snapshotListFirst(b.snapshotList)
 
 	return nil
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -91,33 +91,32 @@ func snapshotIndexNeedsRebuild(index *snapshotIndexData, snapshots []Snapshot) b
 	return index == nil || len(index.positions) != len(snapshots)
 }
 
-// snapshotIndexPosition returns the position for id and an updated index when
-// callers replace the snapshot slice in an in-package fixture. Metadata loaded
-// or built through the normal paths always has a current index, so the linear
-// scan is only a compatibility fallback.
-func snapshotIndexPosition(index *snapshotIndexData, snapshots []Snapshot, id int64) (int, bool, *snapshotIndexData) {
+// snapshotIndexPosition returns the position for id. Metadata loaded or built
+// through the normal paths always has a current index, so the linear scan is
+// only a compatibility fallback for in-package fixtures that replace the slice.
+func snapshotIndexPosition(index *snapshotIndexData, snapshots []Snapshot, id int64) (int, bool) {
 	if index != nil {
 		if i, ok := index.positions[id]; ok {
 			if i >= 0 && i < len(snapshots) && snapshots[i].SnapshotID == id {
-				return i, true, index
+				return i, true
 			}
 
 			index = buildSnapshotIndex(snapshots)
 			if i, ok := index.positions[id]; ok {
-				return i, true, index
+				return i, true
 			}
 
-			return 0, false, index
+			return 0, false
 		}
 	}
 
 	for i := range snapshots {
 		if snapshots[i].SnapshotID == id {
-			return i, true, buildSnapshotIndex(snapshots)
+			return i, true
 		}
 	}
 
-	return 0, false, index
+	return 0, false
 }
 
 // Metadata for an iceberg table as specified in the Iceberg spec
@@ -1304,9 +1303,12 @@ func (b *MetadataBuilder) GetSortOrderByID(id int) (*SortOrder, error) {
 }
 
 func (b *MetadataBuilder) SnapshotByID(id int64) (*Snapshot, error) {
-	b.ensureSnapshotIndex()
-	i, ok, index := snapshotIndexPosition(b.snapshotIndex, b.snapshotList, id)
-	b.snapshotIndex = index
+	index := b.snapshotIndex
+	if snapshotIndexNeedsRebuild(index, b.snapshotList) {
+		index = buildSnapshotIndex(b.snapshotList)
+	}
+
+	i, ok := snapshotIndexPosition(index, b.snapshotList, id)
 	if ok {
 		snapshot := b.snapshotList[i]
 
@@ -2067,7 +2069,7 @@ func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 		index = buildSnapshotIndex(c.SnapshotList)
 	}
 
-	i, ok, _ := snapshotIndexPosition(index, c.SnapshotList, id)
+	i, ok := snapshotIndexPosition(index, c.SnapshotList, id)
 	if ok {
 		return cloneSnapshotPtr(&c.SnapshotList[i])
 	}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -61,6 +61,65 @@ func snapshotIDFromUUID(id uuid.UUID) int64 {
 	return int64(binary.LittleEndian.Uint64(out[:]) & math.MaxInt64)
 }
 
+type snapshotIndexData struct {
+	positions map[int64]int
+	// shared means positions is owned by more than one builder or metadata
+	// value and must be copied before a builder mutates it.
+	shared bool
+}
+
+func buildSnapshotIndex(snapshots []Snapshot) *snapshotIndexData {
+	positions := make(map[int64]int, len(snapshots))
+	for i, snapshot := range snapshots {
+		if _, exists := positions[snapshot.SnapshotID]; !exists {
+			positions[snapshot.SnapshotID] = i
+		}
+	}
+
+	return &snapshotIndexData{positions: positions}
+}
+
+func cloneSnapshotIndex(index *snapshotIndexData) *snapshotIndexData {
+	if index == nil {
+		return nil
+	}
+
+	return &snapshotIndexData{positions: maps.Clone(index.positions)}
+}
+
+func snapshotIndexNeedsRebuild(index *snapshotIndexData, snapshots []Snapshot) bool {
+	return index == nil || len(index.positions) != len(snapshots)
+}
+
+// snapshotIndexPosition returns the position for id and an updated index when
+// callers replace the snapshot slice in an in-package fixture. Metadata loaded
+// or built through the normal paths always has a current index, so the linear
+// scan is only a compatibility fallback.
+func snapshotIndexPosition(index *snapshotIndexData, snapshots []Snapshot, id int64) (int, bool, *snapshotIndexData) {
+	if index != nil {
+		if i, ok := index.positions[id]; ok {
+			if i >= 0 && i < len(snapshots) && snapshots[i].SnapshotID == id {
+				return i, true, index
+			}
+
+			index = buildSnapshotIndex(snapshots)
+			if i, ok := index.positions[id]; ok {
+				return i, true, index
+			}
+
+			return 0, false, index
+		}
+	}
+
+	for i := range snapshots {
+		if snapshots[i].SnapshotID == id {
+			return i, true, buildSnapshotIndex(snapshots)
+		}
+	}
+
+	return 0, false, index
+}
+
 // Metadata for an iceberg table as specified in the Iceberg spec
 //
 // https://iceberg.apache.org/spec/#iceberg-table-spec
@@ -182,6 +241,7 @@ type MetadataBuilder struct {
 	lastPartitionID    *int
 	props              iceberg.Properties
 	snapshotList       []Snapshot
+	snapshotIndex      *snapshotIndexData // Derived from snapshotList; not serialized.
 	currentSnapshotID  *int64
 	snapshotLog        []SnapshotLogEntry
 	metadataLog        []MetadataLogEntry
@@ -214,6 +274,7 @@ func NewMetadataBuilder(formatVersion int) (*MetadataBuilder, error) {
 		specs:              make([]iceberg.PartitionSpec, 0),
 		props:              make(iceberg.Properties),
 		snapshotList:       make([]Snapshot, 0),
+		snapshotIndex:      buildSnapshotIndex(nil),
 		snapshotLog:        make([]SnapshotLogEntry, 0),
 		metadataLog:        make([]MetadataLogEntry, 0),
 		sortOrderList:      make([]SortOrder, 0),
@@ -252,6 +313,7 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 	b.lastPartitionID = metadata.LastPartitionSpecID()
 	b.props = maps.Clone(metadata.Properties())
 	b.snapshotList = slices.Clone(metadata.Snapshots())
+	b.snapshotIndex = buildSnapshotIndex(b.snapshotList)
 	b.sortOrderList = slices.Clone(metadata.SortOrders())
 	b.defaultSortOrderID = metadata.DefaultSortOrder()
 	if metadata.Version() > 1 {
@@ -319,6 +381,7 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 		lastPartitionID:      clonePtr(b.lastPartitionID),
 		props:                maps.Clone(b.props),
 		snapshotList:         slices.Clone(b.snapshotList),
+		snapshotIndex:        b.snapshotIndex,
 		currentSnapshotID:    clonePtr(b.currentSnapshotID),
 		snapshotLog:          slices.Clone(b.snapshotLog),
 		metadataLog:          slices.Clone(b.metadataLog),
@@ -334,6 +397,9 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 		lastAddedSchemaID:    clonePtr(b.lastAddedSchemaID),
 		lastAddedPartitionID: clonePtr(b.lastAddedPartitionID),
 		lastAddedSortOrderID: clonePtr(b.lastAddedSortOrderID),
+	}
+	if b.snapshotIndex != nil {
+		b.snapshotIndex.shared = true
 	}
 
 	return cloned
@@ -370,12 +436,27 @@ func (b *MetadataBuilder) nextSequenceNumber() int64 {
 }
 
 func (b *MetadataBuilder) newSnapshotID() int64 {
-	snapshotID := generateSnapshotID()
-	for slices.ContainsFunc(b.snapshotList, func(s Snapshot) bool { return s.SnapshotID == snapshotID }) {
-		snapshotID = generateSnapshotID()
-	}
+	b.ensureSnapshotIndex()
 
-	return snapshotID
+	for {
+		snapshotID := generateSnapshotID()
+		if _, exists := b.snapshotIndex.positions[snapshotID]; !exists {
+			return snapshotID
+		}
+	}
+}
+
+func (b *MetadataBuilder) ensureSnapshotIndex() {
+	if snapshotIndexNeedsRebuild(b.snapshotIndex, b.snapshotList) {
+		b.snapshotIndex = buildSnapshotIndex(b.snapshotList)
+	}
+}
+
+func (b *MetadataBuilder) ensureSnapshotIndexMutable() {
+	b.ensureSnapshotIndex()
+	if b.snapshotIndex.shared {
+		b.snapshotIndex = cloneSnapshotIndex(b.snapshotIndex)
+	}
 }
 
 func (b *MetadataBuilder) currentSnapshot() *Snapshot {
@@ -572,7 +653,9 @@ func (b *MetadataBuilder) addSnapshotInternal(snapshot *Snapshot, preserveUpdate
 	b.updates = append(b.updates, upd)
 	b.lastUpdatedMS = snapshot.TimestampMs
 	b.lastSequenceNumber = &snapshot.SequenceNumber
+	b.ensureSnapshotIndexMutable()
 	b.snapshotList = append(b.snapshotList, *snapshot)
+	b.snapshotIndex.positions[snapshot.SnapshotID] = len(b.snapshotList) - 1
 
 	return nil
 }
@@ -655,11 +738,15 @@ func (b *MetadataBuilder) RemoveSnapshots(snapshotIds []int64, postCommit bool) 
 		}
 	}
 
+	previousSnapshotCount := len(b.snapshotList)
 	b.snapshotList = slices.DeleteFunc(b.snapshotList, func(e Snapshot) bool {
 		_, ok := removedIDs[e.SnapshotID]
 
 		return ok
 	})
+	if len(b.snapshotList) != previousSnapshotCount {
+		b.snapshotIndex = buildSnapshotIndex(b.snapshotList)
+	}
 	// Snapshot-log pruning is deferred to updateSnapshotLog during Build so
 	// removed entries remain available when trimming history gaps.
 
@@ -1087,6 +1174,11 @@ func (b *MetadataBuilder) SetLastUpdatedMS() *MetadataBuilder {
 }
 
 func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
+	b.ensureSnapshotIndex()
+	if b.snapshotIndex != nil {
+		b.snapshotIndex.shared = true
+	}
+
 	if _, err := b.GetSpecByID(b.defaultSpecID); err != nil {
 		return nil, fmt.Errorf("%w: defaultSpecID is invalid: %w", ErrInvalidMetadata, err)
 	}
@@ -1121,6 +1213,7 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 		LastPartitionID:    b.lastPartitionID,
 		Props:              b.props,
 		SnapshotList:       b.snapshotList,
+		snapshotIndex:      b.snapshotIndex,
 		CurrentSnapshotID:  b.currentSnapshotID,
 		SnapshotLog:        b.snapshotLog,
 		MetadataLog:        b.metadataLog,
@@ -1211,10 +1304,13 @@ func (b *MetadataBuilder) GetSortOrderByID(id int) (*SortOrder, error) {
 }
 
 func (b *MetadataBuilder) SnapshotByID(id int64) (*Snapshot, error) {
-	for _, s := range b.snapshotList {
-		if s.SnapshotID == id {
-			return &s, nil
-		}
+	b.ensureSnapshotIndex()
+	i, ok, index := snapshotIndexPosition(b.snapshotIndex, b.snapshotList, id)
+	b.snapshotIndex = index
+	if ok {
+		snapshot := b.snapshotList[i]
+
+		return &snapshot, nil
 	}
 
 	return nil, fmt.Errorf("%w: id %d", ErrSnapshotNotFound, id)
@@ -1777,6 +1873,8 @@ type commonMetadata struct {
 	LastSequenceNumber *int64 `json:"last-sequence-number,omitempty"`
 	// V3+ fields
 	NextRowID *int64 `json:"next-row-id,omitempty"` // V3: Next available row ID
+
+	snapshotIndex *snapshotIndexData
 }
 
 func initCommonMetadataForDeserialization() commonMetadata {
@@ -1964,10 +2062,14 @@ func (c *commonMetadata) Snapshots() []Snapshot {
 }
 
 func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
-	for i := range c.SnapshotList {
-		if c.SnapshotList[i].SnapshotID == id {
-			return cloneSnapshotPtr(&c.SnapshotList[i])
-		}
+	if snapshotIndexNeedsRebuild(c.snapshotIndex, c.SnapshotList) {
+		c.snapshotIndex = buildSnapshotIndex(c.SnapshotList)
+	}
+
+	i, ok, index := snapshotIndexPosition(c.snapshotIndex, c.SnapshotList, id)
+	c.snapshotIndex = index
+	if ok {
+		return cloneSnapshotPtr(&c.SnapshotList[i])
 	}
 
 	return nil
@@ -2310,6 +2412,8 @@ func (c *commonMetadata) preValidate() {
 	if c.SnapshotLog == nil {
 		c.SnapshotLog = []SnapshotLogEntry{}
 	}
+
+	c.snapshotIndex = buildSnapshotIndex(c.SnapshotList)
 }
 
 func (c *commonMetadata) checkSchemas() error {

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var removeSnapshotsBenchmarkSink int
+var metadataBuilderBenchmarkSink int
 
 var removeSnapshotsBenchmarkCases = []struct {
 	snapshotCount int
@@ -95,6 +96,27 @@ func BenchmarkRemoveSnapshotsBuild(b *testing.B) {
 				b.StopTimer()
 				removeSnapshotsBenchmarkSink = len(builder.snapshotLog)
 				b.StartTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkMetadataBuilderCloneAndBuild(b *testing.B) {
+	for _, snapshotCount := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {
+			template := benchmarkSnapshotBuilder(snapshotCount)
+			template.ensureSnapshotIndex()
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries")
+			b.ResetTimer()
+
+			for range b.N {
+				builder := template.clone()
+				if _, err := builder.Build(); err != nil {
+					b.Fatal(err)
+				}
+				metadataBuilderBenchmarkSink = len(builder.snapshotIndex.positions)
 			}
 		})
 	}

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -23,8 +23,10 @@ import (
 	"testing"
 )
 
-var removeSnapshotsBenchmarkSink int
-var metadataBuilderBenchmarkSink int
+var (
+	removeSnapshotsBenchmarkSink int
+	metadataBuilderBenchmarkSink int
+)
 
 var removeSnapshotsBenchmarkCases = []struct {
 	snapshotCount int

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -122,6 +122,31 @@ func BenchmarkMetadataBuilderCloneAndBuild(b *testing.B) {
 	}
 }
 
+func BenchmarkMetadataBuilderFromBase(b *testing.B) {
+	for _, snapshotCount := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {
+			source := benchmarkSnapshotBuilder(snapshotCount)
+			source.ensureSnapshotIndex()
+			metadata, err := source.Build()
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries")
+			b.ResetTimer()
+
+			for range b.N {
+				builder, err := MetadataBuilderFromBase(metadata, "")
+				if err != nil {
+					b.Fatal(err)
+				}
+				metadataBuilderBenchmarkSink = len(builder.snapshotIndex.positions)
+			}
+		})
+	}
+}
+
 func benchmarkSnapshotLog(snapshotCount int) []SnapshotLogEntry {
 	log := make([]SnapshotLogEntry, snapshotCount)
 	for i := range log {

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -3446,7 +3446,7 @@ func TestSetFormatVersionV2ToV3FromDeserializedMetadata(t *testing.T) {
 // both the drift guard and its filler consult it.
 var sharedCloneFields = map[string]struct{}{
 	"base":          {}, // immutable snapshot, shared by design.
-	"snapshotIndex": {}, // immutable index state, copied on snapshot mutation.
+	"snapshotIndex": {}, // immutable index positions, copied on snapshot mutation.
 }
 
 // TestMetadataBuilderCloneCoversAllFields guards clone() against field drift:

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -3445,7 +3445,8 @@ func TestSetFormatVersionV2ToV3FromDeserializedMetadata(t *testing.T) {
 // shares with the original instead of copying. Keep this in sync with clone();
 // both the drift guard and its filler consult it.
 var sharedCloneFields = map[string]struct{}{
-	"base": {}, // immutable snapshot, shared by design.
+	"base":          {}, // immutable snapshot, shared by design.
+	"snapshotIndex": {}, // immutable index state, copied on snapshot mutation.
 }
 
 // TestMetadataBuilderCloneCoversAllFields guards clone() against field drift:

--- a/table/snapshot_index_bench_test.go
+++ b/table/snapshot_index_bench_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import "testing"
+
+var snapshotLookupBenchmarkSink int64
+
+func BenchmarkSnapshotByID(b *testing.B) {
+	const snapshotCount = 10_000
+
+	snapshots := make([]Snapshot, snapshotCount)
+	for i := range snapshots {
+		snapshots[i].SnapshotID = int64(i)
+	}
+
+	metadata := commonMetadata{SnapshotList: snapshots}
+	metadata.SnapshotByID(int64(snapshotCount - 1))
+
+	b.Run("indexed", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(snapshotCount, "snapshots")
+		b.ResetTimer()
+		for range b.N {
+			snapshotLookupBenchmarkSink = metadata.SnapshotByID(int64(snapshotCount - 1)).SnapshotID
+		}
+	})
+
+	b.Run("linear", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(snapshotCount, "snapshots")
+		b.ResetTimer()
+		for range b.N {
+			snapshotLookupBenchmarkSink = linearSnapshotByID(snapshots, int64(snapshotCount-1)).SnapshotID
+		}
+	})
+}
+
+func linearSnapshotByID(snapshots []Snapshot, id int64) *Snapshot {
+	for i := range snapshots {
+		if snapshots[i].SnapshotID == id {
+			return cloneSnapshotPtr(&snapshots[i])
+		}
+	}
+
+	return nil
+}

--- a/table/snapshot_index_bench_test.go
+++ b/table/snapshot_index_bench_test.go
@@ -43,12 +43,36 @@ func BenchmarkSnapshotByID(b *testing.B) {
 		}
 	})
 
+	b.Run("indexed-miss", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(snapshotCount, "snapshots")
+		b.ResetTimer()
+		for range b.N {
+			snapshotLookupBenchmarkSink = 0
+			if metadata.SnapshotByID(-1) != nil {
+				snapshotLookupBenchmarkSink = 1
+			}
+		}
+	})
+
 	b.Run("linear", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ReportMetric(snapshotCount, "snapshots")
 		b.ResetTimer()
 		for range b.N {
 			snapshotLookupBenchmarkSink = linearSnapshotByID(snapshots, int64(snapshotCount-1)).SnapshotID
+		}
+	})
+
+	b.Run("linear-miss", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(snapshotCount, "snapshots")
+		b.ResetTimer()
+		for range b.N {
+			snapshotLookupBenchmarkSink = 0
+			if linearSnapshotByID(snapshots, -1) != nil {
+				snapshotLookupBenchmarkSink = 1
+			}
 		}
 	})
 }

--- a/table/snapshot_index_bench_test.go
+++ b/table/snapshot_index_bench_test.go
@@ -29,8 +29,10 @@ func BenchmarkSnapshotByID(b *testing.B) {
 		snapshots[i].SnapshotID = int64(i)
 	}
 
-	metadata := commonMetadata{SnapshotList: snapshots}
-	metadata.SnapshotByID(int64(snapshotCount - 1))
+	metadata := commonMetadata{
+		SnapshotList:  snapshots,
+		snapshotIndex: buildSnapshotIndex(snapshots),
+	}
 
 	b.Run("indexed", func(b *testing.B) {
 		b.ReportAllocs()

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -25,14 +25,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {
+func TestSnapshotByIDUsesReadOnlyFallbackAfterSliceReplacement(t *testing.T) {
 	metadata := commonMetadata{
 		SnapshotList: []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}},
 	}
+	metadata.snapshotIndex = buildSnapshotIndex(metadata.SnapshotList)
+	originalIndex := metadata.snapshotIndex
 
 	snapshot := metadata.SnapshotByID(2)
 	require.NotNil(t, snapshot)
 	require.Equal(t, int64(2), snapshot.SnapshotID)
+	require.Same(t, originalIndex, metadata.snapshotIndex)
 
 	// Keep the slice length unchanged so the lookup must validate the cached
 	// position instead of relying only on ensureSnapshotIndex.
@@ -41,15 +44,15 @@ func TestSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {
 	snapshot = metadata.SnapshotByID(4)
 	require.NotNil(t, snapshot)
 	require.Equal(t, int64(4), snapshot.SnapshotID)
-	require.Equal(t, 1, metadata.snapshotIndex.positions[4])
+	require.Same(t, originalIndex, metadata.snapshotIndex)
 	require.Nil(t, metadata.SnapshotByID(2))
-	require.NotContains(t, metadata.snapshotIndex.positions, int64(2))
+	require.Equal(t, map[int64]int{1: 0, 2: 1}, metadata.snapshotIndex.positions)
 
 	metadata.SnapshotList = []Snapshot{{SnapshotID: 5}}
 	snapshot = metadata.SnapshotByID(5)
 	require.NotNil(t, snapshot)
 	require.Equal(t, int64(5), snapshot.SnapshotID)
-	require.Equal(t, map[int64]int{5: 0}, metadata.snapshotIndex.positions)
+	require.Same(t, originalIndex, metadata.snapshotIndex)
 }
 
 func TestMetadataBuilderSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -155,4 +156,51 @@ func TestMetadataBuilderCloneSharesSnapshotIndexUntilSnapshotMutation(t *testing
 	require.NotSame(t, builder.snapshotIndex, cloned.snapshotIndex)
 	require.NotContains(t, builder.snapshotIndex.positions, second.SnapshotID)
 	require.Equal(t, 1, cloned.snapshotIndex.positions[second.SnapshotID])
+}
+
+func TestCommonMetadataSnapshotLookupsConcurrent(t *testing.T) {
+	currentSnapshotID := int64(2)
+	metadata := &commonMetadata{
+		SnapshotList:      []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}},
+		CurrentSnapshotID: &currentSnapshotID,
+		SnapshotRefs: map[string]SnapshotRef{
+			MainBranch: {SnapshotID: currentSnapshotID, SnapshotRefType: BranchRef},
+		},
+	}
+	metadata.snapshotIndex = buildSnapshotIndex(metadata.SnapshotList)
+
+	const (
+		goroutineCount = 8
+		lookupCount    = 100
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+	for i := range goroutineCount {
+		go func(i int) {
+			defer wg.Done()
+
+			for range lookupCount {
+				var snapshot *Snapshot
+				var expectedID int64
+				switch i % 3 {
+				case 0:
+					snapshot = metadata.SnapshotByID(1)
+					expectedID = 1
+				case 1:
+					snapshot = metadata.SnapshotByName(MainBranch)
+					expectedID = currentSnapshotID
+				default:
+					snapshot = metadata.CurrentSnapshot()
+					expectedID = currentSnapshotID
+				}
+
+				if snapshot == nil || snapshot.SnapshotID != expectedID {
+					t.Errorf("expected snapshot %d, got %v", expectedID, snapshot)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -154,7 +154,8 @@ func TestMetadataBuilderCloneSharesSnapshotIndexUntilSnapshotMutation(t *testing
 	require.NoError(t, builder.AddSnapshot(&first))
 
 	cloned := builder.clone()
-	require.Same(t, builder.snapshotIndex, cloned.snapshotIndex)
+	require.NotSame(t, builder.snapshotIndex, cloned.snapshotIndex)
+	require.Equal(t, builder.snapshotIndex.positions, cloned.snapshotIndex.positions)
 
 	second := freshBuilderSnapshot(2, &first.SnapshotID, 1, baseTimestamp+2)
 	require.NoError(t, cloned.AddSnapshot(&second))

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {
+	metadata := commonMetadata{
+		SnapshotList: []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}},
+	}
+
+	snapshot := metadata.SnapshotByID(2)
+	require.NotNil(t, snapshot)
+	require.Equal(t, int64(2), snapshot.SnapshotID)
+
+	// Keep the slice length unchanged so the lookup must validate the cached
+	// position instead of relying only on ensureSnapshotIndex.
+	metadata.SnapshotList = []Snapshot{{SnapshotID: 3}, {SnapshotID: 4}}
+
+	snapshot = metadata.SnapshotByID(4)
+	require.NotNil(t, snapshot)
+	require.Equal(t, int64(4), snapshot.SnapshotID)
+	require.Equal(t, 1, metadata.snapshotIndex.positions[4])
+	require.Nil(t, metadata.SnapshotByID(2))
+	require.NotContains(t, metadata.snapshotIndex.positions, int64(2))
+
+	metadata.SnapshotList = []Snapshot{{SnapshotID: 5}}
+	snapshot = metadata.SnapshotByID(5)
+	require.NotNil(t, snapshot)
+	require.Equal(t, int64(5), snapshot.SnapshotID)
+	require.Equal(t, map[int64]int{5: 0}, metadata.snapshotIndex.positions)
+}
+
+func TestMetadataBuilderSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	builder.snapshotList = []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}}
+	builder.snapshotIndex = buildSnapshotIndex(builder.snapshotList)
+
+	// Package-level fixtures can replace the snapshot slice directly. The
+	// cached index still has the same length, so the lookup must fall back.
+	builder.snapshotList = []Snapshot{{SnapshotID: 3}, {SnapshotID: 4}}
+
+	snapshot, err := builder.SnapshotByID(4)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), snapshot.SnapshotID)
+	require.Equal(t, 1, builder.snapshotIndex.positions[4])
+	_, err = builder.SnapshotByID(2)
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+	require.NotContains(t, builder.snapshotIndex.positions, int64(2))
+}
+
+func TestMetadataBuilderSnapshotIndexFollowsUpdates(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	baseTimestamp := builder.base.LastUpdatedMillis()
+	parentID := int64(1)
+
+	first := Snapshot{SnapshotID: 1, TimestampMs: baseTimestamp + 1}
+	second := Snapshot{SnapshotID: 2, ParentSnapshotID: &parentID, SequenceNumber: 1, TimestampMs: baseTimestamp + 2}
+	require.NoError(t, builder.AddSnapshot(&first))
+	require.NoError(t, builder.AddSnapshot(&second))
+
+	snapshot, err := builder.SnapshotByID(second.SnapshotID)
+	require.NoError(t, err)
+	require.Equal(t, second.SnapshotID, snapshot.SnapshotID)
+
+	require.NoError(t, builder.RemoveSnapshots([]int64{first.SnapshotID}, false))
+	require.NotContains(t, builder.snapshotIndex.positions, first.SnapshotID)
+	require.Equal(t, 0, builder.snapshotIndex.positions[second.SnapshotID])
+	_, err = builder.SnapshotByID(first.SnapshotID)
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+	snapshot, err = builder.SnapshotByID(second.SnapshotID)
+	require.NoError(t, err)
+	require.Equal(t, second.SnapshotID, snapshot.SnapshotID)
+}
+
+func TestMetadataBuilderFromBaseBuildsSnapshotIndex(t *testing.T) {
+	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+	require.Len(t, builder.snapshotIndex.positions, len(builder.snapshotList))
+
+	id := builder.snapshotList[len(builder.snapshotList)-1].SnapshotID
+	snapshot, err := builder.SnapshotByID(id)
+	require.NoError(t, err)
+	require.Equal(t, id, snapshot.SnapshotID)
+}
+
+func TestMetadataBuilderBuildIncludesSnapshotIndex(t *testing.T) {
+	builder := freshMetadataBuilder(t, 2)
+	snapshot := freshBuilderSnapshot(1, nil, 0, time.Now().UnixMilli())
+	require.NoError(t, builder.AddSnapshot(&snapshot))
+
+	metadata, err := builder.Build()
+	require.NoError(t, err)
+	require.Same(t, builder.snapshotIndex, metadataCommon(metadata).snapshotIndex)
+
+	found := metadata.SnapshotByID(snapshot.SnapshotID)
+	require.NotNil(t, found)
+	require.Equal(t, snapshot.SnapshotID, found.SnapshotID)
+}
+
+func TestMetadataDecodeBuildsSnapshotIndex(t *testing.T) {
+	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	common := metadataCommon(metadata)
+	require.Len(t, common.snapshotIndex.positions, len(common.SnapshotList))
+	for i, snapshot := range common.SnapshotList {
+		require.Equal(t, i, common.snapshotIndex.positions[snapshot.SnapshotID])
+	}
+}
+
+func TestMetadataBuilderCloneSharesSnapshotIndexUntilSnapshotMutation(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	baseTimestamp := builder.base.LastUpdatedMillis()
+	first := freshBuilderSnapshot(1, nil, 0, baseTimestamp+1)
+	require.NoError(t, builder.AddSnapshot(&first))
+
+	cloned := builder.clone()
+	require.Same(t, builder.snapshotIndex, cloned.snapshotIndex)
+
+	second := freshBuilderSnapshot(2, &first.SnapshotID, 1, baseTimestamp+2)
+	require.NoError(t, cloned.AddSnapshot(&second))
+
+	require.NotSame(t, builder.snapshotIndex, cloned.snapshotIndex)
+	require.NotContains(t, builder.snapshotIndex.positions, second.SnapshotID)
+	require.Equal(t, 1, cloned.snapshotIndex.positions[second.SnapshotID])
+}

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -200,6 +200,7 @@ func TestCommonMetadataSnapshotLookupsConcurrent(t *testing.T) {
 
 				if snapshot == nil || snapshot.SnapshotID != expectedID {
 					t.Errorf("expected snapshot %d, got %v", expectedID, snapshot)
+
 					return
 				}
 			}

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -55,10 +55,11 @@ func TestSnapshotByIDUsesReadOnlyFallbackAfterSliceReplacement(t *testing.T) {
 	require.Same(t, originalIndex, metadata.snapshotIndex)
 }
 
-func TestMetadataBuilderSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *testing.T) {
+func TestMetadataBuilderSnapshotByIDUsesReadOnlyFallbackAfterSliceReplacement(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	builder.snapshotList = []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}}
 	builder.snapshotIndex = buildSnapshotIndex(builder.snapshotList)
+	originalIndex := builder.snapshotIndex
 
 	// Package-level fixtures can replace the snapshot slice directly. The
 	// cached index still has the same length, so the lookup must fall back.
@@ -67,10 +68,12 @@ func TestMetadataBuilderSnapshotByIDRepairsStaleIndexAfterSliceReplacement(t *te
 	snapshot, err := builder.SnapshotByID(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), snapshot.SnapshotID)
-	require.Equal(t, 1, builder.snapshotIndex.positions[4])
+	require.Same(t, originalIndex, builder.snapshotIndex)
+	require.Equal(t, map[int64]int{1: 0, 2: 1}, builder.snapshotIndex.positions)
 	_, err = builder.SnapshotByID(2)
 	require.ErrorIs(t, err, ErrSnapshotNotFound)
-	require.NotContains(t, builder.snapshotIndex.positions, int64(2))
+	require.Same(t, originalIndex, builder.snapshotIndex)
+	require.Equal(t, map[int64]int{1: 0, 2: 1}, builder.snapshotIndex.positions)
 }
 
 func TestMetadataBuilderSnapshotIndexFollowsUpdates(t *testing.T) {
@@ -205,6 +208,35 @@ func TestCommonMetadataSnapshotLookupsConcurrent(t *testing.T) {
 				}
 			}
 		}(i)
+	}
+	wg.Wait()
+}
+
+func TestMetadataBuilderSnapshotByIDConcurrent(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	builder.snapshotList = []Snapshot{{SnapshotID: 1}, {SnapshotID: 2}}
+	builder.snapshotIndex = buildSnapshotIndex(builder.snapshotList)
+
+	const (
+		goroutineCount = 8
+		lookupCount    = 100
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+	for range goroutineCount {
+		go func() {
+			defer wg.Done()
+
+			for range lookupCount {
+				snapshot, err := builder.SnapshotByID(2)
+				if err != nil || snapshot == nil || snapshot.SnapshotID != 2 {
+					t.Errorf("expected snapshot 2, got snapshot=%v err=%v", snapshot, err)
+
+					return
+				}
+			}
+		}()
 	}
 	wg.Wait()
 }

--- a/table/snapshot_index_test.go
+++ b/table/snapshot_index_test.go
@@ -119,6 +119,14 @@ func TestMetadataBuilderBuildIncludesSnapshotIndex(t *testing.T) {
 	found := metadata.SnapshotByID(snapshot.SnapshotID)
 	require.NotNil(t, found)
 	require.Equal(t, snapshot.SnapshotID, found.SnapshotID)
+
+	parentID := snapshot.SnapshotID
+	next := freshBuilderSnapshot(2, &parentID, 1, snapshot.TimestampMs+1)
+	require.NoError(t, builder.AddSnapshot(&next))
+	require.Nil(t, metadata.SnapshotByID(next.SnapshotID))
+	found, err = builder.SnapshotByID(next.SnapshotID)
+	require.NoError(t, err)
+	require.Equal(t, next.SnapshotID, found.SnapshotID)
 }
 
 func TestMetadataDecodeBuildsSnapshotIndex(t *testing.T) {


### PR DESCRIPTION
## Summary

- Index snapshot IDs in table metadata and metadata builders.
- Keep the index in sync when snapshots are added or removed.
- Keep a safe fallback for package-level fixtures that replace the snapshot slice.
- Add regression coverage and a lookup benchmark.

## Performance

Snapshot lookup is roughly 150x faster in the 10,000-snapshot benchmark on an Apple M1 Pro.

| Approach | Result | Relative speed |
| --- | ---: | ---: |
| Indexed lookup | 49 ns/op | ~150x faster |
| Linear scan | 7.8 us/op | Baseline |

This keeps the existing defensive copy behavior for returned snapshots.

## Validation

- go test ./table
- go test -race ./table/...
- go vet ./table
- repository-wide tests for the remaining packages