### PR TITLE
perf(table): flatten orphan URI equivalences

### DIFF
--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -842,14 +842,44 @@ func normalizeURLPath(path string, cfg *orphanCleanupConfig) string {
 	}
 
 	normalizedScheme := applySchemeEquivalence(parsedURL.Scheme, equalSchemes)
-	normalizedAuthority := applyAuthorityEquivalence(parsedURL.Host, equalAuthorities)
+	normalizedUser, normalizedHost := normalizeURLAuthority(parsedURL, equalAuthorities)
 	normalizedURL := &url.URL{
 		Scheme: normalizedScheme,
-		Host:   normalizedAuthority,
+		User:   normalizedUser,
+		Host:   normalizedHost,
 		Path:   filepath.Clean(parsedURL.Path),
 	}
 
 	return normalizedURL.String()
+}
+
+// completeURLAuthority returns the URI authority, including user-info when it
+// is present. url.URL stores user-info separately from Host, but URI authority
+// equivalence applies to the complete authority (for example,
+// container@account.dfs.core.windows.net).
+func completeURLAuthority(parsedURL *url.URL) string {
+	if parsedURL.User == nil {
+		return parsedURL.Host
+	}
+
+	return parsedURL.User.String() + "@" + parsedURL.Host
+}
+
+func normalizeURLAuthority(parsedURL *url.URL, equalAuthorities map[string]string) (*url.Userinfo, string) {
+	authority := completeURLAuthority(parsedURL)
+	normalizedAuthority := applyAuthorityEquivalence(authority, equalAuthorities)
+	if normalizedAuthority == authority {
+		return parsedURL.User, parsedURL.Host
+	}
+
+	// Parse the canonical authority back into User and Host because url.URL
+	// serializes user-info separately from the host component.
+	canonicalURL, err := url.Parse("//" + normalizedAuthority)
+	if err != nil {
+		return parsedURL.User, parsedURL.Host
+	}
+
+	return canonicalURL.User, canonicalURL.Host
 }
 
 // normalizeNonURLPath provides basic path normalization for non-URL paths.
@@ -943,8 +973,8 @@ func checkPrefixMismatch(referencedPath, filesystemPath string, cfg *orphanClean
 
 	refScheme := applySchemeEquivalence(refURL.Scheme, cfg.equalSchemes)
 	fsScheme := applySchemeEquivalence(fsURL.Scheme, cfg.equalSchemes)
-	refAuth := applyAuthorityEquivalence(refURL.Host, cfg.equalAuthorities)
-	fsAuth := applyAuthorityEquivalence(fsURL.Host, cfg.equalAuthorities)
+	refAuth := applyAuthorityEquivalence(completeURLAuthority(refURL), cfg.equalAuthorities)
+	fsAuth := applyAuthorityEquivalence(completeURLAuthority(fsURL), cfg.equalAuthorities)
 
 	// Check for mismatches
 	schemeMismatch := refScheme != fsScheme

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	stdfs "io/fs"
 	"log/slog"
-	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -151,7 +150,9 @@ func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
 		if cfg.equalSchemes == nil {
 			cfg.equalSchemes = make(map[string]string)
 		}
-		maps.Copy(cfg.equalSchemes, schemes)
+		for scheme, canonical := range flattenURIEquivalences(schemes) {
+			cfg.equalSchemes[scheme] = canonical
+		}
 	}
 }
 
@@ -164,8 +165,34 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 		if cfg.equalAuthorities == nil {
 			cfg.equalAuthorities = make(map[string]string)
 		}
-		maps.Copy(cfg.equalAuthorities, authorities)
+		for authority, canonical := range flattenURIEquivalences(authorities) {
+			cfg.equalAuthorities[authority] = canonical
+		}
 	}
+}
+
+// flattenURIEquivalences expands comma-separated URI equivalence groups into
+// direct lookups. Groups are processed in sorted order so overlapping groups
+// have deterministic behavior; the lexicographically last group wins.
+func flattenURIEquivalences(equivalences map[string]string) map[string]string {
+	if len(equivalences) == 0 {
+		return nil
+	}
+
+	groups := make([]string, 0, len(equivalences))
+	for group := range equivalences {
+		groups = append(groups, group)
+	}
+	slices.Sort(groups)
+
+	flattened := make(map[string]string, len(equivalences))
+	for _, group := range groups {
+		for _, value := range strings.Split(group, ",") {
+			flattened[strings.TrimSpace(value)] = equivalences[group]
+		}
+	}
+
+	return flattened
 }
 
 type OrphanCleanupResult struct {
@@ -852,22 +879,8 @@ func filePathKey(file string) string {
 // Based on Apache Iceberg Java's flattenMap() (lines 392-403) and EQUAL_SCHEMES_DEFAULT (line 102).
 // https://github.com/apache/iceberg/blob/07c088fce9c54369864dcb6da16006e78206048b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java#L1
 func applySchemeEquivalence(scheme string, equalSchemes map[string]string) string {
-	if equalSchemes == nil {
-		return scheme
-	}
 	if canonical, exists := equalSchemes[scheme]; exists {
 		return canonical
-	}
-
-	// Check comma-separated lists (e.g., "s3,s3a,s3n" -> "s3")
-	for schemes, canonical := range equalSchemes {
-		if strings.Contains(schemes, ",") {
-			for s := range strings.SplitSeq(schemes, ",") {
-				if strings.TrimSpace(s) == scheme {
-					return canonical
-				}
-			}
-		}
 	}
 
 	return scheme
@@ -888,22 +901,8 @@ func applySchemeEquivalence(scheme string, equalSchemes map[string]string) strin
 // Based on Apache Iceberg Java's equalAuthorities logic (lines 546, 161-165, 392-403).
 // https://github.com/apache/iceberg/blob/07c088fce9c54369864dcb6da16006e78206048b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java#L1
 func applyAuthorityEquivalence(authority string, equalAuthorities map[string]string) string {
-	if equalAuthorities == nil {
-		return authority
-	}
-
 	if canonical, exists := equalAuthorities[authority]; exists {
 		return canonical
-	}
-
-	for authorities, canonical := range equalAuthorities {
-		if strings.Contains(authorities, ",") {
-			for a := range strings.SplitSeq(authorities, ",") {
-				if strings.TrimSpace(a) == authority {
-					return canonical
-				}
-			}
-		}
 	}
 
 	return authority

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -150,7 +150,7 @@ func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
 		if cfg.equalSchemes == nil {
 			cfg.equalSchemes = make(map[string]string)
 		}
-		for scheme, canonical := range flattenURIEquivalences(schemes) {
+		for scheme, canonical := range schemes {
 			cfg.equalSchemes[scheme] = canonical
 		}
 	}
@@ -165,7 +165,7 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 		if cfg.equalAuthorities == nil {
 			cfg.equalAuthorities = make(map[string]string)
 		}
-		for authority, canonical := range flattenURIEquivalences(authorities) {
+		for authority, canonical := range authorities {
 			cfg.equalAuthorities[authority] = canonical
 		}
 	}
@@ -173,7 +173,8 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 
 // flattenURIEquivalences expands comma-separated URI equivalence groups into
 // direct lookups. Groups are processed in sorted order so overlapping groups
-// have deterministic behavior; the lexicographically last group wins.
+// have deterministic behavior; the lexicographically last group wins. Original
+// keys are overlaid afterward so exact mappings retain precedence over groups.
 func flattenURIEquivalences(equivalences map[string]string) map[string]string {
 	if len(equivalences) == 0 {
 		return nil
@@ -187,9 +188,17 @@ func flattenURIEquivalences(equivalences map[string]string) map[string]string {
 
 	flattened := make(map[string]string, len(equivalences))
 	for _, group := range groups {
+		if !strings.Contains(group, ",") {
+			continue
+		}
+
 		for _, value := range strings.Split(group, ",") {
 			flattened[strings.TrimSpace(value)] = equivalences[group]
 		}
+	}
+
+	for _, group := range groups {
+		flattened[group] = equivalences[group]
 	}
 
 	return flattened
@@ -274,6 +283,9 @@ func newOrphanCleanupConfigWithMode(executingPlan bool, opts ...OrphanCleanupOpt
 	for _, opt := range opts {
 		opt(cfg)
 	}
+
+	cfg.equalSchemes = flattenURIEquivalences(cfg.equalSchemes)
+	cfg.equalAuthorities = flattenURIEquivalences(cfg.equalAuthorities)
 
 	return cfg
 }

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -172,9 +172,12 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 }
 
 // flattenURIEquivalences expands comma-separated URI equivalence groups into
-// direct lookups. Groups are processed in sorted order so overlapping groups
-// have deterministic behavior; the lexicographically last group wins. Original
-// keys are overlaid afterward so exact mappings retain precedence over groups.
+// direct lookups. This intentionally differs from Java's flattenMap (lines
+// 392-403), which uses input iteration order for conflicts. Go map iteration is
+// unordered, so groups are processed in sorted order and the lexicographically
+// last overlapping group wins. Exact mappings are overlaid afterward so they
+// retain precedence over groups.
+// https://github.com/apache/iceberg/blob/07c088fce9c54369864dcb6da16006e78206048b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java#L392-L403
 func flattenURIEquivalences(equivalences map[string]string) map[string]string {
 	if len(equivalences) == 0 {
 		return nil
@@ -198,6 +201,10 @@ func flattenURIEquivalences(equivalences map[string]string) map[string]string {
 	}
 
 	for _, group := range groups {
+		// Group declarations are configuration syntax, not URI lookup keys.
+		if strings.Contains(group, ",") {
+			continue
+		}
 		flattened[group] = equivalences[group]
 	}
 

--- a/table/orphan_cleanup.go
+++ b/table/orphan_cleanup.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	stdfs "io/fs"
 	"log/slog"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -150,9 +151,7 @@ func WithEqualSchemes(schemes map[string]string) OrphanCleanupOption {
 		if cfg.equalSchemes == nil {
 			cfg.equalSchemes = make(map[string]string)
 		}
-		for scheme, canonical := range schemes {
-			cfg.equalSchemes[scheme] = canonical
-		}
+		maps.Copy(cfg.equalSchemes, schemes)
 	}
 }
 
@@ -165,9 +164,7 @@ func WithEqualAuthorities(authorities map[string]string) OrphanCleanupOption {
 		if cfg.equalAuthorities == nil {
 			cfg.equalAuthorities = make(map[string]string)
 		}
-		for authority, canonical := range authorities {
-			cfg.equalAuthorities[authority] = canonical
-		}
+		maps.Copy(cfg.equalAuthorities, authorities)
 	}
 }
 

--- a/table/orphan_cleanup_bench_test.go
+++ b/table/orphan_cleanup_bench_test.go
@@ -7,7 +7,7 @@
 // with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 )
+
+var orphanCleanupBenchmarkSink string
 
 // BenchmarkApplyURIEquivalence measures the per-path lookup cost as the
 // number of paths and configured equivalence groups grows. Configuration is
@@ -56,9 +58,8 @@ func BenchmarkApplyURIEquivalence(b *testing.B) {
 				}
 			}
 			b.StopTimer()
-			if result == "" {
-				b.Fatal("equivalence lookup returned an empty scheme")
-			}
+			// Keep the result observable without including the sink in the benchmark.
+			orphanCleanupBenchmarkSink = result
 		})
 	}
 }

--- a/table/orphan_cleanup_bench_test.go
+++ b/table/orphan_cleanup_bench_test.go
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkApplyURIEquivalence measures the per-path lookup cost as the
+// number of paths and configured equivalence groups grows. Configuration is
+// built before the timer starts so only the repeated lookup is measured.
+func BenchmarkApplyURIEquivalence(b *testing.B) {
+	for _, tc := range []struct {
+		paths  int
+		groups int
+	}{
+		{paths: 100, groups: 1},
+		{paths: 100, groups: 100},
+		{paths: 10_000, groups: 1},
+		{paths: 10_000, groups: 100},
+	} {
+		b.Run(fmt.Sprintf("paths=%d/groups=%d", tc.paths, tc.groups), func(b *testing.B) {
+			equivalences := make(map[string]string, tc.groups)
+			for i := range tc.groups {
+				equivalences[fmt.Sprintf("scheme-%d,scheme-%d-alt", i, i)] = "canonical"
+			}
+			cfg := newOrphanCleanupConfig(WithEqualSchemes(equivalences))
+
+			schemes := make([]string, tc.paths)
+			for i := range schemes {
+				schemes[i] = fmt.Sprintf("scheme-%d", i%tc.groups)
+			}
+
+			b.ReportAllocs()
+			var result string
+			b.ResetTimer()
+			for b.Loop() {
+				for _, scheme := range schemes {
+					result = applySchemeEquivalence(scheme, cfg.equalSchemes)
+				}
+			}
+			b.StopTimer()
+			if result == "" {
+				b.Fatal("equivalence lookup returned an empty scheme")
+			}
+		})
+	}
+}

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -102,6 +102,19 @@ func TestFlattenURIEquivalences(t *testing.T) {
 	}, flattenURIEquivalences(equivalences))
 }
 
+func TestFlattenURIEquivalencesUsesLexicographicallyLastGroup(t *testing.T) {
+	equivalences := map[string]string{
+		"s3, s3a": "s3",
+		"s3a,s3n": "s3n",
+	}
+
+	assert.Equal(t, map[string]string{
+		"s3":  "s3",
+		"s3a": "s3n",
+		"s3n": "s3n",
+	}, flattenURIEquivalences(equivalences))
+}
+
 func TestFlattenURIEquivalencesPreservesExactMappingPrecedence(t *testing.T) {
 	equivalences := map[string]string{
 		"host1":       "canonical",
@@ -127,6 +140,22 @@ func TestEqualAuthoritiesPreservesExactMappingAcrossOptions(t *testing.T) {
 
 	assert.Equal(t, "canonical", applyAuthorityEquivalence("host1", cfg.equalAuthorities))
 	assert.Equal(t, "canonical", applyAuthorityEquivalence("host2", cfg.equalAuthorities))
+}
+
+func TestNewOrphanCleanupConfigFlattensURIEquivalences(t *testing.T) {
+	cfg := newOrphanCleanupConfig(
+		WithEqualSchemes(map[string]string{
+			"s3,s3a": "s3",
+		}),
+		WithEqualAuthorities(map[string]string{
+			"host1,host2": "canonical",
+		}),
+	)
+
+	assert.Equal(t, "s3", applySchemeEquivalence("s3a", cfg.equalSchemes))
+	assert.Equal(t, "canonical", applyAuthorityEquivalence("host2", cfg.equalAuthorities))
+	assert.NotContains(t, cfg.equalSchemes, "s3,s3a")
+	assert.NotContains(t, cfg.equalAuthorities, "host1,host2")
 }
 
 func TestOrphanCleanupPlanDoesNotExpandAfterPlanning(t *testing.T) {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -79,11 +79,27 @@ func TestOrphanCleanupOptions(t *testing.T) {
 
 	schemes := map[string]string{"s3,s3a,s3n": "s3"}
 	WithEqualSchemes(schemes)(cfg)
-	assert.Equal(t, schemes, cfg.equalSchemes)
+	assert.Equal(t, map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"}, cfg.equalSchemes)
 
 	authorities := map[string]string{"host1,host2": "canonical"}
 	WithEqualAuthorities(authorities)(cfg)
-	assert.Equal(t, authorities, cfg.equalAuthorities)
+	assert.Equal(t, map[string]string{"host1": "canonical", "host2": "canonical"}, cfg.equalAuthorities)
+}
+
+func TestFlattenURIEquivalences(t *testing.T) {
+	equivalences := map[string]string{
+		"s3,s3a,s3n": "s3",
+		"s3a,gs":     "gs",
+		"single":     "canonical",
+	}
+
+	assert.Equal(t, map[string]string{
+		"s3":     "s3",
+		"s3a":    "gs",
+		"s3n":    "s3",
+		"gs":     "gs",
+		"single": "canonical",
+	}, flattenURIEquivalences(equivalences))
 }
 
 func TestOrphanCleanupPlanDoesNotExpandAfterPlanning(t *testing.T) {
@@ -184,8 +200,8 @@ func TestPlanOrphanFilesHonorsModificationTimes(t *testing.T) {
 
 func TestNormalizeFilePath(t *testing.T) {
 	cfg := &orphanCleanupConfig{
-		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
-		equalAuthorities: map[string]string{"endpoint1,endpoint2": "canonical"},
+		equalSchemes:     map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"},
+		equalAuthorities: map[string]string{"endpoint1": "canonical", "endpoint2": "canonical"},
 	}
 
 	tests := []struct {
@@ -301,8 +317,10 @@ func TestVersionHintLocation(t *testing.T) {
 
 func TestApplySchemeEquivalence(t *testing.T) {
 	equalSchemes := map[string]string{
-		"s3,s3a,s3n": "s3",
-		"gs":         "gs",
+		"s3":  "s3",
+		"s3a": "s3",
+		"s3n": "s3",
+		"gs":  "gs",
 	}
 
 	tests := []struct {
@@ -347,8 +365,9 @@ func TestApplySchemeEquivalence(t *testing.T) {
 
 func TestApplyAuthorityEquivalence(t *testing.T) {
 	equalAuthorities := map[string]string{
-		"host1,host2": "canonical",
-		"single":      "single",
+		"host1":  "canonical",
+		"host2":  "canonical",
+		"single": "single",
 	}
 
 	tests := []struct {
@@ -389,8 +408,8 @@ func TestApplyAuthorityEquivalence(t *testing.T) {
 func TestCheckPrefixMismatch(t *testing.T) {
 	cfg := &orphanCleanupConfig{
 		prefixMismatchMode: PrefixMismatchError,
-		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
-		equalAuthorities:   map[string]string{"host1,host2": "canonical"},
+		equalSchemes:       map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"},
+		equalAuthorities:   map[string]string{"host1": "canonical", "host2": "canonical"},
 	}
 
 	tests := []struct {
@@ -477,8 +496,8 @@ func TestIsFileOrphan(t *testing.T) {
 	// instead of the existence check (_, ok).
 	cfg := &orphanCleanupConfig{
 		prefixMismatchMode: PrefixMismatchError,
-		equalSchemes:       map[string]string{"s3,s3a,s3n": "s3"},
-		equalAuthorities:   map[string]string{"host-a,host-b": "host-a"},
+		equalSchemes:       map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"},
+		equalAuthorities:   map[string]string{"host-a": "host-a", "host-b": "host-a"},
 	}
 
 	referencedFiles := map[string]bool{
@@ -552,8 +571,8 @@ func TestIsFileOrphan(t *testing.T) {
 
 func TestNormalizeURLPath(t *testing.T) {
 	cfg := &orphanCleanupConfig{
-		equalSchemes:     map[string]string{"s3,s3a,s3n": "s3"},
-		equalAuthorities: map[string]string{"host1,host2": "canonical"},
+		equalSchemes:     map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"},
+		equalAuthorities: map[string]string{"host1": "canonical", "host2": "canonical"},
 	}
 
 	tests := []struct {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -79,11 +79,11 @@ func TestOrphanCleanupOptions(t *testing.T) {
 
 	schemes := map[string]string{"s3,s3a,s3n": "s3"}
 	WithEqualSchemes(schemes)(cfg)
-	assert.Equal(t, map[string]string{"s3": "s3", "s3a": "s3", "s3n": "s3"}, cfg.equalSchemes)
+	assert.Equal(t, schemes, cfg.equalSchemes)
 
 	authorities := map[string]string{"host1,host2": "canonical"}
 	WithEqualAuthorities(authorities)(cfg)
-	assert.Equal(t, map[string]string{"host1": "canonical", "host2": "canonical"}, cfg.equalAuthorities)
+	assert.Equal(t, authorities, cfg.equalAuthorities)
 }
 
 func TestFlattenURIEquivalences(t *testing.T) {
@@ -94,12 +94,41 @@ func TestFlattenURIEquivalences(t *testing.T) {
 	}
 
 	assert.Equal(t, map[string]string{
-		"s3":     "s3",
-		"s3a":    "gs",
-		"s3n":    "s3",
-		"gs":     "gs",
-		"single": "canonical",
+		"s3":         "s3",
+		"s3a":        "gs",
+		"s3n":        "s3",
+		"gs":         "gs",
+		"single":     "canonical",
+		"s3,s3a,s3n": "s3",
+		"s3a,gs":     "gs",
 	}, flattenURIEquivalences(equivalences))
+}
+
+func TestFlattenURIEquivalencesPreservesExactMappingPrecedence(t *testing.T) {
+	equivalences := map[string]string{
+		"host1":       "canonical",
+		"host1,host2": "other",
+		"host2":       "canonical",
+	}
+
+	flattened := flattenURIEquivalences(equivalences)
+	assert.Equal(t, "canonical", flattened["host1"])
+	assert.Equal(t, "canonical", flattened["host2"])
+}
+
+func TestEqualAuthoritiesPreservesExactMappingAcrossOptions(t *testing.T) {
+	cfg := newOrphanCleanupConfig(
+		WithEqualAuthorities(map[string]string{
+			"host1": "canonical",
+		}),
+		WithEqualAuthorities(map[string]string{
+			"host1,host2": "other",
+			"host2":       "canonical",
+		}),
+	)
+
+	assert.Equal(t, "canonical", applyAuthorityEquivalence("host1", cfg.equalAuthorities))
+	assert.Equal(t, "canonical", applyAuthorityEquivalence("host2", cfg.equalAuthorities))
 }
 
 func TestOrphanCleanupPlanDoesNotExpandAfterPlanning(t *testing.T) {
@@ -487,6 +516,25 @@ func TestCheckPrefixMismatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckPrefixMismatchPreservesExactEquivalencePrecedence(t *testing.T) {
+	cfg := newOrphanCleanupConfig(
+		WithPrefixMismatchMode(PrefixMismatchDelete),
+		WithEqualAuthorities(map[string]string{
+			"host1":       "canonical",
+			"host1,host2": "other",
+			"host2":       "canonical",
+		}),
+	)
+
+	decision, err := checkPrefixMismatch(
+		"s3://host1/path/file.txt",
+		"s3://host2/path/file.txt",
+		cfg,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, prefixMismatchKeep, decision)
 }
 
 func TestIsFileOrphan(t *testing.T) {

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -564,6 +564,22 @@ func TestCheckPrefixMismatchPreservesExactEquivalencePrecedence(t *testing.T) {
 	assert.Equal(t, prefixMismatchKeep, decision)
 }
 
+func TestCheckPrefixMismatchUsesCompleteAuthority(t *testing.T) {
+	cfg := newOrphanCleanupConfig(
+		WithEqualAuthorities(map[string]string{
+			"container@account-a.dfs.core.windows.net,container@account-b.dfs.core.windows.net": "container@canonical.dfs.core.windows.net",
+		}),
+	)
+
+	decision, err := checkPrefixMismatch(
+		"abfs://container@account-a.dfs.core.windows.net/data/file.parquet",
+		"abfs://container@account-b.dfs.core.windows.net/data/file.parquet",
+		cfg,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, prefixMismatchKeep, decision)
+}
+
 func TestIsFileOrphan(t *testing.T) {
 	// PrefixMismatchError ensures that metadata files (value=false) found via
 	// normalized lookup don't accidentally fall through to the prefix-mismatch
@@ -681,6 +697,37 @@ func TestNormalizeURLPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := normalizeURLPath(tt.input, cfg)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeURLPathUsesCompleteAuthority(t *testing.T) {
+	cfg := newOrphanCleanupConfig(
+		WithEqualAuthorities(map[string]string{
+			"container@account-a.dfs.core.windows.net,container@account-b.dfs.core.windows.net": "container@canonical.dfs.core.windows.net",
+		}),
+	)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "account_a",
+			input:    "abfs://container@account-a.dfs.core.windows.net/data/../file.parquet",
+			expected: "abfs://container@canonical.dfs.core.windows.net/file.parquet",
+		},
+		{
+			name:     "account_b",
+			input:    "abfs://container@account-b.dfs.core.windows.net/data/file.parquet",
+			expected: "abfs://container@canonical.dfs.core.windows.net/data/file.parquet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeURLPath(tt.input, cfg))
 		})
 	}
 }

--- a/table/orphan_cleanup_test.go
+++ b/table/orphan_cleanup_test.go
@@ -94,13 +94,11 @@ func TestFlattenURIEquivalences(t *testing.T) {
 	}
 
 	assert.Equal(t, map[string]string{
-		"s3":         "s3",
-		"s3a":        "gs",
-		"s3n":        "s3",
-		"gs":         "gs",
-		"single":     "canonical",
-		"s3,s3a,s3n": "s3",
-		"s3a,gs":     "gs",
+		"s3":     "s3",
+		"s3a":    "gs",
+		"s3n":    "s3",
+		"gs":     "gs",
+		"single": "canonical",
 	}, flattenURIEquivalences(equivalences))
 }
 


### PR DESCRIPTION
Closes #1808

## What changed

- Expand comma-separated scheme and authority groups once when options are applied.
- Use direct map lookups during orphan path normalization and prefix checks.
- Exact single-key mappings take precedence over comma-separated groups.
- Overlapping groups are deterministic: the lexicographically last group wins. This intentionally differs from Java’s input-iteration-order behavior because Go map iteration is unordered.
- Comma-joined group keys are configuration syntax and are not retained as lookup keys.
- Add tests and a benchmark across path and group counts.

## Benchmark

I ran the same benchmark before and after this change on an Apple M1 Pro with GOMAXPROCS=1. These are the medians from 3 runs. ns/op is for one benchmark operation, which processes all paths in that case.

| Paths | Groups | Before | After | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 1 | 15,965 ns/op | 908 ns/op | 17.6x |
| 100 | 100 | 480,338 ns/op | 1,258 ns/op | 381.8x |
| 10,000 | 1 | 1,102,166 ns/op | 72,268 ns/op | 15.3x |
| 10,000 | 100 | 51,545,935 ns/op | 103,446 ns/op | 498.3x |

The old implementation also allocated 100, 5,050, 10,000, and 505,611 objects per operation for those four cases. The new implementation reported 0 allocations per operation in every case.

## Tests run

- go test ./... passed
- go vet ./table passed
- GOMAXPROCS=1 go test ./table -run BenchmarkApplyURIEquivalence -benchmem -count=3 -v passed