### PR TITLE
perf(io): delete GoCloud files concurrently

### DIFF
--- a/io/gocloud/blob.go
+++ b/io/gocloud/blob.go
@@ -26,6 +26,7 @@ import (
 	pathpkg "path"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	icebergio "github.com/apache/iceberg-go/io"
@@ -187,6 +188,10 @@ type BlobFileIO struct {
 }
 
 var _ icebergio.ListableIO = (*BlobFileIO)(nil)
+
+// deleteFilesMaxConcurrency bounds the number of in-flight object-store
+// deletes without creating one goroutine per path for large cleanup jobs.
+const deleteFilesMaxConcurrency = 16
 
 type blobFileInfo struct {
 	name    string
@@ -420,37 +425,70 @@ func (bfs *BlobFileIO) WalkDir(root string, fn fs.WalkDirFunc) error {
 	})
 }
 
+func (bfs *BlobFileIO) deleteFile(ctx context.Context, p string) (bool, error) {
+	key, err := bfs.preprocess(p)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete %s: %w", p, err)
+	}
+
+	if err := bfs.Delete(ctx, key); err != nil {
+		// Missing files are not errors per the interface contract.
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to delete %s: %w", p, err)
+	}
+
+	return true, nil
+}
+
 func (bfs *BlobFileIO) DeleteFiles(ctx context.Context, paths []string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
 
-	deleted := make([]string, 0, len(paths))
+	type result struct {
+		deleted bool
+		err     error
+	}
 
-	var errs error
+	results := make([]result, len(paths))
+	workers := len(paths)
+	if workers > deleteFilesMaxConcurrency {
+		workers = deleteFilesMaxConcurrency
+	}
 
-	for _, p := range paths {
-		key, err := bfs.preprocess(p)
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
 
-			continue
-		}
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
 
-		if err := bfs.Delete(ctx, key); err != nil {
-			// Missing files are not errors per the interface contract.
-			if gcerrors.Code(err) == gcerrors.NotFound {
-				deleted = append(deleted, p)
-
-				continue
+			for idx := range jobs {
+				results[idx].deleted, results[idx].err = bfs.deleteFile(ctx, paths[idx])
 			}
+		}()
+	}
 
-			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", p, err))
+	for idx := range paths {
+		jobs <- idx
+	}
+	close(jobs)
+	wg.Wait()
 
-			continue
+	deleted := make([]string, 0, len(paths))
+	var errs error
+	for idx, result := range results {
+		if result.deleted {
+			deleted = append(deleted, paths[idx])
 		}
 
-		deleted = append(deleted, p)
+		if result.err != nil {
+			errs = errors.Join(errs, result.err)
+		}
 	}
 
 	return deleted, errs

--- a/io/gocloud/blob_test.go
+++ b/io/gocloud/blob_test.go
@@ -19,17 +19,23 @@ package gocloud
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	icebergio "github.com/apache/iceberg-go/io"
 	"gocloud.dev/blob"
+	"gocloud.dev/blob/driver"
 	"gocloud.dev/blob/memblob"
+	"gocloud.dev/gcerrors"
 )
 
 func TestDefaultKeyExtractor(t *testing.T) {
@@ -723,6 +729,131 @@ func TestBlobFileIODeleteFilesEmpty(t *testing.T) {
 	deleted, err := bulk.DeleteFiles(ctx, nil)
 	require.NoError(t, err)
 	assert.Nil(t, deleted)
+}
+
+type trackingDeleteBucket struct {
+	started chan<- struct{}
+	release chan struct{}
+
+	mu          sync.Mutex
+	inFlight    int
+	maxInFlight int
+}
+
+var errTrackingDeleteUnsupported = errors.New("unsupported test operation")
+
+func (b *trackingDeleteBucket) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Unknown }
+func (b *trackingDeleteBucket) As(any) bool                        { return false }
+func (b *trackingDeleteBucket) ErrorAs(error, any) bool            { return false }
+func (b *trackingDeleteBucket) Attributes(context.Context, string) (*driver.Attributes, error) {
+	return nil, errTrackingDeleteUnsupported
+}
+
+func (b *trackingDeleteBucket) ListPaged(context.Context, *driver.ListOptions) (*driver.ListPage, error) {
+	return nil, errTrackingDeleteUnsupported
+}
+
+func (b *trackingDeleteBucket) NewRangeReader(context.Context, string, int64, int64, *driver.ReaderOptions) (driver.Reader, error) {
+	return nil, errTrackingDeleteUnsupported
+}
+
+func (b *trackingDeleteBucket) NewTypedWriter(context.Context, string, string, *driver.WriterOptions) (driver.Writer, error) {
+	return nil, errTrackingDeleteUnsupported
+}
+
+func (b *trackingDeleteBucket) Copy(context.Context, string, string, *driver.CopyOptions) error {
+	return errTrackingDeleteUnsupported
+}
+
+func (b *trackingDeleteBucket) Delete(ctx context.Context, _ string) error {
+	b.mu.Lock()
+	b.inFlight++
+	if b.inFlight > b.maxInFlight {
+		b.maxInFlight = b.inFlight
+	}
+	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		b.inFlight--
+		b.mu.Unlock()
+	}()
+
+	select {
+	case b.started <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *trackingDeleteBucket) SignedURL(context.Context, string, *driver.SignedURLOptions) (string, error) {
+	return "", errTrackingDeleteUnsupported
+}
+func (b *trackingDeleteBucket) Close() error { return nil }
+
+func TestBlobFileIODeleteFilesIsConcurrentAndBounded(t *testing.T) {
+	const pathCount = deleteFilesMaxConcurrency * 2
+
+	started := make(chan struct{}, pathCount)
+	tracker := &trackingDeleteBucket{
+		started: started,
+		release: make(chan struct{}),
+	}
+	bucket := blob.NewBucket(tracker)
+	defer bucket.Close()
+
+	bfs := &BlobFileIO{
+		Bucket:        bucket,
+		extractObject: defaultObjectLocationExtractor("test-bucket"),
+		ctx:           context.Background(),
+	}
+	paths := make([]string, pathCount)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("s3://test-bucket/data/file%d.parquet", i)
+	}
+
+	deletedCh := make(chan struct{})
+	var deleted []string
+	var deleteErr error
+	go func() {
+		deleted, deleteErr = bfs.DeleteFiles(context.Background(), paths)
+		close(deletedCh)
+	}()
+
+	for i := 0; i < deleteFilesMaxConcurrency; i++ {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("DeleteFiles did not start the expected concurrent deletes")
+		}
+	}
+
+	tracker.mu.Lock()
+	maxInFlight := tracker.maxInFlight
+	tracker.mu.Unlock()
+	assert.Equal(t, deleteFilesMaxConcurrency, maxInFlight)
+
+	select {
+	case <-started:
+		t.Fatal("DeleteFiles exceeded its concurrency limit")
+	default:
+	}
+
+	close(tracker.release)
+	select {
+	case <-deletedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DeleteFiles did not finish after deletes were released")
+	}
+
+	require.NoError(t, deleteErr)
+	assert.Equal(t, paths, deleted)
 }
 
 func TestBlobFileIOStat(t *testing.T) {


### PR DESCRIPTION
## What changed

- Delete files with up to 16 workers in `BlobFileIO.DeleteFiles`.
- Keep best-effort deletes, missing-file handling, and joined errors.
- Keep deleted paths and errors in input order.
- Add a test for the concurrency cap and result ordering.

## Why

`DeleteFiles` was deleting one object at a time. This makes cleanup slow when a cloud store has many files.

## Speed

Local synthetic benchmark on an Apple M1 Pro:

- 64 files
- 5 ms simulated delete latency per file
- serial: 386.6 ms
- concurrent: 24.0 ms
- speedup: 16.1x

This measures request latency hiding. It is not a provider-specific benchmark.

## Tests

- `go test -p 2 ./...`
- `go test -race ./io/gocloud -run TestBlobFileIODeleteFiles -count=1`
- `go vet ./io/gocloud`