### PR TITLE
perf(expr): pre-size literal sets

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -950,7 +950,7 @@ type BoundSetPredicate interface {
 func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (BooleanExpression, error) {
 	boundType := term.Type()
 
-	typedSet := newLiteralSet()
+	typedSet := make(literalSet, lits.Len())
 	for _, v := range lits.Members() {
 		casted, err := v.To(boundType)
 		if err != nil {

--- a/exprs_literal_set_bench_test.go
+++ b/exprs_literal_set_bench_test.go
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"strconv"
+	"testing"
+)
+
+var (
+	benchmarkLiteralSetSink  Set[Literal]
+	benchmarkBooleanExprSink BooleanExpression
+)
+
+func benchmarkLiteralSetValues(size int) []Literal {
+	values := make([]Literal, size)
+	for i := range values {
+		values[i] = NewLiteral(int32(i))
+	}
+
+	return values
+}
+
+func BenchmarkNewLiteralSet(b *testing.B) {
+	for _, size := range []int{8, 64, 1024, 8192} {
+		values := benchmarkLiteralSetValues(size)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				benchmarkLiteralSetSink = newLiteralSet(values...)
+			}
+		})
+	}
+}
+
+func BenchmarkBindLiteralSet(b *testing.B) {
+	schema := NewSchema(1, NestedField{ID: 1, Name: "value", Type: PrimitiveTypes.Int32})
+	for _, size := range []int{8, 64, 1024, 8192} {
+		values := benchmarkLiteralSetValues(size)
+		predicate := SetPredicate(OpIn, Reference("value"), values).(UnboundPredicate)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				var err error
+				benchmarkBooleanExprSink, err = predicate.Bind(schema, true)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -120,7 +120,7 @@ var lzseed = maphash.MakeSeed()
 type literalSet map[any]struct{ orig Literal }
 
 func newLiteralSet(vals ...Literal) Set[Literal] {
-	s := literalSet{}
+	s := make(literalSet, len(vals))
 	for _, v := range vals {
 		s.addliteral(v)
 	}


### PR DESCRIPTION
## What

- Pre-size the literal set map from the input literal count.
- Pre-size the typed literal set rebuilt during predicate binding.
- Add benchmarks for 8, 64, 1,024, and 8,192 value `IN` sets.

## Why

Large `IN` predicates currently build maps from an empty capacity. The maps grow and rehash while the literals are inserted, and binding builds a second set with the same issue.

## Performance

For 8,192 `IN` values on an Apple M1 Pro, using three 250 ms benchmark runs:

- Literal set construction: 1.31 MB/op to 656 KB/op, about 50% less memory.
- Predicate binding: 1.47 MB/op to 819 KB/op, about 44% less memory.
- Predicate binding was about 3x faster in the local median run.

The exact CPU result depends on the literal count and workload. The allocation reduction is the main benefit.

## Tests

- `go test .`
- `go test -race .`
- `go test ./...`
