### PR TITLE
perf(table): format object-store hashes with a fixed buffer

### DIFF
--- a/table/locations.go
+++ b/table/locations.go
@@ -28,9 +28,11 @@ import (
 )
 
 const (
-	hashBinaryStringBits = 20
-	entropyDirDepth      = 3
-	hashPathLength       = hashBinaryStringBits + entropyDirDepth
+	hashBits         = 20
+	entropyDirLength = 4
+	entropyDirDepth  = 3
+	hashPathLength   = hashBits + entropyDirDepth
+	hashNibbleMask   = (1 << entropyDirLength) - 1
 	// Binary representation of all 4-bit values, indexed by nibble.
 	binaryHashNibbles = "0000000100100011010001010110011110001001101010111100110111101111"
 )
@@ -120,20 +122,22 @@ type objectStoreLocationProvider struct {
 }
 
 func computeHash(dataFileName string) string {
-	hashCode := murmur3.Sum32([]byte(dataFileName)) & ((1 << hashBinaryStringBits) - 1)
+	hashCode := murmur3.Sum32([]byte(dataFileName)) & ((1 << hashBits) - 1)
 
 	// Format the hash directly into the final directory layout. The fixed
 	// buffer contains 20 bits and one separator for each of the three
 	// four-bit entropy directories.
+	// Masking the hash is equivalent to the old sentinel-bit approach because
+	// each nibble is copied explicitly, including leading zeroes.
 	var hashPath [hashPathLength]byte
-	copy(hashPath[0:4], binaryHashNibbles[((hashCode>>16)&0xf)*4:])
-	hashPath[4] = '/'
-	copy(hashPath[5:9], binaryHashNibbles[((hashCode>>12)&0xf)*4:])
-	hashPath[9] = '/'
-	copy(hashPath[10:14], binaryHashNibbles[((hashCode>>8)&0xf)*4:])
-	hashPath[14] = '/'
-	copy(hashPath[15:19], binaryHashNibbles[((hashCode>>4)&0xf)*4:])
-	copy(hashPath[19:23], binaryHashNibbles[(hashCode&0xf)*4:])
+	copy(hashPath[0:entropyDirLength], binaryHashNibbles[((hashCode>>(hashBits-entropyDirLength))&hashNibbleMask)*entropyDirLength:])
+	hashPath[entropyDirLength] = '/'
+	copy(hashPath[entropyDirLength+1:2*entropyDirLength+1], binaryHashNibbles[((hashCode>>(hashBits-2*entropyDirLength))&hashNibbleMask)*entropyDirLength:])
+	hashPath[2*entropyDirLength+1] = '/'
+	copy(hashPath[2*entropyDirLength+2:3*entropyDirLength+2], binaryHashNibbles[((hashCode>>(hashBits-3*entropyDirLength))&hashNibbleMask)*entropyDirLength:])
+	hashPath[3*entropyDirLength+2] = '/'
+	copy(hashPath[3*entropyDirLength+3:4*entropyDirLength+3], binaryHashNibbles[((hashCode>>(hashBits-4*entropyDirLength))&hashNibbleMask)*entropyDirLength:])
+	copy(hashPath[4*entropyDirLength+3:5*entropyDirLength+3], binaryHashNibbles[(hashCode&hashNibbleMask)*entropyDirLength:])
 
 	return string(hashPath[:])
 }

--- a/table/locations.go
+++ b/table/locations.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"strconv"
-	"strings"
 
 	"github.com/apache/iceberg-go"
 	"github.com/google/uuid"
@@ -31,8 +29,10 @@ import (
 
 const (
 	hashBinaryStringBits = 20
-	entropyDirLength     = 4
 	entropyDirDepth      = 3
+	hashPathLength       = hashBinaryStringBits + entropyDirDepth
+	// Binary representation of all 4-bit values, indexed by nibble.
+	binaryHashNibbles = "0000000100100011010001010110011110001001101010111100110111101111"
 )
 
 type LocationProvider interface {
@@ -120,30 +120,22 @@ type objectStoreLocationProvider struct {
 }
 
 func computeHash(dataFileName string) string {
-	// Bitwise AND to combat sign-extension; bitwise OR to preserve leading zeroes
-	topMask := 1 << hashBinaryStringBits
-	hashCode := int(murmur3.Sum32([]byte(dataFileName)))&(topMask-1) | topMask
+	hashCode := murmur3.Sum32([]byte(dataFileName)) & ((1 << hashBinaryStringBits) - 1)
 
-	// Convert to binary string and take the last hashBinaryStringBits
-	binaryStr := strconv.FormatInt(int64(hashCode), 2)
+	// Format the hash directly into the final directory layout. The fixed
+	// buffer contains 20 bits and one separator for each of the three
+	// four-bit entropy directories.
+	var hashPath [hashPathLength]byte
+	copy(hashPath[0:4], binaryHashNibbles[((hashCode>>16)&0xf)*4:])
+	hashPath[4] = '/'
+	copy(hashPath[5:9], binaryHashNibbles[((hashCode>>12)&0xf)*4:])
+	hashPath[9] = '/'
+	copy(hashPath[10:14], binaryHashNibbles[((hashCode>>8)&0xf)*4:])
+	hashPath[14] = '/'
+	copy(hashPath[15:19], binaryHashNibbles[((hashCode>>4)&0xf)*4:])
+	copy(hashPath[19:23], binaryHashNibbles[(hashCode&0xf)*4:])
 
-	return dirsFromHash(binaryStr[len(binaryStr)-hashBinaryStringBits:])
-}
-
-func dirsFromHash(fileHash string) string {
-	// Divides hash into directories for optimized orphan removal operation
-	totalEntropyLength := entropyDirDepth * entropyDirLength
-
-	hashWithDirs := make([]string, 0)
-	for i := 0; i < totalEntropyLength; i += entropyDirLength {
-		hashWithDirs = append(hashWithDirs, fileHash[i:i+entropyDirLength])
-	}
-
-	if len(fileHash) > totalEntropyLength {
-		hashWithDirs = append(hashWithDirs, fileHash[totalEntropyLength:])
-	}
-
-	return strings.Join(hashWithDirs, "/")
+	return string(hashPath[:])
 }
 
 func (p *objectStoreLocationProvider) NewDataLocation(dataFileName string) string {

--- a/table/locations_bench_test.go
+++ b/table/locations_bench_test.go
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import "testing"
+
+var computeHashBenchmarkSink string
+
+func BenchmarkComputeHash(b *testing.B) {
+	const dataFileName = "part-00000-8f4c2e1d-2d6b-4e38-9f7f-2bca3d8e6a10-c000.snappy.parquet"
+
+	b.ReportAllocs()
+	for range b.N {
+		computeHashBenchmarkSink = computeHash(dataFileName)
+	}
+}

--- a/table/locations_test.go
+++ b/table/locations_test.go
@@ -84,6 +84,8 @@ func TestObjectStoreLocationProvider(t *testing.T) {
 	assert.Equal(t, "table_location/data/1110/0111/1110/00000011/b", provider.NewDataLocation("b"))
 	assert.Equal(t, "table_location/data/0010/1101/0110/01011111/c", provider.NewDataLocation("c"))
 	assert.Equal(t, "table_location/data/1001/0001/0100/01110011/d", provider.NewDataLocation("d"))
+	assert.Equal(t, "table_location/data/0000/0000/0000/00000000/part-00164929.parquet",
+		provider.NewDataLocation("part-00164929.parquet"))
 }
 
 // TestObjectStoreLocationProviderPartitionedPathsDisabled tests that when partitioned paths are disabled,


### PR DESCRIPTION
## Why

Object-store paths currently format the 20-bit Murmur3 hash by converting it to a binary string, slicing it into directories, and joining the pieces. This creates temporary allocations for every data file path.

## What changed

- Write the hash directly into a fixed-size buffer.
- Keep the existing hash and directory layout unchanged.
- Add a focused `computeHash` benchmark.

## Benchmark

Apple M1 Pro, Go 1.26.3, GOMAXPROCS=1. Median of five 1-second runs:

| | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Before | 1,422 | 112 | 3 |
| After | 646 | 24 | 1 |

The new version is about 2.2x faster.

## Tests

- `go test ./...`
- `go test -race ./table/...`