### PR TITLE
fix(table): look up removed-file partition specs by ID

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -1018,9 +1018,8 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 		}
 	}
 
-	specs := sp.txn.meta.specs
 	for _, df := range sp.deletedFiles {
-		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
 			return nil, err
 		}
 	}
@@ -1028,7 +1027,7 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
 			continue
 		}
-		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
 			return nil, err
 		}
 	}
@@ -1036,7 +1035,7 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
 			continue
 		}
-		if err = ssc.removeFile(df, currentSchema, specs[df.SpecID()]); err != nil {
+		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
 			return nil, err
 		}
 	}

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -26,6 +26,7 @@ import (
 	"io/fs"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1060,6 +1061,61 @@ func TestAddedDeleteManifestsUseDeleteFileSpecID(t *testing.T) {
 	}
 
 	require.ElementsMatch(t, []int32{0, 1}, deleteManifestSpecIDs)
+}
+
+// changedPartitionPaths returns the partition paths named by a snapshot
+// summary's changed-partition entries.
+func changedPartitionPaths(summary iceberg.Properties) map[string]bool {
+	paths := make(map[string]bool)
+	for key := range summary {
+		if path, ok := strings.CutPrefix(key, changedPartitionPrefix); ok {
+			paths[path] = true
+		}
+	}
+
+	return paths
+}
+
+// TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID checks that removed
+// files resolve their partition spec by ID, the way added files already do.
+// Removing a non-default spec that precedes the default one leaves a specs
+// slice whose positions no longer line up with spec IDs, so treating a spec ID
+// as a slice index reads the wrong spec or runs off the end of the slice.
+func TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID(t *testing.T) {
+	txn, wfs := createTestTransactionWithMemIO(t, iceberg.NewPartitionSpec())
+	require.NoError(t, txn.meta.SetProperties(iceberg.Properties{WritePartitionSummaryLimitKey: "10"}))
+
+	bucketSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id_bucket", Transform: iceberg.BucketTransform{NumBuckets: 4},
+	})
+	require.NoError(t, txn.meta.AddPartitionSpec(&bucketSpec, false))
+	truncSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1001, Name: "id_trunc", Transform: iceberg.TruncateTransform{Width: 8},
+	})
+	require.NoError(t, txn.meta.AddPartitionSpec(&truncSpec, false))
+	require.NoError(t, txn.meta.SetDefaultSpecID(-1))
+	require.NoError(t, txn.meta.RemovePartitionSpecs([]int{1}))
+
+	currentSpec, err := txn.meta.CurrentSpec()
+	require.NoError(t, err)
+	require.Equal(t, 2, currentSpec.ID(), "test setup should leave spec 2 as the default")
+	require.Len(t, txn.meta.specs, 2, "removing spec 1 should decouple slice positions from spec IDs")
+
+	df := newTestDataFile(t, *currentSpec, "mem://default/table-location/data/spec-2.parquet",
+		map[int]any{currentSpec.Field(0).FieldID: int32(0)})
+
+	appended := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+	appended.appendDataFile(df)
+	addedSummary, err := appended.accumulateSummaryDelta(nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]bool{"id_trunc=0": true}, changedPartitionPaths(addedSummary))
+
+	deleted := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+	deleted.deleteDataFile(df)
+	removedSummary, err := deleted.accumulateSummaryDelta(nil)
+	require.NoError(t, err)
+	require.Equal(t, changedPartitionPaths(addedSummary), changedPartitionPaths(removedSummary),
+		"adding and removing the same file must report the same changed partition")
 }
 
 // TestCreateManifestClosesUnderlyingFile tests that createManifest properly


### PR DESCRIPTION
Fixes #1815

`accumulateSummaryDelta` resolves partition specs two different ways. Added files use `sp.spec(int(df.SpecID()))`, a by-ID lookup over `GetSpecByID`; removed data files, delete files and deletion vectors index the slice directly, `specs[df.SpecID()]`.

Spec ID is an identifier, not a slice position. `RemovePartitionSpecs` filters the slice without renumbering the survivors, and specs loaded from metadata keep the `partition-specs` array order (no sort), so positions and IDs come apart on ordinary tables. Because `specs[df.SpecID()]` is evaluated as a call argument, it fails before `removeFile` ever runs: any Delete/Overwrite/RewriteFiles commit that removes files panics with `index out of range`, or — when the ID stays in bounds but points at the wrong entry — silently attributes the change to the wrong partition.

`RemovePartitionSpecs([]int{1})` over specs 0/1/2 leaves `specs == [id0, id2]`. Sending the *same* spec-2 data file down both branches:

| path | result |
| --- | --- |
| add | `partitions.id_trunc=0` |
| remove | `panic: runtime error: index out of range [2] with length 2` |

Same file, same spec, same function; only the branch differs.

The fix calls `sp.spec(...)` in the three removal loops and drops the now-unused local. Unknown IDs then yield an empty unpartitioned spec instead of panicking, matching the add path.

<details>
<summary>Test evidence</summary>

Regression test `TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID` in `table/snapshot_producers_test.go`. It asserts the add path first, so the failure output itself shows the asymmetry rather than just "remove panics".

Before the fix:

```
=== RUN   TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID
--- FAIL: TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID (0.00s)
panic: runtime error: index out of range [2] with length 2 [recovered, repanicked]
...
github.com/apache/iceberg-go/table.(*snapshotProducer).accumulateSummaryDelta(...)
	table/snapshot_producers.go:1023 +0x5e8
github.com/apache/iceberg-go/table.TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID(...)
	table/snapshot_producers_test.go:1115 +0x950
FAIL	github.com/apache/iceberg-go/table	0.933s
```

After the fix:

```
=== RUN   TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID
--- PASS: TestAccumulateSummaryDeltaResolvesRemovedFileSpecByID (0.00s)
ok  	github.com/apache/iceberg-go/table	0.922s
```

| check | result |
| --- | --- |
| `go test ./...` | all 26 packages with tests ok |
| `go test -race ./codec/... ./table/...` | ok |
| `golangci-lint run` (v2.11.4, whole repo) | 0 issues |
| `gofmt -l` | clean |

Not run: the Docker-gated integration suite (`go test -tags integration ./...`) and the s390x cross-compile job. The change is confined to in-memory summary accounting, with no catalog, IO or platform-specific code involved.

</details>

Assisted by Cursor; I reproduced the panic locally and reviewed every line of the change.
