### PR TITLE
perf(transform): hash decimal buckets without allocating

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -375,6 +375,28 @@ func hashTimestampNano(v any) uint32 {
 	return hashHelperInt[int64](micros)
 }
 
+func hashDecimal(v Decimal) uint32 {
+	// Decimal bucket transforms hash the minimum two's-complement
+	// big-endian representation of the unscaled value. Keep the full
+	// decimal128 value on the stack and trim only redundant sign bytes.
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[:8], uint64(v.Val.HighBits()))
+	binary.BigEndian.PutUint64(buf[8:], v.Val.LowBits())
+
+	start := 0
+	if v.Val.Sign() >= 0 {
+		for start < len(buf)-1 && buf[start] == 0 && buf[start+1]&0x80 == 0 {
+			start++
+		}
+	} else {
+		for start < len(buf)-1 && buf[start] == 0xff && buf[start+1]&0x80 != 0 {
+			start++
+		}
+	}
+
+	return murmur3.Sum32(buf[start:])
+}
+
 func (t BucketTransform) Equals(other Transform) bool {
 	rhs, ok := other.(BucketTransform)
 	if !ok {
@@ -401,8 +423,7 @@ func (t BucketTransform) Apply(value Optional[Literal]) Optional[Literal] {
 	case UUIDLiteral:
 		hash = murmur3.Sum32(v[:])
 	case DecimalLiteral:
-		b, _ := v.MarshalBinary()
-		hash = murmur3.Sum32(b)
+		hash = hashDecimal(Decimal(v))
 	case Int32Literal:
 		hash = hashHelperInt[int64](int64(v))
 	case Int64Literal:
@@ -451,9 +472,7 @@ func (t BucketTransform) Transformer(src Type) func(any) Optional[int32] {
 		h = hashTimestampNano
 	case DecimalType:
 		h = func(v any) uint32 {
-			b, _ := DecimalLiteral(v.(Decimal)).MarshalBinary()
-
-			return murmur3.Sum32(b)
+			return hashDecimal(v.(Decimal))
 		}
 	case StringType, FixedType, BinaryType:
 		h = func(v any) uint32 {

--- a/transforms_decimal_bench_test.go
+++ b/transforms_decimal_bench_test.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/iceberg-go"
+)
+
+var (
+	benchmarkDecimalBucketLiteralResult iceberg.Optional[iceberg.Literal]
+	benchmarkDecimalBucketResult        iceberg.Optional[int32]
+)
+
+func BenchmarkBucketTransformDecimal(b *testing.B) {
+	values := []iceberg.Decimal{
+		{Val: decimal128.FromI64(0)},
+		{Val: decimal128.FromI64(127)},
+		{Val: decimal128.FromI64(128)},
+		{Val: decimal128.FromI64(-128)},
+		{Val: decimal128.New(0, 1<<63)},
+		{Val: decimal128.New(-1, 0)},
+		{Val: decimal128.New(-1, 1)},
+	}
+	literals := make([]iceberg.Literal, len(values))
+	boxedValues := make([]any, len(values))
+	for i, value := range values {
+		literals[i] = iceberg.DecimalLiteral(value)
+		boxedValues[i] = value
+	}
+	transform := iceberg.BucketTransform{NumBuckets: 97}
+
+	b.Run("Apply", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkDecimalBucketLiteralResult = transform.Apply(iceberg.Optional[iceberg.Literal]{
+				Valid: true,
+				Val:   literals[i%len(literals)],
+			})
+		}
+	})
+
+	b.Run("Transformer", func(b *testing.B) {
+		transformer := transform.Transformer(iceberg.DecimalTypeOf(38, 0))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkDecimalBucketResult = transformer(boxedValues[i%len(boxedValues)])
+		}
+	})
+}

--- a/transforms_decimal_bench_test.go
+++ b/transforms_decimal_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkBucketTransformDecimal(b *testing.B) {
 	b.Run("Apply", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			benchmarkDecimalBucketLiteralResult = transform.Apply(iceberg.Optional[iceberg.Literal]{
 				Valid: true,
 				Val:   literals[i%len(literals)],
@@ -62,7 +62,7 @@ func BenchmarkBucketTransformDecimal(b *testing.B) {
 		transformer := transform.Transformer(iceberg.DecimalTypeOf(38, 0))
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := range b.N {
 			benchmarkDecimalBucketResult = transformer(boxedValues[i%len(boxedValues)])
 		}
 	})

--- a/transforms_decimal_test.go
+++ b/transforms_decimal_test.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/murmur3"
+)
+
+func TestBucketTransformDecimalHashMatchesMarshalBinary(t *testing.T) {
+	values := []struct {
+		name  string
+		value Decimal
+	}{
+		{name: "zero", value: Decimal{Val: decimal128.FromI64(0)}},
+		{name: "one", value: Decimal{Val: decimal128.FromI64(1)}},
+		{name: "negative one", value: Decimal{Val: decimal128.FromI64(-1)}},
+		{name: "127", value: Decimal{Val: decimal128.FromI64(127)}},
+		{name: "128", value: Decimal{Val: decimal128.FromI64(128)}},
+		{name: "129", value: Decimal{Val: decimal128.FromI64(129)}},
+		{name: "negative 127", value: Decimal{Val: decimal128.FromI64(-127)}},
+		{name: "negative 128", value: Decimal{Val: decimal128.FromI64(-128)}},
+		{name: "negative 129", value: Decimal{Val: decimal128.FromI64(-129)}},
+		{name: "int64 max", value: Decimal{Val: decimal128.FromI64(math.MaxInt64)}},
+		{name: "int64 min", value: Decimal{Val: decimal128.FromI64(math.MinInt64)}},
+		{name: "uint64 max", value: Decimal{Val: decimal128.FromU64(math.MaxUint64)}},
+		{name: "int128 max", value: Decimal{Val: decimal128.New(math.MaxInt64, math.MaxUint64)}},
+		{name: "int128 min", value: Decimal{Val: decimal128.New(math.MinInt64, 0)}},
+		{name: "int128 min plus one", value: Decimal{Val: decimal128.New(math.MinInt64, 1)}},
+	}
+
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			literal := DecimalLiteral(tt.value)
+			encoded, err := literal.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, murmur3.Sum32(encoded), hashDecimal(tt.value))
+		})
+	}
+
+	rng := rand.New(rand.NewSource(0))
+	for i := 0; i < 10_000; i++ {
+		value := Decimal{Val: decimal128.New(rng.Int63(), rng.Uint64())}
+		encoded, err := DecimalLiteral(value).MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, murmur3.Sum32(encoded), hashDecimal(value), "random value %d", i)
+	}
+}

--- a/transforms_decimal_test.go
+++ b/transforms_decimal_test.go
@@ -59,11 +59,20 @@ func TestBucketTransformDecimalHashMatchesMarshalBinary(t *testing.T) {
 		})
 	}
 
+	// Generate random signed 128-bit values, including ordinary negative
+	// values. The boundary cases above cover the sign-width changes.
 	rng := rand.New(rand.NewSource(0))
 	for i := 0; i < 10_000; i++ {
-		value := Decimal{Val: decimal128.New(rng.Int63(), rng.Uint64())}
+		value := Decimal{Val: decimal128.New(int64(rng.Uint64()), rng.Uint64())}
 		encoded, err := DecimalLiteral(value).MarshalBinary()
 		require.NoError(t, err)
 		assert.Equal(t, murmur3.Sum32(encoded), hashDecimal(value), "random value %d", i)
 	}
+}
+
+func TestBucketTransformDecimalHashMatchesSpecExample(t *testing.T) {
+	value := Decimal{Val: decimal128.FromI64(1420), Scale: 2}
+
+	assert.Equal(t, int32(-500754589), int32(hashDecimal(value)))
+	assert.Equal(t, hashDecimal(value), hashDecimal(Decimal{Val: value.Val, Scale: 7}))
 }

--- a/transforms_decimal_test.go
+++ b/transforms_decimal_test.go
@@ -62,7 +62,7 @@ func TestBucketTransformDecimalHashMatchesMarshalBinary(t *testing.T) {
 	// Generate random signed 128-bit values, including ordinary negative
 	// values. The boundary cases above cover the sign-width changes.
 	rng := rand.New(rand.NewSource(0))
-	for i := 0; i < 10_000; i++ {
+	for i := range 10_000 {
 		value := Decimal{Val: decimal128.New(int64(rng.Uint64()), rng.Uint64())}
 		encoded, err := DecimalLiteral(value).MarshalBinary()
 		require.NoError(t, err)


### PR DESCRIPTION
## What

- Hash decimal bucket values directly from decimal128 signed two-complement bytes.
- Keep DecimalLiteral.MarshalBinary unchanged.
- Add boundary and random compatibility tests.
- Add focused benchmarks.

## Why

Decimal bucketing used to build a big.Int and an allocated byte slice for every value.

## Benchmark

Apple M1 Pro, arm64. Inputs are pre-boxed:

| Path | Before | After | Result |
|---|---:|---:|---|
| Bucket Apply | 124.9 ns, 97 B, 4 allocs | 17.3 ns, 0 B, 0 allocs | 7.2x faster, zero allocations |
| Bound Transformer | 126.3 ns, 97 B, 4 allocs | 13.5 ns, 0 B, 0 allocs | 9.4x faster, zero allocations |

## Tests

- go test ./...
- go vet .