### PR TITLE
feat(table): allow added data files to target any registered partition spec

### DIFF
--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -904,8 +904,8 @@ func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, fi
 			groups[specID] = append(groups[specID], df)
 		}
 
-		for specID, files := range groups {
-			mf, err := sp.writeAddedManifest(content, specID, files)
+		for _, specID := range slices.Sorted(maps.Keys(groups)) {
+			mf, err := sp.writeAddedManifest(content, specID, groups[specID])
 			if err != nil {
 				return err
 			}
@@ -917,7 +917,15 @@ func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, fi
 }
 
 func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, specID int, files []iceberg.DataFile) (_ iceberg.ManifestFile, retErr error) {
-	wr, path, counter, out, err := sp.newManifestWriter(sp.spec(specID), iceberg.WithManifestWriterContent(content))
+	// Resolve the spec strictly: the sp.spec helper silently substitutes an
+	// empty spec on lookup failure, which here would write a manifest whose
+	// declared spec disagrees with its entries' partition tuples.
+	spec, err := sp.txn.meta.GetSpecByID(specID)
+	if err != nil || spec == nil {
+		return nil, fmt.Errorf("cannot write manifest for unregistered partition spec id %d: %w", specID, err)
+	}
+
+	wr, path, counter, out, err := sp.newManifestWriter(*spec, iceberg.WithManifestWriterContent(content))
 	if err != nil {
 		return nil, err
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1278,12 +1278,15 @@ func (t *TableWritingTestSuite) TestAddDataFilesMultipleSpecs() {
 
 	filesBySpec := map[int32]iceberg.DataFile{}
 	for _, m := range manifests {
-		entries, err := m.FetchEntries(fs, false)
-		t.Require().NoError(err)
-		t.Require().Len(entries, 1)
-		df := entries[0].DataFile()
-		t.Equal(m.PartitionSpecID(), df.SpecID())
-		filesBySpec[m.PartitionSpecID()] = df
+		numEntries := 0
+		for entry, err := range m.Entries(fs, false) {
+			t.Require().NoError(err)
+			numEntries++
+			df := entry.DataFile()
+			t.Equal(m.PartitionSpecID(), df.SpecID())
+			filesBySpec[m.PartitionSpecID()] = df
+		}
+		t.Equal(1, numEntries)
 	}
 	t.Require().Contains(filesBySpec, int32(0))
 	t.Require().Contains(filesBySpec, int32(1))

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1216,6 +1216,143 @@ func (t *TableWritingTestSuite) TestAddDataFiles() {
 	t.Equal("1", staged.CurrentSnapshot().Summary.Properties["added-data-files"])
 }
 
+// TestAddDataFilesMultipleSpecs pins that a single commit may add data files
+// targeting any partition spec registered in the table metadata, with one
+// manifest written per spec — the shape of Java's MergingSnapshotProducer.
+// This is what allows writers to keep producing under a previous spec after a
+// partition evolution, and rewrites to migrate files between specs.
+func (t *TableWritingTestSuite) TestAddDataFilesMultipleSpecs() {
+	ident := table.Identifier{"default", "add_data_files_multispec_v" + strconv.Itoa(t.formatVersion)}
+	oldSpec := iceberg.NewPartitionSpec(
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+	)
+	tbl := t.createTable(ident, t.formatVersion, oldSpec, t.tableSchema)
+
+	// Evolve the default spec; the identity(baz) spec 0 stays registered.
+	// Partition summaries are off by default, so opt in for the summary
+	// assertions below.
+	tx := tbl.NewTransaction()
+	t.Require().NoError(tx.SetProperties(iceberg.Properties{table.WritePartitionSummaryLimitKey: "10"}))
+	t.Require().NoError(tx.UpdateSpec(false).AddField("bar", iceberg.IdentityTransform{}, "").Commit())
+	tbl, err := tx.Commit(t.ctx)
+	t.Require().NoError(err)
+	newSpec := tbl.Spec()
+	t.Require().Equal(1, newSpec.ID())
+	t.Require().Len(tbl.Metadata().PartitionSpecs(), 2)
+
+	fs := mustFS(t.T(), tbl).(iceio.WriteFileIO)
+	oldPath := fmt.Sprintf("%s/%s/old-spec.parquet", t.location, ident[1])
+	newPath := fmt.Sprintf("%s/%s/new-spec.parquet", t.location, ident[1])
+	t.writeParquet(fs, oldPath, t.arrTbl)
+	t.writeParquet(fs, newPath, t.arrTbl)
+
+	// One file per spec, each with its partition tuple encoded under its own
+	// spec, committed in a single transaction. The row data is
+	// {baz: 123, bar: "bar_string"} in both files. v3 files must carry
+	// caller-supplied first-row-ids; make them disjoint (one row each).
+	newDataFile := func(spec iceberg.PartitionSpec, path string, partition map[int]any, firstRowID int64) iceberg.DataFile {
+		builder, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData,
+			path, iceberg.ParquetFile, partition, nil, nil, 1, mustFileSize(t.T(), path))
+		t.Require().NoError(err)
+		if t.formatVersion >= 3 {
+			builder = builder.FirstRowID(firstRowID)
+		}
+
+		return builder.Build()
+	}
+	fileOld := newDataFile(oldSpec, oldPath, map[int]any{1000: int32(123)}, 0)
+	fileNew := newDataFile(newSpec, newPath,
+		map[int]any{1000: int32(123), 1001: "bar_string"}, 1)
+
+	tx = tbl.NewTransaction()
+	t.Require().NoError(tx.AddDataFiles(t.ctx, []iceberg.DataFile{fileOld, fileNew}, nil))
+	tbl, err = tx.Commit(t.ctx)
+	t.Require().NoError(err)
+
+	// One manifest per spec, each declaring its own spec id and carrying
+	// entries whose spec ids and partition tuples round-trip.
+	snap := tbl.CurrentSnapshot()
+	manifests, err := snap.Manifests(fs)
+	t.Require().NoError(err)
+	t.Require().Len(manifests, 2)
+
+	filesBySpec := map[int32]iceberg.DataFile{}
+	for _, m := range manifests {
+		entries, err := m.FetchEntries(fs, false)
+		t.Require().NoError(err)
+		t.Require().Len(entries, 1)
+		df := entries[0].DataFile()
+		t.Equal(m.PartitionSpecID(), df.SpecID())
+		filesBySpec[m.PartitionSpecID()] = df
+	}
+	t.Require().Contains(filesBySpec, int32(0))
+	t.Require().Contains(filesBySpec, int32(1))
+	t.Equal(oldPath, filesBySpec[0].FilePath())
+	t.Equal(newPath, filesBySpec[1].FilePath())
+	t.Equal(int32(123), filesBySpec[0].Partition()[1000])
+	t.Equal(int32(123), filesBySpec[1].Partition()[1000])
+	t.Equal("bar_string", filesBySpec[1].Partition()[1001])
+
+	// The mixed-spec commit's summary renders each partition path with the
+	// file's own spec, not the default.
+	t.Equal("2", snap.Summary.Properties["added-data-files"])
+	t.Equal("2", snap.Summary.Properties["changed-partition-count"])
+	t.Contains(snap.Summary.Properties, "partitions.baz=123")
+	t.Contains(snap.Summary.Properties, "partitions.baz=123/bar=bar_string")
+
+	// Read back: a full scan returns the rows of both specs' files.
+	full, err := tbl.Scan().ToArrowTable(t.ctx)
+	t.Require().NoError(err)
+	defer full.Release()
+	t.EqualValues(2, full.NumRows())
+
+	// Partition pruning evaluates each manifest with its own spec. Neither
+	// file carries column stats, so only partition pruning can drop files.
+	planned := func(filter iceberg.BooleanExpression) []string {
+		tasks, err := tbl.Scan(table.WithRowFilter(filter)).PlanFiles(t.ctx)
+		t.Require().NoError(err)
+		paths := make([]string, 0, len(tasks))
+		for _, task := range tasks {
+			paths = append(paths, task.File.FilePath())
+		}
+
+		return paths
+	}
+	t.ElementsMatch([]string{oldPath, newPath},
+		planned(iceberg.EqualTo(iceberg.Reference("baz"), int32(123))))
+	// bar is a partition column only in the new spec: the new-spec manifest is
+	// pruned via its own spec while the old-spec file cannot be.
+	t.ElementsMatch([]string{oldPath},
+		planned(iceberg.EqualTo(iceberg.Reference("bar"), "nope")))
+	// baz prunes both manifests, each evaluated with its own spec.
+	t.Empty(planned(iceberg.EqualTo(iceberg.Reference("baz"), int32(456))))
+
+	// Row-id assignment (v3) is indifferent to the multi-spec grouping: the
+	// snapshot covers both groups' rows from a single first-row-id and the
+	// caller-supplied per-file ids round-trip unchanged.
+	if t.formatVersion >= 3 {
+		t.Require().NotNil(snap.FirstRowID)
+		t.EqualValues(0, *snap.FirstRowID)
+		t.Require().NotNil(snap.AddedRows)
+		t.EqualValues(2, *snap.AddedRows)
+		t.EqualValues(2, tbl.Metadata().NextRowID())
+		t.Require().NotNil(filesBySpec[0].FirstRowID())
+		t.EqualValues(0, *filesBySpec[0].FirstRowID())
+		t.Require().NotNil(filesBySpec[1].FirstRowID())
+		t.EqualValues(1, *filesBySpec[1].FirstRowID())
+	}
+
+	// A spec id that is not registered in the table metadata is rejected.
+	ghost := iceberg.NewPartitionSpecID(99,
+		iceberg.PartitionField{SourceIDs: []int{4}, FieldID: 1000, Transform: iceberg.IdentityTransform{}, Name: "baz"},
+	)
+	fileGhost := t.mustDataFile(ghost, fmt.Sprintf("%s/%s/ghost.parquet", t.location, ident[1]),
+		map[int]any{1000: int32(123)}, 1, 1)
+	tx = tbl.NewTransaction()
+	err = tx.AddDataFiles(t.ctx, []iceberg.DataFile{fileGhost}, nil)
+	t.ErrorContains(err, "unregistered partition spec id 99")
+}
+
 func (t *TableWritingTestSuite) TestAddDataFilesAutoNameMapping() {
 	for _, tc := range []struct {
 		name      string
@@ -1401,7 +1538,7 @@ func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartit
 	tx = tbl.NewTransaction()
 	err = tx.ReplaceDataFilesWithDataFiles(t.ctx, []iceberg.DataFile{deleteFile}, []iceberg.DataFile{addFile}, nil)
 	t.Error(err)
-	t.ErrorContains(err, "invalid partition spec id")
+	t.ErrorContains(err, "unregistered partition spec id 999")
 }
 
 func (t *TableWritingTestSuite) TestReplaceDataFilesWithDataFilesValidatesPartitionData() {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -934,7 +934,7 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 }
 
 // validateDataFilePartitionData verifies that DataFile partition values match
-// the current partition spec fields by ID without reading file contents.
+// the given partition spec's fields by ID without reading file contents.
 func validateDataFilePartitionData(df iceberg.DataFile, spec *iceberg.PartitionSpec) error {
 	partitionData := dataFilePartition(df)
 
@@ -984,7 +984,12 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 		return nil, fmt.Errorf("%s: %w", operation, err)
 	}
 
-	expectedSpecID := int32(currentSpec.ID())
+	// A data file may target any partition spec registered in the table
+	// metadata, not just the default: its manifest is written with that
+	// spec (see snapshotProducer.manifestProducer). Cache lookups since
+	// files typically share a handful of specs.
+	specsByID := make(map[int32]*iceberg.PartitionSpec)
+
 	setToAdd := make(map[string]struct{}, len(dataFiles))
 
 	for i, df := range dataFiles {
@@ -1012,12 +1017,20 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 			return nil, fmt.Errorf("data file %s has invalid file format %s for %s", path, df.FileFormat(), operation)
 		}
 
-		if df.SpecID() != expectedSpecID {
-			return nil, fmt.Errorf("data file %s has invalid partition spec id %d for %s: expected %d",
-				path, df.SpecID(), operation, expectedSpecID)
+		spec, ok := specsByID[df.SpecID()]
+		if !ok {
+			spec, err = meta.GetSpecByID(int(df.SpecID()))
+			if err != nil || spec == nil {
+				return nil, fmt.Errorf("data file %s has unregistered partition spec id %d for %s",
+					path, df.SpecID(), operation)
+			}
+			if err := checkNoUnknownTransform(spec); err != nil {
+				return nil, fmt.Errorf("data file %s for %s: %w", path, operation, err)
+			}
+			specsByID[df.SpecID()] = spec
 		}
 
-		if err := validateDataFilePartitionData(df, currentSpec); err != nil {
+		if err := validateDataFilePartitionData(df, spec); err != nil {
 			return nil, fmt.Errorf("data file %s has invalid partition data for %s: %w", path, operation, err)
 		}
 
@@ -1108,6 +1121,12 @@ func (t *Transaction) ensureNameMapping() error {
 //
 // Unlike AddFiles, this method does not read files from storage. It validates only metadata
 // that can be checked without opening files (for example spec-id and partition field IDs).
+//
+// Each DataFile may target any partition spec registered in the table metadata,
+// identified by its SpecID; files are grouped into one manifest per spec. This
+// permits writers to continue producing data under a previous spec after a
+// partition evolution, and rewrites that migrate files between specs.
+// Unregistered spec ids are rejected.
 //
 // By default this method automatically sets the schema name mapping in table
 // properties if one does not already exist. Pass [WithoutAutoNameMapping] to


### PR DESCRIPTION
## What

`Transaction.AddDataFiles` (and the replace paths sharing its validation) rejected any `DataFile` whose `SpecID()` was not the current default spec — even though the snapshot producer already groups added files by spec id and writes one manifest per spec. This PR makes that path reachable and safe:

- `validateDataFilesToAdd` now resolves each file's spec from the table metadata and validates the partition tuple against *that* spec. Unregistered spec ids are still rejected (`unregistered partition spec id %d`).
- `writeAddedManifest` resolved each group's spec via the `sp.spec()` helper, which silently substitutes an **empty** spec on lookup failure — previously unreachable, but it would have written a manifest whose declared spec disagrees with its entries' partition tuples. It now errors instead, and spec groups are written in sorted order for deterministic output.

## Why

Manifests declare their own `partition-spec-id` and readers plan per-manifest with that spec; the default spec is a writer convention for new data, not a format constraint. Enforcing it as a constraint strands data after a partition evolution: a compactor holding correctly-encoded old-spec files cannot consolidate them even among themselves, and a rewrite migrating files between specs cannot express its adds. The delete side of the Go producer already groups entries per spec — this brings the add side in line.

## Java analogue

`MergingSnapshotProducer.add(DataFile)` has always resolved the file's spec via `spec(file.specId())` and routed it to a per-spec `ManifestWriter`, producing one manifest per spec per commit, with unknown spec ids failing on lookup. This PR matches that behavior; nothing in Java requires added files to use the default spec.

## Testing

New `TestAddDataFilesMultipleSpecs` in `TableWritingTestSuite` (runs v1/v2/v3): a mixed-spec commit produces one manifest per spec with spec ids and partition tuples round-tripping; real parquet files scan back fully; `PlanFiles` prunes each manifest via its own spec; the snapshot summary renders partition paths with each file's own spec; v3 first-row-id accounting is unaffected by the grouping; unregistered spec ids are rejected. The existing spec-id validation test keeps its scenario (spec id 999) with the new error message.

`AddFiles` (path-based) is intentionally unchanged — it still infers partition values against the current spec only.

Made with [Cursor](https://cursor.com)