### PR TITLE
perf(table): prebind metadata partition builders

### DIFF
--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -345,7 +345,7 @@ func appendContentFileRecord(bldr *array.RecordBuilder, partitionType *iceberg.S
 		return err
 	}
 
-	return contentFileBuilder.append(partitionType, file)
+	return contentFileBuilder.append(file)
 }
 
 func newInspectContentFileAppender(partitionType *iceberg.StructType) func(*array.RecordBuilder, iceberg.DataFile) error {
@@ -362,7 +362,7 @@ func newInspectContentFileAppender(partitionType *iceberg.StructType) func(*arra
 			return bindErr
 		}
 
-		return contentFileBuilder.append(partitionType, file)
+		return contentFileBuilder.append(file)
 	}
 }
 
@@ -371,7 +371,7 @@ type inspectContentFileBuilder struct {
 	filePath           *array.StringBuilder
 	fileFormat         *array.StringBuilder
 	specID             *array.Int32Builder
-	partition          *array.StructBuilder
+	partition          *inspectPartitionBuilder
 	recordCount        *array.Int64Builder
 	fileSize           *array.Int64Builder
 	columnSizes        *array.MapBuilder
@@ -388,6 +388,19 @@ type inspectContentFileBuilder struct {
 	referencedDataFile *array.StringBuilder
 	contentOffset      *array.Int64Builder
 	contentSize        *array.Int64Builder
+}
+
+type inspectPartitionBuilder struct {
+	builder *array.StructBuilder
+	fields  []inspectPartitionFieldBuilder
+}
+
+type inspectPartitionFieldBuilder struct {
+	id        int
+	name      string
+	typ       iceberg.Type
+	arrowType arrow.DataType
+	builder   array.Builder
 }
 
 func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceberg.StructType) (inspectContentFileBuilder, error) {
@@ -413,7 +426,11 @@ func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceb
 		return out, err
 	}
 	if partitionType != nil && len(partitionType.FieldList) > 0 {
-		if out.partition, err = inspectBuilderAs[*array.StructBuilder](lookup, inspectContentFieldIDPartition, "partition"); err != nil {
+		partitionBuilder, bindErr := inspectBuilderAs[*array.StructBuilder](lookup, inspectContentFieldIDPartition, "partition")
+		if bindErr != nil {
+			return out, bindErr
+		}
+		if out.partition, err = newInspectPartitionBuilder(partitionBuilder, partitionType); err != nil {
 			return out, err
 		}
 	}
@@ -469,14 +486,14 @@ func newInspectContentFileBuilder(bldr *array.RecordBuilder, partitionType *iceb
 	return out, nil
 }
 
-func (b inspectContentFileBuilder) append(partitionType *iceberg.StructType, file iceberg.DataFile) error {
+func (b inspectContentFileBuilder) append(file iceberg.DataFile) error {
 	b.content.Append(int32(file.ContentType()))
 	b.filePath.Append(file.FilePath())
 	b.fileFormat.Append(string(file.FileFormat()))
 	b.specID.Append(file.SpecID())
 
 	if b.partition != nil {
-		if err := appendInspectPartition(b.partition, partitionType, file.Partition()); err != nil {
+		if err := b.partition.append(file.Partition()); err != nil {
 			return err
 		}
 	}
@@ -519,37 +536,55 @@ func (b inspectContentFileBuilder) append(partitionType *iceberg.StructType, fil
 	return nil
 }
 
-func appendInspectPartition(builder *array.StructBuilder, partitionType *iceberg.StructType, values map[int]any) error {
+func newInspectPartitionBuilder(
+	builder *array.StructBuilder,
+	partitionType *iceberg.StructType,
+) (*inspectPartitionBuilder, error) {
 	arrowType, ok := builder.Type().(*arrow.StructType)
 	if !ok {
-		return fmt.Errorf("partition builder has type %T, want struct", builder.Type())
+		return nil, fmt.Errorf("partition builder has type %T, want struct", builder.Type())
 	}
 	lookup, err := newInspectBuilderLookup("partition", arrowType.Fields(), builder.FieldBuilder)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	expected := make(map[int]struct{}, len(partitionType.FieldList))
 	for _, field := range partitionType.FieldList {
 		expected[field.ID] = struct{}{}
 	}
 	if err := validateInspectBuilderLookup("partition", lookup, expected); err != nil {
-		return err
+		return nil, err
 	}
 
-	builder.Append(true)
+	fields := make([]inspectPartitionFieldBuilder, 0, len(partitionType.FieldList))
 	for _, field := range partitionType.FieldList {
-		value := values[field.ID]
 		fieldBuilder := lookup[field.ID]
+		fields = append(fields, inspectPartitionFieldBuilder{
+			id:        field.ID,
+			name:      field.Name,
+			typ:       field.Type,
+			arrowType: fieldBuilder.Type(),
+			builder:   fieldBuilder,
+		})
+	}
+
+	return &inspectPartitionBuilder{builder: builder, fields: fields}, nil
+}
+
+func (b *inspectPartitionBuilder) append(values map[int]any) error {
+	b.builder.Append(true)
+	for _, field := range b.fields {
+		value := values[field.id]
 		if value == nil {
-			fieldBuilder.AppendNull()
+			field.builder.AppendNull()
 
 			continue
 		}
-		sc, err := inspectValueScalar(value, field.Type, fieldBuilder.Type())
+		sc, err := inspectValueScalar(value, field.typ, field.arrowType)
 		if err != nil {
-			return fmt.Errorf("partition field %q: %w", field.Name, err)
+			return fmt.Errorf("partition field %q: %w", field.name, err)
 		}
-		if err := scalar.Append(fieldBuilder, sc); err != nil {
+		if err := scalar.Append(field.builder, sc); err != nil {
 			return err
 		}
 	}

--- a/table/inspect_files_bench_test.go
+++ b/table/inspect_files_bench_test.go
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+)
+
+func BenchmarkInspectContentFileAppender(b *testing.B) {
+	for _, fieldCount := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("fields=%d/files=4096", fieldCount), func(b *testing.B) {
+			partitionType, files := benchmarkInspectContentFiles(b, fieldCount, 4096)
+			arrowSchema, err := SchemaToArrowSchema(DataFilesSchema(partitionType), nil, true, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+			defer builder.Release()
+			appendFile := newInspectContentFileAppender(partitionType)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for _, file := range files {
+					if err := appendFile(builder, file); err != nil {
+						b.Fatal(err)
+					}
+				}
+				record := builder.NewRecordBatch()
+				record.Release()
+			}
+			b.StopTimer()
+		})
+	}
+}
+
+func benchmarkInspectContentFiles(
+	b *testing.B,
+	fieldCount int,
+	fileCount int,
+) (*iceberg.StructType, []iceberg.DataFile) {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := 0; i < fieldCount; i++ {
+		sourceID := i + 1
+		fieldID := 1000 + i
+		schemaFields[i] = iceberg.NestedField{
+			ID: sourceID, Name: fmt.Sprintf("source_%d", sourceID),
+			Type: iceberg.PrimitiveTypes.Int32, Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{sourceID}, FieldID: fieldID,
+			Name: fmt.Sprintf("partition_%d", fieldID), Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	schema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(partitionFields...)
+	partitionType := spec.PartitionType(schema)
+	files := make([]iceberg.DataFile, fileCount)
+	for i := range files {
+		values := make(map[int]any, fieldCount)
+		for field := range partitionFields {
+			values[partitionFields[field].FieldID] = int32(i + field)
+		}
+		dataFile, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, fmt.Sprintf("file-%d.parquet", i),
+			iceberg.ParquetFile, values, nil, nil, 1, 1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = dataFile.Build()
+	}
+
+	return partitionType, files
+}

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -1428,6 +1428,36 @@ func TestAppendContentFileRecordUsesFieldIDs(t *testing.T) {
 	require.EqualValues(t, file.Count(), record.Column(countIndex).(*array.Int64).Value(0))
 }
 
+func TestAppendContentFileRecordUsesPartitionFieldIDs(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "first", Type: iceberg.PrimitiveTypes.Int32},
+		{ID: 1001, Name: "second", Type: iceberg.PrimitiveTypes.Int32},
+	}}
+	reorderedPartitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		partitionType.FieldList[1], partitionType.FieldList[0],
+	}}
+	arrowSchema, err := SchemaToArrowSchema(DataFilesSchema(reorderedPartitionType), nil, true, false)
+	require.NoError(t, err)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer bldr.Release()
+	spec := iceberg.NewPartitionSpec(
+		iceberg.PartitionField{SourceIDs: []int{1}, FieldID: 1000, Name: "first", Transform: iceberg.IdentityTransform{}},
+		iceberg.PartitionField{SourceIDs: []int{2}, FieldID: 1001, Name: "second", Transform: iceberg.IdentityTransform{}},
+	)
+	file := newTestDataFile(t, spec, "mem://default/table-location/data/reordered-partition.parquet", map[int]any{
+		1000: int32(7), 1001: int32(9),
+	})
+	require.NoError(t, appendContentFileRecord(bldr, partitionType, file))
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	partitionIndex := record.Schema().FieldIndices("partition")[0]
+	partition := record.Column(partitionIndex).(*array.Struct)
+	require.EqualValues(t, 9, partition.Field(0).(*array.Int32).Value(0))
+	require.EqualValues(t, 7, partition.Field(1).(*array.Int32).Value(0))
+}
+
 func TestInspectPartitionTypeUsesAllActiveSpecs(t *testing.T) {
 	schema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "region", Type: iceberg.PrimitiveTypes.String, Required: true},


### PR DESCRIPTION
## Summary

- Bind metadata partition child builders when the record builder is created.
- Avoid rebuilding lookup maps and validating the same partition shape for every file.
- Keep field ID based lookup for reordered Arrow schemas.
- Add a 1, 8, and 32 field benchmark with 4,096 files.

## Benchmark

Apple M1 Pro, arm64. Each row appends 4,096 content files:

| Partition fields | Before | After | Result |
|---:|---:|---:|---|
| 1 | 5.00 ms, 7.80 MB, 74,317 allocs | 2.36 ms, 3.01 MB, 21,068 allocs | 2.1x faster, 61% fewer bytes, 72% fewer allocs |
| 8 | 18.31 ms, 20.82 MB, 273,439 allocs | 5.20 ms, 4.65 MB, 105,501 allocs | 3.5x faster, 79% fewer bytes, 61% fewer allocs |
| 32 | 54.72 ms, 93.31 MB, 993,399 allocs | 17.56 ms, 16.15 MB, 403,567 allocs | 3.1x faster, 83% fewer bytes, 59% fewer allocs |

## Tests

- go test ./...
- go vet .