### PR TITLE
perf(table): decode metadata updates in one pass

### DIFF
--- a/table/updates.go
+++ b/table/updates.go
@@ -100,7 +100,7 @@ var requiredUpdateFields = map[string][]string{
 	UpdateRemoveEncryptionKey:       {"key-id"},
 }
 
-func normalizeLegacyPropertyFields(action string, raw json.RawMessage) (json.RawMessage, error) {
+func normalizeLegacyPropertyFields(action string, object map[string]json.RawMessage) bool {
 	var modern, legacy string
 	switch action {
 	case UpdateSetProperties:
@@ -108,33 +108,28 @@ func normalizeLegacyPropertyFields(action string, raw json.RawMessage) (json.Raw
 	case UpdateRemoveProperties:
 		modern, legacy = "removals", "removed"
 	default:
-		return raw, nil
+		return false
 	}
 
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &object); err != nil {
-		return nil, err
-	}
-
+	normalized := false
 	if _, ok := object[modern]; !ok {
 		if value, ok := object[legacy]; ok {
 			object[modern] = value
+			normalized = true
 		}
 	}
-	delete(object, legacy)
+	if _, ok := object[legacy]; ok {
+		delete(object, legacy)
+		normalized = true
+	}
 
-	return json.Marshal(object)
+	return normalized
 }
 
-func validateRequiredUpdateFields(action string, raw json.RawMessage) error {
+func validateRequiredUpdateFields(action string, object map[string]json.RawMessage) error {
 	fields := requiredUpdateFields[action]
 	if len(fields) == 0 {
 		return nil
-	}
-
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &object); err != nil {
-		return err
 	}
 
 	for _, field := range fields {
@@ -158,17 +153,20 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		updates = make(Updates, 0, len(rawUpdates))
 	}
 	for _, raw := range rawUpdates {
-		var baseWire struct {
-			Action *string `json:"action"`
-		}
-		if err := json.Unmarshal(raw, &baseWire); err != nil {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &object); err != nil {
 			return err
 		}
-		if baseWire.Action == nil {
+		actionValue, ok := object["action"]
+		if !ok || bytes.Equal(bytes.TrimSpace(actionValue), []byte("null")) {
 			return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
 		}
+		var action string
+		if err := json.Unmarshal(actionValue, &action); err != nil {
+			return err
+		}
 
-		base := baseUpdate{ActionName: *baseWire.Action}
+		base := baseUpdate{ActionName: action}
 
 		var upd Update
 		switch base.ActionName {
@@ -221,12 +219,14 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		default:
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
-		normalized, err := normalizeLegacyPropertyFields(base.ActionName, raw)
-		if err != nil {
-			return err
+		if normalizeLegacyPropertyFields(base.ActionName, object) {
+			normalized, err := json.Marshal(object)
+			if err != nil {
+				return err
+			}
+			raw = normalized
 		}
-		raw = normalized
-		if err := validateRequiredUpdateFields(base.ActionName, raw); err != nil {
+		if err := validateRequiredUpdateFields(base.ActionName, object); err != nil {
 			return err
 		}
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/io"
@@ -157,13 +158,38 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(raw, &object); err != nil {
 			return err
 		}
-		actionValue, ok := object["action"]
-		if !ok || bytes.Equal(bytes.TrimSpace(actionValue), []byte("null")) {
-			return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+
+		actionValue, exactAction := object["action"]
+		actionFieldCount := 0
+		caseVariantAction := false
+		for field := range object {
+			if strings.EqualFold(field, "action") {
+				actionFieldCount++
+				if field != "action" {
+					caseVariantAction = true
+				}
+			}
 		}
+
 		var action string
-		if err := json.Unmarshal(actionValue, &action); err != nil {
-			return err
+		if exactAction && !caseVariantAction {
+			if bytes.Equal(bytes.TrimSpace(actionValue), []byte("null")) {
+				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+			}
+			if err := json.Unmarshal(actionValue, &action); err != nil {
+				return err
+			}
+		} else {
+			var baseWire struct {
+				Action *string `json:"action"`
+			}
+			if err := json.Unmarshal(raw, &baseWire); err != nil {
+				return err
+			}
+			if baseWire.Action == nil {
+				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+			}
+			action = *baseWire.Action
 		}
 
 		base := baseUpdate{ActionName: action}
@@ -220,6 +246,18 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
 		if normalizeLegacyPropertyFields(base.ActionName, object) {
+			if actionFieldCount > 1 {
+				for field := range object {
+					if strings.EqualFold(field, "action") {
+						delete(object, field)
+					}
+				}
+				actionJSON, err := json.Marshal(base.ActionName)
+				if err != nil {
+					return err
+				}
+				object["action"] = actionJSON
+			}
 			normalized, err := json.Marshal(object)
 			if err != nil {
 				return err

--- a/table/updates.go
+++ b/table/updates.go
@@ -143,6 +143,14 @@ func validateRequiredUpdateFields(action string, object map[string]json.RawMessa
 	return nil
 }
 
+func validateUpdateActionDecode(raw json.RawMessage) error {
+	var actionWire struct {
+		Action *string `json:"action"`
+	}
+
+	return json.Unmarshal(raw, &actionWire)
+}
+
 func (u *Updates) UnmarshalJSON(data []byte) error {
 	var rawUpdates []json.RawMessage
 	if err := json.Unmarshal(data, &rawUpdates); err != nil {
@@ -154,29 +162,48 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		updates = make(Updates, 0, len(rawUpdates))
 	}
 	for _, raw := range rawUpdates {
-		var baseWire struct {
-			Action *string `json:"action"`
-		}
-		if err := json.Unmarshal(raw, &baseWire); err != nil {
-			return err
-		}
-		if baseWire.Action == nil {
-			return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
-		}
-
 		var object map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &object); err != nil {
 			return err
 		}
 
+		actionValue, exactAction := object["action"]
 		actionFieldCount := 0
+		caseVariantAction := false
 		for field := range object {
 			if strings.EqualFold(field, "action") {
 				actionFieldCount++
+				if field != "action" {
+					caseVariantAction = true
+				}
 			}
 		}
 
-		base := baseUpdate{ActionName: *baseWire.Action}
+		var action string
+		if exactAction && !caseVariantAction {
+			if bytes.Equal(bytes.TrimSpace(actionValue), []byte("null")) {
+				if err := validateUpdateActionDecode(raw); err != nil {
+					return err
+				}
+				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+			}
+			if err := json.Unmarshal(actionValue, &action); err != nil {
+				return err
+			}
+		} else {
+			var baseWire struct {
+				Action *string `json:"action"`
+			}
+			if err := json.Unmarshal(raw, &baseWire); err != nil {
+				return err
+			}
+			if baseWire.Action == nil {
+				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+			}
+			action = *baseWire.Action
+		}
+
+		base := baseUpdate{ActionName: action}
 
 		var upd Update
 		switch base.ActionName {
@@ -227,9 +254,15 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		case UpdateRemoveEncryptionKey:
 			upd = &removeEncryptionKeyUpdate{}
 		default:
+			if err := validateUpdateActionDecode(raw); err != nil {
+				return err
+			}
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
 		if normalizeLegacyPropertyFields(base.ActionName, object) {
+			if err := validateUpdateActionDecode(raw); err != nil {
+				return err
+			}
 			if actionFieldCount > 1 {
 				for field := range object {
 					if strings.EqualFold(field, "action") {
@@ -249,6 +282,9 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			raw = normalized
 		}
 		if err := validateRequiredUpdateFields(base.ActionName, object); err != nil {
+			if actionErr := validateUpdateActionDecode(raw); actionErr != nil {
+				return actionErr
+			}
 			return err
 		}
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -246,6 +246,12 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
 		if normalizeLegacyPropertyFields(base.ActionName, object) {
+			var actionWire struct {
+				Action *string `json:"action"`
+			}
+			if err := json.Unmarshal(raw, &actionWire); err != nil {
+				return err
+			}
 			if actionFieldCount > 1 {
 				for field := range object {
 					if strings.EqualFold(field, "action") {

--- a/table/updates.go
+++ b/table/updates.go
@@ -185,6 +185,7 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 				if err := validateUpdateActionDecode(raw); err != nil {
 					return err
 				}
+
 				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
 			}
 			if err := json.Unmarshal(actionValue, &action); err != nil {
@@ -257,6 +258,7 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			if err := validateUpdateActionDecode(raw); err != nil {
 				return err
 			}
+
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
 		if normalizeLegacyPropertyFields(base.ActionName, object) {
@@ -285,6 +287,7 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			if actionErr := validateUpdateActionDecode(raw); actionErr != nil {
 				return actionErr
 			}
+
 			return err
 		}
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -154,45 +154,29 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 		updates = make(Updates, 0, len(rawUpdates))
 	}
 	for _, raw := range rawUpdates {
+		var baseWire struct {
+			Action *string `json:"action"`
+		}
+		if err := json.Unmarshal(raw, &baseWire); err != nil {
+			return err
+		}
+		if baseWire.Action == nil {
+			return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
+		}
+
 		var object map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &object); err != nil {
 			return err
 		}
 
-		actionValue, exactAction := object["action"]
 		actionFieldCount := 0
-		caseVariantAction := false
 		for field := range object {
 			if strings.EqualFold(field, "action") {
 				actionFieldCount++
-				if field != "action" {
-					caseVariantAction = true
-				}
 			}
 		}
 
-		var action string
-		if exactAction && !caseVariantAction {
-			if bytes.Equal(bytes.TrimSpace(actionValue), []byte("null")) {
-				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
-			}
-			if err := json.Unmarshal(actionValue, &action); err != nil {
-				return err
-			}
-		} else {
-			var baseWire struct {
-				Action *string `json:"action"`
-			}
-			if err := json.Unmarshal(raw, &baseWire); err != nil {
-				return err
-			}
-			if baseWire.Action == nil {
-				return fmt.Errorf("%w: update requires field %q", iceberg.ErrInvalidArgument, "action")
-			}
-			action = *baseWire.Action
-		}
-
-		base := baseUpdate{ActionName: action}
+		base := baseUpdate{ActionName: *baseWire.Action}
 
 		var upd Update
 		switch base.ActionName {
@@ -246,12 +230,6 @@ func (u *Updates) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("%w: unknown update action: %s", iceberg.ErrInvalidArgument, base.ActionName)
 		}
 		if normalizeLegacyPropertyFields(base.ActionName, object) {
-			var actionWire struct {
-				Action *string `json:"action"`
-			}
-			if err := json.Unmarshal(raw, &actionWire); err != nil {
-				return err
-			}
 			if actionFieldCount > 1 {
 				for field := range object {
 					if strings.EqualFold(field, "action") {

--- a/table/updates_bench_test.go
+++ b/table/updates_bench_test.go
@@ -39,15 +39,18 @@ func BenchmarkUnmarshalUpdates(b *testing.B) {
 				}
 
 				b.ReportAllocs()
+				b.SetBytes(int64(len(payload)))
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					var updates Updates
 					if err := json.Unmarshal(payload, &updates); err != nil {
 						b.Fatal(err)
 					}
+					if len(updates) != count {
+						b.Fatalf("decoded %d updates, want %d", len(updates), count)
+					}
 					benchmarkUpdates = updates
 				}
-				b.StopTimer()
 			})
 		}
 	}

--- a/table/updates_bench_test.go
+++ b/table/updates_bench_test.go
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+var benchmarkUpdates Updates
+
+func BenchmarkUnmarshalUpdates(b *testing.B) {
+	for _, legacy := range []bool{false, true} {
+		label := "canonical"
+		if legacy {
+			label = "legacy-properties"
+		}
+		for _, count := range []int{1, 10, 100, 1000} {
+			b.Run(fmt.Sprintf("%s/%d", label, count), func(b *testing.B) {
+				payload, err := benchmarkUpdatesPayload(count, legacy)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					var updates Updates
+					if err := json.Unmarshal(payload, &updates); err != nil {
+						b.Fatal(err)
+					}
+					benchmarkUpdates = updates
+				}
+				b.StopTimer()
+			})
+		}
+	}
+}
+
+func benchmarkUpdatesPayload(count int, legacyProperties bool) ([]byte, error) {
+	updates := make([]map[string]any, count)
+	for i := range updates {
+		switch i % 8 {
+		case 0:
+			updates[i] = map[string]any{
+				"action": "assign-uuid",
+				"uuid":   "550e8400-e29b-41d4-a716-446655440000",
+			}
+		case 1:
+			updates[i] = map[string]any{
+				"action":         "upgrade-format-version",
+				"format-version": 2,
+			}
+		case 2:
+			updates[i] = map[string]any{
+				"action":   "set-location",
+				"location": "s3://bucket/table",
+			}
+		case 3:
+			field := "updates"
+			if legacyProperties {
+				field = "updated"
+			}
+			updates[i] = map[string]any{
+				"action": "set-properties",
+				field:    map[string]string{"key": "value"},
+			}
+		case 4:
+			field := "removals"
+			if legacyProperties {
+				field = "removed"
+			}
+			updates[i] = map[string]any{
+				"action": "remove-properties",
+				field:    []string{"key"},
+			}
+		case 5:
+			updates[i] = map[string]any{
+				"action":     "remove-schemas",
+				"schema-ids": []int{1, 2, 3},
+			}
+		case 6:
+			updates[i] = map[string]any{
+				"action":   "remove-partition-specs",
+				"spec-ids": []int{1, 2, 3},
+			}
+		default:
+			updates[i] = map[string]any{
+				"action":      "set-snapshot-ref",
+				"ref-name":    "main",
+				"type":        "branch",
+				"snapshot-id": 1,
+			}
+		}
+	}
+
+	return json.Marshal(updates)
+}

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -768,6 +768,54 @@ func TestUnmarshalUpdatesRejectsMissingOrNullAction(t *testing.T) {
 	}
 }
 
+func TestUnmarshalUpdatesUsesJSONActionFieldSemantics(t *testing.T) {
+	tests := []struct {
+		name           string
+		data           string
+		expectedAction string
+		assert         func(*testing.T, Update)
+	}{
+		{
+			name:           "accepts mixed-case action key",
+			data:           `[{"Action":"set-location","location":"s3://bucket/table"}]`,
+			expectedAction: UpdateSetLocation,
+			assert: func(t *testing.T, update Update) {
+				t.Helper()
+				location, ok := update.(*setLocationUpdate)
+				require.True(t, ok)
+				assert.Equal(t, "s3://bucket/table", location.Location)
+			},
+		},
+		{
+			name:           "uses the last duplicate case-variant action key",
+			data:           `[{"action":"set-location","ACTION":"assign-uuid","location":"s3://bucket/table","uuid":"550e8400-e29b-41d4-a716-446655440000"}]`,
+			expectedAction: UpdateAssignUUID,
+			assert: func(t *testing.T, update Update) {
+				t.Helper()
+				assignUUID, ok := update.(*assignUUIDUpdate)
+				require.True(t, ok)
+				assert.Equal(t, uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"), assignUUID.UUID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var updates Updates
+			require.NoError(t, json.Unmarshal([]byte(tt.data), &updates))
+			require.Len(t, updates, 1)
+			assert.Equal(t, tt.expectedAction, updates[0].Action())
+			tt.assert(t, updates[0])
+		})
+	}
+
+	t.Run("rejects unknown action from duplicate case-variant key", func(t *testing.T) {
+		var updates Updates
+		err := json.Unmarshal([]byte(`[{"action":"set-location","ACTION":"unknown","location":"s3://bucket/table"}]`), &updates)
+		require.ErrorContains(t, err, "unknown update action: unknown")
+	})
+}
+
 func TestUnmarshalUpdatesAcceptsOptionalAndEmptyValues(t *testing.T) {
 	data := []byte(`[
 		{"action":"add-schema","schema":{"type":"struct","fields":[]}},

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -826,6 +826,10 @@ func TestUnmarshalUpdatesPreservesDuplicateActionTypeError(t *testing.T) {
 			data: `[{"action":123,"action":"set-properties","updated":{"k":"v"}}]`,
 		},
 		{
+			name: "valid final action with missing required field",
+			data: `[{"action":123,"action":"set-location"}]`,
+		},
+		{
 			name: "unknown final action",
 			data: `[{"action":123,"action":"unknown"}]`,
 		},

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -816,6 +816,14 @@ func TestUnmarshalUpdatesUsesJSONActionFieldSemantics(t *testing.T) {
 	})
 }
 
+func TestUnmarshalUpdatesPreservesDuplicateActionTypeError(t *testing.T) {
+	var updates Updates
+	var typeErr *json.UnmarshalTypeError
+	err := json.Unmarshal([]byte(`[{"action":123,"action":"set-properties","updated":{"k":"v"}}]`), &updates)
+
+	require.ErrorAs(t, err, &typeErr)
+}
+
 func TestUnmarshalUpdatesAcceptsOptionalAndEmptyValues(t *testing.T) {
 	data := []byte(`[
 		{"action":"add-schema","schema":{"type":"struct","fields":[]}},

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -817,11 +817,33 @@ func TestUnmarshalUpdatesUsesJSONActionFieldSemantics(t *testing.T) {
 }
 
 func TestUnmarshalUpdatesPreservesDuplicateActionTypeError(t *testing.T) {
-	var updates Updates
-	var typeErr *json.UnmarshalTypeError
-	err := json.Unmarshal([]byte(`[{"action":123,"action":"set-properties","updated":{"k":"v"}}]`), &updates)
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "valid final action",
+			data: `[{"action":123,"action":"set-properties","updated":{"k":"v"}}]`,
+		},
+		{
+			name: "unknown final action",
+			data: `[{"action":123,"action":"unknown"}]`,
+		},
+		{
+			name: "null final action",
+			data: `[{"action":123,"action":null}]`,
+		},
+	}
 
-	require.ErrorAs(t, err, &typeErr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var updates Updates
+			var typeErr *json.UnmarshalTypeError
+			err := json.Unmarshal([]byte(tt.data), &updates)
+
+			require.ErrorAs(t, err, &typeErr)
+		})
+	}
 }
 
 func TestUnmarshalUpdatesAcceptsOptionalAndEmptyValues(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reuse one raw field map for update action dispatch and required-field validation.
- Keep legacy property field normalization working.
- Avoid repeated JSON object decoding for every update.
- Add canonical and legacy update benchmarks.

## Benchmark

Apple M1 Pro, arm64. 1,000 updates:

| Payload | Before | After | Result |
|---|---:|---:|---|
| Canonical | 4.04 ms, 1.71 MB, 36,149 allocs | 2.96 ms, 1.39 MB, 26,897 allocs | 27% faster, 18% fewer bytes, 26% fewer allocs |
| Legacy properties | 4.19 ms, 1.71 MB, 36,151 allocs | 3.36 ms, 1.45 MB, 28,400 allocs | 20% faster, 16% fewer bytes, 21% fewer allocs |

## Tests

- go test ./...
- go vet .