### PR TITLE
perf(dv): avoid dense expansion for sparse masks

### DIFF
--- a/table/dv/roaring_bitmap.go
+++ b/table/dv/roaring_bitmap.go
@@ -299,6 +299,7 @@ func (b *RoaringPositionBitmap) KeepMaskBytes(length int64) []byte {
 				globalPos := bucketBitBase + pos
 				out[globalPos>>3] &^= byte(1 << (globalPos & 7))
 			}
+
 			continue
 		}
 

--- a/table/dv/roaring_bitmap.go
+++ b/table/dv/roaring_bitmap.go
@@ -281,18 +281,35 @@ func (b *RoaringPositionBitmap) KeepMaskBytes(length int64) []byte {
 	memory.Set(out, 0xFF)
 
 	for key, bm := range b.bitmaps {
-		bucketBitBase := int64(key) << 32
-		if bucketBitBase >= length {
+		bucketBitBase := uint64(key) << 32
+		if bucketBitBase >= uint64(length) {
 			continue
 		}
+		bucketBits := uint64(length) - bucketBitBase
+		if bucketBits > 1<<32 {
+			bucketBits = 1 << 32
+		}
+		if bm.CardinalityInRange(0, bucketBits) < bm.DenseSize() {
+			it := bm.Iterator()
+			for it.HasNext() {
+				pos := uint64(it.Next())
+				if pos >= bucketBits {
+					break
+				}
+				globalPos := bucketBitBase + pos
+				out[globalPos>>3] &^= byte(1 << (globalPos & 7))
+			}
+			continue
+		}
+
 		dense := bm.ToDense()
 		if len(dense) == 0 {
 			continue
 		}
 		// Cap the bucket's bit range to what fits in `length`.
-		bucketBits := int64(len(dense)) * 64
-		if bucketBitBase+bucketBits > length {
-			bucketBits = length - bucketBitBase
+		bucketBits = uint64(len(dense)) * 64
+		if bucketBits > uint64(length)-bucketBitBase {
+			bucketBits = uint64(length) - bucketBitBase
 		}
 		// bucketBitBase = key << 32 is always 8-byte-aligned, so the
 		// BitmapWordWriter runs with offset=0 internally. The trailing-byte

--- a/table/dv/roaring_bitmap_bench_test.go
+++ b/table/dv/roaring_bitmap_bench_test.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dv
+
+import "testing"
+
+var benchmarkKeepMask []byte
+
+func BenchmarkKeepMaskBytes(b *testing.B) {
+	const length int64 = 1 << 20
+
+	for _, tt := range []struct {
+		name       string
+		deletions  int
+		outOfRange bool
+		dense      bool
+	}{
+		{name: "sparse-10", deletions: 10},
+		{name: "sparse-1000", deletions: 1000},
+		{name: "medium-100000", deletions: 100000},
+		{name: "dense-range", dense: true},
+		{name: "sparse-out-of-range", deletions: 1, outOfRange: true},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			bitmap := NewRoaringPositionBitmap()
+			benchmarkLength := length
+			if tt.outOfRange {
+				benchmarkLength = 64
+				bitmap.Set(1 << 24)
+			} else if tt.dense {
+				bitmap.SetRange(0, uint64(length))
+			} else {
+				for i := 0; i < tt.deletions; i++ {
+					bitmap.Set(uint64(i) * uint64(length) / uint64(tt.deletions))
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkKeepMask = bitmap.KeepMaskBytes(benchmarkLength)
+			}
+		})
+	}
+}

--- a/table/dv/roaring_bitmap_bench_test.go
+++ b/table/dv/roaring_bitmap_bench_test.go
@@ -45,14 +45,14 @@ func BenchmarkKeepMaskBytes(b *testing.B) {
 			} else if tt.dense {
 				bitmap.SetRange(0, uint64(length))
 			} else {
-				for i := 0; i < tt.deletions; i++ {
+				for i := range tt.deletions {
 					bitmap.Set(uint64(i) * uint64(length) / uint64(tt.deletions))
 				}
 			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				benchmarkKeepMask = bitmap.KeepMaskBytes(benchmarkLength)
 			}
 		})

--- a/table/dv/roaring_bitmap_test.go
+++ b/table/dv/roaring_bitmap_test.go
@@ -235,6 +235,17 @@ func TestKeepMaskBytes(t *testing.T) {
 		}
 	})
 
+	t.Run("sparse high position", func(t *testing.T) {
+		const length int64 = 1 << 20
+		bm := NewRoaringPositionBitmap()
+		bm.Set(uint64(length - 1))
+
+		mask := bm.KeepMaskBytes(length)
+		require.Len(t, mask, int(length/8))
+		assert.False(t, bitAt(mask, length-1))
+		assert.True(t, bitAt(mask, length-2))
+	})
+
 	t.Run("length not byte-aligned: trailing bits cleared", func(t *testing.T) {
 		// Length 13 → 2 bytes, bits 13..15 in byte 1 must be 0 even when no
 		// deletes touch them. Pins the trailing-byte mask logic.


### PR DESCRIPTION
## Summary

- Clear sparse deletion positions directly in the keep mask.
- Keep the dense word path for dense and run-heavy vectors.
- Skip out-of-range buckets without expanding them.
- Add sparse and dense benchmarks plus a high-position correctness case.

## Benchmark

Apple M1 Pro, arm64. The mask covers 1 MiB of rows:

| Case | Before | After | Result |
|---|---:|---:|---|
| 10 sparse deletes | 95.2 us, 254 KB, 3 allocs | 25.0 us, 131 KB, 2 allocs | 3.8x faster, 48% fewer bytes |
| 1,000 sparse deletes | 108.1 us, 262 KB, 3 allocs | 27.5 us, 131 KB, 2 allocs | 3.9x faster, 50% fewer bytes |
| Dense range | 115.0 us, 262 KB, 3 allocs | 112.4 us, 262 KB, 3 allocs | essentially unchanged |
| Out-of-range delete | 208.3 us, 2.1 MB, 3 allocs | 126.6 ns, 120 B, 2 allocs | no dense temporary |

## Tests

- go test ./...
- go vet .