### PR TITLE
fix(table): release owned nested element refs in list / map projection

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1304,6 +1304,10 @@ func (a *arrowProjectionVisitor) List(listType iceberg.ListType, listArr arrow.A
 		return nil
 	}
 
+	if _, ok := valArr.DataType().(arrow.NestedType); ok {
+		defer valArr.Release()
+	}
+
 	valArr = a.castIfNeeded(listType.ElementField(), valArr)
 	defer valArr.Release()
 
@@ -1354,8 +1358,15 @@ func (a *arrowProjectionVisitor) Map(m iceberg.MapType, mapArray, keyResult, val
 		return nil
 	}
 
+	if _, ok := keyResult.DataType().(arrow.NestedType); ok {
+		defer keyResult.Release()
+	}
 	keys := a.castIfNeeded(m.KeyField(), keyResult)
 	defer keys.Release()
+
+	if _, ok := valResult.DataType().(arrow.NestedType); ok {
+		defer valResult.Release()
+	}
 	vals := a.castIfNeeded(m.ValueField(), valResult)
 	defer vals.Release()
 

--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1232,6 +1232,16 @@ func (a *arrowProjectionVisitor) Schema(_ *iceberg.Schema, _ arrow.Array, result
 	return result
 }
 
+func ownsChildResult(arr arrow.Array) bool {
+	if arr == nil {
+		return false
+	}
+
+	_, nested := arr.DataType().(arrow.NestedType)
+
+	return nested
+}
+
 func (a *arrowProjectionVisitor) Struct(st iceberg.StructType, structArr arrow.Array, fieldResults []arrow.Array) arrow.Array {
 	if structArr == nil {
 		return nil
@@ -1242,7 +1252,7 @@ func (a *arrowProjectionVisitor) Struct(st iceberg.StructType, structArr arrow.A
 	for i, field := range st.FieldList {
 		arr := fieldResults[i]
 		if arr != nil {
-			if _, ok := arr.DataType().(arrow.NestedType); ok {
+			if ownsChildResult(arr) {
 				defer arr.Release()
 			}
 
@@ -1299,13 +1309,13 @@ func (a *arrowProjectionVisitor) Field(_ iceberg.NestedField, _ arrow.Array, fie
 }
 
 func (a *arrowProjectionVisitor) List(listType iceberg.ListType, listArr arrow.Array, valArr arrow.Array) arrow.Array {
+	if ownsChildResult(valArr) {
+		defer valArr.Release()
+	}
+
 	arr, ok := listArr.(array.ListLike)
 	if !ok || valArr == nil {
 		return nil
-	}
-
-	if _, ok := valArr.DataType().(arrow.NestedType); ok {
-		defer valArr.Release()
 	}
 
 	valArr = a.castIfNeeded(listType.ElementField(), valArr)
@@ -1349,6 +1359,14 @@ func (a *arrowProjectionVisitor) List(listType iceberg.ListType, listArr arrow.A
 }
 
 func (a *arrowProjectionVisitor) Map(m iceberg.MapType, mapArray, keyResult, valResult arrow.Array) arrow.Array {
+	if ownsChildResult(keyResult) {
+		defer keyResult.Release()
+	}
+
+	if ownsChildResult(valResult) {
+		defer valResult.Release()
+	}
+
 	if keyResult == nil || valResult == nil {
 		return nil
 	}
@@ -1358,15 +1376,8 @@ func (a *arrowProjectionVisitor) Map(m iceberg.MapType, mapArray, keyResult, val
 		return nil
 	}
 
-	if _, ok := keyResult.DataType().(arrow.NestedType); ok {
-		defer keyResult.Release()
-	}
 	keys := a.castIfNeeded(m.KeyField(), keyResult)
 	defer keys.Release()
-
-	if _, ok := valResult.DataType().(arrow.NestedType); ok {
-		defer valResult.Release()
-	}
 	vals := a.castIfNeeded(m.ValueField(), valResult)
 	defer vals.Release()
 
@@ -1400,7 +1411,8 @@ func (a *arrowProjectionVisitor) Variant(_ iceberg.VariantType, arr arrow.Array)
 	}
 	// UnshredVariant returns a caller-owned array whose ref is balanced by
 	// castIfNeeded's Retain/Release. This holds only because VariantType is not
-	// an arrow.NestedType; if it were, Struct would also Release and double-free.
+	// an arrow.NestedType; if it were, ownsChildResult would report true and the
+	// parent Struct/List/Map would Release and double-free.
 	// The checked-allocator leak tests guard this invariant.
 	out, err := extensions.UnshredVariant(varr, compute.GetAllocator(a.ctx))
 	if err != nil {

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -1403,6 +1403,146 @@ func TestToRequestedSchemaListLargeTypeCoercion(t *testing.T) {
 	})
 }
 
+func TestToRequestedSchemaListOfStructNoLeak(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	elemStruct := arrow.StructOf(
+		arrow.Field{Name: "x", Type: arrow.PrimitiveTypes.Int32, Nullable: false, Metadata: fieldIDMeta("2")},
+	)
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "nested", Type: arrow.ListOfField(arrow.Field{
+			Name: "element", Type: elemStruct, Nullable: false, Metadata: fieldIDMeta("3"),
+		}), Nullable: false, Metadata: fieldIDMeta("1")},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, arrowSchema)
+	defer bldr.Release()
+	lb := bldr.Field(0).(*array.ListBuilder)
+	sb := lb.ValueBuilder().(*array.StructBuilder)
+	lb.Append(true)
+	sb.Append(true)
+	sb.FieldBuilder(0).(*array.Int32Builder).Append(42)
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	icesc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "nested", Type: &iceberg.ListType{
+			ElementID: 3, Element: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 2, Name: "x", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+				},
+			}, ElementRequired: true,
+		}, Required: false},
+	)
+
+	converted, err := table.ToRequestedSchema(ctx, icesc, icesc, rec, table.SchemaOptions{})
+	require.NoError(t, err)
+	defer converted.Release()
+
+	list := converted.Column(0).(*array.List)
+	require.Equal(t, 1, list.Len())
+	elems := list.ListValues().(*array.Struct)
+	require.Equal(t, 1, elems.Len())
+	assert.Equal(t, int32(42), elems.Field(0).(*array.Int32).Value(0))
+}
+
+func TestToRequestedSchemaMapStructValueNoLeak(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	valStruct := arrow.StructOf(
+		arrow.Field{Name: "x", Type: arrow.PrimitiveTypes.Int32, Nullable: false, Metadata: fieldIDMeta("3")},
+	)
+	mapType := arrow.MapOfWithMetadata(arrow.BinaryTypes.String, fieldIDMeta("2"), valStruct, fieldIDMeta("4"))
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "m", Type: mapType, Nullable: false, Metadata: fieldIDMeta("1")},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, arrowSchema)
+	defer bldr.Release()
+	mb := bldr.Field(0).(*array.MapBuilder)
+	kb := mb.KeyBuilder().(*array.StringBuilder)
+	vb := mb.ItemBuilder().(*array.StructBuilder)
+	mb.Append(true)
+	kb.Append("k")
+	vb.Append(true)
+	vb.FieldBuilder(0).(*array.Int32Builder).Append(7)
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	icesc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "m", Type: &iceberg.MapType{
+			KeyID: 2, KeyType: iceberg.PrimitiveTypes.String,
+			ValueID: 4, ValueType: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 3, Name: "x", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+				},
+			}, ValueRequired: true,
+		}, Required: false},
+	)
+
+	converted, err := table.ToRequestedSchema(ctx, icesc, icesc, rec, table.SchemaOptions{})
+	require.NoError(t, err)
+	defer converted.Release()
+
+	m := converted.Column(0).(*array.Map)
+	require.Equal(t, 1, m.Keys().Len())
+	assert.Equal(t, "k", m.Keys().(*array.String).Value(0))
+	vals := m.Items().(*array.Struct)
+	require.Equal(t, 1, vals.Len())
+	assert.Equal(t, int32(7), vals.Field(0).(*array.Int32).Value(0))
+}
+
+func TestToRequestedSchemaListOfListNoLeak(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	innerList := arrow.ListOfField(arrow.Field{
+		Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false, Metadata: fieldIDMeta("3"),
+	})
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "nested", Type: arrow.ListOfField(arrow.Field{
+			Name: "element", Type: innerList, Nullable: false, Metadata: fieldIDMeta("2"),
+		}), Nullable: false, Metadata: fieldIDMeta("1")},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, arrowSchema)
+	defer bldr.Release()
+	outerLb := bldr.Field(0).(*array.ListBuilder)
+	innerLb := outerLb.ValueBuilder().(*array.ListBuilder)
+	ib := innerLb.ValueBuilder().(*array.Int32Builder)
+	outerLb.Append(true)
+	innerLb.Append(true)
+	ib.Append(9)
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	icesc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "nested", Type: &iceberg.ListType{
+			ElementID: 2, Element: &iceberg.ListType{
+				ElementID: 3, Element: iceberg.PrimitiveTypes.Int32, ElementRequired: true,
+			}, ElementRequired: true,
+		}, Required: false},
+	)
+
+	converted, err := table.ToRequestedSchema(ctx, icesc, icesc, rec, table.SchemaOptions{})
+	require.NoError(t, err)
+	defer converted.Release()
+
+	outer := converted.Column(0).(*array.List)
+	require.Equal(t, 1, outer.Len())
+	inner := outer.ListValues().(*array.List)
+	require.Equal(t, 1, inner.Len())
+	assert.Equal(t, int32(9), inner.ListValues().(*array.Int32).Value(0))
+}
+
 func TestToRequestedSchemaWriteDefaults(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())

--- a/table/arrow_utils_test.go
+++ b/table/arrow_utils_test.go
@@ -1498,6 +1498,56 @@ func TestToRequestedSchemaMapStructValueNoLeak(t *testing.T) {
 	assert.Equal(t, int32(7), vals.Field(0).(*array.Int32).Value(0))
 }
 
+func TestToRequestedSchemaMapStructKeyNoLeak(t *testing.T) {
+	ctx := context.Background()
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	keyStruct := arrow.StructOf(
+		arrow.Field{Name: "k", Type: arrow.BinaryTypes.String, Nullable: false, Metadata: fieldIDMeta("3")},
+	)
+	mapType := arrow.MapOfWithMetadata(keyStruct, fieldIDMeta("2"), arrow.PrimitiveTypes.Int32, fieldIDMeta("4"))
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "m", Type: mapType, Nullable: false, Metadata: fieldIDMeta("1")},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, arrowSchema)
+	defer bldr.Release()
+	mb := bldr.Field(0).(*array.MapBuilder)
+	kb := mb.KeyBuilder().(*array.StructBuilder)
+	vb := mb.ItemBuilder().(*array.Int32Builder)
+	mb.Append(true)
+	kb.Append(true)
+	kb.FieldBuilder(0).(*array.StringBuilder).Append("k")
+	vb.Append(7)
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	icesc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "m", Type: &iceberg.MapType{
+			KeyID: 2, KeyType: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 3, Name: "k", Type: iceberg.PrimitiveTypes.String, Required: true},
+				},
+			},
+			ValueID: 4, ValueType: iceberg.PrimitiveTypes.Int32, ValueRequired: true,
+		}, Required: false},
+	)
+
+	converted, err := table.ToRequestedSchema(ctx, icesc, icesc, rec, table.SchemaOptions{})
+	require.NoError(t, err)
+	defer converted.Release()
+
+	m := converted.Column(0).(*array.Map)
+	keys := m.Keys().(*array.Struct)
+	require.Equal(t, 1, keys.Len())
+	assert.Equal(t, "k", keys.Field(0).(*array.String).Value(0))
+	vals := m.Items().(*array.Int32)
+	require.Equal(t, 1, vals.Len())
+	assert.Equal(t, int32(7), vals.Value(0))
+}
+
 func TestToRequestedSchemaListOfListNoLeak(t *testing.T) {
 	ctx := context.Background()
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())


### PR DESCRIPTION
### Description

Fixes #1819 

There was a reference counting leak in schema projection - `ToRequestedSchema` for list / map columns whose element / key / value is struct, list or map. 

`List()` / `Map()` overwrote the caller-owned original array with `castIfNeeded`'s retained copy without releasing the original first — `Struct()` already does this correctly via a two-defer pattern; ports the same pattern.

### Testing
Added three regression tests that fail without the fix.