### PR TITLE
fix(table): skip reserved lineage columns missing from the metrics plan

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1051,7 +1051,21 @@ func (p parquetFormat) DataFileStatsFromMeta(meta Metadata, statsCols map[int]St
 
 				panic(fmt.Errorf("column chunk %q not found in column mapping", colChunk.PathInSchema()))
 			}
-			statsCol := statsCols[fieldID]
+			statsCol, ok := statsCols[fieldID]
+			if !ok {
+				// Only the reserved row-lineage metadata columns (_row_id,
+				// _last_updated_sequence_number) may legitimately appear in
+				// a file without a metrics-plan entry: writers materialize
+				// them without adding them to the table schema. Any other
+				// field id missing from the plan means the plan and the
+				// file disagree — fail loudly rather than silently dropping
+				// that column's stats.
+				if iceberg.IsMetadataColumn(fieldID) {
+					continue
+				}
+
+				panic(fmt.Errorf("field id %d (column %q) not found in the metrics plan", fieldID, colChunk.PathInSchema()))
+			}
 			if statsCol.Mode.Typ == MetricModeNone {
 				continue
 			}

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -437,6 +437,63 @@ func getCollector() map[int]internal.StatisticsCollector {
 	}
 }
 
+// TestMetricsSkipColumnOutsidePlan: only a reserved row-lineage
+// metadata column (e.g. a writer-materialized _row_id, which is never
+// part of the table schema) may appear in a file without a
+// metrics-plan entry; it must be skipped entirely, not aggregated
+// through a zero-value collector (whose nil Iceberg type panics inside
+// the stats aggregator). Any other field id missing from the plan is a
+// plan/file mismatch and must fail loudly.
+func TestMetricsSkipColumnOutsidePlan(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	t.Run("reserved lineage column is skipped", func(t *testing.T) {
+		meta, tblMeta := constructTestTablePrimitiveTypes(t)
+		mapping, err := format.PathToIDMapping(tblMeta.CurrentSchema())
+		require.NoError(t, err)
+
+		// Simulate a writer-materialized lineage column: the file column
+		// "binaries" resolves to the reserved _row_id field id, which has
+		// no entry in the metrics plan.
+		mapping["binaries"] = iceberg.RowIDFieldID
+		collector := getCollector()
+		delete(collector, 12)
+
+		stats := format.DataFileStatsFromMeta(internal.Metadata(meta), collector, mapping, nil, nil)
+		df := stats.ToDataFile(internal.DataFileOpts{
+			Schema:   tblMeta.CurrentSchema(),
+			Spec:     tblMeta.PartitionSpec(),
+			Path:     "fake-path.parquet",
+			Format:   iceberg.ParquetFile,
+			Content:  iceberg.EntryContentData,
+			FileSize: meta.GetSourceFileSize(),
+		})
+
+		for _, id := range []int{12, iceberg.RowIDFieldID} {
+			assert.NotContains(t, df.ValueCounts(), id)
+			assert.NotContains(t, df.NullValueCounts(), id)
+			assert.NotContains(t, df.ColumnSizes(), id)
+			assert.NotContains(t, df.LowerBoundValues(), id)
+			assert.NotContains(t, df.UpperBoundValues(), id)
+		}
+		assert.Len(t, df.ValueCounts(), 14)
+		assert.Len(t, df.LowerBoundValues(), 14)
+	})
+
+	t.Run("non-reserved column missing from plan fails", func(t *testing.T) {
+		meta, tblMeta := constructTestTablePrimitiveTypes(t)
+		mapping, err := format.PathToIDMapping(tblMeta.CurrentSchema())
+		require.NoError(t, err)
+
+		collector := getCollector()
+		delete(collector, 12) // "binaries" is a schema column: mismatch
+
+		assert.PanicsWithError(t, `field id 12 (column "binaries") not found in the metrics plan`, func() {
+			format.DataFileStatsFromMeta(internal.Metadata(meta), collector, mapping, nil, nil)
+		})
+	})
+}
+
 func TestMetricsPrimitiveTypes(t *testing.T) {
 	format := internal.GetFileFormat(iceberg.ParquetFile)
 
@@ -1090,11 +1147,22 @@ func TestWriteDataFileErrOnClose(t *testing.T) {
 	icesc, err := table.ArrowSchemaToIceberg(schema, false, nil)
 	require.NoError(t, err)
 
+	// The stats plan must cover every non-lineage file column: the list
+	// element (field id 2) is the only parquet leaf column here.
+	statsCols := map[int]internal.StatisticsCollector{
+		2: {
+			FieldID:    2,
+			Mode:       internal.MetricsMode{Typ: internal.MetricModeFull},
+			ColName:    "nested.element",
+			IcebergTyp: iceberg.PrimitiveTypes.Int32,
+		},
+	}
+
 	_, err = fm.WriteDataFile(ctx, &mockfs, nil, internal.WriteFileInfo{
 		FileSchema: icesc,
 		Spec:       iceberg.PartitionSpec{},
 		FileName:   "f",
-		StatsCols:  nil,
+		StatsCols:  statsCols,
 		WriteProps: []parquet.WriterProperty{},
 	}, []arrow.RecordBatch{rec})
 	require.ErrorContains(t, err, "error on close")


### PR DESCRIPTION
## What

`DataFileStatsFromMeta` panics on Parquet files that materialize the reserved v3 row-lineage columns `_row_id` (field-id 2147483540) and `_last_updated_sequence_number` (2147483539): writers emit those columns without adding them to the table schema, so they have no entry in the metrics plan, and the zero-value `StatisticsCollector` panics inside the aggregator on its nil Iceberg type.

After resolving a column's field id, the collector lookup now checks `ok`. Missing and `iceberg.IsMetadataColumn(fieldID)`: skip the column (no stats). Missing and a real schema column: panic with the field id and column path — a plan/file mismatch is a bug, not a condition to paper over. `MetricModeNone` still skips as before.

## Why

Per the spec ([Reserved Field IDs](https://iceberg.apache.org/spec/#reserved-field-ids), [Row Lineage](https://iceberg.apache.org/spec/#row-lineage)) these are reserved metadata columns; a writer that materializes them is not required to put them on the table schema. This repo's own `position_delta_writer.go` does exactly that — it writes `_row_id` into data files without touching the table schema — so stats collection over such a file panics today.

One disclosed tightening: a nil or partial `StatsCols` plan now panics deterministically for any real schema column holding values (previously it could pass silently when the column happened to contain only nulls). `TestWriteDataFileErrOnClose` was updated to supply a plan covering the list-element leaf so it reaches the close error it actually tests.

## Tests

- Reserved `_row_id` outside the plan is skipped and produces no stats; a non-reserved schema column outside the plan panics with the field id and path.
- `go test ./table/...` and `golangci-lint run` are clean.

Made with [Cursor](https://cursor.com)
