### PR TITLE
fix(catalog/rest): keep status override when error body is malformed

### DIFF
--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -597,9 +597,13 @@ func handleNon200(rsp *http.Response, override map[int]error, typeOverride map[s
 		if decErr != nil && decErr != io.EOF {
 			// Preserve the HTTP metadata even when the server returned a non-JSON
 			// error page. Callers such as WaitForPlan still need the status to apply
-			// transport-level retry policy; the wrapping sentinel retains the prior
-			// ErrRESTError classification for malformed error payloads.
+			// transport-level retry policy. A status the caller mapped keeps that
+			// classification (e.g. an ambiguous commit 5xx stays ErrCommitStateUnknown)
+			// even when a proxy garbled the body; unmapped statuses keep ErrRESTError.
 			e.wrapping = ErrRESTError
+			if statusErr, ok := override[rsp.StatusCode]; ok {
+				e.wrapping = statusErr
+			}
 
 			return fmt.Errorf("%w: failed to decode error response: %s", e, decErr.Error())
 		}

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -1419,6 +1419,97 @@ func TestHandleNon200_PreservesStatusOnMalformedBody(t *testing.T) {
 	require.ErrorIs(t, err, ErrRESTError)
 }
 
+func TestHandleNon200_StatusOverrideAppliesOnMalformedBody(t *testing.T) {
+	// The caller-supplied status override carries the semantics of the status
+	// line itself, so a 5xx commit with a garbled body must classify the same
+	// as a well-formed envelope: ErrCommitStateUnknown. Callers retry on that
+	// sentinel; stripping it when a proxy mangles the payload would turn a
+	// retryable unknown commit into a fatal decode error. Unmapped statuses
+	// keep the plain decode-failure classification.
+	commitOverride := map[int]error{
+		http.StatusConflict:            ErrCommitFailed,
+		http.StatusInternalServerError: ErrCommitStateUnknown,
+		http.StatusBadGateway:          ErrCommitStateUnknown,
+		http.StatusServiceUnavailable:  ErrCommitStateUnknown,
+		http.StatusGatewayTimeout:      ErrCommitStateUnknown,
+	}
+
+	wellFormed := func(status int) string {
+		return fmt.Sprintf(`{"error":{"message":"%s","type":"ServerException","code":%d}}`,
+			http.StatusText(status), status)
+	}
+	const malformed = `{"error":{"message":"boom`
+
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantIs     error
+		wantNotIs  error
+		wantDecode bool
+	}{
+		{
+			name:   "well-formed 500",
+			status: http.StatusInternalServerError,
+			body:   wellFormed(http.StatusInternalServerError),
+			wantIs: ErrCommitStateUnknown,
+		},
+		{
+			name:       "malformed 500",
+			status:     http.StatusInternalServerError,
+			body:       malformed,
+			wantIs:     ErrCommitStateUnknown,
+			wantDecode: true,
+		},
+		{
+			name:   "well-formed 409",
+			status: http.StatusConflict,
+			body:   wellFormed(http.StatusConflict),
+			wantIs: ErrCommitFailed,
+		},
+		{
+			name:       "malformed 409",
+			status:     http.StatusConflict,
+			body:       malformed,
+			wantIs:     ErrCommitFailed,
+			wantNotIs:  ErrCommitStateUnknown,
+			wantDecode: true,
+		},
+		{
+			name:       "malformed unmapped 404",
+			status:     http.StatusNotFound,
+			body:       malformed,
+			wantIs:     ErrRESTError,
+			wantNotIs:  ErrCommitStateUnknown,
+			wantDecode: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rsp := &http.Response{
+				StatusCode:    tc.status,
+				ContentLength: int64(len(tc.body)),
+				Body:          io.NopCloser(bytes.NewBufferString(tc.body)),
+			}
+
+			err := handleNon200(rsp, commitOverride, nil)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantIs)
+			if tc.wantNotIs != nil {
+				require.NotErrorIs(t, err, tc.wantNotIs)
+			}
+			if tc.wantDecode {
+				require.ErrorContains(t, err, "failed to decode error response")
+			}
+
+			var restErr errorResponse
+			require.ErrorAs(t, err, &restErr)
+			require.Equal(t, tc.status, restErr.statusCode)
+		})
+	}
+}
+
 func TestHandleNon200_ErrorTypeOverride(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/rest_test.go
+++ b/catalog/rest/rest_test.go
@@ -3481,6 +3481,77 @@ func (r *RestCatalogSuite) TestCommitTableErrCommitStateUnknown() {
 	}
 }
 
+func (r *RestCatalogSuite) TestCommitTableErrorBodyKeepsCommitStateUnknown() {
+	// A 5xx commit with a well-formed Iceberg error envelope and one whose
+	// body a proxy replaced with invalid JSON must classify the same:
+	// ErrCommitStateUnknown. The status line, not the payload, carries the
+	// ambiguous-commit semantics callers retry on.
+	var statusCode int
+	var body []byte
+
+	r.mux.HandleFunc("/v1/oauth/tokens", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": TestToken, "token_type": "Bearer", "expires_in": 3600,
+		})
+	})
+
+	r.mux.HandleFunc("/v1/namespaces/db/tables/tbl", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		w.Write(body)
+	})
+
+	cat, err := rest.NewCatalog(context.Background(), "rest", r.srv.URL,
+		rest.WithCredential(TestCreds))
+	r.Require().NoError(err)
+
+	wellFormed := func(code int) []byte {
+		b, err := json.Marshal(map[string]any{
+			"error": map[string]any{
+				"message": http.StatusText(code),
+				"type":    "ServerException",
+				"code":    code,
+			},
+		})
+		r.Require().NoError(err)
+
+		return b
+	}
+
+	for _, tc := range []struct {
+		name       string
+		body       func(int) []byte
+		wantDecode bool
+	}{
+		{"well-formed envelope", wellFormed, false},
+		{"malformed body", func(int) []byte { return []byte(`{"error":{"message":"boom`) }, true},
+	} {
+		for _, code := range []int{
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout,
+		} {
+			statusCode = code
+			body = tc.body(code)
+			r.Run(tc.name+"/"+strconv.Itoa(code), func() {
+				_, _, err := cat.CommitTable(context.Background(),
+					table.Identifier{"db", "tbl"},
+					[]table.Requirement{},
+					[]table.Update{},
+				)
+				r.Require().Error(err)
+				r.ErrorIs(err, rest.ErrCommitStateUnknown,
+					"%s %d should return ErrCommitStateUnknown, got: %v", tc.name, code, err)
+				if tc.wantDecode {
+					r.ErrorContains(err, "failed to decode error response")
+				}
+			})
+		}
+	}
+}
+
 func (r *RestCatalogSuite) TestUpdateTableErrCommitStateUnknown() {
 	var statusCode int
 


### PR DESCRIPTION
## What

`handleNon200` returned early when the Iceberg error-envelope JSON failed to decode, before applying the per-status override map. A 5xx commit response whose body a proxy or load balancer replaced with an HTML error page (or truncated JSON) therefore surfaced as a bare `ErrRESTError` decode failure instead of `ErrCommitStateUnknown`.

Callers classify `ErrCommitStateUnknown` as an ambiguous commit — the write may or may not have landed — and handle it accordingly. Losing that sentinel turns a transient catalog/proxy fault into a fatal error after one attempt; transport garbling should not strip commit-state classification.

On a non-EOF decode failure, `handleNon200` now looks up the caller-supplied `override[status]` and wraps that sentinel (else `ErrRESTError`), still wrapping the `errorResponse` so the HTTP status and `Retry-After` survive for pollers like `WaitForPlan`. Mapped 5xx commits stay `ErrCommitStateUnknown`, mapped 409s stay `ErrCommitFailed`, unmapped statuses still classify as `ErrRESTError`, and the decode failure remains in the error message.

## Tests

- Table-driven `TestHandleNon200_StatusOverrideAppliesOnMalformedBody`: well-formed vs malformed 500 both map to `ErrCommitStateUnknown`; well-formed vs malformed 409 both map to `ErrCommitFailed`; unmapped malformed 404 stays `ErrRESTError`.
- `TestCommitTableErrorBodyKeepsCommitStateUnknown` pins the same well-formed/malformed pairs end-to-end through `CommitTable` for 500/502/503/504.
- `go test ./catalog/...` and `golangci-lint run` are clean.

Made with [Cursor](https://cursor.com)
