### PR TITLE
feat(table): add Transaction.ReplaceSortOrder (Java Table.replaceSortOrder parity)

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -1740,7 +1740,10 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 				}
 			}()
 
-			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, meta.props)
+			// Pass 0 so AddFiles does not claim sort_order_id on files
+			// it did not write (#1184). Callers that know the file's
+			// sort layout use FileToDataFile with an explicit id.
+			dataFiles[i] = fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, 0, meta.props)
 
 			return nil
 		})
@@ -1753,9 +1756,30 @@ func filesToDataFiles(ctx context.Context, fileIO iceio.IO, meta *MetadataBuilde
 	return dataFiles, nil
 }
 
-// fileToDataFile builds a DataFile for a pre-existing file. The caller cannot
-// convey its sort layout, so no sort_order_id is claimed.
-func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, props iceberg.Properties) iceberg.DataFile {
+// FileToDataFile builds a DataFile for an existing parquet file at
+// filePath, reading its footer to populate record count, file size,
+// column sizes, value/null counts and lower/upper bounds, and to infer
+// partition values for order-preserving transforms. sortOrderID is
+// stamped onto the DataFile so callers converting foreign parquet
+// footers can convey the file's sort layout (spec data-file field
+// sort_order_id); pass 0 to make no claim. Panics from the unexported
+// conversion are recovered into an error.
+func FileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, sortOrderID int, props iceberg.Properties) (df iceberg.DataFile, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch e := r.(type) {
+			case error:
+				err = fmt.Errorf("error encountered during file conversion: %w", e)
+			default:
+				err = fmt.Errorf("error encountered during file conversion: %v", e)
+			}
+		}
+	}()
+
+	return fileToDataFile(ctx, fileIO, filePath, currentSchema, currentSpec, sortOrderID, props), nil
+}
+
+func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, currentSchema *iceberg.Schema, currentSpec iceberg.PartitionSpec, sortOrderID int, props iceberg.Properties) iceberg.DataFile {
 	format := tblutils.FormatFromFileName(filePath)
 	rdr := must(format.Open(ctx, fileIO, filePath))
 	defer rdr.Close()
@@ -1802,6 +1826,7 @@ func fileToDataFile(ctx context.Context, fileIO iceio.IO, filePath string, curre
 		Content:         iceberg.EntryContentData,
 		FileSize:        rdr.SourceFileSize(),
 		PartitionValues: partitionValues,
+		SortOrderID:     sortOrderID,
 	})
 }
 

--- a/table/file_to_data_file_test.go
+++ b/table/file_to_data_file_test.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileToDataFile(t *testing.T) {
+	ctx := context.Background()
+	fs := iceio.LocalFS{}
+	path := t.TempDir() + "/data.parquet"
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+	bldr := array.NewInt32Builder(memory.DefaultAllocator)
+	defer bldr.Release()
+	bldr.AppendValues([]int32{3, 7}, nil)
+	col := bldr.NewArray()
+	defer col.Release()
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{col}, 2)
+	defer rec.Release()
+	arrTbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer arrTbl.Release()
+
+	fo, err := fs.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(arrTbl, fo, arrTbl.NumRows(), nil, pqarrow.DefaultWriterProps()))
+
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+
+	df, err := table.FileToDataFile(ctx, fs, path, schema, *iceberg.UnpartitionedSpec, 0, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, df.Count())
+	require.Positive(t, df.FileSizeBytes())
+	require.NotEmpty(t, df.LowerBoundValues()[1])
+	require.NotEmpty(t, df.UpperBoundValues()[1])
+	require.EqualValues(t, 2, df.ValueCounts()[1])
+	require.EqualValues(t, 0, df.NullValueCounts()[1])
+	require.Nil(t, df.SortOrderID(), "sortOrderID 0 must leave sort_order_id unset")
+
+	const claimedOrder = 3
+	sorted, err := table.FileToDataFile(ctx, fs, path, schema, *iceberg.UnpartitionedSpec, claimedOrder, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sorted.SortOrderID())
+	require.Equal(t, claimedOrder, *sorted.SortOrderID())
+
+	_, err = table.FileToDataFile(ctx, fs, path+".missing", schema, *iceberg.UnpartitionedSpec, 0, nil)
+	require.Error(t, err)
+}

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -508,6 +508,41 @@ func (t *Transaction) UpdateSpec(caseSensitive bool) *UpdateSpec {
 	return NewUpdateSpec(t, caseSensitive)
 }
 
+// ReplaceSortOrder stages order as the table's new default sort order,
+// the analogue of Java's Table.replaceSortOrder() / BaseReplaceSortOrder.
+// The metadata builder reuses the ID of an equivalent existing order or
+// assigns the next available one, so order's own ID is ignored. The
+// commit is fenced by AssertDefaultSortOrderID, matching
+// UpdateRequirements.forUpdateTable on SetDefaultSortOrder. Replacing
+// the default with a field-identical order is a no-op.
+func (t *Transaction) ReplaceSortOrder(order SortOrder) error {
+	meta, err := t.txnMeta()
+	if err != nil {
+		return err
+	}
+	if cur, err := meta.GetSortOrderByID(meta.defaultSortOrderID); err == nil && sameSortFields(*cur, order) {
+		return nil
+	}
+
+	return t.apply(
+		[]Update{NewAddSortOrderUpdate(&order), NewSetDefaultSortOrderUpdate(-1)},
+		[]Requirement{AssertDefaultSortOrderID(t.tbl.Metadata().DefaultSortOrder())},
+	)
+}
+
+func sameSortFields(a, b SortOrder) bool {
+	if a.Len() != b.Len() {
+		return false
+	}
+	for i := 0; i < a.Len(); i++ {
+		if !a.Field(i).Equals(b.Field(i)) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // UpdateSchema creates a new UpdateSchema instance for managing schema changes
 // within this transaction.
 //

--- a/table/transaction_sort_order_test.go
+++ b/table/transaction_sort_order_test.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table_test
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+func sortOrderOf(t *testing.T, fields ...table.SortField) table.SortOrder {
+	t.Helper()
+	order, err := table.NewSortOrder(1, fields)
+	require.NoError(t, err)
+
+	return order
+}
+
+func TestReplaceSortOrder(t *testing.T) {
+	byID := table.SortField{
+		SourceIDs: []int{1},
+		Transform: iceberg.IdentityTransform{},
+		Direction: table.SortASC,
+		NullOrder: table.NullsFirst,
+	}
+	byName := table.SortField{
+		SourceIDs: []int{2},
+		Transform: iceberg.IdentityTransform{},
+		Direction: table.SortDESC,
+		NullOrder: table.NullsLast,
+	}
+
+	t.Run("replace unsorted with new order", func(t *testing.T) {
+		txn := testNonPartitionedTable.NewTransaction()
+		require.NoError(t, txn.ReplaceSortOrder(sortOrderOf(t, byID, byName)))
+
+		staged, err := txn.StagedTable()
+		require.NoError(t, err)
+
+		got := staged.SortOrder()
+		require.Equal(t, 1, got.OrderID())
+		require.Equal(t, 2, got.Len())
+		fields := make([]table.SortField, 0, got.Len())
+		for _, f := range got.Fields() {
+			fields = append(fields, f)
+		}
+		require.True(t, fields[0].Equals(byID))
+		require.True(t, fields[1].Equals(byName))
+		require.Len(t, staged.Metadata().SortOrders(), 2)
+	})
+
+	t.Run("field-identical replace is a no-op", func(t *testing.T) {
+		txn := testNonPartitionedTable.NewTransaction()
+		require.NoError(t, txn.ReplaceSortOrder(table.UnsortedSortOrder))
+
+		staged, err := txn.StagedTable()
+		require.NoError(t, err)
+		require.Equal(t, table.UnsortedSortOrderID, staged.SortOrder().OrderID())
+		require.Len(t, staged.Metadata().SortOrders(), 1)
+	})
+
+	t.Run("sequential replaces assign fresh ids", func(t *testing.T) {
+		txn := testNonPartitionedTable.NewTransaction()
+		require.NoError(t, txn.ReplaceSortOrder(sortOrderOf(t, byID)))
+		require.NoError(t, txn.ReplaceSortOrder(sortOrderOf(t, byName)))
+
+		staged, err := txn.StagedTable()
+		require.NoError(t, err)
+		require.Equal(t, 2, staged.SortOrder().OrderID())
+		require.Len(t, staged.Metadata().SortOrders(), 3)
+	})
+}


### PR DESCRIPTION
## What

Adds `Transaction.ReplaceSortOrder(order)`: the Go analogue of Java's [`Table.replaceSortOrder()`](https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/Table.java) / [`BaseReplaceSortOrder`](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java), which replaces the table's default write order. It applies `AddSortOrder` + `SetDefaultSortOrder(-1)`, and no-ops when the staged default already has identical fields (field-only compare — the incoming order's id must not affect the result). Java's version is a fluent `asc()`/`desc()` builder; taking a complete `SortOrder` is the idiomatic Go adaptation of the same operation.

It also exports `FileToDataFile`, the parquet-footer-to-`DataFile` conversion backing `AddFiles`, with a `sortOrderID` parameter. #1184 removed that parameter from the internal function so `AddFiles` would not claim `sort_order_id` on files it did not write — correct for that caller, but it left no way for a caller who *does* know a foreign file's sort layout to convey it (data-file field `sort_order_id` in the spec). `AddFiles`/`filesToDataFiles` still pass 0, preserving #1184's behavior.

The two ship together because a rewrite/compaction flow uses both: `ReplaceSortOrder` installs the table's write order, and `FileToDataFile` stamps that order id on the rewritten files it registers.

Behavioral note: re-selecting an order that already exists in base metadata should emit only `set-default-sort-order` with the concrete id — that is #1831's fix; without it, strict REST catalogs reject the reuse commit's `add-sort-order`. The diffs are independent; this PR does not depend on it textually.

## Tests

- Replace unsorted→new order; field-identical replace is a no-op; sequential replaces assign fresh ids.
- `FileToDataFile`: stats round-trip; `sortOrderID` 0 leaves the field unset, non-zero is stamped; missing file returns an error.
- `go test ./table/...` and `golangci-lint run` are clean.

Made with [Cursor](https://cursor.com)
