### PR TITLE
fix(table): assert default spec id when the default partition spec changes

### DIFF
--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -190,6 +190,12 @@ func (us *UpdateSpec) BuildUpdates() ([]Update, []Requirement, error) {
 			requiredLastAssignedPartitionID = &base
 		}
 		requirements = append(requirements, AssertLastAssignedPartitionID(*requiredLastAssignedPartitionID))
+		// Java UpdateRequirements.forUpdateTable registers
+		// AssertDefaultSpecID on SetDefaultPartitionSpec: two racing
+		// remove-only spec evolutions (which assign no new field ids)
+		// can both pass last-assigned-partition-id, so the default
+		// spec id itself must be pinned.
+		requirements = append(requirements, AssertDefaultSpecID(us.txn.tbl.Metadata().DefaultPartitionSpec()))
 	}
 
 	return updates, requirements, nil

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -802,11 +802,12 @@ func TestUpdateSpecBuildChanges(t *testing.T) {
 		assert.NotNil(t, reqs)
 
 		assert.Equal(t, 2, len(updates))
-		assert.Equal(t, 1, len(reqs))
+		assert.Equal(t, 2, len(reqs))
 
 		assert.Equal(t, table.UpdateAddSpec, updates[0].Action())
 		assert.Equal(t, table.UpdateSetDefaultSpec, updates[1].Action())
 		assert.Equal(t, "assert-last-assigned-partition-id", reqs[0].GetType())
+		assert.Equal(t, table.AssertDefaultSpecID(testNonPartitionedTable.Metadata().DefaultPartitionSpec()), reqs[1])
 	})
 
 	t.Run("build changes on removed partition field", func(t *testing.T) {
@@ -821,11 +822,12 @@ func TestUpdateSpecBuildChanges(t *testing.T) {
 		assert.NotNil(t, reqs)
 
 		assert.Equal(t, 2, len(updates))
-		assert.Equal(t, 1, len(reqs))
+		assert.Equal(t, 2, len(reqs))
 
 		assert.Equal(t, table.UpdateAddSpec, updates[0].Action())
 		assert.Equal(t, table.UpdateSetDefaultSpec, updates[1].Action())
 		assert.Equal(t, "assert-last-assigned-partition-id", reqs[0].GetType())
+		assert.Equal(t, table.AssertDefaultSpecID(testPartitionedTable.Metadata().DefaultPartitionSpec()), reqs[1])
 	})
 
 	t.Run("build changes on renamed partition field", func(t *testing.T) {
@@ -838,12 +840,46 @@ func TestUpdateSpecBuildChanges(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(updates))
-		assert.Equal(t, 1, len(reqs))
+		assert.Equal(t, 2, len(reqs))
 
 		assert.Equal(t, table.UpdateAddSpec, updates[0].Action())
 		assert.Equal(t, table.UpdateSetDefaultSpec, updates[1].Action())
 		assert.Equal(t, "assert-last-assigned-partition-id", reqs[0].GetType())
+		assert.Equal(t, table.AssertDefaultSpecID(testPartitionedTable.Metadata().DefaultPartitionSpec()), reqs[1])
 	})
+}
+
+func TestUpdateSpecRemoveOnlyRaceIsFenced(t *testing.T) {
+	// Two racing remove-only spec evolutions assign no new partition field
+	// ids, so assert-last-assigned-partition-id cannot order them; only
+	// assert-default-spec-id detects that the loser read a stale default.
+
+	// Writer A builds its requirements against the base table.
+	txnA := testPartitionedTable.NewTransaction()
+	_, reqsA, err := table.NewUpdateSpec(txnA, false).
+		RemoveField("street_void").
+		BuildUpdates()
+	require.NoError(t, err)
+
+	// Writer B commits the same remove-only evolution first: the default
+	// spec id moves, the last assigned partition field id does not.
+	txnB := testPartitionedTable.NewTransaction()
+	require.NoError(t, table.NewUpdateSpec(txnB, false).RemoveField("street_void").Commit())
+	stagedB, err := txnB.StagedTable()
+	require.NoError(t, err)
+	movedMeta := stagedB.Metadata()
+	require.NotEqual(t, testPartitionedTable.Metadata().DefaultPartitionSpec(), movedMeta.DefaultPartitionSpec())
+	require.Equal(t, testPartitionedTable.Metadata().LastPartitionSpecID(), movedMeta.LastPartitionSpecID())
+
+	// Validating A's requirements against B's committed state must fail on
+	// exactly the default-spec fence.
+	failed := make([]string, 0)
+	for _, req := range reqsA {
+		if err := req.Validate(movedMeta); err != nil {
+			failed = append(failed, req.GetType())
+		}
+	}
+	assert.Equal(t, []string{"assert-default-spec-id"}, failed)
 }
 
 func TestUpdateSpecCommit(t *testing.T) {


### PR DESCRIPTION
## What

`UpdateSpec.BuildUpdates` fenced spec evolution with `assert-last-assigned-partition-id` only. Two racing **remove-only** spec evolutions assign no new field ids, so both pass that assertion and both commit — last writer wins and the other spec change is silently lost.

This adds the missing requirement: `AssertDefaultSpecID`, pinned to the base default spec id, whenever the default partition spec changes.

## Why

Java parity: [`UpdateRequirements.forUpdateTable`](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/UpdateRequirements.java) registers `AssertDefaultSpecID` whenever a `SetDefaultPartitionSpec` update is present, alongside the last-assigned-partition-id assertion. With this in place, the second of two concurrent remove-only evolutions fails `assert-default-spec-id` instead of clobbering the first.

## Tests

- `TestUpdateSpecBuildChanges` now expects both requirements on add / remove / rename, with `assert-default-spec-id` pinning the base spec id.
- `go test ./table/...` and `golangci-lint run` are clean.

Made with [Cursor](https://cursor.com)
