### PR TITLE
fix(table): wrap RollbackToSnapshot input rejections in ErrInvalidArgument

### DIFF
--- a/table/transaction.go
+++ b/table/transaction.go
@@ -486,7 +486,8 @@ func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
 	// main instead. An absent ref must fail here, never fall back.
 	ref, ok := meta.refs[branch]
 	if !ok {
-		return fmt.Errorf("cannot rollback: branch %q does not exist", branch)
+		return fmt.Errorf("%w: cannot rollback: branch %q does not exist",
+			iceberg.ErrInvalidArgument, branch)
 	}
 
 	if ref.SnapshotRefType != BranchRef {
@@ -498,6 +499,8 @@ func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
 	// (checkRefsExist) rejects dangling refs on load, so reaching this means
 	// in-flight builder state is inconsistent. Fail closed and name the ref
 	// rather than reporting the branch as empty.
+	// Delibertely not wrapped in iceberg.ErrInvalidArgument:
+	// table state is invalid; not caller input
 	cs, err := meta.SnapshotByID(ref.SnapshotID)
 	if err != nil {
 		return fmt.Errorf("cannot rollback: branch %q references unknown snapshot %d: %w",
@@ -511,8 +514,8 @@ func (t *Transaction) RollbackToSnapshot(snapshotID int64) error {
 	}
 
 	if !IsAncestorOf(cs.SnapshotID, snapshotID, lookup) {
-		return fmt.Errorf("snapshot %d is not an ancestor of branch %q head snapshot %d",
-			snapshotID, branch, cs.SnapshotID)
+		return fmt.Errorf("%w: snapshot %d is not an ancestor of branch %q head snapshot %d",
+			iceberg.ErrInvalidArgument, snapshotID, branch, cs.SnapshotID)
 	}
 
 	update := meta.NewRetainingSnapshotRefUpdate(branch, snapshotID, BranchRef)

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -1522,6 +1522,8 @@ func TestRollbackToSnapshotValidatesAncestryAgainstTargetBranch(t *testing.T) {
 
 	err = branchTxn.RollbackToSnapshot(20)
 	require.Error(t, err, "snapshot 20 is only on main's lineage, not diverged's")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument,
+		"every caller-input rejection must be matchable with errors.Is, not just the tag-type one")
 	require.ErrorContains(t, err, "not an ancestor")
 	require.ErrorContains(t, err, `"diverged"`,
 		"the error must name the branch whose lineage rejected the snapshot")
@@ -1542,6 +1544,8 @@ func TestRollbackToSnapshotRejectsUnknownBranch(t *testing.T) {
 
 	err = branchTxn.RollbackToSnapshot(10)
 	require.Error(t, err, "an unknown branch must fail rather than fall back to main")
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument,
+		"every caller-input rejection must be matchable with errors.Is, not just the tag-type one")
 	require.ErrorContains(t, err, `branch "ghost" does not exist`)
 
 	require.NotContains(t, branchTxn.meta.refs, "ghost", "a failed rollback must not create the branch")
@@ -1562,6 +1566,9 @@ func TestRollbackToSnapshotRejectsDanglingBranchRef(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, `branch "feature" references unknown snapshot 9999`,
 		"a dangling ref must be reported as inconsistent, not as a missing snapshot")
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+	require.NotErrorIs(t, err, iceberg.ErrInvalidArgument,
+		"inconsistent table state is not a caller-input error and must stay distinguishable from one")
 	require.Empty(t, refAssertions(branchTxn), "a rejected rollback must stage no requirement")
 }
 


### PR DESCRIPTION
### Description

Follow-up to the [review comment](https://github.com/apache/iceberg-go/pull/1828#pullrequestreview-4938910701) on #1828.

Added`iceberg.ErrInvalidArgument` at two places, excluding at one place with a proper reason.

Extended the three existing `RollbackToSnapshot` rejection tests.
