### PR TITLE
fix(deps): bump twmb/avro to v1.8.0 and adapt to its API changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/substrait-io/substrait-go/v8 v8.1.1
 	github.com/testcontainers/testcontainers-go/modules/compose v0.44.0
-	github.com/twmb/avro v1.7.2
+	github.com/twmb/avro v1.8.0
 	github.com/twmb/murmur3 v1.1.8
 	github.com/twpayne/go-geom v1.6.1
 	github.com/uptrace/bun v1.2.18

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,8 @@ github.com/transparency-dev/formats v0.1.1 h1:4bVHJc+KdBgpA1OJD1yjI+g0i5Z1graCpp
 github.com/transparency-dev/formats v0.1.1/go.mod h1:qtZ8goRuJ8FTBG9c9+Bj0rn2rUG7eG/AUTkr+Aw3jFw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/twmb/avro v1.7.2 h1:cmrEBRSbELRqsg/dRkQvVWuOaR2EfGifHIt/2iJ9lfI=
-github.com/twmb/avro v1.7.2/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
+github.com/twmb/avro v1.8.0 h1:UMWLg+nH4P3yad5Om7yFSohYLy2RG1s7BcFFiOvmK9Q=
+github.com/twmb/avro v1.8.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twpayne/go-geom v1.6.1 h1:iLE+Opv0Ihm/ABIcvQFGIiFBXd76oBIar9drAwHFhR4=

--- a/internal/avro_schemas.go
+++ b/internal/avro_schemas.go
@@ -39,7 +39,7 @@ func mustSchema(n avro.SchemaNode) *avro.Schema {
 }
 
 func NullableSchema(schema *avro.Schema) *avro.Schema {
-	return mustSchema(NullableNode(schema.Root()))
+	return mustSchema(NullableNode(*schema.Root()))
 }
 
 var requiredLength = [...]int{
@@ -423,7 +423,7 @@ func newDataFileSchema(partitionType *avro.Schema, version int) (*avro.Schema, e
 	node := schema.Root()
 	node.Fields = append(slices.Clone(node.Fields), avro.SchemaField{
 		Name:  "partition",
-		Type:  partitionType.Root(),
+		Type:  *partitionType.Root(),
 		Props: map[string]any{"field-id": 102},
 	})
 
@@ -460,7 +460,7 @@ func NewManifestEntrySchema(partitionType *avro.Schema, version int) (*avro.Sche
 	node := schema.Root()
 	node.Fields = append(slices.Clone(node.Fields), avro.SchemaField{
 		Name:  "data_file",
-		Type:  dfschema.Root(),
+		Type:  *dfschema.Root(),
 		Props: map[string]any{"field-id": 2},
 	})
 

--- a/manifest.go
+++ b/manifest.go
@@ -469,7 +469,7 @@ func getFieldIDMap(sc *avro.Schema) dataFileFieldMaps {
 	decimalScales := make(map[int]int)
 	unknownFieldIDs := make(map[int]struct{})
 
-	entryField := getField(root, "data_file")
+	entryField := getField(*root, "data_file")
 	partitionField := getField(entryField.Type, "partition")
 
 	for _, field := range partitionField.Type.Fields {
@@ -1013,6 +1013,8 @@ func schemaFieldID(f avro.SchemaField) (int, bool) {
 	switch v := f.Props["field-id"].(type) {
 	case int:
 		return v, true
+	case int64:
+		return int(v), true
 	case float64:
 		return int(v), true
 	}


### PR DESCRIPTION
Bumps `github.com/twmb/avro` from v1.7.2 to v1.8.0. Two changes in that release affect this repo — one is a compile error, the other is silent.

### `Schema.Root()` returns `*SchemaNode`

Field access auto-derefs, so only the four value-context uses need a change: passing the node to `NullableNode`/`getField`, and assigning it to `SchemaField.Type`.

### `Root()` numeric metadata is now `int64`, not `float64`

v1.8.0 preserves numeric precision when decoding schema JSON metadata, because integers above 2^53 previously rounded through `float64`. A field's `field-id` property therefore comes back as `int64` where it used to be `float64`.

`schemaFieldID` matched only `int` and `float64`, so on v1.8.0 it returns `false` for **every** field. Nothing errors — `getFieldIDMap` just ends up empty, `avroEncodePartitionData` iterates an empty map, and **partition values are written to the manifest as null**. The header schema is still written correctly, and the read path drops the same keys for the same reason, so the loss is silent in both directions.

Accepting `int64` alongside the existing cases keeps this correct on both avro versions.

### Verification

Two existing tests catch this and fail on the bump without the `schemaFieldID` change; both pass with it:

- `table/internal` — `TestDataFileStatisticsDecimalPartitionManifestRoundTrip` (decimal partition value)
- `table/compaction` — `TestCollectDeadPositionDeletesPartitioned` (string partition values, and this package doesn't import avro at all)

The second one confirms the problem is partition values generally, not anything decimal-specific.

`gofmt` and `go vet` are clean on the changed packages. I ran the two tests above rather than the full suite locally; relying on CI for the rest.

Disclosure: I maintain `twmb/avro`. The `int64` change there was deliberate and matches Avro Java, whose `JsonProperties.getObjectProp` yields an integer for integral metadata — v1.7.2's `float64` was the divergence. It should have been called out in that release's notes, and I'm fixing that separately.