### PR TITLE
hotfix: remove redundant loop variable copy in test

### DIFF
--- a/table/positional_delete_index_test.go
+++ b/table/positional_delete_index_test.go
@@ -191,7 +191,6 @@ func TestPositionalDeleteIndexMatchesReferenceApplicability(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, dataEntry := range dataEntries {
-		dataEntry := dataEntry
 		t.Run(fmt.Sprintf("%s/spec=%d/sequence=%d",
 			dataEntry.DataFile().FilePath(), dataEntry.DataFile().SpecID(), dataEntry.SequenceNum()), func(t *testing.T) {
 			matched, err := idx.forDataFile(dataEntry)


### PR DESCRIPTION
### Description

Removes the copy (`dataEntry := dataEntry`) in TestPositionalDeleteIndexForDataFile, which tripped the `copyloopvar` linter.

EDIT:
Go `1.22+` scopes range variables per iteration, so the copy is redundant.