### PR TITLE
fix(table): retain equality fields for delete scans

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -742,7 +742,7 @@ func collectLeafIDs(typ iceberg.Type, fieldID int, idset set[int]) {
 	}
 }
 
-func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression) (set[int], error) {
+func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression, equalityDeletes []*equalityDeleteSet) (set[int], error) {
 	idset := set[int]{}
 	// Collect leaf field IDs for column pruning.
 	// For nested types (map, list, struct), we recursively descend to find
@@ -761,6 +761,11 @@ func (as *arrowScan) projectedFieldIDs(rowFilter iceberg.BooleanExpression) (set
 			idset[id] = struct{}{}
 		}
 	}
+	for _, deletes := range equalityDeletes {
+		for _, id := range deletes.fieldIDs {
+			idset[id] = struct{}{}
+		}
+	}
 
 	return idset, nil
 }
@@ -771,8 +776,8 @@ type enumeratedRecord struct {
 	Err    error
 }
 
-func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, rowFilter iceberg.BooleanExpression) (*iceberg.Schema, []int, tblutils.FileReader, error) {
-	ids, err := as.projectedFieldIDs(rowFilter)
+func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, rowFilter iceberg.BooleanExpression, equalityDeletes []*equalityDeleteSet) (*iceberg.Schema, []int, tblutils.FileReader, error) {
+	ids, err := as.projectedFieldIDs(rowFilter, equalityDeletes)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1344,7 +1349,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 		return err
 	}
 
-	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, rowFilter)
+	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, rowFilter, eqDeleteSets)
 	if err != nil {
 		return err
 	}
@@ -1472,7 +1477,7 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 		dropFile   bool
 	)
 
-	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, as.boundRowFilter)
+	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, as.boundRowFilter, nil)
 	if err != nil {
 		return err
 	}

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -142,6 +142,22 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 	}
 
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows with id=2 and id=4 deleted")
+
+	_, itr, err = tbl.Scan(table.WithSelectedFields("data")).ToArrowRecords(t.Context())
+	require.NoError(t, err)
+
+	var data []string
+	for rec, err := range itr {
+		require.NoError(t, err)
+		col := rec.Column(0).(*array.String)
+		for i := range col.Len() {
+			data = append(data, col.Value(i))
+		}
+		rec.Release()
+	}
+
+	assert.Equal(t, []string{"alpha", "gamma", "epsilon"}, data,
+		"expected equality deletes to apply when the equality field is not projected")
 }
 
 func TestEqualityDeleteReadSharesMultiFileUnionAcrossConcurrentTasks(t *testing.T) {

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -143,12 +143,15 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 
 	assert.Equal(t, []int64{1, 3, 5}, ids, "expected rows with id=2 and id=4 deleted")
 
-	_, itr, err = tbl.Scan(table.WithSelectedFields("data")).ToArrowRecords(t.Context())
+	resultSchema, itr, err := tbl.Scan(table.WithSelectedFields("data")).ToArrowRecords(t.Context())
 	require.NoError(t, err)
+	require.Len(t, resultSchema.Fields(), 1)
+	assert.Equal(t, "data", resultSchema.Fields()[0].Name)
 
 	var data []string
 	for rec, err := range itr {
 		require.NoError(t, err)
+		require.EqualValues(t, 1, rec.NumCols())
 		col := rec.Column(0).(*array.String)
 		for i := range col.Len() {
 			data = append(data, col.Value(i))

--- a/table/projjson_roundtrip_internal_test.go
+++ b/table/projjson_roundtrip_internal_test.go
@@ -92,7 +92,7 @@ func TestWriteRecordsRecoversExactProjJSONCRSOnRead(t *testing.T) {
 		projectedSchema: tbl.Schema(),
 		concurrency:     1,
 		nameMapping:     tbl.Metadata().NameMapping(),
-	}).prepareToRead(ctx, dataFiles[0], nil)
+	}).prepareToRead(ctx, dataFiles[0], nil, nil)
 	require.NoError(t, err)
 	defer rdr.Close()
 


### PR DESCRIPTION
Fixes #1849.

## Summary

- include applicable equality-delete field IDs in the physical data-file projection
- keep the requested result projection unchanged, so execution-only equality fields are not exposed
- cover scans that select a non-key column while deleting by an omitted equality key

## Why

Equality deletes are row semantics and must be evaluated independently of the selected output columns. Previously, the scanner pruned an omitted equality key before applying deletes, causing the record iterator to fail with `equality field ID ... not found`.

## Testing

- `go test ./table -run '^TestEqualityDeleteReadRoundTrip$' -count=1 -v`
- `go test ./...`
- `golangci-lint run --timeout=10m`
- `go test -race ./codec/... ./metrics/... ./table/...`

