### PR TITLE
fix(table): drain RollingDataWriter's recordCh on mid-stream write errors

### DIFF
--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -389,14 +389,9 @@ func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, partit
 
 // Add appends a record to the writer's buffer.
 func (r *RollingDataWriter) Add(record arrow.RecordBatch) error {
-	// Hold the read lock across the whole check-and-enqueue so it is atomic
-	// with stream's shutdown drain (which takes the write lock). Once the
-	// drain has set noMoreSends, this returns before retaining, so a record
-	// can never be enqueued into a channel that will not be drained again.
-	// The enqueue below can still block for backpressure while the writer is
-	// live, but stream's cleanup cancels ctx before it takes the write lock,
-	// so a parked send unblocks via ctx.Done() and releases the read lock
-	// rather than deadlocking the drain.
+	// Read lock held across the whole check-and-enqueue so it is atomic with
+	// stream's shutdown (which takes the write lock): once noMoreSends is set
+	// this returns before retaining, so nothing is enqueued into a dead channel.
 	r.sendMu.RLock()
 	defer r.sendMu.RUnlock()
 
@@ -432,6 +427,13 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 	var currentWriter tblutils.FileWriter
 	var fileArrowSchema *arrow.Schema // per-file shredded schema; nil => factory default
 
+	// Set only when stream reaches the end of its input and finalizes without
+	// error. The cleanup defer uses it to skip cancelling ctx on the success
+	// path — cancellation is an error-exit signal that unblocks parked senders,
+	// and on the clean path there are none (input is closed after all senders
+	// finish), so the barrier's write lock is uncontended anyway.
+	exitedCleanly := false
+
 	// bootstrap buffer of converted batches, held until inference runs.
 	var buf []arrow.RecordBatch
 	var bufRows int64
@@ -466,22 +468,19 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 		if currentWriter != nil {
 			_ = currentWriter.Abort()
 		}
-		// stream is exiting; release any records producers left buffered in
-		// recordCh. This is a hard barrier against in-flight Add calls, not
-		// just a drain: an Add that already observed noMoreSends as false
-		// could otherwise enqueue after a lockless drain saw the channel
-		// empty, leaving a retained record with no consumer. Cancel first so
-		// any send currently parked on recordCh unblocks via ctx.Done() and
-		// releases its read lock; then take the write lock, which cannot be
-		// acquired until every active Add has returned. Setting noMoreSends
-		// under that lock makes the set of records ever placed in recordCh
-		// final, so the drain below releases all of them and nothing can be
-		// enqueued afterward. recordCh is deliberately not closed here: an Add
-		// may still hold the read lock about to observe noMoreSends, and
-		// closing under a live sender could panic. This runs before the
-		// CompareAndDelete defer above, so cleanup does not depend on abortAll
-		// finding this writer in the registry.
-		r.cancel()
+		// Release anything producers left buffered in recordCh, behind a hard
+		// barrier with in-flight Add calls (see sendMu). On the error exit,
+		// cancel first so a send parked on a full channel unblocks via
+		// ctx.Done() and drops its read lock; the clean exit has no parked
+		// senders (closeInput ran after all senders finished), so skip the
+		// cancel. Then the write lock — which waits out every active Add — plus
+		// noMoreSends makes the buffered set final, and the drain releases it.
+		// recordCh is not closed here: another goroutine may close it via
+		// closeInput (the drain's !ok case ends the loop then), and closing
+		// under a live sender could panic.
+		if !exitedCleanly {
+			r.cancel()
+		}
 		r.sendMu.Lock()
 		defer r.sendMu.Unlock()
 		r.noMoreSends = true
@@ -697,7 +696,10 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 	}
 	if err := closeWriter(); err != nil {
 		r.sendError(err)
+
+		return
 	}
+	exitedCleanly = true
 }
 
 // inferShreddingFromBatches infers the inner type per top-level variant column, keyed

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -328,6 +328,15 @@ type RollingDataWriter struct {
 	cancel          context.CancelFunc
 	wg              sync.WaitGroup
 	closeRecordCh   sync.Once
+
+	// sendMu forms a barrier between Add (read lock) and stream's shutdown
+	// drain (write lock). While an Add holds the read lock its check of
+	// noMoreSends and its enqueue are atomic with respect to the drain: once
+	// the drain holds the write lock and sets noMoreSends, no Add can be
+	// mid-enqueue and none can start one, so the drain releases every record
+	// that will ever reach recordCh.
+	sendMu      sync.RWMutex
+	noMoreSends bool
 }
 
 func (w *writerFactory) newRollingDataWriter(ctx context.Context, partition string, partitionValues map[int]any, outputDataFilesCh chan<- iceberg.DataFile) *RollingDataWriter {
@@ -380,6 +389,21 @@ func (w *writerFactory) getOrCreateRollingDataWriter(ctx context.Context, partit
 
 // Add appends a record to the writer's buffer.
 func (r *RollingDataWriter) Add(record arrow.RecordBatch) error {
+	// Hold the read lock across the whole check-and-enqueue so it is atomic
+	// with stream's shutdown drain (which takes the write lock). Once the
+	// drain has set noMoreSends, this returns before retaining, so a record
+	// can never be enqueued into a channel that will not be drained again.
+	// The enqueue below can still block for backpressure while the writer is
+	// live, but stream's cleanup cancels ctx before it takes the write lock,
+	// so a parked send unblocks via ctx.Done() and releases the read lock
+	// rather than deadlocking the drain.
+	r.sendMu.RLock()
+	defer r.sendMu.RUnlock()
+
+	if r.noMoreSends {
+		return ErrWriterClosed
+	}
+
 	record.Retain()
 	select {
 	case r.recordCh <- record:
@@ -441,6 +465,36 @@ func (r *RollingDataWriter) stream(outputDataFilesCh chan<- iceberg.DataFile) {
 		releaseBuf()
 		if currentWriter != nil {
 			_ = currentWriter.Abort()
+		}
+		// stream is exiting; release any records producers left buffered in
+		// recordCh. This is a hard barrier against in-flight Add calls, not
+		// just a drain: an Add that already observed noMoreSends as false
+		// could otherwise enqueue after a lockless drain saw the channel
+		// empty, leaving a retained record with no consumer. Cancel first so
+		// any send currently parked on recordCh unblocks via ctx.Done() and
+		// releases its read lock; then take the write lock, which cannot be
+		// acquired until every active Add has returned. Setting noMoreSends
+		// under that lock makes the set of records ever placed in recordCh
+		// final, so the drain below releases all of them and nothing can be
+		// enqueued afterward. recordCh is deliberately not closed here: an Add
+		// may still hold the read lock about to observe noMoreSends, and
+		// closing under a live sender could panic. This runs before the
+		// CompareAndDelete defer above, so cleanup does not depend on abortAll
+		// finding this writer in the registry.
+		r.cancel()
+		r.sendMu.Lock()
+		defer r.sendMu.Unlock()
+		r.noMoreSends = true
+		for {
+			select {
+			case record, ok := <-r.recordCh:
+				if !ok {
+					return
+				}
+				record.Release()
+			default:
+				return
+			}
 		}
 	}()
 

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -22,9 +22,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -975,4 +978,174 @@ func (s *RollingDataWriterTestSuite) TestStreamRecoversWriterClosePanic() {
 			s.Contains(err.Error(), "simulated NewDataFileBuilder failure")
 		})
 	}
+}
+
+// failingOpenFormat always fails to open a file writer, simulating a
+// mid-stream write error (e.g. an unwritable location) that makes stream
+// return before it ever dequeues most of what's already buffered in recordCh.
+type failingOpenFormat struct {
+	tblutils.FileFormat
+}
+
+func (failingOpenFormat) NewFileWriter(context.Context, iceio.WriteFileIO, map[int]any, tblutils.WriteFileInfo, *arrow.Schema) (tblutils.FileWriter, error) {
+	return nil, errors.New("simulated open failure")
+}
+
+// TestStreamErrorDrainsBufferedRecords reproduces the leak from #1825: when
+// stream exits early on a write error, records already sitting in recordCh —
+// queued by Add before stream's first dequeue attempt fails — must still be
+// released. Before the fix, stream's deferred CompareAndDelete deregisters the
+// writer before abortAll ever has a chance to run, so nothing drains what's
+// left in recordCh. Records are queued directly, bypassing Add and the
+// goroutine start in newRollingDataWriter, so all of them are buffered before
+// stream ever runs — otherwise Add would race stream's error exit for the
+// later records once errorCh closes.
+func (s *RollingDataWriterTestSuite) TestStreamErrorDrainsBufferedRecords() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+	factory.format = failingOpenFormat{FileFormat: factory.format}
+
+	outputCh := make(chan iceberg.DataFile, 10)
+	ctx, cancel := context.WithCancel(s.ctx)
+	writer := &RollingDataWriter{
+		recordCh: make(chan arrow.RecordBatch, 64),
+		errorCh:  make(chan error, 1),
+		factory:  factory,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+
+	const numRecords = 5
+	for range numRecords {
+		record := s.buildRecord(arrSchema, 3)
+		record.Retain()
+		writer.recordCh <- record
+		record.Release()
+	}
+
+	writer.wg.Add(1)
+	go writer.stream(outputCh)
+	writer.wg.Wait()
+
+	checked := s.mem.(*memory.CheckedAllocator)
+	s.Require().Zero(checked.CurrentAlloc(),
+		"records still queued in recordCh when stream exited on the open error must still be released")
+}
+
+// gatedFailFormat blocks the first file open until openGate is closed, then
+// fails it. Holding stream inside openFileWriter keeps ctx live and stops it
+// consuming, so the drain can be triggered at a controlled moment. inOpen lets
+// the test observe that stream has actually parked in the open.
+type gatedFailFormat struct {
+	tblutils.FileFormat
+	openGate chan struct{}
+	inOpen   *atomic.Bool
+}
+
+func (f gatedFailFormat) NewFileWriter(context.Context, iceio.WriteFileIO, map[int]any, tblutils.WriteFileInfo, *arrow.Schema) (tblutils.FileWriter, error) {
+	f.inOpen.Store(true)
+	<-f.openGate
+
+	return nil, errors.New("simulated open failure")
+}
+
+// gatedRetainRecord blocks in Retain until retainGate is closed, signalling
+// atRetain first. Add calls Retain between its closed check and its enqueue, so
+// this parks a sender in exactly that window: past the check, not yet sent. It
+// is the interleaving the reviewer hit with an instrumented Retain, made
+// deterministic. Every other method (Release included) delegates to the
+// embedded batch, so allocator accounting is unaffected.
+type gatedRetainRecord struct {
+	arrow.RecordBatch
+	retainGate chan struct{}
+	atRetain   *sync.WaitGroup
+}
+
+func (r gatedRetainRecord) Retain() {
+	r.atRetain.Done()
+	<-r.retainGate
+	r.RecordBatch.Retain()
+}
+
+// TestConcurrentAddDuringStreamErrorLeaksNothing exercises the barrier between
+// in-flight Add calls and stream's shutdown drain. Every record handed to Add
+// must end owned by exactly one path: enqueued and released by the drain, or
+// rejected/aborted and released by Add itself. Without a real barrier a send
+// that lands in free buffer after the drain emptied the channel strands its
+// record; the checked allocator must still return to zero.
+//
+// The interleaving is forced, not left to chance. A trigger record parks stream
+// in the gated open with ctx still live. The real senders then pass their
+// closed check and block in Retain (via gatedRetainRecord) — past the check,
+// not yet enqueued. Closing openGate makes stream fail and run its drain; only
+// then does retainGate release the senders to complete their sends. On a
+// lockless drain those sends land in the drained-empty channel and strand; the
+// write-lock barrier serializes them against the drain so none can.
+func (s *RollingDataWriterTestSuite) TestConcurrentAddDuringStreamErrorLeaksNothing() {
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	loc := filepath.ToSlash(s.T().TempDir())
+	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+	openGate := make(chan struct{})
+	var inOpen atomic.Bool
+	factory.format = gatedFailFormat{FileFormat: factory.format, openGate: openGate, inOpen: &inOpen}
+
+	outputCh := make(chan iceberg.DataFile, 64)
+	ctx, cancel := context.WithCancel(s.ctx)
+	writer := &RollingDataWriter{
+		recordCh: make(chan arrow.RecordBatch, 64),
+		errorCh:  make(chan error, 1),
+		factory:  factory,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+	writer.wg.Add(1)
+	go writer.stream(outputCh)
+
+	// Trigger record: drives stream into the gated open so ctx stays live while
+	// the real senders line up. Consumed and released by stream itself.
+	trigger := s.buildRecord(arrSchema, 3)
+	trigger.Retain()
+	writer.recordCh <- trigger
+	trigger.Release()
+	for !inOpen.Load() {
+		runtime.Gosched()
+	}
+
+	const senders = 24
+	retainGate := make(chan struct{})
+	var atRetain, done sync.WaitGroup
+	atRetain.Add(senders)
+	for range senders {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			record := s.buildRecord(arrSchema, 3)
+			// Add retains (via gatedRetainRecord.Retain, which parks the sender
+			// between the closed check and the enqueue) then enqueues or aborts;
+			// the caller always drops its own reference afterward.
+			_ = writer.Add(gatedRetainRecord{RecordBatch: record, retainGate: retainGate, atRetain: &atRetain})
+			record.Release()
+		}()
+	}
+
+	atRetain.Wait() // every sender is past its closed check, parked in Retain
+	close(openGate) // stream's open fails -> cleanup runs its drain
+	time.Sleep(20 * time.Millisecond)
+	close(retainGate) // now release the parked sends into the just-drained channel
+
+	done.Wait()      // every Add call has returned
+	writer.wg.Wait() // stream has exited and finished its drain
+
+	checked := s.mem.(*memory.CheckedAllocator)
+	s.Require().Zero(checked.CurrentAlloc(),
+		"no record may be stranded when a send completes after stream's shutdown drain")
 }

--- a/table/rolling_data_writer_test.go
+++ b/table/rolling_data_writer_test.go
@@ -1008,10 +1008,12 @@ func (s *RollingDataWriterTestSuite) TestStreamErrorDrainsBufferedRecords() {
 
 	loc := filepath.ToSlash(s.T().TempDir())
 	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+	defer factory.closeAll() // stops the iter.Pull counter goroutine
 	factory.format = failingOpenFormat{FileFormat: factory.format}
 
 	outputCh := make(chan iceberg.DataFile, 10)
 	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
 	writer := &RollingDataWriter{
 		recordCh: make(chan arrow.RecordBatch, 64),
 		errorCh:  make(chan error, 1),
@@ -1094,12 +1096,14 @@ func (s *RollingDataWriterTestSuite) TestConcurrentAddDuringStreamErrorLeaksNoth
 
 	loc := filepath.ToSlash(s.T().TempDir())
 	factory, _ := s.createWriterFactory(loc, arrSchema, 1024*1024)
+	defer factory.closeAll() // stops the iter.Pull counter goroutine
 	openGate := make(chan struct{})
 	var inOpen atomic.Bool
 	factory.format = gatedFailFormat{FileFormat: factory.format, openGate: openGate, inOpen: &inOpen}
 
 	outputCh := make(chan iceberg.DataFile, 64)
 	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
 	writer := &RollingDataWriter{
 		recordCh: make(chan arrow.RecordBatch, 64),
 		errorCh:  make(chan error, 1),


### PR DESCRIPTION
## What

When a `RollingDataWriter`'s `stream()` goroutine exits early on a write
error, batches already queued in its `recordCh` (sent via `Add` before the
error surfaced) were never released, leaking their Arrow buffers.

Closes #1825.

## Root cause

`stream()` deregisters itself from `writerFactory.writers` via a deferred
`CompareAndDelete` the moment it returns. On an early error return, that
runs while `recordCh` may still hold queued batches. The cleanup path that
is supposed to drain those batches, `abortAll()`, walks the writer registry
— but the writer has already removed itself, so `abortAll()` never sees it
and the buffered batches are stranded.

This is independent of any partitioning race: any write error partway
through a rolling writer's stream strands whatever is still buffered in
`recordCh`. (An earlier revision of #1825 described a Windows-specific
trigger for the same symptom; that turned out to be a separate path-parsing
bug, tracked in #1262.)

## Fix

- `stream()`'s cleanup now cancels its context and drains `recordCh`
  (non-blocking) before the `CompareAndDelete` defer deregisters the writer,
  so cleanup no longer depends on `abortAll()` finding it in the registry.
- `Add()` checks `ctx.Done()` up front (non-blocking) so that once a writer
  has died, in-flight sends from other fanout workers back off instead of
  queuing into a channel nobody will drain.
- `recordCh` is never closed from inside `stream()` — that stays with the
  external `closeAll()`/`abortAll()` paths, which only run after all `Add`
  callers have returned, avoiding a send-on-closed-channel panic.

## Test plan

- Added `TestStreamErrorDrainsBufferedRecords`: queues several batches, forces
  the file open to fail, and asserts the checked allocator returns to zero.
  Fails on `main`, passes with this change.
- `go test ./table/ -run TestRollingDataWriter -race` passes.
- 50x `-race` stress run of the fanout/rolling-writer tests: no panics, no
  data races.