### PR TITLE
fix(table): fail closed when a partition spec id is not registered (#1855)

### DIFF
--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -1534,3 +1534,57 @@ func TestRowDeltaWritesRegisteredNonDefaultSpec(t *testing.T) {
 		assert.Equal(t, 1, entries)
 	}
 }
+
+func TestRowDeltaMixedSpecCommitLeavesNoManifests(t *testing.T) {
+	validData := func() iceberg.DataFile { return buildDataFile(t, "s3://bucket/data/insert.parquet") }
+	validDelete := func() iceberg.DataFile { return buildPosDeleteFile(t, "s3://bucket/data/pos-del.parquet") }
+	orphanData := func() iceberg.DataFile {
+		return buildDataFileForSpec(t, unregisteredSpec(), "s3://bucket/data/orphan.parquet", map[int]any{1000: int64(7)})
+	}
+	orphanDelete := func() iceberg.DataFile {
+		return buildPosDeleteFileForSpec(t, unregisteredSpec(), "s3://bucket/data/orphan-del.parquet", map[int]any{1000: int64(7)})
+	}
+
+	tests := []struct {
+		name    string
+		rows    []iceberg.DataFile
+		deletes []iceberg.DataFile
+	}{
+		{"valid data with unregistered delete", []iceberg.DataFile{validData()}, []iceberg.DataFile{orphanDelete()}},
+		{"valid delete with unregistered data", []iceberg.DataFile{orphanData()}, []iceberg.DataFile{validDelete()}},
+		{"valid data group before unregistered one", []iceberg.DataFile{validData(), orphanData()}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tbl := newRowDeltaCommitTestTable(t)
+
+			tx := tbl.NewTransaction()
+			rd := tx.NewRowDelta(nil)
+			rd.AddRows(tt.rows...)
+			rd.AddDeletes(tt.deletes...)
+
+			err := rd.Commit(t.Context())
+			require.Error(t, err)
+			assert.ErrorIs(t, err, table.ErrPartitionSpecNotFound)
+			assert.Empty(t, writtenManifests(t, tbl.Location()),
+				"a rejected row delta must not leave manifests behind")
+
+			validTx := tbl.NewTransaction()
+			validRd := validTx.NewRowDelta(nil)
+			validRd.AddRows(validData())
+			require.NoError(t, validRd.Commit(t.Context()))
+			assert.NotEmpty(t, writtenManifests(t, tbl.Location()),
+				"the same probe must observe the manifests a successful commit writes")
+		})
+	}
+}
+
+func writtenManifests(t *testing.T, location string) []string {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(location, "metadata", "*.avro"))
+	require.NoError(t, err)
+
+	return paths
+}

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -1427,3 +1427,110 @@ func assertRowCount(t *testing.T, tbl *table.Table, expected int64) {
 
 	assert.Equal(t, expected, total, "unexpected row count")
 }
+
+func unregisteredSpec() iceberg.PartitionSpec {
+	return iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id_identity", Transform: iceberg.IdentityTransform{},
+	})
+}
+
+func buildPosDeleteFileForSpec(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any) iceberg.DataFile {
+	t.Helper()
+
+	b, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes,
+		path, iceberg.ParquetFile, partition, nil, nil, 5, 512)
+	require.NoError(t, err)
+
+	return b.Build()
+}
+
+func buildDataFileForSpec(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any) iceberg.DataFile {
+	t.Helper()
+
+	b, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentData,
+		path, iceberg.ParquetFile, partition, nil, nil, 10, 1024)
+	require.NoError(t, err)
+
+	return b.Build()
+}
+
+func TestRowDeltaRejectsDeleteFileWithUnregisteredSpec(t *testing.T) {
+	tbl := newRowDeltaCommitTestTable(t)
+
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddDeletes(buildPosDeleteFileForSpec(t, unregisteredSpec(),
+		"s3://bucket/data/pos-del.parquet", map[int]any{1000: int64(7)}))
+
+	err := rd.Commit(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, table.ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+
+	result, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, result.CurrentSnapshot(), "a rejected row delta must not produce a snapshot")
+}
+
+func TestRowDeltaRejectsDataFileWithUnregisteredSpec(t *testing.T) {
+	tbl := newRowDeltaCommitTestTable(t)
+
+	tx := tbl.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddRows(buildDataFileForSpec(t, unregisteredSpec(),
+		"s3://bucket/data/insert.parquet", map[int]any{1000: int64(7)}))
+
+	err := rd.Commit(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, table.ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+}
+
+func TestRowDeltaWritesRegisteredNonDefaultSpec(t *testing.T) {
+	tbl := newRowDeltaCommitTestTable(t)
+
+	evolveTx := tbl.NewTransaction()
+	require.NoError(t, evolveTx.UpdateSpec(false).
+		AddField("id", iceberg.IdentityTransform{}, "id_identity").
+		Commit())
+	evolved, err := evolveTx.Commit(t.Context())
+	require.NoError(t, err)
+
+	spec := evolved.Metadata().PartitionSpec()
+	require.NotEqual(t, 0, spec.ID(), "spec evolution must register a new spec id")
+	require.Equal(t, 1, spec.NumFields())
+	fieldID := spec.Field(0).FieldID
+	partition := map[int]any{fieldID: int64(7)}
+
+	tx := evolved.NewTransaction()
+	rd := tx.NewRowDelta(nil)
+	rd.AddRows(buildDataFileForSpec(t, spec, "s3://bucket/data/insert.parquet", partition))
+	rd.AddDeletes(buildPosDeleteFileForSpec(t, spec, "s3://bucket/data/pos-del.parquet", partition))
+	require.NoError(t, rd.Commit(t.Context()))
+
+	result, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	snap := result.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	fs := iceio.LocalFS{}
+	manifests, err := snap.Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, manifests, 2)
+
+	for _, m := range manifests {
+		assert.Equal(t, int32(spec.ID()), m.PartitionSpecID(),
+			"manifest must declare the spec its entries were written under")
+		entries := 0
+		for e, err := range m.Entries(fs, true) {
+			require.NoError(t, err)
+			assert.Equal(t, int32(spec.ID()), e.DataFile().SpecID())
+			assert.Equal(t, int64(7), e.DataFile().Partition()[fieldID])
+			entries++
+		}
+		assert.Equal(t, 1, entries)
+	}
+}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -376,7 +376,12 @@ func (m *manifestMergeManager) groupBySpec(manifests []iceberg.ManifestFile) map
 }
 
 func (m *manifestMergeManager) createManifest(specID int, bin []iceberg.ManifestFile) (mf iceberg.ManifestFile, err error) {
-	wr, path, counter, fileCloser, err := m.snap.newManifestWriter(m.snap.spec(specID))
+	spec, err := m.snap.spec(specID)
+	if err != nil {
+		return nil, err
+	}
+
+	wr, path, counter, fileCloser, err := m.snap.newManifestWriter(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -626,12 +631,16 @@ func createSnapshotProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO
 	}
 }
 
-func (sp *snapshotProducer) spec(id int) iceberg.PartitionSpec {
-	if spec, _ := sp.txn.meta.GetSpecByID(id); spec != nil {
-		return *spec
+func (sp *snapshotProducer) spec(id int) (iceberg.PartitionSpec, error) {
+	spec, err := sp.txn.meta.GetSpecByID(id)
+	if err == nil && spec == nil {
+		err = ErrPartitionSpecNotFound
+	}
+	if err != nil {
+		return iceberg.PartitionSpec{}, fmt.Errorf("unregistered partition spec id %d: %w", id, err)
 	}
 
-	return iceberg.NewPartitionSpec()
+	return *spec, nil
 }
 
 func (sp *snapshotProducer) appendDataFile(df iceberg.DataFile) *snapshotProducer {
@@ -880,6 +889,11 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 			}
 
 			writeGroup := func(key groupKey, entries []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
+				spec, err := sp.spec(key.specID)
+				if err != nil {
+					return nil, err
+				}
+
 				out, path, err := sp.newManifestOutput()
 				if err != nil {
 					return nil, err
@@ -888,7 +902,7 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 
 				counter := &internal.CountingWriter{W: out}
 				wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter,
-					sp.spec(key.specID), sp.txn.meta.CurrentSchema(),
+					spec, sp.txn.meta.CurrentSchema(),
 					sp.snapshotID, iceberg.WithManifestWriterContent(key.content))
 				if err != nil {
 					return nil, err
@@ -964,15 +978,12 @@ func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, fi
 }
 
 func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, specID int, files []iceberg.DataFile) (_ iceberg.ManifestFile, retErr error) {
-	// Resolve the spec strictly: the sp.spec helper silently substitutes an
-	// empty spec on lookup failure, which here would write a manifest whose
-	// declared spec disagrees with its entries' partition tuples.
-	spec, err := sp.txn.meta.GetSpecByID(specID)
-	if err != nil || spec == nil {
-		return nil, fmt.Errorf("cannot write manifest for unregistered partition spec id %d: %w", specID, err)
+	spec, err := sp.spec(specID)
+	if err != nil {
+		return nil, err
 	}
 
-	wr, path, counter, out, err := sp.newManifestWriter(*spec, iceberg.WithManifestWriterContent(content))
+	wr, path, counter, out, err := sp.newManifestWriter(spec, iceberg.WithManifestWriterContent(content))
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1013,12 @@ func (sp *snapshotProducer) writeAddedManifest(content iceberg.ManifestContent, 
 }
 
 func (sp *snapshotProducer) writeAddedDeleteManifest(specID int, additions []deleteFileAddition) (_ iceberg.ManifestFile, retErr error) {
-	wr, path, counter, out, err := sp.newManifestWriter(sp.spec(specID), iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
+	spec, err := sp.spec(specID)
+	if err != nil {
+		return nil, err
+	}
+
+	wr, path, counter, out, err := sp.newManifestWriter(spec, iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
 	if err != nil {
 		return nil, err
 	}
@@ -1091,19 +1107,37 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 	if err != nil || partitionSpec == nil {
 		return nil, fmt.Errorf("could not get current partition spec: %w", err)
 	}
+
+	addFile := func(df iceberg.DataFile) error {
+		spec, err := sp.spec(int(df.SpecID()))
+		if err != nil {
+			return err
+		}
+
+		return ssc.addFile(df, currentSchema, spec)
+	}
+	removeFile := func(df iceberg.DataFile) error {
+		spec, err := sp.spec(int(df.SpecID()))
+		if err != nil {
+			return err
+		}
+
+		return ssc.removeFile(df, currentSchema, spec)
+	}
+
 	for _, df := range sp.addedFiles {
-		if err = ssc.addFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+		if err = addFile(df); err != nil {
 			return nil, err
 		}
 	}
 	for _, addition := range sp.addedDeleteFiles {
-		if err = ssc.addFile(addition.file, currentSchema, sp.spec(int(addition.file.SpecID()))); err != nil {
+		if err = addFile(addition.file); err != nil {
 			return nil, err
 		}
 	}
 
 	for _, df := range sp.deletedFiles {
-		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+		if err = removeFile(df); err != nil {
 			return nil, err
 		}
 	}
@@ -1111,7 +1145,7 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
 			continue
 		}
-		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+		if err = removeFile(df); err != nil {
 			return nil, err
 		}
 	}
@@ -1119,7 +1153,7 @@ func (sp *snapshotProducer) accumulateSummaryDelta(countDeleteRemoval func(icebe
 		if countDeleteRemoval != nil && !countDeleteRemoval(df) {
 			continue
 		}
-		if err = ssc.removeFile(df, currentSchema, sp.spec(int(df.SpecID()))); err != nil {
+		if err = removeFile(df); err != nil {
 			return nil, err
 		}
 	}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -634,11 +634,8 @@ func createSnapshotProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO
 
 func (sp *snapshotProducer) spec(id int) (iceberg.PartitionSpec, error) {
 	spec, err := sp.txn.meta.GetSpecByID(id)
-	if err == nil && spec == nil {
-		err = ErrPartitionSpecNotFound
-	}
 	if err != nil {
-		return iceberg.PartitionSpec{}, fmt.Errorf("unregistered partition spec id %d: %w", id, err)
+		return iceberg.PartitionSpec{}, err
 	}
 
 	return *spec, nil
@@ -775,6 +772,10 @@ func (sp *snapshotProducer) manifests(ctx context.Context) ([]iceberg.ManifestFi
 // (which evaluates deletedEntries) is built before any added-content writer is
 // created, so a delete-side failure cannot orphan added-content writers.
 func (sp *snapshotProducer) buildManifests(ctx context.Context, parent *Snapshot) (all, addedContent []iceberg.ManifestFile, err error) {
+	if err := sp.validateSpecs(); err != nil {
+		return nil, nil, err
+	}
+
 	dependent, err := sp.parentDependentManifests(ctx, parent)
 	if err != nil {
 		return nil, nil, err
@@ -798,10 +799,6 @@ func (sp *snapshotProducer) buildManifests(ctx context.Context, parent *Snapshot
 // written once and reused verbatim across OCC retries (rewriting them would
 // churn manifest paths and orphan object-store files on every attempt).
 func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, error) {
-	if err := sp.validateAddedSpecs(); err != nil {
-		return nil, err
-	}
-
 	var g errgroup.Group
 
 	addedManifests := make([]iceberg.ManifestFile, 0)
@@ -822,16 +819,35 @@ func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, err
 	return slices.Concat(addedManifests, positionDeleteManifests), nil
 }
 
-func (sp *snapshotProducer) validateAddedSpecs() error {
-	for _, df := range sp.addedFiles {
+// validateSpecs resolves every spec id the commit references before any phase
+// writes, because the parent-dependent manifests are written before the added
+// ones and a later rejection would orphan them.
+func (sp *snapshotProducer) validateSpecs() error {
+	check := func(df iceberg.DataFile) error {
 		if _, err := sp.spec(int(df.SpecID())); err != nil {
+			return fmt.Errorf("file %s: %w", df.FilePath(), err)
+		}
+
+		return nil
+	}
+
+	for _, df := range sp.addedFiles {
+		if err := check(df); err != nil {
 			return err
 		}
 	}
 
 	for _, addition := range sp.addedDeleteFiles {
-		if _, err := sp.spec(int(addition.file.SpecID())); err != nil {
+		if err := check(addition.file); err != nil {
 			return err
+		}
+	}
+
+	for _, removed := range []map[string]iceberg.DataFile{sp.deletedFiles, sp.deletedDeleteFiles, sp.deletedDVsByRef} {
+		for _, df := range removed {
+			if err := check(df); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -865,6 +881,10 @@ func (sp *snapshotProducer) deleteManifestProducer(output *[]iceberg.ManifestFil
 // otherwise). Used on OCC retries, where addedContent was written at attempt 0
 // and is reused verbatim.
 func (sp *snapshotProducer) assembleManifests(ctx context.Context, parent *Snapshot, addedContent []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	if err := sp.validateSpecs(); err != nil {
+		return nil, err
+	}
+
 	dependent, err := sp.parentDependentManifests(ctx, parent)
 	if err != nil {
 		return nil, err
@@ -883,15 +903,6 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 	deleted, err := sp.deletedEntries(ctx, parent)
 	if err != nil {
 		return nil, err
-	}
-
-	// existingManifests only resolves the spec of a manifest that lost an entry,
-	// so these are the same ids both goroutines below need. Rejecting them here
-	// keeps a later group's failure from orphaning the manifests already written.
-	for _, entry := range deleted {
-		if _, err := sp.spec(int(entry.DataFile().SpecID())); err != nil {
-			return nil, err
-		}
 	}
 
 	var g errgroup.Group

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -797,6 +798,10 @@ func (sp *snapshotProducer) buildManifests(ctx context.Context, parent *Snapshot
 // written once and reused verbatim across OCC retries (rewriting them would
 // churn manifest paths and orphan object-store files on every attempt).
 func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, error) {
+	if err := sp.validateAddedSpecs(); err != nil {
+		return nil, err
+	}
+
 	var g errgroup.Group
 
 	addedManifests := make([]iceberg.ManifestFile, 0)
@@ -815,6 +820,22 @@ func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, err
 	}
 
 	return slices.Concat(addedManifests, positionDeleteManifests), nil
+}
+
+func (sp *snapshotProducer) validateAddedSpecs() error {
+	for _, df := range sp.addedFiles {
+		if _, err := sp.spec(int(df.SpecID())); err != nil {
+			return err
+		}
+	}
+
+	for _, addition := range sp.addedDeleteFiles {
+		if _, err := sp.spec(int(addition.file.SpecID())); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (sp *snapshotProducer) deleteManifestProducer(output *[]iceberg.ManifestFile) func() error {
@@ -862,6 +883,15 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 	deleted, err := sp.deletedEntries(ctx, parent)
 	if err != nil {
 		return nil, err
+	}
+
+	// existingManifests only resolves the spec of a manifest that lost an entry,
+	// so these are the same ids both goroutines below need. Rejecting them here
+	// keeps a later group's failure from orphaning the manifests already written.
+	for _, entry := range deleted {
+		if _, err := sp.spec(int(entry.DataFile().SpecID())); err != nil {
+			return nil, err
+		}
 	}
 
 	var g errgroup.Group
@@ -928,8 +958,16 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 				return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(key.content))
 			}
 
-			for key, entries := range groups {
-				mf, err := writeGroup(key, entries)
+			keys := slices.SortedFunc(maps.Keys(groups), func(a, b groupKey) int {
+				if c := cmp.Compare(a.specID, b.specID); c != 0 {
+					return c
+				}
+
+				return cmp.Compare(a.content, b.content)
+			})
+
+			for _, key := range keys {
+				mf, err := writeGroup(key, groups[key])
 				if err != nil {
 					return err
 				}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -819,9 +819,8 @@ func (sp *snapshotProducer) addedContentManifests() ([]iceberg.ManifestFile, err
 	return slices.Concat(addedManifests, positionDeleteManifests), nil
 }
 
-// validateSpecs resolves every spec id the commit references before any phase
-// writes, because the parent-dependent manifests are written before the added
-// ones and a later rejection would orphan them.
+// validateSpecs resolves the spec ids of this producer's added and removed files up front.
+// Manifests are written phase by phase, so rejecting an id mid-way would leave the earlier phase's manifests orphaned.
 func (sp *snapshotProducer) validateSpecs() error {
 	check := func(df iceberg.DataFile) error {
 		if _, err := sp.spec(int(df.SpecID())); err != nil {

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/fs"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1930,6 +1931,14 @@ func TestExistingManifests_ExactDVStillExpunged(t *testing.T) {
 func writeParentSnapshotWithDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.PartitionSpec, snapshotID int64, tag string, deleteFiles ...iceberg.DataFile) *Snapshot {
 	t.Helper()
 
+	mf := writeTestDeletesManifest(t, fs, spec, snapshotID, tag, deleteFiles...)
+
+	return writeParentSnapshotFromManifests(t, fs, snapshotID, tag, mf)
+}
+
+func writeTestDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.PartitionSpec, snapshotID int64, tag string, deleteFiles ...iceberg.DataFile) iceberg.ManifestFile {
+	t.Helper()
+
 	manifestPath := "mem://default/table-location/metadata/deletes-" + tag + ".avro"
 	var buf bytes.Buffer
 	wr, err := iceberg.NewManifestWriter(3, &buf, spec, simpleSchema(), snapshotID,
@@ -1949,11 +1958,17 @@ func writeParentSnapshotWithDeletesManifest(t *testing.T, fs iceio.WriteFileIO, 
 	require.NoError(t, err)
 	require.NoError(t, out.Close())
 
+	return mf
+}
+
+func writeParentSnapshotFromManifests(t *testing.T, fs iceio.WriteFileIO, snapshotID int64, tag string, manifests ...iceberg.ManifestFile) *Snapshot {
+	t.Helper()
+
 	listPath := "mem://default/table-location/metadata/snap-" + tag + ".avro"
 	lout, err := fs.Create(listPath)
 	require.NoError(t, err)
 	seq := int64(1)
-	require.NoError(t, iceberg.WriteManifestList(3, lout, snapshotID, nil, &seq, 0, []iceberg.ManifestFile{mf}))
+	require.NoError(t, iceberg.WriteManifestList(3, lout, snapshotID, nil, &seq, 0, manifests))
 	require.NoError(t, lout.Close())
 
 	return &Snapshot{
@@ -2109,4 +2124,58 @@ func TestAccumulateSummaryDeltaRejectsUnregisteredSpec(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.ErrorContains(t, err, "99")
+}
+
+func TestParentDependentManifestsMixedSpecWritesNoManifests(t *testing.T) {
+	registered := partitionedSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, registered)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	validDV := newTestDeletionVectorForRef(t, registered,
+		"mem://default/table-location/data/dv-valid.puffin",
+		"mem://default/table-location/data/valid.parquet")
+	orphanDV := newTestDeletionVectorForRef(t, unregisteredSpec(),
+		"mem://default/table-location/data/dv-orphan.puffin",
+		"mem://default/table-location/data/orphan.parquet")
+	sp.removeDeletionVector(validDV)
+	sp.removeDeletionVector(orphanDV)
+
+	parent := writeParentSnapshotFromManifests(t, wfs, 96, "mixed",
+		writeTestDeletesManifest(t, wfs, registered, 96, "mixed-valid", validDV),
+		writeTestDeletesManifest(t, wfs, unregisteredSpec(), 96, "mixed-orphan", orphanDV))
+
+	before := metadataFiles(t, wfs)
+	_, err := sp.parentDependentManifests(context.Background(), parent)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.Equal(t, before, metadataFiles(t, wfs),
+		"a rejected operation must not leave manifests behind")
+
+	valid := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+	valid.removeDeletionVector(validDV)
+	_, err = valid.parentDependentManifests(context.Background(), parent)
+	require.NoError(t, err)
+	assert.Greater(t, len(metadataFiles(t, wfs)), len(before),
+		"the same probe must observe the manifests a successful run writes")
+}
+
+func metadataFiles(t *testing.T, wfs iceio.WriteFileIO) []string {
+	t.Helper()
+
+	listable, ok := wfs.(iceio.ListableIO)
+	require.True(t, ok, "test IO must support listing")
+
+	var paths []string
+	require.NoError(t, listable.WalkDir("mem://default/table-location/metadata",
+		func(path string, d fs.DirEntry, err error) error {
+			require.NoError(t, err)
+			if !d.IsDir() {
+				paths = append(paths, path)
+			}
+
+			return nil
+		}))
+	slices.Sort(paths)
+
+	return paths
 }

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -2014,3 +2014,99 @@ func TestAddDataFilesV2SucceedsWithoutFirstRowID(t *testing.T) {
 	err := txn.AddDataFiles(context.Background(), []iceberg.DataFile{df}, nil)
 	require.NoError(t, err)
 }
+
+func unregisteredSpec() iceberg.PartitionSpec {
+	return iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+	})
+}
+
+func TestSnapshotProducerSpecFailsClosed(t *testing.T) {
+	registered := partitionedSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, registered)
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+
+	got, err := sp.spec(registered.ID())
+	require.NoError(t, err)
+	assert.True(t, got.Equals(registered), "registered id must resolve to the table's spec")
+
+	_, err = sp.spec(99)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+}
+
+func TestWriteAddedDeleteManifestRejectsUnregisteredSpec(t *testing.T) {
+	spec := partitionedSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+
+	posDel := newTestPosDeleteFileForSpec(t, unregisteredSpec(),
+		"mem://default/table-location/data/pos-del.parquet", map[int]any{1000: int32(7)},
+		"mem://default/table-location/data/data.parquet")
+
+	_, err := sp.writeAddedDeleteManifest(99, []deleteFileAddition{{file: posDel}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+}
+
+func TestCreateManifestRejectsUnregisteredSpec(t *testing.T) {
+	registered := partitionedSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, registered)
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+	mgr := manifestMergeManager{snap: sp}
+
+	orphan := writeTestManifestFile(t, wfs, unregisteredSpec(), simpleSchema(), sp.snapshotID, 1)
+	require.Equal(t, int32(99), orphan.PartitionSpecID())
+
+	_, err := mgr.createManifest(99, []iceberg.ManifestFile{orphan})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+
+	merged, err := mgr.createManifest(registered.ID(),
+		[]iceberg.ManifestFile{writeTestManifestFile(t, wfs, registered, simpleSchema(), sp.snapshotID, 2)})
+	require.NoError(t, err, "a registered spec id must still merge")
+	assert.Equal(t, int32(registered.ID()), merged.PartitionSpecID())
+}
+
+func TestParentDependentManifestsRejectsUnregisteredSpec(t *testing.T) {
+	txn, wfs := createTestTransactionWithMemIO(t, partitionedSpec())
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	staleDV := newTestDeletionVectorForRef(t, unregisteredSpec(),
+		"mem://default/table-location/data/dv-old.puffin",
+		"mem://default/table-location/data/d.parquet")
+	sp.removeDeletionVector(staleDV)
+
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, unregisteredSpec(), 95, "unregistered", staleDV)
+
+	tombstones, err := sp.deletedEntries(context.Background(), parent)
+	require.NoError(t, err)
+	require.Len(t, tombstones, 1, "the removed DV must be tombstoned under the parent manifest's spec")
+	require.Equal(t, int32(99), tombstones[0].DataFile().SpecID())
+
+	_, err = sp.parentDependentManifests(context.Background(), parent)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+}
+
+func TestAccumulateSummaryDeltaRejectsUnregisteredSpec(t *testing.T) {
+	registered := partitionedSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, registered)
+
+	sp := newFastAppendFilesProducer(OpAppend, txn, wfs, nil, nil)
+	sp.appendDataFile(newTestDataFile(t, registered,
+		"mem://default/table-location/data/ok.parquet", map[int]any{1000: int32(7)}))
+	_, err := sp.accumulateSummaryDelta(nil)
+	require.NoError(t, err, "a registered spec must still be summarized")
+
+	sp.appendDataFile(newTestDataFile(t, unregisteredSpec(),
+		"mem://default/table-location/data/orphan.parquet", map[int]any{1000: int32(7)}))
+	_, err = sp.accumulateSummaryDelta(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.ErrorContains(t, err, "99")
+}

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -1931,14 +1931,6 @@ func TestExistingManifests_ExactDVStillExpunged(t *testing.T) {
 func writeParentSnapshotWithDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.PartitionSpec, snapshotID int64, tag string, deleteFiles ...iceberg.DataFile) *Snapshot {
 	t.Helper()
 
-	mf := writeTestDeletesManifest(t, fs, spec, snapshotID, tag, deleteFiles...)
-
-	return writeParentSnapshotFromManifests(t, fs, snapshotID, tag, mf)
-}
-
-func writeTestDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.PartitionSpec, snapshotID int64, tag string, deleteFiles ...iceberg.DataFile) iceberg.ManifestFile {
-	t.Helper()
-
 	manifestPath := "mem://default/table-location/metadata/deletes-" + tag + ".avro"
 	var buf bytes.Buffer
 	wr, err := iceberg.NewManifestWriter(3, &buf, spec, simpleSchema(), snapshotID,
@@ -1958,17 +1950,11 @@ func writeTestDeletesManifest(t *testing.T, fs iceio.WriteFileIO, spec iceberg.P
 	require.NoError(t, err)
 	require.NoError(t, out.Close())
 
-	return mf
-}
-
-func writeParentSnapshotFromManifests(t *testing.T, fs iceio.WriteFileIO, snapshotID int64, tag string, manifests ...iceberg.ManifestFile) *Snapshot {
-	t.Helper()
-
 	listPath := "mem://default/table-location/metadata/snap-" + tag + ".avro"
 	lout, err := fs.Create(listPath)
 	require.NoError(t, err)
 	seq := int64(1)
-	require.NoError(t, iceberg.WriteManifestList(3, lout, snapshotID, nil, &seq, 0, manifests))
+	require.NoError(t, iceberg.WriteManifestList(3, lout, snapshotID, nil, &seq, 0, []iceberg.ManifestFile{mf}))
 	require.NoError(t, lout.Close())
 
 	return &Snapshot{
@@ -2032,7 +2018,7 @@ func TestAddDataFilesV2SucceedsWithoutFirstRowID(t *testing.T) {
 
 func unregisteredSpec() iceberg.PartitionSpec {
 	return iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
-		SourceIDs: []int{1}, FieldID: 1000, Name: "id", Transform: iceberg.IdentityTransform{},
+		SourceIDs: []int{1}, FieldID: 1000, Name: "id_identity", Transform: iceberg.IdentityTransform{},
 	})
 }
 
@@ -2126,37 +2112,59 @@ func TestAccumulateSummaryDeltaRejectsUnregisteredSpec(t *testing.T) {
 	assert.ErrorContains(t, err, "99")
 }
 
-func TestParentDependentManifestsMixedSpecWritesNoManifests(t *testing.T) {
+func TestBuildManifestsRejectsUnregisteredSpecBeforeWriting(t *testing.T) {
 	registered := partitionedSpec()
-	txn, wfs := createTestTransactionWithMemIO(t, registered)
-	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+	partition := map[int]any{1000: int32(7)}
+	dataPath := "mem://default/table-location/data/d.parquet"
 
-	validDV := newTestDeletionVectorForRef(t, registered,
-		"mem://default/table-location/data/dv-valid.puffin",
-		"mem://default/table-location/data/valid.parquet")
-	orphanDV := newTestDeletionVectorForRef(t, unregisteredSpec(),
-		"mem://default/table-location/data/dv-orphan.puffin",
-		"mem://default/table-location/data/orphan.parquet")
-	sp.removeDeletionVector(validDV)
-	sp.removeDeletionVector(orphanDV)
+	setup := func(t *testing.T, tag string) (*snapshotProducer, iceio.WriteFileIO, *Snapshot) {
+		t.Helper()
 
-	parent := writeParentSnapshotFromManifests(t, wfs, 96, "mixed",
-		writeTestDeletesManifest(t, wfs, registered, 96, "mixed-valid", validDV),
-		writeTestDeletesManifest(t, wfs, unregisteredSpec(), 96, "mixed-orphan", orphanDV))
+		txn, wfs := createTestTransactionWithMemIO(t, registered)
+		sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+		validDV := newTestDeletionVectorForRef(t, registered,
+			"mem://default/table-location/data/dv-valid.puffin", dataPath)
+		sp.removeDeletionVector(validDV)
 
-	before := metadataFiles(t, wfs)
-	_, err := sp.parentDependentManifests(context.Background(), parent)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
-	assert.Equal(t, before, metadataFiles(t, wfs),
-		"a rejected operation must not leave manifests behind")
+		return sp, wfs, writeParentSnapshotWithDeletesManifest(t, wfs, registered, 97, tag, validDV)
+	}
 
-	valid := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
-	valid.removeDeletionVector(validDV)
-	_, err = valid.parentDependentManifests(context.Background(), parent)
-	require.NoError(t, err)
-	assert.Greater(t, len(metadataFiles(t, wfs)), len(before),
-		"the same probe must observe the manifests a successful run writes")
+	t.Run("unregistered added file", func(t *testing.T) {
+		sp, wfs, parent := setup(t, "added")
+		sp.appendDataFile(newTestDataFile(t, unregisteredSpec(),
+			"mem://default/table-location/data/orphan.parquet", partition))
+
+		before := metadataFiles(t, wfs)
+		_, _, err := sp.buildManifests(context.Background(), parent)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+		assert.Equal(t, before, metadataFiles(t, wfs),
+			"the valid deletion must not be written before the added spec is rejected")
+	})
+
+	t.Run("unregistered removed file", func(t *testing.T) {
+		sp, wfs, parent := setup(t, "removed")
+		sp.removeDeleteFile(newTestPosDeleteFileForSpec(t, unregisteredSpec(),
+			"mem://default/table-location/data/orphan-del.parquet", partition, dataPath))
+
+		before := metadataFiles(t, wfs)
+		_, _, err := sp.buildManifests(context.Background(), parent)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+		assert.Equal(t, before, metadataFiles(t, wfs))
+	})
+
+	t.Run("all specs registered", func(t *testing.T) {
+		sp, wfs, parent := setup(t, "registered")
+		sp.appendDataFile(newTestDataFile(t, registered,
+			"mem://default/table-location/data/added.parquet", partition))
+
+		before := metadataFiles(t, wfs)
+		_, _, err := sp.buildManifests(context.Background(), parent)
+		require.NoError(t, err)
+		assert.Greater(t, len(metadataFiles(t, wfs)), len(before),
+			"the same probe must observe the manifests a successful build writes")
+	})
 }
 
 func metadataFiles(t *testing.T, wfs iceio.WriteFileIO) []string {


### PR DESCRIPTION
### Description

Fixes #1855, a long running issue, unnoticed till #1818.

Previous to it, `snapshotProducer.spec(id)` returned an empty partition spec when a spec id was not registered in table metadata. Four callers relied on it. So, a delete-file carrying an unknown spec id committed happily into a manifest declaring the unpartitioned spec 0, while its entry still held a different partition tuple. 

That is corrupt metadata written with no error at all. As I said earlier, #1818 did spot this but it fixed the added-data-file path only.

This moves the check into the helper itself so every path behaves the same way. 

### Testing

Added regression tests wherever required.