### PR TITLE
feat(table,rest): complete server-side scan delegation (Phase 5)

### DIFF
--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -59,5 +59,6 @@ func (r *FetchScanTasksResponse) UnmarshalJSON(data []byte) error {
 	}
 
 	*r = FetchScanTasksResponse(decoded)
+
 	return nil
 }

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -57,6 +57,10 @@ func validatePlanningTaskEnvelope(data []byte, status PlanStatus, tasks ScanTask
 }
 
 func (r *FetchScanTasksResponse) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return fmt.Errorf("%w: fetchScanTasks response must be an object", ErrRESTError)
+	}
+
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -65,9 +65,6 @@ func (r *FetchScanTasksResponse) UnmarshalJSON(data []byte) error {
 	planTasks, hasPlanTasks := fields["plan-tasks"]
 	fileScanTasks, hasFileScanTasks := fields["file-scan-tasks"]
 	deleteFiles, hasDeleteFiles := fields["delete-files"]
-	if !hasPlanTasks && !hasFileScanTasks {
-		return fmt.Errorf("%w: fetchScanTasks response is missing both plan-tasks and file-scan-tasks", ErrRESTError)
-	}
 
 	isNull := func(raw json.RawMessage) bool {
 		return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func (r *FetchScanTasksResponse) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	planTasks, hasPlanTasks := fields["plan-tasks"]
+	fileScanTasks, hasFileScanTasks := fields["file-scan-tasks"]
+	deleteFiles, hasDeleteFiles := fields["delete-files"]
+	if !hasPlanTasks && !hasFileScanTasks {
+		return fmt.Errorf("%w: fetchScanTasks response is missing both plan-tasks and file-scan-tasks", ErrRESTError)
+	}
+
+	isNull := func(raw json.RawMessage) bool {
+		return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+	}
+	if hasPlanTasks && isNull(planTasks) {
+		return fmt.Errorf("%w: fetchScanTasks response field plan-tasks must not be null", ErrRESTError)
+	}
+	if hasFileScanTasks && isNull(fileScanTasks) {
+		return fmt.Errorf("%w: fetchScanTasks response field file-scan-tasks must not be null", ErrRESTError)
+	}
+	if hasDeleteFiles && isNull(deleteFiles) {
+		return fmt.Errorf("%w: fetchScanTasks response field delete-files must not be null", ErrRESTError)
+	}
+
+	type responseAlias FetchScanTasksResponse
+	var decoded responseAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if len(decoded.DeleteFiles) > 0 && len(decoded.FileScanTasks) == 0 {
+		return fmt.Errorf("%w: fetchScanTasks response has delete-files without file-scan-tasks", ErrRESTError)
+	}
+
+	*r = FetchScanTasksResponse(decoded)
+	return nil
+}

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -23,6 +23,39 @@ import (
 	"fmt"
 )
 
+// validatePlanningTaskEnvelope mirrors the Java response validation for the
+// status-discriminated planning responses. Empty arrays are still present on
+// the wire, so inspect the raw JSON instead of relying only on decoded slice
+// lengths when rejecting task fields before planning completes.
+func validatePlanningTaskEnvelope(data []byte, status PlanStatus, tasks ScanTasks, endpoint string) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	if status != PlanStatusCompleted {
+		for _, name := range []string{"plan-tasks", "file-scan-tasks"} {
+			raw, ok := fields[name]
+			if ok && !isJSONNull(raw) {
+				return fmt.Errorf("%w: %s response includes %s for status %q", ErrRESTError, endpoint, name, status)
+			}
+		}
+		if len(tasks.DeleteFiles) > 0 {
+			return fmt.Errorf("%w: %s response includes delete-files for status %q", ErrRESTError, endpoint, status)
+		}
+	}
+
+	if len(tasks.DeleteFiles) > 0 && len(tasks.FileScanTasks) == 0 {
+		return fmt.Errorf(
+			"%w: %s response has delete-files without file-scan-tasks",
+			ErrRESTError,
+			endpoint,
+		)
+	}
+
+	return nil
+}
+
 func (r *FetchScanTasksResponse) UnmarshalJSON(data []byte) error {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -34,14 +34,11 @@ func validatePlanningTaskEnvelope(data []byte, status PlanStatus, tasks ScanTask
 	}
 
 	if status != PlanStatusCompleted {
-		for _, name := range []string{"plan-tasks", "file-scan-tasks"} {
+		for _, name := range []string{"plan-tasks", "file-scan-tasks", "delete-files"} {
 			raw, ok := fields[name]
 			if ok && !isJSONNull(raw) {
 				return fmt.Errorf("%w: %s response includes %s for status %q", ErrRESTError, endpoint, name, status)
 			}
-		}
-		if len(tasks.DeleteFiles) > 0 {
-			return fmt.Errorf("%w: %s response includes delete-files for status %q", ErrRESTError, endpoint, status)
 		}
 	}
 

--- a/catalog/rest/fetch_scan_tasks_validation_test.go
+++ b/catalog/rest/fetch_scan_tasks_validation_test.go
@@ -28,29 +28,40 @@ import (
 func TestFetchScanTasksResponseRejectsInvalidShape(t *testing.T) {
 	t.Parallel()
 
-	for _, payload := range []string{
-		`{"plan-tasks":null}`,
-		`{"file-scan-tasks":null}`,
-		`{"plan-tasks":[],"delete-files":[{"content":"position-deletes"}]}`,
-	} {
-		var resp FetchScanTasksResponse
-		err := json.Unmarshal([]byte(payload), &resp)
-		require.ErrorIs(t, err, ErrRESTError, payload)
+	tests := map[string]string{
+		"null plan-tasks":            `{"plan-tasks":null}`,
+		"null file-scan-tasks":       `{"file-scan-tasks":null}`,
+		"delete-files without tasks": `{"plan-tasks":[],"delete-files":[{"content":"position-deletes"}]}`,
+	}
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var resp FetchScanTasksResponse
+			err := json.Unmarshal([]byte(payload), &resp)
+			require.ErrorIs(t, err, ErrRESTError)
+		})
 	}
 }
 
 func TestFetchScanTasksResponseAcceptsPresentEmptyTaskField(t *testing.T) {
 	t.Parallel()
 
-	for _, payload := range []string{
-		`{}`,
-		`{"plan-tasks":[]}`,
-		`{"file-scan-tasks":[]}`,
-		`{"delete-files":[]}`,
-	} {
-		var resp FetchScanTasksResponse
-		require.NoError(t, json.Unmarshal([]byte(payload), &resp), payload)
-		assert.Empty(t, resp.PlanTasks)
-		assert.Empty(t, resp.FileScanTasks)
+	tests := map[string]string{
+		"no task fields":        `{}`,
+		"empty plan-tasks":      `{"plan-tasks":[]}`,
+		"empty file-scan-tasks": `{"file-scan-tasks":[]}`,
+		"empty delete-files":    `{"delete-files":[]}`,
+	}
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var resp FetchScanTasksResponse
+			require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+			assert.Empty(t, resp.PlanTasks)
+			assert.Empty(t, resp.FileScanTasks)
+			assert.Empty(t, resp.DeleteFiles)
+		})
 	}
 }

--- a/catalog/rest/fetch_scan_tasks_validation_test.go
+++ b/catalog/rest/fetch_scan_tasks_validation_test.go
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchScanTasksResponseRejectsInvalidShape(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []string{
+		`{}`,
+		`{"plan-tasks":null}`,
+		`{"file-scan-tasks":null}`,
+		`{"plan-tasks":[],"delete-files":[{"content":"position-deletes"}]}`,
+	} {
+		var resp FetchScanTasksResponse
+		err := json.Unmarshal([]byte(payload), &resp)
+		require.ErrorIs(t, err, ErrRESTError, payload)
+	}
+}
+
+func TestFetchScanTasksResponseAcceptsPresentEmptyTaskField(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []string{
+		`{"plan-tasks":[]}`,
+		`{"file-scan-tasks":[]}`,
+	} {
+		var resp FetchScanTasksResponse
+		require.NoError(t, json.Unmarshal([]byte(payload), &resp), payload)
+		assert.Empty(t, resp.PlanTasks)
+		assert.Empty(t, resp.FileScanTasks)
+	}
+}

--- a/catalog/rest/fetch_scan_tasks_validation_test.go
+++ b/catalog/rest/fetch_scan_tasks_validation_test.go
@@ -29,7 +29,6 @@ func TestFetchScanTasksResponseRejectsInvalidShape(t *testing.T) {
 	t.Parallel()
 
 	for _, payload := range []string{
-		`{}`,
 		`{"plan-tasks":null}`,
 		`{"file-scan-tasks":null}`,
 		`{"plan-tasks":[],"delete-files":[{"content":"position-deletes"}]}`,
@@ -44,8 +43,10 @@ func TestFetchScanTasksResponseAcceptsPresentEmptyTaskField(t *testing.T) {
 	t.Parallel()
 
 	for _, payload := range []string{
+		`{}`,
 		`{"plan-tasks":[]}`,
 		`{"file-scan-tasks":[]}`,
+		`{"delete-files":[]}`,
 	} {
 		var resp FetchScanTasksResponse
 		require.NoError(t, json.Unmarshal([]byte(payload), &resp), payload)

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1217,7 +1217,15 @@ func (r *Catalog) checkValidNamespace(ident table.Identifier) error {
 	return nil
 }
 
-func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, metadata table.Metadata, loc string, config iceberg.Properties, credsVended bool) (*table.Table, error) {
+func (r *Catalog) tableFromResponse(
+	_ context.Context,
+	identifier []string,
+	metadata table.Metadata,
+	loc string,
+	config iceberg.Properties,
+	scanPlanningConfig iceberg.Properties,
+	credsVended bool,
+) (*table.Table, error) {
 	var fsF func(context.Context) (iceio.IO, error)
 	if credsVended {
 		refresher := &vendedCredentialRefresher{
@@ -1274,6 +1282,7 @@ func (r *Catalog) tableFromResponse(_ context.Context, identifier []string, meta
 		fsF,
 		r,
 		table.WithMetricsReporter(reporter),
+		table.WithScanPlanningIOProperties(scanPlanningConfig),
 	), nil
 }
 
@@ -1509,10 +1518,11 @@ func (r *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 // commitStagedCreate performs the second phase of a staged table
@@ -1724,10 +1734,11 @@ func (r *Catalog) RegisterTable(ctx context.Context, identifier table.Identifier
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 // LoadTable loads a table from the catalog. It implements [catalog.Catalog].
@@ -1768,10 +1779,11 @@ func (r *Catalog) loadTableWithMode(ctx context.Context, identifier table.Identi
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 	maps.Copy(config, ret.Config)
+	scanPlanningConfig := maps.Clone(config)
 	credsVended := len(ret.StorageCredentials) > 0
 	maps.Copy(config, resolveStorageCredentials(ret.StorageCredentials, ret.MetadataLoc))
 
-	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, credsVended)
+	return r.tableFromResponse(ctx, identifier, ret.Metadata, ret.MetadataLoc, config, scanPlanningConfig, credsVended)
 }
 
 func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requirements []table.Requirement, updates []table.Update) (*table.Table, error) {
@@ -1815,7 +1827,7 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 	config := maps.Clone(r.props)
 	maps.Copy(config, ret.Metadata.Properties())
 
-	return r.tableFromResponse(ctx, ident, ret.Metadata, ret.MetadataLoc, config, false)
+	return r.tableFromResponse(ctx, ident, ret.Metadata, ret.MetadataLoc, config, config, false)
 }
 
 func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -1083,7 +1083,7 @@ func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
 	default:
 		return fmt.Errorf("%w: planTableScan response has unknown status %q", ErrRESTError, resp.Status)
 	}
-	if decodePlanningError(resp.Error) != nil && resp.Status != PlanStatusFailed {
+	if resp.Status != PlanStatusFailed && len(resp.Error) > 0 && !isJSONNull(resp.Error) {
 		return fmt.Errorf("%w: planTableScan response includes error for status %q", ErrRESTError, resp.Status)
 	}
 	if err := validatePlanningTaskEnvelope(data, resp.Status, resp.ScanTasks, "planTableScan"); err != nil {
@@ -1127,7 +1127,7 @@ func (r *FetchPlanningResultResponse) UnmarshalJSON(data []byte) error {
 	default:
 		return fmt.Errorf("%w: fetchPlanningResult response has unknown status %q", ErrRESTError, resp.Status)
 	}
-	if decodePlanningError(resp.Error) != nil && resp.Status != PlanStatusFailed {
+	if resp.Status != PlanStatusFailed && len(resp.Error) > 0 && !isJSONNull(resp.Error) {
 		return fmt.Errorf("%w: fetchPlanningResult response includes error for status %q", ErrRESTError, resp.Status)
 	}
 	if err := validatePlanningTaskEnvelope(data, resp.Status, resp.ScanTasks, "fetchPlanningResult"); err != nil {

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -47,6 +47,10 @@ import (
 // Compile-time proof that the REST catalog satisfies the table planner seam.
 var _ table.ScanPlanner = (*Catalog)(nil)
 
+// Compile-time proof that the REST catalog exposes the optional full-capability
+// extension used by table.Scan's auto planning mode.
+var _ table.FullRemoteScanPlanner = (*Catalog)(nil)
+
 // ErrPlanExpired is returned when polling a plan that the server no longer
 // knows about: a fetchPlanningResult 404 whose error.type is exactly
 // NoSuchPlanIdException. It is distinct from a table/namespace-gone 404
@@ -173,7 +177,8 @@ func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 
 // SupportsRemoteScanPlanning reports whether this catalog can submit a remote
 // plan. Any continuation capability is validated against the response returned
-// by the server.
+// by the server; SupportsFullRemoteScanPlanning reports whether auto mode can
+// safely use the complete continuation flow without a local fallback.
 func (r *Catalog) SupportsRemoteScanPlanning() bool {
 	return r.SupportsPlanTableScan()
 }
@@ -438,9 +443,6 @@ func marshalScanFilter(req table.ScanPlanningRequest) ([]byte, error) {
 
 	schema := req.Schema
 	if schema == nil {
-		if req.Metadata == nil {
-			return nil, fmt.Errorf("%w: cannot encode scan filter without table metadata", iceberg.ErrInvalidArgument)
-		}
 		schema = req.Metadata.CurrentSchema()
 	}
 	if schema == nil {

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -16,9 +16,8 @@
 // under the License.
 
 // This file contains the REST server-side scan planning client surface for
-// apache/iceberg-go#1178. Low-level client methods and endpoint capability
-// checks are implemented here; higher-level orchestration, scanner delegation,
-// expression wrappers, and scan-task content decoding land in follow-up phases.
+// apache/iceberg-go#1178. It includes the low-level endpoint methods and the
+// end-to-end planner implementation used by table.Scan.
 
 package rest
 
@@ -31,6 +30,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -145,48 +145,36 @@ const headerIdempotencyKey = "Idempotency-Key"
 // --- Capability gating -------------------------------------------------------
 //
 // Capability is split into two predicates. SupportsPlanTableScan is the narrow
-// "server can plan inline" check (plan endpoint only). SupportsFullRemoteScanPlanning
-// is the endpoint-level "server advertises all four endpoints" check: an
-// end-to-end plan can come back `submitted` or with `plan-tasks` that need the
-// poll/cancel/fetch endpoints to finish, and auto mode has no second chance to
-// fall back to local once it commits to remote, so a plan-only server must not
-// count as end-to-end capable.
-//
-// SupportsRemoteScanPlanning is the table.ScanPlanner-facing predicate that
-// table.Scan's auto mode routes on. It is deliberately gated to false while
-// PlanFiles is an unimplemented stub: routing on endpoint capability alone would
-// send an auto-mode scan into PlanFiles and surface ErrNotImplemented instead of
-// falling back to local planning. It flips on with the PlanFiles phase.
+// "server can plan" check (plan endpoint only). SupportsFullRemoteScanPlanning
+// reports whether every continuation endpoint is also advertised. A plan-only
+// server can still complete a remote scan synchronously with inline file tasks,
+// so table.Scan routes on the narrow predicate and PlanFiles checks continuation
+// endpoints only when the response requires polling or task expansion. The
+// cancel endpoint is best-effort cleanup rather than an execution dependency.
 
-// SupportsPlanTableScan reports whether the server advertised the synchronous
-// plan endpoint.
+// SupportsPlanTableScan reports whether the server advertised the plan
+// submission endpoint.
 func (r *Catalog) SupportsPlanTableScan() bool {
 	return r.endpoints.contains(endpointPlanTableScan)
 }
 
-// SupportsFullRemoteScanPlanning reports whether the server advertised all four
-// scan-planning endpoints (plan, fetch-result, cancel, fetch-tasks), i.e. it can
-// drive the async/fanout path, not just sync inline planning.
+// SupportsFullRemoteScanPlanning reports whether the server advertised the
+// execution endpoints (plan, fetch-result, fetch-tasks), i.e. it can drive the
+// async/fanout path, not just sync inline planning. Cancellation is optional
+// cleanup and does not prevent a plan from producing tasks.
 func (r *Catalog) SupportsFullRemoteScanPlanning() bool {
 	return r.SupportsPlanTableScan() &&
 		r.endpoints.contains(endpointFetchPlanResult) &&
-		r.endpoints.contains(endpointCancelPlanning) &&
 		r.endpoints.contains(endpointFetchScanTasks)
 }
 
 // --- table.ScanPlanner implementation ---------------------------------------
 
-// SupportsRemoteScanPlanning reports whether this catalog can complete a remote
-// plan end-to-end. table.Scan's auto mode routes on it, calling PlanFiles when it
-// is true, so it must stay false until PlanFiles is implemented — otherwise an
-// auto-mode scan against a server advertising all four endpoints would fail with
-// ErrNotImplemented instead of falling back to local planning.
-//
-// TODO(#1178): return SupportsFullRemoteScanPlanning() once PlanFiles is wired
-// end-to-end. Until then, callers probing endpoint capability should use
-// SupportsFullRemoteScanPlanning / SupportsPlanTableScan directly.
+// SupportsRemoteScanPlanning reports whether this catalog can submit a remote
+// plan. Any continuation capability is validated against the response returned
+// by the server.
 func (r *Catalog) SupportsRemoteScanPlanning() bool {
-	return false
+	return r.SupportsPlanTableScan()
 }
 
 // PlanFiles plans a scan server-side and returns tasks (and, optionally, a
@@ -194,11 +182,10 @@ func (r *Catalog) SupportsRemoteScanPlanning() bool {
 // submitted plan to completion, and expands any plan-task handles into their
 // tasks before returning.
 //
-// Decoding the returned tasks into table.FileScanTask is the one piece still
-// stubbed: RESTFileScanTask/RESTDeleteFile are empty pending the scan-task
-// decoder phase, so a plan that yields any task surfaces ErrNotImplemented (see
-// remoteScanTasks). SupportsRemoteScanPlanning therefore stays false until that
-// lands, so auto-mode scans keep planning locally rather than routing here.
+// Each response is decoded as its own ScanTasks envelope before the results are
+// combined. Delete-file references are scoped to the envelope that returned
+// them, so flattening all responses first would attach deletes to the wrong
+// data files when the server uses plan-task fanout.
 func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) (table.ScanPlanningResult, error) {
 	wire, err := planTableScanRequestFrom(req)
 	if err != nil {
@@ -208,6 +195,16 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 	resp, err := r.PlanTableScan(ctx, req.Identifier, wire)
 	if err != nil {
 		return table.ScanPlanningResult{}, err
+	}
+
+	planID := ""
+	if resp.PlanID != nil {
+		planID = *resp.PlanID
+	}
+	cleanup := func() {
+		if planID != "" {
+			r.abandonPlan(ctx, req.Identifier, planID, DefaultWaitForPlanOptions.CancelGracePeriod)
+		}
 	}
 
 	// Resolve to a completed plan: use an inline result as-is, or poll a
@@ -223,6 +220,20 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 	case PlanStatusSubmitted:
 		completed, err = r.WaitForPlan(ctx, req.Identifier, *resp.PlanID, WaitForPlanOptions{})
 		if err != nil {
+			// WaitForPlan already abandons plans when its retry budget or the
+			// caller's context is exhausted. Other terminal client/transport
+			// errors can leave a submitted plan active, so release it here.
+			if !errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) &&
+				!errors.Is(err, ErrPlanPollExhausted) &&
+				!errors.Is(err, ErrPlanFailed) &&
+				!errors.Is(err, ErrPlanCancelled) &&
+				!errors.Is(err, ErrPlanExpired) &&
+				!errors.Is(err, catalog.ErrNoSuchTable) &&
+				!errors.Is(err, catalog.ErrNoSuchNamespace) {
+				cleanup()
+			}
+
 			return table.ScanPlanningResult{}, err
 		}
 	default:
@@ -230,43 +241,51 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 			"%w: unexpected plan status %q from planTableScan", ErrRESTError, resp.Status)
 	}
 
-	files, deletes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
+	envelopes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
 	if err != nil {
+		cleanup()
+
 		return table.ScanPlanningResult{}, err
 	}
 
-	tasks, err := remoteScanTasks(files, deletes)
+	tasks, err := remoteScanTasks(envelopes, req)
 	if err != nil {
+		cleanup()
+
 		return table.ScanPlanningResult{}, err
 	}
 
-	return table.ScanPlanningResult{
+	result := table.ScanPlanningResult{
 		Tasks: tasks,
-		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req.Metadata)),
-	}, nil
+		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req)),
+	}
+	cleanup()
+
+	return result, nil
 }
 
-// planIOBaseProps rebuilds the props the table's own FileIO was built with, so a
-// plan-scoped IO keeps settings like a custom S3 endpoint or region. loadTable's
-// config block never reaches the planner seam, so it isn't included.
-func (r *Catalog) planIOBaseProps(meta table.ScanPlanningMetadata) iceberg.Properties {
+// planIOBaseProps rebuilds the props the table's own FileIO was built with, so
+// a plan-scoped IO keeps settings like a custom S3 endpoint or region. The
+// table-scoped properties take precedence over catalog and metadata defaults;
+// this mirrors the merge order used by LoadTable.
+func (r *Catalog) planIOBaseProps(req table.ScanPlanningRequest) iceberg.Properties {
 	props := make(iceberg.Properties, len(r.props))
 	maps.Copy(props, r.props)
-	if meta != nil {
-		maps.Copy(props, meta.Properties())
+	if req.Metadata != nil {
+		maps.Copy(props, req.Metadata.Properties())
 	}
+	maps.Copy(props, req.FileIOProperties)
 
 	return props
 }
 
-// collectScanTasks expands plan-task handles into their tasks, walking the
-// fanout: a fetchScanTasks response can itself return more plan-tasks. It
-// accumulates the file-scan-tasks and delete-files reachable from the initial
-// set. A handle is fetched at most once; a server that re-issues one would
-// otherwise loop forever.
-func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]RESTFileScanTask, []RESTDeleteFile, error) {
-	files := append([]RESTFileScanTask(nil), tasks.FileScanTasks...)
-	deletes := append([]RESTDeleteFile(nil), tasks.DeleteFiles...)
+// collectScanTasks expands plan-task handles into their task envelopes, walking
+// the fanout: a fetchScanTasks response can itself return more plan-tasks. A
+// handle is fetched at most once; a server that re-issues one would otherwise
+// loop forever. The envelope boundaries are retained because delete-file
+// references are local to each response.
+func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]ScanTasks, error) {
+	envelopes := []ScanTasks{tasks}
 
 	queue := append([]string(nil), tasks.PlanTasks...)
 	seen := make(map[string]bool, len(queue))
@@ -280,49 +299,52 @@ func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, 
 
 		resp, err := r.FetchScanTasks(ctx, ident, FetchScanTasksRequest{PlanTask: handle})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		files = append(files, resp.FileScanTasks...)
-		deletes = append(deletes, resp.DeleteFiles...)
+		envelopes = append(envelopes, resp.ScanTasks)
 		queue = append(queue, resp.PlanTasks...)
 	}
 
-	return files, deletes, nil
+	return envelopes, nil
 }
 
-// remoteScanTasks decodes the server's task payload into domain FileScanTasks.
-// Blocked for now: RESTFileScanTask/RESTDeleteFile are empty pending the
-// scan-task decoder phase, so an empty plan decodes to no tasks while any actual
-// task surfaces ErrNotImplemented. The decoder phase replaces this body.
-func remoteScanTasks(files []RESTFileScanTask, deletes []RESTDeleteFile) ([]table.FileScanTask, error) {
-	if len(files) == 0 && len(deletes) == 0 {
-		return nil, nil
+// remoteScanTasks decodes each server task envelope into domain FileScanTasks.
+// The decoder must run before envelopes are combined because delete-file
+// references are indexes into the envelope-local delete-files array.
+func remoteScanTasks(envelopes []ScanTasks, req table.ScanPlanningRequest) ([]table.FileScanTask, error) {
+	var result []table.FileScanTask
+	for i, envelope := range envelopes {
+		// Keep empty completed plans cheap and allow the low-level planner method
+		// to return no tasks even when a caller did not provide metadata.
+		if len(envelope.FileScanTasks) == 0 && len(envelope.DeleteFiles) == 0 {
+			continue
+		}
+
+		tasks, err := DecodeScanTasks(envelope, req.Metadata, req.Schema, req.RowFilter)
+		if err != nil {
+			return nil, fmt.Errorf("decoding remote scan task envelope %d: %w", i, err)
+		}
+		result = append(result, tasks...)
 	}
 
-	return nil, fmt.Errorf("%w: decoding remote scan tasks", iceberg.ErrNotImplemented)
+	return result, nil
 }
 
-// planIOFromCredentials wraps a plan's vended storage credentials in a lazy
-// PlanIO, overlaid on the table's base IO props so vended keys win on collision.
-// With none vended it returns a nil PlanIO, and the scan falls back to the
-// table's own FileIO.
+// planIOFromCredentials wraps a plan's prefix-scoped storage credentials in a
+// lazy PlanIO. The returned IO resolves the longest matching credential prefix
+// for each data or delete file it opens, overlaid on the table's base IO props
+// so vended keys win on collision. With none vended it returns a nil PlanIO,
+// and the scan falls back to the table's own FileIO.
 func planIOFromCredentials(creds []StorageCredential, location string, baseProps iceberg.Properties) table.PlanIO {
 	if len(creds) == 0 {
 		return nil
 	}
 
-	// TODO(#1178): plan.storage-credentials is prefix-scoped, but this builds one
-	// IO from the metadata location — wrong cred if data/delete files sit under a
-	// different prefix. The scan-task decoder settles the PlanIO shape.
-	resolved := resolveStorageCredentials(creds, location)
-	props := make(iceberg.Properties, len(baseProps)+len(resolved))
-	maps.Copy(props, baseProps)
-	maps.Copy(props, resolved)
-
 	return &planScopedIO{refresher: &vendedCredentialRefresher{
-		mu:       semaphore.NewWeighted(1),
-		location: location,
-		props:    props,
+		mu:          semaphore.NewWeighted(1),
+		location:    location,
+		props:       maps.Clone(baseProps),
+		credentials: slices.Clone(creds),
 		// fetchCreds stays nil: a plan's creds can't be renewed via the
 		// table-credentials endpoint, so an expiry is fatal, not a re-fetch.
 	}}
@@ -348,11 +370,16 @@ func (p *planScopedIO) Close() error {
 func planTableScanRequestFrom(req table.ScanPlanningRequest) (PlanTableScanRequest, error) {
 	out := PlanTableScanRequest{
 		SnapshotID:        req.SnapshotID,
-		Select:            req.SelectedFields,
 		MinRowsRequested:  req.MinRowsRequested,
 		CaseSensitive:     req.CaseSensitive,
 		UseSnapshotSchema: req.UseSnapshotSchema,
 		StatsFields:       req.StatsFields,
+	}
+	// `*` is table.Scan's local sentinel, not a REST FieldName. A planner
+	// normally expands it to schema field names before reaching this function;
+	// omitting it here is the safe fallback for direct callers without a schema.
+	if len(req.SelectedFields) > 0 && !slices.Contains(req.SelectedFields, "*") {
+		out.Select = slices.Clone(req.SelectedFields)
 	}
 
 	if req.RowFilter != nil && !req.RowFilter.Equals(iceberg.AlwaysTrue{}) {
@@ -380,8 +407,18 @@ func marshalScanFilter(req table.ScanPlanningRequest) ([]byte, error) {
 		caseSensitive = *req.CaseSensitive
 	}
 
-	// Snapshot-schema selection (UseSnapshotSchema) is OQ4, deferred; bind current.
-	bound, err := iceberg.BindExpr(req.Metadata.CurrentSchema(), req.RowFilter, caseSensitive)
+	schema := req.Schema
+	if schema == nil {
+		if req.Metadata == nil {
+			return nil, fmt.Errorf("%w: cannot encode scan filter without table metadata", iceberg.ErrInvalidArgument)
+		}
+		schema = req.Metadata.CurrentSchema()
+	}
+	if schema == nil {
+		return nil, fmt.Errorf("%w: cannot encode scan filter without a scan schema", iceberg.ErrInvalidArgument)
+	}
+
+	bound, err := iceberg.BindExpr(schema, req.RowFilter, caseSensitive)
 	if err != nil {
 		return nil, fmt.Errorf("%w: binding scan filter: %s", iceberg.ErrInvalidArgument, err)
 	}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -33,6 +33,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -259,7 +260,15 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 		Tasks: tasks,
 		IO:    planIOFromCredentials(completed.StorageCredentials, req.MetadataLocation, r.planIOBaseProps(req)),
 	}
-	cleanup()
+	if result.IO == nil {
+		// Without plan-scoped credentials, all task materialization is complete
+		// and the plan can be released before the caller reads the files.
+		cleanup()
+	} else {
+		// Keep the plan alive while the lazy plan-scoped IO may still be used.
+		// table.Scan closes this IO after its active readers release their lease.
+		result.IO = &planIOWithCleanup{io: result.IO, cleanup: cleanup}
+	}
 
 	return result, nil
 }
@@ -362,6 +371,26 @@ func (p *planScopedIO) Load(ctx context.Context) (iceio.IO, error) {
 
 func (p *planScopedIO) Close() error {
 	return p.refresher.close()
+}
+
+// planIOWithCleanup keeps the remote plan alive for the lifetime of the
+// plan-scoped IO. Scan owns the IO through its PlanIO state and closes it only
+// after replacing the plan and releasing active readers, so cancellation cannot
+// invalidate credentials before ReadTasks opens the files.
+type planIOWithCleanup struct {
+	io      table.PlanIO
+	cleanup func()
+	once    sync.Once
+}
+
+func (p *planIOWithCleanup) Load(ctx context.Context) (iceio.IO, error) {
+	return p.io.Load(ctx)
+}
+
+func (p *planIOWithCleanup) Close() error {
+	defer p.once.Do(p.cleanup)
+
+	return p.io.Close()
 }
 
 // planTableScanRequestFrom builds the planTableScan request body from the

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -1044,10 +1044,19 @@ func (r *PlanTableScanResponse) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("%w: planTableScan response with status %q missing plan-id", ErrRESTError, resp.Status)
 		}
 	case PlanStatusFailed:
+		if resp.PlanID != nil {
+			return fmt.Errorf("%w: planTableScan response with status %q must not include plan-id", ErrRESTError, resp.Status)
+		}
 	case PlanStatusCancelled:
 		return fmt.Errorf("%w: planTableScan response has invalid status %q", ErrRESTError, resp.Status)
 	default:
 		return fmt.Errorf("%w: planTableScan response has unknown status %q", ErrRESTError, resp.Status)
+	}
+	if decodePlanningError(resp.Error) != nil && resp.Status != PlanStatusFailed {
+		return fmt.Errorf("%w: planTableScan response includes error for status %q", ErrRESTError, resp.Status)
+	}
+	if err := validatePlanningTaskEnvelope(data, resp.Status, resp.ScanTasks, "planTableScan"); err != nil {
+		return err
 	}
 
 	*r = PlanTableScanResponse{
@@ -1086,6 +1095,12 @@ func (r *FetchPlanningResultResponse) UnmarshalJSON(data []byte) error {
 	case PlanStatusFailed:
 	default:
 		return fmt.Errorf("%w: fetchPlanningResult response has unknown status %q", ErrRESTError, resp.Status)
+	}
+	if decodePlanningError(resp.Error) != nil && resp.Status != PlanStatusFailed {
+		return fmt.Errorf("%w: fetchPlanningResult response includes error for status %q", ErrRESTError, resp.Status)
+	}
+	if err := validatePlanningTaskEnvelope(data, resp.Status, resp.ScanTasks, "fetchPlanningResult"); err != nil {
+		return err
 	}
 
 	*r = FetchPlanningResultResponse{

--- a/catalog/rest/scan_planning_fake_test.go
+++ b/catalog/rest/scan_planning_fake_test.go
@@ -89,7 +89,7 @@ func TestPlanFakeCapabilityDiscovery(t *testing.T) {
 				planfake.FetchScanTasksEndpoint,
 			},
 			wantPlan:         true,
-			wantFullPlanning: false,
+			wantFullPlanning: true,
 		},
 		{
 			name: "missing task fetch",
@@ -121,6 +121,7 @@ func TestPlanFakeCapabilityDiscovery(t *testing.T) {
 
 			assert.Equal(t, test.wantPlan, catalog.SupportsPlanTableScan())
 			assert.Equal(t, test.wantFullPlanning, catalog.SupportsFullRemoteScanPlanning())
+			assert.Equal(t, test.wantPlan, catalog.SupportsRemoteScanPlanning())
 
 			requests := srv.Requests()
 			require.Len(t, requests, 1)

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1268,6 +1268,36 @@ func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
 	assert.Equal(t, int32(1), cancels.Load())
 }
 
+func TestPlanFilesDefersCancelWithVendedCredentials(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","storage-credentials":[{"prefix":"s3://bucket/","config":{"s3.access-key-id":"vended"}}]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	result, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.NoError(t, err)
+	require.NotNil(t, result.IO)
+	assert.Equal(t, int32(0), cancels.Load())
+
+	require.NoError(t, result.IO.Close())
+	assert.Equal(t, int32(1), cancels.Load())
+	require.NoError(t, result.IO.Close())
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
 func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {
 	t.Parallel()
 
@@ -1441,12 +1471,15 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.IO)
 
-	planIO, ok := result.IO.(*planScopedIO)
+	wrapped, ok := result.IO.(*planIOWithCleanup)
+	require.True(t, ok)
+	planIO, ok := wrapped.io.(*planScopedIO)
 	require.True(t, ok)
 	assert.Equal(t, "https://table.local", planIO.refresher.props["s3.endpoint"])
 	assert.Equal(t, "table-static", planIO.refresher.props["s3.access-key-id"])
 	require.Len(t, planIO.refresher.credentials, 1)
 	assert.Equal(t, "vended", planIO.refresher.credentials[0].Config["s3.access-key-id"])
+	require.NoError(t, result.IO.Close())
 }
 
 // TestPlanScopedIOExpiredCredentials checks a plan whose creds state an expiry

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -120,13 +120,12 @@ func TestScanPlanningCapabilities(t *testing.T) {
 	t.Run("plan only", func(t *testing.T) {
 		t.Parallel()
 
-		// A plan-only server can plan inline, but a `submitted` reply could not
-		// be polled, so it is not full-remote capable. SupportsRemoteScanPlanning
-		// is false here too (gated off while PlanFiles is a stub).
+		// A plan-only server can plan inline even though it cannot handle response
+		// shapes that require polling or task expansion.
 		cat := &Catalog{endpoints: newEndpointSet([]endpoint{endpointPlanTableScan})}
 		assert.True(t, cat.SupportsPlanTableScan())
 		assert.False(t, cat.SupportsFullRemoteScanPlanning())
-		assert.False(t, cat.SupportsRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
 	})
 
 	t.Run("full remote planning", func(t *testing.T) {
@@ -140,11 +139,19 @@ func TestScanPlanningCapabilities(t *testing.T) {
 		})}
 		assert.True(t, cat.SupportsPlanTableScan())
 		assert.True(t, cat.SupportsFullRemoteScanPlanning())
-		// SupportsRemoteScanPlanning stays false while PlanFiles is a stub, even
-		// when all four endpoints are advertised, so auto mode falls back to
-		// local instead of routing into ErrNotImplemented. Flips on with the
-		// PlanFiles phase.
-		assert.False(t, cat.SupportsRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
+	})
+
+	t.Run("execution endpoints without optional cancel", func(t *testing.T) {
+		t.Parallel()
+
+		cat := &Catalog{endpoints: newEndpointSet([]endpoint{
+			endpointPlanTableScan,
+			endpointFetchPlanResult,
+			endpointFetchScanTasks,
+		})}
+		assert.True(t, cat.SupportsFullRemoteScanPlanning())
+		assert.True(t, cat.SupportsRemoteScanPlanning())
 	})
 
 	t.Run("default fallback does not advertise scan planning", func(t *testing.T) {
@@ -923,6 +930,10 @@ func TestPlanTableScanRequestFromPassesFields(t *testing.T) {
 	assert.Equal(t, &caseSensitive, wire.CaseSensitive)
 	assert.Equal(t, []string{"a"}, wire.StatsFields)
 	assert.Nil(t, wire.Filter)
+
+	wire, err = planTableScanRequestFrom(table.ScanPlanningRequest{SelectedFields: []string{"*"}})
+	require.NoError(t, err)
+	assert.Nil(t, wire.Select, "the local wildcard sentinel is not a REST FieldName")
 }
 
 // scanFilterSchema is the schema filter-binding tests resolve references against.
@@ -944,6 +955,15 @@ func (m scanTestMetadata) PartitionSpecByID(int) *iceberg.PartitionSpec { return
 func (m scanTestMetadata) CurrentSnapshot() *table.Snapshot             { return nil }
 func (m scanTestMetadata) SnapshotByID(int64) *table.Snapshot           { return nil }
 func (m scanTestMetadata) Properties() iceberg.Properties               { return nil }
+
+type scanPlanningSchemaMetadata struct {
+	*scanTaskDecoderMetadata
+	current *iceberg.Schema
+	schemas []*iceberg.Schema
+}
+
+func (m scanPlanningSchemaMetadata) CurrentSchema() *iceberg.Schema { return m.current }
+func (m scanPlanningSchemaMetadata) Schemas() []*iceberg.Schema     { return m.schemas }
 
 // planFilesReq is a minimal planner request naming the test table.
 func planFilesReq() table.ScanPlanningRequest {
@@ -972,6 +992,65 @@ func TestPlanFilesCompletedEmpty(t *testing.T) {
 	assert.Nil(t, result.IO)
 }
 
+func TestScanPlanningRemoteSupportsSynchronousPlanOnlyServer(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			planID := "plan-1"
+			require.NoError(t, json.NewEncoder(w).Encode(PlanTableScanResponse{
+				Status:    PlanStatusCompleted,
+				PlanID:    &planID,
+				ScanTasks: validScanTasksWire(),
+			}))
+		})
+	})
+
+	assert.True(t, cat.SupportsRemoteScanPlanning())
+	assert.False(t, cat.SupportsFullRemoteScanPlanning())
+
+	req := planFilesReq()
+	req.Metadata = metadata
+	req.Schema = metadata.schema
+	result, err := cat.PlanFiles(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 1)
+	assert.Equal(t, "s3://bucket/table/data.parquet", result.Tasks[0].File.FilePath())
+}
+
+func TestPlanFilesRequiresAdvertisedResponseContinuation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "submitted plan requires result fetch",
+			response: `{"status":"submitted","plan-id":"plan-1"}`,
+		},
+		{
+			name:     "plan task requires task fetch",
+			response: `{"status":"completed","plan-id":"plan-1","plan-tasks":["task-1"]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
+				mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+					_, err := w.Write([]byte(test.response))
+					require.NoError(t, err)
+				})
+			})
+
+			_, err := cat.PlanFiles(context.Background(), planFilesReq())
+			require.ErrorIs(t, err, ErrEndpointNotSupported)
+		})
+	}
+}
+
 // TestPlanFilesEncodesFilter checks the row filter reaches the plan request body
 // as ExpressionParser JSON.
 func TestPlanFilesEncodesFilter(t *testing.T) {
@@ -997,10 +1076,9 @@ func TestPlanFilesEncodesFilter(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestPlanFilesTasksNotYetDecodable documents the one stubbed boundary: a plan
-// that returns actual file-scan-tasks surfaces ErrNotImplemented until the
-// scan-task decoder phase fills in RESTFileScanTask.
-func TestPlanFilesTasksNotYetDecodable(t *testing.T) {
+// TestPlanFilesRejectsMalformedScanTasks makes sure remote planning validates
+// the task payload instead of returning partially decoded tasks.
+func TestPlanFilesRejectsMalformedScanTasks(t *testing.T) {
 	t.Parallel()
 
 	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan}, func(mux *http.ServeMux) {
@@ -1011,7 +1089,7 @@ func TestPlanFilesTasksNotYetDecodable(t *testing.T) {
 	})
 
 	_, err := cat.PlanFiles(context.Background(), planFilesReq())
-	require.ErrorIs(t, err, iceberg.ErrNotImplemented)
+	require.ErrorIs(t, err, ErrRESTError)
 }
 
 // TestPlanFilesPollsSubmittedPlan covers the async arm: a submitted plan is
@@ -1093,8 +1171,224 @@ func TestPlanFilesFanoutCycleTerminates(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load())
 }
 
+func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1","h2"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			if body.PlanTask == "h1" {
+				_, err := w.Write([]byte(`{}`))
+				require.NoError(t, err)
+
+				return
+			}
+
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.ErrorIs(t, err, ErrServiceUnavailable)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestPlanFilesCancelsAfterSuccessfulMaterialization(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, "h1", body.PlanTask)
+			_, err := w.Write([]byte(`{"file-scan-tasks":[]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	result, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.NoError(t, err)
+	assert.Empty(t, result.Tasks)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestPlanFilesCancelsAfterTaskDecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchScanTasks,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"completed","plan-id":"plan-1","plan-tasks":["h1"]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, "h1", body.PlanTask)
+			_, err := w.Write([]byte(`{"file-scan-tasks":[{}]}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodDelete, req.Method)
+			cancels.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.ErrorIs(t, err, ErrRESTError)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestPlanFilesCancelsAfterTerminalPollError(t *testing.T) {
+	t.Parallel()
+
+	var cancels atomic.Int32
+	cat := newScanPlanningTestCatalog(t, []endpoint{
+		endpointPlanTableScan,
+		endpointFetchPlanResult,
+		endpointCancelPlanning,
+	}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			_, err := w.Write([]byte(`{"status":"submitted","plan-id":"plan-1"}`))
+			require.NoError(t, err)
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan/plan-1", func(w http.ResponseWriter, req *http.Request) {
+			switch req.Method {
+			case http.MethodGet:
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			case http.MethodDelete:
+				cancels.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			}
+		})
+	})
+
+	_, err := cat.PlanFiles(context.Background(), planFilesReq())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), cancels.Load())
+}
+
+func TestRemoteScanTasksUsesResolvedSchemaForResiduals(t *testing.T) {
+	t.Parallel()
+
+	decoderMetadata := newScanTaskDecoderMetadata()
+	oldSchema := decoderMetadata.schema
+	currentFields := append([]iceberg.NestedField(nil), oldSchema.Fields()...)
+	currentFields[1].Name = "new_category"
+	currentSchema := iceberg.NewSchema(11, currentFields...)
+	metadata := scanPlanningSchemaMetadata{
+		scanTaskDecoderMetadata: decoderMetadata,
+		current:                 currentSchema,
+		schemas:                 []*iceberg.Schema{currentSchema, oldSchema},
+	}
+	req := table.ScanPlanningRequest{
+		Metadata: metadata,
+		Schema:   oldSchema,
+		RowFilter: iceberg.GreaterThan(
+			iceberg.Reference("category"),
+			"old",
+		),
+	}
+	wireReq, err := planTableScanRequestFrom(req)
+	require.NoError(t, err)
+
+	wire := validScanTasksWire()
+	wire.FileScanTasks[0].ResidualFilter = wireReq.Filter
+	tasks, err := remoteScanTasks([]ScanTasks{wire}, req)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.True(t, tasks[0].Residual.Equals(req.RowFilter))
+}
+
+// TestPlanFilesDecodesFanoutTaskEnvelopes exercises the Phase 5 boundary from
+// REST wire tasks to table.FileScanTask. In particular, each fetchScanTasks
+// response has its own delete-file reference namespace; decoding after
+// flattening the responses would attach the second task to the first delete.
+func TestPlanFilesDecodesFanoutTaskEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	first := validScanTasksWire()
+	first.FileScanTasks[0].DataFile.FilePath = "s3://bucket/table/first-data.parquet"
+	first.DeleteFiles[0].FilePath = "s3://bucket/table/first-delete.parquet"
+	first.PlanTasks = []string{"h1"}
+
+	second := validScanTasksWire()
+	second.FileScanTasks[0].DataFile.FilePath = "s3://bucket/table/second-data.parquet"
+	second.DeleteFiles[0].FilePath = "s3://bucket/table/second-delete.parquet"
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan, endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
+			response := struct {
+				Status PlanStatus `json:"status"`
+				PlanID string     `json:"plan-id"`
+				ScanTasks
+			}{
+				Status:    PlanStatusCompleted,
+				PlanID:    "plan-1",
+				ScanTasks: first,
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var got FetchScanTasksRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&got))
+			require.Equal(t, "h1", got.PlanTask)
+			require.NoError(t, json.NewEncoder(w).Encode(FetchScanTasksResponse{ScanTasks: second}))
+		})
+	})
+
+	req := planFilesReq()
+	req.Metadata = newScanTaskDecoderMetadata()
+	req.RowFilter = iceberg.GreaterThan(iceberg.Reference("id"), int64(10))
+
+	result, err := cat.PlanFiles(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 2)
+	assert.Equal(t, "s3://bucket/table/first-data.parquet", result.Tasks[0].File.FilePath())
+	assert.Equal(t, "s3://bucket/table/first-delete.parquet", result.Tasks[0].DeleteFiles[0].FilePath())
+	assert.Equal(t, "s3://bucket/table/second-data.parquet", result.Tasks[1].File.FilePath())
+	assert.Equal(t, "s3://bucket/table/second-delete.parquet", result.Tasks[1].DeleteFiles[0].FilePath())
+	assert.Same(t, req.RowFilter, result.Tasks[0].Residual)
+}
+
 // TestPlanFilesSurfacesVendedCredentials checks a plan that vends storage
-// credentials yields a plan-scoped IO that keeps the catalog's IO props (the
+// credentials yields a plan-scoped IO that keeps the table's IO props (the
 // custom endpoint here) rather than running on the vended creds alone, with the
 // vended values winning where they overlap.
 func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
@@ -1106,11 +1400,15 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 			require.NoError(t, err)
 		})
 	})
-	cat.props["s3.endpoint"] = "https://minio.local"
-	cat.props["s3.access-key-id"] = "static"
+	cat.props["s3.endpoint"] = "https://catalog.local"
+	cat.props["s3.access-key-id"] = "catalog-static"
 
 	req := planFilesReq()
 	req.MetadataLocation = "s3://bucket/db/tbl/metadata/v1.json"
+	req.FileIOProperties = iceberg.Properties{
+		"s3.endpoint":      "https://table.local",
+		"s3.access-key-id": "table-static",
+	}
 
 	result, err := cat.PlanFiles(context.Background(), req)
 	require.NoError(t, err)
@@ -1118,12 +1416,15 @@ func TestPlanFilesSurfacesVendedCredentials(t *testing.T) {
 
 	planIO, ok := result.IO.(*planScopedIO)
 	require.True(t, ok)
-	assert.Equal(t, "https://minio.local", planIO.refresher.props["s3.endpoint"])
-	assert.Equal(t, "vended", planIO.refresher.props["s3.access-key-id"])
+	assert.Equal(t, "https://table.local", planIO.refresher.props["s3.endpoint"])
+	assert.Equal(t, "table-static", planIO.refresher.props["s3.access-key-id"])
+	require.Len(t, planIO.refresher.credentials, 1)
+	assert.Equal(t, "vended", planIO.refresher.credentials[0].Config["s3.access-key-id"])
 }
 
 // TestPlanScopedIOExpiredCredentials checks a plan whose creds state an expiry
-// fails loudly once past it, since plan creds can't be renewed.
+// fails loudly for a matching location once past it, since plan creds can't be
+// renewed.
 func TestPlanScopedIOExpiredCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -1144,20 +1445,26 @@ func TestPlanScopedIOExpiredCredentials(t *testing.T) {
 	require.True(t, ok)
 	p.refresher.nowFunc = func() time.Time { return now }
 
-	// The first load caches an IO and picks up the stated expiry.
+	// The first load caches the prefix resolver rather than treating the plan's
+	// location-specific credentials as one global credential set.
 	fs, err := p.Load(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, fs)
-	assert.Equal(t, now.Add(time.Hour).UnixMilli(), p.refresher.expiresAt.UnixMilli())
+	assert.True(t, p.refresher.expiresAt.IsZero())
+	prefixIO, ok := fs.(*prefixScopedIO)
+	require.True(t, ok)
+	_, err = prefixIO.filesystemFor("file:///bucket/data.parquet")
+	require.NoError(t, err)
 
-	// Past the expiry, with no endpoint to renew from, the load fails.
+	// Past the expiry, access under the credential's prefix fails even though
+	// its filesystem was already cached.
 	p.refresher.nowFunc = func() time.Time { return now.Add(2 * time.Hour) }
-	_, err = p.Load(context.Background())
+	_, err = prefixIO.filesystemFor("file:///bucket/data.parquet")
 	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
 }
 
 // TestPlanScopedIOAlreadyExpiredCredentials checks creds that are already past
-// their expiry on the very first load fail loudly instead of yielding an IO.
+// their expiry fail loudly when a matching location is first opened.
 func TestPlanScopedIOAlreadyExpiredCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -1174,7 +1481,43 @@ func TestPlanScopedIOAlreadyExpiredCredentials(t *testing.T) {
 	require.True(t, ok)
 	p.refresher.nowFunc = func() time.Time { return now }
 
-	_, err := p.Load(context.Background())
+	fs, err := p.Load(context.Background())
+	require.NoError(t, err)
+	_, err = fs.Open("file:///bucket/data.parquet")
+	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
+}
+
+func TestPlanScopedIOIgnoresExpiredCredentialForUnrelatedPrefix(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	creds := []StorageCredential{
+		{
+			Prefix: "file:///archive/",
+			Config: iceberg.Properties{
+				keyS3TokenExpiresAtMs: strconv.FormatInt(now.Add(-time.Hour).UnixMilli(), 10),
+			},
+		},
+		{
+			Prefix: "file:///current/",
+			Config: iceberg.Properties{
+				keyS3TokenExpiresAtMs: strconv.FormatInt(now.Add(time.Hour).UnixMilli(), 10),
+			},
+		},
+	}
+
+	p, ok := planIOFromCredentials(creds, "file:///metadata/v1.json", nil).(*planScopedIO)
+	require.True(t, ok)
+	p.refresher.nowFunc = func() time.Time { return now }
+
+	fs, err := p.Load(context.Background())
+	require.NoError(t, err)
+	prefixIO, ok := fs.(*prefixScopedIO)
+	require.True(t, ok)
+	_, err = prefixIO.filesystemFor("file:///current/data.parquet")
+	require.NoError(t, err)
+
+	_, err = prefixIO.filesystemFor("file:///archive/data.parquet")
 	require.ErrorIs(t, err, ErrVendedCredentialsExpired)
 }
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -500,6 +500,26 @@ func TestFetchScanTasksRejectsEmptyBody(t *testing.T) {
 	assert.Equal(t, FetchScanTasksResponse{}, resp)
 }
 
+func TestFetchScanTasksRejectsNullBody(t *testing.T) {
+	t.Parallel()
+
+	key := "0190b6c5-1c3d-7000-8000-000000000005"
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			require.Equal(t, http.MethodPost, req.Method)
+			_, err := w.Write([]byte("null"))
+			require.NoError(t, err)
+		})
+	})
+
+	resp, err := cat.FetchScanTasks(context.Background(), table.Identifier{"db", "tbl"}, FetchScanTasksRequest{
+		IdempotencyKey: &key,
+		PlanTask:       "task-1",
+	})
+	require.ErrorIs(t, err, ErrRESTError)
+	assert.Equal(t, FetchScanTasksResponse{}, resp)
+}
+
 func TestFetchPlanningResultRequest(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -208,6 +208,20 @@ func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
 	assert.Equal(t, "position-deletes", resp.DeleteFiles[0].Content)
 }
 
+func TestPlanTableScanResponseRejectsInvalidStatusEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []string{
+		`{"status":"submitted","plan-id":"abc","file-scan-tasks":[]}`,
+		`{"status":"failed","plan-tasks":[]}`,
+		`{"status":"completed","plan-id":"abc","delete-files":[{}]}`,
+		`{"status":"failed","plan-id":"abc"}`,
+	} {
+		var resp PlanTableScanResponse
+		require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+	}
+}
+
 func TestPlanTableScanResponseAcceptsFailedWithoutUsableError(t *testing.T) {
 	t.Parallel()
 
@@ -265,6 +279,19 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 		var resp FetchPlanningResultResponse
 		err := json.Unmarshal([]byte(`{"status":"bogus"}`), &resp)
 		require.ErrorIs(t, err, ErrRESTError)
+	})
+
+	t.Run("rejects task fields before completion", func(t *testing.T) {
+		t.Parallel()
+
+		for _, payload := range []string{
+			`{"status":"submitted","plan-tasks":[]}`,
+			`{"status":"cancelled","file-scan-tasks":[]}`,
+			`{"status":"completed","delete-files":[{}]}`,
+		} {
+			var resp FetchPlanningResultResponse
+			require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+		}
 	})
 }
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -256,6 +256,22 @@ func TestPlanTableScanResponseAcceptsFailedWithError(t *testing.T) {
 	assert.Equal(t, "boom", resp.Error.Message)
 }
 
+func TestPlanTableScanResponseRejectsErrorOnNonFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	for i, payload := range []string{
+		`{"status":"completed","plan-id":"abc","error":"oops"}`,
+		`{"status":"submitted","plan-id":"abc","error":[]}`,
+	} {
+		t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			var resp PlanTableScanResponse
+			require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+		})
+	}
+}
+
 func TestPlanTableScanResponseRejectsUnknownStatus(t *testing.T) {
 	t.Parallel()
 
@@ -302,6 +318,23 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 			`{"status":"submitted","delete-files":[]}`,
 			`{"status":"cancelled","file-scan-tasks":[]}`,
 			`{"status":"completed","delete-files":[{}]}`,
+		} {
+			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				var resp FetchPlanningResultResponse
+				require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+			})
+		}
+	})
+
+	t.Run("rejects error on non-failed status", func(t *testing.T) {
+		t.Parallel()
+
+		for i, payload := range []string{
+			`{"status":"completed","error":"oops"}`,
+			`{"status":"submitted","error":[]}`,
+			`{"status":"cancelled","error":{}}`,
 		} {
 			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
 				t.Parallel()

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -213,6 +213,7 @@ func TestPlanTableScanResponseRejectsInvalidStatusEnvelope(t *testing.T) {
 
 	for _, payload := range []string{
 		`{"status":"submitted","plan-id":"abc","file-scan-tasks":[]}`,
+		`{"status":"submitted","plan-id":"abc","delete-files":[]}`,
 		`{"status":"failed","plan-tasks":[]}`,
 		`{"status":"completed","plan-id":"abc","delete-files":[{}]}`,
 		`{"status":"failed","plan-id":"abc"}`,
@@ -286,6 +287,7 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 
 		for _, payload := range []string{
 			`{"status":"submitted","plan-tasks":[]}`,
+			`{"status":"submitted","delete-files":[]}`,
 			`{"status":"cancelled","file-scan-tasks":[]}`,
 			`{"status":"completed","delete-files":[{}]}`,
 		} {

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -211,30 +211,38 @@ func TestPlanTableScanResponseAcceptsCompletedWithPlanID(t *testing.T) {
 func TestPlanTableScanResponseRejectsInvalidStatusEnvelope(t *testing.T) {
 	t.Parallel()
 
-	for _, payload := range []string{
+	for i, payload := range []string{
 		`{"status":"submitted","plan-id":"abc","file-scan-tasks":[]}`,
 		`{"status":"submitted","plan-id":"abc","delete-files":[]}`,
 		`{"status":"failed","plan-tasks":[]}`,
 		`{"status":"completed","plan-id":"abc","delete-files":[{}]}`,
 		`{"status":"failed","plan-id":"abc"}`,
 	} {
-		var resp PlanTableScanResponse
-		require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+		t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			var resp PlanTableScanResponse
+			require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+		})
 	}
 }
 
 func TestPlanTableScanResponseAcceptsFailedWithoutUsableError(t *testing.T) {
 	t.Parallel()
 
-	for _, payload := range []string{
+	for i, payload := range []string{
 		`{"status":"failed"}`,
 		`{"status":"failed","error":null}`,
 		`{"status":"failed","error":"oops"}`,
 	} {
-		var resp PlanTableScanResponse
-		require.NoError(t, json.Unmarshal([]byte(payload), &resp))
-		assert.Equal(t, PlanStatusFailed, resp.Status)
-		assert.Nil(t, resp.Error)
+		t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			var resp PlanTableScanResponse
+			require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+			assert.Equal(t, PlanStatusFailed, resp.Status)
+			assert.Nil(t, resp.Error)
+		})
 	}
 }
 
@@ -262,15 +270,19 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 	t.Run("failed without usable error is accepted", func(t *testing.T) {
 		t.Parallel()
 
-		for _, payload := range []string{
+		for i, payload := range []string{
 			`{"status":"failed"}`,
 			`{"status":"failed","error":null}`,
 			`{"status":"failed","error":"oops"}`,
 		} {
-			var resp FetchPlanningResultResponse
-			require.NoError(t, json.Unmarshal([]byte(payload), &resp))
-			assert.Equal(t, PlanStatusFailed, resp.Status)
-			assert.Nil(t, resp.Error)
+			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				var resp FetchPlanningResultResponse
+				require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+				assert.Equal(t, PlanStatusFailed, resp.Status)
+				assert.Nil(t, resp.Error)
+			})
 		}
 	})
 
@@ -285,14 +297,18 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 	t.Run("rejects task fields before completion", func(t *testing.T) {
 		t.Parallel()
 
-		for _, payload := range []string{
+		for i, payload := range []string{
 			`{"status":"submitted","plan-tasks":[]}`,
 			`{"status":"submitted","delete-files":[]}`,
 			`{"status":"cancelled","file-scan-tasks":[]}`,
 			`{"status":"completed","delete-files":[{}]}`,
 		} {
-			var resp FetchPlanningResultResponse
-			require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				var resp FetchPlanningResultResponse
+				require.ErrorIs(t, json.Unmarshal([]byte(payload), &resp), ErrRESTError, payload)
+			})
 		}
 	})
 }

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1188,7 +1188,7 @@ func TestPlanFilesCancelsAfterFanoutFailure(t *testing.T) {
 			var body FetchScanTasksRequest
 			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
 			if body.PlanTask == "h1" {
-				_, err := w.Write([]byte(`{}`))
+				_, err := w.Write([]byte(`{"plan-tasks":[]}`))
 				require.NoError(t, err)
 
 				return

--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -348,8 +348,8 @@ func decodeRESTDeleteFile(
 			builder.ContentOffset(*wire.ContentOffset)
 		}
 		if wire.ContentSizeInBytes != nil {
-			if *wire.ContentSizeInBytes <= 0 {
-				return nil, fmt.Errorf("content-size-in-bytes must be positive: %d", *wire.ContentSizeInBytes)
+			if *wire.ContentSizeInBytes < 0 {
+				return nil, fmt.Errorf("content-size-in-bytes must be non-negative: %d", *wire.ContentSizeInBytes)
 			}
 			builder.ContentSizeInBytes(*wire.ContentSizeInBytes)
 		}
@@ -391,11 +391,11 @@ func contentFileBuilder(
 	if !ok || actualContent != expectedContent {
 		return nil, "", fmt.Errorf("content is %q, want %q", wire.Content, wantContent)
 	}
-	if wire.RecordCount <= 0 {
-		return nil, "", fmt.Errorf("record-count must be positive: %d", wire.RecordCount)
+	if wire.RecordCount < 0 {
+		return nil, "", fmt.Errorf("record-count must be non-negative: %d", wire.RecordCount)
 	}
-	if wire.FileSizeInBytes <= 0 {
-		return nil, "", fmt.Errorf("file-size-in-bytes must be positive: %d", wire.FileSizeInBytes)
+	if wire.FileSizeInBytes < 0 {
+		return nil, "", fmt.Errorf("file-size-in-bytes must be non-negative: %d", wire.FileSizeInBytes)
 	}
 
 	spec := metadata.PartitionSpecByID(wire.SpecID)
@@ -707,8 +707,11 @@ func decodeTaskResidual(
 	fallback iceberg.BooleanExpression,
 ) (iceberg.BooleanExpression, error) {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if len(trimmed) == 0 {
 		return fallback, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, errors.New("explicit null residual-filter is invalid")
 	}
 
 	// Accept the object spelling from the OpenAPI schema in addition to the

--- a/catalog/rest/scan_task_decoder_test.go
+++ b/catalog/rest/scan_task_decoder_test.go
@@ -185,6 +185,32 @@ func TestDecodeScanTasksUsesFallbackAndAcceptsSpecConstants(t *testing.T) {
 	assert.True(t, tasks[0].Residual.Equals(iceberg.AlwaysFalse{}))
 }
 
+func TestDecodeScanTasksRejectsExplicitNullResidual(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	wire := validScanTasksWire()
+	wire.FileScanTasks[0].ResidualFilter = json.RawMessage(`null`)
+
+	_, err := DecodeScanTasks(wire, metadata, metadata.schema, iceberg.AlwaysTrue{})
+	require.ErrorContains(t, err, "explicit null residual-filter is invalid")
+}
+
+func TestDecodeScanTasksAcceptsEmptyDataFile(t *testing.T) {
+	t.Parallel()
+
+	metadata := newScanTaskDecoderMetadata()
+	wire := validScanTasksWire()
+	wire.FileScanTasks[0].DataFile.RecordCount = 0
+	wire.FileScanTasks[0].DataFile.FileSizeInBytes = 0
+
+	tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Zero(t, tasks[0].File.Count())
+	assert.Zero(t, tasks[0].File.FileSizeBytes())
+}
+
 func TestDecodeScanTasksKeepsDeleteReferencesEnvelopeLocal(t *testing.T) {
 	t.Parallel()
 
@@ -436,28 +462,14 @@ func TestDecodeScanTasksRejectsMalformedPayloads(t *testing.T) {
 			mutate: func(w *ScanTasks) {
 				w.FileScanTasks[0].DataFile.RecordCount = -1
 			},
-			want: "record-count must be positive",
-		},
-		{
-			name: "zero record count",
-			mutate: func(w *ScanTasks) {
-				w.FileScanTasks[0].DataFile.RecordCount = 0
-			},
-			want: "record-count must be positive",
+			want: "record-count must be non-negative",
 		},
 		{
 			name: "negative file size",
 			mutate: func(w *ScanTasks) {
 				w.FileScanTasks[0].DataFile.FileSizeInBytes = -1
 			},
-			want: "file-size-in-bytes must be positive",
-		},
-		{
-			name: "zero file size",
-			mutate: func(w *ScanTasks) {
-				w.FileScanTasks[0].DataFile.FileSizeInBytes = 0
-			},
-			want: "file-size-in-bytes must be positive",
+			want: "file-size-in-bytes must be non-negative",
 		},
 		{
 			name: "referenced data file disagrees with task",

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -449,18 +449,20 @@ func closeOptionalIO(fs iceio.IO) error {
 
 func (p *prefixScopedIO) Close() error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	if p.closed {
+		p.mu.Unlock()
+
 		return nil
 	}
 	p.closed = true
+	filesystems := p.filesystems
+	p.filesystems = nil
+	p.mu.Unlock()
 
 	var closeErr error
-	for _, fs := range p.filesystems {
+	for _, fs := range filesystems {
 		closeErr = errors.Join(closeErr, closeOptionalIO(fs))
 	}
-	p.filesystems = nil
 
 	return closeErr
 }

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -19,10 +19,14 @@ package rest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"net/url"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -48,40 +52,55 @@ const (
 // resolveStorageCredentials finds the best-matching credential for the given
 // location using longest-prefix match, mirroring the Java and Python implementations.
 func resolveStorageCredentials(creds []StorageCredential, location string) iceberg.Properties {
-	var best *StorageCredential
-	for i := range creds {
-		c := &creds[i]
-		if strings.HasPrefix(location, c.Prefix) {
-			if best == nil || len(c.Prefix) > len(best.Prefix) {
-				best = c
-			}
-		}
-	}
-	if best == nil {
+	index := matchingStorageCredentialIndex(creds, location)
+	if index < 0 {
 		return nil
 	}
 
-	return best.Config
+	return creds[index].Config
+}
+
+func matchingStorageCredentialIndex(creds []StorageCredential, location string) int {
+	best := -1
+	for i := range creds {
+		if !strings.HasPrefix(location, creds[i].Prefix) {
+			continue
+		}
+		if best == -1 || len(creds[i].Prefix) > len(creds[best].Prefix) {
+			best = i
+		}
+	}
+
+	return best
 }
 
 var credentialExpiryKeys = []string{
 	keyS3TokenExpiresAtMs,
-	keyAdlsSasExpiresAtMs,
 	keyGcsOAuthExpiresAt,
 	keyExpirationTime,
 }
 
 func parseCredentialExpiry(config iceberg.Properties) (time.Time, bool) {
-	for _, key := range credentialExpiryKeys {
-		if v, ok := config[key]; ok {
-			ms, err := strconv.ParseInt(v, 10, 64)
-			if err == nil && ms > 0 {
-				return time.UnixMilli(ms), true
+	var earliest time.Time
+	found := false
+	for key, value := range config {
+		if !slices.Contains(credentialExpiryKeys, key) &&
+			key != keyAdlsSasExpiresAtMs &&
+			!strings.HasPrefix(key, keyAdlsSasExpiresAtMs+".") {
+			continue
+		}
+
+		ms, err := strconv.ParseInt(value, 10, 64)
+		if err == nil && ms > 0 {
+			expiresAt := time.UnixMilli(ms)
+			if !found || expiresAt.Before(earliest) {
+				earliest = expiresAt
+				found = true
 			}
 		}
 	}
 
-	return time.Time{}, false
+	return earliest, found
 }
 
 type vendedCredentialRefresher struct {
@@ -96,6 +115,10 @@ type vendedCredentialRefresher struct {
 	identifier []string
 	location   string
 	props      iceberg.Properties
+	// credentials is populated only for scan-plan IO. Unlike table-load
+	// credentials, which are already resolved against the metadata location,
+	// plan credentials must be selected against every file path opened later.
+	credentials []StorageCredential
 
 	fetchCreds func(ctx context.Context, ident []string) (iceberg.Properties, error)
 
@@ -124,11 +147,14 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 	switch {
 	case v.cachedIO == nil:
 		config = v.props
-		// Plan creds can already be past their expiry by the time we first use
-		// them, so check before building an IO we'd only hand back 403s from.
-		if v.fetchCreds == nil {
-			if exp, ok := parseCredentialExpiry(config); ok && v.now().After(exp) {
-				return nil, v.expiredError(exp)
+		// A single resolved credential can already be past its expiry by the
+		// time we first use it, so check before building an IO we'd only hand
+		// back 403s from. Plan credentials are resolved later, per location, by
+		// prefixScopedIO and must not be rejected as one global credential set.
+		if v.fetchCreds == nil && len(v.credentials) == 0 {
+			expiresAt, ok := parseCredentialExpiry(config)
+			if ok && v.now().After(expiresAt) {
+				return nil, v.expiredError(expiresAt)
 			}
 		}
 	case v.fetchCreds == nil:
@@ -143,6 +169,17 @@ func (v *vendedCredentialRefresher) loadFS(ctx context.Context) (iceio.IO, error
 
 		config = maps.Clone(v.props)
 		maps.Copy(config, freshCreds)
+	}
+
+	if len(v.credentials) > 0 {
+		prefixIO := newPrefixScopedIO(ctx, v.props, v.credentials)
+		prefixIO.nowFunc = v.now
+		v.cachedIO = prefixIO
+		// Expiry is enforced by prefixScopedIO against only the credential
+		// selected for each object location.
+		v.expiresAt = time.Time{}
+
+		return v.cachedIO, nil
 	}
 
 	newIO, err := iceio.LoadFS(ctx, config, v.location)
@@ -203,6 +240,10 @@ func (v *vendedCredentialRefresher) refreshBuffer() time.Duration {
 }
 
 func (v *vendedCredentialRefresher) expiresAtFromConfig(config iceberg.Properties) time.Time {
+	if len(v.credentials) > 0 {
+		return time.Time{}
+	}
+
 	if exp, ok := parseCredentialExpiry(config); ok {
 		return exp
 	}
@@ -229,4 +270,166 @@ func (v *vendedCredentialRefresher) close() error {
 	}
 
 	return nil
+}
+
+// prefixScopedIO selects a plan credential using the actual object location
+// passed to Open/Remove. A single plan may cover metadata, data, and delete
+// files in different storage prefixes, so resolving credentials once at plan
+// creation would be incorrect.
+type prefixScopedIO struct {
+	ctx         context.Context
+	baseProps   iceberg.Properties
+	credentials []StorageCredential
+
+	mu          sync.Mutex
+	filesystems map[string]iceio.IO
+	closed      bool
+	nowFunc     func() time.Time
+}
+
+func newPrefixScopedIO(ctx context.Context, baseProps iceberg.Properties, credentials []StorageCredential) *prefixScopedIO {
+	return &prefixScopedIO{
+		ctx:         ctx,
+		baseProps:   maps.Clone(baseProps),
+		credentials: slices.Clone(credentials),
+		filesystems: make(map[string]iceio.IO),
+	}
+}
+
+func (p *prefixScopedIO) Open(name string) (iceio.File, error) {
+	fs, err := p.filesystemFor(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fs.Open(name)
+}
+
+func (p *prefixScopedIO) Remove(name string) error {
+	fs, err := p.filesystemFor(name)
+	if err != nil {
+		return err
+	}
+
+	return fs.Remove(name)
+}
+
+func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
+	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	if credentialIndex >= 0 {
+		if expiresAt, ok := parseCredentialExpiry(p.credentials[credentialIndex].Config); ok &&
+			p.now().After(expiresAt) {
+			return nil, fmt.Errorf("%w: %s expired at %s",
+				ErrVendedCredentialsExpired, name, expiresAt.Format(time.RFC3339))
+		}
+	}
+
+	key := scopedFilesystemKey(credentialIndex, name)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, errors.New("prefix-scoped IO is closed")
+	}
+	if fs, ok := p.filesystems[key]; ok {
+		return fs, nil
+	}
+
+	props := p.propertiesForLocation(name)
+
+	fs, err := iceio.LoadFS(p.ctx, props, name)
+	if err != nil {
+		return nil, err
+	}
+
+	p.filesystems[key] = fs
+
+	return fs, nil
+}
+
+func (p *prefixScopedIO) now() time.Time {
+	if p.nowFunc != nil {
+		return p.nowFunc()
+	}
+
+	return time.Now()
+}
+
+func (p *prefixScopedIO) propertiesForLocation(name string) iceberg.Properties {
+	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	props := make(iceberg.Properties, len(p.baseProps))
+	maps.Copy(props, p.baseProps)
+	if credentialIndex >= 0 {
+		credentialConfig := p.credentials[credentialIndex].Config
+		clearOverriddenCredentialProperties(props, credentialConfig)
+		maps.Copy(props, credentialConfig)
+	}
+
+	return props
+}
+
+// clearOverriddenCredentialProperties prevents a matched credential from being
+// combined with optional fields from another credential. In particular, an S3
+// access/secret pair without a session token must not inherit a stale token
+// from the table or catalog configuration.
+func clearOverriddenCredentialProperties(props, credentialConfig iceberg.Properties) {
+	_, hasS3AccessKey := credentialConfig[iceio.S3AccessKeyID]
+	_, hasS3SecretKey := credentialConfig[iceio.S3SecretAccessKey]
+	_, hasS3SessionToken := credentialConfig[iceio.S3SessionToken]
+	if hasS3AccessKey || hasS3SecretKey || hasS3SessionToken {
+		delete(props, iceio.S3AccessKeyID)
+		delete(props, iceio.S3SecretAccessKey)
+		delete(props, iceio.S3SessionToken)
+		delete(props, keyS3TokenExpiresAtMs)
+	}
+
+	_, hasGCSOAuthToken := credentialConfig[iceio.GCSOAuthToken]
+	_, hasGCSOAuthExpiry := credentialConfig[iceio.GCSOAuthExpiresAt]
+	if hasGCSOAuthToken || hasGCSOAuthExpiry {
+		delete(props, iceio.GCSOAuthToken)
+		delete(props, iceio.GCSOAuthExpiresAt)
+	}
+
+	for key := range credentialConfig {
+		switch {
+		case strings.HasPrefix(key, iceio.ADLSSasTokenPrefix):
+			suffix := strings.TrimPrefix(key, iceio.ADLSSasTokenPrefix)
+			delete(props, iceio.ADLSSasTokenPrefix+suffix)
+			delete(props, keyAdlsSasExpiresAtMs+"."+suffix)
+		case strings.HasPrefix(key, keyAdlsSasExpiresAtMs+"."):
+			suffix := strings.TrimPrefix(key, keyAdlsSasExpiresAtMs+".")
+			delete(props, iceio.ADLSSasTokenPrefix+suffix)
+			delete(props, keyAdlsSasExpiresAtMs+"."+suffix)
+		}
+	}
+}
+
+func scopedFilesystemKey(credentialIndex int, location string) string {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return fmt.Sprintf("%d:%s", credentialIndex, location)
+	}
+
+	return fmt.Sprintf("%d:%s://%s", credentialIndex, parsed.Scheme, parsed.Host)
+}
+
+func (p *prefixScopedIO) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	var closeErr error
+	for _, fs := range p.filesystems {
+		if closer, ok := fs.(interface{ Close() error }); ok {
+			closeErr = errors.Join(closeErr, closer.Close())
+		}
+	}
+	p.filesystems = nil
+
+	return closeErr
 }

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -351,10 +351,19 @@ func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
 	if p.closed {
 		p.mu.Unlock()
 
+		closeErr := closeOptionalIO(fs)
+		if closeErr != nil {
+			return nil, errors.Join(errors.New("prefix-scoped IO is closed"), closeErr)
+		}
+
 		return nil, errors.New("prefix-scoped IO is closed")
 	}
 	if existing, ok := p.filesystems[key]; ok {
 		p.mu.Unlock()
+
+		if err := closeOptionalIO(fs); err != nil {
+			return nil, err
+		}
 
 		return existing, nil
 	}
@@ -430,6 +439,14 @@ func scopedFilesystemKey(credentialIndex int, location string) string {
 	return fmt.Sprintf("%d:%s://%s", credentialIndex, parsed.Scheme, parsed.Host)
 }
 
+func closeOptionalIO(fs iceio.IO) error {
+	if closer, ok := fs.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+
+	return nil
+}
+
 func (p *prefixScopedIO) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -441,9 +458,7 @@ func (p *prefixScopedIO) Close() error {
 
 	var closeErr error
 	for _, fs := range p.filesystems {
-		if closer, ok := fs.(interface{ Close() error }); ok {
-			closeErr = errors.Join(closeErr, closer.Close())
-		}
+		closeErr = errors.Join(closeErr, closeOptionalIO(fs))
 	}
 	p.filesystems = nil
 

--- a/catalog/rest/vended_creds.go
+++ b/catalog/rest/vended_creds.go
@@ -316,25 +316,29 @@ func (p *prefixScopedIO) Remove(name string) error {
 
 func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
 	credentialIndex := matchingStorageCredentialIndex(p.credentials, name)
+	key := scopedFilesystemKey(credentialIndex, name)
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+
+		return nil, errors.New("prefix-scoped IO is closed")
+	}
 	if credentialIndex >= 0 {
 		if expiresAt, ok := parseCredentialExpiry(p.credentials[credentialIndex].Config); ok &&
 			p.now().After(expiresAt) {
+			p.mu.Unlock()
+
 			return nil, fmt.Errorf("%w: %s expired at %s",
 				ErrVendedCredentialsExpired, name, expiresAt.Format(time.RFC3339))
 		}
 	}
-
-	key := scopedFilesystemKey(credentialIndex, name)
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.closed {
-		return nil, errors.New("prefix-scoped IO is closed")
-	}
 	if fs, ok := p.filesystems[key]; ok {
+		p.mu.Unlock()
+
 		return fs, nil
 	}
+	p.mu.Unlock()
 
 	props := p.propertiesForLocation(name)
 
@@ -343,7 +347,19 @@ func (p *prefixScopedIO) filesystemFor(name string) (iceio.IO, error) {
 		return nil, err
 	}
 
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+
+		return nil, errors.New("prefix-scoped IO is closed")
+	}
+	if existing, ok := p.filesystems[key]; ok {
+		p.mu.Unlock()
+
+		return existing, nil
+	}
 	p.filesystems[key] = fs
+	p.mu.Unlock()
 
 	return fs, nil
 }

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -360,6 +360,18 @@ func TestVendedCredsServerExpiryUsedOnRefresh(t *testing.T) {
 	assert.Equal(t, serverExpiry.UnixMilli(), r.expiresAt.UnixMilli())
 }
 
+func TestParseCredentialExpirySupportsAccountScopedADLSKey(t *testing.T) {
+	t.Parallel()
+
+	want := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+	got, ok := parseCredentialExpiry(iceberg.Properties{
+		keyAdlsSasExpiresAtMs + ".account.dfs.core.windows.net": strconv.FormatInt(want.UnixMilli(), 10),
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
 func TestVendedCredsRefreshTriggeredWithinExpiryBuffer(t *testing.T) {
 	t.Parallel()
 
@@ -635,4 +647,73 @@ func TestResolveStorageCredentials(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestPrefixScopedIOUsesLongestCredentialPerLocation(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{"base": "yes"}, []StorageCredential{
+		{Prefix: "s3://metadata/table/", Config: iceberg.Properties{"credential": "metadata"}},
+		{Prefix: "s3://data/table/", Config: iceberg.Properties{"credential": "data"}},
+		{Prefix: "s3://data/table/private/", Config: iceberg.Properties{"credential": "private"}},
+	})
+
+	assert.Equal(t, "metadata", p.propertiesForLocation("s3://metadata/table/metadata.json")["credential"])
+	assert.Equal(t, "data", p.propertiesForLocation("s3://data/table/file.parquet")["credential"])
+	assert.Equal(t, "private", p.propertiesForLocation("s3://data/table/private/file.parquet")["credential"])
+	assert.Equal(t, "yes", p.propertiesForLocation("s3://other/table/file.parquet")["base"])
+}
+
+func TestPrefixScopedIOReplacesS3CredentialAtomically(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{
+		iceio.S3EndpointURL:     "https://s3.local",
+		iceio.S3AccessKeyID:     "load-access",
+		iceio.S3SecretAccessKey: "load-secret",
+		iceio.S3SessionToken:    "load-token",
+		keyS3TokenExpiresAtMs:   "1000",
+	}, []StorageCredential{{
+		Prefix: "s3://bucket/data/",
+		Config: iceberg.Properties{
+			iceio.S3AccessKeyID:     "plan-access",
+			iceio.S3SecretAccessKey: "plan-secret",
+		},
+	}})
+
+	props := p.propertiesForLocation("s3://bucket/data/file.parquet")
+	assert.Equal(t, "https://s3.local", props[iceio.S3EndpointURL])
+	assert.Equal(t, "plan-access", props[iceio.S3AccessKeyID])
+	assert.Equal(t, "plan-secret", props[iceio.S3SecretAccessKey])
+	assert.NotContains(t, props, iceio.S3SessionToken)
+	assert.NotContains(t, props, keyS3TokenExpiresAtMs)
+}
+
+func TestPrefixScopedIODoesNotApplyCredentialOutsidePrefix(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixScopedIO(context.Background(), iceberg.Properties{
+		iceio.S3EndpointURL: "https://s3.local",
+	}, []StorageCredential{{
+		Prefix: "s3://bucket/data/",
+		Config: iceberg.Properties{
+			iceio.S3AccessKeyID:     "plan-access",
+			iceio.S3SecretAccessKey: "plan-secret",
+		},
+	}})
+
+	props := p.propertiesForLocation("s3://other-bucket/data/file.parquet")
+	assert.Equal(t, "https://s3.local", props[iceio.S3EndpointURL])
+	assert.NotContains(t, props, iceio.S3AccessKeyID)
+	assert.NotContains(t, props, iceio.S3SecretAccessKey)
+}
+
+func TestPrefixScopedIOPreservesReadContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := newPrefixScopedIO(ctx, nil, nil)
+
+	cancel()
+	require.ErrorIs(t, p.ctx.Err(), context.Canceled)
 }

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -716,8 +716,8 @@ func TestPrefixScopedIODoesNotHoldLockDuringFilesystemLoad(t *testing.T) {
 	lockAcquired := make(chan struct{})
 	go func() {
 		p.mu.Lock()
-		p.mu.Unlock()
 		close(lockAcquired)
+		p.mu.Unlock()
 	}()
 
 	select {

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -741,6 +741,19 @@ func (f *closeTrackingIO) Close() error {
 	return nil
 }
 
+type blockingCloseIO struct {
+	iceio.IO
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (f *blockingCloseIO) Close() error {
+	close(f.started)
+	<-f.release
+
+	return nil
+}
+
 func TestPrefixScopedIOClosesFilesystemLostToCacheRace(t *testing.T) {
 	const scheme = "prefix-scoped-cache-race-test"
 
@@ -845,6 +858,46 @@ func TestPrefixScopedIOClosesFilesystemLoadedAfterClose(t *testing.T) {
 	}
 	assert.Equal(t, int32(1), closeCount.Load(),
 		"a filesystem loaded after Close must be closed before returning")
+}
+
+func TestPrefixScopedIODoesNotHoldLockDuringFilesystemClose(t *testing.T) {
+	t.Parallel()
+
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+	defer release()
+
+	p := newPrefixScopedIO(context.Background(), nil, nil)
+	p.filesystems["cached"] = &blockingCloseIO{
+		IO:      iceio.LocalFS{},
+		started: closeStarted,
+		release: releaseClose,
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- p.Close() }()
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for filesystem close")
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		p.mu.Lock()
+		close(lockAcquired)
+		p.mu.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("filesystem cache lock was held during filesystem close")
+	}
+
+	release()
+	require.NoError(t, <-closeDone)
 }
 
 func TestPrefixScopedIODoesNotApplyCredentialOutsidePrefix(t *testing.T) {

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -730,6 +730,123 @@ func TestPrefixScopedIODoesNotHoldLockDuringFilesystemLoad(t *testing.T) {
 	require.NoError(t, <-loaded)
 }
 
+type closeTrackingIO struct {
+	iceio.IO
+	closeCount *atomic.Int32
+}
+
+func (f *closeTrackingIO) Close() error {
+	f.closeCount.Add(1)
+
+	return nil
+}
+
+func TestPrefixScopedIOClosesFilesystemLostToCacheRace(t *testing.T) {
+	const scheme = "prefix-scoped-cache-race-test"
+
+	loadStarted := make(chan struct{}, 2)
+	releaseLoad := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLoad) }) }
+	defer release()
+
+	var closeCount atomic.Int32
+	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		loadStarted <- struct{}{}
+		<-releaseLoad
+
+		return &closeTrackingIO{IO: iceio.LocalFS{}, closeCount: &closeCount}, nil
+	})
+	defer iceio.Unregister(scheme)
+
+	p := newPrefixScopedIO(context.Background(), nil, nil)
+	type result struct {
+		fs  iceio.IO
+		err error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			fs, err := p.filesystemFor(scheme + "://bucket/file.parquet")
+			results <- result{fs: fs, err: err}
+		}()
+	}
+
+	for range 2 {
+		select {
+		case <-loadStarted:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent filesystem loads")
+		}
+	}
+	release()
+
+	var cached iceio.IO
+	for range 2 {
+		select {
+		case result := <-results:
+			require.NoError(t, result.err)
+			if cached == nil {
+				cached = result.fs
+			} else {
+				assert.Same(t, cached, result.fs)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for filesystem loads")
+		}
+	}
+
+	assert.Equal(t, int32(1), closeCount.Load(),
+		"the filesystem that lost the cache race must be closed")
+	require.NoError(t, p.Close())
+	assert.Equal(t, int32(2), closeCount.Load(),
+		"the cached filesystem must be closed when the scoped IO closes")
+}
+
+func TestPrefixScopedIOClosesFilesystemLoadedAfterClose(t *testing.T) {
+	const scheme = "prefix-scoped-close-during-load-test"
+
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLoad) }) }
+	defer release()
+
+	var closeCount atomic.Int32
+	iceio.Register(scheme, func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		close(loadStarted)
+		<-releaseLoad
+
+		return &closeTrackingIO{IO: iceio.LocalFS{}, closeCount: &closeCount}, nil
+	})
+	defer iceio.Unregister(scheme)
+
+	p := newPrefixScopedIO(context.Background(), nil, nil)
+	loaded := make(chan error, 1)
+	go func() {
+		_, err := p.filesystemFor(scheme + "://bucket/file.parquet")
+		loaded <- err
+	}()
+
+	select {
+	case <-loadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for filesystem load")
+	}
+	require.NoError(t, p.Close())
+	release()
+
+	select {
+	case err := <-loaded:
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "prefix-scoped IO is closed")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for filesystem load to finish")
+	}
+	assert.Equal(t, int32(1), closeCount.Load(),
+		"a filesystem loaded after Close must be closed before returning")
+}
+
 func TestPrefixScopedIODoesNotApplyCredentialOutsidePrefix(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/vended_creds_test.go
+++ b/catalog/rest/vended_creds_test.go
@@ -20,6 +20,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"net/url"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -687,6 +688,46 @@ func TestPrefixScopedIOReplacesS3CredentialAtomically(t *testing.T) {
 	assert.Equal(t, "plan-secret", props[iceio.S3SecretAccessKey])
 	assert.NotContains(t, props, iceio.S3SessionToken)
 	assert.NotContains(t, props, keyS3TokenExpiresAtMs)
+}
+
+func TestPrefixScopedIODoesNotHoldLockDuringFilesystemLoad(t *testing.T) {
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLoad) }) }
+
+	iceio.Register("prefix-scoped-lock-test", func(context.Context, *url.URL, map[string]string) (iceio.IO, error) {
+		close(loadStarted)
+		<-releaseLoad
+
+		return iceio.LocalFS{}, nil
+	})
+	defer iceio.Unregister("prefix-scoped-lock-test")
+	defer release()
+
+	p := newPrefixScopedIO(context.Background(), nil, nil)
+	loaded := make(chan error, 1)
+	go func() {
+		_, err := p.filesystemFor("prefix-scoped-lock-test://bucket/file.parquet")
+		loaded <- err
+	}()
+
+	<-loadStarted
+	lockAcquired := make(chan struct{})
+	go func() {
+		p.mu.Lock()
+		p.mu.Unlock()
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("filesystem cache lock was held during filesystem loading")
+	}
+
+	release()
+	require.NoError(t, <-loaded)
 }
 
 func TestPrefixScopedIODoesNotApplyCredentialOutsidePrefix(t *testing.T) {

--- a/manifest.go
+++ b/manifest.go
@@ -2715,12 +2715,12 @@ func NewDataFileBuilder(
 		)
 	}
 
-	if recordCount <= 0 {
-		return nil, fmt.Errorf("%w: record count must be greater than 0", ErrInvalidArgument)
+	if recordCount < 0 {
+		return nil, fmt.Errorf("%w: record count must be non-negative", ErrInvalidArgument)
 	}
 
-	if fileSize <= 0 {
-		return nil, fmt.Errorf("%w: file size must be greater than 0", ErrInvalidArgument)
+	if fileSize < 0 {
+		return nil, fmt.Errorf("%w: file size must be non-negative", ErrInvalidArgument)
 	}
 	partitionData := make(map[string]any)
 	fieldNameToID := make(map[string]int)

--- a/table/pos_delete_partitioned_fanout_writer_test.go
+++ b/table/pos_delete_partitioned_fanout_writer_test.go
@@ -427,7 +427,8 @@ func TestPositionDeletePartitionedFanoutWriterEarlyStopCancelsRecordProduction(t
 	require.NoError(t, metadataBuilder.SetCurrentSchemaID(0))
 	require.NoError(t, metadataBuilder.AddPartitionSpec(&partitionSpec, true))
 	require.NoError(t, metadataBuilder.SetDefaultSpecID(0))
-	require.NoError(t, metadataBuilder.AddSortOrder(&UnsortedSortOrder))
+	unsortedSortOrder := UnsortedSortOrder
+	require.NoError(t, metadataBuilder.AddSortOrder(&unsortedSortOrder))
 	require.NoError(t, metadataBuilder.SetDefaultSortOrderID(0))
 	latestMeta, err := metadataBuilder.Build()
 	require.NoError(t, err)

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -15,13 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// This file is a PROPOSED public API surface for REST server-side scan
-// planning (apache/iceberg-go#1178). It defines the table-side seam — the
-// option, request/result types, and the ScanPlanner interface (implemented by
-// catalog/rest) — so it can be reviewed as Go rather than prose.
-// WithScanPlanningMode records the requested mode on the Scan; the delegation
-// skeleton rejects unavailable remote planning so the exported option is not a
-// silent no-op if this surface is released before the full implementation lands.
+// This file contains the table-side seam for REST server-side scan planning
+// (apache/iceberg-go#1178): the scan option, request/result types, and the
+// ScanPlanner interface implemented by catalog/rest.
 
 package table
 
@@ -51,13 +47,13 @@ const (
 	// ScanPlanningRemote requires a planner that advertises remote capability
 	// and fails loudly if remote planning is unavailable.
 	ScanPlanningRemote ScanPlanningMode = "remote"
-	// ScanPlanningAuto uses remote planning when available and allowed by the
-	// table config, otherwise falls back to local.
+	// ScanPlanningAuto uses remote planning when available, otherwise it falls
+	// back to local.
 	ScanPlanningAuto ScanPlanningMode = "auto"
 )
 
 // WithScanPlanningMode sets the scan-planning mode for a scan. The default is
-// ScanPlanningLocal unless the REST table config requires server planning.
+// ScanPlanningLocal.
 func WithScanPlanningMode(mode ScanPlanningMode) ScanOption {
 	return func(scan *Scan) { scan.planningMode = mode }
 }
@@ -84,17 +80,22 @@ var _ ScanPlanningMetadata = (Metadata)(nil)
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
 // the resolved scan state a planner needs without depending on catalog/rest.
 //
-// Open question (epic OQ4): when the table has evolved, UseSnapshotSchema must
-// pin which schema binds a returned residual and the partition decode: the
-// snapshot's schema (via schema-id), kept separate from each file's partition
-// spec-id. Incremental scans (start/end snapshot) are deferred to a later
-// phase; point-in-time SnapshotID lands first.
+// Schema is the schema resolved for this scan. It is kept separate from
+// Metadata.CurrentSchema because a historical/tag scan may use a snapshot
+// schema while a branch scan uses the table schema. Planners should use this
+// same schema for filter binding and returned residual decoding.
 type ScanPlanningRequest struct {
 	Identifier Identifier
 	// Metadata is the narrowed planner view of table metadata (see
 	// ScanPlanningMetadata); MetadataLocation is kept separate.
 	Metadata         ScanPlanningMetadata
+	Schema           *iceberg.Schema
 	MetadataLocation string
+	// FileIOProperties are the table-scoped properties used to build the
+	// table's normal FileIO. A remote planner can overlay plan-scoped
+	// credentials on these properties without serializing them into the plan
+	// request.
+	FileIOProperties iceberg.Properties
 	SnapshotID       *int64
 	SelectedFields   []string
 	RowFilter        iceberg.BooleanExpression
@@ -144,8 +145,7 @@ type ScanPlanner interface {
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
 }
 
-// Scan integration, added here as a delegation skeleton and completed in the
-// scanner-delegation phase:
+// Scan integration:
 //
 //	type Scan struct {
 //		// ...existing fields...

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -120,6 +120,9 @@ type ScanPlanningRequest struct {
 // Scan that planned it; every ReadTasks call loads from it instead of the
 // table's FileIO. Replacing the plan releases that Scan's ownership; the old IO
 // closes after its remaining scan owners and active record iterators finish.
+// Call Scan.Close when the scan is no longer needed, including when planning
+// succeeds but its tasks are not read. Close is idempotent and waits for active
+// ReadTasks iterators before the plan IO is closed.
 // This ties a plan-scoped scan to PlanFiles -> ReadTasks: tasks from a remote
 // plan must be read by the Scan that produced them or one of its derived scans.
 // A Scan carrying plan-scoped IO is not safe for concurrent PlanFiles or

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -141,11 +141,22 @@ type ScanPlanningResult struct {
 // ScanPlanner plans scans for a table. rest.Catalog implements it; non-REST
 // catalogs leave it nil and planning stays local.
 //
-// SupportsRemoteScanPlanning reports whether the planner can complete a remote
-// plan end-to-end for the requested scan.
+// SupportsRemoteScanPlanning reports whether the planner can submit a remote
+// plan for the requested scan. A planner with separate continuation
+// capabilities can implement FullRemoteScanPlanner so auto mode can require
+// the complete remote scan flow.
 type ScanPlanner interface {
 	SupportsRemoteScanPlanning() bool
 	PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error)
+}
+
+// FullRemoteScanPlanner is an optional capability extension for ScanPlanner.
+// A planner that exposes separate submission and continuation capabilities can
+// implement SupportsFullRemoteScanPlanning so auto mode only selects it when
+// the complete remote scan flow is available. Planners that do not implement
+// this extension retain the original ScanPlanner behavior.
+type FullRemoteScanPlanner interface {
+	SupportsFullRemoteScanPlanning() bool
 }
 
 // Scan integration:

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -23,6 +23,7 @@ package table
 
 import (
 	"context"
+	"io"
 
 	"github.com/apache/iceberg-go"
 	icebergio "github.com/apache/iceberg-go/io"
@@ -76,6 +77,9 @@ type ScanPlanningMetadata interface {
 // Compile-time guard that the full Metadata interface still satisfies the
 // narrowed planner view, so callers can pass a table.Metadata directly.
 var _ ScanPlanningMetadata = (Metadata)(nil)
+
+// Compile-time guard that Scan exposes the lifecycle contract as io.Closer.
+var _ io.Closer = (*Scan)(nil)
 
 // ScanPlanningRequest is the input a Scan hands to a ScanPlanner. It carries
 // the resolved scan state a planner needs without depending on catalog/rest.

--- a/table/scan_planning_remote.go
+++ b/table/scan_planning_remote.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"slices"
+
+	"github.com/apache/iceberg-go"
+)
+
+type fullRemoteScanPlanner interface {
+	SupportsFullRemoteScanPlanning() bool
+}
+
+// supportsAutomaticRemotePlanning is deliberately more conservative than
+// explicit remote mode when a planner exposes a split capability surface. A
+// REST server that only advertises the initial /plan endpoint may complete an
+// inline plan, but auto mode cannot know that before submitting and has no safe
+// local fallback once the server responds with a continuation handle.
+func supportsAutomaticRemotePlanning(planner ScanPlanner) bool {
+	if planner == nil {
+		return false
+	}
+	if full, ok := planner.(fullRemoteScanPlanner); ok {
+		return full.SupportsFullRemoteScanPlanning()
+	}
+
+	return planner.SupportsRemoteScanPlanning()
+}
+
+// remotePlanningSelectedFields returns the fully qualified physical field names
+// sent for a wildcard REST scan projection. It mirrors Java's
+// TypeUtil.getProjectedIds + Schema.findColumnName behavior by sending nested
+// leaf paths rather than only top-level struct names. Explicit projections keep
+// their user-provided names unchanged.
+func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string, error) {
+	if schema == nil || !slices.Contains(scan.selectedFields, "*") {
+		return scan.remoteSelectedFields(schema), nil
+	}
+
+	idToField, err := iceberg.IndexByID(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int, 0, len(idToField))
+	for id, field := range idToField {
+		switch field.Type.(type) {
+		case *iceberg.StructType, *iceberg.ListType, *iceberg.MapType:
+			continue
+		}
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	selected := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if name, ok := schema.FindColumnName(id); ok {
+			selected = append(selected, name)
+		}
+	}
+
+	return selected, nil
+}

--- a/table/scan_planning_remote.go
+++ b/table/scan_planning_remote.go
@@ -45,9 +45,10 @@ func supportsAutomaticRemotePlanning(planner ScanPlanner) bool {
 
 // remotePlanningSelectedFields returns the fully qualified physical field names
 // sent for a wildcard REST scan projection. It mirrors Java's
-// TypeUtil.getProjectedIds + Schema.findColumnName behavior by sending nested
-// leaf paths rather than only top-level struct names. Explicit projections keep
-// their user-provided names unchanged.
+// TypeUtil.getProjectedIds + Schema.findColumnName behavior. Java includes
+// struct field IDs as well as primitive/variant field IDs, while list/map field
+// IDs are represented by their nested element/key/value fields. Explicit
+// projections keep their user-provided names unchanged.
 func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string, error) {
 	if schema == nil || !slices.Contains(scan.selectedFields, "*") {
 		return scan.remoteSelectedFields(schema), nil
@@ -61,7 +62,7 @@ func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string,
 	ids := make([]int, 0, len(idToField))
 	for id, field := range idToField {
 		switch field.Type.(type) {
-		case *iceberg.StructType, *iceberg.ListType, *iceberg.MapType:
+		case *iceberg.ListType, *iceberg.MapType:
 			continue
 		}
 		ids = append(ids, id)

--- a/table/scan_planning_remote.go
+++ b/table/scan_planning_remote.go
@@ -23,10 +23,6 @@ import (
 	"github.com/apache/iceberg-go"
 )
 
-type fullRemoteScanPlanner interface {
-	SupportsFullRemoteScanPlanning() bool
-}
-
 // supportsAutomaticRemotePlanning is deliberately more conservative than
 // explicit remote mode when a planner exposes a split capability surface. A
 // REST server that only advertises the initial /plan endpoint may complete an
@@ -36,7 +32,7 @@ func supportsAutomaticRemotePlanning(planner ScanPlanner) bool {
 	if planner == nil {
 		return false
 	}
-	if full, ok := planner.(fullRemoteScanPlanner); ok {
+	if full, ok := planner.(FullRemoteScanPlanner); ok {
 		return full.SupportsFullRemoteScanPlanning()
 	}
 
@@ -95,6 +91,7 @@ func appendRemoteProjectedTypeIDs(ids *[]int, typ iceberg.Type, fieldID int, inc
 			*ids = append(*ids, typ.KeyID, typ.ValueID)
 		} else {
 			appendRemoteProjectedTypeIDs(ids, typ.ValueType, typ.ValueID, false)
+			appendRemoteProjectedTypeIDs(ids, typ.KeyType, typ.KeyID, false)
 		}
 	default:
 		if includeFieldID {

--- a/table/scan_planning_remote.go
+++ b/table/scan_planning_remote.go
@@ -46,26 +46,18 @@ func supportsAutomaticRemotePlanning(planner ScanPlanner) bool {
 // remotePlanningSelectedFields returns the fully qualified physical field names
 // sent for a wildcard REST scan projection. It mirrors Java's
 // TypeUtil.getProjectedIds + Schema.findColumnName behavior. Java includes
-// struct field IDs as well as primitive/variant field IDs, while list/map field
-// IDs are represented by their nested element/key/value fields. Explicit
-// projections keep their user-provided names unchanged.
+// struct field IDs as well as primitive/variant field IDs. List element IDs are
+// included only for primitive elements, and map key/value IDs are included only
+// when the value is primitive. Explicit projections keep their user-provided
+// names unchanged.
 func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string, error) {
 	if schema == nil || !slices.Contains(scan.selectedFields, "*") {
 		return scan.remoteSelectedFields(schema), nil
 	}
 
-	idToField, err := iceberg.IndexByID(schema)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]int, 0, len(idToField))
-	for id, field := range idToField {
-		switch field.Type.(type) {
-		case *iceberg.ListType, *iceberg.MapType:
-			continue
-		}
-		ids = append(ids, id)
+	ids := make([]int, 0, len(schema.Fields()))
+	for _, field := range schema.Fields() {
+		appendRemoteProjectedFieldIDs(&ids, field)
 	}
 	slices.Sort(ids)
 
@@ -77,4 +69,46 @@ func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string,
 	}
 
 	return selected, nil
+}
+
+func appendRemoteProjectedFieldIDs(ids *[]int, field iceberg.NestedField) {
+	appendRemoteProjectedTypeIDs(ids, field.Type, field.ID, true)
+}
+
+func appendRemoteProjectedTypeIDs(ids *[]int, typ iceberg.Type, fieldID int, includeFieldID bool) {
+	switch typ := typ.(type) {
+	case *iceberg.StructType:
+		if includeFieldID {
+			*ids = append(*ids, fieldID)
+		}
+		for _, field := range typ.Fields() {
+			appendRemoteProjectedFieldIDs(ids, field)
+		}
+	case *iceberg.ListType:
+		if remoteProjectedLeaf(typ.Element) {
+			*ids = append(*ids, typ.ElementID)
+		} else {
+			appendRemoteProjectedTypeIDs(ids, typ.Element, typ.ElementID, false)
+		}
+	case *iceberg.MapType:
+		if remoteProjectedLeaf(typ.ValueType) {
+			*ids = append(*ids, typ.KeyID, typ.ValueID)
+		} else {
+			appendRemoteProjectedTypeIDs(ids, typ.ValueType, typ.ValueID, false)
+		}
+	default:
+		if includeFieldID {
+			*ids = append(*ids, fieldID)
+		}
+	}
+}
+
+func remoteProjectedLeaf(typ iceberg.Type) bool {
+	switch typ.(type) {
+	case *iceberg.StructType, *iceberg.ListType, *iceberg.MapType:
+		return false
+	default:
+		// Variant types are leaves for TypeUtil.getProjectedIds as well.
+		return true
+	}
 }

--- a/table/scan_planning_remote_test.go
+++ b/table/scan_planning_remote_test.go
@@ -32,9 +32,11 @@ type splitCapabilityPlanner struct {
 }
 
 func (p *splitCapabilityPlanner) SupportsRemoteScanPlanning() bool { return p.remote }
+
 func (p *splitCapabilityPlanner) SupportsFullRemoteScanPlanning() bool {
 	return p.full
 }
+
 func (p *splitCapabilityPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
 	return ScanPlanningResult{}, nil
 }
@@ -44,6 +46,7 @@ type basicCapabilityPlanner struct {
 }
 
 func (p *basicCapabilityPlanner) SupportsRemoteScanPlanning() bool { return p.remote }
+
 func (p *basicCapabilityPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
 	return ScanPlanningResult{}, nil
 }

--- a/table/scan_planning_remote_test.go
+++ b/table/scan_planning_remote_test.go
@@ -73,10 +73,57 @@ func TestRemotePlanningSelectedFieldsExpandsWildcardNestedProjection(t *testing.
 				{ID: 4, Name: "zip", Type: iceberg.PrimitiveTypes.String},
 			}},
 		},
+		iceberg.NestedField{
+			ID:   5,
+			Name: "list_struct",
+			Type: &iceberg.ListType{
+				ElementID: 6,
+				Element: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 7, Name: "a", Type: iceberg.PrimitiveTypes.String},
+					{ID: 8, Name: "b", Type: iceberg.PrimitiveTypes.Int32},
+				}},
+			},
+		},
+		iceberg.NestedField{
+			ID:   9,
+			Name: "map_struct",
+			Type: &iceberg.MapType{
+				KeyID: 10, KeyType: iceberg.PrimitiveTypes.String,
+				ValueID: 11, ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 12, Name: "a", Type: iceberg.PrimitiveTypes.String},
+					{ID: 13, Name: "b", Type: iceberg.PrimitiveTypes.Int32},
+				}},
+			},
+		},
+		iceberg.NestedField{
+			ID:   14,
+			Name: "list_primitive",
+			Type: &iceberg.ListType{ElementID: 15, Element: iceberg.PrimitiveTypes.String},
+		},
+		iceberg.NestedField{
+			ID:   16,
+			Name: "map_primitive",
+			Type: &iceberg.MapType{
+				KeyID: 17, KeyType: iceberg.PrimitiveTypes.String,
+				ValueID: 18, ValueType: iceberg.PrimitiveTypes.Int32,
+			},
+		},
 	)
 
 	scan := &Scan{selectedFields: []string{"*"}, caseSensitive: true}
 	got, err := remotePlanningSelectedFields(scan, schema)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"id", "address", "address.city", "address.zip"}, got)
+	assert.Equal(t, []string{
+		"id",
+		"address",
+		"address.city",
+		"address.zip",
+		"list_struct.element.a",
+		"list_struct.element.b",
+		"map_struct.value.a",
+		"map_struct.value.b",
+		"list_primitive.element",
+		"map_primitive.key",
+		"map_primitive.value",
+	}, got)
 }

--- a/table/scan_planning_remote_test.go
+++ b/table/scan_planning_remote_test.go
@@ -108,6 +108,20 @@ func TestRemotePlanningSelectedFieldsExpandsWildcardNestedProjection(t *testing.
 				ValueID: 18, ValueType: iceberg.PrimitiveTypes.Int32,
 			},
 		},
+		iceberg.NestedField{
+			ID:   19,
+			Name: "map_struct_key",
+			Type: &iceberg.MapType{
+				KeyID: 20, KeyType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 21, Name: "a", Type: iceberg.PrimitiveTypes.String},
+					{ID: 22, Name: "b", Type: iceberg.PrimitiveTypes.Int32},
+				}},
+				ValueID: 23, ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: 24, Name: "a", Type: iceberg.PrimitiveTypes.String},
+					{ID: 25, Name: "b", Type: iceberg.PrimitiveTypes.Int32},
+				}},
+			},
+		},
 	)
 
 	scan := &Scan{selectedFields: []string{"*"}, caseSensitive: true}
@@ -125,5 +139,9 @@ func TestRemotePlanningSelectedFieldsExpandsWildcardNestedProjection(t *testing.
 		"list_primitive.element",
 		"map_primitive.key",
 		"map_primitive.value",
+		"map_struct_key.key.a",
+		"map_struct_key.key.b",
+		"map_struct_key.value.a",
+		"map_struct_key.value.b",
 	}, got)
 }

--- a/table/scan_planning_remote_test.go
+++ b/table/scan_planning_remote_test.go
@@ -78,5 +78,5 @@ func TestRemotePlanningSelectedFieldsExpandsWildcardNestedProjection(t *testing.
 	scan := &Scan{selectedFields: []string{"*"}, caseSensitive: true}
 	got, err := remotePlanningSelectedFields(scan, schema)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"id", "address.city", "address.zip"}, got)
+	assert.Equal(t, []string{"id", "address", "address.city", "address.zip"}, got)
 }

--- a/table/scan_planning_remote_test.go
+++ b/table/scan_planning_remote_test.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type splitCapabilityPlanner struct {
+	remote bool
+	full   bool
+}
+
+func (p *splitCapabilityPlanner) SupportsRemoteScanPlanning() bool { return p.remote }
+func (p *splitCapabilityPlanner) SupportsFullRemoteScanPlanning() bool {
+	return p.full
+}
+func (p *splitCapabilityPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+	return ScanPlanningResult{}, nil
+}
+
+type basicCapabilityPlanner struct {
+	remote bool
+}
+
+func (p *basicCapabilityPlanner) SupportsRemoteScanPlanning() bool { return p.remote }
+func (p *basicCapabilityPlanner) PlanFiles(context.Context, ScanPlanningRequest) (ScanPlanningResult, error) {
+	return ScanPlanningResult{}, nil
+}
+
+func TestSupportsAutomaticRemotePlanningUsesFullCapabilityWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, supportsAutomaticRemotePlanning(&splitCapabilityPlanner{remote: true, full: false}))
+	assert.True(t, supportsAutomaticRemotePlanning(&splitCapabilityPlanner{remote: true, full: true}))
+	assert.True(t, supportsAutomaticRemotePlanning(&basicCapabilityPlanner{remote: true}))
+	assert.False(t, supportsAutomaticRemotePlanning(nil))
+}
+
+func TestRemotePlanningSelectedFieldsExpandsWildcardNestedProjection(t *testing.T) {
+	t.Parallel()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{
+			ID:   2,
+			Name: "address",
+			Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 3, Name: "city", Type: iceberg.PrimitiveTypes.String},
+				{ID: 4, Name: "zip", Type: iceberg.PrimitiveTypes.String},
+			}},
+		},
+	)
+
+	scan := &Scan{selectedFields: []string{"*"}, caseSensitive: true}
+	got, err := remotePlanningSelectedFields(scan, schema)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id", "address.city", "address.zip"}, got)
+}

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -316,6 +316,8 @@ func TestScanCloseReleasesPlanIO(t *testing.T) {
 }
 
 func TestScanCloseWaitsForActiveReadTasks(t *testing.T) {
+	t.Parallel()
+
 	pio := &countingPlanIO{fs: icebergio.LocalFS{}}
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
 	scan, err := txn.Scan()
@@ -324,12 +326,14 @@ func TestScanCloseWaitsForActiveReadTasks(t *testing.T) {
 
 	_, records, err := scan.ReadTasks(context.Background(), nil)
 	require.NoError(t, err)
-	require.NoError(t, scan.Close())
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- scan.Close() }()
 	assert.Equal(t, 0, pio.closeCalls)
 
 	for _, err := range records {
 		require.NoError(t, err)
 	}
+	require.NoError(t, <-closeDone)
 	assert.Equal(t, 1, pio.closeCalls)
 }
 

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/apache/iceberg-go"
 	icebergio "github.com/apache/iceberg-go/io"
@@ -333,6 +334,196 @@ func TestScanPlanningAutoUsesCapablePlanner(t *testing.T) {
 	assert.Len(t, tasks, 1)
 }
 
+func TestScanPlanningRemoteResolvesDefaultProjectionAndSchema(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	planner := &fakeScanPlanner{supports: true}
+	scan := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+	)
+	scan.planner = planner
+
+	_, err = scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, planner.receivedRequest.SelectedFields)
+	assert.True(t, planner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	require.NotNil(t, planner.receivedRequest.UseSnapshotSchema)
+	assert.False(t, *planner.receivedRequest.UseSnapshotSchema)
+	assert.Nil(t, planner.receivedRequest.MinRowsRequested)
+}
+
+func TestScanPlanningRemoteOmitsNegativeRowLimit(t *testing.T) {
+	t.Parallel()
+
+	planner := &fakeScanPlanner{supports: true}
+	scan := &Scan{
+		planner:        planner,
+		planningMode:   ScanPlanningRemote,
+		selectedFields: []string{"*"},
+		limit:          -2,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, planner.receivedRequest.MinRowsRequested)
+}
+
+func TestScanPlanningRemotePropagatesSnapshotSchemaSemantics(t *testing.T) {
+	t.Parallel()
+
+	snapshotTime := time.Now().UnixMilli()
+	schemaID := 0
+	metadata, err := createTestMetadata([]Snapshot{{
+		SnapshotID:  10,
+		TimestampMs: snapshotTime,
+		SchemaID:    &schemaID,
+	}}, []SnapshotLogEntry{{SnapshotID: 10, TimestampMs: snapshotTime}})
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+	currentSchema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String},
+	)
+	require.NoError(t, builder.AddSchema(currentSchema))
+	require.NoError(t, builder.SetCurrentSchemaID(-1))
+	require.NoError(t, builder.SetSnapshotRef("branch", 10, BranchRef))
+	require.NoError(t, builder.SetSnapshotRef("tag", 10, TagRef))
+	metadata, err = builder.Build()
+	require.NoError(t, err)
+
+	var snapshotSchema *iceberg.Schema
+	for _, schema := range metadata.Schemas() {
+		if schema.ID == schemaID {
+			snapshotSchema = schema
+
+			break
+		}
+	}
+	require.NotNil(t, snapshotSchema)
+	require.False(t, snapshotSchema.Equals(metadata.CurrentSchema()))
+
+	base := (&Table{metadata: metadata}).Scan(WithScanPlanningMode(ScanPlanningRemote))
+	livePlanner := &fakeScanPlanner{supports: true}
+	base.planner = livePlanner
+	_, err = base.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.True(t, livePlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	assert.Equal(t, []string{"id", "category"}, livePlanner.receivedRequest.SelectedFields)
+
+	branch, err := base.UseRef("branch")
+	require.NoError(t, err)
+	branchPlanner := &fakeScanPlanner{supports: true}
+	branch.planner = branchPlanner
+	_, err = branch.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, branchPlanner.receivedRequest.UseSnapshotSchema)
+	assert.False(t, *branchPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, branchPlanner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
+	assert.Equal(t, []string{"id", "category"}, branchPlanner.receivedRequest.SelectedFields)
+
+	tag, err := base.UseRef("tag")
+	require.NoError(t, err)
+	tagPlanner := &fakeScanPlanner{supports: true}
+	tag.planner = tagPlanner
+	_, err = tag.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, tagPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *tagPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, tagPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, tagPlanner.receivedRequest.SelectedFields)
+
+	historical := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+		WithSnapshotID(10),
+		WithLimit(25),
+	)
+	historicalPlanner := &fakeScanPlanner{supports: true}
+	historical.planner = historicalPlanner
+	_, err = historical.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, historicalPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *historicalPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, historicalPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, historicalPlanner.receivedRequest.SelectedFields)
+	require.NotNil(t, historicalPlanner.receivedRequest.MinRowsRequested)
+	assert.Equal(t, int64(25), *historicalPlanner.receivedRequest.MinRowsRequested)
+
+	asOf := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningRemote),
+		WithSnapshotAsOf(snapshotTime),
+	)
+	asOfPlanner := &fakeScanPlanner{supports: true}
+	asOf.planner = asOfPlanner
+	_, err = asOf.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, asOfPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, *asOfPlanner.receivedRequest.UseSnapshotSchema)
+	assert.True(t, asOfPlanner.receivedRequest.Schema.Equals(snapshotSchema))
+	assert.Equal(t, []string{"id"}, asOfPlanner.receivedRequest.SelectedFields)
+}
+
+func TestScanPlanningRemoteRejectsLastUpdatedSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	planner := &fakeScanPlanner{supports: true}
+	scan := &Scan{
+		planner:        planner,
+		planningMode:   ScanPlanningRemote,
+		selectedFields: []string{iceberg.LastUpdatedSequenceNumberColumnName},
+		caseSensitive:  true,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+	assert.Empty(t, planner.receivedIdentifier)
+}
+
+func TestScanPlanningAutoFallsBackForLastUpdatedSequenceNumber(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	planner := &fakeScanPlanner{supports: true}
+	scan := (&Table{metadata: metadata}).Scan(
+		WithScanPlanningMode(ScanPlanningAuto),
+		WithRowLineage(),
+	)
+	scan.planner = planner
+
+	tasks, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+	assert.Empty(t, planner.receivedIdentifier)
+}
+
+func TestScanPlanningRemotePassesFileIOProperties(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := createTestMetadata(nil, nil)
+	require.NoError(t, err)
+	props := iceberg.Properties{"s3.endpoint": "https://table.local"}
+	planner := &fakeScanPlanner{supports: true}
+	tbl := New(
+		Identifier{"db", "tbl"},
+		metadata,
+		"s3://bucket/db/tbl/metadata/v1.json",
+		nil,
+		nil,
+		WithScanPlanningIOProperties(props),
+	)
+	tbl.planner = planner
+
+	_, err = tbl.Scan(WithScanPlanningMode(ScanPlanningRemote)).PlanFiles(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, props, planner.receivedRequest.FileIOProperties)
+
+	planner.receivedRequest.FileIOProperties["s3.endpoint"] = "https://mutated.local"
+	assert.Equal(t, "https://table.local", props["s3.endpoint"])
+}
+
 func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 	t.Parallel()
 
@@ -357,18 +548,40 @@ func TestScanPlanningPassesIdentifierCopy(t *testing.T) {
 
 func TestTransactionScanCopiesIdentifier(t *testing.T) {
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
-	txn.tbl.planner = &fakeScanPlanner{
+
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.identifier[0] = "corrupt"
+	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
+}
+
+func TestTransactionScanKeepsStagedMetadataLocal(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	planner := &fakeScanPlanner{
 		result:   ScanPlanningResult{Tasks: []FileScanTask{{}}},
 		supports: true,
 	}
+	txn.tbl.planner = planner
+	dataFile := newTestDataFile(
+		t,
+		*iceberg.UnpartitionedSpec,
+		"mem://default/table-location/data.parquet",
+		nil,
+	)
+	require.NoError(t, txn.AddDataFiles(context.Background(), []iceberg.DataFile{dataFile}, nil))
 
 	scan, err := txn.Scan(WithScanPlanningMode(ScanPlanningAuto))
 	require.NoError(t, err)
-	_, err = scan.PlanFiles(context.Background())
+	tasks, err := scan.PlanFiles(context.Background())
 	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, dataFile.FilePath(), tasks[0].File.FilePath())
+	assert.Empty(t, planner.receivedIdentifier)
 
-	scan.identifier[0] = "corrupt"
-	assert.Equal(t, Identifier{"db", "tbl"}, txn.tbl.identifier)
+	remote, err := txn.Scan(WithScanPlanningMode(ScanPlanningRemote))
+	require.NoError(t, err)
+	_, err = remote.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
 }
 
 func TestTransactionScanRejectsConflictingSnapshotSelectors(t *testing.T) {
@@ -395,6 +608,7 @@ type fakeScanPlanner struct {
 	called   bool
 	// captured after PlanFiles receives it
 	receivedIdentifier Identifier
+	receivedRequest    ScanPlanningRequest
 }
 
 func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports }
@@ -402,6 +616,7 @@ func (f *fakeScanPlanner) SupportsRemoteScanPlanning() bool { return f.supports 
 func (f *fakeScanPlanner) PlanFiles(_ context.Context, req ScanPlanningRequest) (ScanPlanningResult, error) {
 	f.called = true
 	f.receivedIdentifier = req.Identifier
+	f.receivedRequest = req
 
 	return f.result, f.err
 }

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -280,6 +280,20 @@ func TestScanPlanningLocalClosesPreviousPlanIOAfterSuccess(t *testing.T) {
 	assert.Equal(t, 1, pio.closeCalls)
 }
 
+func TestScanPlanningLocalPropagatesPlanIOCloseError(t *testing.T) {
+	closeErr := errors.New("close plan io")
+	pio := &countingPlanIO{closeErr: closeErr}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = mustPlanIOState(t, pio)
+
+	_, err = scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, closeErr)
+	assert.Nil(t, scan.planIO)
+	assert.Equal(t, 1, pio.closeCalls)
+}
+
 func TestScanCloseReleasesPlanIO(t *testing.T) {
 	t.Parallel()
 
@@ -668,6 +682,7 @@ func (fakePlanIO) Close() error                               { return nil }
 type countingPlanIO struct {
 	loadErrs   []error
 	fs         icebergio.IO
+	closeErr   error
 	loadCalls  int
 	closeCalls int
 }
@@ -684,7 +699,7 @@ func (p *countingPlanIO) Load(context.Context) (icebergio.IO, error) {
 func (p *countingPlanIO) Close() error {
 	p.closeCalls++
 
-	return nil
+	return p.closeErr
 }
 
 type sequenceScanPlanner struct {

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -117,8 +117,8 @@ func TestRefinedScanRetainsPlanIOOwnership(t *testing.T) {
 			assert.Same(t, first, scan.planIO.io)
 			assert.Same(t, second, refined.planIO.io)
 
-			scan.closePlanIO()
-			refined.closePlanIO()
+			require.NoError(t, scan.Close())
+			require.NoError(t, refined.Close())
 			assert.Equal(t, 1, first.closeCalls)
 			assert.Equal(t, 1, second.closeCalls)
 		})
@@ -277,6 +277,45 @@ func TestScanPlanningLocalClosesPreviousPlanIOAfterSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, scan.planIO)
+	assert.Equal(t, 1, pio.closeCalls)
+}
+
+func TestScanCloseReleasesPlanIO(t *testing.T) {
+	t.Parallel()
+
+	pio := &countingPlanIO{}
+	scan := &Scan{
+		planner:      &fakeScanPlanner{result: ScanPlanningResult{IO: pio}, supports: true},
+		planningMode: ScanPlanningRemote,
+	}
+
+	_, err := scan.PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, scan.Close())
+	require.NoError(t, scan.Close())
+
+	assert.Equal(t, 1, pio.closeCalls)
+	assert.Nil(t, scan.planIO)
+
+	_, err = scan.PlanFiles(context.Background())
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestScanCloseWaitsForActiveReadTasks(t *testing.T) {
+	pio := &countingPlanIO{fs: icebergio.LocalFS{}}
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	scan.planIO = mustPlanIOState(t, pio)
+
+	_, records, err := scan.ReadTasks(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, scan.Close())
+	assert.Equal(t, 0, pio.closeCalls)
+
+	for _, err := range records {
+		require.NoError(t, err)
+	}
 	assert.Equal(t, 1, pio.closeCalls)
 }
 

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -242,7 +243,7 @@ type Scan struct {
 	// planning. ReadTasks leases it instead of falling back to ioF, and replacing
 	// the plan retires it after all active readers finish. See PlanIO.
 	planIO         *planIOState
-	closed         bool
+	closed         uint32
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool
@@ -848,7 +849,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 // scan's reporter on success; remote (server-side) planning reports its own
 // metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
-	if scan.closed {
+	if atomic.LoadUint32(&scan.closed) != 0 {
 		return nil, fmt.Errorf("%w: scan is closed", ErrInvalidOperation)
 	}
 
@@ -927,7 +928,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) (results []FileScanTask, err error) {
 	defer func() {
 		if err == nil {
-			_ = scan.closePlanIO()
+			err = scan.closePlanIO()
 		}
 	}()
 
@@ -1255,7 +1256,7 @@ func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[
 // scan's projection, per-task residual filters, and positional delete handling. This
 // is useful when the caller has already planned or selected specific tasks to read.
 func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
-	if scan.closed {
+	if atomic.LoadUint32(&scan.closed) != 0 {
 		return nil, nil, fmt.Errorf("%w: scan is closed", ErrInvalidOperation)
 	}
 
@@ -1364,11 +1365,9 @@ func (scan *Scan) closePlanIO() error {
 // can finish; the plan IO closes after the last lease is released. A scan must
 // not be used after Close.
 func (scan *Scan) Close() error {
-	if scan == nil || scan.closed {
+	if scan == nil || !atomic.CompareAndSwapUint32(&scan.closed, 0, 1) {
 		return nil
 	}
-
-	scan.closed = true
 
 	return scan.closePlanIO()
 }

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -231,6 +231,9 @@ func IsDeletionVector(df iceberg.DataFile) bool {
 		df.ContentType() == iceberg.EntryContentPosDeletes
 }
 
+// Scan represents a table scan. It implements [io.Closer]; callers should
+// close it when they are done, including early exits after remote planning
+// succeeds but before all records are consumed.
 type Scan struct {
 	identifier          Identifier
 	metadata            Metadata

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -864,7 +864,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	case ScanPlanningRemote:
 		return scan.planFilesRemote(ctx)
 	case ScanPlanningAuto:
-		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() &&
+		if supportsAutomaticRemotePlanning(scan.planner) &&
 			!scan.requiresLastUpdatedSequenceNumber() {
 			return scan.planFilesRemote(ctx)
 		}
@@ -1028,6 +1028,11 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		}
 	}
 
+	selectedFields, err := remotePlanningSelectedFields(scan, schema)
+	if err != nil {
+		return nil, err
+	}
+
 	caseSensitive := scan.caseSensitive
 	useSnapshotSchema := scan.snapshotSchemaEnabled()
 	var minRowsRequested *int64
@@ -1043,7 +1048,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		MetadataLocation:  scan.metadataLocation,
 		FileIOProperties:  maps.Clone(scan.scanPlanningIOProps),
 		SnapshotID:        scan.snapshotID,
-		SelectedFields:    scan.remoteSelectedFields(schema),
+		SelectedFields:    selectedFields,
 		RowFilter:         scan.rowFilter,
 		MinRowsRequested:  minRowsRequested,
 		CaseSensitive:     &caseSensitive,

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -231,13 +231,14 @@ func IsDeletionVector(df iceberg.DataFile) bool {
 }
 
 type Scan struct {
-	identifier       Identifier
-	metadata         Metadata
-	metadataLocation string
-	ioF              FSysF
-	planner          ScanPlanner
-	planningMode     ScanPlanningMode
-	// planIO, when non-nil, owns the plan-scoped FileIO loader set by remote
+	identifier          Identifier
+	metadata            Metadata
+	metadataLocation    string
+	ioF                 FSysF
+	planner             ScanPlanner
+	scanPlanningIOProps iceberg.Properties
+	planningMode        ScanPlanningMode
+	// planIO, when non-nil, is a plan-scoped FileIO loader set by remote scan
 	// planning. ReadTasks leases it instead of falling back to ioF, and replacing
 	// the plan retires it after all active readers finish. See PlanIO.
 	planIO         *planIOState
@@ -246,9 +247,14 @@ type Scan struct {
 	caseSensitive  bool
 	snapshotID     *int64
 	asOfTimestamp  *int64
-	selectorErr    error
-	options        iceberg.Properties
-	limit          int64
+	// useSnapshotSchema is set for explicit snapshot/time-travel and tag
+	// scans. A branch ref deliberately keeps the table's current schema. A nil
+	// value preserves the historical behavior for scans assembled directly in
+	// package tests with snapshotID/asOfTimestamp fields set.
+	useSnapshotSchema *bool
+	options           iceberg.Properties
+	limit             int64
+	selectorErr       error
 
 	includeRowLineage bool
 
@@ -309,6 +315,16 @@ func (scan *Scan) UseRef(name string) (*Scan, error) {
 	if snap := scan.metadata.SnapshotByName(name); snap != nil {
 		out := scan.clone()
 		out.snapshotID = &snap.SnapshotID
+		out.asOfTimestamp = nil
+		useSnapshotSchema := true
+		for refName, ref := range scan.metadata.Refs() {
+			if refName == name {
+				useSnapshotSchema = ref.SnapshotRefType == TagRef
+
+				break
+			}
+		}
+		out.useSnapshotSchema = &useSnapshotSchema
 
 		return out, nil
 	}
@@ -423,10 +439,11 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 	}
 
 	curSchema := scan.metadata.CurrentSchema()
-	if scan.snapshotID == nil && scan.asOfTimestamp == nil {
+	if !scan.snapshotSchemaEnabled() {
 		// Live scans intentionally use the table's current schema. A schema-only
 		// metadata update can advance CurrentSchema without creating a snapshot,
-		// while explicit snapshot/as-of scans use the snapshot schema below.
+		// and branch refs intentionally use the table schema even though they
+		// resolve to a snapshot.
 		return curSchema, nil
 	}
 
@@ -447,6 +464,14 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 
 	return nil, fmt.Errorf("%w: snapshot %d references unknown schema id %d",
 		ErrInvalidMetadata, snap.SnapshotID, *snap.SchemaID)
+}
+
+func (scan *Scan) snapshotSchemaEnabled() bool {
+	if scan.useSnapshotSchema != nil {
+		return *scan.useSnapshotSchema
+	}
+
+	return scan.snapshotID != nil || scan.asOfTimestamp != nil
 }
 
 // splitLineageMetadataFields partitions selectedFields into user fields and
@@ -839,7 +864,8 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 	case ScanPlanningRemote:
 		return scan.planFilesRemote(ctx)
 	case ScanPlanningAuto:
-		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() {
+		if scan.planner != nil && scan.planner.SupportsRemoteScanPlanning() &&
+			!scan.requiresLastUpdatedSequenceNumber() {
 			return scan.planFilesRemote(ctx)
 		}
 	case ScanPlanningLocal:
@@ -981,19 +1007,47 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 }
 
 func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
+	if scan.requiresLastUpdatedSequenceNumber() {
+		return nil, fmt.Errorf(
+			"%w: remote scan planning cannot populate %s",
+			ErrInvalidOperation,
+			iceberg.LastUpdatedSequenceNumberColumnName,
+		)
+	}
+
 	if scan.planner == nil || !scan.planner.SupportsRemoteScanPlanning() {
 		return nil, fmt.Errorf("%w: remote scan planning is unavailable", ErrInvalidOperation)
 	}
 
+	var schema *iceberg.Schema
+	if scan.metadata != nil {
+		var err error
+		schema, err = scan.effectiveSchema()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	caseSensitive := scan.caseSensitive
+	useSnapshotSchema := scan.snapshotSchemaEnabled()
+	var minRowsRequested *int64
+	if scan.limit >= 0 {
+		minRows := scan.limit
+		minRowsRequested = &minRows
+	}
+
 	result, err := scan.planner.PlanFiles(ctx, ScanPlanningRequest{
-		Identifier:       slices.Clone(scan.identifier),
-		Metadata:         scan.metadata,
-		MetadataLocation: scan.metadataLocation,
-		SnapshotID:       scan.snapshotID,
-		SelectedFields:   scan.selectedFields,
-		RowFilter:        scan.rowFilter,
-		CaseSensitive:    &caseSensitive,
+		Identifier:        slices.Clone(scan.identifier),
+		Metadata:          scan.metadata,
+		Schema:            schema,
+		MetadataLocation:  scan.metadataLocation,
+		FileIOProperties:  maps.Clone(scan.scanPlanningIOProps),
+		SnapshotID:        scan.snapshotID,
+		SelectedFields:    scan.remoteSelectedFields(schema),
+		RowFilter:         scan.rowFilter,
+		MinRowsRequested:  minRowsRequested,
+		CaseSensitive:     &caseSensitive,
+		UseSnapshotSchema: &useSnapshotSchema,
 	})
 	if err != nil {
 		return nil, err
@@ -1017,6 +1071,47 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	}
 
 	return result.Tasks, nil
+}
+
+// requiresLastUpdatedSequenceNumber reports whether the scan projection needs
+// the manifest-entry data sequence number. The REST FileScanTask payload does
+// not carry that value, so remote planning cannot safely synthesize the
+// _last_updated_sequence_number metadata column for files that do not store it
+// physically. Auto mode falls back to local planning; explicit remote mode
+// fails before making a request rather than returning silently incomplete data.
+func (scan *Scan) requiresLastUpdatedSequenceNumber() bool {
+	if scan.includeRowLineage {
+		return true
+	}
+
+	for _, field := range scan.selectedFields {
+		if scan.caseSensitive {
+			if field == iceberg.LastUpdatedSequenceNumberColumnName {
+				return true
+			}
+		} else if strings.EqualFold(field, iceberg.LastUpdatedSequenceNumberColumnName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (scan *Scan) remoteSelectedFields(schema *iceberg.Schema) []string {
+	if !slices.Contains(scan.selectedFields, "*") {
+		return slices.Clone(scan.selectedFields)
+	}
+	if schema == nil {
+		return nil
+	}
+
+	fields := schema.Fields()
+	selected := make([]string, 0, len(fields))
+	for _, field := range fields {
+		selected = append(selected, field.Name)
+	}
+
+	return selected
 }
 
 type planIOState struct {
@@ -1109,8 +1204,8 @@ type FileScanTask struct {
 	Start, Length       int64
 	// Residual is the portion of the scan filter that must still be evaluated
 	// for this task. Remote planners may simplify the original filter using
-	// file metadata; nil means the caller did not provide a task residual and
-	// ReadTasks falls back to the Scan's original row filter.
+	// file metadata; nil means the caller did not provide a task residual.
+	// ReadTasks applies the scan's original row filter and each task residual.
 	Residual iceberg.BooleanExpression
 
 	// Row lineage (v3): constants used when reading to synthesize _row_id and _last_updated_sequence_number.
@@ -1144,7 +1239,6 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 	if scan.selectorErr != nil {
 		return nil, nil, scan.selectorErr
 	}
-
 	var (
 		boundFilter iceberg.BooleanExpression
 		err         error

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1058,15 +1058,15 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		return nil, err
 	}
 
-	planIO, err := newPlanIOState(result.IO)
-	if err != nil {
-		return nil, err
-	}
-
 	// Replace the current plan only after the new plan is available. A planner
 	// failure or invalid PlanIO must not destroy a previously usable plan.
 	if scan.planIO != nil && scan.planIO.matches(result.IO) {
 		return result.Tasks, nil
+	}
+
+	planIO, err := newPlanIOState(result.IO)
+	if err != nil {
+		return nil, err
 	}
 
 	oldPlanIO := scan.planIO

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -242,6 +242,7 @@ type Scan struct {
 	// planning. ReadTasks leases it instead of falling back to ioF, and replacing
 	// the plan retires it after all active readers finish. See PlanIO.
 	planIO         *planIOState
+	closed         bool
 	rowFilter      iceberg.BooleanExpression
 	selectedFields []string
 	caseSensitive  bool
@@ -847,6 +848,10 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 // scan's reporter on success; remote (server-side) planning reports its own
 // metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
+	if scan.closed {
+		return nil, fmt.Errorf("%w: scan is closed", ErrInvalidOperation)
+	}
+
 	if scan.selectorErr != nil {
 		return nil, scan.selectorErr
 	}
@@ -922,7 +927,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) (results []FileScanTask, err error) {
 	defer func() {
 		if err == nil {
-			scan.closePlanIO()
+			_ = scan.closePlanIO()
 		}
 	}()
 
@@ -1072,7 +1077,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 	oldPlanIO := scan.planIO
 	scan.planIO = planIO
 	if oldPlanIO != nil {
-		oldPlanIO.releaseOwner()
+		_ = oldPlanIO.releaseOwner()
 	}
 
 	return result.Tasks, nil
@@ -1126,6 +1131,7 @@ type planIOState struct {
 	owners    int
 	readers   int
 	closeOnce sync.Once
+	closeErr  error
 }
 
 func newPlanIOState(planIO PlanIO) (*planIOState, error) {
@@ -1186,19 +1192,27 @@ func (p *planIOState) release() {
 	p.mu.Unlock()
 
 	if closeNow {
-		p.closeOnce.Do(func() { _ = p.io.Close() })
+		_ = p.close()
 	}
 }
 
-func (p *planIOState) releaseOwner() {
+func (p *planIOState) releaseOwner() error {
 	p.mu.Lock()
 	p.owners--
 	closeNow := p.owners == 0 && p.readers == 0
 	p.mu.Unlock()
 
 	if closeNow {
-		p.closeOnce.Do(func() { _ = p.io.Close() })
+		return p.close()
 	}
+
+	return nil
+}
+
+func (p *planIOState) close() error {
+	p.closeOnce.Do(func() { p.closeErr = p.io.Close() })
+
+	return p.closeErr
 }
 
 type FileScanTask struct {
@@ -1241,6 +1255,10 @@ func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[
 // scan's projection, per-task residual filters, and positional delete handling. This
 // is useful when the caller has already planned or selected specific tasks to read.
 func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
+	if scan.closed {
+		return nil, nil, fmt.Errorf("%w: scan is closed", ErrInvalidOperation)
+	}
+
 	if scan.selectorErr != nil {
 		return nil, nil, scan.selectorErr
 	}
@@ -1330,14 +1348,29 @@ func (scan *Scan) ReadTasks(ctx context.Context, tasks []FileScanTask) (*arrow.S
 
 // closePlanIO releases the scoped resources associated with the current
 // remote plan. It is safe to call when no remote plan has been installed.
-func (scan *Scan) closePlanIO() {
+func (scan *Scan) closePlanIO() error {
 	if scan.planIO == nil {
-		return
+		return nil
 	}
 
 	planIO := scan.planIO
 	scan.planIO = nil
-	planIO.releaseOwner()
+
+	return planIO.releaseOwner()
+}
+
+// Close releases the plan-scoped resources owned by this scan. It is safe to
+// call more than once. Active ReadTasks iterators retain their reader lease and
+// can finish; the plan IO closes after the last lease is released. A scan must
+// not be used after Close.
+func (scan *Scan) Close() error {
+	if scan == nil || scan.closed {
+		return nil
+	}
+
+	scan.closed = true
+
+	return scan.closePlanIO()
 }
 
 // releasePlanIOAfter wraps an arrow record iterator so its plan-scoped IO lease

--- a/table/table.go
+++ b/table/table.go
@@ -105,7 +105,12 @@ type Table struct {
 	cat              CatalogIO
 	fsF              FSysF
 	planner          ScanPlanner
-	reporter         metrics.Reporter
+	// scanPlanningIOProps are the table-scoped FileIO properties supplied by a
+	// catalog load response. They are separate from metadata properties because
+	// REST catalogs can return FileIO configuration in the response's config
+	// block.
+	scanPlanningIOProps iceberg.Properties
+	reporter            metrics.Reporter
 	// reporterSet records whether a caller injected a reporter via
 	// WithMetricsReporter. It distinguishes an explicit reporter (including an
 	// explicit NopReporter opt-out) from the construction-time default, so
@@ -231,6 +236,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
 	t.planner = fresh.planner
+	t.scanPlanningIOProps = maps.Clone(fresh.scanPlanningIOProps)
 	// Only inherit the catalog-derived reporter when the caller hasn't set one
 	// of their own. Refresh runs inside commit retry loops, so unconditionally
 	// copying fresh.reporter would silently revert a WithMetricsReporter-injected
@@ -798,7 +804,15 @@ func (t Table) doCommit(ctx context.Context, updates []Update, reqs []Requiremen
 		}
 	}
 
-	return New(t.identifier, newMeta, newLoc, t.fsF, t.cat, withReporterState(t.reporter, t.reporterSet)), nil
+	return New(
+		t.identifier,
+		newMeta,
+		newLoc,
+		t.fsF,
+		t.cat,
+		withReporterState(t.reporter, t.reporterSet),
+		WithScanPlanningIOProperties(t.scanPlanningIOProps),
+	), nil
 }
 
 // rewriteRefSnapshotRequirements returns a copy of reqs with every
@@ -1199,6 +1213,9 @@ func WithSnapshotID(n int64) ScanOption {
 			return
 		}
 		scan.snapshotID = &n
+		scan.asOfTimestamp = nil
+		useSnapshotSchema := true
+		scan.useSnapshotSchema = &useSnapshotSchema
 	}
 }
 
@@ -1211,6 +1228,9 @@ func WithSnapshotAsOf(timeStampMs int64) ScanOption {
 			return
 		}
 		scan.asOfTimestamp = &timeStampMs
+		scan.snapshotID = nil
+		useSnapshotSchema := true
+		scan.useSnapshotSchema = &useSnapshotSchema
 	}
 }
 
@@ -1286,11 +1306,12 @@ func WithRowLineage() ScanOption {
 
 func (t Table) Scan(opts ...ScanOption) *Scan {
 	s := &Scan{
-		identifier:       slices.Clone(t.identifier),
-		metadata:         t.metadata,
-		metadataLocation: t.metadataLocation,
-		ioF:              t.fsF,
-		planner:          t.planner,
+		identifier:          slices.Clone(t.identifier),
+		metadata:            t.metadata,
+		metadataLocation:    t.metadataLocation,
+		ioF:                 t.fsF,
+		planner:             t.planner,
+		scanPlanningIOProps: maps.Clone(t.scanPlanningIOProps),
 		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
@@ -1328,6 +1349,20 @@ func WithMetricsReporter(r metrics.Reporter) Option {
 	return func(t *Table) {
 		t.reporter = r
 		t.reporterSet = true
+	}
+}
+
+// WithScanPlanningIOProperties supplies the table-scoped FileIO properties
+// that a remote scan planner needs when it builds a plan-scoped FileIO. This
+// is intended for catalog implementations whose table-load response carries
+// FileIO configuration separately from table metadata properties.
+func WithScanPlanningIOProperties(props iceberg.Properties) Option {
+	if props == nil {
+		return noopTableOption
+	}
+
+	return func(t *Table) {
+		t.scanPlanningIOProps = maps.Clone(props)
 	}
 }
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3175,7 +3175,10 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,
-		planner:          t.tbl.planner,
+		// Catalog planners can only see committed table state, not metadata
+		// staged inside this transaction. Keep transaction scans local so auto
+		// mode cannot silently return stale tasks.
+		planner: nil,
 		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
 		planningMode:   ScanPlanningLocal,
 		rowFilter:      iceberg.AlwaysTrue{},
@@ -3214,6 +3217,7 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 			t.tbl.fsF,
 			t.tbl.cat,
 			withReporterState(t.tbl.reporter, t.tbl.reporterSet),
+			WithScanPlanningIOProperties(t.tbl.scanPlanningIOProps),
 		),
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Enable REST catalogs to advertise all four scan-planning endpoints.
- Decode inline and fetched ScanTasks envelopes into `table.FileScanTask` values.
- Preserve envelope-local delete-file references and residual filters.
- Keep local planning as the default while remote and auto modes use the planner seam.

## Test plan

- `go test ./table ./catalog/rest`
- `go vet ./table ./catalog/rest`