### PR TITLE
fix(table): validate required metadata identity fields

### DIFF
--- a/table/arrow_utils_internal_test.go
+++ b/table/arrow_utils_internal_test.go
@@ -42,6 +42,7 @@ import (
 func constructTestTable(t *testing.T, writeStats []string) (*metadata.FileMetaData, Metadata) {
 	tableMeta, err := ParseMetadataString(`{
 		"format-version": 2,
+		"table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
 		"last-sequence-number": 0,
         "location": "s3://bucket/test/location",
         "last-column-id": 7,

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -155,6 +155,7 @@ func newAbortTestWriter(t *testing.T, fs iceio.WriteFileIO, fileName string) int
 func constructTestTablePrimitiveTypes(t *testing.T) (*metadata.FileMetaData, table.Metadata) {
 	tableMeta, err := table.ParseMetadataString(`{
         "format-version": 2,
+        "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
         "last-sequence-number": 0,
         "location": "s3://bucket/test/location",
         "last-column-id": 7,
@@ -700,6 +701,7 @@ func TestNanosecondTimestampMetrics(t *testing.T) {
 
 	tableMeta, err := table.ParseMetadataString(`{
 		"format-version": 3,
+		"table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
 		"last-sequence-number": 0,
 		"location": "s3://bucket/test/location",
 		"last-column-id": 2,
@@ -887,6 +889,7 @@ func TestDecimalPhysicalTypes(t *testing.T) {
 			// Create table metadata with decimal type
 			tableMeta, err := table.ParseMetadataString(fmt.Sprintf(`{
 				"format-version": 2,
+				"table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
 				"last-sequence-number": 0,
 				"location": "s3://bucket/test/location",
 				"last-column-id": 1,

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1801,6 +1801,21 @@ func requireLastUpdatedMS(fields map[string]json.RawMessage) error {
 	return nil
 }
 
+// checkRequiredFields validates fields required when reading persisted table
+// metadata. Keep this at the JSON boundary: catalog create-via-commit paths use
+// builders with an empty staging location. Location becomes optional in format
+// v4, so the location check must be version-gated when v4 support is added.
+func (c *commonMetadata) checkRequiredFields() error {
+	if c.UUID == uuid.Nil && c.FormatVersion > 1 {
+		return fmt.Errorf("%w: table-uuid is required for format version %d", ErrInvalidMetadata, c.FormatVersion)
+	}
+	if c.Loc == "" {
+		return fmt.Errorf("%w: location is required", ErrInvalidMetadata)
+	}
+
+	return nil
+}
+
 func (c *commonMetadata) Ref() SnapshotRef {
 	return cloneSnapshotRef(c.SnapshotRefs[MainBranch])
 }
@@ -2624,6 +2639,9 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 	}
 
 	next.preValidate()
+	if err := next.checkRequiredFields(); err != nil {
+		return err
+	}
 
 	if err := next.validate(); err != nil {
 		return err
@@ -2637,7 +2655,7 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 func (m *metadataV1) ToV2() metadataV2 {
 	commonOut := m.commonMetadata
 	commonOut.FormatVersion = 2
-	if commonOut.UUID.String() == "" {
+	if commonOut.UUID == uuid.Nil {
 		commonOut.UUID = uuid.New()
 	}
 
@@ -2692,6 +2710,9 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 	}
 
 	next.preValidate()
+	if err := next.checkRequiredFields(); err != nil {
+		return err
+	}
 
 	if err := next.validate(); err != nil {
 		return err
@@ -2768,6 +2789,9 @@ func (m *metadataV3) UnmarshalJSON(b []byte) error {
 	}
 
 	next.preValidate()
+	if err := next.checkRequiredFields(); err != nil {
+		return err
+	}
 
 	if err := next.validate(); err != nil {
 		return err
@@ -2876,6 +2900,11 @@ const DefaultFormatVersion = 2
 // the new table metadata. By default, this will generate a V2 table metadata, but this can be modified
 // by adding a "format-version" property to the props map. An error will be returned if the "format-version"
 // property exists and is not a valid version number.
+//
+// location should be non-empty: [ParseMetadata] rejects persisted metadata
+// without one, so metadata built with an empty location cannot be read back.
+// The constructor stays permissive because catalog create-via-commit paths seed
+// a location-less base and supply the location as a set-location update.
 func NewMetadata(sc *iceberg.Schema, partitions *iceberg.PartitionSpec, sortOrder SortOrder, location string, props iceberg.Properties) (Metadata, error) {
 	return NewMetadataWithUUID(sc, partitions, sortOrder, location, props, uuid.Nil)
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -608,6 +608,65 @@ func assertMissingLastUpdatedMS(t *testing.T, metadata map[string]any) {
 	assert.ErrorContains(t, err, "last-updated-ms is absent or null")
 }
 
+func TestMetadataRequiredFields(t *testing.T) {
+	versions := []struct {
+		name          string
+		formatVersion int
+		data          string
+	}{
+		{name: "v1", formatVersion: 1, data: ExampleTableMetadataV1},
+		{name: "v2", formatVersion: 2, data: ExampleTableMetadataV2},
+		{name: "v3", formatVersion: 3, data: ExampleTableMetadataV3},
+	}
+	mutations := []struct {
+		name       string
+		key        string
+		value      any
+		remove     bool
+		errorMatch string
+	}{
+		{name: "missing-location", key: "location", remove: true, errorMatch: "location is required"},
+		{name: "null-location", key: "location", value: nil, errorMatch: "location is required"},
+		{name: "empty-location", key: "location", value: "", errorMatch: "location is required"},
+		{name: "missing-table-uuid", key: "table-uuid", remove: true, errorMatch: "table-uuid is required"},
+		{name: "null-table-uuid", key: "table-uuid", value: nil, errorMatch: "table-uuid is required"},
+		{name: "zero-table-uuid", key: "table-uuid", value: uuid.Nil.String(), errorMatch: "table-uuid is required"},
+	}
+
+	for _, version := range versions {
+		var metadata map[string]any
+		decoder := json.NewDecoder(strings.NewReader(version.data))
+		decoder.UseNumber() // Preserve snapshot IDs larger than float64 can represent exactly.
+		require.NoError(t, decoder.Decode(&metadata))
+
+		for _, mutation := range mutations {
+			t.Run(version.name+"/"+mutation.name, func(t *testing.T) {
+				mutated := maps.Clone(metadata)
+				if mutation.remove {
+					delete(mutated, mutation.key)
+				} else {
+					mutated[mutation.key] = mutation.value
+				}
+
+				raw, err := json.Marshal(mutated)
+				require.NoError(t, err)
+
+				parsed, err := ParseMetadataBytes(raw)
+				required := mutation.key == "location" || version.formatVersion > 1
+				if required {
+					require.ErrorIs(t, err, ErrInvalidMetadata)
+					assert.ErrorContains(t, err, mutation.errorMatch)
+
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, uuid.Nil, parsed.TableUUID())
+			})
+		}
+	}
+}
+
 // A full v3 metadata document must load when its partition spec and sort order
 // use unknown transforms — nothing on the metadata path may trip a guard.
 func TestMetadataV3ParsesUnknownTransforms(t *testing.T) {
@@ -1449,12 +1508,14 @@ func TestV1WriteMetadataToV2(t *testing.T) {
 	metaV2 := meta.(*metadataV1).ToV2()
 	metaV2Json, err := json.Marshal(metaV2)
 	require.NoError(t, err)
+	_, err = ParseMetadataBytes(metaV2Json)
+	require.NoError(t, err)
 
 	rawData := make(map[string]any)
 	require.NoError(t, json.Unmarshal(metaV2Json, &rawData))
 
 	assert.EqualValues(t, 0, rawData["last-sequence-number"])
-	assert.NotEmpty(t, rawData["table-uuid"])
+	assert.NotEqual(t, uuid.Nil.String(), rawData["table-uuid"])
 	assert.EqualValues(t, 0, rawData["current-schema-id"])
 	assert.Equal(t, []any{map[string]any{
 		"fields": []any{

--- a/table/update_spec_test.go
+++ b/table/update_spec_test.go
@@ -95,7 +95,7 @@ func TestUpdateSpecPreservesSourceLessVoidTombstone(t *testing.T) {
 		SourceIDs: []int{1}, FieldID: 1000, Name: "id",
 		Transform: iceberg.VoidTransform{},
 	})
-	meta, err := table.NewMetadata(testSchema, &spec, table.UnsortedSortOrder, "", nil)
+	meta, err := table.NewMetadata(testSchema, &spec, table.UnsortedSortOrder, "s3://bucket/test/location", nil)
 	require.NoError(t, err)
 
 	metadataJSON, err := json.Marshal(meta)


### PR DESCRIPTION
### Description

This PR validates required identity fields when parsing table metadata:

- Rejects missing, null, or empty `location` for format versions 1–3.
- Rejects missing, null, or zero-valued `table-uuid` for format versions 2–3.
- Preserves v1 compatibility by allowing an absent `table-uuid`.
- Fixes v1-to-v2 conversion so a UUID is generated when the v1 metadata has no UUID.
- Updates affected test fixtures to contain valid required fields.

Validation is performed at the JSON parsing boundary rather than in the shared metadata validator. This keeps the existing create-via-commit staging flow valid, where metadata may temporarily have an empty location before it is persisted.

### Why are these changes needed?

Previously, invalid table metadata was silently accepted:

- A missing location became `""`.
- A missing UUID became `uuid.Nil`.

This could cause location providers to produce bogus relative paths and could make `assert-table-uuid` requirements incorrectly match unrelated UUID-less tables.

The behavior now matches the Iceberg requirements for the currently supported format versions. Two deliberate deltas from Java: `"location": ""` and an explicitly all-zeros `table-uuid` are rejected here, where Java only checks for null. Both are covered by tests. If format v4 support is added, location validation will need to account for location becoming optional.

**Note: this is a behavior change.** Metadata that previously parsed successfully may now return an error.

Real-world compatibility risk is limited:

- Normal table creation generates a UUID through `NewMetadata`.
- Builder-based v1-to-v2/v3 upgrades assign a UUID through `SetFormatVersion`.
- Create-via-commit temporarily constructs metadata with an empty location, but supplies the actual location through an update before persistence.

Malformed externally produced metadata and the direct v1-to-v2 conversion path are the primary cases affected. This behavior change may warrant a release note.

### Tests

Added coverage for:

- Missing, null, and empty locations across v1–v3.
- Missing, null, and zero UUIDs across v2–v3.
- v1 compatibility for absent UUIDs.
- UUID generation during v1-to-v2 conversion.
- Successful reparsing of converted metadata.

Validated with:

- `go test ./... -count=1`
- `go vet -tags=integration ./...`

Closes #1864
