### PR TITLE
fix(expr): drop out-of-range set literals

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -956,6 +956,10 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 		if err != nil {
 			return nil, err
 		}
+		switch casted.(type) {
+		case AboveMaxLiteral, BelowMinLiteral:
+			continue
+		}
 		typedSet.Add(cloneBoundLiteral(casted))
 	}
 

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -1006,9 +1006,12 @@ func TestBindAboveBelowIntMax(t *testing.T) {
 		}{
 			{"int in mixed range", iceberg.IsIn(ref, int64(34), above, below), iceberg.EqualTo(ref, int32(34))},
 			{"int not in mixed range", iceberg.NotIn(ref, int64(34), above, below), iceberg.NotEqualTo(ref, int32(34))},
+			{"int in mixed range set", iceberg.IsIn(ref, int64(34), int64(35), above, below), iceberg.IsIn(ref, int32(34), int32(35))},
 			{"int in outside range", iceberg.IsIn(ref, above, below), iceberg.AlwaysFalse{}},
 			{"int not in outside range", iceberg.NotIn(ref, above, below), iceberg.AlwaysTrue{}},
 			{"float in mixed range", iceberg.IsIn(ref2, float64(34), above2, below2), iceberg.EqualTo(ref2, float32(34))},
+			{"float not in mixed range", iceberg.NotIn(ref2, float64(34), above2, below2), iceberg.NotEqualTo(ref2, float32(34))},
+			{"float in outside range", iceberg.IsIn(ref2, above2, below2), iceberg.AlwaysFalse{}},
 			{"float not in outside range", iceberg.NotIn(ref2, above2, below2), iceberg.AlwaysTrue{}},
 		}
 
@@ -1016,9 +1019,9 @@ func TestBindAboveBelowIntMax(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				bound, err := iceberg.BindExpr(sc, tt.pred, true)
 				require.NoError(t, err)
-				expected, err := iceberg.BindExpr(sc, tt.expected, true)
+				wantBound, err := iceberg.BindExpr(sc, tt.expected, true)
 				require.NoError(t, err)
-				assert.True(t, expected.Equals(bound), "expected %s, got %s", expected, bound)
+				assert.True(t, wantBound.Equals(bound), "expected %s, got %s", wantBound, bound)
 			})
 		}
 	})

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -997,6 +997,31 @@ func TestBindAboveBelowIntMax(t *testing.T) {
 			assert.Equal(t, tt.exp, b)
 		})
 	}
+
+	t.Run("set predicates", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			pred     iceberg.BooleanExpression
+			expected iceberg.BooleanExpression
+		}{
+			{"int in mixed range", iceberg.IsIn(ref, int64(34), above, below), iceberg.EqualTo(ref, int32(34))},
+			{"int not in mixed range", iceberg.NotIn(ref, int64(34), above, below), iceberg.NotEqualTo(ref, int32(34))},
+			{"int in outside range", iceberg.IsIn(ref, above, below), iceberg.AlwaysFalse{}},
+			{"int not in outside range", iceberg.NotIn(ref, above, below), iceberg.AlwaysTrue{}},
+			{"float in mixed range", iceberg.IsIn(ref2, float64(34), above2, below2), iceberg.EqualTo(ref2, float32(34))},
+			{"float not in outside range", iceberg.NotIn(ref2, above2, below2), iceberg.AlwaysTrue{}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				bound, err := iceberg.BindExpr(sc, tt.pred, true)
+				require.NoError(t, err)
+				expected, err := iceberg.BindExpr(sc, tt.expected, true)
+				require.NoError(t, err)
+				assert.True(t, expected.Equals(bound), "expected %s, got %s", expected, bound)
+			})
+		}
+	})
 }
 
 func TestVariantBoundLiteralRejectionMessage(t *testing.T) {

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -1929,6 +1929,7 @@ func (suite *InclusiveMetricsTestSuite) TestInMetrics() {
 		{iceberg.IsIn(ref, IntMinValue-1, IntMinValue), true, "should read: id equal to lower bound"},
 		{iceberg.IsIn(ref, IntMaxValue-4, IntMaxValue-3), true, "should read: id between upper and lower bounds"},
 		{iceberg.IsIn(ref, IntMaxValue, IntMaxValue+1), true, "should read: id equal to upper bound"},
+		{iceberg.IsIn(ref, int64(IntMaxValue), int64(math.MaxInt32)+1), true, "should read: ignore value outside int32 range"},
 		{iceberg.IsIn(ref, IntMaxValue+1, IntMaxValue+2), false, "should skip: id above upper bound"},
 		{iceberg.IsIn(ref, IntMaxValue+6, IntMaxValue+7), false, "should skip: id above upper bound"},
 		{iceberg.IsIn(iceberg.Reference("all_nulls"), "abc", "def"), false, "should skip: in on all nulls column"},

--- a/table/evaluators_test.go
+++ b/table/evaluators_test.go
@@ -3022,6 +3022,7 @@ func (suite *StrictMetricsTestSuite) TestNotInMetrics() {
 		{iceberg.NotIn(ref, IntMinValue-1, IntMinValue), false, "should skip: some values may be == 30"},
 		{iceberg.NotIn(ref, IntMaxValue-4, IntMaxValue-3), false, "should skip: some value may be == 75 or == 76"},
 		{iceberg.NotIn(ref, IntMaxValue, IntMaxValue+1), false, "should skip: some value may be == 79"},
+		{iceberg.NotIn(ref, int64(IntMaxValue), int64(IntMaxValue-1), int64(math.MaxInt32)+1), false, "should skip: in-range values remain after ignoring value outside int32 range"},
 		{iceberg.NotIn(ref, IntMaxValue+1, IntMaxValue+2), true, "should read: no values == 80 or == 81"},
 		{iceberg.NotIn(iceberg.Reference("always_5"), int32(5), int32(6)), false, "should skip: all values == 5"},
 		{iceberg.NotIn(iceberg.Reference("all_nulls"), "abc", "def"), true, "should read: notIn on all nulls column"},


### PR DESCRIPTION
## Summary

- discard above-max and below-min sentinels while binding `IN` and `NOT IN` predicates
- reuse the existing empty- and singleton-set simplifications after impossible values are removed
- cover integer and floating-point narrowing plus the inclusive metrics scan-planning regression

## Why

Applications can construct a filter with a wider Go literal type than the Iceberg field type. When a set mixes representable and out-of-range values, binding currently retains range sentinels that cannot equal any field value. Metrics pruning later treats those sentinels as regular typed literals and returns an interface-conversion error instead of planning the scan.

Removing impossible set members during binding preserves membership semantics and keeps sentinels out of downstream predicate consumers.

Closes #1870.

## Testing

- `go test . -run '^TestBindAboveBelowIntMax$' -count=1`
- `go test ./table -run '^TestEvaluators/TestInMetrics$' -count=1 -v`
- `go test ./...`
- `make test-assert`
- `make test-race`
- `golangci-lint v2.12.2 run --timeout=10m --new-from-rev origin/main` (`0 issues`)

The full repository lint invocation reports two existing `intrange` findings in unchanged `catalog/rest/load_table_bench_test.go` lines 84 and 101. Current upstream `main` fails on the same findings ([run](https://github.com/apache/iceberg-go/actions/runs/32528308563)), so the PR's Go matrix currently stops in lint before its test steps; the diff-scoped lint run is clean.
