### PR TITLE
fix(updates): decode add-spec and add-sort-order unbound

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -219,23 +219,31 @@ type PartitionSpec struct {
 	sourceIdToFields map[int][]PartitionField
 }
 
-// UnboundPartitionSpec decodes a partition spec that a client sent in a
-// create-table request, before it has been bound to a schema. Such a spec
-// carries the client's placeholder source IDs rather than table field IDs.
-// A client numbers those placeholders however it likes, so unlike bound field
-// IDs they need not be positive: Spark numbers the columns of a new table from
-// zero, so partitioning by the first column arrives as source-id 0.
+// UnboundPartitionSpec decodes a partition spec whose source IDs have not yet
+// been resolved against the schema that decides them, so unlike bound field IDs
+// they need not be positive. Two wire forms arrive this way:
 //
-// The placeholders are field IDs of the schema the client sent with the spec,
-// so BindToSchema resolves them only when given that same schema. Passing the
-// schema the table ends up with instead binds against unrelated IDs, and a
-// placeholder that collides with one of them binds silently to the wrong
-// column. table.NewMetadata does the whole create-table flow, resolving the
-// placeholders through the request schema by name and reassigning fresh IDs.
+//   - A create-table request's spec, which carries the client's placeholder
+//     source IDs rather than table field IDs. A client numbers those
+//     placeholders however it likes: Spark numbers the columns of a new table
+//     from zero, so partitioning by the first column arrives as source-id 0.
+//   - An add-spec commit payload, whose source IDs are the current schema's
+//     field IDs, except that a dropped partition field arrives as a void
+//     transform over source-id 0. Applying the update binds the spec to the
+//     table's current schema, which is what decides whether the rest resolve.
+//
+// A create-table spec's placeholders are field IDs of the schema the client
+// sent with it, so BindToSchema resolves them only when given that same
+// schema. Passing the schema the table ends up with instead binds against
+// unrelated IDs, and a placeholder that collides with one of them binds
+// silently to the wrong column. table.NewMetadata does the whole create-table
+// flow, resolving the placeholders through the request schema by name and
+// reassigning fresh IDs.
 //
 // Use PartitionSpec for specs read from table metadata, where source IDs are
-// bound field IDs and must be positive. Catalog implementations that serve the
-// REST create-table request should decode its partition spec into this type.
+// bound field IDs: positive, apart from the void tombstone a dropped field
+// leaves behind. Catalog implementations should decode both the REST
+// create-table request's spec and an add-spec commit payload into this type.
 type UnboundPartitionSpec struct {
 	PartitionSpec
 }

--- a/table/sorting.go
+++ b/table/sorting.go
@@ -257,17 +257,27 @@ type SortOrder struct {
 	fields  []SortField
 }
 
-// UnboundSortOrder decodes a sort order that a client sent in a create-table
-// request, before it has been bound to a schema. Such an order carries the
-// client's placeholder source IDs rather than table field IDs. A client numbers
-// those placeholders however it likes, so unlike bound field IDs they need not
-// be positive: Spark numbers the columns of a new table from zero, so sorting
-// by the first column arrives as source-id 0. Binding the embedded order to the
-// schema the client sent resolves the placeholders to field IDs.
+// UnboundSortOrder decodes a sort order whose source IDs have not yet been
+// resolved against the schema that decides them, so unlike bound field IDs they
+// need not be positive. Two wire forms arrive this way:
+//
+//   - A create-table request's write order, which carries the client's
+//     placeholder source IDs rather than table field IDs. A client numbers those
+//     placeholders however it likes: Spark numbers the columns of a new table
+//     from zero, so sorting by the first column arrives as source-id 0. Binding
+//     the embedded order to the schema the client sent resolves them.
+//   - An add-sort-order commit payload, which applying the update checks against
+//     the table's current schema.
+//
+// Decoding unbound defers the check rather than dropping it: every source ID
+// must still resolve in the schema it is checked against, and no transform is
+// exempt, so an order the schema cannot satisfy is rejected when the update is
+// applied.
 //
 // Use SortOrder for orders read from table metadata, where source IDs are bound
-// field IDs and must be positive. Catalog implementations that serve the REST
-// create-table request should decode its write order into this type.
+// field IDs and must be positive. Catalog implementations should decode both the
+// REST create-table request's write order and an add-sort-order commit payload
+// into this type.
 type UnboundSortOrder struct {
 	SortOrder
 }

--- a/table/updates.go
+++ b/table/updates.go
@@ -389,7 +389,11 @@ func (u *setCurrentSchemaUpdate) Apply(builder *MetadataBuilder) error {
 
 type addPartitionSpecUpdate struct {
 	baseUpdate
-	Spec    *iceberg.PartitionSpec `json:"spec"`
+	// The spec arrives unbound: Apply binds it to the table's current schema,
+	// so its source IDs are only required to resolve there. A dropped
+	// partition field in particular is a void transform over source ID 0,
+	// which BindToSchema carries across but a bound decode rejects.
+	Spec    *iceberg.UnboundPartitionSpec `json:"spec"`
 	initial bool
 }
 
@@ -397,15 +401,23 @@ type addPartitionSpecUpdate struct {
 // metadata. If the initial flag is set to true, the spec is considered the initial spec of the table,
 // and all other previously added specs in the metadata builder are removed.
 func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) *addPartitionSpecUpdate {
-	return &addPartitionSpecUpdate{
+	upd := &addPartitionSpecUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSpec},
-		Spec:       spec,
 		initial:    initial,
 	}
+	if spec != nil {
+		upd.Spec = &iceberg.UnboundPartitionSpec{PartitionSpec: *spec}
+	}
+
+	return upd
 }
 
 func (u *addPartitionSpecUpdate) Apply(builder *MetadataBuilder) error {
-	return builder.AddPartitionSpec(u.Spec, u.initial)
+	if u.Spec == nil {
+		return fmt.Errorf("%w: %s requires field %q", iceberg.ErrInvalidArgument, UpdateAddSpec, "spec")
+	}
+
+	return builder.AddPartitionSpec(&u.Spec.PartitionSpec, u.initial)
 }
 
 type setDefaultSpecUpdate struct {
@@ -428,7 +440,10 @@ func (u *setDefaultSpecUpdate) Apply(builder *MetadataBuilder) error {
 
 type addSortOrderUpdate struct {
 	baseUpdate
-	SortOrder *SortOrder `json:"sort-order"`
+	// Unbound for the same reason as addPartitionSpecUpdate.Spec: Apply checks
+	// the order against the table's current schema, which is what decides
+	// whether its source IDs resolve.
+	SortOrder *UnboundSortOrder `json:"sort-order"`
 	initial   bool
 }
 
@@ -436,14 +451,22 @@ type addSortOrderUpdate struct {
 // If the initial flag is set to true, the sort order is considered the initial sort order of the table,
 // and all previously added sort orders in the metadata builder are removed.
 func NewAddSortOrderUpdate(sortOrder *SortOrder) *addSortOrderUpdate {
-	return &addSortOrderUpdate{
+	upd := &addSortOrderUpdate{
 		baseUpdate: baseUpdate{ActionName: UpdateAddSortOrder},
-		SortOrder:  sortOrder,
 	}
+	if sortOrder != nil {
+		upd.SortOrder = &UnboundSortOrder{SortOrder: *sortOrder}
+	}
+
+	return upd
 }
 
 func (u *addSortOrderUpdate) Apply(builder *MetadataBuilder) error {
-	return builder.AddSortOrder(u.SortOrder)
+	if u.SortOrder == nil {
+		return fmt.Errorf("%w: %s requires field %q", iceberg.ErrInvalidArgument, UpdateAddSortOrder, "sort-order")
+	}
+
+	return builder.AddSortOrder(&u.SortOrder.SortOrder)
 }
 
 type setDefaultSortOrderUpdate struct {

--- a/table/updates.go
+++ b/table/updates.go
@@ -466,6 +466,8 @@ func (u *addSortOrderUpdate) Apply(builder *MetadataBuilder) error {
 		return fmt.Errorf("%w: update %q requires field %q", iceberg.ErrInvalidArgument, UpdateAddSortOrder, "sort-order")
 	}
 
+	// AddSortOrder writes the fresh order ID into the order it is given and
+	// keeps a pointer to that field, so the builder aliases this update.
 	return builder.AddSortOrder(&u.SortOrder.SortOrder)
 }
 

--- a/table/updates.go
+++ b/table/updates.go
@@ -414,7 +414,7 @@ func NewAddPartitionSpecUpdate(spec *iceberg.PartitionSpec, initial bool) *addPa
 
 func (u *addPartitionSpecUpdate) Apply(builder *MetadataBuilder) error {
 	if u.Spec == nil {
-		return fmt.Errorf("%w: %s requires field %q", iceberg.ErrInvalidArgument, UpdateAddSpec, "spec")
+		return fmt.Errorf("%w: update %q requires field %q", iceberg.ErrInvalidArgument, UpdateAddSpec, "spec")
 	}
 
 	return builder.AddPartitionSpec(&u.Spec.PartitionSpec, u.initial)
@@ -440,9 +440,9 @@ func (u *setDefaultSpecUpdate) Apply(builder *MetadataBuilder) error {
 
 type addSortOrderUpdate struct {
 	baseUpdate
-	// Unbound for the same reason as addPartitionSpecUpdate.Spec: Apply checks
-	// the order against the table's current schema, which is what decides
-	// whether its source IDs resolve.
+	// Unbound so decoding accepts placeholder source IDs. Unlike the spec
+	// above, none are exempt at Apply: CheckCompatibility still requires every
+	// source ID to resolve in the current schema, so this only defers the error.
 	SortOrder *UnboundSortOrder `json:"sort-order"`
 	initial   bool
 }
@@ -463,7 +463,7 @@ func NewAddSortOrderUpdate(sortOrder *SortOrder) *addSortOrderUpdate {
 
 func (u *addSortOrderUpdate) Apply(builder *MetadataBuilder) error {
 	if u.SortOrder == nil {
-		return fmt.Errorf("%w: %s requires field %q", iceberg.ErrInvalidArgument, UpdateAddSortOrder, "sort-order")
+		return fmt.Errorf("%w: update %q requires field %q", iceberg.ErrInvalidArgument, UpdateAddSortOrder, "sort-order")
 	}
 
 	return builder.AddSortOrder(&u.SortOrder.SortOrder)

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -524,12 +524,12 @@ func TestUnmarshalUpdates(t *testing.T) {
 					case "add-partition-spec":
 						expectedAddPartitionSpec := u.(*addPartitionSpecUpdate)
 						actualAddPartitionSpec := actual[idx].(*addPartitionSpecUpdate)
-						assert.True(t, expectedAddPartitionSpec.Spec.Equals(*actualAddPartitionSpec.Spec))
+						assert.True(t, expectedAddPartitionSpec.Spec.Equals(actualAddPartitionSpec.Spec.PartitionSpec))
 						assert.Equal(t, actualAddPartitionSpec.initial, expectedAddPartitionSpec.initial)
 					case "add-sort-order":
 						expectedAddSortOrder := u.(*addSortOrderUpdate)
 						actualAddSortOrder := actual[idx].(*addSortOrderUpdate)
-						assert.True(t, expectedAddSortOrder.SortOrder.Equals(*actualAddSortOrder.SortOrder))
+						assert.True(t, expectedAddSortOrder.SortOrder.Equals(actualAddSortOrder.SortOrder.SortOrder))
 						assert.Equal(t, actualAddSortOrder.initial, expectedAddSortOrder.initial)
 					default:
 						assert.Equal(t, u, actual[idx])
@@ -1298,4 +1298,63 @@ func TestRemoveEncryptionKeyUpdate_Apply_NoOp(t *testing.T) {
 	// Removing a key that doesn't exist should not error.
 	b := buildFromBase(t)
 	require.NoError(t, NewRemoveEncryptionKeyUpdate("nonexistent").Apply(b))
+}
+
+func TestAddPartitionSpecUpdate_UnmarshalVoidTombstone(t *testing.T) {
+	// A dropped partition field whose source column is gone is a void
+	// transform over source ID 0; BindToSchema carries it across, so the
+	// decoder must let it through.
+	data := []byte(`[{"action":"add-spec","spec":{"spec-id":1,"fields":[{"source-id":0,"field-id":1000,"transform":"void","name":"x_bucket"}]}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	b := buildFromBaseV3(t)
+	require.NoError(t, updates[0].Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	spec := meta.PartitionSpecByID(1)
+	require.NotNil(t, spec)
+	require.Equal(t, 1, spec.NumFields())
+	assert.Equal(t, "x_bucket", spec.Field(0).Name)
+	assert.IsType(t, iceberg.VoidTransform{}, spec.Field(0).Transform)
+}
+
+func TestAddPartitionSpecUpdate_UnmarshalUnresolvableSourceID(t *testing.T) {
+	// A non-void source ID that the current schema cannot resolve is still
+	// rejected, but by binding rather than by decoding.
+	data := []byte(`[{"action":"add-spec","spec":{"spec-id":1,"fields":[{"source-id":0,"field-id":1000,"transform":"identity","name":"x"}]}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	err := updates[0].Apply(buildFromBaseV3(t))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "must be positive")
+}
+
+func TestAddSortOrderUpdate_UnmarshalDefersBindingToApply(t *testing.T) {
+	// Decoding accepts the order; the schema it must resolve against is only
+	// known at Apply, which is where an unresolvable source ID is reported.
+	data := []byte(`[{"action":"add-sort-order","sort-order":{"order-id":1,"fields":[{"source-id":0,"transform":"identity","direction":"asc","null-order":"nulls-first"}]}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	err := updates[0].Apply(buildFromBaseV3(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not compatible with current schema")
+}
+
+func TestAddSpecAndSortOrderUpdates_ApplyRejectNilPayload(t *testing.T) {
+	err := NewAddPartitionSpecUpdate(nil, true).Apply(buildFromBaseV3(t))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+	err = NewAddSortOrderUpdate(nil).Apply(buildFromBaseV3(t))
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 }

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -348,7 +348,7 @@ func TestUnmarshalUpdates(t *testing.T) {
 		22,
 		[]SortField{
 			{SourceIDs: []int{19}, Transform: iceberg.IdentityTransform{}, NullOrder: NullsFirst, Direction: SortASC},
-			{SourceIDs: []int{25}, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: NullsFirst, Direction: SortDESC},
+			{SourceIDs: []int{25}, Transform: iceberg.BucketTransform{NumBuckets: 4}, NullOrder: NullsLast, Direction: SortDESC},
 			{SourceIDs: []int{22}, Transform: iceberg.VoidTransform{}, NullOrder: NullsFirst, Direction: SortASC},
 		},
 	)
@@ -513,26 +513,26 @@ func TestUnmarshalUpdates(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, len(tc.expected), len(actual))
-				for idx, u := range actual {
-					switch u.Action() {
-					case "add-schema":
-						expectedAddSchema := u.(*addSchemaUpdate)
+				require.Len(t, actual, len(tc.expected))
+				for idx, expected := range tc.expected {
+					switch expected.Action() {
+					case UpdateAddSchema:
+						expectedAddSchema := expected.(*addSchemaUpdate)
 						actualAddSchema := actual[idx].(*addSchemaUpdate)
 						assert.True(t, expectedAddSchema.Schema.Equals(actualAddSchema.Schema))
-						assert.Equal(t, actualAddSchema.initial, expectedAddSchema.initial)
-					case "add-partition-spec":
-						expectedAddPartitionSpec := u.(*addPartitionSpecUpdate)
+						assert.Equal(t, expectedAddSchema.initial, actualAddSchema.initial)
+					case UpdateAddSpec:
+						expectedAddPartitionSpec := expected.(*addPartitionSpecUpdate)
 						actualAddPartitionSpec := actual[idx].(*addPartitionSpecUpdate)
 						assert.True(t, expectedAddPartitionSpec.Spec.Equals(actualAddPartitionSpec.Spec.PartitionSpec))
-						assert.Equal(t, actualAddPartitionSpec.initial, expectedAddPartitionSpec.initial)
-					case "add-sort-order":
-						expectedAddSortOrder := u.(*addSortOrderUpdate)
+						assert.Equal(t, expectedAddPartitionSpec.initial, actualAddPartitionSpec.initial)
+					case UpdateAddSortOrder:
+						expectedAddSortOrder := expected.(*addSortOrderUpdate)
 						actualAddSortOrder := actual[idx].(*addSortOrderUpdate)
 						assert.True(t, expectedAddSortOrder.SortOrder.Equals(actualAddSortOrder.SortOrder.SortOrder))
-						assert.Equal(t, actualAddSortOrder.initial, expectedAddSortOrder.initial)
+						assert.Equal(t, expectedAddSortOrder.initial, actualAddSortOrder.initial)
 					default:
-						assert.Equal(t, u, actual[idx])
+						assert.Equal(t, expected, actual[idx])
 					}
 				}
 			}
@@ -1334,6 +1334,7 @@ func TestAddPartitionSpecUpdate_UnmarshalUnresolvableSourceID(t *testing.T) {
 
 	err := updates[0].Apply(buildFromBaseV3(t))
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot find source column with id: 0 in schema")
 	assert.NotContains(t, err.Error(), "must be positive")
 }
 

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -1333,8 +1333,9 @@ func TestAddPartitionSpecUpdate_UnmarshalUnresolvableSourceID(t *testing.T) {
 	require.Len(t, updates, 1)
 
 	err := updates[0].Apply(buildFromBaseV3(t))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot find source column with id: 0 in schema")
+	// Pinned to BindToSchema's wording on purpose: the assertion below only
+	// shows the decoder let the field through, not who rejected it.
+	require.ErrorContains(t, err, "cannot find source column with id: 0 in schema")
 	assert.NotContains(t, err.Error(), "must be positive")
 }
 
@@ -1347,9 +1348,39 @@ func TestAddSortOrderUpdate_UnmarshalDefersBindingToApply(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &updates))
 	require.Len(t, updates, 1)
 
-	err := updates[0].Apply(buildFromBaseV3(t))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not compatible with current schema")
+	require.ErrorContains(t, updates[0].Apply(buildFromBaseV3(t)), "not compatible with current schema")
+}
+
+func TestAddSortOrderUpdate_UnmarshalRoundTrip(t *testing.T) {
+	// The decode no longer validates source IDs, so cover the resolvable case
+	// end to end: field 1 is x in baseMetaV3JSON.
+	data := []byte(`[{"action":"add-sort-order","sort-order":{"order-id":1,"fields":[{"source-id":1,"transform":"identity","direction":"desc","null-order":"nulls-last"}]}}]`)
+
+	var updates Updates
+	require.NoError(t, json.Unmarshal(data, &updates))
+	require.Len(t, updates, 1)
+
+	b := buildFromBaseV3(t)
+	require.NoError(t, updates[0].Apply(b))
+
+	meta, err := b.Build()
+	require.NoError(t, err)
+
+	var order SortOrder
+	var found bool
+	for _, o := range meta.SortOrders() {
+		if o.OrderID() == 1 {
+			order, found = o, true
+		}
+	}
+	require.True(t, found)
+	require.Equal(t, 1, order.Len())
+
+	field := order.Field(0)
+	assert.Equal(t, []int{1}, field.SourceIDs)
+	assert.Equal(t, SortDESC, field.Direction)
+	assert.Equal(t, NullsLast, field.NullOrder)
+	assert.IsType(t, iceberg.IdentityTransform{}, field.Transform)
 }
 
 func TestAddSpecAndSortOrderUpdates_ApplyRejectNilPayload(t *testing.T) {

--- a/table/updates_test.go
+++ b/table/updates_test.go
@@ -1340,15 +1340,33 @@ func TestAddPartitionSpecUpdate_UnmarshalUnresolvableSourceID(t *testing.T) {
 }
 
 func TestAddSortOrderUpdate_UnmarshalDefersBindingToApply(t *testing.T) {
-	// Decoding accepts the order; the schema it must resolve against is only
-	// known at Apply, which is where an unresolvable source ID is reported.
-	data := []byte(`[{"action":"add-sort-order","sort-order":{"order-id":1,"fields":[{"source-id":0,"transform":"identity","direction":"asc","null-order":"nulls-first"}]}}]`)
+	// Decoding accepts the order either way; Apply reports both the positivity
+	// check and the schema lookup, which needs a schema only Apply knows. Source
+	// ID 0 fails the first and never reaches the second, so 999 covers the
+	// lookup: positive, and absent from baseMetaV3JSON.
+	for _, tt := range []struct {
+		name     string
+		sourceID int
+		message  string
+	}{
+		{name: "not positive", sourceID: 0, message: "source ID must be positive: 0"},
+		{name: "unresolvable", sourceID: 999, message: "sort field with source id 999 not found in schema"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data := fmt.Appendf(nil,
+				`[{"action":"add-sort-order","sort-order":{"order-id":1,"fields":[{"source-id":%d,"transform":"identity","direction":"asc","null-order":"nulls-first"}]}}]`,
+				tt.sourceID,
+			)
 
-	var updates Updates
-	require.NoError(t, json.Unmarshal(data, &updates))
-	require.Len(t, updates, 1)
+			var updates Updates
+			require.NoError(t, json.Unmarshal(data, &updates))
+			require.Len(t, updates, 1)
 
-	require.ErrorContains(t, updates[0].Apply(buildFromBaseV3(t)), "not compatible with current schema")
+			err := updates[0].Apply(buildFromBaseV3(t))
+			require.ErrorContains(t, err, "not compatible with current schema")
+			assert.ErrorContains(t, err, tt.message)
+		})
+	}
 }
 
 func TestAddSortOrderUpdate_UnmarshalRoundTrip(t *testing.T) {
@@ -1371,6 +1389,8 @@ func TestAddSortOrderUpdate_UnmarshalRoundTrip(t *testing.T) {
 	for _, o := range meta.SortOrders() {
 		if o.OrderID() == 1 {
 			order, found = o, true
+
+			break
 		}
 	}
 	require.True(t, found)
@@ -1384,9 +1404,13 @@ func TestAddSortOrderUpdate_UnmarshalRoundTrip(t *testing.T) {
 }
 
 func TestAddSpecAndSortOrderUpdates_ApplyRejectNilPayload(t *testing.T) {
-	err := NewAddPartitionSpecUpdate(nil, true).Apply(buildFromBaseV3(t))
-	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	t.Run("add-spec", func(t *testing.T) {
+		err := NewAddPartitionSpecUpdate(nil, true).Apply(buildFromBaseV3(t))
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	})
 
-	err = NewAddSortOrderUpdate(nil).Apply(buildFromBaseV3(t))
-	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	t.Run("add-sort-order", func(t *testing.T) {
+		err := NewAddSortOrderUpdate(nil).Apply(buildFromBaseV3(t))
+		require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+	})
 }


### PR DESCRIPTION
Follow-up to #1665 

A commit request's add-spec and add-sort-order payloads are bound to a schema by Apply, not by the decoder: AddPartitionSpec calls BindToSchema and AddSortOrder calls CheckCompatibility, both against the table's current schema. Decoding them into the bound types therefore enforced an invariant the wire form does not carry.

That rejected a spec a client is entitled to send. A dropped partition field is a void transform over source ID 0, which BindToSchema preserves as a tombstone, so re-sending a spec after dropping a partition column failed with "partition source ID must be positive: 0" before binding ran.

Decode into UnboundPartitionSpec and UnboundSortOrder, and hand the embedded bound values to the builder. Source IDs that do not resolve are still rejected, now by binding, which reports them against the schema that decides. The constructors keep taking bound values, so callers are unaffected, and Apply reports a nil payload rather than dereferencing it.