### PR TITLE
fix(rest): use range-over-int in the load table benchmark

### DIFF
--- a/catalog/rest/load_table_bench_test.go
+++ b/catalog/rest/load_table_bench_test.go
@@ -81,7 +81,7 @@ func BenchmarkDecodeTableMetadata(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				var resp loadTableResponse
 				err := tc.decode(body, &resp)
 				require.NoError(b, err)
@@ -98,7 +98,7 @@ func makeTableResponseWithSnapshots(snapshotCount int64) []byte {
 	schemaID := 0
 	var snapshotTimestamp int64
 	var snapshotID int64
-	for i := int64(0); i < snapshotCount; i++ {
+	for i := range snapshotCount {
 		var parentID *int64
 		if i > 0 {
 			parentID = &i


### PR DESCRIPTION
The two loops in the load table decoding benchmark trip intrange, which .golangci.yml enables, so the tree does not lint clean.

Converting makeTableResponseWithSnapshots also fixes a bug the old form hid. The C-style loop shares one i across all iterations, so parentID = &i stored the same address in every snapshot, and the slice is marshalled only after the loop exits: every snapshot reported the same parent, the post-loop value of i. Range-over-int gives each iteration its own i, so each snapshot now reports its own index.

The fixture still makes each snapshot its own parent rather than its predecessor, which is pre-existing and does not change the response size the benchmark measures.