### PR TITLE
fix(literals): reject out-of-range int64-date conversion

### DIFF
--- a/exprs_test.go
+++ b/exprs_test.go
@@ -1027,6 +1027,38 @@ func TestBindAboveBelowIntMax(t *testing.T) {
 	})
 }
 
+func TestBindOutOfRangeDate(t *testing.T) {
+	sc := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "d", Type: iceberg.PrimitiveTypes.Date},
+	)
+
+	ref := iceberg.Reference("d")
+	above, below := int64(math.MaxInt32)+1, int64(math.MinInt32)-1
+
+	tests := []struct {
+		name     string
+		pred     iceberg.BooleanExpression
+		expected iceberg.BooleanExpression
+	}{
+		{"eq above max", iceberg.EqualTo(ref, above), iceberg.AlwaysFalse{}},
+		{"eq below min", iceberg.EqualTo(ref, below), iceberg.AlwaysFalse{}},
+		{"neq above max", iceberg.NotEqualTo(ref, above), iceberg.AlwaysTrue{}},
+		{"in mixed range", iceberg.IsIn(ref, int64(34), above, below), iceberg.EqualTo(ref, iceberg.Date(34))},
+		{"in outside range", iceberg.IsIn(ref, above, below), iceberg.AlwaysFalse{}},
+		{"not in outside range", iceberg.NotIn(ref, above, below), iceberg.AlwaysTrue{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bound, err := iceberg.BindExpr(sc, tt.pred, true)
+			require.NoError(t, err)
+			wantBound, err := iceberg.BindExpr(sc, tt.expected, true)
+			require.NoError(t, err)
+			assert.True(t, wantBound.Equals(bound), "expected %s, got %s", wantBound, bound)
+		})
+	}
+}
+
 func TestVariantBoundLiteralRejectionMessage(t *testing.T) {
 	sc := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "payload", Type: iceberg.VariantType{}, Required: false},

--- a/literals.go
+++ b/literals.go
@@ -548,6 +548,12 @@ func (i Int64Literal) To(t Type) (Literal, error) {
 	case Float64Type:
 		return Float64Literal(i), nil
 	case DateType:
+		if math.MaxInt32 < i {
+			return Int32AboveMaxLiteral(), nil
+		} else if math.MinInt32 > i {
+			return Int32BelowMinLiteral(), nil
+		}
+
 		return DateLiteral(i), nil
 	case TimeType:
 		return TimeLiteral(i), nil

--- a/literals_test.go
+++ b/literals_test.go
@@ -347,6 +347,22 @@ func TestInt64ToInt32OutsideBound(t *testing.T) {
 	assert.Equal(t, iceberg.PrimitiveTypes.Int32, belowMin.Type())
 }
 
+func TestInt64ToDateOutsideBound(t *testing.T) {
+	bigLit := iceberg.NewLiteral(int64(math.MaxInt32) + 1)
+	aboveMax, err := bigLit.To(iceberg.PrimitiveTypes.Date)
+	require.NoError(t, err)
+	assert.Implements(t, (*iceberg.AboveMaxLiteral)(nil), aboveMax)
+
+	smallLit := iceberg.NewLiteral(int64(math.MinInt32) - 1)
+	belowMin, err := smallLit.To(iceberg.PrimitiveTypes.Date)
+	require.NoError(t, err)
+	assert.Implements(t, (*iceberg.BelowMinLiteral)(nil), belowMin)
+
+	inRange, err := iceberg.NewLiteral(int64(math.MaxInt32)).To(iceberg.PrimitiveTypes.Date)
+	require.NoError(t, err)
+	assert.Equal(t, iceberg.DateLiteral(math.MaxInt32), inRange)
+}
+
 func TestBelowMinLiteralMarshalBinary(t *testing.T) {
 	_, err := iceberg.Int32BelowMinLiteral().MarshalBinary()
 	require.ErrorIs(t, err, iceberg.ErrInvalidBinSerialization)


### PR DESCRIPTION
`Int64Literal.To(DateType)` narrowed with a plain `DateLiteral(i)` conversion, silently wrapping out-of-range values so `Eq`/`In` predicates could match rows the user never asked for. 

Return `Int32AboveMaxLiteral()`/`Int32BelowMinLiteral()` instead, similar to int64 -> int32 narrowing. Binding already handles the sentinels: unary predicates simplify to `AlwaysFalse`/`AlwaysTrue`, and set predicates drop the impossible members (#1870).

related to #1870 and #1872