### PR TITLE
test(rest): harden Java scan planning integration coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ integration-env:
 	@echo "export SPARK_CONTAINER_ID=$$(docker ps -qf 'name=spark-iceberg')"
 	@echo "export DOCKER_API_VERSION=$$(docker version -f '{{.Server.APIVersion}}')"
 
+# Keep the isolated Java scan-planning suite in umbrella CI so its wire
+# compatibility coverage runs alongside the other integration tests.
 integration-test: integration-scanner integration-io integration-rest integration-rest-scan-planning integration-spark integration-hive integration-hadoop
 
 integration-scanner:

--- a/catalog/rest/scan_planning_integration_test.go
+++ b/catalog/rest/scan_planning_integration_test.go
@@ -64,7 +64,8 @@ func (s *RestIntegrationSuite) TestScanPlanningJavaSynchronousInteroperability()
 	ident := catalog.ToIdentifier(TestNamespaceIdent, "scan-planning-java-wire")
 	tbl, dataPath := s.createScanPlanningTable(planningCatalog, ident)
 
-	filter, err := json.Marshal(iceberg.EqualTo(iceberg.Reference("foo"), "hello"))
+	filterExpr := iceberg.EqualTo(iceberg.Reference("foo"), "hello")
+	filter, err := json.Marshal(filterExpr)
 	s.Require().NoError(err)
 	snapshotID := tbl.CurrentSnapshot().SnapshotID
 	caseSensitive := true
@@ -98,6 +99,19 @@ func (s *RestIntegrationSuite) TestScanPlanningJavaSynchronousInteroperability()
 	s.Require().Len(response.FileScanTasks, 1)
 	s.Empty(response.DeleteFiles)
 	s.assertJavaPlanningCredentials(response.StorageCredentials)
+
+	decodedTasks, err := rest.DecodeScanTasks(response.ScanTasks, tbl.Metadata(), tbl.Schema(), filterExpr)
+	s.Require().NoError(err)
+	s.Require().Len(decodedTasks, 1)
+	decodedTask := decodedTasks[0]
+	s.Equal(dataPath, decodedTask.File.FilePath())
+	s.Equal(iceberg.ParquetFile, decodedTask.File.FileFormat())
+	s.Equal(int64(1), decodedTask.File.Count())
+	s.Equal(map[int]any{1000: int32(17)}, decodedTask.File.Partition())
+	s.True(decodedTask.Residual.Equals(filterExpr))
+	s.Empty(decodedTask.DeleteFiles)
+	s.Empty(decodedTask.EqualityDeleteFiles)
+	s.Empty(decodedTask.DeletionVectorFiles)
 
 	rawResponses := transport.PlanResponses()
 	s.Require().Len(rawResponses, 1)
@@ -214,7 +228,7 @@ func (s *RestIntegrationSuite) ensureNamespaceIn(cat *rest.Catalog) {
 		s.Require().NoError(cat.DropNamespace(s.ctx, catalog.ToIdentifier(TestNamespaceIdent)))
 	}
 
-	s.NoError(cat.CreateNamespace(s.ctx, catalog.ToIdentifier(TestNamespaceIdent),
+	s.Require().NoError(cat.CreateNamespace(s.ctx, catalog.ToIdentifier(TestNamespaceIdent),
 		iceberg.Properties{"foo": "bar", "prop": "yes"}))
 }
 
@@ -242,7 +256,9 @@ func (s *RestIntegrationSuite) createScanPlanningTable(cat *rest.Catalog, ident 
 
 	dataPath, err := url.JoinPath(tbl.Location(), "data", "bar=17", "data.parquet")
 	s.Require().NoError(err)
-	file, err := mustFS(s.T(), tbl).(iceio.WriteFileIO).Create(dataPath)
+	writeFS, ok := mustFS(s.T(), tbl).(iceio.WriteFileIO)
+	s.Require().True(ok, "table filesystem must implement WriteFileIO")
+	file, err := writeFS.Create(dataPath)
 	s.Require().NoError(err)
 	s.Require().NoError(pqarrow.WriteTable(arrowTable, file, arrowTable.NumRows(),
 		nil, pqarrow.DefaultWriterProps()))

--- a/internal/recipe/docker-compose.yml
+++ b/internal/recipe/docker-compose.yml
@@ -62,8 +62,10 @@ services:
   rest-scan-planning:
     # 1.10.1 predates the fixture's scan-planning implementation. Pin the
     # multi-platform image built from apache/iceberg@b0df3ca so the Java wire
-    # compatibility tests are reproducible even though the released tag is not
-    # available yet.
+    # compatibility tests are reproducible.
+    # TODO(#1880): Replace the digest with a stable release tag once a
+    # scan-planning-capable fixture tag is published.
+    # The image declares a /v1/config healthcheck that compose up --wait uses.
     image: apache/iceberg-rest-fixture:latest@sha256:db8de90b5b7693d4ac334c336f91d9bbe320d7b19f4f514d26de84cdfbcbfe8d
     container_name: iceberg-rest-scan-planning
     networks:


### PR DESCRIPTION
## Summary

- run the isolated Java scan-planning suite from the umbrella integration target
- decode the Java response into Go scan tasks and assert the decoded data
- harden fixture setup and document the pinned scan-planning image

## Testing

- go test ./catalog/rest
- go test -tags=integration -run ^$ ./catalog/rest
- docker compose -f internal/recipe/docker-compose.yml config --quiet