### PR TITLE
perf(compaction): reuse survivor partition tuple

### DIFF
--- a/table/compaction/eq_delete_decision.go
+++ b/table/compaction/eq_delete_decision.go
@@ -78,28 +78,30 @@ func (s *SurvivorSurvey) AddSurvivor(partition map[int]any, seq int64) {
 		return
 	}
 
-	key := partitionMatchKey(partition)
-	if cur, ok := s.PartMinSeq[key]; ok {
-		seq = min(seq, cur)
-	}
-	s.PartMinSeq[key] = seq
+	updatePartitionMinSeq(s.PartMinSeq, partitionMatchKey(partition), seq)
 }
 
 // AddSurvivorWithSpec records a surviving data file's spec ID, partition, and
 // sequence number for exact equality-delete matching. It also maintains the
 // conservative survey used by [DecideDeadEqualityDeletes].
 func (s *SurvivorSurvey) AddSurvivorWithSpec(specID int32, partition map[int]any, seq int64) {
-	s.AddSurvivor(partition, seq)
 	if seq < 0 {
 		seq = 0
 	}
+
+	var specKey string
+	if len(partition) == 0 {
+		s.EmptyPartMinSeq = min(seq, s.EmptyPartMinSeq)
+		specKey = partitionBucketKey(specID, partition)
+	} else {
+		tuple := appendPartitionTuple(nil, partition)
+		updatePartitionMinSeq(s.PartMinSeq, string(tuple), seq)
+		specKey = partitionBucketKeyFromTuple(specID, tuple)
+	}
+
 	s.minSeq = min(seq, s.minSeq)
 
-	key := partitionBucketKey(specID, partition)
-	if cur, ok := s.specPartMinSeq[key]; ok {
-		seq = min(seq, cur)
-	}
-	s.specPartMinSeq[key] = seq
+	updatePartitionMinSeq(s.specPartMinSeq, specKey, seq)
 }
 
 func (s *SurvivorSurvey) conservativeMinSeq() int64 {
@@ -239,7 +241,14 @@ func partitionBucketKey(specID int32, part map[int]any) string {
 		return fmt.Sprintf("%d:_", specID)
 	}
 
-	return string(appendPartitionTuple(fmt.Appendf(nil, "%d:", specID), part))
+	return partitionBucketKeyFromTuple(specID, appendPartitionTuple(nil, part))
+}
+
+func partitionBucketKeyFromTuple(specID int32, tuple []byte) string {
+	key := make([]byte, 0, len(tuple)+12)
+	key = fmt.Appendf(key, "%d:", specID)
+
+	return string(append(key, tuple...))
 }
 
 // appendPartitionTuple emits the sorted "id=value;" tuple into dst.
@@ -255,4 +264,11 @@ func appendPartitionTuple(dst []byte, part map[int]any) []byte {
 	}
 
 	return dst
+}
+
+func updatePartitionMinSeq(partitions map[string]int64, key string, seq int64) {
+	if cur, ok := partitions[key]; ok {
+		seq = min(seq, cur)
+	}
+	partitions[key] = seq
 }

--- a/table/compaction/eq_delete_decision_bench_test.go
+++ b/table/compaction/eq_delete_decision_bench_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/apache/iceberg-go/table/compaction"
 )
 
-var benchmarkDeadEqualityDeletes []iceberg.DataFile
-var benchmarkSurvivorSurvey *compaction.SurvivorSurvey
+var (
+	benchmarkDeadEqualityDeletes []iceberg.DataFile
+	benchmarkSurvivorSurvey      *compaction.SurvivorSurvey
+)
 
 func BenchmarkAddSurvivorWithSpec(b *testing.B) {
 	for _, fields := range []int{1, 8, 32} {

--- a/table/compaction/eq_delete_decision_bench_test.go
+++ b/table/compaction/eq_delete_decision_bench_test.go
@@ -26,6 +26,27 @@ import (
 )
 
 var benchmarkDeadEqualityDeletes []iceberg.DataFile
+var benchmarkSurvivorSurvey *compaction.SurvivorSurvey
+
+func BenchmarkAddSurvivorWithSpec(b *testing.B) {
+	for _, fields := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("fields=%d", fields), func(b *testing.B) {
+			partition := make(map[int]any, fields)
+			for i := range fields {
+				partition[1000+i] = i
+			}
+
+			survey := compaction.NewSurvivorSurvey()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				survey.AddSurvivorWithSpec(1, partition, 10)
+			}
+			b.StopTimer()
+			benchmarkSurvivorSurvey = survey
+		})
+	}
+}
 
 func BenchmarkDecideDeadEqualityDeletes(b *testing.B) {
 	for _, tc := range []struct {

--- a/table/compaction/eq_delete_decision_test.go
+++ b/table/compaction/eq_delete_decision_test.go
@@ -331,6 +331,30 @@ func TestSurvivorSurvey_AddSurvivor_DefensiveSeq(t *testing.T) {
 	assert.Empty(t, got, "negative-seq survivor must keep eq-delete alive")
 }
 
+func TestSurvivorSurvey_AddSurvivorWithSpec_UsesMinimumSequence(t *testing.T) {
+	specs := compactionTestSpecs()
+	partition := map[int]any{1000: "us"}
+	survey := compaction.NewSurvivorSurvey()
+	survey.AddSurvivorWithSpec(1, partition, 9)
+	survey.AddSurvivorWithSpec(1, partition, 3)
+
+	alive, err := compaction.DecideDeadEqualityDeletesWithSpecs(
+		survey,
+		[]iceberg.ManifestEntry{makeEqDeleteEntry(t, specs[1], partition, 4, "/alive.parquet")},
+		specs,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, alive, "the lowest sequence survivor must keep the delete alive")
+
+	dead, err := compaction.DecideDeadEqualityDeletesWithSpecs(
+		survey,
+		[]iceberg.ManifestEntry{makeEqDeleteEntry(t, specs[1], partition, 3, "/dead.parquet")},
+		specs,
+	)
+	require.NoError(t, err)
+	assert.Len(t, dead, 1, "a delete at the survivor sequence must be dead")
+}
+
 type survivor struct {
 	specID    int32
 	partition map[int]any


### PR DESCRIPTION
## Summary

- Reuse the canonical partition tuple in `AddSurvivorWithSpec`.
- Avoid sorting and formatting the same partition twice.
- Keep empty-partition and negative-sequence behavior unchanged.

## Benchmark

The benchmark is included in this PR at `table/compaction/eq_delete_decision_bench_test.go`.

Command: `go test ./table/compaction -run=^$ -bench=^BenchmarkAddSurvivorWithSpec$ -benchmem -count=5`

Measured on an Apple M1 Pro. Parent commit -> this PR:

- 1 field: 72 -> 32 B/op, 7 -> 4 allocs/op
- 8 fields: 624 -> 456 B/op, 28 -> 16 allocs/op
- 32 fields: 2544 -> 1816 B/op, 80 -> 42 allocs/op

The 32-field case was about 40% faster in the local comparison.

## Checks

- `go test ./... -count=1`
- `go test -race ./table/compaction -count=1`
- `go vet ./table/compaction`