### PR TITLE
Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -20,6 +20,7 @@ LICENSE
 NOTICE
 go.sum
 build
+CLAUDE.md
 rat-results.txt
 operation_string.go
 duckdb_v3_manifest_list.avro


### PR DESCRIPTION
As part of the ongoing conversations around LLM-generated code, we should ensure that Claude is following the guidelines the community has set. Claude doesn't follow AGENTS.md, but instead looks for a CLAUDE.md file, so I made a symlink.

This won't solve all of our issues, but it's hopefully some low-hanging fruit.

AI-disclosure: I didn't need AI to make a symlink, but I did need a Google search to remember the order of the arguments 😄