### PR TITLE
build(dev): upgrade RAT to 0.17 in check-license

### DIFF
--- a/dev/check-license
+++ b/dev/check-license
@@ -55,7 +55,7 @@ else
     declare java_cmd=java
 fi
 
-export RAT_VERSION=0.15
+export RAT_VERSION=0.17
 export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
 mkdir -p "$FWDIR"/lib
 
@@ -64,20 +64,15 @@ mkdir -p "$FWDIR"/lib
     exit 1
 }
 
-mkdir -p build
-$java_cmd -jar "$rat_jar" -E "$FWDIR"/dev/release/rat_exclude_files.txt -d "$FWDIR" > build/rat-results.txt
+# --input-exclude-std GIT skips .git and anything .gitignore'd. Without it RAT
+# flags the .git pointer *file* that git worktrees use, since its built-in SCM
+# exclusion only covers .git directories.
+$java_cmd -jar "$rat_jar" \
+  --input-exclude-file "$FWDIR"/dev/release/rat_exclude_files.txt \
+  --input-exclude-std GIT IDEA MAC \
+  --input-include-std HIDDEN_DIR \
+  --output-style missing-headers \
+  --log-level ERROR \
+  -- "$FWDIR" || exit 1
 
-if [ $? -ne 0 ]; then
-   echo "RAT exited abnormally"
-   exit 1
-fi
-
-ERRORS="$(cat build/rat-results.txt | grep -e "??")"
-
-if test ! -z "$ERRORS"; then 
-    echo "Could not find Apache license headers in the following files:"
-    echo "$ERRORS"
-    exit 1
-else 
-    echo -e "RAT checks passed."
-fi
+echo "RAT checks passed."


### PR DESCRIPTION
After merging the CLAUDE.md symlink, I noticed that most of our other Iceberg repositories seem to accept the symlink without having to add a new RAT exclusion.

This PR bumps up the RAT version and better makes the script match what I've seen in other repositories (mainly, no leftover files)