### PR TITLE
perf(dv): add single-position append fast path

### DIFF
--- a/table/arrow_utils.go
+++ b/table/arrow_utils.go
@@ -2120,7 +2120,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 	// V3+ tables write deletion vectors via Puffin regardless of partitioning,
 	// matching the Java reference implementation, which hardcodes DV for v3 and
 	// does not expose a property to opt out. The DV path threads each data
-	// file's spec id and partition record through DVWriter.Add so partitioned
+	// file's spec id and partition record through DVWriter so partitioned
 	// outputs carry the correct manifest-entry partition.
 	if latestMetadata.Version() >= 3 {
 		return positionDeleteRecordsToDataFilesDV(ctx, rootLocation, args, latestMetadata, partitionContextByFilePath)
@@ -2178,7 +2178,7 @@ func positionDeleteRecordsToDataFiles(ctx context.Context, rootLocation string, 
 // positionDeleteRecordsToDataFilesDV produces deletion-vector Puffin output
 // for v3+ tables. Each row's data file path must have an entry in
 // partitionContextByFilePath: the (specID, partitionData) is captured on
-// DVWriter.Add and lands on the output DataFile manifest entry, mirroring
+// DVWriter.Load/AddPosition and lands on the output DataFile manifest entry, mirroring
 // Java's BaseDVFileWriter, which keys deletes by (path, spec, partition).
 // A missing entry is a programming error (the caller failed to pre-register
 // every data file targeted by the delete) and surfaces as an error rather
@@ -2230,7 +2230,7 @@ func positionDeleteRecordsToDataFilesDV(ctx context.Context, rootLocation string
 
 					return
 				}
-				if err := writer.Add(filePath, []int64{positions.Value(int(i))}, pCtx.specID, pCtx.partitionData); err != nil {
+				if err := writer.AddPosition(filePath, positions.Value(int(i)), pCtx.specID, pCtx.partitionData); err != nil {
 					yield(nil, err)
 
 					return

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -66,6 +66,29 @@ func NewDVWriter(fs iceio.WriteFileIO, specByID SpecResolver) *DVWriter {
 	}
 }
 
+func (w *DVWriter) getOrCreateEntry(dataFilePath string, specID int32, partitionData map[int]any) *dvEntry {
+	entry, ok := w.entries[dataFilePath]
+	if ok {
+		return entry
+	}
+
+	// Defensive copy of partitionData on capture so a caller that
+	// mutates or reuses the map between calls and Flush can't silently
+	// corrupt the entry. Mirrors Java's StructLikeUtil.copy(partition)
+	// in BaseDVFileWriter.Deletes. partitionData=nil round-trips as
+	// nil (maps.Clone returns nil on nil input). specID is a value
+	// type so no copy is needed.
+	entry = &dvEntry{
+		bitmap:        NewRoaringPositionBitmap(),
+		specID:        specID,
+		partitionData: maps.Clone(partitionData),
+	}
+	w.entries[dataFilePath] = entry
+	w.order = append(w.order, dataFilePath)
+
+	return entry
+}
+
 // Add accumulates positions to delete for a given data file. specID and
 // partitionData come from the data file's own manifest entry (typically
 // partitionContext.specID + partitionContext.partitionData on the caller
@@ -100,22 +123,7 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 		}
 	}
 
-	entry, ok := w.entries[dataFilePath]
-	if !ok {
-		// Defensive copy of partitionData on capture so a caller that
-		// mutates or reuses the map between Add and Flush can't silently
-		// corrupt the entry. Mirrors Java's StructLikeUtil.copy(partition)
-		// in BaseDVFileWriter.Deletes. partitionData=nil round-trips as
-		// nil (maps.Clone returns nil on nil input). specID is a value
-		// type so no copy is needed.
-		entry = &dvEntry{
-			bitmap:        NewRoaringPositionBitmap(),
-			specID:        specID,
-			partitionData: maps.Clone(partitionData),
-		}
-		w.entries[dataFilePath] = entry
-		w.order = append(w.order, dataFilePath)
-	}
+	entry := w.getOrCreateEntry(dataFilePath, specID, partitionData)
 
 	for _, pos := range positions {
 		entry.bitmap.Set(uint64(pos))
@@ -125,26 +133,19 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 }
 
 // AddPosition accumulates one position to delete for a given data file.
-// It has the same first-write partition metadata and validation semantics as
-// Add, without requiring callers that process one deleted row at a time to
-// allocate a one-element positions slice.
+// It has the same first-write partition metadata and per-call validation
+// semantics as Add, while avoiding Add's batch loop for callers that process
+// one deleted row at a time. This mirrors Java's per-position delete operation.
+// AddPosition calls are independent rather than transactional as a group. If
+// a later call fails, positions added by earlier successful calls remain in
+// the writer.
 func (w *DVWriter) AddPosition(dataFilePath string, position int64, specID int32, partitionData map[int]any) error {
 	if position < 0 {
 		return fmt.Errorf("%w: invalid deletion position %d for %q: positions must be >= 0",
 			iceberg.ErrInvalidArgument, position, dataFilePath)
 	}
 
-	entry, ok := w.entries[dataFilePath]
-	if !ok {
-		// Keep the same defensive-copy and first-write-wins semantics as Add.
-		entry = &dvEntry{
-			bitmap:        NewRoaringPositionBitmap(),
-			specID:        specID,
-			partitionData: maps.Clone(partitionData),
-		}
-		w.entries[dataFilePath] = entry
-		w.order = append(w.order, dataFilePath)
-	}
+	entry := w.getOrCreateEntry(dataFilePath, specID, partitionData)
 
 	entry.bitmap.Set(uint64(position))
 
@@ -152,15 +153,16 @@ func (w *DVWriter) AddPosition(dataFilePath string, position int64, specID int32
 }
 
 // Load seeds the writer with an already-written deletion vector for a data
-// file so subsequent Add calls merge new positions into it. The spec permits
-// at most one DV per data file per snapshot, so when a data file that already
-// has a DV receives more deletes the old positions must be carried into the
-// replacement DV (and the old DV superseded) rather than dropped.
+// file so subsequent Add or AddPosition calls merge new positions into it.
+// The spec permits at most one DV per data file per snapshot. When a data file
+// that already has a DV receives more deletes, the old positions must be
+// carried into the replacement DV (and the old DV superseded) rather than dropped.
 //
-// Load is intended to be called before any Add for the same path: on the first
-// call for a path it captures specID and partitionData exactly as Add would and
-// unions the supplied bitmap into a fresh entry. If an entry already exists
-// (because Add or Load ran first for this path), Load only unions the bitmap in
+// Load is intended to be called before any Add or AddPosition call for the same
+// path: on the first call for a path it captures specID and partitionData
+// exactly as Add would and unions the supplied bitmap into a fresh entry. If an
+// entry already exists (because Add, AddPosition, or Load ran first for this
+// path), Load only unions the bitmap in
 // and the earlier specID/partitionData are kept — the later values are ignored,
 // mirroring Add's first-write-wins behavior. Callers must not pass conflicting
 // partition values across calls for the same path.
@@ -170,16 +172,7 @@ func (w *DVWriter) AddPosition(dataFilePath string, position int64, specID int32
 // useful — collectExistingDVs always supplies a non-nil bitmap read from the
 // existing DV.)
 func (w *DVWriter) Load(dataFilePath string, bitmap *RoaringPositionBitmap, specID int32, partitionData map[int]any) {
-	entry, ok := w.entries[dataFilePath]
-	if !ok {
-		entry = &dvEntry{
-			bitmap:        NewRoaringPositionBitmap(),
-			specID:        specID,
-			partitionData: maps.Clone(partitionData),
-		}
-		w.entries[dataFilePath] = entry
-		w.order = append(w.order, dataFilePath)
-	}
+	entry := w.getOrCreateEntry(dataFilePath, specID, partitionData)
 
 	entry.bitmap.Or(bitmap)
 }

--- a/table/dv/dv_writer.go
+++ b/table/dv/dv_writer.go
@@ -124,6 +124,33 @@ func (w *DVWriter) Add(dataFilePath string, positions []int64, specID int32, par
 	return nil
 }
 
+// AddPosition accumulates one position to delete for a given data file.
+// It has the same first-write partition metadata and validation semantics as
+// Add, without requiring callers that process one deleted row at a time to
+// allocate a one-element positions slice.
+func (w *DVWriter) AddPosition(dataFilePath string, position int64, specID int32, partitionData map[int]any) error {
+	if position < 0 {
+		return fmt.Errorf("%w: invalid deletion position %d for %q: positions must be >= 0",
+			iceberg.ErrInvalidArgument, position, dataFilePath)
+	}
+
+	entry, ok := w.entries[dataFilePath]
+	if !ok {
+		// Keep the same defensive-copy and first-write-wins semantics as Add.
+		entry = &dvEntry{
+			bitmap:        NewRoaringPositionBitmap(),
+			specID:        specID,
+			partitionData: maps.Clone(partitionData),
+		}
+		w.entries[dataFilePath] = entry
+		w.order = append(w.order, dataFilePath)
+	}
+
+	entry.bitmap.Set(uint64(position))
+
+	return nil
+}
+
 // Load seeds the writer with an already-written deletion vector for a data
 // file so subsequent Add calls merge new positions into it. The spec permits
 // at most one DV per data file per snapshot, so when a data file that already

--- a/table/dv/dv_writer_bench_test.go
+++ b/table/dv/dv_writer_bench_test.go
@@ -22,11 +22,15 @@ import "testing"
 func BenchmarkDVWriterAddSinglePosition(b *testing.B) {
 	w := NewDVWriter(nil, nil)
 	const dataFilePath = "s3://bucket/data/file.parquet"
+	// Seed a fixed-size bitmap so the timed loop does not measure bitmap growth.
+	if err := w.Add(dataFilePath, []int64{0}, 0, nil); err != nil {
+		b.Fatal(err)
+	}
 
-	b.ReportAllocs()
 	b.ResetTimer()
-	for i := range b.N {
-		if err := w.Add(dataFilePath, []int64{int64(i)}, 0, nil); err != nil {
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if err := w.Add(dataFilePath, []int64{1}, 0, nil); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -35,11 +39,15 @@ func BenchmarkDVWriterAddSinglePosition(b *testing.B) {
 func BenchmarkDVWriterAddPosition(b *testing.B) {
 	w := NewDVWriter(nil, nil)
 	const dataFilePath = "s3://bucket/data/file.parquet"
+	// Seed a fixed-size bitmap so the timed loop does not measure bitmap growth.
+	if err := w.AddPosition(dataFilePath, 0, 0, nil); err != nil {
+		b.Fatal(err)
+	}
 
-	b.ReportAllocs()
 	b.ResetTimer()
-	for i := range b.N {
-		if err := w.AddPosition(dataFilePath, int64(i), 0, nil); err != nil {
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if err := w.AddPosition(dataFilePath, 1, 0, nil); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/table/dv/dv_writer_bench_test.go
+++ b/table/dv/dv_writer_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkDVWriterAddSinglePosition(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if err := w.Add(dataFilePath, []int64{int64(i)}, 0, nil); err != nil {
 			b.Fatal(err)
 		}
@@ -38,7 +38,7 @@ func BenchmarkDVWriterAddPosition(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if err := w.AddPosition(dataFilePath, int64(i), 0, nil); err != nil {
 			b.Fatal(err)
 		}

--- a/table/dv/dv_writer_bench_test.go
+++ b/table/dv/dv_writer_bench_test.go
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dv
+
+import "testing"
+
+func BenchmarkDVWriterAddSinglePosition(b *testing.B) {
+	w := NewDVWriter(nil, nil)
+	const dataFilePath = "s3://bucket/data/file.parquet"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := w.Add(dataFilePath, []int64{int64(i)}, 0, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDVWriterAddPosition(b *testing.B) {
+	w := NewDVWriter(nil, nil)
+	const dataFilePath = "s3://bucket/data/file.parquet"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := w.AddPosition(dataFilePath, int64(i), 0, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -206,6 +206,7 @@ func TestDVWriterAddPosition(t *testing.T) {
 	partition := map[int]any{1000: "EU"}
 
 	require.NoError(t, w.AddPosition(dataPath, 1, 0, partition))
+	partition[1000] = "MUTATED"
 	require.NoError(t, w.AddPosition(dataPath, 3, 0, partition))
 	require.NoError(t, w.AddPosition(dataPath, 1, 0, map[int]any{1000: "US"}))
 
@@ -213,7 +214,7 @@ func TestDVWriterAddPosition(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dataFiles, 1)
 	assert.Equal(t, int64(2), dataFiles[0].Count())
-	assert.Equal(t, partition, dataFiles[0].Partition())
+	assert.Equal(t, map[int]any{1000: "EU"}, dataFiles[0].Partition())
 	verifyDVReadBack(t, fs, dataFiles[0])
 }
 
@@ -254,6 +255,26 @@ func TestDVWriterAddPositionRejectsNegativePosition(t *testing.T) {
 	dataFiles, err := w.Flush(context.Background(), "mem://test/negative-position.puffin")
 	require.NoError(t, err)
 	assert.Nil(t, dataFiles)
+}
+
+func TestDVWriterAddPositionRejectsNegativeAfterValidPosition(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs, unpartitionedResolver())
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	require.NoError(t, w.AddPosition(dataPath, 1, 0, nil))
+	require.ErrorIs(t, w.AddPosition(dataPath, -1, 0, nil), iceberg.ErrInvalidArgument)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/negative-position-after-valid.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+	assert.Equal(t, int64(1), dataFiles[0].Count(),
+		"negative AddPosition should not mutate prior valid state")
+
+	bm, err := ReadDV(fs, dataFiles[0])
+	require.NoError(t, err)
+	assert.True(t, bm.Contains(1))
+	assert.Equal(t, dataFiles[0].Count(), bm.Cardinality())
 }
 
 func TestDVWriterAddNegativeFirstCreatesNoEntry(t *testing.T) {

--- a/table/dv/dv_writer_test.go
+++ b/table/dv/dv_writer_test.go
@@ -193,6 +193,30 @@ func TestDVWriterDeduplicatesPositions(t *testing.T) {
 	verifyDVReadBack(t, fs, dataFiles[0])
 }
 
+func TestDVWriterAddPosition(t *testing.T) {
+	fs := newTestFS()
+	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
+		SourceIDs: []int{2},
+		FieldID:   1000,
+		Name:      "region",
+		Transform: iceberg.IdentityTransform{},
+	})
+	w := NewDVWriter(fs, specMapResolver(spec))
+	dataPath := "s3://bucket/region=EU/file.parquet"
+	partition := map[int]any{1000: "EU"}
+
+	require.NoError(t, w.AddPosition(dataPath, 1, 0, partition))
+	require.NoError(t, w.AddPosition(dataPath, 3, 0, partition))
+	require.NoError(t, w.AddPosition(dataPath, 1, 0, map[int]any{1000: "US"}))
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/add-position.puffin")
+	require.NoError(t, err)
+	require.Len(t, dataFiles, 1)
+	assert.Equal(t, int64(2), dataFiles[0].Count())
+	assert.Equal(t, partition, dataFiles[0].Partition())
+	verifyDVReadBack(t, fs, dataFiles[0])
+}
+
 func TestDVWriterAddRejectsNegativePositions(t *testing.T) {
 	fs := newTestFS()
 	w := NewDVWriter(fs, unpartitionedResolver())
@@ -217,6 +241,19 @@ func TestDVWriterAddRejectsNegativePositions(t *testing.T) {
 	assert.False(t, bm.Contains(7))
 
 	assert.Equal(t, dataFiles[0].Count(), bm.Cardinality())
+}
+
+func TestDVWriterAddPositionRejectsNegativePosition(t *testing.T) {
+	fs := newTestFS()
+	w := NewDVWriter(fs, unpartitionedResolver())
+
+	dataPath := "s3://bucket/data/file-001.parquet"
+	err := w.AddPosition(dataPath, -1, 0, nil)
+	require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+
+	dataFiles, err := w.Flush(context.Background(), "mem://test/negative-position.puffin")
+	require.NoError(t, err)
+	assert.Nil(t, dataFiles)
 }
 
 func TestDVWriterAddNegativeFirstCreatesNoEntry(t *testing.T) {


### PR DESCRIPTION
## What changed

The v3 deletion-vector path handles one deleted row at a time. It currently calls:

```go
writer.Add(filePath, []int64{position}, specID, partitionData)
```

That goes through the slice API even though there is only one position.

This PR:

- Adds `DVWriter.AddPosition`.
- Sets the position directly on the per-file bitmap.
- Uses the new method from the v3 Arrow path.
- Keeps `Add` for callers that already have a slice.

## Correctness

- Negative positions still return `iceberg.ErrInvalidArgument`.
- Repeated positions are still deduplicated.
- The first call still captures `specID` and a defensive copy of `partitionData`.
- A rejected position does not create a writer entry.
- Puffin output and flush behavior are unchanged.

## Benchmark

Local Apple M1 Pro, Go 1.26.3, five runs:

- `Add`: 16.8 ns/op, 0 allocs/op
- `AddPosition`: 15.5 ns/op, 0 allocs/op

The focused benchmark is about 7% faster with `AddPosition`.

## Tests

- `go test ./table/dv ./table`
- `go test -race ./table/dv ./table`
- `go vet ./table/dv ./table`