### PR TITLE
perf(table): reuse position-delete file metadata

### DIFF
--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -3066,7 +3066,8 @@ func TestAppendParquetPositionDeleteRowsRejectsNegativePosition(t *testing.T) {
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
+		positionDeleteFileMeta{},
+		func(positionDeleteFileMeta, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 
 			return true, nil
@@ -3152,7 +3153,8 @@ func TestAppendParquetPositionDeleteRowsRejectsNullRow(t *testing.T) {
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		context.Background(), memFS, newPosDeleteFile(t, deletePath, 1, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
+		positionDeleteFileMeta{},
+		func(positionDeleteFileMeta, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 
 			return true, nil
@@ -3450,7 +3452,8 @@ func TestAppendParquetPositionDeleteRowsStopsOnContextCancellation(t *testing.T)
 	rows := 0
 	keepGoing, err := appendParquetPositionDeleteRows(
 		ctx, memFS, newPosDeleteFile(t, deletePath, 2, 128),
-		func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error) {
+		positionDeleteFileMeta{},
+		func(positionDeleteFileMeta, string, int64, scalar.Scalar, bool) (bool, error) {
 			rows++
 			cancel()
 

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -103,6 +104,14 @@ type positionDeleteRecordAppender struct {
 	partitionIDByOld map[int]int
 	formatVersion    int
 	projection       positionDeleteProjectionOptions
+}
+
+type positionDeleteFileMeta struct {
+	partition      map[int]any
+	specID         int32
+	deleteFilePath string
+	contentOffset  *int64
+	contentSize    *int64
 }
 
 type positionDeleteProjectionOptions struct {
@@ -189,6 +198,43 @@ func (a positionDeleteRecordAppender) append(
 	deletedRow scalar.Scalar,
 	projected ...bool,
 ) error {
+	return a.appendPrepared(a.prepareFile(file), dataFilePath, pos, deletedRow, projected...)
+}
+
+func (a positionDeleteRecordAppender) prepareFile(file iceberg.DataFile) positionDeleteFileMeta {
+	meta := positionDeleteFileMeta{
+		specID:         file.SpecID(),
+		deleteFilePath: file.FilePath(),
+	}
+	if a.partition != nil {
+		borrowedPartition := dataFilePartition(file)
+		meta.partition = make(map[int]any, len(borrowedPartition))
+		for oldID, value := range borrowedPartition {
+			newID, ok := a.partitionIDByOld[oldID]
+			if !ok {
+				continue
+			}
+			if bytes, ok := value.([]byte); ok {
+				value = slices.Clone(bytes)
+			}
+			meta.partition[newID] = value
+		}
+	}
+	if a.formatVersion >= 3 || file.FileFormat() == iceberg.PuffinFile {
+		meta.contentOffset = file.ContentOffset()
+		meta.contentSize = positionDeleteContentSize(file)
+	}
+
+	return meta
+}
+
+func (a positionDeleteRecordAppender) appendPrepared(
+	meta positionDeleteFileMeta,
+	dataFilePath string,
+	pos int64,
+	deletedRow scalar.Scalar,
+	projected ...bool,
+) error {
 	a.filePath.Append(dataFilePath)
 	a.pos.Append(pos)
 	var err error
@@ -206,21 +252,15 @@ func (a positionDeleteRecordAppender) append(
 	}
 
 	if a.partition != nil {
-		partition := make(map[int]any, len(file.Partition()))
-		for oldID, value := range file.Partition() {
-			if newID, ok := a.partitionIDByOld[oldID]; ok {
-				partition[newID] = value
-			}
-		}
-		if err := a.partition.append(partition); err != nil {
+		if err := a.partition.append(meta.partition); err != nil {
 			return err
 		}
 	}
-	a.specID.Append(file.SpecID())
-	a.deleteFilePath.Append(file.FilePath())
+	a.specID.Append(meta.specID)
+	a.deleteFilePath.Append(meta.deleteFilePath)
 	if a.formatVersion >= 3 {
-		appendInspectOptionalInt64(a.contentOffset, file.ContentOffset())
-		appendInspectOptionalInt64(a.contentSize, positionDeleteContentSize(file))
+		appendInspectOptionalInt64(a.contentOffset, meta.contentOffset)
+		appendInspectOptionalInt64(a.contentSize, meta.contentSize)
 	}
 
 	return nil
@@ -482,8 +522,8 @@ func (i InspectTable) positionDeleteRecordReader(
 		yieldError := func(err error) {
 			_ = yield(nil, err)
 		}
-		appendRow := func(file iceberg.DataFile, path string, pos int64, deletedRow scalar.Scalar, projected bool) (bool, error) {
-			if err := appender.append(file, path, pos, deletedRow, projected); err != nil {
+		appendRow := func(meta positionDeleteFileMeta, path string, pos int64, deletedRow scalar.Scalar, projected bool) (bool, error) {
+			if err := appender.appendPrepared(meta, path, pos, deletedRow, projected); err != nil {
 				return false, err
 			}
 			rows++
@@ -523,9 +563,12 @@ func (i InspectTable) positionDeleteRecordReader(
 				var keepGoing bool
 				switch file.FileFormat() {
 				case iceberg.PuffinFile:
-					keepGoing, err = appendDeletionVectorRows(ctx, fs, file, appendRow)
+					meta := appender.prepareFile(file)
+					keepGoing, err = appendDeletionVectorRows(ctx, fs, file, meta, appendRow)
 				case iceberg.ParquetFile:
-					keepGoing, err = appendParquetPositionDeleteRows(ctx, fs, file, appendRow, appender.projection)
+					meta := appender.prepareFile(file)
+					keepGoing, err = appendParquetPositionDeleteRows(
+						ctx, fs, file, meta, appendRow, appender.projection)
 				default:
 					keepGoing = false
 					err = fmt.Errorf("%w: unsupported position delete file format %s",
@@ -551,12 +594,13 @@ func (i InspectTable) positionDeleteRecordReader(
 	})
 }
 
-type appendPositionDeleteRow func(iceberg.DataFile, string, int64, scalar.Scalar, bool) (bool, error)
+type appendPositionDeleteRow func(positionDeleteFileMeta, string, int64, scalar.Scalar, bool) (bool, error)
 
 func appendDeletionVectorRows(
 	ctx context.Context,
 	fs iceio.IO,
 	file iceberg.DataFile,
+	meta positionDeleteFileMeta,
 	appendRow appendPositionDeleteRow,
 ) (bool, error) {
 	referencedDataFile := file.ReferencedDataFile()
@@ -564,7 +608,7 @@ func appendDeletionVectorRows(
 		return false, fmt.Errorf("%w: deletion vector is missing referenced_data_file",
 			iceberg.ErrInvalidSchema)
 	}
-	if file.ContentOffset() == nil || file.ContentSizeInBytes() == nil {
+	if meta.contentOffset == nil || meta.contentSize == nil {
 		return false, fmt.Errorf("%w: deletion vector is missing content_offset/content_size_in_bytes",
 			iceberg.ErrInvalidSchema)
 	}
@@ -579,7 +623,7 @@ func appendDeletionVectorRows(
 		if position > math.MaxInt64 {
 			return false, fmt.Errorf("%w: deletion position %d exceeds int64", iceberg.ErrInvalidSchema, position)
 		}
-		keepGoing, err := appendRow(file, *referencedDataFile, int64(position), nil, false)
+		keepGoing, err := appendRow(meta, *referencedDataFile, int64(position), nil, false)
 		if err != nil || !keepGoing {
 			return keepGoing, err
 		}
@@ -592,6 +636,7 @@ func appendParquetPositionDeleteRows(
 	ctx context.Context,
 	fs iceio.IO,
 	file iceberg.DataFile,
+	meta positionDeleteFileMeta,
 	appendRow appendPositionDeleteRow,
 	options ...positionDeleteProjectionOptions,
 ) (keepGoing bool, err error) {
@@ -627,7 +672,7 @@ func appendParquetPositionDeleteRows(
 
 	for records.Next() {
 		continueReading, appendErr := appendPositionDeleteRecord(
-			ctx, file, records.RecordBatch(), appendRow, projection)
+			ctx, meta, records.RecordBatch(), appendRow, projection)
 		if appendErr != nil || !continueReading {
 			return continueReading, appendErr
 		}
@@ -641,7 +686,7 @@ func appendParquetPositionDeleteRows(
 
 func appendPositionDeleteRecord(
 	ctx context.Context,
-	file iceberg.DataFile,
+	meta positionDeleteFileMeta,
 	record arrow.RecordBatch,
 	appendRow appendPositionDeleteRow,
 	projection positionDeleteProjectionOptions,
@@ -715,7 +760,7 @@ func appendPositionDeleteRecord(
 			}
 		}
 		continueReading, appendErr := appendRow(
-			file, filePaths.Value(row), positions.Value(row), deletedRow, projected)
+			meta, filePaths.Value(row), positions.Value(row), deletedRow, projected)
 		releasePositionDeleteScalar(deletedRow)
 		if appendErr != nil || !continueReading {
 			return continueReading, appendErr

--- a/table/inspect_position_deletes_bench_test.go
+++ b/table/inspect_position_deletes_bench_test.go
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this
+// file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+type countingPositionDeleteDataFile struct {
+	iceberg.DataFile
+	partitionCalls     int
+	specIDCalls        int
+	filePathCalls      int
+	contentOffsetCalls int
+	contentSizeCalls   int
+}
+
+func (f *countingPositionDeleteDataFile) Partition() map[int]any {
+	f.partitionCalls++
+
+	return f.DataFile.Partition()
+}
+
+func (f *countingPositionDeleteDataFile) SpecID() int32 {
+	f.specIDCalls++
+
+	return f.DataFile.SpecID()
+}
+
+func (f *countingPositionDeleteDataFile) FilePath() string {
+	f.filePathCalls++
+
+	return f.DataFile.FilePath()
+}
+
+func (f *countingPositionDeleteDataFile) ContentOffset() *int64 {
+	f.contentOffsetCalls++
+
+	return f.DataFile.ContentOffset()
+}
+
+func (f *countingPositionDeleteDataFile) ContentSizeInBytes() *int64 {
+	f.contentSizeCalls++
+
+	return f.DataFile.ContentSizeInBytes()
+}
+
+func TestPositionDeleteAppenderReusesFileMetadata(t *testing.T) {
+	schema := simpleSchema()
+	spec := partitionedSpec()
+	baseBuilder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentPosDeletes,
+		"mem://position-deletes/table/data/delete.puffin",
+		iceberg.PuffinFile,
+		map[int]any{1000: int32(7)},
+		nil,
+		nil,
+		3,
+		128,
+	)
+	require.NoError(t, err)
+	baseFile := baseBuilder.ContentOffset(16).ContentSizeInBytes(64).Build()
+	file := &countingPositionDeleteDataFile{DataFile: baseFile}
+
+	partitionType := spec.PartitionType(schema)
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(schema, partitionType, 3), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(
+		bldr, partitionType, map[int]int{1000: 1000}, 3)
+	require.NoError(t, err)
+
+	meta := appender.prepareFile(file)
+	require.Equal(t, map[int]any{1000: int32(7)}, meta.partition)
+	require.EqualValues(t, 0, meta.specID)
+	require.Equal(t, baseFile.FilePath(), meta.deleteFilePath)
+	require.Equal(t, int64(16), *meta.contentOffset)
+	require.Equal(t, int64(64), *meta.contentSize)
+
+	for pos := range 100 {
+		require.NoError(t, appender.appendPrepared(
+			meta, "mem://position-deletes/table/data/data.parquet", int64(pos), nil, false))
+	}
+
+	record := bldr.NewRecordBatch()
+	defer record.Release()
+	require.EqualValues(t, 100, record.NumRows())
+	partition := record.Column(3).(*array.Struct)
+	require.EqualValues(t, 7, partition.Field(0).(*array.Int32).Value(0))
+	require.EqualValues(t, 0, record.Column(4).(*array.Int32).Value(0))
+	require.Equal(t, baseFile.FilePath(), record.Column(5).(*array.String).Value(0))
+	require.EqualValues(t, 16, record.Column(6).(*array.Int64).Value(0))
+	require.EqualValues(t, 64, record.Column(7).(*array.Int64).Value(0))
+
+	require.Equal(t, 1, file.partitionCalls)
+	require.Equal(t, 1, file.specIDCalls)
+	require.Equal(t, 1, file.filePathCalls)
+	require.Equal(t, 1, file.contentOffsetCalls)
+	require.Equal(t, 1, file.contentSizeCalls)
+}
+
+func TestPositionDeleteAppenderCopiesBinaryPartitionValueWhenPreparingMetadata(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "part", Type: iceberg.PrimitiveTypes.Binary, Required: false},
+	}}
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(simpleSchema(), partitionType, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(
+		bldr, partitionType, map[int]int{1000: 1000}, 2)
+	require.NoError(t, err)
+
+	partitionValue := []byte("before")
+	file := &mockDataFile{
+		path:      "mem://position-deletes/table/data/delete.parquet",
+		format:    iceberg.ParquetFile,
+		partition: map[int]any{1000: partitionValue},
+	}
+	meta := appender.prepareFile(file)
+	partitionValue[0] = 'a'
+
+	require.Equal(t, []byte("before"), meta.partition[1000])
+}
+
+func TestPositionDeleteAppenderDoesNotReadUnpartitionedPartition(t *testing.T) {
+	file := &countingPositionDeleteDataFile{
+		DataFile: newPosDeleteFile(t,
+			"mem://position-deletes/table/data/delete.parquet", 1, 128),
+	}
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(simpleSchema(), &iceberg.StructType{}, 2), nil, true, false)
+	require.NoError(t, err)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(
+		bldr, &iceberg.StructType{}, nil, 2)
+	require.NoError(t, err)
+
+	meta := appender.prepareFile(file)
+
+	require.Nil(t, meta.partition)
+	require.Zero(t, file.partitionCalls)
+}
+
+func BenchmarkPositionDeleteAppender(b *testing.B) {
+	for _, fieldCount := range []int{1, 5} {
+		for _, rowCount := range []int{1_000, 100_000} {
+			for _, reuse := range []struct {
+				name  string
+				reuse bool
+			}{
+				{name: "prepare_per_row", reuse: false},
+				{name: "prepare_once", reuse: true},
+			} {
+				b.Run(fmt.Sprintf("fields=%d/rows=%d/%s", fieldCount, rowCount, reuse.name),
+					func(b *testing.B) {
+						benchmarkPositionDeleteAppender(b, fieldCount, rowCount, reuse.reuse)
+					})
+			}
+		}
+	}
+}
+
+func benchmarkPositionDeleteAppender(b *testing.B, fieldCount, rowCount int, reuse bool) {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	partitionValues := make(map[int]any, fieldCount)
+	partitionIDs := make(map[int]int, fieldCount)
+	for i := range fieldCount {
+		sourceID := i + 1
+		fieldID := 1000 + i
+		schemaFields[i] = iceberg.NestedField{
+			ID: sourceID, Name: fmt.Sprintf("source_%d", sourceID),
+			Type: iceberg.PrimitiveTypes.Int32, Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{sourceID}, FieldID: fieldID,
+			Name: fmt.Sprintf("partition_%d", fieldID), Transform: iceberg.IdentityTransform{},
+		}
+		partitionValues[fieldID] = int32(i)
+		partitionIDs[fieldID] = fieldID
+	}
+
+	tableSchema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(partitionFields...)
+	partitionType := spec.PartitionType(tableSchema)
+	fileBuilder, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentPosDeletes, "delete.puffin", iceberg.PuffinFile,
+		partitionValues, nil, nil, int64(rowCount), 128)
+	if err != nil {
+		b.Fatal(err)
+	}
+	file := fileBuilder.ContentOffset(16).ContentSizeInBytes(64).Build()
+
+	outputSchema, err := SchemaToArrowSchema(
+		PositionDeletesSchema(tableSchema, partitionType, 3), nil, true, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, outputSchema)
+	defer bldr.Release()
+	appender, err := newPositionDeleteRecordAppender(bldr, partitionType, partitionIDs, 3)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(rowCount), "rows/op")
+	b.ResetTimer()
+	for range b.N {
+		var meta positionDeleteFileMeta
+		if reuse {
+			meta = appender.prepareFile(file)
+		}
+		for pos := range rowCount {
+			var err error
+			if reuse {
+				err = appender.appendPrepared(
+					meta, "data.parquet", int64(pos), nil, false)
+			} else {
+				err = appender.append(file, "data.parquet", int64(pos), nil, false)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		record := bldr.NewRecordBatch()
+		record.Release()
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
## Summary

- **Reuse** metadata that is constant for all rows from one position-delete file.
- Prepare the partition, spec ID, delete-file path, and v3 content metadata once per file.
- Pass the prepared metadata through both the Puffin DV and Parquet position-delete paths.
- Keep the public DataFile getters unchanged.
- No public API changes.

## Why

InspectTable.PositionDeletes() emits one row per deleted position. Before this change, the appender rebuilt the same file metadata for every row.

This was especially expensive for partitioned delete files:

- Partition() returned a defensive copy for each row.
- The partition map was remapped for each row.
- v3 offset and size metadata were read for each row.
- A deletion vector with 100,000 positions repeated this work 100,000 times.

The change moves that work from per-row to per-file. Binary partition values are copied once before the prepared metadata is reused.

## Correctness

- The borrowed partition helper is used only for the internal preparation step.
- The remapped partition map is owned by the prepared metadata.
- Public DataFile getter behavior is unchanged.
- Existing output and v3 metadata coverage continue to pass.

## Validation

- go test ./...
- go test -race ./table
- go test -tags=assert -v -run="^(TestInspectFilesTablesEarlyRelease|TestInspectDataFilesEmitsEmptyBatchWhenAllEntriesAreDeleted|TestInspectDataFilesEmptyTableEarlyRelease|TestInspectPositionDeletesEarlyRelease)$" ./table
- go vet ./table

## Benchmark

Focused appender benchmark comparing preparation once per row with preparation once per file:

- 100k rows, 1 partition field: 34.1 ms, 52.0 MB, 600k allocs -> 14.8 ms, 24.8 MB, 200k allocs
- 100k rows, 5 partition fields: 75.7 ms, 77.1 MB, 1.4M allocs -> 49.9 ms, 49.9 MB, 1.0M allocs

Benchmark: table/inspect_position_deletes_bench_test.go