### PR TITLE
perf(table): borrow partition records during scan planning

### DIFF
--- a/data_file_refs.go
+++ b/data_file_refs.go
@@ -31,8 +31,7 @@ import "github.com/apache/iceberg-go/internal"
 // evaluators. ColumnSizes and DistinctValueCounts are excluded because the
 // evaluator does not read them, and cloning those maps would add work to the
 // hot path without changing its result. Partition has a separate borrowed
-// accessor because partition records are built once per file during scan
-// planning.
+// accessor because partition data is read during scan planning.
 func (d *dataFile) DataFileStatsRef(_ internal.DataFileRef) (
 	valueCounts map[int]int64,
 	nullCounts map[int]int64,

--- a/table/data_file_stats_ref_test.go
+++ b/table/data_file_stats_ref_test.go
@@ -255,6 +255,31 @@ func TestDataFilePartitionFallsBackToPublicGetter(t *testing.T) {
 	assert.Equal(t, map[int]any{1000: "partition"}, dataFilePartition(file))
 }
 
+func TestBorrowedPartitionRecordUsesPartitionFieldOrder(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "first", Type: iceberg.PrimitiveTypes.Int32},
+		{ID: 1001, Name: "second", Type: iceberg.PrimitiveTypes.Binary},
+	}}
+	partition := map[int]any{
+		1000: int32(7),
+		1001: []byte{1, 2},
+	}
+	record := borrowedPartitionRecord{
+		partition:     partition,
+		partitionType: partitionType,
+	}
+
+	assert.Equal(t, 2, record.Size())
+	assert.Equal(t, int32(7), record.Get(0))
+	assert.Equal(t, []byte{1, 2}, record.Get(1))
+
+	binaryValue := record.Get(1).([]byte)
+	binaryValue[0] = 9
+	assert.Equal(t, []byte{9, 2}, partition[1001])
+	binaryValue[0] = 1
+	assert.Panics(t, func() { record.Set(0, int32(8)) })
+}
+
 func TestGetPartitionRecordClonesBinaryValues(t *testing.T) {
 	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
 		SourceIDs: []int{1}, FieldID: 1000, Name: "payload_part", Transform: iceberg.IdentityTransform{},

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -127,6 +127,26 @@ func (p partitionRecord) Size() int            { return len(p) }
 func (p partitionRecord) Get(pos int) any      { return p[pos] }
 func (p partitionRecord) Set(pos int, val any) { p[pos] = val }
 
+// borrowedPartitionRecord exposes a DataFile's immutable partition map in
+// partition-field order without materializing a positional record or cloning
+// binary values. It is only valid for the current evaluator call.
+type borrowedPartitionRecord struct {
+	partition     map[int]any
+	partitionType *iceberg.StructType
+}
+
+func (p borrowedPartitionRecord) Size() int {
+	return len(p.partitionType.FieldList)
+}
+
+func (p borrowedPartitionRecord) Get(pos int) any {
+	return p.partition[p.partitionType.FieldList[pos].ID]
+}
+
+func (borrowedPartitionRecord) Set(int, any) {
+	panic("cannot set a borrowed partition record")
+}
+
 // manifestEntries holds the data, positional delete, and equality delete
 // entries read from manifests.
 type manifestEntries struct {
@@ -542,7 +562,10 @@ func buildPartitionEvaluator(specID int, metadata Metadata, schema *iceberg.Sche
 	}
 
 	return func(d iceberg.DataFile) (bool, error) {
-		return fn(GetPartitionRecord(d, partType))
+		return fn(borrowedPartitionRecord{
+			partition:     dataFilePartition(d),
+			partitionType: partType,
+		})
 	}, nil
 }
 

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -704,6 +704,61 @@ func TestBuildPartitionEvaluatorWithInvalidSpecID(t *testing.T) {
 	assert.ErrorContains(t, err, "id 999")
 }
 
+func TestBuildPartitionEvaluatorMatchesPartitionValues(t *testing.T) {
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "id_part",
+		Transform: iceberg.IdentityTransform{},
+	})
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	})
+	metadata, err := NewMetadata(
+		schema, &spec, UnsortedSortOrder, "s3://test-bucket/test_table", iceberg.Properties{},
+	)
+	require.NoError(t, err)
+
+	partitionFilter := iceberg.EqualTo(iceberg.Reference("id_part"), int32(7))
+	partitionFilters := newKeyDefaultMapWrapErr(func(int) (iceberg.BooleanExpression, error) {
+		return partitionFilter, nil
+	})
+	evaluator, err := buildPartitionEvaluator(spec.ID(), metadata, schema, partitionFilters, true)
+	require.NoError(t, err)
+
+	dataFile, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"s3://test-bucket/test_table/data.parquet",
+		iceberg.ParquetFile,
+		map[int]any{1000: int32(7)},
+		nil,
+		nil,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+	matches, err := evaluator(dataFile.Build())
+	require.NoError(t, err)
+	assert.True(t, matches)
+
+	dataFile, err = iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"s3://test-bucket/test_table/other.parquet",
+		iceberg.ParquetFile,
+		map[int]any{1000: int32(8)},
+		nil,
+		nil,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+	matches, err = evaluator(dataFile.Build())
+	require.NoError(t, err)
+	assert.False(t, matches)
+}
+
 func TestTimeTravelManifestPruningUsesSnapshotSchema(t *testing.T) {
 	spec := iceberg.NewPartitionSpecID(0, iceberg.PartitionField{
 		SourceIDs: []int{1},

--- a/table/scanner_partition_bench_test.go
+++ b/table/scanner_partition_bench_test.go
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var partitionEvaluatorBenchmarkSink int
+
+func BenchmarkPartitionEvaluator(b *testing.B) {
+	for _, fieldCount := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("fields=%d/files=4096", fieldCount), func(b *testing.B) {
+			materialized, borrowed, files := benchmarkPartitionEvaluator(b, fieldCount, 4096)
+			benchmarkPartitionEvaluatorVariant(b, "materialized", files, materialized)
+			benchmarkPartitionEvaluatorVariant(b, "borrowed", files, borrowed)
+		})
+	}
+}
+
+func benchmarkPartitionEvaluatorVariant(
+	b *testing.B,
+	name string,
+	files []iceberg.DataFile,
+	evaluate func(iceberg.DataFile) (bool, error),
+) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			matched := 0
+			for _, file := range files {
+				matches, err := evaluate(file)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if matches {
+					matched++
+				}
+			}
+			partitionEvaluatorBenchmarkSink = matched
+		}
+		b.StopTimer()
+
+		if partitionEvaluatorBenchmarkSink != len(files)/2 {
+			b.Fatalf("expected %d matches, got %d", len(files)/2, partitionEvaluatorBenchmarkSink)
+		}
+	})
+}
+
+func benchmarkPartitionEvaluator(
+	b *testing.B,
+	fieldCount, fileCount int,
+) (func(iceberg.DataFile) (bool, error), func(iceberg.DataFile) (bool, error), []iceberg.DataFile) {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := range fieldCount {
+		sourceID := i + 1
+		fieldID := 1000 + i
+		name := fmt.Sprintf("partition_%d", fieldID)
+		schemaFields[i] = iceberg.NestedField{
+			ID: sourceID, Name: fmt.Sprintf("source_%d", sourceID),
+			Type: iceberg.PrimitiveTypes.Int32, Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{sourceID}, FieldID: fieldID,
+			Name: name, Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	schema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(partitionFields...)
+
+	filter := iceberg.EqualTo(iceberg.Reference("partition_1000"), int32(1))
+	partType := spec.PartitionType(schema)
+	partSchema := iceberg.NewSchema(0, partType.FieldList...)
+	fn, err := iceberg.ExpressionEvaluator(partSchema, filter, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	metadata, err := NewMetadata(
+		schema, &spec, UnsortedSortOrder, "s3://bucket/table", iceberg.Properties{},
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	partitionFilters := newKeyDefaultMapWrapErr(func(int) (iceberg.BooleanExpression, error) {
+		return filter, nil
+	})
+	borrowed, err := buildPartitionEvaluator(spec.ID(), metadata, schema, partitionFilters, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	materialized := func(file iceberg.DataFile) (bool, error) {
+		return fn(GetPartitionRecord(file, partType))
+	}
+
+	files := make([]iceberg.DataFile, fileCount)
+	for i := range files {
+		partition := make(map[int]any, fieldCount)
+		for field := range partitionFields {
+			partition[partitionFields[field].FieldID] = int32((i + field) % 2)
+		}
+		file, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, fmt.Sprintf("file-%d.parquet", i),
+			iceberg.ParquetFile, partition, nil, nil, 1, 1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = file.Build()
+	}
+
+	return materialized, borrowed, files
+}


### PR DESCRIPTION
## Summary

- **Borrow** partition data during scan planning through a read-only `StructLike` view.
- Avoid rebuilding a positional `[]any` record for every candidate data file.
- Avoid cloning binary partition values on the internal hot path.
- Keep public `GetPartitionRecord` behavior defensive and unchanged.
- No public API changes.

## Why

Scan planning reuses a partition predicate for every candidate data file. Before this change, each evaluation called `GetPartitionRecord`, which allocated a positional record, walked every partition field, and copied binary values.

The new internal view looks up partition values by field ID in partition-field order and is used only for the current evaluator call. Its `Set` method is read-only, so the borrowed data cannot be changed through the view.

## Performance

Focused `BenchmarkPartitionEvaluator` result for 4,096 files on an Apple M1 Pro:

- 1 partition field: about 0.51 ms/op and 295 KB/op -> 0.43 ms/op and 197 KB/op
- 8 partition fields: about 0.76 ms/op and 754 KB/op -> 0.42 ms/op and 197 KB/op
- 32 partition fields: about 2.84 ms/op and 2.33 MB/op -> 0.52 ms/op and 197 KB/op

Each case also drops from 12,288 to 8,192 allocations per benchmark operation.

## Tests

- `go test ./...`
- `go test -race ./table`
- `go vet ./table`
- `go test -tags=assert -run='^(TestBuildPartitionEvaluator|TestBorrowedPartitionRecord|TestGetPartitionRecord)' ./table`
- `git diff --check`