### PR TITLE
perf(manifest): remove reflection from partition summary updates

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -26,7 +26,6 @@ import (
 	"maps"
 	"math"
 	"math/big"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -1199,7 +1198,19 @@ type partitionFieldStats[T LiteralType] struct {
 	min          *T
 	max          *T
 
-	cmp Comparator[T]
+	cmp     Comparator[T]
+	convert partitionValueConverter[T]
+}
+
+type partitionValueConverter[T LiteralType] func(any) (T, bool)
+
+func partitionLiteralValue(value any) (any, bool) {
+	literal, ok := value.(Literal)
+	if !ok {
+		return nil, false
+	}
+
+	return literal.Any(), true
 }
 
 // unknownPartitionFieldStats records null presence but omits bounds because
@@ -1222,38 +1233,328 @@ func (p *unknownPartitionFieldStats) update(any) error {
 	return nil
 }
 
+func newPartitionFieldStats[T LiteralType](convert partitionValueConverter[T]) fieldStats {
+	return &partitionFieldStats[T]{
+		cmp:     getComparator[T](),
+		convert: convert,
+	}
+}
+
+func convertPartitionBool(value any) (bool, bool) {
+	converted, ok := value.(bool)
+
+	return converted, ok
+}
+
+func convertPartitionInt32(value any) (int32, bool) {
+	switch value := value.(type) {
+	case int:
+		return int32(value), true
+	case int8:
+		return int32(value), true
+	case int16:
+		return int32(value), true
+	case int32:
+		return value, true
+	case int64:
+		return int32(value), true
+	case uint:
+		return int32(value), true
+	case uint8:
+		return int32(value), true
+	case uint16:
+		return int32(value), true
+	case uint32:
+		return int32(value), true
+	case uint64:
+		return int32(value), true
+	case uintptr:
+		return int32(value), true
+	case float32:
+		return int32(value), true
+	case float64:
+		return int32(value), true
+	case Date:
+		return int32(value), true
+	case Time:
+		return int32(value), true
+	case Timestamp:
+		return int32(value), true
+	case TimestampNano:
+		return int32(value), true
+	case time.Duration:
+		return int32(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionInt32(literal)
+		}
+
+		return 0, false
+	}
+}
+
+func convertPartitionInt64(value any) (int64, bool) {
+	switch value := value.(type) {
+	case int:
+		return int64(value), true
+	case int8:
+		return int64(value), true
+	case int16:
+		return int64(value), true
+	case int32:
+		return int64(value), true
+	case int64:
+		return value, true
+	case uint:
+		return int64(value), true
+	case uint8:
+		return int64(value), true
+	case uint16:
+		return int64(value), true
+	case uint32:
+		return int64(value), true
+	case uint64:
+		return int64(value), true
+	case uintptr:
+		return int64(value), true
+	case float32:
+		return int64(value), true
+	case float64:
+		return int64(value), true
+	case Date:
+		return int64(value), true
+	case Time:
+		return int64(value), true
+	case Timestamp:
+		return int64(value), true
+	case TimestampNano:
+		return int64(value), true
+	case time.Duration:
+		return int64(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionInt64(literal)
+		}
+
+		return 0, false
+	}
+}
+
+func convertPartitionFloat32(value any) (float32, bool) {
+	switch value := value.(type) {
+	case int:
+		return float32(value), true
+	case int8:
+		return float32(value), true
+	case int16:
+		return float32(value), true
+	case int32:
+		return float32(value), true
+	case int64:
+		return float32(value), true
+	case uint:
+		return float32(value), true
+	case uint8:
+		return float32(value), true
+	case uint16:
+		return float32(value), true
+	case uint32:
+		return float32(value), true
+	case uint64:
+		return float32(value), true
+	case uintptr:
+		return float32(value), true
+	case float32:
+		return value, true
+	case float64:
+		return float32(value), true
+	case Date:
+		return float32(value), true
+	case Time:
+		return float32(value), true
+	case Timestamp:
+		return float32(value), true
+	case TimestampNano:
+		return float32(value), true
+	case time.Duration:
+		return float32(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionFloat32(literal)
+		}
+
+		return 0, false
+	}
+}
+
+func convertPartitionFloat64(value any) (float64, bool) {
+	switch value := value.(type) {
+	case int:
+		return float64(value), true
+	case int8:
+		return float64(value), true
+	case int16:
+		return float64(value), true
+	case int32:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case uint:
+		return float64(value), true
+	case uint8:
+		return float64(value), true
+	case uint16:
+		return float64(value), true
+	case uint32:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case uintptr:
+		return float64(value), true
+	case float32:
+		return float64(value), true
+	case float64:
+		return value, true
+	case Date:
+		return float64(value), true
+	case Time:
+		return float64(value), true
+	case Timestamp:
+		return float64(value), true
+	case TimestampNano:
+		return float64(value), true
+	case time.Duration:
+		return float64(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionFloat64(literal)
+		}
+
+		return 0, false
+	}
+}
+
+func convertPartitionString(value any) (string, bool) {
+	switch value := value.(type) {
+	case string:
+		return value, true
+	case []byte:
+		return string(value), true
+	case []rune:
+		return string(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionString(literal)
+		}
+
+		return "", false
+	}
+}
+
+func convertPartitionBytes(value any) ([]byte, bool) {
+	switch value := value.(type) {
+	case []byte:
+		return value, true
+	case string:
+		return []byte(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionBytes(literal)
+		}
+
+		return nil, false
+	}
+}
+
+func convertPartitionUUID(value any) (uuid.UUID, bool) {
+	switch value := value.(type) {
+	case uuid.UUID:
+		return value, true
+	case [16]byte:
+		return uuid.UUID(value), true
+	case []byte:
+		if len(value) < len(uuid.UUID{}) {
+			return uuid.UUID{}, false
+		}
+
+		var converted uuid.UUID
+		copy(converted[:], value)
+
+		return converted, true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionUUID(literal)
+		}
+
+		return uuid.UUID{}, false
+	}
+}
+
+func convertPartitionDecimal(value any) (Decimal, bool) {
+	switch value := value.(type) {
+	case Decimal:
+		return value, true
+	case DecimalLiteral:
+		return Decimal(value), true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionDecimal(literal)
+		}
+
+		return Decimal{}, false
+	}
+}
+
+func convertPartitionDate(value any) (Date, bool) {
+	converted, ok := convertPartitionInt32(value)
+
+	return Date(converted), ok
+}
+
+func convertPartitionTime(value any) (Time, bool) {
+	converted, ok := convertPartitionInt64(value)
+
+	return Time(converted), ok
+}
+
+func convertPartitionTimestamp(value any) (Timestamp, bool) {
+	converted, ok := convertPartitionInt64(value)
+
+	return Timestamp(converted), ok
+}
+
 func newPartitionFieldStat(typ PrimitiveType) (fieldStats, error) {
 	switch typ.(type) {
 	case UnknownType:
 		return &unknownPartitionFieldStats{}, nil
 	case BooleanType:
-		return &partitionFieldStats[bool]{cmp: getComparator[bool]()}, nil
+		return newPartitionFieldStats[bool](convertPartitionBool), nil
 	case Int32Type:
-		return &partitionFieldStats[int32]{cmp: getComparator[int32]()}, nil
+		return newPartitionFieldStats[int32](convertPartitionInt32), nil
 	case Int64Type:
-		return &partitionFieldStats[int64]{cmp: getComparator[int64]()}, nil
+		return newPartitionFieldStats[int64](convertPartitionInt64), nil
 	case Float32Type:
-		return &partitionFieldStats[float32]{cmp: getComparator[float32]()}, nil
+		return newPartitionFieldStats[float32](convertPartitionFloat32), nil
 	case Float64Type:
-		return &partitionFieldStats[float64]{cmp: getComparator[float64]()}, nil
+		return newPartitionFieldStats[float64](convertPartitionFloat64), nil
 	case StringType:
-		return &partitionFieldStats[string]{cmp: getComparator[string]()}, nil
+		return newPartitionFieldStats[string](convertPartitionString), nil
 	case DateType:
-		return &partitionFieldStats[Date]{cmp: getComparator[Date]()}, nil
+		return newPartitionFieldStats[Date](convertPartitionDate), nil
 	case TimeType:
-		return &partitionFieldStats[Time]{cmp: getComparator[Time]()}, nil
+		return newPartitionFieldStats[Time](convertPartitionTime), nil
 	case TimestampType:
-		return &partitionFieldStats[Timestamp]{cmp: getComparator[Timestamp]()}, nil
+		return newPartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
 	case TimestampTzType:
-		return &partitionFieldStats[Timestamp]{cmp: getComparator[Timestamp]()}, nil
+		return newPartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
 	case UUIDType:
-		return &partitionFieldStats[uuid.UUID]{cmp: getComparator[uuid.UUID]()}, nil
+		return newPartitionFieldStats[uuid.UUID](convertPartitionUUID), nil
 	case BinaryType:
-		return &partitionFieldStats[[]byte]{cmp: getComparator[[]byte]()}, nil
+		return newPartitionFieldStats[[]byte](convertPartitionBytes), nil
 	case FixedType:
-		return &partitionFieldStats[[]byte]{cmp: getComparator[[]byte]()}, nil
+		return newPartitionFieldStats[[]byte](convertPartitionBytes), nil
 	case DecimalType:
-		return &partitionFieldStats[Decimal]{cmp: getComparator[Decimal]()}, nil
+		return newPartitionFieldStats[Decimal](convertPartitionDecimal), nil
 	default:
 		return nil, fmt.Errorf("expected primitive type for partition type: %s", typ)
 	}
@@ -1293,13 +1594,11 @@ func (p *partitionFieldStats[T]) update(value any) (err error) {
 		return err
 	}
 
-	var actualVal T
-	v := reflect.ValueOf(value)
-	if !v.CanConvert(reflect.TypeOf(actualVal)) {
+	actualVal, ok := p.convert(value)
+	if !ok {
 		return fmt.Errorf("expected type %T, got %T", actualVal, value)
 	}
 
-	actualVal = v.Convert(reflect.TypeOf(actualVal)).Interface().(T)
 	if data, ok := any(actualVal).([]byte); ok {
 		actualVal = any(slices.Clone(data)).(T)
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -1205,6 +1205,11 @@ type partitionFieldStats[T LiteralType] struct {
 type partitionValueConverter[T LiteralType] func(any) (T, bool)
 
 func partitionLiteralValue(value any) (any, bool) {
+	switch value.(type) {
+	case AboveMaxLiteral, BelowMinLiteral:
+		return nil, false
+	}
+
 	literal, ok := value.(Literal)
 	if !ok {
 		return nil, false
@@ -1233,7 +1238,7 @@ func (p *unknownPartitionFieldStats) update(any) error {
 	return nil
 }
 
-func newPartitionFieldStats[T LiteralType](convert partitionValueConverter[T]) fieldStats {
+func makePartitionFieldStats[T LiteralType](convert partitionValueConverter[T]) fieldStats {
 	return &partitionFieldStats[T]{
 		cmp:     getComparator[T](),
 		convert: convert,
@@ -1241,9 +1246,16 @@ func newPartitionFieldStats[T LiteralType](convert partitionValueConverter[T]) f
 }
 
 func convertPartitionBool(value any) (bool, bool) {
-	converted, ok := value.(bool)
+	switch value := value.(type) {
+	case bool:
+		return value, true
+	default:
+		if literal, ok := partitionLiteralValue(value); ok {
+			return convertPartitionBool(literal)
+		}
 
-	return converted, ok
+		return false, false
+	}
 }
 
 func convertPartitionInt32(value any) (int32, bool) {
@@ -1473,7 +1485,7 @@ func convertPartitionUUID(value any) (uuid.UUID, bool) {
 	case [16]byte:
 		return uuid.UUID(value), true
 	case []byte:
-		if len(value) < len(uuid.UUID{}) {
+		if len(value) != len(uuid.UUID{}) {
 			return uuid.UUID{}, false
 		}
 
@@ -1494,8 +1506,6 @@ func convertPartitionDecimal(value any) (Decimal, bool) {
 	switch value := value.(type) {
 	case Decimal:
 		return value, true
-	case DecimalLiteral:
-		return Decimal(value), true
 	default:
 		if literal, ok := partitionLiteralValue(value); ok {
 			return convertPartitionDecimal(literal)
@@ -1528,33 +1538,33 @@ func newPartitionFieldStat(typ PrimitiveType) (fieldStats, error) {
 	case UnknownType:
 		return &unknownPartitionFieldStats{}, nil
 	case BooleanType:
-		return newPartitionFieldStats[bool](convertPartitionBool), nil
+		return makePartitionFieldStats[bool](convertPartitionBool), nil
 	case Int32Type:
-		return newPartitionFieldStats[int32](convertPartitionInt32), nil
+		return makePartitionFieldStats[int32](convertPartitionInt32), nil
 	case Int64Type:
-		return newPartitionFieldStats[int64](convertPartitionInt64), nil
+		return makePartitionFieldStats[int64](convertPartitionInt64), nil
 	case Float32Type:
-		return newPartitionFieldStats[float32](convertPartitionFloat32), nil
+		return makePartitionFieldStats[float32](convertPartitionFloat32), nil
 	case Float64Type:
-		return newPartitionFieldStats[float64](convertPartitionFloat64), nil
+		return makePartitionFieldStats[float64](convertPartitionFloat64), nil
 	case StringType:
-		return newPartitionFieldStats[string](convertPartitionString), nil
+		return makePartitionFieldStats[string](convertPartitionString), nil
 	case DateType:
-		return newPartitionFieldStats[Date](convertPartitionDate), nil
+		return makePartitionFieldStats[Date](convertPartitionDate), nil
 	case TimeType:
-		return newPartitionFieldStats[Time](convertPartitionTime), nil
+		return makePartitionFieldStats[Time](convertPartitionTime), nil
 	case TimestampType:
-		return newPartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
+		return makePartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
 	case TimestampTzType:
-		return newPartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
+		return makePartitionFieldStats[Timestamp](convertPartitionTimestamp), nil
 	case UUIDType:
-		return newPartitionFieldStats[uuid.UUID](convertPartitionUUID), nil
+		return makePartitionFieldStats[uuid.UUID](convertPartitionUUID), nil
 	case BinaryType:
-		return newPartitionFieldStats[[]byte](convertPartitionBytes), nil
+		return makePartitionFieldStats[[]byte](convertPartitionBytes), nil
 	case FixedType:
-		return newPartitionFieldStats[[]byte](convertPartitionBytes), nil
+		return makePartitionFieldStats[[]byte](convertPartitionBytes), nil
 	case DecimalType:
-		return newPartitionFieldStats[Decimal](convertPartitionDecimal), nil
+		return makePartitionFieldStats[Decimal](convertPartitionDecimal), nil
 	default:
 		return nil, fmt.Errorf("expected primitive type for partition type: %s", typ)
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -517,17 +517,19 @@ func TestPartitionFieldStatsAcceptsConvertibleValues(t *testing.T) {
 		want  Literal
 	}{
 		{name: "boolean", typ: PrimitiveTypes.Bool, value: true, want: NewLiteral(true)},
+		{name: "boolean from literal", typ: PrimitiveTypes.Bool, value: BoolLiteral(true), want: NewLiteral(true)},
 		{name: "int32 from int", typ: PrimitiveTypes.Int32, value: int(7), want: NewLiteral(int32(7))},
 		{name: "int32 from literal", typ: PrimitiveTypes.Int32, value: Int32Literal(7), want: NewLiteral(int32(7))},
+		{name: "int32 wraps overflowing int64", typ: PrimitiveTypes.Int32, value: int64(math.MaxInt32) + 1, want: NewLiteral(int32(math.MinInt32))},
 		{name: "int64 from int", typ: PrimitiveTypes.Int64, value: int(8), want: NewLiteral(int64(8))},
 		{name: "float32 from float64", typ: PrimitiveTypes.Float32, value: float64(1.5), want: NewLiteral(float32(1.5))},
+		{name: "float32 overflows to infinity", typ: PrimitiveTypes.Float32, value: float64(math.MaxFloat32) * 2, want: NewLiteral(float32(math.Inf(1)))},
 		{name: "float64 from int", typ: PrimitiveTypes.Float64, value: int(9), want: NewLiteral(float64(9))},
 		{name: "string from bytes", typ: PrimitiveTypes.String, value: []byte("east"), want: NewLiteral("east")},
 		{name: "string from literal", typ: PrimitiveTypes.String, value: StringLiteral("east"), want: NewLiteral("east")},
 		{name: "date from int32", typ: PrimitiveTypes.Date, value: int32(10), want: NewLiteral(Date(10))},
 		{name: "time from duration", typ: PrimitiveTypes.Time, value: time.Duration(11), want: NewLiteral(Time(11))},
 		{name: "timestamp from int64", typ: PrimitiveTypes.Timestamp, value: int64(12), want: NewLiteral(Timestamp(12))},
-		{name: "timestamp with timezone from nanoseconds", typ: PrimitiveTypes.TimestampTz, value: TimestampNano(13), want: NewLiteral(Timestamp(13))},
 		{name: "binary from string", typ: PrimitiveTypes.Binary, value: "shard", want: NewLiteral([]byte("shard"))},
 		{name: "fixed from bytes", typ: FixedTypeOf(5), value: "fixed", want: NewLiteral([]byte("fixed"))},
 		{
@@ -567,6 +569,81 @@ func TestPartitionFieldStatsAcceptsConvertibleValues(t *testing.T) {
 				t.Fatalf("got bounds (%v, %v), want (%v, %v)", *got.LowerBound, *got.UpperBound, want, want)
 			}
 		})
+	}
+}
+
+func TestPartitionFieldStatsRejectsUnsupportedValues(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  PrimitiveType
+	}{
+		{name: "boolean", typ: PrimitiveTypes.Bool},
+		{name: "int32", typ: PrimitiveTypes.Int32},
+		{name: "int64", typ: PrimitiveTypes.Int64},
+		{name: "float32", typ: PrimitiveTypes.Float32},
+		{name: "float64", typ: PrimitiveTypes.Float64},
+		{name: "string", typ: PrimitiveTypes.String},
+		{name: "date", typ: PrimitiveTypes.Date},
+		{name: "time", typ: PrimitiveTypes.Time},
+		{name: "timestamp", typ: PrimitiveTypes.Timestamp},
+		{name: "timestamp with timezone", typ: PrimitiveTypes.TimestampTz},
+		{name: "uuid", typ: PrimitiveTypes.UUID},
+		{name: "binary", typ: PrimitiveTypes.Binary},
+		{name: "fixed", typ: FixedTypeOf(5)},
+		{name: "decimal", typ: DecimalTypeOf(10, 2)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats, err := newPartitionFieldStat(tt.typ)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := stats.update(struct{}{}); err == nil {
+				t.Fatal("expected unsupported value to return an error")
+			}
+		})
+	}
+}
+
+func TestPartitionFieldStatsRejectsSentinelLiterals(t *testing.T) {
+	tests := []struct {
+		name  string
+		typ   PrimitiveType
+		value Literal
+	}{
+		{name: "int32 above max", typ: PrimitiveTypes.Int32, value: Int32AboveMaxLiteral()},
+		{name: "int32 below min", typ: PrimitiveTypes.Int32, value: Int32BelowMinLiteral()},
+		{name: "int64 above max", typ: PrimitiveTypes.Int64, value: Int64AboveMaxLiteral()},
+		{name: "int64 below min", typ: PrimitiveTypes.Int64, value: Int64BelowMinLiteral()},
+		{name: "float32 above max", typ: PrimitiveTypes.Float32, value: Float32AboveMaxLiteral()},
+		{name: "float32 below min", typ: PrimitiveTypes.Float32, value: Float32BelowMinLiteral()},
+		{name: "float64 above max", typ: PrimitiveTypes.Float64, value: Float64AboveMaxLiteral()},
+		{name: "float64 below min", typ: PrimitiveTypes.Float64, value: Float64BelowMinLiteral()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats, err := newPartitionFieldStat(tt.typ)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := stats.update(tt.value); err == nil {
+				t.Fatal("expected sentinel literal to return an error")
+			}
+		})
+	}
+}
+
+func TestPartitionFieldStatsRejectsInvalidUUIDLengths(t *testing.T) {
+	for _, value := range [][]byte{make([]byte, len(uuid.UUID{})-1), make([]byte, len(uuid.UUID{})+1)} {
+		stats, err := newPartitionFieldStat(PrimitiveTypes.UUID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := stats.update(value); err == nil {
+			t.Fatalf("expected UUID with length %d to return an error", len(value))
+		}
 	}
 }
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -505,6 +506,67 @@ func TestConstructPartitionSummariesWithDroppedSource(t *testing.T) {
 	}
 	if summaries[0].LowerBound != nil || summaries[0].UpperBound != nil {
 		t.Fatal("expected the unknown partition field summary to omit bounds")
+	}
+}
+
+func TestPartitionFieldStatsAcceptsConvertibleValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		typ   PrimitiveType
+		value any
+		want  Literal
+	}{
+		{name: "boolean", typ: PrimitiveTypes.Bool, value: true, want: NewLiteral(true)},
+		{name: "int32 from int", typ: PrimitiveTypes.Int32, value: int(7), want: NewLiteral(int32(7))},
+		{name: "int32 from literal", typ: PrimitiveTypes.Int32, value: Int32Literal(7), want: NewLiteral(int32(7))},
+		{name: "int64 from int", typ: PrimitiveTypes.Int64, value: int(8), want: NewLiteral(int64(8))},
+		{name: "float32 from float64", typ: PrimitiveTypes.Float32, value: float64(1.5), want: NewLiteral(float32(1.5))},
+		{name: "float64 from int", typ: PrimitiveTypes.Float64, value: int(9), want: NewLiteral(float64(9))},
+		{name: "string from bytes", typ: PrimitiveTypes.String, value: []byte("east"), want: NewLiteral("east")},
+		{name: "string from literal", typ: PrimitiveTypes.String, value: StringLiteral("east"), want: NewLiteral("east")},
+		{name: "date from int32", typ: PrimitiveTypes.Date, value: int32(10), want: NewLiteral(Date(10))},
+		{name: "time from duration", typ: PrimitiveTypes.Time, value: time.Duration(11), want: NewLiteral(Time(11))},
+		{name: "timestamp from int64", typ: PrimitiveTypes.Timestamp, value: int64(12), want: NewLiteral(Timestamp(12))},
+		{name: "timestamp with timezone from nanoseconds", typ: PrimitiveTypes.TimestampTz, value: TimestampNano(13), want: NewLiteral(Timestamp(13))},
+		{name: "binary from string", typ: PrimitiveTypes.Binary, value: "shard", want: NewLiteral([]byte("shard"))},
+		{name: "fixed from bytes", typ: FixedTypeOf(5), value: "fixed", want: NewLiteral([]byte("fixed"))},
+		{
+			name:  "uuid from array",
+			typ:   PrimitiveTypes.UUID,
+			value: [16]byte{1, 2, 3, 4},
+			want:  NewLiteral(uuid.UUID{1, 2, 3, 4}),
+		},
+		{
+			name:  "decimal from decimal literal",
+			typ:   DecimalTypeOf(10, 2),
+			value: DecimalLiteral{Val: decimal128.FromI64(130), Scale: 2},
+			want:  NewLiteral(Decimal{Val: decimal128.FromI64(130), Scale: 2}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats, err := newPartitionFieldStat(tt.typ)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := stats.update(tt.value); err != nil {
+				t.Fatal(err)
+			}
+
+			got := stats.toSummary()
+			if got.LowerBound == nil || got.UpperBound == nil {
+				t.Fatalf("expected bounds, got lower=%v upper=%v", got.LowerBound, got.UpperBound)
+			}
+
+			want, err := tt.want.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(*got.LowerBound, want) || !bytes.Equal(*got.UpperBound, want) {
+				t.Fatalf("got bounds (%v, %v), want (%v, %v)", *got.LowerBound, *got.UpperBound, want, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

`partitionFieldStats.update` used reflection for every non-null partition value. This runs once for every partition field in every manifest entry.

This PR:

- stores a typed converter when each field stat is created
- handles scalar, logical, literal, UUID, binary, and decimal values without reflection
- keeps the defensive copy for binary bounds
- keeps the existing error for unsupported values

## Benchmark

Existing `BenchmarkManifestWriterPartitionSummaries`, 10,000 entries, Apple M1 Pro, Go 1.26.3:

- allocations: 140,485 -> 120,485, about 14% fewer
- allocated bytes: about 22.4 MB -> 22.3 MB
- time: about 38.7 ms -> 38.0 ms

## Tests

- `go test . -count=1`
- `go test -race . -count=1`
- `go test ./... -run ^$ -count=1`
- tests for all non-integration packages
- `go vet ./...`