### PR TITLE
perf(table): stream projected position-delete reads

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -346,8 +346,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2292,4 +2293,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -43,8 +43,10 @@ import (
 )
 
 const (
-	ScanOptionArrowUseLargeTypes              = "arrow.use_large_types"
-	ScanOptionRowLineageEnabled               = "row_lineage.enabled"
+	ScanOptionArrowUseLargeTypes = "arrow.use_large_types"
+	ScanOptionRowLineageEnabled  = "row_lineage.enabled"
+	// This must stay a power of two because appendFilePathChunk uses a bit mask
+	// for periodic cancellation checks.
 	positionalDeleteCancellationCheckInterval = 16 * 1024
 )
 
@@ -381,6 +383,10 @@ func (a *posDeleteAccumulator) release() {
 }
 
 func (a *posDeleteAccumulator) finish() map[string]*arrow.Chunked {
+	if a.builders == nil {
+		panic("position delete accumulator is already finished or released")
+	}
+
 	results := make(map[string]*arrow.Chunked, len(a.builders))
 	for path, builder := range a.builders {
 		positions := builder.NewInt64Array()
@@ -394,8 +400,8 @@ func (a *posDeleteAccumulator) finish() map[string]*arrow.Chunked {
 	return results
 }
 
-func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int, filePathLen int,
-	posType arrow.DataType, posNulls int, posLen int,
+func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int,
+	posType arrow.DataType, posNulls int,
 ) error {
 	if filePathNulls > 0 {
 		return fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
@@ -411,6 +417,11 @@ func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int, fi
 		return fmt.Errorf("%w: unsupported pos column type %s in position delete file",
 			iceberg.ErrInvalidSchema, posType)
 	}
+
+	return nil
+}
+
+func validatePosDeleteColumnLengths(filePathLen, posLen int) error {
 	if filePathLen != posLen {
 		return fmt.Errorf("%w: file_path and pos columns have different lengths: %d and %d",
 			iceberg.ErrInvalidSchema, filePathLen, posLen)
@@ -476,8 +487,11 @@ func (a *posDeleteAccumulator) appendChunked(ctx context.Context, filePathCol, p
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(), filePathCol.Len(),
-		posCol.DataType(), posCol.NullN(), posCol.Len()); err != nil {
+	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(),
+		posCol.DataType(), posCol.NullN()); err != nil {
+		return err
+	}
+	if err := validatePosDeleteColumnLengths(filePathCol.Len(), posCol.Len()); err != nil {
 		return err
 	}
 
@@ -503,16 +517,12 @@ func (a *posDeleteAccumulator) appendRecord(ctx context.Context, record arrow.Re
 
 	filePathCol := record.Column(0)
 	posCol := record.Column(1)
-	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(), filePathCol.Len(),
-		posCol.DataType(), posCol.NullN(), posCol.Len()); err != nil {
+	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(),
+		posCol.DataType(), posCol.NullN()); err != nil {
 		return err
 	}
 
-	posArr, ok := posCol.(*array.Int64)
-	if !ok {
-		return fmt.Errorf("%w: unsupported pos chunk array type %T in position delete file",
-			iceberg.ErrInvalidSchema, posCol)
-	}
+	posArr := posCol.(*array.Int64)
 	posCursor := posDeleteCursor{chunks: []*array.Int64{posArr}}
 	if err := a.appendFilePathChunk(ctx, filePathCol, &posCursor); err != nil {
 		return err
@@ -604,10 +614,14 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 	if err != nil {
 		return nil, err
 	}
+	// Do not unify dictionaries here: appendFilePathChunk decodes each batch to
+	// string values, so independent dictionaries across batches are safe.
 	defer records.Release()
 
 	acc := newPosDeleteAccumulator(ctx)
 	defer func() {
+		// Returning an error assigns the named return value before deferred
+		// functions run, which releases builders on every error path.
 		if err != nil {
 			acc.release()
 		}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -361,106 +361,177 @@ func (c *posDeleteCursor) next() (int64, bool) {
 	return pos, true
 }
 
-func groupPosDeletesByFilePath(ctx context.Context, filePathCol, posCol *arrow.Chunked) (results map[string]*arrow.Chunked, err error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	if filePathCol.NullN() > 0 {
-		return nil, fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
-	}
-	if filePathValueType(filePathCol.DataType()).ID() == arrow.STRING_VIEW {
-		return nil, fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
-			iceberg.ErrInvalidSchema, filePathCol.DataType())
-	}
-	if posCol.NullN() > 0 {
-		return nil, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
-	}
-	if posCol.DataType().ID() != arrow.INT64 {
-		return nil, fmt.Errorf("%w: unsupported pos column type %s in position delete file",
-			iceberg.ErrInvalidSchema, posCol.DataType())
-	}
-	if filePathCol.Len() != posCol.Len() {
-		return nil, fmt.Errorf("%w: file_path and pos columns have different lengths: %d and %d",
-			iceberg.ErrInvalidSchema, filePathCol.Len(), posCol.Len())
-	}
+type posDeleteAccumulator struct {
+	mem      memory.Allocator
+	builders map[string]*array.Int64Builder
+}
 
-	mem := compute.GetAllocator(ctx)
-	posCursor, err := newPosDeleteCursor(posCol)
-	if err != nil {
-		return nil, err
+func newPosDeleteAccumulator(ctx context.Context) *posDeleteAccumulator {
+	return &posDeleteAccumulator{
+		mem:      compute.GetAllocator(ctx),
+		builders: make(map[string]*array.Int64Builder),
 	}
+}
 
-	builders := make(map[string]*array.Int64Builder)
-	defer func() {
-		if err != nil {
-			for _, builder := range builders {
-				builder.Release()
-			}
-		}
-	}()
-
-	for _, filePathChunk := range filePathCol.Chunks() {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		paths, pathErr := filePathValues(filePathChunk)
-		if pathErr != nil {
-			return nil, pathErr
-		}
-
-		var dictionary arrow.Array
-		var indices *array.Dictionary
-		if dict, ok := filePathChunk.(*array.Dictionary); ok && dict.Dictionary().NullN() > 0 {
-			dictionary = dict.Dictionary()
-			indices = dict
-		}
-
-		for i := range filePathChunk.Len() {
-			if i&(positionalDeleteCancellationCheckInterval-1) == 0 {
-				if err := ctx.Err(); err != nil {
-					return nil, err
-				}
-			}
-
-			pos, ok := posCursor.next()
-			if !ok {
-				return nil, fmt.Errorf("%w: position delete columns ended before file_path column",
-					iceberg.ErrInvalidSchema)
-			}
-			if pos < 0 {
-				return nil, fmt.Errorf("%w: negative pos %d in position delete file",
-					iceberg.ErrInvalidSchema, pos)
-			}
-			if dictionary != nil && dictionary.IsNull(indices.GetValueIndex(i)) {
-				return nil, fmt.Errorf("%w: null file_path dictionary value in position delete file",
-					iceberg.ErrInvalidSchema)
-			}
-
-			path := paths.Value(i)
-			builder, ok := builders[path]
-			if !ok {
-				path = strings.Clone(path)
-				builder = array.NewInt64Builder(mem)
-				builders[path] = builder
-			}
-			builder.Append(pos)
-		}
+func (a *posDeleteAccumulator) release() {
+	for _, builder := range a.builders {
+		builder.Release()
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
+	a.builders = nil
+}
 
-	results = make(map[string]*arrow.Chunked, len(builders))
-	for path, builder := range builders {
+func (a *posDeleteAccumulator) finish() map[string]*arrow.Chunked {
+	results := make(map[string]*arrow.Chunked, len(a.builders))
+	for path, builder := range a.builders {
 		positions := builder.NewInt64Array()
 		builder.Release()
 
 		results[path] = arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{positions})
 		positions.Release()
 	}
+	a.builders = nil
 
-	return results, nil
+	return results
+}
+
+func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int, filePathLen int,
+	posType arrow.DataType, posNulls int, posLen int) error {
+	if filePathNulls > 0 {
+		return fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
+	}
+	if filePathValueType(filePathType).ID() == arrow.STRING_VIEW {
+		return fmt.Errorf("%w: unsupported file_path column type %s in position delete file",
+			iceberg.ErrInvalidSchema, filePathType)
+	}
+	if posNulls > 0 {
+		return fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
+	}
+	if posType.ID() != arrow.INT64 {
+		return fmt.Errorf("%w: unsupported pos column type %s in position delete file",
+			iceberg.ErrInvalidSchema, posType)
+	}
+	if filePathLen != posLen {
+		return fmt.Errorf("%w: file_path and pos columns have different lengths: %d and %d",
+			iceberg.ErrInvalidSchema, filePathLen, posLen)
+	}
+
+	return nil
+}
+
+func (a *posDeleteAccumulator) appendFilePathChunk(ctx context.Context, filePathChunk arrow.Array,
+	posCursor *posDeleteCursor) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	paths, err := filePathValues(filePathChunk)
+	if err != nil {
+		return err
+	}
+
+	var dictionary arrow.Array
+	var indices *array.Dictionary
+	if dict, ok := filePathChunk.(*array.Dictionary); ok && dict.Dictionary().NullN() > 0 {
+		dictionary = dict.Dictionary()
+		indices = dict
+	}
+
+	for i := range filePathChunk.Len() {
+		if i&(positionalDeleteCancellationCheckInterval-1) == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+
+		pos, ok := posCursor.next()
+		if !ok {
+			return fmt.Errorf("%w: position delete columns ended before file_path column",
+				iceberg.ErrInvalidSchema)
+		}
+		if pos < 0 {
+			return fmt.Errorf("%w: negative pos %d in position delete file",
+				iceberg.ErrInvalidSchema, pos)
+		}
+		if dictionary != nil && dictionary.IsNull(indices.GetValueIndex(i)) {
+			return fmt.Errorf("%w: null file_path dictionary value in position delete file",
+				iceberg.ErrInvalidSchema)
+		}
+
+		path := paths.Value(i)
+		builder, ok := a.builders[path]
+		if !ok {
+			path = strings.Clone(path)
+			builder = array.NewInt64Builder(a.mem)
+			a.builders[path] = builder
+		}
+		builder.Append(pos)
+	}
+
+	return nil
+}
+
+func (a *posDeleteAccumulator) appendChunked(ctx context.Context, filePathCol, posCol *arrow.Chunked) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(), filePathCol.Len(),
+		posCol.DataType(), posCol.NullN(), posCol.Len()); err != nil {
+		return err
+	}
+
+	posCursor, err := newPosDeleteCursor(posCol)
+	if err != nil {
+		return err
+	}
+
+	for _, filePathChunk := range filePathCol.Chunks() {
+		if err := a.appendFilePathChunk(ctx, filePathChunk, &posCursor); err != nil {
+			return err
+		}
+	}
+
+	return ctx.Err()
+}
+
+func (a *posDeleteAccumulator) appendRecord(ctx context.Context, record arrow.RecordBatch) error {
+	if record.NumCols() != 2 {
+		return fmt.Errorf("%w: projected position delete record has %d columns, expected 2",
+			iceberg.ErrInvalidSchema, record.NumCols())
+	}
+
+	filePathCol := record.Column(0)
+	posCol := record.Column(1)
+	if err := validatePosDeleteColumns(filePathCol.DataType(), filePathCol.NullN(), filePathCol.Len(),
+		posCol.DataType(), posCol.NullN(), posCol.Len()); err != nil {
+		return err
+	}
+
+	posArr, ok := posCol.(*array.Int64)
+	if !ok {
+		return fmt.Errorf("%w: unsupported pos chunk array type %T in position delete file",
+			iceberg.ErrInvalidSchema, posCol)
+	}
+	posCursor := posDeleteCursor{chunks: []*array.Int64{posArr}}
+	if err := a.appendFilePathChunk(ctx, filePathCol, &posCursor); err != nil {
+		return err
+	}
+
+	return ctx.Err()
+}
+
+func groupPosDeletesByFilePath(ctx context.Context, filePathCol, posCol *arrow.Chunked) (results map[string]*arrow.Chunked, err error) {
+	acc := newPosDeleteAccumulator(ctx)
+	defer func() {
+		if err != nil {
+			acc.release()
+		}
+	}()
+
+	if err := acc.appendChunked(ctx, filePathCol, posCol); err != nil {
+		return nil, err
+	}
+
+	return acc.finish(), nil
 }
 
 func collectPosDeletePositions(positionalDeletes positionDeletes) (set[int64], error) {
@@ -517,29 +588,42 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 	}
 	defer iceinternal.CheckedClose(rdr, &err)
 
-	tbl, err := rdr.ReadTable(ctx)
+	schema, err := rdr.Schema()
 	if err != nil {
 		return nil, err
 	}
-	defer tbl.Release()
 
-	tbl, err = array.UnifyTableDicts(compute.GetAllocator(ctx), tbl)
+	filePathIndex, posIndex, err := positionDeleteColumnIndices(schema)
 	if err != nil {
 		return nil, err
 	}
-	defer tbl.Release()
 
-	filePathIndex, posIndex, err := positionDeleteColumnIndices(tbl.Schema())
+	records, err := rdr.GetRecords(ctx, []int{filePathIndex, posIndex}, nil)
 	if err != nil {
 		return nil, err
 	}
-	filePathCol := tbl.Column(filePathIndex).Data()
-	posCol := tbl.Column(posIndex).Data()
-	if posCol.NullN() > 0 {
-		return nil, fmt.Errorf("%w: null pos in position delete file", iceberg.ErrInvalidSchema)
+	defer records.Release()
+
+	acc := newPosDeleteAccumulator(ctx)
+	defer func() {
+		if err != nil {
+			acc.release()
+		}
+	}()
+
+	for records.Next() {
+		if err := acc.appendRecord(ctx, records.RecordBatch()); err != nil {
+			return nil, err
+		}
+	}
+	if err := records.Err(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	return groupPosDeletesByFilePath(ctx, filePathCol, posCol)
+	return acc.finish(), nil
 }
 
 func positionDeleteColumnIndices(schema *arrow.Schema) (int, int, error) {

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -395,7 +395,8 @@ func (a *posDeleteAccumulator) finish() map[string]*arrow.Chunked {
 }
 
 func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int, filePathLen int,
-	posType arrow.DataType, posNulls int, posLen int) error {
+	posType arrow.DataType, posNulls int, posLen int,
+) error {
 	if filePathNulls > 0 {
 		return fmt.Errorf("%w: null file_path in position delete file", iceberg.ErrInvalidSchema)
 	}
@@ -419,7 +420,8 @@ func validatePosDeleteColumns(filePathType arrow.DataType, filePathNulls int, fi
 }
 
 func (a *posDeleteAccumulator) appendFilePathChunk(ctx context.Context, filePathChunk arrow.Array,
-	posCursor *posDeleteCursor) error {
+	posCursor *posDeleteCursor,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exprs"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/iceberg-go"
 	iceinternal "github.com/apache/iceberg-go/internal"
 	iceio "github.com/apache/iceberg-go/io"
@@ -605,12 +606,12 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 		return nil, err
 	}
 
-	filePathIndex, posIndex, err := positionDeleteColumnIndices(schema)
+	columns, err := positionDeleteProjectionIndices(schema, rdr)
 	if err != nil {
 		return nil, err
 	}
 
-	records, err := rdr.GetRecords(ctx, []int{filePathIndex, posIndex}, nil)
+	records, err := rdr.GetRecords(ctx, columns, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -640,6 +641,30 @@ func readDeletes(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_
 	}
 
 	return acc.finish(), nil
+}
+
+func positionDeleteProjectionIndices(schema *arrow.Schema, reader tblutils.FileReader) ([]int, error) {
+	filePathIndex, posIndex, err := positionDeleteColumnIndices(schema)
+	if err != nil {
+		return nil, err
+	}
+	fileMetadata, ok := reader.Metadata().(*metadata.FileMetaData)
+	if !ok {
+		return nil, fmt.Errorf("%w: position delete reader does not expose Parquet metadata", iceberg.ErrInvalidSchema)
+	}
+
+	// Parquet projection uses leaf indices. A nested row column can shift
+	// those indices relative to the top-level Arrow fields.
+	columns := make([]int, 2)
+	for i, fieldIndex := range []int{filePathIndex, posIndex} {
+		name := schema.Field(fieldIndex).Name
+		columns[i] = fileMetadata.Schema.ColumnIndexByName(name)
+		if columns[i] < 0 {
+			return nil, fmt.Errorf("%w: position delete column %q must be a primitive column", iceberg.ErrInvalidSchema, name)
+		}
+	}
+
+	return columns, nil
 }
 
 func positionDeleteColumnIndices(schema *arrow.Schema) (int, int, error) {

--- a/table/arrow_scanner_posdelete_bench_test.go
+++ b/table/arrow_scanner_posdelete_bench_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -27,7 +28,138 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	tblutils "github.com/apache/iceberg-go/table/internal"
 )
+
+func BenchmarkReadDeletesProjected(b *testing.B) {
+	for _, numRows := range []int{100_000, 1_000_000} {
+		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+			memFS, dataFile := benchmarkPositionDeleteFile(b, numRows)
+			ctx := tblutils.WithTableProperties(context.Background(), iceberg.Properties{
+				ParquetBatchSizeKey: "65536",
+			})
+
+			b.Run("before", func(b *testing.B) {
+				benchmarkReadDeletes(b, ctx, memFS, dataFile, readDeletesBefore)
+			})
+			b.Run("after", func(b *testing.B) {
+				benchmarkReadDeletes(b, ctx, memFS, dataFile, readDeletes)
+			})
+		})
+	}
+}
+
+func benchmarkReadDeletes(
+	b *testing.B,
+	ctx context.Context,
+	memFS *iceio.MemFS,
+	dataFile iceberg.DataFile,
+	read func(context.Context, iceio.IO, iceberg.DataFile) (map[string]*arrow.Chunked, error),
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		deletes, err := read(ctx, memFS, dataFile)
+		if err != nil {
+			b.Fatal(err)
+		}
+		releasePosDeletes(deletes)
+	}
+}
+
+func benchmarkPositionDeleteFile(b *testing.B, numRows int) (*iceio.MemFS, iceberg.DataFile) {
+	b.Helper()
+
+	mem := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "unused", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+	pathBuilder := array.NewStringBuilder(mem)
+	posBuilder := array.NewInt64Builder(mem)
+	unusedBuilder := array.NewStringBuilder(mem)
+	unusedValue := strings.Repeat("unused-value-", 16)
+	for i := range numRows {
+		pathBuilder.Append("mem://bucket/data/data.parquet")
+		posBuilder.Append(int64(i))
+		unusedBuilder.Append(unusedValue)
+	}
+	paths := pathBuilder.NewStringArray()
+	pathBuilder.Release()
+	positions := posBuilder.NewInt64Array()
+	posBuilder.Release()
+	unused := unusedBuilder.NewStringArray()
+	unusedBuilder.Release()
+	record := array.NewRecordBatch(schema, []arrow.Array{paths, positions, unused}, int64(numRows))
+	paths.Release()
+	positions.Release()
+	unused.Release()
+	defer record.Release()
+	tbl := array.NewTableFromRecords(schema, []arrow.RecordBatch{record})
+	defer tbl.Release()
+
+	deletePath := "mem://bucket/deletes/benchmark.parquet"
+	memFS := iceio.NewMemFS()
+	fw, err := memFS.Create(deletePath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := pqarrow.WriteTable(tbl, fw, int64(numRows),
+		parquet.NewWriterProperties(parquet.WithStats(true)),
+		pqarrow.DefaultWriterProps()); err != nil {
+		_ = fw.Close()
+		b.Fatal(err)
+	}
+	if err := fw.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		deletePath, iceberg.ParquetFile, nil, nil, nil, int64(numRows), 128)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return memFS, builder.Build()
+}
+
+func readDeletesBefore(ctx context.Context, fs iceio.IO, dataFile iceberg.DataFile) (_ map[string]*arrow.Chunked, err error) {
+	src, err := tblutils.GetFile(ctx, fs, dataFile, true)
+	if err != nil {
+		return nil, err
+	}
+	rdr, err := src.GetReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rdr.Close() }()
+
+	tbl, err := rdr.ReadTable(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tbl.Release()
+	tbl, err = array.UnifyTableDicts(compute.GetAllocator(ctx), tbl)
+	if err != nil {
+		return nil, err
+	}
+	defer tbl.Release()
+
+	filePathIndex, posIndex, err := positionDeleteColumnIndices(tbl.Schema())
+	if err != nil {
+		return nil, err
+	}
+
+	return groupPosDeletesByFilePath(ctx, tbl.Column(filePathIndex).Data(), tbl.Column(posIndex).Data())
+}
 
 func BenchmarkGroupPosDeletesByFilePath(b *testing.B) {
 	const numRows = 1_000_000

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -1035,3 +1035,39 @@ func int64Values(chunked *arrow.Chunked) []int64 {
 
 	return out
 }
+
+func TestReadDeletesProjectsLeafColumnsAroundNestedRow(t *testing.T) {
+	rowField := arrow.Field{Name: "row", Type: arrow.StructOf(
+		arrow.Field{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		arrow.Field{Name: "name", Type: arrow.BinaryTypes.String},
+	)}
+	filePath := PositionalDeleteArrowSchema.Field(0)
+	pos := PositionalDeleteArrowSchema.Field(1)
+	for _, tc := range []struct {
+		name   string
+		fields []arrow.Field
+	}{
+		{"row first", []arrow.Field{rowField, filePath, pos}},
+		{"row between delete columns", []arrow.Field{filePath, rowField, pos}},
+		{"row last", []arrow.Field{filePath, pos, rowField}},
+		{"reversed delete columns", []arrow.Field{pos, rowField, filePath}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			ctx := compute.WithAllocator(t.Context(), mem)
+			defer mem.AssertSize(t, 0)
+			deletePath := "mem://bucket/deletes/nested-row.parquet"
+			dataPath := "mem://bucket/data/needed.parquet"
+			memFS := iceio.NewMemFS()
+			writePosDeleteParquetToMemFSWithSchema(t, memFS, deletePath, arrow.NewSchema(tc.fields, nil), `[
+                {"file_path": "`+dataPath+`", "pos": 1, "row": {"id": 10, "name": "a"}},
+                {"file_path": "other.parquet", "pos": 2, "row": {"id": 20, "name": "b"}},
+                {"file_path": "`+dataPath+`", "pos": 3, "row": {"id": 30, "name": "c"}}
+            ]`)
+			deletes, err := readDeletes(ctx, memFS, newPosDeleteFile(t, deletePath, 3, 128))
+			require.NoError(t, err)
+			defer releasePosDeletes(deletes)
+			assert.Equal(t, []int64{1, 3}, int64Values(deletes[dataPath]))
+		})
+	}
+}

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -97,6 +97,68 @@ func TestReadDeletesRejectsMissingFilePath(t *testing.T) {
 	assert.Contains(t, err.Error(), `exactly one "file_path" column, found 0`)
 }
 
+func TestReadDeletesProjectsColumnsAndAccumulatesBatches(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	ctx = internal.WithTableProperties(ctx, iceberg.Properties{ParquetBatchSizeKey: "2"})
+	defer mem.AssertSize(t, 0)
+
+	deleteSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "unused", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+	deletePath := "mem://bucket/deletes/projected.parquet"
+	dataPath := "mem://bucket/data/data.parquet"
+	rec := mustLoadRecordBatchFromJSON(deleteSchema, `[
+		{"file_path": "`+dataPath+`", "pos": 10, "unused": "unused-0"},
+		{"file_path": "other/data.parquet", "pos": 20, "unused": "unused-1"},
+		{"file_path": "`+dataPath+`", "pos": 30, "unused": "unused-2"},
+		{"file_path": "third/data.parquet", "pos": 40, "unused": "unused-3"},
+		{"file_path": "other/data.parquet", "pos": 50, "unused": "unused-4"}
+	]`)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(deleteSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	memFS := iceio.NewMemFS()
+	fw, err := memFS.Create(deletePath)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
+		parquet.NewWriterProperties(parquet.WithStats(true)),
+		pqarrow.DefaultWriterProps()))
+	require.NoError(t, fw.Close())
+
+	dataFile := newPosDeleteFile(t, deletePath, rec.NumRows(), 128)
+	src, err := internal.GetFile(ctx, memFS, dataFile, true)
+	require.NoError(t, err)
+	rdr, err := src.GetReader(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rdr.Close()) }()
+
+	projected, err := rdr.GetRecords(ctx, []int{0, 1}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, projected.Schema().NumFields())
+	assert.Equal(t, "file_path", projected.Schema().Field(0).Name)
+	assert.Equal(t, "pos", projected.Schema().Field(1).Name)
+	var batchCount int
+	for projected.Next() {
+		batchCount++
+		assert.Equal(t, int64(2), projected.RecordBatch().NumCols())
+	}
+	require.NoError(t, projected.Err())
+	projected.Release()
+	assert.Equal(t, 3, batchCount)
+
+	deletes, err := readDeletes(ctx, memFS, dataFile)
+	require.NoError(t, err)
+	defer releasePosDeletes(deletes)
+
+	assert.Equal(t, []int64{10, 30}, int64Values(deletes[dataPath]))
+	assert.Equal(t, []int64{20, 50}, int64Values(deletes["other/data.parquet"]))
+	assert.Equal(t, []int64{40}, int64Values(deletes["third/data.parquet"]))
+}
+
 func TestGroupPosDeletesByFilePathSupportsStringLayouts(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string

--- a/table/arrow_scanner_posdelete_regression_test.go
+++ b/table/arrow_scanner_posdelete_regression_test.go
@@ -159,6 +159,89 @@ func TestReadDeletesProjectsColumnsAndAccumulatesBatches(t *testing.T) {
 	assert.Equal(t, []int64{40}, int64Values(deletes["third/data.parquet"]))
 }
 
+func TestReadDeletesHandlesDictionaryEncodedFilePath(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	ctx = internal.WithTableProperties(ctx, iceberg.Properties{ParquetBatchSizeKey: "2"})
+	defer mem.AssertSize(t, 0)
+
+	deleteSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+	deletePath := "mem://bucket/deletes/dictionary-file-path.parquet"
+	dataPath := "mem://bucket/data/data.parquet"
+	memFS := iceio.NewMemFS()
+	writePosDeleteParquetToMemFSWithSchema(t, memFS, deletePath, deleteSchema, `[
+		{"file_path": "`+dataPath+`", "pos": 10},
+		{"file_path": "other/data.parquet", "pos": 20},
+		{"file_path": "`+dataPath+`", "pos": 30},
+		{"file_path": "`+dataPath+`", "pos": 40}
+	]`)
+
+	dataFile := newPosDeleteFile(t, deletePath, 4, 128)
+	src, err := internal.GetFile(ctx, memFS, dataFile, true)
+	require.NoError(t, err)
+	rdr, err := src.GetReader(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rdr.Close()) }()
+
+	records, err := rdr.GetRecords(ctx, []int{0, 1}, nil)
+	require.NoError(t, err)
+	defer records.Release()
+	var dictionaryBatches int
+	for records.Next() {
+		if _, ok := records.RecordBatch().Column(0).(*array.Dictionary); ok {
+			dictionaryBatches++
+		}
+	}
+	require.NoError(t, records.Err())
+	assert.Greater(t, dictionaryBatches, 0)
+
+	deletes, err := readDeletes(ctx, memFS, dataFile)
+	require.NoError(t, err)
+	defer releasePosDeletes(deletes)
+
+	assert.Equal(t, []int64{10, 30, 40}, int64Values(deletes[dataPath]))
+	assert.Equal(t, []int64{20}, int64Values(deletes["other/data.parquet"]))
+}
+
+func TestReadDeletesHandlesReversedPhysicalSchema(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	ctx := compute.WithAllocator(t.Context(), mem)
+	ctx = internal.WithTableProperties(ctx, iceberg.Properties{ParquetBatchSizeKey: "2"})
+	defer mem.AssertSize(t, 0)
+
+	deleteSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "pos", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "file_path", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+	deletePath := "mem://bucket/deletes/reversed-schema.parquet"
+	dataPath := "mem://bucket/data/data.parquet"
+	memFS := iceio.NewMemFS()
+	writePosDeleteParquetToMemFSWithSchema(t, memFS, deletePath, deleteSchema, `[
+		{"pos": 10, "file_path": "`+dataPath+`"},
+		{"pos": 20, "file_path": "other/data.parquet"},
+		{"pos": 30, "file_path": "`+dataPath+`"}
+	]`)
+
+	deletes, err := readDeletes(ctx, memFS, newPosDeleteFile(t, deletePath, 3, 128))
+	require.NoError(t, err)
+	defer releasePosDeletes(deletes)
+
+	assert.Equal(t, []int64{10, 30}, int64Values(deletes[dataPath]))
+	assert.Equal(t, []int64{20}, int64Values(deletes["other/data.parquet"]))
+}
+
+func TestPosDeleteAccumulatorFinishAfterReleasePanics(t *testing.T) {
+	acc := newPosDeleteAccumulator(t.Context())
+	acc.release()
+
+	assert.PanicsWithValue(t, "position delete accumulator is already finished or released", func() {
+		acc.finish()
+	})
+}
+
 func TestGroupPosDeletesByFilePathSupportsStringLayouts(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string

--- a/table/arrow_scanner_test.go
+++ b/table/arrow_scanner_test.go
@@ -275,17 +275,25 @@ func mustLoadRecordBatchFromJSON(schema *arrow.Schema, content string) arrow.Rec
 func writePosDeleteParquetToMemFS(t *testing.T, memFS *iceio.MemFS, path, content string) {
 	t.Helper()
 
-	rec := mustLoadRecordBatchFromJSON(PositionalDeleteArrowSchema, content)
+	writePosDeleteParquetToMemFSWithSchema(t, memFS, path, PositionalDeleteArrowSchema, content)
+}
+
+func writePosDeleteParquetToMemFSWithSchema(t *testing.T, memFS *iceio.MemFS, path string,
+	schema *arrow.Schema, content string,
+) {
+	t.Helper()
+
+	rec := mustLoadRecordBatchFromJSON(schema, content)
 	defer rec.Release()
 
-	tbl := array.NewTableFromRecords(PositionalDeleteArrowSchema, []arrow.RecordBatch{rec})
+	tbl := array.NewTableFromRecords(schema, []arrow.RecordBatch{rec})
 	defer tbl.Release()
 
 	fw, err := memFS.Create(path)
 	require.NoError(t, err)
 
 	require.NoError(t, pqarrow.WriteTable(tbl, fw, rec.NumRows(),
-		parquet.NewWriterProperties(parquet.WithStats(true)),
+		parquet.NewWriterProperties(parquet.WithDictionaryDefault(true), parquet.WithStats(true)),
 		pqarrow.DefaultWriterProps()))
 	require.NoError(t, fw.Close())
 }


### PR DESCRIPTION
## Summary

- Read position deletes with `GetRecords` using only `file_path` and `pos`.
- Process record batches incrementally with one grouping accumulator.
- Avoid full-table materialization and `UnifyTableDicts`.
- Keep the existing string, dictionary, validation, and ordering behavior.

## Performance

Local benchmark on an Apple M1 Pro with Go 1.26.3. Each case used a 100 ms benchmark run and included an unused string column in the Parquet file.

| Rows | Before | After |
| ---: | ---: | ---: |
| 100K | 11.1 ms/op, 77.7 MB/op, 1,009 allocs/op | 4.1 ms/op, 12.3 MB/op, 612 allocs/op |
| 1M | 93.8 ms/op, 613.0 MB/op, 4,851 allocs/op | 26.6 ms/op, 75.6 MB/op, 1,960 allocs/op |

The exact numbers will vary by machine and storage backend, but the projected reader avoids decoding and retaining unused columns.

## Tests

- `go test ./table/... -count=1`
- `go test -race ./table -count=1`
- `go vet ./table`
- `go test ./table -run ^$ -bench ^BenchmarkReadDeletesProjected/(rows=100000|rows=1000000)/(before|after) -benchtime=100ms -count=1`
