### PR TITLE
perf(table): skip equality-delete filtering for untouched batches

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -781,14 +781,8 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 		mem := compute.GetAllocator(ctx)
 		numRows := int(r.NumRows())
 
-		maskBuf := memory.NewResizableBuffer(mem)
-		defer maskBuf.Release()
-		maskBuf.Resize(int(bitutil.BytesForBits(int64(numRows))))
-		maskBytes := maskBuf.Bytes()
-
-		for i := range maskBytes {
-			maskBytes[i] = 0xFF
-		}
+		var maskBuf *memory.Buffer
+		var maskBytes []byte
 
 		var keyBuf bytes.Buffer
 
@@ -798,12 +792,16 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 				var err error
 				encoders[i], err = makeArrowFieldEncoder(r, fieldRefs[setIdx][i], eqDel.fieldIDs[i], name, dataFilePath)
 				if err != nil {
+					if maskBuf != nil {
+						maskBuf.Release()
+					}
+
 					return nil, err
 				}
 			}
 
 			for row := range numRows {
-				if !bitutil.BitIsSet(maskBytes, row) {
+				if maskBytes != nil && !bitutil.BitIsSet(maskBytes, row) {
 					continue
 				}
 
@@ -813,21 +811,40 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 					enc(&keyBuf, row)
 				}
 
-				if _, deleted := eqDel.keys[bufString(&keyBuf)]; deleted {
-					bitutil.ClearBit(maskBytes, row)
+				if _, deleted := eqDel.keys[bufString(&keyBuf)]; !deleted {
+					continue
 				}
+
+				if maskBuf == nil {
+					maskBuf = memory.NewResizableBuffer(mem)
+					maskBuf.Resize(int(bitutil.BytesForBits(int64(numRows))))
+					maskBytes = maskBuf.Bytes()
+
+					for i := range maskBytes {
+						maskBytes[i] = 0xFF
+					}
+				}
+
+				bitutil.ClearBit(maskBytes, row)
 			}
+		}
+
+		if maskBuf == nil {
+			r.Retain()
+
+			return r, nil
 		}
 
 		mask := array.NewBooleanData(array.NewData(
 			arrow.FixedWidthTypes.Boolean, numRows,
 			[]*memory.Buffer{nil, maskBuf}, nil, 0, 0))
-		defer mask.Release()
 
 		filtered, err := compute.Filter(ctx,
 			compute.NewDatumWithoutOwning(r),
 			compute.NewDatumWithoutOwning(mask),
 			*compute.DefaultFilterOptions())
+		mask.Release()
+		maskBuf.Release()
 		if err != nil {
 			return nil, err
 		}

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -792,10 +792,6 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 				var err error
 				encoders[i], err = makeArrowFieldEncoder(r, fieldRefs[setIdx][i], eqDel.fieldIDs[i], name, dataFilePath)
 				if err != nil {
-					if maskBuf != nil {
-						maskBuf.Release()
-					}
-
 					return nil, err
 				}
 			}
@@ -817,6 +813,7 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 
 				if maskBuf == nil {
 					maskBuf = memory.NewResizableBuffer(mem)
+					defer maskBuf.Release()
 					maskBuf.Resize(int(bitutil.BytesForBits(int64(numRows))))
 					maskBytes = maskBuf.Bytes()
 
@@ -835,16 +832,17 @@ func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*
 			return r, nil
 		}
 
-		mask := array.NewBooleanData(array.NewData(
+		maskData := array.NewData(
 			arrow.FixedWidthTypes.Boolean, numRows,
-			[]*memory.Buffer{nil, maskBuf}, nil, 0, 0))
+			[]*memory.Buffer{nil, maskBuf}, nil, 0, 0)
+		mask := array.NewBooleanData(maskData)
+		maskData.Release()
+		defer mask.Release()
 
 		filtered, err := compute.Filter(ctx,
 			compute.NewDatumWithoutOwning(r),
 			compute.NewDatumWithoutOwning(mask),
 			*compute.DefaultFilterOptions())
-		mask.Release()
-		maskBuf.Release()
 		if err != nil {
 			return nil, err
 		}

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -242,10 +242,60 @@ func buildBenchDeleteSetString(numDeletes int) *equalityDeleteSet {
 	}
 }
 
+func buildBenchDeleteSetIntNoMatch(numDeletes int) *equalityDeleteSet {
+	keys := make(set[string])
+	var buf bytes.Buffer
+
+	for i := range numDeletes {
+		buf.Reset()
+		buf.WriteByte(1)
+		_ = binary.Write(&buf, binary.BigEndian, int64(i*3))
+		buf.WriteByte(1)
+		_ = binary.Write(&buf, binary.BigEndian, int64((i*3+1)%100))
+		keys[buf.String()] = struct{}{}
+	}
+
+	return &equalityDeleteSet{
+		keys:     keys,
+		fieldIDs: []int{1, 2},
+		colNames: []string{"id", "category"},
+	}
+}
+
+func buildBenchDeleteSetStringNoMatch(numDeletes int) *equalityDeleteSet {
+	keys := make(set[string])
+	var buf bytes.Buffer
+
+	for i := range numDeletes {
+		buf.Reset()
+		buf.WriteByte(1)
+		_ = binary.Write(&buf, binary.BigEndian, int64(i*3))
+		buf.WriteByte(1)
+		name := fmt.Sprintf("user-%08d", i*3+1)
+		_ = binary.Write(&buf, binary.BigEndian, int32(len(name)))
+		buf.WriteString(name)
+		keys[buf.String()] = struct{}{}
+	}
+
+	return &equalityDeleteSet{
+		keys:     keys,
+		fieldIDs: []int{1, 2},
+		colNames: []string{"id", "name"},
+	}
+}
+
 func BenchmarkProcessEqualityDeletesInt(b *testing.B) {
 	benchEqDeletes(b, buildBenchRecordInt, buildBenchDeleteSetInt)
 }
 
 func BenchmarkProcessEqualityDeletesString(b *testing.B) {
 	benchEqDeletes(b, buildBenchRecordString, buildBenchDeleteSetString)
+}
+
+func BenchmarkProcessEqualityDeletesNoMatchInt(b *testing.B) {
+	benchEqDeletes(b, buildBenchRecordInt, buildBenchDeleteSetIntNoMatch)
+}
+
+func BenchmarkProcessEqualityDeletesNoMatchString(b *testing.B) {
+	benchEqDeletes(b, buildBenchRecordString, buildBenchDeleteSetStringNoMatch)
 }

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -115,7 +115,22 @@ func BenchmarkReadEqualityDeleteFile(b *testing.B) {
 	}
 }
 
-func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.RecordBatch, buildDel func(int) *equalityDeleteSet) {
+func benchEqDeletes(
+	b *testing.B,
+	buildRec func(memory.Allocator, int) arrow.RecordBatch,
+	buildDel func(int) *equalityDeleteSet,
+	fileSchema *iceberg.Schema,
+) {
+	b.Helper()
+	benchEqDeletesForFile(b, buildRec, buildDel, fileSchema)
+}
+
+func benchEqDeletesForFile(
+	b *testing.B,
+	buildRec func(memory.Allocator, int) arrow.RecordBatch,
+	buildDel func(int) *equalityDeleteSet,
+	fileSchema *iceberg.Schema,
+) {
 	b.Helper()
 
 	dataRows := []int{1_000, 100_000, 1_000_000}
@@ -133,12 +148,8 @@ func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.Rec
 				rec := buildRec(mem, nData)
 				defer rec.Release()
 
-				delSet := buildDel(nDel)
-				fileSchema := iceberg.NewSchema(0,
-					iceberg.NestedField{ID: 1, Name: "first", Type: iceberg.PrimitiveTypes.Int64},
-					iceberg.NestedField{ID: 2, Name: "second", Type: iceberg.PrimitiveTypes.Int64},
-				)
-				filterFn, err := processEqualityDeletesColumnarForFile(ctx, []*equalityDeleteSet{delSet}, fileSchema, "data.parquet")
+				delSets := []*equalityDeleteSet{buildDel(nDel)}
+				filterFn, err := processEqualityDeletesColumnarForFile(ctx, delSets, fileSchema, "bench.parquet")
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -158,6 +169,20 @@ func benchEqDeletes(b *testing.B, buildRec func(memory.Allocator, int) arrow.Rec
 			})
 		}
 	}
+}
+
+func benchIntFileSchema() *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.Int64},
+	)
+}
+
+func benchStringFileSchema() *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
+	)
 }
 
 func buildBenchRecordInt(mem memory.Allocator, numRows int) arrow.RecordBatch {
@@ -187,9 +212,9 @@ func buildBenchDeleteSetInt(numDeletes int) *equalityDeleteSet {
 	for i := range numDeletes {
 		buf.Reset()
 		buf.WriteByte(1)
-		binary.Write(&buf, binary.BigEndian, int64(i*3))
+		_ = binary.Write(&buf, binary.BigEndian, int64(i*3))
 		buf.WriteByte(1)
-		binary.Write(&buf, binary.BigEndian, int64((i*3)%100))
+		_ = binary.Write(&buf, binary.BigEndian, int64((i*3)%100))
 		keys[buf.String()] = struct{}{}
 	}
 
@@ -227,10 +252,10 @@ func buildBenchDeleteSetString(numDeletes int) *equalityDeleteSet {
 	for i := range numDeletes {
 		buf.Reset()
 		buf.WriteByte(1)
-		binary.Write(&buf, binary.BigEndian, int64(i*3))
+		_ = binary.Write(&buf, binary.BigEndian, int64(i*3))
 		buf.WriteByte(1)
 		s := fmt.Sprintf("user-%08d", i*3)
-		binary.Write(&buf, binary.BigEndian, int32(len(s)))
+		_ = binary.Write(&buf, binary.BigEndian, int32(len(s)))
 		buf.WriteString(s)
 		keys[buf.String()] = struct{}{}
 	}
@@ -285,17 +310,17 @@ func buildBenchDeleteSetStringNoMatch(numDeletes int) *equalityDeleteSet {
 }
 
 func BenchmarkProcessEqualityDeletesInt(b *testing.B) {
-	benchEqDeletes(b, buildBenchRecordInt, buildBenchDeleteSetInt)
+	benchEqDeletes(b, buildBenchRecordInt, buildBenchDeleteSetInt, benchIntFileSchema())
 }
 
 func BenchmarkProcessEqualityDeletesString(b *testing.B) {
-	benchEqDeletes(b, buildBenchRecordString, buildBenchDeleteSetString)
+	benchEqDeletes(b, buildBenchRecordString, buildBenchDeleteSetString, benchStringFileSchema())
 }
 
 func BenchmarkProcessEqualityDeletesNoMatchInt(b *testing.B) {
-	benchEqDeletes(b, buildBenchRecordInt, buildBenchDeleteSetIntNoMatch)
+	benchEqDeletesForFile(b, buildBenchRecordInt, buildBenchDeleteSetIntNoMatch, benchIntFileSchema())
 }
 
 func BenchmarkProcessEqualityDeletesNoMatchString(b *testing.B) {
-	benchEqDeletes(b, buildBenchRecordString, buildBenchDeleteSetStringNoMatch)
+	benchEqDeletesForFile(b, buildBenchRecordString, buildBenchDeleteSetStringNoMatch, benchStringFileSchema())
 }

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -481,6 +481,43 @@ func TestProcessEqualityDeletesUsesStructuralFieldPaths(t *testing.T) {
 	result.Release()
 }
 
+func TestProcessEqualityDeletesReturnsOriginalBatchWhenNoRowsMatch(t *testing.T) {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.AppendValues([]int64{1, 2}, nil)
+	values := builder.NewArray()
+	builder.Release()
+
+	unmatchedBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	unmatchedBuilder.Append(3)
+	unmatched := unmatchedBuilder.NewArray()
+	unmatchedBuilder.Release()
+	var unmatchedKey bytes.Buffer
+	encodeArrowValue(&unmatchedKey, unmatched, 0)
+	unmatched.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "id", Type: arrow.PrimitiveTypes.Int64,
+	}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{values}, 2)
+	values.Release()
+
+	fileSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+	)
+	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
+		keys:     set[string]{unmatchedKey.String(): {}},
+		fieldIDs: []int{1},
+		colNames: []string{"id"},
+	}}, fileSchema, "data.parquet")
+	require.NoError(t, err)
+
+	result, err := process(record)
+	require.NoError(t, err)
+	assert.Same(t, record, result)
+	assert.Equal(t, int64(2), result.NumRows())
+	result.Release()
+}
+
 func TestProcessEqualityDeletesRejectsMismatchedFieldMetadata(t *testing.T) {
 	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
 		keys:     make(set[string]),

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -468,7 +468,7 @@ func TestProcessEqualityDeletesUsesStructuralFieldPaths(t *testing.T) {
 		iceberg.NestedField{ID: 1, Name: "left", Type: iceberg.PrimitiveTypes.Int64},
 		iceberg.NestedField{ID: 2, Name: "right", Type: iceberg.PrimitiveTypes.Int64},
 	)
-	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
+	process, err := processEqualityDeletesColumnarForFile(t.Context(), []*equalityDeleteSet{{
 		keys:     set[string]{key.String(): {}},
 		fieldIDs: []int{1},
 		colNames: []string{"id"},
@@ -482,18 +482,14 @@ func TestProcessEqualityDeletesUsesStructuralFieldPaths(t *testing.T) {
 }
 
 func TestProcessEqualityDeletesReturnsOriginalBatchWhenNoRowsMatch(t *testing.T) {
-	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	ctx := compute.WithAllocator(t.Context(), mem)
+
+	builder := array.NewInt64Builder(mem)
 	builder.AppendValues([]int64{1, 2}, nil)
 	values := builder.NewArray()
 	builder.Release()
-
-	unmatchedBuilder := array.NewInt64Builder(memory.DefaultAllocator)
-	unmatchedBuilder.Append(3)
-	unmatched := unmatchedBuilder.NewArray()
-	unmatchedBuilder.Release()
-	var unmatchedKey bytes.Buffer
-	encodeArrowValue(&unmatchedKey, unmatched, 0)
-	unmatched.Release()
 
 	schema := arrow.NewSchema([]arrow.Field{{
 		Name: "id", Type: arrow.PrimitiveTypes.Int64,
@@ -504,11 +500,8 @@ func TestProcessEqualityDeletesReturnsOriginalBatchWhenNoRowsMatch(t *testing.T)
 	fileSchema := iceberg.NewSchema(0,
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
 	)
-	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
-		keys:     set[string]{unmatchedKey.String(): {}},
-		fieldIDs: []int{1},
-		colNames: []string{"id"},
-	}}, fileSchema, "data.parquet")
+	process, err := processEqualityDeletesColumnarForFile(ctx,
+		[]*equalityDeleteSet{int64EqualityDeleteSet(3)}, fileSchema, "data.parquet")
 	require.NoError(t, err)
 
 	result, err := process(record)
@@ -518,8 +511,75 @@ func TestProcessEqualityDeletesReturnsOriginalBatchWhenNoRowsMatch(t *testing.T)
 	result.Release()
 }
 
+func int64EqualityDeleteSet(values ...int64) *equalityDeleteSet {
+	keys := make(set[string], len(values))
+	for _, value := range values {
+		var key bytes.Buffer
+		key.WriteByte(1)
+		bufPutUint64(&key, uint64(value))
+		keys[key.String()] = struct{}{}
+	}
+
+	return &equalityDeleteSet{
+		keys:     keys,
+		fieldIDs: []int{1},
+		colNames: []string{"id"},
+	}
+}
+
+func TestProcessEqualityDeletesAppliesMultipleDeleteSetsLazily(t *testing.T) {
+	tests := []struct {
+		name       string
+		deleteSets []*equalityDeleteSet
+	}{
+		{
+			name: "later set skips rows cleared by earlier set",
+			deleteSets: []*equalityDeleteSet{
+				int64EqualityDeleteSet(1),
+				int64EqualityDeleteSet(2),
+			},
+		},
+		{
+			name: "later set allocates after earlier set misses",
+			deleteSets: []*equalityDeleteSet{
+				int64EqualityDeleteSet(3),
+				int64EqualityDeleteSet(1, 2),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+			ctx := compute.WithAllocator(t.Context(), mem)
+
+			builder := array.NewInt64Builder(mem)
+			builder.AppendValues([]int64{1, 2}, nil)
+			values := builder.NewArray()
+			builder.Release()
+			schema := arrow.NewSchema([]arrow.Field{{
+				Name: "id", Type: arrow.PrimitiveTypes.Int64,
+			}}, nil)
+			record := array.NewRecordBatch(schema, []arrow.Array{values}, 2)
+			values.Release()
+
+			fileSchema := iceberg.NewSchema(0,
+				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+			)
+			process, err := processEqualityDeletesColumnarForFile(ctx, tt.deleteSets, fileSchema, "data.parquet")
+			require.NoError(t, err)
+
+			result, err := process(record)
+			require.NoError(t, err)
+			assert.Zero(t, result.NumRows())
+			result.Release()
+		})
+	}
+}
+
 func TestProcessEqualityDeletesRejectsMismatchedFieldMetadata(t *testing.T) {
-	process, err := processEqualityDeletesColumnarForFile(context.Background(), []*equalityDeleteSet{{
+	process, err := processEqualityDeletesColumnarForFile(t.Context(), []*equalityDeleteSet{{
 		keys:     make(set[string]),
 		fieldIDs: []int{1},
 		colNames: []string{"id", "other"},


### PR DESCRIPTION
## What changed

- Allocate the equality-delete mask only after the first matching row.
- Return the input batch directly when no row matches.
- Keep the existing `compute.Filter` path for batches with matches.
- Add a no-match correctness test and integer/string benchmarks.

## Why

An equality delete set can be non-empty even when a record batch has no matching rows. The old path allocated and filled a full bitmap and called `compute.Filter` for every batch.

## Benchmark

Run on an Apple M1 Pro with:

`go test ./table -run '^$' -bench 'BenchmarkProcessEqualityDeletesNoMatch(Int|String)/rows=(100000|1000000)/deletes=10$' -benchmem -count=5`

Representative medians:

| Case | Before | After |
| --- | --- | --- |
| Int, 100K rows / 10 deletes | 2.76 ms/op, 2.03 MB/op, 86 allocs/op | 2.22 ms/op, 176 B/op, 4 allocs/op |
| Int, 1M rows / 10 deletes | 26.46 ms/op, 20.15 MB/op, 87 allocs/op | 22.12 ms/op, 176 B/op, 4 allocs/op |
| String, 100K rows / 10 deletes | 4.58 ms/op, 2.94 MB/op, 95 allocs/op | 2.63 ms/op, 208 B/op, 4 allocs/op |
| String, 1M rows / 10 deletes | 40.57 ms/op, 29.28 MB/op, 96 allocs/op | 26.18 ms/op, 208 B/op, 4 allocs/op |

The allocation reduction is the main result. Wall time had normal run-to-run noise.

## Testing

- `go test ./table -count=1`
- `go test ./table -race -count=1`
