### PR TITLE
perf(table): avoid re-extracting filter field IDs per task

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -883,6 +883,10 @@ func (as *arrowScan) scanInvariants(tableProperties iceberg.Properties) (*arrowS
 
 func (as *arrowScan) addTaskProjectedFieldIDs(invariants *arrowScanInvariants, tasks []FileScanTask) error {
 	for _, task := range tasks {
+		if task.Residual == nil {
+			continue
+		}
+
 		rowFilter, err := as.rowFilterForTask(task)
 		if err != nil {
 			return err

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -190,3 +190,62 @@ func BenchmarkArrowScanManyFilesAndBatches(b *testing.B) {
 		})
 	}
 }
+
+func benchmarkComplexBoundFilter(b *testing.B, schema *iceberg.Schema) iceberg.BooleanExpression {
+	b.Helper()
+
+	filter := iceberg.NewAnd(
+		iceberg.EqualTo(iceberg.Reference("field_0.value"), "value_0"),
+		iceberg.NewOr(
+			iceberg.GreaterThan(iceberg.Reference("field_1.count"), int64(10)),
+			iceberg.LessThan(iceberg.Reference("field_2.count"), int64(20)),
+		),
+		iceberg.NewNot(iceberg.IsNull(iceberg.Reference("field_3.value"))),
+		iceberg.IsIn(iceberg.Reference("field_4.count"), int64(1), int64(2), int64(3)),
+		iceberg.NotEqualTo(iceberg.Reference("field_5.value"), "value_5"),
+	)
+
+	bound, err := iceberg.BindExpr(schema, filter, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return bound
+}
+
+func BenchmarkArrowScanAddTaskProjectedFieldIDs(b *testing.B) {
+	schema := benchmarkScanSchema(8)
+	filter := benchmarkComplexBoundFilter(b, schema)
+	baseIDs, err := iceberg.ExtractFieldIDs(filter)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, taskCount := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("tasks=%d/residual=nil", taskCount), func(b *testing.B) {
+			tasks := make([]FileScanTask, taskCount)
+			scanner := &arrowScan{
+				scanSchema:     schema,
+				boundRowFilter: filter,
+			}
+			invariants := &arrowScanInvariants{projectedIDs: make(set[int], len(baseIDs))}
+			for _, id := range baseIDs {
+				invariants.projectedIDs[id] = struct{}{}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := scanner.addTaskProjectedFieldIDs(invariants, tasks); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.StopTimer()
+			if len(invariants.projectedIDs) != len(baseIDs) {
+				b.Fatalf("projected field IDs changed: got %d, want %d", len(invariants.projectedIDs), len(baseIDs))
+			}
+			b.ReportMetric(float64(taskCount), "tasks/op")
+		})
+	}
+}

--- a/table/arrow_scanner_test.go
+++ b/table/arrow_scanner_test.go
@@ -149,6 +149,31 @@ func TestArrowScanSnapshotsInvariants(t *testing.T) {
 	assert.Equal(t, 1, metadata.nameMappingCalls)
 }
 
+func TestArrowScanAddTaskProjectedFieldIDsSkipsNilResiduals(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+	)
+	boundFilter, err := iceberg.BindExpr(schema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	scanner := &arrowScan{
+		scanSchema:     schema,
+		boundRowFilter: boundFilter,
+	}
+	invariants := &arrowScanInvariants{projectedIDs: set[int]{1: {}}}
+	tasks := []FileScanTask{
+		{},
+		{Residual: iceberg.EqualTo(iceberg.Reference("data"), "value")},
+		{},
+	}
+
+	err = scanner.addTaskProjectedFieldIDs(invariants, tasks)
+	require.NoError(t, err)
+	assert.Equal(t, set[int]{1: {}, 2: {}}, invariants.projectedIDs)
+}
+
 func TestEnrichRecordsWithPosDeleteFields(t *testing.T) {
 	testSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "first_name", Type: &arrow.StringType{}, Nullable: false},


### PR DESCRIPTION
## What changed

- Skip task filter extraction when `Residual` is nil.
- Keep binding and extraction for non-nil task residuals.
- Add a mixed-task correctness test.
- Add a benchmark for 1K, 10K, and 100K tasks with a complex filter.

## Why

`scanInvariants` already extracts the bound scan filter once. Normal tasks have no residual, so extracting that same filter again for every task only repeats work.

## Benchmark

Run on an Apple M1 Pro with:

`go test ./table -run '^$' -bench 'BenchmarkArrowScanAddTaskProjectedFieldIDs/tasks=(1000|10000|100000)/residual=nil$' -benchmem -count=5`

These are medians over five runs. Before is `upstream/main` and after is this change.

| Tasks | Before | After |
| --- | --- | --- |
| 1K | 907.823 µs/op, 1.20 MB/op, 13,000 allocs/op | 2.995 µs/op, 0 B/op, 0 allocs/op |
| 10K | 8.932 ms/op, 12.00 MB/op, 130,000 allocs/op | 31.966 µs/op, 0 B/op, 0 allocs/op |
| 100K | 82.351 ms/op, 120.00 MB/op, 1,300,000 allocs/op | 342.928 µs/op, 0 B/op, 0 allocs/op |

## Testing

- `go test ./table -count=1`
- `go test ./table -race -count=1`
- `go vet ./table`
