### PR TITLE
perf(table): cache equality delete field groups

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -183,8 +183,17 @@ func makeArrowFieldEncoder(record arrow.RecordBatch, ref arrowFieldRef, fieldID 
 }
 
 type equalityDeleteFileSet struct {
-	id int
+	id       int
+	groupKey string
 	*equalityDeleteSet
+}
+
+func newEqualityDeleteFileSet(id int, deleteSet *equalityDeleteSet) *equalityDeleteFileSet {
+	return &equalityDeleteFileSet{
+		id:                id,
+		groupKey:          fmt.Sprint(deleteSet.fieldIDs),
+		equalityDeleteSet: deleteSet,
+	}
 }
 
 // readAllEqualityDeleteFiles reads all unique equality delete files from
@@ -266,14 +275,11 @@ func readAllEqualityDeleteFiles(ctx context.Context, fs iceio.IO, schema *iceber
 
 	perFile := make(map[string]*equalityDeleteFileSet)
 	for result := range resultCh {
-		perFile[result.path] = &equalityDeleteFileSet{
-			id: result.id,
-			equalityDeleteSet: &equalityDeleteSet{
-				fieldIDs: result.fieldIDs,
-				colNames: result.colNames,
-				keys:     result.keys,
-			},
-		}
+		perFile[result.path] = newEqualityDeleteFileSet(result.id, &equalityDeleteSet{
+			fieldIDs: result.fieldIDs,
+			colNames: result.colNames,
+			keys:     result.keys,
+		})
 	}
 
 	if err := g.Wait(); err != nil {
@@ -298,16 +304,45 @@ func buildEqualityDeleteSetsPerTask(
 			continue
 		}
 
-		// Group delete files by their field IDs key.
-		groups := make(map[string][]*equalityDeleteFileSet)
+		var (
+			groupKey   string
+			groupFiles []*equalityDeleteFileSet
+			groups     map[string][]*equalityDeleteFileSet
+		)
+
 		for _, d := range t.EqualityDeleteFiles {
 			dk, ok := perFile[d.FilePath()]
 			if !ok {
 				continue
 			}
 
-			groupKey := fmt.Sprint(dk.fieldIDs)
-			groups[groupKey] = append(groups[groupKey], dk)
+			if groups == nil {
+				if len(groupFiles) == 0 {
+					groupKey = dk.groupKey
+				} else if dk.groupKey != groupKey {
+					groups = make(map[string][]*equalityDeleteFileSet, 2)
+					groups[groupKey] = groupFiles
+				}
+			}
+
+			if groups == nil {
+				groupFiles = append(groupFiles, dk)
+			} else {
+				groups[dk.groupKey] = append(groups[dk.groupKey], dk)
+			}
+		}
+
+		if groups == nil {
+			if len(groupFiles) == 0 {
+				continue
+			}
+
+			deleteSet := equalityDeleteSetForFiles(groupFiles, sharedSets)
+			if len(deleteSet.keys) > 0 {
+				perTask[i] = []*equalityDeleteSet{deleteSet}
+			}
+
+			continue
 		}
 
 		sets := make([]*equalityDeleteSet, 0, len(groups))

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -190,7 +190,9 @@ type equalityDeleteFileSet struct {
 
 func newEqualityDeleteFileSet(id int, deleteSet *equalityDeleteSet) *equalityDeleteFileSet {
 	return &equalityDeleteFileSet{
-		id:                id,
+		id: id,
+		// Keys are encoded in fieldIDs order, so this key must remain
+		// order-sensitive unless the encoded keys are canonicalized too.
 		groupKey:          fmt.Sprint(deleteSet.fieldIDs),
 		equalityDeleteSet: deleteSet,
 	}
@@ -316,19 +318,18 @@ func buildEqualityDeleteSetsPerTask(
 				continue
 			}
 
-			if groups == nil {
-				if len(groupFiles) == 0 {
-					groupKey = dk.groupKey
-				} else if dk.groupKey != groupKey {
-					groups = make(map[string][]*equalityDeleteFileSet, 2)
-					groups[groupKey] = groupFiles
-				}
-			}
-
-			if groups == nil {
-				groupFiles = append(groupFiles, dk)
-			} else {
+			if groups != nil {
 				groups[dk.groupKey] = append(groups[dk.groupKey], dk)
+			} else if len(groupFiles) == 0 {
+				groupKey = dk.groupKey
+				groupFiles = append(groupFiles, dk)
+			} else if dk.groupKey != groupKey {
+				groups = make(map[string][]*equalityDeleteFileSet, 2)
+				groups[groupKey] = groupFiles
+				groupFiles = nil
+				groups[dk.groupKey] = append(groups[dk.groupKey], dk)
+			} else {
+				groupFiles = append(groupFiles, dk)
 			}
 		}
 

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -623,6 +623,7 @@ func TestBuildEqualityDeleteSetsPerTaskSharesIdenticalSets(t *testing.T) {
 
 func TestBuildEqualityDeleteSetsPerTaskKeepsFieldGroupsSeparate(t *testing.T) {
 	deleteID := newEqualityDeleteSetAssemblyTestFile(t, "delete-id.parquet", []int{1})
+	deleteIDAgain := newEqualityDeleteSetAssemblyTestFile(t, "delete-id-again.parquet", []int{1})
 	deleteCategory := newEqualityDeleteSetAssemblyTestFile(t, "delete-category.parquet", []int{2})
 
 	perFile := map[string]*equalityDeleteFileSet{
@@ -631,24 +632,51 @@ func TestBuildEqualityDeleteSetsPerTaskKeepsFieldGroupsSeparate(t *testing.T) {
 			fieldIDs: []int{1},
 			colNames: []string{"id"},
 		}),
-		deleteCategory.FilePath(): newEqualityDeleteFileSet(1, &equalityDeleteSet{
+		deleteIDAgain.FilePath(): newEqualityDeleteFileSet(1, &equalityDeleteSet{
+			keys:     set[string]{"id-again": {}},
+			fieldIDs: []int{1},
+			colNames: []string{"id"},
+		}),
+		deleteCategory.FilePath(): newEqualityDeleteFileSet(2, &equalityDeleteSet{
 			keys:     set[string]{"category": {}},
 			fieldIDs: []int{2},
 			colNames: []string{"category"},
 		}),
 	}
 
-	perTask := buildEqualityDeleteSetsPerTask([]FileScanTask{{
-		EqualityDeleteFiles: []iceberg.DataFile{deleteID, deleteCategory},
-	}}, perFile)
-	require.Len(t, perTask[0], 2)
-
-	setsByFieldID := make(map[int]*equalityDeleteSet)
-	for _, deleteSet := range perTask[0] {
-		setsByFieldID[deleteSet.fieldIDs[0]] = deleteSet
+	tasks := []FileScanTask{
+		// Two files accumulate under the first key before the second group
+		// promotes the fast path to a map.
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteID, deleteIDAgain, deleteCategory}},
+		// The first file for the original key arrives after promotion.
+		{EqualityDeleteFiles: []iceberg.DataFile{deleteID, deleteCategory, deleteIDAgain}},
 	}
-	assert.Same(t, perFile[deleteID.FilePath()].equalityDeleteSet, setsByFieldID[1])
-	assert.Same(t, perFile[deleteCategory.FilePath()].equalityDeleteSet, setsByFieldID[2])
+
+	perTask := buildEqualityDeleteSetsPerTask(tasks, perFile)
+	require.Len(t, perTask, len(tasks))
+
+	for taskIndex, wantIDs := range map[int]set[string]{
+		0: {"id": {}, "id-again": {}},
+		1: {"id": {}, "id-again": {}},
+	} {
+		setsByFieldID := make(map[int]*equalityDeleteSet)
+		for _, deleteSet := range perTask[taskIndex] {
+			setsByFieldID[deleteSet.fieldIDs[0]] = deleteSet
+		}
+
+		assert.Equal(t, wantIDs, setsByFieldID[1].keys)
+		assert.Equal(t, set[string]{"category": {}}, setsByFieldID[2].keys)
+	}
+}
+
+func TestBuildEqualityDeleteSetsPerTaskSkipsMissingDeleteFiles(t *testing.T) {
+	missing := newEqualityDeleteSetAssemblyTestFile(t, "missing-delete.parquet", []int{1})
+
+	perTask := buildEqualityDeleteSetsPerTask([]FileScanTask{{
+		EqualityDeleteFiles: []iceberg.DataFile{missing},
+	}}, map[string]*equalityDeleteFileSet{})
+
+	assert.Empty(t, perTask)
 }
 
 func newEqualityDeleteSetAssemblyTestFile(

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -583,30 +583,21 @@ func TestBuildEqualityDeleteSetsPerTaskSharesIdenticalSets(t *testing.T) {
 	deleteC := newEqualityDeleteSetAssemblyTestFile(t, "delete-c.parquet", []int{1})
 
 	perFile := map[string]*equalityDeleteFileSet{
-		deleteA.FilePath(): {
-			id: 0,
-			equalityDeleteSet: &equalityDeleteSet{
-				keys:     set[string]{"a": {}},
-				fieldIDs: []int{1},
-				colNames: []string{"id"},
-			},
-		},
-		deleteB.FilePath(): {
-			id: 1,
-			equalityDeleteSet: &equalityDeleteSet{
-				keys:     set[string]{"b": {}},
-				fieldIDs: []int{1},
-				colNames: []string{"id"},
-			},
-		},
-		deleteC.FilePath(): {
-			id: 2,
-			equalityDeleteSet: &equalityDeleteSet{
-				keys:     set[string]{"c": {}},
-				fieldIDs: []int{1},
-				colNames: []string{"id"},
-			},
-		},
+		deleteA.FilePath(): newEqualityDeleteFileSet(0, &equalityDeleteSet{
+			keys:     set[string]{"a": {}},
+			fieldIDs: []int{1},
+			colNames: []string{"id"},
+		}),
+		deleteB.FilePath(): newEqualityDeleteFileSet(1, &equalityDeleteSet{
+			keys:     set[string]{"b": {}},
+			fieldIDs: []int{1},
+			colNames: []string{"id"},
+		}),
+		deleteC.FilePath(): newEqualityDeleteFileSet(2, &equalityDeleteSet{
+			keys:     set[string]{"c": {}},
+			fieldIDs: []int{1},
+			colNames: []string{"id"},
+		}),
 	}
 
 	tasks := []FileScanTask{
@@ -635,22 +626,16 @@ func TestBuildEqualityDeleteSetsPerTaskKeepsFieldGroupsSeparate(t *testing.T) {
 	deleteCategory := newEqualityDeleteSetAssemblyTestFile(t, "delete-category.parquet", []int{2})
 
 	perFile := map[string]*equalityDeleteFileSet{
-		deleteID.FilePath(): {
-			id: 0,
-			equalityDeleteSet: &equalityDeleteSet{
-				keys:     set[string]{"id": {}},
-				fieldIDs: []int{1},
-				colNames: []string{"id"},
-			},
-		},
-		deleteCategory.FilePath(): {
-			id: 1,
-			equalityDeleteSet: &equalityDeleteSet{
-				keys:     set[string]{"category": {}},
-				fieldIDs: []int{2},
-				colNames: []string{"category"},
-			},
-		},
+		deleteID.FilePath(): newEqualityDeleteFileSet(0, &equalityDeleteSet{
+			keys:     set[string]{"id": {}},
+			fieldIDs: []int{1},
+			colNames: []string{"id"},
+		}),
+		deleteCategory.FilePath(): newEqualityDeleteFileSet(1, &equalityDeleteSet{
+			keys:     set[string]{"category": {}},
+			fieldIDs: []int{2},
+			colNames: []string{"category"},
+		}),
 	}
 
 	perTask := buildEqualityDeleteSetsPerTask([]FileScanTask{{

--- a/table/equality_delete_set_assembly_bench_test.go
+++ b/table/equality_delete_set_assembly_bench_test.go
@@ -182,14 +182,11 @@ func equalityDeleteAssemblyBenchmarkInput(
 			for keyIndex := range keysPerFile {
 				keys[fmt.Sprintf("key-%d-%d", fileID, keyIndex)] = struct{}{}
 			}
-			perFile[path] = &equalityDeleteFileSet{
-				id: fileID,
-				equalityDeleteSet: &equalityDeleteSet{
-					keys:     keys,
-					fieldIDs: []int{1},
-					colNames: []string{"id"},
-				},
-			}
+			perFile[path] = newEqualityDeleteFileSet(fileID, &equalityDeleteSet{
+				keys:     keys,
+				fieldIDs: []int{1},
+				colNames: []string{"id"},
+			})
 			fileID++
 		}
 


### PR DESCRIPTION
## What changed

- Cache the equality field-group key once per delete file.
- Avoid allocating the per-task grouping map when all delete files use one field group.
- Keep the existing grouping path for tasks with multiple field groups.
- Reuse the existing assembly coverage and benchmark setup.

## Why

Most tasks have one equality field group. The old path formatted the same `fieldIDs` slice and allocated a grouping map for every task, even when there was nothing to split.

## Benchmark

Run on an Apple M1 Pro with:

`go test ./table -run '^$' -bench '^BenchmarkEqualityDeleteSetAssembly/(shared-single-file|shared-four-file-union)/shared$' -benchmem -benchtime=2s -count=5`

These are medians over five runs. Before is `upstream/main` and after is this change.

| Case | Before | After |
| --- | --- | --- |
| 1 shared delete file, 1 group | 295.826 µs/op, 216,383 B/op, 5,022 allocs/op | 109.775 µs/op, 176,328 B/op, 2,022 allocs/op |
| 4 shared delete files, 1 group | 909.692 µs/op, 525,542 B/op, 17,045 allocs/op | 324.757 µs/op, 365,408 B/op, 5,045 allocs/op |

## Testing

- `go test ./table -count=1`
- `go test ./table -race -count=1`
- `go vet ./table`
