### PR TITLE
perf(table): deduplicate conflict-validation manifest reads

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -51,7 +51,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"slices"
 	"sort"
@@ -200,19 +199,26 @@ type conflictManifestList struct {
 	err       error
 }
 
+const maxConflictManifestCacheBytes = 64 << 20
+
+var errConflictManifestIOReadOnly = errors.New("conflict manifest IO is read-only")
+
 // conflictManifestIO is a read-through cache used only while conflict
 // validators inspect one conflictContext. Manifest files are immutable after
 // they are committed, so the same path can be safely served from the cached
 // bytes to later validators without reopening the backing object store.
 //
 // The cache stores raw bytes instead of decoded entries. The first read still
-// streams from the backing IO and is recorded only when it reaches EOF, so an
-// early validator exit does not force a full manifest read. Later reads stream
-// decoded entries from the completed bytes and let each ManifestFile
-// descriptor apply its own inheritance metadata.
+// streams from the backing IO and is recorded only when it has consumed the
+// size reported by Stat, so an early validator exit does not cache a partial
+// manifest. The cache is bounded per validation attempt; reads after the
+// bound fall through to the backing IO. Later reads stream decoded entries
+// from completed bytes and let each ManifestFile descriptor apply its own
+// inheritance metadata.
 type conflictManifestIO struct {
-	base  iceio.IO
-	files map[string][]byte
+	base        iceio.IO
+	files       map[string][]byte
+	cachedBytes int64
 }
 
 func newConflictManifestIO(base iceio.IO) *conflictManifestIO {
@@ -231,19 +237,33 @@ func (c *conflictManifestIO) Open(name string) (iceio.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	if c.cachedBytes >= maxConflictManifestCacheBytes {
+		return f, nil
+	}
+
+	info, statErr := f.Stat()
+	if statErr != nil || info == nil || info.Size() < 0 {
+		if statIO, ok := c.base.(iceio.StatIO); ok {
+			info, statErr = statIO.Stat(name)
+		}
+	}
+	if statErr != nil || info == nil || info.Size() < 0 {
+		return f, nil
+	}
 
 	return &conflictManifestRecordingFile{
-		base:      f,
-		cache:     c,
-		name:      name,
-		cacheable: true,
+		base:         f,
+		cache:        c,
+		name:         name,
+		expectedSize: info.Size(),
+		cacheLimit:   maxConflictManifestCacheBytes - c.cachedBytes,
+		cacheable:    true,
+		complete:     info.Size() == 0,
 	}, nil
 }
 
-func (c *conflictManifestIO) Remove(name string) error {
-	delete(c.files, name)
-
-	return c.base.Remove(name)
+func (c *conflictManifestIO) Remove(string) error {
+	return errConflictManifestIOReadOnly
 }
 
 func (c *conflictManifestIO) Stat(name string) (fs.FileInfo, error) {
@@ -285,34 +305,39 @@ func (f *conflictManifestFile) Stat() (fs.FileInfo, error) {
 }
 
 type conflictManifestRecordingFile struct {
-	base      iceio.File
-	cache     *conflictManifestIO
-	name      string
-	data      []byte
-	cacheable bool
-	complete  bool
+	base         iceio.File
+	cache        *conflictManifestIO
+	name         string
+	expectedSize int64
+	cacheLimit   int64
+	data         []byte
+	cacheable    bool
+	complete     bool
 }
 
 func (f *conflictManifestRecordingFile) Read(p []byte) (int, error) {
 	n, err := f.base.Read(p)
 	if f.cacheable && n > 0 {
-		f.data = append(f.data, p[:n]...)
-	}
-	if f.cacheable && errors.Is(err, io.EOF) {
-		f.complete = true
+		if int64(len(f.data))+int64(n) > f.cacheLimit {
+			f.cacheable = false
+			f.data = nil
+		} else {
+			f.data = append(f.data, p[:n]...)
+			f.complete = int64(len(f.data)) == f.expectedSize
+		}
 	}
 
 	return n, err
 }
 
 func (f *conflictManifestRecordingFile) ReadAt(p []byte, offset int64) (int, error) {
-	f.cacheable = false
+	f.disableCaching()
 
 	return f.base.ReadAt(p, offset)
 }
 
 func (f *conflictManifestRecordingFile) Seek(offset int64, whence int) (int64, error) {
-	f.cacheable = false
+	f.disableCaching()
 
 	return f.base.Seek(offset, whence)
 }
@@ -323,12 +348,25 @@ func (f *conflictManifestRecordingFile) Stat() (fs.FileInfo, error) {
 
 func (f *conflictManifestRecordingFile) Close() error {
 	err := f.base.Close()
-	if err == nil && f.cacheable && f.complete {
+	if err == nil && f.cacheable && f.complete && int64(len(f.data)) == f.expectedSize {
 		f.cache.files[f.name] = f.data
+		f.cache.cachedBytes += int64(len(f.data))
 	}
 
 	return err
 }
+
+func (f *conflictManifestRecordingFile) disableCaching() {
+	f.cacheable = false
+	f.complete = false
+	f.data = nil
+}
+
+var (
+	_ iceio.IO   = (*conflictManifestIO)(nil)
+	_ iceio.File = (*conflictManifestFile)(nil)
+	_ iceio.File = (*conflictManifestRecordingFile)(nil)
+)
 
 type conflictManifestFileInfo struct {
 	name string
@@ -358,7 +396,7 @@ func (c *conflictContext) manifestsFor(snap Snapshot) ([]iceberg.ManifestFile, e
 		return cached.manifests, cached.err
 	}
 
-	manifests, err := snap.Manifests(c.manifestReadIO())
+	manifests, err := snap.Manifests(c.fs)
 	c.manifestLists[snap.SnapshotID] = conflictManifestList{manifests: manifests, err: err}
 
 	return manifests, err
@@ -527,12 +565,10 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 				continue
 			}
 			path := entry.DataFile().FilePath()
-			if _, ok := needed[path]; ok {
-				delete(needed, path)
-				if len(needed) == 0 {
-					return nil
-				}
-			}
+			delete(needed, path)
+		}
+		if len(needed) == 0 {
+			return nil
 		}
 	}
 

--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -51,10 +51,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/apache/iceberg-go"
 	iceberginternal "github.com/apache/iceberg-go/internal"
@@ -168,11 +171,11 @@ var (
 // concurrent commits and validators return nil without reading
 // manifests.
 //
-// conflictContext is immutable once constructed — do NOT reuse the
-// same context across retry attempts that re-fetch catalog state,
-// because the cached concurrent-snapshot walk becomes stale. There
-// is deliberately no Refresh or mutator method; a refresh must flow
-// as a fresh call to newConflictContext(newBase, newCurrent, ...).
+// The metadata and concurrent-snapshot walk are fixed once constructed — do
+// NOT reuse the same context across retry attempts that re-fetch catalog
+// state, because both the walk and its read caches would become stale. There
+// is deliberately no Refresh or mutator method; a refresh must flow as a
+// fresh call to newConflictContext(newBase, newCurrent, ...).
 type conflictContext struct {
 	current       Metadata
 	branch        string
@@ -181,6 +184,184 @@ type conflictContext struct {
 
 	// Resolved once; subsequent validator calls reuse the walk.
 	concurrent []Snapshot
+
+	// Lazily caches raw manifest bytes for this validation attempt. The
+	// cache is intentionally scoped to the context because all validators
+	// inspect the same immutable metadata snapshot, while ManifestFile.Entries
+	// still performs descriptor-specific inheritance for each logical read.
+	manifestIO *conflictManifestIO
+
+	// Parsed manifest-list descriptors are also shared across validators.
+	manifestLists map[int64]conflictManifestList
+}
+
+type conflictManifestList struct {
+	manifests []iceberg.ManifestFile
+	err       error
+}
+
+// conflictManifestIO is a read-through cache used only while conflict
+// validators inspect one conflictContext. Manifest files are immutable after
+// they are committed, so the same path can be safely served from the cached
+// bytes to later validators without reopening the backing object store.
+//
+// The cache stores raw bytes instead of decoded entries. The first read still
+// streams from the backing IO and is recorded only when it reaches EOF, so an
+// early validator exit does not force a full manifest read. Later reads stream
+// decoded entries from the completed bytes and let each ManifestFile
+// descriptor apply its own inheritance metadata.
+type conflictManifestIO struct {
+	base  iceio.IO
+	files map[string][]byte
+}
+
+func newConflictManifestIO(base iceio.IO) *conflictManifestIO {
+	return &conflictManifestIO{
+		base:  base,
+		files: make(map[string][]byte),
+	}
+}
+
+func (c *conflictManifestIO) Open(name string) (iceio.File, error) {
+	if data, ok := c.files[name]; ok {
+		return newConflictManifestFile(name, data), nil
+	}
+
+	f, err := c.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conflictManifestRecordingFile{
+		base:      f,
+		cache:     c,
+		name:      name,
+		cacheable: true,
+	}, nil
+}
+
+func (c *conflictManifestIO) Remove(name string) error {
+	delete(c.files, name)
+
+	return c.base.Remove(name)
+}
+
+func (c *conflictManifestIO) Stat(name string) (fs.FileInfo, error) {
+	if data, ok := c.files[name]; ok {
+		return conflictManifestFileInfo{name: name, size: int64(len(data))}, nil
+	}
+
+	if statIO, ok := c.base.(iceio.StatIO); ok {
+		return statIO.Stat(name)
+	}
+
+	f, err := c.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return f.Stat()
+}
+
+type conflictManifestFile struct {
+	*bytes.Reader
+	name string
+	size int64
+}
+
+func newConflictManifestFile(name string, data []byte) *conflictManifestFile {
+	return &conflictManifestFile{
+		Reader: bytes.NewReader(data),
+		name:   name,
+		size:   int64(len(data)),
+	}
+}
+
+func (f *conflictManifestFile) Close() error { return nil }
+
+func (f *conflictManifestFile) Stat() (fs.FileInfo, error) {
+	return conflictManifestFileInfo{name: f.name, size: f.size}, nil
+}
+
+type conflictManifestRecordingFile struct {
+	base      iceio.File
+	cache     *conflictManifestIO
+	name      string
+	data      []byte
+	cacheable bool
+	complete  bool
+}
+
+func (f *conflictManifestRecordingFile) Read(p []byte) (int, error) {
+	n, err := f.base.Read(p)
+	if f.cacheable && n > 0 {
+		f.data = append(f.data, p[:n]...)
+	}
+	if f.cacheable && errors.Is(err, io.EOF) {
+		f.complete = true
+	}
+
+	return n, err
+}
+
+func (f *conflictManifestRecordingFile) ReadAt(p []byte, offset int64) (int, error) {
+	f.cacheable = false
+
+	return f.base.ReadAt(p, offset)
+}
+
+func (f *conflictManifestRecordingFile) Seek(offset int64, whence int) (int64, error) {
+	f.cacheable = false
+
+	return f.base.Seek(offset, whence)
+}
+
+func (f *conflictManifestRecordingFile) Stat() (fs.FileInfo, error) {
+	return f.base.Stat()
+}
+
+func (f *conflictManifestRecordingFile) Close() error {
+	err := f.base.Close()
+	if err == nil && f.cacheable && f.complete {
+		f.cache.files[f.name] = f.data
+	}
+
+	return err
+}
+
+type conflictManifestFileInfo struct {
+	name string
+	size int64
+}
+
+func (f conflictManifestFileInfo) Name() string       { return f.name }
+func (f conflictManifestFileInfo) Size() int64        { return f.size }
+func (f conflictManifestFileInfo) Mode() fs.FileMode  { return 0 }
+func (f conflictManifestFileInfo) ModTime() time.Time { return time.Time{} }
+func (f conflictManifestFileInfo) IsDir() bool        { return false }
+func (f conflictManifestFileInfo) Sys() any           { return nil }
+
+func (c *conflictContext) manifestReadIO() *conflictManifestIO {
+	if c.manifestIO == nil {
+		c.manifestIO = newConflictManifestIO(c.fs)
+	}
+
+	return c.manifestIO
+}
+
+func (c *conflictContext) manifestsFor(snap Snapshot) ([]iceberg.ManifestFile, error) {
+	if c.manifestLists == nil {
+		c.manifestLists = make(map[int64]conflictManifestList)
+	}
+	if cached, ok := c.manifestLists[snap.SnapshotID]; ok {
+		return cached.manifests, cached.err
+	}
+
+	manifests, err := snap.Manifests(c.manifestReadIO())
+	c.manifestLists[snap.SnapshotID] = conflictManifestList{manifests: manifests, err: err}
+
+	return manifests, err
 }
 
 // newConflictContext builds a validation context for the given
@@ -259,20 +440,30 @@ func newConflictContext(base, current Metadata, branch string, fs iceio.IO, case
 // The visitor returns early if the callback returns a non-nil error.
 func (c *conflictContext) forEachAddedEntry(content iceberg.ManifestContent, visit func(Snapshot, iceberg.ManifestEntry) error) error {
 	for _, snap := range c.concurrent {
-		for entry, err := range snap.entries(c.fs, content) {
-			if err != nil {
-				return fmt.Errorf("loading entries for concurrent snapshot %d: %w", snap.SnapshotID, err)
-			}
-			if entry.Status() != iceberg.EntryStatusADDED {
+		manifests, err := c.manifestsFor(snap)
+		if err != nil {
+			return fmt.Errorf("loading entries for concurrent snapshot %d: %w", snap.SnapshotID, err)
+		}
+		for _, mf := range manifests {
+			if content >= 0 && mf.ManifestContent() != content {
 				continue
 			}
-			if entry.SnapshotID() != snap.SnapshotID {
-				// Entry was inherited from a prior snapshot and is
-				// not attributable to this concurrent commit.
-				continue
-			}
-			if err := visit(snap, entry); err != nil {
-				return err
+
+			for entry, err := range mf.Entries(c.manifestReadIO(), false) {
+				if err != nil {
+					return fmt.Errorf("loading entries for concurrent snapshot %d: %w", snap.SnapshotID, err)
+				}
+				if entry.Status() != iceberg.EntryStatusADDED {
+					continue
+				}
+				if entry.SnapshotID() != snap.SnapshotID {
+					// Entry was inherited from a prior snapshot and is
+					// not attributable to this concurrent commit.
+					continue
+				}
+				if err := visit(snap, entry); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -317,21 +508,30 @@ func validateDataFilesExist(ctx *conflictContext, referencedPaths []string) erro
 		return fmt.Errorf("%w: branch %q missing on current metadata", ErrCommitDiverged, ctx.branch)
 	}
 
-	for entry, err := range head.entries(ctx.fs, iceberg.ManifestContentData) {
-		if err != nil {
-			return fmt.Errorf("iterating data files for current head %d: %w", head.SnapshotID, err)
-		}
-		// A DELETED entry means the file was removed (e.g. rewritten by a
-		// concurrent compaction); it is no longer live data a pos-delete can
-		// apply to, so it does not satisfy existence.
-		if entry.Status() == iceberg.EntryStatusDELETED {
+	manifests, err := ctx.manifestsFor(*head)
+	if err != nil {
+		return fmt.Errorf("iterating data files for current head %d: %w", head.SnapshotID, err)
+	}
+	for _, mf := range manifests {
+		if mf.ManifestContent() != iceberg.ManifestContentData {
 			continue
 		}
-		path := entry.DataFile().FilePath()
-		if _, ok := needed[path]; ok {
-			delete(needed, path)
-			if len(needed) == 0 {
-				return nil
+		for entry, err := range mf.Entries(ctx.manifestReadIO(), false) {
+			if err != nil {
+				return fmt.Errorf("iterating data files for current head %d: %w", head.SnapshotID, err)
+			}
+			// A DELETED entry means the file was removed (e.g. rewritten by a
+			// concurrent compaction); it is no longer live data a pos-delete can
+			// apply to, so it does not satisfy existence.
+			if entry.Status() == iceberg.EntryStatusDELETED {
+				continue
+			}
+			path := entry.DataFile().FilePath()
+			if _, ok := needed[path]; ok {
+				delete(needed, path)
+				if len(needed) == 0 {
+					return nil
+				}
 			}
 		}
 	}
@@ -403,7 +603,7 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 	}
 
 	for _, snap := range ctx.concurrent {
-		manifests, err := snap.Manifests(ctx.fs)
+		manifests, err := ctx.manifestsFor(snap)
 		if err != nil {
 			return fmt.Errorf("loading manifests for concurrent snapshot %d: %w", snap.SnapshotID, err)
 		}
@@ -428,7 +628,7 @@ func validateAddedDataFilesMatchingFilter(ctx *conflictContext, filter iceberg.B
 			if err != nil {
 				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
 			}
-			for e, err := range mf.Entries(ctx.fs, false) {
+			for e, err := range mf.Entries(ctx.manifestReadIO(), false) {
 				if err != nil {
 					return fmt.Errorf("reading entries from manifest %s: %w", mf.FilePath(), err)
 				}

--- a/table/conflict_validation_bench_test.go
+++ b/table/conflict_validation_bench_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -113,6 +114,37 @@ func BenchmarkConflictValidationSharedManifestReads(b *testing.B) {
 	}
 }
 
+func BenchmarkConflictValidationMixedValidators(b *testing.B) {
+	for _, entryCount := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("entries=%d", entryCount), func(b *testing.B) {
+			baseContext := newConflictValidationBenchmarkContext(b, entryCount)
+			fs := baseContext.fs.(*conflictValidationBenchmarkIO)
+			referencedPath := "data-0.parquet"
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				ctx := &conflictContext{
+					current:    baseContext.current,
+					branch:     baseContext.branch,
+					fs:         baseContext.fs,
+					concurrent: baseContext.concurrent,
+				}
+				if err := validateDataFilesExist(ctx, []string{referencedPath}); err != nil {
+					b.Fatal(err)
+				}
+
+				err := validateAddedDataFilesMatchingFilter(ctx, iceberg.AlwaysTrue{})
+				if !errors.Is(err, ErrConflictingDataFiles) {
+					b.Fatalf("validateAddedDataFilesMatchingFilter() error = %v", err)
+				}
+			}
+			b.ReportMetric(float64(fs.opens)/float64(b.N), "backend-opens/op")
+			b.ReportMetric(float64(fs.bytes)/float64(b.N), "backend-bytes/op")
+		})
+	}
+}
+
 type conflictValidationBenchmarkIO struct {
 	iceio.IO
 	opens int
@@ -200,11 +232,66 @@ func newConflictValidationBenchmarkContext(b *testing.B, entryCount int) *confli
 		b.Fatal(err)
 	}
 
+	baseID := int64(1)
+	baseMeta, err := NewMetadata(
+		schema,
+		&spec,
+		UnsortedSortOrder,
+		"mem://conflict-validation-benchmark",
+		iceberg.Properties{PropertyFormatVersion: "2"},
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	baseBuilder, err := MetadataBuilderFromBase(baseMeta, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+	baseSnapshot := Snapshot{
+		SnapshotID:     baseID,
+		SequenceNumber: 1,
+		TimestampMs:    baseMeta.LastUpdatedMillis() + 1,
+		Summary:        &Summary{Operation: OpAppend},
+	}
+	if err := baseBuilder.AddSnapshot(&baseSnapshot); err != nil {
+		b.Fatal(err)
+	}
+	if err := baseBuilder.SetSnapshotRef(MainBranch, baseID, BranchRef); err != nil {
+		b.Fatal(err)
+	}
+	baseMeta, err = baseBuilder.Build()
+	if err != nil {
+		b.Fatal(err)
+	}
+	currentBuilder, err := MetadataBuilderFromBase(baseMeta, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+	concurrentSnapshot := Snapshot{
+		SnapshotID:       snapshotID,
+		ParentSnapshotID: &baseID,
+		SequenceNumber:   2,
+		TimestampMs:      baseMeta.LastUpdatedMillis() + 2,
+		ManifestList:     manifestListPath,
+		Summary:          &Summary{Operation: OpAppend},
+	}
+	if err := currentBuilder.AddSnapshot(&concurrentSnapshot); err != nil {
+		b.Fatal(err)
+	}
+	if err := currentBuilder.SetSnapshotRef(MainBranch, snapshotID, BranchRef); err != nil {
+		b.Fatal(err)
+	}
+	currentMeta, err := currentBuilder.Build()
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	return &conflictContext{
-		fs: &conflictValidationBenchmarkIO{IO: baseFS},
-		concurrent: []Snapshot{{
-			SnapshotID:   snapshotID,
-			ManifestList: manifestListPath,
-		}},
+		current: currentMeta,
+		branch:  MainBranch,
+		fs:      &conflictValidationBenchmarkIO{IO: baseFS},
+		concurrent: []Snapshot{
+			concurrentSnapshot,
+		},
 	}
 }

--- a/table/conflict_validation_bench_test.go
+++ b/table/conflict_validation_bench_test.go
@@ -18,7 +18,12 @@
 package table
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 )
 
 var canonicalPartitionKeyBenchmarkSink string
@@ -78,5 +83,128 @@ func BenchmarkCanonicalPartitionKey(b *testing.B) {
 				canonicalPartitionKeyBenchmarkSink = key
 			}
 		})
+	}
+}
+
+func BenchmarkConflictValidationSharedManifestReads(b *testing.B) {
+	for _, entryCount := range []int{1_000, 10_000} {
+		for _, validatorCount := range []int{2, 8} {
+			b.Run(fmt.Sprintf("entries=%d/validators=%d", entryCount, validatorCount), func(b *testing.B) {
+				baseContext := newConflictValidationBenchmarkContext(b, entryCount)
+				fs := baseContext.fs.(*conflictValidationBenchmarkIO)
+				visit := func(Snapshot, iceberg.ManifestEntry) error { return nil }
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					// Each iteration models one commit attempt. Validators
+					// within that attempt share the context and its cache.
+					ctx := &conflictContext{fs: baseContext.fs, concurrent: baseContext.concurrent}
+					for range validatorCount {
+						if err := ctx.forEachAddedEntry(iceberg.ManifestContentData, visit); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+				b.ReportMetric(float64(fs.opens)/float64(b.N), "backend-opens/op")
+				b.ReportMetric(float64(fs.bytes)/float64(b.N), "backend-bytes/op")
+			})
+		}
+	}
+}
+
+type conflictValidationBenchmarkIO struct {
+	iceio.IO
+	opens int
+	bytes int64
+}
+
+func (f *conflictValidationBenchmarkIO) Open(name string) (iceio.File, error) {
+	f.opens++
+
+	file, err := f.IO.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conflictValidationBenchmarkFile{File: file, owner: f}, nil
+}
+
+type conflictValidationBenchmarkFile struct {
+	iceio.File
+	owner *conflictValidationBenchmarkIO
+}
+
+func (f *conflictValidationBenchmarkFile) Read(p []byte) (int, error) {
+	n, err := f.File.Read(p)
+	f.owner.bytes += int64(n)
+
+	return n, err
+}
+
+func (f *conflictValidationBenchmarkFile) ReadAt(p []byte, offset int64) (int, error) {
+	n, err := f.File.ReadAt(p, offset)
+	f.owner.bytes += int64(n)
+
+	return n, err
+}
+
+func newConflictValidationBenchmarkContext(b *testing.B, entryCount int) *conflictContext {
+	b.Helper()
+
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	spec := *iceberg.UnpartitionedSpec
+	snapshotID := int64(2)
+	entries := make([]iceberg.ManifestEntry, entryCount)
+	for i := range entryCount {
+		dataFile, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentData,
+			fmt.Sprintf("data-%d.parquet", i),
+			iceberg.ParquetFile,
+			nil,
+			nil,
+			nil,
+			1,
+			1024,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entries[i] = iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID, dataFile.Build()).
+			SequenceNum(1).
+			Build()
+	}
+
+	manifestPath := "mem://conflict-validation-benchmark/manifest.avro"
+	manifestListPath := "mem://conflict-validation-benchmark/manifest-list.avro"
+	baseFS := iceio.NewMemFS()
+
+	var manifest bytes.Buffer
+	mf, err := iceberg.WriteManifest(manifestPath, &manifest, 2, spec, schema, snapshotID, entries)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := baseFS.WriteFile(manifestPath, manifest.Bytes()); err != nil {
+		b.Fatal(err)
+	}
+
+	var manifestList bytes.Buffer
+	sequenceNumber := int64(1)
+	if err := iceberg.WriteManifestList(2, &manifestList, snapshotID, nil, &sequenceNumber, 0, []iceberg.ManifestFile{mf}); err != nil {
+		b.Fatal(err)
+	}
+	if err := baseFS.WriteFile(manifestListPath, manifestList.Bytes()); err != nil {
+		b.Fatal(err)
+	}
+
+	return &conflictContext{
+		fs: &conflictValidationBenchmarkIO{IO: baseFS},
+		concurrent: []Snapshot{{
+			SnapshotID:   snapshotID,
+			ManifestList: manifestListPath,
+		}},
 	}
 }

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -863,3 +863,65 @@ func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
 
 	require.NoError(t, validateNoConflictingDataFiles(ctx, iceberg.AlwaysTrue{}, IsolationSnapshot))
 }
+
+func TestConflictValidationReusesSharedManifestReads(t *testing.T) {
+	tio := newTrackingCallsIO()
+	dir := filepath.ToSlash(t.TempDir())
+	snapshotID := int64(2)
+	manifestPath := filepath.Join(dir, "manifest.avro")
+	manifestListPath := filepath.Join(dir, "manifest-list-1.avro")
+	sharedManifestListPath := filepath.Join(dir, "manifest-list-2.avro")
+
+	mf := writeManifest(t, tio.trackingIO, snapshotID, 1, manifestPath, filepath.Join(dir, "data.parquet"))
+	writeManifestList(t, tio.trackingIO, snapshotID, manifestListPath, []iceberg.ManifestFile{mf})
+	writeManifestList(t, tio.trackingIO, snapshotID+1, sharedManifestListPath, []iceberg.ManifestFile{mf})
+
+	ctx := &conflictContext{
+		fs: tio,
+		concurrent: []Snapshot{
+			{SnapshotID: snapshotID, ManifestList: manifestListPath},
+			{SnapshotID: snapshotID + 1, ManifestList: sharedManifestListPath},
+		},
+	}
+
+	var visited int
+	visit := func(Snapshot, iceberg.ManifestEntry) error {
+		visited++
+		return nil
+	}
+	for range 2 {
+		require.NoError(t, ctx.forEachAddedEntry(iceberg.ManifestContentData, visit))
+	}
+
+	assert.Equal(t, 2, visited)
+	assert.Equal(t, 1, tio.openCount[manifestListPath])
+	assert.Equal(t, 1, tio.openCount[sharedManifestListPath])
+	assert.Equal(t, 1, tio.openCount[manifestPath])
+}
+
+func TestConflictValidationDoesNotCacheEarlyManifestExit(t *testing.T) {
+	tio := newTrackingCallsIO()
+	dir := filepath.ToSlash(t.TempDir())
+	snapshotID := int64(2)
+	manifestPath := filepath.Join(dir, "manifest.avro")
+	manifestListPath := filepath.Join(dir, "manifest-list.avro")
+
+	mf := writeManifest(t, tio.trackingIO, snapshotID, 1, manifestPath, filepath.Join(dir, "data.parquet"))
+	writeManifestList(t, tio.trackingIO, snapshotID, manifestListPath, []iceberg.ManifestFile{mf})
+	ctx := &conflictContext{
+		fs:         tio,
+		concurrent: []Snapshot{{SnapshotID: snapshotID, ManifestList: manifestListPath}},
+	}
+
+	stop := errors.New("stop validation")
+	err := ctx.forEachAddedEntry(iceberg.ManifestContentData, func(Snapshot, iceberg.ManifestEntry) error {
+		return stop
+	})
+	require.ErrorIs(t, err, stop)
+
+	require.NoError(t, ctx.forEachAddedEntry(iceberg.ManifestContentData, func(Snapshot, iceberg.ManifestEntry) error {
+		return nil
+	}))
+	assert.Equal(t, 1, tio.openCount[manifestListPath])
+	assert.Equal(t, 2, tio.openCount[manifestPath])
+}

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -887,6 +887,7 @@ func TestConflictValidationReusesSharedManifestReads(t *testing.T) {
 	var visited int
 	visit := func(Snapshot, iceberg.ManifestEntry) error {
 		visited++
+
 		return nil
 	}
 	for range 2 {

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"math"
 	"path/filepath"
@@ -864,6 +865,19 @@ func TestValidateNoConflictingDataFiles_SnapshotIsolationIsNoOp(t *testing.T) {
 	require.NoError(t, validateNoConflictingDataFiles(ctx, iceberg.AlwaysTrue{}, IsolationSnapshot))
 }
 
+type conflictValidationStatIO struct {
+	*trackingCallsIO
+}
+
+func (c *conflictValidationStatIO) Stat(name string) (fs.FileInfo, error) {
+	data, ok := c.files[name]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+
+	return conflictManifestFileInfo{name: name, size: int64(len(data))}, nil
+}
+
 func TestConflictValidationReusesSharedManifestReads(t *testing.T) {
 	tio := newTrackingCallsIO()
 	dir := filepath.ToSlash(t.TempDir())
@@ -877,7 +891,7 @@ func TestConflictValidationReusesSharedManifestReads(t *testing.T) {
 	writeManifestList(t, tio.trackingIO, snapshotID+1, sharedManifestListPath, []iceberg.ManifestFile{mf})
 
 	ctx := &conflictContext{
-		fs: tio,
+		fs: &conflictValidationStatIO{trackingCallsIO: tio},
 		concurrent: []Snapshot{
 			{SnapshotID: snapshotID, ManifestList: manifestListPath},
 			{SnapshotID: snapshotID + 1, ManifestList: sharedManifestListPath},
@@ -900,7 +914,7 @@ func TestConflictValidationReusesSharedManifestReads(t *testing.T) {
 	assert.Equal(t, 1, tio.openCount[manifestPath])
 }
 
-func TestConflictValidationDoesNotCacheEarlyManifestExit(t *testing.T) {
+func TestConflictValidationCachesFullyReadManifestAfterEarlyExit(t *testing.T) {
 	tio := newTrackingCallsIO()
 	dir := filepath.ToSlash(t.TempDir())
 	snapshotID := int64(2)
@@ -910,7 +924,7 @@ func TestConflictValidationDoesNotCacheEarlyManifestExit(t *testing.T) {
 	mf := writeManifest(t, tio.trackingIO, snapshotID, 1, manifestPath, filepath.Join(dir, "data.parquet"))
 	writeManifestList(t, tio.trackingIO, snapshotID, manifestListPath, []iceberg.ManifestFile{mf})
 	ctx := &conflictContext{
-		fs:         tio,
+		fs:         &conflictValidationStatIO{trackingCallsIO: tio},
 		concurrent: []Snapshot{{SnapshotID: snapshotID, ManifestList: manifestListPath}},
 	}
 
@@ -924,5 +938,96 @@ func TestConflictValidationDoesNotCacheEarlyManifestExit(t *testing.T) {
 		return nil
 	}))
 	assert.Equal(t, 1, tio.openCount[manifestListPath])
-	assert.Equal(t, 2, tio.openCount[manifestPath])
+	assert.Equal(t, 1, tio.openCount[manifestPath])
+}
+
+func TestConflictValidationSharesManifestAfterDataFileEarlyExit(t *testing.T) {
+	tio := newTrackingCallsIO()
+	dir := filepath.ToSlash(t.TempDir())
+	baseID := int64(1)
+	snapshotID := int64(2)
+	manifestPath := filepath.Join(dir, "manifest.avro")
+	manifestListPath := filepath.Join(dir, "manifest-list.avro")
+	dataPath := filepath.Join(dir, "data.parquet")
+
+	mf := writeManifest(t, tio.trackingIO, snapshotID, 2, manifestPath, dataPath)
+	writeManifestList(t, tio.trackingIO, snapshotID, manifestListPath, []iceberg.ManifestFile{mf})
+
+	base := newConflictTestMetadata(t, &baseID)
+	builder, err := MetadataBuilderFromBase(base, "")
+	require.NoError(t, err)
+	concSnapshot := Snapshot{
+		SnapshotID:       snapshotID,
+		ParentSnapshotID: &baseID,
+		SequenceNumber:   2,
+		TimestampMs:      base.LastUpdatedMillis() + 2,
+		ManifestList:     manifestListPath,
+		Summary:          &Summary{Operation: OpAppend},
+	}
+	require.NoError(t, builder.AddSnapshot(&concSnapshot))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	current, err := builder.Build()
+	require.NoError(t, err)
+
+	ctx, err := newConflictContext(
+		base,
+		current,
+		MainBranch,
+		&conflictValidationStatIO{trackingCallsIO: tio},
+		true,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, validateDataFilesExist(ctx, []string{dataPath}))
+	err = validateAddedDataFilesMatchingFilter(ctx, iceberg.AlwaysTrue{})
+	require.ErrorIs(t, err, ErrConflictingDataFiles)
+
+	assert.Equal(t, 1, tio.openCount[manifestListPath])
+	assert.Equal(t, 1, tio.openCount[manifestPath])
+}
+
+func TestConflictManifestIODoesNotCachePartialRead(t *testing.T) {
+	tio := newTrackingCallsIO()
+	manifestPath := "manifest.avro"
+	tio.files[manifestPath] = []byte("abc")
+	cache := newConflictManifestIO(&conflictValidationStatIO{trackingCallsIO: tio})
+
+	f, err := cache.Open(manifestPath)
+	require.NoError(t, err)
+	buf := make([]byte, 1)
+	_, err = f.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	assert.NotContains(t, cache.files, manifestPath)
+}
+
+func TestConflictManifestIOIsReadOnly(t *testing.T) {
+	tio := newTrackingCallsIO()
+	cache := newConflictManifestIO(tio)
+
+	err := cache.Remove("manifest.avro")
+	require.Error(t, err)
+	assert.Zero(t, tio.removeCount["manifest.avro"])
+}
+
+func TestConflictManifestIOStopsCachingAtByteLimit(t *testing.T) {
+	tio := newTrackingCallsIO()
+	manifestPath := "manifest.avro"
+	tio.files[manifestPath] = []byte("ab")
+	cache := &conflictManifestIO{
+		base:        &conflictValidationStatIO{trackingCallsIO: tio},
+		files:       make(map[string][]byte),
+		cachedBytes: maxConflictManifestCacheBytes - 1,
+	}
+
+	f, err := cache.Open(manifestPath)
+	require.NoError(t, err)
+	buf := make([]byte, 2)
+	_, err = f.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	assert.NotContains(t, cache.files, manifestPath)
+	assert.Equal(t, int64(maxConflictManifestCacheBytes-1), cache.cachedBytes)
 }


### PR DESCRIPTION
## What changed

- Cache parsed manifest-list descriptors for one conflict-validation context.
- Reuse completed manifest reads by path across validators and snapshots.
- Keep the first scan streaming and do not retain early exits.
- Add shared-read and early-exit correctness coverage.
- Add a benchmark that reports backend opens and bytes fetched.

## Why

A commit can run more than one conflict validator against the same `conflictContext`. Each pass used to reopen the same manifest list and manifest file, which added extra object-store reads.

The cache only lives for one validation attempt. Manifest entry decoding still runs with each descriptor, so inheritance behavior stays unchanged.

## Benchmark

Run on an Apple M1 Pro with:

`go test ./table -run '^$' -bench '^BenchmarkConflictValidationSharedManifestReads/(entries=(1000|10000))/(validators=(2|8))$' -benchmem -benchtime=1s -count=5`

These are medians over five runs. Before is `upstream/main` at `c9813324`. The backend metrics are per commit attempt. Local wall time is mostly Avro decoding and is more noisy.

| Workload | Before | After |
| --- | --- | --- |
| 1K entries / 2 validators | 4 opens, 16,160 B, 21,302 allocs | 2 opens, 8,080 B, 19,954 allocs |
| 1K entries / 8 validators | 16 opens, 64,640 B, 85,214 allocs | 2 opens, 8,080 B, 75,718 allocs |
| 10K entries / 2 validators | 4 opens, 63,976 B, 148,189 allocs | 2 opens, 31,988 B, 146,843 allocs |
| 10K entries / 8 validators | 16 opens, 255,904 B, 592,759 allocs | 2 opens, 31,988 B, 583,261 allocs |

## Testing

- `go test ./table -count=1`
- `go test ./table -race -count=1`
- `go vet ./table`
- `go test ./... -run '^$'`
