### PR TITLE
fix(table): reject deleted schema move targets

### DIFF
--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -388,6 +388,11 @@ func (u *UpdateSchema) deleteColumn(path []string) error {
 			return fmt.Errorf("field that has updates cannot be deleted: %s", fullName)
 		}
 	}
+	for _, move := range u.moves[parentID] {
+		if move.RelativeTo == field.ID {
+			return fmt.Errorf("field that is used as a move target cannot be deleted: %s", fullName)
+		}
+	}
 
 	delete(u.identifierFieldNames, fullName)
 
@@ -625,6 +630,9 @@ func (u *UpdateSchema) moveColumn(op MoveOp, path []string, relativeTo []string)
 
 		if relativeToFieldID == fieldID {
 			return fmt.Errorf("cannot move a field to itself: %s", fullName)
+		}
+		if u.isDeleted(relativeToFieldID) {
+			return fmt.Errorf("field that has been deleted cannot be used as a move target: %s", relativeToFullName)
 		}
 
 		if u.findParentID(relativeToFieldID) != parentID {

--- a/table/update_schema.go
+++ b/table/update_schema.go
@@ -1388,7 +1388,7 @@ func moveFields(fields []iceberg.NestedField, moves []move) []iceberg.NestedFiel
 			}
 		}
 		if !found {
-			continue
+			panic(fmt.Errorf("cannot move field %d: field not found", move.FieldID))
 		}
 
 		reordered = append(reordered[:fieldIndex], reordered[fieldIndex+1:]...)
@@ -1408,7 +1408,7 @@ func moveFields(fields []iceberg.NestedField, moves []move) []iceberg.NestedFiel
 				}
 			}
 			if !found {
-				continue
+				panic(fmt.Errorf("cannot move field %d: target field %d not found", move.FieldID, move.RelativeTo))
 			}
 
 			if move.Op == MoveOpBefore {

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -490,6 +490,16 @@ func TestApplyChanges(t *testing.T) {
 			{ID: 4, Name: "name", Type: iceberg.PrimitiveTypes.UUID, Required: false, Doc: ""},
 		}, st.(*iceberg.StructType).Fields())
 	})
+
+	t.Run("test move with missing target fails", func(t *testing.T) {
+		_, err := iceberg.Visit(originalSchema, &applyChanges{
+			deletes: map[int]struct{}{2: {}},
+			moves: map[int][]move{
+				TableRootID: {{FieldID: 3, RelativeTo: 2, Op: MoveOpBefore}},
+			},
+		})
+		require.ErrorContains(t, err, "cannot move field 3: target field 2 not found")
+	})
 }
 
 func TestDeleteColumn(t *testing.T) {
@@ -889,32 +899,37 @@ func TestMoveColumn(t *testing.T) {
 
 func TestMoveRelativeToDeletedColumnRejected(t *testing.T) {
 	tests := []struct {
-		name  string
-		build func(*UpdateSchema) *UpdateSchema
+		name    string
+		build   func(*UpdateSchema) *UpdateSchema
+		wantErr string
 	}{
 		{
 			name: "delete then move before",
 			build: func(update *UpdateSchema) *UpdateSchema {
 				return update.DeleteColumn([]string{"name"}).MoveBefore([]string{"age"}, []string{"name"})
 			},
+			wantErr: "has been deleted",
 		},
 		{
 			name: "move before then delete",
 			build: func(update *UpdateSchema) *UpdateSchema {
 				return update.MoveBefore([]string{"age"}, []string{"name"}).DeleteColumn([]string{"name"})
 			},
+			wantErr: "cannot be deleted",
 		},
 		{
 			name: "delete then move after",
 			build: func(update *UpdateSchema) *UpdateSchema {
 				return update.DeleteColumn([]string{"name"}).MoveAfter([]string{"age"}, []string{"name"})
 			},
+			wantErr: "has been deleted",
 		},
 		{
 			name: "move after then delete",
 			build: func(update *UpdateSchema) *UpdateSchema {
 				return update.MoveAfter([]string{"age"}, []string{"name"}).DeleteColumn([]string{"name"})
 			},
+			wantErr: "cannot be deleted",
 		},
 	}
 
@@ -922,10 +937,43 @@ func TestMoveRelativeToDeletedColumnRejected(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tbl := New([]string{"id"}, testMetadata, "", nil, nil)
 			_, err := tt.build(NewUpdateSchema(tbl.NewTransaction(), true, true)).Apply()
-			require.ErrorContains(t, err, "move target")
+			require.ErrorContains(t, err, tt.wantErr)
 			require.ErrorContains(t, err, "name")
 		})
 	}
+
+	t.Run("move then delete source", func(t *testing.T) {
+		tbl := New([]string{"id"}, testMetadata, "", nil, nil)
+		_, err := NewUpdateSchema(tbl.NewTransaction(), true, true).
+			MoveBefore([]string{"age"}, []string{"name"}).
+			DeleteColumn([]string{"age"}).
+			Apply()
+		require.ErrorContains(t, err, "cannot move field 3: field not found")
+	})
+
+	t.Run("delete with unrelated move", func(t *testing.T) {
+		tbl := New([]string{"id"}, testMetadata, "", nil, nil)
+		updated, err := NewUpdateSchema(tbl.NewTransaction(), true, true).
+			DeleteColumn([]string{"name"}).
+			MoveBefore([]string{"age"}, []string{"id"}).
+			Apply()
+		require.NoError(t, err)
+		fields := updated.Fields()
+		names := make([]string, len(fields))
+		for i, field := range fields {
+			names[i] = field.Name
+		}
+		require.Equal(t, []string{"age", "id", "address", "tags", "properties"}, names)
+	})
+
+	t.Run("nested move target cannot be deleted", func(t *testing.T) {
+		tbl := New([]string{"id"}, testMetadata, "", nil, nil)
+		_, err := NewUpdateSchema(tbl.NewTransaction(), true, true).
+			MoveBefore([]string{"address", "zip"}, []string{"address", "city"}).
+			DeleteColumn([]string{"address", "city"}).
+			Apply()
+		require.ErrorContains(t, err, "cannot be deleted: address.city")
+	})
 }
 
 func TestChainedOperations(t *testing.T) {

--- a/table/update_schema_test.go
+++ b/table/update_schema_test.go
@@ -887,6 +887,47 @@ func TestMoveColumn(t *testing.T) {
 	})
 }
 
+func TestMoveRelativeToDeletedColumnRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*UpdateSchema) *UpdateSchema
+	}{
+		{
+			name: "delete then move before",
+			build: func(update *UpdateSchema) *UpdateSchema {
+				return update.DeleteColumn([]string{"name"}).MoveBefore([]string{"age"}, []string{"name"})
+			},
+		},
+		{
+			name: "move before then delete",
+			build: func(update *UpdateSchema) *UpdateSchema {
+				return update.MoveBefore([]string{"age"}, []string{"name"}).DeleteColumn([]string{"name"})
+			},
+		},
+		{
+			name: "delete then move after",
+			build: func(update *UpdateSchema) *UpdateSchema {
+				return update.DeleteColumn([]string{"name"}).MoveAfter([]string{"age"}, []string{"name"})
+			},
+		},
+		{
+			name: "move after then delete",
+			build: func(update *UpdateSchema) *UpdateSchema {
+				return update.MoveAfter([]string{"age"}, []string{"name"}).DeleteColumn([]string{"name"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tbl := New([]string{"id"}, testMetadata, "", nil, nil)
+			_, err := tt.build(NewUpdateSchema(tbl.NewTransaction(), true, true)).Apply()
+			require.ErrorContains(t, err, "move target")
+			require.ErrorContains(t, err, "name")
+		})
+	}
+}
+
 func TestChainedOperations(t *testing.T) {
 	t.Run("test multiple operations in chain", func(t *testing.T) {
 		table := New([]string{"id"}, testMetadata, "", nil, nil)


### PR DESCRIPTION
### Description

Fixes #1903.

Reject schema updates that either move a field relative to a column already staged for deletion or delete a column already referenced as a move target. This prevents `moveFields` from silently omitting the moved field when the target is absent from the resulting schema.

The regression test covers both operation orders and both `MoveBefore` and `MoveAfter`.

### Testing

- `go test ./table -run 'TestMoveRelativeToDeletedColumnRejected|TestMoveColumn|TestDeleteColumn|TestChainedOperations' -count=1`
- `make test`
- `make test-assert`
- `make test-race`
- `make lint`
- `go build ./...`
