### PR TITLE
perf(dv): coalesce shared Puffin range reads

### DIFF
--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -56,6 +56,10 @@ const (
 	dvMagicSize  = 4 // magic field
 	dvCRCSize    = 4 // CRC-32 checksum
 	dvMinSize    = dvLengthSize + dvMagicSize + dvCRCSize
+
+	// maxCoalescedDVRangeSize caps a range only when it is extended with
+	// another blob. A single blob may still be up to DefaultMaxBlobSize.
+	maxCoalescedDVRangeSize int64 = 8 << 20
 )
 
 // DeserializeDV parses a deletion vector blob and returns a bitmap of deleted positions.
@@ -292,6 +296,8 @@ func ReadDVs(fs iceio.IO, dvFiles []iceberg.DataFile) ([]*RoaringPositionBitmap,
 		for end < len(reads) {
 			next := reads[end]
 			nextEnd := next.offset + next.blob.Length
+			// Only coalesce contiguous or overlapping blobs. Gaps are left as
+			// separate reads so the range does not fetch unrelated bytes.
 			if next.offset > rangeEnd || nextEnd-rangeStart > maxCoalescedDVRangeSize {
 				break
 			}
@@ -308,10 +314,11 @@ func ReadDVs(fs iceio.IO, dvFiles []iceberg.DataFile) ([]*RoaringPositionBitmap,
 		for _, read := range reads[start:end] {
 			blobStart := read.offset - rangeStart
 			blobEnd := blobStart + read.blob.Length
-			bitmaps[read.index], err = DeserializeDV(rangeData[blobStart:blobEnd], read.manifestCardinality)
+			bitmap, err := DeserializeDV(rangeData[blobStart:blobEnd], read.manifestCardinality)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("deserialize DV blob at offset %d: %w", read.offset, err)
 			}
+			bitmaps[read.index] = bitmap
 		}
 
 		start = end
@@ -319,8 +326,6 @@ func ReadDVs(fs iceio.IO, dvFiles []iceberg.DataFile) ([]*RoaringPositionBitmap,
 
 	return bitmaps, nil
 }
-
-const maxCoalescedDVRangeSize int64 = 8 << 20
 
 func validateDVFile(dvFile iceberg.DataFile) error {
 	if dvFile.FileFormat() != iceberg.PuffinFile {

--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -19,12 +19,14 @@ package dv
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/crc32"
 	"log/slog"
 	"math"
+	"slices"
 	"strconv"
 
 	"github.com/apache/iceberg-go"
@@ -248,7 +250,14 @@ func ReadDVs(fs iceio.IO, dvFiles []iceberg.DataFile) ([]*RoaringPositionBitmap,
 	defer f.Close()
 
 	blobsByOffset := indexBlobMetadataByOffset(reader.Blobs())
-	bitmaps := make([]*RoaringPositionBitmap, len(dvFiles))
+	type dvBlobRead struct {
+		index               int
+		blob                puffin.BlobMetadata
+		offset              int64
+		manifestCardinality int64
+	}
+
+	reads := make([]dvBlobRead, len(dvFiles))
 	for i, dvFile := range dvFiles {
 		_, _, manifestReferencedDataFile, contentOffset, contentSize := iceberginternal.BorrowedDataFilePointers(dvFile)
 		offset, size := *contentOffset, *contentSize
@@ -256,14 +265,62 @@ func ReadDVs(fs iceio.IO, dvFiles []iceberg.DataFile) ([]*RoaringPositionBitmap,
 		if err != nil {
 			return nil, fmt.Errorf("%w: DV file %s: %w", ErrInvalidDeletionVector, dvFile.FilePath(), err)
 		}
-		bitmaps[i], err = readDV(reader, blob, dvFile, offset, manifestReferencedDataFile)
+
+		manifestCardinality, err := validateDVBlobMetadata(blob, dvFile, offset, manifestReferencedDataFile)
 		if err != nil {
 			return nil, err
 		}
+
+		reads[i] = dvBlobRead{
+			index:               i,
+			blob:                blob,
+			offset:              offset,
+			manifestCardinality: manifestCardinality,
+		}
+	}
+
+	slices.SortFunc(reads, func(a, b dvBlobRead) int {
+		return cmp.Compare(a.offset, b.offset)
+	})
+
+	bitmaps := make([]*RoaringPositionBitmap, len(dvFiles))
+	for start := 0; start < len(reads); {
+		end := start + 1
+		rangeStart := reads[start].offset
+		rangeEnd := rangeStart + reads[start].blob.Length
+
+		for end < len(reads) {
+			next := reads[end]
+			nextEnd := next.offset + next.blob.Length
+			if next.offset > rangeEnd || nextEnd-rangeStart > maxCoalescedDVRangeSize {
+				break
+			}
+
+			rangeEnd = max(rangeEnd, nextEnd)
+			end++
+		}
+
+		rangeData := make([]byte, rangeEnd-rangeStart)
+		if _, err := reader.ReadAt(rangeData, rangeStart); err != nil {
+			return nil, fmt.Errorf("read DV blob range at offset %d: %w", rangeStart, err)
+		}
+
+		for _, read := range reads[start:end] {
+			blobStart := read.offset - rangeStart
+			blobEnd := blobStart + read.blob.Length
+			bitmaps[read.index], err = DeserializeDV(rangeData[blobStart:blobEnd], read.manifestCardinality)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		start = end
 	}
 
 	return bitmaps, nil
 }
+
+const maxCoalescedDVRangeSize int64 = 8 << 20
 
 func validateDVFile(dvFile iceberg.DataFile) error {
 	if dvFile.FileFormat() != iceberg.PuffinFile {
@@ -303,22 +360,36 @@ func openDVReader(fs iceio.IO, filePath string) (*puffin.Reader, iceio.File, err
 }
 
 func readDV(reader *puffin.Reader, blob puffin.BlobMetadata, dvFile iceberg.DataFile, offset int64, manifestReferencedDataFile *string) (*RoaringPositionBitmap, error) {
+	manifestCardinality, err := validateDVBlobMetadata(blob, dvFile, offset, manifestReferencedDataFile)
+	if err != nil {
+		return nil, err
+	}
+
+	blobData := make([]byte, blob.Length)
+	if _, err := reader.ReadAt(blobData, offset); err != nil {
+		return nil, fmt.Errorf("read DV blob at offset %d: %w", offset, err)
+	}
+
+	return DeserializeDV(blobData, manifestCardinality)
+}
+
+func validateDVBlobMetadata(blob puffin.BlobMetadata, dvFile iceberg.DataFile, offset int64, manifestReferencedDataFile *string) (int64, error) {
 	if blob.Type != puffin.BlobTypeDeletionVector {
-		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d has type %q, expected %q", ErrInvalidDeletionVector,
+		return 0, fmt.Errorf("%w: DV file %s: blob at offset %d has type %q, expected %q", ErrInvalidDeletionVector,
 			dvFile.FilePath(), offset, blob.Type, puffin.BlobTypeDeletionVector)
 	}
 	if blob.CompressionCodec != nil && *blob.CompressionCodec != "" {
-		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d uses unsupported compression codec %q",
+		return 0, fmt.Errorf("%w: DV file %s: blob at offset %d uses unsupported compression codec %q",
 			ErrInvalidDeletionVector, dvFile.FilePath(), offset, *blob.CompressionCodec)
 	}
 
 	referencedDataFile, ok := blob.Properties[dvReferencedDataFileProperty]
 	if !ok || referencedDataFile == "" {
-		return nil, fmt.Errorf("%w: DV file %s: blob at offset %d missing or empty %s property", ErrInvalidDeletionVector,
+		return 0, fmt.Errorf("%w: DV file %s: blob at offset %d missing or empty %s property", ErrInvalidDeletionVector,
 			dvFile.FilePath(), offset, dvReferencedDataFileProperty)
 	}
 	if referencedDataFile != *manifestReferencedDataFile {
-		return nil, fmt.Errorf("%w: DV file %s: manifest referenced_data_file %q does not match puffin %s %q", ErrInvalidDeletionVector,
+		return 0, fmt.Errorf("%w: DV file %s: manifest referenced_data_file %q does not match puffin %s %q", ErrInvalidDeletionVector,
 			dvFile.FilePath(), *manifestReferencedDataFile, dvReferencedDataFileProperty, referencedDataFile)
 	}
 
@@ -331,7 +402,7 @@ func readDV(reader *puffin.Reader, blob puffin.BlobMetadata, dvFile iceberg.Data
 	// mandated property; when present it is a second source to cross-check.
 	puffinCardinality, hasPuffinCardinality, err := blobCardinality(blob)
 	if err != nil {
-		return nil, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
+		return 0, fmt.Errorf("DV file %s: %w", dvFile.FilePath(), err)
 	}
 
 	// When both sources are available they must agree. A disagreement means a
@@ -339,7 +410,7 @@ func readDV(reader *puffin.Reader, blob puffin.BlobMetadata, dvFile iceberg.Data
 	// (e.g. a stale record_count after an incremental merge against a freshly
 	// written blob) — fail fast rather than silently trusting one over the other.
 	if hasPuffinCardinality && manifestCardinality != puffinCardinality {
-		return nil, fmt.Errorf("DV file %s: manifest record_count %d disagrees with puffin cardinality property %d",
+		return 0, fmt.Errorf("DV file %s: manifest record_count %d disagrees with puffin cardinality property %d",
 			dvFile.FilePath(), manifestCardinality, puffinCardinality)
 	}
 
@@ -352,15 +423,7 @@ func readDV(reader *puffin.Reader, blob puffin.BlobMetadata, dvFile iceberg.Data
 			"dv_file", dvFile.FilePath(), "offset", offset)
 	}
 
-	blobData := make([]byte, blob.Length)
-	if _, err := reader.ReadAt(blobData, offset); err != nil {
-		return nil, fmt.Errorf("read DV blob at offset %d: %w", offset, err)
-	}
-
-	// Validate the decoded bitmap against the manifest record_count (always
-	// present, including zero). When the puffin property is present it has
-	// already been confirmed to agree with this value above.
-	return DeserializeDV(blobData, manifestCardinality)
+	return manifestCardinality, nil
 }
 
 func indexBlobMetadataByOffset(blobs []puffin.BlobMetadata) map[int64]puffin.BlobMetadata {

--- a/table/dv/deletion_vector_bench_test.go
+++ b/table/dv/deletion_vector_bench_test.go
@@ -80,9 +80,8 @@ func BenchmarkReadDVs(b *testing.B) {
 			fs := &countingReadIO{base: iceio.LocalFS{}}
 
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
-				fs.reads = 0
+				fs.reset()
 				bitmaps, err := ReadDVs(fs, files)
 				if err != nil {
 					b.Fatal(err)
@@ -92,7 +91,6 @@ func BenchmarkReadDVs(b *testing.B) {
 				}
 			}
 			b.ReportMetric(float64(fs.reads), "range-reads/op")
-			b.StopTimer()
 		})
 	}
 }
@@ -127,7 +125,7 @@ func benchmarkDVFiles(b *testing.B, numDVs int) []iceberg.DataFile {
 			Type:           puffin.BlobTypeDeletionVector,
 			SnapshotID:     -1,
 			SequenceNumber: -1,
-			Fields:         []int32{},
+			Fields:         []int32{2147483546},
 			Properties: map[string]string{
 				dvReferencedDataFileProperty: referencedDataFile,
 				dvCardinalityProperty:        "1",

--- a/table/dv/deletion_vector_bench_test.go
+++ b/table/dv/deletion_vector_bench_test.go
@@ -17,7 +17,16 @@
 
 package dv
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/puffin"
+)
 
 var benchmarkSerializedDV []byte
 
@@ -62,4 +71,86 @@ func BenchmarkSerializeDV(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkReadDVs(b *testing.B) {
+	for _, numDVs := range []int{2, 16, 64} {
+		b.Run(fmt.Sprintf("dvs=%d", numDVs), func(b *testing.B) {
+			files := benchmarkDVFiles(b, numDVs)
+			fs := &countingReadIO{base: iceio.LocalFS{}}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				fs.reads = 0
+				bitmaps, err := ReadDVs(fs, files)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(bitmaps) != numDVs {
+					b.Fatalf("got %d bitmaps, want %d", len(bitmaps), numDVs)
+				}
+			}
+			b.ReportMetric(float64(fs.reads), "range-reads/op")
+			b.StopTimer()
+		})
+	}
+}
+
+func benchmarkDVFiles(b *testing.B, numDVs int) []iceberg.DataFile {
+	b.Helper()
+
+	path := filepath.Join(b.TempDir(), "deletion-vectors.puffin")
+	f, err := os.Create(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	writer, err := puffin.NewWriter(f)
+	if err != nil {
+		_ = f.Close()
+		b.Fatal(err)
+	}
+
+	files := make([]iceberg.DataFile, numDVs)
+	for i := range numDVs {
+		bitmap := NewRoaringPositionBitmap()
+		bitmap.Set(uint64(i))
+		data, err := SerializeDV(bitmap)
+		if err != nil {
+			_ = f.Close()
+			b.Fatal(err)
+		}
+
+		referencedDataFile := fmt.Sprintf("data-%03d.parquet", i)
+		meta, err := writer.AddBlob(puffin.BlobMetadataInput{
+			Type:           puffin.BlobTypeDeletionVector,
+			SnapshotID:     -1,
+			SequenceNumber: -1,
+			Fields:         []int32{},
+			Properties: map[string]string{
+				dvReferencedDataFileProperty: referencedDataFile,
+				dvCardinalityProperty:        "1",
+			},
+		}, data)
+		if err != nil {
+			_ = f.Close()
+			b.Fatal(err)
+		}
+
+		offset, size := meta.Offset, meta.Length
+		file := newDVTestFile(path, 1, &offset, &size)
+		file.referencedDataFile = strPtr(referencedDataFile)
+		files[i] = file
+	}
+
+	if err := writer.Finish(); err != nil {
+		_ = f.Close()
+		b.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	return files
 }

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -221,6 +221,35 @@ type failingOpenFS struct {
 func (f failingOpenFS) Open(string) (iceio.File, error) { return nil, f.err }
 func (f failingOpenFS) Remove(string) error             { return nil }
 
+type countingReadIO struct {
+	base  iceio.IO
+	reads int
+}
+
+func (f *countingReadIO) Open(name string) (iceio.File, error) {
+	file, err := f.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &countingReadFile{File: file, reads: &f.reads}, nil
+}
+
+func (f *countingReadIO) Remove(name string) error {
+	return f.base.Remove(name)
+}
+
+type countingReadFile struct {
+	iceio.File
+	reads *int
+}
+
+func (f *countingReadFile) ReadAt(p []byte, off int64) (int, error) {
+	(*f.reads)++
+
+	return f.File.ReadAt(p, off)
+}
+
 // Why: SerializeDV run-length encodes before emitting bytes, so a caller that
 // records contiguous deletes one position at a time still gets a compact blob
 // rather than dense containers. Without that step the envelope carries a full
@@ -529,6 +558,53 @@ func TestReadDVs(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidDeletionVector)
 		assert.ErrorContains(t, err, "manifest referenced_data_file")
 	})
+}
+
+func TestReadDVsCoalescesAdjacentBlobReads(t *testing.T) {
+	dir := t.TempDir()
+	first := NewRoaringPositionBitmap()
+	first.Set(1)
+	firstData, err := SerializeDV(first)
+	require.NoError(t, err)
+
+	second := NewRoaringPositionBitmap()
+	second.Set(2)
+	secondData, err := SerializeDV(second)
+	require.NoError(t, err)
+
+	path, metas := writePuffinWithDVBlobs(t, dir,
+		testPuffinBlobInput{
+			data: firstData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-001.parquet",
+				dvCardinalityProperty:        "1",
+			},
+		},
+		testPuffinBlobInput{
+			data: secondData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-002.parquet",
+				dvCardinalityProperty:        "1",
+			},
+		},
+	)
+
+	firstOffset, firstSize := metas[0].Offset, metas[0].Length
+	secondOffset, secondSize := metas[1].Offset, metas[1].Length
+	files := []iceberg.DataFile{
+		newDVTestFile(path, 1, &secondOffset, &secondSize),
+		newDVTestFile(path, 1, &firstOffset, &firstSize),
+	}
+	files[0].(*mockDVFile).referencedDataFile = strPtr("data-002.parquet")
+	files[1].(*mockDVFile).referencedDataFile = strPtr("data-001.parquet")
+
+	fs := &countingReadIO{base: iceio.LocalFS{}}
+	bitmaps, err := ReadDVs(fs, files)
+	require.NoError(t, err)
+	require.Len(t, bitmaps, 2)
+	assert.True(t, bitmaps[0].Contains(2))
+	assert.True(t, bitmaps[1].Contains(1))
+	assert.Equal(t, 3, fs.reads)
 }
 
 // Why: ReadDV should reject callers that pass the wrong file type before doing any I/O.

--- a/table/dv/deletion_vector_test.go
+++ b/table/dv/deletion_vector_test.go
@@ -26,6 +26,7 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -203,6 +204,49 @@ func writeRawPuffinBlob(t *testing.T, dir, name string, blobBytes []byte, blobTy
 	return path, meta
 }
 
+func writeRawPuffinWithDVBlobs(t *testing.T, dir string, gap int, blobs ...testPuffinBlobInput) (string, []puffin.BlobMetadata) {
+	t.Helper()
+
+	const puffinMagic = "PFA1"
+	var buf bytes.Buffer
+	buf.WriteString(puffinMagic)
+
+	metas := make([]puffin.BlobMetadata, 0, len(blobs))
+	for i, blob := range blobs {
+		if i > 0 {
+			buf.Write(make([]byte, gap))
+		}
+
+		meta := puffin.BlobMetadata{
+			Type:           puffin.BlobTypeDeletionVector,
+			SnapshotID:     -1,
+			SequenceNumber: -1,
+			Fields:         []int32{2147483546},
+			Offset:         int64(buf.Len()),
+			Length:         int64(len(blob.data)),
+			Properties:     blob.props,
+		}
+		buf.Write(blob.data)
+		metas = append(metas, meta)
+	}
+
+	payload, err := json.Marshal(puffin.Footer{Blobs: metas})
+	require.NoError(t, err)
+	buf.WriteString(puffinMagic)
+	buf.Write(payload)
+
+	var trailer [12]byte // PayloadSize(4) + Flags(4) + Magic(4)
+	binary.LittleEndian.PutUint32(trailer[0:4], uint32(len(payload)))
+	binary.LittleEndian.PutUint32(trailer[4:8], 0)
+	copy(trailer[8:12], puffinMagic)
+	buf.Write(trailer[:])
+
+	path := filepath.Join(dir, "raw-dv-with-gap.puffin")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+
+	return path, metas
+}
+
 func newDVTestFile(path string, count int64, offset, size *int64) *mockDVFile {
 	return &mockDVFile{
 		path:               path,
@@ -222,8 +266,9 @@ func (f failingOpenFS) Open(string) (iceio.File, error) { return nil, f.err }
 func (f failingOpenFS) Remove(string) error             { return nil }
 
 type countingReadIO struct {
-	base  iceio.IO
-	reads int
+	base      iceio.IO
+	reads     int
+	readCalls []readAtCall
 }
 
 func (f *countingReadIO) Open(name string) (iceio.File, error) {
@@ -232,22 +277,49 @@ func (f *countingReadIO) Open(name string) (iceio.File, error) {
 		return nil, err
 	}
 
-	return &countingReadFile{File: file, reads: &f.reads}, nil
+	return &countingReadFile{File: file, reads: &f.reads, readCalls: &f.readCalls}, nil
 }
 
 func (f *countingReadIO) Remove(name string) error {
 	return f.base.Remove(name)
 }
 
+func (f *countingReadIO) reset() {
+	f.reads = 0
+	f.readCalls = f.readCalls[:0]
+}
+
+type readAtCall struct {
+	offset int64
+	length int
+}
+
 type countingReadFile struct {
 	iceio.File
-	reads *int
+	reads     *int
+	readCalls *[]readAtCall
 }
 
 func (f *countingReadFile) ReadAt(p []byte, off int64) (int, error) {
 	(*f.reads)++
+	*f.readCalls = append(*f.readCalls, readAtCall{offset: off, length: len(p)})
 
 	return f.File.ReadAt(p, off)
+}
+
+func blobReadCalls(calls []readAtCall, metas []puffin.BlobMetadata) []readAtCall {
+	reads := make([]readAtCall, 0, len(metas))
+	for _, call := range calls {
+		for _, meta := range metas {
+			if call.offset == meta.Offset {
+				reads = append(reads, call)
+
+				break
+			}
+		}
+	}
+
+	return reads
 }
 
 // Why: SerializeDV run-length encodes before emitting bytes, so a caller that
@@ -604,7 +676,122 @@ func TestReadDVsCoalescesAdjacentBlobReads(t *testing.T) {
 	require.Len(t, bitmaps, 2)
 	assert.True(t, bitmaps[0].Contains(2))
 	assert.True(t, bitmaps[1].Contains(1))
-	assert.Equal(t, 3, fs.reads)
+	assert.Equal(t, []readAtCall{{
+		offset: firstOffset,
+		length: int(firstSize + secondSize),
+	}}, blobReadCalls(fs.readCalls, metas))
+}
+
+func TestReadDVsDoesNotCoalesceRangesOverSizeLimit(t *testing.T) {
+	largeData, cardinality := largeDVData(t)
+	dir := t.TempDir()
+	path, metas := writePuffinWithDVBlobs(t, dir,
+		testPuffinBlobInput{
+			data: largeData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-001.parquet",
+				dvCardinalityProperty:        strconv.FormatInt(cardinality, 10),
+			},
+		},
+		testPuffinBlobInput{
+			data: largeData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-002.parquet",
+				dvCardinalityProperty:        strconv.FormatInt(cardinality, 10),
+			},
+		},
+	)
+	require.LessOrEqual(t, metas[0].Length, maxCoalescedDVRangeSize)
+	require.LessOrEqual(t, metas[1].Length, maxCoalescedDVRangeSize)
+	require.Greater(t, metas[0].Length+metas[1].Length, maxCoalescedDVRangeSize)
+
+	files := make([]iceberg.DataFile, len(metas))
+	for i, meta := range metas {
+		offset, size := meta.Offset, meta.Length
+		file := newDVTestFile(path, cardinality, &offset, &size)
+		file.referencedDataFile = strPtr(fmt.Sprintf("data-%03d.parquet", i+1))
+		files[i] = file
+	}
+
+	fs := &countingReadIO{base: iceio.LocalFS{}}
+	bitmaps, err := ReadDVs(fs, files)
+	require.NoError(t, err)
+	require.Len(t, bitmaps, 2)
+	assert.Equal(t, cardinality, bitmaps[0].Cardinality())
+	assert.Equal(t, cardinality, bitmaps[1].Cardinality())
+	assert.Equal(t, []readAtCall{
+		{offset: metas[0].Offset, length: int(metas[0].Length)},
+		{offset: metas[1].Offset, length: int(metas[1].Length)},
+	}, blobReadCalls(fs.readCalls, metas))
+}
+
+func TestReadDVsDoesNotCoalesceBlobsWithGaps(t *testing.T) {
+	first := NewRoaringPositionBitmap()
+	first.Set(1)
+	firstData, err := SerializeDV(first)
+	require.NoError(t, err)
+
+	second := NewRoaringPositionBitmap()
+	second.Set(2)
+	secondData, err := SerializeDV(second)
+	require.NoError(t, err)
+
+	path, metas := writeRawPuffinWithDVBlobs(t, t.TempDir(), 1,
+		testPuffinBlobInput{
+			data: firstData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-001.parquet",
+				dvCardinalityProperty:        "1",
+			},
+		},
+		testPuffinBlobInput{
+			data: secondData,
+			props: map[string]string{
+				dvReferencedDataFileProperty: "data-002.parquet",
+				dvCardinalityProperty:        "1",
+			},
+		},
+	)
+
+	files := make([]iceberg.DataFile, len(metas))
+	for i, meta := range metas {
+		offset, size := meta.Offset, meta.Length
+		file := newDVTestFile(path, 1, &offset, &size)
+		file.referencedDataFile = strPtr(fmt.Sprintf("data-%03d.parquet", i+1))
+		files[i] = file
+	}
+
+	fs := &countingReadIO{base: iceio.LocalFS{}}
+	bitmaps, err := ReadDVs(fs, files)
+	require.NoError(t, err)
+	require.Len(t, bitmaps, 2)
+	assert.True(t, bitmaps[0].Contains(1))
+	assert.True(t, bitmaps[1].Contains(2))
+	assert.Equal(t, []readAtCall{
+		{offset: metas[0].Offset, length: int(metas[0].Length)},
+		{offset: metas[1].Offset, length: int(metas[1].Length)},
+	}, blobReadCalls(fs.readCalls, metas))
+}
+
+func largeDVData(t *testing.T) ([]byte, int64) {
+	t.Helper()
+
+	const (
+		buckets         = 1024
+		valuesPerBucket = 2048
+	)
+
+	bitmap := NewRoaringPositionBitmap()
+	for bucket := range buckets {
+		for value := uint64(0); value < valuesPerBucket*2; value += 2 {
+			bitmap.Set(uint64(bucket)<<32 | value)
+		}
+	}
+
+	data, err := SerializeDV(bitmap)
+	require.NoError(t, err)
+
+	return data, bitmap.Cardinality()
 }
 
 // Why: ReadDV should reject callers that pass the wrong file type before doing any I/O.


### PR DESCRIPTION
## What changed

- Coalesce adjacent and overlapping deletion-vector blob ranges when `ReadDVs` reads one Puffin file.
- Keep the output in the same order as the input files.
- Keep metadata validation per blob and cap each coalesced range at 8 MiB.
- Add a regression test for reversed input order and a benchmark for 2, 16, and 64 DVs.

## Why

`ReadDVs` already opens a shared Puffin file once, but it still made one range read per DV blob. Puffin writers place blobs back-to-back, so reading adjacent payloads together cuts object-store requests.

## Benchmark

Command:

```text
go test ./table/dv -run '^$' -bench '^BenchmarkReadDVs$' -benchmem -benchtime=1s -count=5
```

Before is `upstream/main` and after is this branch. These are medians over five runs. `range-reads/op` includes Puffin header and footer reads.

| DVs in one Puffin | Before | After |
| --- | --- | --- |
| 2 | 24.9 µs/op, 4 range reads/op | 23.5 µs/op, 3 range reads/op |
| 16 | 86.0 µs/op, 18 range reads/op | 68.2 µs/op, 3 range reads/op |
| 64 | 272.6 µs/op, 72 range reads/op | 222.5 µs/op, 9 range reads/op |

The coalesced buffer is capped at 8 MiB. The benchmark used about 5% more allocated bytes for the larger batches, while allocations dropped from 470 to 456 at 16 DVs and from 1,771 to 1,709 at 64 DVs.

## Testing

- `go test ./... -count=1`
- `go test ./table/dv -race -count=1`
- `go vet ./table`
