### PR TITLE
perf(table): borrow equality-delete partitions

### DIFF
--- a/table/equality_delete_index.go
+++ b/table/equality_delete_index.go
@@ -159,7 +159,7 @@ func buildEqualityDeleteIndex(
 			continue
 		}
 
-		partition := df.Partition()
+		partition := dataFilePartition(df)
 		key, err := newEqualityDeletePartitionKey(df.SpecID(), partition)
 		if err != nil {
 			return nil, fmt.Errorf("indexing equality delete file %s: %w", df.FilePath(), err)
@@ -194,7 +194,7 @@ func (idx *equalityDeleteIndex) forDataFile(dataEntry iceberg.ManifestEntry) ([]
 	partitionEntries := []iceberg.ManifestEntry(nil)
 	if len(idx.byPartition) > 0 {
 		dataFile := dataEntry.DataFile()
-		partition := dataFile.Partition()
+		partition := dataFilePartition(dataFile)
 		if len(partition) > 0 {
 			key, err := newEqualityDeletePartitionKey(dataFile.SpecID(), partition)
 			if err != nil {

--- a/table/equality_delete_index_bench_test.go
+++ b/table/equality_delete_index_bench_test.go
@@ -157,3 +157,103 @@ func BenchmarkEqualityDeleteIndexNoDataFiles(b *testing.B) {
 		equalityDeleteBenchmarkSink = len(idx.global) + len(idx.byPartition)
 	}
 }
+
+func BenchmarkEqualityDeleteIndexBuiltInPartition(b *testing.B) {
+	for _, fieldCount := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("fields=%d", fieldCount), func(b *testing.B) {
+			spec := equalityDeleteIndexBenchmarkSpec(fieldCount)
+			specs := equalityDeleteIndexTestSpecLookup{1: spec}
+			deleteEntry := newEqualityDeleteIndexBuiltInEntry(
+				b, spec, iceberg.EntryContentEqDeletes, "delete.parquet",
+				equalityDeleteIndexBenchmarkPartition(fieldCount, -1), 2,
+			)
+			dataEntry := newEqualityDeleteIndexBuiltInEntry(
+				b, spec, iceberg.EntryContentData, "data.parquet",
+				equalityDeleteIndexBenchmarkPartition(fieldCount, 1), 1,
+			)
+
+			b.Run("build", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs)
+					if err != nil {
+						b.Fatal(err)
+					}
+					equalityDeleteBenchmarkSink = len(idx.byPartition)
+				}
+			})
+
+			idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.Run("lookup", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					matched, err := idx.forDataFile(dataEntry)
+					if err != nil {
+						b.Fatal(err)
+					}
+					equalityDeleteBenchmarkSink = len(matched)
+				}
+			})
+		})
+	}
+}
+
+func equalityDeleteIndexBenchmarkSpec(fieldCount int) iceberg.PartitionSpec {
+	fields := make([]iceberg.PartitionField, fieldCount)
+	for i := range fields {
+		fields[i] = iceberg.PartitionField{
+			SourceIDs: []int{i + 1},
+			FieldID:   1000 + i,
+			Name:      fmt.Sprintf("partition_%d", i),
+			Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	return iceberg.NewPartitionSpecID(1, fields...)
+}
+
+func equalityDeleteIndexBenchmarkPartition(fieldCount int, value int32) map[int]any {
+	partition := make(map[int]any, fieldCount)
+	for i := range fieldCount {
+		partition[1000+int(i)] = value
+	}
+
+	return partition
+}
+
+func newEqualityDeleteIndexBuiltInEntry(
+	b *testing.B,
+	spec iceberg.PartitionSpec,
+	content iceberg.ManifestEntryContent,
+	path string,
+	partition map[int]any,
+	sequenceNumber int64,
+) iceberg.ManifestEntry {
+	b.Helper()
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		content,
+		path,
+		iceberg.ParquetFile,
+		partition,
+		nil,
+		nil,
+		1,
+		1,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED,
+		nil,
+		&sequenceNumber,
+		nil,
+		builder.Build(),
+	)
+}


### PR DESCRIPTION
## What

- Use the existing borrowed partition view while building the equality-delete index.
- Use it again while matching data files against partitioned equality deletes.
- Keep the public `DataFile.Partition()` defensive-copy behavior unchanged.
- Add a focused benchmark using the built-in `DataFile` implementation.

## Why

`DataFile.Partition()` creates a defensive copy. The equality-delete index only reads the partition while it immediately builds a lookup key, so the copy is unnecessary on this trusted internal path.

The existing `dataFilePartition` helper already falls back to `Partition()` for external `DataFile` implementations.

## Benchmark

Command:

```text
go test ./table -run '^TestEqualityDeleteIndex' -bench '^BenchmarkEqualityDeleteIndexBuiltInPartition$' -benchmem -benchtime=200ms -count=5
```

Median of 5 runs on an Apple M1 Pro with Go 1.26.3. Each value is `ns/op, B/op, allocs/op`.

| Case | Before | After |
| --- | --- | --- |
| lookup, 1 field | 236.5, 256, 2 | 83.1, 0, 0 |
| lookup, 8 fields | 675.2, 648, 9 | 486.0, 392, 7 |
| lookup, 32 fields | 2542, 3472, 13 | 1788, 1592, 9 |
| build, 1 field | 639.3, 1112, 8 | 527.0, 856, 6 |
| build, 8 fields | 1086, 1512, 14 | 937.7, 1256, 12 |
| build, 32 fields | 3095, 4352, 18 | 2182, 2472, 14 |

## Testing

- `go test ./table -count=1 -timeout=5m`
- `go test ./table -race -run '^TestEqualityDeleteIndex' -count=1 -timeout=5m`
- `go test ./... -run '^$' -count=1`
