### PR TITLE
perf(table): borrow manifest partition summaries

### DIFF
--- a/internal/manifest_file_ref.go
+++ b/internal/manifest_file_ref.go
@@ -18,6 +18,33 @@
 package internal
 
 // ManifestFileRef authorizes zero-copy access to immutable manifest state from
-// trusted packages within this module. Go's internal-package rule prevents
-// external callers from constructing this token.
+// trusted packages within this module. Data obtained with this token is
+// borrowed, must be treated as read-only, and must not be retained beyond the
+// current operation. Go's internal-package rule prevents external callers
+// from constructing this token.
 type ManifestFileRef struct{}
+
+// ManifestFilePartitions is the public partition-summary surface needed by
+// the internal borrowed-partition helper. It is parameterized so this package
+// does not need to import the root package.
+type ManifestFilePartitions[T any] interface {
+	Partitions() []T
+}
+
+// ManifestPartitionBorrower is implemented by the built-in manifest file to
+// expose its partition summaries to trusted in-module callers.
+type ManifestPartitionBorrower[T any] interface {
+	ManifestFilePartitionRef(ManifestFileRef) []T
+}
+
+// BorrowedManifestFilePartitions returns partition summaries without copying
+// for the built-in manifest file and falls back to the public getter for
+// external implementations. The returned slice and all nested values are
+// read-only borrows that must not escape the current operation.
+func BorrowedManifestFilePartitions[T any](file ManifestFilePartitions[T]) []T {
+	if ref, ok := file.(ManifestPartitionBorrower[T]); ok {
+		return ref.ManifestFilePartitionRef(ManifestFileRef{})
+	}
+
+	return file.Partitions()
+}

--- a/internal/manifest_file_ref.go
+++ b/internal/manifest_file_ref.go
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+// ManifestFileRef authorizes zero-copy access to immutable manifest state from
+// trusted packages within this module. Go's internal-package rule prevents
+// external callers from constructing this token.
+type ManifestFileRef struct{}

--- a/manifest_file_ref.go
+++ b/manifest_file_ref.go
@@ -28,5 +28,7 @@ func (m *manifestFile) ManifestFilePartitionRef(_ internal.ManifestFileRef) []Fi
 		return nil
 	}
 
+	// The builder and decoder maintain that a non-nil PartitionList points to
+	// a non-nil slice.
 	return *m.PartitionList
 }

--- a/manifest_file_refs.go
+++ b/manifest_file_refs.go
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import "github.com/apache/iceberg-go/internal"
+
+// ManifestFilePartitionRef returns the manifest's partition summaries without
+// copying for trusted in-module callers. The returned slice and all nested
+// bounds alias the manifest and must be treated as read-only for the current
+// operation.
+func (m *manifestFile) ManifestFilePartitionRef(_ internal.ManifestFileRef) []FieldSummary {
+	if m.PartitionList == nil {
+		return nil
+	}
+
+	return *m.PartitionList
+}

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -62,7 +62,7 @@ type manifestEvalVisitor struct {
 }
 
 func (m *manifestEvalVisitor) Eval(manifest iceberg.ManifestFile) (bool, error) {
-	parts := manifest.Partitions()
+	parts := manifestFilePartitions(manifest)
 	if len(parts) == 0 {
 		return rowsMightMatch, nil
 	}

--- a/table/evaluators_bench_test.go
+++ b/table/evaluators_bench_test.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -46,8 +47,6 @@ func BenchmarkManifestEvaluatorBuiltInPartitions(b *testing.B) {
 				}
 
 				b.ReportAllocs()
-				b.ReportMetric(float64(manifestCount), "manifests")
-				b.ReportMetric(float64(fieldCount), "partition_fields")
 				b.ResetTimer()
 				for range b.N {
 					matched := 0
@@ -97,18 +96,20 @@ func manifestEvaluatorBenchmarkFilter(fieldCount int) iceberg.BooleanExpression 
 }
 
 func manifestEvaluatorBenchmarkSummaries(fieldCount int) []iceberg.FieldSummary {
-	lower, err := iceberg.Int32Literal(0).MarshalBinary()
+	lowerBound, err := iceberg.Int32Literal(0).MarshalBinary()
 	if err != nil {
 		panic(err)
 	}
-	upper, err := iceberg.Int32Literal(100).MarshalBinary()
+	upperBound, err := iceberg.Int32Literal(100).MarshalBinary()
 	if err != nil {
 		panic(err)
 	}
-	containsNaN := false
 
 	summaries := make([]iceberg.FieldSummary, fieldCount)
 	for i := range summaries {
+		containsNaN := false
+		lower := slices.Clone(lowerBound)
+		upper := slices.Clone(upperBound)
 		summaries[i] = iceberg.FieldSummary{
 			ContainsNaN: &containsNaN,
 			LowerBound:  &lower,

--- a/table/evaluators_bench_test.go
+++ b/table/evaluators_bench_test.go
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var manifestEvaluatorBenchmarkSink int
+
+func BenchmarkManifestEvaluatorBuiltInPartitions(b *testing.B) {
+	for _, manifestCount := range []int{1, 100, 1_000} {
+		for _, fieldCount := range []int{1, 8, 32} {
+			b.Run(fmt.Sprintf("manifests=%d/fields=%d", manifestCount, fieldCount), func(b *testing.B) {
+				spec, schema := manifestEvaluatorBenchmarkSpec(fieldCount)
+				filter := manifestEvaluatorBenchmarkFilter(fieldCount)
+				eval, err := newManifestEvaluator(spec, schema, filter, true)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				summaries := manifestEvaluatorBenchmarkSummaries(fieldCount)
+				manifests := make([]iceberg.ManifestFile, manifestCount)
+				for i := range manifests {
+					manifests[i] = iceberg.NewManifestFile(
+						2, fmt.Sprintf("manifest-%d.avro", i), 0, int32(spec.ID()), 1,
+					).Partitions(summaries).Build()
+				}
+
+				b.ReportAllocs()
+				b.ReportMetric(float64(manifestCount), "manifests")
+				b.ReportMetric(float64(fieldCount), "partition_fields")
+				b.ResetTimer()
+				for range b.N {
+					matched := 0
+					for _, manifest := range manifests {
+						keep, err := eval(manifest)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if keep {
+							matched++
+						}
+					}
+					manifestEvaluatorBenchmarkSink = matched
+				}
+			})
+		}
+	}
+}
+
+func manifestEvaluatorBenchmarkSpec(fieldCount int) (iceberg.PartitionSpec, *iceberg.Schema) {
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := range fieldCount {
+		fieldID := i + 1
+		fieldName := fmt.Sprintf("field_%d", i)
+		schemaFields[i] = iceberg.NestedField{
+			ID: fieldID, Name: fieldName, Type: iceberg.PrimitiveTypes.Int32, Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{fieldID}, FieldID: 1000 + i,
+			Name: fieldName, Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	return iceberg.NewPartitionSpecID(1, partitionFields...), iceberg.NewSchema(1, schemaFields...)
+}
+
+func manifestEvaluatorBenchmarkFilter(fieldCount int) iceberg.BooleanExpression {
+	var filter iceberg.BooleanExpression = iceberg.GreaterThanEqual(
+		iceberg.Reference("field_0"), int32(0))
+	for i := 1; i < fieldCount; i++ {
+		filter = iceberg.NewAnd(filter,
+			iceberg.GreaterThanEqual(iceberg.Reference(fmt.Sprintf("field_%d", i)), int32(0)))
+	}
+
+	return filter
+}
+
+func manifestEvaluatorBenchmarkSummaries(fieldCount int) []iceberg.FieldSummary {
+	lower, err := iceberg.Int32Literal(0).MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	upper, err := iceberg.Int32Literal(100).MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	containsNaN := false
+
+	summaries := make([]iceberg.FieldSummary, fieldCount)
+	for i := range summaries {
+		summaries[i] = iceberg.FieldSummary{
+			ContainsNaN: &containsNaN,
+			LowerBound:  &lower,
+			UpperBound:  &upper,
+		}
+	}
+
+	return summaries
+}

--- a/table/manifest_file_ref.go
+++ b/table/manifest_file_ref.go
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
+)
+
+type manifestFilePartitionRef interface {
+	ManifestFilePartitionRef(iceberginternal.ManifestFileRef) []iceberg.FieldSummary
+}
+
+// manifestFilePartitions returns partition summaries without copying for the
+// built-in manifest file and falls back to the public getter for external
+// implementations. Callers must treat the returned slice and nested bounds as
+// read-only and must not retain them beyond the current operation.
+func manifestFilePartitions(file iceberg.ManifestFile) []iceberg.FieldSummary {
+	if ref, ok := file.(manifestFilePartitionRef); ok {
+		return ref.ManifestFilePartitionRef(iceberginternal.ManifestFileRef{})
+	}
+
+	return file.Partitions()
+}

--- a/table/manifest_file_ref.go
+++ b/table/manifest_file_ref.go
@@ -22,18 +22,10 @@ import (
 	iceberginternal "github.com/apache/iceberg-go/internal"
 )
 
-type manifestFilePartitionRef interface {
-	ManifestFilePartitionRef(iceberginternal.ManifestFileRef) []iceberg.FieldSummary
-}
-
 // manifestFilePartitions returns partition summaries without copying for the
 // built-in manifest file and falls back to the public getter for external
 // implementations. Callers must treat the returned slice and nested bounds as
 // read-only and must not retain them beyond the current operation.
 func manifestFilePartitions(file iceberg.ManifestFile) []iceberg.FieldSummary {
-	if ref, ok := file.(manifestFilePartitionRef); ok {
-		return ref.ManifestFilePartitionRef(iceberginternal.ManifestFileRef{})
-	}
-
-	return file.Partitions()
+	return iceberginternal.BorrowedManifestFilePartitions(file)
 }

--- a/table/manifest_file_ref_test.go
+++ b/table/manifest_file_ref_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,16 +49,24 @@ func TestManifestFilePartitionsUsesBorrowedView(t *testing.T) {
 		}},
 	).Build()
 
-	require.Implements(t, (*manifestFilePartitionRef)(nil), manifest)
+	require.Implements(t, (*iceberginternal.ManifestPartitionBorrower[iceberg.FieldSummary])(nil), manifest)
 	partitions := manifestFilePartitions(manifest)
 	require.Len(t, partitions, 1)
 	assert.Equal(t, []byte{1, 2}, *partitions[0].LowerBound)
 	assert.Equal(t, []byte{3, 4}, *partitions[0].UpperBound)
 
+	// This intentionally violates the read-only borrow contract to prove that
+	// the returned bound aliases manifest storage. Callers must not mutate it.
+	(*partitions[0].LowerBound)[0] = 9
+	borrowedAgain := manifestFilePartitions(manifest)
+	require.NotNil(t, borrowedAgain[0].LowerBound)
+	assert.Equal(t, byte(9), (*borrowedAgain[0].LowerBound)[0])
+	(*partitions[0].LowerBound)[0] = 1
+
 	allocs := testing.AllocsPerRun(100, func() {
 		partitions = manifestFilePartitions(manifest)
 	})
-	assert.InDelta(t, 0.0, allocs, 0.5)
+	assert.Zero(t, allocs)
 }
 
 func TestManifestFilePartitionsFallsBackToPublicGetter(t *testing.T) {

--- a/table/manifest_file_ref_test.go
+++ b/table/manifest_file_ref_test.go
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type publicManifestFile struct {
+	iceberg.ManifestFile
+	partitionCalls int
+}
+
+func (m *publicManifestFile) Partitions() []iceberg.FieldSummary {
+	m.partitionCalls++
+
+	return m.ManifestFile.Partitions()
+}
+
+func TestManifestFilePartitionsUsesBorrowedView(t *testing.T) {
+	containsNaN := false
+	lower := []byte{1, 2}
+	upper := []byte{3, 4}
+	manifest := iceberg.NewManifestFile(2, "manifest.avro", 0, 1, 1).Partitions(
+		[]iceberg.FieldSummary{{
+			ContainsNaN: &containsNaN,
+			LowerBound:  &lower,
+			UpperBound:  &upper,
+		}},
+	).Build()
+
+	require.Implements(t, (*manifestFilePartitionRef)(nil), manifest)
+	partitions := manifestFilePartitions(manifest)
+	require.Len(t, partitions, 1)
+	assert.Equal(t, []byte{1, 2}, *partitions[0].LowerBound)
+	assert.Equal(t, []byte{3, 4}, *partitions[0].UpperBound)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		partitions = manifestFilePartitions(manifest)
+	})
+	assert.InDelta(t, 0.0, allocs, 0.5)
+}
+
+func TestManifestFilePartitionsFallsBackToPublicGetter(t *testing.T) {
+	manifest := iceberg.NewManifestFile(2, "manifest.avro", 0, 1, 1).
+		Partitions([]iceberg.FieldSummary{{}}).Build()
+	file := &publicManifestFile{ManifestFile: manifest}
+
+	partitions := manifestFilePartitions(file)
+	require.Len(t, partitions, 1)
+	assert.Equal(t, 1, file.partitionCalls)
+}


### PR DESCRIPTION
## What

- Add a trusted borrowed view for built-in manifest partition summaries.
- Use the borrowed view in `manifestEvalVisitor.Eval`.
- Fall back to `ManifestFile.Partitions()` for external implementations.
- Keep the public `ManifestFile.Partitions()` defensive-copy behavior unchanged.
- Add focused tests and benchmarks.

## Why

`ManifestFile.Partitions()` copies the full summary slice, every lower and upper bound, and every `ContainsNaN` pointer. The manifest evaluator only reads these values during the current evaluation, so those copies are unnecessary on the built-in manifest path.

## Benchmark

Command:

```text
go test ./table -run '^$' -bench '^BenchmarkManifestEvaluatorBuiltInPartitions/manifests=1000/fields=32$' -benchmem -benchtime=200ms -count=5
```

Median of 5 runs on an Apple M1 Pro with Go 1.26.3:

| Case | Before | After |
| --- | --- | --- |
| 1,000 manifests, 32 fields | 4.97 ms/op, 4.27 MB/op, 194,000 allocs/op | 2.14 ms/op, 816 KB/op, 33,000 allocs/op |

This is about **57% lower latency**, **81% fewer bytes**, and **83% fewer allocations** in this wide-manifest evaluator workload.

The benchmark also covers 1, 100, and 1,000 manifests with 1, 8, and 32 partition fields.

## Testing

- `go test ./table -count=1 -timeout=5m`
- `go test ./table -race -run '^(TestManifestFilePartitions|TestManifestEvaluator|TestManifestEvalVisitorEvalRace)' -count=1 -timeout=5m`
- `go test ./... -run '^$' -count=1`
- `go vet ./table`
