### PR TITLE
perf(dv): serialize deletion vectors in one buffer

### DIFF
--- a/table/dv/deletion_vector.go
+++ b/table/dv/deletion_vector.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log/slog"
+	"math"
 	"strconv"
 
 	"github.com/apache/iceberg-go"
@@ -121,22 +122,42 @@ func DeserializeDV(data []byte, expectedCardinality int64) (*RoaringPositionBitm
 func SerializeDV(bitmap *RoaringPositionBitmap) ([]byte, error) {
 	bitmap.RunLengthEncode()
 
-	var bitmapBuf bytes.Buffer
-	if err := bitmap.Serialize(&bitmapBuf); err != nil {
+	serializedSize := bitmap.serializedSize()
+	innerLen := uint64(dvMagicSize) + serializedSize
+	if innerLen > math.MaxUint32 {
+		return nil, fmt.Errorf("deletion vector payload too large: %d bytes", innerLen)
+	}
+
+	totalSize := uint64(dvLengthSize+dvMagicSize+dvCRCSize) + serializedSize
+	if totalSize > uint64(math.MaxInt) {
+		return nil, fmt.Errorf("deletion vector serialized size %d exceeds maximum supported size %d", totalSize, math.MaxInt)
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(int(totalSize))
+
+	var header [dvLengthSize + dvMagicSize]byte
+	binary.LittleEndian.PutUint32(header[dvLengthSize:], DVMagicNumber)
+	_, _ = buf.Write(header[:])
+
+	if err := bitmap.Serialize(&buf); err != nil {
 		return nil, fmt.Errorf("serialize roaring bitmap: %w", err)
 	}
 
-	bitmapBytes := bitmapBuf.Bytes()
-	innerLen := dvMagicSize + len(bitmapBytes)
-	totalSize := dvLengthSize + innerLen + dvCRCSize
-	out := make([]byte, totalSize)
+	bitmapDataEnd := buf.Len()
+	innerLen = uint64(bitmapDataEnd - dvLengthSize)
+	if innerLen > math.MaxUint32 {
+		return nil, fmt.Errorf("deletion vector payload too large: %d bytes", innerLen)
+	}
 
-	binary.BigEndian.PutUint32(out[0:dvLengthSize], uint32(innerLen))
-	binary.LittleEndian.PutUint32(out[dvLengthSize:dvLengthSize+dvMagicSize], DVMagicNumber)
-	copy(out[dvLengthSize+dvMagicSize:], bitmapBytes)
+	crc := crc32.ChecksumIEEE(buf.Bytes()[dvLengthSize:bitmapDataEnd])
 
-	crc := crc32.ChecksumIEEE(out[dvLengthSize : totalSize-dvCRCSize])
-	binary.BigEndian.PutUint32(out[totalSize-dvCRCSize:], crc)
+	var trailer [dvCRCSize]byte
+	binary.BigEndian.PutUint32(trailer[:], crc)
+	_, _ = buf.Write(trailer[:])
+
+	out := buf.Bytes()
+	binary.BigEndian.PutUint32(out[:dvLengthSize], uint32(innerLen))
 
 	return out, nil
 }

--- a/table/dv/deletion_vector_bench_test.go
+++ b/table/dv/deletion_vector_bench_test.go
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dv
+
+import "testing"
+
+var benchmarkSerializedDV []byte
+
+func BenchmarkSerializeDV(b *testing.B) {
+	for _, tt := range []struct {
+		name              string
+		positions         int
+		stride            uint64
+		explicitPositions []uint64
+	}{
+		{name: "sparse-1k", positions: 1_000, stride: 1_024},
+		{name: "sparse-100k", positions: 100_000, stride: 32},
+		{name: "sparse-1m", positions: 1_000_000, stride: 4},
+		{name: "two-buckets", explicitPositions: []uint64{0, 1 << 32}},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			bitmap := NewRoaringPositionBitmap()
+			if tt.explicitPositions != nil {
+				for _, position := range tt.explicitPositions {
+					bitmap.Set(position)
+				}
+			} else {
+				for i := range tt.positions {
+					bitmap.Set(uint64(i) * tt.stride)
+				}
+			}
+
+			// SerializeDV run-length-optimizes the bitmap in place. Warm up once
+			// so the timed loop measures steady-state re-serialization.
+			sample, err := SerializeDV(bitmap)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.SetBytes(int64(len(sample)))
+			for range b.N {
+				benchmarkSerializedDV, err = SerializeDV(bitmap)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/table/dv/roaring_bitmap.go
+++ b/table/dv/roaring_bitmap.go
@@ -209,6 +209,20 @@ func (b *RoaringPositionBitmap) Serialize(w io.Writer) error {
 	return nil
 }
 
+// serializedSize returns the exact size of the portable bitmap encoding after
+// RunLengthEncode has been called. Empty buckets are omitted by Serialize and
+// therefore do not contribute.
+func (b *RoaringPositionBitmap) serializedSize() uint64 {
+	size := uint64(8) // bitmap count
+	for _, bm := range b.bitmaps {
+		if bm.GetCardinality() > 0 {
+			size += 4 + bm.GetSerializedSizeInBytes() // bucket key + bitmap
+		}
+	}
+
+	return size
+}
+
 // DeserializeRoaringPositionBitmap reads a bitmap from the Iceberg portable format.
 // Format: [count] { [key][bitmap] } .....{[key_n][bitmap_n]}
 func DeserializeRoaringPositionBitmap(data []byte) (*RoaringPositionBitmap, error) {

--- a/table/dv/roaring_bitmap_test.go
+++ b/table/dv/roaring_bitmap_test.go
@@ -74,6 +74,38 @@ func TestDeserializeRoaringBitmapJava32BitValues(t *testing.T) {
 	assert.False(t, bm.Contains(10))
 }
 
+// Why: SerializeDV reserves the exact portable bitmap size before writing the
+// envelope, so the size helper must stay in sync with Serialize.
+// Condition: empty, sparse multi-bucket, and run-optimized bitmaps.
+// Assertion: the predicted size equals the bytes written for every shape.
+func TestRoaringPositionBitmapSerializedSize(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		positions []uint64
+		emptyKey  bool
+	}{
+		{name: "empty"},
+		{name: "sparse multi-bucket", positions: []uint64{1, 3, (uint64(1) << 32) | 7}},
+		{name: "run-optimized", positions: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		{name: "empty bucket omitted", emptyKey: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bm := NewRoaringPositionBitmap()
+			for _, position := range tt.positions {
+				bm.Set(position)
+			}
+			if tt.emptyKey {
+				bm.bitmaps[7] = roaring.New()
+			}
+			bm.RunLengthEncode()
+
+			var buf bytes.Buffer
+			require.NoError(t, bm.Serialize(&buf))
+			assert.Equal(t, uint64(buf.Len()), bm.serializedSize())
+		})
+	}
+}
+
 // Why: metadata-table readers need deterministic expansion of deletion vectors.
 // Condition: positions span multiple high-bit buckets and were inserted out of order.
 // Assertion: Positions yields every value once in ascending order.


### PR DESCRIPTION
## Summary

- **Writes the DV envelope directly into one `bytes.Buffer`.**
- Reserves the exact portable bitmap size after run-length encoding.
- Patches the length field after the bitmap is written, then appends the CRC.
- Keeps the existing wire format and Java byte-for-byte fixtures unchanged.

## Benchmark

Command:

`go test ./table/dv -run ^$ -bench ^BenchmarkSerializeDV$ -benchmem -benchtime=200ms -count=5`

Median of 5 runs on Apple M1 Pro, Go 1.25.9:

| Workload | Before | After |
| --- | ---: | ---: |
| sparse-1k | 3,153 ns/op, 7,664 B/op, 11 allocs/op | 2,018 ns/op, 2,512 B/op, 5 allocs/op |
| sparse-100k | 227,145 ns/op, 855,235 B/op, 14 allocs/op | 142,696 ns/op, 205,280 B/op, 5 allocs/op |
| sparse-1m | 336,744 ns/op, 1,807,430 B/op, 14 allocs/op | 171,052 ns/op, 508,482 B/op, 5 allocs/op |

## Checks

- `go test ./table/dv -count=1 -timeout=5m`
- `go test ./table/dv -race -count=1 -timeout=5m`
- `go test ./table -count=1 -timeout=5m`
- `go test ./... -run ^$ -count=1`
- `go vet ./table/dv`