### PR TITLE
perf(table): index partition specs by ID

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -218,8 +218,9 @@ func schemaIndexLookup(index *schemaIndexData, schemas []*iceberg.Schema, id int
 
 type partitionSpecIndexData struct {
 	positions map[int]int
-	// sourceCount records the number of specs used to build positions. It is
-	// separate from len(positions) because multiple specs may have the same ID.
+	// sourceCount records the number of specs used to build positions. Persisted
+	// metadata rejects duplicate IDs, but this remains separate from
+	// len(positions) for unvalidated in-package fixtures.
 	sourceCount int
 	// firstSpec identifies the spec slice used to build positions. It lets
 	// read-only lookups detect an index left behind by an in-package fixture
@@ -2898,6 +2899,9 @@ func (c *commonMetadata) checkSchemas() error {
 }
 
 func (c *commonMetadata) checkPartitionSpecs() error {
+	// Partition spec IDs are unique in persisted metadata. Keep this validation
+	// aligned with the schema and snapshot ID checks so normal read paths never
+	// need to tolerate duplicate IDs.
 	seen := make(map[int]struct{}, len(c.Specs))
 	defaultFound := false
 	for _, spec := range c.Specs {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -228,6 +228,7 @@ type partitionSpecIndexData struct {
 }
 
 // Small spec slices are faster to search directly than to hash-map lookup.
+// 32 is a conservative cutoff; keep it aligned with the lookup benchmarks.
 const partitionSpecIndexMinSize = 32
 
 func partitionSpecListFirst(specs []iceberg.PartitionSpec) *iceberg.PartitionSpec {
@@ -239,6 +240,10 @@ func partitionSpecListFirst(specs []iceberg.PartitionSpec) *iceberg.PartitionSpe
 }
 
 func buildPartitionSpecIndex(specs []iceberg.PartitionSpec) *partitionSpecIndexData {
+	if len(specs) < partitionSpecIndexMinSize {
+		return nil
+	}
+
 	positions := make(map[int]int, len(specs))
 	for i := range specs {
 		id := specs[i].ID()
@@ -265,7 +270,15 @@ func clonePartitionSpecIndex(index *partitionSpecIndexData) *partitionSpecIndexD
 }
 
 func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []iceberg.PartitionSpec) bool {
-	if index == nil || len(index.positions) != len(specs) {
+	if len(specs) < partitionSpecIndexMinSize {
+		return false
+	}
+	if index == nil {
+		return true
+	}
+	// Persisted metadata rejects duplicate IDs, so map and source cardinality
+	// are equal on the indexed read path.
+	if index.positions == nil || len(index.positions) != len(specs) {
 		return true
 	}
 
@@ -734,7 +747,7 @@ func (b *MetadataBuilder) ensurePartitionSpecIndex() {
 
 func (b *MetadataBuilder) ensurePartitionSpecIndexMutable() {
 	b.ensurePartitionSpecIndex()
-	if b.partitionSpecIndex.shared {
+	if b.partitionSpecIndex != nil && b.partitionSpecIndex.shared {
 		b.partitionSpecIndex = clonePartitionSpecIndex(b.partitionSpecIndex)
 	}
 }
@@ -854,8 +867,15 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 	} else {
 		b.ensurePartitionSpecIndexMutable()
 		b.specs = append(b.specs, freshSpec)
-		b.partitionSpecIndex.positions[newSpecID] = len(b.specs) - 1
-		b.partitionSpecIndex.firstSpec = partitionSpecListFirst(b.specs)
+		if len(b.specs) >= partitionSpecIndexMinSize {
+			if len(b.specs) == partitionSpecIndexMinSize ||
+				b.partitionSpecIndex == nil || b.partitionSpecIndex.positions == nil {
+				b.partitionSpecIndex = buildPartitionSpecIndex(b.specs)
+			} else {
+				b.partitionSpecIndex.positions[newSpecID] = len(b.specs) - 1
+				b.partitionSpecIndex.firstSpec = partitionSpecListFirst(b.specs)
+			}
+		}
 	}
 
 	b.lastPartitionID = &lastPartitionID
@@ -1466,7 +1486,9 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 		b.schemaIndex.shared = true
 	}
 	b.ensurePartitionSpecIndex()
-	b.partitionSpecIndex.shared = true
+	if b.partitionSpecIndex != nil {
+		b.partitionSpecIndex.shared = true
+	}
 	b.ensureSnapshotIndex()
 	if b.snapshotIndex != nil {
 		b.snapshotIndex.shared = true
@@ -2898,8 +2920,8 @@ func (c *commonMetadata) checkPartitionSpecs() error {
 	// need to tolerate duplicate IDs.
 	seen := make(map[int]struct{}, len(c.Specs))
 	defaultFound := false
-	for _, spec := range c.Specs {
-		id := spec.ID()
+	for i := range c.Specs {
+		id := c.Specs[i].ID()
 		if _, ok := seen[id]; ok {
 			return fmt.Errorf("%w: duplicate partition spec ID %d", ErrInvalidMetadata, id)
 		}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -218,10 +218,6 @@ func schemaIndexLookup(index *schemaIndexData, schemas []*iceberg.Schema, id int
 
 type partitionSpecIndexData struct {
 	positions map[int]int
-	// sourceCount records the number of specs used to build positions. Persisted
-	// metadata rejects duplicate IDs, but this remains separate from
-	// len(positions) for unvalidated in-package fixtures.
-	sourceCount int
 	// firstSpec identifies the spec slice used to build positions. It lets
 	// read-only lookups detect an index left behind by an in-package fixture
 	// that replaced the slice.
@@ -252,9 +248,8 @@ func buildPartitionSpecIndex(specs []iceberg.PartitionSpec) *partitionSpecIndexD
 	}
 
 	return &partitionSpecIndexData{
-		positions:   positions,
-		sourceCount: len(specs),
-		firstSpec:   partitionSpecListFirst(specs),
+		positions: positions,
+		firstSpec: partitionSpecListFirst(specs),
 	}
 }
 
@@ -264,14 +259,13 @@ func clonePartitionSpecIndex(index *partitionSpecIndexData) *partitionSpecIndexD
 	}
 
 	return &partitionSpecIndexData{
-		positions:   maps.Clone(index.positions),
-		sourceCount: index.sourceCount,
-		firstSpec:   index.firstSpec,
+		positions: maps.Clone(index.positions),
+		firstSpec: index.firstSpec,
 	}
 }
 
 func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []iceberg.PartitionSpec) bool {
-	if index == nil || index.sourceCount != len(specs) {
+	if index == nil || len(index.positions) != len(specs) {
 		return true
 	}
 
@@ -647,10 +641,9 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 	}
 	if b.partitionSpecIndex != nil {
 		cloned.partitionSpecIndex = &partitionSpecIndexData{
-			positions:   b.partitionSpecIndex.positions,
-			sourceCount: b.partitionSpecIndex.sourceCount,
-			firstSpec:   partitionSpecListFirst(cloned.specs),
-			shared:      true,
+			positions: b.partitionSpecIndex.positions,
+			firstSpec: partitionSpecListFirst(cloned.specs),
+			shared:    true,
 		}
 		b.partitionSpecIndex.shared = true
 	}
@@ -862,7 +855,6 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 		b.ensurePartitionSpecIndexMutable()
 		b.specs = append(b.specs, freshSpec)
 		b.partitionSpecIndex.positions[newSpecID] = len(b.specs) - 1
-		b.partitionSpecIndex.sourceCount = len(b.specs)
 		b.partitionSpecIndex.firstSpec = partitionSpecListFirst(b.specs)
 	}
 
@@ -2447,6 +2439,8 @@ func (c *commonMetadata) DefaultPartitionSpec() int {
 func (c *commonMetadata) partitionSpecIndexForLookup() *partitionSpecIndexData {
 	index := c.partitionSpecIndex
 	if partitionSpecIndexNeedsRebuild(index, c.Specs) {
+		// Keep fixture recovery local: validated metadata has a stable index, and
+		// read-only lookups must not write to shared metadata state.
 		index = buildPartitionSpecIndex(c.Specs)
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -216,6 +216,80 @@ func schemaIndexLookup(index *schemaIndexData, schemas []*iceberg.Schema, id int
 	return nil, false
 }
 
+type partitionSpecIndexData struct {
+	positions map[int]int
+	// firstSpec identifies the spec slice used to build positions. It lets
+	// read-only lookups detect an index left behind by an in-package fixture
+	// that replaced the slice.
+	firstSpec *iceberg.PartitionSpec
+	// shared means positions is owned by more than one builder or metadata
+	// value and must be copied before a builder mutates it.
+	shared bool
+}
+
+// Small spec slices are faster to search directly than to hash-map lookup.
+const partitionSpecIndexMinSize = 32
+
+func partitionSpecListFirst(specs []iceberg.PartitionSpec) *iceberg.PartitionSpec {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	return &specs[0]
+}
+
+func buildPartitionSpecIndex(specs []iceberg.PartitionSpec) *partitionSpecIndexData {
+	positions := make(map[int]int, len(specs))
+	for i := range specs {
+		id := specs[i].ID()
+		if _, exists := positions[id]; !exists {
+			positions[id] = i
+		}
+	}
+
+	return &partitionSpecIndexData{positions: positions, firstSpec: partitionSpecListFirst(specs)}
+}
+
+func clonePartitionSpecIndex(index *partitionSpecIndexData) *partitionSpecIndexData {
+	if index == nil {
+		return nil
+	}
+
+	return &partitionSpecIndexData{
+		positions: maps.Clone(index.positions),
+		firstSpec: index.firstSpec,
+	}
+}
+
+func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []iceberg.PartitionSpec) bool {
+	if index == nil || len(index.positions) != len(specs) {
+		return true
+	}
+
+	return len(specs) > 0 && index.firstSpec != &specs[0]
+}
+
+// partitionSpecIndexPosition returns the position for id. The map is the fast
+// path, while the linear scan preserves lookup behavior if an in-package
+// fixture mutates a spec in place without rebuilding the derived index.
+func partitionSpecIndexPosition(index *partitionSpecIndexData, specs []iceberg.PartitionSpec, id int) (int, bool) {
+	if index != nil && len(specs) >= partitionSpecIndexMinSize {
+		if i, ok := index.positions[id]; ok {
+			if i >= 0 && i < len(specs) && specs[i].ID() == id {
+				return i, true
+			}
+		}
+	}
+
+	for i := range specs {
+		if specs[i].ID() == id {
+			return i, true
+		}
+	}
+
+	return 0, false
+}
+
 // Metadata for an iceberg table as specified in the Iceberg spec
 //
 // https://iceberg.apache.org/spec/#iceberg-table-spec
@@ -334,6 +408,7 @@ type MetadataBuilder struct {
 	schemaIndex        *schemaIndexData // Derived from schemaList; not serialized.
 	currentSchemaID    int
 	specs              []iceberg.PartitionSpec
+	partitionSpecIndex *partitionSpecIndexData // Derived from specs; not serialized.
 	defaultSpecID      int
 	lastPartitionID    *int
 	props              iceberg.Properties
@@ -370,6 +445,7 @@ func NewMetadataBuilder(formatVersion int) (*MetadataBuilder, error) {
 		schemaList:         make([]*iceberg.Schema, 0),
 		schemaIndex:        buildSchemaIndex(nil),
 		specs:              make([]iceberg.PartitionSpec, 0),
+		partitionSpecIndex: buildPartitionSpecIndex(nil),
 		props:              make(iceberg.Properties),
 		snapshotList:       make([]Snapshot, 0),
 		snapshotIndex:      buildSnapshotIndex(nil),
@@ -487,6 +563,8 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 	}
 	b.schemaIndex = buildSchemaIndex(b.schemaList)
 
+	b.partitionSpecIndex = buildPartitionSpecIndex(b.specs)
+
 	if currentFileLocation != "" {
 		b.previousFileEntry = &MetadataLogEntry{
 			MetadataFile: currentFileLocation,
@@ -556,14 +634,20 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 		}
 		b.schemaIndex.shared = true
 	}
+	if b.partitionSpecIndex != nil {
+		cloned.partitionSpecIndex = &partitionSpecIndexData{
+			positions: b.partitionSpecIndex.positions,
+			firstSpec: partitionSpecListFirst(cloned.specs),
+			shared:    true,
+		}
+		b.partitionSpecIndex.shared = true
+	}
 	if b.snapshotIndex != nil {
 		cloned.snapshotIndex = &snapshotIndexData{
 			positions:     b.snapshotIndex.positions,
 			firstSnapshot: snapshotListFirst(cloned.snapshotList),
 			shared:        true,
 		}
-	}
-	if b.snapshotIndex != nil {
 		b.snapshotIndex.shared = true
 	}
 
@@ -634,6 +718,19 @@ func (b *MetadataBuilder) ensureSnapshotIndexMutable() {
 	b.ensureSnapshotIndex()
 	if b.snapshotIndex.shared {
 		b.snapshotIndex = cloneSnapshotIndex(b.snapshotIndex)
+	}
+}
+
+func (b *MetadataBuilder) ensurePartitionSpecIndex() {
+	if partitionSpecIndexNeedsRebuild(b.partitionSpecIndex, b.specs) {
+		b.partitionSpecIndex = buildPartitionSpecIndex(b.specs)
+	}
+}
+
+func (b *MetadataBuilder) ensurePartitionSpecIndexMutable() {
+	b.ensurePartitionSpecIndex()
+	if b.partitionSpecIndex.shared {
+		b.partitionSpecIndex = clonePartitionSpecIndex(b.partitionSpecIndex)
 	}
 }
 
@@ -746,14 +843,16 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 	}
 	lastPartitionID := max(maxFieldID, prev)
 
-	var specs []iceberg.PartitionSpec
 	if initial {
-		specs = []iceberg.PartitionSpec{freshSpec}
+		b.specs = []iceberg.PartitionSpec{freshSpec}
+		b.partitionSpecIndex = buildPartitionSpecIndex(b.specs)
 	} else {
-		specs = append(b.specs, freshSpec)
+		b.ensurePartitionSpecIndexMutable()
+		b.specs = append(b.specs, freshSpec)
+		b.partitionSpecIndex.positions[newSpecID] = len(b.specs) - 1
+		b.partitionSpecIndex.firstSpec = partitionSpecListFirst(b.specs)
 	}
 
-	b.specs = specs
 	b.lastPartitionID = &lastPartitionID
 	b.lastAddedPartitionID = &newSpecID
 	b.updates = append(b.updates, NewAddPartitionSpecUpdate(&freshSpec, initial))
@@ -1361,6 +1460,8 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 	if b.schemaIndex != nil {
 		b.schemaIndex.shared = true
 	}
+	b.ensurePartitionSpecIndex()
+	b.partitionSpecIndex.shared = true
 	b.ensureSnapshotIndex()
 	if b.snapshotIndex != nil {
 		b.snapshotIndex.shared = true
@@ -1397,6 +1498,7 @@ func (b *MetadataBuilder) buildCommonMetadata() (*commonMetadata, error) {
 		schemaIndex:        b.schemaIndex,
 		CurrentSchemaID:    b.currentSchemaID,
 		Specs:              b.specs,
+		partitionSpecIndex: b.partitionSpecIndex,
 		DefaultSpecID:      defaultSpecID,
 		LastPartitionID:    b.lastPartitionID,
 		Props:              b.props,
@@ -1474,10 +1576,13 @@ func (b *MetadataBuilder) GetSchemaByID(id int) (*iceberg.Schema, error) {
 }
 
 func (b *MetadataBuilder) GetSpecByID(id int) (*iceberg.PartitionSpec, error) {
-	for _, s := range b.specs {
-		if s.ID() == id {
-			return &s, nil
-		}
+	b.ensurePartitionSpecIndex()
+
+	i, ok := partitionSpecIndexPosition(b.partitionSpecIndex, b.specs, id)
+	if ok {
+		spec := b.specs[i]
+
+		return &spec, nil
 	}
 
 	return nil, fmt.Errorf("%w: id %d", ErrPartitionSpecNotFound, id)
@@ -1701,9 +1806,9 @@ func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 		newSpecs = append(newSpecs, spec)
 	}
 
-	b.specs = newSpecs
-
 	if len(removed) != 0 {
+		b.specs = newSpecs
+		b.partitionSpecIndex = buildPartitionSpecIndex(b.specs)
 		b.updates = append(b.updates, NewRemoveSpecUpdate(removed))
 	}
 
@@ -2140,9 +2245,10 @@ type commonMetadata struct {
 	// V3+ fields
 	NextRowID *int64 `json:"next-row-id,omitempty"` // V3: Next available row ID
 
-	schemaIndex       *schemaIndexData
-	snapshotIndex     *snapshotIndexData
-	deferredSnapshots *deferredSnapshotState
+	schemaIndex        *schemaIndexData
+	partitionSpecIndex *partitionSpecIndexData
+	snapshotIndex      *snapshotIndexData
+	deferredSnapshots  *deferredSnapshotState
 }
 
 func (c *commonMetadata) metadataBuilderCommon() *commonMetadata { return c }
@@ -2325,23 +2431,29 @@ func (c *commonMetadata) DefaultPartitionSpec() int {
 	return c.DefaultSpecID
 }
 
+func (c *commonMetadata) ensurePartitionSpecIndex() {
+	if partitionSpecIndexNeedsRebuild(c.partitionSpecIndex, c.Specs) {
+		c.partitionSpecIndex = buildPartitionSpecIndex(c.Specs)
+	}
+}
+
 func (c *commonMetadata) PartitionSpec() iceberg.PartitionSpec {
-	for _, s := range c.Specs {
-		if s.ID() == c.DefaultSpecID {
-			return clonePartitionSpec(s)
-		}
+	c.ensurePartitionSpecIndex()
+
+	if i, ok := partitionSpecIndexPosition(c.partitionSpecIndex, c.Specs, c.DefaultSpecID); ok {
+		return clonePartitionSpec(c.Specs[i])
 	}
 
 	return clonePartitionSpec(*iceberg.UnpartitionedSpec)
 }
 
 func (c *commonMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
-	for _, s := range c.Specs {
-		if s.ID() == id {
-			clone := clonePartitionSpec(s)
+	c.ensurePartitionSpecIndex()
 
-			return &clone
-		}
+	if i, ok := partitionSpecIndexPosition(c.partitionSpecIndex, c.Specs, id); ok {
+		clone := clonePartitionSpec(c.Specs[i])
+
+		return &clone
 	}
 
 	return nil
@@ -2742,6 +2854,7 @@ func (c *commonMetadata) preValidate() {
 	}
 
 	c.schemaIndex = buildSchemaIndex(c.SchemaList)
+	c.partitionSpecIndex = buildPartitionSpecIndex(c.Specs)
 	c.snapshotIndex = buildSnapshotIndex(c.SnapshotList)
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -279,7 +279,9 @@ func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []icebe
 
 // partitionSpecIndexPosition returns the position for id. The map is the fast
 // path, while the linear scan preserves lookup behavior if an in-package
-// fixture mutates a spec in place without rebuilding the derived index.
+// fixture mutates a spec in place without rebuilding the derived index. An
+// absent map entry is indistinguishable from an in-place mutation that added a
+// new ID, so misses intentionally scan the slice too.
 func partitionSpecIndexPosition(index *partitionSpecIndexData, specs []iceberg.PartitionSpec, id int) (int, bool) {
 	if index != nil && len(specs) >= partitionSpecIndexMinSize {
 		if i, ok := index.positions[id]; ok {
@@ -2441,16 +2443,19 @@ func (c *commonMetadata) DefaultPartitionSpec() int {
 	return c.DefaultSpecID
 }
 
-func (c *commonMetadata) ensurePartitionSpecIndex() {
-	if partitionSpecIndexNeedsRebuild(c.partitionSpecIndex, c.Specs) {
-		c.partitionSpecIndex = buildPartitionSpecIndex(c.Specs)
+func (c *commonMetadata) partitionSpecIndexForLookup() *partitionSpecIndexData {
+	index := c.partitionSpecIndex
+	if partitionSpecIndexNeedsRebuild(index, c.Specs) {
+		index = buildPartitionSpecIndex(c.Specs)
 	}
+
+	return index
 }
 
 func (c *commonMetadata) PartitionSpec() iceberg.PartitionSpec {
-	c.ensurePartitionSpecIndex()
+	index := c.partitionSpecIndexForLookup()
 
-	if i, ok := partitionSpecIndexPosition(c.partitionSpecIndex, c.Specs, c.DefaultSpecID); ok {
+	if i, ok := partitionSpecIndexPosition(index, c.Specs, c.DefaultSpecID); ok {
 		return clonePartitionSpec(c.Specs[i])
 	}
 
@@ -2458,9 +2463,9 @@ func (c *commonMetadata) PartitionSpec() iceberg.PartitionSpec {
 }
 
 func (c *commonMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
-	c.ensurePartitionSpecIndex()
+	index := c.partitionSpecIndexForLookup()
 
-	if i, ok := partitionSpecIndexPosition(c.partitionSpecIndex, c.Specs, id); ok {
+	if i, ok := partitionSpecIndexPosition(index, c.Specs, id); ok {
 		clone := clonePartitionSpec(c.Specs[i])
 
 		return &clone
@@ -2893,10 +2898,21 @@ func (c *commonMetadata) checkSchemas() error {
 }
 
 func (c *commonMetadata) checkPartitionSpecs() error {
+	seen := make(map[int]struct{}, len(c.Specs))
+	defaultFound := false
 	for _, spec := range c.Specs {
-		if spec.ID() == c.DefaultSpecID {
-			return nil
+		id := spec.ID()
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("%w: duplicate partition spec ID %d", ErrInvalidMetadata, id)
 		}
+		seen[id] = struct{}{}
+
+		if id == c.DefaultSpecID {
+			defaultFound = true
+		}
+	}
+	if defaultFound {
+		return nil
 	}
 
 	return fmt.Errorf("%w: default-spec-id %d can't be found",

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -282,7 +282,7 @@ func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []icebe
 		return true
 	}
 
-	return len(specs) > 0 && index.firstSpec != &specs[0]
+	return index.firstSpec != partitionSpecListFirst(specs)
 }
 
 // partitionSpecIndexPosition returns the position for id. The map is the fast

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -218,6 +218,9 @@ func schemaIndexLookup(index *schemaIndexData, schemas []*iceberg.Schema, id int
 
 type partitionSpecIndexData struct {
 	positions map[int]int
+	// sourceCount records the number of specs used to build positions. It is
+	// separate from len(positions) because multiple specs may have the same ID.
+	sourceCount int
 	// firstSpec identifies the spec slice used to build positions. It lets
 	// read-only lookups detect an index left behind by an in-package fixture
 	// that replaced the slice.
@@ -247,7 +250,11 @@ func buildPartitionSpecIndex(specs []iceberg.PartitionSpec) *partitionSpecIndexD
 		}
 	}
 
-	return &partitionSpecIndexData{positions: positions, firstSpec: partitionSpecListFirst(specs)}
+	return &partitionSpecIndexData{
+		positions:   positions,
+		sourceCount: len(specs),
+		firstSpec:   partitionSpecListFirst(specs),
+	}
 }
 
 func clonePartitionSpecIndex(index *partitionSpecIndexData) *partitionSpecIndexData {
@@ -256,13 +263,14 @@ func clonePartitionSpecIndex(index *partitionSpecIndexData) *partitionSpecIndexD
 	}
 
 	return &partitionSpecIndexData{
-		positions: maps.Clone(index.positions),
-		firstSpec: index.firstSpec,
+		positions:   maps.Clone(index.positions),
+		sourceCount: index.sourceCount,
+		firstSpec:   index.firstSpec,
 	}
 }
 
 func partitionSpecIndexNeedsRebuild(index *partitionSpecIndexData, specs []iceberg.PartitionSpec) bool {
-	if index == nil || len(index.positions) != len(specs) {
+	if index == nil || index.sourceCount != len(specs) {
 		return true
 	}
 
@@ -636,9 +644,10 @@ func (b *MetadataBuilder) clone() *MetadataBuilder {
 	}
 	if b.partitionSpecIndex != nil {
 		cloned.partitionSpecIndex = &partitionSpecIndexData{
-			positions: b.partitionSpecIndex.positions,
-			firstSpec: partitionSpecListFirst(cloned.specs),
-			shared:    true,
+			positions:   b.partitionSpecIndex.positions,
+			sourceCount: b.partitionSpecIndex.sourceCount,
+			firstSpec:   partitionSpecListFirst(cloned.specs),
+			shared:      true,
 		}
 		b.partitionSpecIndex.shared = true
 	}
@@ -850,6 +859,7 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 		b.ensurePartitionSpecIndexMutable()
 		b.specs = append(b.specs, freshSpec)
 		b.partitionSpecIndex.positions[newSpecID] = len(b.specs) - 1
+		b.partitionSpecIndex.sourceCount = len(b.specs)
 		b.partitionSpecIndex.firstSpec = partitionSpecListFirst(b.specs)
 	}
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -218,9 +218,9 @@ func schemaIndexLookup(index *schemaIndexData, schemas []*iceberg.Schema, id int
 
 type partitionSpecIndexData struct {
 	positions map[int]int
-	// firstSpec identifies the spec slice used to build positions. It lets
-	// read-only lookups detect an index left behind by an in-package fixture
-	// that replaced the slice.
+	// firstSpec identifies the first element of the spec slice used to build
+	// positions. It lets read-only lookups detect an index left behind by an
+	// in-package fixture that replaced the slice.
 	firstSpec *iceberg.PartitionSpec
 	// shared means positions is owned by more than one builder or metadata
 	// value and must be copied before a builder mutates it.

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -3620,9 +3620,10 @@ func TestSetFormatVersionV2ToV3FromDeserializedMetadata(t *testing.T) {
 // shares with the original instead of copying. Keep this in sync with clone();
 // both the drift guard and its filler consult it.
 var sharedCloneFields = map[string]struct{}{
-	"base":          {}, // immutable snapshot, shared by design.
-	"schemaIndex":   {}, // immutable schema references, copied on schema mutation.
-	"snapshotIndex": {}, // immutable index positions, copied on snapshot mutation.
+	"base":               {}, // immutable snapshot, shared by design.
+	"schemaIndex":        {}, // immutable schema references, copied on schema mutation.
+	"partitionSpecIndex": {}, // immutable index positions, copied on spec mutation.
+	"snapshotIndex":      {}, // immutable index positions, copied on snapshot mutation.
 }
 
 // TestMetadataBuilderCloneCoversAllFields guards clone() against field drift:

--- a/table/partition_spec_index_bench_test.go
+++ b/table/partition_spec_index_bench_test.go
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var partitionSpecLookupBenchmarkSink int
+
+func BenchmarkPartitionSpecByID(b *testing.B) {
+	for _, specCount := range []int{1, 4, 8, 16, 32, 256, 2_048} {
+		specs := partitionSpecBenchmarkSpecs(specCount)
+		metadata := commonMetadata{
+			Specs:              specs,
+			DefaultSpecID:      specs[specCount-1].ID(),
+			partitionSpecIndex: buildPartitionSpecIndex(specs),
+		}
+
+		for _, tt := range []struct {
+			name string
+			id   int
+		}{
+			{name: "first", id: specs[0].ID()},
+			{name: "middle", id: specs[specCount/2].ID()},
+			{name: "last", id: specs[specCount-1].ID()},
+			{name: "miss", id: -1},
+		} {
+			b.Run(specCountName(specCount)+"/"+tt.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(specCount), "specs")
+				b.ResetTimer()
+				for range b.N {
+					spec := metadata.PartitionSpecByID(tt.id)
+					if spec == nil {
+						partitionSpecLookupBenchmarkSink = -1
+
+						continue
+					}
+					partitionSpecLookupBenchmarkSink = spec.ID()
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkMetadataBuilderGetSpecByID(b *testing.B) {
+	for _, specCount := range []int{1, 4, 8, 16, 32, 256, 2_048} {
+		specs := partitionSpecBenchmarkSpecs(specCount)
+		builder := MetadataBuilder{
+			specs:              specs,
+			partitionSpecIndex: buildPartitionSpecIndex(specs),
+		}
+
+		for _, tt := range []struct {
+			name string
+			id   int
+		}{
+			{name: "first", id: specs[0].ID()},
+			{name: "middle", id: specs[specCount/2].ID()},
+			{name: "last", id: specs[specCount-1].ID()},
+			{name: "miss", id: -1},
+		} {
+			b.Run(specCountName(specCount)+"/"+tt.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(specCount), "specs")
+				b.ResetTimer()
+				for range b.N {
+					spec, err := builder.GetSpecByID(tt.id)
+					if err != nil {
+						partitionSpecLookupBenchmarkSink = -1
+
+						continue
+					}
+					partitionSpecLookupBenchmarkSink = spec.ID()
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkCurrentPartitionSpec(b *testing.B) {
+	for _, specCount := range []int{1, 4, 8, 16, 32, 256, 2_048} {
+		specs := partitionSpecBenchmarkSpecs(specCount)
+		metadata := commonMetadata{
+			Specs:              specs,
+			DefaultSpecID:      specs[specCount-1].ID(),
+			partitionSpecIndex: buildPartitionSpecIndex(specs),
+		}
+
+		b.Run(specCountName(specCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(specCount), "specs")
+			b.ResetTimer()
+			for range b.N {
+				spec := metadata.PartitionSpec()
+				partitionSpecLookupBenchmarkSink = spec.ID()
+			}
+		})
+	}
+}
+
+func partitionSpecBenchmarkSpecs(count int) []iceberg.PartitionSpec {
+	specs := make([]iceberg.PartitionSpec, count)
+	for i := range count {
+		specs[i] = iceberg.NewPartitionSpecID(i)
+	}
+
+	return specs
+}
+
+func specCountName(count int) string {
+	return "specs=" + strconv.Itoa(count)
+}

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -33,7 +33,7 @@ import (
 // index is initialized from the same slice.
 // Assertion: first, default, and missing lookups return the expected values.
 func TestCommonMetadataPartitionSpecIndexLookups(t *testing.T) {
-	specs := partitionSpecIndexTestSpecs(0, 7, 42)
+	specs := partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 0, 7, 42)
 	metadata := commonMetadata{
 		Specs:              specs,
 		DefaultSpecID:      42,
@@ -49,32 +49,29 @@ func TestCommonMetadataPartitionSpecIndexLookups(t *testing.T) {
 	assert.Nil(t, metadata.PartitionSpecByID(99))
 }
 
-// Why: decoded metadata must initialize the same derived index as metadata
-// built by a writer, rather than rebuilding it on every lookup.
-// Condition: parse a valid metadata document containing partition specs.
-// Assertion: the decoded common metadata owns one index entry per spec.
-func TestParsedMetadataBuildsPartitionSpecIndex(t *testing.T) {
+// Why: small metadata should not allocate an index that its linear lookup path
+// will never read.
+// Condition: parse a valid metadata document containing one partition spec.
+// Assertion: the decoded common metadata keeps only the slice identity.
+func TestParsedMetadataSkipsSmallPartitionSpecIndex(t *testing.T) {
 	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
 	require.NoError(t, err)
 
 	common := metadataCommon(metadata)
-	require.Len(t, common.partitionSpecIndex.positions, len(common.Specs))
-	for i, spec := range common.Specs {
-		require.Equal(t, i, common.partitionSpecIndex.positions[spec.ID()])
-	}
+	require.Nil(t, common.partitionSpecIndex)
 }
 
-// Why: builders created from existing metadata must get an index before their
-// first partition-spec lookup.
+// Why: builders created from existing metadata should use the same small-slice
+// lookup policy as parsed metadata.
 // Condition: create a builder from parsed metadata and look up its final spec.
-// Assertion: the builder index covers every copied partition spec.
-func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
+// Assertion: the lookup works without allocating a map for one spec.
+func TestMetadataBuilderFromBaseSkipsSmallPartitionSpecIndex(t *testing.T) {
 	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
 	require.NoError(t, err)
 
 	builder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
-	require.Len(t, builder.partitionSpecIndex.positions, len(builder.specs))
+	require.Nil(t, builder.partitionSpecIndex)
 
 	id := builder.specs[len(builder.specs)-1].ID()
 	spec, err := builder.GetSpecByID(id)
@@ -89,7 +86,7 @@ func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
 // Assertion: lookups use the replacement slice without mutating the cached
 // index.
 func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testing.T) {
-	specs := partitionSpecIndexTestSpecs(1, 2)
+	specs := partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2)
 	metadata := commonMetadata{
 		Specs:              specs,
 		DefaultSpecID:      2,
@@ -97,7 +94,7 @@ func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testi
 	}
 	originalIndex := metadata.partitionSpecIndex
 
-	metadata.Specs = partitionSpecIndexTestSpecs(3, 4)
+	metadata.Specs = partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 3, 4)
 	metadata.DefaultSpecID = 4
 	byID := metadata.PartitionSpecByID(4)
 	require.NotNil(t, byID)
@@ -106,15 +103,16 @@ func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testi
 	assert.Equal(t, 4, defaultSpec.ID())
 	assert.Nil(t, metadata.PartitionSpecByID(2))
 	assert.Same(t, originalIndex, metadata.partitionSpecIndex)
-	assert.Equal(t, map[int]int{1: 0, 2: 1}, metadata.partitionSpecIndex.positions)
+	assert.Equal(t, 0, metadata.partitionSpecIndex.positions[1])
+	assert.Equal(t, 1, metadata.partitionSpecIndex.positions[2])
 }
 
 func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacementConcurrent(t *testing.T) {
 	metadata := &commonMetadata{
-		Specs:              partitionSpecIndexTestSpecs(1, 2),
-		partitionSpecIndex: buildPartitionSpecIndex(partitionSpecIndexTestSpecs(1, 2)),
+		Specs:              partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2),
+		partitionSpecIndex: buildPartitionSpecIndex(partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2)),
 	}
-	metadata.Specs = partitionSpecIndexTestSpecs(3, 4)
+	metadata.Specs = partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 3, 4)
 	originalIndex := metadata.partitionSpecIndex
 
 	const goroutineCount = 8
@@ -158,19 +156,20 @@ func TestRejectsDuplicatePartitionSpecIDs(t *testing.T) {
 // Condition: a spec is replaced in place after the index is built.
 // Assertion: lookup still finds the replacement and does not return the old ID.
 func TestCommonMetadataPartitionSpecIndexFallsBackAfterElementMutation(t *testing.T) {
-	specs := partitionSpecIndexTestSpecs(1, 2)
+	specs := partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2)
+	oldID := specs[7].ID()
 	metadata := commonMetadata{
 		Specs:              specs,
 		DefaultSpecID:      1,
 		partitionSpecIndex: buildPartitionSpecIndex(specs),
 	}
 
-	specs[1] = iceberg.NewPartitionSpecID(3)
+	specs[7] = iceberg.NewPartitionSpecID(3)
 
 	byID := metadata.PartitionSpecByID(3)
 	require.NotNil(t, byID)
 	assert.Equal(t, 3, byID.ID())
-	assert.Nil(t, metadata.PartitionSpecByID(2))
+	assert.Nil(t, metadata.PartitionSpecByID(oldID))
 }
 
 // Why: builders can also be used by package-level fixtures that replace their
@@ -178,14 +177,14 @@ func TestCommonMetadataPartitionSpecIndexFallsBackAfterElementMutation(t *testin
 // Condition: an indexed builder receives a replacement slice of equal length.
 // Assertion: GetSpecByID resolves the replacement slice and refreshes its index.
 func TestMetadataBuilderPartitionSpecIndexFallsBackAfterSliceReplacement(t *testing.T) {
-	specs := partitionSpecIndexTestSpecs(1, 2)
+	specs := partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2)
 	builder := MetadataBuilder{
 		specs:              specs,
 		partitionSpecIndex: buildPartitionSpecIndex(specs),
 	}
 	originalIndex := builder.partitionSpecIndex
 
-	builder.specs = partitionSpecIndexTestSpecs(3, 4)
+	builder.specs = partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 3, 4)
 	byID, err := builder.GetSpecByID(4)
 	require.NoError(t, err)
 	require.NotNil(t, byID)
@@ -193,8 +192,10 @@ func TestMetadataBuilderPartitionSpecIndexFallsBackAfterSliceReplacement(t *test
 	_, err = builder.GetSpecByID(2)
 	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.NotSame(t, originalIndex, builder.partitionSpecIndex)
-	assert.Equal(t, map[int]int{3: 0, 4: 1}, builder.partitionSpecIndex.positions)
-	assert.Equal(t, map[int]int{1: 0, 2: 1}, originalIndex.positions)
+	assert.Equal(t, 0, builder.partitionSpecIndex.positions[3])
+	assert.Equal(t, 1, builder.partitionSpecIndex.positions[4])
+	assert.Equal(t, 0, originalIndex.positions[1])
+	assert.Equal(t, 1, originalIndex.positions[2])
 }
 
 // Why: builder updates and clones must keep the spec index aligned without
@@ -204,26 +205,31 @@ func TestMetadataBuilderPartitionSpecIndexFallsBackAfterSliceReplacement(t *test
 // Assertion: each builder resolves the IDs in its own current spec slice.
 func TestMetadataBuilderPartitionSpecIndexFollowsUpdates(t *testing.T) {
 	builder := builderWithoutChanges(2)
-	require.Len(t, builder.specs, 1)
-	require.Equal(t, map[int]int{0: 0}, builder.partitionSpecIndex.positions)
+	for id := 1; len(builder.specs) < partitionSpecIndexMinSize; id++ {
+		builder.specs = append(builder.specs, iceberg.NewPartitionSpecID(id))
+	}
+	builder.partitionSpecIndex = buildPartitionSpecIndex(builder.specs)
+	require.Len(t, builder.specs, partitionSpecIndexMinSize)
+	require.Equal(t, 0, builder.partitionSpecIndex.positions[0])
 
 	added := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
 		SourceIDs: []int{1}, Name: "x", Transform: iceberg.IdentityTransform{},
 	})
 	require.NoError(t, builder.AddPartitionSpec(&added, false))
-	require.Equal(t, 1, builder.partitionSpecIndex.positions[1])
+	require.Equal(t, partitionSpecIndexMinSize, builder.partitionSpecIndex.positions[partitionSpecIndexMinSize])
 
-	got, err := builder.GetSpecByID(1)
+	got, err := builder.GetSpecByID(partitionSpecIndexMinSize)
 	require.NoError(t, err)
 	require.NotNil(t, got)
+	assert.Equal(t, partitionSpecIndexMinSize, got.ID())
 
 	clone := builder.clone()
 	cloneAdded := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
 		SourceIDs: []int{3}, Name: "z", Transform: iceberg.IdentityTransform{},
 	})
 	require.NoError(t, clone.AddPartitionSpec(&cloneAdded, false))
-	assert.NotContains(t, builder.partitionSpecIndex.positions, 2)
-	assert.Equal(t, 2, clone.partitionSpecIndex.positions[2])
+	assert.NotContains(t, builder.partitionSpecIndex.positions, partitionSpecIndexMinSize+1)
+	assert.Equal(t, partitionSpecIndexMinSize+1, clone.partitionSpecIndex.positions[partitionSpecIndexMinSize+1])
 
 	require.NoError(t, builder.RemovePartitionSpecs([]int{1}))
 	assert.NotContains(t, builder.partitionSpecIndex.positions, 1)
@@ -232,6 +238,23 @@ func TestMetadataBuilderPartitionSpecIndexFollowsUpdates(t *testing.T) {
 	got, err = clone.GetSpecByID(1)
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.ID())
+}
+
+func TestMetadataBuilderPartitionSpecIndexBuildsAtThreshold(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	for id := 1; len(builder.specs) < partitionSpecIndexMinSize-1; id++ {
+		builder.specs = append(builder.specs, iceberg.NewPartitionSpecID(id))
+	}
+	builder.partitionSpecIndex = buildPartitionSpecIndex(builder.specs)
+	require.Nil(t, builder.partitionSpecIndex)
+
+	added := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{1}, Name: "threshold", Transform: iceberg.IdentityTransform{},
+	})
+	require.NoError(t, builder.AddPartitionSpec(&added, false))
+	require.NotNil(t, builder.partitionSpecIndex.positions)
+	assert.Equal(t, partitionSpecIndexMinSize-1,
+		builder.partitionSpecIndex.positions[partitionSpecIndexMinSize-1])
 }
 
 // Why: removing unknown IDs is a no-op and must not leave the derived index
@@ -255,6 +278,10 @@ func TestMetadataBuilderRemoveUnknownPartitionSpecKeepsIndex(t *testing.T) {
 // remains unchanged.
 func TestMetadataBuilderPartitionSpecIndexIsolatedFromBuiltMetadata(t *testing.T) {
 	builder := builderWithoutChanges(2)
+	for id := 1; len(builder.specs) < partitionSpecIndexMinSize; id++ {
+		builder.specs = append(builder.specs, iceberg.NewPartitionSpecID(id))
+	}
+	builder.partitionSpecIndex = buildPartitionSpecIndex(builder.specs)
 	metadata, err := builder.Build()
 	require.NoError(t, err)
 	common := metadataCommon(metadata)
@@ -266,9 +293,9 @@ func TestMetadataBuilderPartitionSpecIndexIsolatedFromBuiltMetadata(t *testing.T
 	require.NoError(t, builder.AddPartitionSpec(&added, false))
 
 	assert.NotSame(t, originalIndex, builder.partitionSpecIndex)
-	assert.Contains(t, builder.partitionSpecIndex.positions, 1)
-	assert.NotContains(t, originalIndex.positions, 1)
-	assert.Nil(t, common.PartitionSpecByID(1))
+	assert.NotContains(t, originalIndex.positions, partitionSpecIndexMinSize)
+	assert.Contains(t, builder.partitionSpecIndex.positions, partitionSpecIndexMinSize)
+	assert.Nil(t, common.PartitionSpecByID(partitionSpecIndexMinSize))
 	got, err := builder.GetSpecByID(1)
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.ID())
@@ -375,6 +402,15 @@ func partitionSpecIndexTestSpecs(ids ...int) []iceberg.PartitionSpec {
 	specs := make([]iceberg.PartitionSpec, len(ids))
 	for i, id := range ids {
 		specs[i] = iceberg.NewPartitionSpecID(id)
+	}
+
+	return specs
+}
+
+func partitionSpecIndexTestSpecsAtLeast(count int, ids ...int) []iceberg.PartitionSpec {
+	specs := partitionSpecIndexTestSpecs(ids...)
+	for id := 1_000; len(specs) < count; id++ {
+		specs = append(specs, iceberg.NewPartitionSpecID(id))
 	}
 
 	return specs

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -272,6 +272,53 @@ func TestCommonMetadataPartitionSpecLookupsConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+// Why: read-only metadata lookups must not rebuild the shared index when
+// partition spec IDs are duplicated in an in-package fixture.
+// Condition: the index contains 64 specs with the same ID and many goroutines
+// repeatedly look up that ID.
+// Assertion: every lookup succeeds and the index remains stable.
+func TestCommonMetadataPartitionSpecIndexDuplicateIDsConcurrent(t *testing.T) {
+	const (
+		specCount      = 64
+		goroutineCount = 8
+		lookupCount    = 1_000
+	)
+	specs := make([]iceberg.PartitionSpec, specCount)
+	for i := range specs {
+		specs[i] = iceberg.NewPartitionSpecID(7)
+	}
+	metadata := &commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      7,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+	originalIndex := metadata.partitionSpecIndex
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+	for range goroutineCount {
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for range lookupCount {
+				spec := metadata.PartitionSpecByID(7)
+				if spec == nil || spec.ID() != 7 {
+					t.Errorf("expected partition spec 7, got %v", spec)
+
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Same(t, originalIndex, metadata.partitionSpecIndex)
+	assert.Equal(t, specCount, metadata.partitionSpecIndex.sourceCount)
+}
+
 func TestMetadataBuilderPartitionSpecIndexCopyOnWriteConcurrent(t *testing.T) {
 	builderValue := builderWithoutChanges(2)
 	const indexedSpecCount = 1_024

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -1,0 +1,336 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Why: metadata lookups must use the derived ID index without changing the
+// existing default-spec fallback or missing-ID behavior.
+// Condition: metadata contains non-sequential partition spec IDs and the
+// index is initialized from the same slice.
+// Assertion: first, default, and missing lookups return the expected values.
+func TestCommonMetadataPartitionSpecIndexLookups(t *testing.T) {
+	specs := partitionSpecIndexTestSpecs(0, 7, 42)
+	metadata := commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      42,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+
+	byID := metadata.PartitionSpecByID(7)
+	require.NotNil(t, byID)
+	assert.Equal(t, 7, byID.ID())
+
+	defaultSpec := metadata.PartitionSpec()
+	assert.Equal(t, 42, defaultSpec.ID())
+	assert.Nil(t, metadata.PartitionSpecByID(99))
+}
+
+// Why: decoded metadata must initialize the same derived index as metadata
+// built by a writer, rather than rebuilding it on every lookup.
+// Condition: parse a valid metadata document containing partition specs.
+// Assertion: the decoded common metadata owns one index entry per spec.
+func TestParsedMetadataBuildsPartitionSpecIndex(t *testing.T) {
+	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	common := metadataCommon(metadata)
+	require.Len(t, common.partitionSpecIndex.positions, len(common.Specs))
+	for i, spec := range common.Specs {
+		require.Equal(t, i, common.partitionSpecIndex.positions[spec.ID()])
+	}
+}
+
+// Why: builders created from existing metadata must get an index before their
+// first partition-spec lookup.
+// Condition: create a builder from parsed metadata and look up its final spec.
+// Assertion: the builder index covers every copied partition spec.
+func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
+	metadata, err := ParseMetadataBytes([]byte(ExampleTableMetadataV2))
+	require.NoError(t, err)
+
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+	require.Len(t, builder.partitionSpecIndex.positions, len(builder.specs))
+
+	id := builder.specs[len(builder.specs)-1].ID()
+	spec, err := builder.GetSpecByID(id)
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+	assert.Equal(t, id, spec.ID())
+}
+
+// Why: in-package fixtures can replace metadata slices directly, so a stale
+// derived index must not return a spec at the old position or hide a new one.
+// Condition: the indexed slice is replaced with another slice of equal length.
+// Assertion: lookups use the replacement slice and refresh the derived index.
+func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testing.T) {
+	specs := partitionSpecIndexTestSpecs(1, 2)
+	metadata := commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      2,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+	originalIndex := metadata.partitionSpecIndex
+
+	metadata.Specs = partitionSpecIndexTestSpecs(3, 4)
+	metadata.DefaultSpecID = 4
+	byID := metadata.PartitionSpecByID(4)
+	require.NotNil(t, byID)
+	assert.Equal(t, 4, byID.ID())
+	defaultSpec := metadata.PartitionSpec()
+	assert.Equal(t, 4, defaultSpec.ID())
+	assert.Nil(t, metadata.PartitionSpecByID(2))
+	assert.NotSame(t, originalIndex, metadata.partitionSpecIndex)
+	assert.Equal(t, map[int]int{3: 0, 4: 1}, metadata.partitionSpecIndex.positions)
+	assert.Equal(t, map[int]int{1: 0, 2: 1}, originalIndex.positions)
+}
+
+// Why: in-package fixtures can mutate an existing spec slice without changing
+// its length or backing array, which cannot be detected by index metadata alone.
+// Condition: a spec is replaced in place after the index is built.
+// Assertion: lookup still finds the replacement and does not return the old ID.
+func TestCommonMetadataPartitionSpecIndexFallsBackAfterElementMutation(t *testing.T) {
+	specs := partitionSpecIndexTestSpecs(1, 2)
+	metadata := commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      1,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+
+	specs[1] = iceberg.NewPartitionSpecID(3)
+
+	byID := metadata.PartitionSpecByID(3)
+	require.NotNil(t, byID)
+	assert.Equal(t, 3, byID.ID())
+	assert.Nil(t, metadata.PartitionSpecByID(2))
+}
+
+// Why: builders can also be used by package-level fixtures that replace their
+// spec slice without updating derived state.
+// Condition: an indexed builder receives a replacement slice of equal length.
+// Assertion: GetSpecByID resolves the replacement slice and refreshes its index.
+func TestMetadataBuilderPartitionSpecIndexFallsBackAfterSliceReplacement(t *testing.T) {
+	specs := partitionSpecIndexTestSpecs(1, 2)
+	builder := MetadataBuilder{
+		specs:              specs,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+	originalIndex := builder.partitionSpecIndex
+
+	builder.specs = partitionSpecIndexTestSpecs(3, 4)
+	byID, err := builder.GetSpecByID(4)
+	require.NoError(t, err)
+	require.NotNil(t, byID)
+	assert.Equal(t, 4, byID.ID())
+	_, err = builder.GetSpecByID(2)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	assert.NotSame(t, originalIndex, builder.partitionSpecIndex)
+	assert.Equal(t, map[int]int{3: 0, 4: 1}, builder.partitionSpecIndex.positions)
+	assert.Equal(t, map[int]int{1: 0, 2: 1}, originalIndex.positions)
+}
+
+// Why: builder updates and clones must keep the spec index aligned without
+// sharing mutable lookup state with a built metadata value or sibling builder.
+// Condition: add a spec, clone the builder, add another spec to the clone, and
+// remove the first added spec from the original.
+// Assertion: each builder resolves the IDs in its own current spec slice.
+func TestMetadataBuilderPartitionSpecIndexFollowsUpdates(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	require.Len(t, builder.specs, 1)
+	require.Equal(t, map[int]int{0: 0}, builder.partitionSpecIndex.positions)
+
+	added := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{1}, Name: "x", Transform: iceberg.IdentityTransform{},
+	})
+	require.NoError(t, builder.AddPartitionSpec(&added, false))
+	require.Equal(t, 1, builder.partitionSpecIndex.positions[1])
+
+	got, err := builder.GetSpecByID(1)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	clone := builder.clone()
+	cloneAdded := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{3}, Name: "z", Transform: iceberg.IdentityTransform{},
+	})
+	require.NoError(t, clone.AddPartitionSpec(&cloneAdded, false))
+	assert.NotContains(t, builder.partitionSpecIndex.positions, 2)
+	assert.Equal(t, 2, clone.partitionSpecIndex.positions[2])
+
+	require.NoError(t, builder.RemovePartitionSpecs([]int{1}))
+	assert.NotContains(t, builder.partitionSpecIndex.positions, 1)
+	_, err = builder.GetSpecByID(1)
+	assert.ErrorIs(t, err, ErrPartitionSpecNotFound)
+	got, err = clone.GetSpecByID(1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.ID())
+}
+
+// Why: removing unknown IDs is a no-op and must not leave the derived index
+// pointing at a newly allocated but unindexed slice.
+// Condition: remove an ID that is not present in the builder.
+// Assertion: the specs slice and its index remain unchanged.
+func TestMetadataBuilderRemoveUnknownPartitionSpecKeepsIndex(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	originalIndex := builder.partitionSpecIndex
+	originalFirst := &builder.specs[0]
+
+	require.NoError(t, builder.RemovePartitionSpecs([]int{99}))
+	assert.Same(t, originalIndex, builder.partitionSpecIndex)
+	assert.Same(t, originalFirst, &builder.specs[0])
+}
+
+// Why: a built metadata value shares the derived index with its builder until
+// the builder mutates its spec list.
+// Condition: build metadata, then add a new partition spec to the builder.
+// Assertion: the builder sees the new spec while the already-built metadata
+// remains unchanged.
+func TestMetadataBuilderPartitionSpecIndexIsolatedFromBuiltMetadata(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	metadata, err := builder.Build()
+	require.NoError(t, err)
+	common := metadataCommon(metadata)
+	originalIndex := common.partitionSpecIndex
+
+	added := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+		SourceIDs: []int{3}, Name: "z", Transform: iceberg.IdentityTransform{},
+	})
+	require.NoError(t, builder.AddPartitionSpec(&added, false))
+
+	assert.NotSame(t, originalIndex, builder.partitionSpecIndex)
+	assert.Contains(t, builder.partitionSpecIndex.positions, 1)
+	assert.NotContains(t, originalIndex.positions, 1)
+	assert.Nil(t, common.PartitionSpecByID(1))
+	got, err := builder.GetSpecByID(1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.ID())
+}
+
+func TestCommonMetadataPartitionSpecLookupsConcurrent(t *testing.T) {
+	specs := partitionSpecIndexTestSpecs(1, 2)
+	metadata := &commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      2,
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+
+	const (
+		goroutineCount = 8
+		lookupCount    = 100
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+	for i := range goroutineCount {
+		go func(i int) {
+			defer wg.Done()
+
+			for range lookupCount {
+				if i%2 == 0 {
+					spec := metadata.PartitionSpecByID(1)
+					if spec == nil || spec.ID() != 1 {
+						t.Errorf("expected partition spec 1, got %v", spec)
+
+						return
+					}
+
+					continue
+				}
+
+				spec := metadata.PartitionSpec()
+				if spec.ID() != 2 {
+					t.Errorf("expected default partition spec 2, got %d", spec.ID())
+
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestMetadataBuilderPartitionSpecIndexCopyOnWriteConcurrent(t *testing.T) {
+	builderValue := builderWithoutChanges(2)
+	const indexedSpecCount = 1_024
+	for id := 1; id < indexedSpecCount; id++ {
+		builderValue.specs = append(builderValue.specs, iceberg.NewPartitionSpecID(id))
+	}
+	builderValue.partitionSpecIndex = buildPartitionSpecIndex(builderValue.specs)
+
+	metadata, err := builderValue.Build()
+	require.NoError(t, err)
+	common := metadataCommon(metadata)
+	builder := &builderValue
+
+	const lookupCount = 1_000
+
+	start := make(chan struct{})
+	readerStarted := make(chan struct{})
+	writerErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+
+		for i := range lookupCount {
+			spec := common.PartitionSpecByID(0)
+			if spec == nil || spec.ID() != 0 {
+				t.Errorf("expected partition spec 0, got %v", spec)
+
+				return
+			}
+			if i == 0 {
+				close(readerStarted)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		<-readerStarted
+
+		added := iceberg.NewPartitionSpecID(99, iceberg.PartitionField{
+			SourceIDs: []int{1}, Name: "copy-on-write", Transform: iceberg.IdentityTransform{},
+		})
+		writerErr <- builder.AddPartitionSpec(&added, false)
+	}()
+	close(start)
+	wg.Wait()
+	require.NoError(t, <-writerErr)
+	assert.NotSame(t, common.partitionSpecIndex, builder.partitionSpecIndex)
+	assert.NotContains(t, common.partitionSpecIndex.positions, indexedSpecCount)
+	assert.Contains(t, builder.partitionSpecIndex.positions, indexedSpecCount)
+}
+
+func partitionSpecIndexTestSpecs(ids ...int) []iceberg.PartitionSpec {
+	specs := make([]iceberg.PartitionSpec, len(ids))
+	for i, id := range ids {
+		specs[i] = iceberg.NewPartitionSpecID(id)
+	}
+
+	return specs
+}

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -185,6 +185,23 @@ func TestCommonMetadataPartitionSpecIndexFallsBackAfterElementMutation(t *testin
 	assert.Nil(t, metadata.PartitionSpecByID(oldID))
 }
 
+// Why: the default-spec lookup must not return a stale indexed value after an
+// in-place fixture mutation removes the configured default ID.
+// Condition: the spec at the indexed default position is replaced in place.
+// Assertion: PartitionSpec falls back to the unpartitioned spec, as before the index.
+func TestCommonMetadataPartitionSpecIndexFallsBackAfterDefaultElementMutation(t *testing.T) {
+	specs := partitionSpecIndexTestSpecsAtLeast(partitionSpecIndexMinSize+8, 1, 2)
+	metadata := commonMetadata{
+		Specs:              specs,
+		DefaultSpecID:      specs[7].ID(),
+		partitionSpecIndex: buildPartitionSpecIndex(specs),
+	}
+
+	specs[7] = iceberg.NewPartitionSpecID(3)
+
+	assert.True(t, metadata.PartitionSpec().IsUnpartitioned())
+}
+
 // Why: builders can also be used by package-level fixtures that replace their
 // spec slice without updating derived state.
 // Condition: an indexed builder receives a replacement slice of equal length.

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -58,7 +58,7 @@ func TestParsedMetadataBuildsPartitionSpecIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	common := metadataCommon(metadata)
-	require.Equal(t, len(common.Specs), common.partitionSpecIndex.sourceCount)
+	require.Len(t, common.partitionSpecIndex.positions, len(common.Specs))
 	for i, spec := range common.Specs {
 		require.Equal(t, i, common.partitionSpecIndex.positions[spec.ID()])
 	}
@@ -74,7 +74,7 @@ func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
 
 	builder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
-	require.Equal(t, len(builder.specs), builder.partitionSpecIndex.sourceCount)
+	require.Len(t, builder.partitionSpecIndex.positions, len(builder.specs))
 
 	id := builder.specs[len(builder.specs)-1].ID()
 	spec, err := builder.GetSpecByID(id)
@@ -315,53 +315,6 @@ func TestCommonMetadataPartitionSpecLookupsConcurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-}
-
-// Why: read-only metadata lookups must not rebuild the shared index when
-// partition spec IDs are duplicated in an in-package fixture.
-// Condition: the index contains 64 specs with the same ID and many goroutines
-// repeatedly look up that ID.
-// Assertion: every lookup succeeds and the index remains stable.
-func TestCommonMetadataPartitionSpecIndexDuplicateIDsConcurrent(t *testing.T) {
-	const (
-		specCount      = 64
-		goroutineCount = 8
-		lookupCount    = 1_000
-	)
-	specs := make([]iceberg.PartitionSpec, specCount)
-	for i := range specs {
-		specs[i] = iceberg.NewPartitionSpecID(7)
-	}
-	metadata := &commonMetadata{
-		Specs:              specs,
-		DefaultSpecID:      7,
-		partitionSpecIndex: buildPartitionSpecIndex(specs),
-	}
-	originalIndex := metadata.partitionSpecIndex
-
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(goroutineCount)
-	for range goroutineCount {
-		go func() {
-			defer wg.Done()
-			<-start
-
-			for range lookupCount {
-				spec := metadata.PartitionSpecByID(7)
-				if spec == nil || spec.ID() != 7 {
-					t.Errorf("expected partition spec 7, got %v", spec)
-
-					return
-				}
-			}
-		}()
-	}
-	close(start)
-	wg.Wait()
-
-	assert.Same(t, originalIndex, metadata.partitionSpecIndex)
-	assert.Equal(t, specCount, metadata.partitionSpecIndex.sourceCount)
 }
 
 func TestMetadataBuilderPartitionSpecIndexCopyOnWriteConcurrent(t *testing.T) {

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestParsedMetadataBuildsPartitionSpecIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	common := metadataCommon(metadata)
-	require.Len(t, common.partitionSpecIndex.positions, len(common.Specs))
+	require.Equal(t, len(common.Specs), common.partitionSpecIndex.sourceCount)
 	for i, spec := range common.Specs {
 		require.Equal(t, i, common.partitionSpecIndex.positions[spec.ID()])
 	}
@@ -73,7 +74,7 @@ func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
 
 	builder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
-	require.Len(t, builder.partitionSpecIndex.positions, len(builder.specs))
+	require.Equal(t, len(builder.specs), builder.partitionSpecIndex.sourceCount)
 
 	id := builder.specs[len(builder.specs)-1].ID()
 	spec, err := builder.GetSpecByID(id)
@@ -85,7 +86,8 @@ func TestMetadataBuilderFromBaseBuildsPartitionSpecIndex(t *testing.T) {
 // Why: in-package fixtures can replace metadata slices directly, so a stale
 // derived index must not return a spec at the old position or hide a new one.
 // Condition: the indexed slice is replaced with another slice of equal length.
-// Assertion: lookups use the replacement slice and refresh the derived index.
+// Assertion: lookups use the replacement slice without mutating the cached
+// index.
 func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testing.T) {
 	specs := partitionSpecIndexTestSpecs(1, 2)
 	metadata := commonMetadata{
@@ -103,9 +105,52 @@ func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacement(t *testi
 	defaultSpec := metadata.PartitionSpec()
 	assert.Equal(t, 4, defaultSpec.ID())
 	assert.Nil(t, metadata.PartitionSpecByID(2))
-	assert.NotSame(t, originalIndex, metadata.partitionSpecIndex)
-	assert.Equal(t, map[int]int{3: 0, 4: 1}, metadata.partitionSpecIndex.positions)
-	assert.Equal(t, map[int]int{1: 0, 2: 1}, originalIndex.positions)
+	assert.Same(t, originalIndex, metadata.partitionSpecIndex)
+	assert.Equal(t, map[int]int{1: 0, 2: 1}, metadata.partitionSpecIndex.positions)
+}
+
+func TestCommonMetadataPartitionSpecIndexFallsBackAfterSliceReplacementConcurrent(t *testing.T) {
+	metadata := &commonMetadata{
+		Specs:              partitionSpecIndexTestSpecs(1, 2),
+		partitionSpecIndex: buildPartitionSpecIndex(partitionSpecIndexTestSpecs(1, 2)),
+	}
+	metadata.Specs = partitionSpecIndexTestSpecs(3, 4)
+	originalIndex := metadata.partitionSpecIndex
+
+	const goroutineCount = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+	for range goroutineCount {
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				if spec := metadata.PartitionSpecByID(4); spec == nil || spec.ID() != 4 {
+					t.Errorf("expected partition spec 4, got %v", spec)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Same(t, originalIndex, metadata.partitionSpecIndex)
+}
+
+func TestRejectsDuplicatePartitionSpecIDs(t *testing.T) {
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &raw))
+
+	var specs []json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["partition-specs"], &specs))
+	specs = append(specs, specs[0])
+	encodedSpecs, err := json.Marshal(specs)
+	require.NoError(t, err)
+	raw["partition-specs"] = encodedSpecs
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	_, err = ParseMetadataBytes(data)
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "duplicate partition spec ID 0")
 }
 
 // Why: in-package fixtures can mutate an existing spec slice without changing

--- a/table/partition_spec_index_test.go
+++ b/table/partition_spec_index_test.go
@@ -151,6 +151,19 @@ func TestRejectsDuplicatePartitionSpecIDs(t *testing.T) {
 	assert.ErrorContains(t, err, "duplicate partition spec ID 0")
 }
 
+// Why: builder-produced metadata must enforce the same unique partition spec
+// ID invariant as metadata read from JSON.
+// Condition: an in-package builder is given duplicate spec IDs before Build.
+// Assertion: Build rejects the metadata instead of publishing an ambiguous index.
+func TestMetadataBuilderBuildRejectsDuplicatePartitionSpecIDs(t *testing.T) {
+	builder := builderWithoutChanges(2)
+	builder.specs = append(builder.specs, builder.specs[0])
+
+	_, err := builder.Build()
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "duplicate partition spec ID 0")
+}
+
 // Why: in-package fixtures can mutate an existing spec slice without changing
 // its length or backing array, which cannot be detected by index metadata alone.
 // Condition: a spec is replaced in place after the index is built.


### PR DESCRIPTION
## Summary

- **Adds an ID to position index for partition specs.**
- Uses it for metadata `PartitionSpecByID`, default `PartitionSpec`, and builder `GetSpecByID`.
- Keeps the existing defensive-copy behavior.
- Rejects duplicate partition-spec IDs during metadata validation.
- Updates the index on add/remove and uses copy-on-write for builder clones.
- Includes fallback coverage for stale in-package slices and read-only concurrent lookups.

## Benchmark

Command:

`go test ./table -run '^$' -bench '^(BenchmarkPartitionSpecByID|BenchmarkMetadataBuilderGetSpecByID)$' -benchmem -benchtime=200ms -count=5`

Median of 5 runs on Apple M1 Pro:

| Workload | Before | After |
| --- | ---: | ---: |
| Metadata, 2,048 specs, last hit | 2,528 ns/op | 74 ns/op |
| Metadata, 2,048 specs, miss | 2,443 ns/op | 1,390 ns/op |
| Builder, 2,048 specs, last hit | 54.9 us, 98,304 B/op, 2,048 allocs/op | 33.3 ns/op, 48 B/op, 1 alloc/op |
| Builder, 2,048 specs, miss | 56.5 us, 98,403 B/op, 2,051 allocs/op | 1.47 us, 72 B/op, 3 allocs/op |

The metadata path still clones the returned spec. Builder misses still format the existing error. Indexed hits are O(1). Misses intentionally scan the slice to preserve fallback behavior for in-package element mutations, so miss lookups remain O(n). Small slices use the existing linear-scan path.

## Checks

- `go test ./table -count=1 -timeout=5m`
- `go test ./table -race -run '^(Test.*PartitionSpecIndex|Test.*PartitionSpecLookupsConcurrent|TestMetadataBuilderRemoveUnknownPartitionSpecKeepsIndex|TestRejectsDuplicatePartitionSpecIDs)$' -count=1`
- `go test ./... -run '^$' -count=1`
- `go vet ./table`
