### PR TITLE
perf(table): precompute IN predicate extrema

### DIFF
--- a/bound_set_extrema_internal_test.go
+++ b/bound_set_extrema_internal_test.go
@@ -27,19 +27,19 @@ import (
 
 func TestLiteralSetExtrema(t *testing.T) {
 	t.Run("int32", func(t *testing.T) {
-		min, max, ok := literalSetExtrema[int32](newLiteralSet(
+		minLit, maxLit, ok := literalSetExtrema[int32](newLiteralSet(
 			NewLiteral(int32(7)), NewLiteral(int32(-2)), NewLiteral(int32(4))).(literalSet))
 		require.True(t, ok)
-		assert.Equal(t, Int32Literal(-2), min)
-		assert.Equal(t, Int32Literal(7), max)
+		assert.Equal(t, Int32Literal(-2), minLit)
+		assert.Equal(t, Int32Literal(7), maxLit)
 	})
 
 	t.Run("binary", func(t *testing.T) {
-		min, max, ok := literalSetExtrema[[]byte](newLiteralSet(
+		minLit, maxLit, ok := literalSetExtrema[[]byte](newLiteralSet(
 			NewLiteral([]byte("z")), NewLiteral([]byte("a")), NewLiteral([]byte("m"))).(literalSet))
 		require.True(t, ok)
-		assert.Equal(t, BinaryLiteral("a"), min)
-		assert.Equal(t, BinaryLiteral("z"), max)
+		assert.Equal(t, BinaryLiteral("a"), minLit)
+		assert.Equal(t, BinaryLiteral("z"), maxLit)
 	})
 
 	t.Run("geo has no ordering", func(t *testing.T) {
@@ -56,11 +56,11 @@ func TestLiteralSetExtrema(t *testing.T) {
 
 type boundSetExtremaVisitVisitor struct {
 	boundSetVisitVisitor
-	min, max Literal
+	minLit, maxLit Literal
 }
 
-func (v *boundSetExtremaVisitVisitor) VisitInWithExtrema(_ BoundTerm, _ Set[Literal], min, max Literal) bool {
-	v.min, v.max = min, max
+func (v *boundSetExtremaVisitVisitor) VisitInWithExtrema(_ BoundTerm, _ Set[Literal], minLit, maxLit Literal) bool {
+	v.minLit, v.maxLit = minLit, maxLit
 
 	return true
 }
@@ -79,12 +79,12 @@ func TestVisitBoundPredicateRefPassesInExtrema(t *testing.T) {
 		found = VisitBoundPredicateRef(bound, visitor, internal.BoundPredicateRef{})
 	}))
 	assert.True(t, found)
-	assert.Equal(t, StringLiteral("hello"), visitor.min)
-	assert.Equal(t, StringLiteral("world"), visitor.max)
+	assert.Equal(t, StringLiteral("hello"), visitor.minLit)
+	assert.Equal(t, StringLiteral("world"), visitor.maxLit)
 
-	visitor.min, visitor.max = nil, nil
+	visitor.minLit, visitor.maxLit = nil, nil
 	found = VisitBoundPredicate(bound, visitor)
 	assert.True(t, found)
-	assert.Nil(t, visitor.min)
-	assert.Nil(t, visitor.max)
+	assert.Nil(t, visitor.minLit)
+	assert.Nil(t, visitor.maxLit)
 }

--- a/bound_set_extrema_internal_test.go
+++ b/bound_set_extrema_internal_test.go
@@ -61,6 +61,7 @@ type boundSetExtremaVisitVisitor struct {
 
 func (v *boundSetExtremaVisitVisitor) VisitInWithExtrema(_ BoundTerm, _ Set[Literal], min, max Literal) bool {
 	v.min, v.max = min, max
+
 	return true
 }
 

--- a/bound_set_extrema_internal_test.go
+++ b/bound_set_extrema_internal_test.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiteralSetExtrema(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		min, max, ok := literalSetExtrema[int32](newLiteralSet(
+			NewLiteral(int32(7)), NewLiteral(int32(-2)), NewLiteral(int32(4))).(literalSet))
+		require.True(t, ok)
+		assert.Equal(t, Int32Literal(-2), min)
+		assert.Equal(t, Int32Literal(7), max)
+	})
+
+	t.Run("binary", func(t *testing.T) {
+		min, max, ok := literalSetExtrema[[]byte](newLiteralSet(
+			NewLiteral([]byte("z")), NewLiteral([]byte("a")), NewLiteral([]byte("m"))).(literalSet))
+		require.True(t, ok)
+		assert.Equal(t, BinaryLiteral("a"), min)
+		assert.Equal(t, BinaryLiteral("z"), max)
+	})
+
+	t.Run("geo has no ordering", func(t *testing.T) {
+		geometry := GeometryType{}
+		first, err := LiteralFromBytes(geometry, []byte("1234567890abcdef"))
+		require.NoError(t, err)
+		second, err := LiteralFromBytes(geometry, []byte("fedcba9876543210"))
+		require.NoError(t, err)
+
+		_, _, ok := literalSetExtrema[[]byte](newLiteralSet(first, second).(literalSet))
+		assert.False(t, ok)
+	})
+}
+
+type boundSetExtremaVisitVisitor struct {
+	boundSetVisitVisitor
+	min, max Literal
+}
+
+func (v *boundSetExtremaVisitVisitor) VisitInWithExtrema(_ BoundTerm, _ Set[Literal], min, max Literal) bool {
+	v.min, v.max = min, max
+	return true
+}
+
+func TestVisitBoundPredicateRefPassesInExtrema(t *testing.T) {
+	predicate, err := IsIn(Reference("value"), "world", "hello", "ice").(UnboundPredicate).Bind(
+		NewSchema(1, NestedField{ID: 1, Name: "value", Type: PrimitiveTypes.String}), true,
+	)
+	require.NoError(t, err)
+
+	visitor := &boundSetExtremaVisitVisitor{boundSetVisitVisitor: boundSetVisitVisitor{needle: NewLiteral("hello")}}
+	bound := predicate.(BoundPredicate)
+	var found bool
+
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		found = VisitBoundPredicateRef(bound, visitor, internal.BoundPredicateRef{})
+	}))
+	assert.True(t, found)
+	assert.Equal(t, StringLiteral("hello"), visitor.min)
+	assert.Equal(t, StringLiteral("world"), visitor.max)
+
+	visitor.min, visitor.max = nil, nil
+	found = VisitBoundPredicate(bound, visitor)
+	assert.True(t, found)
+	assert.Nil(t, visitor.min)
+	assert.Nil(t, visitor.max)
+}

--- a/bound_set_literal_view.go
+++ b/bound_set_literal_view.go
@@ -51,14 +51,14 @@ type boundSetLiteralRef interface {
 }
 
 type boundSetExtremaRef interface {
-	boundSetExtremaRef() (min, max Literal, ok bool)
+	boundSetExtremaRef() (minLit, maxLit Literal, ok bool)
 }
 
 func (bsp *boundSetPredicate[T]) boundSetLiteralsRef() Set[Literal] {
 	return bsp.lits
 }
 
-func (bsp *boundSetPredicate[T]) boundSetExtremaRef() (min, max Literal, ok bool) {
+func (bsp *boundSetPredicate[T]) boundSetExtremaRef() (minLit, maxLit Literal, ok bool) {
 	return bsp.minLiteral, bsp.maxLiteral, bsp.hasExtrema
 }
 

--- a/bound_set_literal_view.go
+++ b/bound_set_literal_view.go
@@ -50,8 +50,16 @@ type boundSetLiteralRef interface {
 	boundSetLiteralsRef() Set[Literal]
 }
 
+type boundSetExtremaRef interface {
+	boundSetExtremaRef() (min, max Literal, ok bool)
+}
+
 func (bsp *boundSetPredicate[T]) boundSetLiteralsRef() Set[Literal] {
 	return bsp.lits
+}
+
+func (bsp *boundSetPredicate[T]) boundSetExtremaRef() (min, max Literal, ok bool) {
+	return bsp.minLiteral, bsp.maxLiteral, bsp.hasExtrema
 }
 
 func boundSetLiteralsForVisit(predicate BoundPredicate) Set[Literal] {

--- a/exprs.go
+++ b/exprs.go
@@ -1008,14 +1008,62 @@ func createBoundSetPredicate(op Operation, term BoundTerm, lits Set[Literal]) (B
 		ErrType, term.Type())
 }
 
-func newBoundSetPredicate[T LiteralType](op Operation, term BoundTerm, lits Set[Literal]) *boundSetPredicate[T] {
-	return &boundSetPredicate[T]{op: op, term: term, lits: lits}
+func newBoundSetPredicate[T LiteralType](op Operation, term BoundTerm, lits literalSet) *boundSetPredicate[T] {
+	predicate := &boundSetPredicate[T]{op: op, term: term, lits: lits}
+	if op == OpIn {
+		predicate.minLiteral, predicate.maxLiteral, predicate.hasExtrema = literalSetExtrema[T](lits)
+	}
+
+	return predicate
 }
 
 type boundSetPredicate[T LiteralType] struct {
-	op   Operation
-	term BoundTerm
-	lits Set[Literal]
+	op         Operation
+	term       BoundTerm
+	lits       Set[Literal]
+	minLiteral Literal
+	maxLiteral Literal
+	hasExtrema bool
+}
+
+func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok bool) {
+	var (
+		cmp                Comparator[T]
+		minValue, maxValue T
+		valid              = true
+	)
+
+	lits.All(func(lit Literal) bool {
+		typed, typeOK := lit.(TypedLiteral[T])
+		if !typeOK {
+			valid = false
+			return false
+		}
+
+		value := typed.Value()
+		if !ok {
+			cmp = typed.Comparator()
+			min, max = lit, lit
+			minValue, maxValue = value, value
+			ok = true
+			return true
+		}
+
+		if cmp(value, minValue) < 0 {
+			min, minValue = lit, value
+		}
+		if cmp(value, maxValue) > 0 {
+			max, maxValue = lit, value
+		}
+
+		return true
+	})
+
+	if !valid {
+		return nil, nil, false
+	}
+
+	return min, max, ok
 }
 
 func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
@@ -1031,8 +1079,12 @@ func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
 func (bsp *boundSetPredicate[T]) Op() Operation { return bsp.op }
 func (bsp *boundSetPredicate[T]) Negate() BooleanExpression {
 	return &boundSetPredicate[T]{
-		op: bsp.op.Negate(), term: bsp.term,
-		lits: bsp.lits,
+		op:         bsp.op.Negate(),
+		term:       bsp.term,
+		lits:       bsp.lits,
+		minLiteral: bsp.minLiteral,
+		maxLiteral: bsp.maxLiteral,
+		hasExtrema: bsp.hasExtrema,
 	}
 }
 func (bsp *boundSetPredicate[T]) Term() BoundTerm     { return bsp.term }

--- a/exprs.go
+++ b/exprs.go
@@ -1026,7 +1026,7 @@ type boundSetPredicate[T LiteralType] struct {
 	hasExtrema bool
 }
 
-func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok bool) {
+func literalSetExtrema[T LiteralType](lits literalSet) (minLit, maxLit Literal, ok bool) {
 	var (
 		cmp                Comparator[T]
 		minValue, maxValue T
@@ -1044,7 +1044,7 @@ func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok boo
 		value := typed.Value()
 		if !ok {
 			cmp = typed.Comparator()
-			min, max = lit, lit
+			minLit, maxLit = lit, lit
 			minValue, maxValue = value, value
 			ok = true
 
@@ -1052,10 +1052,10 @@ func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok boo
 		}
 
 		if cmp(value, minValue) < 0 {
-			min, minValue = lit, value
+			minLit, minValue = lit, value
 		}
 		if cmp(value, maxValue) > 0 {
-			max, maxValue = lit, value
+			maxLit, maxValue = lit, value
 		}
 
 		return true
@@ -1065,7 +1065,7 @@ func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok boo
 		return nil, nil, false
 	}
 
-	return min, max, ok
+	return minLit, maxLit, ok
 }
 
 func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
@@ -1081,12 +1081,9 @@ func (bsp *boundSetPredicate[T]) Equals(other BooleanExpression) bool {
 func (bsp *boundSetPredicate[T]) Op() Operation { return bsp.op }
 func (bsp *boundSetPredicate[T]) Negate() BooleanExpression {
 	return &boundSetPredicate[T]{
-		op:         bsp.op.Negate(),
-		term:       bsp.term,
-		lits:       bsp.lits,
-		minLiteral: bsp.minLiteral,
-		maxLiteral: bsp.maxLiteral,
-		hasExtrema: bsp.hasExtrema,
+		op:   bsp.op.Negate(),
+		term: bsp.term,
+		lits: bsp.lits,
 	}
 }
 func (bsp *boundSetPredicate[T]) Term() BoundTerm     { return bsp.term }

--- a/exprs.go
+++ b/exprs.go
@@ -1037,6 +1037,7 @@ func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok boo
 		typed, typeOK := lit.(TypedLiteral[T])
 		if !typeOK {
 			valid = false
+
 			return false
 		}
 
@@ -1046,6 +1047,7 @@ func literalSetExtrema[T LiteralType](lits literalSet) (min, max Literal, ok boo
 			min, max = lit, lit
 			minValue, maxValue = value, value
 			ok = true
+
 			return true
 		}
 

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -150,6 +150,8 @@ func allBoundCheck(bound iceberg.Literal, set iceberg.Set[iceberg.Literal], want
 		return allBoundCmp[iceberg.Time](bound, set, want)
 	case iceberg.TimestampType, iceberg.TimestampTzType:
 		return allBoundCmp[iceberg.Timestamp](bound, set, want)
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		return allBoundCmp[iceberg.TimestampNano](bound, set, want)
 	case iceberg.BinaryType, iceberg.FixedType:
 		return allBoundCmp[[]byte](bound, set, want)
 	case iceberg.StringType:
@@ -162,7 +164,53 @@ func allBoundCheck(bound iceberg.Literal, set iceberg.Set[iceberg.Literal], want
 	panic(iceberg.ErrType)
 }
 
+func compareBound[T iceberg.LiteralType](bound, value iceberg.Literal) int {
+	val := bound.(iceberg.TypedLiteral[T])
+
+	return val.Comparator()(val.Value(), value.(iceberg.TypedLiteral[T]).Value())
+}
+
+func boundCompare(bound, value iceberg.Literal) int {
+	switch bound.Type().(type) {
+	case iceberg.BooleanType:
+		return compareBound[bool](bound, value)
+	case iceberg.Int32Type:
+		return compareBound[int32](bound, value)
+	case iceberg.Int64Type:
+		return compareBound[int64](bound, value)
+	case iceberg.Float32Type:
+		return compareBound[float32](bound, value)
+	case iceberg.Float64Type:
+		return compareBound[float64](bound, value)
+	case iceberg.DateType:
+		return compareBound[iceberg.Date](bound, value)
+	case iceberg.TimeType:
+		return compareBound[iceberg.Time](bound, value)
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		return compareBound[iceberg.Timestamp](bound, value)
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		return compareBound[iceberg.TimestampNano](bound, value)
+	case iceberg.BinaryType, iceberg.FixedType:
+		return compareBound[[]byte](bound, value)
+	case iceberg.StringType:
+		return compareBound[string](bound, value)
+	case iceberg.UUIDType:
+		return compareBound[uuid.UUID](bound, value)
+	case iceberg.DecimalType:
+		return compareBound[iceberg.Decimal](bound, value)
+	}
+	panic(iceberg.ErrType)
+}
+
 func (m *manifestEvalVisitor) VisitIn(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal]) bool {
+	return m.visitIn(term, literals, nil, nil)
+}
+
+func (m *manifestEvalVisitor) VisitInWithExtrema(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], min, max iceberg.Literal) bool {
+	return m.visitIn(term, literals, min, max)
+}
+
+func (m *manifestEvalVisitor) visitIn(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], min, max iceberg.Literal) bool {
 	pos := term.Ref().Pos()
 	field := m.partitionFields[pos]
 
@@ -179,7 +227,11 @@ func (m *manifestEvalVisitor) VisitIn(term iceberg.BoundTerm, literals iceberg.S
 		panic(err)
 	}
 
-	if allBoundCheck(lower, literals, 1) {
+	if max != nil {
+		if boundCompare(lower, max) == 1 {
+			return rowsCannotMatch
+		}
+	} else if allBoundCheck(lower, literals, 1) {
 		return rowsCannotMatch
 	}
 
@@ -189,7 +241,11 @@ func (m *manifestEvalVisitor) VisitIn(term iceberg.BoundTerm, literals iceberg.S
 			panic(err)
 		}
 
-		if allBoundCheck(upper, literals, -1) {
+		if min != nil {
+			if boundCompare(upper, min) == -1 {
+				return rowsCannotMatch
+			}
+		} else if allBoundCheck(upper, literals, -1) {
 			return rowsCannotMatch
 		}
 	}

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -111,6 +111,8 @@ func removeBoundCheck(bound iceberg.Literal, vals []iceberg.Literal, toDelete in
 		return removeBoundCmp[iceberg.Time](bound, vals, toDelete)
 	case iceberg.TimestampType, iceberg.TimestampTzType:
 		return removeBoundCmp[iceberg.Timestamp](bound, vals, toDelete)
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		return removeBoundCmp[iceberg.TimestampNano](bound, vals, toDelete)
 	case iceberg.BinaryType, iceberg.FixedType:
 		return removeBoundCmp[[]byte](bound, vals, toDelete)
 	case iceberg.StringType:
@@ -164,53 +166,15 @@ func allBoundCheck(bound iceberg.Literal, set iceberg.Set[iceberg.Literal], want
 	panic(iceberg.ErrType)
 }
 
-func compareBound[T iceberg.LiteralType](bound, value iceberg.Literal) int {
-	val := bound.(iceberg.TypedLiteral[T])
-
-	return val.Comparator()(val.Value(), value.(iceberg.TypedLiteral[T]).Value())
-}
-
-func boundCompare(bound, value iceberg.Literal) int {
-	switch bound.Type().(type) {
-	case iceberg.BooleanType:
-		return compareBound[bool](bound, value)
-	case iceberg.Int32Type:
-		return compareBound[int32](bound, value)
-	case iceberg.Int64Type:
-		return compareBound[int64](bound, value)
-	case iceberg.Float32Type:
-		return compareBound[float32](bound, value)
-	case iceberg.Float64Type:
-		return compareBound[float64](bound, value)
-	case iceberg.DateType:
-		return compareBound[iceberg.Date](bound, value)
-	case iceberg.TimeType:
-		return compareBound[iceberg.Time](bound, value)
-	case iceberg.TimestampType, iceberg.TimestampTzType:
-		return compareBound[iceberg.Timestamp](bound, value)
-	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
-		return compareBound[iceberg.TimestampNano](bound, value)
-	case iceberg.BinaryType, iceberg.FixedType:
-		return compareBound[[]byte](bound, value)
-	case iceberg.StringType:
-		return compareBound[string](bound, value)
-	case iceberg.UUIDType:
-		return compareBound[uuid.UUID](bound, value)
-	case iceberg.DecimalType:
-		return compareBound[iceberg.Decimal](bound, value)
-	}
-	panic(iceberg.ErrType)
-}
-
 func (m *manifestEvalVisitor) VisitIn(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal]) bool {
 	return m.visitIn(term, literals, nil, nil)
 }
 
-func (m *manifestEvalVisitor) VisitInWithExtrema(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], min, max iceberg.Literal) bool {
-	return m.visitIn(term, literals, min, max)
+func (m *manifestEvalVisitor) VisitInWithExtrema(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], minLit, maxLit iceberg.Literal) bool {
+	return m.visitIn(term, literals, minLit, maxLit)
 }
 
-func (m *manifestEvalVisitor) visitIn(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], min, max iceberg.Literal) bool {
+func (m *manifestEvalVisitor) visitIn(term iceberg.BoundTerm, literals iceberg.Set[iceberg.Literal], minLit, maxLit iceberg.Literal) bool {
 	pos := term.Ref().Pos()
 	field := m.partitionFields[pos]
 
@@ -218,21 +182,22 @@ func (m *manifestEvalVisitor) visitIn(term iceberg.BoundTerm, literals iceberg.S
 		return rowsCannotMatch
 	}
 
-	if literals.Len() > inPredicateLimit {
-		return rowsMightMatch
-	}
-
 	lower, err := iceberg.LiteralFromBytes(term.Type(), *field.LowerBound)
 	if err != nil {
 		panic(err)
 	}
 
-	if max != nil {
-		if boundCompare(lower, max) == 1 {
+	if maxLit != nil {
+		if getCmpLiteral(lower)(lower, maxLit) > 0 {
 			return rowsCannotMatch
 		}
-	} else if allBoundCheck(lower, literals, 1) {
-		return rowsCannotMatch
+	} else {
+		if literals.Len() > inPredicateLimit {
+			return rowsMightMatch
+		}
+		if allBoundCheck(lower, literals, 1) {
+			return rowsCannotMatch
+		}
 	}
 
 	if field.UpperBound != nil {
@@ -241,8 +206,8 @@ func (m *manifestEvalVisitor) visitIn(term iceberg.BoundTerm, literals iceberg.S
 			panic(err)
 		}
 
-		if min != nil {
-			if boundCompare(upper, min) == -1 {
+		if minLit != nil {
+			if getCmpLiteral(upper)(upper, minLit) < 0 {
 				return rowsCannotMatch
 			}
 		} else if allBoundCheck(upper, literals, -1) {
@@ -337,6 +302,8 @@ func getCmpLiteral(boundary iceberg.Literal) func(iceberg.Literal, iceberg.Liter
 	case iceberg.TypedLiteral[iceberg.Time]:
 		return getCmp(l)
 	case iceberg.TypedLiteral[iceberg.Timestamp]:
+		return getCmp(l)
+	case iceberg.TypedLiteral[iceberg.TimestampNano]:
 		return getCmp(l)
 	case iceberg.TypedLiteral[[]byte]:
 		return getCmp(l)

--- a/table/in_predicate_extrema_bench_test.go
+++ b/table/in_predicate_extrema_bench_test.go
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/iceberg-go"
+)
+
+var manifestInPredicateBenchmarkSink bool
+
+func BenchmarkManifestEvaluatorInPredicate(b *testing.B) {
+	for _, literalCount := range []int{2, 10, 50, 200} {
+		b.Run("int32/in="+strconv.Itoa(literalCount), func(b *testing.B) {
+			values := make([]int32, literalCount)
+			for i := range values {
+				values[i] = int32(i)
+			}
+
+			b.Run("pruned-lower", func(b *testing.B) {
+				benchmarkManifestIn(b, values, int32(literalCount+1), int32(literalCount+1), iceberg.PrimitiveTypes.Int32)
+			})
+			b.Run("pruned-upper", func(b *testing.B) {
+				benchmarkManifestIn(b, values, int32(-1), int32(-1), iceberg.PrimitiveTypes.Int32)
+			})
+			b.Run("no-prune", func(b *testing.B) {
+				benchmarkManifestIn(b, values, int32(-1), int32(literalCount+1), iceberg.PrimitiveTypes.Int32)
+			})
+		})
+
+		b.Run("string/in="+strconv.Itoa(literalCount), func(b *testing.B) {
+			values := make([]string, literalCount)
+			for i := range values {
+				values[i] = "v" + strconv.Itoa(i)
+			}
+
+			b.Run("pruned-lower", func(b *testing.B) {
+				benchmarkManifestIn(b, values, "z", "z", iceberg.PrimitiveTypes.String)
+			})
+			b.Run("pruned-upper", func(b *testing.B) {
+				benchmarkManifestIn(b, values, "a", "a", iceberg.PrimitiveTypes.String)
+			})
+			b.Run("no-prune", func(b *testing.B) {
+				benchmarkManifestIn(b, values, "a", "z", iceberg.PrimitiveTypes.String)
+			})
+		})
+
+		b.Run("decimal/in="+strconv.Itoa(literalCount), func(b *testing.B) {
+			values := make([]iceberg.Decimal, literalCount)
+			for i := range values {
+				values[i] = iceberg.Decimal{Val: decimal128.FromI64(int64(i * 100)), Scale: 2}
+			}
+
+			b.Run("pruned-lower", func(b *testing.B) {
+				benchmarkManifestIn(b, values, iceberg.Decimal{Val: decimal128.FromI64(int64(literalCount+1) * 100), Scale: 2}, iceberg.Decimal{Val: decimal128.FromI64(int64(literalCount+1) * 100), Scale: 2}, iceberg.DecimalTypeOf(12, 2))
+			})
+			b.Run("pruned-upper", func(b *testing.B) {
+				benchmarkManifestIn(b, values, iceberg.Decimal{Val: decimal128.FromI64(-100), Scale: 2}, iceberg.Decimal{Val: decimal128.FromI64(-100), Scale: 2}, iceberg.DecimalTypeOf(12, 2))
+			})
+			b.Run("no-prune", func(b *testing.B) {
+				benchmarkManifestIn(b, values, iceberg.Decimal{Val: decimal128.FromI64(-100), Scale: 2}, iceberg.Decimal{Val: decimal128.FromI64(int64(literalCount+1) * 100), Scale: 2}, iceberg.DecimalTypeOf(12, 2))
+			})
+		})
+	}
+}
+
+func benchmarkManifestIn[T iceberg.LiteralType](b *testing.B, values []T, lower, upper T, typ iceberg.Type) {
+	b.Helper()
+	lowerBytes, err := iceberg.NewLiteral(lower).MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	upperBytes, err := iceberg.NewLiteral(upper).MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "value", Type: typ})
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "value", Transform: iceberg.IdentityTransform{},
+	})
+	eval, err := newManifestEvaluator(spec, schema, iceberg.IsIn(iceberg.Reference("value"), values...), true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	manifest := iceberg.NewManifestFile(2, "manifest.avro", 1, 0, 1).Partitions(
+		[]iceberg.FieldSummary{{LowerBound: &lowerBytes, UpperBound: &upperBytes}},
+	).Build()
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(values)), "literals")
+	b.ResetTimer()
+	for range b.N {
+		matched, err := eval(manifest)
+		if err != nil {
+			b.Fatal(err)
+		}
+		manifestInPredicateBenchmarkSink = matched
+	}
+}

--- a/table/in_predicate_extrema_test.go
+++ b/table/in_predicate_extrema_test.go
@@ -31,14 +31,16 @@ func TestManifestEvaluatorInPredicateExtrema(t *testing.T) {
 		return iceberg.Decimal{Val: decimal128.FromI64(value), Scale: 2}
 	}
 
-	tests := []struct {
+	type testCase struct {
 		name       string
 		typ        iceberg.Type
 		expr       iceberg.BooleanExpression
 		lower      iceberg.Literal
 		upper      iceberg.Literal
 		expectRead bool
-	}{
+	}
+
+	tests := []testCase{
 		{
 			name:       "decimal below lower bound",
 			typ:        iceberg.DecimalTypeOf(12, 2),
@@ -89,6 +91,30 @@ func TestManifestEvaluatorInPredicateExtrema(t *testing.T) {
 		},
 	}
 
+	largeValues := make([]int32, inPredicateLimit+1)
+	for i := range largeValues {
+		largeValues[i] = int32(i)
+	}
+	largeIn := iceberg.IsIn(iceberg.Reference("value"), largeValues...)
+	tests = append(tests,
+		testCase{
+			name:       "large IN below lower bound",
+			typ:        iceberg.PrimitiveTypes.Int32,
+			expr:       largeIn,
+			lower:      iceberg.NewLiteral(int32(inPredicateLimit + 1)),
+			upper:      iceberg.NewLiteral(int32(inPredicateLimit + 2)),
+			expectRead: false,
+		},
+		testCase{
+			name:       "large IN includes lower bound",
+			typ:        iceberg.PrimitiveTypes.Int32,
+			expr:       largeIn,
+			lower:      iceberg.NewLiteral(int32(inPredicateLimit)),
+			upper:      iceberg.NewLiteral(int32(inPredicateLimit)),
+			expectRead: true,
+		},
+	)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "value", Type: tt.typ})
@@ -111,4 +137,18 @@ func TestManifestEvaluatorInPredicateExtrema(t *testing.T) {
 			assert.Equal(t, tt.expectRead, result)
 		})
 	}
+}
+
+func TestRemoveBoundCheckSupportsTimestampNanos(t *testing.T) {
+	bound := iceberg.NewLiteral(iceberg.TimestampNano(2))
+	values := []iceberg.Literal{
+		iceberg.NewLiteral(iceberg.TimestampNano(1)),
+		iceberg.NewLiteral(iceberg.TimestampNano(2)),
+		iceberg.NewLiteral(iceberg.TimestampNano(3)),
+	}
+
+	assert.Equal(t, []iceberg.Literal{
+		iceberg.NewLiteral(iceberg.TimestampNano(2)),
+		iceberg.NewLiteral(iceberg.TimestampNano(3)),
+	}, removeBoundCheck(bound, values, 1))
 }

--- a/table/in_predicate_extrema_test.go
+++ b/table/in_predicate_extrema_test.go
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestEvaluatorInPredicateExtrema(t *testing.T) {
+	decimal := func(value int64) iceberg.Decimal {
+		return iceberg.Decimal{Val: decimal128.FromI64(value), Scale: 2}
+	}
+
+	tests := []struct {
+		name       string
+		typ        iceberg.Type
+		expr       iceberg.BooleanExpression
+		lower      iceberg.Literal
+		upper      iceberg.Literal
+		expectRead bool
+	}{
+		{
+			name:       "decimal below lower bound",
+			typ:        iceberg.DecimalTypeOf(12, 2),
+			expr:       iceberg.IsIn(iceberg.Reference("value"), decimal(100), decimal(200), decimal(300)),
+			lower:      iceberg.NewLiteral(decimal(400)),
+			upper:      iceberg.NewLiteral(decimal(500)),
+			expectRead: false,
+		},
+		{
+			name:       "decimal above upper bound",
+			typ:        iceberg.DecimalTypeOf(12, 2),
+			expr:       iceberg.IsIn(iceberg.Reference("value"), decimal(100), decimal(200), decimal(300)),
+			lower:      iceberg.NewLiteral(decimal(-100)),
+			upper:      iceberg.NewLiteral(decimal(0)),
+			expectRead: false,
+		},
+		{
+			name:       "decimal overlaps bound",
+			typ:        iceberg.DecimalTypeOf(12, 2),
+			expr:       iceberg.IsIn(iceberg.Reference("value"), decimal(100), decimal(200), decimal(300)),
+			lower:      iceberg.NewLiteral(decimal(200)),
+			upper:      iceberg.NewLiteral(decimal(250)),
+			expectRead: true,
+		},
+		{
+			name:       "timestamp nanos below lower bound",
+			typ:        iceberg.PrimitiveTypes.TimestampNs,
+			expr:       iceberg.IsIn(iceberg.Reference("value"), iceberg.TimestampNano(100), iceberg.TimestampNano(200), iceberg.TimestampNano(300)),
+			lower:      iceberg.NewLiteral(iceberg.TimestampNano(400)),
+			upper:      iceberg.NewLiteral(iceberg.TimestampNano(500)),
+			expectRead: false,
+		},
+		{
+			name:       "timestamp nanos above upper bound",
+			typ:        iceberg.PrimitiveTypes.TimestampNs,
+			expr:       iceberg.IsIn(iceberg.Reference("value"), iceberg.TimestampNano(100), iceberg.TimestampNano(200), iceberg.TimestampNano(300)),
+			lower:      iceberg.NewLiteral(iceberg.TimestampNano(-100)),
+			upper:      iceberg.NewLiteral(iceberg.TimestampNano(99)),
+			expectRead: false,
+		},
+		{
+			name:       "timestamp nanos overlaps bound",
+			typ:        iceberg.PrimitiveTypes.TimestampNs,
+			expr:       iceberg.IsIn(iceberg.Reference("value"), iceberg.TimestampNano(100), iceberg.TimestampNano(200), iceberg.TimestampNano(300)),
+			lower:      iceberg.NewLiteral(iceberg.TimestampNano(200)),
+			upper:      iceberg.NewLiteral(iceberg.TimestampNano(250)),
+			expectRead: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := iceberg.NewSchema(1, iceberg.NestedField{ID: 1, Name: "value", Type: tt.typ})
+			spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+				SourceIDs: []int{1}, FieldID: 1000, Name: "value", Transform: iceberg.IdentityTransform{},
+			})
+			eval, err := newManifestEvaluator(spec, schema, tt.expr, true)
+			require.NoError(t, err)
+
+			lower, err := tt.lower.MarshalBinary()
+			require.NoError(t, err)
+			upper, err := tt.upper.MarshalBinary()
+			require.NoError(t, err)
+			manifest := iceberg.NewManifestFile(2, "manifest.avro", 1, 0, 1).Partitions(
+				[]iceberg.FieldSummary{{LowerBound: &lower, UpperBound: &upper}},
+			).Build()
+
+			result, err := eval(manifest)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectRead, result)
+		})
+	}
+}

--- a/visitors.go
+++ b/visitors.go
@@ -82,6 +82,9 @@ type BoundGeospatialExprVisitor[T any] interface {
 	VisitBBoxNotIntersects(BoundTerm, BoundingBox) T
 }
 
+// boundSetExtremaExprVisitor is consulted only by the borrowed
+// VisitBoundPredicateRef path. The table package's manifest evaluator is
+// currently the only implementation.
 type boundSetExtremaExprVisitor[T any] interface {
 	VisitInWithExtrema(BoundTerm, Set[Literal], Literal, Literal) T
 }
@@ -209,10 +212,10 @@ func visitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisito
 		literals := literalSetForVisit(e, borrowed)
 		if borrowed {
 			if extrema, ok := e.(boundSetExtremaRef); ok {
-				min, max, hasExtrema := extrema.boundSetExtremaRef()
+				minLit, maxLit, hasExtrema := extrema.boundSetExtremaRef()
 				if hasExtrema {
 					if extremaVisitor, ok := visitor.(boundSetExtremaExprVisitor[T]); ok {
-						return extremaVisitor.VisitInWithExtrema(e.Term(), literals, min, max)
+						return extremaVisitor.VisitInWithExtrema(e.Term(), literals, minLit, maxLit)
 					}
 				}
 			}

--- a/visitors.go
+++ b/visitors.go
@@ -82,6 +82,10 @@ type BoundGeospatialExprVisitor[T any] interface {
 	VisitBBoxNotIntersects(BoundTerm, BoundingBox) T
 }
 
+type boundSetExtremaExprVisitor[T any] interface {
+	VisitInWithExtrema(BoundTerm, Set[Literal], Literal, Literal) T
+}
+
 // VisitExpr is a convenience function to use a given visitor to visit all parts of
 // a boolean expression in-order. Values returned from the methods are passed to the
 // subsequent methods, effectively "bubbling up" the results.
@@ -202,7 +206,19 @@ func VisitBoundPredicateRef[T any](e BoundPredicate, visitor BoundBooleanExprVis
 func visitBoundPredicate[T any](e BoundPredicate, visitor BoundBooleanExprVisitor[T], borrowed bool) T {
 	switch e.Op() {
 	case OpIn:
-		return visitor.VisitIn(e.Term(), literalSetForVisit(e, borrowed))
+		literals := literalSetForVisit(e, borrowed)
+		if borrowed {
+			if extrema, ok := e.(boundSetExtremaRef); ok {
+				min, max, hasExtrema := extrema.boundSetExtremaRef()
+				if hasExtrema {
+					if extremaVisitor, ok := visitor.(boundSetExtremaExprVisitor[T]); ok {
+						return extremaVisitor.VisitInWithExtrema(e.Term(), literals, min, max)
+					}
+				}
+			}
+		}
+
+		return visitor.VisitIn(e.Term(), literals)
 	case OpNotIn:
 		return visitor.VisitNotIn(e.Term(), literalSetForVisit(e, borrowed))
 	case OpIsNan:


### PR DESCRIPTION
**What changed**

- **Precompute min/max for `IN`** when the bound expression is created.
- **Use one comparison per manifest** instead of scanning every literal for both partition bounds.
- **Keep existing visitor behavior** for public visitors and literals without a total ordering.
- Added focused tests and a benchmark for int32, string, decimal, binary, and nanosecond timestamp values.

**Benchmark**

- **Machine:** Apple M1 Pro
- **200 literals, lower-bound prune, median:**
  - int32: **3.14 µs -> 0.18 µs**
  - string: **3.77 µs -> 0.20 µs**
  - decimal: **3.52 µs -> 0.24 µs**
- **Allocations:** int32 **192 B / 7 -> 144 B / 6**; string **208 B / 8 -> 160 B / 7**; decimal **240 B / 10 -> 192 B / 9**
- Command: `go test ./table -run '^$' -bench '^BenchmarkManifestEvaluatorInPredicate$' -benchmem -benchtime=200ms -count=5`

**Checks**

- `go test . ./table ./table/dv ./table/substrait -count=1`
- `go test -race . ./table -run '^(TestLiteralSetExtrema|TestVisitBoundPredicateRefPassesInExtrema|TestVisitBoundPredicateRefDoesNotAllocate|TestManifestEvaluatorInPredicateExtrema|TestManifestEvaluator|TestManifestEvalVisitorEvalRace)$' -count=1`
- `go vet ./...`
