### PR TITLE
perf(table): classify manifest entries outside merge lock

### DIFF
--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -141,6 +141,29 @@ func TestManifestEntries_DVClassification(t *testing.T) {
 	assert.Len(t, entries.equalityDeleteEntries, 1)
 }
 
+func TestManifestEntries_MergeRejectsUnknownContent(t *testing.T) {
+	snapshotID := int64(1)
+	validEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/data-001.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+	invalidEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/unknown.bin",
+		contentType: iceberg.ManifestEntryContent(99),
+	})
+	entryAfterInvalid := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/data-002.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+
+	entries := newManifestEntries()
+	err := entries.merge([]iceberg.ManifestEntry{validEntry, invalidEntry, entryAfterInvalid})
+
+	assert.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "unknown DataFileContent type")
+	assert.Equal(t, []iceberg.ManifestEntry{validEntry}, entries.dataEntries)
+}
+
 func TestManifestEntries_ConcurrentMerge(t *testing.T) {
 	snapshotID := int64(1)
 	batch := []iceberg.ManifestEntry{

--- a/table/dv_scan_planning_test.go
+++ b/table/dv_scan_planning_test.go
@@ -164,6 +164,41 @@ func TestManifestEntries_MergeRejectsUnknownContent(t *testing.T) {
 	assert.Equal(t, []iceberg.ManifestEntry{validEntry}, entries.dataEntries)
 }
 
+func TestManifestEntries_MergeRejectsUnknownContentAfterMixedEntries(t *testing.T) {
+	snapshotID := int64(1)
+	dataEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/data-001.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+	positionalDeleteEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/pos-delete-001.parquet",
+		contentType: iceberg.EntryContentPosDeletes,
+	})
+	invalidEntry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/unknown.bin",
+		contentType: iceberg.ManifestEntryContent(99),
+	})
+	entryAfterInvalid := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "s3://bucket/data/data-002.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+
+	entries := newManifestEntries()
+	err := entries.merge([]iceberg.ManifestEntry{
+		dataEntry,
+		positionalDeleteEntry,
+		invalidEntry,
+		entryAfterInvalid,
+	})
+
+	assert.ErrorIs(t, err, ErrInvalidMetadata)
+	assert.ErrorContains(t, err, "unknown DataFileContent type")
+	assert.Equal(t, []iceberg.ManifestEntry{dataEntry}, entries.dataEntries)
+	assert.Equal(t, []iceberg.ManifestEntry{positionalDeleteEntry}, entries.positionalDeleteEntries)
+	assert.Empty(t, entries.equalityDeleteEntries)
+	assert.Empty(t, entries.dvEntries)
+}
+
 func TestManifestEntries_ConcurrentMerge(t *testing.T) {
 	snapshotID := int64(1)
 	batch := []iceberg.ManifestEntry{

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -173,6 +173,7 @@ func classifyManifestEntry(entry iceberg.ManifestEntry) (manifestEntryKind, erro
 		if IsDeletionVector(dataFile) {
 			return manifestEntryDV, nil
 		}
+
 		return manifestEntryPositionalDelete, nil
 	case iceberg.EntryContentEqDeletes:
 		return manifestEntryEqualityDelete, nil
@@ -232,12 +233,13 @@ func classifyManifestEntries(entries []iceberg.ManifestEntry) (classifiedManifes
 			for j, validEntry := range entries[:i] {
 				appendClassifiedManifestEntry(&classified, kinds[j], validEntry)
 			}
+
 			return classified, err
 		}
 
 		if kinds == nil && kind != firstKind {
 			kinds = make([]manifestEntryKind, len(entries))
-			for j := 0; j < i; j++ {
+			for j := range i {
 				kinds[j] = firstKind
 			}
 			counts[firstKind] = i

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -138,6 +138,23 @@ type manifestEntries struct {
 	mu                      sync.Mutex
 }
 
+type classifiedManifestEntries struct {
+	dataEntries             []iceberg.ManifestEntry
+	positionalDeleteEntries []iceberg.ManifestEntry
+	equalityDeleteEntries   []iceberg.ManifestEntry
+	dvEntries               []iceberg.ManifestEntry
+}
+
+type manifestEntryKind uint8
+
+const (
+	manifestEntryData manifestEntryKind = iota
+	manifestEntryPositionalDelete
+	manifestEntryEqualityDelete
+	manifestEntryDV
+	manifestEntryKindCount
+)
+
 func newManifestEntries() *manifestEntries {
 	return &manifestEntries{
 		dataEntries:             make([]iceberg.ManifestEntry, 0),
@@ -147,30 +164,126 @@ func newManifestEntries() *manifestEntries {
 	}
 }
 
-func (m *manifestEntries) merge(entries []iceberg.ManifestEntry) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+func classifyManifestEntry(entry iceberg.ManifestEntry) (manifestEntryKind, error) {
+	dataFile := entry.DataFile()
+	switch dataFile.ContentType() {
+	case iceberg.EntryContentData:
+		return manifestEntryData, nil
+	case iceberg.EntryContentPosDeletes:
+		if IsDeletionVector(dataFile) {
+			return manifestEntryDV, nil
+		}
+		return manifestEntryPositionalDelete, nil
+	case iceberg.EntryContentEqDeletes:
+		return manifestEntryEqualityDelete, nil
+	default:
+		return 0, fmt.Errorf("%w: unknown DataFileContent type (%s): %s",
+			ErrInvalidMetadata, dataFile.ContentType(), entry)
+	}
+}
 
-	for _, entry := range entries {
-		dataFile := entry.DataFile()
-		switch dataFile.ContentType() {
-		case iceberg.EntryContentData:
-			m.dataEntries = append(m.dataEntries, entry)
-		case iceberg.EntryContentPosDeletes:
-			if IsDeletionVector(dataFile) {
-				m.dvEntries = append(m.dvEntries, entry)
-			} else {
-				m.positionalDeleteEntries = append(m.positionalDeleteEntries, entry)
+func newClassifiedManifestEntries(counts [manifestEntryKindCount]int) classifiedManifestEntries {
+	return classifiedManifestEntries{
+		dataEntries:             make([]iceberg.ManifestEntry, 0, counts[manifestEntryData]),
+		positionalDeleteEntries: make([]iceberg.ManifestEntry, 0, counts[manifestEntryPositionalDelete]),
+		equalityDeleteEntries:   make([]iceberg.ManifestEntry, 0, counts[manifestEntryEqualityDelete]),
+		dvEntries:               make([]iceberg.ManifestEntry, 0, counts[manifestEntryDV]),
+	}
+}
+
+func classifiedManifestEntriesForKind(kind manifestEntryKind, entries []iceberg.ManifestEntry) classifiedManifestEntries {
+	classified := classifiedManifestEntries{}
+	switch kind {
+	case manifestEntryData:
+		classified.dataEntries = entries
+	case manifestEntryPositionalDelete:
+		classified.positionalDeleteEntries = entries
+	case manifestEntryEqualityDelete:
+		classified.equalityDeleteEntries = entries
+	case manifestEntryDV:
+		classified.dvEntries = entries
+	}
+
+	return classified
+}
+
+func classifyManifestEntries(entries []iceberg.ManifestEntry) (classifiedManifestEntries, error) {
+	if len(entries) == 0 {
+		return classifiedManifestEntries{}, nil
+	}
+
+	firstKind, err := classifyManifestEntry(entries[0])
+	if err != nil {
+		return classifiedManifestEntries{}, err
+	}
+
+	var (
+		kinds  []manifestEntryKind
+		counts [manifestEntryKindCount]int
+	)
+	for i := 1; i < len(entries); i++ {
+		kind, err := classifyManifestEntry(entries[i])
+		if err != nil {
+			if kinds == nil {
+				return classifiedManifestEntriesForKind(firstKind, entries[:i]), err
 			}
-		case iceberg.EntryContentEqDeletes:
-			m.equalityDeleteEntries = append(m.equalityDeleteEntries, entry)
-		default:
-			return fmt.Errorf("%w: unknown DataFileContent type (%s): %s",
-				ErrInvalidMetadata, dataFile.ContentType(), entry)
+
+			classified := newClassifiedManifestEntries(counts)
+			for j, validEntry := range entries[:i] {
+				appendClassifiedManifestEntry(&classified, kinds[j], validEntry)
+			}
+			return classified, err
+		}
+
+		if kinds == nil && kind != firstKind {
+			kinds = make([]manifestEntryKind, len(entries))
+			for j := 0; j < i; j++ {
+				kinds[j] = firstKind
+			}
+			counts[firstKind] = i
+		}
+		if kinds != nil {
+			kinds[i] = kind
+			counts[kind]++
 		}
 	}
 
-	return nil
+	if kinds == nil {
+		return classifiedManifestEntriesForKind(firstKind, entries), nil
+	}
+
+	classified := newClassifiedManifestEntries(counts)
+	for i, entry := range entries {
+		appendClassifiedManifestEntry(&classified, kinds[i], entry)
+	}
+
+	return classified, nil
+}
+
+func appendClassifiedManifestEntry(classified *classifiedManifestEntries, kind manifestEntryKind, entry iceberg.ManifestEntry) {
+	switch kind {
+	case manifestEntryData:
+		classified.dataEntries = append(classified.dataEntries, entry)
+	case manifestEntryPositionalDelete:
+		classified.positionalDeleteEntries = append(classified.positionalDeleteEntries, entry)
+	case manifestEntryEqualityDelete:
+		classified.equalityDeleteEntries = append(classified.equalityDeleteEntries, entry)
+	case manifestEntryDV:
+		classified.dvEntries = append(classified.dvEntries, entry)
+	}
+}
+
+func (m *manifestEntries) merge(entries []iceberg.ManifestEntry) error {
+	classified, err := classifyManifestEntries(entries)
+
+	m.mu.Lock()
+	m.dataEntries = append(m.dataEntries, classified.dataEntries...)
+	m.positionalDeleteEntries = append(m.positionalDeleteEntries, classified.positionalDeleteEntries...)
+	m.equalityDeleteEntries = append(m.equalityDeleteEntries, classified.equalityDeleteEntries...)
+	m.dvEntries = append(m.dvEntries, classified.dvEntries...)
+	m.mu.Unlock()
+
+	return err
 }
 
 func newPartitionRecord(partitionData map[int]any, partitionType *iceberg.StructType) partitionRecord {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -203,6 +203,8 @@ func classifiedManifestEntriesForKind(kind manifestEntryKind, entries []iceberg.
 		classified.equalityDeleteEntries = entries
 	case manifestEntryDV:
 		classified.dvEntries = entries
+	default:
+		panic(fmt.Sprintf("unhandled manifest entry kind %d", kind))
 	}
 
 	return classified
@@ -272,18 +274,23 @@ func appendClassifiedManifestEntry(classified *classifiedManifestEntries, kind m
 		classified.equalityDeleteEntries = append(classified.equalityDeleteEntries, entry)
 	case manifestEntryDV:
 		classified.dvEntries = append(classified.dvEntries, entry)
+	default:
+		panic(fmt.Sprintf("unhandled manifest entry kind %d", kind))
 	}
 }
 
 func (m *manifestEntries) merge(entries []iceberg.ManifestEntry) error {
 	classified, err := classifyManifestEntries(entries)
 
+	// Preserve the existing partial-commit behavior on classification errors.
+	// Callers discard the accumulator when merge returns an error.
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.dataEntries = append(m.dataEntries, classified.dataEntries...)
 	m.positionalDeleteEntries = append(m.positionalDeleteEntries, classified.positionalDeleteEntries...)
 	m.equalityDeleteEntries = append(m.equalityDeleteEntries, classified.equalityDeleteEntries...)
 	m.dvEntries = append(m.dvEntries, classified.dvEntries...)
-	m.mu.Unlock()
 
 	return err
 }


### PR DESCRIPTION
## What changed

- **Classify manifest entries before taking `manifestEntries.mu`.**
- Keep only the bulk appends to the shared slices inside the lock.
- Reuse homogeneous batches and use exact-size buckets for mixed batches.
- Preserve the existing error behavior for unknown file content.

## Why

Large manifest batches were doing `DataFile()` and content checks while holding the shared mutex. This made concurrent manifest collection wait on work that does not touch shared state.

## Benchmark

Command:

```text
go test ./table -run '^$' -bench '^BenchmarkManifestEntryCollection/content=(data|deletes)/manifests=(8|64)/concurrency=(1|4|16)/entries=10000$' -benchtime=1s -count=3
```

Apple M1 Pro, Go 1.26.3. Median of 3 runs, 8 manifests with 10,000 entries each:

| Workload | Concurrency | Before | After |
| --- | ---: | ---: | ---: |
| Data | 4 | 1.952 ms/op | 1.403 ms/op |
| Data | 16 | 1.959 ms/op | 1.357 ms/op |
| Mixed deletes | 4 | 1.810 ms/op | 1.636 ms/op |
| Mixed deletes | 16 | 1.924 ms/op | 1.772 ms/op |

The 64-manifest cases stayed roughly flat at concurrency 16 while the lock covered less work. Data batches also dropped from 54 to 34 allocs/op in the 8-manifest cases.

## Tests

- `go test ./table -count=1`
- `go test -race ./table -run 'TestManifestEntries|TestIsDeletionVector' -count=1`
- `go vet ./table`
- `go test ./... -run '^$' -count=1`
