### PR TITLE
perf(table): avoid per-file partition materialization in partitions metadata

### DIFF
--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2654,6 +2654,19 @@ func TestInspectPartitionAggregateTreeLookupPartition(t *testing.T) {
 		1001: []byte{1, 2, 4},
 		1002: math.NaN(),
 	}, partitionType))
+
+	// A file written with an older partition spec does not have the field
+	// added by a later spec. Both lookup paths must key the missing field as nil.
+	evolvedPartition := map[int]any{
+		1000: int32(7),
+		1002: math.NaN(),
+	}
+	evolvedRecord := newPartitionRecord(inspectCoercePartition(evolvedPartition, partitionType), partitionType)
+	evolvedAggregate := &inspectPartitionAggregate{specID: 2}
+	tree.insert(evolvedRecord, evolvedAggregate)
+
+	require.Same(t, evolvedAggregate, tree.lookupPartition(evolvedPartition, partitionType))
+	require.Same(t, evolvedAggregate, tree.lookup(evolvedRecord))
 }
 
 func TestCloneInspectPartitionClonesBinaryValues(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2632,6 +2632,43 @@ func TestInspectPartitionAggregateTreeDistinguishesFloatWidthsAndSignedZero(t *t
 	require.Nil(t, tree.lookup(partitionRecord{float64(0)}))
 }
 
+func TestInspectPartitionAggregateTreeLookupPartition(t *testing.T) {
+	partitionType := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 1000, Name: "id", Type: iceberg.PrimitiveTypes.Int32},
+		{ID: 1001, Name: "payload", Type: iceberg.PrimitiveTypes.Binary},
+		{ID: 1002, Name: "score", Type: iceberg.PrimitiveTypes.Float64},
+	}}
+	partition := map[int]any{
+		1000: int32(7),
+		1001: []byte{1, 2, 3},
+		1002: math.NaN(),
+	}
+	record := newPartitionRecord(inspectCoercePartition(partition, partitionType), partitionType)
+	aggregate := &inspectPartitionAggregate{specID: 1}
+	tree := newInspectPartitionAggregateTree()
+	tree.insert(record, aggregate)
+
+	require.Same(t, aggregate, tree.lookupPartition(partition, partitionType))
+	require.Nil(t, tree.lookupPartition(map[int]any{
+		1000: int32(7),
+		1001: []byte{1, 2, 4},
+		1002: math.NaN(),
+	}, partitionType))
+}
+
+func TestCloneInspectPartitionClonesBinaryValues(t *testing.T) {
+	value := []byte{1, 2, 3}
+	cloned := cloneInspectPartition(map[int]any{1000: value})
+
+	value[0] = 4
+	require.Equal(t, []byte{1, 2, 3}, cloned[1000])
+
+	clonedValue := cloned[1000].([]byte)
+	clonedValue[1] = 5
+
+	require.Equal(t, []byte{4, 2, 3}, value)
+}
+
 func TestInspectPartitionsAggregatesDataAndDeletes(t *testing.T) {
 	const snapshotID = int64(1)
 	spec := partitionedSpec()

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -43,7 +43,6 @@ type inspectPartitionAggregate struct {
 	equalityDeleteFiles int32
 	lastUpdatedAt       *int64
 	lastUpdatedSnapshot *int64
-	partitionRecord     partitionRecord
 	orderingKey         string
 }
 
@@ -76,10 +75,6 @@ func (t *inspectPartitionAggregateTree) lookupPartition(
 	partitionType *iceberg.StructType,
 ) *inspectPartitionAggregate {
 	node := t
-	if partitionType == nil {
-		return node.aggregate
-	}
-
 	for _, field := range partitionType.FieldList {
 		child, ok := node.children[comparablePartitionKey(partition[field.ID])]
 		if !ok {
@@ -91,6 +86,9 @@ func (t *inspectPartitionAggregateTree) lookupPartition(
 	return node.aggregate
 }
 
+// insert walks the positional record, while lookupPartition walks partition
+// field IDs. Build records with the same partition type so their field order
+// stays aligned.
 func (t *inspectPartitionAggregateTree) insert(record partitionRecord, aggregate *inspectPartitionAggregate) {
 	node := t
 	for _, value := range record {
@@ -179,9 +177,8 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 				partition := inspectCoercePartition(partitionValues, partitionType)
 				record := newPartitionRecord(partition, partitionType)
 				aggregate = &inspectPartitionAggregate{
-					partition:       cloneInspectPartition(partition),
-					partitionRecord: record,
-					orderingKey:     inspectPartitionKey(partition),
+					partition:   cloneInspectPartition(partition),
+					orderingKey: inspectPartitionKey(partition),
 				}
 				aggregates = append(aggregates, aggregate)
 				aggregateTree.insert(record, aggregate)

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -61,6 +62,26 @@ func (t *inspectPartitionAggregateTree) lookup(record partitionRecord) *inspectP
 	node := t
 	for _, value := range record {
 		child, ok := node.children[comparablePartitionKey(value)]
+		if !ok {
+			return nil
+		}
+		node = child
+	}
+
+	return node.aggregate
+}
+
+func (t *inspectPartitionAggregateTree) lookupPartition(
+	partition map[int]any,
+	partitionType *iceberg.StructType,
+) *inspectPartitionAggregate {
+	node := t
+	if partitionType == nil {
+		return node.aggregate
+	}
+
+	for _, field := range partitionType.FieldList {
+		child, ok := node.children[comparablePartitionKey(partition[field.ID])]
 		if !ok {
 			return nil
 		}
@@ -152,10 +173,11 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 				return nil, err
 			}
 			file := entry.DataFile()
-			partition := inspectCoercePartition(file.Partition(), partitionType)
-			record := newPartitionRecord(partition, partitionType)
-			aggregate := aggregateTree.lookup(record)
+			partitionValues := dataFilePartition(file)
+			aggregate := aggregateTree.lookupPartition(partitionValues, partitionType)
 			if aggregate == nil {
+				partition := inspectCoercePartition(partitionValues, partitionType)
+				record := newPartitionRecord(partition, partitionType)
 				aggregate = &inspectPartitionAggregate{
 					partition:       cloneInspectPartition(partition),
 					partitionRecord: record,
@@ -253,6 +275,9 @@ func cloneInspectPartition(partition map[int]any) map[int]any {
 	}
 	returnMap := make(map[int]any, len(partition))
 	for id, value := range partition {
+		if bytes, ok := value.([]byte); ok {
+			value = slices.Clone(bytes)
+		}
 		returnMap[id] = value
 	}
 

--- a/table/inspect_partitions_bench_test.go
+++ b/table/inspect_partitions_bench_test.go
@@ -1,0 +1,160 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var inspectPartitionAggregationBenchmarkSink int
+
+func BenchmarkInspectPartitionAggregation(b *testing.B) {
+	for _, benchmark := range []struct {
+		name           string
+		fileCount      int
+		partitionCount int
+		fieldCount     int
+		binary         bool
+	}{
+		{name: "int32", fileCount: 10_000, partitionCount: 100, fieldCount: 1},
+		{name: "int32", fileCount: 100_000, partitionCount: 100, fieldCount: 8},
+		{name: "binary", fileCount: 100_000, partitionCount: 100, fieldCount: 32, binary: true},
+	} {
+		b.Run(fmt.Sprintf("%s/files=%d/partitions=%d/fields=%d",
+			benchmark.name, benchmark.fileCount, benchmark.partitionCount, benchmark.fieldCount), func(b *testing.B) {
+			partitionType, files := benchmarkInspectPartitionFiles(b, benchmark)
+			b.Run("before", func(b *testing.B) {
+				benchmarkInspectPartitionAggregation(b, partitionType, files, true)
+			})
+			b.Run("after", func(b *testing.B) {
+				benchmarkInspectPartitionAggregation(b, partitionType, files, false)
+			})
+		})
+	}
+}
+
+func benchmarkInspectPartitionAggregation(
+	b *testing.B,
+	partitionType *iceberg.StructType,
+	files []iceberg.DataFile,
+	materialize bool,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(files)), "files/op")
+	b.ResetTimer()
+	for b.Loop() {
+		tree := newInspectPartitionAggregateTree()
+		aggregateCount := 0
+		for _, file := range files {
+			var aggregate *inspectPartitionAggregate
+			if materialize {
+				partition := inspectCoercePartition(file.Partition(), partitionType)
+				record := newPartitionRecord(partition, partitionType)
+				aggregate = tree.lookup(record)
+				if aggregate == nil {
+					aggregate = &inspectPartitionAggregate{
+						partition:       cloneInspectPartition(partition),
+						partitionRecord: record,
+						orderingKey:     inspectPartitionKey(partition),
+					}
+					tree.insert(record, aggregate)
+					aggregateCount++
+				}
+			} else {
+				partitionValues := dataFilePartition(file)
+				aggregate = tree.lookupPartition(partitionValues, partitionType)
+				if aggregate == nil {
+					partition := inspectCoercePartition(partitionValues, partitionType)
+					record := newPartitionRecord(partition, partitionType)
+					aggregate = &inspectPartitionAggregate{
+						partition:       cloneInspectPartition(partition),
+						partitionRecord: record,
+						orderingKey:     inspectPartitionKey(partition),
+					}
+					tree.insert(record, aggregate)
+					aggregateCount++
+				}
+			}
+
+			aggregate.dataFileCount++
+		}
+		inspectPartitionAggregationBenchmarkSink = aggregateCount
+	}
+}
+
+func benchmarkInspectPartitionFiles(
+	b *testing.B,
+	benchmark struct {
+		name           string
+		fileCount      int
+		partitionCount int
+		fieldCount     int
+		binary         bool
+	},
+) (*iceberg.StructType, []iceberg.DataFile) {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, benchmark.fieldCount)
+	partitionFields := make([]iceberg.PartitionField, benchmark.fieldCount)
+	for i := range benchmark.fieldCount {
+		sourceID := i + 1
+		fieldID := 1000 + i
+		fieldType := iceberg.PrimitiveTypes.Int32
+		if benchmark.binary {
+			fieldType = iceberg.PrimitiveTypes.Binary
+		}
+		schemaFields[i] = iceberg.NestedField{
+			ID: sourceID, Name: fmt.Sprintf("source_%d", sourceID), Type: fieldType, Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{sourceID}, FieldID: fieldID,
+			Name: fmt.Sprintf("partition_%d", fieldID), Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	schema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(partitionFields...)
+	partitionType := spec.PartitionType(schema)
+	files := make([]iceberg.DataFile, benchmark.fileCount)
+	for i := range benchmark.fileCount {
+		partitionID := i % benchmark.partitionCount
+		partition := make(map[int]any, benchmark.fieldCount)
+		for field, partitionField := range partitionFields {
+			if benchmark.binary {
+				partition[partitionField.FieldID] = []byte(fmt.Sprintf("partition-%d-field-%d", partitionID, field))
+			} else {
+				partition[partitionField.FieldID] = int32(partitionID + field)
+			}
+		}
+
+		file, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, fmt.Sprintf("file-%d.parquet", i),
+			iceberg.ParquetFile, partition, nil, nil, 1, 1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = file.Build()
+	}
+
+	return partitionType, files
+}

--- a/table/inspect_partitions_bench_test.go
+++ b/table/inspect_partitions_bench_test.go
@@ -24,16 +24,18 @@ import (
 	"github.com/apache/iceberg-go"
 )
 
+type inspectPartitionAggregationBenchmarkCase struct {
+	name           string
+	fileCount      int
+	partitionCount int
+	fieldCount     int
+	binary         bool
+}
+
 var inspectPartitionAggregationBenchmarkSink int
 
 func BenchmarkInspectPartitionAggregation(b *testing.B) {
-	for _, benchmark := range []struct {
-		name           string
-		fileCount      int
-		partitionCount int
-		fieldCount     int
-		binary         bool
-	}{
+	for _, benchmark := range []inspectPartitionAggregationBenchmarkCase{
 		{name: "int32", fileCount: 10_000, partitionCount: 100, fieldCount: 1},
 		{name: "int32", fileCount: 100_000, partitionCount: 100, fieldCount: 8},
 		{name: "binary", fileCount: 100_000, partitionCount: 100, fieldCount: 32, binary: true},
@@ -60,7 +62,6 @@ func benchmarkInspectPartitionAggregation(
 	b.Helper()
 	b.ReportAllocs()
 	b.ReportMetric(float64(len(files)), "files/op")
-	b.ResetTimer()
 	for b.Loop() {
 		tree := newInspectPartitionAggregateTree()
 		aggregateCount := 0
@@ -72,9 +73,8 @@ func benchmarkInspectPartitionAggregation(
 				aggregate = tree.lookup(record)
 				if aggregate == nil {
 					aggregate = &inspectPartitionAggregate{
-						partition:       cloneInspectPartition(partition),
-						partitionRecord: record,
-						orderingKey:     inspectPartitionKey(partition),
+						partition:   cloneInspectPartition(partition),
+						orderingKey: inspectPartitionKey(partition),
 					}
 					tree.insert(record, aggregate)
 					aggregateCount++
@@ -86,9 +86,8 @@ func benchmarkInspectPartitionAggregation(
 					partition := inspectCoercePartition(partitionValues, partitionType)
 					record := newPartitionRecord(partition, partitionType)
 					aggregate = &inspectPartitionAggregate{
-						partition:       cloneInspectPartition(partition),
-						partitionRecord: record,
-						orderingKey:     inspectPartitionKey(partition),
+						partition:   cloneInspectPartition(partition),
+						orderingKey: inspectPartitionKey(partition),
 					}
 					tree.insert(record, aggregate)
 					aggregateCount++
@@ -103,13 +102,7 @@ func benchmarkInspectPartitionAggregation(
 
 func benchmarkInspectPartitionFiles(
 	b *testing.B,
-	benchmark struct {
-		name           string
-		fileCount      int
-		partitionCount int
-		fieldCount     int
-		binary         bool
-	},
+	benchmark inspectPartitionAggregationBenchmarkCase,
 ) (*iceberg.StructType, []iceberg.DataFile) {
 	b.Helper()
 


### PR DESCRIPTION
## What changed

- **`Partitions()` now uses the borrowed partition map for aggregate-tree lookups.**
- **The coerced map and positional record are built only when a partition is first seen.**
- **Binary values are copied before they are retained by an aggregate.**
- Added coverage for binary, NaN, and binary ownership behavior.
- Added a before/after benchmark for repeated partitions.

## Why

`InspectTable.Partitions` was materializing several partition representations for every manifest entry. Most files share an existing partition, so that work was repeated and then discarded.

The new path keeps the existing partition evolution behavior. It also keeps the public `DataFile.Partition()` fallback for custom data file implementations.

## Benchmark

- **Command:** `go test ./table -run=^\\$ -bench=BenchmarkInspectPartitionAggregation -benchmem -benchtime=200ms -count=5`
- **Machine:** Apple M1 Pro, darwin/arm64
- **Scope:** aggregation loop only. Manifest decoding and Arrow output are outside the timed section.
- **Median of five samples:**
  - **10,000 files / 100 partitions / 1 int32 field:** `2.01 ms, 2.78 MB, 30.8k allocs` -> `0.395 ms, 59.0 KB, 911 allocs` (**80% lower time, 98% fewer bytes**)
  - **100,000 files / 100 partitions / 8 int32 fields:** `53.5 ms, 38.7 MB, 304k allocs` -> `25.8 ms, 295 KB, 4.11k allocs` (**52% lower time, 99% fewer bytes**)
  - **100,000 files / 100 partitions / 32 binary fields:** `610 ms, 732 MB, 13.6M allocs` -> `182 ms, 2.89 MB, 33.8k allocs` (**70% lower time, 99.6% fewer bytes**)

## Tests

- `go test ./... -count=1`
- `go vet ./table`