### PR TITLE
perf(table): borrow partitions in positional delete index

### DIFF
--- a/table/positional_delete_index.go
+++ b/table/positional_delete_index.go
@@ -47,7 +47,7 @@ func buildPositionalDeleteIndex(entries []iceberg.ManifestEntry) (*positionalDel
 			continue
 		}
 
-		partitionKey, err := canonicalPartitionKey(deleteFile.SpecID(), deleteFile.Partition())
+		partitionKey, err := canonicalPartitionKey(deleteFile.SpecID(), dataFilePartition(deleteFile))
 		if err != nil {
 			return nil, fmt.Errorf("indexing positional delete file %s: %w", deleteFile.FilePath(), err)
 		}
@@ -83,7 +83,7 @@ func (idx *positionalDeleteIndex) forDataFile(dataEntry iceberg.ManifestEntry) (
 	dataFile := dataEntry.DataFile()
 	var partitionEntries []iceberg.ManifestEntry
 	if len(idx.byPartition) > 0 {
-		partitionKey, err := canonicalPartitionKey(dataFile.SpecID(), dataFile.Partition())
+		partitionKey, err := canonicalPartitionKey(dataFile.SpecID(), dataFilePartition(dataFile))
 		if err != nil {
 			return nil, fmt.Errorf("matching positional deletes to data file %s: %w", dataFile.FilePath(), err)
 		}

--- a/table/positional_delete_index_bench_test.go
+++ b/table/positional_delete_index_bench_test.go
@@ -26,6 +26,31 @@ import (
 )
 
 var positionalDeleteBenchmarkSink int
+var positionalDeletePartitionKeyBenchmarkSink string
+
+func BenchmarkPositionalDeletePartitionKey(b *testing.B) {
+	for _, benchmark := range []struct {
+		name        string
+		fieldCount  int
+		binaryValue bool
+	}{
+		{name: "int32", fieldCount: 1},
+		{name: "int32", fieldCount: 8},
+		{name: "binary", fieldCount: 32, binaryValue: true},
+	} {
+		b.Run(fmt.Sprintf("%s/fields=%d/files=10000", benchmark.name, benchmark.fieldCount), func(b *testing.B) {
+			files := positionalDeletePartitionKeyBenchmarkFiles(
+				b, benchmark.fieldCount, benchmark.binaryValue, 10_000)
+
+			b.Run("before", func(b *testing.B) {
+				benchmarkPositionalDeletePartitionKeys(b, files, false)
+			})
+			b.Run("after", func(b *testing.B) {
+				benchmarkPositionalDeletePartitionKeys(b, files, true)
+			})
+		})
+	}
+}
 
 func BenchmarkPositionalDeleteIndexSparsePaths20KBy5K(b *testing.B) {
 	const (
@@ -44,6 +69,86 @@ func BenchmarkPositionalDeleteIndexSparsePaths20KBy5K(b *testing.B) {
 	if positionalDeleteBenchmarkSink != deleteFileCount {
 		b.Fatalf("expected %d matches, got %d", deleteFileCount, positionalDeleteBenchmarkSink)
 	}
+}
+
+func positionalDeletePartitionKeyBenchmarkFiles(
+	b *testing.B,
+	fieldCount int,
+	binaryValue bool,
+	fileCount int,
+) []iceberg.DataFile {
+	b.Helper()
+
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := range fieldCount {
+		fieldID := 1000 + i
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{i + 1},
+			FieldID:   fieldID,
+			Name:      fmt.Sprintf("partition_%d", fieldID),
+			Transform: iceberg.IdentityTransform{},
+		}
+	}
+	spec := iceberg.NewPartitionSpecID(1, partitionFields...)
+	files := make([]iceberg.DataFile, fileCount)
+	for i := range files {
+		partition := make(map[int]any, fieldCount)
+		for field, partitionField := range partitionFields {
+			if binaryValue {
+				partition[partitionField.FieldID] = []byte(fmt.Sprintf(
+					"partition-%02d-%02d", i%100, field))
+			} else {
+				partition[partitionField.FieldID] = int32(i % 100)
+			}
+		}
+
+		builder, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentData,
+			fmt.Sprintf("data-%05d.parquet", i),
+			iceberg.ParquetFile,
+			partition,
+			nil,
+			nil,
+			1,
+			1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = builder.Build()
+	}
+
+	return files
+}
+
+func benchmarkPositionalDeletePartitionKeys(
+	b *testing.B,
+	files []iceberg.DataFile,
+	borrowed bool,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(files)), "files/op")
+	b.ResetTimer()
+
+	var key string
+	for range b.N {
+		for _, file := range files {
+			var partition map[int]any
+			if borrowed {
+				partition = dataFilePartition(file)
+			} else {
+				partition = file.Partition()
+			}
+			var err error
+			key, err = canonicalPartitionKey(file.SpecID(), partition)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	positionalDeletePartitionKeyBenchmarkSink = key
 }
 
 func BenchmarkPositionalDeletePlanningSparsePaths(b *testing.B) {

--- a/table/positional_delete_index_bench_test.go
+++ b/table/positional_delete_index_bench_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/apache/iceberg-go"
 )
 
-var positionalDeleteBenchmarkSink int
-var positionalDeletePartitionKeyBenchmarkSink string
+var (
+	positionalDeleteBenchmarkSink             int
+	positionalDeletePartitionKeyBenchmarkSink string
+)
 
 func BenchmarkPositionalDeletePartitionKey(b *testing.B) {
 	for _, benchmark := range []struct {

--- a/table/positional_delete_index_test.go
+++ b/table/positional_delete_index_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,6 +95,70 @@ func newPositionalDeleteIndexDataEntry(
 
 	return iceberg.NewManifestEntry(
 		iceberg.EntryStatusADDED, nil, &sequenceNumber, nil, file)
+}
+
+type borrowedPartitionDataFile struct {
+	iceberg.DataFile
+	publicPartitionCalls   int
+	borrowedPartitionCalls int
+}
+
+func (f *borrowedPartitionDataFile) Partition() map[int]any {
+	f.publicPartitionCalls++
+
+	return f.DataFile.Partition()
+}
+
+func (f *borrowedPartitionDataFile) DataFilePartitionRef(_ internal.DataFileRef) map[int]any {
+	f.borrowedPartitionCalls++
+
+	return internal.BorrowedDataFilePartition(f.DataFile)
+}
+
+func newBorrowedPartitionDataFile(
+	t *testing.T,
+	contentType iceberg.ManifestEntryContent,
+	path string,
+	partition map[int]any,
+) *borrowedPartitionDataFile {
+	t.Helper()
+
+	spec := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "part",
+		Transform: iceberg.IdentityTransform{},
+	})
+	builder, err := iceberg.NewDataFileBuilder(
+		spec, contentType, path, iceberg.ParquetFile, partition, nil, nil, 1, 1)
+	require.NoError(t, err)
+
+	return &borrowedPartitionDataFile{DataFile: builder.Build()}
+}
+
+func TestPositionalDeleteIndexUsesBorrowedPartitions(t *testing.T) {
+	partition := map[int]any{1000: int32(7)}
+	deleteFile := newBorrowedPartitionDataFile(
+		t, iceberg.EntryContentPosDeletes, "delete.parquet", partition)
+	dataFile := newBorrowedPartitionDataFile(
+		t, iceberg.EntryContentData, "data.parquet", partition)
+	deleteSequence, dataSequence := int64(2), int64(1)
+	deleteEntry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, nil, &deleteSequence, nil, deleteFile)
+	dataEntry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, nil, &dataSequence, nil, dataFile)
+
+	idx, err := buildPositionalDeleteIndex([]iceberg.ManifestEntry{deleteEntry})
+	require.NoError(t, err)
+
+	matched, err := idx.forDataFile(dataEntry)
+	require.NoError(t, err)
+	require.Len(t, matched, 1)
+	assert.Equal(t, "delete.parquet", matched[0].FilePath())
+	assert.Zero(t, deleteFile.publicPartitionCalls)
+	assert.Equal(t, 1, deleteFile.borrowedPartitionCalls)
+	assert.Zero(t, dataFile.publicPartitionCalls)
+	assert.Equal(t, 1, dataFile.borrowedPartitionCalls)
 }
 
 func TestPositionalDeleteIndexMatchesPathPartitionAndSequence(t *testing.T) {


### PR DESCRIPTION
## What changed

- **Use `dataFilePartition`** when building the positional-delete index.
- **Use the borrowed view for data-file lookups** when matching partition-scoped deletes.
- **Keep the public fallback** for other `DataFile` implementations.
- **Add regression coverage** for the borrowed accessor.
- **Add a before/after benchmark** with 10,000 files and wide partitions.

## Benchmark

Command:

`go test ./table -bench=BenchmarkPositionalDeletePartitionKey -benchmem -benchtime=200ms -count=5`

Machine: Apple M1 Pro, darwin/arm64

Median of 5 runs:

| case | before | after | before B/op | after B/op | before allocs/op | after allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 int32 field | 2.54 ms | 1.42 ms | 2.96 MB | 0.40 MB | 50,000 | 30,000 |
| 8 int32 fields | 5.99 ms | 4.37 ms | 6.62 MB | 4.06 MB | 90,000 | 70,000 |
| 32 binary fields | 62.45 ms | 37.25 ms | 90.88 MB | 59.28 MB | 790,000 | 110,000 |

## Tests

- `go test ./table -count=1`
- `go vet ./table`
- `go test ./... -count=1`