### PR TITLE
perf(table): avoid cloning schema history for snapshot scans

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2060,12 +2060,25 @@ func (c *commonMetadata) LastUpdatedMillis() int64   { return c.LastUpdatedMS }
 func (c *commonMetadata) LastColumnID() int          { return c.LastColumnId }
 func (c *commonMetadata) Schemas() []*iceberg.Schema { return cloneSchemas(c.SchemaList) }
 func (c *commonMetadata) CurrentSchema() *iceberg.Schema {
-	for _, s := range c.SchemaList {
-		if s.ID == c.CurrentSchemaID {
-			return cloneSchema(s)
+	if schema := c.schemaByID(c.CurrentSchemaID); schema != nil {
+		return schema
+	}
+
+	panic("should never get here")
+}
+
+// schemaByID returns a defensive copy of one schema without cloning the rest
+// of the schema history. The method is promoted by the concrete metadata
+// versions through commonMetadata and is intentionally not part of Metadata,
+// so custom Metadata implementations keep the public Schemas fallback.
+func (c *commonMetadata) schemaByID(id int) *iceberg.Schema {
+	for _, schema := range c.SchemaList {
+		if schema.ID == id {
+			return cloneSchema(schema)
 		}
 	}
-	panic("should never get here")
+
+	return nil
 }
 
 func (c *commonMetadata) PartitionSpecs() []iceberg.PartitionSpec {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -446,13 +446,12 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 		return nil, scan.selectorErr
 	}
 
-	curSchema := scan.metadata.CurrentSchema()
 	if !scan.snapshotSchemaEnabled() {
 		// Live scans intentionally use the table's current schema. A schema-only
 		// metadata update can advance CurrentSchema without creating a snapshot,
 		// and branch refs intentionally use the table schema even though they
 		// resolve to a snapshot.
-		return curSchema, nil
+		return scan.metadata.CurrentSchema(), nil
 	}
 
 	snap, err := scan.ResolveSnapshot()
@@ -461,17 +460,33 @@ func (scan *Scan) effectiveSchema() (*iceberg.Schema, error) {
 	}
 
 	if snap.SchemaID == nil {
-		return curSchema, nil
+		return scan.metadata.CurrentSchema(), nil
 	}
 
-	for _, schema := range scan.metadata.Schemas() {
-		if schema.ID == *snap.SchemaID {
-			return schema, nil
-		}
+	if schema := schemaFromMetadata(scan.metadata, *snap.SchemaID); schema != nil {
+		return schema, nil
 	}
 
 	return nil, fmt.Errorf("%w: snapshot %d references unknown schema id %d",
 		ErrInvalidMetadata, snap.SnapshotID, *snap.SchemaID)
+}
+
+type metadataSchemaByID interface {
+	schemaByID(int) *iceberg.Schema
+}
+
+func schemaFromMetadata(metadata Metadata, id int) *iceberg.Schema {
+	if lookup, ok := metadata.(metadataSchemaByID); ok {
+		return lookup.schemaByID(id)
+	}
+
+	for _, schema := range metadata.Schemas() {
+		if schema.ID == id {
+			return schema
+		}
+	}
+
+	return nil
 }
 
 func (scan *Scan) snapshotSchemaEnabled() bool {

--- a/table/scanner_bench_test.go
+++ b/table/scanner_bench_test.go
@@ -27,6 +27,107 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 )
 
+var effectiveSchemaBenchmarkSink int
+
+func BenchmarkEffectiveSchemaSnapshot(b *testing.B) {
+	for _, schemaCount := range []int{1, 16, 128, 1024} {
+		for _, fieldCount := range []int{16, 128} {
+			b.Run(fmt.Sprintf("schemas=%d/fields=%d", schemaCount, fieldCount), func(b *testing.B) {
+				scan := benchmarkHistoricalSchemaScan(b, schemaCount, fieldCount)
+
+				b.Run("before", func(b *testing.B) {
+					benchmarkEffectiveSchema(b, scan, false)
+				})
+				b.Run("after", func(b *testing.B) {
+					benchmarkEffectiveSchema(b, scan, true)
+				})
+			})
+		}
+	}
+}
+
+func benchmarkHistoricalSchemaScan(b *testing.B, schemaCount, fieldCount int) *Scan {
+	b.Helper()
+
+	schemas := make([]*iceberg.Schema, schemaCount)
+	for schemaID := range schemaCount {
+		fields := make([]iceberg.NestedField, fieldCount)
+		for fieldID := range fieldCount {
+			fields[fieldID] = iceberg.NestedField{
+				ID:       fieldID + 1,
+				Name:     fmt.Sprintf("field_%d", fieldID),
+				Type:     iceberg.PrimitiveTypes.Int64,
+				Required: true,
+			}
+		}
+		schemas[schemaID] = iceberg.NewSchema(schemaID, fields...)
+	}
+
+	snapshotID := int64(1)
+	snapshotSchemaID := schemas[len(schemas)-1].ID
+	snapshots := []Snapshot{{SnapshotID: snapshotID, SchemaID: &snapshotSchemaID}}
+	metadata := &metadataV2{
+		commonMetadata: commonMetadata{
+			SchemaList:        schemas,
+			CurrentSchemaID:   schemas[0].ID,
+			SnapshotList:      snapshots,
+			CurrentSnapshotID: &snapshotID,
+			snapshotIndex:     buildSnapshotIndex(snapshots),
+		},
+	}
+
+	return &Scan{
+		metadata:   metadata,
+		snapshotID: &snapshotID,
+	}
+}
+
+func benchmarkEffectiveSchema(b *testing.B, scan *Scan, useLookup bool) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var (
+			schema *iceberg.Schema
+			err    error
+		)
+		if useLookup {
+			schema, err = scan.effectiveSchema()
+		} else {
+			schema, err = effectiveSchemaBeforeLookup(scan)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		effectiveSchemaBenchmarkSink += schema.ID
+	}
+}
+
+func effectiveSchemaBeforeLookup(scan *Scan) (*iceberg.Schema, error) {
+	curSchema := scan.metadata.CurrentSchema()
+	if !scan.snapshotSchemaEnabled() {
+		return curSchema, nil
+	}
+
+	snap, err := scan.ResolveSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	if snap.SchemaID == nil {
+		return curSchema, nil
+	}
+
+	for _, schema := range scan.metadata.Schemas() {
+		if schema.ID == *snap.SchemaID {
+			return schema, nil
+		}
+	}
+
+	return nil, fmt.Errorf("schema %d not found", *snap.SchemaID)
+}
+
 func BenchmarkOpenManifestPartitionRejectsMostEntries(b *testing.B) {
 	const (
 		entryCount    = 1_000

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -950,6 +950,71 @@ func TestTimeTravelUnknownSnapshotSchemaIDErrors(t *testing.T) {
 	assert.ErrorContains(t, err, strconv.Itoa(missingSchemaID))
 }
 
+type trackingSchemaMetadata struct {
+	*metadataV2
+	schemaByIDCalls    int
+	currentSchemaCalls int
+	schemasCalls       int
+}
+
+func (m *trackingSchemaMetadata) schemaByID(id int) *iceberg.Schema {
+	m.schemaByIDCalls++
+
+	return m.metadataV2.schemaByID(id)
+}
+
+func (m *trackingSchemaMetadata) CurrentSchema() *iceberg.Schema {
+	m.currentSchemaCalls++
+
+	return m.metadataV2.CurrentSchema()
+}
+
+func (m *trackingSchemaMetadata) Schemas() []*iceberg.Schema {
+	m.schemasCalls++
+
+	return m.metadataV2.Schemas()
+}
+
+func TestEffectiveSchemaUsesBuiltInSchemaLookup(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	scan, oldSchema, _ := newSchemaEvolutionScan(t, &spec, iceio.NewMemFS())
+	native, ok := scan.metadata.(*metadataV2)
+	require.True(t, ok)
+
+	tracked := &trackingSchemaMetadata{metadataV2: native}
+	scan.metadata = tracked
+
+	got, err := scan.effectiveSchema()
+	require.NoError(t, err)
+	assert.Equal(t, oldSchema.ID, got.ID)
+	assert.Equal(t, 1, tracked.schemaByIDCalls)
+	assert.Zero(t, tracked.currentSchemaCalls)
+	assert.Zero(t, tracked.schemasCalls)
+}
+
+type fallbackSchemaMetadata struct {
+	Metadata
+	schemasCalls int
+}
+
+func (m *fallbackSchemaMetadata) Schemas() []*iceberg.Schema {
+	m.schemasCalls++
+
+	return m.Metadata.Schemas()
+}
+
+func TestEffectiveSchemaFallsBackToPublicSchemaList(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	scan, oldSchema, _ := newSchemaEvolutionScan(t, &spec, iceio.NewMemFS())
+	fallback := &fallbackSchemaMetadata{Metadata: scan.metadata}
+	scan.metadata = fallback
+
+	got, err := scan.effectiveSchema()
+	require.NoError(t, err)
+	assert.Equal(t, oldSchema.ID, got.ID)
+	assert.Equal(t, 1, fallback.schemasCalls)
+}
+
 func int32Bound(v int32) []byte {
 	out := make([]byte, 4)
 	binary.LittleEndian.PutUint32(out, uint32(v))


### PR DESCRIPTION
## What changed

- **Resolve snapshot schemas directly** for built-in table metadata.
- **Clone only the selected schema** instead of cloning the whole schema history.
- **Keep the public `Schemas()` fallback** for custom `Metadata` implementations.
- **Avoid the current-schema clone** when a historical snapshot already has a schema ID.
- Add regression coverage and a before/after benchmark.

## Why

`Schemas()` returns defensive copies of every schema. A historical scan only needs the schema referenced by its snapshot.

## Benchmark

Command:

`go test ./table -run ^$ -bench BenchmarkEffectiveSchemaSnapshot -benchmem -benchtime=200ms -count=5`

Machine: Apple M1 Pro, darwin/arm64

Median of 5 runs. Values are ns/op, B/op, allocs/op:

| schemas / fields | before | after |
| --- | ---: | ---: |
| 1 / 16 | 4,691 / 10,704 / 31 | 2,363 / 5,408 / 16 |
| 16 / 16 | 41,198 / 90,144 / 241 | 3,151 / 5,408 / 16 |
| 128 / 128 | 2,077,597 / 5,253,126 / 2,583 | 16,991 / 40,832 / 22 |
| 1,024 / 128 | 13,907,661 / 41,739,414 / 20,503 | 14,323 / 40,832 / 22 |

## Tests

- `go test ./table -count=1`
- `go test ./table -race -count=1`
- `go vet ./...`
- `go test ./... -count=1`