### PR TITLE
perf(table): deduplicate equality-delete conflict partitions

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -510,14 +510,24 @@ func validateNoConflictingDataFilesInPartitions(ctx *conflictContext, eqDeleteFi
 	return validateNoConflictingDataFiles(ctx, filter, level)
 }
 
+type equalityDeletePartitionSpecInfo struct {
+	fields       map[int]iceberg.PartitionField
+	sourceFields map[int]equalityDeleteSourceFieldInfo
+}
+
+type equalityDeleteSourceFieldInfo struct {
+	name  string
+	found bool
+}
+
 // eqDeletePartitionsToFilter converts equality-delete data files into an
 // OR-of-ANDs BooleanExpression in row (source) space, suitable for passing
 // to validateAddedDataFilesMatchingFilter.
 //
-// For each eq-delete file it resolves each partition field ID to the source
-// schema field name via the file's partition spec, then builds an EqualTo
-// predicate using Reference(sourceFieldName). Multiple fields within one
-// partition are AND-ed; multiple eq-delete files are OR-ed.
+// For each distinct (spec ID, partition) tuple it resolves each partition
+// field ID to the source schema field name via the file's partition spec, then
+// builds an EqualTo predicate using Reference(sourceFieldName). Multiple
+// fields within one partition are AND-ed; multiple partitions are OR-ed.
 //
 // The resulting expression is projected per-concurrent-manifest's spec ID
 // inside validateAddedDataFilesMatchingFilter (via buildPartitionProjection),
@@ -529,21 +539,32 @@ func validateNoConflictingDataFilesInPartitions(ctx *conflictContext, eqDeleteFi
 // RowDelta.validate).
 func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceberg.BooleanExpression, error) {
 	terms := make([]iceberg.BooleanExpression, 0, len(files))
+	specInfoByID := make(map[int]*equalityDeletePartitionSpecInfo)
+	seen := make(map[string]struct{}, len(files))
+	var currentSchema *iceberg.Schema
+
 	for _, f := range files {
 		p := iceberginternal.BorrowedDataFilePartition(f)
 		if len(p) == 0 {
 			return iceberg.AlwaysTrue{}, nil
 		}
 
-		spec := meta.PartitionSpecByID(int(f.SpecID()))
-		if spec == nil {
-			return nil, fmt.Errorf("partition spec ID %d not found in metadata", f.SpecID())
-		}
+		specID := int(f.SpecID())
+		specInfo, ok := specInfoByID[specID]
+		if !ok {
+			spec := meta.PartitionSpecByID(specID)
+			if spec == nil {
+				return nil, fmt.Errorf("partition spec ID %d not found in metadata", f.SpecID())
+			}
 
-		// Build partition field ID → PartitionField lookup for this spec.
-		partFieldByID := make(map[int]iceberg.PartitionField, spec.NumFields())
-		for _, pf := range spec.Fields() {
-			partFieldByID[pf.FieldID] = pf
+			specInfo = &equalityDeletePartitionSpecInfo{
+				fields:       make(map[int]iceberg.PartitionField, spec.NumFields()),
+				sourceFields: make(map[int]equalityDeleteSourceFieldInfo, spec.NumFields()),
+			}
+			for _, pf := range spec.Fields() {
+				specInfo.fields[pf.FieldID] = pf
+			}
+			specInfoByID[specID] = specInfo
 		}
 
 		// Sort partition field IDs for deterministic expression order.
@@ -561,7 +582,7 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 		// until a full PartitionSet-style partition-space approach is added.
 		identityOnly := true
 		for _, fid := range fieldIDs {
-			if pf, ok := partFieldByID[fid]; ok {
+			if pf, ok := specInfo.fields[fid]; ok {
 				if _, isIdentity := pf.Transform.(iceberg.IdentityTransform); !isIdentity {
 					identityOnly = false
 
@@ -570,37 +591,55 @@ func eqDeletePartitionsToFilter(files []iceberg.DataFile, meta Metadata) (iceber
 			}
 		}
 		if !identityOnly {
-			terms = append(terms, iceberg.AlwaysTrue{})
+			return iceberg.AlwaysTrue{}, nil
+		}
 
-			continue
+		// canonicalPartitionKey is injective for the supported partition values
+		// and includes the spec ID. If a custom Literal implementation is not
+		// part of that closed set, skip deduplication and let the existing literal
+		// conversion below preserve its behavior.
+		if key, err := canonicalPartitionKey(f.SpecID(), p); err == nil {
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
 		}
 
 		conjuncts := make([]iceberg.BooleanExpression, 0, len(p))
 		for _, partFieldID := range fieldIDs {
-			pf, ok := partFieldByID[partFieldID]
+			pf, ok := specInfo.fields[partFieldID]
 			if !ok {
 				return nil, fmt.Errorf("partition field ID %d not found in spec %d", partFieldID, f.SpecID())
 			}
 
-			// Resolve to source schema field to obtain the Reference name.
-			sourceField, ok := meta.CurrentSchema().FindFieldByID(pf.SourceID())
-			if !ok {
+			// Resolve each source field at most once per partition spec. The
+			// current schema is cloned lazily, and only once for this filter.
+			sourceField, resolved := specInfo.sourceFields[partFieldID]
+			if !resolved {
+				if currentSchema == nil {
+					currentSchema = meta.CurrentSchema()
+				}
+				field, found := currentSchema.FindFieldByID(pf.SourceID())
+				sourceField = equalityDeleteSourceFieldInfo{name: field.Name, found: found}
+				specInfo.sourceFields[partFieldID] = sourceField
+			}
+			if !sourceField.found {
 				return nil, fmt.Errorf("source field ID %d (partition field %q) not found in schema", pf.SourceID(), pf.Name)
 			}
 
 			value := p[partFieldID]
 			if value == nil {
-				conjuncts = append(conjuncts, iceberg.IsNull(iceberg.Reference(sourceField.Name)))
+				conjuncts = append(conjuncts, iceberg.IsNull(iceberg.Reference(sourceField.name)))
 
 				continue
 			}
 
 			lit, err := internal.LiteralForPartitionValue(value)
 			if err != nil {
-				return nil, fmt.Errorf("partition field %q: %w", sourceField.Name, err)
+				return nil, fmt.Errorf("partition field %q: %w", sourceField.name, err)
 			}
 
-			conjuncts = append(conjuncts, iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference(sourceField.Name), lit))
+			conjuncts = append(conjuncts, iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference(sourceField.name), lit))
 		}
 
 		if len(conjuncts) == 1 {

--- a/table/partition_conflict_bench_test.go
+++ b/table/partition_conflict_bench_test.go
@@ -91,7 +91,7 @@ func equalityDeleteConflictBenchmarkInput(
 
 	schemaFields := make([]iceberg.NestedField, fieldCount)
 	partitionFields := make([]iceberg.PartitionField, fieldCount)
-	for i := 0; i < fieldCount; i++ {
+	for i := range fieldCount {
 		fieldID := i + 1
 		fieldName := fmt.Sprintf("partition_%d", i)
 		schemaFields[i] = iceberg.NestedField{
@@ -122,10 +122,10 @@ func equalityDeleteConflictBenchmarkInput(
 	}
 
 	files := make([]iceberg.DataFile, fileCount)
-	for i := 0; i < fileCount; i++ {
+	for i := range fileCount {
 		partition := make(map[int]any, fieldCount)
 		partitionID := i % partitionCount
-		for field := 0; field < fieldCount; field++ {
+		for field := range fieldCount {
 			partition[1000+field] = fmt.Sprintf("partition-%d-field-%d", partitionID, field)
 		}
 

--- a/table/partition_conflict_bench_test.go
+++ b/table/partition_conflict_bench_test.go
@@ -1,0 +1,240 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
+	"github.com/apache/iceberg-go/table/internal"
+)
+
+var equalityDeleteConflictFilterBenchmarkSink iceberg.BooleanExpression
+
+func BenchmarkEqDeletePartitionsToFilter(b *testing.B) {
+	for _, fieldCount := range []int{1, 4} {
+		for _, tc := range []struct {
+			fileCount      int
+			partitionCount int
+		}{
+			{fileCount: 1_000, partitionCount: 100},
+			{fileCount: 10_000, partitionCount: 100},
+			{fileCount: 1_000, partitionCount: 1_000},
+		} {
+			name := fmt.Sprintf(
+				"fields=%d/files=%d/partitions=%d",
+				fieldCount,
+				tc.fileCount,
+				tc.partitionCount,
+			)
+			b.Run(name, func(b *testing.B) {
+				meta, files := equalityDeleteConflictBenchmarkInput(
+					b, fieldCount, tc.fileCount, tc.partitionCount)
+
+				b.Run("before", func(b *testing.B) {
+					benchmarkEqDeletePartitionFilter(b, files, meta, eqDeletePartitionsToFilterBeforeDedup)
+				})
+				b.Run("after", func(b *testing.B) {
+					benchmarkEqDeletePartitionFilter(b, files, meta, eqDeletePartitionsToFilter)
+				})
+			})
+		}
+	}
+}
+
+type eqDeletePartitionFilterBuilder func(
+	[]iceberg.DataFile, Metadata,
+) (iceberg.BooleanExpression, error)
+
+func benchmarkEqDeletePartitionFilter(
+	b *testing.B,
+	files []iceberg.DataFile,
+	meta Metadata,
+	build eqDeletePartitionFilterBuilder,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		filter, err := build(files, meta)
+		if err != nil {
+			b.Fatal(err)
+		}
+		equalityDeleteConflictFilterBenchmarkSink = filter
+	}
+}
+
+func equalityDeleteConflictBenchmarkInput(
+	b *testing.B,
+	fieldCount, fileCount, partitionCount int,
+) (Metadata, []iceberg.DataFile) {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := 0; i < fieldCount; i++ {
+		fieldID := i + 1
+		fieldName := fmt.Sprintf("partition_%d", i)
+		schemaFields[i] = iceberg.NestedField{
+			ID:       fieldID,
+			Name:     fieldName,
+			Type:     iceberg.PrimitiveTypes.String,
+			Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			FieldID:   1000 + i,
+			SourceIDs: []int{fieldID},
+			Name:      fieldName,
+			Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	schema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(partitionFields...)
+	meta, err := NewMetadata(
+		schema,
+		&spec,
+		UnsortedSortOrder,
+		"file:///tmp/eq-delete-conflict-benchmark",
+		iceberg.Properties{PropertyFormatVersion: "2"},
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	files := make([]iceberg.DataFile, fileCount)
+	for i := 0; i < fileCount; i++ {
+		partition := make(map[int]any, fieldCount)
+		partitionID := i % partitionCount
+		for field := 0; field < fieldCount; field++ {
+			partition[1000+field] = fmt.Sprintf("partition-%d-field-%d", partitionID, field)
+		}
+
+		builder, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentEqDeletes,
+			fmt.Sprintf("eq-delete-%d.parquet", i),
+			iceberg.ParquetFile,
+			partition,
+			nil,
+			nil,
+			1,
+			1024,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = builder.Build()
+	}
+
+	return meta, files
+}
+
+// eqDeletePartitionsToFilterBeforeDedup mirrors the pre-optimization path so
+// the benchmark measures the cost of the production change directly.
+func eqDeletePartitionsToFilterBeforeDedup(
+	files []iceberg.DataFile,
+	meta Metadata,
+) (iceberg.BooleanExpression, error) {
+	terms := make([]iceberg.BooleanExpression, 0, len(files))
+	for _, f := range files {
+		p := iceberginternal.BorrowedDataFilePartition(f)
+		if len(p) == 0 {
+			return iceberg.AlwaysTrue{}, nil
+		}
+
+		spec := meta.PartitionSpecByID(int(f.SpecID()))
+		if spec == nil {
+			return nil, fmt.Errorf("partition spec ID %d not found in metadata", f.SpecID())
+		}
+
+		partFieldByID := make(map[int]iceberg.PartitionField, spec.NumFields())
+		for _, pf := range spec.Fields() {
+			partFieldByID[pf.FieldID] = pf
+		}
+
+		fieldIDs := make([]int, 0, len(p))
+		for id := range p {
+			fieldIDs = append(fieldIDs, id)
+		}
+		sort.Ints(fieldIDs)
+
+		identityOnly := true
+		for _, fid := range fieldIDs {
+			if pf, ok := partFieldByID[fid]; ok {
+				if _, isIdentity := pf.Transform.(iceberg.IdentityTransform); !isIdentity {
+					identityOnly = false
+
+					break
+				}
+			}
+		}
+		if !identityOnly {
+			terms = append(terms, iceberg.AlwaysTrue{})
+
+			continue
+		}
+
+		conjuncts := make([]iceberg.BooleanExpression, 0, len(p))
+		for _, partFieldID := range fieldIDs {
+			pf, ok := partFieldByID[partFieldID]
+			if !ok {
+				return nil, fmt.Errorf("partition field ID %d not found in spec %d", partFieldID, f.SpecID())
+			}
+
+			sourceField, ok := meta.CurrentSchema().FindFieldByID(pf.SourceID())
+			if !ok {
+				return nil, fmt.Errorf("source field ID %d (partition field %q) not found in schema", pf.SourceID(), pf.Name)
+			}
+
+			value := p[partFieldID]
+			if value == nil {
+				conjuncts = append(conjuncts, iceberg.IsNull(iceberg.Reference(sourceField.Name)))
+
+				continue
+			}
+
+			lit, err := internal.LiteralForPartitionValue(value)
+			if err != nil {
+				return nil, fmt.Errorf("partition field %q: %w", sourceField.Name, err)
+			}
+
+			conjuncts = append(conjuncts, iceberg.LiteralPredicate(iceberg.OpEQ, iceberg.Reference(sourceField.Name), lit))
+		}
+
+		if len(conjuncts) == 1 {
+			terms = append(terms, conjuncts[0])
+		} else {
+			terms = append(terms, iceberg.NewAnd(conjuncts[0], conjuncts[1], conjuncts[2:]...))
+		}
+	}
+
+	if len(terms) == 0 {
+		return iceberg.AlwaysTrue{}, nil
+	}
+
+	if len(terms) == 1 {
+		return terms[0], nil
+	}
+
+	return iceberg.NewOr(terms[0], terms[1], terms[2:]...), nil
+}

--- a/table/partition_conflict_test.go
+++ b/table/partition_conflict_test.go
@@ -174,6 +174,114 @@ func buildPartitionedContext(
 	return ctx
 }
 
+type countingPartitionConflictMetadata struct {
+	Metadata
+	specOverrides        map[int]*iceberg.PartitionSpec
+	currentSchemaCalls   int
+	partitionSpecIDCalls int
+}
+
+func (m *countingPartitionConflictMetadata) CurrentSchema() *iceberg.Schema {
+	m.currentSchemaCalls++
+
+	return m.Metadata.CurrentSchema()
+}
+
+func (m *countingPartitionConflictMetadata) PartitionSpecByID(id int) *iceberg.PartitionSpec {
+	m.partitionSpecIDCalls++
+	if spec, ok := m.specOverrides[id]; ok {
+		return spec
+	}
+
+	return m.Metadata.PartitionSpecByID(id)
+}
+
+func equalityDeleteTestFile(
+	t *testing.T,
+	spec iceberg.PartitionSpec,
+	path string,
+	partition map[int]any,
+) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentEqDeletes,
+		path,
+		iceberg.ParquetFile,
+		partition,
+		nil,
+		nil,
+		1,
+		1024,
+	)
+	require.NoError(t, err)
+
+	return builder.Build()
+}
+
+func TestEqDeletePartitionsToFilterDeduplicatesPartitions(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "region", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	meta := partitionedConflictMeta(t, schema, 2, nil)
+	spec := meta.PartitionSpec()
+	fieldID := spec.Field(0).FieldID
+	countingMeta := &countingPartitionConflictMetadata{Metadata: meta}
+
+	files := []iceberg.DataFile{
+		equalityDeleteTestFile(t, spec, "eq-us-1.parquet", map[int]any{fieldID: "us-east-1"}),
+		equalityDeleteTestFile(t, spec, "eq-us-2.parquet", map[int]any{fieldID: "us-east-1"}),
+		equalityDeleteTestFile(t, spec, "eq-eu.parquet", map[int]any{fieldID: "eu-west-1"}),
+		equalityDeleteTestFile(t, spec, "eq-us-3.parquet", map[int]any{fieldID: "us-east-1"}),
+	}
+
+	filter, err := eqDeletePartitionsToFilter(files, countingMeta)
+	require.NoError(t, err)
+
+	expected := iceberg.NewOr(
+		iceberg.EqualTo(iceberg.Reference("region"), "us-east-1"),
+		iceberg.EqualTo(iceberg.Reference("region"), "eu-west-1"),
+	)
+	assert.True(t, filter.Equals(expected), "duplicate equality-delete partitions should produce one filter term")
+	assert.Equal(t, 1, countingMeta.currentSchemaCalls,
+		"the current schema should be cloned once per filter")
+	assert.Equal(t, 1, countingMeta.partitionSpecIDCalls,
+		"each partition spec should be resolved once per filter")
+}
+
+func TestEqDeletePartitionsToFilterKeepsSpecIDsDistinct(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "region", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	meta := partitionedConflictMeta(t, schema, 1, nil)
+	specA := meta.PartitionSpec()
+	specB := iceberg.NewPartitionSpecID(1, iceberg.PartitionField{
+		FieldID:   specA.Field(0).FieldID,
+		SourceIDs: []int{1},
+		Name:      "region_v2",
+		Transform: iceberg.IdentityTransform{},
+	})
+	countingMeta := &countingPartitionConflictMetadata{
+		Metadata:      meta,
+		specOverrides: map[int]*iceberg.PartitionSpec{specB.ID(): &specB},
+	}
+
+	files := []iceberg.DataFile{
+		equalityDeleteTestFile(t, specA, "eq-a.parquet", map[int]any{specA.Field(0).FieldID: "us-east-1"}),
+		equalityDeleteTestFile(t, specB, "eq-b.parquet", map[int]any{specB.Field(0).FieldID: "us-east-1"}),
+	}
+
+	filter, err := eqDeletePartitionsToFilter(files, countingMeta)
+	require.NoError(t, err)
+
+	leaf := iceberg.EqualTo(iceberg.Reference("region"), "us-east-1")
+	expected := iceberg.NewOr(leaf, leaf)
+	assert.True(t, filter.Equals(expected),
+		"identical partition values under different specs must remain separate terms")
+}
+
 // ---------------------------------------------------------------------------
 // validateNoConflictingDataFilesInPartitions short-circuit paths
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- **Deduplicate repeated partitions** while building equality-delete conflict filters.
- **Reuse partition spec info** instead of resolving it for every delete file.
- **Reuse the current schema and source-field lookups** during one filter build.
- **Return the conservative `AlwaysTrue` path early** for non-identity transforms.
- Add regression tests and a before/after benchmark.

## Why

`eqDeletePartitionsToFilter` builds one row-space predicate for each equality-delete file. Multiple files can point to the same `(spec ID, partition)` tuple, so the same work gets repeated.

This keeps the same conflict semantics but builds one term per distinct identity partition.

## Benchmark

Command:

```text
go test ./table -run '^$' -bench '^BenchmarkEqDeletePartitionsToFilter$' -benchmem -benchtime=200ms -count=5
```

Machine: Apple M1 Pro, darwin/arm64

Median of 5 runs. Values are ns/op, B/op, allocs/op:

| case | before | after |
| --- | ---: | ---: |
| fields=1, files=1,000, partitions=100 | 1,688,863 / 2,256,360 / 27,000 | 262,357 / 245,456 / 5,333 |
| fields=1, files=10,000, partitions=100 | 14,162,586 / 22,563,829 / 270,000 | 2,602,603 / 2,215,171 / 49,461 |
| fields=4, files=10,000, partitions=100 | 60,167,771 / 102,883,812 / 940,000 | 4,549,333 / 4,416,563 / 61,773 |
| fields=1, files=1,000, partitions=1,000 | 1,435,163 / 2,256,359 / 27,000 | 379,229 / 310,256 / 8,123 |

## Tests

- `go test ./table -count=1`
- `go test ./table -race -count=1`
- `go test ./... -count=1`
- `go vet ./...`