### PR TITLE
perf(table): skip inactive parquet stats columns

### DIFF
--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1483,13 +1483,13 @@ func (p parquetFormat) DataFileStatsFromMeta(meta Metadata, statsCols map[int]St
 			}
 
 			fieldID, statsCol := column.fieldID, column.statsCol
-			if _, invalid := invalidateCol[fieldID]; invalid {
-				continue
-			}
-
 			colChunk, err = rowGroup.ColumnChunk(pos)
 			if err != nil {
 				panic(err)
+			}
+
+			if _, invalid := invalidateCol[fieldID]; invalid {
+				continue
 			}
 
 			colSizes[fieldID] += colChunk.TotalCompressedSize()

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1470,25 +1470,26 @@ func (p parquetFormat) DataFileStatsFromMeta(meta Metadata, statsCols map[int]St
 		}
 
 		for pos := range rowGroup.NumColumns() {
-			colChunk, err = rowGroup.ColumnChunk(pos)
-			if err != nil {
-				panic(err)
-			}
-
 			column := columns[pos]
 			if column.resolveErr != nil {
+				if _, err = rowGroup.ColumnChunk(pos); err != nil {
+					panic(err)
+				}
+
 				panic(column.resolveErr)
 			}
-			if column.variantChild || column.skipStats {
+			if column.variantChild || column.skipStats || column.statsCol.Mode.Typ == MetricModeNone {
 				continue
 			}
 
 			fieldID, statsCol := column.fieldID, column.statsCol
-			if statsCol.Mode.Typ == MetricModeNone {
-				continue
-			}
 			if _, invalid := invalidateCol[fieldID]; invalid {
 				continue
+			}
+
+			colChunk, err = rowGroup.ColumnChunk(pos)
+			if err != nil {
+				panic(err)
 			}
 
 			colSizes[fieldID] += colChunk.TotalCompressedSize()

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -694,6 +694,26 @@ func TestDataFileStatsFromMetaWithMalformedFixedLenDecimalStats(t *testing.T) {
 	assert.NotContains(t, dataFile.UpperBoundValues(), 15)
 }
 
+func TestDataFileStatsFromMetaDoesNotSkipInvalidatedColumnMetadata(t *testing.T) {
+	format := internal.GetFileFormat(iceberg.ParquetFile)
+
+	meta, tblMeta := constructTestTablePrimitiveTypes(t)
+	mapping, err := format.PathToIDMapping(tblMeta.CurrentSchema())
+	require.NoError(t, err)
+
+	const columnPos = 1
+	meta.RowGroups[0].Columns[columnPos].MetaData.Statistics = nil
+
+	secondRowGroup := *meta.RowGroups[0]
+	secondRowGroup.Columns = append(secondRowGroup.Columns[:0:0], secondRowGroup.Columns...)
+	secondRowGroup.Columns[columnPos] = nil
+	meta.RowGroups = append(meta.RowGroups, &secondRowGroup)
+
+	assert.Panics(t, func() {
+		format.DataFileStatsFromMeta(internal.Metadata(meta), getCollector(), mapping, nil, nil)
+	})
+}
+
 // TestNanosecondTimestampMetrics tests that nanosecond timestamp types (v3)
 // are correctly handled for Parquet stats collection and physical type mapping.
 func TestNanosecondTimestampMetrics(t *testing.T) {

--- a/table/internal/parquet_stats_columns_bench_test.go
+++ b/table/internal/parquet_stats_columns_bench_test.go
@@ -279,3 +279,34 @@ func BenchmarkDataFileStatsFromMetaNestedVariant(b *testing.B) {
 	b.ReportMetric(float64(rowGroups*rows), "rows/op")
 	b.ReportMetric(float64(rowGroups*9), "columns/op")
 }
+
+func BenchmarkDataFileStatsFromMetaMostlyInactive(b *testing.B) {
+	const (
+		rowGroups = 32
+		rows      = 10_000
+	)
+
+	fixture := newStatsColumnsBenchmarkFixture(b, rowGroups, rows)
+	statsCols := map[int]StatisticsCollector{
+		1: {FieldID: 1, Mode: MetricsMode{Typ: MetricModeNone}, IcebergTyp: iceberg.PrimitiveTypes.Int32},
+		2: {FieldID: 2, Mode: MetricsMode{Typ: MetricModeNone}, IcebergTyp: iceberg.PrimitiveTypes.Float64},
+		3: {FieldID: 3, Mode: MetricsMode{Typ: MetricModeFull}, IcebergTyp: iceberg.PrimitiveTypes.String},
+		4: {FieldID: 4, Mode: MetricsMode{Typ: MetricModeNone}, ColName: "payload"},
+	}
+
+	format := parquetFormat{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		stats := format.DataFileStatsFromMeta(
+			fixture.meta, statsCols, fixture.colMapping, fixture.variantFieldIDs, nil)
+		if stats.RecordCount != int64(rowGroups*rows) {
+			b.Fatalf("unexpected record count: %d", stats.RecordCount)
+		}
+		if len(stats.ValueCounts) != 1 {
+			b.Fatalf("expected one active column, got %d", len(stats.ValueCounts))
+		}
+	}
+	b.ReportMetric(float64(rowGroups*rows), "rows/op")
+	b.ReportMetric(float64(rowGroups*9), "columns/op")
+}


### PR DESCRIPTION
## What

- Skip `ColumnChunk` construction for variant-child, lineage, and `none` metrics columns.
- Keep the existing stats behavior for active columns.

## Why

`DataFileStatsFromMeta` visits every physical column in every row group. Inactive columns only added metadata wrapper work and allocations.

## Benchmark

Mostly inactive 32-row-group, 9-column case:

- 1,404 -> 636 allocs/op
- 202 KB -> 114 KB/op

## Checks

- `go test ./...`
- `go test -race ./table/internal ./table`
- `golangci-lint run --timeout=10m`