### PR TITLE
perf(table): reuse field ID scratch in files metadata

### DIFF
--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -533,6 +533,7 @@ type inspectContentFileBuilder struct {
 	referencedDataFile *array.StringBuilder
 	contentOffset      *array.Int64Builder
 	contentSize        *array.Int64Builder
+	mapFieldIDs        []int
 }
 
 type inspectPartitionBuilder struct {
@@ -648,7 +649,7 @@ func newInspectContentFileBuilderFromFields(
 	return out, nil
 }
 
-func (b inspectContentFileBuilder) append(file iceberg.DataFile) error {
+func (b *inspectContentFileBuilder) append(file iceberg.DataFile) error {
 	b.content.Append(int32(file.ContentType()))
 	b.filePath.Append(file.FilePath())
 	b.fileFormat.Append(string(file.FileFormat()))
@@ -663,23 +664,23 @@ func (b inspectContentFileBuilder) append(file iceberg.DataFile) error {
 	b.recordCount.Append(file.Count())
 	b.fileSize.Append(file.FileSizeBytes())
 	columnSizes, keyMetadata, splitOffsets, equalityFieldIDs := dataFileCollections(file)
-	if err := appendInspectInt64Map(b.columnSizes, columnSizes); err != nil {
+	if err := appendInspectInt64Map(b.columnSizes, columnSizes, &b.mapFieldIDs); err != nil {
 		return err
 	}
 	valueCounts, nullCounts, nanCounts, lowerBounds, upperBounds := dataFileStats(file)
-	if err := appendInspectInt64Map(b.valueCounts, valueCounts); err != nil {
+	if err := appendInspectInt64Map(b.valueCounts, valueCounts, &b.mapFieldIDs); err != nil {
 		return err
 	}
-	if err := appendInspectInt64Map(b.nullValueCounts, nullCounts); err != nil {
+	if err := appendInspectInt64Map(b.nullValueCounts, nullCounts, &b.mapFieldIDs); err != nil {
 		return err
 	}
-	if err := appendInspectInt64Map(b.nanValueCounts, nanCounts); err != nil {
+	if err := appendInspectInt64Map(b.nanValueCounts, nanCounts, &b.mapFieldIDs); err != nil {
 		return err
 	}
-	if err := appendInspectBinaryMap(b.lowerBounds, lowerBounds); err != nil {
+	if err := appendInspectBinaryMap(b.lowerBounds, lowerBounds, &b.mapFieldIDs); err != nil {
 		return err
 	}
-	if err := appendInspectBinaryMap(b.upperBounds, upperBounds); err != nil {
+	if err := appendInspectBinaryMap(b.upperBounds, upperBounds, &b.mapFieldIDs); err != nil {
 		return err
 	}
 	appendInspectBytes(b.keyMetadata, keyMetadata)
@@ -891,7 +892,7 @@ func inspectInt32Value(value int, name string) (int32, error) {
 	return int32(value), nil
 }
 
-func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) error {
+func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64, scratch *[]int) error {
 	if values == nil {
 		builder.AppendNull()
 
@@ -906,10 +907,11 @@ func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) erro
 	if !ok {
 		return fmt.Errorf("map item builder has type %T, want int64", builder.ItemBuilder())
 	}
-	ids := make([]int, 0, len(values))
+	ids := (*scratch)[:0]
 	for id := range values {
 		ids = append(ids, id)
 	}
+	*scratch = ids
 	sort.Ints(ids)
 	for _, id := range ids {
 		key, err := inspectInt32Value(id, "field ID")
@@ -923,7 +925,7 @@ func appendInspectInt64Map(builder *array.MapBuilder, values map[int]int64) erro
 	return nil
 }
 
-func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) error {
+func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte, scratch *[]int) error {
 	if values == nil {
 		builder.AppendNull()
 
@@ -938,10 +940,11 @@ func appendInspectBinaryMap(builder *array.MapBuilder, values map[int][]byte) er
 	if !ok {
 		return fmt.Errorf("map item builder has type %T, want binary", builder.ItemBuilder())
 	}
-	ids := make([]int, 0, len(values))
+	ids := (*scratch)[:0]
 	for id := range values {
 		ids = append(ids, id)
 	}
+	*scratch = ids
 	sort.Ints(ids)
 	for _, id := range ids {
 		key, err := inspectInt32Value(id, "field ID")


### PR DESCRIPTION
## What changed

- Reuse one `[]int` scratch slice while sorting field IDs for the six stats maps written by the files metadata table.
- Keep deterministic sorted keys and the existing validation.

## Benchmark

- **Machine:** Apple M1 Pro, darwin/arm64
- **Go:** go1.26.3
- **Command:** `go test ./table -run '^$' -bench '^BenchmarkInspectContentFileAppenderDataFileStats/files=(4096|16384)/stats=(32|128)/(borrowed|public)$' -benchmem -count=5 -benchtime=1s`
- **Representative borrowed-data results (median of 5 runs):**

| case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| 4096 files / 32 stats | 42,162,059 -> 40,548,478 | 49,853,388 -> 43,561,937 (**12.6% less**) | 54,222 -> 29,646 (**45.3% fewer**) |
| 16384 files / 128 stats | 707,448,646 -> 727,017,084 | 773,116,304 -> 672,455,176 (**13.0% less**) | 312,525 -> 214,226 (**31.5% fewer**) |

Runtime varied between runs, while the allocation reduction was consistent.
