### PR TITLE
perf(table): avoid heap scratch in canonical partition keys

### DIFF
--- a/table/conflict_validation.go
+++ b/table/conflict_validation.go
@@ -754,13 +754,18 @@ var filePathFieldID = func() int {
 // Java's DeleteFileIndex keys its PartitionMap by specId, and field IDs
 // are only meaningful within a single spec.
 func canonicalPartitionKey(specID int32, partition map[int]any) (string, error) {
-	ids := make([]int, 0, len(partition))
+	var idStorage [8]int
+	ids := idStorage[:0]
+	if len(partition) > len(idStorage) {
+		ids = make([]int, 0, len(partition))
+	}
 	for id := range partition {
 		ids = append(ids, id)
 	}
 	slices.Sort(ids)
 
-	buf := strconv.AppendInt(nil, int64(specID), 10)
+	var bufStorage [256]byte
+	buf := strconv.AppendInt(bufStorage[:0], int64(specID), 10)
 	buf = append(buf, '|')
 	for _, id := range ids {
 		buf = strconv.AppendInt(buf, int64(id), 10)

--- a/table/conflict_validation_bench_test.go
+++ b/table/conflict_validation_bench_test.go
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+)
+
+var canonicalPartitionKeyBenchmarkSink string
+
+func BenchmarkCanonicalPartitionKey(b *testing.B) {
+	for _, tc := range []struct {
+		name      string
+		partition map[int]any
+	}{
+		{
+			name:      "fields=1/int32",
+			partition: map[int]any{1: int32(1)},
+		},
+		{
+			name: "fields=2/int32",
+			partition: map[int]any{
+				1: int32(1), 2: int32(2),
+			},
+		},
+		{
+			name: "fields=4/int32",
+			partition: map[int]any{
+				1: int32(1), 2: int32(2), 3: int32(3), 4: int32(4),
+			},
+		},
+		{
+			name: "fields=8/mixed",
+			partition: map[int]any{
+				1: int32(1), 2: "two", 3: int64(3), 4: "four",
+				5: int32(5), 6: "six", 7: int64(7), 8: "eight",
+			},
+		},
+		{
+			name: "fields=4/binary-string",
+			partition: map[int]any{
+				1: []byte("one"), 2: "two", 3: []byte("three"), 4: "four",
+			},
+		},
+		{
+			name: "fields=16/mixed",
+			partition: map[int]any{
+				1: int32(1), 2: "two", 3: int64(3), 4: "four",
+				5: int32(5), 6: "six", 7: int64(7), 8: "eight",
+				9: int32(9), 10: "ten", 11: int64(11), 12: "twelve",
+				13: int32(13), 14: "fourteen", 15: int64(15), 16: "sixteen",
+			},
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				key, err := canonicalPartitionKey(7, tc.partition)
+				if err != nil {
+					b.Fatal(err)
+				}
+				canonicalPartitionKeyBenchmarkSink = key
+			}
+		})
+	}
+}

--- a/table/conflict_validation_test.go
+++ b/table/conflict_validation_test.go
@@ -585,6 +585,22 @@ func TestCanonicalPartitionKey(t *testing.T) {
 			assert.Contains(t, err.Error(), "unsupported partition value type")
 		}
 	})
+
+	t.Run("wide partition uses fallback storage", func(t *testing.T) {
+		first := make(map[int]any, 16)
+		second := make(map[int]any, 16)
+		for id := 1; id <= 16; id++ {
+			value := fmt.Sprintf("field-%d-012345678901234567890123456789", id)
+			first[id] = value
+		}
+		for id := 16; id >= 1; id-- {
+			second[id] = first[id]
+		}
+
+		assert.Equal(t,
+			mustCanonicalPartitionKey(t, 0, first),
+			mustCanonicalPartitionKey(t, 0, second))
+	})
 }
 
 // TestValidateNoNewDeletesForRewrittenFiles_PosDeleteMatching drives the


### PR DESCRIPTION
## What changed

- Reuse small stack buffers in `canonicalPartitionKey`.
- Keep the existing heap fallback for wider partitions and longer keys.
- Keep sorting, value normalization, and key encoding unchanged.
- Add a focused benchmark and a test for the wide-partition fallback.

## Benchmark

Ran on an Apple M1 Pro (`darwin/arm64`) with Go `go1.26.3`.

```text
go test ./table -run '^$' -bench '^BenchmarkCanonicalPartitionKey$' -benchmem -count=5 -benchtime=1s
```

Median of 5 runs:

| Case | ns/op before | ns/op after | B/op before -> after | allocs/op before -> after |
| --- | ---: | ---: | ---: | ---: |
| fields=1/int32 | 84.39 | 73.89 | 16 -> 8 | 2 -> 1 |
| fields=2/int32 | 179.8 | 94.01 | 40 -> 16 | 3 -> 1 |
| fields=4/int32 | 244.6 | 140.5 | 88 -> 32 | 4 -> 1 |
| fields=8/mixed | 435.8 | 247.0 | 392 -> 80 | 7 -> 1 |
| fields=4/binary-string | 254.8 | 157.2 | 184 -> 64 | 5 -> 1 |
| fields=16/mixed | 782.1 | 602.8 | 792 -> 288 | 8 -> 2 |

The common cases now use one allocation for the returned string. The wide case still exercises the heap fallback.

## Checks

- `go test ./...`
- `go vet ./...`
- `go test -race ./table`
