### PR TITLE
perf(rest): reuse referenced deletion vectors during scan task decode

### DIFF
--- a/catalog/rest/scan_task_decoder.go
+++ b/catalog/rest/scan_task_decoder.go
@@ -207,9 +207,11 @@ func DecodeScanTasks(
 				dvOwners[ref] = dataFile.FilePath()
 				// Derive referenced-data-file from the FileScanTask association
 				// when the server omits Java's optional extension field.
-				deleteFile, err = decodeRESTDeleteFile(wireDelete, metadata, dataFile.FilePath())
-				if err != nil {
-					return nil, fmt.Errorf("%w: decoding scan tasks: delete-files[%d]: %w", ErrRESTError, ref, err)
+				if wireDelete.ReferencedDataFile == nil {
+					deleteFile, err = decodeRESTDeleteFile(wireDelete, metadata, dataFile.FilePath())
+					if err != nil {
+						return nil, fmt.Errorf("%w: decoding scan tasks: delete-files[%d]: %w", ErrRESTError, ref, err)
+					}
 				}
 			}
 

--- a/catalog/rest/scan_task_decoder_bench_test.go
+++ b/catalog/rest/scan_task_decoder_bench_test.go
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"fmt"
+	"testing"
+)
+
+var decodeScanTasksBenchmarkSink int
+
+func BenchmarkDecodeScanTasksDeletionVectors(b *testing.B) {
+	metadata := newScanTaskDecoderMetadata()
+
+	for _, tc := range []struct {
+		name          string
+		taskCount     int
+		explicitOwner bool
+	}{
+		{name: "explicit-owner/tasks=100", taskCount: 100, explicitOwner: true},
+		{name: "derived-owner/tasks=100", taskCount: 100},
+		{name: "explicit-owner/tasks=1000", taskCount: 1000, explicitOwner: true},
+		{name: "derived-owner/tasks=1000", taskCount: 1000},
+		{name: "explicit-owner/tasks=10000", taskCount: 10000, explicitOwner: true},
+		{name: "derived-owner/tasks=10000", taskCount: 10000},
+	} {
+		wire := deletionVectorScanTasksWire(tc.taskCount, tc.explicitOwner)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				tasks, err := DecodeScanTasks(wire, metadata, metadata.schema, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				decodeScanTasksBenchmarkSink = len(tasks)
+			}
+		})
+	}
+}
+
+func deletionVectorScanTasksWire(taskCount int, explicitOwner bool) ScanTasks {
+	base := validScanTasksWire()
+	dataFile := *base.FileScanTasks[0].DataFile
+	deleteFile := base.DeleteFiles[0]
+	deleteFile.FileFormat = "puffin"
+	deleteFile.ContentOffset = int64Ptr(10)
+	deleteFile.ContentSizeInBytes = int64Ptr(20)
+
+	wire := ScanTasks{
+		FileScanTasks: make([]RESTFileScanTask, taskCount),
+		DeleteFiles:   make([]RESTDeleteFile, taskCount),
+	}
+	for i := range taskCount {
+		data := dataFile
+		data.FilePath = fmt.Sprintf("s3://bucket/table/data-%d.parquet", i)
+		delete := deleteFile
+		delete.FilePath = fmt.Sprintf("s3://bucket/table/delete-%d.puffin", i)
+		if explicitOwner {
+			delete.ReferencedDataFile = stringPtr(data.FilePath)
+		}
+
+		wire.FileScanTasks[i] = RESTFileScanTask{
+			DataFile:             &data,
+			DeleteFileReferences: []int{i},
+		}
+		wire.DeleteFiles[i] = delete
+	}
+
+	return wire
+}


### PR DESCRIPTION
## What changed

- Reuse the delete file decoded before resolving task references when a Puffin deletion vector already includes `referenced-data-file`.
- Keep the existing second decode when that field is omitted.
- Keep the existing owner validation and deletion-vector behavior unchanged.
- Add a benchmark for explicit and derived deletion-vector ownership.

## Benchmark

Ran on an Apple M1 Pro (`darwin/arm64`) with Go `go1.26.3`.

```text
go test ./catalog/rest -run '^$' -bench '^BenchmarkDecodeScanTasksDeletionVectors$' -benchmem -count=5 -benchtime=1s
```

Median of 5 runs:

| Owner | Tasks | ns/op before | ns/op after | B/op before -> after | allocs/op before -> after |
| --- | ---: | ---: | ---: | ---: | ---: |
| explicit | 100 | 936382 | 635246 | 1511743 -> 1014941 | 12712 -> 8412 |
| derived | 100 | 958570 | 911513 | 1510143 -> 1510142 | 12612 -> 12612 |
| explicit | 1000 | 11346750 | 6137807 | 15153473 -> 10185471 | 127023 -> 84023 |
| derived | 1000 | 11135820 | 11817984 | 15137478 -> 15137484 | 126023 -> 126023 |
| explicit | 10000 | 127284729 | 61087905 | 151295556 -> 101615522 | 1270082 -> 840082 |
| derived | 10000 | 103055288 | 89958272 | 151135522 -> 151135542 | 1260082 -> 1260082 |

The explicit-owner path removes about one decode per referenced deletion vector. The derived-owner control keeps the fallback allocation profile unchanged.

## Checks

- `go test ./...`
- `go vet ./...`
- `go test -race ./catalog/rest`
