### PR TITLE
perf(table): borrow remaining DataFile metadata in files tables

### DIFF
--- a/data_file_refs.go
+++ b/data_file_refs.go
@@ -44,6 +44,27 @@ func (d *dataFile) DataFileStatsRef(_ internal.DataFileRef) (
 	return d.valCntMap, d.nullCntMap, d.nanCntMap, d.lowerBoundMap, d.upperBoundMap
 }
 
+func (d *dataFile) DataFileCollectionsRef(_ internal.DataFileRef) (
+	map[int]int64, []byte, []int64, []int,
+) {
+	d.initColumnStatsData()
+
+	var keyMetadata []byte
+	if d.Key != nil {
+		keyMetadata = *d.Key
+	}
+	var splitOffsets []int64
+	if d.Splits != nil {
+		splitOffsets = *d.Splits
+	}
+	var equalityFieldIDs []int
+	if d.EqualityIDs != nil {
+		equalityFieldIDs = *d.EqualityIDs
+	}
+
+	return d.colSizeMap, keyMetadata, splitOffsets, equalityFieldIDs
+}
+
 // DataFilePartitionRef returns the data file's partition map without copying.
 // The token restricts this zero-copy accessor to trusted in-module callers;
 // the public Partition getter continues returning a defensive copy. The

--- a/internal/data_file_ref.go
+++ b/internal/data_file_ref.go
@@ -64,6 +64,35 @@ func BorrowedDataFileStats(file DataFileStats) (
 		file.LowerBoundValues(), file.UpperBoundValues()
 }
 
+type DataFileCollections interface {
+	ColumnSizes() map[int]int64
+	KeyMetadata() []byte
+	SplitOffsets() []int64
+	EqualityFieldIDs() []int
+}
+
+type DataFileCollectionsRef interface {
+	DataFileCollectionsRef(DataFileRef) (
+		columnSizes map[int]int64,
+		keyMetadata []byte,
+		splitOffsets []int64,
+		equalityFieldIDs []int,
+	)
+}
+
+func BorrowedDataFileCollections(file DataFileCollections) (
+	columnSizes map[int]int64,
+	keyMetadata []byte,
+	splitOffsets []int64,
+	equalityFieldIDs []int,
+) {
+	if ref, ok := file.(DataFileCollectionsRef); ok {
+		return ref.DataFileCollectionsRef(DataFileRef{})
+	}
+
+	return file.ColumnSizes(), file.KeyMetadata(), file.SplitOffsets(), file.EqualityFieldIDs()
+}
+
 // BorrowedDataFileBounds returns the lower and upper bounds without copying
 // for the built-in data file and falls back to the public getters for external
 // implementations. The returned maps and byte slices are read-only borrows.

--- a/table/data_file_stats_ref.go
+++ b/table/data_file_stats_ref.go
@@ -36,6 +36,15 @@ func dataFileStats(file iceberg.DataFile) (
 	return internal.BorrowedDataFileStats(file)
 }
 
+func dataFileCollections(file iceberg.DataFile) (
+	columnSizes map[int]int64,
+	keyMetadata []byte,
+	splitOffsets []int64,
+	equalityFieldIDs []int,
+) {
+	return internal.BorrowedDataFileCollections(file)
+}
+
 // dataFilePartition returns a borrowed partition map for the concrete
 // manifest data file and falls back to the public getter for other DataFile
 // implementations. Callers must use the map only for the current planning

--- a/table/data_file_stats_ref_test.go
+++ b/table/data_file_stats_ref_test.go
@@ -75,6 +75,30 @@ func (f *publicStatsDataFile) UpperBoundValues() map[int][]byte {
 	return f.DataFile.UpperBoundValues()
 }
 
+func (f *publicStatsDataFile) ColumnSizes() map[int]int64 {
+	f.getterCalls++
+
+	return f.DataFile.ColumnSizes()
+}
+
+func (f *publicStatsDataFile) KeyMetadata() []byte {
+	f.getterCalls++
+
+	return f.DataFile.KeyMetadata()
+}
+
+func (f *publicStatsDataFile) SplitOffsets() []int64 {
+	f.getterCalls++
+
+	return f.DataFile.SplitOffsets()
+}
+
+func (f *publicStatsDataFile) EqualityFieldIDs() []int {
+	f.getterCalls++
+
+	return f.DataFile.EqualityFieldIDs()
+}
+
 func testDataFileWithStats(t *testing.T) iceberg.DataFile {
 	t.Helper()
 
@@ -98,11 +122,15 @@ func testDataFileWithStats(t *testing.T) iceberg.DataFile {
 	require.NoError(t, err)
 
 	return builder.
+		ColumnSizes(map[int]int64{1: 10}).
 		ValueCounts(map[int]int64{1: 2}).
 		NullValueCounts(map[int]int64{1: 0}).
 		NaNValueCounts(map[int]int64{1: 0}).
 		LowerBoundValues(map[int][]byte{1: {1, 2}}).
 		UpperBoundValues(map[int][]byte{1: {3, 4}}).
+		KeyMetadata([]byte{5, 6}).
+		SplitOffsets([]int64{0, 64}).
+		EqualityFieldIDs([]int{1}).
 		Build()
 }
 
@@ -135,6 +163,35 @@ func TestDataFileStatsFallsBackToPublicGetters(t *testing.T) {
 	assert.Equal(t, map[int][]byte{1: {1, 2}}, lowerBounds)
 	assert.Equal(t, map[int][]byte{1: {3, 4}}, upperBounds)
 	assert.Equal(t, 5, file.getterCalls)
+}
+
+func TestDataFileCollectionsUsesBorrowedView(t *testing.T) {
+	file := testDataFileWithStats(t)
+	require.Implements(t, (*internal.DataFileCollectionsRef)(nil), file)
+
+	columnSizes, keyMetadata, splitOffsets, equalityFieldIDs := dataFileCollections(file)
+	assert.Equal(t, map[int]int64{1: 10}, columnSizes)
+	assert.Equal(t, []byte{5, 6}, keyMetadata)
+	assert.Equal(t, []int64{0, 64}, splitOffsets)
+	assert.Equal(t, []int{1}, equalityFieldIDs)
+
+	var measuredColumnSizes map[int]int64
+	allocs := testing.AllocsPerRun(100, func() {
+		measuredColumnSizes, _, _, _ = dataFileCollections(file)
+	})
+	assert.InDelta(t, 0.0, allocs, 0.5)
+	assert.Equal(t, map[int]int64{1: 10}, measuredColumnSizes)
+}
+
+func TestDataFileCollectionsFallsBackToPublicGetters(t *testing.T) {
+	file := &publicStatsDataFile{DataFile: testDataFileWithStats(t)}
+
+	columnSizes, keyMetadata, splitOffsets, equalityFieldIDs := dataFileCollections(file)
+	assert.Equal(t, map[int]int64{1: 10}, columnSizes)
+	assert.Equal(t, []byte{5, 6}, keyMetadata)
+	assert.Equal(t, []int64{0, 64}, splitOffsets)
+	assert.Equal(t, []int{1}, equalityFieldIDs)
+	assert.Equal(t, 4, file.getterCalls)
 }
 
 func TestDataFileBoundsUseBorrowedView(t *testing.T) {

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -662,7 +662,8 @@ func (b inspectContentFileBuilder) append(file iceberg.DataFile) error {
 
 	b.recordCount.Append(file.Count())
 	b.fileSize.Append(file.FileSizeBytes())
-	if err := appendInspectInt64Map(b.columnSizes, file.ColumnSizes()); err != nil {
+	columnSizes, keyMetadata, splitOffsets, equalityFieldIDs := dataFileCollections(file)
+	if err := appendInspectInt64Map(b.columnSizes, columnSizes); err != nil {
 		return err
 	}
 	valueCounts, nullCounts, nanCounts, lowerBounds, upperBounds := dataFileStats(file)
@@ -681,11 +682,11 @@ func (b inspectContentFileBuilder) append(file iceberg.DataFile) error {
 	if err := appendInspectBinaryMap(b.upperBounds, upperBounds); err != nil {
 		return err
 	}
-	appendInspectBytes(b.keyMetadata, file.KeyMetadata())
-	if err := appendInspectInt64List(b.splitOffsets, file.SplitOffsets()); err != nil {
+	appendInspectBytes(b.keyMetadata, keyMetadata)
+	if err := appendInspectInt64List(b.splitOffsets, splitOffsets); err != nil {
 		return err
 	}
-	if err := appendInspectInt32List(b.equalityIDs, file.EqualityFieldIDs()); err != nil {
+	if err := appendInspectInt32List(b.equalityIDs, equalityFieldIDs); err != nil {
 		return err
 	}
 	if err := appendInspectOptionalInt32(b.sortOrderID, file.SortOrderID()); err != nil {

--- a/table/inspect_files_stats_bench_test.go
+++ b/table/inspect_files_stats_bench_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/internal"
 )
 
 type inspectPublicStatsDataFile struct {
@@ -62,6 +63,59 @@ func BenchmarkInspectContentFileAppenderDataFileStats(b *testing.B) {
 				publicFiles := make([]iceberg.DataFile, len(files))
 				for i, file := range files {
 					publicFiles[i] = &inspectPublicStatsDataFile{DataFile: file}
+				}
+
+				b.Run("borrowed", func(b *testing.B) {
+					benchmarkAppendInspectContentFiles(b, partitionType, files)
+				})
+				b.Run("public", func(b *testing.B) {
+					benchmarkAppendInspectContentFiles(b, partitionType, publicFiles)
+				})
+			})
+		}
+	}
+}
+
+type inspectPublicCollectionsDataFile struct {
+	iceberg.DataFile
+}
+
+func (f *inspectPublicCollectionsDataFile) DataFileStatsRef(_ internal.DataFileRef) (
+	map[int]int64, map[int]int64, map[int]int64, map[int][]byte, map[int][]byte,
+) {
+	return internal.BorrowedDataFileStats(f.DataFile)
+}
+
+func (f *inspectPublicCollectionsDataFile) DataFilePartitionRef(_ internal.DataFileRef) map[int]any {
+	return internal.BorrowedDataFilePartition(f.DataFile)
+}
+
+func BenchmarkInspectContentFileAppenderDataFileCollections(b *testing.B) {
+	cases := []struct {
+		name             string
+		columnSizes      int
+		splitOffsets     int
+		equalityFieldIDs int
+		keyMetadata      int
+	}{
+		{name: "empty"},
+		{name: "medium", columnSizes: 32, splitOffsets: 16, equalityFieldIDs: 8, keyMetadata: 32},
+		{name: "wide", columnSizes: 128, splitOffsets: 64, equalityFieldIDs: 16, keyMetadata: 128},
+	}
+	for _, fileCount := range []int{4096, 16384} {
+		for _, benchmarkCase := range cases {
+			b.Run(fmt.Sprintf("files=%d/%s", fileCount, benchmarkCase.name), func(b *testing.B) {
+				partitionType, files := benchmarkInspectContentFilesWithCollections(
+					b,
+					benchmarkCase.columnSizes,
+					benchmarkCase.splitOffsets,
+					benchmarkCase.equalityFieldIDs,
+					benchmarkCase.keyMetadata,
+					fileCount,
+				)
+				publicFiles := make([]iceberg.DataFile, len(files))
+				for i, file := range files {
+					publicFiles[i] = &inspectPublicCollectionsDataFile{DataFile: file}
 				}
 
 				b.Run("borrowed", func(b *testing.B) {
@@ -158,6 +212,78 @@ func benchmarkInspectContentFilesWithStats(
 				NaNValueCounts(nanCounts).
 				LowerBoundValues(lowerBounds).
 				UpperBoundValues(upperBounds)
+		}
+		files[i] = builder.Build()
+	}
+
+	return partitionType, files
+}
+
+func benchmarkInspectContentFilesWithCollections(
+	b *testing.B,
+	columnSizesWidth int,
+	splitOffsetsWidth int,
+	equalityFieldIDsWidth int,
+	keyMetadataWidth int,
+	fileCount int,
+) (*iceberg.StructType, []iceberg.DataFile) {
+	b.Helper()
+
+	schemaWidth := max(max(columnSizesWidth, equalityFieldIDsWidth), 1)
+	schemaFields := make([]iceberg.NestedField, schemaWidth)
+	for i := range schemaFields {
+		fieldID := i + 1
+		schemaFields[i] = iceberg.NestedField{
+			ID: fieldID, Name: fmt.Sprintf("field_%d", fieldID),
+			Type: iceberg.PrimitiveTypes.Int32, Required: true,
+		}
+	}
+	schema := iceberg.NewSchema(0, schemaFields...)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "partition", Transform: iceberg.IdentityTransform{},
+	})
+	partitionType := spec.PartitionType(schema)
+
+	var keyMetadata []byte
+	if keyMetadataWidth > 0 {
+		keyMetadata = make([]byte, keyMetadataWidth)
+		for i := range keyMetadata {
+			keyMetadata[i] = byte(i)
+		}
+	}
+
+	files := make([]iceberg.DataFile, fileCount)
+	for i := range files {
+		builder, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, fmt.Sprintf("file-%d.parquet", i),
+			iceberg.ParquetFile, map[int]any{1000: int32(i)}, nil, nil, 1, 1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if columnSizesWidth > 0 {
+			columnSizes := make(map[int]int64, columnSizesWidth)
+			for field := range columnSizesWidth {
+				columnSizes[field+1] = int64(field + 1)
+			}
+			builder = builder.ColumnSizes(columnSizes)
+		}
+		if keyMetadata != nil {
+			builder = builder.KeyMetadata(keyMetadata)
+		}
+		if splitOffsetsWidth > 0 {
+			splitOffsets := make([]int64, splitOffsetsWidth)
+			for offset := range splitOffsets {
+				splitOffsets[offset] = int64(offset * 4096)
+			}
+			builder = builder.SplitOffsets(splitOffsets)
+		}
+		if equalityFieldIDsWidth > 0 {
+			equalityFieldIDs := make([]int, equalityFieldIDsWidth)
+			for field := range equalityFieldIDs {
+				equalityFieldIDs[field] = field + 1
+			}
+			builder = builder.EqualityFieldIDs(equalityFieldIDs)
 		}
 		files[i] = builder.Build()
 	}

--- a/table/inspect_files_stats_test.go
+++ b/table/inspect_files_stats_test.go
@@ -56,10 +56,32 @@ func (f *borrowedInspectDataFile) UpperBoundValues() map[int][]byte {
 	panic("metadata appender called the public UpperBoundValues getter")
 }
 
+func (f *borrowedInspectDataFile) ColumnSizes() map[int]int64 {
+	panic("metadata appender called the public ColumnSizes getter")
+}
+
+func (f *borrowedInspectDataFile) KeyMetadata() []byte {
+	panic("metadata appender called the public KeyMetadata getter")
+}
+
+func (f *borrowedInspectDataFile) SplitOffsets() []int64 {
+	panic("metadata appender called the public SplitOffsets getter")
+}
+
+func (f *borrowedInspectDataFile) EqualityFieldIDs() []int {
+	panic("metadata appender called the public EqualityFieldIDs getter")
+}
+
 func (f *borrowedInspectDataFile) DataFileStatsRef(_ internal.DataFileRef) (
 	map[int]int64, map[int]int64, map[int]int64, map[int][]byte, map[int][]byte,
 ) {
 	return internal.BorrowedDataFileStats(f.DataFile)
+}
+
+func (f *borrowedInspectDataFile) DataFileCollectionsRef(_ internal.DataFileRef) (
+	map[int]int64, []byte, []int64, []int,
+) {
+	return internal.BorrowedDataFileCollections(f.DataFile)
 }
 
 func (f *borrowedInspectDataFile) DataFilePartitionRef(_ internal.DataFileRef) map[int]any {
@@ -82,6 +104,25 @@ func TestInspectContentFileBuilderUsesBorrowedDataFileMetadata(t *testing.T) {
 		start, end := valueCounts.ValueOffsets(0)
 		require.EqualValues(t, 1, end-start)
 		require.EqualValues(t, 2, valueCounts.Items().(*array.Int64).Value(int(start)))
+
+		columnSizes := record.Column(7).(*array.Map)
+		require.False(t, columnSizes.IsNull(0))
+		start, end = columnSizes.ValueOffsets(0)
+		require.EqualValues(t, 1, end-start)
+		require.EqualValues(t, 10, columnSizes.Items().(*array.Int64).Value(int(start)))
+
+		require.Equal(t, []byte{5, 6}, record.Column(13).(*array.Binary).Value(0))
+
+		splitOffsets := record.Column(14).(*array.List)
+		start, end = splitOffsets.ValueOffsets(0)
+		require.EqualValues(t, 2, end-start)
+		require.EqualValues(t, 0, splitOffsets.ListValues().(*array.Int64).Value(int(start)))
+		require.EqualValues(t, 64, splitOffsets.ListValues().(*array.Int64).Value(int(start+1)))
+
+		equalityIDs := record.Column(15).(*array.List)
+		start, end = equalityIDs.ValueOffsets(0)
+		require.EqualValues(t, 1, end-start)
+		require.EqualValues(t, 1, equalityIDs.ListValues().(*array.Int32).Value(int(start)))
 	})
 }
 
@@ -94,7 +135,7 @@ func TestInspectContentFileBuilderFallsBackToPublicDataFileMetadata(t *testing.T
 	withInspectContentFileRecord(t, partitionType, file, func(record arrow.RecordBatch) {
 		require.EqualValues(t, 1, record.NumRows())
 	})
-	require.Equal(t, 5, file.getterCalls)
+	require.Equal(t, 9, file.getterCalls)
 }
 
 func withInspectContentFileRecord(


### PR DESCRIPTION
## What

- Borrow `ColumnSizes`, `KeyMetadata`, `SplitOffsets`, and `EqualityFieldIDs` for built-in manifest `DataFile` values.
- Keep the public getter fallback for custom `DataFile` implementations.
- Add focused tests for both paths.
- Add a benchmark with empty, medium, and wide metadata.

## Benchmark

Same benchmark fixture before and after. Apple M1 Pro, darwin/arm64, Go 1.26.3. `-benchtime=3x`.

- `files=4096/medium/borrowed`: **13.16 ms -> 8.67 ms**, **17.3 MB -> 11.3 MB**, **45,773 -> 17,102 allocs/op**.
- `files=16384/wide/borrowed`: **181.0 ms -> 126.2 ms**, **247.2 MB -> 153.5 MB**, **197,465 -> 82,776 allocs/op**.
- The public wrapper stayed at about **247.2 MB** and **197K allocs/op** in the wide case.

Command:

```text
go test ./table -run '^$' -bench 'BenchmarkInspectContentFileAppenderDataFileCollections' -benchmem -benchtime=3x -count=1
```

## Checks

- `go test ./...`
- `go test -race ./table`
- `go test -tags=assert -run='^(TestInspectFilesTablesEarlyRelease|TestInspectDataFilesEmitsEmptyBatchWhenAllEntriesAreDeleted|TestInspectDataFilesEmptyTableEarlyRelease|TestInspectPositionDeletesEarlyRelease)$' ./table`
- `go vet ./...`
- `golangci-lint run --timeout=10m`
