### PR TITLE
fix(table): trim carried binary upper bounds

### DIFF
--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -567,7 +567,7 @@ func TruncateUpperBoundBinary(val []byte, trunc int) []byte {
 		if result[i] < 255 {
 			result[i]++
 
-			return result
+			return result[:i+1]
 		}
 	}
 

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -105,7 +105,8 @@ func TestTruncateUpperBoundBinary(t *testing.T) {
 		expected []byte
 	}{
 		{"increment", []byte{0x01, 0x02, 0x03}, 2, []byte{0x01, 0x03}},
-		{"carry", []byte{0x01, 0x02, 0xff, 0x03}, 3, []byte{0x01, 0x03, 0xff}},
+		{"carry past ff suffix", []byte{0x01, 0x02, 0xff, 0x03}, 3, []byte{0x01, 0x03}},
+		{"carry past multiple ff bytes", []byte{0x01, 0xff, 0xff, 0x03}, 3, []byte{0x02}},
 		{"all ff", []byte{0xff, 0xff, 0x00}, 2, nil},
 		{"no truncation", []byte{0x01, 0x02}, 2, []byte{0x01, 0x02}},
 	}
@@ -120,9 +121,15 @@ func TestTruncateUpperBoundBinary(t *testing.T) {
 			assert.Equal(t, first, second)
 			assert.Equal(t, original, tt.value)
 
+			if tt.truncate < len(tt.value) && len(first) > 0 {
+				assert.LessOrEqual(t, len(first), tt.truncate)
+				assert.Greater(t, bytes.Compare(first, tt.value), 0)
+			}
+
 			if len(first) > 0 {
 				first[0] ^= 0xff
 				assert.Equal(t, original, tt.value)
+				assert.Equal(t, tt.expected, second)
 			}
 		})
 	}


### PR DESCRIPTION
resolves #1927