### PR TITLE
perf(table): speed up bulk schema and partition spec removals

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -346,8 +346,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2292,4 +2293,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1548,27 +1548,30 @@ func (b *MetadataBuilder) reuseOrCreateNewSchemaID(newSchema *iceberg.Schema) in
 	return newSchemaID
 }
 
+func makeIntContainsFn(ints []int) func(int) bool {
+	// Scan small removal lists; reserve the index for bulk requests.
+	if len(ints) <= 16 {
+		return func(id int) bool { return slices.Contains(ints, id) }
+	}
+
+	ids := make(map[int]struct{}, len(ints))
+	for _, id := range ints {
+		ids[id] = struct{}{}
+	}
+
+	return func(id int) bool {
+		_, ok := ids[id]
+
+		return ok
+	}
+}
+
 func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 	if len(ints) == 0 {
 		return nil
 	}
 
-	var removedIDs map[int]struct{}
-	if len(ints) > 1 {
-		removedIDs = make(map[int]struct{}, len(ints))
-		for _, id := range ints {
-			removedIDs[id] = struct{}{}
-		}
-	}
-	containsID := func(id int) bool {
-		if removedIDs == nil {
-			return id == ints[0]
-		}
-		_, ok := removedIDs[id]
-
-		return ok
-	}
-
+	containsID := makeIntContainsFn(ints)
 	if containsID(b.defaultSpecID) {
 		return fmt.Errorf("%w: can't remove default partition spec with id %d", iceberg.ErrInvalidArgument, b.defaultSpecID)
 	}
@@ -1598,22 +1601,7 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 		return nil
 	}
 
-	var removedIDs map[int]struct{}
-	if len(ints) > 1 {
-		removedIDs = make(map[int]struct{}, len(ints))
-		for _, id := range ints {
-			removedIDs[id] = struct{}{}
-		}
-	}
-	containsID := func(id int) bool {
-		if removedIDs == nil {
-			return id == ints[0]
-		}
-		_, ok := removedIDs[id]
-
-		return ok
-	}
-
+	containsID := makeIntContainsFn(ints)
 	if containsID(b.currentSchemaID) {
 		return fmt.Errorf("%w: can't remove current schema with id %d", iceberg.ErrInvalidArgument, b.currentSchemaID)
 	}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1553,14 +1553,19 @@ func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 		return nil
 	}
 
-	if slices.Contains(ints, b.defaultSpecID) {
+	removedIDs := make(map[int]struct{}, len(ints))
+	for _, id := range ints {
+		removedIDs[id] = struct{}{}
+	}
+
+	if _, ok := removedIDs[b.defaultSpecID]; ok {
 		return fmt.Errorf("%w: can't remove default partition spec with id %d", iceberg.ErrInvalidArgument, b.defaultSpecID)
 	}
 
 	newSpecs := make([]iceberg.PartitionSpec, 0, len(b.specs))
 	removed := make([]int, 0, len(ints))
 	for _, spec := range b.specs {
-		if slices.Contains(ints, spec.ID()) {
+		if _, ok := removedIDs[spec.ID()]; ok {
 			removed = append(removed, spec.ID())
 
 			continue
@@ -1582,13 +1587,18 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 		return nil
 	}
 
-	if slices.Contains(ints, b.currentSchemaID) {
+	removedIDs := make(map[int]struct{}, len(ints))
+	for _, id := range ints {
+		removedIDs[id] = struct{}{}
+	}
+
+	if _, ok := removedIDs[b.currentSchemaID]; ok {
 		return fmt.Errorf("%w: can't remove current schema with id %d", iceberg.ErrInvalidArgument, b.currentSchemaID)
 	}
 
 	removed := make([]int, 0, len(ints))
 	b.schemaList = slices.DeleteFunc(b.schemaList, func(s *iceberg.Schema) bool {
-		if slices.Contains(ints, s.ID) {
+		if _, ok := removedIDs[s.ID]; ok {
 			removed = append(removed, s.ID)
 
 			return true

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1553,19 +1553,30 @@ func (b *MetadataBuilder) RemovePartitionSpecs(ints []int) error {
 		return nil
 	}
 
-	removedIDs := make(map[int]struct{}, len(ints))
-	for _, id := range ints {
-		removedIDs[id] = struct{}{}
+	var removedIDs map[int]struct{}
+	if len(ints) > 1 {
+		removedIDs = make(map[int]struct{}, len(ints))
+		for _, id := range ints {
+			removedIDs[id] = struct{}{}
+		}
+	}
+	containsID := func(id int) bool {
+		if removedIDs == nil {
+			return id == ints[0]
+		}
+		_, ok := removedIDs[id]
+
+		return ok
 	}
 
-	if _, ok := removedIDs[b.defaultSpecID]; ok {
+	if containsID(b.defaultSpecID) {
 		return fmt.Errorf("%w: can't remove default partition spec with id %d", iceberg.ErrInvalidArgument, b.defaultSpecID)
 	}
 
 	newSpecs := make([]iceberg.PartitionSpec, 0, len(b.specs))
 	removed := make([]int, 0, len(ints))
 	for _, spec := range b.specs {
-		if _, ok := removedIDs[spec.ID()]; ok {
+		if containsID(spec.ID()) {
 			removed = append(removed, spec.ID())
 
 			continue
@@ -1587,18 +1598,29 @@ func (b *MetadataBuilder) RemoveSchemas(ints []int) error {
 		return nil
 	}
 
-	removedIDs := make(map[int]struct{}, len(ints))
-	for _, id := range ints {
-		removedIDs[id] = struct{}{}
+	var removedIDs map[int]struct{}
+	if len(ints) > 1 {
+		removedIDs = make(map[int]struct{}, len(ints))
+		for _, id := range ints {
+			removedIDs[id] = struct{}{}
+		}
+	}
+	containsID := func(id int) bool {
+		if removedIDs == nil {
+			return id == ints[0]
+		}
+		_, ok := removedIDs[id]
+
+		return ok
 	}
 
-	if _, ok := removedIDs[b.currentSchemaID]; ok {
+	if containsID(b.currentSchemaID) {
 		return fmt.Errorf("%w: can't remove current schema with id %d", iceberg.ErrInvalidArgument, b.currentSchemaID)
 	}
 
 	removed := make([]int, 0, len(ints))
 	b.schemaList = slices.DeleteFunc(b.schemaList, func(s *iceberg.Schema) bool {
-		if _, ok := removedIDs[s.ID]; ok {
+		if containsID(s.ID) {
 			removed = append(removed, s.ID)
 
 			return true

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -51,6 +51,14 @@ var bulkRemovalBenchmarkCases = []struct {
 	removedCount int
 }{
 	{entryCount: 8, removedCount: 1},
+	{entryCount: 8, removedCount: 2},
+	{entryCount: 8, removedCount: 4},
+	{entryCount: 32, removedCount: 8},
+	{entryCount: 32, removedCount: 9},
+	{entryCount: 32, removedCount: 16},
+	{entryCount: 128, removedCount: 16},
+	{entryCount: 128, removedCount: 17},
+	{entryCount: 128, removedCount: 32},
 	{entryCount: 128, removedCount: 64},
 	{entryCount: 1_024, removedCount: 512},
 	{entryCount: 8_192, removedCount: 4_096},
@@ -63,13 +71,15 @@ func BenchmarkRemovePartitionSpecs(b *testing.B) {
 			removed := benchmarkRemovedIDs(tc.removedCount)
 
 			b.ReportAllocs()
+			b.ResetTimer()
 			b.ReportMetric(float64(tc.entryCount), "spec_entries")
 			b.ReportMetric(float64(len(removed)), "removed_specs")
-			b.ResetTimer()
 
 			for range b.N {
+				b.StopTimer()
 				builder := template
-				builder.updates = nil
+				builder.specs = slices.Clone(template.specs)
+				b.StartTimer()
 
 				if err := builder.RemovePartitionSpecs(removed); err != nil {
 					b.Fatal(err)
@@ -87,15 +97,14 @@ func BenchmarkRemoveSchemas(b *testing.B) {
 			removed := benchmarkRemovedIDs(tc.removedCount)
 
 			b.ReportAllocs()
+			b.ResetTimer()
 			b.ReportMetric(float64(tc.entryCount), "schema_entries")
 			b.ReportMetric(float64(len(removed)), "removed_schemas")
-			b.ResetTimer()
 
 			for range b.N {
 				b.StopTimer()
 				builder := template
 				builder.schemaList = slices.Clone(template.schemaList)
-				builder.updates = nil
 				b.StartTimer()
 
 				if err := builder.RemoveSchemas(removed); err != nil {

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -29,6 +29,7 @@ import (
 var (
 	removeSnapshotsBenchmarkSink int
 	metadataBuilderBenchmarkSink int
+	bulkRemovalBenchmarkSink     int
 )
 
 var removeSnapshotsBenchmarkCases = []struct {
@@ -43,6 +44,67 @@ var removeSnapshotsBenchmarkCases = []struct {
 	{snapshotCount: 10_000, removedCount: 8},
 	{snapshotCount: 10_000, removedCount: 64},
 	{snapshotCount: 10_000, removedCount: 5_000},
+}
+
+var bulkRemovalBenchmarkCases = []struct {
+	entryCount   int
+	removedCount int
+}{
+	{entryCount: 8, removedCount: 1},
+	{entryCount: 128, removedCount: 64},
+	{entryCount: 1_024, removedCount: 512},
+	{entryCount: 8_192, removedCount: 4_096},
+}
+
+func BenchmarkRemovePartitionSpecs(b *testing.B) {
+	for _, tc := range bulkRemovalBenchmarkCases {
+		b.Run(fmt.Sprintf("specs=%d/removed=%d", tc.entryCount, tc.removedCount), func(b *testing.B) {
+			template := benchmarkPartitionSpecBuilder(tc.entryCount)
+			removed := benchmarkRemovedIDs(tc.removedCount)
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(tc.entryCount), "spec_entries")
+			b.ReportMetric(float64(len(removed)), "removed_specs")
+			b.ResetTimer()
+
+			for range b.N {
+				builder := template
+				builder.updates = nil
+
+				if err := builder.RemovePartitionSpecs(removed); err != nil {
+					b.Fatal(err)
+				}
+				bulkRemovalBenchmarkSink = len(builder.specs)
+			}
+		})
+	}
+}
+
+func BenchmarkRemoveSchemas(b *testing.B) {
+	for _, tc := range bulkRemovalBenchmarkCases {
+		b.Run(fmt.Sprintf("schemas=%d/removed=%d", tc.entryCount, tc.removedCount), func(b *testing.B) {
+			template := benchmarkSchemaBuilder(tc.entryCount)
+			removed := benchmarkRemovedIDs(tc.removedCount)
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(tc.entryCount), "schema_entries")
+			b.ReportMetric(float64(len(removed)), "removed_schemas")
+			b.ResetTimer()
+
+			for range b.N {
+				b.StopTimer()
+				builder := template
+				builder.schemaList = slices.Clone(template.schemaList)
+				builder.updates = nil
+				b.StartTimer()
+
+				if err := builder.RemoveSchemas(removed); err != nil {
+					b.Fatal(err)
+				}
+				bulkRemovalBenchmarkSink = len(builder.schemaList)
+			}
+		})
+	}
 }
 
 func BenchmarkRemoveSnapshots(b *testing.B) {
@@ -300,4 +362,31 @@ func benchmarkSnapshots(snapshotCount int) []Snapshot {
 	}
 
 	return snapshots
+}
+
+func benchmarkPartitionSpecBuilder(entryCount int) MetadataBuilder {
+	specs := make([]iceberg.PartitionSpec, entryCount)
+	for i := range specs {
+		specs[i] = iceberg.NewPartitionSpecID(i)
+	}
+
+	return MetadataBuilder{specs: specs, defaultSpecID: -1}
+}
+
+func benchmarkSchemaBuilder(entryCount int) MetadataBuilder {
+	schemas := make([]*iceberg.Schema, entryCount)
+	for i := range schemas {
+		schemas[i] = iceberg.NewSchema(i)
+	}
+
+	return MetadataBuilder{schemaList: schemas, currentSchemaID: -1}
+}
+
+func benchmarkRemovedIDs(removedCount int) []int {
+	removed := make([]int, removedCount)
+	for i := range removed {
+		removed[i] = i * 2
+	}
+
+	return removed
 }

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -358,11 +358,46 @@ func TestAddRemovePartitionSpec(t *testing.T) {
 }
 
 func TestRemovePartitionSpecsNoMatchDoesNotUpdate(t *testing.T) {
-	builder := builderWithoutChanges(2)
+	for _, count := range []int{1, 2, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := builderWithoutChanges(2)
+			originalSpecs := slices.Clone(builder.specs)
+			requested := make([]int, count)
+			for i := range requested {
+				requested[i] = 99 + i
+			}
 
-	require.NoError(t, builder.RemovePartitionSpecs([]int{99, 100}))
-	require.Empty(t, builder.updates)
-	require.Len(t, builder.specs, 1)
+			require.NoError(t, builder.RemovePartitionSpecs(requested))
+			require.Empty(t, builder.updates)
+			require.Equal(t, originalSpecs, builder.specs)
+		})
+	}
+}
+
+func TestRemovePartitionSpecsSingleID(t *testing.T) {
+	for _, id := range []int{1, 7} {
+		t.Run(fmt.Sprintf("id=%d", id), func(t *testing.T) {
+			builder := MetadataBuilder{
+				specs: []iceberg.PartitionSpec{
+					iceberg.NewPartitionSpecID(1),
+					iceberg.NewPartitionSpecID(4),
+					iceberg.NewPartitionSpecID(7),
+				},
+				defaultSpecID: 4,
+			}
+
+			require.NoError(t, builder.RemovePartitionSpecs([]int{id}))
+			require.Len(t, builder.specs, 2)
+			if id == 1 {
+				require.Equal(t, []int{4, 7}, []int{builder.specs[0].ID(), builder.specs[1].ID()})
+			} else {
+				require.Equal(t, []int{1, 4}, []int{builder.specs[0].ID(), builder.specs[1].ID()})
+			}
+			require.Equal(t, 4, builder.defaultSpecID)
+			require.Len(t, builder.updates, 1)
+			require.Equal(t, []int{id}, builder.updates[0].(*removeSpecUpdate).SpecIds)
+		})
+	}
 }
 
 func TestRemovePartitionSpecsEmptyDoesNotUpdate(t *testing.T) {
@@ -374,34 +409,57 @@ func TestRemovePartitionSpecsEmptyDoesNotUpdate(t *testing.T) {
 }
 
 func TestRemovePartitionSpecsPreservesStoredOrderAndIgnoresDuplicates(t *testing.T) {
-	builder := MetadataBuilder{
-		specs: []iceberg.PartitionSpec{
-			iceberg.NewPartitionSpecID(4),
-			iceberg.NewPartitionSpecID(1),
-			iceberg.NewPartitionSpecID(7),
-		},
-		defaultSpecID: 99,
-	}
+	for _, count := range []int{4, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := MetadataBuilder{
+				specs: []iceberg.PartitionSpec{
+					iceberg.NewPartitionSpecID(4),
+					iceberg.NewPartitionSpecID(1),
+					iceberg.NewPartitionSpecID(8),
+					iceberg.NewPartitionSpecID(7),
+					iceberg.NewPartitionSpecID(2),
+				},
+				defaultSpecID: 4,
+			}
+			requested := []int{7, 1, 7, 123}
+			for len(requested) < count {
+				requested = append(requested, 123+len(requested))
+			}
 
-	require.NoError(t, builder.RemovePartitionSpecs([]int{7, 1, 7, 123}))
-	require.Len(t, builder.specs, 1)
-	require.Equal(t, 4, builder.specs[0].ID())
-	require.Len(t, builder.updates, 1)
-	require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSpecUpdate).SpecIds)
+			require.NoError(t, builder.RemovePartitionSpecs(requested))
+			require.Len(t, builder.specs, 3)
+			require.Equal(t, []int{4, 8, 2}, []int{builder.specs[0].ID(), builder.specs[1].ID(), builder.specs[2].ID()})
+			require.Len(t, builder.updates, 1)
+			// Preserve the existing Go payload: only IDs found in metadata, in stored order.
+			require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSpecUpdate).SpecIds)
+		})
+	}
 }
 
 func TestRemovePartitionSpecsProtectsDefaultSpecBeforeMutation(t *testing.T) {
-	builder := MetadataBuilder{
-		specs: []iceberg.PartitionSpec{
-			iceberg.NewPartitionSpecID(1),
-			iceberg.NewPartitionSpecID(2),
-		},
-		defaultSpecID: 2,
-	}
+	for _, count := range []int{3, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := MetadataBuilder{
+				specs: []iceberg.PartitionSpec{
+					iceberg.NewPartitionSpecID(1),
+					iceberg.NewPartitionSpecID(2),
+				},
+				defaultSpecID: 2,
+			}
+			originalSpecs := slices.Clone(builder.specs)
+			requested := make([]int, count)
+			for i := range requested {
+				requested[i] = 1
+			}
+			requested[len(requested)-1] = 2
 
-	require.ErrorContains(t, builder.RemovePartitionSpecs([]int{1, 2, 2}), "can't remove default partition spec with id 2")
-	require.Equal(t, []int{1, 2}, []int{builder.specs[0].ID(), builder.specs[1].ID()})
-	require.Empty(t, builder.updates)
+			err := builder.RemovePartitionSpecs(requested)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, "can't remove default partition spec with id 2")
+			require.Equal(t, originalSpecs, builder.specs)
+			require.Empty(t, builder.updates)
+		})
+	}
 }
 
 func TestSetDefaultPartitionSpec(t *testing.T) {
@@ -1798,45 +1856,100 @@ func TestRemoveSchemas(t *testing.T) {
 }
 
 func TestRemoveSchemasNoMatchDoesNotUpdate(t *testing.T) {
-	meta, err := getTestTableMetadata("TableMetadataV2Valid.json")
-	require.NoError(t, err)
+	for _, count := range []int{0, 1, 2, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := builderWithoutChanges(2)
+			originalSchemas := slices.Clone(builder.schemaList)
+			requested := make([]int, count)
+			for i := range requested {
+				requested[i] = 99 + i
+			}
 
-	builder, err := MetadataBuilderFromBase(meta, "")
-	require.NoError(t, err)
-	require.NoError(t, builder.RemoveSchemas([]int{99, 100}))
-	require.Empty(t, builder.updates)
-	require.Len(t, builder.schemaList, 2)
+			require.NoError(t, builder.RemoveSchemas(requested))
+			require.Empty(t, builder.updates)
+			require.Equal(t, originalSchemas, builder.schemaList)
+		})
+	}
+}
+
+func TestRemoveSchemasSingleID(t *testing.T) {
+	for _, id := range []int{1, 7} {
+		t.Run(fmt.Sprintf("id=%d", id), func(t *testing.T) {
+			builder := MetadataBuilder{
+				schemaList: []*iceberg.Schema{
+					iceberg.NewSchema(1),
+					iceberg.NewSchema(4),
+					iceberg.NewSchema(7),
+				},
+				currentSchemaID: 4,
+			}
+
+			require.NoError(t, builder.RemoveSchemas([]int{id}))
+			require.Len(t, builder.schemaList, 2)
+			if id == 1 {
+				require.Equal(t, []int{4, 7}, []int{builder.schemaList[0].ID, builder.schemaList[1].ID})
+			} else {
+				require.Equal(t, []int{1, 4}, []int{builder.schemaList[0].ID, builder.schemaList[1].ID})
+			}
+			require.Equal(t, 4, builder.currentSchemaID)
+			require.Len(t, builder.updates, 1)
+			require.Equal(t, []int{id}, builder.updates[0].(*removeSchemasUpdate).SchemaIDs)
+		})
+	}
 }
 
 func TestRemoveSchemasPreservesStoredOrderAndIgnoresDuplicates(t *testing.T) {
-	builder := MetadataBuilder{
-		schemaList: []*iceberg.Schema{
-			iceberg.NewSchema(4),
-			iceberg.NewSchema(1),
-			iceberg.NewSchema(7),
-		},
-		currentSchemaID: 99,
-	}
+	for _, count := range []int{4, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := MetadataBuilder{
+				schemaList: []*iceberg.Schema{
+					iceberg.NewSchema(4),
+					iceberg.NewSchema(1),
+					iceberg.NewSchema(8),
+					iceberg.NewSchema(7),
+					iceberg.NewSchema(2),
+				},
+				currentSchemaID: 4,
+			}
+			requested := []int{7, 1, 7, 123}
+			for len(requested) < count {
+				requested = append(requested, 123+len(requested))
+			}
 
-	require.NoError(t, builder.RemoveSchemas([]int{7, 1, 7, 123}))
-	require.Len(t, builder.schemaList, 1)
-	require.Equal(t, 4, builder.schemaList[0].ID)
-	require.Len(t, builder.updates, 1)
-	require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSchemasUpdate).SchemaIDs)
+			require.NoError(t, builder.RemoveSchemas(requested))
+			require.Len(t, builder.schemaList, 3)
+			require.Equal(t, []int{4, 8, 2}, []int{builder.schemaList[0].ID, builder.schemaList[1].ID, builder.schemaList[2].ID})
+			require.Len(t, builder.updates, 1)
+			// Preserve the existing Go payload: only IDs found in metadata, in stored order.
+			require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSchemasUpdate).SchemaIDs)
+		})
+	}
 }
 
 func TestRemoveSchemasProtectsCurrentSchemaBeforeMutation(t *testing.T) {
-	builder := MetadataBuilder{
-		schemaList: []*iceberg.Schema{
-			iceberg.NewSchema(1),
-			iceberg.NewSchema(2),
-		},
-		currentSchemaID: 2,
-	}
+	for _, count := range []int{3, 8, 9, 16, 17, 32, 33, 64} {
+		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {
+			builder := MetadataBuilder{
+				schemaList: []*iceberg.Schema{
+					iceberg.NewSchema(1),
+					iceberg.NewSchema(2),
+				},
+				currentSchemaID: 2,
+			}
+			originalSchemas := slices.Clone(builder.schemaList)
+			requested := make([]int, count)
+			for i := range requested {
+				requested[i] = 1
+			}
+			requested[len(requested)-1] = 2
 
-	require.ErrorContains(t, builder.RemoveSchemas([]int{1, 2, 2}), "can't remove current schema with id 2")
-	require.Equal(t, []int{1, 2}, []int{builder.schemaList[0].ID, builder.schemaList[1].ID})
-	require.Empty(t, builder.updates)
+			err := builder.RemoveSchemas(requested)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.ErrorContains(t, err, "can't remove current schema with id 2")
+			require.Equal(t, originalSchemas, builder.schemaList)
+			require.Empty(t, builder.updates)
+		})
+	}
 }
 
 // Java: TestTableMetadata.testUpdateSchema

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -373,6 +373,37 @@ func TestRemovePartitionSpecsEmptyDoesNotUpdate(t *testing.T) {
 	require.Len(t, builder.specs, 1)
 }
 
+func TestRemovePartitionSpecsPreservesStoredOrderAndIgnoresDuplicates(t *testing.T) {
+	builder := MetadataBuilder{
+		specs: []iceberg.PartitionSpec{
+			iceberg.NewPartitionSpecID(4),
+			iceberg.NewPartitionSpecID(1),
+			iceberg.NewPartitionSpecID(7),
+		},
+		defaultSpecID: 99,
+	}
+
+	require.NoError(t, builder.RemovePartitionSpecs([]int{7, 1, 7, 123}))
+	require.Len(t, builder.specs, 1)
+	require.Equal(t, 4, builder.specs[0].ID())
+	require.Len(t, builder.updates, 1)
+	require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSpecUpdate).SpecIds)
+}
+
+func TestRemovePartitionSpecsProtectsDefaultSpecBeforeMutation(t *testing.T) {
+	builder := MetadataBuilder{
+		specs: []iceberg.PartitionSpec{
+			iceberg.NewPartitionSpecID(1),
+			iceberg.NewPartitionSpecID(2),
+		},
+		defaultSpecID: 2,
+	}
+
+	require.ErrorContains(t, builder.RemovePartitionSpecs([]int{1, 2, 2}), "can't remove default partition spec with id 2")
+	require.Equal(t, []int{1, 2}, []int{builder.specs[0].ID(), builder.specs[1].ID()})
+	require.Empty(t, builder.updates)
+}
+
 func TestSetDefaultPartitionSpec(t *testing.T) {
 	builder := builderWithoutChanges(2)
 	curSchema, err := builder.GetSchemaByID(builder.currentSchemaID)
@@ -1775,6 +1806,37 @@ func TestRemoveSchemasNoMatchDoesNotUpdate(t *testing.T) {
 	require.NoError(t, builder.RemoveSchemas([]int{99, 100}))
 	require.Empty(t, builder.updates)
 	require.Len(t, builder.schemaList, 2)
+}
+
+func TestRemoveSchemasPreservesStoredOrderAndIgnoresDuplicates(t *testing.T) {
+	builder := MetadataBuilder{
+		schemaList: []*iceberg.Schema{
+			iceberg.NewSchema(4),
+			iceberg.NewSchema(1),
+			iceberg.NewSchema(7),
+		},
+		currentSchemaID: 99,
+	}
+
+	require.NoError(t, builder.RemoveSchemas([]int{7, 1, 7, 123}))
+	require.Len(t, builder.schemaList, 1)
+	require.Equal(t, 4, builder.schemaList[0].ID)
+	require.Len(t, builder.updates, 1)
+	require.Equal(t, []int{1, 7}, builder.updates[0].(*removeSchemasUpdate).SchemaIDs)
+}
+
+func TestRemoveSchemasProtectsCurrentSchemaBeforeMutation(t *testing.T) {
+	builder := MetadataBuilder{
+		schemaList: []*iceberg.Schema{
+			iceberg.NewSchema(1),
+			iceberg.NewSchema(2),
+		},
+		currentSchemaID: 2,
+	}
+
+	require.ErrorContains(t, builder.RemoveSchemas([]int{1, 2, 2}), "can't remove current schema with id 2")
+	require.Equal(t, []int{1, 2}, []int{builder.schemaList[0].ID, builder.schemaList[1].ID})
+	require.Empty(t, builder.updates)
 }
 
 // Java: TestTableMetadata.testUpdateSchema


### PR DESCRIPTION
## What

- Build a set of requested IDs once in `RemovePartitionSpecs` and `RemoveSchemas`.
- Reuse it for protected-ID validation and list filtering.
- Keep removal order, update payloads, and no-op behavior unchanged.
- Add coverage for duplicates, requested-order differences, and atomic validation errors.
- Add benchmarks for small and historical metadata workloads.

## Why

Both methods used `slices.Contains` for every stored schema or partition spec. For `n` stored entries and `k` requested IDs, that makes the membership work O(n*k).

## Benchmark

Apple M1 Pro. Median of 3 runs:

```text
go test ./table -run '^$' -bench '^BenchmarkRemove(PartitionSpecs|Schemas)$' -benchmem -count=3 -benchtime=50ms
```

| Workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Partition specs 128/64 | 4.65 us/op | 3.02 us/op | 1.5x |
| Partition specs 1,024/512 | 168 us/op | 21.0 us/op | 8.0x |
| Partition specs 8,192/4,096 | 8.69 ms/op | 183 us/op | 47x |
| Schemas 128/64 | 4.17 us/op | 3.52 us/op | 1.2x |
| Schemas 1,024/512 | 163 us/op | 18.6 us/op | 8.7x |
| Schemas 8,192/4,096 | 8.33 ms/op | 140 us/op | 60x |

The indexed path uses extra memory for the ID set, in exchange for avoiding repeated linear scans. The one-entry cases are not the target workload.

## Tests

- `go test ./table -count=1`
- `go vet ./table`
