### PR TITLE
perf(table): collapse metadata JSON preflight passes

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -346,8 +346,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2292,4 +2293,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -18,7 +18,6 @@
 package table
 
 import (
-	"bytes"
 	"cmp"
 	"encoding/binary"
 	"encoding/json"
@@ -1796,9 +1795,6 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := requirePartitionSpecIDsFromMetadata(metadata); err != nil {
-		return nil, err
-	}
 
 	if err := json.Unmarshal(normalized, ret); err != nil {
 		if errors.Is(err, ErrInvalidMetadata) {
@@ -1826,27 +1822,27 @@ func requirePartitionSpecIDsFromMetadata(metadata map[string]json.RawMessage) er
 		return nil
 	}
 
-	var specs []json.RawMessage
+	var specs []rawPartitionSpec
 	if err := json.Unmarshal(rawSpecs, &specs); err != nil {
 		return fmt.Errorf("%w: invalid partition-specs: %w", ErrInvalidMetadata, err)
 	}
-	for i, rawSpec := range specs {
-		var spec map[string]json.RawMessage
-		if err := json.Unmarshal(rawSpec, &spec); err != nil {
-			return fmt.Errorf("%w: invalid partition spec at index %d: %w", ErrInvalidMetadata, i, err)
-		}
-		rawID, ok := spec["spec-id"]
-		if !ok || bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
+
+	return validatePartitionSpecIDs(specs)
+}
+
+type rawPartitionSpec struct {
+	ID     *int                         `json:"spec-id"`
+	Fields []map[string]json.RawMessage `json:"fields"`
+}
+
+func validatePartitionSpecIDs(specs []rawPartitionSpec) error {
+	for i, spec := range specs {
+		if spec.ID == nil {
 			return fmt.Errorf("%w: partition spec at index %d is missing required spec-id", ErrInvalidMetadata, i)
 		}
 	}
 
 	return nil
-}
-
-type rawPartitionSpec struct {
-	ID     int                          `json:"spec-id"`
-	Fields []map[string]json.RawMessage `json:"fields"`
 }
 
 func assignMissingPartitionFieldIDs(b []byte) ([]byte, error) {
@@ -1870,6 +1866,9 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 			return nil, err
 		}
 		usesSpecList = true
+		if err := validatePartitionSpecIDs(specs); err != nil {
+			return nil, err
+		}
 	} else if rawFields, ok := metadata["partition-spec"]; ok {
 		var fields []map[string]json.RawMessage
 		if err := json.Unmarshal(rawFields, &fields); err != nil {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1766,15 +1766,22 @@ func ParseMetadataString(s string) (Metadata, error) {
 
 // ParseMetadataBytes is like [ParseMetadataString] but for a byte slice.
 func ParseMetadataBytes(b []byte) (Metadata, error) {
-	ver := struct {
-		FormatVersion int `json:"format-version"`
-	}{}
-	if err := json.Unmarshal(b, &ver); err != nil {
+	// Keep the raw top-level object for all preflight checks so it is only
+	// decoded once before the version-specific metadata decode below.
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(b, &metadata); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
 	}
 
+	var formatVersion int
+	if rawVersion, ok := metadata["format-version"]; ok {
+		if err := json.Unmarshal(rawVersion, &formatVersion); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+		}
+	}
+
 	var ret Metadata
-	switch ver.FormatVersion {
+	switch formatVersion {
 	case 1:
 		ret = &metadataV1{}
 	case 2:
@@ -1785,11 +1792,11 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 		return nil, ErrInvalidMetadataFormatVersion
 	}
 
-	normalized, err := assignMissingPartitionFieldIDs(b)
+	normalized, err := assignMissingPartitionFieldIDsFromMetadata(b, metadata)
 	if err != nil {
 		return nil, err
 	}
-	if err := requirePartitionSpecIDs(normalized); err != nil {
+	if err := requirePartitionSpecIDsFromMetadata(metadata); err != nil {
 		return nil, err
 	}
 
@@ -1810,6 +1817,10 @@ func requirePartitionSpecIDs(b []byte) error {
 		return fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
 	}
 
+	return requirePartitionSpecIDsFromMetadata(metadata)
+}
+
+func requirePartitionSpecIDsFromMetadata(metadata map[string]json.RawMessage) error {
 	rawSpecs, ok := metadata["partition-specs"]
 	if !ok {
 		return nil
@@ -1833,18 +1844,23 @@ func requirePartitionSpecIDs(b []byte) error {
 	return nil
 }
 
+type rawPartitionSpec struct {
+	ID     int                          `json:"spec-id"`
+	Fields []map[string]json.RawMessage `json:"fields"`
+}
+
 func assignMissingPartitionFieldIDs(b []byte) ([]byte, error) {
 	var metadata map[string]json.RawMessage
 	if err := json.Unmarshal(b, &metadata); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
 	}
+
+	return assignMissingPartitionFieldIDsFromMetadata(b, metadata)
+}
+
+func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]json.RawMessage) ([]byte, error) {
 	if err := requireLastUpdatedMS(metadata); err != nil {
 		return nil, err
-	}
-
-	type rawPartitionSpec struct {
-		ID     int                          `json:"spec-id"`
-		Fields []map[string]json.RawMessage `json:"fields"`
 	}
 
 	var specs []rawPartitionSpec

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1803,6 +1803,10 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
 	}
+	if ret.Version() != formatVersion {
+		return nil, fmt.Errorf("%w: preflight selected version %d, decoded version %d",
+			ErrInvalidMetadataFormatVersion, formatVersion, ret.Version())
+	}
 
 	return ret, nil
 }

--- a/table/metadata_internal_test.go
+++ b/table/metadata_internal_test.go
@@ -1315,19 +1315,39 @@ func TestRejectZeroSourceIDInV1LegacyPartitionSpec(t *testing.T) {
 }
 
 func TestRejectsStoredPartitionSpecWithoutID(t *testing.T) {
-	var metadata map[string]any
-	decoder := json.NewDecoder(strings.NewReader(ExampleTableMetadataV2))
-	decoder.UseNumber()
-	require.NoError(t, decoder.Decode(&metadata))
-	specs := metadata["partition-specs"].([]any)
-	delete(specs[0].(map[string]any), "spec-id")
+	for _, tt := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{
+			name: "missing",
+			mutate: func(spec map[string]any) {
+				delete(spec, "spec-id")
+			},
+		},
+		{
+			name: "null",
+			mutate: func(spec map[string]any) {
+				spec["spec-id"] = nil
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var metadata map[string]any
+			decoder := json.NewDecoder(strings.NewReader(ExampleTableMetadataV2))
+			decoder.UseNumber()
+			require.NoError(t, decoder.Decode(&metadata))
+			specs := metadata["partition-specs"].([]any)
+			tt.mutate(specs[0].(map[string]any))
 
-	data, err := json.Marshal(metadata)
-	require.NoError(t, err)
+			data, err := json.Marshal(metadata)
+			require.NoError(t, err)
 
-	_, err = ParseMetadataBytes(data)
-	require.ErrorIs(t, err, ErrInvalidMetadata)
-	assert.ErrorContains(t, err, "missing required spec-id")
+			_, err = ParseMetadataBytes(data)
+			require.ErrorIs(t, err, ErrInvalidMetadata)
+			assert.ErrorContains(t, err, "missing required spec-id")
+		})
+	}
 }
 
 func TestSortOrderNotFound(t *testing.T) {

--- a/table/metadata_preflight_bench_test.go
+++ b/table/metadata_preflight_bench_test.go
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+var metadataParseBenchmarkSink int
+
+func BenchmarkParseMetadataBytes(b *testing.B) {
+	for _, tc := range []struct {
+		name               string
+		schemaCount        int
+		partitionSpecCount int
+		snapshotCount      int
+		propertyCount      int
+	}{
+		{name: "schemas=1/specs=1/snapshots=10", schemaCount: 1, partitionSpecCount: 1, snapshotCount: 10},
+		{name: "schemas=32/specs=32/snapshots=1000", schemaCount: 32, partitionSpecCount: 32, snapshotCount: 1_000, propertyCount: 16},
+		{name: "schemas=256/specs=256/snapshots=10000", schemaCount: 256, partitionSpecCount: 256, snapshotCount: 10_000, propertyCount: 64},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			data := benchmarkMetadataJSON(tc.schemaCount, tc.partitionSpecCount, tc.snapshotCount, tc.propertyCount)
+			if _, err := ParseMetadataBytes(data); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+
+			for range b.N {
+				metadata, err := ParseMetadataBytes(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				metadataParseBenchmarkSink = metadata.Version()
+			}
+		})
+	}
+}
+
+func benchmarkMetadataJSON(schemaCount, partitionSpecCount, snapshotCount, propertyCount int) []byte {
+	const minuteInMS = int64(60_000)
+
+	metadata := map[string]any{
+		"format-version":        2,
+		"table-uuid":            "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+		"location":              "s3://bucket/test/location",
+		"last-sequence-number":  snapshotCount,
+		"last-updated-ms":       int64(snapshotCount+1) * minuteInMS,
+		"last-column-id":        1,
+		"current-schema-id":     schemaCount - 1,
+		"default-spec-id":       0,
+		"last-partition-id":     1000 + partitionSpecCount - 1,
+		"sort-orders":           []any{map[string]any{"order-id": 0, "fields": []any{}}},
+		"default-sort-order-id": 0,
+		"schemas":               benchmarkSchemas(schemaCount),
+		"partition-specs":       benchmarkPartitionSpecs(partitionSpecCount),
+		"properties":            benchmarkMetadataProperties(propertyCount),
+		"snapshots":             benchmarkParseMetadataSnapshots(snapshotCount, minuteInMS),
+		"snapshot-log":          benchmarkParseMetadataSnapshotLogEntries(snapshotCount, minuteInMS),
+		"metadata-log":          []any{map[string]any{"metadata-file": "s3://bucket/metadata/v1.json", "timestamp-ms": int64(0)}},
+		"current-snapshot-id":   int64(snapshotCount),
+		"refs":                  map[string]any{"main": map[string]any{"snapshot-id": int64(snapshotCount), "type": "branch"}},
+	}
+
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func benchmarkSchemas(count int) []any {
+	schemas := make([]any, count)
+	for i := range schemas {
+		schemas[i] = map[string]any{
+			"type":      "struct",
+			"schema-id": i,
+			"fields": []any{map[string]any{
+				"id":       1,
+				"name":     "id",
+				"required": true,
+				"type":     "long",
+			}},
+		}
+	}
+
+	return schemas
+}
+
+func benchmarkPartitionSpecs(count int) []any {
+	specs := make([]any, count)
+	for i := range specs {
+		specs[i] = map[string]any{
+			"spec-id": i,
+			"fields": []any{map[string]any{
+				"name":      "id",
+				"transform": "identity",
+				"source-id": 1,
+				"field-id":  1000 + i,
+			}},
+		}
+	}
+
+	return specs
+}
+
+func benchmarkMetadataProperties(count int) map[string]string {
+	properties := make(map[string]string, count)
+	for i := range count {
+		properties[fmt.Sprintf("property-%d", i)] = "value"
+	}
+
+	return properties
+}
+
+func benchmarkParseMetadataSnapshots(count int, minuteInMS int64) []any {
+	snapshots := make([]any, count)
+	for i := range snapshots {
+		id := int64(i + 1)
+		snapshot := map[string]any{
+			"snapshot-id":     id,
+			"timestamp-ms":    id * minuteInMS,
+			"sequence-number": i + 1,
+			"summary":         map[string]any{"operation": "append"},
+			"manifest-list":   fmt.Sprintf("s3://bucket/manifests/%d.avro", id),
+		}
+		if i > 0 {
+			snapshot["parent-snapshot-id"] = id - 1
+		}
+		snapshots[i] = snapshot
+	}
+
+	return snapshots
+}
+
+func benchmarkParseMetadataSnapshotLogEntries(count int, minuteInMS int64) []any {
+	entries := make([]any, count)
+	for i := range entries {
+		id := int64(i + 1)
+		entries[i] = map[string]any{
+			"snapshot-id":  id,
+			"timestamp-ms": id * minuteInMS,
+		}
+	}
+
+	return entries
+}

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -84,3 +84,16 @@ func TestParseMetadataBytesAssignsMissingPartitionFieldIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMetadataBytesRejectsCaseFoldedFormatVersionCollision(t *testing.T) {
+	data := strings.Replace(
+		ExampleTableMetadataV2,
+		`"format-version": 2,`,
+		`"format-version": 1, "FORMAT-VERSION": 2,`,
+		1,
+	)
+	data = strings.Replace(data, `"last-sequence-number": 34,`, "", 1)
+
+	_, err := ParseMetadataBytes([]byte(data))
+	require.ErrorIs(t, err, ErrInvalidMetadataFormatVersion)
+}

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMetadataBytesAssignsMissingPartitionFieldIDs(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		metadata          string
+		partitionSpecsKey string
+		wantFieldID       int
+		wantLastFieldID   int
+		hasLastFieldID    bool
+	}{
+		{
+			name:              "v1 legacy partition spec",
+			metadata:          ExampleTableMetadataV1,
+			partitionSpecsKey: "partition-spec",
+			wantFieldID:       1000,
+			wantLastFieldID:   1000,
+			hasLastFieldID:    true,
+		},
+		{
+			name:              "v2 partition spec list",
+			metadata:          ExampleTableMetadataV2,
+			partitionSpecsKey: "partition-specs",
+			wantFieldID:       1001,
+			wantLastFieldID:   1001,
+			hasLastFieldID:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var metadata map[string]any
+			decoder := json.NewDecoder(strings.NewReader(tt.metadata))
+			decoder.UseNumber()
+			require.NoError(t, decoder.Decode(&metadata))
+
+			var partitionFields []any
+			if tt.partitionSpecsKey == "partition-spec" {
+				partitionFields = metadata[tt.partitionSpecsKey].([]any)
+			} else {
+				partitionSpecs := metadata[tt.partitionSpecsKey].([]any)
+				partitionSpec := partitionSpecs[0].(map[string]any)
+				partitionFields = partitionSpec["fields"].([]any)
+			}
+			delete(partitionFields[0].(map[string]any), "field-id")
+
+			data, err := json.Marshal(metadata)
+			require.NoError(t, err)
+
+			parsed, err := ParseMetadataBytes(data)
+			require.NoError(t, err)
+			parsedSpec := parsed.PartitionSpec()
+			assert.Equal(t, tt.wantFieldID, parsedSpec.Field(0).FieldID)
+			if !tt.hasLastFieldID {
+				assert.Nil(t, parsed.LastPartitionSpecID())
+			} else {
+				require.NotNil(t, parsed.LastPartitionSpecID())
+				assert.Equal(t, tt.wantLastFieldID, *parsed.LastPartitionSpecID())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Reuse the top-level raw JSON map** in ParseMetadataBytes.
- Use the same map for format-version detection, legacy partition field ID normalization, and required spec-id checks.
- Keep the version-specific metadata decode and existing helper behavior unchanged.
- Added coverage for v1 legacy specs, v2 spec lists, and missing/null spec-id values. 🧪

## Benchmark

Local Apple M1 Pro. The fixture uses 1, 32, and 256 schemas/specs with 10, 1,000, and 10,000 snapshots.

| Case | Before ns/op | After ns/op | ns/op change | Before B/op | After B/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 schema, 1 spec, 10 snapshots | 151,089 | 107,116 | **-29.1%** | 39,381 | 32,994 |
| 32 schemas, 32 specs, 1,000 snapshots | 9,543,420 | 7,189,167 | **-24.7%** | 2,127,197 | 1,887,373 |
| 256 schemas, 256 specs, 10,000 snapshots | 95,382,604 | 69,582,812 | **-27.1%** | 22,700,280 | 20,409,368 |

**Commands:**

- go test ./table -run BenchmarkParseMetadataBytes -benchmem -benchtime=100ms -count=1
- go test ./table -count=1
- go test ./... -run no_such_test -count=1

🚀