### PR TITLE
perf(table): avoid full rune allocation for truncated bounds

### DIFF
--- a/table/internal/truncated_bounds_bench_test.go
+++ b/table/internal/truncated_bounds_bench_test.go
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/apache/iceberg-go"
+)
+
+var (
+	truncateUpperBoundTextBenchmarkSink string
+	truncateVariantBoundBenchmarkSink   [2]iceberg.Literal
+)
+
+func BenchmarkTruncateUpperBoundText(b *testing.B) {
+	for _, tc := range benchmarkTruncatedBoundValues() {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.value)))
+			b.ResetTimer()
+
+			for range b.N {
+				truncateUpperBoundTextBenchmarkSink = TruncateUpperBoundText(tc.value, 16)
+			}
+		})
+	}
+}
+
+func BenchmarkTruncateVariantBoundString(b *testing.B) {
+	for _, tc := range benchmarkTruncatedBoundValues() {
+		b.Run(tc.name, func(b *testing.B) {
+			lower := iceberg.StringLiteral(tc.value)
+			upper := iceberg.StringLiteral(tc.value)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.value)))
+			b.ResetTimer()
+
+			for range b.N {
+				lo, hi := truncateVariantBound(iceberg.PrimitiveTypes.String, lower, upper, 16)
+				truncateVariantBoundBenchmarkSink = [2]iceberg.Literal{lo, hi}
+			}
+		})
+	}
+}
+
+func benchmarkTruncatedBoundValues() []struct {
+	name  string
+	value string
+} {
+	return []struct {
+		name  string
+		value string
+	}{
+		{name: "ascii-32B", value: strings.Repeat("a", 32)},
+		{name: "ascii-1KB", value: strings.Repeat("a", 1024)},
+		{name: "ascii-64KB", value: strings.Repeat("a", 64*1024)},
+		{name: "utf8-32B", value: strings.Repeat("é", 15) + "ab"},
+		{name: "utf8-1KB", value: strings.Repeat("é", 511) + "ab"},
+		{name: "utf8-64KB", value: strings.Repeat("é", 32767) + "ab"},
+		{name: "upper-surrogate-gap", value: strings.Repeat("a", 15) + string('\uD7FF') + "x"},
+		{name: "upper-max-rune-carry", value: strings.Repeat("a", 15) + string(utf8.MaxRune) + "x"},
+		{name: "upper-all-max-runes", value: strings.Repeat(string(utf8.MaxRune), 17)},
+	}
+}

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -528,21 +528,42 @@ func (s *statsAggregator[T]) MaxAsBytes() ([]byte, error) {
 	}
 }
 
-func TruncateUpperBoundText(s string, trunc int) string {
-	if trunc >= utf8.RuneCountInString(s) {
-		return s
-	}
-
-	result := []rune(s)[:trunc]
-	for i := len(result) - 1; i >= 0; i-- {
-		if next, ok := nextValidRune(result[i]); ok {
-			result[i] = next
-
-			return string(result[:i+1])
+// truncateString returns the prefix containing at most width UTF-8 code
+// points. The boolean is true when the input was actually truncated.
+func truncateString(s string, width int) (string, bool) {
+	for idx := range s {
+		if width == 0 {
+			return s[:idx], true
 		}
+
+		width--
 	}
 
-	return ""
+	return s, false
+}
+
+func TruncateUpperBoundText(s string, trunc int) string {
+	result, _ := truncateUpperBoundText(s, trunc)
+
+	return result
+}
+
+func truncateUpperBoundText(s string, trunc int) (string, bool) {
+	result, truncated := truncateString(s, trunc)
+	if !truncated {
+		return s, false
+	}
+
+	for len(result) > 0 {
+		r, size := utf8.DecodeLastRuneInString(result)
+		if next, ok := nextValidRune(r); ok {
+			return result[:len(result)-size] + string(next), true
+		}
+
+		result = result[:len(result)-size]
+	}
+
+	return "", true
 }
 
 func nextValidRune(r rune) (rune, bool) {

--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -578,6 +578,11 @@ func nextValidRune(r rune) (rune, bool) {
 }
 
 func TruncateUpperBoundBinary(val []byte, trunc int) []byte {
+	if trunc < 0 {
+		// A negative width cannot describe a prefix. Keep the original bound
+		// instead of panicking on the slice expression below.
+		return slices.Clone(val)
+	}
 	if trunc >= len(val) {
 		return slices.Clone(val)
 	}

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -78,6 +78,8 @@ func TestTruncateUpperBoundString(t *testing.T) {
 		{name: "preceding scalar", value: "\uD7FEx", truncate: 1, expected: "\uD7FF"},
 		{name: "carry past maximal suffix", value: string([]rune{'a', utf8.MaxRune, utf8.MaxRune, 'x'}), truncate: 3, expected: "b"},
 		{name: "carry to maximal scalar", value: string([]rune{utf8.MaxRune - 1, utf8.MaxRune, 'x'}), truncate: 2, expected: string([]rune{utf8.MaxRune})},
+		{name: "no truncation", value: "ab", truncate: 2, expected: "ab"},
+		{name: "zero width", value: "ab", truncate: 0, expected: ""},
 		// U+10FFFF U+10FFFF NUL has no greater valid Unicode prefix.
 		{name: "all maximal", value: "\xf4\x8f\xbf\xbf\xf4\x8f\xbf\xbf\x00", truncate: 2, expected: ""},
 	}

--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -110,6 +110,7 @@ func TestTruncateUpperBoundBinary(t *testing.T) {
 		{"carry", []byte{0x01, 0x02, 0xff, 0x03}, 3, []byte{0x01, 0x03, 0xff}},
 		{"all ff", []byte{0xff, 0xff, 0x00}, 2, nil},
 		{"no truncation", []byte{0x01, 0x02}, 2, []byte{0x01, 0x02}},
+		{"negative width keeps bound", []byte{0x01, 0x02}, -1, []byte{0x01, 0x02}},
 	}
 
 	for _, tt := range tests {

--- a/table/internal/variant_bounds.go
+++ b/table/internal/variant_bounds.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/decimal"
@@ -219,11 +218,14 @@ func truncateVariantBound(it iceberg.PrimitiveType, lo, hi iceberg.Literal, trun
 	}
 	switch it.(type) {
 	case iceberg.StringType:
-		if s := lo.Any().(string); utf8.RuneCountInString(s) > truncLen {
-			lo = iceberg.StringLiteral(string([]rune(s)[:truncLen]))
+		s := lo.Any().(string)
+		if truncated, ok := truncateString(s, truncLen); ok {
+			lo = iceberg.StringLiteral(strings.Clone(truncated))
 		}
-		if s := hi.Any().(string); utf8.RuneCountInString(s) > truncLen {
-			if up := TruncateUpperBoundText(s, truncLen); up != "" {
+
+		s = hi.Any().(string)
+		if up, truncated := truncateUpperBoundText(s, truncLen); truncated {
+			if up != "" {
 				hi = iceberg.StringLiteral(up)
 			} else {
 				hi = nil

--- a/table/internal/variant_bounds_test.go
+++ b/table/internal/variant_bounds_test.go
@@ -405,6 +405,15 @@ func TestTruncateVariantBound(t *testing.T) {
 			wantUpper: strings.Repeat("a", 7) + "b",
 		},
 		{
+			name:      "unicode string truncates at rune boundaries",
+			typ:       iceberg.PrimitiveTypes.String,
+			lower:     iceberg.NewLiteral("ééé"),
+			upper:     iceberg.NewLiteral("ééé"),
+			truncLen:  2,
+			wantLower: "éé",
+			wantUpper: "éê",
+		},
+		{
 			name:      "string upper dropped when it cannot be incremented",
 			typ:       iceberg.PrimitiveTypes.String,
 			lower:     iceberg.NewLiteral(strings.Repeat("\U0010FFFF", 40)),


### PR DESCRIPTION
## Summary

- **Avoid a full-string rune scan and `[]rune` allocation** when truncating text bounds.
- Walk only to the requested UTF-8 rune boundary.
- Reuse the same path for variant string lower and upper bounds.
- Keep upper-bound carry behavior for the surrogate gap and maximal rune cases.
- Clone only the small truncated lower bound so it does not retain a large source string. ⚡

## Benchmark

Local Apple M1 Pro. `width=16`, `-benchmem`, `-benchtime=100ms`.

| Path | Before | After |
| --- | ---: | ---: |
| `TruncateUpperBoundText`, ASCII 64 KB | ~111,008 ns/op, 262,169 B/op | ~38 ns/op, 16 B/op |
| `TruncateUpperBoundText`, UTF-8 64 KB | ~375,620 ns/op, 139,312 B/op | ~73 ns/op, 32 B/op |
| Variant string bounds, ASCII 64 KB | ~285,109 ns/op, 524,432 B/op | ~169 ns/op, 128 B/op |
| Variant string bounds, UTF-8 64 KB | ~624,216 ns/op, 278,721 B/op | ~236 ns/op, 160 B/op |

The benchmark also covers 32 B and 1 KB values, Unicode boundaries, surrogate-gap carry, maximal-rune carry, and the all-maximal case.

## Tests

- `go test ./table/... -count=1`
- `go test ./... -run "^$" -count=1`
- `go test ./table/internal -run "^$" -bench "^(BenchmarkTruncateUpperBoundText|BenchmarkTruncateVariantBoundString)$" -benchmem -benchtime=100ms -count=1`
