### PR TITLE
perf(table): honor row limits during local planning

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1103,6 +1103,13 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}
+	if scan.canLimitLocalPlanning(acc) {
+		// The manifest counters above describe partition pruning. Keep them
+		// unchanged when a row limit narrows the manifest list afterwards.
+		if limitedManifests, limited := limitManifestListByRows(manifestList, scan.limit); limited {
+			manifestList = limitedManifests
+		}
+	}
 
 	// Step 2: Read manifest entries concurrently, accumulating data and positional deletes.
 	entries, err := scan.collectManifestEntriesWithSchema(ctx, manifestList, schema)
@@ -1176,6 +1183,45 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	acc.applyResultDeleteMetrics(results)
 
 	return results, nil
+}
+
+// canLimitLocalPlanning reports whether the manifest-list row counts are
+// sufficient to safely narrow local planning for this scan. A row filter can
+// remove rows from a data file, and delete manifests can remove rows at read
+// time, so both cases keep the existing full planning path.
+func (scan *Scan) canLimitLocalPlanning(acc *scanMetricsAccumulator) bool {
+	return scan.limit > 0 &&
+		(scan.rowFilter == nil || scan.rowFilter.Equals(iceberg.AlwaysTrue{})) &&
+		acc.totalDeleteManifests == 0
+}
+
+// limitManifestListByRows returns the shortest manifest prefix whose live row
+// counts reach limit. It falls back to the complete list when a count is
+// unknown, overflows, or when every manifest is needed anyway.
+func limitManifestListByRows(manifestList []iceberg.ManifestFile, limit int64) ([]iceberg.ManifestFile, bool) {
+	if limit <= 0 {
+		return manifestList, false
+	}
+
+	remaining := limit
+	for i, manifest := range manifestList {
+		addedRows, existingRows := manifest.AddedRows(), manifest.ExistingRows()
+		if addedRows < 0 || existingRows < 0 || existingRows > math.MaxInt64-addedRows {
+			return manifestList, false
+		}
+
+		rows := addedRows + existingRows
+		if rows >= remaining {
+			if i+1 == len(manifestList) {
+				return manifestList, false
+			}
+
+			return manifestList[:i+1], true
+		}
+		remaining -= rows
+	}
+
+	return manifestList, false
 }
 
 func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1199,7 +1199,7 @@ func (scan *Scan) canLimitLocalPlanning(acc *scanMetricsAccumulator) bool {
 // counts reach limit. It falls back to the complete list when a count is
 // unknown, overflows, or when every manifest is needed anyway.
 func limitManifestListByRows(manifestList []iceberg.ManifestFile, limit int64) ([]iceberg.ManifestFile, bool) {
-	if limit <= 0 {
+	if limit <= 0 || len(manifestList) < 2 {
 		return manifestList, false
 	}
 

--- a/table/scanner_row_limit_bench_test.go
+++ b/table/scanner_row_limit_bench_test.go
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+var rowLimitPlanningBenchmarkSink int
+
+func BenchmarkPlanFilesWithRowLimit(b *testing.B) {
+	for _, manifestCount := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("manifests=%d/no-limit", manifestCount), func(b *testing.B) {
+			tbl := newRowLimitPlanningBenchmarkTable(b, manifestCount)
+			scan := tbl.Scan(WithMaxConcurrency(1))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				tasks, err := scan.PlanFiles(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				}
+				rowLimitPlanningBenchmarkSink = len(tasks)
+			}
+		})
+
+		b.Run(fmt.Sprintf("manifests=%d/limit-1", manifestCount), func(b *testing.B) {
+			tbl := newRowLimitPlanningBenchmarkTable(b, manifestCount)
+			scan := tbl.Scan(WithMaxConcurrency(1)).UseRowLimit(1)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				tasks, err := scan.PlanFiles(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				}
+				rowLimitPlanningBenchmarkSink = len(tasks)
+			}
+		})
+	}
+}
+
+func newRowLimitPlanningBenchmarkTable(b testing.TB, manifestCount int) *Table {
+	b.Helper()
+
+	fs := newTrackingIO()
+	schema := simpleSchema()
+	const tableLocation = "mem://row-limit-benchmark"
+
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, tableLocation, nil)
+	require.NoError(b, err)
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(b, err)
+
+	const snapshotID = int64(1)
+	manifests := make([]iceberg.ManifestFile, 0, manifestCount)
+	for i := range manifestCount {
+		manifestPath := fmt.Sprintf("%s/metadata/manifest-%d.avro", tableLocation, i)
+		dataPath := fmt.Sprintf("%s/data-%d.parquet", tableLocation, i)
+		manifests = append(manifests, writeRowLimitPlanningBenchmarkManifest(
+			b, fs, schema, snapshotID, 1, manifestPath, dataPath))
+	}
+
+	manifestListPath := tableLocation + "/metadata/snap-1.avro"
+	var listBuf bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(b, iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0, manifests))
+	require.NoError(b, fs.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	schemaID := meta.CurrentSchema().ID
+	require.NoError(b, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		ManifestList:   manifestListPath,
+		Summary:        &Summary{Operation: OpAppend},
+		SchemaID:       &schemaID,
+	}))
+	require.NoError(b, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	built, err := builder.Build()
+	require.NoError(b, err)
+
+	return New(Identifier{"db", "row-limit-benchmark"}, built, tableLocation+"/metadata/metadata.json", testFSF(fs), nil)
+}
+
+func writeRowLimitPlanningBenchmarkManifest(
+	b testing.TB,
+	fs *trackingIO,
+	schema *iceberg.Schema,
+	snapshotID, sequenceNumber int64,
+	manifestPath, dataPath string,
+) iceberg.ManifestFile {
+	b.Helper()
+
+	spec := iceberg.NewPartitionSpec()
+	dataFile, err := iceberg.NewDataFileBuilder(
+		spec, iceberg.EntryContentData, dataPath, iceberg.ParquetFile,
+		nil, nil, nil, 1, 1024,
+	)
+	require.NoError(b, err)
+
+	entry := iceberg.NewManifestEntryBuilder(iceberg.EntryStatusADDED, &snapshotID, dataFile.Build()).
+		SequenceNum(sequenceNumber).
+		Build()
+
+	var manifestBuf bytes.Buffer
+	_, err = iceberg.WriteManifest(manifestPath, &manifestBuf, 2, spec, schema, snapshotID,
+		[]iceberg.ManifestEntry{entry})
+	require.NoError(b, err)
+	require.NoError(b, fs.WriteFile(manifestPath, manifestBuf.Bytes()))
+
+	return iceberg.NewManifestFile(2, manifestPath, int64(manifestBuf.Len()), 0, snapshotID).
+		SequenceNum(sequenceNumber, sequenceNumber).
+		AddedFiles(1).
+		AddedRows(1).
+		Build()
+}

--- a/table/scanner_row_limit_test.go
+++ b/table/scanner_row_limit_test.go
@@ -76,6 +76,15 @@ func TestLimitManifestListByRows(t *testing.T) {
 			wantLimited: true,
 		},
 		{
+			name: "single manifest does not narrow",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 5, 0),
+			},
+			limit:       1,
+			wantPaths:   []string{"manifest-1"},
+			wantLimited: false,
+		},
+		{
 			name: "unknown count after prefix does not block limit",
 			manifests: []iceberg.ManifestFile{
 				rowCountManifest("manifest-1", 5, 0),

--- a/table/scanner_row_limit_test.go
+++ b/table/scanner_row_limit_test.go
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rowCountManifest(path string, addedRows, existingRows int64) iceberg.ManifestFile {
+	return iceberg.NewManifestFile(3, path, 1, 0, 1).
+		AddedRows(addedRows).
+		ExistingRows(existingRows).
+		Build()
+}
+
+func TestLimitManifestListByRows(t *testing.T) {
+	tests := []struct {
+		name        string
+		manifests   []iceberg.ManifestFile
+		limit       int64
+		wantPaths   []string
+		wantLimited bool
+	}{
+		{
+			name: "first manifest reaches limit",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 8, 4),
+				rowCountManifest("manifest-2", 2, 0),
+			},
+			limit:       10,
+			wantPaths:   []string{"manifest-1"},
+			wantLimited: true,
+		},
+		{
+			name: "cumulative counts reach limit",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 2, 1),
+				rowCountManifest("manifest-2", 3, 2),
+				rowCountManifest("manifest-3", 4, 0),
+			},
+			limit:       8,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: true,
+		},
+		{
+			name: "zero row manifests are retained in prefix",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 0, 0),
+				rowCountManifest("manifest-2", 5, 0),
+				rowCountManifest("manifest-3", 1, 0),
+			},
+			limit:       5,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: true,
+		},
+		{
+			name: "unknown count after prefix does not block limit",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 5, 0),
+				rowCountManifest("manifest-2", -1, 0),
+			},
+			limit:       3,
+			wantPaths:   []string{"manifest-1"},
+			wantLimited: true,
+		},
+		{
+			name: "unknown count before prefix falls back",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", -1, 0),
+				rowCountManifest("manifest-2", 5, 0),
+			},
+			limit:       3,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+		{
+			name: "negative existing count falls back",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 5, -1),
+				rowCountManifest("manifest-2", 5, 0),
+			},
+			limit:       3,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+		{
+			name: "row count overflow falls back",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", math.MaxInt64, 1),
+				rowCountManifest("manifest-2", 5, 0),
+			},
+			limit:       3,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+		{
+			name: "limit needs all manifests",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 2, 0),
+				rowCountManifest("manifest-2", 3, 0),
+			},
+			limit:       5,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+		{
+			name: "total rows are below limit",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 2, 0),
+				rowCountManifest("manifest-2", 1, 0),
+			},
+			limit:       5,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+		{
+			name: "zero and negative limits do not narrow",
+			manifests: []iceberg.ManifestFile{
+				rowCountManifest("manifest-1", 5, 0),
+				rowCountManifest("manifest-2", 5, 0),
+			},
+			limit:       0,
+			wantPaths:   []string{"manifest-1", "manifest-2"},
+			wantLimited: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, limited := limitManifestListByRows(tt.manifests, tt.limit)
+			require.Equal(t, tt.wantLimited, limited)
+			require.Len(t, got, len(tt.wantPaths))
+			for i, path := range tt.wantPaths {
+				assert.Equal(t, path, got[i].FilePath())
+			}
+		})
+	}
+
+	negativeLimit := int64(-1)
+	manifests := []iceberg.ManifestFile{rowCountManifest("manifest-1", 5, 0)}
+	got, limited := limitManifestListByRows(manifests, negativeLimit)
+	require.False(t, limited)
+	require.Equal(t, manifests, got)
+}
+
+func TestCanLimitLocalPlanning(t *testing.T) {
+	tests := []struct {
+		name             string
+		limit            int64
+		rowFilter        iceberg.BooleanExpression
+		totalDeleteFiles int64
+		want             bool
+	}{
+		{name: "positive limit and no filter", limit: 10, rowFilter: iceberg.AlwaysTrue{}, want: true},
+		{name: "nil filter", limit: 10, want: true},
+		{name: "no limit", limit: ScanNoLimit, rowFilter: iceberg.AlwaysTrue{}, want: false},
+		{name: "zero limit", limit: 0, rowFilter: iceberg.AlwaysTrue{}, want: false},
+		{
+			name:      "row filter",
+			limit:     10,
+			rowFilter: iceberg.EqualTo(iceberg.Reference("id"), int32(1)),
+			want:      false,
+		},
+		{
+			name:             "delete manifests",
+			limit:            10,
+			rowFilter:        iceberg.AlwaysTrue{},
+			totalDeleteFiles: 1,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scan := &Scan{limit: tt.limit, rowFilter: tt.rowFilter}
+			acc := &scanMetricsAccumulator{totalDeleteManifests: tt.totalDeleteFiles}
+			assert.Equal(t, tt.want, scan.canLimitLocalPlanning(acc))
+		})
+	}
+}
+
+func TestPlanFilesLocalUsesRowLimitToStopOpeningManifests(t *testing.T) {
+	fs := newTrackingCallsIO()
+	schema := simpleSchema()
+	const tableLocation = "mem://row-limit"
+
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, tableLocation,
+		iceberg.Properties{PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	const snapshotID = int64(1)
+	manifestPaths := []string{
+		tableLocation + "/metadata/manifest-1.avro",
+		tableLocation + "/metadata/manifest-2.avro",
+		tableLocation + "/metadata/manifest-3.avro",
+	}
+	manifests := make([]iceberg.ManifestFile, 0, len(manifestPaths))
+	for i, manifestPath := range manifestPaths {
+		dataPath := fmt.Sprintf("%s/data-%d.parquet", tableLocation, i+1)
+		manifests = append(manifests, writeManifest(t, fs.trackingIO, snapshotID, int64(i+1), manifestPath, dataPath))
+	}
+	manifestListPath := tableLocation + "/metadata/snap-1.avro"
+	writeManifestList(t, fs.trackingIO, snapshotID, manifestListPath, manifests)
+
+	schemaID := meta.CurrentSchema().ID
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		ManifestList:   manifestListPath,
+		Summary:        &Summary{Operation: OpAppend},
+		SchemaID:       &schemaID,
+	}))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	built, err := builder.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "row-limit"}, built, tableLocation+"/metadata/metadata.json", testFSF(fs), nil)
+	tasks, err := tbl.Scan(WithMaxConcurrency(1)).UseRowLimit(2).PlanFiles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	assert.Equal(t, 1, fs.openCount[manifestListPath])
+	assert.Equal(t, 1, fs.openCount[manifestPaths[0]])
+	assert.Equal(t, 1, fs.openCount[manifestPaths[1]])
+	assert.Zero(t, fs.openCount[manifestPaths[2]])
+}


### PR DESCRIPTION
## Summary

- **Use manifest-list row counts to stop local planning after enough rows are covered.**
- Keep the existing full planner for row filters, delete manifests, unknown counts, overflow, and limits that need the full list.
- Keep exact row-limit enforcement in the record reader.
- Add boundary tests, a manifest-open regression test, and a planning benchmark. ⚡

## Why

With no row filter and no delete manifests, all live rows in the selected data manifests are returned. The manifest list already has the live row counts, so local planning can stop opening manifests once the requested minimum is covered.

## Benchmark

**Machine:** Apple M1 Pro, arm64
**Setup:** in-memory v2 table, one data file and one row per manifest, max concurrency 1
**Command:** `go test ./table -run ^ -bench ^BenchmarkPlanFilesWithRowLimit -benchmem -benchtime=100ms -count=1`

`no-limit` is the full-planning control. `limit-1` means `UseRowLimit(1)`.

| Manifests | No limit | `UseRowLimit(1)` |
| ---: | ---: | ---: |
| 100 | 23.5 ms/op, 27.5 MB/op | 403 µs/op, 514 KB/op |
| 1,000 | 188.5 ms/op, 273.2 MB/op | 785 µs/op, 910 KB/op |
| 10,000 | 1.73 s/op, 2.73 GB/op | 4.71 ms/op, 5.19 MB/op |

The 10,000-manifest case is about **368x faster** with about **525x fewer allocated bytes**. 📈

## Tests

- `go test ./table/... -count=1`
- `go test -race ./table -run 'Test(LimitManifestListByRows|CanLimitLocalPlanning|PlanFilesLocalUsesRowLimitToStopOpeningManifests)$' -count=1`
- `go test ./... -run '^$' -count=1`
- `go vet ./table`