### PR TITLE
perf(table): cache compiled filter and pruning plans

### DIFF
--- a/table/arrow_filter_plan.go
+++ b/table/arrow_filter_plan.go
@@ -169,6 +169,7 @@ func (v *physicalSchemaKeyVisitor) Schema(_ *iceberg.Schema, _ struct{}) struct{
 func (v *physicalSchemaKeyVisitor) Struct(_ iceberg.StructType, _ []struct{}) struct{} {
 	return struct{}{}
 }
+
 func (v *physicalSchemaKeyVisitor) Field(_ iceberg.NestedField, _ struct{}) struct{} {
 	return struct{}{}
 }

--- a/table/arrow_filter_plan.go
+++ b/table/arrow_filter_plan.go
@@ -56,6 +56,13 @@ func (p *compiledFileFilterPlan) recordProcessor(ctx context.Context) recProcess
 }
 
 func (p *compiledFileFilterPlan) statsEvaluator() func(*metadata.RowGroupMetaData, []int) (bool, error) {
+	// Passing an AlwaysTrue evaluator still allocates fresh metric maps for
+	// every row group. A nil evaluator has the same keep-all semantics and lets
+	// the Parquet reader take its no-pruning path.
+	if p == nil || p.statsFilter == nil || p.statsFilter.Equals(iceberg.AlwaysTrue{}) {
+		return nil
+	}
+
 	return newParquetRowGroupStatsEvaluatorFromRewritten(p.statsFilter, false)
 }
 

--- a/table/arrow_filter_plan.go
+++ b/table/arrow_filter_plan.go
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/apache/arrow-go/v18/arrow/compute/exprs"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/iceberg-go"
+	tblutils "github.com/apache/iceberg-go/table/internal"
+	"github.com/apache/iceberg-go/table/substrait"
+	"github.com/substrait-io/substrait-go/v8/expr"
+)
+
+// compiledFileFilterPlan contains immutable work derived from one Iceberg
+// filter and one physical file schema. Row-group stats evaluators are created
+// from statsFilter for each file because inclusiveMetricsEval stores mutable
+// per-row-group maps.
+type compiledFileFilterPlan struct {
+	statsFilter iceberg.BooleanExpression
+	bloomPreds  []tblutils.RowGroupBloomPred
+
+	recordFilter      expr.Expression
+	extensionRegistry *expr.ExtensionRegistry
+	dropFile          bool
+}
+
+func (p *compiledFileFilterPlan) recordProcessor(ctx context.Context) recProcessFn {
+	if p == nil || p.recordFilter == nil {
+		return nil
+	}
+
+	ctx = exprs.WithExtensionIDSet(ctx, exprs.NewExtensionSetDefault(*p.extensionRegistry))
+
+	return filterRecords(ctx, p.recordFilter)
+}
+
+func (p *compiledFileFilterPlan) statsEvaluator() func(*metadata.RowGroupMetaData, []int) (bool, error) {
+	return newParquetRowGroupStatsEvaluatorFromRewritten(p.statsFilter, false)
+}
+
+type compiledFileFilterPlans struct {
+	record  *compiledFileFilterPlan
+	pruning *compiledFileFilterPlan
+}
+
+type compiledFileFilterPlanCache struct {
+	mu    sync.RWMutex
+	plans map[string]*compiledFileFilterPlans
+}
+
+// cachedFileFilterPlans returns plans for the scan's fixed filter(s). The
+// schema string is a structural key: the schema ID is intentionally omitted
+// because files from different schema versions can share the same physical
+// layout and use the same compiled plan. Pruning plans are only built when the
+// caller is reading a format that supports Parquet row-group pruning.
+func (as *arrowScan) cachedFileFilterPlans(fileSchema *iceberg.Schema, includePruning bool) (*compiledFileFilterPlans, error) {
+	if fileSchema == nil {
+		return nil, fmt.Errorf("%w: cannot compile a filter plan for a nil file schema", iceberg.ErrInvalidArgument)
+	}
+
+	key, err := physicalSchemaKey(fileSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	as.filterPlanCache.mu.RLock()
+	plans, ok := as.filterPlanCache.plans[key]
+	if ok && (!includePruning || plans.pruning != nil) {
+		as.filterPlanCache.mu.RUnlock()
+
+		return plans, nil
+	}
+	as.filterPlanCache.mu.RUnlock()
+
+	as.filterPlanCache.mu.Lock()
+	defer as.filterPlanCache.mu.Unlock()
+
+	plans, ok = as.filterPlanCache.plans[key]
+	if as.filterPlanCache.plans == nil {
+		as.filterPlanCache.plans = make(map[string]*compiledFileFilterPlans)
+	}
+
+	if !ok {
+		sharePruning := includePruning && as.rowGroupFilter == nil
+		record, err := compileFileFilterPlan(fileSchema, as.boundRowFilter, as.caseSensitive, true, sharePruning)
+		if err != nil {
+			return nil, err
+		}
+		plans = &compiledFileFilterPlans{record: record}
+		if sharePruning {
+			plans.pruning = record
+		}
+		as.filterPlanCache.plans[key] = plans
+	}
+	if !includePruning || plans.pruning != nil {
+		return plans, nil
+	}
+
+	pruningFilter := as.rowGroupFilter
+	if pruningFilter == nil {
+		pruningFilter = as.boundRowFilter
+	}
+
+	logicalSchema := as.filterSchema
+	if logicalSchema == nil {
+		logicalSchema = as.projectedSchema
+	}
+	hasMissingDefault, err := pruningFilterHasMissingInitialDefault(
+		pruningFilter, logicalSchema, fileSchema)
+	if err != nil {
+		return nil, err
+	}
+	if hasMissingDefault {
+		// TranslateColumnNames treats fields missing from the physical file as
+		// null. That is unsafe for an initial default, so keep pruning disabled
+		// just as the uncached path does.
+		pruningFilter = iceberg.AlwaysTrue{}
+	}
+
+	pruning, err := compileFileFilterPlan(fileSchema, pruningFilter, as.caseSensitive, false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	plans.pruning = pruning
+
+	return plans, nil
+}
+
+func physicalSchemaKey(fileSchema *iceberg.Schema) (string, error) {
+	// The key includes field names, IDs, requiredness, and type details. Schema
+	// IDs, docs, and defaults do not affect filter translation or compilation.
+	visitor := &physicalSchemaKeyVisitor{}
+	_, err := iceberg.Visit(fileSchema, visitor)
+	if err != nil {
+		return "", fmt.Errorf("%w: cannot encode physical schema key: %v", iceberg.ErrInvalidSchema, err)
+	}
+
+	return visitor.builder.String(), nil
+}
+
+type physicalSchemaKeyVisitor struct {
+	builder strings.Builder
+	depth   int
+}
+
+func (v *physicalSchemaKeyVisitor) Schema(_ *iceberg.Schema, _ struct{}) struct{} { return struct{}{} }
+func (v *physicalSchemaKeyVisitor) Struct(_ iceberg.StructType, _ []struct{}) struct{} {
+	return struct{}{}
+}
+func (v *physicalSchemaKeyVisitor) Field(_ iceberg.NestedField, _ struct{}) struct{} {
+	return struct{}{}
+}
+func (v *physicalSchemaKeyVisitor) List(_ iceberg.ListType, _ struct{}) struct{}  { return struct{}{} }
+func (v *physicalSchemaKeyVisitor) Map(_ iceberg.MapType, _, _ struct{}) struct{} { return struct{}{} }
+func (v *physicalSchemaKeyVisitor) Primitive(_ iceberg.PrimitiveType) struct{}    { return struct{}{} }
+func (v *physicalSchemaKeyVisitor) Variant(_ iceberg.VariantType) struct{}        { return struct{}{} }
+
+func (v *physicalSchemaKeyVisitor) BeforeField(field iceberg.NestedField) {
+	if v.depth == 0 {
+		writePhysicalFieldKey(&v.builder, field)
+	}
+	v.depth++
+}
+
+func (v *physicalSchemaKeyVisitor) AfterField(_ iceberg.NestedField) { v.depth-- }
+
+func (v *physicalSchemaKeyVisitor) BeforeListElement(_ iceberg.NestedField) { v.depth++ }
+func (v *physicalSchemaKeyVisitor) AfterListElement(_ iceberg.NestedField)  { v.depth-- }
+func (v *physicalSchemaKeyVisitor) BeforeMapKey(_ iceberg.NestedField)      { v.depth++ }
+func (v *physicalSchemaKeyVisitor) AfterMapKey(_ iceberg.NestedField)       { v.depth-- }
+func (v *physicalSchemaKeyVisitor) BeforeMapValue(_ iceberg.NestedField)    { v.depth++ }
+func (v *physicalSchemaKeyVisitor) AfterMapValue(_ iceberg.NestedField)     { v.depth-- }
+
+func writePhysicalFieldKey(builder *strings.Builder, field iceberg.NestedField) {
+	builder.WriteByte('f')
+	writePhysicalInt(builder, field.ID)
+	writePhysicalString(builder, field.Name)
+	if field.Required {
+		builder.WriteByte('1')
+	} else {
+		builder.WriteByte('0')
+	}
+	writePhysicalTypeKey(builder, field.Type)
+}
+
+func writePhysicalTypeKey(builder *strings.Builder, typ iceberg.Type) {
+	switch t := typ.(type) {
+	case *iceberg.StructType:
+		builder.WriteByte('s')
+		builder.WriteByte('{')
+		for _, field := range t.FieldList {
+			writePhysicalFieldKey(builder, field)
+		}
+		builder.WriteByte('}')
+	case *iceberg.ListType:
+		builder.WriteByte('l')
+		writePhysicalInt(builder, t.ElementID)
+		if t.ElementRequired {
+			builder.WriteByte('1')
+		} else {
+			builder.WriteByte('0')
+		}
+		writePhysicalTypeKey(builder, t.Element)
+	case *iceberg.MapType:
+		builder.WriteByte('m')
+		writePhysicalInt(builder, t.KeyID)
+		writePhysicalTypeKey(builder, t.KeyType)
+		writePhysicalInt(builder, t.ValueID)
+		if t.ValueRequired {
+			builder.WriteByte('1')
+		} else {
+			builder.WriteByte('0')
+		}
+		writePhysicalTypeKey(builder, t.ValueType)
+	case nil:
+		builder.WriteString("n")
+	default:
+		builder.WriteByte('p')
+		writePhysicalString(builder, typ.String())
+	}
+}
+
+func writePhysicalInt(builder *strings.Builder, value int) {
+	var buf [20]byte
+	builder.Write(strconv.AppendInt(buf[:0], int64(value), 10))
+	builder.WriteByte(':')
+}
+
+func writePhysicalString(builder *strings.Builder, value string) {
+	writePhysicalInt(builder, len(value))
+	builder.WriteString(value)
+	builder.WriteByte(':')
+}
+
+func compileFileFilterPlan(
+	fileSchema *iceberg.Schema,
+	rowFilter iceberg.BooleanExpression,
+	caseSensitive, includeRecordFilter, includePruning bool,
+) (*compiledFileFilterPlan, error) {
+	if rowFilter == nil {
+		rowFilter = iceberg.AlwaysTrue{}
+	}
+
+	translatedFilter, err := iceberg.TranslateColumnNames(rowFilter, fileSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	boundFilter := translatedFilter
+	if !translatedFilter.Equals(iceberg.AlwaysFalse{}) {
+		boundFilter, err = iceberg.BindExpr(fileSchema, translatedFilter, caseSensitive)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	plan := &compiledFileFilterPlan{}
+	if includePruning {
+		statsFilter, err := iceberg.RewriteNotExpr(boundFilter)
+		if err != nil {
+			return nil, err
+		}
+		bloomPreds, err := newBloomFilterPredicatesFromRewritten(statsFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		plan.statsFilter = statsFilter
+		plan.bloomPreds = bloomPreds
+	}
+	if !includeRecordFilter {
+		return plan, nil
+	}
+	if boundFilter.Equals(iceberg.AlwaysFalse{}) {
+		plan.dropFile = true
+
+		return plan, nil
+	}
+	if boundFilter.Equals(iceberg.AlwaysTrue{}) {
+		return plan, nil
+	}
+
+	extSet, recordFilter, err := substrait.ConvertExpr(fileSchema, boundFilter, caseSensitive)
+	if err != nil {
+		return nil, err
+	}
+	plan.recordFilter = recordFilter
+	plan.extensionRegistry = extSet
+
+	return plan, nil
+}

--- a/table/arrow_filter_plan_test.go
+++ b/table/arrow_filter_plan_test.go
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompiledFileFilterPlansReusePhysicalSchema(t *testing.T) {
+	physicalFields := []iceberg.NestedField{{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	}}
+	firstSchema := iceberg.NewSchema(1, physicalFields...)
+	secondSchema := iceberg.NewSchema(2, physicalFields...)
+	filter, err := iceberg.BindExpr(firstSchema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	scan := &arrowScan{
+		boundRowFilter: filter,
+		caseSensitive:  true,
+	}
+	first, err := scan.cachedFileFilterPlans(firstSchema, true)
+	require.NoError(t, err)
+	second, err := scan.cachedFileFilterPlans(secondSchema, true)
+	require.NoError(t, err)
+
+	assert.Same(t, first, second)
+	assert.Same(t, first.record, first.pruning)
+	assert.Len(t, scan.filterPlanCache.plans, 1)
+}
+
+func TestCompiledFileFilterPlansSeparatePhysicalTypes(t *testing.T) {
+	int32Schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,
+	})
+	int64Schema := iceberg.NewSchema(2, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	filter, err := iceberg.BindExpr(int64Schema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	scan := &arrowScan{
+		boundRowFilter:  filter,
+		rowGroupFilter:  filter,
+		filterSchema:    int64Schema,
+		projectedSchema: int64Schema,
+		caseSensitive:   true,
+	}
+	int32Plans, err := scan.cachedFileFilterPlans(int32Schema, true)
+	require.NoError(t, err)
+	int64Plans, err := scan.cachedFileFilterPlans(int64Schema, true)
+	require.NoError(t, err)
+
+	assert.NotSame(t, int32Plans, int64Plans)
+	assert.Len(t, scan.filterPlanCache.plans, 2)
+	require.Len(t, int32Plans.pruning.bloomPreds, 1)
+	require.Len(t, int64Plans.pruning.bloomPreds, 1)
+	assert.Equal(t, []byte{1, 0, 0, 0}, int32Plans.pruning.bloomPreds[0].PhysBytes[0])
+	assert.Equal(t, []byte{1, 0, 0, 0, 0, 0, 0, 0}, int64Plans.pruning.bloomPreds[0].PhysBytes[0])
+}
+
+func TestPhysicalSchemaKeyIncludesNestedFieldIDs(t *testing.T) {
+	firstSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "items", Type: &iceberg.ListType{
+			ElementID:       2,
+			Element:         iceberg.PrimitiveTypes.Int64,
+			ElementRequired: false,
+		},
+	})
+	secondSchema := iceberg.NewSchema(2, iceberg.NestedField{
+		ID: 1, Name: "items", Type: &iceberg.ListType{
+			ElementID:       3,
+			Element:         iceberg.PrimitiveTypes.Int64,
+			ElementRequired: false,
+		},
+	})
+
+	firstKey, err := physicalSchemaKey(firstSchema)
+	require.NoError(t, err)
+	secondKey, err := physicalSchemaKey(secondSchema)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, firstKey, secondKey)
+}
+
+func TestCompiledFileFilterPlansConcurrent(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "value", Type: iceberg.PrimitiveTypes.String},
+	)
+	filter, err := iceberg.BindExpr(schema, iceberg.NewAnd(
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+		iceberg.NotEqualTo(iceberg.Reference("value"), "ignored"),
+	), true)
+	require.NoError(t, err)
+
+	scan := &arrowScan{boundRowFilter: filter, caseSensitive: true}
+	const workerCount = 32
+	results := make([]struct {
+		plans *compiledFileFilterPlans
+		err   error
+	}, workerCount)
+
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for i := range workerCount {
+		go func(i int) {
+			defer wg.Done()
+			results[i].plans, results[i].err = scan.cachedFileFilterPlans(schema, true)
+		}(i)
+	}
+	wg.Wait()
+
+	for _, result := range results {
+		require.NoError(t, result.err)
+		require.Same(t, results[0].plans, result.plans)
+	}
+	assert.Len(t, scan.filterPlanCache.plans, 1)
+}
+
+func TestCompiledFileFilterPlansBuildPruningLazily(t *testing.T) {
+	schema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	filter, err := iceberg.BindExpr(schema,
+		iceberg.EqualTo(iceberg.Reference("id"), int64(1)), true)
+	require.NoError(t, err)
+
+	scan := &arrowScan{
+		boundRowFilter: filter,
+		rowGroupFilter: filter,
+		caseSensitive:  true,
+	}
+	plans, err := scan.cachedFileFilterPlans(schema, false)
+	require.NoError(t, err)
+	assert.Nil(t, plans.pruning)
+
+	plans, err = scan.cachedFileFilterPlans(schema, true)
+	require.NoError(t, err)
+	assert.NotNil(t, plans.pruning)
+}
+
+func TestCompiledFileFilterPlansDisablePruningForMissingInitialDefault(t *testing.T) {
+	fileSchema := iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	logicalSchema := iceberg.NewSchema(2,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{
+			ID: 2, Name: "flag", Type: iceberg.PrimitiveTypes.Int32,
+			InitialDefault: int32(1),
+		},
+	)
+	filter, err := iceberg.BindExpr(logicalSchema, iceberg.NewAnd(
+		iceberg.GreaterThan(iceberg.Reference("id"), int64(5)),
+		iceberg.NotNull(iceberg.Reference("flag")),
+	), true)
+	require.NoError(t, err)
+
+	scan := &arrowScan{
+		rowGroupFilter:  filter,
+		projectedSchema: logicalSchema,
+		caseSensitive:   true,
+	}
+	plans, err := scan.cachedFileFilterPlans(fileSchema, true)
+	require.NoError(t, err)
+
+	assert.True(t, plans.pruning.statsFilter.Equals(iceberg.AlwaysTrue{}))
+	assert.Empty(t, plans.pruning.bloomPreds)
+}

--- a/table/arrow_filter_plan_test.go
+++ b/table/arrow_filter_plan_test.go
@@ -50,6 +50,12 @@ func TestCompiledFileFilterPlansReusePhysicalSchema(t *testing.T) {
 	assert.Len(t, scan.filterPlanCache.plans, 1)
 }
 
+func TestCompiledFileFilterPlanSkipsAlwaysTrueStatsEvaluator(t *testing.T) {
+	plan := &compiledFileFilterPlan{statsFilter: iceberg.AlwaysTrue{}}
+
+	assert.Nil(t, plan.statsEvaluator())
+}
+
 func TestCompiledFileFilterPlansSeparatePhysicalTypes(t *testing.T) {
 	int32Schema := iceberg.NewSchema(1, iceberg.NestedField{
 		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true,

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -788,11 +788,12 @@ type arrowScan struct {
 	// rowGroupFilter is used only for Parquet statistics and bloom-filter
 	// pruning. It lets callers keep boundRowFilter as AlwaysTrue while they
 	// must evaluate the real row filter after position-dependent enrichment.
-	rowGroupFilter iceberg.BooleanExpression
-	filterSchema   *iceberg.Schema
-	caseSensitive  bool
-	rowLimit       int64
-	options        iceberg.Properties
+	rowGroupFilter  iceberg.BooleanExpression
+	filterSchema    *iceberg.Schema
+	caseSensitive   bool
+	rowLimit        int64
+	options         iceberg.Properties
+	filterPlanCache compiledFileFilterPlanCache
 
 	useLargeTypes bool
 	concurrency   int
@@ -953,32 +954,20 @@ func (as *arrowScan) getRecordFilter(ctx context.Context, fileSchema *iceberg.Sc
 		return nil, false, nil
 	}
 
-	translatedFilter, err := iceberg.TranslateColumnNames(rowFilter, fileSchema)
+	plan, err := compileFileFilterPlan(fileSchema, rowFilter, as.caseSensitive, true, false)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if translatedFilter.Equals(iceberg.AlwaysFalse{}) {
-		return nil, true, nil
+	return plan.recordProcessor(ctx), plan.dropFile, nil
+}
+
+func (as *arrowScan) getRecordFilterFromPlan(ctx context.Context, plan *compiledFileFilterPlan) (recProcessFn, bool, error) {
+	if plan == nil {
+		return nil, false, nil
 	}
 
-	translatedFilter, err = iceberg.BindExpr(fileSchema, translatedFilter, as.caseSensitive)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if !translatedFilter.Equals(iceberg.AlwaysTrue{}) {
-		extSet, recordFilter, err := substrait.ConvertExpr(fileSchema, translatedFilter, as.caseSensitive)
-		if err != nil {
-			return nil, false, err
-		}
-
-		ctx = exprs.WithExtensionIDSet(ctx, exprs.NewExtensionSetDefault(*extSet))
-
-		return filterRecords(ctx, recordFilter), false, nil
-	}
-
-	return nil, false, nil
+	return plan.recordProcessor(ctx), plan.dropFile, nil
 }
 
 type filterBindingState struct {
@@ -1310,6 +1299,21 @@ func (as *arrowScan) processRecords(
 	pipeline []recProcessFn,
 	posSource *rowPositionSource,
 	out chan<- enumeratedRecord,
+) error {
+	return as.processRecordsWithPlans(ctx, task, fileSchema, rowFilter, rdr, columns, pipeline, posSource, out, nil)
+}
+
+func (as *arrowScan) processRecordsWithPlans(
+	ctx context.Context,
+	task tblutils.Enumerated[FileScanTask],
+	fileSchema *iceberg.Schema,
+	rowFilter iceberg.BooleanExpression,
+	rdr tblutils.FileReader,
+	columns []int,
+	pipeline []recProcessFn,
+	posSource *rowPositionSource,
+	out chan<- enumeratedRecord,
+	plans *compiledFileFilterPlans,
 ) (err error) {
 	var (
 		testRowGroups any
@@ -1331,47 +1335,55 @@ func (as *arrowScan) processRecords(
 	// stays enabled.
 	switch {
 	case task.Value.File.FileFormat() == iceberg.ParquetFile:
-		logicalSchema := as.filterSchema
-		if logicalSchema == nil {
-			logicalSchema = as.projectedSchema
-		}
+		var tester *tblutils.ParquetRowGroupTester
+		if plans != nil && plans.pruning != nil {
+			tester = &tblutils.ParquetRowGroupTester{
+				StatsFn:    plans.pruning.statsEvaluator(),
+				BloomPreds: plans.pruning.bloomPreds,
+			}
+		} else {
+			logicalSchema := as.filterSchema
+			if logicalSchema == nil {
+				logicalSchema = as.projectedSchema
+			}
 
-		hasMissingDefault, err := pruningFilterHasMissingInitialDefault(
-			pruningFilter, logicalSchema, fileSchema)
-		if err != nil {
-			return err
-		}
-		if hasMissingDefault {
-			// TranslateColumnNames treats fields missing from the physical file
-			// as null. That is unsafe for fields added with a non-null
-			// initial-default because Iceberg materializes the default on read.
-			// Keep the actual row filter, but conservatively skip early pruning.
-			pruningFilter = iceberg.AlwaysTrue{}
-		}
+			hasMissingDefault, err := pruningFilterHasMissingInitialDefault(
+				pruningFilter, logicalSchema, fileSchema)
+			if err != nil {
+				return err
+			}
+			if hasMissingDefault {
+				// TranslateColumnNames treats fields missing from the physical file
+				// as null. That is unsafe for fields added with a non-null
+				// initial-default because Iceberg materializes the default on read.
+				// Keep the actual row filter, but conservatively skip early pruning.
+				pruningFilter = iceberg.AlwaysTrue{}
+			}
 
-		filePruningFilter, err := iceberg.TranslateColumnNames(pruningFilter, fileSchema)
-		if err != nil {
-			return err
-		}
+			filePruningFilter, err := iceberg.TranslateColumnNames(pruningFilter, fileSchema)
+			if err != nil {
+				return err
+			}
 
-		filePruningFilter, err = iceberg.BindExpr(fileSchema, filePruningFilter, as.caseSensitive)
-		if err != nil {
-			return err
-		}
+			filePruningFilter, err = iceberg.BindExpr(fileSchema, filePruningFilter, as.caseSensitive)
+			if err != nil {
+				return err
+			}
 
-		statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, filePruningFilter, false)
-		if err != nil {
-			return err
-		}
+			statsFn, err := newParquetRowGroupStatsEvaluator(fileSchema, filePruningFilter, false)
+			if err != nil {
+				return err
+			}
 
-		bloomPreds, err := newBloomFilterPredicates(filePruningFilter)
-		if err != nil {
-			return err
-		}
+			bloomPreds, err := newBloomFilterPredicates(filePruningFilter)
+			if err != nil {
+				return err
+			}
 
-		tester := &tblutils.ParquetRowGroupTester{
-			StatsFn:    statsFn,
-			BloomPreds: bloomPreds,
+			tester = &tblutils.ParquetRowGroupTester{
+				StatsFn:    statsFn,
+				BloomPreds: bloomPreds,
+			}
 		}
 		if posSource != nil {
 			tester.Survivors = &posSource.spans
@@ -1471,12 +1483,13 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 	}()
 
 	var (
-		rowFilter  iceberg.BooleanExpression
-		rdr        tblutils.FileReader
-		iceSchema  *iceberg.Schema
-		colIndices []int
-		filterFunc recProcessFn
-		dropFile   bool
+		rowFilter   iceberg.BooleanExpression
+		rdr         tblutils.FileReader
+		iceSchema   *iceberg.Schema
+		colIndices  []int
+		filterFunc  recProcessFn
+		dropFile    bool
+		filterPlans *compiledFileFilterPlans
 	)
 
 	rowFilter, err = as.rowFilterForTask(task.Value)
@@ -1489,6 +1502,13 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 		return err
 	}
 	defer iceinternal.CheckedClose(rdr, &err)
+	if task.Value.Residual == nil {
+		filterPlans, err = as.cachedFileFilterPlans(
+			iceSchema, task.Value.File.FileFormat() == iceberg.ParquetFile)
+		if err != nil {
+			return err
+		}
+	}
 
 	pipeline := make([]recProcessFn, 0, 4)
 
@@ -1561,7 +1581,11 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 		pipeline = append(pipeline, eqFn)
 	}
 
-	filterFunc, dropFile, err = as.getRecordFilter(ctx, iceSchema, rowFilter)
+	if filterPlans != nil {
+		filterFunc, dropFile, err = as.getRecordFilterFromPlan(ctx, filterPlans.record)
+	} else {
+		filterFunc, dropFile, err = as.getRecordFilter(ctx, iceSchema, rowFilter)
+	}
 	if err != nil {
 		return err
 	}
@@ -1592,7 +1616,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task tblutils.Enumerat
 		})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, rowFilter, rdr, colIndices, pipeline, posSource, out)
+	err = as.processRecordsWithPlans(ctx, task, iceSchema, rowFilter, rdr, colIndices, pipeline, posSource, out, filterPlans)
 
 	return err
 }
@@ -1605,11 +1629,12 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 	}()
 
 	var (
-		rdr        tblutils.FileReader
-		iceSchema  *iceberg.Schema
-		colIndices []int
-		filterFunc recProcessFn
-		dropFile   bool
+		rdr         tblutils.FileReader
+		iceSchema   *iceberg.Schema
+		colIndices  []int
+		filterFunc  recProcessFn
+		dropFile    bool
+		filterPlans *compiledFileFilterPlans
 	)
 
 	iceSchema, colIndices, rdr, err = as.prepareToRead(ctx, task.Value.File, invariants)
@@ -1617,6 +1642,11 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 		return err
 	}
 	defer iceinternal.CheckedClose(rdr, &err)
+	filterPlans, err = as.cachedFileFilterPlans(
+		iceSchema, task.Value.File.FileFormat() == iceberg.ParquetFile)
+	if err != nil {
+		return err
+	}
 
 	fields := append(iceSchema.Fields(), iceberg.PositionalDeleteSchema.Fields()...)
 	enrichedIcebergSchema := iceberg.NewSchema(iceSchema.ID+1, fields...)
@@ -1638,7 +1668,7 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 		pipeline = append(pipeline, processPositionalDeletes(ctx, deletes, posSource.cursor()))
 	}
 
-	filterFunc, dropFile, err = as.getRecordFilter(ctx, iceSchema, as.boundRowFilter)
+	filterFunc, dropFile, err = as.getRecordFilterFromPlan(ctx, filterPlans.record)
 	if err != nil {
 		return err
 	}
@@ -1666,7 +1696,7 @@ func (as *arrowScan) producePosDeletesFromTask(ctx context.Context, task tblutil
 		return ToRequestedSchema(ctx, iceberg.PositionalDeleteSchema, enrichedIcebergSchema, r, SchemaOptions{IncludeFieldIDs: true, UseLargeTypes: as.useLargeTypes})
 	})
 
-	err = as.processRecords(ctx, task, iceSchema, as.boundRowFilter, rdr, colIndices, pipeline, posSource, out)
+	err = as.processRecordsWithPlans(ctx, task, iceSchema, as.boundRowFilter, rdr, colIndices, pipeline, posSource, out, filterPlans)
 
 	return err
 }

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -213,6 +213,55 @@ func benchmarkComplexBoundFilter(b *testing.B, schema *iceberg.Schema) iceberg.B
 	return bound
 }
 
+var benchmarkCompiledFilterPlansSink *compiledFileFilterPlans
+
+func BenchmarkArrowScanFilterPlanSetup(b *testing.B) {
+	schema := benchmarkScanSchema(8)
+	filter := benchmarkComplexBoundFilter(b, schema)
+
+	b.Run("recompile_each_file", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			recordPlan, err := compileFileFilterPlan(schema, filter, true, true, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			pruningPlan, err := compileFileFilterPlan(schema, filter, true, false, true)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkCompiledFilterPlansSink = &compiledFileFilterPlans{
+				record:  recordPlan,
+				pruning: pruningPlan,
+			}
+		}
+	})
+
+	b.Run("cache_hit", func(b *testing.B) {
+		scan := &arrowScan{
+			boundRowFilter:  filter,
+			rowGroupFilter:  filter,
+			filterSchema:    schema,
+			projectedSchema: schema,
+			caseSensitive:   true,
+		}
+		if _, err := scan.cachedFileFilterPlans(schema, true); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			plans, err := scan.cachedFileFilterPlans(schema, true)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkCompiledFilterPlansSink = plans
+		}
+	})
+}
+
 func BenchmarkArrowScanAddTaskProjectedFieldIDs(b *testing.B) {
 	schema := benchmarkScanSchema(8)
 	filter := benchmarkComplexBoundFilter(b, schema)

--- a/table/evaluators.go
+++ b/table/evaluators.go
@@ -749,10 +749,16 @@ func newParquetRowGroupStatsEvaluator(fileSchema *iceberg.Schema, expr iceberg.B
 		return nil, err
 	}
 
+	return newParquetRowGroupStatsEvaluatorFromRewritten(rewritten, includeEmptyFiles), nil
+}
+
+func newParquetRowGroupStatsEvaluatorFromRewritten(
+	expr iceberg.BooleanExpression, includeEmptyFiles bool,
+) func(*metadata.RowGroupMetaData, []int) (bool, error) {
 	return (&inclusiveMetricsEval{
 		includeEmptyFiles: includeEmptyFiles,
-		expr:              rewritten,
-	}).TestRowGroup, nil
+		expr:              expr,
+	}).TestRowGroup
 }
 
 type inclusiveMetricsEval struct {
@@ -1890,5 +1896,13 @@ func newBloomFilterPredicates(expr iceberg.BooleanExpression) ([]internal.RowGro
 		return nil, err
 	}
 
-	return iceberg.VisitExpr(rewritten, &bloomPredicateCollector{})
+	return newBloomFilterPredicatesFromRewritten(rewritten)
+}
+
+func newBloomFilterPredicatesFromRewritten(expr iceberg.BooleanExpression) ([]internal.RowGroupBloomPred, error) {
+	if expr == nil {
+		return nil, nil
+	}
+
+	return iceberg.VisitExpr(expr, &bloomPredicateCollector{})
 }


### PR DESCRIPTION
## Summary

- **Cache Arrow filter setup per physical file schema during one scan.**
- Reuse column translation, binding, Substrait expression conversion, rewritten stats filters, and bloom predicates.
- Keep row-group stats evaluator creation per file because it owns mutable row-group maps.
- Build a fresh record processor for each task context.
- Use a low-allocation structural key that includes nested list/map field IDs.
- Keep residual task filters on the existing path.
- Keep the missing initial-default pruning fallback. Pruning plans are built only for Parquet files. ⚡

## Benchmark

Command:

```text
go test ./table -run '^$' -bench '^BenchmarkArrowScanFilterPlanSetup$' -benchmem -benchtime=1s -count=1
```

Apple M1 Pro, darwin/arm64:

| Case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| recompile_each_file | 22,898 | 18,984 | 414 |
| cache_hit | 1,821 | 1,064 | 8 |

This benchmark isolates repeated filter and pruning setup from file I/O.

## Tests

- `go test ./...`
- `go test -race ./table -run '^TestCompiledFileFilterPlans|TestPhysicalSchemaKey|TestProcessRecords' -count=1`
- `go vet ./...`
