### PR TITLE
perf(table): split parquet scan tasks by byte range

### DIFF
--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1092,11 +1092,11 @@ func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, i
 		return nil, nil, nil, err
 	}
 	keepReader := false
-	defer func() {
+	defer func(reader tblutils.FileReader) {
 		if !keepReader {
-			_ = rdr.Close()
+			_ = reader.Close()
 		}
-	}()
+	}(rdr)
 
 	if !as.cacheFileReadPlan {
 		var fileSchema *arrow.Schema

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -913,15 +913,54 @@ type arrowScan struct {
 	// rowGroupFilter is used only for Parquet statistics and bloom-filter
 	// pruning. It lets callers keep boundRowFilter as AlwaysTrue while they
 	// must evaluate the real row filter after position-dependent enrichment.
-	rowGroupFilter  iceberg.BooleanExpression
-	filterSchema    *iceberg.Schema
-	caseSensitive   bool
-	rowLimit        int64
-	options         iceberg.Properties
-	filterPlanCache compiledFileFilterPlanCache
+	rowGroupFilter    iceberg.BooleanExpression
+	filterSchema      *iceberg.Schema
+	caseSensitive     bool
+	rowLimit          int64
+	options           iceberg.Properties
+	filterPlanCache   compiledFileFilterPlanCache
+	fileReadPlanCache preparedFileReadPlanCache
+	cacheFileReadPlan bool
 
 	useLargeTypes bool
 	concurrency   int
+}
+
+// preparedFileRead contains the physical schema projection shared by all
+// tasks reading the same data file during one scan. The actual FileReader is
+// intentionally not shared: split tasks may run concurrently and each reader
+// owns its column readers and input handle.
+type preparedFileRead struct {
+	schema     *iceberg.Schema
+	colIndices []int
+}
+
+type preparedFileReadEntry struct {
+	once sync.Once
+	plan *preparedFileRead
+	err  error
+}
+
+type preparedFileReadPlanCache struct {
+	mu      sync.Mutex
+	entries map[string]*preparedFileReadEntry
+}
+
+func (c *preparedFileReadPlanCache) entry(path string) *preparedFileReadEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.entries == nil {
+		c.entries = make(map[string]*preparedFileReadEntry)
+	}
+	if entry, ok := c.entries[path]; ok {
+		return entry
+	}
+
+	entry := &preparedFileReadEntry{}
+	c.entries[path] = entry
+
+	return entry
 }
 
 // arrowScanInvariants holds metadata-derived values that cannot change during
@@ -1042,36 +1081,75 @@ type enumeratedRecord struct {
 	Err    error
 }
 
-func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, invariants *arrowScanInvariants) (*iceberg.Schema, []int, tblutils.FileReader, error) {
+func (as *arrowScan) prepareToRead(ctx context.Context, file iceberg.DataFile, invariants *arrowScanInvariants) (iceSchema *iceberg.Schema, colIndices []int, rdr tblutils.FileReader, err error) {
 	src, err := tblutils.GetFile(ctx, as.fs, file, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	rdr, err := src.GetReader(ctx)
+	rdr, err = src.GetReader(ctx)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	keepReader := false
+	defer func() {
+		if !keepReader {
+			_ = rdr.Close()
+		}
+	}()
 
-	fileSchema, colIndices, err := rdr.PrunedSchema(invariants.projectedIDs, invariants.nameMapping)
-	if err != nil {
-		rdr.Close()
+	if !as.cacheFileReadPlan {
+		var fileSchema *arrow.Schema
+		fileSchema, colIndices, err = rdr.PrunedSchema(
+			invariants.projectedIDs, invariants.nameMapping)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 
-		return nil, nil, nil, err
+		iceSchema, err = ArrowSchemaToIcebergWithOptions(fileSchema, ArrowToIcebergOptions{
+			NameMapping:     invariants.nameMapping,
+			TableSchema:     invariants.tableSchema,
+			TableProperties: invariants.tableProperties,
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		keepReader = true
+
+		return iceSchema, colIndices, rdr, nil
 	}
 
-	iceSchema, err := ArrowSchemaToIcebergWithOptions(fileSchema, ArrowToIcebergOptions{
-		NameMapping:     invariants.nameMapping,
-		TableSchema:     invariants.tableSchema,
-		TableProperties: invariants.tableProperties,
+	entry := as.fileReadPlanCache.entry(file.FilePath())
+	entry.once.Do(func() {
+		var fileSchema *arrow.Schema
+		var colIndices []int
+		fileSchema, colIndices, entry.err = rdr.PrunedSchema(
+			invariants.projectedIDs, invariants.nameMapping)
+		if entry.err != nil {
+			return
+		}
+
+		var iceSchema *iceberg.Schema
+		iceSchema, entry.err = ArrowSchemaToIcebergWithOptions(fileSchema, ArrowToIcebergOptions{
+			NameMapping:     invariants.nameMapping,
+			TableSchema:     invariants.tableSchema,
+			TableProperties: invariants.tableProperties,
+		})
+		if entry.err == nil {
+			entry.plan = &preparedFileRead{
+				schema:     iceSchema,
+				colIndices: colIndices,
+			}
+		}
 	})
-	if err != nil {
-		rdr.Close()
-
-		return nil, nil, nil, err
+	if entry.err != nil {
+		return nil, nil, nil, entry.err
 	}
 
-	return iceSchema, colIndices, rdr, nil
+	keepReader = true
+
+	return entry.plan.schema, entry.plan.colIndices, rdr, nil
 }
 
 func (as *arrowScan) getRecordFilter(ctx context.Context, fileSchema *iceberg.Schema, rowFilter iceberg.BooleanExpression) (recProcessFn, bool, error) {
@@ -2010,6 +2088,13 @@ func (as *arrowScan) GetRecords(ctx context.Context, tasks []FileScanTask) (*arr
 
 	if as.rowLimit == 0 {
 		return resultSchema, func(yield func(arrow.RecordBatch, error) bool) {}, nil
+	}
+
+	if len(tasks) > 1 {
+		as.cacheFileReadPlan = true
+		ctx = tblutils.WithParquetMetadataCache(ctx)
+	} else {
+		as.cacheFileReadPlan = false
 	}
 
 	invariants, err := as.scanInvariants(tableProperties)

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1510,6 +1510,14 @@ func (as *arrowScan) processRecordsWithPlans(
 				BloomPreds: bloomPreds,
 			}
 		}
+		// A complete task already reads every row group. Leave its byte range
+		// unset so malformed or legacy row-group offsets cannot change the
+		// historical full-file behavior. Split and remote partial tasks carry
+		// their range through to the reader.
+		if task.Value.Start != 0 || task.Value.Length != task.Value.File.FileSizeBytes() {
+			tester.Start = task.Value.Start
+			tester.Length = task.Value.Length
+		}
 		if posSource != nil {
 			tester.Survivors = &posSource.spans
 		}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1506,6 +1506,26 @@ func (as *arrowScan) processRecords(
 	return as.processRecordsWithPlans(ctx, task, fileSchema, rowFilter, rdr, columns, pipeline, posSource, out, nil)
 }
 
+// adjustParquetTaskRange keeps a planned last range aligned with the physical
+// file when manifest and footer sizes differ. A range that ends at the
+// manifest's file size is the last planned range, so it can safely extend to
+// the physical end or clamp to it without overlapping another task.
+func adjustParquetTaskRange(task FileScanTask, physicalFileSize int64) (start, length int64) {
+	start, length = task.Start, task.Length
+	if task.File == nil || physicalFileSize <= 0 || start < 0 || start > physicalFileSize {
+		return start, length
+	}
+
+	maxLength := physicalFileSize - start
+	manifestFileSize := task.File.FileSizeBytes()
+	lastRange := manifestFileSize >= start && length == manifestFileSize-start
+	if length > maxLength || (lastRange && physicalFileSize != manifestFileSize) {
+		length = maxLength
+	}
+
+	return start, length
+}
+
 func (as *arrowScan) processRecordsWithPlans(
 	ctx context.Context,
 	task tblutils.Enumerated[FileScanTask],
@@ -1596,8 +1616,8 @@ func (as *arrowScan) processRecordsWithPlans(
 		if task.Value.Start != 0 ||
 			(task.Value.Length != 0 && task.Value.Length != task.Value.File.FileSizeBytes()) {
 			tester.RangeSet = true
-			tester.Start = task.Value.Start
-			tester.Length = task.Value.Length
+			tester.Start, tester.Length = adjustParquetTaskRange(task.Value, rdr.SourceFileSize())
+			tester.PlanningSplitOffsets = task.Value.File.SplitOffsets()
 		}
 		if posSource != nil {
 			tester.Survivors = &posSource.spans

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1506,10 +1506,9 @@ func (as *arrowScan) processRecords(
 	return as.processRecordsWithPlans(ctx, task, fileSchema, rowFilter, rdr, columns, pipeline, posSource, out, nil)
 }
 
-// adjustParquetTaskRange keeps a planned last range aligned with the physical
-// file when manifest and footer sizes differ. A range that ends at the
-// manifest's file size is the last planned range, so it can safely extend to
-// the physical end or clamp to it without overlapping another task.
+// adjustParquetTaskRange keeps a planned range within the physical file when
+// manifest and footer sizes differ. It only clamps ranges that run past the
+// physical end; caller-owned task boundaries must never be extended.
 func adjustParquetTaskRange(task FileScanTask, physicalFileSize int64) (start, length int64) {
 	start, length = task.Start, task.Length
 	if task.File == nil || physicalFileSize <= 0 || start < 0 || start > physicalFileSize {
@@ -1517,9 +1516,7 @@ func adjustParquetTaskRange(task FileScanTask, physicalFileSize int64) (start, l
 	}
 
 	maxLength := physicalFileSize - start
-	manifestFileSize := task.File.FileSizeBytes()
-	lastRange := manifestFileSize >= start && length == manifestFileSize-start
-	if length > maxLength || (lastRange && physicalFileSize != manifestFileSize) {
+	if length > maxLength {
 		length = maxLength
 	}
 

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -1512,9 +1512,12 @@ func (as *arrowScan) processRecordsWithPlans(
 		}
 		// A complete task already reads every row group. Leave its byte range
 		// unset so malformed or legacy row-group offsets cannot change the
-		// historical full-file behavior. Split and remote partial tasks carry
-		// their range through to the reader.
-		if task.Value.Start != 0 || task.Value.Length != task.Value.File.FileSizeBytes() {
+		// historical full-file behavior. A zero-value task is also treated as
+		// complete for callers that omit the range. Split and remote partial
+		// tasks carry their range through to the reader.
+		if task.Value.Start != 0 ||
+			(task.Value.Length != 0 && task.Value.Length != task.Value.File.FileSizeBytes()) {
+			tester.RangeSet = true
 			tester.Start = task.Value.Start
 			tester.Length = task.Value.Length
 		}

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -214,7 +214,7 @@ func benchmarkSplitParquetScan(b *testing.B) (Metadata, iceio.IO, []FileScanTask
 
 	idBuilder := array.NewInt64Builder(memory.DefaultAllocator)
 	payloadBuilder := array.NewStringBuilder(memory.DefaultAllocator)
-	for i := int64(0); i < rowCount; i++ {
+	for i := range rowCount {
 		idBuilder.Append(i)
 		payloadBuilder.Append(fmt.Sprintf("payload-%d", i%128))
 	}

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -18,13 +18,17 @@
 package table
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
@@ -187,6 +191,142 @@ func BenchmarkArrowScanManyFilesAndBatches(b *testing.B) {
 			}
 			b.ReportMetric(fileCount, "files/op")
 			b.ReportMetric(fileCount*batchCount, "batches/op")
+		})
+	}
+}
+
+func benchmarkSplitParquetScan(b *testing.B) (Metadata, iceio.IO, []FileScanTask, []FileScanTask, int64) {
+	b.Helper()
+
+	const (
+		rowGroups    = 8
+		rowsPerGroup = 32768
+	)
+	rowCount := int64(rowGroups * rowsPerGroup)
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.PrimitiveTypes.String},
+	)
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	idBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	payloadBuilder := array.NewStringBuilder(memory.DefaultAllocator)
+	for i := int64(0); i < rowCount; i++ {
+		idBuilder.Append(i)
+		payloadBuilder.Append(fmt.Sprintf("payload-%d", i%128))
+	}
+	ids := idBuilder.NewArray()
+	payload := payloadBuilder.NewArray()
+	idBuilder.Release()
+	payloadBuilder.Release()
+	record := array.NewRecordBatch(arrowSchema, []arrow.Array{ids, payload}, rowCount)
+	ids.Release()
+	payload.Release()
+	table := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{record})
+	record.Release()
+	defer table.Release()
+
+	var buf bytes.Buffer
+	writerProps := parquet.NewWriterProperties(
+		parquet.WithStats(true),
+		parquet.WithMaxRowGroupLength(rowsPerGroup),
+	)
+	if err := pqarrow.WriteTable(table, &buf, rowsPerGroup, writerProps, pqarrow.DefaultWriterProps()); err != nil {
+		b.Fatal(err)
+	}
+
+	const path = "mem://split-benchmark/data.parquet"
+	fs := iceio.NewMemFS()
+	if err := fs.WriteFile(path, buf.Bytes()); err != nil {
+		b.Fatal(err)
+	}
+
+	pqReader, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	offsets := make([]int64, pqReader.NumRowGroups())
+	for i := range offsets {
+		offsets[i] = pqReader.MetaData().RowGroup(i).FileOffset()
+	}
+	if err := pqReader.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	dataFileBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		path,
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		rowCount,
+		int64(buf.Len()),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dataFile := dataFileBuilder.SplitOffsets(offsets).Build()
+	fullTask := FileScanTask{File: dataFile, Start: 0, Length: int64(buf.Len())}
+	splitTasks, split := splitParquetScanTask(fullTask, 1)
+	if !split || len(splitTasks) != rowGroups {
+		b.Fatalf("expected one split task per row group, got %d", len(splitTasks))
+	}
+
+	metadata, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://split-benchmark", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return metadata, fs, []FileScanTask{fullTask}, splitTasks, rowCount
+}
+
+func BenchmarkArrowScanLargeParquetFileSplitTasks(b *testing.B) {
+	metadata, fs, fullTasks, splitTasks, wantRows := benchmarkSplitParquetScan(b)
+
+	for _, tc := range []struct {
+		name  string
+		tasks []FileScanTask
+	}{
+		{name: "one_task", tasks: fullTasks},
+		{name: "row_group_tasks", tasks: splitTasks},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(tc.tasks)), "tasks/op")
+			b.ResetTimer()
+			for b.Loop() {
+				scan := &arrowScan{
+					fs:              fs,
+					metadata:        metadata,
+					scanSchema:      metadata.CurrentSchema(),
+					projectedSchema: metadata.CurrentSchema(),
+					boundRowFilter:  iceberg.AlwaysTrue{},
+					rowLimit:        -1,
+					concurrency:     8,
+				}
+				_, records, err := scan.GetRecords(context.Background(), tc.tasks)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				var rows int64
+				for record, err := range records {
+					if err != nil {
+						b.Fatal(err)
+					}
+					rows += record.NumRows()
+					record.Release()
+				}
+				if rows != wantRows {
+					b.Fatalf("unexpected row count: got %d, want %d", rows, wantRows)
+				}
+			}
 		})
 	}
 }

--- a/table/arrow_scanner_bench_test.go
+++ b/table/arrow_scanner_bench_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -238,8 +239,10 @@ func benchmarkSplitParquetScan(b *testing.B) (Metadata, iceio.IO, []FileScanTask
 		b.Fatal(err)
 	}
 
-	const path = "mem://split-benchmark/data.parquet"
-	fs := iceio.NewMemFS()
+	// MemFS intentionally returns a copy from Open. Use a local file here so
+	// B/op measures scanner allocations instead of one full-file copy per task.
+	path := filepath.Join(b.TempDir(), "data.parquet")
+	fs := iceio.LocalFS{}
 	if err := fs.WriteFile(path, buf.Bytes()); err != nil {
 		b.Fatal(err)
 	}

--- a/table/internal/export_test.go
+++ b/table/internal/export_test.go
@@ -21,5 +21,5 @@ import "github.com/apache/arrow-go/v18/parquet/pqarrow"
 
 // WrapParquetFileReader exposes wrapPqArrowReader for testing.
 func WrapParquetFileReader(fr *pqarrow.FileReader) FileReader {
-	return wrapPqArrowReader{fr}
+	return wrapPqArrowReader{FileReader: fr}
 }

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -127,7 +127,7 @@ func (parquetFormat) Open(ctx context.Context, fs iceio.IO, path string) (_ File
 		return nil, err
 	}
 
-	return wrapPqArrowReader{arrRdr}, nil
+	return wrapPqArrowReader{FileReader: arrRdr}, nil
 }
 
 func (parquetFormat) PathToIDMapping(sc *iceberg.Schema) (map[string]int, error) {
@@ -1822,6 +1822,7 @@ type RowGroupSpan struct {
 
 type wrapPqArrowReader struct {
 	*pqarrow.FileReader
+	rowGroupInfos []parquetRowGroupInfo
 }
 
 func (w wrapPqArrowReader) Metadata() Metadata {
@@ -1861,6 +1862,19 @@ func parquetRowGroupSplitOffset(rgMeta *metadata.RowGroupMetaData) int64 {
 	}
 
 	return rgMeta.FileOffset()
+}
+
+func parquetRowGroupInfos(rdr *file.Reader) []parquetRowGroupInfo {
+	result := make([]parquetRowGroupInfo, rdr.NumRowGroups())
+	for i := range result {
+		rgMeta := rdr.MetaData().RowGroup(i)
+		result[i] = parquetRowGroupInfo{
+			splitOffset: parquetRowGroupSplitOffset(rgMeta),
+			numRows:     rgMeta.NumRows(),
+		}
+	}
+
+	return result
 }
 
 func validateParquetRowGroupRange(fileSize, start, length int64) error {
@@ -1918,15 +1932,31 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 		rgList = make([]int, 0)
 		var firstRowPos int64
 		for rg := range numRg {
-			rgMeta := fileMeta.RowGroup(rg)
-			numRows := rgMeta.NumRows()
 			pos := firstRowPos
+			var (
+				rgMeta  *metadata.RowGroupMetaData
+				numRows int64
+				offset  int64
+			)
+			if len(w.rowGroupInfos) == numRg {
+				info := w.rowGroupInfos[rg]
+				numRows = info.numRows
+				offset = info.splitOffset
+			} else {
+				rgMeta = fileMeta.RowGroup(rg)
+				numRows = rgMeta.NumRows()
+			}
 			firstRowPos += numRows
 
 			use := true
 			if rangeSet {
-				offset := parquetRowGroupSplitOffset(rgMeta)
+				if len(w.rowGroupInfos) != numRg {
+					offset = parquetRowGroupSplitOffset(rgMeta)
+				}
 				use = offset >= rangeStart && offset < rangeEnd
+			}
+			if use && (rowGroupTester.StatsFn != nil || bfReader != nil) && rgMeta == nil {
+				rgMeta = fileMeta.RowGroup(rg)
 			}
 			if use && rowGroupTester.StatsFn != nil {
 				var err error
@@ -2042,10 +2072,42 @@ func (pfs *ParquetFileSource) GetReader(ctx context.Context) (result FileReader,
 		}
 	}()
 
-	rdr, err := file.NewParquetReader(pf,
-		file.WithReadProps(parquet.NewReaderProperties(pfs.mem)))
-	if err != nil {
-		return nil, err
+	readProps := parquet.NewReaderProperties(pfs.mem)
+	var rdr *file.Reader
+	var rowGroupInfos []parquetRowGroupInfo
+	if cache := parquetMetadataCacheFromContext(ctx); cache != nil {
+		entry := cache.entry(parquetMetadataCacheKey{
+			path: pfs.file.FilePath(),
+			size: pfs.file.FileSizeBytes(),
+		})
+
+		var parsed *file.Reader
+		entry.once.Do(func() {
+			parsed, entry.err = file.NewParquetReader(pf, file.WithReadProps(readProps))
+			if entry.err == nil {
+				entry.fileMetadata = parsed.MetaData()
+				entry.rowGroupInfos = parquetRowGroupInfos(parsed)
+			}
+		})
+		if entry.err != nil {
+			return nil, entry.err
+		}
+		rowGroupInfos = entry.rowGroupInfos
+
+		if parsed != nil {
+			rdr = parsed
+		} else {
+			rdr, err = file.NewParquetReader(pf,
+				file.WithMetadata(entry.fileMetadata), file.WithReadProps(readProps))
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		rdr, err = file.NewParquetReader(pf, file.WithReadProps(readProps))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	props := TablePropertiesFromContext(ctx)
@@ -2064,7 +2126,7 @@ func (pfs *ParquetFileSource) GetReader(ctx context.Context) (result FileReader,
 		return nil, err
 	}
 
-	result = wrapPqArrowReader{fr}
+	result = wrapPqArrowReader{FileReader: fr, rowGroupInfos: rowGroupInfos}
 
 	return result, nil
 }

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1806,6 +1806,11 @@ type ParquetRowGroupTester struct {
 	// When RangeSet is true, Start and Length select row groups whose absolute
 	// Parquet row-group offset falls in [Start, Start+Length).
 	Start, Length int64
+	// PlanningSplitOffsets contains the split offsets used when the scan task
+	// was planned. When it contains one valid offset per row group, range
+	// selection uses these offsets instead of re-deriving them from the opened
+	// Parquet footer. Sparse split-offset lists fall back to the footer offsets.
+	PlanningSplitOffsets []int64
 	// Survivors, if non-nil, is reset and then filled with one span per row group
 	// that survives pruning, in file order, with positions relative to the full
 	// file. It lets callers reconstruct each emitted row's original position even
@@ -1887,6 +1892,20 @@ func validateParquetRowGroupRange(fileSize, start, length int64) error {
 	return nil
 }
 
+func validParquetRowGroupOffsets(offsets []int64, numRowGroups int, fileSize int64) bool {
+	if len(offsets) != numRowGroups {
+		return false
+	}
+
+	for i, offset := range offsets {
+		if offset < 0 || offset >= fileSize || (i > 0 && offset <= offsets[i-1]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester any) (array.RecordReader, error) {
 	var rowGroupTester *ParquetRowGroupTester
 
@@ -1898,8 +1917,7 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 		}
 	}
 
-	rangeSet := rowGroupTester != nil &&
-		(rowGroupTester.RangeSet || rowGroupTester.Start != 0 || rowGroupTester.Length != 0)
+	rangeSet := rowGroupTester != nil && rowGroupTester.RangeSet
 	if rangeSet {
 		if err := validateParquetRowGroupRange(
 			w.SourceFileSize(), rowGroupTester.Start, rowGroupTester.Length); err != nil {
@@ -1912,6 +1930,10 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 		rowGroupTester.StatsFn != nil || len(rowGroupTester.BloomPreds) > 0) {
 		fileMeta := w.ParquetReader().MetaData()
 		numRg := w.ParquetReader().NumRowGroups()
+		planningOffsets := rowGroupTester.PlanningSplitOffsets
+		if !validParquetRowGroupOffsets(planningOffsets, numRg, w.SourceFileSize()) {
+			planningOffsets = nil
+		}
 
 		var (
 			fieldIDToColIdx map[int]int
@@ -1950,7 +1972,9 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 
 			use := true
 			if rangeSet {
-				if len(w.rowGroupInfos) != numRg {
+				if planningOffsets != nil {
+					offset = planningOffsets[rg]
+				} else if len(w.rowGroupInfos) != numRg {
 					offset = parquetRowGroupSplitOffset(rgMeta)
 				}
 				use = offset >= rangeStart && offset < rangeEnd

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1799,6 +1799,12 @@ type RowGroupBloomPred struct {
 type ParquetRowGroupTester struct {
 	StatsFn    func(*metadata.RowGroupMetaData, []int) (bool, error)
 	BloomPreds []RowGroupBloomPred // nil = no bloom filter pass
+	// Start and Length, when Length is positive, select row groups whose
+	// absolute Parquet row-group offset falls in [Start, Start+Length). A
+	// non-positive Length keeps the historical behavior of reading the whole
+	// file, which is useful for callers that construct a tester without a scan
+	// task.
+	Start, Length int64
 	// Survivors, if non-nil, is reset and then filled with one span per row group
 	// that survives pruning, in file order, with positions relative to the full
 	// file. It lets callers reconstruct each emitted row's original position even
@@ -1845,7 +1851,8 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 	}
 
 	var rgList []int
-	if rowGroupTester != nil && (rowGroupTester.StatsFn != nil || len(rowGroupTester.BloomPreds) > 0) {
+	if rowGroupTester != nil && (rowGroupTester.Length > 0 ||
+		rowGroupTester.StatsFn != nil || len(rowGroupTester.BloomPreds) > 0) {
 		fileMeta := w.ParquetReader().MetaData()
 		numRg := w.ParquetReader().NumRowGroups()
 
@@ -1872,7 +1879,12 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 			firstRowPos += numRows
 
 			use := true
-			if rowGroupTester.StatsFn != nil {
+			if rowGroupTester.Length > 0 {
+				end := rowGroupTester.Start + rowGroupTester.Length
+				use = rowGroupTester.Start >= 0 && end > rowGroupTester.Start &&
+					rgMeta.FileOffset() >= rowGroupTester.Start && rgMeta.FileOffset() < end
+			}
+			if use && rowGroupTester.StatsFn != nil {
 				var err error
 				use, err = rowGroupTester.StatsFn(rgMeta, cols)
 				if err != nil {

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1799,11 +1799,12 @@ type RowGroupBloomPred struct {
 type ParquetRowGroupTester struct {
 	StatsFn    func(*metadata.RowGroupMetaData, []int) (bool, error)
 	BloomPreds []RowGroupBloomPred // nil = no bloom filter pass
-	// Start and Length, when Length is positive, select row groups whose
-	// absolute Parquet row-group offset falls in [Start, Start+Length). A
-	// non-positive Length keeps the historical behavior of reading the whole
-	// file, which is useful for callers that construct a tester without a scan
-	// task.
+	// RangeSet indicates that Start and Length came from an explicit scan task.
+	// Without it, the zero value keeps the historical full-file behavior for
+	// callers that construct a tester only for row-group pruning.
+	RangeSet bool
+	// When RangeSet is true, Start and Length select row groups whose absolute
+	// Parquet row-group offset falls in [Start, Start+Length).
 	Start, Length int64
 	// Survivors, if non-nil, is reset and then filled with one span per row group
 	// that survives pruning, in file order, with positions relative to the full
@@ -1862,6 +1863,16 @@ func parquetRowGroupSplitOffset(rgMeta *metadata.RowGroupMetaData) int64 {
 	return rgMeta.FileOffset()
 }
 
+func validateParquetRowGroupRange(fileSize, start, length int64) error {
+	if start < 0 || length <= 0 || start > fileSize || length > fileSize-start {
+		return fmt.Errorf(
+			"%w: invalid parquet row-group range: start=%d, length=%d, file size=%d",
+			iceberg.ErrInvalidArgument, start, length, fileSize)
+	}
+
+	return nil
+}
+
 func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester any) (array.RecordReader, error) {
 	var rowGroupTester *ParquetRowGroupTester
 
@@ -1873,8 +1884,17 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 		}
 	}
 
+	rangeSet := rowGroupTester != nil &&
+		(rowGroupTester.RangeSet || rowGroupTester.Start != 0 || rowGroupTester.Length != 0)
+	if rangeSet {
+		if err := validateParquetRowGroupRange(
+			w.SourceFileSize(), rowGroupTester.Start, rowGroupTester.Length); err != nil {
+			return nil, err
+		}
+	}
+
 	var rgList []int
-	if rowGroupTester != nil && (rowGroupTester.Length > 0 ||
+	if rowGroupTester != nil && (rangeSet ||
 		rowGroupTester.StatsFn != nil || len(rowGroupTester.BloomPreds) > 0) {
 		fileMeta := w.ParquetReader().MetaData()
 		numRg := w.ParquetReader().NumRowGroups()
@@ -1895,7 +1915,6 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 
 		rangeStart := rowGroupTester.Start
 		rangeEnd := rangeStart + rowGroupTester.Length
-		validRange := rangeStart >= 0 && rangeEnd > rangeStart
 		rgList = make([]int, 0)
 		var firstRowPos int64
 		for rg := range numRg {
@@ -1905,9 +1924,9 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 			firstRowPos += numRows
 
 			use := true
-			if rowGroupTester.Length > 0 {
+			if rangeSet {
 				offset := parquetRowGroupSplitOffset(rgMeta)
-				use = validRange && offset >= rangeStart && offset < rangeEnd
+				use = offset >= rangeStart && offset < rangeEnd
 			}
 			if use && rowGroupTester.StatsFn != nil {
 				var err error

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -1839,6 +1839,29 @@ func (w wrapPqArrowReader) PrunedSchema(projectedIDs map[int]struct{}, mapping i
 	return pruneParquetColumns(w.Manifest, projectedIDs, false, mapping)
 }
 
+// parquetRowGroupSplitOffset returns the same first-page offset used when
+// DataFileStatistics.SplitOffsets is built. RowGroup.file_offset is optional
+// in Parquet and Arrow returns zero when it is absent, so relying on it can
+// discard every row group in a split task from an otherwise valid file.
+func parquetRowGroupSplitOffset(rgMeta *metadata.RowGroupMetaData) int64 {
+	if rgMeta.NumColumns() > 0 {
+		if firstColumn, err := rgMeta.ColumnChunk(0); err == nil {
+			dataOffset := firstColumn.DataPageOffset()
+			if firstColumn.HasDictionaryPage() {
+				dictOffset := firstColumn.DictionaryPageOffset()
+				if dictOffset >= 0 && (dataOffset < 0 || dictOffset < dataOffset) {
+					return dictOffset
+				}
+			}
+			if dataOffset >= 0 {
+				return dataOffset
+			}
+		}
+	}
+
+	return rgMeta.FileOffset()
+}
+
 func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester any) (array.RecordReader, error) {
 	var rowGroupTester *ParquetRowGroupTester
 
@@ -1870,6 +1893,9 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 			*rowGroupTester.Survivors = (*rowGroupTester.Survivors)[:0]
 		}
 
+		rangeStart := rowGroupTester.Start
+		rangeEnd := rangeStart + rowGroupTester.Length
+		validRange := rangeStart >= 0 && rangeEnd > rangeStart
 		rgList = make([]int, 0)
 		var firstRowPos int64
 		for rg := range numRg {
@@ -1880,9 +1906,8 @@ func (w wrapPqArrowReader) GetRecords(ctx context.Context, cols []int, tester an
 
 			use := true
 			if rowGroupTester.Length > 0 {
-				end := rowGroupTester.Start + rowGroupTester.Length
-				use = rowGroupTester.Start >= 0 && end > rowGroupTester.Start &&
-					rgMeta.FileOffset() >= rowGroupTester.Start && rgMeta.FileOffset() < end
+				offset := parquetRowGroupSplitOffset(rgMeta)
+				use = validRange && offset >= rangeStart && offset < rangeEnd
 			}
 			if use && rowGroupTester.StatsFn != nil {
 				var err error

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -2231,6 +2231,7 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 		name          string
 		start         int64
 		length        int64
+		rangeSet      bool
 		bloomPreds    []internal.RowGroupBloomPred
 		wantRows      int64
 		wantSurvivors []internal.RowGroupSpan
@@ -2239,6 +2240,7 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 			name:          "first row group",
 			start:         offsets[0],
 			length:        offsets[1] - offsets[0],
+			rangeSet:      true,
 			wantRows:      rgSize,
 			wantSurvivors: []internal.RowGroupSpan{{FirstRowPos: 0, NumRows: rgSize}},
 		},
@@ -2246,13 +2248,15 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 			name:          "second row group",
 			start:         offsets[1],
 			length:        int64(len(data)) - offsets[1],
+			rangeSet:      true,
 			wantRows:      rgSize,
 			wantSurvivors: []internal.RowGroupSpan{{FirstRowPos: rgSize, NumRows: rgSize}},
 		},
 		{
-			name:   "range and bloom pruning combine",
-			start:  offsets[0],
-			length: offsets[1] - offsets[0],
+			name:     "range and bloom pruning combine",
+			start:    offsets[0],
+			length:   offsets[1] - offsets[0],
+			rangeSet: true,
 			bloomPreds: []internal.RowGroupBloomPred{{
 				FieldID: 1, PhysBytes: [][]byte{int32PhysBytes(150)},
 			}},
@@ -2262,6 +2266,14 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 			name:          "whole file range",
 			start:         offsets[0],
 			length:        int64(len(data)) - offsets[0],
+			rangeSet:      true,
+			wantRows:      2 * rgSize,
+			wantSurvivors: nil,
+		},
+		{
+			name:          "nonzero range fields without explicit range keep legacy behavior",
+			start:         offsets[0],
+			length:        offsets[1] - offsets[0],
 			wantRows:      2 * rgSize,
 			wantSurvivors: nil,
 		},
@@ -2282,6 +2294,7 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 			tester := &internal.ParquetRowGroupTester{
 				StatsFn:    alwaysKeep,
 				BloomPreds: tt.bloomPreds,
+				RangeSet:   tt.rangeSet,
 				Start:      tt.start,
 				Length:     tt.length,
 				Survivors:  &survivors,
@@ -2310,14 +2323,13 @@ func TestParquetRowGroupRangeSelectionRejectsInvalidRanges(t *testing.T) {
 		return true, nil
 	}
 	tests := []struct {
-		name     string
-		start    int64
-		length   int64
-		rangeSet bool
+		name   string
+		start  int64
+		length int64
 	}{
 		{name: "negative start", start: -1, length: 1},
 		{name: "zero length", start: firstOffset, length: 0},
-		{name: "zero length at file start", start: 0, length: 0, rangeSet: true},
+		{name: "zero length at file start", start: 0, length: 0},
 		{name: "negative length", start: 0, length: -1},
 		{name: "start beyond file", start: fileSize + 1, length: 1},
 		{name: "length beyond file", start: firstOffset, length: fileSize - firstOffset + 1},
@@ -2331,13 +2343,93 @@ func TestParquetRowGroupRangeSelectionRejectsInvalidRanges(t *testing.T) {
 
 			tester := &internal.ParquetRowGroupTester{
 				StatsFn:  alwaysKeep,
-				RangeSet: tt.rangeSet,
+				RangeSet: true,
 				Start:    tt.start,
 				Length:   tt.length,
 			}
 			rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
 			assert.Nil(t, rr)
 			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+		})
+	}
+}
+
+func TestParquetRowGroupRangeSelectionUsesPlanningOffsets(t *testing.T) {
+	const rgSize = 100
+	alwaysKeep := func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) {
+		return true, nil
+	}
+
+	data := buildBloomTestParquet(t, rgSize)
+	pqReader, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	meta := pqReader.MetaData()
+	actualOffsets := make([]int64, meta.NumRowGroups())
+	for i := range actualOffsets {
+		rg := meta.RowGroup(i)
+		column, columnErr := rg.ColumnChunk(0)
+		require.NoError(t, columnErr)
+		actualOffsets[i] = column.DataPageOffset()
+		if column.HasDictionaryPage() && column.DictionaryPageOffset() < actualOffsets[i] {
+			actualOffsets[i] = column.DictionaryPageOffset()
+		}
+	}
+	require.Less(t, actualOffsets[1]+1, int64(len(data)))
+	require.NoError(t, pqReader.Close())
+
+	// A writer may record a row-group split offset that differs from the
+	// first data page offset used by the reader. The planning offsets must win
+	// when they are complete, otherwise a boundary can move a row group into
+	// the wrong split.
+	planningOffsets := append([]int64(nil), actualOffsets...)
+	planningOffsets[1]++
+
+	splitReader, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	arrReader, err := pqarrow.NewFileReader(
+		splitReader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+	rdr := internal.WrapParquetFileReader(arrReader)
+	defer rdr.Close()
+
+	tests := []struct {
+		name      string
+		start     int64
+		length    int64
+		wantRows  int64
+		wantSpans []internal.RowGroupSpan
+	}{
+		{
+			name:      "first planned range",
+			start:     0,
+			length:    planningOffsets[1],
+			wantRows:  rgSize,
+			wantSpans: []internal.RowGroupSpan{{FirstRowPos: 0, NumRows: rgSize}},
+		},
+		{
+			name:      "second planned range",
+			start:     planningOffsets[1],
+			length:    int64(len(data)) - planningOffsets[1],
+			wantRows:  rgSize,
+			wantSpans: []internal.RowGroupSpan{{FirstRowPos: rgSize, NumRows: rgSize}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var survivors []internal.RowGroupSpan
+			tester := &internal.ParquetRowGroupTester{
+				StatsFn:              alwaysKeep,
+				RangeSet:             true,
+				Start:                tt.start,
+				Length:               tt.length,
+				PlanningSplitOffsets: planningOffsets,
+				Survivors:            &survivors,
+			}
+			rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRows, countRecords(t, rr))
+			assert.Equal(t, tt.wantSpans, survivors)
 		})
 	}
 }
@@ -2373,9 +2465,10 @@ func TestParquetRowGroupRangeSelectionFallsBackToFirstColumnOffset(t *testing.T)
 	defer rdr.Close()
 
 	tester := &internal.ParquetRowGroupTester{
-		StatsFn: func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) { return true, nil },
-		Start:   offsets[1],
-		Length:  int64(len(data)) - offsets[1],
+		StatsFn:  func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) { return true, nil },
+		RangeSet: true,
+		Start:    offsets[1],
+		Length:   int64(len(data)) - offsets[1],
 	}
 	rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
 	require.NoError(t, err)

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -2252,6 +2252,46 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 	}
 }
 
+func TestParquetRowGroupRangeSelectionFallsBackToFirstColumnOffset(t *testing.T) {
+	const rgSize = 100
+
+	data := buildBloomTestParquet(t, rgSize)
+	pqReader, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer pqReader.Close()
+
+	meta := pqReader.MetaData()
+	offsets := make([]int64, meta.NumRowGroups())
+	for i := range offsets {
+		rg := meta.RowGroup(i)
+		column, columnErr := rg.ColumnChunk(0)
+		require.NoError(t, columnErr)
+		offsets[i] = column.DataPageOffset()
+		if column.HasDictionaryPage() && column.DictionaryPageOffset() < offsets[i] {
+			offsets[i] = column.DictionaryPageOffset()
+		}
+	}
+
+	// RowGroup.file_offset is optional. Removing it reproduces a valid file
+	// where the old range check saw offset zero instead of the planned split
+	// offset for the second group.
+	meta.RowGroups[1].FileOffset = nil
+
+	arrReader, err := pqarrow.NewFileReader(pqReader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+	rdr := internal.WrapParquetFileReader(arrReader)
+	defer rdr.Close()
+
+	tester := &internal.ParquetRowGroupTester{
+		StatsFn: func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) { return true, nil },
+		Start:   offsets[1],
+		Length:  int64(len(data)) - offsets[1],
+	}
+	rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
+	require.NoError(t, err)
+	assert.Equal(t, int64(rgSize), countRecords(t, rr))
+}
+
 func TestShreddedVariantStatsDoesNotPanic(t *testing.T) {
 	mem := memory.DefaultAllocator
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -2168,6 +2168,90 @@ func TestBloomFilterRowGroupPruning(t *testing.T) {
 	})
 }
 
+func TestParquetRowGroupRangeSelection(t *testing.T) {
+	const rgSize = 100
+
+	data := buildBloomTestParquet(t, rgSize)
+	pqReader, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer pqReader.Close()
+
+	meta := pqReader.MetaData()
+	offsets := []int64{meta.RowGroup(0).FileOffset(), meta.RowGroup(1).FileOffset()}
+	require.Less(t, offsets[0], offsets[1])
+
+	alwaysKeep := func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) {
+		return true, nil
+	}
+
+	tests := []struct {
+		name          string
+		start         int64
+		length        int64
+		bloomPreds    []internal.RowGroupBloomPred
+		wantRows      int64
+		wantSurvivors []internal.RowGroupSpan
+	}{
+		{
+			name:          "first row group",
+			start:         offsets[0],
+			length:        offsets[1] - offsets[0],
+			wantRows:      rgSize,
+			wantSurvivors: []internal.RowGroupSpan{{FirstRowPos: 0, NumRows: rgSize}},
+		},
+		{
+			name:          "second row group",
+			start:         offsets[1],
+			length:        int64(len(data)) - offsets[1],
+			wantRows:      rgSize,
+			wantSurvivors: []internal.RowGroupSpan{{FirstRowPos: rgSize, NumRows: rgSize}},
+		},
+		{
+			name:   "range and bloom pruning combine",
+			start:  offsets[0],
+			length: offsets[1] - offsets[0],
+			bloomPreds: []internal.RowGroupBloomPred{{
+				FieldID: 1, PhysBytes: [][]byte{int32PhysBytes(150)},
+			}},
+			wantRows: 0,
+		},
+		{
+			name:          "whole file range",
+			start:         offsets[0],
+			length:        int64(len(data)) - offsets[0],
+			wantRows:      2 * rgSize,
+			wantSurvivors: nil,
+		},
+		{
+			name:     "zero length keeps legacy whole file behavior",
+			start:    offsets[1],
+			length:   0,
+			wantRows: 2 * rgSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdr := openBloomTestReader(t, data)
+			defer rdr.Close()
+
+			var survivors []internal.RowGroupSpan
+			tester := &internal.ParquetRowGroupTester{
+				StatsFn:    alwaysKeep,
+				BloomPreds: tt.bloomPreds,
+				Start:      tt.start,
+				Length:     tt.length,
+				Survivors:  &survivors,
+			}
+			rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantRows, countRecords(t, rr))
+			assert.Equal(t, tt.wantSurvivors, survivors)
+		})
+	}
+}
+
 func TestShreddedVariantStatsDoesNotPanic(t *testing.T) {
 	mem := memory.DefaultAllocator
 

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -2223,8 +2223,8 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 			wantSurvivors: nil,
 		},
 		{
-			name:     "zero length keeps legacy whole file behavior",
-			start:    offsets[1],
+			name:     "unset range keeps legacy whole file behavior",
+			start:    0,
 			length:   0,
 			wantRows: 2 * rgSize,
 		},
@@ -2248,6 +2248,53 @@ func TestParquetRowGroupRangeSelection(t *testing.T) {
 
 			assert.Equal(t, tt.wantRows, countRecords(t, rr))
 			assert.Equal(t, tt.wantSurvivors, survivors)
+		})
+	}
+}
+
+func TestParquetRowGroupRangeSelectionRejectsInvalidRanges(t *testing.T) {
+	const rgSize = 100
+
+	data := buildBloomTestParquet(t, rgSize)
+	pqReader, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	meta := pqReader.MetaData()
+	firstOffset := meta.RowGroup(0).FileOffset()
+	fileSize := int64(len(data))
+	require.NoError(t, pqReader.Close())
+
+	alwaysKeep := func(_ *metadata.RowGroupMetaData, _ []int) (bool, error) {
+		return true, nil
+	}
+	tests := []struct {
+		name     string
+		start    int64
+		length   int64
+		rangeSet bool
+	}{
+		{name: "negative start", start: -1, length: 1},
+		{name: "zero length", start: firstOffset, length: 0},
+		{name: "zero length at file start", start: 0, length: 0, rangeSet: true},
+		{name: "negative length", start: 0, length: -1},
+		{name: "start beyond file", start: fileSize + 1, length: 1},
+		{name: "length beyond file", start: firstOffset, length: fileSize - firstOffset + 1},
+		{name: "range end overflows", start: math.MaxInt64, length: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdr := openBloomTestReader(t, data)
+			defer rdr.Close()
+
+			tester := &internal.ParquetRowGroupTester{
+				StatsFn:  alwaysKeep,
+				RangeSet: tt.rangeSet,
+				Start:    tt.start,
+				Length:   tt.length,
+			}
+			rr, err := rdr.GetRecords(context.Background(), []int{0}, tester)
+			assert.Nil(t, rr)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
 		})
 	}
 }

--- a/table/internal/parquet_files_test.go
+++ b/table/internal/parquet_files_test.go
@@ -71,12 +71,19 @@ type trackingOpenFile struct {
 	*bytes.Reader
 	closeErr error
 	closed   bool
+	readAt   int
 }
 
 func (f *trackingOpenFile) Close() error {
 	f.closed = true
 
 	return f.closeErr
+}
+
+func (f *trackingOpenFile) ReadAt(p []byte, off int64) (int, error) {
+	f.readAt++
+
+	return f.Reader.ReadAt(p, off)
 }
 
 func (f *trackingOpenFile) Stat() (iofs.FileInfo, error) {
@@ -331,6 +338,42 @@ func TestParquetGetReaderClosesFileOnNewFileReaderFailure(t *testing.T) {
 	_, err = fileSource.GetReader(context.Background())
 	require.Error(t, err)
 	assert.True(t, mockFile.closed)
+}
+
+func TestParquetGetReaderReusesMetadataWithinContext(t *testing.T) {
+	data := buildBloomTestParquet(t, 2)
+	mockFile := &trackingOpenFile{Reader: bytes.NewReader(data)}
+	mockIO := &trackingFileSystem{file: mockFile}
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		"data.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		4,
+		int64(len(data)),
+	)
+	require.NoError(t, err)
+
+	fileSource, err := internal.GetFile(context.Background(), mockIO, builder.Build(), false)
+	require.NoError(t, err)
+
+	ctx := internal.WithParquetMetadataCache(context.Background())
+	first, err := fileSource.GetReader(ctx)
+	require.NoError(t, err)
+	firstReadAt := mockFile.readAt
+	require.Positive(t, firstReadAt)
+
+	second, err := fileSource.GetReader(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, firstReadAt, mockFile.readAt,
+		"the second reader should reuse the parsed footer metadata")
+
+	require.NoError(t, first.Close())
+	require.NoError(t, second.Close())
 }
 
 func assertBounds[T iceberg.LiteralType](t *testing.T, bound []byte, typ iceberg.Type, expected T) {

--- a/table/internal/parquet_read_cache.go
+++ b/table/internal/parquet_read_cache.go
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+)
+
+type parquetMetadataCacheContextKey struct{}
+
+type parquetMetadataCacheKey struct {
+	path string
+	size int64
+}
+
+type parquetMetadataCacheEntry struct {
+	once          sync.Once
+	fileMetadata  *metadata.FileMetaData
+	rowGroupInfos []parquetRowGroupInfo
+	err           error
+}
+
+type parquetMetadataCache struct {
+	mu      sync.Mutex
+	entries map[parquetMetadataCacheKey]*parquetMetadataCacheEntry
+}
+
+// WithParquetMetadataCache adds a per-operation cache for immutable Parquet
+// file metadata. Readers and input handles are still created per task, so
+// parallel split tasks do not share mutable reader state.
+func WithParquetMetadataCache(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(parquetMetadataCacheContextKey{}).(*parquetMetadataCache); ok {
+		return ctx
+	}
+
+	return context.WithValue(ctx, parquetMetadataCacheContextKey{}, &parquetMetadataCache{})
+}
+
+func parquetMetadataCacheFromContext(ctx context.Context) *parquetMetadataCache {
+	cache, _ := ctx.Value(parquetMetadataCacheContextKey{}).(*parquetMetadataCache)
+
+	return cache
+}
+
+func (c *parquetMetadataCache) entry(key parquetMetadataCacheKey) *parquetMetadataCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.entries == nil {
+		c.entries = make(map[parquetMetadataCacheKey]*parquetMetadataCacheEntry)
+	}
+	if entry, ok := c.entries[key]; ok {
+		return entry
+	}
+
+	entry := &parquetMetadataCacheEntry{}
+	c.entries[key] = entry
+
+	return entry
+}
+
+type parquetRowGroupInfo struct {
+	splitOffset int64
+	numRows     int64
+}

--- a/table/properties.go
+++ b/table/properties.go
@@ -34,6 +34,9 @@ const (
 	ObjectStoreEnabledKey                   = "write.object-storage.enabled"
 	ObjectStoreEnabledDefault               = false
 
+	ReadSplitTargetSizeKey     = "read.split.target-size"
+	ReadSplitTargetSizeDefault = 128 * 1024 * 1024 // 128 MB
+
 	DefaultNameMappingKey = "schema.name-mapping.default"
 
 	MetricsModeColumnConfPrefix    = "write.metadata.metrics.column"

--- a/table/properties.go
+++ b/table/properties.go
@@ -34,8 +34,19 @@ const (
 	ObjectStoreEnabledKey                   = "write.object-storage.enabled"
 	ObjectStoreEnabledDefault               = false
 
+	// ReadSplitTargetSizeKey controls coalescing of safe row-group ranges during
+	// local Parquet scan planning. Remote plans already contain catalog-owned
+	// ranges and do not use this property.
 	ReadSplitTargetSizeKey     = "read.split.target-size"
-	ReadSplitTargetSizeDefault = 128 * 1024 * 1024 // 128 MB
+	ReadSplitTargetSizeDefault = 128 * 1024 * 1024 // 128 MiB
+
+	// These Java-compatible properties are reserved for future task-group
+	// planning. They are exported so applications can share configuration
+	// names across Iceberg implementations.
+	ReadSplitPlanningLookbackKey     = "read.split.planning-lookback"
+	ReadSplitPlanningLookbackDefault = 10
+	ReadSplitOpenFileCostKey         = "read.split.open-file-cost"
+	ReadSplitOpenFileCostDefault     = 4 * 1024 * 1024 // 4 MiB
 
 	DefaultNameMappingKey = "schema.name-mapping.default"
 

--- a/table/scan_metrics.go
+++ b/table/scan_metrics.go
@@ -79,20 +79,24 @@ func counterBytes(v int64) *metrics.CounterResult {
 // so the Puffin length would over-count.
 func (acc *scanMetricsAccumulator) applyResultDeleteMetrics(tasks []FileScanTask) {
 	for _, t := range tasks {
-		for _, df := range t.DeleteFiles {
-			acc.positionalDeleteFiles++
-			acc.totalDeleteFileSize += df.FileSizeBytes()
-		}
-		for _, df := range t.EqualityDeleteFiles {
-			acc.equalityDeleteFiles++
-			acc.totalDeleteFileSize += df.FileSizeBytes()
-		}
-		for _, df := range t.DeletionVectorFiles {
-			acc.dvs++
-			_, _, _, _, csb := iceberginternal.BorrowedDataFilePointers(df)
-			if csb != nil {
-				acc.totalDeleteFileSize += *csb
-			}
+		acc.addResultDeleteMetrics(t)
+	}
+}
+
+func (acc *scanMetricsAccumulator) addResultDeleteMetrics(t FileScanTask) {
+	for _, df := range t.DeleteFiles {
+		acc.positionalDeleteFiles++
+		acc.totalDeleteFileSize += df.FileSizeBytes()
+	}
+	for _, df := range t.EqualityDeleteFiles {
+		acc.equalityDeleteFiles++
+		acc.totalDeleteFileSize += df.FileSizeBytes()
+	}
+	for _, df := range t.DeletionVectorFiles {
+		acc.dvs++
+		_, _, _, _, csb := iceberginternal.BorrowedDataFilePointers(df)
+		if csb != nil {
+			acc.totalDeleteFileSize += *csb
 		}
 	}
 

--- a/table/scan_splits.go
+++ b/table/scan_splits.go
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import "github.com/apache/iceberg-go"
+
+// splitParquetScanTask returns one task per valid Parquet split offset when a
+// complete, large-file task can be split safely. The boolean is false when the
+// original task should be used unchanged. Split offsets are absolute byte
+// positions in the data file and each resulting range ends at the next offset,
+// or at the end of the file.
+//
+// Tasks that are already partial, small, non-Parquet, or missing usable split
+// offsets stay unchanged. Keeping the original task in those cases preserves
+// the existing behavior for remote tasks and older files.
+func splitParquetScanTask(task FileScanTask, targetSize int64) ([]FileScanTask, bool) {
+	file := task.File
+	if file == nil || file.FileFormat() != iceberg.ParquetFile || targetSize <= 0 {
+		return nil, false
+	}
+
+	fileSize := file.FileSizeBytes()
+	if fileSize <= targetSize || task.Start != 0 || task.Length != fileSize {
+		return nil, false
+	}
+
+	offsets := file.SplitOffsets()
+	if len(offsets) < 2 {
+		return nil, false
+	}
+
+	for i, offset := range offsets {
+		if offset < 0 || offset >= fileSize || (i > 0 && offset <= offsets[i-1]) {
+			return nil, false
+		}
+	}
+
+	result := make([]FileScanTask, 0, len(offsets))
+	for i, start := range offsets {
+		end := fileSize
+		if i+1 < len(offsets) {
+			end = offsets[i+1]
+		}
+		if end <= start {
+			return nil, false
+		}
+
+		split := task
+		split.Start = start
+		split.Length = end - start
+		result = append(result, split)
+	}
+
+	return result, true
+}

--- a/table/scan_splits.go
+++ b/table/scan_splits.go
@@ -19,11 +19,12 @@ package table
 
 import "github.com/apache/iceberg-go"
 
-// splitParquetScanTask returns one task per valid Parquet split offset when a
-// complete, large-file task can be split safely. The boolean is false when the
-// original task should be used unchanged. Split offsets are absolute byte
-// positions in the data file and each resulting range ends at the next offset,
-// or at the end of the file.
+// splitParquetScanTask returns coalesced byte-range tasks when a complete,
+// large-file task can be split safely. The boolean is false when the original
+// task should be used unchanged. Split offsets are absolute byte positions in
+// the data file and each safe range ends at the next supplied offset, or at the
+// end of the file. The first range starts at byte zero so sparse split-offset
+// lists cannot leave leading row groups unassigned.
 //
 // Tasks that are already partial, small, non-Parquet, or missing usable split
 // offsets stay unchanged. Keeping the original task in those cases preserves
@@ -51,20 +52,38 @@ func splitParquetScanTask(task FileScanTask, targetSize int64) ([]FileScanTask, 
 	}
 
 	result := make([]FileScanTask, 0, len(offsets))
-	for i, start := range offsets {
-		end := fileSize
-		if i+1 < len(offsets) {
-			end = offsets[i+1]
-		}
-		if end <= start {
-			return nil, false
-		}
-
+	appendTask := func(start, end int64) {
 		split := task
 		split.Start = start
 		split.Length = end - start
 		result = append(result, split)
 	}
+
+	var taskStart, taskEnd int64
+	for i := range offsets {
+		chunkStart := int64(0)
+		if i > 0 {
+			chunkStart = offsets[i]
+		}
+
+		chunkEnd := fileSize
+		if i+1 < len(offsets) {
+			chunkEnd = offsets[i+1]
+		}
+		if chunkEnd <= chunkStart {
+			return nil, false
+		}
+
+		if taskEnd > taskStart && chunkEnd-taskStart > targetSize {
+			appendTask(taskStart, taskEnd)
+			taskStart = chunkStart
+		}
+		taskEnd = chunkEnd
+	}
+	if taskEnd <= taskStart {
+		return nil, false
+	}
+	appendTask(taskStart, taskEnd)
 
 	return result, true
 }

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -240,7 +240,7 @@ func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
 		ids := idChunks[chunk].(*array.Int64)
 		rowIDs := rowIDChunks[chunk].(*array.Int64)
 		require.Equal(t, ids.Len(), rowIDs.Len())
-		for i := 0; i < ids.Len(); i++ {
+		for i := range ids.Len() {
 			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
 		}
 	}
@@ -277,7 +277,7 @@ func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
 		require.NoError(t, err)
 		ids := record.Column(record.Schema().FieldIndices("id")[0]).(*array.Int64)
 		rowIDs := record.Column(record.Schema().FieldIndices(iceberg.RowIDColumnName)[0]).(*array.Int64)
-		for i := 0; i < int(record.NumRows()); i++ {
+		for i := range int(record.NumRows()) {
 			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
 		}
 		record.Release()
@@ -308,7 +308,7 @@ func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
 		require.NoError(t, err)
 		ids := record.Column(record.Schema().FieldIndices("id")[0]).(*array.Int64)
 		rowIDs := record.Column(record.Schema().FieldIndices(iceberg.RowIDColumnName)[0]).(*array.Int64)
-		for i := 0; i < int(record.NumRows()); i++ {
+		for i := range int(record.NumRows()) {
 			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
 		}
 		record.Release()

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -1,0 +1,318 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
+	"github.com/apache/iceberg-go/table/dv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSplitParquetFile(t testing.TB, path string, sc *arrow.Schema, jsonData string) {
+	t.Helper()
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, sc, strings.NewReader(jsonData))
+	require.NoError(t, err)
+	defer rec.Release()
+
+	fs := iceio.LocalFS{}
+	fw, err := fs.Create(path)
+	require.NoError(t, err)
+	defer fw.Close()
+
+	data := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
+	defer data.Release()
+
+	props := parquet.NewWriterProperties(parquet.WithStats(true))
+	require.NoError(t, pqarrow.WriteTable(data, fw, rec.NumRows(), props, pqarrow.DefaultWriterProps()))
+}
+
+func splitTestDataFile(t *testing.T, format iceberg.FileFormat, size int64, offsets []int64) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentData,
+		"mem://table/data.parquet",
+		format,
+		nil,
+		nil,
+		nil,
+		100,
+		size,
+	)
+	require.NoError(t, err)
+	if offsets != nil {
+		builder.SplitOffsets(offsets)
+	}
+
+	return builder.Build()
+}
+
+func TestSplitParquetScanTask(t *testing.T) {
+	firstRowID := int64(10)
+	file := splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 70})
+	task := FileScanTask{
+		File:        file,
+		DeleteFiles: []iceberg.DataFile{file},
+		Start:       0,
+		Length:      100,
+		Residual:    iceberg.AlwaysTrue{},
+		FirstRowID:  &firstRowID,
+	}
+
+	got, split := splitParquetScanTask(task, 50)
+	require.True(t, split)
+	require.Len(t, got, 3)
+
+	assert.Equal(t, []int64{32, 30, 30}, []int64{got[0].Length, got[1].Length, got[2].Length})
+	assert.Equal(t, []int64{8, 40, 70}, []int64{got[0].Start, got[1].Start, got[2].Start})
+	for _, split := range got {
+		assert.Equal(t, task.File, split.File)
+		assert.Equal(t, task.DeleteFiles, split.DeleteFiles)
+		assert.Equal(t, task.Residual, split.Residual)
+		assert.Equal(t, task.FirstRowID, split.FirstRowID)
+	}
+}
+
+func TestSplitParquetScanTaskKeepsUnsafeTasksIntact(t *testing.T) {
+	baseFile := splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 70})
+
+	tests := []struct {
+		name   string
+		file   iceberg.DataFile
+		task   FileScanTask
+		target int64
+	}{
+		{
+			name:   "small file",
+			file:   splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 70}),
+			target: 100,
+		},
+		{
+			name:   "no split offsets",
+			file:   splitTestDataFile(t, iceberg.ParquetFile, 100, nil),
+			target: 50,
+		},
+		{
+			name:   "negative offset",
+			file:   splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{-1, 40}),
+			target: 50,
+		},
+		{
+			name:   "non increasing offsets",
+			file:   splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 40}),
+			target: 50,
+		},
+		{
+			name:   "offset at file end",
+			file:   splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 100}),
+			target: 50,
+		},
+		{
+			name:   "partial task",
+			file:   baseFile,
+			task:   FileScanTask{File: baseFile, Start: 8, Length: 92},
+			target: 50,
+		},
+		{
+			name:   "non parquet file",
+			file:   splitTestDataFile(t, iceberg.AvroFile, 100, []int64{8, 40, 70}),
+			target: 50,
+		},
+		{
+			name:   "invalid target",
+			file:   baseFile,
+			target: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := tt.task
+			if task.File == nil {
+				task = FileScanTask{File: tt.file, Start: 0, Length: tt.file.FileSizeBytes()}
+			}
+
+			got, split := splitParquetScanTask(task, tt.target)
+			assert.False(t, split)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
+	ctx := context.Background()
+	location := filepath.ToSlash(t.TempDir())
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+	)
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, location,
+		iceberg.Properties{
+			PropertyFormatVersion:   "3",
+			ParquetRowGroupLimitKey: "2",
+			ReadSplitTargetSizeKey:  "1",
+		})
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "split"}, meta, location+"/metadata/v1.metadata.json",
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		&countingCatalog{metadata: meta})
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "data", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	data, err := array.TableFromJSON(memory.DefaultAllocator, arrowSchema, []string{
+		`[{"id":1,"data":"a"},{"id":2,"data":"b"},{"id":3,"data":"c"},{"id":4,"data":"d"},` +
+			`{"id":5,"data":"e"},{"id":6,"data":"f"},{"id":7,"data":"g"},{"id":8,"data":"h"}]`,
+	})
+	require.NoError(t, err)
+	defer data.Release()
+
+	tbl, err = tbl.Append(ctx, array.NewTableReader(data, -1), nil)
+	require.NoError(t, err)
+
+	reporter := &metrics.InMemoryReporter{}
+	tasks, err := tbl.Scan(WithReporter(reporter)).PlanFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 4, "one task should be planned per row group")
+	reports := reporter.Reports()
+	require.Len(t, reports, 1)
+	report, ok := reports[0].(metrics.ScanReport)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), report.Metrics.ResultDataFiles.Value,
+		"split tasks must still report one data file")
+	assert.Equal(t, tasks[0].File.FileSizeBytes(), report.Metrics.TotalFileSizeInBytes.Value,
+		"split tasks must report the original file size once")
+	for i, task := range tasks {
+		assert.Equal(t, tasks[0].File.FilePath(), task.File.FilePath())
+		assert.Positive(t, task.Length)
+		if i > 0 {
+			assert.Equal(t, tasks[i-1].Start+tasks[i-1].Length, task.Start)
+		}
+	}
+
+	result, err := tbl.Scan(WithRowLineage()).ToArrowTable(ctx)
+	require.NoError(t, err)
+	defer result.Release()
+
+	assert.EqualValues(t, 8, result.NumRows())
+	idIdx := result.Schema().FieldIndices("id")
+	rowIDIdx := result.Schema().FieldIndices(iceberg.RowIDColumnName)
+	require.Len(t, idIdx, 1)
+	require.Len(t, rowIDIdx, 1)
+	idChunks := result.Column(idIdx[0]).Data().Chunks()
+	rowIDChunks := result.Column(rowIDIdx[0]).Data().Chunks()
+	require.Equal(t, len(idChunks), len(rowIDChunks))
+
+	gotRowIDs := make(map[int64]int64, 8)
+	for chunk := range idChunks {
+		ids := idChunks[chunk].(*array.Int64)
+		rowIDs := rowIDChunks[chunk].(*array.Int64)
+		require.Equal(t, ids.Len(), rowIDs.Len())
+		for i := 0; i < ids.Len(); i++ {
+			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
+		}
+	}
+	assert.Equal(t, map[int64]int64{1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 7: 6, 8: 7}, gotRowIDs)
+
+	posDelPath := tbl.Location() + "/data/pos-del.parquet"
+	posSc, err := SchemaToArrowSchema(iceberg.PositionalDeleteSchema, nil, true, false)
+	require.NoError(t, err)
+	writeSplitParquetFile(t, posDelPath, posSc, fmt.Sprintf(
+		`[{"file_path":%q,"pos":1},{"file_path":%q,"pos":6}]`,
+		tasks[0].File.FilePath(), tasks[0].File.FilePath()))
+	posDelBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentPosDeletes,
+		posDelPath,
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		2,
+		256,
+	)
+	require.NoError(t, err)
+
+	tasksWithDeletes := make([]FileScanTask, len(tasks))
+	for i, task := range tasks {
+		tasksWithDeletes[i] = task
+		tasksWithDeletes[i].DeleteFiles = []iceberg.DataFile{posDelBuilder.Build()}
+	}
+	_, records, err := tbl.Scan(WithRowLineage()).ReadTasks(ctx, tasksWithDeletes)
+	require.NoError(t, err)
+	gotRowIDs = make(map[int64]int64, 6)
+	for record, err := range records {
+		require.NoError(t, err)
+		ids := record.Column(record.Schema().FieldIndices("id")[0]).(*array.Int64)
+		rowIDs := record.Column(record.Schema().FieldIndices(iceberg.RowIDColumnName)[0]).(*array.Int64)
+		for i := 0; i < int(record.NumRows()); i++ {
+			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
+		}
+		record.Release()
+	}
+	assert.Equal(t, map[int64]int64{1: 0, 3: 2, 4: 3, 5: 4, 6: 5, 8: 7}, gotRowIDs,
+		"position deletes must use original positions across split tasks")
+
+	dvWriter := dv.NewDVWriter(iceio.LocalFS{}, func(specID int32) *iceberg.PartitionSpec {
+		if specID == 0 {
+			return iceberg.UnpartitionedSpec
+		}
+
+		return nil
+	})
+	require.NoError(t, dvWriter.Add(tasks[0].File.FilePath(), []int64{2, 5}, 0, nil))
+	dvFiles, err := dvWriter.Flush(ctx, tbl.Location()+"/data/scan-split.puffin")
+	require.NoError(t, err)
+
+	tasksWithDVs := make([]FileScanTask, len(tasks))
+	for i, task := range tasks {
+		tasksWithDVs[i] = task
+		tasksWithDVs[i].DeletionVectorFiles = dvFiles
+	}
+	_, records, err = tbl.Scan(WithRowLineage()).ReadTasks(ctx, tasksWithDVs)
+	require.NoError(t, err)
+	gotRowIDs = make(map[int64]int64, 6)
+	for record, err := range records {
+		require.NoError(t, err)
+		ids := record.Column(record.Schema().FieldIndices("id")[0]).(*array.Int64)
+		rowIDs := record.Column(record.Schema().FieldIndices(iceberg.RowIDColumnName)[0]).(*array.Int64)
+		for i := 0; i < int(record.NumRows()); i++ {
+			gotRowIDs[ids.Value(i)] = rowIDs.Value(i)
+		}
+		record.Release()
+	}
+	assert.Equal(t, map[int64]int64{1: 0, 2: 1, 4: 3, 5: 4, 7: 6, 8: 7}, gotRowIDs,
+		"deletion vectors must use original positions across split tasks")
+}

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -405,3 +405,62 @@ func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
 	assert.Equal(t, map[int64]int64{1: 0, 2: 1, 4: 3, 5: 4, 7: 6, 8: 7}, gotRowIDs,
 		"deletion vectors must use original positions across split tasks")
 }
+
+type prepareReadTrackingIO struct {
+	iceio.IO
+	closed int
+}
+
+func (fs *prepareReadTrackingIO) Open(path string) (iceio.File, error) {
+	file, err := fs.IO.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &prepareReadTrackingFile{File: file, fs: fs}, nil
+}
+
+type prepareReadTrackingFile struct {
+	iceio.File
+	fs *prepareReadTrackingIO
+}
+
+func (f *prepareReadTrackingFile) Close() error {
+	f.fs.closed++
+
+	return f.File.Close()
+}
+
+func TestPrepareToReadClosesReaderOnSchemaError(t *testing.T) {
+	for _, cache := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cache=%t", cache), func(t *testing.T) {
+			for _, withIDs := range []bool{false, true} {
+				t.Run(fmt.Sprintf("field_ids=%t", withIDs), func(t *testing.T) {
+					field := arrow.Field{Name: "id", Type: arrow.FixedWidthTypes.Time64ns}
+					if withIDs {
+						field.Metadata = arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})
+					}
+					path := filepath.Join(t.TempDir(), "invalid-schema.parquet")
+					writeSplitParquetFile(t, path, arrow.NewSchema([]arrow.Field{field}, nil), `[{"id":"00:00:01.000000000"}]`)
+					file, err := iceberg.NewDataFileBuilder(*iceberg.UnpartitionedSpec,
+						iceberg.EntryContentData, path, iceberg.ParquetFile, nil, nil, nil, 1, 100)
+					require.NoError(t, err)
+					fs := &prepareReadTrackingIO{IO: iceio.LocalFS{}}
+					scanner := &arrowScan{fs: fs, cacheFileReadPlan: cache}
+					invariants := &arrowScanInvariants{projectedIDs: map[int]struct{}{1: {}}}
+					for attempt := 1; attempt <= 2; attempt++ {
+						_, _, reader, err := scanner.prepareToRead(context.Background(), file.Build(), invariants)
+						require.Error(t, err)
+						if withIDs {
+							require.ErrorContains(t, err, "unsupported arrow type")
+						} else {
+							require.ErrorContains(t, err, "missing field_id")
+						}
+						assert.Nil(t, reader)
+						assert.Equal(t, attempt, fs.closed)
+					}
+				})
+			}
+		})
+	}
+}

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -254,11 +254,11 @@ func TestAdjustParquetTaskRangeToPhysicalFileSize(t *testing.T) {
 			wantLength:   40,
 		},
 		{
-			name:         "extends last range when file grew",
+			name:         "does not extend caller-owned range when file grew",
 			task:         FileScanTask{File: file, Start: 40, Length: 60},
 			physicalSize: 120,
 			wantStart:    40,
-			wantLength:   80,
+			wantLength:   60,
 		},
 		{
 			name:         "keeps non-last range unchanged",

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -115,11 +116,11 @@ func TestSplitParquetScanTask(t *testing.T) {
 
 	assert.Equal(t, []int64{40, 30, 30}, []int64{got[0].Length, got[1].Length, got[2].Length})
 	assert.Equal(t, []int64{0, 40, 70}, []int64{got[0].Start, got[1].Start, got[2].Start})
-	for _, split := range got {
-		assert.Equal(t, task.File, split.File)
-		assert.Equal(t, task.DeleteFiles, split.DeleteFiles)
-		assert.Equal(t, task.Residual, split.Residual)
-		assert.Equal(t, task.FirstRowID, split.FirstRowID)
+	for _, taskSplit := range got {
+		assert.Equal(t, task.File, taskSplit.File)
+		assert.Equal(t, task.DeleteFiles, taskSplit.DeleteFiles)
+		assert.Equal(t, task.Residual, taskSplit.Residual)
+		assert.Equal(t, task.FirstRowID, taskSplit.FirstRowID)
 	}
 }
 
@@ -232,6 +233,47 @@ func TestSplitParquetScanTaskKeepsUnsafeTasksIntact(t *testing.T) {
 			got, split := splitParquetScanTask(task, tt.target)
 			assert.False(t, split)
 			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestAdjustParquetTaskRangeToPhysicalFileSize(t *testing.T) {
+	file := splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 70})
+	tests := []struct {
+		name         string
+		task         FileScanTask
+		physicalSize int64
+		wantStart    int64
+		wantLength   int64
+	}{
+		{
+			name:         "clamps last range when file was truncated",
+			task:         FileScanTask{File: file, Start: 40, Length: 60},
+			physicalSize: 80,
+			wantStart:    40,
+			wantLength:   40,
+		},
+		{
+			name:         "extends last range when file grew",
+			task:         FileScanTask{File: file, Start: 40, Length: 60},
+			physicalSize: 120,
+			wantStart:    40,
+			wantLength:   80,
+		},
+		{
+			name:         "keeps non-last range unchanged",
+			task:         FileScanTask{File: file, Start: 40, Length: 20},
+			physicalSize: 120,
+			wantStart:    40,
+			wantLength:   20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStart, gotLength := adjustParquetTaskRange(tt.task, tt.physicalSize)
+			assert.Equal(t, tt.wantStart, gotStart)
+			assert.Equal(t, tt.wantLength, gotLength)
 		})
 	}
 }
@@ -433,9 +475,9 @@ func (f *prepareReadTrackingFile) Close() error {
 
 func TestPrepareToReadClosesReaderOnSchemaError(t *testing.T) {
 	for _, cache := range []bool{false, true} {
-		t.Run(fmt.Sprintf("cache=%t", cache), func(t *testing.T) {
+		t.Run("cache="+strconv.FormatBool(cache), func(t *testing.T) {
 			for _, withIDs := range []bool{false, true} {
-				t.Run(fmt.Sprintf("field_ids=%t", withIDs), func(t *testing.T) {
+				t.Run("field_ids="+strconv.FormatBool(withIDs), func(t *testing.T) {
 					field := arrow.Field{Name: "id", Type: arrow.FixedWidthTypes.Time64ns}
 					if withIDs {
 						field.Metadata = arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})

--- a/table/scan_splits_test.go
+++ b/table/scan_splits_test.go
@@ -78,6 +78,25 @@ func splitTestDataFile(t *testing.T, format iceberg.FileFormat, size int64, offs
 	return builder.Build()
 }
 
+func dataFileWithSplitOffsets(t *testing.T, source iceberg.DataFile, offsets []int64) iceberg.DataFile {
+	t.Helper()
+
+	builder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		source.ContentType(),
+		source.FilePath(),
+		source.FileFormat(),
+		nil,
+		nil,
+		nil,
+		source.Count(),
+		source.FileSizeBytes(),
+	)
+	require.NoError(t, err)
+
+	return builder.SplitOffsets(offsets).Build()
+}
+
 func TestSplitParquetScanTask(t *testing.T) {
 	firstRowID := int64(10)
 	file := splitTestDataFile(t, iceberg.ParquetFile, 100, []int64{8, 40, 70})
@@ -94,14 +113,61 @@ func TestSplitParquetScanTask(t *testing.T) {
 	require.True(t, split)
 	require.Len(t, got, 3)
 
-	assert.Equal(t, []int64{32, 30, 30}, []int64{got[0].Length, got[1].Length, got[2].Length})
-	assert.Equal(t, []int64{8, 40, 70}, []int64{got[0].Start, got[1].Start, got[2].Start})
+	assert.Equal(t, []int64{40, 30, 30}, []int64{got[0].Length, got[1].Length, got[2].Length})
+	assert.Equal(t, []int64{0, 40, 70}, []int64{got[0].Start, got[1].Start, got[2].Start})
 	for _, split := range got {
 		assert.Equal(t, task.File, split.File)
 		assert.Equal(t, task.DeleteFiles, split.DeleteFiles)
 		assert.Equal(t, task.Residual, split.Residual)
 		assert.Equal(t, task.FirstRowID, split.FirstRowID)
 	}
+}
+
+func TestSplitParquetScanTaskCoversSparseOffsets(t *testing.T) {
+	tests := []struct {
+		name    string
+		offsets []int64
+		starts  []int64
+		lengths []int64
+	}{
+		{
+			name:    "omitted leading row group",
+			offsets: []int64{40, 70},
+			starts:  []int64{0, 70},
+			lengths: []int64{70, 30},
+		},
+		{
+			name:    "omitted interior row group",
+			offsets: []int64{8, 70},
+			starts:  []int64{0, 70},
+			lengths: []int64{70, 30},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := splitTestDataFile(t, iceberg.ParquetFile, 100, tt.offsets)
+			task := FileScanTask{File: file, Start: 0, Length: file.FileSizeBytes()}
+
+			got, split := splitParquetScanTask(task, 50)
+			require.True(t, split)
+			require.Len(t, got, len(tt.starts))
+			assert.Equal(t, tt.starts, []int64{got[0].Start, got[1].Start})
+			assert.Equal(t, tt.lengths, []int64{got[0].Length, got[1].Length})
+			assert.Equal(t, file.FileSizeBytes(), got[len(got)-1].Start+got[len(got)-1].Length)
+		})
+	}
+}
+
+func TestSplitParquetScanTaskCoalescesRangesToTarget(t *testing.T) {
+	file := splitTestDataFile(t, iceberg.ParquetFile, 80, []int64{10, 20, 30, 40, 50, 60, 70})
+	task := FileScanTask{File: file, Start: 0, Length: file.FileSizeBytes()}
+
+	got, split := splitParquetScanTask(task, 25)
+	require.True(t, split)
+	require.Len(t, got, 4)
+	assert.Equal(t, []int64{0, 20, 40, 60}, []int64{got[0].Start, got[1].Start, got[2].Start, got[3].Start})
+	assert.Equal(t, []int64{20, 20, 20, 20}, []int64{got[0].Length, got[1].Length, got[2].Length, got[3].Length})
 }
 
 func TestSplitParquetScanTaskKeepsUnsafeTasksIntact(t *testing.T) {
@@ -221,6 +287,29 @@ func TestPlanFilesSplitsLargeParquetFileAndReadsEachRowOnce(t *testing.T) {
 			assert.Equal(t, tasks[i-1].Start+tasks[i-1].Length, task.Start)
 		}
 	}
+
+	fullOffsets := tasks[0].File.SplitOffsets()
+	require.Len(t, fullOffsets, 4)
+	sparseFile := dataFileWithSplitOffsets(t, tasks[0].File, []int64{fullOffsets[1], fullOffsets[3]})
+	sparseTask := FileScanTask{File: sparseFile, Start: 0, Length: sparseFile.FileSizeBytes()}
+	sparseTasks, split := splitParquetScanTask(sparseTask, 1)
+	require.True(t, split)
+	require.Len(t, sparseTasks, 2)
+
+	_, sparseRecords, err := tbl.Scan().ReadTasks(ctx, sparseTasks)
+	require.NoError(t, err)
+	seen := make(map[int64]int)
+	for record, readErr := range sparseRecords {
+		require.NoError(t, readErr)
+		ids := record.Column(record.Schema().FieldIndices("id")[0]).(*array.Int64)
+		for i := range ids.Len() {
+			seen[ids.Value(i)]++
+		}
+		record.Release()
+	}
+	wantSeen := map[int64]int{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1}
+	assert.Equal(t, wantSeen, seen,
+		"sparse split offsets must retain leading and interior row groups")
 
 	result, err := tbl.Scan(WithRowLineage()).ToArrowTable(ctx)
 	require.NoError(t, err)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1162,6 +1162,8 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	}
 
 	results = make([]FileScanTask, 0, len(entries.dataEntries))
+	splitTargetSize := scan.metadata.Properties().GetInt64(
+		ReadSplitTargetSizeKey, ReadSplitTargetSizeDefault)
 	for _, e := range entries.dataEntries {
 		// Spec §Scan Planning: when a deletion vector applies to a data
 		// file, positional-delete files must NOT be applied. The DV is
@@ -1201,15 +1203,17 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 			s := seq
 			task.DataSequenceNumber = &s
 		}
-		results = append(results, task)
+		// Metrics count data files and their deletes once per base file. The
+		// execution task can contain one range per row group.
+		acc.resultDataFiles++
+		acc.addResultDeleteMetrics(task)
+		if splitTasks, split := splitParquetScanTask(task, splitTargetSize); split {
+			results = append(results, splitTasks...)
+		} else {
+			results = append(results, task)
+		}
 		acc.totalFileSize += e.DataFile().FileSizeBytes()
 	}
-
-	acc.resultDataFiles = int64(len(results))
-	// Delete-file metrics are derived from the planned tasks so they are
-	// result-scoped, consistent with result-data-files and total-file-size (a
-	// DV-suppressed positional delete never lands on a task, so it is excluded).
-	acc.applyResultDeleteMetrics(results)
 
 	return results, nil
 }

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -319,6 +319,10 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 |---|---|---|
 | `read.split.target-size` | `134217728` | Target size for coalescing safe row-group ranges when splitting large local Parquet files. A range may exceed the target when no supplied offset can divide it safely. |
 
+The Java-compatible `read.split.planning-lookback` and `read.split.open-file-cost`
+names and defaults are also exported by the Go API for shared configuration,
+but are reserved for future task-group planning and are not currently read.
+
 ### Metrics and metadata lifecycle
 
 | Key | Description |

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -317,7 +317,7 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 
 | Key | Default | Description |
 |---|---|---|
-| `read.split.target-size` | `134217728` | Target size for splitting large local Parquet files at their recorded row-group offsets. |
+| `read.split.target-size` | `134217728` | Target size for coalescing safe row-group ranges when splitting large local Parquet files. A range may exceed the target when no supplied offset can divide it safely. |
 
 ### Metrics and metadata lifecycle
 

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -313,6 +313,12 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 | `write.format.default` | `parquet` | File format used when writing data files. Read in `table/writer.go` and `table/rolling_data_writer.go`. |
 | `write.target-file-size-bytes` | (set by writer) | Target size for newly written data files. Read in `table/arrow_utils.go` and `table/equality_delete_writer.go`. |
 
+### Scan reads
+
+| Key | Default | Description |
+|---|---|---|
+| `read.split.target-size` | `134217728` | Target size for splitting large local Parquet files at their recorded row-group offsets. |
+
 ### Metrics and metadata lifecycle
 
 | Key | Description |


### PR DESCRIPTION
## What changed

- **Split large local Parquet files** at their recorded row-group offsets.
- Added `read.split.target-size` with a **128 MB default**.
- Parquet reads now keep only row groups inside each task range.
- Reuse immutable Parquet metadata, row-group range info, and physical schema projections across split tasks.
- Keep original file row positions for `_row_id`, positional deletes, and deletion vectors.
- Keep scan report file and delete metrics at the original data-file level.

## Why

A table with a few large Parquet files currently gives the scan one task per file. This lets the existing workers read independent row groups in parallel. Files without safe split offsets stay as one task.

Each split still owns its reader and decoded buffers for safe parallel reads. The repeated file metadata and schema setup is now shared within one scan.

## Benchmark 📈

Apple M1 Pro, 8 row groups, 32768 rows per group, a Parquet file read with 8 workers. Three runs with `-benchtime=2s -count=3`.

- One task: **7.07 to 8.41 ms/op**, 27.3 MB/op, about 2,322 allocs/op
- Row-group tasks: **4.14 to 4.24 ms/op**, 50.4 MB/op, about 3,995 allocs/op
- About **45% faster** in this workload.
- Splitting still uses more allocations because each task owns its reader and decoded buffers.
- The benchmark uses a local temporary file instead of `MemFS`. `MemFS.Open` copies the full file on every task open, which inflated the allocation comparison.

## Tests

- `go test ./table ./table/internal`
- `go test -race ./table ./table/internal`
- `go vet ./table ./table/internal`
- `go test ./table -run ^$ -bench BenchmarkArrowScanLargeParquetFileSplitTasks -benchmem -benchtime=2s -count=3`