### PR TITLE
feat(table): add RewriteManifests clustering

### DIFF
--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -83,6 +83,7 @@ type rewriteManifestsCfg struct {
 	targetSizeBytes int64
 	specID          *int
 	predicate       func(iceberg.ManifestFile) bool
+	clusterBy       func(iceberg.DataFile) any
 }
 
 // RewriteManifestsOpt configures [Transaction.RewriteManifests].
@@ -108,6 +109,14 @@ func WithRewriteSpecID(id int) RewriteManifestsOpt {
 // Manifests that don't match are left untouched.
 func WithRewriteManifestPredicate(pred func(iceberg.ManifestFile) bool) RewriteManifestsOpt {
 	return func(c *rewriteManifestsCfg) { c.predicate = pred }
+}
+
+// WithRewriteManifestClusterBy groups rewritten data files by the key returned
+// by clusterBy. Files with the same key and partition spec are written to the
+// same manifest until the target size is reached, after which another manifest
+// is started for that key. The key must be non-nil and comparable.
+func WithRewriteManifestClusterBy(clusterBy func(iceberg.DataFile) any) RewriteManifestsOpt {
+	return func(c *rewriteManifestsCfg) { c.clusterBy = clusterBy }
 }
 
 // rewriteManifests is a producer that merges small data manifests into
@@ -180,6 +189,7 @@ func (r *rewriteManifests) processManifests(manifests []iceberg.ManifestFile) ([
 		targetSizeBytes: r.cfg.targetSizeBytes,
 		minCountToMerge: 1,    // force a merge regardless of count
 		mergeEnabled:    true, // explicit op ignores commit.manifest-merge.enabled
+		clusterBy:       r.cfg.clusterBy,
 		snap:            r.base,
 	}
 	merged, err := mgr.mergeManifests(toRewrite)
@@ -344,9 +354,11 @@ func manifestActiveFiles(fs iceio.IO, manifests []iceberg.ManifestFile) (int64, 
 // rewrites metadata only; no data files are read or written. Delete manifests
 // are left untouched.
 //
-// Manifests are clustered by size only (bin-packed toward the target size);
-// clustering by partition or sort key, which Java exposes via clusterBy, is a
-// future extension.
+// By default, manifests are clustered by size only (bin-packed toward the
+// target size). With WithRewriteManifestClusterBy, entries are grouped by the
+// returned key and partition spec before the same target-size rolling is
+// applied. This can reduce planning time when the key matches common query
+// filters, because each manifest contains fewer unrelated partition values.
 //
 // On a V3 table each rewrite advances next-row-id by the eligible manifests'
 // row count even though no rows are written, so running it on a cadence

--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -114,7 +114,7 @@ func WithRewriteManifestPredicate(pred func(iceberg.ManifestFile) bool) RewriteM
 // WithRewriteManifestClusterBy groups rewritten data files by the key returned
 // by clusterBy. Files with the same key and partition spec are written to the
 // same manifest until the target size is reached, after which another manifest
-// is started for that key. The key must be non-nil and comparable.
+// is started for that key. The key must be non-nil, comparable, and equal to itself.
 func WithRewriteManifestClusterBy(clusterBy func(iceberg.DataFile) any) RewriteManifestsOpt {
 	return func(c *rewriteManifestsCfg) { c.clusterBy = clusterBy }
 }

--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -89,9 +89,10 @@ type rewriteManifestsCfg struct {
 // RewriteManifestsOpt configures [Transaction.RewriteManifests].
 type RewriteManifestsOpt func(*rewriteManifestsCfg)
 
-// WithManifestTargetSize overrides the target manifest size in bytes. A
-// non-positive size is ignored, leaving the default from the
-// commit.manifest.target-size-bytes property.
+// WithManifestTargetSize overrides the target manifest size in bytes. The
+// clustered writer observes the size after Avro blocks flush, so an output can
+// exceed the target by nearly one block. A non-positive size is ignored,
+// leaving the default from the commit.manifest.target-size-bytes property.
 func WithManifestTargetSize(size int64) RewriteManifestsOpt {
 	return func(c *rewriteManifestsCfg) {
 		if size > 0 {
@@ -114,7 +115,14 @@ func WithRewriteManifestPredicate(pred func(iceberg.ManifestFile) bool) RewriteM
 // WithRewriteManifestClusterBy groups rewritten data files by the key returned
 // by clusterBy. Files with the same key and partition spec are written to the
 // same manifest until the target size is reached, after which another manifest
-// is started for that key. The key must be non-nil, comparable, and equal to itself.
+// is started for that key. Clustering replaces normal size-only bin-packing,
+// including minCountToMerge. One writer remains open for each distinct
+// (partition spec, key) pair, so clusterBy should have reasonable cardinality
+// to avoid exhausting object-store handles. The key must be non-nil,
+// comparable, and equal to itself.
+// The callback should be deterministic because an OCC retry may need to
+// re-cluster manifests displaced by a concurrent writer. When all rewritten
+// inputs remain present, the existing clustered output is reused instead.
 func WithRewriteManifestClusterBy(clusterBy func(iceberg.DataFile) any) RewriteManifestsOpt {
 	return func(c *rewriteManifestsCfg) { c.clusterBy = clusterBy }
 }
@@ -175,6 +183,69 @@ func (r *rewriteManifests) deletedEntries(context.Context, *Snapshot) ([]iceberg
 	return nil, nil
 }
 
+// rebuildManifests reuses the clustered output when a concurrent commit only
+// added manifests and left every input manifest this rewrite replaced in the
+// fresh parent. This is the same requiresRewrite optimization used by Java's
+// rewrite-manifest producer: the old output remains valid, and only the fresh
+// parent's additional manifests need to be inherited.
+func (r *rewriteManifests) rebuildManifests(ctx context.Context, parent *Snapshot, addedContent []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	if r.cfg.clusterBy != nil {
+		if reused, ok, err := r.reuseManifests(parent); err != nil {
+			return nil, err
+		} else if ok {
+			return reused, nil
+		}
+	}
+
+	return r.base.assembleManifests(ctx, parent, addedContent)
+}
+
+func (r *rewriteManifests) reuseManifests(parent *Snapshot) ([]iceberg.ManifestFile, bool, error) {
+	if parent == nil || len(r.rewritten) == 0 || len(r.added) == 0 {
+		return nil, false, nil
+	}
+
+	current, err := parent.Manifests(r.base.io)
+	if err != nil {
+		return nil, false, err
+	}
+
+	required := make(map[string]struct{}, len(r.rewritten))
+	for _, manifest := range r.rewritten {
+		required[manifest.FilePath()] = struct{}{}
+	}
+	for _, manifest := range current {
+		delete(required, manifest.FilePath())
+	}
+	if len(required) > 0 {
+		return nil, false, nil
+	}
+	// The fresh parent may contain manifests added by a concurrent writer.
+	// They remain untouched in the reused output and must be included in the
+	// summary's kept count even though no re-merge was needed.
+	r.base.snapshotProps[manifestsKeptKey] = strconv.Itoa(len(current) - len(r.rewritten))
+
+	result := make([]iceberg.ManifestFile, 0, len(current)-len(r.rewritten)+len(r.added))
+	rewritten := make(map[string]struct{}, len(r.rewritten))
+	for _, manifest := range r.rewritten {
+		rewritten[manifest.FilePath()] = struct{}{}
+	}
+	inserted := false
+	for _, manifest := range current {
+		if _, ok := rewritten[manifest.FilePath()]; ok {
+			if !inserted {
+				result = append(result, r.added...)
+				inserted = true
+			}
+
+			continue
+		}
+		result = append(result, manifest)
+	}
+
+	return result, inserted, nil
+}
+
 func (r *rewriteManifests) processManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
 	var toRewrite, kept []iceberg.ManifestFile
 	for _, m := range manifests {
@@ -207,8 +278,8 @@ func (r *rewriteManifests) processManifests(manifests []iceberg.ManifestFile) ([
 		}
 	}()
 
-	// Record on every pass, not just the first. An OCC retry re-runs this
-	// against the fresh parent and writes a different merged set; the last
+	// Record on every pass that actually re-merges, not just the first. An OCC
+	// retry that finds a displaced input writes a different merged set; the last
 	// pass is the one that commits, so its counts are the ones that must win.
 	// record also runs the file-count guard, so an error here leaves the
 	// merged files to the defer above for cleanup.

--- a/table/rewrite_manifests_bench_test.go
+++ b/table/rewrite_manifests_bench_test.go
@@ -44,6 +44,8 @@ func BenchmarkManifestMergeModes(b *testing.B) {
 }
 
 func benchmarkManifestMergeMode(b *testing.B, cluster bool) {
+	b.Helper()
+
 	spec := iceberg.NewPartitionSpec()
 	schema := simpleSchema()
 	mem := newMemIO(1<<30, errLimitedWrite)

--- a/table/rewrite_manifests_bench_test.go
+++ b/table/rewrite_manifests_bench_test.go
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// BenchmarkManifestMergeModes compares the existing size-only merge with the
+// cluster-by path on the same 64 one-entry manifests. Both modes use eight
+// output-sized groups and a single merge worker so the benchmark focuses on
+// entry routing and manifest writing rather than scheduling.
+func BenchmarkManifestMergeModes(b *testing.B) {
+	for _, cluster := range []bool{false, true} {
+		name := "BySize"
+		if cluster {
+			name = "ByClusterKey"
+		}
+		b.Run(name, func(b *testing.B) {
+			benchmarkManifestMergeMode(b, cluster)
+		})
+	}
+}
+
+func benchmarkManifestMergeMode(b *testing.B, cluster bool) {
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<30, errLimitedWrite)
+	meta, err := NewMetadata(schema, &spec, UnsortedSortOrder, "table-location", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	tbl := New(Identifier{"db", "benchmark"}, meta, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return mem, nil }, nil)
+	txn := tbl.NewTransaction()
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{})
+
+	const inputCount = 64
+	const clusterCount = 8
+	inputSnapshotID := int64(1)
+	inputSequenceNumber := int64(1)
+	manifests := make([]iceberg.ManifestFile, 0, inputCount)
+	clusterKeys := make(map[string]int, inputCount)
+	var maxLength int64
+	for i := range inputCount {
+		path := fmt.Sprintf("file://data-%d.parquet", i)
+		builder, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, path, iceberg.ParquetFile,
+			nil, nil, nil, 1, 100,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &inputSnapshotID, &inputSequenceNumber, nil, builder.Build())
+		manifestPath := fmt.Sprintf("table-location/metadata/input-%d.avro", i)
+		var buf bytes.Buffer
+		manifest, err := iceberg.WriteManifest(manifestPath, &buf, 2, spec, schema, inputSnapshotID, []iceberg.ManifestEntry{entry})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := mem.WriteFile(manifestPath, buf.Bytes()); err != nil {
+			b.Fatal(err)
+		}
+		manifests = append(manifests, manifest)
+		clusterKeys[path] = i % clusterCount
+		maxLength = max(maxLength, manifest.Length())
+	}
+
+	mgr := manifestMergeManager{
+		targetSizeBytes:  8 * maxLength,
+		mergeEnabled:     true,
+		mergeConcurrency: 1,
+		snap:             prod,
+	}
+	if cluster {
+		mgr.clusterBy = func(df iceberg.DataFile) any { return clusterKeys[df.FilePath()] }
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		output, err := mgr.mergeManifests(manifests)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		for _, manifest := range output {
+			if err := mem.Remove(manifest.FilePath()); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StartTimer()
+	}
+}

--- a/table/rewrite_manifests_bench_test.go
+++ b/table/rewrite_manifests_bench_test.go
@@ -112,3 +112,134 @@ func benchmarkManifestMergeMode(b *testing.B, cluster bool) {
 		b.StartTimer()
 	}
 }
+
+// BenchmarkManifestPruningModes measures the read-side reason for clustering.
+// The input manifests interleave 32 partition values. A size-only merge keeps
+// that mix in every output group, while cluster-by partition value lets the
+// manifest evaluator reject unrelated groups before opening their entries.
+func BenchmarkManifestPruningModes(b *testing.B) {
+	for _, cluster := range []bool{false, true} {
+		name := "BySize"
+		if cluster {
+			name = "ByClusterKey"
+		}
+		b.Run(name, func(b *testing.B) {
+			benchmarkManifestPruningMode(b, cluster)
+		})
+	}
+}
+
+func benchmarkManifestPruningMode(b *testing.B, cluster bool) {
+	b.Helper()
+
+	const (
+		inputCount   = 512
+		clusterCount = 32
+		targetValue  = int32(7)
+	)
+
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<30, errLimitedWrite)
+	meta, err := NewMetadata(schema, &spec, UnsortedSortOrder, "table-location", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	tbl := New(Identifier{"db", "benchmark-pruning"}, meta, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return mem, nil }, nil)
+	prod := newRewriteManifestsProducer(tbl.NewTransaction(), mem, iceberg.Properties{}, rewriteManifestsCfg{})
+
+	inputSnapshotID := int64(1)
+	inputSequenceNumber := int64(1)
+	manifests := make([]iceberg.ManifestFile, 0, inputCount)
+	for i := range inputCount {
+		partitionValue := int32((i / 8) % (clusterCount - 1))
+		if partitionValue >= targetValue {
+			partitionValue++
+		}
+		if i%8 == 0 {
+			// Put the queried value in every size-only input group. The
+			// size-only output therefore cannot prune any group, while the
+			// clustered output keeps these entries together.
+			partitionValue = targetValue
+		}
+		builder, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData,
+			fmt.Sprintf("file://data-%d.parquet", i), iceberg.ParquetFile,
+			map[int]any{1000: partitionValue},
+			nil, nil, 1, 100,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entry := iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED,
+			&inputSnapshotID,
+			&inputSequenceNumber,
+			nil,
+			builder.Build(),
+		)
+
+		manifestPath := fmt.Sprintf("table-location/metadata/input-%d.avro", i)
+		var buf bytes.Buffer
+		manifest, err := iceberg.WriteManifest(
+			manifestPath, &buf, 2, spec, schema, inputSnapshotID,
+			[]iceberg.ManifestEntry{entry},
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := mem.WriteFile(manifestPath, buf.Bytes()); err != nil {
+			b.Fatal(err)
+		}
+		manifests = append(manifests, manifest)
+	}
+
+	var maxLength int64
+	for _, manifest := range manifests {
+		maxLength = max(maxLength, manifest.Length())
+	}
+	mgr := manifestMergeManager{
+		targetSizeBytes:  8 * maxLength,
+		mergeEnabled:     true,
+		mergeConcurrency: 1,
+		snap:             prod,
+	}
+	if cluster {
+		mgr.clusterBy = func(df iceberg.DataFile) any {
+			return df.Partition()[1000]
+		}
+	}
+	merged, err := mgr.mergeManifests(manifests)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), targetValue)))
+	filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	wantSelected := len(filtered)
+	if cluster {
+		if wantSelected >= len(merged) {
+			b.Fatalf("clustered layout selected %d/%d manifests, want pruning", wantSelected, len(merged))
+		}
+	} else if wantSelected != len(merged) {
+		b.Fatalf("size-only layout selected %d/%d manifests, want all", wantSelected, len(merged))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(len(merged)), "manifests/op")
+	b.ReportMetric(float64(wantSelected), "selected-manifests/op")
+	for range b.N {
+		filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(filtered) != wantSelected {
+			b.Fatalf("selected %d manifests, want %d", len(filtered), wantSelected)
+		}
+	}
+}

--- a/table/rewrite_manifests_bench_test.go
+++ b/table/rewrite_manifests_bench_test.go
@@ -216,7 +216,8 @@ func benchmarkManifestPruningMode(b *testing.B, cluster bool) {
 	}
 
 	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), targetValue)))
-	filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{})
+	partitionFilters := scan.partitionFiltersForSchema(schema)
+	filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{}, partitionFilters)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -234,7 +235,7 @@ func benchmarkManifestPruningMode(b *testing.B, cluster bool) {
 	b.ReportMetric(float64(len(merged)), "manifests/op")
 	b.ReportMetric(float64(wantSelected), "selected-manifests/op")
 	for range b.N {
-		filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{})
+		filtered, err := scan.filterManifestsWithSchema(merged, schema, &scanMetricsAccumulator{}, partitionFilters)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -228,6 +228,7 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 		writer := writers[key]
 		if writer.writer == nil || !writer.hasEntries {
 			writer.abort()
+
 			continue
 		}
 		if err := closeWriter(writer); err != nil {

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -227,8 +227,6 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 	for _, key := range order {
 		writer := writers[key]
 		if writer.writer == nil || !writer.hasEntries {
-			writer.abort()
-
 			return nil, fmt.Errorf("cluster writer for key %v is incomplete", key.value)
 		}
 		if err := closeWriter(writer); err != nil {

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -118,9 +118,11 @@ func validateManifestClusterKey(key any) error {
 // partition spec. Writers stay open while entries for other keys are read so a
 // later file with the same key is still written beside the earlier files.
 func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
-	writers := make(map[manifestClusterKey]*manifestClusterWriter)
-	order := make([]manifestClusterKey, 0)
-	paths := make([]string, 0)
+	// One output writer is tracked per key, so reserve space for the common
+	// case where each input manifest introduces a new cluster.
+	writers := make(map[manifestClusterKey]*manifestClusterWriter, len(manifests))
+	order := make([]manifestClusterKey, 0, len(manifests))
+	paths := make([]string, 0, len(manifests))
 	completed := false
 
 	defer func() {

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -99,16 +99,19 @@ func validateManifestClusterKey(key any) error {
 	}
 
 	typ := reflect.TypeOf(key)
-	if !typ.Comparable() {
+	value := reflect.ValueOf(key)
+	if !value.Comparable() {
 		return fmt.Errorf("manifest cluster key type %s is not comparable", typ)
 	}
 
-	value := reflect.ValueOf(key)
 	switch value.Kind() {
 	case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
 		if value.IsNil() {
 			return errors.New("manifest cluster key must be non-nil")
 		}
+	}
+	if !value.Equal(value) {
+		return fmt.Errorf("manifest cluster key type %s is not reflexive", typ)
 	}
 
 	return nil

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -200,8 +200,8 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 			// The counter advances when the Avro writer flushes a block, so a
 			// manifest can exceed targetSizeBytes by nearly one block.
 			if writer.writer != nil && writer.hasEntries && m.targetSizeBytes > 0 && writer.counter.Count >= m.targetSizeBytes {
-				if entryErr := closeWriter(writer); entryErr != nil {
-					return nil, entryErr
+				if closeErr := closeWriter(writer); closeErr != nil {
+					return nil, closeErr
 				}
 			}
 			if writer.writer == nil {
@@ -229,7 +229,7 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 		if writer.writer == nil || !writer.hasEntries {
 			writer.abort()
 
-			continue
+			return nil, fmt.Errorf("cluster writer for key %v is incomplete", key.value)
 		}
 		if err := closeWriter(writer); err != nil {
 			return nil, err

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -132,7 +132,9 @@ func validateManifestClusterKeyComparable(key any) error {
 
 // clusterManifests rewrites entries into one rolling writer per cluster key and
 // partition spec. Writers stay open while entries for other keys are read so a
-// later file with the same key is still written beside the earlier files.
+// later file with the same key is still written beside the earlier files. This
+// assumes a producer that only reorganizes live data entries; it does not add
+// new files or preserve tombstones.
 func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
 	// One output writer is tracked per key, so reserve space for the common
 	// case where each input manifest introduces a new cluster.
@@ -185,9 +187,10 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 				if clusterErr := validateManifestClusterKey(clusterValue); clusterErr != nil {
 					return nil, fmt.Errorf("cluster data file %q: %w", entry.DataFile().FilePath(), clusterErr)
 				}
-				writer, entryErr = m.newClusterWriter(specID)
-				if entryErr != nil {
-					return nil, entryErr
+				var openErr error
+				writer, openErr = m.newClusterWriter(specID)
+				if openErr != nil {
+					return nil, openErr
 				}
 				writers[key] = writer
 				order = append(order, key)
@@ -224,6 +227,7 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 	for _, key := range order {
 		writer := writers[key]
 		if writer.writer == nil || !writer.hasEntries {
+			writer.abort()
 			continue
 		}
 		if err := closeWriter(writer); err != nil {
@@ -231,7 +235,7 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 		}
 	}
 
-	result := make([]iceberg.ManifestFile, 0)
+	result := make([]iceberg.ManifestFile, 0, len(order))
 	for _, key := range order {
 		result = append(result, writers[key].manifests...)
 	}

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -1,0 +1,219 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/internal"
+)
+
+type manifestClusterKey struct {
+	specID int
+	value  any
+}
+
+type manifestClusterWriter struct {
+	writer     *iceberg.ManifestWriter
+	path       string
+	counter    *internal.CountingWriter
+	fileCloser io.Closer
+	hasEntries bool
+	manifests  []iceberg.ManifestFile
+}
+
+func (w *manifestClusterWriter) close() (mf iceberg.ManifestFile, err error) {
+	if w.writer == nil {
+		return nil, nil
+	}
+
+	writer := w.writer
+	w.writer = nil
+	defer func() {
+		if w.fileCloser != nil {
+			err = errors.Join(err, w.fileCloser.Close())
+			w.fileCloser = nil
+		}
+	}()
+
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	return writer.ToManifestFile(w.path, w.counter.Count)
+}
+
+func (w *manifestClusterWriter) abort() {
+	if w.writer != nil {
+		_ = w.writer.Close()
+		w.writer = nil
+	}
+	if w.fileCloser != nil {
+		_ = w.fileCloser.Close()
+		w.fileCloser = nil
+	}
+}
+
+func (m *manifestMergeManager) newClusterWriter(specID int) (*manifestClusterWriter, error) {
+	spec, err := m.snap.spec(specID)
+	if err != nil {
+		return nil, err
+	}
+
+	writer, path, counter, fileCloser, err := m.snap.newManifestWriter(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifestClusterWriter{
+		writer:     writer,
+		path:       path,
+		counter:    counter,
+		fileCloser: fileCloser,
+	}, nil
+}
+
+func validateManifestClusterKey(key any) error {
+	if key == nil {
+		return errors.New("manifest cluster key must be non-nil")
+	}
+
+	typ := reflect.TypeOf(key)
+	if !typ.Comparable() {
+		return fmt.Errorf("manifest cluster key type %s is not comparable", typ)
+	}
+
+	value := reflect.ValueOf(key)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
+		if value.IsNil() {
+			return errors.New("manifest cluster key must be non-nil")
+		}
+	}
+
+	return nil
+}
+
+// clusterManifests rewrites entries into one rolling writer per cluster key and
+// partition spec. Writers stay open while entries for other keys are read so a
+// later file with the same key is still written beside the earlier files.
+func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	writers := make(map[manifestClusterKey]*manifestClusterWriter)
+	order := make([]manifestClusterKey, 0)
+	paths := make([]string, 0)
+	completed := false
+
+	defer func() {
+		if completed {
+			return
+		}
+
+		for _, writer := range writers {
+			writer.abort()
+		}
+		for _, path := range paths {
+			if removeErr := m.snap.io.Remove(path); removeErr != nil {
+				log.Printf("Warning: failed to delete orphaned clustered manifest %s: %v", path, removeErr)
+			}
+		}
+	}()
+
+	closeWriter := func(writer *manifestClusterWriter) error {
+		manifest, closeErr := writer.close()
+		if closeErr != nil {
+			return closeErr
+		}
+		if manifest != nil {
+			writer.manifests = append(writer.manifests, manifest)
+		}
+
+		return nil
+	}
+
+	for _, manifest := range manifests {
+		specID := int(manifest.PartitionSpecID())
+		for entry, entryErr := range m.snap.iterManifestEntries(manifest, true) {
+			if entryErr != nil {
+				return nil, entryErr
+			}
+
+			clusterValue := m.clusterBy(entry.DataFile())
+			if clusterErr := validateManifestClusterKey(clusterValue); clusterErr != nil {
+				return nil, fmt.Errorf("cluster data file %q: %w", entry.DataFile().FilePath(), clusterErr)
+			}
+			key := manifestClusterKey{specID: specID, value: clusterValue}
+			writer, ok := writers[key]
+			if !ok {
+				writer, entryErr = m.newClusterWriter(specID)
+				if entryErr != nil {
+					return nil, entryErr
+				}
+				writers[key] = writer
+				order = append(order, key)
+				paths = append(paths, writer.path)
+			}
+
+			if writer.writer != nil && writer.hasEntries && m.targetSizeBytes > 0 && writer.counter.Count >= m.targetSizeBytes {
+				if entryErr := closeWriter(writer); entryErr != nil {
+					return nil, entryErr
+				}
+			}
+			if writer.writer == nil {
+				next, openErr := m.newClusterWriter(specID)
+				if openErr != nil {
+					return nil, openErr
+				}
+				writer.writer = next.writer
+				writer.path = next.path
+				writer.counter = next.counter
+				writer.fileCloser = next.fileCloser
+				writer.hasEntries = false
+				paths = append(paths, writer.path)
+			}
+
+			if err := writer.writer.Existing(entry); err != nil {
+				return nil, err
+			}
+			writer.hasEntries = true
+		}
+	}
+
+	for _, key := range order {
+		writer := writers[key]
+		if writer.writer == nil || !writer.hasEntries {
+			continue
+		}
+		if err := closeWriter(writer); err != nil {
+			return nil, err
+		}
+	}
+
+	result := make([]iceberg.ManifestFile, 0)
+	for _, key := range order {
+		result = append(result, writers[key].manifests...)
+	}
+
+	completed = true
+
+	return result, nil
+}

--- a/table/rewrite_manifests_cluster.go
+++ b/table/rewrite_manifests_cluster.go
@@ -117,6 +117,19 @@ func validateManifestClusterKey(key any) error {
 	return nil
 }
 
+func validateManifestClusterKeyComparable(key any) error {
+	if key == nil {
+		return errors.New("manifest cluster key must be non-nil")
+	}
+
+	value := reflect.ValueOf(key)
+	if !value.Comparable() {
+		return fmt.Errorf("manifest cluster key type %s is not comparable", value.Type())
+	}
+
+	return nil
+}
+
 // clusterManifests rewrites entries into one rolling writer per cluster key and
 // partition spec. Writers stay open while entries for other keys are read so a
 // later file with the same key is still written beside the earlier files.
@@ -163,12 +176,15 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 			}
 
 			clusterValue := m.clusterBy(entry.DataFile())
-			if clusterErr := validateManifestClusterKey(clusterValue); clusterErr != nil {
+			if clusterErr := validateManifestClusterKeyComparable(clusterValue); clusterErr != nil {
 				return nil, fmt.Errorf("cluster data file %q: %w", entry.DataFile().FilePath(), clusterErr)
 			}
 			key := manifestClusterKey{specID: specID, value: clusterValue}
 			writer, ok := writers[key]
 			if !ok {
+				if clusterErr := validateManifestClusterKey(clusterValue); clusterErr != nil {
+					return nil, fmt.Errorf("cluster data file %q: %w", entry.DataFile().FilePath(), clusterErr)
+				}
 				writer, entryErr = m.newClusterWriter(specID)
 				if entryErr != nil {
 					return nil, entryErr
@@ -178,6 +194,8 @@ func (m *manifestMergeManager) clusterManifests(manifests []iceberg.ManifestFile
 				paths = append(paths, writer.path)
 			}
 
+			// The counter advances when the Avro writer flushes a block, so a
+			// manifest can exceed targetSizeBytes by nearly one block.
 			if writer.writer != nil && writer.hasEntries && m.targetSizeBytes > 0 && writer.counter.Count >= m.targetSizeBytes {
 				if entryErr := closeWriter(writer); entryErr != nil {
 					return nil, entryErr

--- a/table/rewrite_manifests_internal_test.go
+++ b/table/rewrite_manifests_internal_test.go
@@ -19,11 +19,13 @@ package table
 
 import (
 	"bytes"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,10 +118,11 @@ func TestRewriteManifestsCleansOrphanOnValidationError(t *testing.T) {
 	// Two real manifests, each holding one entry. A two-manifest bin forces a
 	// real merge; a one-manifest bin would pass through untouched.
 	inputs := make([]iceberg.ManifestFile, 2)
+	sequenceNumber := int64(1)
 	for i := range inputs {
 		df := newTestDataFile(t, spec, "file://data-"+string(rune('a'+i))+".parquet", nil)
 		entries := []iceberg.ManifestEntry{
-			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, nil, nil, df),
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, &sequenceNumber, nil, df),
 		}
 		path := "table-location/metadata/input-" + string(rune('a'+i)) + ".avro"
 		var buf bytes.Buffer
@@ -142,6 +145,94 @@ func TestRewriteManifestsCleansOrphanOnValidationError(t *testing.T) {
 		_, preexisting := before[path]
 		require.Truef(t, preexisting, "merged manifest %s written before validation must be cleaned up", path)
 	}
+}
+
+// TestRewriteManifestsCleansOrphansOnInvalidClusterKey checks that a writer
+// opened for an earlier key is removed when a later callback returns an invalid
+// key.
+func TestRewriteManifestsCleansOrphansOnInvalidClusterKey(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<20, errLimitedWrite)
+	txn := createTestTransaction(t, mem, spec)
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{
+		targetSizeBytes: 8 << 20,
+	})
+
+	inputs := make([]iceberg.ManifestFile, 2)
+	sequenceNumber := int64(1)
+	for i := range inputs {
+		df := newTestDataFile(t, spec, "file://data-"+string(rune('a'+i))+".parquet", nil)
+		entries := []iceberg.ManifestEntry{
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, &sequenceNumber, nil, df),
+		}
+		path := "table-location/metadata/cluster-input-" + string(rune('a'+i)) + ".avro"
+		var buf bytes.Buffer
+		mf, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, prod.snapshotID, entries)
+		require.NoError(t, err)
+		require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+		inputs[i] = mf
+	}
+
+	before := memKeys(mem)
+	mgr := manifestMergeManager{
+		targetSizeBytes: 8 << 20,
+		mergeEnabled:    true,
+		clusterBy: func(df iceberg.DataFile) any {
+			if strings.HasSuffix(df.FilePath(), "data-a.parquet") {
+				return "valid"
+			}
+
+			return []string{"not-comparable"}
+		},
+		snap: prod,
+	}
+	_, err := mgr.mergeManifests(inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not comparable")
+
+	for path := range memKeys(mem) {
+		_, preexisting := before[path]
+		assert.Truef(t, preexisting, "invalid cluster key left orphaned manifest %s", path)
+	}
+}
+
+// TestManifestMergeClusterSeparatesSpecsWithSameKey verifies that a key is
+// scoped to its partition spec, just like the manifest writer's schema.
+func TestManifestMergeClusterSeparatesSpecsWithSameKey(t *testing.T) {
+	spec0 := iceberg.NewPartitionSpec()
+	spec1 := iceberg.NewPartitionSpecID(1)
+	schema := simpleSchema()
+	mem := newMemIO(1<<20, errLimitedWrite)
+	txn := createTestTransaction(t, mem, spec0)
+	txn.meta.specs = append(txn.meta.specs, spec1)
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{
+		targetSizeBytes: 8 << 20,
+	})
+
+	inputs := make([]iceberg.ManifestFile, 0, 2)
+	sequenceNumber := int64(1)
+	for i, spec := range []iceberg.PartitionSpec{spec0, spec1} {
+		df := newTestDataFile(t, spec, "file://spec-"+string(rune('a'+i))+".parquet", nil)
+		entry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &prod.snapshotID, &sequenceNumber, nil, df)
+		path := "table-location/metadata/spec-cluster-" + string(rune('a'+i)) + ".avro"
+		var buf bytes.Buffer
+		mf, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, prod.snapshotID, []iceberg.ManifestEntry{entry})
+		require.NoError(t, err)
+		require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+		inputs = append(inputs, mf)
+	}
+
+	mgr := manifestMergeManager{
+		targetSizeBytes: 8 << 20,
+		mergeEnabled:    true,
+		clusterBy:       func(iceberg.DataFile) any { return "same" },
+		snap:            prod,
+	}
+	merged, err := mgr.mergeManifests(inputs)
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+	assert.ElementsMatch(t, []int32{0, 1}, []int32{merged[0].PartitionSpecID(), merged[1].PartitionSpecID()})
 }
 
 // failSecondCreateIO fails every Create after the first, so a concurrent merge

--- a/table/rewrite_manifests_internal_test.go
+++ b/table/rewrite_manifests_internal_test.go
@@ -19,6 +19,9 @@ package table
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -89,6 +92,64 @@ func TestManifestActiveFilesCountsEntriesWhenHeaderCountsAbsent(t *testing.T) {
 	got, err = manifestActiveFiles(fs, []iceberg.ManifestFile{known})
 	require.NoError(t, err)
 	require.EqualValues(t, n, got)
+}
+
+// TestManifestMergeClusterRollsAfterAvroBlockFlush uses enough incompressible
+// per-entry metadata to cross the Avro writer's 64 KiB block boundary. The
+// target is below one flushed block, so the test exercises the documented
+// block-granularity roll rather than a header-only threshold.
+func TestManifestMergeClusterRollsAfterAvroBlockFlush(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<20, errLimitedWrite)
+	txn := createTestTransaction(t, mem, spec)
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{})
+
+	const entryCount = 96
+	entries := make([]iceberg.ManifestEntry, 0, entryCount)
+	snapshotID := prod.snapshotID
+	sequenceNumber := int64(1)
+	for i := range entryCount {
+		metadata := make([]byte, 2<<10)
+		for offset := 0; offset < len(metadata); offset += sha256.Size {
+			var seed [16]byte
+			binary.LittleEndian.PutUint64(seed[:8], uint64(i))
+			binary.LittleEndian.PutUint64(seed[8:], uint64(offset))
+			digest := sha256.Sum256(seed[:])
+			copy(metadata[offset:], digest[:])
+		}
+
+		builder, err := iceberg.NewDataFileBuilder(
+			spec,
+			iceberg.EntryContentData,
+			"file://data-"+strconv.Itoa(i)+".parquet",
+			iceberg.ParquetFile,
+			nil, nil, nil, 1, 100,
+		)
+		require.NoError(t, err)
+		entries = append(entries, iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, &sequenceNumber, nil,
+			builder.KeyMetadata(metadata).Build(),
+		))
+	}
+
+	path := "table-location/metadata/block-boundary-input.avro"
+	var buf bytes.Buffer
+	input, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err)
+	require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+
+	mgr := manifestMergeManager{
+		targetSizeBytes:  input.Length() / 4,
+		mergeEnabled:     true,
+		mergeConcurrency: 1,
+		clusterBy:        func(iceberg.DataFile) any { return "same" },
+		snap:             prod,
+	}
+	merged, err := mgr.mergeManifests([]iceberg.ManifestFile{input})
+	require.NoError(t, err)
+	require.Greater(t, len(merged), 1,
+		"a flushed Avro block must roll the clustered writer once it crosses the target")
 }
 
 // memKeys snapshots the set of paths a memIO currently holds.

--- a/table/rewrite_manifests_internal_test.go
+++ b/table/rewrite_manifests_internal_test.go
@@ -208,6 +208,30 @@ func TestRewriteManifestsCleansOrphanOnValidationError(t *testing.T) {
 	}
 }
 
+// TestManifestMergeClusterCleansOrphanOnWriterConstructionError checks that
+// a manifest path created before writer construction fails is removed.
+func TestManifestMergeClusterCleansOrphanOnWriterConstructionError(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	mem := newMemIO(1<<20, errLimitedWrite)
+	txn := createTestTransaction(t, mem, spec)
+	prod := newRewriteManifestsProducer(txn, mem, iceberg.Properties{}, rewriteManifestsCfg{})
+	input := writeTestManifestFile(t, mem, spec, simpleSchema(), prod.snapshotID, 0)
+
+	// Make the writer factory fail after it has created its output path.
+	prod.txn.meta.formatVersion = 4
+	before := memKeys(mem)
+	mgr := manifestMergeManager{
+		mergeEnabled: true,
+		clusterBy:    func(iceberg.DataFile) any { return "same" },
+		snap:         prod,
+	}
+
+	_, err := mgr.mergeManifests([]iceberg.ManifestFile{input})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported manifest version")
+	assert.Equal(t, before, memKeys(mem), "writer construction failure must not leave an orphan")
+}
+
 // TestRewriteManifestsCleansOrphansOnInvalidClusterKey checks that a writer
 // opened for an earlier key is removed when a later callback returns an invalid
 // key.

--- a/table/rewrite_manifests_pruning_test.go
+++ b/table/rewrite_manifests_pruning_test.go
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRewriteManifestsClusterByPrunesManifests keeps the read-side benefit of
+// clustering under ordinary test coverage. Size-only output contains the
+// queried partition value in every bin; clustered output can reject the bins
+// for the other partition values without opening their entries.
+func TestRewriteManifestsClusterByPrunesManifests(t *testing.T) {
+	const (
+		inputCount   = 64
+		clusterCount = 8
+		targetValue  = int32(7)
+	)
+
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<30, errLimitedWrite)
+	meta, err := NewMetadata(schema, &spec, UnsortedSortOrder, "table-location", nil)
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "pruning"}, meta, "metadata.json",
+		func(context.Context) (iceio.IO, error) { return mem, nil }, nil)
+	prod := newRewriteManifestsProducer(tbl.NewTransaction(), mem, iceberg.Properties{}, rewriteManifestsCfg{})
+
+	inputSnapshotID := int64(1)
+	inputSequenceNumber := int64(1)
+	manifests := make([]iceberg.ManifestFile, 0, inputCount)
+	for i := range inputCount {
+		partitionValue := int32((i / 8) % (clusterCount - 1))
+		if partitionValue >= targetValue {
+			partitionValue++
+		}
+		if i%8 == 0 {
+			partitionValue = targetValue
+		}
+
+		builder, err := iceberg.NewDataFileBuilder(
+			spec, iceberg.EntryContentData, fmt.Sprintf("file://data-%d.parquet", i),
+			iceberg.ParquetFile, map[int]any{1000: partitionValue}, nil, nil, 1, 100,
+		)
+		require.NoError(t, err)
+		entry := iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED,
+			&inputSnapshotID,
+			&inputSequenceNumber,
+			nil,
+			builder.Build(),
+		)
+
+		path := fmt.Sprintf("table-location/metadata/input-%d.avro", i)
+		var buf bytes.Buffer
+		manifest, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, inputSnapshotID,
+			[]iceberg.ManifestEntry{entry})
+		require.NoError(t, err)
+		require.NoError(t, mem.WriteFile(path, buf.Bytes()))
+		manifests = append(manifests, manifest)
+	}
+
+	var maxLength int64
+	for _, manifest := range manifests {
+		maxLength = max(maxLength, manifest.Length())
+	}
+	newManager := func(cluster bool) []iceberg.ManifestFile {
+		mgr := manifestMergeManager{
+			targetSizeBytes:  8 * maxLength,
+			mergeEnabled:     true,
+			mergeConcurrency: 1,
+			snap:             prod,
+		}
+		if cluster {
+			mgr.clusterBy = func(df iceberg.DataFile) any { return df.Partition()[1000] }
+		}
+
+		merged, mergeErr := mgr.mergeManifests(manifests)
+		require.NoError(t, mergeErr)
+
+		return merged
+	}
+
+	sizeOnly := newManager(false)
+	clustered := newManager(true)
+	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), targetValue)))
+	sizeOnlySelected, err := scan.filterManifestsWithSchema(sizeOnly, schema, &scanMetricsAccumulator{})
+	require.NoError(t, err)
+	clusteredSelected, err := scan.filterManifestsWithSchema(clustered, schema, &scanMetricsAccumulator{})
+	require.NoError(t, err)
+
+	require.Len(t, sizeOnlySelected, len(sizeOnly),
+		"size-only output should keep the queried partition in every manifest")
+	require.Less(t, len(clusteredSelected), len(clustered),
+		"clustered output should prune manifests for unrelated partition values")
+}

--- a/table/rewrite_manifests_pruning_test.go
+++ b/table/rewrite_manifests_pruning_test.go
@@ -106,9 +106,10 @@ func TestRewriteManifestsClusterByPrunesManifests(t *testing.T) {
 	sizeOnly := newManager(false)
 	clustered := newManager(true)
 	scan := tbl.Scan(WithRowFilter(iceberg.EqualTo(iceberg.Reference("id"), targetValue)))
-	sizeOnlySelected, err := scan.filterManifestsWithSchema(sizeOnly, schema, &scanMetricsAccumulator{})
+	partitionFilters := scan.partitionFiltersForSchema(schema)
+	sizeOnlySelected, err := scan.filterManifestsWithSchema(sizeOnly, schema, &scanMetricsAccumulator{}, partitionFilters)
 	require.NoError(t, err)
-	clusteredSelected, err := scan.filterManifestsWithSchema(clustered, schema, &scanMetricsAccumulator{})
+	clusteredSelected, err := scan.filterManifestsWithSchema(clustered, schema, &scanMetricsAccumulator{}, partitionFilters)
 	require.NoError(t, err)
 
 	require.Len(t, sizeOnlySelected, len(sizeOnly),

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -547,150 +547,178 @@ func TestRewriteManifestsUnknownSpecID(t *testing.T) {
 // TestRewriteManifestsPredicate rewrites only the manifests the predicate
 // selects and leaves the rest untouched.
 func TestRewriteManifestsPredicate(t *testing.T) {
-	ctx := context.Background()
-	dir := t.TempDir()
-	fs := iceio.LocalFS{}
+	for _, tc := range []struct {
+		name      string
+		clustered bool
+	}{
+		{name: "SizeOnly"},
+		{name: "Clustered", clustered: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			fs := iceio.LocalFS{}
 
-	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
-		table.UnsortedSortOrder, dir, iceberg.Properties{
-			table.ManifestMergeEnabledKey: "false",
+			meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+				table.UnsortedSortOrder, dir, iceberg.Properties{
+					table.ManifestMergeEnabledKey: "false",
+				})
+			require.NoError(t, err)
+
+			cat := &mergeCatalog{meta: meta}
+			tbl := table.New(table.Identifier{"default", "pred"}, meta, dir+"/metadata/00000.json",
+				func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+			const numCommits = 3
+			tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numCommits)
+
+			before, err := tbl.CurrentSnapshot().Manifests(fs)
+			require.NoError(t, err)
+			require.Len(t, before, numCommits)
+
+			// Select two of the three manifests by path; the third must be left alone.
+			selected := map[string]struct{}{
+				before[0].FilePath(): {},
+				before[1].FilePath(): {},
+			}
+			pred := func(m iceberg.ManifestFile) bool {
+				_, ok := selected[m.FilePath()]
+
+				return ok
+			}
+
+			opts := []table.RewriteManifestsOpt{table.WithRewriteManifestPredicate(pred)}
+			if tc.clustered {
+				opts = append(opts, table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+					return "selected"
+				}))
+			}
+
+			txn := tbl.NewTransaction()
+			res, err := txn.RewriteManifests(ctx, opts...)
+			require.NoError(t, err)
+			tbl, err = txn.Commit(ctx)
+			require.NoError(t, err)
+
+			assert.Len(t, res.AddedManifests, 1, "the two selected manifests merge into one")
+			assert.Len(t, res.RewrittenManifests, 2)
+
+			snap := tbl.CurrentSnapshot()
+			require.NotNil(t, snap)
+			assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+			assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
+			assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"])
+
+			after, err := snap.Manifests(fs)
+			require.NoError(t, err)
+			assert.Len(t, after, 2, "one merged manifest plus the untouched one")
+			assert.Equal(t, numCommits, activeFiles(t, after), "no data file may be dropped")
+
+			// The untouched manifest must survive verbatim.
+			var keptPaths []string
+			for _, m := range after {
+				keptPaths = append(keptPaths, m.FilePath())
+			}
+			assert.Contains(t, keptPaths, before[2].FilePath(), "unselected manifest must be kept as-is")
 		})
-	require.NoError(t, err)
-
-	cat := &mergeCatalog{meta: meta}
-	tbl := table.New(table.Identifier{"default", "pred"}, meta, dir+"/metadata/00000.json",
-		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
-
-	const numCommits = 3
-	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", numCommits)
-
-	before, err := tbl.CurrentSnapshot().Manifests(fs)
-	require.NoError(t, err)
-	require.Len(t, before, numCommits)
-
-	// Select two of the three manifests by path; the third must be left alone.
-	selected := map[string]struct{}{
-		before[0].FilePath(): {},
-		before[1].FilePath(): {},
 	}
-	pred := func(m iceberg.ManifestFile) bool {
-		_, ok := selected[m.FilePath()]
-
-		return ok
-	}
-
-	txn := tbl.NewTransaction()
-	res, err := txn.RewriteManifests(ctx,
-		table.WithRewriteManifestPredicate(pred),
-		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any { return "selected" }),
-	)
-	require.NoError(t, err)
-	tbl, err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	assert.Len(t, res.AddedManifests, 1, "the two selected manifests merge into one")
-	assert.Len(t, res.RewrittenManifests, 2)
-
-	snap := tbl.CurrentSnapshot()
-	require.NotNil(t, snap)
-	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
-	assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
-	assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"])
-
-	after, err := snap.Manifests(fs)
-	require.NoError(t, err)
-	assert.Len(t, after, 2, "one merged manifest plus the untouched one")
-	assert.Equal(t, numCommits, activeFiles(t, after), "no data file may be dropped")
-
-	// The untouched manifest must survive verbatim.
-	var keptPaths []string
-	for _, m := range after {
-		keptPaths = append(keptPaths, m.FilePath())
-	}
-	assert.Contains(t, keptPaths, before[2].FilePath(), "unselected manifest must be kept as-is")
 }
 
 // TestRewriteManifestsSpecIDFilter rewrites only the manifests of the requested
 // partition spec and leaves manifests written under another spec untouched.
 func TestRewriteManifestsSpecIDFilter(t *testing.T) {
-	ctx := context.Background()
-	dir := t.TempDir()
-	fs := iceio.LocalFS{}
+	for _, tc := range []struct {
+		name      string
+		clustered bool
+	}{
+		{name: "SizeOnly"},
+		{name: "Clustered", clustered: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			fs := iceio.LocalFS{}
 
-	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
-		table.UnsortedSortOrder, dir, iceberg.Properties{
-			table.ManifestMergeEnabledKey: "false",
+			meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+				table.UnsortedSortOrder, dir, iceberg.Properties{
+					table.ManifestMergeEnabledKey: "false",
+				})
+			require.NoError(t, err)
+
+			cat := &mergeCatalog{meta: meta}
+			tbl := table.New(table.Identifier{"default", "specfilter"}, meta, dir+"/metadata/00000.json",
+				func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+
+			// Two manifests under the original unpartitioned spec (id 0).
+			tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "spec0", 2)
+
+			// Evolve the spec, then add a file so it lands in a manifest of the new spec.
+			txn := tbl.NewTransaction()
+			require.NoError(t, table.NewUpdateSpec(txn, false).
+				AddField("id", iceberg.IdentityTransform{}, "id_part").Commit())
+			tbl, err = txn.Commit(ctx)
+			require.NoError(t, err)
+
+			specOneFile := dir + "/spec1-0.parquet"
+			writeOneRowParquet(t, fs, specOneFile)
+			txn = tbl.NewTransaction()
+			require.NoError(t, txn.AddFiles(ctx, []string{specOneFile}, nil, false))
+			tbl, err = txn.Commit(ctx)
+			require.NoError(t, err)
+
+			before, err := tbl.CurrentSnapshot().Manifests(fs)
+			require.NoError(t, err)
+			require.Len(t, before, 3, "two spec-0 manifests plus one spec-1 manifest")
+
+			// Find the lone spec-1 manifest so we can prove it survives verbatim.
+			var specOnePath string
+			specCount := map[int]int{}
+			for _, m := range before {
+				specCount[int(m.PartitionSpecID())]++
+				if int(m.PartitionSpecID()) == 1 {
+					specOnePath = m.FilePath()
+				}
+			}
+			require.Equal(t, 2, specCount[0], "setup must leave two spec-0 manifests")
+			require.Equal(t, 1, specCount[1], "setup must leave one spec-1 manifest")
+
+			opts := []table.RewriteManifestsOpt{table.WithRewriteSpecID(0)}
+			if tc.clustered {
+				opts = append(opts, table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+					return "spec-0"
+				}))
+			}
+
+			txn = tbl.NewTransaction()
+			res, err := txn.RewriteManifests(ctx, opts...)
+			require.NoError(t, err)
+			tbl, err = txn.Commit(ctx)
+			require.NoError(t, err)
+
+			assert.Len(t, res.AddedManifests, 1, "the two spec-0 manifests merge into one")
+			assert.Len(t, res.RewrittenManifests, 2)
+			for _, m := range res.RewrittenManifests {
+				assert.EqualValues(t, 0, m.PartitionSpecID(), "only spec-0 manifests may be rewritten")
+			}
+
+			snap := tbl.CurrentSnapshot()
+			require.NotNil(t, snap)
+			assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
+			assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
+			assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"], "the spec-1 manifest is kept")
+
+			after, err := snap.Manifests(fs)
+			require.NoError(t, err)
+			assert.Len(t, after, 2, "one merged spec-0 manifest plus the untouched spec-1 manifest")
+			assert.Equal(t, 3, activeFiles(t, after), "no data file may be dropped")
+
+			var keptPaths []string
+			for _, m := range after {
+				keptPaths = append(keptPaths, m.FilePath())
+			}
+			assert.Contains(t, keptPaths, specOnePath, "spec-1 manifest must be kept as-is")
 		})
-	require.NoError(t, err)
-
-	cat := &mergeCatalog{meta: meta}
-	tbl := table.New(table.Identifier{"default", "specfilter"}, meta, dir+"/metadata/00000.json",
-		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
-
-	// Two manifests under the original unpartitioned spec (id 0).
-	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "spec0", 2)
-
-	// Evolve the spec, then add a file so it lands in a manifest of the new spec.
-	txn := tbl.NewTransaction()
-	require.NoError(t, table.NewUpdateSpec(txn, false).
-		AddField("id", iceberg.IdentityTransform{}, "id_part").Commit())
-	tbl, err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	specOneFile := dir + "/spec1-0.parquet"
-	writeOneRowParquet(t, fs, specOneFile)
-	txn = tbl.NewTransaction()
-	require.NoError(t, txn.AddFiles(ctx, []string{specOneFile}, nil, false))
-	tbl, err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	before, err := tbl.CurrentSnapshot().Manifests(fs)
-	require.NoError(t, err)
-	require.Len(t, before, 3, "two spec-0 manifests plus one spec-1 manifest")
-
-	// Find the lone spec-1 manifest so we can prove it survives verbatim.
-	var specOnePath string
-	specCount := map[int]int{}
-	for _, m := range before {
-		specCount[int(m.PartitionSpecID())]++
-		if int(m.PartitionSpecID()) == 1 {
-			specOnePath = m.FilePath()
-		}
 	}
-	require.Equal(t, 2, specCount[0], "setup must leave two spec-0 manifests")
-	require.Equal(t, 1, specCount[1], "setup must leave one spec-1 manifest")
-
-	txn = tbl.NewTransaction()
-	res, err := txn.RewriteManifests(ctx,
-		table.WithRewriteSpecID(0),
-		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any { return "spec-0" }),
-	)
-	require.NoError(t, err)
-	tbl, err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	assert.Len(t, res.AddedManifests, 1, "the two spec-0 manifests merge into one")
-	assert.Len(t, res.RewrittenManifests, 2)
-	for _, m := range res.RewrittenManifests {
-		assert.EqualValues(t, 0, m.PartitionSpecID(), "only spec-0 manifests may be rewritten")
-	}
-
-	snap := tbl.CurrentSnapshot()
-	require.NotNil(t, snap)
-	assert.Equal(t, "1", snap.Summary.Properties["manifests-created"])
-	assert.Equal(t, "2", snap.Summary.Properties["manifests-replaced"])
-	assert.Equal(t, "1", snap.Summary.Properties["manifests-kept"], "the spec-1 manifest is kept")
-
-	after, err := snap.Manifests(fs)
-	require.NoError(t, err)
-	assert.Len(t, after, 2, "one merged spec-0 manifest plus the untouched spec-1 manifest")
-	assert.Equal(t, 3, activeFiles(t, after), "no data file may be dropped")
-
-	var keptPaths []string
-	for _, m := range after {
-		keptPaths = append(keptPaths, m.FilePath())
-	}
-	assert.Contains(t, keptPaths, specOnePath, "spec-1 manifest must be kept as-is")
 }
 
 // classifyManifests counts data vs delete manifests and returns the path of the
@@ -1065,6 +1093,100 @@ func TestRewriteManifestsClusterByReusesOutputOnOCCRetry(t *testing.T) {
 		"all original files must remain in the reused clustered output")
 	assert.Len(t, res.RewrittenManifests, 3)
 	assert.Len(t, res.AddedManifests, 1)
+}
+
+// TestRewriteManifestsClusterByDoesNotReuseDisplacedOutput verifies that a
+// concurrent rewrite replacing every input manifest forces a fresh clustering
+// pass. Reusing the first attempt's output in that case would retain the peer's
+// replacement and duplicate every data file from the stale inputs.
+func TestRewriteManifestsClusterByDoesNotReuseDisplacedOutput(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	props := iceberg.Properties{
+		table.PropertyFormatVersion:        "2",
+		table.ManifestMergeEnabledKey:      "false",
+		table.CommitMinRetryWaitMsKey:      "0",
+		table.CommitMaxRetryWaitMsKey:      "0",
+		table.CommitTotalRetryTimeoutMsKey: "60000",
+		table.CommitNumRetriesKey:          "1",
+	}
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, props)
+	require.NoError(t, err)
+
+	setup := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "displaced"}, meta,
+		dir+"/metadata/00000.json", fsF, setup)
+	tbl = appendSeparateManifests(t, ctx, tbl, track, dir, "stale", 3)
+	staleMeta := tbl.Metadata()
+
+	// Build the concurrent head by replacing all three manifests the stale
+	// rewrite will consume. None of those original paths survives in the fresh
+	// parent, so the retry must not reuse the stale rewrite output.
+	peerCat := &mergeCatalog{meta: staleMeta}
+	peer := table.New(table.Identifier{"default", "displaced"}, staleMeta,
+		dir+"/metadata/peer.json", fsF, peerCat)
+	peerTxn := peer.NewTransaction()
+	_, err = peerTxn.RewriteManifests(ctx)
+	require.NoError(t, err)
+	peer, err = peerTxn.Commit(ctx)
+	require.NoError(t, err)
+	peerMeta := peer.Metadata()
+	peerManifests, err := peer.CurrentSnapshot().Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, peerManifests, 1, "the peer must replace all stale manifests")
+
+	cat := &stagedHeadCatalog{
+		current:  staleMeta,
+		heads:    []table.Metadata{peerMeta},
+		failures: 1,
+		location: dir,
+		fsF:      fsF,
+	}
+	staleTbl := table.New(table.Identifier{"default", "displaced"}, staleMeta,
+		dir+"/metadata/00000.json", fsF, cat)
+
+	var clusterCalls atomic.Int32
+	txn := staleTbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx,
+		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+			clusterCalls.Add(1)
+
+			return "same"
+		}),
+	)
+	require.NoError(t, err)
+	committed, err := txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 2, cat.commitTableCalls.Load(),
+		"expected one conflict followed by one successful commit")
+	assert.EqualValues(t, 6, clusterCalls.Load(),
+		"displaced inputs must be clustered again on the retry")
+	assert.Len(t, res.RewrittenManifests, 1,
+		"the winning retry should report the peer manifest it replaced")
+	assert.Len(t, res.AddedManifests, 1)
+
+	snap := committed.CurrentSnapshot()
+	require.NotNil(t, snap)
+	after, err := snap.Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "the retry should replace the peer manifest once")
+
+	counts := make(map[string]int)
+	for _, manifest := range after {
+		for entry, entryErr := range manifest.Entries(track, true) {
+			require.NoError(t, entryErr)
+			counts[filepath.Base(entry.DataFile().FilePath())]++
+		}
+	}
+	for i := range 3 {
+		assert.Equal(t, 1, counts[fmt.Sprintf("stale-%d.parquet", i)],
+			"each stale data file must appear exactly once after the retry")
+	}
 }
 
 // TestRewriteManifestsStaleCountsAfterOCCRetry forces a commit conflict and

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -20,6 +20,7 @@ package table_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -221,6 +222,56 @@ func TestRewriteManifestsClusterBy(t *testing.T) {
 				"a clustered manifest must not mix cluster keys")
 		}
 	}
+}
+
+func TestRewriteManifestsRejectsRuntimeUncomparableClusterKey(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "uncomparable_cluster_key"}, meta,
+		dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", 2)
+
+	txn := tbl.NewTransaction()
+	_, err = txn.RewriteManifests(ctx, table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+		return struct{ Value any }{Value: []int{1}}
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not comparable")
+}
+
+func TestRewriteManifestsRejectsNonReflexiveClusterKey(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "nan_cluster_key"}, meta,
+		dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", 1)
+
+	txn := tbl.NewTransaction()
+	_, err = txn.RewriteManifests(ctx, table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+		return math.NaN()
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not reflexive")
 }
 
 // TestRewriteManifestsClusterByRollsAtTargetSize verifies that one cluster key

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -163,6 +163,103 @@ func TestRewriteManifests(t *testing.T) {
 	assert.Equal(t, wantFiles, activeFiles(t, after), "rewrite must preserve the data file count")
 }
 
+// TestRewriteManifestsClusterBy keeps files with the same user-provided key in
+// separate manifests, even when their input manifests were interleaved.
+func TestRewriteManifestsClusterBy(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "clustered"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", 6)
+
+	clusterKey := func(df iceberg.DataFile) any {
+		if strings.HasSuffix(df.FilePath(), "-0.parquet") ||
+			strings.HasSuffix(df.FilePath(), "-2.parquet") ||
+			strings.HasSuffix(df.FilePath(), "-4.parquet") {
+			return "even"
+		}
+
+		return "odd"
+	}
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx, table.WithRewriteManifestClusterBy(clusterKey))
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 2)
+	assert.Len(t, res.RewrittenManifests, 6)
+
+	manifests, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, manifests, 2)
+	for _, manifest := range manifests {
+		entries, err := manifest.FetchEntries(fs, true)
+		require.NoError(t, err)
+		require.NotEmpty(t, entries)
+
+		want := clusterKey(entries[0].DataFile())
+		for _, entry := range entries {
+			assert.Equal(t, iceberg.EntryStatusEXISTING, entry.Status(),
+				"clustered rewrite should write live files as existing")
+		}
+		for _, entry := range entries[1:] {
+			assert.Equal(t, want, clusterKey(entry.DataFile()),
+				"a clustered manifest must not mix cluster keys")
+		}
+	}
+}
+
+// TestRewriteManifestsClusterByRollsAtTargetSize verifies that one cluster key
+// can produce multiple manifests when its writer reaches the target size.
+func TestRewriteManifestsClusterByRollsAtTargetSize(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := iceio.LocalFS{}
+
+	meta, err := table.NewMetadata(rewriteSchema(), iceberg.UnpartitionedSpec,
+		table.UnsortedSortOrder, dir, iceberg.Properties{
+			table.ManifestMergeEnabledKey: "false",
+		})
+	require.NoError(t, err)
+
+	cat := &mergeCatalog{meta: meta}
+	tbl := table.New(table.Identifier{"default", "clustered_roll"}, meta, dir+"/metadata/00000.json",
+		func(_ context.Context) (iceio.IO, error) { return fs, nil }, cat)
+	tbl = appendSeparateManifests(t, ctx, tbl, fs, dir, "data", 3)
+
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx,
+		table.WithManifestTargetSize(1),
+		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any { return "same" }),
+	)
+	require.NoError(t, err)
+	tbl, err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	assert.Len(t, res.AddedManifests, 3)
+	assert.Len(t, res.RewrittenManifests, 3)
+
+	manifests, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	require.Len(t, manifests, 3)
+	for _, manifest := range manifests {
+		entries, err := manifest.FetchEntries(fs, true)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "target size should roll the single cluster key")
+	}
+}
+
 // TestRewriteManifestsMultipleBins forces a small target size so the merge emits
 // more than one output manifest — the manifests-created > 1 path the default
 // target size (far larger than any test manifest) never exercises.

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -204,8 +204,11 @@ func TestRewriteManifestsClusterBy(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, manifests, 2)
 	for _, manifest := range manifests {
-		entries, err := manifest.FetchEntries(fs, true)
-		require.NoError(t, err)
+		entries := make([]iceberg.ManifestEntry, 0)
+		for entry, entryErr := range manifest.Entries(fs, true) {
+			require.NoError(t, entryErr)
+			entries = append(entries, entry)
+		}
 		require.NotEmpty(t, entries)
 
 		want := clusterKey(entries[0].DataFile())
@@ -254,9 +257,12 @@ func TestRewriteManifestsClusterByRollsAtTargetSize(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, manifests, 3)
 	for _, manifest := range manifests {
-		entries, err := manifest.FetchEntries(fs, true)
-		require.NoError(t, err)
-		assert.Len(t, entries, 1, "target size should roll the single cluster key")
+		entryCount := 0
+		for _, entryErr := range manifest.Entries(fs, true) {
+			require.NoError(t, entryErr)
+			entryCount++
+		}
+		assert.Equal(t, 1, entryCount, "target size should roll the single cluster key")
 	}
 }
 

--- a/table/rewrite_manifests_test.go
+++ b/table/rewrite_manifests_test.go
@@ -580,7 +580,10 @@ func TestRewriteManifestsPredicate(t *testing.T) {
 	}
 
 	txn := tbl.NewTransaction()
-	res, err := txn.RewriteManifests(ctx, table.WithRewriteManifestPredicate(pred))
+	res, err := txn.RewriteManifests(ctx,
+		table.WithRewriteManifestPredicate(pred),
+		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any { return "selected" }),
+	)
 	require.NoError(t, err)
 	tbl, err = txn.Commit(ctx)
 	require.NoError(t, err)
@@ -658,7 +661,10 @@ func TestRewriteManifestsSpecIDFilter(t *testing.T) {
 	require.Equal(t, 1, specCount[1], "setup must leave one spec-1 manifest")
 
 	txn = tbl.NewTransaction()
-	res, err := txn.RewriteManifests(ctx, table.WithRewriteSpecID(0))
+	res, err := txn.RewriteManifests(ctx,
+		table.WithRewriteSpecID(0),
+		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any { return "spec-0" }),
+	)
 	require.NoError(t, err)
 	tbl, err = txn.Commit(ctx)
 	require.NoError(t, err)
@@ -997,6 +1003,68 @@ func TestRewriteManifestsCleansSupersededOnExhaustedRetries(t *testing.T) {
 	for _, p := range merged {
 		assert.Truef(t, track.wasRemoved(p), "orphaned manifest %s must be cleaned on the failure path", p)
 	}
+}
+
+// TestRewriteManifestsClusterByReusesOutputOnOCCRetry verifies that a
+// concurrent append does not force an otherwise-valid clustered rewrite to
+// read and rewrite every original entry again. The fresh parent retains all
+// manifests replaced by the first attempt, so the existing clustered output
+// can be reused while the peer manifests are inherited as-is.
+func TestRewriteManifestsClusterByReusesOutputOnOCCRetry(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	track := &trackingFS{}
+	fsF := func(_ context.Context) (iceio.IO, error) { return track, nil }
+
+	h0, h1, h2 := stagedRewriteHeads(t, ctx, dir, "2", fsF, track)
+	cat := &stagedHeadCatalog{current: h0, heads: []table.Metadata{h1, h2}, failures: 2, location: dir, fsF: fsF}
+	tbl := table.New(table.Identifier{"default", "staged-cluster"}, h0,
+		dir+"/metadata/00000.json", fsF, cat)
+
+	preExisting := track.snapshotCreated()
+	var clusterCalls atomic.Int32
+	txn := tbl.NewTransaction()
+	res, err := txn.RewriteManifests(ctx,
+		table.WithRewriteManifestClusterBy(func(iceberg.DataFile) any {
+			clusterCalls.Add(1)
+
+			return "same"
+		}),
+	)
+	require.NoError(t, err)
+	committed, err := txn.Commit(ctx)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 3, cat.commitTableCalls.Load(),
+		"expected two conflicts followed by one successful commit")
+	assert.EqualValues(t, 3, clusterCalls.Load(),
+		"reusing the clustered output must avoid re-reading entries on retries")
+
+	merged := mergedManifestsCreated(track, preExisting)
+	require.Len(t, merged, 1, "only the initial attempt should write clustered data manifests")
+
+	snap := committed.CurrentSnapshot()
+	require.NotNil(t, snap)
+	assert.Equal(t, "2", snap.Summary.Properties["manifests-kept"],
+		"concurrent manifests inherited by the reused output must be counted as kept")
+	after, err := snap.Manifests(track)
+	require.NoError(t, err)
+	require.Len(t, after, 3,
+		"the reused clustered output plus two concurrent manifests must be retained")
+
+	var clusteredEntries int
+	for _, manifest := range after {
+		for entry, entryErr := range manifest.Entries(track, true) {
+			require.NoError(t, entryErr)
+			if strings.HasPrefix(filepath.Base(entry.DataFile().FilePath()), "stale-") {
+				clusteredEntries++
+			}
+		}
+	}
+	assert.Equal(t, 3, clusteredEntries,
+		"all original files must remain in the reused clustered output")
+	assert.Len(t, res.RewrittenManifests, 3)
+	assert.Len(t, res.AddedManifests, 1)
 }
 
 // TestRewriteManifestsStaleCountsAfterOCCRetry forces a commit conflict and

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -947,19 +947,13 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 					return nil, err
 				}
 
-				out, path, err := sp.newManifestOutput()
+				wr, path, counter, out, err := sp.newManifestWriter(spec,
+					iceberg.WithManifestWriterContent(key.content))
 				if err != nil {
 					return nil, err
 				}
 				defer internal.CheckedClose(out, &retErr)
 
-				counter := &internal.CountingWriter{W: out}
-				wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter,
-					spec, sp.txn.meta.CurrentSchema(),
-					sp.snapshotID, iceberg.WithManifestWriterContent(key.content))
-				if err != nil {
-					return nil, err
-				}
 				writerClosed := false
 				defer func() {
 					if !writerClosed {

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -80,6 +80,14 @@ type supersededAccumulator interface {
 	supersededManifests(committed bool) []string
 }
 
+// retryManifestRebuilder lets a producer reuse parent-independent manifest
+// output when a retry's fresh parent still contains every manifest it rewrote.
+// Producers that do not implement it fall back to assembling and processing
+// the complete manifest set again.
+type retryManifestRebuilder interface {
+	rebuildManifests(ctx context.Context, parent *Snapshot, addedContent []iceberg.ManifestFile) ([]iceberg.ManifestFile, error)
+}
+
 func newManifestFileName(num int, commit uuid.UUID) string {
 	return fmt.Sprintf("%s-m%d.avro", commit, num)
 }
@@ -1523,11 +1531,18 @@ func (sp *snapshotProducer) commitManifests(newManifests, addedContent []iceberg
 			return nil, err
 		}
 
-		// Recompute the parent-dependent manifests (inherited/filtered existing
-		// manifests plus DELETE tombstones) against the fresh parent and combine
-		// them with the reused added-content manifests. This drops the removed
-		// files from the fresh parent's manifests rather than resurrecting them.
-		combined, procErr := sp.assembleManifests(rebuildCtx, freshParent, addedContent)
+		// Rebuild or reuse the parent-dependent manifest set against the fresh
+		// parent and combine it with the producer's own manifests. This drops
+		// removed files from the fresh parent's manifests rather than
+		// resurrecting them; rewrite clustering can reuse its prior output when
+		// none of the rewritten inputs were displaced.
+		var combined []iceberg.ManifestFile
+		var procErr error
+		if rebuilder, ok := sp.producerImpl.(retryManifestRebuilder); ok {
+			combined, procErr = rebuilder.rebuildManifests(rebuildCtx, freshParent, addedContent)
+		} else {
+			combined, procErr = sp.assembleManifests(rebuildCtx, freshParent, addedContent)
+		}
 		if procErr != nil {
 			return nil, fmt.Errorf("rebuild manifest list: assemble manifests: %w", procErr)
 		}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -511,6 +511,7 @@ func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) 
 		return manifests, nil
 	}
 	if m.clusterBy != nil {
+		// Clustering replaces size-only bin-packing, including minCountToMerge.
 		return m.clusterManifests(manifests)
 	}
 

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -732,7 +732,7 @@ func (sp *snapshotProducer) newManifestWriter(spec iceberg.PartitionSpec, opts .
 	wr, err := iceberg.NewManifestWriter(sp.txn.meta.formatVersion, counter, spec,
 		sp.txn.meta.CurrentSchema(), sp.snapshotID, opts...)
 	if err != nil {
-		return nil, "", nil, nil, errors.Join(err, out.Close())
+		return nil, "", nil, nil, errors.Join(err, out.Close(), sp.io.Remove(path))
 	}
 
 	return wr, path, counter, out, nil

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -354,6 +354,7 @@ type manifestMergeManager struct {
 	minCountToMerge  int
 	mergeEnabled     bool
 	mergeConcurrency int
+	clusterBy        func(iceberg.DataFile) any
 	snap             *snapshotProducer
 }
 
@@ -500,6 +501,9 @@ func (m *manifestMergeManager) removeOrphans(input, output []iceberg.ManifestFil
 func (m *manifestMergeManager) mergeManifests(manifests []iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
 	if !m.mergeEnabled || len(manifests) == 0 {
 		return manifests, nil
+	}
+	if m.clusterBy != nil {
+		return m.clusterManifests(manifests)
 	}
 
 	first := manifests[0]

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -2094,6 +2094,26 @@ func TestParentDependentManifestsRejectsUnregisteredSpec(t *testing.T) {
 	assert.ErrorContains(t, err, "99")
 }
 
+func TestParentDependentManifestsCleansOrphanOnWriterConstructionError(t *testing.T) {
+	spec := iceberg.NewPartitionSpec()
+	txn, wfs := createTestTransactionWithMemIO(t, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, wfs, nil, nil)
+
+	dataPath := "mem://default/table-location/data/d.parquet"
+	staleDV := newTestDeletionVectorForRef(t, spec,
+		"mem://default/table-location/data/dv-old.puffin", dataPath)
+	sp.removeDeletionVector(staleDV)
+	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 96, "writer-error", staleDV)
+
+	sp.txn.meta.formatVersion = 4
+	before := metadataFiles(t, wfs)
+	_, err := sp.parentDependentManifests(context.Background(), parent)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported manifest version")
+	assert.Equal(t, before, metadataFiles(t, wfs),
+		"writer construction failure must not leave an orphan")
+}
+
 func TestAccumulateSummaryDeltaRejectsUnregisteredSpec(t *testing.T) {
 	registered := partitionedSpec()
 	txn, wfs := createTestTransactionWithMemIO(t, registered)


### PR DESCRIPTION
## What changed

- add `WithRewriteManifestClusterBy` for opt-in clustering
- group live data entries by **cluster key + partition spec**
- roll each key at the configured manifest target size
- keep the default size-only path unchanged
- clean open output manifests when a callback or writer fails

## Why

- The Java `RewriteManifests.clusterBy` API uses the same idea: keep files with the same key together.
- This is useful when the key matches a partition value used by common filters.
- The clustered layout can let scan planning reject unrelated manifests before opening their entries.
- The option is opt-in, so existing rewrites keep the current behavior.

## Benchmark

Rewrite throughput was roughly neutral in the benchmark. The important result is the read-side benchmark. It exercises `Scan.filterManifestsWithSchema`, the manifest-pruning stage used by local `PlanFiles`.

Command: `go test ./table -run=^$ -bench=^BenchmarkManifestPruningModes$ -benchmem -benchtime=1s -count=3`

Workload: 512 one-entry input manifests, 32 partition values, and an equality filter on `id = 7`.

- size-only: **18.6–18.8 µs/op**, 17,728 B/op, 580 allocs/op, **64/64 manifests selected**
- cluster-by: **10.8–13.5 µs/op**, 11,456 B/op, 324 allocs/op, **1/32 manifests selected**

That is about **40% lower pruning time**, **35% fewer bytes**, and **44% fewer allocations** for this partition-aligned workload.

Java reference: https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/RewriteManifests.java

## Tests

- `go test ./table/...`
- `go vet ./table/...`
- `go test -race ./table -run 'TestRewriteManifests(ClusterBy|CleansOrphansOnInvalidClusterKey)' -count=1`