### PR TITLE
perf(table): reuse staged schema in UpdateSpec

### DIFF
--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -43,6 +43,7 @@ type UpdateSpec struct {
 	// all schema-dependent operations in this update.
 	meta                  Metadata
 	schema                *iceberg.Schema
+	historicalFields      map[transformKey][]iceberg.PartitionField
 	err                   error
 	nameToField           map[string]iceberg.PartitionField
 	nameToAddedField      map[string]iceberg.PartitionField
@@ -210,10 +211,12 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 		return iceberg.PartitionSpec{}, us.err
 	}
 
-	partitionFields := make([]iceberg.PartitionField, 0)
-	partitionNames := make(map[string]bool)
 	spec := us.meta.PartitionSpec()
-	for _, field := range spec.Fields() {
+	specFields := spec.Fields()
+	capacity := spec.NumFields() + len(us.adds)
+	partitionFields := make([]iceberg.PartitionField, 0, capacity)
+	partitionNames := make(map[string]bool, capacity)
+	for _, field := range specFields {
 		var newField iceberg.PartitionField
 		var err error
 		if _, deleted := us.deletes[field.FieldID]; !deleted {
@@ -416,6 +419,23 @@ func (us *UpdateSpec) rewriteDeleteAndAddField(existing iceberg.PartitionField, 
 	return us.renameField(existing.Name, name)()
 }
 
+func (us *UpdateSpec) historicalPartitionFields(key transformKey) []iceberg.PartitionField {
+	if us.historicalFields == nil {
+		us.historicalFields = make(map[transformKey][]iceberg.PartitionField)
+		for _, spec := range us.meta.PartitionSpecs() {
+			for _, field := range spec.Fields() {
+				historicalKey := transformKey{
+					SourceId:  field.SourceID(),
+					Transform: field.Transform.String(),
+				}
+				us.historicalFields[historicalKey] = append(us.historicalFields[historicalKey], field)
+			}
+		}
+	}
+
+	return us.historicalFields[key]
+}
+
 func (us *UpdateSpec) renameField(name string, newName string) updateSpecOp {
 	return func() error {
 		existingField, exists := us.nameToField[newName]
@@ -454,38 +474,26 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 	// resurrects fields removed in an earlier committed update; same-update
 	// remove/re-add is handled ahead of this call by rewriteDeleteAndAddField.
 	if us.meta.Version() >= 2 {
-		sourceId, transformName := key.SourceId, key.Transform
-		historicalFields := make([]iceberg.PartitionField, 0)
-		// PartitionSpecs() is ordered by ascending spec ID, so when the same
-		// source + transform appears under different names across specs (e.g. a
-		// field renamed before it was removed), the lowest-spec-ID match wins.
-		// The match's own name is returned, which for the no-name case may be an
-		// older name than the current schema uses; this precedence is
+		// PartitionSpecs() is ordered by ascending spec ID, so the cached slice
+		// keeps the lowest-spec-ID match first when a field was renamed across
+		// specs. The match's own name is returned, which for the no-name case may
+		// be an older name than the current schema uses; this precedence is
 		// deterministic and preserves the original (permanent) field ID.
-		for _, spec := range us.meta.PartitionSpecs() {
-			for _, field := range spec.Fields() {
-				historicalFields = append(historicalFields, field)
-			}
-		}
-		for _, field := range historicalFields {
-			// Transform.String() is canonical: field.Transform is a parsed
-			// Transform whose String() re-normalizes any non-canonical on-disk
-			// text (e.g. "bucket[016]" -> "bucket[16]"), and transformName comes
-			// from a Transform.String() as well. The textual compare therefore
-			// distinguishes parameterized transforms (bucket[16] vs bucket[8])
-			// correctly without a structural comparison.
-			if field.SourceID() == sourceId && field.Transform.String() == transformName {
-				// Reuse the historical field's ID when no explicit name is
-				// requested (match on source + transform alone) or when the
-				// requested name matches.
-				if len(name) == 0 || field.Name == name {
-					return iceberg.PartitionField{
-						SourceIDs: []int{sourceId},
-						FieldID:   field.FieldID,
-						Name:      field.Name,
-						Transform: field.Transform,
-					}, nil
-				}
+		for _, field := range us.historicalPartitionFields(key) {
+			// The cache key uses Transform.String(), which re-normalizes any
+			// non-canonical on-disk text (e.g. "bucket[016]" -> "bucket[16]").
+			// This distinguishes parameterized transforms (bucket[16] vs
+			// bucket[8]) without a structural comparison.
+			// Reuse the historical field's ID when no explicit name is
+			// requested (match on source + transform alone) or when the
+			// requested name matches.
+			if len(name) == 0 || field.Name == name {
+				return iceberg.PartitionField{
+					SourceIDs: []int{key.SourceId},
+					FieldID:   field.FieldID,
+					Name:      field.Name,
+					Transform: field.Transform,
+				}, nil
 			}
 		}
 	}

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -39,7 +39,10 @@ type UpdateSpec struct {
 	// when this UpdateSpec is constructed. Schema and partition-spec resolution
 	// read from it so partitioning can reference columns/specs staged earlier in
 	// the transaction; concurrency assertions are handled separately (BuildUpdates).
+	// schema is the single defensive copy of the current staged schema reused by
+	// all schema-dependent operations in this update.
 	meta                  Metadata
+	schema                *iceberg.Schema
 	err                   error
 	nameToField           map[string]iceberg.PartitionField
 	nameToAddedField      map[string]iceberg.PartitionField
@@ -117,6 +120,7 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 		}] = partitionField
 		nameToField[partitionField.Name] = partitionField
 	}
+	us.schema = stagedMeta.CurrentSchema()
 	lastAssignedFieldId := us.meta.LastPartitionSpecID()
 	if lastAssignedFieldId == nil {
 		v := iceberg.PartitionDataIDStart - 1
@@ -214,9 +218,9 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 		var err error
 		if _, deleted := us.deletes[field.FieldID]; !deleted {
 			if rename, renamed := us.renames[field.Name]; renamed {
-				newField, err = us.addNewField(us.meta.CurrentSchema(), field.SourceID(), field.FieldID, rename, field.Transform, partitionNames)
+				newField, err = us.addNewField(us.schema, field.SourceID(), field.FieldID, rename, field.Transform, partitionNames)
 			} else {
-				newField, err = us.addNewField(us.meta.CurrentSchema(), field.SourceID(), field.FieldID, field.Name, field.Transform, partitionNames)
+				newField, err = us.addNewField(us.schema, field.SourceID(), field.FieldID, field.Name, field.Transform, partitionNames)
 			}
 			if err != nil {
 				return iceberg.PartitionSpec{}, err
@@ -224,9 +228,9 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 			partitionFields = append(partitionFields, newField)
 		} else if us.meta.Version() == 1 {
 			if rename, renamed := us.renames[field.Name]; renamed {
-				newField, err = us.addNewField(us.meta.CurrentSchema(), field.SourceID(), field.FieldID, rename, iceberg.VoidTransform{}, partitionNames)
+				newField, err = us.addNewField(us.schema, field.SourceID(), field.FieldID, rename, iceberg.VoidTransform{}, partitionNames)
 			} else {
-				newField, err = us.addNewField(us.meta.CurrentSchema(), field.SourceID(), field.FieldID, field.Name, iceberg.VoidTransform{}, partitionNames)
+				newField, err = us.addNewField(us.schema, field.SourceID(), field.FieldID, field.Name, iceberg.VoidTransform{}, partitionNames)
 			}
 			if err != nil {
 				return iceberg.PartitionSpec{}, err
@@ -240,7 +244,7 @@ func (us *UpdateSpec) Apply() (iceberg.PartitionSpec, error) {
 		return iceberg.PartitionSpec{}, err
 	}
 	candidate := iceberg.NewPartitionSpec(partitionFields...)
-	newSpec, err := candidate.BindToSchema(us.meta.CurrentSchema(), nil, nil)
+	newSpec, err := candidate.BindToSchema(us.schema, nil, nil)
 	if err != nil {
 		return iceberg.PartitionSpec{}, err
 	}
@@ -307,7 +311,7 @@ func (us *UpdateSpec) addField(sourceColName string, transform iceberg.Transform
 	return func() error {
 		// Finds the column in the schema and binds it with case sensitivity.
 		ref := iceberg.Reference(sourceColName)
-		boundTerm, err := ref.Bind(us.meta.CurrentSchema(), us.caseSensitive)
+		boundTerm, err := ref.Bind(us.schema, us.caseSensitive)
 		if err != nil {
 			return err
 		}
@@ -494,7 +498,7 @@ func (us *UpdateSpec) partitionField(key transformKey, name string) (iceberg.Par
 			Transform: transform,
 		}
 		var err error
-		name, err = iceberg.GeneratePartitionFieldName(us.meta.CurrentSchema(), tmpField)
+		name, err = iceberg.GeneratePartitionFieldName(us.schema, tmpField)
 		if err != nil {
 			return iceberg.PartitionField{}, err
 		}

--- a/table/update_spec_bench_test.go
+++ b/table/update_spec_bench_test.go
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var updateSpecBuildBenchmarkSink int
+
+// BenchmarkUpdateSpecBuildUpdates measures schema resolution while validating
+// existing and newly added partition fields. BuildUpdates consumes the queued
+// operations, so each iteration creates a fresh UpdateSpec.
+func BenchmarkUpdateSpecBuildUpdates(b *testing.B) {
+	for _, tc := range []struct {
+		schemaFields   int
+		existingFields int
+		addedFields    int
+		nested         bool
+	}{
+		{schemaFields: 100, existingFields: 8, addedFields: 4},
+		{schemaFields: 1_000, existingFields: 32, addedFields: 16},
+		{schemaFields: 1_000, existingFields: 32, addedFields: 16, nested: true},
+	} {
+		name := fmt.Sprintf("schema=%d/partitions=%d/additions=%d/nested=%t",
+			tc.schemaFields, tc.existingFields, tc.addedFields, tc.nested)
+		b.Run(name, func(b *testing.B) {
+			schema, sourceNames, sourceIDs := benchmarkUpdateSpecSchema(tc.schemaFields, tc.nested)
+			partitionFields := make([]iceberg.PartitionField, tc.existingFields)
+			for i := range tc.existingFields {
+				partitionFields[i] = iceberg.PartitionField{
+					SourceIDs: []int{sourceIDs[i]},
+					FieldID:   iceberg.PartitionDataIDStart + i,
+					Name:      fmt.Sprintf("partition_%04d", i),
+					Transform: iceberg.IdentityTransform{},
+				}
+			}
+			partitionSpec := iceberg.NewPartitionSpec(partitionFields...)
+			metadata, err := NewMetadata(schema, &partitionSpec, UnsortedSortOrder,
+				"s3://bucket/table", nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tbl := New([]string{"benchmark"}, metadata, "", nil, nil)
+			txn := tbl.NewTransaction()
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(tc.schemaFields), "schema_fields")
+			b.ReportMetric(float64(tc.existingFields), "existing_partitions")
+			b.ReportMetric(float64(tc.addedFields), "added_partitions")
+			b.ResetTimer()
+
+			for range b.N {
+				update := NewUpdateSpec(txn, false)
+				for i := tc.existingFields; i < tc.existingFields+tc.addedFields; i++ {
+					update.AddField(sourceNames[i], iceberg.IdentityTransform{},
+						fmt.Sprintf("added_%04d", i))
+				}
+				updates, requirements, err := update.BuildUpdates()
+				if err != nil {
+					b.Fatal(err)
+				}
+				updateSpecBuildBenchmarkSink = len(updates) + len(requirements)
+			}
+		})
+	}
+}
+
+func benchmarkUpdateSpecSchema(fieldCount int, nested bool) (*iceberg.Schema, []string, []int) {
+	fields := make([]iceberg.NestedField, fieldCount)
+	names := make([]string, fieldCount)
+	sourceIDs := make([]int, fieldCount)
+	nextID := fieldCount + 1
+	for i := range fieldCount {
+		name := fmt.Sprintf("field_%04d", i)
+		names[i] = name
+		if !nested {
+			fields[i] = iceberg.NestedField{
+				ID:       i + 1,
+				Name:     name,
+				Required: true,
+				Type:     iceberg.PrimitiveTypes.Int64,
+			}
+			sourceIDs[i] = i + 1
+			continue
+		}
+
+		nestedFields := []iceberg.NestedField{
+			{ID: nextID, Name: "value", Required: true, Type: iceberg.PrimitiveTypes.Int64},
+			{ID: nextID + 1, Name: "label", Required: false, Type: iceberg.PrimitiveTypes.String},
+		}
+		sourceIDs[i] = nextID
+		nextID += len(nestedFields)
+		fields[i] = iceberg.NestedField{
+			ID:       i + 1,
+			Name:     name,
+			Required: true,
+			Type:     &iceberg.StructType{FieldList: nestedFields},
+		}
+		names[i] += ".value"
+	}
+
+	return iceberg.NewSchema(1, fields...), names, sourceIDs
+}

--- a/table/update_spec_bench_test.go
+++ b/table/update_spec_bench_test.go
@@ -44,6 +44,10 @@ func BenchmarkUpdateSpecBuildUpdates(b *testing.B) {
 			tc.schemaFields, tc.existingFields, tc.addedFields, tc.nested)
 		b.Run(name, func(b *testing.B) {
 			schema, sourceNames, sourceIDs := benchmarkUpdateSpecSchema(tc.schemaFields, tc.nested)
+			addedNames := make([]string, tc.addedFields)
+			for i := range addedNames {
+				addedNames[i] = fmt.Sprintf("added_%04d", tc.existingFields+i)
+			}
 			partitionFields := make([]iceberg.PartitionField, tc.existingFields)
 			for i := range tc.existingFields {
 				partitionFields[i] = iceberg.PartitionField{
@@ -72,7 +76,7 @@ func BenchmarkUpdateSpecBuildUpdates(b *testing.B) {
 				update := NewUpdateSpec(txn, false)
 				for i := tc.existingFields; i < tc.existingFields+tc.addedFields; i++ {
 					update.AddField(sourceNames[i], iceberg.IdentityTransform{},
-						fmt.Sprintf("added_%04d", i))
+						addedNames[i-tc.existingFields])
 				}
 				updates, requirements, err := update.BuildUpdates()
 				if err != nil {
@@ -100,6 +104,7 @@ func benchmarkUpdateSpecSchema(fieldCount int, nested bool) (*iceberg.Schema, []
 				Type:     iceberg.PrimitiveTypes.Int64,
 			}
 			sourceIDs[i] = i + 1
+
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- **Reuse one staged schema** throughout UpdateSpec.
- Avoid repeated defensive schema clones during partition field binding and final spec validation.
- Keep the public defensive-copy behavior unchanged.
- Add a focused benchmark for flat and nested large schemas.

## Benchmark

Command:

```
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkUpdateSpecBuildUpdates$' -benchmem -benchtime=500ms -count=5 ./table
```

Apple M1 Pro, darwin/arm64. Results are medians of five runs.

| Case | Before | After | Speedup | Allocations |
| --- | ---: | ---: | ---: | ---: |
| 100 fields, 8 partitions, 4 additions | 0.714 ms | 0.152 ms | **4.7x** | 805 KB -> 139 KB |
| 1,000 flat fields, 32 partitions, 16 additions | 29.73 ms | 1.46 ms | **20.3x** | 38.8 MB -> 1.75 MB |
| 1,000 nested fields, 32 partitions, 16 additions | 91.74 ms | 3.70 ms | **24.8x** | 102.5 MB -> 3.74 MB |

## Checks

- `go test ./table/... -count=1`
- `go test` for all non-cloud packages
- `go vet ./...`
