### PR TITLE
perf(manifest): fuse partition conversion with Avro remapping

### DIFF
--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -211,11 +211,7 @@ func cloneDataFileAvroFields(src *dataFile) *dataFile {
 // avro-friendly map the manifest-entry schema expects. Idempotent:
 // values already in primitive form pass through unchanged.
 func avroEncodePartitionData(idKeyed map[int]any, fields dataFileFieldMaps) (map[string]any, error) {
-	converted, err := avroPartitionData(idKeyed, fields.idToType, fields.idToFixedSize)
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string]any, len(converted))
+	out := make(map[string]any, len(fields.nameToID))
 	for name, id := range fields.nameToID {
 		if _, unknown := fields.unknownFieldIDs[id]; unknown {
 			// UnknownType has no value representation and is encoded as Avro
@@ -224,7 +220,17 @@ func avroEncodePartitionData(idKeyed map[int]any, fields dataFileFieldMaps) (map
 
 			continue
 		}
-		if v, ok := converted[id]; ok {
+		v, ok := idKeyed[id]
+		if !ok {
+			continue
+		}
+		if logical, ok := fields.idToType[id]; ok {
+			converted, err := convertLogicalTypeValue(v, logical, fields.idToFixedSize[id])
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert partition field %d: %w", id, err)
+			}
+			out[name] = converted
+		} else {
 			out[name] = v
 		}
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -2451,23 +2451,6 @@ func mapToAvroColMap[K comparable, V any](m map[K]V) *[]colMap[K, V] {
 	return &out
 }
 
-func avroPartitionData(input map[int]any, logicalTypes map[int]string, fixedSizes map[int]int) (map[int]any, error) {
-	out := make(map[int]any)
-	for k, v := range input {
-		if logical, ok := logicalTypes[k]; ok {
-			converted, err := convertLogicalTypeValue(v, logical, fixedSizes[k])
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert partition field %d: %w", k, err)
-			}
-			out[k] = converted
-		} else {
-			out[k] = v
-		}
-	}
-
-	return out, nil
-}
-
 func convertLogicalTypeValue(v any, logicalType string, fixedSize int) (any, error) {
 	switch logicalType {
 	case atype.Date:

--- a/manifest_partition_bench_test.go
+++ b/manifest_partition_bench_test.go
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/twmb/avro/atype"
+)
+
+var avroEncodePartitionDataBenchmarkSink int
+
+func BenchmarkAvroEncodePartitionData(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		fieldCount int
+		logical    bool
+	}{
+		{name: "empty", fieldCount: 0},
+		{name: "primitive_4", fieldCount: 4},
+		{name: "logical_4", fieldCount: 4, logical: true},
+		{name: "primitive_16", fieldCount: 16},
+		{name: "logical_16", fieldCount: 16, logical: true},
+	} {
+		partition, fields := avroEncodePartitionDataBenchmarkData(tc.fieldCount, tc.logical)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				converted, err := avroEncodePartitionData(partition, fields)
+				if err != nil {
+					b.Fatal(err)
+				}
+				avroEncodePartitionDataBenchmarkSink = len(converted)
+			}
+		})
+	}
+}
+
+func avroEncodePartitionDataBenchmarkData(fieldCount int, logical bool) (map[int]any, dataFileFieldMaps) {
+	partition := make(map[int]any, fieldCount)
+	fields := dataFileFieldMaps{
+		nameToID:      make(map[string]int, fieldCount),
+		idToType:      make(map[int]string),
+		idToFixedSize: make(map[int]int),
+	}
+
+	for i := range fieldCount {
+		id := 1000 + i
+		name := fmt.Sprintf("field_%02d", i)
+		fields.nameToID[name] = id
+
+		switch {
+		case logical && i%4 == 0:
+			fields.idToType[id] = atype.Date
+			partition[id] = Date(i)
+		case logical && i%4 == 1:
+			fields.idToType[id] = atype.TimestampMicros
+			partition[id] = Timestamp(i * 1_000)
+		case logical && i%4 == 2:
+			fields.idToType[id] = atype.Decimal
+			fields.idToFixedSize[id] = 16
+			partition[id] = Decimal{Val: decimal128.FromI64(int64(i + 1)), Scale: 2}
+		default:
+			partition[id] = int32(i)
+		}
+	}
+
+	return partition, fields
+}


### PR DESCRIPTION
## Summary

- Fuse logical-type conversion into the final name-keyed Avro map.
- Remove the temporary ID-keyed converted map.
- Keep date, timestamp, decimal, primitive, and unknown-field handling.
- Add focused partition conversion benchmarks.

## Benchmark

Median of 5 runs on an Apple M1 Pro with `GOMAXPROCS=1`.

Command:

```text
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkAvroEncodePartitionData$' -benchmem -benchtime=500ms -count=5 .
```

| Case | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 4 primitive fields | 565 ns/op | 322 ns/op | 1.75x |
| 4 logical fields | 749 ns/op | 484 ns/op | 1.55x |
| 16 primitive fields | 2.80 us/op | 1.01 us/op | 2.76x |
| 16 logical fields | 3.70 us/op | 1.91 us/op | 1.94x |

For the 16 logical field case, memory dropped from 3,280 B/op and 35 allocs/op to 1,639 B/op and 28 allocs/op.

The existing end-to-end manifest writer benchmark also improved for 10,000 entries:

- 44.37 ms/op -> 41.00 ms/op, about 8% faster
- 22.33 MB/op -> 19.77 MB/op
- 120,463 allocs/op -> 100,460 allocs/op

Command:

```text
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkManifestWriterPartitionSummaries$' -benchmem -benchtime=1s -count=5 .
```

## Checks

- `go test . -count=1`
- `go test ./table/... -count=1`
- All non-cloud packages pass
- `go vet ./...`
