### PR TITLE
perf(table): pre-size equality delete key set

### DIFF
--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -480,7 +480,7 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 	}
 	defer recRdr.Release()
 
-	keys = make(set[string])
+	keys = make(set[string], min(dataFile.Count(), int64(16384)))
 	var keyBuf bytes.Buffer
 
 	for recRdr.Next() {

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -38,8 +38,19 @@ import (
 )
 
 func BenchmarkReadEqualityDeleteFile(b *testing.B) {
-	for _, numRows := range []int{10_000, 100_000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+	for _, benchmarkCase := range []struct {
+		name       string
+		numRows    int
+		uniqueRows int
+	}{
+		{name: "unique", numRows: 10_000, uniqueRows: 10_000},
+		{name: "duplicate-heavy", numRows: 10_000, uniqueRows: 100},
+		{name: "unique", numRows: 100_000, uniqueRows: 100_000},
+		{name: "duplicate-heavy", numRows: 100_000, uniqueRows: 100},
+	} {
+		b.Run(fmt.Sprintf("rows=%d/%s", benchmarkCase.numRows, benchmarkCase.name), func(b *testing.B) {
+			numRows := benchmarkCase.numRows
+			uniqueRows := benchmarkCase.uniqueRows
 			tableSchema := iceberg.NewSchema(0,
 				iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
 				iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String},
@@ -58,8 +69,9 @@ func BenchmarkReadEqualityDeleteFile(b *testing.B) {
 			payloadBuilder := builder.Field(2).(*array.StringBuilder)
 			payload := strings.Repeat("payload-", 64)
 			for i := range numRows {
-				idBuilder.Append(int64(i))
-				nameBuilder.Append(fmt.Sprintf("user-%08d", i))
+				key := i % uniqueRows
+				idBuilder.Append(int64(key))
+				nameBuilder.Append(fmt.Sprintf("user-%08d", key))
 				payloadBuilder.Append(payload)
 			}
 			rec := builder.NewRecordBatch()
@@ -105,8 +117,8 @@ func BenchmarkReadEqualityDeleteFile(b *testing.B) {
 						if err != nil {
 							b.Fatal(err)
 						}
-						if len(keys) != numRows {
-							b.Fatalf("got %d keys, want %d", len(keys), numRows)
+						if len(keys) != uniqueRows {
+							b.Fatalf("got %d keys, want %d", len(keys), uniqueRows)
 						}
 					}
 				})


### PR DESCRIPTION
## What changed

- Pre-size the equality-delete key set from the delete-file row count, capped at 16,384 entries.
- Add benchmark cases for unique and duplicate-heavy keys.

## Why

This targets equality-delete files where most rows produce distinct keys. Pre-sizing avoids repeated map growth in that case.

For duplicate-heavy files, the row count is a less accurate capacity hint, so the benchmark shows a small memory and time regression.

## Benchmark

Command:

`go test ./table -run=none -bench=BenchmarkReadEqualityDeleteFile -benchmem -benchtime=1s -count=5`

Medians from five runs on an Apple M1 Pro. `Before` is `upstream/main`; `After` is this branch. The table shows the streamed reader, which is the path changed here.

| Rows / keys | Before | After |
| --- | ---: | ---: |
| 10,000 / unique | 1.29 ms/op, 3.52 MB/op, 10,534 allocs/op | 1.10 ms/op, 3.08 MB/op, 10,486 allocs/op |
| 10,000 / duplicate-heavy | 0.82 ms/op, 1.95 MB/op, 10,550 allocs/op | 0.87 ms/op, 2.38 MB/op, 10,575 allocs/op |
| 100,000 / unique | 10.89 ms/op, 30.43 MB/op, 101,800 allocs/op | 10.91 ms/op, 29.57 MB/op, 101,720 allocs/op |
| 100,000 / duplicate-heavy | 6.14 ms/op, 16.39 MB/op, 102,010 allocs/op | 6.20 ms/op, 17.27 MB/op, 102,065 allocs/op |

The duplicate-heavy baseline used the same cases in a temporary benchmark harness because those cases are new in this PR.

## Testing

- `go test ./table`
- `go test ./...`