### PR TITLE
perf(table): avoid schema clones in remote wildcard projection

### DIFF
--- a/table/scan_planning_remote.go
+++ b/table/scan_planning_remote.go
@@ -51,7 +51,7 @@ func remotePlanningSelectedFields(scan *Scan, schema *iceberg.Schema) ([]string,
 		return scan.remoteSelectedFields(schema), nil
 	}
 
-	ids := make([]int, 0, len(schema.Fields()))
+	ids := make([]int, 0, schema.NumFields())
 	for _, field := range schema.Fields() {
 		appendRemoteProjectedFieldIDs(&ids, field)
 	}

--- a/table/scan_planning_remote_bench_test.go
+++ b/table/scan_planning_remote_bench_test.go
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var remoteWildcardProjectionBenchmarkSink int
+
+func BenchmarkRemotePlanningSelectedFields(b *testing.B) {
+	for _, fieldCount := range []int{100, 1_000, 5_000} {
+		schema := remoteWildcardProjectionBenchmarkSchema(fieldCount)
+		scan := &Scan{selectedFields: []string{"*"}, caseSensitive: true}
+		if _, err := remotePlanningSelectedFields(scan, schema); err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(fmt.Sprintf("top_level_fields_%d", fieldCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				selected, err := remotePlanningSelectedFields(scan, schema)
+				if err != nil {
+					b.Fatal(err)
+				}
+				remoteWildcardProjectionBenchmarkSink = len(selected)
+			}
+		})
+	}
+}
+
+func remoteWildcardProjectionBenchmarkSchema(fieldCount int) *iceberg.Schema {
+	fields := make([]iceberg.NestedField, fieldCount)
+	nextID := 1
+	for i := range fieldCount {
+		name := fmt.Sprintf("field_%05d", i)
+		switch i % 3 {
+		case 0:
+			fields[i] = iceberg.NestedField{
+				ID:   nextID,
+				Name: name,
+				Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+					{ID: nextID + 1, Name: "city", Type: iceberg.PrimitiveTypes.String, InitialDefault: "default-city"},
+					{ID: nextID + 2, Name: "zip", Type: iceberg.PrimitiveTypes.Int32, WriteDefault: int32(0)},
+				}},
+				InitialDefault: map[string]any{
+					"city": "default-city",
+					"zip":  int32(0),
+				},
+			}
+			nextID += 3
+		case 1:
+			fields[i] = iceberg.NestedField{
+				ID:   nextID,
+				Name: name,
+				Type: &iceberg.ListType{
+					ElementID: nextID + 1,
+					Element: &iceberg.StructType{FieldList: []iceberg.NestedField{
+						{ID: nextID + 2, Name: "city", Type: iceberg.PrimitiveTypes.String, InitialDefault: "default-city"},
+						{ID: nextID + 3, Name: "zip", Type: iceberg.PrimitiveTypes.Int32, WriteDefault: int32(0)},
+					}},
+				},
+				InitialDefault: []any{map[string]any{
+					"city": "default-city",
+					"zip":  int32(0),
+				}},
+			}
+			nextID += 4
+		default:
+			fields[i] = iceberg.NestedField{
+				ID:   nextID,
+				Name: name,
+				Type: &iceberg.MapType{
+					KeyID:   nextID + 1,
+					KeyType: iceberg.PrimitiveTypes.String,
+					ValueID: nextID + 2,
+					ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+						{ID: nextID + 3, Name: "city", Type: iceberg.PrimitiveTypes.String, InitialDefault: "default-city"},
+						{ID: nextID + 4, Name: "zip", Type: iceberg.PrimitiveTypes.Int32, WriteDefault: int32(0)},
+					}},
+				},
+				InitialDefault: map[string]any{
+					"default-key": map[string]any{
+						"city": "default-city",
+						"zip":  int32(0),
+					},
+				},
+			}
+			nextID += 5
+		}
+	}
+
+	return iceberg.NewSchema(0, fields...)
+}


### PR DESCRIPTION
## Summary

- Use `Schema.NumFields()` for the projected ID slice capacity.
- Avoid the extra defensive deep clone from `Schema.Fields()`.
- Keep the existing wildcard traversal and nested collection projection rules.
- Add a focused remote wildcard projection benchmark.

## Benchmark

Median of 5 runs on an Apple M1 Pro with `GOMAXPROCS=1`. The benchmark uses nested structs, lists, maps, and default values.

Command:

```text
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkRemotePlanningSelectedFields$' -benchmem -benchtime=500ms -count=5 ./table
```

| Top-level fields | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 100 | 152 us/op | 76.6 us/op | 1.99x |
| 1,000 | 1.43 ms/op | 750 us/op | 1.91x |
| 5,000 | 6.78 ms/op | 3.63 ms/op | 1.87x |

Memory dropped by about 47% and allocations dropped by about 50%:

- 5,000 fields: 8.52 MB/op and 60,005 allocs/op -> 4.49 MB/op and 30,005 allocs/op

## Checks

- `go test . -count=1`
- `go test ./table/... -count=1`
- All non-cloud packages pass
- `go vet ./...`
