### PR TITLE
perf(table): borrow source fields during DataFile finalization

### DIFF
--- a/table/internal/utils.go
+++ b/table/internal/utils.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
 	"github.com/twmb/avro/atype"
 	"golang.org/x/sync/errgroup"
 )
@@ -160,13 +161,22 @@ func PartitionRecordValue(field iceberg.PartitionField, val iceberg.Literal, sch
 		return ret, nil
 	}
 
-	f, ok := schema.FindFieldByID(field.SourceID())
+	f, ok := schema.FindFieldByIDRef(field.SourceID(), iceberginternal.SchemaRef{})
 	if !ok {
 		return ret, fmt.Errorf("%w: could not find source field in schema for %s",
 			iceberg.ErrInvalidSchema, field.String())
 	}
 
-	out, err := val.To(f.Type)
+	return partitionRecordValue(val, f.Type)
+}
+
+func partitionRecordValue(val iceberg.Literal, sourceType iceberg.Type) (iceberg.Optional[iceberg.Literal], error) {
+	var ret iceberg.Optional[iceberg.Literal]
+	if val == nil {
+		return ret, nil
+	}
+
+	out, err := val.To(sourceType)
 	if err != nil {
 		return ret, err
 	}
@@ -222,8 +232,22 @@ func (d *DataFileStatistics) PartitionValue(field iceberg.PartitionField, sc *ic
 		return nil
 	}
 
-	lowerRec := must(PartitionRecordValue(field, agg.Min(), sc))
-	upperRec := must(PartitionRecordValue(field, agg.Max(), sc))
+	sourceField, ok := sc.FindFieldByIDRef(field.SourceID(), iceberginternal.SchemaRef{})
+	if !ok {
+		panic(fmt.Errorf("%w: could not find source field in schema for %s",
+			iceberg.ErrInvalidSchema, field.String()))
+	}
+
+	return d.partitionValueWithSourceType(field, agg, sourceField.Type)
+}
+
+func (d *DataFileStatistics) partitionValueWithSourceType(field iceberg.PartitionField, agg StatsAgg, sourceType iceberg.Type) any {
+	if agg == nil {
+		return nil
+	}
+
+	lowerRec := must(partitionRecordValue(agg.Min(), sourceType))
+	upperRec := must(partitionRecordValue(agg.Max(), sourceType))
 
 	lowerT := field.Transform.Apply(lowerRec)
 	upperT := field.Transform.Apply(upperRec)
@@ -271,18 +295,25 @@ func (d *DataFileStatistics) ToDataFile(opts DataFileOpts) iceberg.DataFile {
 	if !opts.Spec.Equals(*iceberg.UnpartitionedSpec) {
 		fieldIDToPartitionData = make(map[int]any)
 		for _, field := range opts.Spec.Fields() {
+			sourceField, sourceFieldFound := opts.Schema.FindFieldByIDRef(
+				field.SourceID(), iceberginternal.SchemaRef{})
 			partitionVal := opts.PartitionValues[field.FieldID]
 			switch {
 			case partitionVal != nil:
 				// prioritizing caller-supplied value.
 				fieldIDToPartitionData[field.FieldID] = partitionVal
+			case field.Transform.PreservesOrder() && sourceFieldFound:
+				fieldIDToPartitionData[field.FieldID] = d.partitionValueWithSourceType(
+					field, d.ColAggs[field.SourceID()], sourceField.Type)
 			case field.Transform.PreservesOrder():
+				// Preserve the existing error path for an invalid schema. This branch
+				// is not part of the valid hot path because sourceFieldFound is false.
 				fieldIDToPartitionData[field.FieldID] = d.PartitionValue(field, opts.Schema)
 			default:
 				fieldIDToPartitionData[field.FieldID] = nil
 			}
 
-			if sourceField, ok := opts.Schema.FindFieldByID(field.SourceID()); ok {
+			if sourceFieldFound {
 				resultType := field.Transform.ResultType(sourceField.Type)
 
 				switch resultType.(type) {

--- a/table/internal/utils_bench_test.go
+++ b/table/internal/utils_bench_test.go
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var dataFileFinalizationBenchmarkSink int64
+
+type dataFileFinalizationBenchmarkAgg struct {
+	value iceberg.Literal
+}
+
+func (a *dataFileFinalizationBenchmarkAgg) Min() iceberg.Literal                 { return a.value }
+func (a *dataFileFinalizationBenchmarkAgg) Max() iceberg.Literal                 { return a.value }
+func (a *dataFileFinalizationBenchmarkAgg) Update(interface{ HasMinMax() bool }) {}
+func (a *dataFileFinalizationBenchmarkAgg) MinAsBytes() ([]byte, error)          { return nil, nil }
+func (a *dataFileFinalizationBenchmarkAgg) MaxAsBytes() ([]byte, error)          { return nil, nil }
+
+func BenchmarkDataFileStatisticsToDataFile(b *testing.B) {
+	for _, fieldCount := range []int{1, 8, 32} {
+		schema, spec, stats := dataFileFinalizationBenchmarkData(fieldCount)
+		opts := DataFileOpts{
+			Schema:   schema,
+			Spec:     spec,
+			Path:     "s3://bucket/data/file.parquet",
+			Format:   iceberg.ParquetFile,
+			Content:  iceberg.EntryContentData,
+			FileSize: 1024,
+		}
+		if df := stats.ToDataFile(opts); df.Count() != int64(fieldCount*100) {
+			b.Fatalf("unexpected record count: %d", df.Count())
+		}
+
+		b.Run(fmt.Sprintf("partition_fields_%d", fieldCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				df := stats.ToDataFile(opts)
+				dataFileFinalizationBenchmarkSink = df.Count()
+			}
+		})
+	}
+}
+
+func dataFileFinalizationBenchmarkData(fieldCount int) (*iceberg.Schema, iceberg.PartitionSpec, *DataFileStatistics) {
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	specFields := make([]iceberg.PartitionField, fieldCount)
+	colAggs := make(map[int]StatsAgg, fieldCount)
+	for i := range fieldCount {
+		sourceID := i + 1
+		defaultValue := make([]byte, 32)
+		for j := range defaultValue {
+			defaultValue[j] = byte(i + j)
+		}
+		schemaFields[i] = iceberg.NestedField{
+			ID:             sourceID,
+			Name:           fmt.Sprintf("field_%02d", i),
+			Type:           iceberg.PrimitiveTypes.Binary,
+			InitialDefault: defaultValue,
+			WriteDefault:   defaultValue,
+		}
+		specFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{sourceID},
+			FieldID:   1000 + i,
+			Name:      fmt.Sprintf("field_%02d", i),
+			Transform: iceberg.IdentityTransform{},
+		}
+		colAggs[sourceID] = &dataFileFinalizationBenchmarkAgg{
+			value: iceberg.NewLiteral([]byte{byte(i), byte(i + 1)}),
+		}
+	}
+
+	return iceberg.NewSchema(0, schemaFields...), iceberg.NewPartitionSpec(specFields...), &DataFileStatistics{
+		RecordCount: int64(fieldCount * 100),
+		ColAggs:     colAggs,
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve each partition source field once during `DataFile` finalization.
- Use the borrowed source field type for partition bound conversion and transform result typing.
- Avoid defensive field clones in the normal `ToDataFile` path.
- Keep the existing behavior for missing statistics and invalid schemas.
- Add a focused finalization benchmark.

## Benchmark

Median of 5 runs on an Apple M1 Pro with `GOMAXPROCS=1`.

The fixture uses binary source fields with mutable defaults so the defensive field copies are visible in the allocation numbers.

Command:

```text
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkDataFileStatisticsToDataFile$' -benchmem -benchtime=500ms -count=5 ./table/internal
```

| Partition fields | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 1 | 1.80 us/op | 1.51 us/op | 1.19x |
| 8 | 8.33 us/op | 3.98 us/op | 2.09x |
| 32 | 39.6 us/op | 22.5 us/op | 1.76x |

For 32 partition fields:

- 29,088 B/op -> 18,336 B/op
- 676 allocs/op -> 292 allocs/op

## Checks

- `go test . -count=1`
- `go test ./table/... -count=1`
- All non-cloud packages pass
- `go vet ./...`
