### PR TITLE
perf(table): reuse schema fields when resolving sort keys

### DIFF
--- a/table/sort_keys.go
+++ b/table/sort_keys.go
@@ -47,9 +47,10 @@ func resolveSortKeys(order SortOrder, fileSchema *iceberg.Schema) ([]compute.Sor
 		return nil, nil
 	}
 
+	fields := fileSchema.Fields()
 	keys := make([]compute.SortKey, 0, order.Len())
 	for _, field := range order.fields {
-		idx, ok := topLevelFieldIndex(fileSchema, field.SourceID())
+		idx, ok := topLevelFieldIndex(fields, field.SourceID())
 		if !ok {
 			return nil, fmt.Errorf("sort order %d: source id %d is not a top-level column in schema",
 				order.OrderID(), field.SourceID())
@@ -68,8 +69,8 @@ func resolveSortKeys(order SortOrder, fileSchema *iceberg.Schema) ([]compute.Sor
 	return keys, nil
 }
 
-func topLevelFieldIndex(schema *iceberg.Schema, sourceID int) (int, bool) {
-	for i, f := range schema.Fields() {
+func topLevelFieldIndex(fields []iceberg.NestedField, sourceID int) (int, bool) {
+	for i, f := range fields {
 		if f.ID == sourceID {
 			return i, true
 		}

--- a/table/sort_keys_bench_test.go
+++ b/table/sort_keys_bench_test.go
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/iceberg-go"
+)
+
+var resolveSortKeysBenchmarkSink []compute.SortKey
+
+func BenchmarkResolveSortKeys(b *testing.B) {
+	for _, tc := range []struct {
+		fieldCount int
+		sortFields int
+	}{
+		{fieldCount: 32, sortFields: 1},
+		{fieldCount: 32, sortFields: 4},
+		{fieldCount: 32, sortFields: 16},
+		{fieldCount: 256, sortFields: 1},
+		{fieldCount: 256, sortFields: 8},
+		{fieldCount: 256, sortFields: 32},
+		{fieldCount: 2_048, sortFields: 1},
+		{fieldCount: 2_048, sortFields: 8},
+		{fieldCount: 2_048, sortFields: 32},
+	} {
+		b.Run(fmt.Sprintf("fields=%d/sort-keys=%d", tc.fieldCount, tc.sortFields), func(b *testing.B) {
+			schema := benchmarkSortKeysSchema(tc.fieldCount, false)
+			order := benchmarkSortKeysOrder(tc.sortFields)
+
+			b.Run("before", func(b *testing.B) {
+				benchmarkResolveSortKeys(b, order, schema, resolveSortKeysBefore)
+			})
+			b.Run("after", func(b *testing.B) {
+				benchmarkResolveSortKeys(b, order, schema, resolveSortKeys)
+			})
+		})
+	}
+
+	b.Run("fields=128/sort-keys=16/nested", func(b *testing.B) {
+		schema := benchmarkSortKeysSchema(128, true)
+		order := benchmarkSortKeysOrder(16)
+
+		b.Run("before", func(b *testing.B) {
+			benchmarkResolveSortKeys(b, order, schema, resolveSortKeysBefore)
+		})
+		b.Run("after", func(b *testing.B) {
+			benchmarkResolveSortKeys(b, order, schema, resolveSortKeys)
+		})
+	})
+}
+
+type resolveSortKeysBenchmarkFunc func(SortOrder, *iceberg.Schema) ([]compute.SortKey, error)
+
+func benchmarkResolveSortKeys(
+	b *testing.B,
+	order SortOrder,
+	schema *iceberg.Schema,
+	resolve resolveSortKeysBenchmarkFunc,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		keys, err := resolve(order, schema)
+		if err != nil {
+			b.Fatal(err)
+		}
+		resolveSortKeysBenchmarkSink = keys
+	}
+}
+
+func benchmarkSortKeysSchema(fieldCount int, nested bool) *iceberg.Schema {
+	fields := make([]iceberg.NestedField, fieldCount)
+	nextID := fieldCount + 1
+	for i := range fieldCount {
+		field := iceberg.NestedField{
+			ID:       i + 1,
+			Name:     fmt.Sprintf("field_%d", i),
+			Required: true,
+			Type:     iceberg.PrimitiveTypes.Int64,
+		}
+		if nested {
+			children := make([]iceberg.NestedField, 4)
+			for child := range children {
+				children[child] = iceberg.NestedField{
+					ID:       nextID,
+					Name:     fmt.Sprintf("child_%d", child),
+					Required: true,
+					Type:     iceberg.PrimitiveTypes.Int64,
+				}
+				nextID++
+			}
+			field.Type = &iceberg.StructType{FieldList: children}
+		}
+		fields[i] = field
+	}
+
+	return iceberg.NewSchema(1, fields...)
+}
+
+func benchmarkSortKeysOrder(sortFieldCount int) SortOrder {
+	fields := make([]SortField, sortFieldCount)
+	for i := range sortFieldCount {
+		fields[i] = SortField{
+			SourceIDs: []int{i + 1}, Transform: iceberg.IdentityTransform{},
+			Direction: SortASC, NullOrder: NullsLast,
+		}
+	}
+
+	order, err := NewSortOrder(1, fields)
+	if err != nil {
+		panic(err)
+	}
+
+	return order
+}
+
+// resolveSortKeysBefore keeps the previous implementation available for
+// before/after benchmark comparisons from a single checkout.
+func resolveSortKeysBefore(order SortOrder, fileSchema *iceberg.Schema) ([]compute.SortKey, error) {
+	if order.IsUnsorted() {
+		return nil, nil
+	}
+
+	keys := make([]compute.SortKey, 0, order.Len())
+	for _, field := range order.fields {
+		idx, ok := topLevelFieldIndexBefore(fileSchema, field.SourceID())
+		if !ok {
+			return nil, fmt.Errorf("sort order %d: source id %d is not a top-level column in schema",
+				order.OrderID(), field.SourceID())
+		}
+
+		key := compute.SortKey{ColumnIndex: idx, Order: compute.SortOrderAscending, NullPlacement: compute.SortNullsAtEnd}
+		if field.Direction == SortDESC {
+			key.Order = compute.SortOrderDescending
+		}
+		if field.NullOrder == NullsFirst {
+			key.NullPlacement = compute.SortNullsAtStart
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+func topLevelFieldIndexBefore(schema *iceberg.Schema, sourceID int) (int, bool) {
+	for i, f := range schema.Fields() {
+		if f.ID == sourceID {
+			return i, true
+		}
+	}
+
+	return 0, false
+}


### PR DESCRIPTION
## What

- Reuse the cloned top-level schema fields while resolving sort keys.
- Call Schema.Fields once per sort-order resolution instead of once per sort field.
- Add before and after benchmark coverage for wide and nested schemas.

## Why

Schema.Fields deep-clones fields and nested types. Sort key resolution was repeating that full clone for every sort key. This keeps the lookup behavior and output unchanged while removing the repeated copy work.

## Benchmark

Command: go test ./table -run=^$ -bench=^BenchmarkResolveSortKeys$ -benchmem -benchtime=1s -count=5

Apple M1 Pro, Go 1.26.3, darwin/arm64. Values below are representative samples from the five runs.

| Case | Before | After |
| --- | ---: | ---: |
| 32 fields / 4 sort keys | 12,864 B/op, 5 allocs/op | 3,264 B/op, 2 allocs/op |
| 32 fields / 16 sort keys | 51,456 B/op, 17 allocs/op | 3,456 B/op, 2 allocs/op |
| 256 fields / 8 sort keys | 218,240 B/op, 9 allocs/op | 27,392 B/op, 2 allocs/op |
| 256 fields / 32 sort keys | 872,960 B/op, 33 allocs/op | 27,776 B/op, 2 allocs/op |
| 2,048 fields / 32 sort keys | 6,291,972 B/op, 33 allocs/op | 197,120 B/op, 2 allocs/op |
| 128 nested fields / 16 sort keys | 1,052,929 B/op, 4,113 allocs/op | 66,048 B/op, 258 allocs/op |

The 2,048-field, 32-key case uses about 96.9% fewer bytes per operation.

## Tests

- go test ./table -count=1
- go test -race ./table -count=1
- go vet ./table
- golangci-lint run --timeout=10m (0 issues)

Signed-off-by: Minh Vu <vuhoangminh97@gmail.com>