### PR TITLE
perf(table): collect fanout partitions into one slice

### DIFF
--- a/table/partition_extraction_bench_test.go
+++ b/table/partition_extraction_bench_test.go
@@ -82,6 +82,66 @@ func BenchmarkPartitionExtraction(b *testing.B) {
 	}
 }
 
+func BenchmarkPartitionMapCollection(b *testing.B) {
+	for _, test := range []struct {
+		fieldCount     int
+		partitionCount int
+	}{
+		{fieldCount: 2, partitionCount: 64},
+		{fieldCount: 2, partitionCount: 1_024},
+		{fieldCount: 2, partitionCount: 16_384},
+		{fieldCount: 4, partitionCount: 64},
+		{fieldCount: 4, partitionCount: 1_024},
+		{fieldCount: 4, partitionCount: 16_384},
+	} {
+		b.Run(fmt.Sprintf("fields_%d/partitions_%d", test.fieldCount, test.partitionCount), func(b *testing.B) {
+			tree := benchmarkPartitionMap(b, test.fieldCount, test.partitionCount)
+			b.ReportAllocs()
+			b.ReportMetric(float64(test.partitionCount), "partitions/op")
+			b.ResetTimer()
+			for b.Loop() {
+				partitionCollectionBenchmarkSink = len(tree.collectPartitions())
+			}
+		})
+	}
+}
+
+var partitionCollectionBenchmarkSink int
+
+func benchmarkPartitionMap(b *testing.B, fieldCount, partitionCount int) *partitionMapNode {
+	b.Helper()
+
+	base := 1
+	for {
+		combinations := 1
+		for range fieldCount {
+			combinations *= base
+		}
+		if combinations >= partitionCount {
+			break
+		}
+		base++
+	}
+
+	fieldInfo := make([]partitionFieldInfo, fieldCount)
+	for field := range fieldCount {
+		fieldInfo[field].fieldID = 1000 + field
+	}
+
+	tree := newPartitionMapNode()
+	for partition := range partitionCount {
+		record := make(partitionRecord, fieldCount)
+		value := partition
+		for field := range fieldCount {
+			record[field] = int32(value % base)
+			value /= base
+		}
+		tree.getOrCreate(record, fieldInfo, int64(partitionCount))
+	}
+
+	return tree
+}
+
 func BenchmarkPartitionTransforms(b *testing.B) {
 	const rows = 65_536
 

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -549,9 +549,9 @@ func bindPartitionTransform(transform iceberg.Transform, sourceType iceberg.Type
 // is in the order of the partition spec.
 // The value is either a *partitionMapNode or a *partitionInfo.
 type partitionMapNode struct {
-	children  map[any]any
-	leafCount int
-	// partitionCount is maintained by the root node for the current batch.
+	children map[any]any
+	// partitionCount is maintained by the root node for the current batch and
+	// sizes the single result slice returned by collectPartitions.
 	partitionCount int
 }
 
@@ -602,7 +602,6 @@ func (n *partitionMapNode) getOrCreate(partitionRec partitionRecord, fieldInfo [
 		partitionRec:    partRecCopy,
 	}
 	node.children[lastKey] = partVal
-	node.leafCount++
 	n.partitionCount++
 
 	return partVal
@@ -634,13 +633,18 @@ func initialPartitionRowCapacity(numRows int64, partitionCount int) int {
 // the clustered writer, whose revisit check would otherwise depend on
 // Go's randomized map iteration) must sort the result themselves.
 func (n *partitionMapNode) collectPartitions() []*partitionInfo {
-	result := make([]*partitionInfo, 0, n.leafCount)
+	result := make([]*partitionInfo, 0, n.partitionCount)
+
+	return n.appendPartitions(result)
+}
+
+func (n *partitionMapNode) appendPartitions(result []*partitionInfo) []*partitionInfo {
 	for _, v := range n.children {
 		switch node := v.(type) {
 		case *partitionInfo:
 			result = append(result, node)
 		case *partitionMapNode:
-			result = append(result, node.collectPartitions()...)
+			result = node.appendPartitions(result)
 		}
 	}
 

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -460,6 +460,36 @@ func (s *FanoutWriterTestSuite) TestPartitionMapUsesComparableKeysAtEveryLevel()
 	s.ElementsMatch([][]int64{{0, 1}, {2}, {3, 4}}, rowsByPartition)
 }
 
+func (s *FanoutWriterTestSuite) TestCollectPartitionsReturnsAllLeavesInOneResult() {
+	fieldInfo := []partitionFieldInfo{
+		{fieldID: 1000},
+		{fieldID: 1001},
+		{fieldID: 1002},
+	}
+	records := []partitionRecord{
+		{int32(0), int32(0), int32(0)},
+		{int32(0), int32(1), int32(0)},
+		{int32(1), int32(0), int32(0)},
+		{int32(1), int32(0), int32(1)},
+	}
+
+	tree := newPartitionMapNode()
+	for _, record := range records {
+		tree.getOrCreate(record, fieldInfo, int64(len(records)))
+	}
+
+	partitions := tree.collectPartitions()
+	s.Require().Len(partitions, len(records))
+	s.Equal(len(records), tree.partitionCount)
+	s.Equal(len(records), cap(partitions), "collection should use one exact result buffer")
+
+	got := make([]partitionRecord, 0, len(partitions))
+	for _, partition := range partitions {
+		got = append(got, partition.partitionRec)
+	}
+	s.ElementsMatch(records, got)
+}
+
 func (s *FanoutWriterTestSuite) TestBucketTransform() {
 	arrSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},


### PR DESCRIPTION
## What changed

- **Collect partition leaves into one output slice.**
- Pre-size it from the root partition count.
- Remove per-node leaf count bookkeeping.
- Add multi-field coverage and a high-cardinality benchmark.

## Why

The old collector built a temporary result slice at every nested map level and appended those slices into the parent. This created extra allocations for multi-field partition specs.

The new traversal passes one destination slice through the tree. It keeps the same partition set and map iteration behavior.

## Checks

- `go test ./... -count=1`
- `go test ./table -race -count=1`
- `go vet ./table`
- Collection benchmark reports `1 allocs/op`, including 16,384 partitions.