### PR TITLE
perf(table): reuse Parquet schema metadata across file writers

### DIFF
--- a/table/internal/interfaces.go
+++ b/table/internal/interfaces.go
@@ -119,6 +119,8 @@ type WriteFileInfo struct {
 	Spec             iceberg.PartitionSpec
 	FileName         string
 	StatsCols        map[int]StatisticsCollector
+	ColMapping       map[string]int
+	VariantFieldIDs  map[int]struct{}
 	WriteProps       any
 	RowGroupBytes    int64
 	Content          iceberg.ManifestEntryContent

--- a/table/internal/parquet_files.go
+++ b/table/internal/parquet_files.go
@@ -507,6 +507,7 @@ type ParquetFileWriter struct {
 	info             WriteFileInfo
 	partition        map[int]any
 	colMapping       map[string]int
+	variantFieldIDs  map[int]struct{}
 	geoCols          []geoColumn
 	geoNormalizeCols []int
 	geoAccs          map[int]*geoBoundsAccumulator
@@ -595,11 +596,19 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		return nil, err
 	}
 
-	colMapping, err := p.PathToIDMapping(info.FileSchema)
-	if err != nil {
-		fw.Close()
+	colMapping := info.ColMapping
+	if colMapping == nil {
+		colMapping, err = p.PathToIDMapping(info.FileSchema)
+		if err != nil {
+			fw.Close()
 
-		return nil, err
+			return nil, err
+		}
+	}
+
+	variantFieldIDs := info.VariantFieldIDs
+	if variantFieldIDs == nil {
+		variantFieldIDs = VariantFieldIDsFromSchema(info.FileSchema)
 	}
 
 	counter := &internal.CountingWriter{W: fw}
@@ -642,6 +651,7 @@ func (p parquetFormat) NewFileWriter(ctx context.Context, fs iceio.WriteFileIO,
 		info:             info,
 		partition:        partitionValues,
 		colMapping:       colMapping,
+		variantFieldIDs:  variantFieldIDs,
 		geoCols:          geoCols,
 		geoNormalizeCols: geoNormalizeCols,
 		geoAccs:          geoAccs,
@@ -1125,7 +1135,7 @@ func (w *ParquetFileWriter) Close() (_ iceberg.DataFile, err error) {
 		return nil, err
 	}
 
-	stats := w.format.DataFileStatsFromMeta(filemeta, w.info.StatsCols, w.colMapping, VariantFieldIDsFromSchema(w.info.FileSchema), w.arrowSchema)
+	stats := w.format.DataFileStatsFromMeta(filemeta, w.info.StatsCols, w.colMapping, w.variantFieldIDs, w.arrowSchema)
 	stats.EqualityFieldIDs = w.info.EqualityFieldIDs
 
 	if err = w.applyGeoBounds(stats); err != nil {

--- a/table/internal/parquet_files_internal_test.go
+++ b/table/internal/parquet_files_internal_test.go
@@ -116,3 +116,31 @@ func TestNewFileWriterCachesGeoNormalizationColumns(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, []int{1}, parquetWriter.geoNormalizeCols)
 }
+
+func TestNewFileWriterUsesProvidedSchemaMetadata(t *testing.T) {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+	fileSchema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int32, Required: true},
+	)
+	colMapping := map[string]int{"provided": 99}
+	variantFieldIDs := map[int]struct{}{99: {}}
+	format := parquetFormat{}
+	writer, err := format.NewFileWriter(context.Background(), iceio.NewMemFS(), nil, WriteFileInfo{
+		FileSchema:      fileSchema,
+		Spec:            *iceberg.UnpartitionedSpec,
+		FileName:        "provided-schema-metadata.parquet",
+		ColMapping:      colMapping,
+		VariantFieldIDs: variantFieldIDs,
+		WriteProps:      format.GetWriteProperties(iceberg.Properties{}),
+	}, arrowSchema)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, writer.Abort()) }()
+
+	parquetWriter, ok := writer.(*ParquetFileWriter)
+	require.True(t, ok)
+	assert.Equal(t, colMapping, parquetWriter.colMapping)
+	assert.Equal(t, variantFieldIDs, parquetWriter.variantFieldIDs)
+	assert.Equal(t, 99, parquetWriter.colMapping["provided"])
+}

--- a/table/internal/parquet_schema_bench_test.go
+++ b/table/internal/parquet_schema_bench_test.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+func BenchmarkParquetFileWriterSchemaMapping(b *testing.B) {
+	format := parquetFormat{}
+
+	for _, fieldCount := range []int{8, 64, 256} {
+		b.Run(fmt.Sprintf("fields_%d", fieldCount), func(b *testing.B) {
+			fileSchema, arrowSchema := parquetSchemaBenchmarkSchemas(fieldCount)
+			writeProps := format.GetWriteProperties(iceberg.Properties{})
+			cachedMapping, err := format.PathToIDMapping(fileSchema)
+			if err != nil {
+				b.Fatal(err)
+			}
+			cachedVariantFieldIDs := VariantFieldIDsFromSchema(fileSchema)
+
+			for _, cached := range []bool{false, true} {
+				name := "rebuild"
+				if cached {
+					name = "cached"
+				}
+
+				b.Run(name, func(b *testing.B) {
+					fs := iceio.NewMemFS()
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; b.Loop(); i++ {
+						info := WriteFileInfo{
+							FileSchema: fileSchema,
+							FileName:   "file-" + strconv.Itoa(i) + ".parquet",
+							WriteProps: writeProps,
+						}
+						if cached {
+							info.ColMapping = cachedMapping
+							info.VariantFieldIDs = cachedVariantFieldIDs
+						}
+
+						writer, err := format.NewFileWriter(b.Context(), fs, nil, info, arrowSchema)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if err := writer.Abort(); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func parquetSchemaBenchmarkSchemas(fieldCount int) (*iceberg.Schema, *arrow.Schema) {
+	icebergFields := make([]iceberg.NestedField, fieldCount)
+	arrowFields := make([]arrow.Field, fieldCount)
+	for i := range fieldCount {
+		name := fmt.Sprintf("field_%d", i)
+		icebergFields[i] = iceberg.NestedField{
+			ID:       i + 1,
+			Name:     name,
+			Type:     iceberg.PrimitiveTypes.Int64,
+			Required: true,
+		}
+		arrowFields[i] = arrow.Field{Name: name, Type: arrow.PrimitiveTypes.Int64, Nullable: false}
+	}
+
+	return iceberg.NewSchema(0, icebergFields...), arrow.NewSchema(arrowFields, nil)
+}

--- a/table/rolling_data_writer.go
+++ b/table/rolling_data_writer.go
@@ -63,6 +63,8 @@ type writerFactory struct {
 	writeProps       any
 	rowGroupBytes    int64
 	statsCols        map[int]tblutils.StatisticsCollector
+	colMapping       map[string]int
+	variantFieldIDs  map[int]struct{}
 	currentSpec      iceberg.PartitionSpec
 	fileFormat       iceberg.FileFormat
 	format           tblutils.FileFormat
@@ -218,6 +220,16 @@ func newWriterFactory(rootLocation string, args recordWritingArgs, meta *Metadat
 		}
 	}
 
+	if f.fileFormat == iceberg.ParquetFile {
+		f.colMapping, err = f.format.PathToIDMapping(f.fileSchema)
+		if err != nil {
+			stopCount()
+
+			return nil, err
+		}
+		f.variantFieldIDs = tblutils.VariantFieldIDsFromSchema(f.fileSchema)
+	}
+
 	f.statsCols, err = computeStatsPlan(f.fileSchema, meta.props)
 	if err != nil {
 		stopCount()
@@ -287,6 +299,8 @@ func (w *writerFactory) openFileWriter(ctx context.Context, partitionPath string
 		FileSchema:       w.fileSchema,
 		FileName:         filePath,
 		StatsCols:        w.statsCols,
+		ColMapping:       w.colMapping,
+		VariantFieldIDs:  w.variantFieldIDs,
 		WriteProps:       w.writeProps,
 		RowGroupBytes:    w.rowGroupBytes,
 		Spec:             w.currentSpec,

--- a/table/writer.go
+++ b/table/writer.go
@@ -71,13 +71,15 @@ type defaultDataFileWriter struct {
 // dataWriterInvariants contains the write configuration shared by every task
 // handled by a defaultDataFileWriter.
 type dataWriterInvariants struct {
-	statsCols     map[int]tblutils.StatisticsCollector
-	writeProps    any
-	rowGroupBytes int64
-	spec          iceberg.PartitionSpec
-	extension     string
-	arrowSchema   *arrow.Schema
-	schemaOpts    SchemaOptions
+	statsCols       map[int]tblutils.StatisticsCollector
+	colMapping      map[string]int
+	variantFieldIDs map[int]struct{}
+	writeProps      any
+	rowGroupBytes   int64
+	spec            iceberg.PartitionSpec
+	extension       string
+	arrowSchema     *arrow.Schema
+	schemaOpts      SchemaOptions
 }
 
 type dataFileWriterOption func(writer *defaultDataFileWriter)
@@ -161,13 +163,25 @@ func newDataFileWriter(rootLocation string, fs io.WriteFileIO, meta *MetadataBui
 		return nil, err
 	}
 
+	var colMapping map[string]int
+	var variantFieldIDs map[int]struct{}
+	if w.fileFormat == iceberg.ParquetFile {
+		colMapping, err = w.format.PathToIDMapping(w.fileSchema)
+		if err != nil {
+			return nil, err
+		}
+		variantFieldIDs = tblutils.VariantFieldIDsFromSchema(w.fileSchema)
+	}
+
 	w.invariants = dataWriterInvariants{
-		statsCols:     statsCols,
-		writeProps:    w.format.GetWriteProperties(w.props),
-		rowGroupBytes: rowGroupBytes,
-		spec:          *currentSpec,
-		extension:     strings.ToLower(string(w.fileFormat)),
-		arrowSchema:   arrowSchema,
+		statsCols:       statsCols,
+		colMapping:      colMapping,
+		variantFieldIDs: variantFieldIDs,
+		writeProps:      w.format.GetWriteProperties(w.props),
+		rowGroupBytes:   rowGroupBytes,
+		spec:            *currentSpec,
+		extension:       strings.ToLower(string(w.fileFormat)),
+		arrowSchema:     arrowSchema,
 		schemaOpts: SchemaOptions{
 			DowncastTimestamp: true,
 			IncludeFieldIDs:   true,
@@ -211,6 +225,8 @@ func (w *defaultDataFileWriter) writeFile(ctx context.Context, partitionValues m
 		Content:          w.content,
 		FileName:         filePath,
 		StatsCols:        w.invariants.statsCols,
+		ColMapping:       w.invariants.colMapping,
+		VariantFieldIDs:  w.invariants.variantFieldIDs,
 		WriteProps:       w.invariants.writeProps,
 		RowGroupBytes:    w.invariants.rowGroupBytes,
 		Spec:             w.invariants.spec,

--- a/table/writer_schema_projection_test.go
+++ b/table/writer_schema_projection_test.go
@@ -427,6 +427,26 @@ func TestDefaultDataFileWriterReusesExactBatch(t *testing.T) {
 	assert.Same(t, record, format.batches[0])
 }
 
+func TestDefaultDataFileWriterPrecomputesParquetSchemaMetadata(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.VariantType{}},
+	)
+	props := iceberg.Properties{PropertyFormatVersion: "3"}
+	metadata, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder, t.TempDir(), props)
+	require.NoError(t, err)
+	metaBuilder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+
+	writer, err := newDataFileWriter(t.TempDir(), iceio.LocalFS{}, metaBuilder, props)
+	require.NoError(t, err)
+
+	wantMapping, err := tblutils.GetFileFormat(iceberg.ParquetFile).PathToIDMapping(schema)
+	require.NoError(t, err)
+	assert.Equal(t, wantMapping, writer.invariants.colMapping)
+	assert.Equal(t, map[int]struct{}{2: {}}, writer.invariants.variantFieldIDs)
+}
+
 func TestRollingDataWriterReusesExactBatch(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
@@ -454,6 +474,10 @@ func TestRollingDataWriterReusesExactBatch(t *testing.T) {
 		},
 	}, metaBuilder, schema, 1024*1024)
 	require.NoError(t, err)
+	wantMapping, err := tblutils.GetFileFormat(iceberg.ParquetFile).PathToIDMapping(schema)
+	require.NoError(t, err)
+	assert.Equal(t, wantMapping, factory.colMapping)
+	assert.Empty(t, factory.variantFieldIDs)
 	format := &captureWriteDataFileFormat{FileFormat: tblutils.GetFileFormat(iceberg.ParquetFile)}
 	factory.format = format
 


### PR DESCRIPTION
## What changed

- **Precompute Parquet column mappings once per writer lifecycle.**
- Reuse variant field IDs too.
- Pass both maps through the default and rolling writer paths.
- Keep the existing fallback for direct file-writer callers.
- Add correctness coverage and a writer setup benchmark.

## Why

Each physical Parquet file rebuilt the same schema mappings even though the schema is invariant for the writer. The maps are read-only, so they can be shared safely across files.

## Checks

- `go test ./... -count=1`
- `go test -race ./table -count=1`
- `go test -race ./table/internal -count=1`
- `go vet ./table ./table/internal`

The focused benchmark shows about 12-14% lower writer setup time and 33-790 fewer allocations per file for 8-256 fields.