### PR TITLE
perf(table): lazily materialize dictionary columns

### DIFF
--- a/table/partition_batch_bench_test.go
+++ b/table/partition_batch_bench_test.go
@@ -71,6 +71,28 @@ func BenchmarkPartitionBatchByKey(b *testing.B) {
 	}
 }
 
+func BenchmarkMaterializeDictionaryColumns(b *testing.B) {
+	const rows = 1024
+
+	for _, columns := range []int{1, 8, 64} {
+		record := newPartitionBatchBenchmarkRecord(columns, rows)
+		b.Run(fmt.Sprintf("no_dictionaries_%d_columns", columns), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				record.Retain()
+				materialized, err := materializeDictionaryColumns(context.Background(), record, arrow.Metadata{})
+				if err != nil {
+					b.Fatal(err)
+				}
+				materialized.Release()
+			}
+		})
+		record.Release()
+	}
+}
+
 func newPartitionBatchBenchmarkRecord(columns, rows int) arrow.RecordBatch {
 	fields := make([]arrow.Field, columns)
 	arrays := make([]arrow.Array, columns)

--- a/table/partitioned_fanout_writer.go
+++ b/table/partitioned_fanout_writer.go
@@ -706,11 +706,11 @@ func partitionBatchByKey(ctx context.Context) partitionBatchFn {
 // the complete dictionary, which can otherwise retain a large variable-width
 // buffer in a rolling writer queue.
 func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch, recordMetadata arrow.Metadata) (arrow.RecordBatch, error) {
-	columns := slices.Clone(record.Columns())
-	fields := record.Schema().Fields()
-	materialized := make([]arrow.Array, 0)
+	var columns []arrow.Array
+	var fields []arrow.Field
+	var materialized []arrow.Array
 
-	for i, column := range columns {
+	for i, column := range record.Columns() {
 		values, changed, err := materializeDictionaryArray(ctx, column)
 		if err != nil {
 			for _, materializedColumn := range materialized {
@@ -724,12 +724,18 @@ func materializeDictionaryColumns(ctx context.Context, record arrow.RecordBatch,
 			continue
 		}
 
+		if columns == nil {
+			columns = slices.Clone(record.Columns())
+			fields = record.Schema().Fields()
+			materialized = make([]arrow.Array, 0, 1)
+		}
+
 		columns[i] = values
 		fields[i].Type = values.DataType()
 		materialized = append(materialized, values)
 	}
 
-	if len(materialized) == 0 {
+	if columns == nil {
 		return record, nil
 	}
 

--- a/table/partitioned_fanout_writer_test.go
+++ b/table/partitioned_fanout_writer_test.go
@@ -1014,6 +1014,18 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyCopiesVariableWidthPartia
 	s.Equal([]string{"s", "s"}, []string{values.Value(0), values.Value(1)})
 }
 
+func (s *FanoutWriterTestSuite) TestMaterializeDictionaryColumnsReturnsOriginalRecordWithoutDictionaries() {
+	arrSchema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	record := s.createCustomTestRecord(arrSchema, [][]any{{int64(1)}, {int64(2)}})
+	defer record.Release()
+
+	record.Retain()
+	materialized, err := materializeDictionaryColumns(s.ctx, record, arrow.Metadata{})
+	s.Require().NoError(err)
+	s.Same(record, materialized)
+	materialized.Release()
+}
+
 func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesDictionaryPartialSlices() {
 	largeValue := strings.Repeat("l", 16*1024)
 
@@ -1056,6 +1068,52 @@ func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesDictionaryPar
 	s.Require().True(ok)
 	s.Equal("metadata", recordMetadataValue)
 	values := partitioned.Column(0).(*array.String)
+	s.Equal([]string{"small dictionary value", "small dictionary value"}, []string{values.Value(0), values.Value(1)})
+}
+
+func (s *FanoutWriterTestSuite) TestPartitionBatchByKeyMaterializesDictionaryColumnsAcrossColumns() {
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	indexBuilder := array.NewInt8Builder(s.mem)
+	indexBuilder.AppendValues([]int8{0, 1, 1, 1}, nil)
+	indices := indexBuilder.NewInt8Array()
+	indexBuilder.Release()
+
+	dictBuilder := array.NewStringBuilder(s.mem)
+	dictBuilder.Append("large dictionary value")
+	dictBuilder.Append("small dictionary value")
+	dictionary := dictBuilder.NewStringArray()
+	dictBuilder.Release()
+
+	dict := array.NewDictionaryArray(dictType, indices, dictionary)
+	indices.Release()
+	dictionary.Release()
+
+	idBuilder := array.NewInt64Builder(s.mem)
+	idBuilder.AppendValues([]int64{10, 11, 12, 13}, nil)
+	ids := idBuilder.NewInt64Array()
+	idBuilder.Release()
+
+	arrSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "value", Type: dictType},
+	}, nil)
+	record := array.NewRecordBatch(arrSchema, []arrow.Array{ids, dict}, 4)
+	ids.Release()
+	dict.Release()
+	defer record.Release()
+
+	partitioned, err := partitionBatchByKey(s.ctx)(record, []int64{2, 3})
+	s.Require().NoError(err)
+	defer partitioned.Release()
+
+	s.Equal(arrow.INT64, partitioned.Column(0).DataType().ID())
+	ids = partitioned.Column(0).(*array.Int64)
+	s.Equal([]int64{12, 13}, []int64{ids.Value(0), ids.Value(1)})
+	s.Equal(arrow.STRING, partitioned.Column(1).DataType().ID())
+	values := partitioned.Column(1).(*array.String)
 	s.Equal([]string{"small dictionary value", "small dictionary value"}, []string{values.Value(0), values.Value(1)})
 }
 


### PR DESCRIPTION
## Summary

- **Delay the column and field copies until a dictionary is found.**
- **Keep the common no-dictionary path allocation-free.**
- Add coverage for unchanged batches and dictionaries after an earlier column.
- Add a benchmark for plain records with 1, 8, and 64 columns.

`materializeDictionaryColumns` is used for partial fanout batches. Most batches do not contain dictionary arrays, so the old eager copies were unnecessary.

## Tests

- `go test ./... -count=1`
- `go test ./table -count=1`
- `go test ./table -run no_tests -bench BenchmarkMaterializeDictionaryColumns -benchmem -count=1`
- Benchmark result: `0 B/op`, `0 allocs/op` on the no-dictionary cases.