### PR TITLE
perf(table): skip metadata builds when Transaction.apply has no new requirements

### DIFF
--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -206,6 +206,7 @@ func BenchmarkTransactionApplyNoRequirements(b *testing.B) {
 			txn := &Transaction{meta: template.clone()}
 
 			b.ReportAllocs()
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries")
 			b.ResetTimer()
 
 			for b.Loop() {
@@ -214,7 +215,6 @@ func BenchmarkTransactionApplyNoRequirements(b *testing.B) {
 				}
 				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
 			}
-			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
 		})
 	}
 }
@@ -231,6 +231,7 @@ func BenchmarkTransactionApplyDuplicateRequirement(b *testing.B) {
 			}
 
 			b.ReportAllocs()
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries")
 			b.ResetTimer()
 
 			for b.Loop() {
@@ -239,7 +240,6 @@ func BenchmarkTransactionApplyDuplicateRequirement(b *testing.B) {
 				}
 				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
 			}
-			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
 		})
 	}
 }
@@ -253,6 +253,7 @@ func BenchmarkTransactionApplyNewRequirement(b *testing.B) {
 			requirement := AssertCurrentSchemaID(0)
 
 			b.ReportAllocs()
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries")
 			b.ResetTimer()
 
 			for b.Loop() {
@@ -262,7 +263,6 @@ func BenchmarkTransactionApplyNewRequirement(b *testing.B) {
 				}
 				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
 			}
-			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
 		})
 	}
 }

--- a/table/metadata_builder_bench_test.go
+++ b/table/metadata_builder_bench_test.go
@@ -198,6 +198,75 @@ func BenchmarkMetadataBuilderCloneAndBuild(b *testing.B) {
 	}
 }
 
+func BenchmarkTransactionApplyNoRequirements(b *testing.B) {
+	for _, snapshotCount := range []int{1, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {
+			template := benchmarkSnapshotBuilder(snapshotCount)
+			template.ensureSnapshotIndex()
+			txn := &Transaction{meta: template.clone()}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := txn.apply(nil, nil); err != nil {
+					b.Fatal(err)
+				}
+				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
+			}
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
+		})
+	}
+}
+
+func BenchmarkTransactionApplyDuplicateRequirement(b *testing.B) {
+	for _, snapshotCount := range []int{1, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {
+			template := benchmarkSnapshotBuilder(snapshotCount)
+			template.ensureSnapshotIndex()
+			requirement := AssertCurrentSchemaID(0)
+			txn := &Transaction{
+				meta: template.clone(),
+				reqs: []Requirement{requirement},
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := txn.apply(nil, []Requirement{requirement}); err != nil {
+					b.Fatal(err)
+				}
+				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
+			}
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
+		})
+	}
+}
+
+func BenchmarkTransactionApplyNewRequirement(b *testing.B) {
+	for _, snapshotCount := range []int{1, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {
+			template := benchmarkSnapshotBuilder(snapshotCount)
+			template.ensureSnapshotIndex()
+			txn := &Transaction{meta: template.clone()}
+			requirement := AssertCurrentSchemaID(0)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				txn.reqs = nil
+				if err := txn.apply(nil, []Requirement{requirement}); err != nil {
+					b.Fatal(err)
+				}
+				metadataBuilderBenchmarkSink = len(txn.meta.snapshotList)
+			}
+			b.ReportMetric(float64(snapshotCount), "snapshot_entries/op")
+		})
+	}
+}
+
 func BenchmarkMetadataBuilderFromBase(b *testing.B) {
 	for _, snapshotCount := range []int{1_000, 10_000} {
 		b.Run(fmt.Sprintf("snapshots=%d", snapshotCount), func(b *testing.B) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -183,43 +183,50 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 	// staged metadata: a deduplicated twin re-asserts base state the
 	// staged metadata has intentionally moved past, and its kept twin
 	// was validated when first added.
-	existing := make(map[string]Requirement, len(t.reqs))
-	stagedReqs := make([]Requirement, 0, len(t.reqs)+len(reqs))
-	for _, r := range t.reqs {
-		key, err := requirementSemanticKey(r)
-		if err != nil {
-			return err
-		}
-
-		existing[key] = r
-		stagedReqs = append(stagedReqs, r)
-	}
-
-	for _, r := range reqs {
-		key, err := requirementSemanticKey(r)
-		if err != nil {
-			return err
-		}
-
-		if prev, ok := existing[key]; ok {
-			if err := checkRequirementConflict(prev, r); err != nil {
-				return err
-			}
-
-			continue
-		}
-		if current == nil {
-			built, err := stagedMeta.Build()
+	stagedReqs := t.reqs
+	if len(reqs) > 0 {
+		existing := make(map[string]Requirement, len(t.reqs))
+		for _, r := range t.reqs {
+			key, err := requirementSemanticKey(r)
 			if err != nil {
 				return err
 			}
-			current = built
+
+			existing[key] = r
 		}
-		if err := r.Validate(current); err != nil {
-			return err
+
+		copiedReqs := false
+		for _, r := range reqs {
+			key, err := requirementSemanticKey(r)
+			if err != nil {
+				return err
+			}
+
+			if prev, ok := existing[key]; ok {
+				if err := checkRequirementConflict(prev, r); err != nil {
+					return err
+				}
+
+				continue
+			}
+			if current == nil {
+				built, err := stagedMeta.Build()
+				if err != nil {
+					return err
+				}
+				current = built
+			}
+			if err := r.Validate(current); err != nil {
+				return err
+			}
+			if !copiedReqs {
+				stagedReqs = make([]Requirement, len(t.reqs), len(t.reqs)+len(reqs))
+				copy(stagedReqs, t.reqs)
+				copiedReqs = true
+			}
+			existing[key] = r
+			stagedReqs = append(stagedReqs, r)
 		}
-		existing[key] = r
-		stagedReqs = append(stagedReqs, r)
 	}
 
 	prevUpdates, prevLastUpdated := len(stagedMeta.updates), stagedMeta.lastUpdatedMS

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -172,10 +172,10 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 		return errors.New("cannot apply updates to nil metadata")
 	}
 
-	current, err := stagedMeta.Build()
-	if err != nil {
-		return err
-	}
+	// Only new requirement validation needs the immutable metadata view.
+	// Updates can be applied directly to the staged builder, and duplicate
+	// requirements only need conflict checks.
+	var current Metadata
 
 	// Deduplicate requirements by semantic key, rejecting pairs that
 	// share a key but cannot both hold (see checkRequirementConflict).
@@ -207,6 +207,12 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 			}
 
 			continue
+		}
+		if current == nil {
+			current, err = stagedMeta.Build()
+			if err != nil {
+				return err
+			}
 		}
 		if err := r.Validate(current); err != nil {
 			return err

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3265,8 +3265,9 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 }
 
 // Commit persists the transaction's staged changes. Metadata validation may be
-// deferred until Commit, StagedTable, or Scan when applying an operation only
-// adds no-op updates or duplicate requirements.
+// deferred when applying an operation adds no new requirement to the transaction.
+// The staged metadata is validated when a later transaction operation needs an
+// immutable metadata view, or while the catalog applies the commit.
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	if err := t.checkNotNil(); err != nil {
 		return nil, err

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3263,6 +3263,9 @@ func (t *Transaction) StagedTable() (*StagedTable, error) {
 	}, nil
 }
 
+// Commit persists the transaction's staged changes. Metadata validation may be
+// deferred until Commit, StagedTable, or Scan when applying an operation only
+// adds no-op updates or duplicate requirements.
 func (t *Transaction) Commit(ctx context.Context) (*Table, error) {
 	if err := t.checkNotNil(); err != nil {
 		return nil, err

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -209,10 +209,11 @@ func (t *Transaction) apply(updates []Update, reqs []Requirement) error {
 			continue
 		}
 		if current == nil {
-			current, err = stagedMeta.Build()
+			built, err := stagedMeta.Build()
 			if err != nil {
 				return err
 			}
+			current = built
 		}
 		if err := r.Validate(current); err != nil {
 			return err

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -1288,6 +1289,18 @@ func TestTransactionApplyDefersMetadataBuildForNoopRequirements(t *testing.T) {
 		_, err := txn.meta.Build()
 		require.ErrorIs(t, err, ErrInvalidMetadata)
 	})
+}
+
+func TestTransactionStagedTableBuildsOnePreviousMetadataLogEntry(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+
+	for range 3 {
+		require.NoError(t, txn.SetProperties(iceberg.Properties{"key": "value"}))
+	}
+
+	staged, err := txn.StagedTable()
+	require.NoError(t, err)
+	require.Len(t, slices.Collect(staged.Metadata().PreviousFiles()), 1)
 }
 
 func TestTransactionApplyBuildsMetadataForNewRequirement(t *testing.T) {

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -1266,6 +1266,58 @@ func TestTransactionApplyKeepsRequirementsUnchangedOnUpdateFailure(t *testing.T)
 	require.Equal(t, AssertTableUUID(baseMeta.TableUUID()), txn.reqs[0])
 }
 
+func TestTransactionApplyDefersMetadataBuildForNoopRequirements(t *testing.T) {
+	t.Run("no requirements", func(t *testing.T) {
+		txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+		txn.meta.defaultSpecID = 999
+
+		require.NoError(t, txn.apply(nil, nil))
+		_, err := txn.meta.Build()
+		require.ErrorIs(t, err, ErrInvalidMetadata)
+	})
+
+	t.Run("duplicate requirement", func(t *testing.T) {
+		txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+		requirement := AssertCurrentSchemaID(0)
+		require.NoError(t, txn.apply(nil, []Requirement{requirement}))
+
+		// A duplicate requirement only needs its conflict check. Make Build fail
+		// after the first apply so this path cannot accidentally rebuild metadata.
+		txn.meta.defaultSpecID = 999
+		require.NoError(t, txn.apply(nil, []Requirement{requirement}))
+		_, err := txn.meta.Build()
+		require.ErrorIs(t, err, ErrInvalidMetadata)
+	})
+}
+
+func TestTransactionApplyBuildsMetadataForNewRequirement(t *testing.T) {
+	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+	txn.meta.defaultSpecID = 999
+
+	err := txn.apply(nil, []Requirement{AssertDefaultSpecID(0)})
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+}
+
+func TestTransactionApplyPreservesRequirementValidationErrorAfterDuplicate(t *testing.T) {
+	const expected = "Requirement failed: current schema id has changed: expected 1, found 0"
+
+	t.Run("new requirement", func(t *testing.T) {
+		txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+
+		err := txn.apply(nil, []Requirement{AssertCurrentSchemaID(1)})
+		require.EqualError(t, err, expected)
+	})
+
+	t.Run("new requirement after duplicate", func(t *testing.T) {
+		txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
+		requirement := AssertCurrentSchemaID(0)
+		require.NoError(t, txn.apply(nil, []Requirement{requirement}))
+
+		err := txn.apply(nil, []Requirement{requirement, AssertCurrentSchemaID(1)})
+		require.EqualError(t, err, expected)
+	})
+}
+
 // TestTransactionApplyDedupesIdenticalSameRefAssertions covers repeated
 // producer commits in one transaction: producers build their assertion from
 // the BASE table's branch head, so a second commit re-asserts exactly the

--- a/table/transaction_internal_test.go
+++ b/table/transaction_internal_test.go
@@ -1291,7 +1291,7 @@ func TestTransactionApplyDefersMetadataBuildForNoopRequirements(t *testing.T) {
 	})
 }
 
-func TestTransactionStagedTableBuildsOnePreviousMetadataLogEntry(t *testing.T) {
+func TestTransactionStagedTableBuildsSinglePreviousMetadataLogEntryAfterNoRequirementApplies(t *testing.T) {
 	txn, _ := createTestTransactionWithMemIO(t, *iceberg.UnpartitionedSpec)
 
 	for range 3 {


### PR DESCRIPTION
## Summary

- **Lazy metadata builds:** `Transaction.apply` now waits to build immutable metadata until a new requirement needs validation.
- **No-op requirement paths:** Empty requirement lists and duplicate requirements skip `MetadataBuilder.Build()` while keeping conflict checks.
- **Atomic staging:** Updates are applied to cloned builders and published only after all updates succeed.
- **Staged metadata logs:** Repeated applies with no new requirements no longer add duplicate previous metadata-log entries when `StagedTable()` builds metadata. The commit path is unchanged: the catalog replays staged updates and validates the committed metadata.

## Benchmark

Apple M1 Pro, Go 1.26.3, 10,000 snapshots:

- **No requirements:** about 1.50 MB / 65 allocs to 1.21 MB / 14 allocs
- **Duplicate requirement:** about 1.50 MB / 70 allocs to 1.21 MB / 19 allocs
- **New requirement:** about 1.51 MB / 77 allocs before and after

## Tests

- `go test -timeout=5m` across all packages except `io/gocloud`
- `go test -race -timeout=5m . ./table/...`
- `golangci-lint run --timeout=10m`