### PR TITLE
perf(rest): lazy-decode snapshots in commitTableResponse when snapshot-loading-mode=refs

### DIFF
--- a/catalog/rest/lazy_snapshot_bench_test.go
+++ b/catalog/rest/lazy_snapshot_bench_test.go
@@ -140,6 +140,44 @@ func BenchmarkStageDeferredAllSnapshots(b *testing.B) {
 	}
 }
 
+// BenchmarkStageParseThenMetadataBuilder measures the path taken when a caller
+// starts another transaction from the Table returned by Commit. Builder
+// creation requires complete snapshot history, so this exposes the cost of
+// indexing deferred snapshots and then fully materializing them.
+func BenchmarkStageParseThenMetadataBuilder(b *testing.B) {
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		for _, mode := range []struct {
+			name  string
+			parse func([]byte) (table.Metadata, error)
+		}{
+			{name: "eager", parse: table.ParseMetadataBytes},
+			{name: "deferred", parse: table.ParseMetadataBytesDeferredSnapshots},
+		} {
+			b.Run(metadataBenchmarkName(rawMeta)+"/"+mode.name, func(b *testing.B) {
+				b.ResetTimer()
+				b.ReportAllocs()
+				b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+				b.ReportMetric(float64(n), "snapshots")
+				for range b.N {
+					meta, err := mode.parse(rawMeta)
+					if err != nil {
+						b.Fatal(err)
+					}
+					builder, err := table.MetadataBuilderFromBase(meta, "")
+					if err != nil {
+						b.Fatal(err)
+					}
+					if builder == nil {
+						b.Fatal("missing metadata builder")
+					}
+				}
+			})
+		}
+	}
+}
+
 // BenchmarkStageDeferredRetainedHeap measures the live heap held by one
 // deferred metadata object before and after full snapshot materialization.
 // Run with -benchtime=1x: retained-heap measurements describe one object and

--- a/catalog/rest/lazy_snapshot_bench_test.go
+++ b/catalog/rest/lazy_snapshot_bench_test.go
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+)
+
+// These counts generate metadata payloads of approximately 7 KiB, 58 KiB,
+// 569 KiB, 2 MB, and 5.6 MiB. Benchmark names and metrics report actual bytes.
+var benchSnapshotCounts = []int64{10, 100, 1000, 3418, 10000}
+
+func extractMetadata(tb testing.TB, body []byte) json.RawMessage {
+	tb.Helper()
+	var top map[string]json.RawMessage
+	require.NoError(tb, json.Unmarshal(body, &top))
+
+	return top["metadata"]
+}
+
+func metadataBenchmarkName(raw json.RawMessage) string {
+	return fmt.Sprintf("metadata=%d-bytes", len(raw))
+}
+
+// BenchmarkStageFullParse measures table.ParseMetadataBytes, the call the REST client
+// actually makes on both LoadTable and CommitTable responses.
+func BenchmarkStageFullParse(b *testing.B) {
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		b.Run(metadataBenchmarkName(rawMeta), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+			b.ReportMetric(float64(n), "snapshots")
+			for range b.N {
+				meta, err := table.ParseMetadataBytes(rawMeta)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if meta.CurrentSnapshot() == nil {
+					b.Fatal("missing current snapshot")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkStageDeferredParse measures the parse-time lazy materialization
+// path used for CommitTable responses when snapshot-loading-mode is refs.
+func BenchmarkStageDeferredParse(b *testing.B) {
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		b.Run(metadataBenchmarkName(rawMeta), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+			b.ReportMetric(float64(n), "snapshots")
+			for range b.N {
+				meta, err := table.ParseMetadataBytesDeferredSnapshots(rawMeta)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if meta.CurrentSnapshot() == nil {
+					b.Fatal("missing current snapshot")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkStageDeferredHistoricalLookup measures parsing followed by a lookup
+// of one unreferenced historical snapshot. The indexed lazy path should decode
+// only that snapshot rather than materializing the complete history.
+func BenchmarkStageDeferredHistoricalLookup(b *testing.B) {
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		b.Run(metadataBenchmarkName(rawMeta), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+			b.ReportMetric(float64(n), "snapshots")
+			for range b.N {
+				meta, err := table.ParseMetadataBytesDeferredSnapshots(rawMeta)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if meta.SnapshotByID(0) == nil {
+					b.Fatal("missing historical snapshot")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkStageDeferredAllSnapshots measures the intentional fallback that
+// parses and then materializes the complete snapshot history.
+func BenchmarkStageDeferredAllSnapshots(b *testing.B) {
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		b.Run(metadataBenchmarkName(rawMeta), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+			b.ReportMetric(float64(n), "snapshots")
+			for range b.N {
+				meta, err := table.ParseMetadataBytesDeferredSnapshots(rawMeta)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(meta.Snapshots()) != int(n) {
+					b.Fatal("incomplete snapshot history")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkStageDeferredRetainedHeap measures the live heap held by one
+// deferred metadata object before and after full snapshot materialization.
+// Run with -benchtime=1x: retained-heap measurements describe one object and
+// cannot be meaningfully averaged across b.N independent lifecycles.
+func BenchmarkStageDeferredRetainedHeap(b *testing.B) {
+	if b.N != 1 {
+		b.Skip("retained-heap benchmark requires -benchtime=1x")
+	}
+
+	for _, n := range benchSnapshotCounts {
+		body := makeTableResponseWithSnapshots(n)
+		rawMeta := extractMetadata(b, body)
+		b.Run(metadataBenchmarkName(rawMeta), func(b *testing.B) {
+			meta, err := table.ParseMetadataBytesDeferredSnapshots(rawMeta)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+
+			materializeSnapshots(b, meta, n)
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+
+			b.ReportMetric(float64(len(rawMeta)), "metadata-bytes")
+			b.ReportMetric(float64(before.HeapAlloc), "heap-before-bytes")
+			b.ReportMetric(float64(after.HeapAlloc), "heap-after-bytes")
+			delta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+			b.ReportMetric(float64(delta), "heap-delta-bytes")
+			b.ReportMetric(float64(delta)/float64(len(rawMeta)), "heap-growth-ratio")
+			b.ReportMetric(0, "ns/op")
+			runtime.KeepAlive(meta)
+			runtime.KeepAlive(rawMeta)
+			runtime.KeepAlive(body)
+		})
+	}
+}
+
+// Keep the defensive copy returned by Snapshots out of the post-call heap
+// sample so it measures metadata-owned state rather than caller-owned memory.
+func materializeSnapshots(b *testing.B, meta table.Metadata, expected int64) {
+	b.Helper()
+	if len(meta.Snapshots()) != int(expected) {
+		b.Fatal("incomplete snapshot history")
+	}
+}

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -179,18 +179,6 @@ type identifier struct {
 type commitTableResponse struct {
 	MetadataLoc string          `json:"metadata-location"`
 	RawMetadata json.RawMessage `json:"metadata"`
-	Metadata    table.Metadata  `json:"-"`
-}
-
-func (t *commitTableResponse) UnmarshalJSON(b []byte) (err error) {
-	type Alias commitTableResponse
-	if err = json.Unmarshal(b, (*Alias)(t)); err != nil {
-		return err
-	}
-
-	t.Metadata, err = table.ParseMetadataBytes(t.RawMetadata)
-
-	return err
 }
 
 // StorageCredential carries REST-vended storage credentials scoped to matching
@@ -1645,8 +1633,20 @@ func (r *Catalog) CommitTable(ctx context.Context, ident table.Identifier, requi
 	if err != nil {
 		return nil, "", err
 	}
+	metadata, err := r.parseCommitMetadata(ret.RawMetadata)
+	if err != nil {
+		return nil, "", err
+	}
 
-	return ret.Metadata, ret.MetadataLoc, nil
+	return metadata, ret.MetadataLoc, nil
+}
+
+func (r *Catalog) parseCommitMetadata(raw json.RawMessage) (table.Metadata, error) {
+	if r.snapshotMode == SnapshotModeRefs {
+		return table.ParseMetadataBytesDeferredSnapshots(raw)
+	}
+
+	return table.ParseMetadataBytes(raw)
 }
 
 // CommitTransaction atomically commits changes to multiple tables in a
@@ -1853,11 +1853,15 @@ func (r *Catalog) UpdateTable(ctx context.Context, ident table.Identifier, requi
 	if err != nil {
 		return nil, err
 	}
+	metadata, err := r.parseCommitMetadata(ret.RawMetadata)
+	if err != nil {
+		return nil, err
+	}
 
 	config := maps.Clone(r.props)
-	maps.Copy(config, ret.Metadata.Properties())
+	maps.Copy(config, metadata.Properties())
 
-	return r.tableFromResponse(ctx, ident, ret.Metadata, ret.MetadataLoc, config, config, false)
+	return r.tableFromResponse(ctx, ident, metadata, ret.MetadataLoc, config, config, false)
 }
 
 func (r *Catalog) DropTable(ctx context.Context, identifier table.Identifier) error {

--- a/table/deferred_snapshots.go
+++ b/table/deferred_snapshots.go
@@ -101,11 +101,13 @@ func (s *deferredSnapshotState) snapshotByID(id int64) (*Snapshot, error) {
 		return snapshot, nil
 	}
 	entryIndex, ok := s.byID[id]
-	s.mu.RUnlock()
 	if !ok {
+		s.mu.RUnlock()
+
 		return nil, nil
 	}
 	entry := &s.entries[entryIndex]
+	s.mu.RUnlock()
 
 	entry.once.Do(func() {
 		s.mu.RLock()

--- a/table/deferred_snapshots.go
+++ b/table/deferred_snapshots.go
@@ -168,10 +168,15 @@ func validateStringArray(raw json.RawMessage) error {
 		if i == len(raw)-1 {
 			return nil
 		}
-		if raw[i] != '"' {
+		switch {
+		case raw[i] == '"':
+			i = scanJSONString(raw, i)
+		case hasJSONNullAt(raw, i):
+			// Match encoding/json's []string behavior: null decodes to "".
+			i += len("null")
+		default:
 			return errors.New("cannot unmarshal manifest location into string")
 		}
-		i = scanJSONString(raw, i)
 		i = skipJSONSpace(raw, i)
 		if i < len(raw)-1 && raw[i] == ',' {
 			i++
@@ -194,10 +199,15 @@ func validateSummaryObject(raw json.RawMessage) error {
 	if raw[0] != '{' || raw[len(raw)-1] != '}' {
 		return errors.New("cannot unmarshal summary into map[string]string")
 	}
+	// Summary.UnmarshalJSON decodes through map[string]string. Preserve its
+	// acceptance contract here: null becomes "", and duplicate keys use the
+	// last value. In particular, only the final operation value determines
+	// whether ErrInvalidOperation is returned.
+	operationSeen, operationEmpty := false, false
 	for i := 1; i < len(raw)-1; {
 		i = skipJSONSpace(raw, i)
 		if i == len(raw)-1 {
-			return nil
+			break
 		}
 		if raw[i] != '"' {
 			return errors.New("invalid summary key")
@@ -210,13 +220,27 @@ func validateSummaryObject(raw json.RawMessage) error {
 			return errors.New("invalid summary object")
 		}
 		i = skipJSONSpace(raw, i+1)
-		if i >= len(raw)-1 || raw[i] != '"' {
+		if i >= len(raw)-1 {
 			return errors.New("cannot unmarshal summary value into string")
 		}
-		valueStart := i
-		i = scanJSONString(raw, i)
-		if summaryKeyIsOperation(key) && i == valueStart+2 {
-			return fmt.Errorf("%w: found empty operation", ErrInvalidOperation)
+
+		valueEmpty := false
+		switch {
+		case raw[i] == '"':
+			valueStart := i
+			i = scanJSONString(raw, i)
+			valueEmpty = i == valueStart+2
+		case hasJSONNullAt(raw, i):
+			// Match encoding/json's map[string]string behavior: null decodes
+			// to "". A final null operation is therefore invalid.
+			i += len("null")
+			valueEmpty = true
+		default:
+			return errors.New("cannot unmarshal summary value into string")
+		}
+		if summaryKeyIsOperation(key) {
+			operationSeen = true
+			operationEmpty = valueEmpty
 		}
 		i = skipJSONSpace(raw, i)
 		if i < len(raw)-1 && raw[i] == ',' {
@@ -227,9 +251,18 @@ func validateSummaryObject(raw json.RawMessage) error {
 		if i != len(raw)-1 {
 			return errors.New("invalid summary object")
 		}
+
+		break
+	}
+	if operationSeen && operationEmpty {
+		return fmt.Errorf("%w: found empty operation", ErrInvalidOperation)
 	}
 
 	return nil
+}
+
+func hasJSONNullAt(raw []byte, i int) bool {
+	return i+len("null") <= len(raw) && bytes.Equal(raw[i:i+len("null")], []byte("null"))
 }
 
 func summaryKeyIsOperation(raw []byte) bool {
@@ -276,14 +309,14 @@ type rawJSONSpan struct {
 }
 
 func splitJSONArray(raw []byte) ([]rawJSONSpan, error) {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) < 2 || raw[0] != '[' || raw[len(raw)-1] != ']' {
+	arrayStart, arrayEnd := trimJSONSpan(raw, 0, len(raw))
+	if arrayEnd-arrayStart < 2 || raw[arrayStart] != '[' || raw[arrayEnd-1] != ']' {
 		return nil, errors.New("expected JSON array")
 	}
 
 	elements := make([]rawJSONSpan, 0)
-	start, depth := 1, 0
-	for i := 1; i < len(raw)-1; i++ {
+	start, depth := arrayStart+1, 0
+	for i := start; i < arrayEnd-1; i++ {
 		switch raw[i] {
 		case '"':
 			i = scanJSONString(raw, i) - 1
@@ -299,7 +332,7 @@ func splitJSONArray(raw []byte) ([]rawJSONSpan, error) {
 			}
 		}
 	}
-	elementStart, elementEnd := trimJSONSpan(raw, start, len(raw)-1)
+	elementStart, elementEnd := trimJSONSpan(raw, start, arrayEnd-1)
 	if elementStart < elementEnd {
 		elements = append(elements, rawJSONSpan{start: elementStart, end: elementEnd})
 	}
@@ -329,6 +362,10 @@ func parseNormalizedMetadataBytesDeferredSnapshots(normalized []byte, formatVers
 		}
 
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+	}
+	if metadata.Version() != formatVersion {
+		return nil, fmt.Errorf("%w: preflight selected version %d, decoded version %d",
+			ErrInvalidMetadataFormatVersion, formatVersion, metadata.Version())
 	}
 
 	common := commonMetadataOf(metadata)

--- a/table/deferred_snapshots.go
+++ b/table/deferred_snapshots.go
@@ -1,0 +1,493 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// deferredSnapshotState owns the raw snapshot array and the materialized
+// collection. It is pointer-owned because commonMetadata is copied by format
+// upgrades and builders; copying a used sync.Once would be unsafe.
+type deferredSnapshotState struct {
+	raw     json.RawMessage
+	entries []deferredSnapshotEntry
+	byID    map[int64]int
+
+	allOnce   sync.Once
+	mu        sync.RWMutex
+	snapshots []Snapshot
+	index     *snapshotIndexData
+	err       error
+}
+
+type deferredSnapshotEntry struct {
+	start int
+	end   int
+
+	once     sync.Once
+	snapshot Snapshot
+	err      error
+}
+
+func (s *deferredSnapshotState) load() ([]Snapshot, *snapshotIndexData, error) {
+	s.allOnce.Do(func() {
+		s.mu.RLock()
+		raw := s.raw
+		s.mu.RUnlock()
+
+		var snapshots []Snapshot
+		if err := json.Unmarshal(raw, &snapshots); err != nil {
+			s.mu.Lock()
+			s.err = fmt.Errorf("%w: deferred snapshots: %w", ErrInvalidMetadata, err)
+			s.mu.Unlock()
+
+			return
+		}
+
+		s.mu.Lock()
+		s.snapshots = snapshots
+		s.index = buildSnapshotIndex(snapshots)
+		s.raw = nil
+		s.entries = nil
+		s.byID = nil
+		s.mu.Unlock()
+	})
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.snapshots, s.index, s.err
+}
+
+func (s *deferredSnapshotState) snapshotByID(id int64) (*Snapshot, error) {
+	s.mu.RLock()
+	if s.err != nil {
+		err := s.err
+		s.mu.RUnlock()
+
+		return nil, err
+	}
+	if s.snapshots != nil {
+		i, ok := snapshotIndexPosition(s.index, s.snapshots, id)
+		if !ok {
+			s.mu.RUnlock()
+
+			return nil, nil
+		}
+		snapshot := cloneSnapshotPtr(&s.snapshots[i])
+		s.mu.RUnlock()
+
+		return snapshot, nil
+	}
+	entryIndex, ok := s.byID[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+	entry := &s.entries[entryIndex]
+
+	entry.once.Do(func() {
+		s.mu.RLock()
+		if s.snapshots != nil {
+			i, found := snapshotIndexPosition(s.index, s.snapshots, id)
+			if found {
+				entry.snapshot = s.snapshots[i]
+			}
+			s.mu.RUnlock()
+
+			return
+		}
+		raw := s.raw[entry.start:entry.end]
+		s.mu.RUnlock()
+
+		if err := json.Unmarshal(raw, &entry.snapshot); err != nil {
+			entry.err = fmt.Errorf("%w: deferred snapshot %d: %w", ErrInvalidMetadata, id, err)
+		}
+	})
+	if entry.err != nil {
+		return nil, entry.err
+	}
+
+	return cloneSnapshotPtr(&entry.snapshot), nil
+}
+
+type deferredSnapshotFields struct {
+	SnapshotID        *int64          `json:"snapshot-id"`
+	ParentSnapshotID  *int64          `json:"parent-snapshot-id,omitempty"`
+	SequenceNumber    int64           `json:"sequence-number"`
+	TimestampMs       *int64          `json:"timestamp-ms"`
+	ManifestList      string          `json:"manifest-list,omitempty"`
+	ManifestLocations json.RawMessage `json:"manifests,omitempty"`
+	Summary           json.RawMessage `json:"summary,omitempty"`
+	SchemaID          *int            `json:"schema-id,omitempty"`
+	FirstRowID        *int64          `json:"first-row-id,omitempty"`
+	AddedRows         *int64          `json:"added-rows,omitempty"`
+}
+
+func (s deferredSnapshotFields) validateHeavyFields() error {
+	if err := validateStringArray(s.ManifestLocations); err != nil {
+		return err
+	}
+
+	return validateSummaryObject(s.Summary)
+}
+
+func validateStringArray(raw json.RawMessage) error {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	if raw[0] != '[' || raw[len(raw)-1] != ']' {
+		return errors.New("cannot unmarshal manifests into []string")
+	}
+	for i := 1; i < len(raw)-1; {
+		i = skipJSONSpace(raw, i)
+		if i == len(raw)-1 {
+			return nil
+		}
+		if raw[i] != '"' {
+			return errors.New("cannot unmarshal manifest location into string")
+		}
+		i = scanJSONString(raw, i)
+		i = skipJSONSpace(raw, i)
+		if i < len(raw)-1 && raw[i] == ',' {
+			i++
+
+			continue
+		}
+		if i != len(raw)-1 {
+			return errors.New("invalid manifests array")
+		}
+	}
+
+	return nil
+}
+
+func validateSummaryObject(raw json.RawMessage) error {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	if raw[0] != '{' || raw[len(raw)-1] != '}' {
+		return errors.New("cannot unmarshal summary into map[string]string")
+	}
+	for i := 1; i < len(raw)-1; {
+		i = skipJSONSpace(raw, i)
+		if i == len(raw)-1 {
+			return nil
+		}
+		if raw[i] != '"' {
+			return errors.New("invalid summary key")
+		}
+		keyStart := i
+		i = scanJSONString(raw, i)
+		key := raw[keyStart:i]
+		i = skipJSONSpace(raw, i)
+		if i >= len(raw)-1 || raw[i] != ':' {
+			return errors.New("invalid summary object")
+		}
+		i = skipJSONSpace(raw, i+1)
+		if i >= len(raw)-1 || raw[i] != '"' {
+			return errors.New("cannot unmarshal summary value into string")
+		}
+		valueStart := i
+		i = scanJSONString(raw, i)
+		if summaryKeyIsOperation(key) && i == valueStart+2 {
+			return fmt.Errorf("%w: found empty operation", ErrInvalidOperation)
+		}
+		i = skipJSONSpace(raw, i)
+		if i < len(raw)-1 && raw[i] == ',' {
+			i++
+
+			continue
+		}
+		if i != len(raw)-1 {
+			return errors.New("invalid summary object")
+		}
+	}
+
+	return nil
+}
+
+func summaryKeyIsOperation(raw []byte) bool {
+	if bytes.Equal(raw, []byte(`"operation"`)) {
+		return true
+	}
+	if !bytes.Contains(raw, []byte{'\\'}) {
+		return false
+	}
+	decoded, err := strconv.Unquote(string(raw))
+
+	return err == nil && decoded == operationKey
+}
+
+func skipJSONSpace(raw []byte, i int) int {
+	for i < len(raw) {
+		switch raw[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			return i
+		}
+	}
+
+	return i
+}
+
+func scanJSONString(raw []byte, i int) int {
+	for i++; i < len(raw); i++ {
+		switch raw[i] {
+		case '\\':
+			i++
+		case '"':
+			return i + 1
+		}
+	}
+
+	return len(raw)
+}
+
+type rawJSONSpan struct {
+	start int
+	end   int
+}
+
+func splitJSONArray(raw []byte) ([]rawJSONSpan, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) < 2 || raw[0] != '[' || raw[len(raw)-1] != ']' {
+		return nil, errors.New("expected JSON array")
+	}
+
+	elements := make([]rawJSONSpan, 0)
+	start, depth := 1, 0
+	for i := 1; i < len(raw)-1; i++ {
+		switch raw[i] {
+		case '"':
+			i = scanJSONString(raw, i) - 1
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				elementStart, elementEnd := trimJSONSpan(raw, start, i)
+				elements = append(elements, rawJSONSpan{start: elementStart, end: elementEnd})
+				start = i + 1
+			}
+		}
+	}
+	elementStart, elementEnd := trimJSONSpan(raw, start, len(raw)-1)
+	if elementStart < elementEnd {
+		elements = append(elements, rawJSONSpan{start: elementStart, end: elementEnd})
+	}
+
+	return elements, nil
+}
+
+func trimJSONSpan(raw []byte, start, end int) (int, int) {
+	start = skipJSONSpace(raw, start)
+	for end > start {
+		switch raw[end-1] {
+		case ' ', '\t', '\n', '\r':
+			end--
+		default:
+			return start, end
+		}
+	}
+
+	return start, end
+}
+
+func parseNormalizedMetadataBytesDeferredSnapshots(normalized []byte, formatVersion int) (Metadata, error) {
+	metadata, rawSnapshots, err := decodeMetadataWithRawSnapshots(normalized, formatVersion)
+	if err != nil {
+		if errors.Is(err, ErrInvalidMetadata) {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+	}
+
+	common := commonMetadataOf(metadata)
+	deferred, eager, err := prepareDeferredSnapshots(rawSnapshots, common, metadata)
+	if err != nil {
+		return nil, err
+	}
+	common.SnapshotList = eager
+
+	if err := finishDeferredMetadataUnmarshal(metadata); err != nil {
+		return nil, err
+	}
+	if deferred == nil {
+		return metadata, nil
+	}
+	common.deferredSnapshots = deferred
+
+	return metadata, nil
+}
+
+func decodeMetadataWithRawSnapshots(normalized []byte, formatVersion int) (Metadata, json.RawMessage, error) {
+	var rawSnapshots json.RawMessage
+	switch formatVersion {
+	case 1:
+		next := initMetadataV1Deser()
+		type alias metadataV1
+		aux := struct {
+			*alias
+			SnapshotList json.RawMessage `json:"snapshots"`
+		}{alias: (*alias)(next)}
+		if err := json.Unmarshal(normalized, &aux); err != nil {
+			return nil, nil, err
+		}
+		rawSnapshots = aux.SnapshotList
+
+		return next, rawSnapshots, nil
+	case 2:
+		next := initMetadataV2Deser()
+		type alias metadataV2
+		aux := struct {
+			*alias
+			SnapshotList json.RawMessage `json:"snapshots"`
+		}{alias: (*alias)(next)}
+		if err := json.Unmarshal(normalized, &aux); err != nil {
+			return nil, nil, err
+		}
+		rawSnapshots = aux.SnapshotList
+
+		return next, rawSnapshots, nil
+	case 3:
+		next := initMetadataV3Deser()
+		type alias metadataV3
+		aux := struct {
+			*alias
+			SnapshotList json.RawMessage `json:"snapshots"`
+		}{alias: (*alias)(next)}
+		if err := json.Unmarshal(normalized, &aux); err != nil {
+			return nil, nil, err
+		}
+		rawSnapshots = aux.SnapshotList
+
+		return next, rawSnapshots, nil
+	default:
+		return nil, nil, ErrInvalidMetadataFormatVersion
+	}
+}
+
+func finishDeferredMetadataUnmarshal(metadata Metadata) error {
+	switch typed := metadata.(type) {
+	case *metadataV1:
+		return typed.finishUnmarshal()
+	case *metadataV2:
+		return typed.finishUnmarshal()
+	case *metadataV3:
+		return typed.finishUnmarshal()
+	default:
+		return fmt.Errorf("%w: unsupported metadata implementation %T", ErrInvalidMetadata, metadata)
+	}
+}
+
+func prepareDeferredSnapshots(rawSnapshots json.RawMessage, common *commonMetadata, metadata Metadata) (*deferredSnapshotState, []Snapshot, error) {
+	rawSnapshots = bytes.TrimSpace(rawSnapshots)
+	if len(rawSnapshots) == 0 || bytes.Equal(rawSnapshots, []byte("null")) {
+		return nil, nil, nil
+	}
+
+	rawEntries, err := splitJSONArray(rawSnapshots)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: snapshots: %w", ErrInvalidMetadata, err)
+	}
+	if len(rawEntries) == 0 {
+		return nil, []Snapshot{}, nil
+	}
+
+	refIDs := make(map[int64]struct{})
+	for _, ref := range common.SnapshotRefs {
+		refIDs[ref.SnapshotID] = struct{}{}
+	}
+	if common.CurrentSnapshotID != nil && *common.CurrentSnapshotID != -1 {
+		refIDs[*common.CurrentSnapshotID] = struct{}{}
+	}
+
+	eager := make([]Snapshot, 0, len(refIDs))
+	seen := make(map[int64]struct{}, len(rawEntries))
+	state := &deferredSnapshotState{
+		raw:     rawSnapshots,
+		entries: make([]deferredSnapshotEntry, len(rawEntries)),
+		byID:    make(map[int64]int, len(rawEntries)),
+	}
+	for i, span := range rawEntries {
+		raw := rawSnapshots[span.start:span.end]
+		var fields deferredSnapshotFields
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return nil, nil, fmt.Errorf("%w: snapshot at index %d: %w", ErrInvalidMetadata, i, err)
+		}
+		if fields.SnapshotID == nil {
+			return nil, nil, fmt.Errorf("%w: snapshot-id is absent or null", ErrInvalidMetadata)
+		}
+		if fields.TimestampMs == nil {
+			return nil, nil, fmt.Errorf("%w: timestamp-ms is absent or null", ErrInvalidMetadata)
+		}
+		if _, ok := seen[*fields.SnapshotID]; ok {
+			return nil, nil, fmt.Errorf("%w: duplicate snapshot ID %d", ErrInvalidMetadata, *fields.SnapshotID)
+		}
+		seen[*fields.SnapshotID] = struct{}{}
+		state.entries[i] = deferredSnapshotEntry{start: span.start, end: span.end}
+		state.byID[*fields.SnapshotID] = i
+
+		if err := fields.validateHeavyFields(); err != nil {
+			return nil, nil, fmt.Errorf("%w: snapshot %d: %w", ErrInvalidMetadata, *fields.SnapshotID, err)
+		}
+		if metadata.Version() > 1 && fields.SequenceNumber > metadata.LastSequenceNumber() {
+			return nil, nil, fmt.Errorf("%w: snapshot %d has sequence number %d which is greater than last-sequence-number %d",
+				ErrInvalidMetadata, *fields.SnapshotID, fields.SequenceNumber, metadata.LastSequenceNumber())
+		}
+		if metadata.Version() >= 3 && fields.FirstRowID != nil && *fields.FirstRowID < 0 {
+			return nil, nil, fmt.Errorf("%w: snapshot %d has invalid first-row-id %d",
+				ErrInvalidMetadata, *fields.SnapshotID, *fields.FirstRowID)
+		}
+
+		if _, ok := refIDs[*fields.SnapshotID]; ok {
+			var snapshot Snapshot
+			if err := json.Unmarshal(raw, &snapshot); err != nil {
+				return nil, nil, fmt.Errorf("%w: snapshot %d: %w", ErrInvalidMetadata, *fields.SnapshotID, err)
+			}
+			eager = append(eager, snapshot)
+		}
+	}
+
+	return state, eager, nil
+}
+
+func commonMetadataOf(metadata Metadata) *commonMetadata {
+	switch typed := metadata.(type) {
+	case *metadataV1:
+		return &typed.commonMetadata
+	case *metadataV2:
+		return &typed.commonMetadata
+	case *metadataV3:
+		return &typed.commonMetadata
+	default:
+		return nil
+	}
+}

--- a/table/deferred_snapshots.go
+++ b/table/deferred_snapshots.go
@@ -310,6 +310,9 @@ type rawJSONSpan struct {
 
 func splitJSONArray(raw []byte) ([]rawJSONSpan, error) {
 	arrayStart, arrayEnd := trimJSONSpan(raw, 0, len(raw))
+	if arrayStart == arrayEnd || bytes.Equal(raw[arrayStart:arrayEnd], []byte("null")) {
+		return nil, nil
+	}
 	if arrayEnd-arrayStart < 2 || raw[arrayStart] != '[' || raw[arrayEnd-1] != ']' {
 		return nil, errors.New("expected JSON array")
 	}
@@ -447,14 +450,18 @@ func finishDeferredMetadataUnmarshal(metadata Metadata) error {
 }
 
 func prepareDeferredSnapshots(rawSnapshots json.RawMessage, common *commonMetadata, metadata Metadata) (*deferredSnapshotState, []Snapshot, error) {
-	rawSnapshots = bytes.TrimSpace(rawSnapshots)
-	if len(rawSnapshots) == 0 || bytes.Equal(rawSnapshots, []byte("null")) {
-		return nil, nil, nil
+	if metadata.Version() > 1 {
+		if err := requireLastSequenceNumber(metadata); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	rawEntries, err := splitJSONArray(rawSnapshots)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: snapshots: %w", ErrInvalidMetadata, err)
+	}
+	if rawEntries == nil {
+		return nil, nil, nil
 	}
 	if len(rawEntries) == 0 {
 		return nil, []Snapshot{}, nil

--- a/table/deferred_snapshots_test.go
+++ b/table/deferred_snapshots_test.go
@@ -202,6 +202,43 @@ func TestDeferredSnapshotsConcurrentMaterialization(t *testing.T) {
 	wg.Wait()
 }
 
+func TestDeferredSnapshotsConcurrentLookupAndIndexRelease(t *testing.T) {
+	const (
+		attempts = 100
+		lookups  = 32
+	)
+	historicalID := int64(3051729675574597004)
+
+	for range attempts {
+		meta, err := ParseMetadataBytesDeferredSnapshots(metadataWithUnreferencedSnapshot(t))
+		require.NoError(t, err)
+
+		start := make(chan struct{})
+		results := make(chan bool, lookups+1)
+		for range lookups {
+			go func() {
+				<-start
+				snapshot := meta.SnapshotByID(historicalID)
+				results <- snapshot != nil && snapshot.SnapshotID == historicalID
+			}()
+		}
+		go func() {
+			<-start
+			results <- len(meta.Snapshots()) == 2
+		}()
+		close(start)
+
+		for range lookups + 1 {
+			assert.True(t, <-results)
+		}
+
+		state := commonMetadataOf(meta).deferredSnapshots
+		assert.Nil(t, state.raw)
+		assert.Nil(t, state.entries)
+		assert.Nil(t, state.byID)
+	}
+}
+
 func TestDeferredSnapshotsConcurrentSingleLookupDoesNotMaterializeHistory(t *testing.T) {
 	meta, err := ParseMetadataBytesDeferredSnapshots(metadataWithUnreferencedSnapshot(t))
 	require.NoError(t, err)

--- a/table/deferred_snapshots_test.go
+++ b/table/deferred_snapshots_test.go
@@ -246,6 +246,32 @@ func TestDeferredSnapshotsValidationMatchesEagerJSONSemantics(t *testing.T) {
 	}
 }
 
+func TestDeferredSnapshotsMissingLastSequenceNumberErrorParity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{name: "v2", data: ExampleTableMetadataV2},
+		{name: "v3", data: ExampleTableMetadataV3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var fields map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(tc.data), &fields))
+			delete(fields, "last-sequence-number")
+			data, err := json.Marshal(fields)
+			require.NoError(t, err)
+
+			_, eagerErr := ParseMetadataBytes(data)
+			_, deferredErr := ParseMetadataBytesDeferredSnapshots(data)
+			require.ErrorIs(t, eagerErr, ErrInvalidMetadata)
+			require.ErrorIs(t, deferredErr, ErrInvalidMetadata)
+			assert.EqualError(t, deferredErr, eagerErr.Error())
+			assert.ErrorContains(t, deferredErr,
+				"last-sequence-number is required for format versions greater than 1")
+		})
+	}
+}
+
 func TestSplitJSONArrayOffsetsReferToOriginalInput(t *testing.T) {
 	raw := []byte(" \n [ {\"id\":1}, [\"comma,brace}\"] ] \t")
 	spans, err := splitJSONArray(raw)
@@ -253,6 +279,19 @@ func TestSplitJSONArrayOffsetsReferToOriginalInput(t *testing.T) {
 	require.Len(t, spans, 2)
 	assert.Equal(t, `{"id":1}`, string(raw[spans[0].start:spans[0].end]))
 	assert.Equal(t, `["comma,brace}"]`, string(raw[spans[1].start:spans[1].end]))
+}
+
+func TestSplitJSONArrayPreservesMissingNullAndEmptyDistinction(t *testing.T) {
+	for _, raw := range [][]byte{nil, []byte(" \n\t"), []byte(" \n null\t")} {
+		spans, err := splitJSONArray(raw)
+		require.NoError(t, err)
+		assert.Nil(t, spans)
+	}
+
+	spans, err := splitJSONArray([]byte(" \n []\t"))
+	require.NoError(t, err)
+	assert.NotNil(t, spans)
+	assert.Empty(t, spans)
 }
 
 func TestDeferredSnapshotsMarshalMetadataValues(t *testing.T) {

--- a/table/deferred_snapshots_test.go
+++ b/table/deferred_snapshots_test.go
@@ -39,6 +39,37 @@ func metadataWithUnreferencedSnapshot(t testing.TB) []byte {
 	return data
 }
 
+func metadataWithHistoricalSnapshotFields(
+	t testing.TB,
+	summary, manifests json.RawMessage,
+) []byte {
+	t.Helper()
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(metadataWithUnreferencedSnapshot(t), &fields))
+
+	var snapshots []json.RawMessage
+	require.NoError(t, json.Unmarshal(fields["snapshots"], &snapshots))
+	var historical map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(snapshots[0], &historical))
+	if summary != nil {
+		historical["summary"] = summary
+	}
+	if manifests != nil {
+		historical["manifests"] = manifests
+	}
+
+	var err error
+	snapshots[0], err = json.Marshal(historical)
+	require.NoError(t, err)
+	fields["snapshots"], err = json.Marshal(snapshots)
+	require.NoError(t, err)
+	data, err := json.Marshal(fields)
+	require.NoError(t, err)
+
+	return data
+}
+
 func TestParseMetadataBytesDeferredSnapshots(t *testing.T) {
 	data := metadataWithUnreferencedSnapshot(t)
 	eager, err := ParseMetadataBytes(data)
@@ -165,6 +196,100 @@ func TestDeferredSnapshotsRoundTripAllMetadataVersions(t *testing.T) {
 			reparsed, err := ParseMetadataBytes(serialized)
 			require.NoError(t, err)
 			assert.True(t, eager.Equals(reparsed))
+		})
+	}
+}
+
+func TestDeferredSnapshotsValidationMatchesEagerJSONSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		summary   json.RawMessage
+		manifests json.RawMessage
+		wantErr   error
+	}{
+		{
+			name:    "null summary property",
+			summary: json.RawMessage(`{"operation":"append","extra":null}`),
+		},
+		{
+			name:      "null manifest location",
+			manifests: json.RawMessage(`["a.avro",null]`),
+		},
+		{
+			name:    "duplicate operation uses last value",
+			summary: json.RawMessage(`{"operation":"","operation":"append"}`),
+		},
+		{
+			name:    "null final operation remains invalid",
+			summary: json.RawMessage(`{"operation":"append","operation":null}`),
+			wantErr: ErrInvalidOperation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := metadataWithHistoricalSnapshotFields(t, tt.summary, tt.manifests)
+			eager, eagerErr := ParseMetadataBytes(data)
+			deferred, deferredErr := ParseMetadataBytesDeferredSnapshots(data)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, eagerErr, tt.wantErr)
+				require.ErrorIs(t, deferredErr, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, eagerErr)
+			require.NoError(t, deferredErr)
+			assert.Equal(t, eager.SnapshotByID(3051729675574597004), deferred.SnapshotByID(3051729675574597004))
+		})
+	}
+}
+
+func TestSplitJSONArrayOffsetsReferToOriginalInput(t *testing.T) {
+	raw := []byte(" \n [ {\"id\":1}, [\"comma,brace}\"] ] \t")
+	spans, err := splitJSONArray(raw)
+	require.NoError(t, err)
+	require.Len(t, spans, 2)
+	assert.Equal(t, `{"id":1}`, string(raw[spans[0].start:spans[0].end]))
+	assert.Equal(t, `["comma,brace}"]`, string(raw[spans[1].start:spans[1].end]))
+}
+
+func TestDeferredSnapshotsMarshalMetadataValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{name: "v1", data: ExampleTableMetadataV1},
+		{name: "v2", data: ExampleTableMetadataV2},
+		{name: "v3", data: ExampleTableMetadataV3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var fields map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(tc.data), &fields))
+			fields["refs"] = json.RawMessage(`{}`)
+			data, err := json.Marshal(fields)
+			require.NoError(t, err)
+
+			meta, err := ParseMetadataBytesDeferredSnapshots(data)
+			require.NoError(t, err)
+
+			var serialized []byte
+			switch typed := meta.(type) {
+			case *metadataV1:
+				serialized, err = json.Marshal(*typed)
+			case *metadataV2:
+				serialized, err = json.Marshal(*typed)
+			case *metadataV3:
+				serialized, err = json.Marshal(*typed)
+			default:
+				t.Fatalf("unexpected metadata type %T", meta)
+			}
+			require.NoError(t, err)
+
+			reparsed, err := ParseMetadataBytes(serialized)
+			require.NoError(t, err)
+			assert.Len(t, reparsed.Snapshots(), len(meta.Snapshots()))
 		})
 	}
 }

--- a/table/deferred_snapshots_test.go
+++ b/table/deferred_snapshots_test.go
@@ -1,0 +1,224 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func metadataWithUnreferencedSnapshot(t testing.TB) []byte {
+	t.Helper()
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV2), &fields))
+	fields["refs"] = json.RawMessage(`{}`)
+
+	data, err := json.Marshal(fields)
+	require.NoError(t, err)
+
+	return data
+}
+
+func TestParseMetadataBytesDeferredSnapshots(t *testing.T) {
+	data := metadataWithUnreferencedSnapshot(t)
+	eager, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	require.Len(t, eager.Snapshots(), 2)
+	historicalID := eager.Snapshots()[0].SnapshotID
+
+	meta, err := ParseMetadataBytesDeferredSnapshots(data)
+	require.NoError(t, err)
+	common := commonMetadataOf(meta)
+	require.NotNil(t, common.deferredSnapshots)
+	require.Len(t, common.SnapshotList, 1)
+	assert.Nil(t, common.deferredSnapshots.snapshots)
+
+	assert.Equal(t, eager.CurrentSnapshot(), meta.CurrentSnapshot())
+	assert.Equal(t, eager.SnapshotByName(MainBranch), meta.SnapshotByName(MainBranch))
+	assert.Nil(t, common.deferredSnapshots.snapshots, "referenced snapshot access must remain eager")
+
+	assert.Equal(t, eager.SnapshotByID(historicalID), meta.SnapshotByID(historicalID))
+	assert.Nil(t, common.deferredSnapshots.snapshots, "historical lookup must decode only the requested snapshot")
+	entry := &common.deferredSnapshots.entries[common.deferredSnapshots.byID[historicalID]]
+	assert.Equal(t, historicalID, entry.snapshot.SnapshotID)
+
+	assert.Len(t, meta.Snapshots(), 2)
+	assert.Len(t, common.deferredSnapshots.snapshots, 2)
+	assert.True(t, eager.Equals(meta))
+}
+
+func TestDeferredSnapshotsMaterializeForCollectionAndSerialization(t *testing.T) {
+	data := metadataWithUnreferencedSnapshot(t)
+	meta, err := ParseMetadataBytesDeferredSnapshots(data)
+	require.NoError(t, err)
+	deferredState := commonMetadataOf(meta).deferredSnapshots
+	require.NotEmpty(t, deferredState.raw)
+
+	serialized, err := json.Marshal(meta)
+	require.NoError(t, err)
+	assert.Nil(t, deferredState.raw)
+	assert.Nil(t, deferredState.entries)
+	assert.Nil(t, deferredState.byID)
+	reparsed, err := ParseMetadataBytes(serialized)
+	require.NoError(t, err)
+	assert.Len(t, reparsed.Snapshots(), 2)
+	assert.Len(t, meta.Snapshots(), 2)
+
+	eager, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+	eagerBuilder, err := MetadataBuilderFromBase(eager, "")
+	require.NoError(t, err)
+	eagerRebuilt, err := eagerBuilder.Build()
+	require.NoError(t, err)
+
+	deferredForBuilder, err := ParseMetadataBytesDeferredSnapshots(data)
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(deferredForBuilder, "")
+	require.NoError(t, err)
+	rebuilt, err := builder.Build()
+	require.NoError(t, err)
+	assert.Equal(t, eagerRebuilt.Snapshots(), rebuilt.Snapshots())
+}
+
+func TestDeferredSnapshotsV1ToV2MaterializesHistory(t *testing.T) {
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(ExampleTableMetadataV1), &fields))
+	fields["refs"] = json.RawMessage(`{}`)
+	data, err := json.Marshal(fields)
+	require.NoError(t, err)
+
+	deferred, err := ParseMetadataBytesDeferredSnapshots(data)
+	require.NoError(t, err)
+	eager, err := ParseMetadataBytes(data)
+	require.NoError(t, err)
+
+	converted := deferred.(*metadataV1).ToV2()
+	assert.Equal(t, eager.Snapshots(), converted.Snapshots())
+	assert.Nil(t, converted.deferredSnapshots)
+}
+
+func TestDeferredSnapshotGettersReturnDefensiveCopies(t *testing.T) {
+	meta, err := ParseMetadataBytesDeferredSnapshots(metadataWithUnreferencedSnapshot(t))
+	require.NoError(t, err)
+	historicalID := int64(3051729675574597004)
+
+	historical := meta.SnapshotByID(historicalID)
+	require.NotNil(t, historical)
+	historical.ManifestList = "mutated"
+	historical.Summary.Properties["mutated"] = "true"
+
+	all := meta.Snapshots()
+	require.Len(t, all, 2)
+	all[0].ManifestList = "also-mutated"
+
+	unchanged := meta.SnapshotByID(historicalID)
+	require.NotNil(t, unchanged)
+	assert.NotEqual(t, "mutated", unchanged.ManifestList)
+	assert.NotEqual(t, "also-mutated", unchanged.ManifestList)
+	assert.NotContains(t, unchanged.Summary.Properties, "mutated")
+}
+
+func TestDeferredSnapshotsRoundTripAllMetadataVersions(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{name: "v1", data: ExampleTableMetadataV1},
+		{name: "v2", data: ExampleTableMetadataV2},
+		{name: "v3", data: ExampleTableMetadataV3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var fields map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(tc.data), &fields))
+			fields["refs"] = json.RawMessage(`{}`)
+			data, err := json.Marshal(fields)
+			require.NoError(t, err)
+
+			eager, err := ParseMetadataBytes(data)
+			require.NoError(t, err)
+			deferred, err := ParseMetadataBytesDeferredSnapshots(data)
+			require.NoError(t, err)
+			assert.True(t, eager.Equals(deferred))
+
+			serialized, err := json.Marshal(deferred)
+			require.NoError(t, err)
+			reparsed, err := ParseMetadataBytes(serialized)
+			require.NoError(t, err)
+			assert.True(t, eager.Equals(reparsed))
+		})
+	}
+}
+
+func TestDeferredSnapshotsValidateUnreferencedHistory(t *testing.T) {
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(metadataWithUnreferencedSnapshot(t), &fields))
+
+	var snapshots []map[string]any
+	require.NoError(t, json.Unmarshal(fields["snapshots"], &snapshots))
+	snapshots[0]["summary"] = map[string]any{"operation": "append", "invalid": 1}
+	fields["snapshots"], _ = json.Marshal(snapshots)
+	data, err := json.Marshal(fields)
+	require.NoError(t, err)
+
+	_, err = ParseMetadataBytesDeferredSnapshots(data)
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+}
+
+func TestDeferredSnapshotsConcurrentMaterialization(t *testing.T) {
+	meta, err := ParseMetadataBytesDeferredSnapshots(metadataWithUnreferencedSnapshot(t))
+	require.NoError(t, err)
+	historicalID := int64(3051729675574597004)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NotNil(t, meta.CurrentSnapshot())
+			require.NotNil(t, meta.SnapshotByID(historicalID))
+			require.Len(t, meta.Snapshots(), 2)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDeferredSnapshotsConcurrentSingleLookupDoesNotMaterializeHistory(t *testing.T) {
+	meta, err := ParseMetadataBytesDeferredSnapshots(metadataWithUnreferencedSnapshot(t))
+	require.NoError(t, err)
+	historicalID := int64(3051729675574597004)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.Equal(t, historicalID, meta.SnapshotByID(historicalID).SnapshotID)
+		}()
+	}
+	wg.Wait()
+
+	common := commonMetadataOf(meta)
+	assert.Nil(t, common.deferredSnapshots.snapshots)
+	entry := &common.deferredSnapshots.entries[common.deferredSnapshots.byID[historicalID]]
+	assert.Equal(t, historicalID, entry.snapshot.SnapshotID)
+}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -1943,6 +1943,32 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 	return ret, nil
 }
 
+// ParseMetadataBytesDeferredSnapshots parses metadata while retaining the full
+// snapshot array as raw JSON. Snapshots targeted by refs are decoded eagerly;
+// unreferenced history is materialized on first access.
+func ParseMetadataBytesDeferredSnapshots(b []byte) (Metadata, error) {
+	// Keep the raw top-level object for normalization and format selection so
+	// deferred parsing does not add another full-document preflight decode.
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(b, &metadata); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+	}
+
+	var formatVersion int
+	if rawVersion, ok := metadata["format-version"]; ok {
+		if err := json.Unmarshal(rawVersion, &formatVersion); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+		}
+	}
+
+	normalized, err := assignMissingPartitionFieldIDsFromMetadata(b, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNormalizedMetadataBytesDeferredSnapshots(normalized, formatVersion)
+}
+
 func requirePartitionSpecIDs(b []byte) error {
 	var metadata map[string]json.RawMessage
 	if err := json.Unmarshal(b, &metadata); err != nil {
@@ -2108,8 +2134,9 @@ type commonMetadata struct {
 	// V3+ fields
 	NextRowID *int64 `json:"next-row-id,omitempty"` // V3: Next available row ID
 
-	schemaIndex   *schemaIndexData
-	snapshotIndex *snapshotIndexData
+	schemaIndex       *schemaIndexData
+	snapshotIndex     *snapshotIndexData
+	deferredSnapshots *deferredSnapshotState
 }
 
 func (c *commonMetadata) metadataBuilderCommon() *commonMetadata { return c }
@@ -2230,7 +2257,7 @@ func (c *commonMetadata) Equals(other *commonMetadata) bool {
 	switch {
 	case !iceinternal.SliceEqualHelper(c.SchemaList, other.SchemaList):
 		fallthrough
-	case !iceinternal.SliceEqualHelper(c.SnapshotList, other.SnapshotList):
+	case !iceinternal.SliceEqualHelper(c.allSnapshots(), other.allSnapshots()):
 		fallthrough
 	case !iceinternal.SliceEqualHelper(c.Specs, other.Specs):
 		fallthrough
@@ -2325,7 +2352,7 @@ func (c *commonMetadata) LastPartitionSpecID() *int {
 }
 
 func (c *commonMetadata) Snapshots() []Snapshot {
-	return cloneSnapshots(c.SnapshotList)
+	return cloneSnapshots(c.allSnapshots())
 }
 
 func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
@@ -2338,8 +2365,35 @@ func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 	if ok {
 		return cloneSnapshotPtr(&c.SnapshotList[i])
 	}
+	if c.deferredSnapshots != nil {
+		snapshot, err := c.deferredSnapshots.snapshotByID(id)
+		if err != nil {
+			return nil
+		}
+
+		return snapshot
+	}
 
 	return nil
+}
+
+func (c *commonMetadata) allSnapshots() []Snapshot {
+	snapshots, err := c.snapshotsForMarshal()
+	if err != nil {
+		return nil
+	}
+
+	return snapshots
+}
+
+func (c *commonMetadata) snapshotsForMarshal() ([]Snapshot, error) {
+	if c.deferredSnapshots == nil {
+		return c.SnapshotList, nil
+	}
+
+	snapshots, _, err := c.deferredSnapshots.load()
+
+	return snapshots, err
 }
 
 func (c *commonMetadata) SnapshotByName(name string) *Snapshot {
@@ -2969,32 +3023,7 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
-
-	if err := rejectFieldsBeyondVersion(
-		aux.FormatVersion,
-		versionScopedField{name: "last-sequence-number", introduced: 2, present: aux.LastSequenceNumber != nil},
-		versionScopedField{name: "next-row-id", introduced: 3, present: aux.NextRowID != nil},
-		versionScopedField{name: "encryption-keys", introduced: 3, present: len(aux.EncryptionKeyList) > 0},
-	); err != nil {
-		return err
-	}
-
-	// CurrentSchemaID was optional in v1, it can also be expressed via Schema.
-	if aux.CurrentSchemaID == -1 && aux.Schema != nil {
-		aux.CurrentSchemaID = aux.Schema.ID
-		if !slices.ContainsFunc(aux.SchemaList, func(s *iceberg.Schema) bool {
-			return s.Equals(aux.Schema) && s.ID == aux.CurrentSchemaID
-		}) {
-			aux.SchemaList = append(aux.SchemaList, aux.Schema)
-		}
-	}
-
-	next.preValidate()
-	if err := next.checkRequiredFields(); err != nil {
-		return err
-	}
-
-	if err := next.validate(); err != nil {
+	if err := next.finishUnmarshal(); err != nil {
 		return err
 	}
 
@@ -3003,8 +3032,60 @@ func (m *metadataV1) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (m *metadataV1) finishUnmarshal() error {
+	if err := rejectFieldsBeyondVersion(
+		m.FormatVersion,
+		versionScopedField{name: "last-sequence-number", introduced: 2, present: m.commonMetadata.LastSequenceNumber != nil},
+		versionScopedField{name: "next-row-id", introduced: 3, present: m.commonMetadata.NextRowID != nil},
+		versionScopedField{name: "encryption-keys", introduced: 3, present: len(m.EncryptionKeyList) > 0},
+	); err != nil {
+		return err
+	}
+
+	// CurrentSchemaID was optional in v1, it can also be expressed via Schema.
+	if m.CurrentSchemaID == -1 && m.Schema != nil {
+		m.CurrentSchemaID = m.Schema.ID
+		if !slices.ContainsFunc(m.SchemaList, func(s *iceberg.Schema) bool {
+			return s.Equals(m.Schema) && s.ID == m.CurrentSchemaID
+		}) {
+			m.SchemaList = append(m.SchemaList, m.Schema)
+		}
+	}
+
+	m.preValidate()
+	if err := m.checkRequiredFields(); err != nil {
+		return err
+	}
+
+	if err := m.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *metadataV1) MarshalJSON() ([]byte, error) {
+	snapshots, err := m.snapshotsForMarshal()
+	if err != nil {
+		return nil, err
+	}
+
+	type Alias metadataV1
+
+	return json.Marshal(&struct {
+		*Alias
+		SnapshotList []Snapshot `json:"snapshots,omitempty"`
+	}{
+		Alias:        (*Alias)(m),
+		SnapshotList: snapshots,
+	})
+}
+
 func (m *metadataV1) ToV2() metadataV2 {
 	commonOut := m.commonMetadata
+	commonOut.SnapshotList = m.allSnapshots()
+	commonOut.snapshotIndex = buildSnapshotIndex(commonOut.SnapshotList)
+	commonOut.deferredSnapshots = nil
 	commonOut.FormatVersion = 2
 	if commonOut.UUID == uuid.Nil {
 		commonOut.UUID = uuid.New()
@@ -3051,27 +3132,51 @@ func (m *metadataV2) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
-
-	if err := rejectFieldsBeyondVersion(
-		aux.FormatVersion,
-		versionScopedField{name: "next-row-id", introduced: 3, present: aux.NextRowID != nil},
-		versionScopedField{name: "encryption-keys", introduced: 3, present: len(aux.EncryptionKeyList) > 0},
-	); err != nil {
-		return err
-	}
-
-	next.preValidate()
-	if err := next.checkRequiredFields(); err != nil {
-		return err
-	}
-
-	if err := next.validate(); err != nil {
+	if err := next.finishUnmarshal(); err != nil {
 		return err
 	}
 
 	*m = *next
 
 	return nil
+}
+
+func (m *metadataV2) finishUnmarshal() error {
+	if err := rejectFieldsBeyondVersion(
+		m.FormatVersion,
+		versionScopedField{name: "next-row-id", introduced: 3, present: m.commonMetadata.NextRowID != nil},
+		versionScopedField{name: "encryption-keys", introduced: 3, present: len(m.EncryptionKeyList) > 0},
+	); err != nil {
+		return err
+	}
+
+	m.preValidate()
+	if err := m.checkRequiredFields(); err != nil {
+		return err
+	}
+
+	if err := m.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *metadataV2) MarshalJSON() ([]byte, error) {
+	snapshots, err := m.snapshotsForMarshal()
+	if err != nil {
+		return nil, err
+	}
+
+	type Alias metadataV2
+
+	return json.Marshal(&struct {
+		*Alias
+		SnapshotList []Snapshot `json:"snapshots,omitempty"`
+	}{
+		Alias:        (*Alias)(m),
+		SnapshotList: snapshots,
+	})
 }
 
 func (m *metadataV2) validate() error {
@@ -3134,21 +3239,28 @@ func (m *metadataV3) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, aux); err != nil {
 		return err
 	}
-
-	if err := rejectFieldsBeyondVersion(aux.FormatVersion); err != nil {
-		return err
-	}
-
-	next.preValidate()
-	if err := next.checkRequiredFields(); err != nil {
-		return err
-	}
-
-	if err := next.validate(); err != nil {
+	if err := next.finishUnmarshal(); err != nil {
 		return err
 	}
 
 	*m = *next
+
+	return nil
+}
+
+func (m *metadataV3) finishUnmarshal() error {
+	if err := rejectFieldsBeyondVersion(m.FormatVersion); err != nil {
+		return err
+	}
+
+	m.preValidate()
+	if err := m.checkRequiredFields(); err != nil {
+		return err
+	}
+
+	if err := m.validate(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -3174,6 +3286,10 @@ func (m *metadataV3) MarshalJSON() ([]byte, error) {
 	if m.LastPartitionID == nil {
 		return nil, fmt.Errorf("%w: last-partition-id must be set for v3 metadata", ErrInvalidMetadata)
 	}
+	snapshots, err := m.snapshotsForMarshal()
+	if err != nil {
+		return nil, err
+	}
 
 	// Alias strips the MarshalJSON method off metadataV3 so json.Marshal
 	// doesn't recurse back into this function via the embedded pointer.
@@ -3181,10 +3297,12 @@ func (m *metadataV3) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(&struct {
 		*Alias
-		CurrentSnapshotID *int64 `json:"current-snapshot-id"`
+		CurrentSnapshotID *int64     `json:"current-snapshot-id"`
+		SnapshotList      []Snapshot `json:"snapshots,omitempty"`
 	}{
 		Alias:             (*Alias)(m),
 		CurrentSnapshotID: m.CurrentSnapshotID,
+		SnapshotList:      snapshots,
 	})
 }
 

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -448,7 +448,7 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 			b.nextRowID = &nextRowID
 		}
 		if common.CurrentSnapshotID != nil {
-			if _, ok := snapshotIndexPosition(common.snapshotIndex, common.SnapshotList, *common.CurrentSnapshotID); ok {
+			if _, ok := snapshotIndexPosition(b.snapshotIndex, b.snapshotList, *common.CurrentSnapshotID); ok {
 				b.currentSnapshotID = clonePtr(common.CurrentSnapshotID)
 			}
 		}
@@ -1901,18 +1901,9 @@ func ParseMetadataString(s string) (Metadata, error) {
 
 // ParseMetadataBytes is like [ParseMetadataString] but for a byte slice.
 func ParseMetadataBytes(b []byte) (Metadata, error) {
-	// Keep the raw top-level object for all preflight checks so it is only
-	// decoded once before the version-specific metadata decode below.
-	var metadata map[string]json.RawMessage
-	if err := json.Unmarshal(b, &metadata); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
-	}
-
-	var formatVersion int
-	if rawVersion, ok := metadata["format-version"]; ok {
-		if err := json.Unmarshal(rawVersion, &formatVersion); err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
-		}
+	metadata, formatVersion, err := preflightMetadataBytes(b)
+	if err != nil {
+		return nil, err
 	}
 
 	var ret Metadata
@@ -1949,20 +1940,13 @@ func ParseMetadataBytes(b []byte) (Metadata, error) {
 
 // ParseMetadataBytesDeferredSnapshots parses metadata while retaining the full
 // snapshot array as raw JSON. Snapshots targeted by refs are decoded eagerly;
-// unreferenced history is materialized on first access.
+// unreferenced history is materialized on first access. Operations requiring
+// the complete snapshot collection, including MetadataBuilderFromBase, decode
+// the full history and therefore may cost more than eager parsing overall.
 func ParseMetadataBytesDeferredSnapshots(b []byte) (Metadata, error) {
-	// Keep the raw top-level object for normalization and format selection so
-	// deferred parsing does not add another full-document preflight decode.
-	var metadata map[string]json.RawMessage
-	if err := json.Unmarshal(b, &metadata); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
-	}
-
-	var formatVersion int
-	if rawVersion, ok := metadata["format-version"]; ok {
-		if err := json.Unmarshal(rawVersion, &formatVersion); err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
-		}
+	metadata, formatVersion, err := preflightMetadataBytes(b)
+	if err != nil {
+		return nil, err
 	}
 
 	normalized, err := assignMissingPartitionFieldIDsFromMetadata(b, metadata)
@@ -1971,6 +1955,24 @@ func ParseMetadataBytesDeferredSnapshots(b []byte) (Metadata, error) {
 	}
 
 	return parseNormalizedMetadataBytesDeferredSnapshots(normalized, formatVersion)
+}
+
+// preflightMetadataBytes keeps the raw top-level object for normalization and
+// format selection so eager and deferred parsing share one document scan.
+func preflightMetadataBytes(b []byte) (map[string]json.RawMessage, int, error) {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(b, &metadata); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+	}
+
+	var formatVersion int
+	if rawVersion, ok := metadata["format-version"]; ok {
+		if err := json.Unmarshal(rawVersion, &formatVersion); err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", ErrInvalidMetadata, err)
+		}
+	}
+
+	return metadata, formatVersion, nil
 }
 
 func requirePartitionSpecIDs(b []byte) error {
@@ -2372,6 +2374,9 @@ func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 	if c.deferredSnapshots != nil {
 		snapshot, err := c.deferredSnapshots.snapshotByID(id)
 		if err != nil {
+			// Parser-created deferred state is synchronously validated before
+			// publication, so a later typed decode cannot fail. Keep this branch
+			// for defensive handling of manually constructed in-package state.
 			return nil
 		}
 
@@ -2384,6 +2389,10 @@ func (c *commonMetadata) SnapshotByID(id int64) *Snapshot {
 func (c *commonMetadata) allSnapshots() []Snapshot {
 	snapshots, err := c.snapshotsForMarshal()
 	if err != nil {
+		// prepareDeferredSnapshots validates JSON syntax and every Snapshot
+		// field whose typed decoding can fail before deferred state is
+		// published. This error is therefore unreachable for parser-created
+		// state; callers with an error channel use snapshotsForMarshal directly.
 		return nil
 	}
 
@@ -3068,7 +3077,7 @@ func (m *metadataV1) finishUnmarshal() error {
 	return nil
 }
 
-func (m *metadataV1) MarshalJSON() ([]byte, error) {
+func (m metadataV1) MarshalJSON() ([]byte, error) {
 	snapshots, err := m.snapshotsForMarshal()
 	if err != nil {
 		return nil, err
@@ -3080,7 +3089,7 @@ func (m *metadataV1) MarshalJSON() ([]byte, error) {
 		*Alias
 		SnapshotList []Snapshot `json:"snapshots,omitempty"`
 	}{
-		Alias:        (*Alias)(m),
+		Alias:        (*Alias)(&m),
 		SnapshotList: snapshots,
 	})
 }
@@ -3166,7 +3175,7 @@ func (m *metadataV2) finishUnmarshal() error {
 	return nil
 }
 
-func (m *metadataV2) MarshalJSON() ([]byte, error) {
+func (m metadataV2) MarshalJSON() ([]byte, error) {
 	snapshots, err := m.snapshotsForMarshal()
 	if err != nil {
 		return nil, err
@@ -3178,7 +3187,7 @@ func (m *metadataV2) MarshalJSON() ([]byte, error) {
 		*Alias
 		SnapshotList []Snapshot `json:"snapshots,omitempty"`
 	}{
-		Alias:        (*Alias)(m),
+		Alias:        (*Alias)(&m),
 		SnapshotList: snapshots,
 	})
 }
@@ -3286,7 +3295,7 @@ func (m *metadataV3) finishUnmarshal() error {
 // rejects writes of malformed in-memory state (builder/parser paths
 // always populate it, so this only fires when code constructs metadataV3
 // directly and skips the builder).
-func (m *metadataV3) MarshalJSON() ([]byte, error) {
+func (m metadataV3) MarshalJSON() ([]byte, error) {
 	if m.LastPartitionID == nil {
 		return nil, fmt.Errorf("%w: last-partition-id must be set for v3 metadata", ErrInvalidMetadata)
 	}
@@ -3304,7 +3313,7 @@ func (m *metadataV3) MarshalJSON() ([]byte, error) {
 		CurrentSnapshotID *int64     `json:"current-snapshot-id"`
 		SnapshotList      []Snapshot `json:"snapshots,omitempty"`
 	}{
-		Alias:             (*Alias)(m),
+		Alias:             (*Alias)(&m),
 		CurrentSnapshotID: m.CurrentSnapshotID,
 		SnapshotList:      snapshots,
 	})

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -3361,16 +3361,24 @@ type SequenceNumberValidator interface {
 
 // checkLastSequenceNumber validates that all snapshots have sequence numbers <= the last sequence number
 func checkLastSequenceNumber(validator SequenceNumberValidator, snapshotList []Snapshot) error {
-	lastSequenceNumber := validator.LastSequenceNumber()
-	if lastSequenceNumber == -1 {
-		return fmt.Errorf("%w: last-sequence-number is required for format versions greater than 1", ErrInvalidMetadata)
+	if err := requireLastSequenceNumber(validator); err != nil {
+		return err
 	}
 
+	lastSequenceNumber := validator.LastSequenceNumber()
 	for _, snap := range snapshotList {
 		if snap.SequenceNumber > lastSequenceNumber {
 			return fmt.Errorf("%w: snapshot %d has sequence number %d which is greater than last-sequence-number %d",
 				ErrInvalidMetadata, snap.SnapshotID, snap.SequenceNumber, lastSequenceNumber)
 		}
+	}
+
+	return nil
+}
+
+func requireLastSequenceNumber(validator SequenceNumberValidator) error {
+	if validator.LastSequenceNumber() == -1 {
+		return fmt.Errorf("%w: last-sequence-number is required for format versions greater than 1", ErrInvalidMetadata)
 	}
 
 	return nil

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -422,7 +422,11 @@ func MetadataBuilderFromBase(metadata Metadata, currentFileLocation string) (*Me
 		if b.props == nil {
 			b.props = iceberg.Properties{}
 		}
-		b.snapshotList = cloneSnapshots(common.SnapshotList)
+		snapshots, err := common.snapshotsForMarshal()
+		if err != nil {
+			return nil, err
+		}
+		b.snapshotList = cloneSnapshots(snapshots)
 		b.snapshotLog = cloneCollected(common.SnapshotLog)
 		b.metadataLog = cloneCollected(common.MetadataLog)
 		b.sortOrderList = cloneSortOrders(common.SortOrderList)


### PR DESCRIPTION
## Summary

Avoid materializing unreferenced snapshot history while parsing REST commit responses when the catalog is configured with `snapshot-loading-mode=refs`.

Fixes #1946.

## Motivation

The REST update-table endpoint returns complete table metadata. `Transaction.Commit()` parses that response before returning the committed table, and the existing path decodes every entry in `snapshots` even when `snapshot-loading-mode=refs` means the caller normally needs only the current snapshot and named-ref targets.

Each historical snapshot decode constructs the snapshot, summary map, strings, and—for v1—manifest-location slice. For tables with long retained history, this makes client-side commit-response CPU and allocation cost scale with snapshots the caller may never read.

This change makes `refs` effective on that path. It does not reduce response size, network transfer, snapshot-log decoding, or server work; it avoids constructing unused historical snapshot object graphs.

## Design

`Catalog.parseCommitMetadata` selects the deferred parser only for REST commit responses in `snapshot-loading-mode=refs`. Load-table parsing and default/`all` mode remain eager.

The deferred parser:

1. Runs the normal metadata normalization and version-specific decode while retaining `snapshots` as `json.RawMessage`.
2. Scans the snapshot array once, recording element byte ranges and snapshot IDs.
3. Synchronously validates every snapshot so malformed historical metadata remains a parse-time error. The lightweight validators preserve the eager decoder's acceptance semantics, including JSON `null` and last-key-wins duplicate fields.
4. Materializes the current snapshot and named-ref targets. Other snapshots remain indexed raw JSON.

Access behavior is:

| Access | Behavior |
|---|---|
| Referenced snapshot | Returned from the eager subset |
| Historical `SnapshotByID` | Decodes that indexed entry once |
| `Snapshots`, serialization, equality, conversion, or `MetadataBuilderFromBase` | Materializes the complete array once |

Full materialization clears the raw array, entry boundaries, and deferred ID map, avoiding retention of both representations. Per-entry and full-array `sync.Once` values prevent duplicate decoding; an `RWMutex` protects the transition and prevents historical lookup from racing with index release.

The public `Metadata` API and metadata semantics are unchanged. The custom marshal projection places the top-level `snapshots` key after the embedded metadata fields, so serialized JSON key order changes; JSON content and round-trip behavior are preserved.

## Benchmarks

Measured on an Apple M1 Max after rebasing implementation commit `876b8d8` onto `aa76a28`, the latest `origin/main` commit at measurement time. The eager baseline was run from an isolated worktree at `aa76a28`; the deferred path was run from `876b8d8`. The current branch adds only the empty CI-retry commit `9e7e1bd` on top. Both benchmark sides use the same payload generator and loop. Values are medians of five runs.

```text
# clean aa76a28 worktree, using the same test-only harness
go test ./catalog/rest -run '^$' \
  -bench 'BenchmarkBaseline(FullParse|ParseThenMetadataBuilder)$' \
  -benchtime=1s -benchmem -count=5

# rebased feature implementation 876b8d8
go test ./catalog/rest -run '^$' \
  -bench 'BenchmarkStage(DeferredParse|ParseThenMetadataBuilder)$' \
  -benchtime=1s -benchmem -count=5
```

### Commit-response parse path

| Metadata | Eager parse | Deferred/ref parse | Time | Allocations | Allocated bytes |
|---:|---:|---:|---:|---:|---:|
| 7,056 B | 0.305 ms | 0.222 ms | -27.2% | -41.1% | -14.3% |
| 59,078 B | 2.362 ms | 1.535 ms | -35.0% | -71.1% | -25.1% |
| 582,880 B | 23.270 ms | 14.684 ms | -36.9% | -75.9% | -25.9% |
| 1,999,830 B | 79.229 ms | 49.747 ms | -37.2% | -76.3% | -29.9% |
| 5,856,882 B | 229.716 ms | 145.963 ms | -36.5% | -76.4% | -30.6% |

Small-payload wall time is noisier; allocation counts were stable across repetitions. At approximately 2 MB, deferred parsing uses `41,407 allocs/op` and `7,649,741 B/op`, versus `174,653 allocs/op` and `10,913,526 B/op` for eager parsing.

### Immediate subsequent transaction

`MetadataBuilderFromBase` requires complete history today. Creating another transaction immediately after parsing therefore pays both deferred indexing and full decoding, making this path worse than eager parsing:

| Metadata | Eager parse + builder | Deferred parse + builder | Time | Allocations | Allocated bytes |
|---:|---:|---:|---:|---:|---:|
| 1,999,830 B | 79.397 ms | 97.964 ms | +23.4% | +20.7% | +38.9% |
| 5,856,882 B | 231.899 ms | 287.486 ms | +24.0% | +20.7% | +38.5% |

This PR optimizes the common `refs` commit-response path when the returned table is consumed without immediately starting another write. It is not a strict improvement for repeated writes on the same returned `Table`; carrying deferred state into `MetadataBuilder` is a separate follow-up opportunity.

The retained-heap benchmark also verifies that full materialization releases deferred indexing state:

| Metadata | Retaining deferred index | Releasing deferred index | Reduction |
|---:|---:|---:|---:|
| 7,056 B | 7,648 B | 5,736 B | 25.0% |
| 59,078 B | 68,048 B | 49,272 B | 27.6% |
| 582,880 B | 667,032 B | 474,392 B | 28.9% |
| 1,999,830 B | 2,277,304 B | 1,679,080 B | 26.3% |
| 5,856,882 B | 6,700,568 B | 4,881,240 B | 27.2% |

## Testing

- `go test -race ./...`
- `golangci-lint run --timeout=10m`
- v1/v2/v3 parsing, value/pointer serialization, and round trips
- eager/deferred validation parity for historical snapshots
- selective lookup and complete materialization
- defensive copies, deferred-state release, and concurrent lookup/materialization
