### PR TITLE
perf(table): resolve only requested equality-delete field paths

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -352,8 +352,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema.go
+++ b/schema.go
@@ -278,6 +278,12 @@ func (s *Schema) asStructRef() StructType { return StructType{FieldList: s.field
 func (s *Schema) NumFields() int          { return len(s.fields) }
 func (s *Schema) Field(i int) NestedField { return cloneField(s.fields[i]) }
 func (s *Schema) Fields() []NestedField   { return cloneFields(s.fields) }
+
+// FieldsRef returns the schema-owned fields for trusted internal callers.
+// The returned slice and everything reachable through the fields must be
+// treated as read-only.
+func (s *Schema) FieldsRef(_ internal.SchemaRef) []NestedField { return s.fields }
+
 func (s *Schema) FieldIDs() []int {
 	idx, _ := s.lazyNameToID()
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -427,6 +427,13 @@ func TestSchemaFieldRefLookupDoesNotAllocate(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 1, field.ID)
 
+	var fields []iceberg.NestedField
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		fields = schema.FieldsRef(internal.SchemaRef{})
+		runtime.KeepAlive(fields)
+	}))
+	assert.Len(t, fields, 1)
+
 	parent := field.Type.(*iceberg.StructType)
 	parent.FieldList[0].Name = "shared_child"
 	shared, ok := schema.FindFieldByIDRef(1, internal.SchemaRef{})

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2299,4 +2300,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/equality_delete_reader.go
+++ b/table/equality_delete_reader.go
@@ -93,6 +93,54 @@ func indexArrowFields(schema *iceberg.Schema) arrowFieldRefsByID {
 	return refs
 }
 
+type requestedArrowFieldResolver struct {
+	requested map[int]struct{}
+	refs      arrowFieldRefsByID
+	path      []int
+	pathBuf   [8]int
+}
+
+func (r *requestedArrowFieldResolver) visit(fields []iceberg.NestedField) {
+	for i, field := range fields {
+		parentLen := len(r.path)
+		r.path = append(r.path, i)
+
+		if _, ok := r.requested[field.ID]; ok {
+			r.refs[field.ID] = append(r.refs[field.ID], arrowFieldRef{path: slices.Clone(r.path)})
+		}
+
+		if nested, ok := field.Type.(*iceberg.StructType); ok {
+			r.visit(nested.FieldList)
+		}
+
+		r.path = r.path[:parentLen]
+	}
+}
+
+// resolveArrowFieldsByID resolves paths only for the requested field IDs.
+// It walks the schema using borrowed fields and keeps one reusable path stack,
+// copying a path only when it matches an equality field.
+func resolveArrowFieldsByID(schema *iceberg.Schema, fieldIDs []int) arrowFieldRefsByID {
+	refs := make(arrowFieldRefsByID, len(fieldIDs))
+	if schema == nil || len(fieldIDs) == 0 {
+		return refs
+	}
+
+	requested := make(map[int]struct{}, len(fieldIDs))
+	for _, fieldID := range fieldIDs {
+		requested[fieldID] = struct{}{}
+	}
+
+	resolver := requestedArrowFieldResolver{
+		requested: requested,
+		refs:      refs,
+	}
+	resolver.path = resolver.pathBuf[:0]
+	resolver.visit(schema.FieldsRef(iceinternal.SchemaRef{}))
+
+	return refs
+}
+
 // indexArrowFieldsByMetadata is used for delete files whose Arrow fields carry
 // IDs directly, before any name mapping is needed.
 func indexArrowFieldsByMetadata(schema *arrow.Schema) arrowFieldRefsByID {
@@ -111,6 +159,61 @@ func indexArrowFieldsByMetadata(schema *arrow.Schema) arrowFieldRefsByID {
 		}
 	}
 	visit(schema.Fields(), nil)
+
+	return refs
+}
+
+type requestedArrowMetadataFieldResolver struct {
+	requested map[int]struct{}
+	refs      arrowFieldRefsByID
+	path      []int
+	pathBuf   [8]int
+}
+
+func (r *requestedArrowMetadataFieldResolver) visitField(field arrow.Field, index int) {
+	parentLen := len(r.path)
+	r.path = append(r.path, index)
+
+	if id := getFieldID(field); id != nil {
+		if _, ok := r.requested[*id]; ok {
+			r.refs[*id] = append(r.refs[*id], arrowFieldRef{path: slices.Clone(r.path)})
+		}
+	}
+
+	if nested, ok := field.Type.(*arrow.StructType); ok {
+		r.visitStruct(nested)
+	}
+
+	r.path = r.path[:parentLen]
+}
+
+func (r *requestedArrowMetadataFieldResolver) visitStruct(schema *arrow.StructType) {
+	for i := range schema.NumFields() {
+		r.visitField(schema.Field(i), i)
+	}
+}
+
+// resolveArrowFieldsByMetadata resolves paths only for requested field IDs in
+// an Arrow schema whose fields carry Iceberg IDs in metadata.
+func resolveArrowFieldsByMetadata(schema *arrow.Schema, fieldIDs []int) arrowFieldRefsByID {
+	refs := make(arrowFieldRefsByID, len(fieldIDs))
+	if schema == nil || len(fieldIDs) == 0 {
+		return refs
+	}
+
+	requested := make(map[int]struct{}, len(fieldIDs))
+	for _, fieldID := range fieldIDs {
+		requested[fieldID] = struct{}{}
+	}
+
+	resolver := requestedArrowMetadataFieldResolver{
+		requested: requested,
+		refs:      refs,
+	}
+	resolver.path = resolver.pathBuf[:0]
+	for i := range schema.NumFields() {
+		resolver.visitField(schema.Field(i), i)
+	}
 
 	return refs
 }
@@ -448,9 +551,9 @@ func readEqualityDeleteFile(ctx context.Context, fs iceio.IO, tableSchema *icebe
 
 	var fieldRefsByID arrowFieldRefsByID
 	if hasFieldIDs {
-		fieldRefsByID = indexArrowFieldsByMetadata(projectedSchema)
+		fieldRefsByID = resolveArrowFieldsByMetadata(projectedSchema, fieldIDs)
 	} else {
-		fieldRefsByID = indexArrowFields(fileSchema)
+		fieldRefsByID = resolveArrowFieldsByID(fileSchema, fieldIDs)
 	}
 
 	// Resolve projected field paths from field IDs.
@@ -792,14 +895,25 @@ func makeColEncoder(arr arrow.Array) colEncoder {
 // switches. Each delete set is applied independently because sets may have
 // different field IDs.
 func processEqualityDeletesColumnarForFile(ctx context.Context, eqDeleteSets []*equalityDeleteSet, fileSchema *iceberg.Schema, dataFilePath string) (recProcessFn, error) {
-	fieldRefsByID := indexArrowFields(fileSchema)
-	fieldRefs := make([][]arrowFieldRef, len(eqDeleteSets))
-	for i, eqDel := range eqDeleteSets {
+	requestedFieldIDs := make([]int, 0)
+	requestedFieldIDSet := make(map[int]struct{})
+	for _, eqDel := range eqDeleteSets {
 		if len(eqDel.fieldIDs) != len(eqDel.colNames) {
 			return nil, fmt.Errorf("%w: equality delete set has %d field IDs and %d column names",
 				iceberg.ErrInvalidArgument, len(eqDel.fieldIDs), len(eqDel.colNames))
 		}
 
+		for _, fieldID := range eqDel.fieldIDs {
+			if _, ok := requestedFieldIDSet[fieldID]; !ok {
+				requestedFieldIDSet[fieldID] = struct{}{}
+				requestedFieldIDs = append(requestedFieldIDs, fieldID)
+			}
+		}
+	}
+
+	fieldRefsByID := resolveArrowFieldsByID(fileSchema, requestedFieldIDs)
+	fieldRefs := make([][]arrowFieldRef, len(eqDeleteSets))
+	for i, eqDel := range eqDeleteSets {
 		fieldRefs[i] = make([]arrowFieldRef, len(eqDel.fieldIDs))
 		for fieldIdx, fieldID := range eqDel.fieldIDs {
 			ref, err := resolveArrowField(fieldRefsByID, fieldID, eqDel.colNames[fieldIdx], dataFilePath)

--- a/table/equality_delete_reader_bench_test.go
+++ b/table/equality_delete_reader_bench_test.go
@@ -324,3 +324,109 @@ func BenchmarkProcessEqualityDeletesNoMatchInt(b *testing.B) {
 func BenchmarkProcessEqualityDeletesNoMatchString(b *testing.B) {
 	benchEqDeletesForFile(b, buildBenchRecordString, buildBenchDeleteSetStringNoMatch, benchStringFileSchema())
 }
+
+func BenchmarkResolveEqualityDeleteFieldPaths(b *testing.B) {
+	for _, fieldCount := range []int{32, 256, 2_048} {
+		for _, keySize := range []int{1, 2, 8} {
+			for _, position := range []string{"front", "middle", "end"} {
+				b.Run(fmt.Sprintf("fields=%d/key=%d/position=%s", fieldCount, keySize, position), func(b *testing.B) {
+					schema := benchmarkEqualityDeleteSchema(fieldCount)
+					fieldIDs := benchmarkEqualityDeleteFieldIDs(fieldCount, keySize, position)
+
+					b.ReportAllocs()
+					b.ReportMetric(float64(fieldCount), "schema_fields")
+					b.ReportMetric(float64(keySize), "equality_fields")
+					b.ResetTimer()
+
+					for b.Loop() {
+						refs := resolveArrowFieldsByID(schema, fieldIDs)
+						metadataBuilderBenchmarkSink = len(refs) + len(refs[fieldIDs[0]])
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkResolveEqualityDeleteNestedFieldPaths(b *testing.B) {
+	schema, fieldID := benchmarkNestedEqualityDeleteSchema(8, 3)
+	fieldIDs := []int{fieldID}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		refs := resolveArrowFieldsByID(schema, fieldIDs)
+		metadataBuilderBenchmarkSink = len(refs) + len(refs[fieldID][0].path)
+	}
+}
+
+func benchmarkEqualityDeleteSchema(fieldCount int) *iceberg.Schema {
+	fields := make([]iceberg.NestedField, fieldCount)
+	for i := range fields {
+		fields[i] = iceberg.NestedField{
+			ID:       i + 1,
+			Name:     fmt.Sprintf("field_%d", i+1),
+			Type:     iceberg.PrimitiveTypes.Int64,
+			Required: true,
+		}
+	}
+
+	return iceberg.NewSchema(0, fields...)
+}
+
+func benchmarkEqualityDeleteFieldIDs(fieldCount, keySize int, position string) []int {
+	start := 1
+	switch position {
+	case "middle":
+		start = (fieldCount-keySize)/2 + 1
+	case "end":
+		start = fieldCount - keySize + 1
+	}
+
+	fieldIDs := make([]int, keySize)
+	for i := range fieldIDs {
+		fieldIDs[i] = start + i
+	}
+
+	return fieldIDs
+}
+
+func benchmarkNestedEqualityDeleteSchema(width, depth int) (*iceberg.Schema, int) {
+	nextID := 1
+	lastLeafID := 0
+	var buildStruct func(int) *iceberg.StructType
+	buildStruct = func(level int) *iceberg.StructType {
+		fields := make([]iceberg.NestedField, width)
+		for i := range fields {
+			fieldID := nextID
+			nextID++
+			field := iceberg.NestedField{
+				ID:   fieldID,
+				Name: fmt.Sprintf("nested_%d", fieldID),
+			}
+			if level == 0 {
+				field.Type = iceberg.PrimitiveTypes.Int64
+				lastLeafID = fieldID
+			} else {
+				field.Type = buildStruct(level - 1)
+			}
+			fields[i] = field
+		}
+
+		return &iceberg.StructType{FieldList: fields}
+	}
+
+	fields := make([]iceberg.NestedField, width)
+	for i := range fields {
+		fieldID := nextID
+		nextID++
+		fields[i] = iceberg.NestedField{
+			ID:   fieldID,
+			Name: fmt.Sprintf("root_%d", fieldID),
+			Type: buildStruct(depth - 1),
+		}
+	}
+
+	return iceberg.NewSchema(0, fields...), lastLeafID
+}

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -832,3 +832,27 @@ func newEqualityDeleteSetAssemblyTestFile(
 
 	return builder.EqualityFieldIDs(fieldIDs).Build()
 }
+
+func TestResolveRequestedArrowFieldsPreservesDeepAndSiblingPaths(t *testing.T) {
+	const depth = 12
+	field := iceberg.NestedField{ID: 100, Name: "leaf", Type: iceberg.PrimitiveTypes.Int64}
+	for id := depth; id > 0; id-- {
+		field = iceberg.NestedField{ID: id, Name: "nested", Type: &iceberg.StructType{
+			FieldList: []iceberg.NestedField{field},
+		}}
+	}
+	schema := iceberg.NewSchema(0, field,
+		iceberg.NestedField{ID: 101, Name: "sibling", Type: iceberg.PrimitiveTypes.Int64})
+	arrowSchema, err := SchemaToArrowSchema(schema, nil, true, false)
+	require.NoError(t, err)
+	want := arrowFieldRefsByID{
+		100: {{path: make([]int, depth+1)}},
+		101: {{path: []int{1}}},
+	}
+	assert.Equal(t, want, resolveArrowFieldsByID(schema, []int{100, 101, 100, 999}))
+	assert.Equal(t, want, resolveArrowFieldsByMetadata(arrowSchema, []int{100, 101, 100, 999}))
+	assert.Empty(t, resolveArrowFieldsByID(nil, []int{100}))
+	assert.Empty(t, resolveArrowFieldsByMetadata(nil, []int{100}))
+	assert.Empty(t, resolveArrowFieldsByID(schema, nil))
+	assert.Empty(t, resolveArrowFieldsByMetadata(arrowSchema, nil))
+}

--- a/table/equality_delete_reader_internal_test.go
+++ b/table/equality_delete_reader_internal_test.go
@@ -608,6 +608,40 @@ func TestResolveArrowFieldUsesFieldIDBeforeName(t *testing.T) {
 	assert.Equal(t, []int{2, 0}, ref.path)
 }
 
+func TestResolveArrowFieldsByIDOnlyIndexesRequestedFields(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "ignored", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 2, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		iceberg.NestedField{ID: 4, Name: "record", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+			{ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Int64},
+		}}},
+	)
+
+	refs := resolveArrowFieldsByID(schema, []int{2, 3})
+	assert.Equal(t, arrowFieldRefsByID{
+		2: {{path: []int{1}}},
+		3: {{path: []int{2, 0}}},
+	}, refs)
+}
+
+func TestResolveArrowFieldsByMetadataOnlyIndexesRequestedFields(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "ignored", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{
+			ArrowParquetFieldIDKey: "1",
+		})},
+		{Name: "record", Type: arrow.StructOf(arrow.Field{
+			Name: "value", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{
+				ArrowParquetFieldIDKey: "2",
+			}),
+		})},
+	}, nil)
+
+	refs := resolveArrowFieldsByMetadata(schema, []int{2})
+	assert.Equal(t, arrowFieldRefsByID{
+		2: {{path: []int{1, 0}}},
+	}, refs)
+}
+
 func TestResolveArrowFieldRejectsAmbiguousOrMismatchedIDs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -669,7 +703,7 @@ func TestResolveArrowFieldRejectsDuplicateMetadataIDs(t *testing.T) {
 		{Name: "right", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{ArrowParquetFieldIDKey: "1"})},
 	}, nil)
 
-	_, err := resolveArrowField(indexArrowFieldsByMetadata(schema), 1, "id", "data.parquet")
+	_, err := resolveArrowField(resolveArrowFieldsByMetadata(schema, []int{1}), 1, "id", "data.parquet")
 	require.ErrorIs(t, err, ErrAmbiguousEqualityColumn)
 	require.ErrorContains(t, err, "data.parquet")
 }


### PR DESCRIPTION
## Summary

- **Resolve less:** Equality-delete setup now resolves only field IDs from the active delete sets.
- **Reuse traversal state:** Internal schema fields are borrowed for the read-only walk, and only matching paths are copied.
- **Keep validation:** Existing nested paths and ambiguous-column errors remain covered.

## Benchmark

Apple M1 Pro, Go 1.26.3, 2,048-field schema:

- **1 equality field:** about 586 KB / 4,128 allocs to 672 B / 7 allocs
- **8 equality fields:** about 586 KB / 4,128 allocs to 896 B / 21 allocs
- **1-field setup time:** about 280 us to 10 us

## Tests

- `go test -timeout=5m` across all packages except `io/gocloud`
- `go test -race -timeout=5m . ./table/...`
- `golangci-lint run --timeout=10m`