### PR TITLE
perf(rest): fetch remote scan plan tasks concurrently

### DIFF
--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -33,11 +33,16 @@ func validatePlanningTaskEnvelope(data []byte, status PlanStatus, tasks ScanTask
 		return err
 	}
 
-	if status != PlanStatusCompleted {
-		for _, name := range []string{"plan-tasks", "file-scan-tasks", "delete-files"} {
-			if _, ok := fields[name]; ok {
-				return fmt.Errorf("%w: %s response includes %s for status %q", ErrRESTError, endpoint, name, status)
-			}
+	for _, name := range []string{"plan-tasks", "file-scan-tasks", "delete-files"} {
+		raw, ok := fields[name]
+		if !ok {
+			continue
+		}
+		if isJSONNull(raw) {
+			return fmt.Errorf("%w: %s response field %s must not be null", ErrRESTError, endpoint, name)
+		}
+		if status != PlanStatusCompleted {
+			return fmt.Errorf("%w: %s response includes %s for status %q", ErrRESTError, endpoint, name, status)
 		}
 	}
 

--- a/catalog/rest/fetch_scan_tasks_validation.go
+++ b/catalog/rest/fetch_scan_tasks_validation.go
@@ -35,8 +35,7 @@ func validatePlanningTaskEnvelope(data []byte, status PlanStatus, tasks ScanTask
 
 	if status != PlanStatusCompleted {
 		for _, name := range []string{"plan-tasks", "file-scan-tasks", "delete-files"} {
-			raw, ok := fields[name]
-			if ok && !isJSONNull(raw) {
+			if _, ok := fields[name]; ok {
 				return fmt.Errorf("%w: %s response includes %s for status %q", ErrRESTError, endpoint, name, status)
 			}
 		}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -30,6 +30,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -51,11 +52,6 @@ var _ table.ScanPlanner = (*Catalog)(nil)
 // Compile-time proof that the REST catalog exposes the optional full-capability
 // extension used by table.Scan's auto planning mode.
 var _ table.FullRemoteScanPlanner = (*Catalog)(nil)
-
-// remoteScanTaskFetchConcurrency bounds in-flight fetchScanTasks requests for
-// each frontier. Keeping frontiers separate preserves breadth-first response
-// ordering while allowing independent plan-task handles to fetch concurrently.
-const remoteScanTaskFetchConcurrency = 8
 
 // ErrPlanExpired is returned when polling a plan that the server no longer
 // knows about: a fetchPlanningResult 404 whose error.type is exactly
@@ -253,7 +249,8 @@ func (r *Catalog) PlanFiles(ctx context.Context, req table.ScanPlanningRequest) 
 			"%w: unexpected plan status %q from planTableScan", ErrRESTError, resp.Status)
 	}
 
-	envelopes, err := r.collectScanTasks(ctx, req.Identifier, completed.ScanTasks)
+	envelopes, err := r.collectScanTasksWithConcurrency(
+		ctx, req.Identifier, completed.ScanTasks, req.MaxConcurrency)
 	if err != nil {
 		cleanup()
 
@@ -307,6 +304,23 @@ func (r *Catalog) planIOBaseProps(req table.ScanPlanningRequest) iceberg.Propert
 // forever. The envelope boundaries are retained because delete-file references
 // are local to each response.
 func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]ScanTasks, error) {
+	return r.collectScanTasksWithConcurrency(ctx, ident, tasks, runtime.GOMAXPROCS(0))
+}
+
+// collectScanTasksWithConcurrency expands plan-task handles using the
+// requested maximum number of concurrent fetches. A non-positive limit uses
+// runtime.GOMAXPROCS. On a fetch error, at most the configured number of
+// requests can already be in flight when cancellation reaches their contexts.
+func (r *Catalog) collectScanTasksWithConcurrency(
+	ctx context.Context,
+	ident table.Identifier,
+	tasks ScanTasks,
+	maxConcurrency int,
+) ([]ScanTasks, error) {
+	if maxConcurrency <= 0 {
+		maxConcurrency = runtime.GOMAXPROCS(0)
+	}
+
 	envelopes := []ScanTasks{tasks}
 
 	frontier := append([]string(nil), tasks.PlanTasks...)
@@ -320,8 +334,11 @@ func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, 
 			seen[handle] = true
 			handles = append(handles, handle)
 		}
+		if len(handles) == 0 {
+			break
+		}
 
-		responses, err := r.fetchScanTaskFrontier(ctx, ident, handles)
+		responses, err := r.fetchScanTaskFrontier(ctx, ident, handles, maxConcurrency)
 		if err != nil {
 			return nil, err
 		}
@@ -337,21 +354,39 @@ func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, 
 	return envelopes, nil
 }
 
+// fetchScanTaskFrontier fetches one breadth-first frontier concurrently while
+// placing responses back into handle order. The explicit cancellation context
+// keeps sibling transport errors as context.Canceled instead of propagating an
+// errgroup cancellation cause into those errors.
 func (r *Catalog) fetchScanTaskFrontier(
 	ctx context.Context,
 	ident table.Identifier,
 	handles []string,
+	maxConcurrency int,
 ) ([]FetchScanTasksResponse, error) {
 	responses := make([]FetchScanTasksResponse, len(handles))
 	errs := make([]error, len(handles))
-	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(remoteScanTaskFetchConcurrency)
+	if len(handles) == 0 {
+		return responses, nil
+	}
+	if maxConcurrency <= 0 {
+		maxConcurrency = runtime.GOMAXPROCS(0)
+	}
+	maxConcurrency = min(maxConcurrency, len(handles))
+
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var group errgroup.Group
+	group.SetLimit(maxConcurrency)
 
 	for i, handle := range handles {
+		i, handle := i, handle
 		group.Go(func() error {
-			response, err := r.FetchScanTasks(groupCtx, ident, FetchScanTasksRequest{PlanTask: handle})
+			response, err := r.FetchScanTasks(fetchCtx, ident, FetchScanTasksRequest{PlanTask: handle})
 			if err != nil {
 				errs[i] = fmt.Errorf("fetching scan tasks for handle %q: %w", handle, err)
+				cancel()
 
 				return err
 			}
@@ -367,7 +402,16 @@ func (r *Catalog) fetchScanTaskFrontier(
 		// first error in handle order wins. Sibling requests cancelled by the
 		// first failure are not meaningful candidates for the returned error.
 		for _, err := range errs {
-			if err != nil && !errors.Is(err, context.Canceled) {
+			if err != nil &&
+				!errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+		}
+		// If cancellation is the only error, still return the handle-aware
+		// error recorded for the first handle rather than the bare group error.
+		for _, err := range errs {
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -326,7 +326,7 @@ func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, 
 			return nil, err
 		}
 
-		nextFrontier := make([]string, 0)
+		var nextFrontier []string
 		for _, response := range responses {
 			envelopes = append(envelopes, response.ScanTasks)
 			nextFrontier = append(nextFrontier, response.PlanTasks...)
@@ -351,7 +351,7 @@ func (r *Catalog) fetchScanTaskFrontier(
 		group.Go(func() error {
 			response, err := r.FetchScanTasks(groupCtx, ident, FetchScanTasksRequest{PlanTask: handle})
 			if err != nil {
-				errs[i] = err
+				errs[i] = fmt.Errorf("fetching scan tasks for handle %q: %w", handle, err)
 
 				return err
 			}

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -41,6 +41,7 @@ import (
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -50,6 +51,11 @@ var _ table.ScanPlanner = (*Catalog)(nil)
 // Compile-time proof that the REST catalog exposes the optional full-capability
 // extension used by table.Scan's auto planning mode.
 var _ table.FullRemoteScanPlanner = (*Catalog)(nil)
+
+// remoteScanTaskFetchConcurrency bounds in-flight fetchScanTasks requests for
+// each frontier. Keeping frontiers separate preserves breadth-first response
+// ordering while allowing independent plan-task handles to fetch concurrently.
+const remoteScanTaskFetchConcurrency = 8
 
 // ErrPlanExpired is returned when polling a plan that the server no longer
 // knows about: a fetchPlanningResult 404 whose error.type is exactly
@@ -294,32 +300,70 @@ func (r *Catalog) planIOBaseProps(req table.ScanPlanningRequest) iceberg.Propert
 }
 
 // collectScanTasks expands plan-task handles into their task envelopes, walking
-// the fanout: a fetchScanTasks response can itself return more plan-tasks. A
-// handle is fetched at most once; a server that re-issues one would otherwise
-// loop forever. The envelope boundaries are retained because delete-file
-// references are local to each response.
+// the fanout: a fetchScanTasks response can itself return more plan-tasks. Each
+// frontier is fetched concurrently, but its responses are appended in handle
+// order so completion timing cannot change the result order. A handle is
+// fetched at most once; a server that re-issues one would otherwise loop
+// forever. The envelope boundaries are retained because delete-file references
+// are local to each response.
 func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]ScanTasks, error) {
 	envelopes := []ScanTasks{tasks}
 
-	queue := append([]string(nil), tasks.PlanTasks...)
-	seen := make(map[string]bool, len(queue))
-	for len(queue) > 0 {
-		handle := queue[0]
-		queue = queue[1:]
-		if seen[handle] {
-			continue
+	frontier := append([]string(nil), tasks.PlanTasks...)
+	seen := make(map[string]bool, len(frontier))
+	for len(frontier) > 0 {
+		handles := make([]string, 0, len(frontier))
+		for _, handle := range frontier {
+			if seen[handle] {
+				continue
+			}
+			seen[handle] = true
+			handles = append(handles, handle)
 		}
-		seen[handle] = true
 
-		resp, err := r.FetchScanTasks(ctx, ident, FetchScanTasksRequest{PlanTask: handle})
+		responses, err := r.fetchScanTaskFrontier(ctx, ident, handles)
 		if err != nil {
 			return nil, err
 		}
-		envelopes = append(envelopes, resp.ScanTasks)
-		queue = append(queue, resp.PlanTasks...)
+
+		nextFrontier := make([]string, 0)
+		for _, response := range responses {
+			envelopes = append(envelopes, response.ScanTasks)
+			nextFrontier = append(nextFrontier, response.PlanTasks...)
+		}
+		frontier = nextFrontier
 	}
 
 	return envelopes, nil
+}
+
+func (r *Catalog) fetchScanTaskFrontier(
+	ctx context.Context,
+	ident table.Identifier,
+	handles []string,
+) ([]FetchScanTasksResponse, error) {
+	responses := make([]FetchScanTasksResponse, len(handles))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(remoteScanTaskFetchConcurrency)
+
+	for i, handle := range handles {
+		group.Go(func() error {
+			response, err := r.FetchScanTasks(groupCtx, ident, FetchScanTasksRequest{PlanTask: handle})
+			if err != nil {
+				return err
+			}
+
+			responses[i] = response
+
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	return responses, nil
 }
 
 // remoteScanTasks decodes each server task envelope into domain FileScanTasks.

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -396,7 +396,6 @@ func (r *Catalog) fetchScanTaskFrontier(
 	group.SetLimit(maxConcurrency)
 
 	for i, handle := range handles {
-		i, handle := i, handle
 		group.Go(func() error {
 			response, fetchErr := r.FetchScanTasks(requestCtxs[i], ident, FetchScanTasksRequest{PlanTask: handle})
 

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -343,6 +343,7 @@ func (r *Catalog) fetchScanTaskFrontier(
 	handles []string,
 ) ([]FetchScanTasksResponse, error) {
 	responses := make([]FetchScanTasksResponse, len(handles))
+	errs := make([]error, len(handles))
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(remoteScanTaskFetchConcurrency)
 
@@ -350,6 +351,8 @@ func (r *Catalog) fetchScanTaskFrontier(
 		group.Go(func() error {
 			response, err := r.FetchScanTasks(groupCtx, ident, FetchScanTasksRequest{PlanTask: handle})
 			if err != nil {
+				errs[i] = err
+
 				return err
 			}
 
@@ -359,8 +362,17 @@ func (r *Catalog) fetchScanTaskFrontier(
 		})
 	}
 
-	if err := group.Wait(); err != nil {
-		return nil, err
+	if waitErr := group.Wait(); waitErr != nil {
+		// Preserve the serial fetch contract: when multiple handles fail, the
+		// first error in handle order wins. Sibling requests cancelled by the
+		// first failure are not meaningful candidates for the returned error.
+		for _, err := range errs {
+			if err != nil && !errors.Is(err, context.Canceled) {
+				return nil, err
+			}
+		}
+
+		return nil, waitErr
 	}
 
 	return responses, nil

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -296,20 +296,16 @@ func (r *Catalog) planIOBaseProps(req table.ScanPlanningRequest) iceberg.Propert
 	return props
 }
 
-// collectScanTasks expands plan-task handles into their task envelopes, walking
-// the fanout: a fetchScanTasks response can itself return more plan-tasks. Each
+// collectScanTasksWithConcurrency expands plan-task handles into their task
+// envelopes, walking the fanout: a response can itself return more plan-tasks. Each
 // frontier is fetched concurrently, but its responses are appended in handle
 // order so completion timing cannot change the result order. A handle is
 // fetched at most once; a server that re-issues one would otherwise loop
 // forever. The envelope boundaries are retained because delete-file references
 // are local to each response.
-func (r *Catalog) collectScanTasks(ctx context.Context, ident table.Identifier, tasks ScanTasks) ([]ScanTasks, error) {
-	return r.collectScanTasksWithConcurrency(ctx, ident, tasks, runtime.GOMAXPROCS(0))
-}
-
-// collectScanTasksWithConcurrency expands plan-task handles using the
-// requested maximum number of concurrent fetches. A non-positive limit uses
-// runtime.GOMAXPROCS. On a fetch error, at most the configured number of
+//
+// maxConcurrency bounds the number of concurrent fetches. A non-positive limit
+// uses runtime.GOMAXPROCS. On a fetch error, at most the configured number of
 // requests can already be in flight when cancellation reaches their contexts.
 func (r *Catalog) collectScanTasksWithConcurrency(
 	ctx context.Context,

--- a/catalog/rest/scan_planning.go
+++ b/catalog/rest/scan_planning.go
@@ -355,9 +355,9 @@ func (r *Catalog) collectScanTasksWithConcurrency(
 }
 
 // fetchScanTaskFrontier fetches one breadth-first frontier concurrently while
-// placing responses back into handle order. The explicit cancellation context
-// keeps sibling transport errors as context.Canceled instead of propagating an
-// errgroup cancellation cause into those errors.
+// placing responses back into handle order. When a handle fails, unfinished
+// later handles are canceled, but earlier handles are allowed to finish so the
+// first error in the old serial handle order remains deterministic.
 func (r *Catalog) fetchScanTaskFrontier(
 	ctx context.Context,
 	ident table.Identifier,
@@ -374,8 +374,23 @@ func (r *Catalog) fetchScanTaskFrontier(
 	}
 	maxConcurrency = min(maxConcurrency, len(handles))
 
-	fetchCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	requestCtxs := make([]context.Context, len(handles))
+	requestCancels := make([]context.CancelFunc, len(handles))
+	for i := range handles {
+		requestCtxs[i], requestCancels[i] = context.WithCancel(ctx)
+	}
+	defer func() {
+		for _, cancel := range requestCancels {
+			cancel()
+		}
+	}()
+
+	var (
+		mu               sync.Mutex
+		completed        = make([]bool, len(handles))
+		siblingCanceled  = make([]bool, len(handles))
+		lowestFailureIdx = -1
+	)
 
 	var group errgroup.Group
 	group.SetLimit(maxConcurrency)
@@ -383,35 +398,46 @@ func (r *Catalog) fetchScanTaskFrontier(
 	for i, handle := range handles {
 		i, handle := i, handle
 		group.Go(func() error {
-			response, err := r.FetchScanTasks(fetchCtx, ident, FetchScanTasksRequest{PlanTask: handle})
-			if err != nil {
-				errs[i] = fmt.Errorf("fetching scan tasks for handle %q: %w", handle, err)
-				cancel()
+			response, fetchErr := r.FetchScanTasks(requestCtxs[i], ident, FetchScanTasksRequest{PlanTask: handle})
 
-				return err
+			mu.Lock()
+			defer mu.Unlock()
+			completed[i] = true
+			if fetchErr == nil {
+				responses[i] = response
+
+				return nil
 			}
 
-			responses[i] = response
+			errs[i] = fmt.Errorf("fetching scan tasks for handle %q: %w", handle, fetchErr)
+			if siblingCanceled[i] || (lowestFailureIdx >= 0 && i > lowestFailureIdx) {
+				return fetchErr
+			}
 
-			return nil
+			if lowestFailureIdx < 0 || i < lowestFailureIdx {
+				lowestFailureIdx = i
+				for j := i + 1; j < len(handles); j++ {
+					if completed[j] || siblingCanceled[j] {
+						continue
+					}
+					siblingCanceled[j] = true
+					requestCancels[j]()
+				}
+			}
+
+			return fetchErr
 		})
 	}
 
 	if waitErr := group.Wait(); waitErr != nil {
-		// Preserve the serial fetch contract: when multiple handles fail, the
-		// first error in handle order wins. Sibling requests cancelled by the
-		// first failure are not meaningful candidates for the returned error.
-		for _, err := range errs {
-			if err != nil &&
-				!errors.Is(err, context.Canceled) &&
-				!errors.Is(err, context.DeadlineExceeded) {
-				return nil, err
-			}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
-		// If cancellation is the only error, still return the handle-aware
-		// error recorded for the first handle rather than the bare group error.
-		for _, err := range errs {
-			if err != nil {
+
+		mu.Lock()
+		defer mu.Unlock()
+		for i, err := range errs {
+			if err != nil && !siblingCanceled[i] {
 				return nil, err
 			}
 		}

--- a/catalog/rest/scan_planning_bench_test.go
+++ b/catalog/rest/scan_planning_bench_test.go
@@ -58,11 +58,16 @@ func BenchmarkCollectScanTasks64Handles(b *testing.B) {
 	tasks := ScanTasks{PlanTasks: handles}
 	ident := table.Identifier{"db", "tbl"}
 
-	b.ResetTimer()
-	for range b.N {
-		_, err := catalog.collectScanTasks(context.Background(), ident, tasks)
-		if err != nil {
-			b.Fatal(err)
-		}
+	for _, maxConcurrency := range []int{1, 2, 4, 8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("concurrency-%d", maxConcurrency), func(b *testing.B) {
+			b.ResetTimer()
+			for range b.N {
+				_, err := catalog.collectScanTasksWithConcurrency(
+					context.Background(), ident, tasks, maxConcurrency)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/catalog/rest/scan_planning_bench_test.go
+++ b/catalog/rest/scan_planning_bench_test.go
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go/table"
+)
+
+func BenchmarkCollectScanTasks64Handles(b *testing.B) {
+	const (
+		handleCount = 64
+		latency     = 10 * time.Millisecond
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(latency)
+		_, _ = w.Write([]byte(`{"file-scan-tasks":[]}`))
+	}))
+	b.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	catalog := &Catalog{
+		baseURI:   serverURL.JoinPath("v1"),
+		cl:        server.Client(),
+		endpoints: newEndpointSet([]endpoint{endpointFetchScanTasks}),
+	}
+	handles := make([]string, handleCount)
+	for i := range handles {
+		handles[i] = fmt.Sprintf("task-%d", i)
+	}
+	tasks := ScanTasks{PlanTasks: handles}
+	ident := table.Identifier{"db", "tbl"}
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := catalog.collectScanTasks(context.Background(), ident, tasks)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -220,6 +220,9 @@ func TestPlanTableScanResponseRejectsInvalidStatusEnvelope(t *testing.T) {
 		`{"status":"failed","plan-tasks":[]}`,
 		`{"status":"failed","plan-tasks":null}`,
 		`{"status":"completed","plan-id":"abc","delete-files":[{}]}`,
+		`{"status":"completed","plan-id":"abc","plan-tasks":null}`,
+		`{"status":"completed","plan-id":"abc","file-scan-tasks":null}`,
+		`{"status":"completed","plan-id":"abc","delete-files":null}`,
 		`{"status":"failed","plan-id":"abc"}`,
 	} {
 		t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
@@ -325,6 +328,9 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 			`{"status":"cancelled","file-scan-tasks":[]}`,
 			`{"status":"cancelled","file-scan-tasks":null}`,
 			`{"status":"completed","delete-files":[{}]}`,
+			`{"status":"completed","plan-tasks":null}`,
+			`{"status":"completed","file-scan-tasks":null}`,
+			`{"status":"completed","delete-files":null}`,
 		} {
 			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {
 				t.Parallel()

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1363,6 +1363,7 @@ func TestCollectScanTasksReturnsFirstErrorInHandleOrder(t *testing.T) {
 		PlanTasks: []string{"table", "plan-task"},
 	})
 	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	assert.Contains(t, err.Error(), `handle "table"`)
 	assert.NotErrorIs(t, err, ErrNoSuchPlanTask)
 	assert.Nil(t, envelopes)
 }

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1231,6 +1231,7 @@ func TestPlanFilesPollsSubmittedPlan(t *testing.T) {
 func TestPlanFilesExpandsPlanTasks(t *testing.T) {
 	t.Parallel()
 
+	var mu sync.Mutex
 	var fetched []string
 	cat := newScanPlanningTestCatalog(t, []endpoint{endpointPlanTableScan, endpointFetchScanTasks}, func(mux *http.ServeMux) {
 		mux.HandleFunc("/v1/namespaces/db/tables/tbl/plan", func(w http.ResponseWriter, req *http.Request) {
@@ -1240,7 +1241,9 @@ func TestPlanFilesExpandsPlanTasks(t *testing.T) {
 		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
 			var body FetchScanTasksRequest
 			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			mu.Lock()
 			fetched = append(fetched, body.PlanTask)
+			mu.Unlock()
 			switch body.PlanTask {
 			case "h1":
 				_, err := w.Write([]byte(`{"plan-tasks":["h2"]}`))
@@ -1255,6 +1258,8 @@ func TestPlanFilesExpandsPlanTasks(t *testing.T) {
 	result, err := cat.PlanFiles(context.Background(), planFilesReq())
 	require.NoError(t, err)
 	assert.Empty(t, result.Tasks)
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Equal(t, []string{"h1", "h2"}, fetched)
 }
 
@@ -1297,9 +1302,9 @@ func TestCollectScanTasksFetchesFrontierConcurrentlyInOrder(t *testing.T) {
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+		envelopes, err := cat.collectScanTasksWithConcurrency(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
 			PlanTasks: []string{"h1", "h2"},
-		})
+		}, 2)
 		done <- outcome{envelopes: envelopes, err: err}
 	}()
 
@@ -1375,9 +1380,9 @@ func TestCollectScanTasksReturnsFirstErrorInHandleOrder(t *testing.T) {
 		planTaskReturned: make(chan struct{}),
 	}}
 
-	envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+	envelopes, err := cat.collectScanTasksWithConcurrency(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
 		PlanTasks: []string{"table", "plan-task"},
-	})
+	}, 2)
 	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
 	assert.Contains(t, err.Error(), `handle "table"`)
 	assert.NotErrorIs(t, err, ErrNoSuchPlanTask)
@@ -1931,9 +1936,9 @@ func TestCollectScanTasksDeduplicatesAcrossFrontiers(t *testing.T) {
 		})
 	})
 
-	envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+	envelopes, err := cat.collectScanTasksWithConcurrency(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
 		PlanTasks: []string{"a", "a", "b"},
-	})
+	}, 2)
 	require.NoError(t, err)
 	require.Len(t, envelopes, 6)
 	for i, name := range []string{"a", "b", "c", "d", "e"} {
@@ -1979,9 +1984,9 @@ func TestCollectScanTasksCancelsSiblingRequestsOnFailure(t *testing.T) {
 		})
 	})
 
-	envelopes, err := cat.collectScanTasks(ctx, table.Identifier{"db", "tbl"}, ScanTasks{
+	envelopes, err := cat.collectScanTasksWithConcurrency(ctx, table.Identifier{"db", "tbl"}, ScanTasks{
 		PlanTasks: []string{"failed", "slow"},
-	})
+	}, 2)
 	require.ErrorIs(t, err, ErrBadRequest)
 	assert.Nil(t, envelopes)
 	select {

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1243,6 +1244,152 @@ func TestPlanFilesExpandsPlanTasks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Tasks)
 	assert.Equal(t, []string{"h1", "h2"}, fetched)
+}
+
+func TestCollectScanTasksFetchesFrontierConcurrentlyInOrder(t *testing.T) {
+	t.Parallel()
+
+	h1Started := make(chan struct{})
+	h2Started := make(chan struct{})
+	releaseH1 := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseH1) }) }
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+
+			switch body.PlanTask {
+			case "h1":
+				close(h1Started)
+				<-releaseH1
+				_, _ = w.Write([]byte(`{"file-scan-tasks":[{"data-file":{"file-path":"h1"}}]}`))
+			case "h2":
+				close(h2Started)
+				_, _ = w.Write([]byte(`{"file-scan-tasks":[{"data-file":{"file-path":"h2"}}]}`))
+			default:
+				http.Error(w, "unexpected plan task", http.StatusBadRequest)
+			}
+		})
+	})
+	t.Cleanup(release)
+
+	type outcome struct {
+		envelopes []ScanTasks
+		err       error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+			PlanTasks: []string{"h1", "h2"},
+		})
+		done <- outcome{envelopes: envelopes, err: err}
+	}()
+
+	for name, started := range map[string]<-chan struct{}{
+		"h1": h1Started,
+		"h2": h2Started,
+	} {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s to start", name)
+		}
+	}
+
+	release()
+	select {
+	case result := <-done:
+		require.NoError(t, result.err)
+		require.Len(t, result.envelopes, 3)
+		require.Len(t, result.envelopes[1].FileScanTasks, 1)
+		require.Len(t, result.envelopes[2].FileScanTasks, 1)
+		require.NotNil(t, result.envelopes[1].FileScanTasks[0].DataFile)
+		require.NotNil(t, result.envelopes[2].FileScanTasks[0].DataFile)
+		assert.Equal(t, "h1", result.envelopes[1].FileScanTasks[0].DataFile.FilePath)
+		assert.Equal(t, "h2", result.envelopes[2].FileScanTasks[0].DataFile.FilePath)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for frontier fetches")
+	}
+}
+
+func TestCollectScanTasksBoundsFrontierConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const handleCount = remoteScanTaskFetchConcurrency + 1
+	started := make(chan string, handleCount)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	finish := func() { releaseOnce.Do(func() { close(release) }) }
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+
+			started <- body.PlanTask
+			<-release
+			_, _ = w.Write([]byte(`{"file-scan-tasks":[]}`))
+		})
+	})
+	t.Cleanup(finish)
+
+	handles := make([]string, handleCount)
+	for i := range handles {
+		handles[i] = fmt.Sprintf("h%d", i)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+			PlanTasks: handles,
+		})
+		done <- err
+	}()
+
+	for range remoteScanTaskFetchConcurrency {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for bounded frontier workers")
+		}
+	}
+
+	select {
+	case handle := <-started:
+		t.Fatalf("frontier exceeded concurrency limit with %s", handle)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	finishOne := func() {
+		select {
+		case release <- struct{}{}:
+		case <-time.After(time.Second):
+			t.Fatal("timed out releasing a frontier worker")
+		}
+	}
+	finishOne()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out starting the queued frontier handle")
+	}
+	finish()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for bounded frontier fetches")
+	}
 }
 
 // TestPlanFilesFanoutCycleTerminates guards the seen-set: a server that re-issues

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1968,7 +1968,7 @@ func TestCollectScanTasksCancelsSiblingRequestsOnFailure(t *testing.T) {
 	})
 
 	envelopes, err := cat.collectScanTasks(ctx, table.Identifier{"db", "tbl"}, ScanTasks{
-		PlanTasks: []string{"slow", "failed"},
+		PlanTasks: []string{"failed", "slow"},
 	})
 	require.ErrorIs(t, err, ErrBadRequest)
 	assert.Nil(t, envelopes)

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1341,6 +1341,7 @@ func (t *orderedScanTaskErrorTransport) RoundTrip(req *http.Request) (*http.Resp
 	}
 
 	data := fmt.Sprintf(`{"error":{"message":%q,"type":%q,"code":404}}`, errType, errType)
+
 	return &http.Response{
 		StatusCode:    http.StatusNotFound,
 		Header:        http.Header{"Content-Type": {"application/json"}},

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -214,8 +214,11 @@ func TestPlanTableScanResponseRejectsInvalidStatusEnvelope(t *testing.T) {
 
 	for i, payload := range []string{
 		`{"status":"submitted","plan-id":"abc","file-scan-tasks":[]}`,
+		`{"status":"submitted","plan-id":"abc","file-scan-tasks":null}`,
 		`{"status":"submitted","plan-id":"abc","delete-files":[]}`,
+		`{"status":"submitted","plan-id":"abc","delete-files":null}`,
 		`{"status":"failed","plan-tasks":[]}`,
+		`{"status":"failed","plan-tasks":null}`,
 		`{"status":"completed","plan-id":"abc","delete-files":[{}]}`,
 		`{"status":"failed","plan-id":"abc"}`,
 	} {
@@ -316,8 +319,11 @@ func TestFetchPlanningResultResponseValidation(t *testing.T) {
 
 		for i, payload := range []string{
 			`{"status":"submitted","plan-tasks":[]}`,
+			`{"status":"submitted","plan-tasks":null}`,
 			`{"status":"submitted","delete-files":[]}`,
+			`{"status":"submitted","delete-files":null}`,
 			`{"status":"cancelled","file-scan-tasks":[]}`,
+			`{"status":"cancelled","file-scan-tasks":null}`,
 			`{"status":"completed","delete-files":[{}]}`,
 		} {
 			t.Run(fmt.Sprintf("payload-%d", i), func(t *testing.T) {

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1832,3 +1832,94 @@ func TestPlanFilesPropagatesFailure(t *testing.T) {
 	_, err := cat.PlanFiles(context.Background(), planFilesReq())
 	require.ErrorIs(t, err, ErrPlanFailed)
 }
+
+func TestCollectScanTasksDeduplicatesAcrossFrontiers(t *testing.T) {
+	t.Parallel()
+
+	children := map[string][]string{
+		"a": {"c", "d", "a"},
+		"b": {"d", "e"},
+		"c": {"b"},
+	}
+	var mu sync.Mutex
+	calls := make(map[string]int)
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+			mu.Lock()
+			calls[body.PlanTask]++
+			mu.Unlock()
+			response := ScanTasks{
+				PlanTasks: children[body.PlanTask],
+				FileScanTasks: []RESTFileScanTask{{DataFile: &RESTDataFile{
+					RESTContentFile: RESTContentFile{FilePath: body.PlanTask},
+				}}},
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		})
+	})
+
+	envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+		PlanTasks: []string{"a", "a", "b"},
+	})
+	require.NoError(t, err)
+	require.Len(t, envelopes, 6)
+	for i, name := range []string{"a", "b", "c", "d", "e"} {
+		require.Len(t, envelopes[i+1].FileScanTasks, 1)
+		assert.Equal(t, name, envelopes[i+1].FileScanTasks[0].DataFile.FilePath)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, map[string]int{"a": 1, "b": 1, "c": 1, "d": 1, "e": 1}, calls)
+}
+
+func TestCollectScanTasksCancelsSiblingRequestsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, func(mux *http.ServeMux) {
+		mux.HandleFunc("/v1/namespaces/db/tables/tbl/tasks", func(w http.ResponseWriter, req *http.Request) {
+			var body FetchScanTasksRequest
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+			switch body.PlanTask {
+			case "slow":
+				close(started)
+				<-req.Context().Done()
+				close(cancelled)
+			case "failed":
+				select {
+				case <-started:
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"error":{"message":"invalid handle","type":"BadRequestException","code":400}}`))
+				case <-req.Context().Done():
+				}
+			default:
+				http.Error(w, "unexpected handle", http.StatusBadRequest)
+			}
+		})
+	})
+
+	envelopes, err := cat.collectScanTasks(ctx, table.Identifier{"db", "tbl"}, ScanTasks{
+		PlanTasks: []string{"slow", "failed"},
+	})
+	require.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, envelopes)
+	select {
+	case <-cancelled:
+	case <-ctx.Done():
+		t.Fatal("sibling request was not cancelled after a fetch failure")
+	}
+}

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1318,6 +1318,54 @@ func TestCollectScanTasksFetchesFrontierConcurrentlyInOrder(t *testing.T) {
 	}
 }
 
+type orderedScanTaskErrorTransport struct {
+	planTaskReturned chan struct{}
+}
+
+func (t *orderedScanTaskErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body FetchScanTasksRequest
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+
+	var errType string
+	switch body.PlanTask {
+	case "table":
+		<-t.planTaskReturned
+		errType = errTypeNoSuchTable
+	case "plan-task":
+		close(t.planTaskReturned)
+		errType = errTypeNoSuchPlanTask
+	default:
+		return nil, fmt.Errorf("unexpected plan task %q", body.PlanTask)
+	}
+
+	data := fmt.Sprintf(`{"error":{"message":%q,"type":%q,"code":404}}`, errType, errType)
+	return &http.Response{
+		StatusCode:    http.StatusNotFound,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(data)),
+		ContentLength: int64(len(data)),
+		Request:       req,
+	}, nil
+}
+
+func TestCollectScanTasksReturnsFirstErrorInHandleOrder(t *testing.T) {
+	t.Parallel()
+
+	cat := newScanPlanningTestCatalog(t, []endpoint{endpointFetchScanTasks}, nil)
+	cat.cl = &http.Client{Transport: &orderedScanTaskErrorTransport{
+		planTaskReturned: make(chan struct{}),
+	}}
+
+	envelopes, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+		PlanTasks: []string{"table", "plan-task"},
+	})
+	require.ErrorIs(t, err, catalog.ErrNoSuchTable)
+	assert.NotErrorIs(t, err, ErrNoSuchPlanTask)
+	assert.Nil(t, envelopes)
+}
+
 func TestCollectScanTasksBoundsFrontierConcurrency(t *testing.T) {
 	t.Parallel()
 

--- a/catalog/rest/scan_planning_test.go
+++ b/catalog/rest/scan_planning_test.go
@@ -1331,7 +1331,11 @@ func (t *orderedScanTaskErrorTransport) RoundTrip(req *http.Request) (*http.Resp
 	var errType string
 	switch body.PlanTask {
 	case "table":
-		<-t.planTaskReturned
+		select {
+		case <-t.planTaskReturned:
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
 		errType = errTypeNoSuchTable
 	case "plan-task":
 		close(t.planTaskReturned)
@@ -1371,7 +1375,8 @@ func TestCollectScanTasksReturnsFirstErrorInHandleOrder(t *testing.T) {
 func TestCollectScanTasksBoundsFrontierConcurrency(t *testing.T) {
 	t.Parallel()
 
-	const handleCount = remoteScanTaskFetchConcurrency + 1
+	const maxConcurrency = 8
+	const handleCount = maxConcurrency + 1
 	started := make(chan string, handleCount)
 	release := make(chan struct{})
 	var releaseOnce sync.Once
@@ -1399,13 +1404,13 @@ func TestCollectScanTasksBoundsFrontierConcurrency(t *testing.T) {
 	}
 	done := make(chan error, 1)
 	go func() {
-		_, err := cat.collectScanTasks(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
+		_, err := cat.collectScanTasksWithConcurrency(t.Context(), table.Identifier{"db", "tbl"}, ScanTasks{
 			PlanTasks: handles,
-		})
+		}, maxConcurrency)
 		done <- err
 	}()
 
-	for range remoteScanTaskFetchConcurrency {
+	for range maxConcurrency {
 		select {
 		case <-started:
 		case <-time.After(time.Second):

--- a/schema.go
+++ b/schema.go
@@ -352,6 +352,8 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
+	// Keep this literal in sync with every JSON-marshaled Schema field. Copying
+	// the whole Schema would also copy its lazy atomic caches after they are used.
 	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {

--- a/schema_test.go
+++ b/schema_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -677,6 +678,42 @@ func TestSerializeSchema(t *testing.T) {
 		"schema-id": 1,
 		"identifier-field-ids": [2]
 	}`, string(data))
+}
+
+func TestMarshalSchemaIncludesExportedFields(t *testing.T) {
+	schema := iceberg.NewSchemaWithIdentifiers(17, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+	)
+	data, err := json.Marshal(schema)
+	require.NoError(t, err)
+	var marshaled map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &marshaled))
+
+	require.Contains(t, marshaled, "type")
+	require.Contains(t, marshaled, "fields")
+	wantKeys := 2
+	value := reflect.ValueOf(schema).Elem()
+	for i := range value.NumField() {
+		field := value.Type().Field(i)
+		tag, tagged := field.Tag.Lookup("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if !field.IsExported() || !tagged || name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		wantKeys++
+
+		// A nonzero fixture catches omitted assignments even when the alias
+		// still emits the field's key with a zero value. Extend it for new fields.
+		require.False(t, value.Field(i).IsZero(), "populate Schema.%s in the fixture", field.Name)
+		want, err := json.Marshal(value.Field(i).Interface())
+		require.NoError(t, err)
+		require.Contains(t, marshaled, name)
+		assert.JSONEq(t, string(want), string(marshaled[name]), "Schema.%s", field.Name)
+	}
+	assert.Len(t, marshaled, wantKeys)
 }
 
 func TestUnmarshalSchema(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -2302,6 +2302,8 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	assert.Equal(t, 1, v.geographyCalls)
 }
 
+// This test is intended to be run with -race; without the detector, the old
+// MarshalJSON implementation also passes these assertions.
 func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
 	for range 32 {
 		schema := iceberg.NewSchemaWithIdentifiers(17, nil,

--- a/table/scan_planning.go
+++ b/table/scan_planning.go
@@ -105,6 +105,9 @@ type ScanPlanningRequest struct {
 	RowFilter        iceberg.BooleanExpression
 	MinRowsRequested *int64
 	StatsFields      []string
+	// MaxConcurrency is the maximum number of concurrent operations a planner
+	// may use for this scan. Zero means use the planner's default.
+	MaxConcurrency int
 	// CaseSensitive must carry the Scan's value (which defaults to true), not
 	// Go's false zero value, or the wire request would flip the spec default.
 	// Nil means use the scan default.

--- a/table/scan_planning_test.go
+++ b/table/scan_planning_test.go
@@ -399,12 +399,14 @@ func TestScanPlanningRemoteResolvesDefaultProjectionAndSchema(t *testing.T) {
 	planner := &fakeScanPlanner{supports: true}
 	scan := (&Table{metadata: metadata}).Scan(
 		WithScanPlanningMode(ScanPlanningRemote),
+		WithMaxConcurrency(3),
 	)
 	scan.planner = planner
 
 	_, err = scan.PlanFiles(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"id"}, planner.receivedRequest.SelectedFields)
+	assert.Equal(t, 3, planner.receivedRequest.MaxConcurrency)
 	assert.True(t, planner.receivedRequest.Schema.Equals(metadata.CurrentSchema()))
 	require.NotNil(t, planner.receivedRequest.UseSnapshotSchema)
 	assert.False(t, *planner.receivedRequest.UseSnapshotSchema)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1689,6 +1689,7 @@ func (scan *Scan) planFilesRemote(ctx context.Context) ([]FileScanTask, error) {
 		SelectedFields:    selectedFields,
 		RowFilter:         scan.rowFilter,
 		MinRowsRequested:  minRowsRequested,
+		MaxConcurrency:    scan.concurrency,
 		CaseSensitive:     &caseSensitive,
 		UseSnapshotSchema: &useSnapshotSchema,
 	})


### PR DESCRIPTION
## Summary

- **Concurrency:** Fetch each remote plan-task frontier concurrently. Honor `table.WithMaxConcurrency(n)` through `ScanPlanningRequest.MaxConcurrency`. Default to `runtime.GOMAXPROCS(0)` and cap workers at the frontier size.
- **Ordering:** Preserve breadth-first response order, once-only handle expansion, and cycle protection. Each frontier finishes before the next one starts.
- **Errors:** Return the first failure in handle order with its handle name. Cancel unfinished later requests while allowing earlier handles to finish.
- **Validation:** Reject malformed task payloads before returning a partial scan plan.
- **Schema:** Guard the keys and values of exported JSON fields. Document why marshaling must avoid copying the lazy atomic caches.

## Benchmark

```sh
go test ./catalog/rest -run '^$' -bench '^BenchmarkCollectScanTasks64Handles$' -benchtime=1x -count=5 -benchmem
```

Apple M1 Pro, darwin/arm64, Go 1.26.3. Each run fetches 64 handles with 10 ms of simulated server latency per request. The table shows medians from five runs. Each row uses the explicit concurrency limit named in the benchmark subtest.

| Explicit fetch limit | Time/op | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| `1` | 1056.3 ms | 745 KiB | 8,821 |
| `2` | 492.2 ms | 752 KiB | 8,820 |
| `4` | 232.1 ms | 796 KiB | 9,010 |
| `8` | 128.4 ms | 975 KiB | 9,441 |
| `16` | 74.0 ms | 1025 KiB | 9,753 |
| `32` | 39.2 ms | 1414 KiB | 11,337 |
| `64` | 22.5 ms | 1705 KiB | 12,520 |

These numbers measure the simulated fetch workload. Higher limits reduce elapsed time and use more memory.

## Tests

- `GOFLAGS=-p=1 make test`
- `go test -race -p=1 . ./catalog/rest -count=1`
- `GOMAXPROCS=1 go test ./catalog/rest -run '^TestCollectScanTasks' -count=1`
- `golangci-lint run --timeout=10m --allow-serial-runners`
- Confirmed the schema regression test fails if the ID copy is removed, or a new JSON field is added with or without `omitempty`.
