### PR TITLE
perf(table): prune equality deletes by data-file metrics

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -346,8 +346,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	type Alias Schema
 
-	aliasCopy := *(*Alias)(s)
-	aliasCopy.IdentifierFieldIDs = ids
+	aliasCopy := Alias{ID: s.ID, IdentifierFieldIDs: ids}
 
 	return json.Marshal(struct {
 		Type   string        `json:"type"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -2292,4 +2293,49 @@ func TestVisitGeoSchemaWithSchemaVisitorPerPrimitiveType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v.geometryCalls)
 	assert.Equal(t, 1, v.geographyCalls)
+}
+
+func TestSchemaMarshalJSONConcurrentLazyLookups(t *testing.T) {
+	for range 32 {
+		schema := iceberg.NewSchemaWithIdentifiers(17, nil,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			iceberg.NestedField{ID: 2, Name: "data", Type: iceberg.PrimitiveTypes.String},
+		)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				<-start
+				for range 8 {
+					_, err := json.Marshal(schema)
+					assert.NoError(t, err)
+				}
+			})
+			wg.Go(func() {
+				<-start
+				_, found := schema.FindFieldByID(1)
+				assert.True(t, found)
+				_, found = schema.FindFieldByName("data")
+				assert.True(t, found)
+				_, found = schema.FindFieldByNameCaseInsensitive("DATA")
+				assert.True(t, found)
+				name, found := schema.FindColumnName(2)
+				assert.True(t, found)
+				assert.Equal(t, "data", name)
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "struct", "schema-id": 17, "identifier-field-ids": [],
+			"fields": [
+				{"id": 1, "name": "id", "type": "long", "required": true},
+				{"id": 2, "name": "data", "type": "string", "required": false}
+			]
+		}`, string(data))
+		assert.Nil(t, schema.IdentifierFieldIDs)
+	}
 }

--- a/table/equality_delete_index.go
+++ b/table/equality_delete_index.go
@@ -18,12 +18,15 @@
 package table
 
 import (
+	"bytes"
 	"cmp"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 
 	"github.com/apache/iceberg-go"
+	iceberginternal "github.com/apache/iceberg-go/internal"
 	"github.com/google/uuid"
 )
 
@@ -31,8 +34,229 @@ import (
 // Unpartitioned equality deletes are global and apply across partition specs;
 // partitioned deletes only apply to data files in the same spec and partition.
 type equalityDeleteIndex struct {
-	global      []iceberg.ManifestEntry
-	byPartition map[equalityDeletePartitionKey][]iceberg.ManifestEntry
+	global      []equalityDeleteIndexEntry
+	byPartition map[equalityDeletePartitionKey][]equalityDeleteIndexEntry
+	schema      *iceberg.Schema
+}
+
+type equalityDeleteIndexEntry struct {
+	entry  iceberg.ManifestEntry
+	fields []equalityDeleteFieldMetrics
+}
+
+type equalityDeleteRangeKind uint8
+
+const (
+	equalityDeleteRangeNone equalityDeleteRangeKind = iota
+	equalityDeleteRangeBool
+	equalityDeleteRangeInt32
+	equalityDeleteRangeInt64
+	equalityDeleteRangeFloat32
+	equalityDeleteRangeFloat64
+	equalityDeleteRangeDate
+	equalityDeleteRangeTime
+	equalityDeleteRangeTimestamp
+	equalityDeleteRangeTimestampNano
+	equalityDeleteRangeString
+	equalityDeleteRangeBytes
+	equalityDeleteRangeUUID
+	equalityDeleteRangeDecimal
+)
+
+// equalityDeleteMetricValue keeps decoded bounds in concrete fields so the
+// candidate loop does not pay for interface comparator calls on every file.
+// This is the same comparison work as Java's DeleteFileIndex, but avoids
+// allocating or dispatching through a closure for each bound check.
+type equalityDeleteMetricValue struct {
+	kind         equalityDeleteRangeKind
+	integerValue int64
+	floatValue   float64
+	reference    any
+	uuidValue    uuid.UUID
+	decimalValue iceberg.Decimal
+}
+
+func equalityDeleteMetricValueFromLiteral(
+	kind equalityDeleteRangeKind,
+	literal iceberg.Literal,
+) (equalityDeleteMetricValue, bool) {
+	value := equalityDeleteMetricValue{kind: kind}
+	switch kind {
+	case equalityDeleteRangeBool:
+		v, ok := literal.(iceberg.TypedLiteral[bool])
+		if ok {
+			if v.Value() {
+				value.integerValue = 1
+			}
+		}
+		return value, ok
+	case equalityDeleteRangeInt32:
+		v, ok := literal.(iceberg.TypedLiteral[int32])
+		if ok {
+			value.integerValue = int64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeInt64:
+		v, ok := literal.(iceberg.TypedLiteral[int64])
+		if ok {
+			value.integerValue = v.Value()
+		}
+		return value, ok
+	case equalityDeleteRangeFloat32:
+		v, ok := literal.(iceberg.TypedLiteral[float32])
+		if ok {
+			value.floatValue = float64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeFloat64:
+		v, ok := literal.(iceberg.TypedLiteral[float64])
+		if ok {
+			value.floatValue = v.Value()
+		}
+		return value, ok
+	case equalityDeleteRangeDate:
+		v, ok := literal.(iceberg.TypedLiteral[iceberg.Date])
+		if ok {
+			value.integerValue = int64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeTime:
+		v, ok := literal.(iceberg.TypedLiteral[iceberg.Time])
+		if ok {
+			value.integerValue = int64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeTimestamp:
+		v, ok := literal.(iceberg.TypedLiteral[iceberg.Timestamp])
+		if ok {
+			value.integerValue = int64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeTimestampNano:
+		v, ok := literal.(iceberg.TypedLiteral[iceberg.TimestampNano])
+		if ok {
+			value.integerValue = int64(v.Value())
+		}
+		return value, ok
+	case equalityDeleteRangeString:
+		v, ok := literal.(iceberg.TypedLiteral[string])
+		if ok {
+			value.reference = v.Value()
+		}
+		return value, ok
+	case equalityDeleteRangeBytes:
+		v, ok := literal.(iceberg.TypedLiteral[[]byte])
+		if ok {
+			value.reference = v.Value()
+		}
+		return value, ok
+	case equalityDeleteRangeUUID:
+		v, ok := literal.(iceberg.TypedLiteral[uuid.UUID])
+		if ok {
+			value.uuidValue = v.Value()
+		}
+		return value, ok
+	case equalityDeleteRangeDecimal:
+		v, ok := literal.(iceberg.TypedLiteral[iceberg.Decimal])
+		if ok {
+			value.decimalValue = v.Value()
+		}
+		return value, ok
+	default:
+		return equalityDeleteMetricValue{}, false
+	}
+}
+
+func equalityDeleteMetricValueFromBytes(
+	typ iceberg.Type,
+	kind equalityDeleteRangeKind,
+	data []byte,
+	clone bool,
+) (equalityDeleteMetricValue, bool) {
+	if clone {
+		// String, binary, and fixed literals may retain the input bytes. Clone
+		// once so an index does not retain a borrowed metadata buffer.
+		data = slices.Clone(data)
+	}
+
+	literal, err := iceberg.LiteralFromBytes(typ, data)
+	if err != nil || equalityDeleteLiteralIsNaN(literal) {
+		return equalityDeleteMetricValue{}, false
+	}
+
+	return equalityDeleteMetricValueFromLiteral(kind, literal)
+}
+
+func equalityDeleteMetricValueCompare(left, right *equalityDeleteMetricValue) int {
+	switch left.kind {
+	case equalityDeleteRangeBool:
+		return cmp.Compare(left.integerValue, right.integerValue)
+	case equalityDeleteRangeInt32, equalityDeleteRangeInt64,
+		equalityDeleteRangeDate, equalityDeleteRangeTime,
+		equalityDeleteRangeTimestamp, equalityDeleteRangeTimestampNano:
+		return cmp.Compare(left.integerValue, right.integerValue)
+	case equalityDeleteRangeFloat32, equalityDeleteRangeFloat64:
+		return cmp.Compare(left.floatValue, right.floatValue)
+	case equalityDeleteRangeString:
+		return cmp.Compare(left.reference.(string), right.reference.(string))
+	case equalityDeleteRangeBytes:
+		return bytes.Compare(left.reference.([]byte), right.reference.([]byte))
+	case equalityDeleteRangeUUID:
+		return bytes.Compare(left.uuidValue[:], right.uuidValue[:])
+	case equalityDeleteRangeDecimal:
+		if left.decimalValue.Scale == right.decimalValue.Scale {
+			return left.decimalValue.Val.Cmp(right.decimalValue.Val)
+		}
+
+		rescaled, err := right.decimalValue.Val.Rescale(
+			int32(right.decimalValue.Scale), int32(left.decimalValue.Scale))
+		if err != nil {
+			return -1
+		}
+
+		return left.decimalValue.Val.Cmp(rescaled)
+	default:
+		return 0
+	}
+}
+
+// equalityDeleteFieldMetrics contains the statistics for one equality field
+// in one delete file. Bounds are copied because the DataFile statistics helper
+// may return borrowed maps and byte slices.
+type equalityDeleteFieldMetrics struct {
+	fieldID     int
+	typ         iceberg.Type
+	required    bool
+	primitive   bool
+	canUseRange bool
+	floatType   bool
+	rangeKind   equalityDeleteRangeKind
+
+	valueCount    int64
+	nullCount     int64
+	nanCount      int64
+	hasValueCount bool
+	hasNullCount  bool
+	hasNaNCount   bool
+
+	lowerValue       equalityDeleteMetricValue
+	upperValue       equalityDeleteMetricValue
+	hasDecodedBounds bool
+}
+
+type equalityDeleteDataFileStats struct {
+	valueCounts   map[int]int64
+	nullCounts    map[int]int64
+	nanCounts     map[int]int64
+	lowerBounds   map[int][]byte
+	upperBounds   map[int][]byte
+	decodedBounds map[int]*equalityDeleteDataFileBounds
+}
+
+type equalityDeleteDataFileBounds struct {
+	lower  equalityDeleteMetricValue
+	upper  equalityDeleteMetricValue
+	usable bool
 }
 
 type partitionSpecLookup interface {
@@ -123,14 +347,110 @@ func comparableEqualityDeletePartitionValue(value any) (any, error) {
 	}
 }
 
+func newEqualityDeleteIndexEntry(
+	entry iceberg.ManifestEntry,
+	schema *iceberg.Schema,
+) equalityDeleteIndexEntry {
+	indexed := equalityDeleteIndexEntry{entry: entry}
+	if schema == nil {
+		return indexed
+	}
+
+	dataFile := entry.DataFile()
+	_, _, _, fieldIDs := dataFileCollections(dataFile)
+	if len(fieldIDs) == 0 {
+		return indexed
+	}
+
+	indexed.fields = make([]equalityDeleteFieldMetrics, len(fieldIDs))
+	knownFields := 0
+	for i, fieldID := range fieldIDs {
+		field := &indexed.fields[i]
+		field.fieldID = fieldID
+
+		schemaField, ok := schema.FindFieldByIDRef(fieldID, iceberginternal.SchemaRef{})
+		if !ok {
+			// A field can be absent from the current schema after it was
+			// dropped. Without its type, the bounds cannot be decoded safely.
+			continue
+		}
+
+		field.typ = schemaField.Type
+		field.required = schemaField.Required && !schema.FieldHasOptionalParent(fieldID)
+		_, field.primitive = field.typ.(iceberg.PrimitiveType)
+		field.rangeKind = equalityDeleteRangeKindForType(field.typ)
+		field.canUseRange = field.rangeKind != equalityDeleteRangeNone
+		field.floatType = equalityDeleteFloatType(field.typ)
+		knownFields++
+	}
+
+	if knownFields == 0 {
+		return indexed
+	}
+
+	valueCounts, nullCounts, nanCounts, lowerBounds, upperBounds := dataFileStats(dataFile)
+	for i := range indexed.fields {
+		field := &indexed.fields[i]
+		if field.typ == nil {
+			continue
+		}
+
+		if value, ok := valueCounts[field.fieldID]; ok {
+			field.valueCount = value
+			field.hasValueCount = true
+		}
+		if value, ok := nullCounts[field.fieldID]; ok {
+			field.nullCount = value
+			field.hasNullCount = true
+		}
+		if value, ok := nanCounts[field.fieldID]; ok {
+			field.nanCount = value
+			field.hasNaNCount = true
+		}
+		if field.canUseRange {
+			lowerBytes, hasLowerBytes := lowerBounds[field.fieldID]
+			upperBytes, hasUpperBytes := upperBounds[field.fieldID]
+			if !hasLowerBytes || !hasUpperBytes {
+				continue
+			}
+
+			lowerValue, lowerOK := equalityDeleteMetricValueFromBytes(
+				field.typ, field.rangeKind, lowerBytes, true)
+			upperValue, upperOK := equalityDeleteMetricValueFromBytes(
+				field.typ, field.rangeKind, upperBytes, true)
+			if lowerOK && upperOK {
+				field.lowerValue = lowerValue
+				field.upperValue = upperValue
+				field.hasDecodedBounds = true
+			}
+		}
+	}
+
+	return indexed
+}
+
+func equalityDeleteDataFileStatsFor(file iceberg.DataFile) equalityDeleteDataFileStats {
+	valueCounts, nullCounts, nanCounts, lowerBounds, upperBounds := dataFileStats(file)
+
+	return equalityDeleteDataFileStats{
+		valueCounts: valueCounts,
+		nullCounts:  nullCounts,
+		nanCounts:   nanCounts,
+		lowerBounds: lowerBounds,
+		upperBounds: upperBounds,
+	}
+}
+
 func buildEqualityDeleteIndex(
 	entries []iceberg.ManifestEntry,
 	specs partitionSpecLookup,
+	schema *iceberg.Schema,
 ) (*equalityDeleteIndex, error) {
-	idx := &equalityDeleteIndex{}
+	idx := &equalityDeleteIndex{schema: schema}
 	unpartitionedBySpecID := make(map[int32]bool)
 	for _, entry := range entries {
 		df := entry.DataFile()
+		indexedEntry := newEqualityDeleteIndexEntry(entry, schema)
 		isUnpartitioned, ok := unpartitionedBySpecID[df.SpecID()]
 		if !ok {
 			spec := specs.PartitionSpecByID(int(df.SpecID()))
@@ -142,7 +462,7 @@ func buildEqualityDeleteIndex(
 			unpartitionedBySpecID[df.SpecID()] = isUnpartitioned
 		}
 		if isUnpartitioned {
-			idx.global = append(idx.global, entry)
+			idx.global = append(idx.global, indexedEntry)
 
 			continue
 		}
@@ -153,14 +473,14 @@ func buildEqualityDeleteIndex(
 			return nil, fmt.Errorf("indexing equality delete file %s: %w", df.FilePath(), err)
 		}
 		if idx.byPartition == nil {
-			idx.byPartition = make(map[equalityDeletePartitionKey][]iceberg.ManifestEntry)
+			idx.byPartition = make(map[equalityDeletePartitionKey][]equalityDeleteIndexEntry)
 		}
-		idx.byPartition[key] = append(idx.byPartition[key], entry)
+		idx.byPartition[key] = append(idx.byPartition[key], indexedEntry)
 	}
 
-	sortBySequence := func(entries []iceberg.ManifestEntry) {
-		slices.SortStableFunc(entries, func(a, b iceberg.ManifestEntry) int {
-			return cmp.Compare(a.SequenceNum(), b.SequenceNum())
+	sortBySequence := func(entries []equalityDeleteIndexEntry) {
+		slices.SortStableFunc(entries, func(a, b equalityDeleteIndexEntry) int {
+			return cmp.Compare(a.entry.SequenceNum(), b.entry.SequenceNum())
 		})
 	}
 	sortBySequence(idx.global)
@@ -179,7 +499,7 @@ func (idx *equalityDeleteIndex) forDataFile(dataEntry iceberg.ManifestEntry) ([]
 		return nil, nil
 	}
 
-	partitionEntries := []iceberg.ManifestEntry(nil)
+	partitionEntries := []equalityDeleteIndexEntry(nil)
 	if len(idx.byPartition) > 0 {
 		dataFile := dataEntry.DataFile()
 		partition := dataFilePartition(dataFile)
@@ -193,23 +513,249 @@ func (idx *equalityDeleteIndex) forDataFile(dataEntry iceberg.ManifestEntry) ([]
 	}
 
 	dataSeqNum := dataEntry.SequenceNum()
-	out := appendEqualityDeletesAfter(nil, idx.global, dataSeqNum)
-	out = appendEqualityDeletesAfter(out, partitionEntries, dataSeqNum)
+	var dataStats *equalityDeleteDataFileStats
+	if idx.schema != nil {
+		stats := equalityDeleteDataFileStatsFor(dataEntry.DataFile())
+		dataStats = &stats
+	}
+
+	out := appendEqualityDeletesAfter(nil, idx.global, dataSeqNum, dataStats)
+	out = appendEqualityDeletesAfter(out, partitionEntries, dataSeqNum, dataStats)
 
 	return out, nil
 }
 
 func appendEqualityDeletesAfter(
 	out []iceberg.DataFile,
-	entries []iceberg.ManifestEntry,
+	entries []equalityDeleteIndexEntry,
 	dataSeqNum int64,
+	dataStats *equalityDeleteDataFileStats,
 ) []iceberg.DataFile {
 	start := sort.Search(len(entries), func(i int) bool {
-		return entries[i].SequenceNum() > dataSeqNum
+		return entries[i].entry.SequenceNum() > dataSeqNum
 	})
 	for _, entry := range entries[start:] {
-		out = append(out, entry.DataFile())
+		if !equalityDeleteCanContainData(dataStats, entry.fields) {
+			continue
+		}
+
+		out = append(out, entry.entry.DataFile())
 	}
 
 	return out
+}
+
+func equalityDeleteCanContainData(
+	dataStats *equalityDeleteDataFileStats,
+	deleteFields []equalityDeleteFieldMetrics,
+) bool {
+	if dataStats == nil {
+		return true
+	}
+
+	for i := range deleteFields {
+		deleteField := &deleteFields[i]
+		if deleteField.typ == nil {
+			// The field may have been dropped from the current schema. Its
+			// bounds cannot be decoded safely, so retain the delete file.
+			continue
+		}
+		if !deleteField.primitive {
+			// Metrics are not defined for nested fields.
+			continue
+		}
+
+		if !deleteField.required {
+			if equalityDeleteDataContainsNull(dataStats.nullCounts, deleteField) &&
+				equalityDeleteFieldContainsNull(deleteField) {
+				// Both files may contain null for this field. Ranges cannot
+				// prove that a null equality key is absent.
+				continue
+			}
+
+			if equalityDeleteDataAllNull(*dataStats, deleteField) &&
+				equalityDeleteFieldAllNonNull(deleteField) {
+				return false
+			}
+
+			if equalityDeleteFieldAllNull(deleteField) &&
+				equalityDeleteDataAllNonNull(dataStats.nullCounts, deleteField) {
+				return false
+			}
+		}
+
+		if !deleteField.canUseRange ||
+			(deleteField.floatType && !equalityDeleteFloatRangesAreKnown(*dataStats, deleteField)) {
+			continue
+		}
+		dataBounds := equalityDeleteDataFileBoundsFor(dataStats, deleteField)
+		if !dataBounds.usable || !deleteField.hasDecodedBounds {
+			// Missing bounds are not evidence that the ranges are disjoint.
+			continue
+		}
+
+		if equalityDeleteMetricValueCompare(&dataBounds.lower, &deleteField.upperValue) > 0 ||
+			equalityDeleteMetricValueCompare(&deleteField.lowerValue, &dataBounds.upper) > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalityDeleteDataContainsNull(nullCounts map[int]int64, field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return false
+	}
+	if nullCounts == nil {
+		return true
+	}
+
+	nullCount, ok := nullCounts[field.fieldID]
+	return !ok || nullCount > 0
+}
+
+func equalityDeleteFieldContainsNull(field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return false
+	}
+	if !field.hasNullCount {
+		return true
+	}
+
+	return field.nullCount > 0
+}
+
+func equalityDeleteDataAllNull(stats equalityDeleteDataFileStats, field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return false
+	}
+
+	nullCount, hasNullCount := stats.nullCounts[field.fieldID]
+	valueCount, hasValueCount := stats.valueCounts[field.fieldID]
+	return hasNullCount && hasValueCount && nullCount == valueCount
+}
+
+func equalityDeleteFieldAllNull(field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return false
+	}
+
+	return field.hasNullCount && field.hasValueCount && field.nullCount == field.valueCount
+}
+
+func equalityDeleteDataAllNonNull(nullCounts map[int]int64, field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return true
+	}
+	if nullCounts == nil {
+		return false
+	}
+
+	nullCount, ok := nullCounts[field.fieldID]
+	return ok && nullCount <= 0
+}
+
+func equalityDeleteFieldAllNonNull(field *equalityDeleteFieldMetrics) bool {
+	if field.required {
+		return true
+	}
+
+	return field.hasNullCount && field.nullCount <= 0
+}
+
+func equalityDeleteFloatRangesAreKnown(
+	dataStats equalityDeleteDataFileStats,
+	field *equalityDeleteFieldMetrics,
+) bool {
+	// Float bounds exclude NaN values. Only use them when both files
+	// explicitly prove that the field contains no NaNs.
+	dataNaNCount, dataHasNaNCount := dataStats.nanCounts[field.fieldID]
+	return dataHasNaNCount && dataNaNCount == 0 && field.hasNaNCount && field.nanCount == 0
+}
+
+func equalityDeleteDataFileBoundsFor(
+	dataStats *equalityDeleteDataFileStats,
+	field *equalityDeleteFieldMetrics,
+) *equalityDeleteDataFileBounds {
+	if bounds, ok := dataStats.decodedBounds[field.fieldID]; ok {
+		return bounds
+	}
+
+	bounds := &equalityDeleteDataFileBounds{}
+	dataLower, hasDataLower := dataStats.lowerBounds[field.fieldID]
+	dataUpper, hasDataUpper := dataStats.upperBounds[field.fieldID]
+	if hasDataLower && hasDataUpper && field.canUseRange {
+		lowerValue, lowerOK := equalityDeleteMetricValueFromBytes(
+			field.typ, field.rangeKind, dataLower, false)
+		upperValue, upperOK := equalityDeleteMetricValueFromBytes(
+			field.typ, field.rangeKind, dataUpper, false)
+		if lowerOK && upperOK {
+			*bounds = equalityDeleteDataFileBounds{
+				lower:  lowerValue,
+				upper:  upperValue,
+				usable: true,
+			}
+		}
+	}
+
+	if dataStats.decodedBounds == nil {
+		dataStats.decodedBounds = make(map[int]*equalityDeleteDataFileBounds)
+	}
+	dataStats.decodedBounds[field.fieldID] = bounds
+
+	return bounds
+}
+
+func equalityDeleteRangeKindForType(typ iceberg.Type) equalityDeleteRangeKind {
+	switch typ.(type) {
+	case iceberg.BooleanType:
+		return equalityDeleteRangeBool
+	case iceberg.Int32Type:
+		return equalityDeleteRangeInt32
+	case iceberg.Int64Type:
+		return equalityDeleteRangeInt64
+	case iceberg.Float32Type:
+		return equalityDeleteRangeFloat32
+	case iceberg.Float64Type:
+		return equalityDeleteRangeFloat64
+	case iceberg.DateType:
+		return equalityDeleteRangeDate
+	case iceberg.TimeType:
+		return equalityDeleteRangeTime
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		return equalityDeleteRangeTimestamp
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		return equalityDeleteRangeTimestampNano
+	case iceberg.StringType:
+		return equalityDeleteRangeString
+	case iceberg.BinaryType, iceberg.FixedType:
+		return equalityDeleteRangeBytes
+	case iceberg.UUIDType:
+		return equalityDeleteRangeUUID
+	case iceberg.DecimalType:
+		return equalityDeleteRangeDecimal
+	default:
+		return equalityDeleteRangeNone
+	}
+}
+
+func equalityDeleteFloatType(typ iceberg.Type) bool {
+	switch typ.(type) {
+	case iceberg.Float32Type, iceberg.Float64Type:
+		return true
+	default:
+		return false
+	}
+}
+
+func equalityDeleteLiteralIsNaN(literal iceberg.Literal) bool {
+	switch value := literal.(type) {
+	case iceberg.Float32Literal:
+		return math.IsNaN(float64(value))
+	case iceberg.Float64Literal:
+		return math.IsNaN(float64(value))
+	default:
+		return false
+	}
 }

--- a/table/equality_delete_index.go
+++ b/table/equality_delete_index.go
@@ -431,7 +431,7 @@ func newEqualityDeleteIndexEntry(
 				field.typ, field.rangeKind, lowerBytes, true)
 			upperValue, upperOK := equalityDeleteMetricValueFromBytes(
 				field.typ, field.rangeKind, upperBytes, true)
-			if lowerOK && upperOK {
+			if lowerOK && upperOK && equalityDeleteMetricValueCompare(&lowerValue, &upperValue) <= 0 {
 				field.lowerValue = lowerValue
 				field.upperValue = upperValue
 				field.hasDecodedBounds = true
@@ -626,7 +626,7 @@ func equalityDeleteDataContainsNull(nullCounts map[int]int64, field *equalityDel
 
 	nullCount, ok := nullCounts[field.fieldID]
 
-	return !ok || nullCount > 0
+	return !ok || nullCount != 0
 }
 
 func equalityDeleteFieldContainsNull(field *equalityDeleteFieldMetrics) bool {
@@ -637,7 +637,7 @@ func equalityDeleteFieldContainsNull(field *equalityDeleteFieldMetrics) bool {
 		return true
 	}
 
-	return field.nullCount > 0
+	return field.nullCount != 0
 }
 
 func equalityDeleteDataAllNull(stats equalityDeleteDataFileStats, field *equalityDeleteFieldMetrics) bool {
@@ -648,7 +648,7 @@ func equalityDeleteDataAllNull(stats equalityDeleteDataFileStats, field *equalit
 	nullCount, hasNullCount := stats.nullCounts[field.fieldID]
 	valueCount, hasValueCount := stats.valueCounts[field.fieldID]
 
-	return hasNullCount && hasValueCount && nullCount == valueCount
+	return hasNullCount && hasValueCount && nullCount >= 0 && nullCount == valueCount
 }
 
 func equalityDeleteFieldAllNull(field *equalityDeleteFieldMetrics) bool {
@@ -656,7 +656,7 @@ func equalityDeleteFieldAllNull(field *equalityDeleteFieldMetrics) bool {
 		return false
 	}
 
-	return field.hasNullCount && field.hasValueCount && field.nullCount == field.valueCount
+	return field.hasNullCount && field.hasValueCount && field.nullCount >= 0 && field.nullCount == field.valueCount
 }
 
 func equalityDeleteDataAllNonNull(nullCounts map[int]int64, field *equalityDeleteFieldMetrics) bool {
@@ -669,7 +669,7 @@ func equalityDeleteDataAllNonNull(nullCounts map[int]int64, field *equalityDelet
 
 	nullCount, ok := nullCounts[field.fieldID]
 
-	return ok && nullCount <= 0
+	return ok && nullCount == 0
 }
 
 func equalityDeleteFieldAllNonNull(field *equalityDeleteFieldMetrics) bool {
@@ -677,7 +677,7 @@ func equalityDeleteFieldAllNonNull(field *equalityDeleteFieldMetrics) bool {
 		return true
 	}
 
-	return field.hasNullCount && field.nullCount <= 0
+	return field.hasNullCount && field.nullCount == 0
 }
 
 func equalityDeleteFloatRangesAreKnown(
@@ -707,7 +707,7 @@ func equalityDeleteDataFileBoundsFor(
 			field.typ, field.rangeKind, dataLower, false)
 		upperValue, upperOK := equalityDeleteMetricValueFromBytes(
 			field.typ, field.rangeKind, dataUpper, false)
-		if lowerOK && upperOK {
+		if lowerOK && upperOK && equalityDeleteMetricValueCompare(&lowerValue, &upperValue) <= 0 {
 			*bounds = equalityDeleteDataFileBounds{
 				lower:  lowerValue,
 				upper:  upperValue,

--- a/table/equality_delete_index.go
+++ b/table/equality_delete_index.go
@@ -89,78 +89,91 @@ func equalityDeleteMetricValueFromLiteral(
 				value.integerValue = 1
 			}
 		}
+
 		return value, ok
 	case equalityDeleteRangeInt32:
 		v, ok := literal.(iceberg.TypedLiteral[int32])
 		if ok {
 			value.integerValue = int64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeInt64:
 		v, ok := literal.(iceberg.TypedLiteral[int64])
 		if ok {
 			value.integerValue = v.Value()
 		}
+
 		return value, ok
 	case equalityDeleteRangeFloat32:
 		v, ok := literal.(iceberg.TypedLiteral[float32])
 		if ok {
 			value.floatValue = float64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeFloat64:
 		v, ok := literal.(iceberg.TypedLiteral[float64])
 		if ok {
 			value.floatValue = v.Value()
 		}
+
 		return value, ok
 	case equalityDeleteRangeDate:
 		v, ok := literal.(iceberg.TypedLiteral[iceberg.Date])
 		if ok {
 			value.integerValue = int64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeTime:
 		v, ok := literal.(iceberg.TypedLiteral[iceberg.Time])
 		if ok {
 			value.integerValue = int64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeTimestamp:
 		v, ok := literal.(iceberg.TypedLiteral[iceberg.Timestamp])
 		if ok {
 			value.integerValue = int64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeTimestampNano:
 		v, ok := literal.(iceberg.TypedLiteral[iceberg.TimestampNano])
 		if ok {
 			value.integerValue = int64(v.Value())
 		}
+
 		return value, ok
 	case equalityDeleteRangeString:
 		v, ok := literal.(iceberg.TypedLiteral[string])
 		if ok {
 			value.reference = v.Value()
 		}
+
 		return value, ok
 	case equalityDeleteRangeBytes:
 		v, ok := literal.(iceberg.TypedLiteral[[]byte])
 		if ok {
 			value.reference = v.Value()
 		}
+
 		return value, ok
 	case equalityDeleteRangeUUID:
 		v, ok := literal.(iceberg.TypedLiteral[uuid.UUID])
 		if ok {
 			value.uuidValue = v.Value()
 		}
+
 		return value, ok
 	case equalityDeleteRangeDecimal:
 		v, ok := literal.(iceberg.TypedLiteral[iceberg.Decimal])
 		if ok {
 			value.decimalValue = v.Value()
 		}
+
 		return value, ok
 	default:
 		return equalityDeleteMetricValue{}, false
@@ -612,6 +625,7 @@ func equalityDeleteDataContainsNull(nullCounts map[int]int64, field *equalityDel
 	}
 
 	nullCount, ok := nullCounts[field.fieldID]
+
 	return !ok || nullCount > 0
 }
 
@@ -633,6 +647,7 @@ func equalityDeleteDataAllNull(stats equalityDeleteDataFileStats, field *equalit
 
 	nullCount, hasNullCount := stats.nullCounts[field.fieldID]
 	valueCount, hasValueCount := stats.valueCounts[field.fieldID]
+
 	return hasNullCount && hasValueCount && nullCount == valueCount
 }
 
@@ -653,6 +668,7 @@ func equalityDeleteDataAllNonNull(nullCounts map[int]int64, field *equalityDelet
 	}
 
 	nullCount, ok := nullCounts[field.fieldID]
+
 	return ok && nullCount <= 0
 }
 
@@ -671,6 +687,7 @@ func equalityDeleteFloatRangesAreKnown(
 	// Float bounds exclude NaN values. Only use them when both files
 	// explicitly prove that the field contains no NaNs.
 	dataNaNCount, dataHasNaNCount := dataStats.nanCounts[field.fieldID]
+
 	return dataHasNaNCount && dataNaNCount == 0 && field.hasNaNCount && field.nanCount == 0
 }
 

--- a/table/equality_delete_index_bench_test.go
+++ b/table/equality_delete_index_bench_test.go
@@ -59,7 +59,7 @@ func BenchmarkEqualityDeleteIndex(b *testing.B) {
 				b.ReportMetric(float64(deleteFileCount), "delete_files")
 				b.ResetTimer()
 				for range b.N {
-					idx, err := buildEqualityDeleteIndex(deleteEntries, specs)
+					idx, err := buildEqualityDeleteIndex(deleteEntries, specs, nil)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -77,6 +77,93 @@ func BenchmarkEqualityDeleteIndex(b *testing.B) {
 			})
 		}
 	}
+}
+
+func BenchmarkEqualityDeleteIndexMetrics(b *testing.B) {
+	const (
+		dataFileCount   = 10_000
+		deleteFileCount = 10_000
+		groupCount      = 100
+		filesPerGroup   = deleteFileCount / groupCount
+	)
+
+	specs := equalityDeleteIndexTestSpecs()
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, true)
+	partition := map[int]any{1000: int32(0)}
+
+	lowerBounds := make([][]byte, groupCount)
+	upperBounds := make([][]byte, groupCount)
+	for group := range groupCount {
+		lowerBounds[group], upperBounds[group] = equalityDeleteMetricsTestBounds(
+			b, int32(group*filesPerGroup), int32((group+1)*filesPerGroup-1))
+	}
+
+	deleteEntries := make([]iceberg.ManifestEntry, deleteFileCount)
+	for i := range deleteEntries {
+		group := i / filesPerGroup
+		deleteEntries[i] = newEqualityDeleteMetricsTestEntry(
+			fmt.Sprintf("delete-%d.parquet", i),
+			1,
+			partition,
+			iceberg.EntryContentEqDeletes,
+			int64(i+1),
+			[]int{1},
+			map[int]int64{1: 1},
+			map[int]int64{1: 0},
+			map[int]int64{1: 0},
+			lowerBounds[group],
+			upperBounds[group],
+		)
+	}
+
+	dataEntries := make([]iceberg.ManifestEntry, dataFileCount)
+	for i := range dataEntries {
+		group := i / filesPerGroup
+		dataEntries[i] = newEqualityDeleteMetricsTestEntry(
+			fmt.Sprintf("data-%d.parquet", i),
+			1,
+			partition,
+			iceberg.EntryContentData,
+			0,
+			nil,
+			map[int]int64{1: 1},
+			map[int]int64{1: 0},
+			map[int]int64{1: 0},
+			lowerBounds[group],
+			upperBounds[group],
+		)
+	}
+
+	benchmark := func(b *testing.B, schema *iceberg.Schema) {
+		b.ReportAllocs()
+		attached := 0
+		b.ResetTimer()
+		for range b.N {
+			idx, err := buildEqualityDeleteIndex(deleteEntries, specs, schema)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			attached = 0
+			for _, dataEntry := range dataEntries {
+				files, err := idx.forDataFile(dataEntry)
+				if err != nil {
+					b.Fatal(err)
+				}
+				attached += len(files)
+			}
+			equalityDeleteBenchmarkSink = attached
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(attached)/float64(dataFileCount), "attached_deletes_per_data_file")
+	}
+
+	b.Run("baseline", func(b *testing.B) {
+		benchmark(b, nil)
+	})
+	b.Run("metrics", func(b *testing.B) {
+		benchmark(b, schema)
+	})
 }
 
 func BenchmarkEqualityDeleteIndexOldData(b *testing.B) {
@@ -111,7 +198,7 @@ func BenchmarkEqualityDeleteIndexOldData(b *testing.B) {
 	b.ReportMetric(deleteFileCount, "delete_files")
 	b.ResetTimer()
 	for range b.N {
-		idx, err := buildEqualityDeleteIndex(deleteEntries, specs)
+		idx, err := buildEqualityDeleteIndex(deleteEntries, specs, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -150,7 +237,7 @@ func BenchmarkEqualityDeleteIndexNoDataFiles(b *testing.B) {
 	b.ReportMetric(deleteFileCount, "delete_files")
 	b.ResetTimer()
 	for range b.N {
-		idx, err := buildEqualityDeleteIndex(deleteEntries, specs)
+		idx, err := buildEqualityDeleteIndex(deleteEntries, specs, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -175,7 +262,7 @@ func BenchmarkEqualityDeleteIndexBuiltInPartition(b *testing.B) {
 			b.Run("build", func(b *testing.B) {
 				b.ReportAllocs()
 				for range b.N {
-					idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs)
+					idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs, nil)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -183,7 +270,7 @@ func BenchmarkEqualityDeleteIndexBuiltInPartition(b *testing.B) {
 				}
 			})
 
-			idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs)
+			idx, err := buildEqualityDeleteIndex([]iceberg.ManifestEntry{deleteEntry}, specs, nil)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/table/equality_delete_index_metrics_test.go
+++ b/table/equality_delete_index_metrics_test.go
@@ -337,7 +337,6 @@ func TestEqualityDeleteIndexDoesNotUseUncertainFloatBounds(t *testing.T) {
 	matched, err = idx.forDataFile(dataEntry)
 	require.NoError(t, err)
 	assert.Empty(t, matched)
-
 }
 
 func TestEqualityDeleteMetricValueCompareSupportsRangeTypes(t *testing.T) {
@@ -368,9 +367,11 @@ func TestEqualityDeleteMetricValueCompareSupportsRangeTypes(t *testing.T) {
 		{"string", iceberg.PrimitiveTypes.String, iceberg.NewLiteral("a"), iceberg.NewLiteral("b")},
 		{"binary", iceberg.PrimitiveTypes.Binary, iceberg.NewLiteral([]byte{1}), iceberg.NewLiteral([]byte{2})},
 		{"fixed", iceberg.FixedTypeOf(2), fixedLower, fixedUpper},
-		{"uuid", iceberg.PrimitiveTypes.UUID,
+		{
+			"uuid", iceberg.PrimitiveTypes.UUID,
 			iceberg.NewLiteral(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
-			iceberg.NewLiteral(uuid.MustParse("00000000-0000-0000-0000-000000000002"))},
+			iceberg.NewLiteral(uuid.MustParse("00000000-0000-0000-0000-000000000002")),
+		},
 		{"decimal", iceberg.DecimalTypeOf(9, 0), decimalLower, decimalUpper},
 	}
 

--- a/table/equality_delete_index_metrics_test.go
+++ b/table/equality_delete_index_metrics_test.go
@@ -391,3 +391,94 @@ func TestEqualityDeleteMetricValueCompareSupportsRangeTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestEqualityDeleteIndexKeepsInvertedMetricRanges(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, true)
+	low, high := equalityDeleteMetricsTestBounds(t, int32(10), int32(20))
+	middle, _ := equalityDeleteMetricsTestBounds(t, int32(15), int32(15))
+	for _, invalidData := range []bool{false, true} {
+		name := "delete bounds"
+		if invalidData {
+			name = "data bounds"
+		}
+		t.Run(name, func(t *testing.T) {
+			dataLower, dataUpper := middle, middle
+			deleteLower, deleteUpper := middle, middle
+			if invalidData {
+				dataLower, dataUpper = high, low
+			} else {
+				deleteLower, deleteUpper = high, low
+			}
+			deleteEntry := newEqualityDeleteMetricsTestEntry(
+				"delete.parquet", 0, nil, iceberg.EntryContentEqDeletes, 2,
+				[]int{1}, nil, nil, nil, deleteLower, deleteUpper)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+			require.NoError(t, err)
+			dataEntry := newEqualityDeleteMetricsTestEntry(
+				"data.parquet", 0, nil, iceberg.EntryContentData, 1,
+				nil, nil, nil, nil, dataLower, dataUpper)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			assert.Len(t, matched, 1, "inverted bounds cannot prove that an equality delete is disjoint")
+		})
+	}
+}
+
+func TestEqualityDeleteIndexKeepsUnknownNullCounts(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, false)
+	for _, unknownData := range []bool{false, true} {
+		name := "delete null count"
+		if unknownData {
+			name = "data null count"
+		}
+		t.Run(name, func(t *testing.T) {
+			dataNulls, deleteNulls := int64(1), int64(-1)
+			if unknownData {
+				dataNulls, deleteNulls = deleteNulls, dataNulls
+			}
+			deleteEntry := newEqualityDeleteMetricsTestEntry(
+				"delete.parquet", 0, nil, iceberg.EntryContentEqDeletes, 2,
+				[]int{1}, map[int]int64{1: 1}, map[int]int64{1: deleteNulls}, nil, nil, nil)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+			require.NoError(t, err)
+			dataEntry := newEqualityDeleteMetricsTestEntry(
+				"data.parquet", 0, nil, iceberg.EntryContentData, 1,
+				nil, map[int]int64{1: 1}, map[int]int64{1: dataNulls}, nil, nil, nil)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			assert.Len(t, matched, 1, "negative null counts are not evidence that null keys are absent")
+		})
+	}
+}
+
+func TestEqualityDeleteIndexKeepsUnknownValueAndNullCounts(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, false)
+	for _, unknownData := range []bool{false, true} {
+		name := "delete counts"
+		if unknownData {
+			name = "data counts"
+		}
+		t.Run(name, func(t *testing.T) {
+			dataValues, deleteValues := int64(1), int64(-1)
+			dataNulls, deleteNulls := int64(0), int64(-1)
+			if unknownData {
+				dataValues, deleteValues = deleteValues, dataValues
+				dataNulls, deleteNulls = deleteNulls, dataNulls
+			}
+			deleteEntry := newEqualityDeleteMetricsTestEntry(
+				"delete.parquet", 0, nil, iceberg.EntryContentEqDeletes, 2,
+				[]int{1}, map[int]int64{1: deleteValues}, map[int]int64{1: deleteNulls}, nil, nil, nil)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+			require.NoError(t, err)
+			dataEntry := newEqualityDeleteMetricsTestEntry(
+				"data.parquet", 0, nil, iceberg.EntryContentData, 1,
+				nil, map[int]int64{1: dataValues}, map[int]int64{1: dataNulls}, nil, nil, nil)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			assert.Len(t, matched, 1, "equal negative counts are not evidence that every key is null")
+		})
+	}
+}

--- a/table/equality_delete_index_metrics_test.go
+++ b/table/equality_delete_index_metrics_test.go
@@ -1,0 +1,392 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type equalityDeleteMetricsTestFile struct {
+	*mockDataFile
+	equalityFieldIDs []int
+}
+
+func (f *equalityDeleteMetricsTestFile) EqualityFieldIDs() []int {
+	return f.equalityFieldIDs
+}
+
+func newEqualityDeleteMetricsTestEntry(
+	path string,
+	specID int32,
+	partition map[int]any,
+	content iceberg.ManifestEntryContent,
+	sequenceNumber int64,
+	fieldIDs []int,
+	valueCounts, nullCounts, nanCounts map[int]int64,
+	lowerBound, upperBound []byte,
+) iceberg.ManifestEntry {
+	var lowerBounds, upperBounds map[int][]byte
+	if lowerBound != nil {
+		lowerBounds = map[int][]byte{1: lowerBound}
+	}
+	if upperBound != nil {
+		upperBounds = map[int][]byte{1: upperBound}
+	}
+
+	file := &equalityDeleteMetricsTestFile{
+		mockDataFile: &mockDataFile{
+			path:        path,
+			specid:      specID,
+			partition:   partition,
+			contentType: content,
+			format:      iceberg.ParquetFile,
+			count:       1,
+			valueCounts: valueCounts,
+			nullCounts:  nullCounts,
+			nanCounts:   nanCounts,
+			lowerBounds: lowerBounds,
+			upperBounds: upperBounds,
+		},
+		equalityFieldIDs: fieldIDs,
+	}
+
+	return iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED,
+		nil,
+		&sequenceNumber,
+		nil,
+		file,
+	)
+}
+
+func equalityDeleteMetricsTestSchema(typ iceberg.Type, required bool) *iceberg.Schema {
+	return iceberg.NewSchema(1, iceberg.NestedField{
+		ID: 1, Name: "id", Type: typ, Required: required,
+	})
+}
+
+func equalityDeleteMetricsTestBounds[T iceberg.LiteralType](t testing.TB, lower, upper T) ([]byte, []byte) {
+	t.Helper()
+
+	lowerLiteral := iceberg.NewLiteral(lower)
+	upperLiteral := iceberg.NewLiteral(upper)
+	lowerBytes, err := lowerLiteral.MarshalBinary()
+	require.NoError(t, err)
+	upperBytes, err := upperLiteral.MarshalBinary()
+	require.NoError(t, err)
+
+	return lowerBytes, upperBytes
+}
+
+func equalityDeleteMetricPaths(files []iceberg.DataFile) []string {
+	paths := make([]string, len(files))
+	for i, file := range files {
+		paths[i] = file.FilePath()
+	}
+
+	return paths
+}
+
+func TestEqualityDeleteIndexPrunesDisjointMetricRanges(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, true)
+	partition := map[int]any{1000: int32(0)}
+	dataLower, dataUpper := equalityDeleteMetricsTestBounds(t, int32(0), int32(25))
+	matchingLower, matchingUpper := equalityDeleteMetricsTestBounds(t, int32(10), int32(20))
+	disjointLower, disjointUpper := equalityDeleteMetricsTestBounds(t, int32(30), int32(40))
+
+	deleteEntries := []iceberg.ManifestEntry{
+		newEqualityDeleteMetricsTestEntry(
+			"partition-matching.parquet", 1, partition, iceberg.EntryContentEqDeletes, 2,
+			[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+			matchingLower, matchingUpper),
+		newEqualityDeleteMetricsTestEntry(
+			"partition-disjoint.parquet", 1, partition, iceberg.EntryContentEqDeletes, 3,
+			[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+			disjointLower, disjointUpper),
+		newEqualityDeleteMetricsTestEntry(
+			"partition-no-metrics.parquet", 1, partition, iceberg.EntryContentEqDeletes, 4,
+			[]int{1}, nil, nil, nil, nil, nil),
+		newEqualityDeleteMetricsTestEntry(
+			"global-disjoint.parquet", 0, nil, iceberg.EntryContentEqDeletes, 5,
+			[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+			disjointLower, disjointUpper),
+		newEqualityDeleteMetricsTestEntry(
+			"global-matching.parquet", 0, nil, iceberg.EntryContentEqDeletes, 6,
+			[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+			matchingLower, matchingUpper),
+	}
+
+	idx, err := buildEqualityDeleteIndex(deleteEntries, equalityDeleteIndexTestSpecs(), schema)
+	require.NoError(t, err)
+
+	dataEntry := newEqualityDeleteMetricsTestEntry(
+		"data.parquet", 1, partition, iceberg.EntryContentData, 1,
+		nil, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+		dataLower, dataUpper)
+	matched, err := idx.forDataFile(dataEntry)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"global-matching.parquet",
+		"partition-matching.parquet",
+		"partition-no-metrics.parquet",
+	}, equalityDeleteMetricPaths(matched))
+}
+
+func TestEqualityDeleteIndexPrunesNullOnlyMetricRanges(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, false)
+	partition := map[int]any{1000: int32(0)}
+	lower, upper := equalityDeleteMetricsTestBounds(t, int32(10), int32(20))
+
+	tests := []struct {
+		name         string
+		dataValues   map[int]int64
+		dataNulls    map[int]int64
+		deleteValues map[int]int64
+		deleteNulls  map[int]int64
+		wantFiles    int
+	}{
+		{
+			name:         "data is all null and delete is all non-null",
+			dataValues:   map[int]int64{1: 10},
+			dataNulls:    map[int]int64{1: 10},
+			deleteValues: map[int]int64{1: 10},
+			deleteNulls:  map[int]int64{1: 0},
+		},
+		{
+			name:         "data is all non-null and delete is all null",
+			dataValues:   map[int]int64{1: 10},
+			dataNulls:    map[int]int64{1: 0},
+			deleteValues: map[int]int64{1: 10},
+			deleteNulls:  map[int]int64{1: 10},
+		},
+		{
+			name:         "both files may contain null",
+			dataValues:   map[int]int64{1: 10},
+			dataNulls:    map[int]int64{1: 1},
+			deleteValues: map[int]int64{1: 10},
+			deleteNulls:  map[int]int64{1: 1},
+			wantFiles:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deleteEntry := newEqualityDeleteMetricsTestEntry(
+				"delete.parquet", 1, partition, iceberg.EntryContentEqDeletes, 2,
+				[]int{1}, tt.deleteValues, tt.deleteNulls, nil, lower, upper)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+			require.NoError(t, err)
+
+			dataEntry := newEqualityDeleteMetricsTestEntry(
+				"data.parquet", 1, partition, iceberg.EntryContentData, 1,
+				nil, tt.dataValues, tt.dataNulls, nil, lower, upper)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			assert.Len(t, matched, tt.wantFiles)
+		})
+	}
+}
+
+func TestEqualityDeleteIndexKeepsUncertainMetricRanges(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Int32, true)
+	partition := map[int]any{1000: int32(0)}
+	dataLower, dataUpper := equalityDeleteMetricsTestBounds(t, int32(0), int32(10))
+	deleteLower, deleteUpper := equalityDeleteMetricsTestBounds(t, int32(20), int32(30))
+
+	tests := []struct {
+		name         string
+		dataLower    []byte
+		dataUpper    []byte
+		deleteLower  []byte
+		deleteUpper  []byte
+		dataValues   map[int]int64
+		dataNulls    map[int]int64
+		deleteValues map[int]int64
+		deleteNulls  map[int]int64
+		fieldID      int
+		wantFiles    int
+	}{
+		{
+			name:         "missing data bounds",
+			dataValues:   map[int]int64{1: 1},
+			dataNulls:    map[int]int64{1: 0},
+			deleteValues: map[int]int64{1: 1},
+			deleteNulls:  map[int]int64{1: 0},
+			deleteLower:  deleteLower,
+			deleteUpper:  deleteUpper,
+			wantFiles:    1,
+		},
+		{
+			name:         "malformed data bound",
+			dataLower:    []byte{1},
+			dataUpper:    dataUpper,
+			deleteLower:  deleteLower,
+			deleteUpper:  deleteUpper,
+			dataValues:   map[int]int64{1: 1},
+			dataNulls:    map[int]int64{1: 0},
+			deleteValues: map[int]int64{1: 1},
+			deleteNulls:  map[int]int64{1: 0},
+			wantFiles:    1,
+		},
+		{
+			name:         "missing delete bounds",
+			dataLower:    dataLower,
+			dataUpper:    dataUpper,
+			dataValues:   map[int]int64{1: 1},
+			dataNulls:    map[int]int64{1: 0},
+			deleteValues: map[int]int64{1: 1},
+			deleteNulls:  map[int]int64{1: 0},
+			wantFiles:    1,
+		},
+		{
+			name:         "unknown equality field",
+			dataLower:    dataLower,
+			dataUpper:    dataUpper,
+			deleteLower:  deleteLower,
+			deleteUpper:  deleteUpper,
+			dataValues:   map[int]int64{1: 1},
+			dataNulls:    map[int]int64{1: 0},
+			deleteValues: map[int]int64{1: 1},
+			deleteNulls:  map[int]int64{1: 0},
+			fieldID:      99,
+			wantFiles:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fieldID := tt.fieldID
+			if fieldID == 0 {
+				fieldID = 1
+			}
+			deleteEntry := newEqualityDeleteMetricsTestEntry(
+				"delete.parquet", 1, partition, iceberg.EntryContentEqDeletes, 2,
+				[]int{fieldID}, tt.deleteValues, tt.deleteNulls, nil,
+				tt.deleteLower, tt.deleteUpper)
+			idx, err := buildEqualityDeleteIndex(
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+			require.NoError(t, err)
+
+			dataEntry := newEqualityDeleteMetricsTestEntry(
+				"data.parquet", 1, partition, iceberg.EntryContentData, 1,
+				nil, tt.dataValues, tt.dataNulls, nil, tt.dataLower, tt.dataUpper)
+			matched, err := idx.forDataFile(dataEntry)
+			require.NoError(t, err)
+			assert.Len(t, matched, tt.wantFiles)
+		})
+	}
+}
+
+func TestEqualityDeleteIndexDoesNotUseUncertainFloatBounds(t *testing.T) {
+	schema := equalityDeleteMetricsTestSchema(iceberg.PrimitiveTypes.Float32, true)
+	partition := map[int]any{1000: int32(0)}
+	dataLower, dataUpper := equalityDeleteMetricsTestBounds(t, float32(0), float32(10))
+	deleteLower, deleteUpper := equalityDeleteMetricsTestBounds(t, float32(20), float32(30))
+
+	deleteEntry := newEqualityDeleteMetricsTestEntry(
+		"delete.parquet", 1, partition, iceberg.EntryContentEqDeletes, 2,
+		[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+		deleteLower, deleteUpper)
+	idx, err := buildEqualityDeleteIndex(
+		[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+	require.NoError(t, err)
+
+	dataEntry := newEqualityDeleteMetricsTestEntry(
+		"data.parquet", 1, partition, iceberg.EntryContentData, 1,
+		nil, map[int]int64{1: 1}, map[int]int64{1: 0}, nil,
+		dataLower, dataUpper)
+	matched, err := idx.forDataFile(dataEntry)
+	require.NoError(t, err)
+
+	assert.Len(t, matched, 1, "missing NaN counts must keep float ranges conservative")
+
+	dataEntry = newEqualityDeleteMetricsTestEntry(
+		"data-no-nan.parquet", 1, partition, iceberg.EntryContentData, 1,
+		nil, map[int]int64{1: 1}, map[int]int64{1: 0}, map[int]int64{1: 0},
+		dataLower, dataUpper)
+	deleteEntry = newEqualityDeleteMetricsTestEntry(
+		"delete-no-nan.parquet", 1, partition, iceberg.EntryContentEqDeletes, 2,
+		[]int{1}, map[int]int64{1: 1}, map[int]int64{1: 0}, map[int]int64{1: 0},
+		deleteLower, deleteUpper)
+	idx, err = buildEqualityDeleteIndex(
+		[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), schema)
+	require.NoError(t, err)
+
+	matched, err = idx.forDataFile(dataEntry)
+	require.NoError(t, err)
+	assert.Empty(t, matched)
+
+}
+
+func TestEqualityDeleteMetricValueCompareSupportsRangeTypes(t *testing.T) {
+	decimalLower, err := iceberg.LiteralFromBytes(iceberg.DecimalTypeOf(9, 0), []byte{1})
+	require.NoError(t, err)
+	decimalUpper, err := iceberg.LiteralFromBytes(iceberg.DecimalTypeOf(9, 0), []byte{2})
+	require.NoError(t, err)
+	fixedLower, err := iceberg.LiteralFromBytes(iceberg.FixedTypeOf(2), []byte{1, 0})
+	require.NoError(t, err)
+	fixedUpper, err := iceberg.LiteralFromBytes(iceberg.FixedTypeOf(2), []byte{2, 0})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		typ   iceberg.Type
+		lower iceberg.Literal
+		upper iceberg.Literal
+	}{
+		{"boolean", iceberg.PrimitiveTypes.Bool, iceberg.NewLiteral(false), iceberg.NewLiteral(true)},
+		{"int32", iceberg.PrimitiveTypes.Int32, iceberg.NewLiteral(int32(1)), iceberg.NewLiteral(int32(2))},
+		{"int64", iceberg.PrimitiveTypes.Int64, iceberg.NewLiteral(int64(1)), iceberg.NewLiteral(int64(2))},
+		{"float32", iceberg.PrimitiveTypes.Float32, iceberg.NewLiteral(float32(1)), iceberg.NewLiteral(float32(2))},
+		{"float64", iceberg.PrimitiveTypes.Float64, iceberg.NewLiteral(float64(1)), iceberg.NewLiteral(float64(2))},
+		{"date", iceberg.PrimitiveTypes.Date, iceberg.NewLiteral(iceberg.Date(1)), iceberg.NewLiteral(iceberg.Date(2))},
+		{"time", iceberg.PrimitiveTypes.Time, iceberg.NewLiteral(iceberg.Time(1)), iceberg.NewLiteral(iceberg.Time(2))},
+		{"timestamp", iceberg.PrimitiveTypes.Timestamp, iceberg.NewLiteral(iceberg.Timestamp(1)), iceberg.NewLiteral(iceberg.Timestamp(2))},
+		{"timestamp-nano", iceberg.PrimitiveTypes.TimestampNs, iceberg.NewLiteral(iceberg.TimestampNano(1)), iceberg.NewLiteral(iceberg.TimestampNano(2))},
+		{"string", iceberg.PrimitiveTypes.String, iceberg.NewLiteral("a"), iceberg.NewLiteral("b")},
+		{"binary", iceberg.PrimitiveTypes.Binary, iceberg.NewLiteral([]byte{1}), iceberg.NewLiteral([]byte{2})},
+		{"fixed", iceberg.FixedTypeOf(2), fixedLower, fixedUpper},
+		{"uuid", iceberg.PrimitiveTypes.UUID,
+			iceberg.NewLiteral(uuid.MustParse("00000000-0000-0000-0000-000000000001")),
+			iceberg.NewLiteral(uuid.MustParse("00000000-0000-0000-0000-000000000002"))},
+		{"decimal", iceberg.DecimalTypeOf(9, 0), decimalLower, decimalUpper},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind := equalityDeleteRangeKindForType(tt.typ)
+			lower, ok := equalityDeleteMetricValueFromLiteral(kind, tt.lower)
+			require.True(t, ok)
+			upper, ok := equalityDeleteMetricValueFromLiteral(kind, tt.upper)
+			require.True(t, ok)
+
+			want := getCmpLiteral(tt.lower)(tt.lower, tt.upper)
+			got := equalityDeleteMetricValueCompare(&lower, &upper)
+			assert.Equal(t, want < 0, got < 0)
+			assert.Equal(t, want == 0, got == 0)
+			assert.Equal(t, want > 0, got > 0)
+		})
+	}
+}

--- a/table/equality_delete_reader_test.go
+++ b/table/equality_delete_reader_test.go
@@ -163,7 +163,7 @@ func TestEqualityDeleteReadRoundTrip(t *testing.T) {
 		"expected equality deletes to apply when the equality field is not projected")
 }
 
-func TestEqualityDeleteReadSharesMultiFileUnionAcrossConcurrentTasks(t *testing.T) {
+func TestEqualityDeleteReadPrunesNonOverlappingDeleteFiles(t *testing.T) {
 	ctx := t.Context()
 	tbl := newEqDeleteReadTestTable(t)
 	arrowSc, err := table.SchemaToArrowSchema(tbl.Metadata().CurrentSchema(), nil, false, false)
@@ -218,8 +218,15 @@ func TestEqualityDeleteReadSharesMultiFileUnionAcrossConcurrentTasks(t *testing.
 	require.NoError(t, err)
 	require.Len(t, tasks, 2)
 	for _, task := range tasks {
-		require.Len(t, task.EqualityDeleteFiles, 2,
-			"each task must use the same multi-file equality-delete union")
+		require.Len(t, task.EqualityDeleteFiles, 1)
+		switch {
+		case strings.HasSuffix(task.File.FilePath(), "/data-001.parquet"):
+			assert.Equal(t, deleteTwoFiles[0].FilePath(), task.EqualityDeleteFiles[0].FilePath())
+		case strings.HasSuffix(task.File.FilePath(), "/data-002.parquet"):
+			assert.Equal(t, deleteThreeFiles[0].FilePath(), task.EqualityDeleteFiles[0].FilePath())
+		default:
+			t.Errorf("unexpected data file %s", task.File.FilePath())
+		}
 	}
 
 	_, records, err := scan.ReadTasks(ctx, tasks)

--- a/table/rewrite_data_files_test.go
+++ b/table/rewrite_data_files_test.go
@@ -1024,7 +1024,7 @@ func TestRewriteDataFiles_DeadEqualityDeletesDropped(t *testing.T) {
 //
 //	commit 1: small-0.parquet      (data, will survive — low seq)
 //	commit 2: small-1.parquet      (data, will survive — low seq)
-//	commit 3: eq-delete (id=99)    (eq-delete; seq > both small files)
+//	commit 3: eq-delete (id=1)     (eq-delete; seq > both small files)
 //	commit 4: preserve.parquet     (data, will be rewritten — high seq)
 //
 // The post-rewrite check: eq-delete must remain because small-0/1
@@ -1048,7 +1048,7 @@ func TestRewriteDataFiles_PartialRewritePreservesEqDelete(t *testing.T) {
 	}
 
 	// commit 3: eq-delete.
-	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 99}]`)
+	tbl = appendEqualityDelete(t, tbl, []int{1}, `[{"id": 1}]`)
 
 	// commit 4: preserve.parquet — the high-seq file we'll compact alone.
 	preserveDataPath := tbl.Location() + "/data/preserve.parquet"

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1127,7 +1127,7 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	if err != nil {
 		return nil, err
 	}
-	eqDeleteIndex, err := buildEqualityDeleteIndex(entries.equalityDeleteEntries, scan.metadata)
+	eqDeleteIndex, err := buildEqualityDeleteIndex(entries.equalityDeleteEntries, scan.metadata, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -131,7 +131,7 @@ func TestEqualityDeleteIndexMatchesPartitionAndSequence(t *testing.T) {
 		newEqualityDeleteIndexTestEntry("global-same-sequence.parquet", 0, nil, 5),
 	}
 
-	idx, err := buildEqualityDeleteIndex(deleteEntries, equalityDeleteIndexTestSpecs())
+	idx, err := buildEqualityDeleteIndex(deleteEntries, equalityDeleteIndexTestSpecs(), nil)
 	require.NoError(t, err)
 
 	dataEntry := newEqualityDeleteIndexTestEntry("data.parquet", 1, partition, 5)
@@ -148,7 +148,7 @@ func TestEqualityDeleteIndexKeepsPartitionedDeletesScoped(t *testing.T) {
 	globalDelete := newEqualityDeleteIndexTestEntry("global-delete.parquet", 0, nil, 3)
 
 	idx, err := buildEqualityDeleteIndex(
-		[]iceberg.ManifestEntry{partitionedDelete, globalDelete}, equalityDeleteIndexTestSpecs())
+		[]iceberg.ManifestEntry{partitionedDelete, globalDelete}, equalityDeleteIndexTestSpecs(), nil)
 	require.NoError(t, err)
 
 	unpartitionedData := newEqualityDeleteIndexTestEntry("data.parquet", 0, nil, 1)
@@ -163,7 +163,7 @@ func TestEqualityDeleteIndexTreatsVoidSpecAsGlobal(t *testing.T) {
 		"void-delete.parquet", 3, map[int]any{1000: nil}, 3)
 
 	idx, err := buildEqualityDeleteIndex(
-		[]iceberg.ManifestEntry{voidDelete}, equalityDeleteIndexTestSpecs())
+		[]iceberg.ManifestEntry{voidDelete}, equalityDeleteIndexTestSpecs(), nil)
 	require.NoError(t, err)
 
 	unpartitionedData := newEqualityDeleteIndexTestEntry("data.parquet", 0, nil, 1)
@@ -177,7 +177,7 @@ func TestEqualityDeleteIndexRejectsUnknownPartitionSpec(t *testing.T) {
 	deleteEntry := newEqualityDeleteIndexTestEntry("delete.parquet", 99, nil, 2)
 
 	_, err := buildEqualityDeleteIndex(
-		[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs())
+		[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), nil)
 	require.ErrorIs(t, err, ErrPartitionSpecNotFound)
 	assert.ErrorContains(t, err, "delete.parquet")
 }
@@ -190,7 +190,7 @@ func TestEqualityDeleteIndexSkipsPartitionKeysWithoutPartitionedDeletes(t *testi
 		nil,
 		{newEqualityDeleteIndexTestEntry("global-delete.parquet", 0, nil, 2)},
 	} {
-		idx, err := buildEqualityDeleteIndex(entries, equalityDeleteIndexTestSpecs())
+		idx, err := buildEqualityDeleteIndex(entries, equalityDeleteIndexTestSpecs(), nil)
 		require.NoError(t, err)
 
 		matched, err := idx.forDataFile(dataEntry)
@@ -208,7 +208,7 @@ func TestEqualityDeleteIndexSortsBySequence(t *testing.T) {
 		newEqualityDeleteIndexTestEntry("sequence-2-b.parquet", 1, partition, 2),
 	}
 
-	idx, err := buildEqualityDeleteIndex(deleteEntries, equalityDeleteIndexTestSpecs())
+	idx, err := buildEqualityDeleteIndex(deleteEntries, equalityDeleteIndexTestSpecs(), nil)
 	require.NoError(t, err)
 
 	dataEntry := newEqualityDeleteIndexTestEntry("data.parquet", 1, partition, 1)
@@ -342,7 +342,7 @@ func TestEqualityDeleteIndexUsesFloatSemantics(t *testing.T) {
 			deleteEntry := newEqualityDeleteIndexTestEntry(
 				"delete.parquet", 1, map[int]any{1000: tt.deletePartition}, 2)
 			idx, err := buildEqualityDeleteIndex(
-				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs())
+				[]iceberg.ManifestEntry{deleteEntry}, equalityDeleteIndexTestSpecs(), nil)
 			require.NoError(t, err)
 
 			dataEntry := newEqualityDeleteIndexTestEntry(


### PR DESCRIPTION
## What

- Port the equality-delete metrics pruning used by Java `DeleteFileIndex`.
- After partition and sequence filtering, use equality-field null counts and lower/upper bounds from the data file and delete file.
- Keep the match when stats are missing, malformed, nested, or otherwise uncertain.
- Cache typed bounds so the hot loop avoids repeated literal/interface work. ⚡

Java reference: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java

## Why

With many equality deletes in one partition, most delete files can be ruled out from a data file by its metrics. This reduces the delete files attached to each `FileScanTask`, which also reduces downstream delete-file reads.

## Benchmark

Workload: 10,000 data files, 10,000 equality deletes, one partition, 100 disjoint key-range groups. Each data file overlaps 100 delete files (1%).

```
                                      ns/op       B/op       attached deletes/data file
baseline                              1.41-1.69s  6.66GB     10,000
metrics pruning                       0.93-1.11s  52.5MB     100
```

The benchmark was run with `go test ./table -run ^$ -bench ^BenchmarkEqualityDeleteIndexMetrics$ -benchtime=1x -count=5` on an Apple M1 Pro.

## Checks

- `go test ./...`
- `go test -race ./table`
- `go vet ./...` ✅