### PR TITLE
perf(table): cache snapshot manifests across scans

### DIFF
--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -172,14 +172,11 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		manifests, err := snapshot.Manifests(manifestListFS)
+		manifestSet, err := planningScan.manifestSet(ctx, snapshot, fs)
 		if err != nil {
 			return nil, err
 		}
-		for _, manifest := range manifests {
-			if manifest.ManifestContent() != iceberg.ManifestContentData {
-				continue
-			}
+		for _, manifest := range manifestSet.dataManifests() {
 			if _, ok := appendSnapshots[manifest.SnapshotID()]; !ok {
 				continue
 			}

--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -159,20 +159,17 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 	if s.scan.ioF == nil {
 		return nil, fmt.Errorf("%w: table file IO is not configured", ErrInvalidOperation)
 	}
-	manifestListFS, err := s.scan.ioF(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// An inherited manifest can occur in every later snapshot's manifest list.
 	// Read each manifest path once, just as the Java incremental append scan
 	// collects the selected manifests into a set before opening them.
 	manifestsByPath := make(map[string]iceberg.ManifestFile)
+	manifestFS := sharedSnapshotManifestFSF(s.scan.ioF)
 	for _, snapshot := range snapshots {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		manifestSet, err := planningScan.manifestSet(ctx, snapshot, manifestListFS)
+		manifestSet, err := planningScan.manifestSetWithFSF(ctx, snapshot, manifestFS)
 		if err != nil {
 			return nil, err
 		}

--- a/table/incremental_append_scan.go
+++ b/table/incremental_append_scan.go
@@ -172,7 +172,7 @@ func (s *IncrementalAppendScan) PlanFiles(ctx context.Context) ([]FileScanTask, 
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		manifestSet, err := planningScan.manifestSet(ctx, snapshot, fs)
+		manifestSet, err := planningScan.manifestSet(ctx, snapshot, manifestListFS)
 		if err != nil {
 			return nil, err
 		}

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -30,7 +30,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
-	iceio "github.com/apache/iceberg-go/io"
 )
 
 // InspectTable exposes a table's metadata (snapshots, history, manifests, and
@@ -452,14 +451,7 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 		return nil, errors.New("table file IO is not configured")
 	}
 
-	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, func(loadCtx context.Context) (iceio.IO, error) {
-		fs, err := i.tbl.fsF(loadCtx)
-		if err != nil {
-			return nil, fmt.Errorf("get file IO: %w", err)
-		}
-
-		return fs, nil
-	})
+	manifestSet, err := i.tbl.manifestSet(ctx, *snapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/table/inspect.go
+++ b/table/inspect.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
 )
 
 // InspectTable exposes a table's metadata (snapshots, history, manifests, and
@@ -451,12 +452,19 @@ func (i InspectTable) currentSnapshotManifests(ctx context.Context) ([]iceberg.M
 		return nil, errors.New("table file IO is not configured")
 	}
 
-	fs, err := i.tbl.fsF(ctx)
+	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, func(loadCtx context.Context) (iceio.IO, error) {
+		fs, err := i.tbl.fsF(loadCtx)
+		if err != nil {
+			return nil, fmt.Errorf("get file IO: %w", err)
+		}
+
+		return fs, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("get file IO: %w", err)
+		return nil, err
 	}
 
-	return snapshot.Manifests(fs)
+	return manifestSet.allManifests(), nil
 }
 
 func appendManifestBound(builder *array.StringBuilder, typ iceberg.Type, transform iceberg.Transform, bound *[]byte) error {

--- a/table/inspect_all_manifests.go
+++ b/table/inspect_all_manifests.go
@@ -43,12 +43,14 @@ func (i InspectTable) AllManifests(ctx context.Context) (array.RecordReader, err
 		if i.tbl.fsF == nil {
 			return nil, errors.New("inspect all manifests: table file IO is not configured")
 		}
-		fs, err := i.tbl.fsF(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("inspect all manifests: %w", err)
-		}
+		manifestFS := sharedSnapshotManifestFSF(i.tbl.fsF)
 		readSnapshotManifests = func(snapshot Snapshot) ([]iceberg.ManifestFile, error) {
-			return snapshot.Manifests(fs)
+			manifestSet, err := i.tbl.manifestSetWithFSF(ctx, snapshot, manifestFS)
+			if err != nil {
+				return nil, err
+			}
+
+			return manifestSet.allManifests(), nil
 		}
 	}
 

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -131,13 +131,11 @@ func (i InspectTable) manifestEntryReader(
 		return nil, errors.New("table file IO is not configured")
 	}
 
-	fs, err := i.tbl.fsF(ctx)
+	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, sharedSnapshotManifestFSF(i.tbl.fsF))
 	if err != nil {
 		return nil, err
 	}
-	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, func(context.Context) (iceio.IO, error) {
-		return fs, nil
-	})
+	fs, err := i.tbl.fsF(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +174,7 @@ func (i InspectTable) allManifestEntryReader(
 	if err != nil {
 		return nil, err
 	}
-	manifestFS := func(context.Context) (iceio.IO, error) { return fs, nil }
+	manifestFS := sharedSnapshotManifestFSF(i.tbl.fsF)
 
 	return i.manifestEntryReaderFromManifestSource(
 		ctx, arrowSchema, fs, discardDeleted, includeManifest, appendEntry,

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -135,7 +135,9 @@ func (i InspectTable) manifestEntryReader(
 	if err != nil {
 		return nil, err
 	}
-	manifestSet, err := i.tbl.manifestCache.get(ctx, *snapshot, fs)
+	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, func(context.Context) (iceio.IO, error) {
+		return fs, nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -174,6 +176,7 @@ func (i InspectTable) allManifestEntryReader(
 	if err != nil {
 		return nil, err
 	}
+	manifestFS := func(context.Context) (iceio.IO, error) { return fs, nil }
 
 	return i.manifestEntryReaderFromManifestSource(
 		ctx, arrowSchema, fs, discardDeleted, includeManifest, appendEntry,
@@ -185,7 +188,7 @@ func (i InspectTable) allManifestEntryReader(
 
 					return
 				}
-				manifestSet, err := i.tbl.manifestCache.get(ctx, snapshot, fs)
+				manifestSet, err := i.tbl.manifestSetWithFSF(ctx, snapshot, manifestFS)
 				if err != nil {
 					yield(nil, fmt.Errorf("read snapshot %d manifests: %w", snapshot.SnapshotID, err))
 

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -135,10 +135,11 @@ func (i InspectTable) manifestEntryReader(
 	if err != nil {
 		return nil, err
 	}
-	manifests, err := snapshot.Manifests(fs)
+	manifestSet, err := i.tbl.manifestCache.get(ctx, *snapshot, fs)
 	if err != nil {
 		return nil, err
 	}
+	manifests := manifestSet.allManifests()
 
 	return i.manifestEntryReaderFromManifestSource(
 		ctx, arrowSchema, fs, discardDeleted, includeManifest, appendEntry,
@@ -184,13 +185,13 @@ func (i InspectTable) allManifestEntryReader(
 
 					return
 				}
-				snapshotManifests, err := snapshot.Manifests(fs)
+				manifestSet, err := i.tbl.manifestCache.get(ctx, snapshot, fs)
 				if err != nil {
 					yield(nil, fmt.Errorf("read snapshot %d manifests: %w", snapshot.SnapshotID, err))
 
 					return
 				}
-				for _, manifest := range snapshotManifests {
+				for _, manifest := range manifestSet.allManifests() {
 					if _, ok := seen[manifest.FilePath()]; ok {
 						continue
 					}

--- a/table/inspect_files.go
+++ b/table/inspect_files.go
@@ -131,11 +131,12 @@ func (i InspectTable) manifestEntryReader(
 		return nil, errors.New("table file IO is not configured")
 	}
 
-	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, sharedSnapshotManifestFSF(i.tbl.fsF))
+	manifestFS := sharedSnapshotManifestFSF(i.tbl.fsF)
+	manifestSet, err := i.tbl.manifestSetWithFSF(ctx, *snapshot, manifestFS)
 	if err != nil {
 		return nil, err
 	}
-	fs, err := i.tbl.fsF(ctx)
+	fs, err := manifestFS(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -170,11 +171,11 @@ func (i InspectTable) allManifestEntryReader(
 		return nil, errors.New("table file IO is not configured")
 	}
 
-	fs, err := i.tbl.fsF(ctx)
+	manifestFS := sharedSnapshotManifestFSF(i.tbl.fsF)
+	fs, err := manifestFS(ctx)
 	if err != nil {
 		return nil, err
 	}
-	manifestFS := sharedSnapshotManifestFSF(i.tbl.fsF)
 
 	return i.manifestEntryReaderFromManifestSource(
 		ctx, arrowSchema, fs, discardDeleted, includeManifest, appendEntry,

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2203,13 +2203,13 @@ type inspectManifestListContextIO struct {
 
 func (fs inspectManifestListContextIO) Open(path string) (iceio.File, error) {
 	if fs.rejectManifestList && strings.Contains(path, "manifest-list") {
-		return nil, errors.New("manifest list opened with caller-bound IO")
+		return nil, errors.New("manifest list opened with uncancellable IO")
 	}
 
 	return fs.IO.Open(path)
 }
 
-func TestInspectFilesUseDetachedContextForManifestListRead(t *testing.T) {
+func TestInspectFilesKeepCallerContextForManifestListRead(t *testing.T) {
 	tbl := inspectAllFilesTable(t)
 	baseFS, err := tbl.fsF(context.Background())
 	require.NoError(t, err)
@@ -2220,7 +2220,7 @@ func TestInspectFilesUseDetachedContextForManifestListRead(t *testing.T) {
 
 		return inspectManifestListContextIO{
 			IO:                 baseFS,
-			rejectManifestList: ctx.Done() != nil,
+			rejectManifestList: ctx.Done() == nil,
 		}, nil
 	}
 
@@ -2235,6 +2235,31 @@ func TestInspectFilesUseDetachedContextForManifestListRead(t *testing.T) {
 	require.Len(t, paths, 3)
 	require.Len(t, contents, 3)
 	require.Equal(t, 2, calls)
+}
+
+func TestInspectFilesReuseManifestListIO(t *testing.T) {
+	for _, all := range []bool{false, true} {
+		t.Run(fmt.Sprintf("all=%t", all), func(t *testing.T) {
+			tbl := inspectAllFilesTable(t)
+			baseFS, err := tbl.fsF(t.Context())
+			require.NoError(t, err)
+			calls := 0
+			tbl.fsF = func(context.Context) (iceio.IO, error) {
+				calls++
+
+				return baseFS, nil
+			}
+			read := tbl.Inspect().Files
+			if all {
+				read = tbl.Inspect().AllFiles
+			}
+			rr, err := read(t.Context())
+			require.NoError(t, err)
+			paths, _ := inspectFileRows(t, rr)
+			require.NotEmpty(t, paths)
+			require.Equal(t, 1, calls, "manifest lists and entries should share the operation's IO")
+		})
+	}
 }
 
 func TestInspectAllFilesStopsOnContextCancellation(t *testing.T) {

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -2226,6 +2226,9 @@ func TestInspectFilesUseDetachedContextForManifestListRead(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	manifests, err := tbl.Inspect().Manifests(ctx)
+	require.NoError(t, err)
+	manifests.Release()
 	rr, err := tbl.Inspect().Files(ctx)
 	require.NoError(t, err)
 	paths, contents := inspectFileRows(t, rr)

--- a/table/inspect_internal_test.go
+++ b/table/inspect_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2193,6 +2194,44 @@ func TestInspectFilesTables(t *testing.T) {
 			require.Equal(t, tt.wantContent, contents)
 		})
 	}
+}
+
+type inspectManifestListContextIO struct {
+	iceio.IO
+	rejectManifestList bool
+}
+
+func (fs inspectManifestListContextIO) Open(path string) (iceio.File, error) {
+	if fs.rejectManifestList && strings.Contains(path, "manifest-list") {
+		return nil, errors.New("manifest list opened with caller-bound IO")
+	}
+
+	return fs.IO.Open(path)
+}
+
+func TestInspectFilesUseDetachedContextForManifestListRead(t *testing.T) {
+	tbl := inspectAllFilesTable(t)
+	baseFS, err := tbl.fsF(context.Background())
+	require.NoError(t, err)
+
+	var calls int
+	tbl.fsF = func(ctx context.Context) (iceio.IO, error) {
+		calls++
+
+		return inspectManifestListContextIO{
+			IO:                 baseFS,
+			rejectManifestList: ctx.Done() != nil,
+		}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rr, err := tbl.Inspect().Files(ctx)
+	require.NoError(t, err)
+	paths, contents := inspectFileRows(t, rr)
+	require.Len(t, paths, 3)
+	require.Len(t, contents, 3)
+	require.Equal(t, 2, calls)
 }
 
 func TestInspectAllFilesStopsOnContextCancellation(t *testing.T) {

--- a/table/inspect_partitions.go
+++ b/table/inspect_partitions.go
@@ -146,14 +146,15 @@ func (i InspectTable) partitionAggregates(ctx context.Context, partitionType *ic
 	if i.tbl.fsF == nil {
 		return nil, errors.New("table file IO is not configured")
 	}
+	manifestSet, err := i.tbl.manifestSet(ctx, *snapshot)
+	if err != nil {
+		return nil, err
+	}
 	fs, err := i.tbl.fsF(ctx)
 	if err != nil {
 		return nil, err
 	}
-	manifests, err := snapshot.Manifests(fs)
-	if err != nil {
-		return nil, err
-	}
+	manifests := manifestSet.allManifests()
 
 	snapshotTimes := make(map[int64]int64, len(i.tbl.metadata.Snapshots()))
 	for _, snapshot := range i.tbl.metadata.Snapshots() {

--- a/table/inspect_position_deletes.go
+++ b/table/inspect_position_deletes.go
@@ -80,16 +80,16 @@ func (i InspectTable) currentPositionDeleteManifests(
 	if i.tbl.fsF == nil {
 		return nil, nil, errors.New("table file IO is not configured")
 	}
+	manifestSet, err := i.tbl.manifestSet(ctx, *snapshot)
+	if err != nil {
+		return nil, nil, err
+	}
 	fs, err := i.tbl.fsF(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	manifests, err := snapshot.Manifests(fs)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return fs, manifests, nil
+	return fs, manifestSet.allManifests(), nil
 }
 
 type positionDeleteRecordAppender struct {

--- a/table/properties.go
+++ b/table/properties.go
@@ -40,6 +40,12 @@ const (
 	ReadSplitTargetSizeKey     = "read.split.target-size"
 	ReadSplitTargetSizeDefault = 128 * 1024 * 1024 // 128 MiB
 
+	// ReadManifestListCacheEnabledKey controls reuse of decoded snapshot
+	// manifest lists across scans of a table handle. Disable it to avoid
+	// retaining manifest descriptors between operations.
+	ReadManifestListCacheEnabledKey     = "read.manifest-list-cache.enabled"
+	ReadManifestListCacheEnabledDefault = true
+
 	// These Java-compatible properties are reserved for future task-group
 	// planning. They are exported so applications can share configuration
 	// names across Iceberg implementations.

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -976,13 +976,14 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 	// those counts should use fetchPartitionSpecFilteredManifestsWithSchema and
 	// pass in an accumulator it actually reads.
 	return scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		snap, fs, schema, &scanMetricsAccumulator{}, scan.partitionFiltersForSchema(schema))
+		ctx, snap, fs, schema, &scanMetricsAccumulator{}, scan.partitionFiltersForSchema(schema))
 }
 
 // fetchPartitionSpecFilteredManifestsWithSchema loads the snapshot's manifests
 // with fs and filters them using the given schema. It records
 // total/scanned/skipped manifest counts (split by data vs delete content) into acc.
 func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(
+	ctx context.Context,
 	snap *Snapshot,
 	fs io.IO,
 	schema *iceberg.Schema,
@@ -1004,7 +1005,6 @@ func (scan *Scan) manifestSet(
 	fio io.IO,
 ) (snapshotManifestSet, error) {
 	return scan.manifestCache.get(ctx, snapshot, fio)
->>>>>>> 90c4371 (perf(table): cache snapshot manifests across scans)
 }
 
 // filterManifestsWithSchema applies partition-summary pruning to an existing
@@ -1604,7 +1604,7 @@ func (scan *Scan) planFilesLocal(
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		snap, fs, schema, acc, partitionFilters)
+		ctx, snap, fs, schema, acc, partitionFilters)
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1594,10 +1594,6 @@ func (scan *Scan) planFilesLocal(
 	if err != nil || snap == nil {
 		return nil, err
 	}
-	// Keep the manifest-list load separate from manifest workers. Workers reuse
-	// one FileIO within each concurrent batch, while the next batch loads again
-	// so credential-renewing factories retain their checkpoints.
-
 	// Keep the projection cache alive across both local planning phases. The
 	// manifest and data-file evaluators need the same per-spec projections.
 	partitionFilters := scan.partitionFiltersForSchema(schema)

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -966,32 +966,27 @@ func (scan *Scan) fetchPartitionSpecFilteredManifests(ctx context.Context) ([]ic
 	if err != nil || snap == nil {
 		return nil, err
 	}
-	fs, err := scan.ioF(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	// This path has no reporter behind it, so the manifest counts recorded into
 	// this accumulator are intentionally discarded. A future caller that needs
 	// those counts should use fetchPartitionSpecFilteredManifestsWithSchema and
 	// pass in an accumulator it actually reads.
 	return scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		ctx, snap, fs, schema, &scanMetricsAccumulator{}, scan.partitionFiltersForSchema(schema))
+		ctx, snap, schema, &scanMetricsAccumulator{}, scan.partitionFiltersForSchema(schema))
 }
 
 // fetchPartitionSpecFilteredManifestsWithSchema loads the snapshot's manifests
-// with fs and filters them using the given schema. It records
+// and filters them using the given schema. It records
 // total/scanned/skipped manifest counts (split by data vs delete content) into acc.
 func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(
 	ctx context.Context,
 	snap *Snapshot,
-	fs io.IO,
 	schema *iceberg.Schema,
 	acc *scanMetricsAccumulator,
 	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression],
 ) ([]iceberg.ManifestFile, error) {
 	// Fetch all manifests for the current snapshot.
-	manifestSet, err := scan.manifestSet(ctx, *snap, fs)
+	manifestSet, err := scan.manifestSet(ctx, *snap)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,9 +997,18 @@ func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(
 func (scan *Scan) manifestSet(
 	ctx context.Context,
 	snapshot Snapshot,
-	fio io.IO,
 ) (snapshotManifestSet, error) {
-	return scan.manifestCache.get(ctx, snapshot, fio)
+	return scan.manifestSetWithFSF(ctx, snapshot, scan.ioF)
+}
+
+func (scan *Scan) manifestSetWithFSF(
+	ctx context.Context,
+	snapshot Snapshot,
+	fsF FSysF,
+) (snapshotManifestSet, error) {
+	return scan.manifestCache.get(ctx, snapshot, func(loadCtx context.Context) (snapshotManifestSet, error) {
+		return readSnapshotManifestSet(loadCtx, snapshot, fsF)
+	})
 }
 
 // filterManifestsWithSchema applies partition-summary pruning to an existing
@@ -1590,10 +1594,6 @@ func (scan *Scan) planFilesLocal(
 	if err != nil || snap == nil {
 		return nil, err
 	}
-	fs, err := scan.ioF(ctx)
-	if err != nil {
-		return nil, err
-	}
 	// Keep the manifest-list load separate from manifest workers. Workers reuse
 	// one FileIO within each concurrent batch, while the next batch loads again
 	// so credential-renewing factories retain their checkpoints.
@@ -1604,7 +1604,7 @@ func (scan *Scan) planFilesLocal(
 
 	// Step 1: Retrieve filtered manifests based on snapshot and partition specs.
 	manifestList, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		ctx, snap, fs, schema, acc, partitionFilters)
+		ctx, snap, schema, acc, partitionFilters)
 	if err != nil || len(manifestList) == 0 {
 		return nil, err
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -490,6 +490,7 @@ type Scan struct {
 	metadata            Metadata
 	metadataLocation    string
 	ioF                 FSysF
+	manifestCache       *snapshotManifestCache
 	planner             ScanPlanner
 	scanPlanningIOProps iceberg.Properties
 	planningMode        ScanPlanningMode
@@ -989,12 +990,21 @@ func (scan *Scan) fetchPartitionSpecFilteredManifestsWithSchema(
 	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression],
 ) ([]iceberg.ManifestFile, error) {
 	// Fetch all manifests for the current snapshot.
-	manifestList, err := snap.Manifests(fs)
+	manifestSet, err := scan.manifestSet(ctx, *snap, fs)
 	if err != nil {
 		return nil, err
 	}
 
-	return scan.filterManifestsWithSchema(manifestList, schema, acc, partitionFilters)
+	return scan.filterManifestsWithSchema(manifestSet.allManifests(), schema, acc, partitionFilters)
+}
+
+func (scan *Scan) manifestSet(
+	ctx context.Context,
+	snapshot Snapshot,
+	fio io.IO,
+) (snapshotManifestSet, error) {
+	return scan.manifestCache.get(ctx, snapshot, fio)
+>>>>>>> 90c4371 (perf(table): cache snapshot manifests across scans)
 }
 
 // filterManifestsWithSchema applies partition-summary pruning to an existing

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -1242,7 +1242,7 @@ func TestFetchManifestCountersWithRealSnapshot(t *testing.T) {
 	snapshot, err := scan.ResolveSnapshot()
 	require.NoError(t, err)
 	filtered, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		snapshot, memIO, schema, &acc, scan.partitionFiltersForSchema(schema))
+		context.Background(), snapshot, memIO, schema, &acc, scan.partitionFiltersForSchema(schema))
 	require.NoError(t, err)
 
 	// Two data manifests, one delete manifest.

--- a/table/scanner_internal_test.go
+++ b/table/scanner_internal_test.go
@@ -1242,7 +1242,7 @@ func TestFetchManifestCountersWithRealSnapshot(t *testing.T) {
 	snapshot, err := scan.ResolveSnapshot()
 	require.NoError(t, err)
 	filtered, err := scan.fetchPartitionSpecFilteredManifestsWithSchema(
-		context.Background(), snapshot, memIO, schema, &acc, scan.partitionFiltersForSchema(schema))
+		context.Background(), snapshot, schema, &acc, scan.partitionFiltersForSchema(schema))
 	require.NoError(t, err)
 
 	// Two data manifests, one delete manifest.

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// snapshotManifestSet keeps the complete manifest list and its content
+// partitions together. Manifest descriptors are immutable for an Iceberg
+// snapshot, so a table can safely share this decoded result across scans.
+type snapshotManifestSet struct {
+	all     []iceberg.ManifestFile
+	data    []iceberg.ManifestFile
+	deletes []iceberg.ManifestFile
+}
+
+func newSnapshotManifestSet(manifests []iceberg.ManifestFile) snapshotManifestSet {
+	set := snapshotManifestSet{all: slices.Clone(manifests)}
+	if len(manifests) == 0 {
+		return set
+	}
+
+	set.data = make([]iceberg.ManifestFile, 0, len(manifests))
+	set.deletes = make([]iceberg.ManifestFile, 0, len(manifests))
+	for _, manifest := range set.all {
+		if manifest.ManifestContent() == iceberg.ManifestContentDeletes {
+			set.deletes = append(set.deletes, manifest)
+		} else {
+			set.data = append(set.data, manifest)
+		}
+	}
+
+	return set
+}
+
+func (s snapshotManifestSet) allManifests() []iceberg.ManifestFile {
+	return slices.Clone(s.all)
+}
+
+func (s snapshotManifestSet) dataManifests() []iceberg.ManifestFile {
+	return slices.Clone(s.data)
+}
+
+func (s snapshotManifestSet) deleteManifests() []iceberg.ManifestFile {
+	return slices.Clone(s.deletes)
+}
+
+type snapshotManifestCacheKey struct {
+	snapshotID              int64
+	manifestList            string
+	hasEmbeddedSources      bool
+	embeddedManifestSources string
+}
+
+func snapshotManifestCacheKeyFor(snapshot Snapshot) snapshotManifestCacheKey {
+	var (
+		hasEmbeddedSources      bool
+		embeddedManifestSources string
+	)
+	if snapshot.ManifestList == "" {
+		hasEmbeddedSources = snapshot.ManifestLocations != nil
+		embeddedManifestSources = strings.Join(snapshot.ManifestLocations, "\x00")
+	}
+
+	return snapshotManifestCacheKey{
+		snapshotID:              snapshot.SnapshotID,
+		manifestList:            snapshot.ManifestList,
+		hasEmbeddedSources:      hasEmbeddedSources,
+		embeddedManifestSources: embeddedManifestSources,
+	}
+}
+
+type snapshotManifestCacheEntry struct {
+	ready     chan struct{}
+	manifests snapshotManifestSet
+	err       error
+}
+
+// snapshotManifestCache memoizes successful manifest-list reads and shares an
+// in-flight read with concurrent scans. Failed reads are removed so a
+// transient object-store error does not poison the cache.
+type snapshotManifestCache struct {
+	mu      sync.Mutex
+	entries map[snapshotManifestCacheKey]*snapshotManifestCacheEntry
+}
+
+func newSnapshotManifestCache() *snapshotManifestCache {
+	return &snapshotManifestCache{
+		entries: make(map[snapshotManifestCacheKey]*snapshotManifestCacheEntry),
+	}
+}
+
+func (c *snapshotManifestCache) get(
+	ctx context.Context,
+	snapshot Snapshot,
+	fio iceio.IO,
+) (snapshotManifestSet, error) {
+	if c == nil {
+		manifests, err := snapshot.Manifests(fio)
+
+		return newSnapshotManifestSet(manifests), err
+	}
+
+	key := snapshotManifestCacheKeyFor(snapshot)
+	c.mu.Lock()
+	if entry, ok := c.entries[key]; ok {
+		c.mu.Unlock()
+
+		select {
+		case <-entry.ready:
+			return entry.manifests, entry.err
+		default:
+			select {
+			case <-entry.ready:
+				return entry.manifests, entry.err
+			case <-ctx.Done():
+				return snapshotManifestSet{}, ctx.Err()
+			}
+		}
+	}
+
+	entry := &snapshotManifestCacheEntry{ready: make(chan struct{})}
+	c.entries[key] = entry
+	c.mu.Unlock()
+
+	manifests, err := snapshot.Manifests(fio)
+	value := newSnapshotManifestSet(manifests)
+
+	c.mu.Lock()
+	entry.manifests = value
+	entry.err = err
+	if err != nil {
+		delete(c.entries, key)
+	}
+	close(entry.ready)
+	c.mu.Unlock()
+
+	return value, err
+}

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -19,6 +19,7 @@ package table
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -51,10 +52,11 @@ func newSnapshotManifestSet(manifests []iceberg.ManifestFile) snapshotManifestSe
 	set.data = make([]iceberg.ManifestFile, 0, len(manifests))
 	set.deletes = make([]iceberg.ManifestFile, 0, len(manifests))
 	for _, manifest := range set.all {
-		if manifest.ManifestContent() == iceberg.ManifestContentDeletes {
-			set.deletes = append(set.deletes, manifest)
-		} else {
+		switch manifest.ManifestContent() {
+		case iceberg.ManifestContentData:
 			set.data = append(set.data, manifest)
+		case iceberg.ManifestContentDeletes:
+			set.deletes = append(set.deletes, manifest)
 		}
 	}
 
@@ -87,6 +89,8 @@ func snapshotManifestCacheKeyFor(snapshot Snapshot) snapshotManifestCacheKey {
 	)
 	if snapshot.ManifestList == "" {
 		hasEmbeddedSources = snapshot.ManifestLocations != nil
+		// Valid file locations cannot contain a literal NUL, so this join is
+		// collision-free while preserving nil versus empty locations.
 		embeddedManifestSources = strings.Join(snapshot.ManifestLocations, "\x00")
 	}
 
@@ -103,6 +107,8 @@ type snapshotManifestCacheEntry struct {
 	manifests snapshotManifestSet
 	err       error
 }
+
+type snapshotManifestLoader func(context.Context) (snapshotManifestSet, error)
 
 // snapshotManifestCache memoizes successful manifest-list reads and shares an
 // in-flight read with concurrent scans. Completed reads use a bounded LRU so a
@@ -130,12 +136,10 @@ func newSnapshotManifestCache() *snapshotManifestCache {
 func (c *snapshotManifestCache) get(
 	ctx context.Context,
 	snapshot Snapshot,
-	fio iceio.IO,
+	load snapshotManifestLoader,
 ) (snapshotManifestSet, error) {
 	if c == nil {
-		manifests, err := snapshot.Manifests(fio)
-
-		return newSnapshotManifestSet(manifests), err
+		return load(ctx)
 	}
 
 	key := snapshotManifestCacheKeyFor(snapshot)
@@ -165,10 +169,38 @@ func (c *snapshotManifestCache) get(
 	c.entries[key] = entry
 	c.mu.Unlock()
 
-	manifests, err := snapshot.Manifests(fio)
-	value := newSnapshotManifestSet(manifests)
+	var (
+		value snapshotManifestSet
+		err   error
+	)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.finish(key, entry, snapshotManifestSet{}, fmt.Errorf(
+				"panic while reading snapshot %d manifest list: %v", snapshot.SnapshotID, recovered))
+			panic(recovered)
+		}
 
+		c.finish(key, entry, value, err)
+	}()
+
+	value, err = load(ctx)
+
+	return value, err
+}
+
+func (c *snapshotManifestCache) finish(
+	key snapshotManifestCacheKey,
+	entry *snapshotManifestCacheEntry,
+	value snapshotManifestSet,
+	err error,
+) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if current, ok := c.entries[key]; !ok || current != entry {
+		return
+	}
+
 	delete(c.entries, key)
 	entry.manifests = value
 	entry.err = err
@@ -176,7 +208,55 @@ func (c *snapshotManifestCache) get(
 		c.complete.Add(key, value)
 	}
 	close(entry.ready)
-	c.mu.Unlock()
+}
 
-	return value, err
+func readSnapshotManifestSet(
+	ctx context.Context,
+	snapshot Snapshot,
+	fsF FSysF,
+) (snapshotManifestSet, error) {
+	if err := ctx.Err(); err != nil {
+		return snapshotManifestSet{}, err
+	}
+	if fsF == nil {
+		return snapshotManifestSet{}, fmt.Errorf("%w: table file IO is not configured", ErrInvalidOperation)
+	}
+
+	// Resolve the IO inside the producer so context-aware factories bind the
+	// producer context to the underlying manifest-list read.
+	fio, err := fsF(ctx)
+	if err != nil {
+		return snapshotManifestSet{}, err
+	}
+	manifests, err := snapshot.Manifests(fio)
+	if err != nil {
+		return snapshotManifestSet{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return snapshotManifestSet{}, err
+	}
+
+	return newSnapshotManifestSet(manifests), nil
+}
+
+func sharedSnapshotManifestFSF(fsF FSysF) FSysF {
+	var (
+		once sync.Once
+		fio  iceio.IO
+		err  error
+	)
+
+	return func(ctx context.Context) (iceio.IO, error) {
+		once.Do(func() {
+			if fsF == nil {
+				err = fmt.Errorf("%w: table file IO is not configured", ErrInvalidOperation)
+
+				return
+			}
+
+			fio, err = fsF(ctx)
+		})
+
+		return fio, err
+	}
 }

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -34,29 +34,35 @@ import (
 // history is enough to retain useful locality for repeated historical scans.
 const snapshotManifestCacheSize = 64
 
-// snapshotManifestSet keeps the complete manifest list and its content
-// partitions together. Manifest descriptors are immutable for an Iceberg
-// snapshot, so a table can safely share this decoded result across scans.
+// snapshotManifestCacheManifestLimit bounds the total number of manifest
+// descriptors retained by the cache. This keeps a small number of unusually
+// large snapshots from consuming an unbounded amount of memory.
+const snapshotManifestCacheManifestLimit = 16 * 1024
+
+// snapshotManifestSet keeps the complete manifest list and data partition
+// together. Manifest descriptors are immutable for an Iceberg snapshot, so a
+// table can safely share this decoded result across scans.
 type snapshotManifestSet struct {
-	all     []iceberg.ManifestFile
-	data    []iceberg.ManifestFile
-	deletes []iceberg.ManifestFile
+	all  []iceberg.ManifestFile
+	data []iceberg.ManifestFile
 }
 
 func newSnapshotManifestSet(manifests []iceberg.ManifestFile) snapshotManifestSet {
-	set := snapshotManifestSet{all: slices.Clone(manifests)}
-	if len(manifests) == 0 {
+	set := snapshotManifestSet{all: manifests}
+	dataCount := 0
+	for _, manifest := range manifests {
+		if manifest.ManifestContent() == iceberg.ManifestContentData {
+			dataCount++
+		}
+	}
+	if dataCount == 0 {
 		return set
 	}
 
-	set.data = make([]iceberg.ManifestFile, 0, len(manifests))
-	set.deletes = make([]iceberg.ManifestFile, 0, len(manifests))
-	for _, manifest := range set.all {
-		switch manifest.ManifestContent() {
-		case iceberg.ManifestContentData:
+	set.data = make([]iceberg.ManifestFile, 0, dataCount)
+	for _, manifest := range manifests {
+		if manifest.ManifestContent() == iceberg.ManifestContentData {
 			set.data = append(set.data, manifest)
-		case iceberg.ManifestContentDeletes:
-			set.deletes = append(set.deletes, manifest)
 		}
 	}
 
@@ -71,8 +77,8 @@ func (s snapshotManifestSet) dataManifests() []iceberg.ManifestFile {
 	return slices.Clone(s.data)
 }
 
-func (s snapshotManifestSet) deleteManifests() []iceberg.ManifestFile {
-	return slices.Clone(s.deletes)
+func snapshotManifestSetSize(set snapshotManifestSet) int {
+	return len(set.all) + len(set.data)
 }
 
 type snapshotManifestCacheKey struct {
@@ -116,21 +122,28 @@ type snapshotManifestLoader func(context.Context) (snapshotManifestSet, error)
 // Failed reads are removed so a transient object-store error does not poison
 // the cache.
 type snapshotManifestCache struct {
-	mu       sync.Mutex
-	entries  map[snapshotManifestCacheKey]*snapshotManifestCacheEntry
-	complete *lru.Cache[snapshotManifestCacheKey, snapshotManifestSet]
+	mu                    sync.Mutex
+	entries               map[snapshotManifestCacheKey]*snapshotManifestCacheEntry
+	complete              *lru.Cache[snapshotManifestCacheKey, snapshotManifestSet]
+	completeManifestCount int
 }
 
 func newSnapshotManifestCache() *snapshotManifestCache {
-	complete, err := lru.New[snapshotManifestCacheKey, snapshotManifestSet](snapshotManifestCacheSize)
+	cache := &snapshotManifestCache{
+		entries: make(map[snapshotManifestCacheKey]*snapshotManifestCacheEntry),
+	}
+	complete, err := lru.NewWithEvict(
+		snapshotManifestCacheSize,
+		func(_ snapshotManifestCacheKey, value snapshotManifestSet) {
+			cache.completeManifestCount -= snapshotManifestSetSize(value)
+		},
+	)
 	if err != nil {
 		panic(err)
 	}
+	cache.complete = complete
 
-	return &snapshotManifestCache{
-		entries:  make(map[snapshotManifestCacheKey]*snapshotManifestCacheEntry),
-		complete: complete,
-	}
+	return cache
 }
 
 func (c *snapshotManifestCache) get(
@@ -140,6 +153,9 @@ func (c *snapshotManifestCache) get(
 ) (snapshotManifestSet, error) {
 	if c == nil {
 		return load(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return snapshotManifestSet{}, err
 	}
 
 	key := snapshotManifestCacheKeyFor(snapshot)
@@ -183,7 +199,9 @@ func (c *snapshotManifestCache) get(
 		c.finish(key, entry, value, err)
 	}()
 
-	value, err = load(ctx)
+	// The read is shared with callers whose contexts may outlive this one. Do
+	// not let the producer's cancellation abort a healthy waiter's read.
+	value, err = load(context.WithoutCancel(ctx))
 
 	return value, err
 }
@@ -205,7 +223,16 @@ func (c *snapshotManifestCache) finish(
 	entry.manifests = value
 	entry.err = err
 	if err == nil {
+		if c.complete.Contains(key) {
+			c.complete.Remove(key)
+		}
 		c.complete.Add(key, value)
+		c.completeManifestCount += snapshotManifestSetSize(value)
+		for c.completeManifestCount > snapshotManifestCacheManifestLimit {
+			if _, _, ok := c.complete.RemoveOldest(); !ok {
+				break
+			}
+		}
 	}
 	close(entry.ready)
 }
@@ -223,16 +250,13 @@ func readSnapshotManifestSet(
 	}
 
 	// Resolve the IO inside the producer so context-aware factories bind the
-	// producer context to the underlying manifest-list read.
+	// detached producer context to the underlying manifest-list read.
 	fio, err := fsF(ctx)
 	if err != nil {
 		return snapshotManifestSet{}, err
 	}
 	manifests, err := snapshot.Manifests(fio)
 	if err != nil {
-		return snapshotManifestSet{}, err
-	}
-	if err := ctx.Err(); err != nil {
 		return snapshotManifestSet{}, err
 	}
 

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -35,8 +35,8 @@ import (
 const snapshotManifestCacheSize = 64
 
 // snapshotManifestCacheManifestLimit bounds the total number of manifest
-// descriptors retained by the cache. This keeps a small number of unusually
-// large snapshots from consuming an unbounded amount of memory.
+// descriptors retained by the cache. Memory per descriptor also depends on
+// paths, partition summaries, and key metadata; this is not a byte limit.
 const snapshotManifestCacheManifestLimit = 32 * 1024
 
 // snapshotManifestSet keeps the complete manifest list and data partition
@@ -78,7 +78,7 @@ func (s snapshotManifestSet) dataManifests() []iceberg.ManifestFile {
 }
 
 func snapshotManifestSetSize(set snapshotManifestSet) int {
-	return len(set.all) + len(set.data)
+	return len(set.all)
 }
 
 type snapshotManifestCacheKey struct {
@@ -113,6 +113,7 @@ type snapshotManifestCacheEntry struct {
 	readyOnce sync.Once
 	manifests snapshotManifestSet
 	err       error
+	canceled  bool
 }
 
 type snapshotManifestLoader func(context.Context) (snapshotManifestSet, error)
@@ -147,6 +148,14 @@ func newSnapshotManifestCache() *snapshotManifestCache {
 	return cache
 }
 
+func newSnapshotManifestCacheForMetadata(meta Metadata) *snapshotManifestCache {
+	if meta != nil && !meta.Properties().GetBool(ReadManifestListCacheEnabledKey, ReadManifestListCacheEnabledDefault) {
+		return nil
+	}
+
+	return newSnapshotManifestCache()
+}
+
 func (c *snapshotManifestCache) get(
 	ctx context.Context,
 	snapshot Snapshot,
@@ -155,37 +164,54 @@ func (c *snapshotManifestCache) get(
 	if c == nil {
 		return load(ctx)
 	}
-	if err := ctx.Err(); err != nil {
-		return snapshotManifestSet{}, err
-	}
-
 	key := snapshotManifestCacheKeyFor(snapshot)
-	c.mu.Lock()
-	if manifests, ok := c.complete.Get(key); ok {
-		c.mu.Unlock()
+	for {
+		if err := ctx.Err(); err != nil {
+			return snapshotManifestSet{}, err
+		}
 
-		return manifests, nil
-	}
-	if entry, ok := c.entries[key]; ok {
-		c.mu.Unlock()
+		c.mu.Lock()
+		if manifests, ok := c.complete.Get(key); ok {
+			c.mu.Unlock()
 
-		select {
-		case <-entry.ready:
-			return entry.manifests, entry.err
-		default:
+			return manifests, nil
+		}
+		if entry, ok := c.entries[key]; ok {
+			c.mu.Unlock()
+
 			select {
 			case <-entry.ready:
-				return entry.manifests, entry.err
-			case <-ctx.Done():
-				return snapshotManifestSet{}, ctx.Err()
+			default:
+				select {
+				case <-entry.ready:
+				case <-ctx.Done():
+					return snapshotManifestSet{}, ctx.Err()
+				}
 			}
+			// A failed read owned by a canceled caller must not fail an
+			// independent scan. Retry with this caller's context and FileIO.
+			if entry.canceled {
+				continue
+			}
+
+			return entry.manifests, entry.err
 		}
+
+		entry := &snapshotManifestCacheEntry{ready: make(chan struct{})}
+		c.entries[key] = entry
+		c.mu.Unlock()
+
+		return c.load(ctx, snapshot, key, entry, load)
 	}
+}
 
-	entry := &snapshotManifestCacheEntry{ready: make(chan struct{})}
-	c.entries[key] = entry
-	c.mu.Unlock()
-
+func (c *snapshotManifestCache) load(
+	ctx context.Context,
+	snapshot Snapshot,
+	key snapshotManifestCacheKey,
+	entry *snapshotManifestCacheEntry,
+	load snapshotManifestLoader,
+) (snapshotManifestSet, error) {
 	var (
 		value snapshotManifestSet
 		err   error
@@ -197,12 +223,13 @@ func (c *snapshotManifestCache) get(
 			panic(recovered)
 		}
 
+		entry.canceled = err != nil && ctx.Err() != nil
 		c.finish(key, entry, value, err)
 	}()
 
-	// The read is shared with callers whose contexts may outlive this one. Do
-	// not let the producer's cancellation abort a healthy waiter's read.
-	value, err = load(context.WithoutCancel(ctx))
+	// Both factory resolution and context-bound IO must stop with the caller.
+	// Healthy waiters retry a canceled load instead of inheriting its error.
+	value, err = load(ctx)
 
 	return value, err
 }
@@ -219,9 +246,6 @@ func (c *snapshotManifestCache) finish(
 	if current, ok := c.entries[key]; ok && current == entry {
 		delete(c.entries, key)
 		if err == nil {
-			if c.complete.Contains(key) {
-				c.complete.Remove(key)
-			}
 			c.complete.Add(key, value)
 			c.completeManifestCount += snapshotManifestSetSize(value)
 			for c.completeManifestCount > snapshotManifestCacheManifestLimit {
@@ -249,11 +273,11 @@ func readSnapshotManifestSet(
 		return snapshotManifestSet{}, fmt.Errorf("%w: table file IO is not configured", ErrInvalidOperation)
 	}
 
-	// Resolve the IO inside the producer so context-aware factories bind the
-	// detached producer context to the underlying manifest-list read.
+	// Keep factory resolution and the resulting FileIO on the same cancellable
+	// context, including backends that capture it for subsequent reads.
 	fio, err := fsF(ctx)
 	if err != nil {
-		return snapshotManifestSet{}, err
+		return snapshotManifestSet{}, fmt.Errorf("get file IO: %w", err)
 	}
 	manifests, err := snapshot.Manifests(fio)
 	if err != nil {

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -37,7 +37,7 @@ const snapshotManifestCacheSize = 64
 // snapshotManifestCacheManifestLimit bounds the total number of manifest
 // descriptors retained by the cache. This keeps a small number of unusually
 // large snapshots from consuming an unbounded amount of memory.
-const snapshotManifestCacheManifestLimit = 16 * 1024
+const snapshotManifestCacheManifestLimit = 32 * 1024
 
 // snapshotManifestSet keeps the complete manifest list and data partition
 // together. Manifest descriptors are immutable for an Iceberg snapshot, so a
@@ -110,6 +110,7 @@ func snapshotManifestCacheKeyFor(snapshot Snapshot) snapshotManifestCacheKey {
 
 type snapshotManifestCacheEntry struct {
 	ready     chan struct{}
+	readyOnce sync.Once
 	manifests snapshotManifestSet
 	err       error
 }
@@ -215,26 +216,25 @@ func (c *snapshotManifestCache) finish(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if current, ok := c.entries[key]; !ok || current != entry {
-		return
-	}
-
-	delete(c.entries, key)
-	entry.manifests = value
-	entry.err = err
-	if err == nil {
-		if c.complete.Contains(key) {
-			c.complete.Remove(key)
-		}
-		c.complete.Add(key, value)
-		c.completeManifestCount += snapshotManifestSetSize(value)
-		for c.completeManifestCount > snapshotManifestCacheManifestLimit {
-			if _, _, ok := c.complete.RemoveOldest(); !ok {
-				break
+	if current, ok := c.entries[key]; ok && current == entry {
+		delete(c.entries, key)
+		if err == nil {
+			if c.complete.Contains(key) {
+				c.complete.Remove(key)
+			}
+			c.complete.Add(key, value)
+			c.completeManifestCount += snapshotManifestSetSize(value)
+			for c.completeManifestCount > snapshotManifestCacheManifestLimit {
+				if _, _, ok := c.complete.RemoveOldest(); !ok {
+					break
+				}
 			}
 		}
 	}
-	close(entry.ready)
+
+	entry.manifests = value
+	entry.err = err
+	entry.readyOnce.Do(func() { close(entry.ready) })
 }
 
 func readSnapshotManifestSet(

--- a/table/snapshot_manifest_cache.go
+++ b/table/snapshot_manifest_cache.go
@@ -25,7 +25,13 @@ import (
 
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
+
+// snapshotManifestCacheSize bounds the number of decoded manifest lists held
+// by a table. A table normally reuses its current snapshot, while a bounded
+// history is enough to retain useful locality for repeated historical scans.
+const snapshotManifestCacheSize = 64
 
 // snapshotManifestSet keeps the complete manifest list and its content
 // partitions together. Manifest descriptors are immutable for an Iceberg
@@ -99,16 +105,25 @@ type snapshotManifestCacheEntry struct {
 }
 
 // snapshotManifestCache memoizes successful manifest-list reads and shares an
-// in-flight read with concurrent scans. Failed reads are removed so a
-// transient object-store error does not poison the cache.
+// in-flight read with concurrent scans. Completed reads use a bounded LRU so a
+// historical scan cannot retain every snapshot for the lifetime of a table.
+// Failed reads are removed so a transient object-store error does not poison
+// the cache.
 type snapshotManifestCache struct {
-	mu      sync.Mutex
-	entries map[snapshotManifestCacheKey]*snapshotManifestCacheEntry
+	mu       sync.Mutex
+	entries  map[snapshotManifestCacheKey]*snapshotManifestCacheEntry
+	complete *lru.Cache[snapshotManifestCacheKey, snapshotManifestSet]
 }
 
 func newSnapshotManifestCache() *snapshotManifestCache {
+	complete, err := lru.New[snapshotManifestCacheKey, snapshotManifestSet](snapshotManifestCacheSize)
+	if err != nil {
+		panic(err)
+	}
+
 	return &snapshotManifestCache{
-		entries: make(map[snapshotManifestCacheKey]*snapshotManifestCacheEntry),
+		entries:  make(map[snapshotManifestCacheKey]*snapshotManifestCacheEntry),
+		complete: complete,
 	}
 }
 
@@ -125,6 +140,11 @@ func (c *snapshotManifestCache) get(
 
 	key := snapshotManifestCacheKeyFor(snapshot)
 	c.mu.Lock()
+	if manifests, ok := c.complete.Get(key); ok {
+		c.mu.Unlock()
+
+		return manifests, nil
+	}
 	if entry, ok := c.entries[key]; ok {
 		c.mu.Unlock()
 
@@ -149,10 +169,11 @@ func (c *snapshotManifestCache) get(
 	value := newSnapshotManifestSet(manifests)
 
 	c.mu.Lock()
+	delete(c.entries, key)
 	entry.manifests = value
 	entry.err = err
-	if err != nil {
-		delete(c.entries, key)
+	if err == nil {
+		c.complete.Add(key, value)
 	}
 	close(entry.ready)
 	c.mu.Unlock()

--- a/table/snapshot_manifest_cache_bench_test.go
+++ b/table/snapshot_manifest_cache_bench_test.go
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+var snapshotManifestCacheBenchmarkSink int
+
+func BenchmarkPlanFilesSnapshotManifestCache(b *testing.B) {
+	const manifestListPath = "mem://row-limit-benchmark/metadata/snap-1.avro"
+
+	for _, manifestCount := range []int{1, 1_000, 10_000} {
+		for _, scanCount := range []int{1, 2, 10} {
+			for _, cached := range []bool{false, true} {
+				name := "without-cache"
+				if cached {
+					name = "with-cache"
+				}
+				b.Run(fmt.Sprintf("manifests=%d/scans=%d/%s", manifestCount, scanCount, name), func(b *testing.B) {
+					tbl := newRowLimitPlanningBenchmarkTable(b, manifestCount)
+					baseFS, err := tbl.fsF(context.Background())
+					if err != nil {
+						b.Fatal(err)
+					}
+					fs := &snapshotManifestCacheBenchmarkIO{
+						IO:    baseFS,
+						opens: make(map[string]int),
+					}
+					tbl.fsF = testFSF(fs)
+					if !cached {
+						tbl.manifestCache = nil
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						for range scanCount {
+							tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(context.Background())
+							if err != nil {
+								b.Fatal(err)
+							}
+							snapshotManifestCacheBenchmarkSink = len(tasks)
+						}
+					}
+					b.StopTimer()
+					fs.mu.Lock()
+					listOpens := fs.opens[manifestListPath]
+					fs.mu.Unlock()
+					b.ReportMetric(float64(listOpens), "manifest-list-opens")
+				})
+			}
+		}
+	}
+}
+
+type snapshotManifestCacheBenchmarkIO struct {
+	iceio.IO
+
+	mu    sync.Mutex
+	opens map[string]int
+}
+
+func (fs *snapshotManifestCacheBenchmarkIO) Open(name string) (iceio.File, error) {
+	fs.mu.Lock()
+	fs.opens[name]++
+	fs.mu.Unlock()
+
+	return fs.IO.Open(name)
+}

--- a/table/snapshot_manifest_cache_bench_test.go
+++ b/table/snapshot_manifest_cache_bench_test.go
@@ -56,6 +56,13 @@ func BenchmarkPlanFilesSnapshotManifestCache(b *testing.B) {
 					b.ReportAllocs()
 					b.ResetTimer()
 					for range b.N {
+						b.StopTimer()
+						if cached {
+							tbl.manifestCache = newSnapshotManifestCache()
+						} else {
+							tbl.manifestCache = nil
+						}
+						b.StartTimer()
 						for range scanCount {
 							tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(context.Background())
 							if err != nil {
@@ -68,7 +75,7 @@ func BenchmarkPlanFilesSnapshotManifestCache(b *testing.B) {
 					fs.mu.Lock()
 					listOpens := fs.opens[manifestListPath]
 					fs.mu.Unlock()
-					b.ReportMetric(float64(listOpens), "manifest-list-opens")
+					b.ReportMetric(float64(listOpens)/float64(b.N), "manifest-list-opens")
 				})
 			}
 		}

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -96,15 +96,12 @@ func TestSnapshotManifestCacheSeparatesContentAndProtectsSlices(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, set.allManifests(), 2)
 	require.Len(t, set.dataManifests(), 1)
-	require.Len(t, set.deleteManifests(), 1)
 
 	all := set.allManifests()
 	all[0] = nil
 	assert.Equal(t, "data.avro", set.allManifests()[0].FilePath())
 	dataManifests := set.dataManifests()
-	deleteManifests := set.deleteManifests()
 	assert.Equal(t, "data.avro", dataManifests[0].FilePath())
-	assert.Equal(t, "delete.avro", deleteManifests[0].FilePath())
 }
 
 func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
@@ -127,11 +124,13 @@ func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
 	const callers = 16
 	errs := make(chan error, callers)
+	waitersStarted := make(chan struct{}, callers)
 	var release sync.Once
 	t.Cleanup(func() { release.Do(func() { close(fs.release) }) })
 	for range callers {
+		ctx := &countingContext{Context: t.Context(), entered: waitersStarted}
 		go func() {
-			_, err := cache.get(t.Context(), snapshot, testSnapshotManifestLoader(snapshot, fs))
+			_, err := cache.get(ctx, snapshot, testSnapshotManifestLoader(snapshot, fs))
 			errs <- err
 		}()
 	}
@@ -140,6 +139,13 @@ func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
 	case <-fs.started:
 	case <-time.After(time.Second):
 		t.Fatal("manifest-list read did not start")
+	}
+	for range callers - 1 {
+		select {
+		case <-waitersStarted:
+		case <-time.After(time.Second):
+			t.Fatal("all concurrent callers did not wait on the shared read")
+		}
 	}
 	release.Do(func() { close(fs.release) })
 
@@ -204,6 +210,21 @@ func TestSnapshotManifestCacheBoundsCompletedEntries(t *testing.T) {
 	assert.LessOrEqual(t, cache.complete.Len(), snapshotManifestCacheSize)
 }
 
+func TestSnapshotManifestCacheBoundsManifestDescriptors(t *testing.T) {
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/large.avro"}
+	largeSet := snapshotManifestSet{
+		all: make([]iceberg.ManifestFile, snapshotManifestCacheManifestLimit+1),
+	}
+
+	_, err := cache.get(context.Background(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		return largeSet, nil
+	})
+	require.NoError(t, err)
+	assert.Zero(t, cache.complete.Len(), "an oversized manifest set should not be retained")
+	assert.Zero(t, cache.completeManifestCount)
+}
+
 func TestTableRefreshReplacesSnapshotManifestCache(t *testing.T) {
 	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
 		"mem://snapshot-manifest-cache-refresh", nil)
@@ -255,27 +276,17 @@ func (fs *blockingSnapshotManifestIO) Open(name string) (iceio.File, error) {
 	return fs.IO.Open(name)
 }
 
-type contextAwareSnapshotManifestIO struct {
-	iceio.IO
-	ctx     context.Context
-	started chan struct{}
-	once    sync.Once
-}
-
-func (fs *contextAwareSnapshotManifestIO) Open(string) (iceio.File, error) {
-	fs.once.Do(func() { close(fs.started) })
-	<-fs.ctx.Done()
-
-	return nil, fs.ctx.Err()
-}
-
 type notifyingContext struct {
 	context.Context
 	entered chan struct{}
 	once    sync.Once
 }
 
-type producerContextKey struct{}
+type countingContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
 
 func (c *notifyingContext) Done() <-chan struct{} {
 	c.once.Do(func() { close(c.entered) })
@@ -283,41 +294,86 @@ func (c *notifyingContext) Done() <-chan struct{} {
 	return c.Context.Done()
 }
 
-func TestSnapshotManifestCacheProducerContextCancelsRead(t *testing.T) {
-	base := iceio.NewMemFS()
+func (c *countingContext) Done() <-chan struct{} {
+	c.once.Do(func() { c.entered <- struct{}{} })
+
+	return c.Context.Done()
+}
+
+type producerContextKey struct{}
+
+func TestSnapshotManifestCacheProducerCancellationDoesNotCancelSharedRead(t *testing.T) {
 	cache := newSnapshotManifestCache()
-	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/context-cancel.avro"}
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/detached-context.avro"}
 	ctx, cancel := context.WithCancel(t.Context())
 	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 	load := func(loadCtx context.Context) (snapshotManifestSet, error) {
-		return readSnapshotManifestSet(loadCtx, snapshot, func(ioCtx context.Context) (iceio.IO, error) {
-			return &contextAwareSnapshotManifestIO{IO: base, ctx: ioCtx, started: started}, nil
-		})
+		close(started)
+		select {
+		case <-release:
+			return snapshotManifestSet{}, nil
+		case <-loadCtx.Done():
+			return snapshotManifestSet{}, loadCtx.Err()
+		}
 	}
 
-	done := make(chan error, 1)
+	producerDone := make(chan error, 1)
 	go func() {
 		_, err := cache.get(ctx, snapshot, load)
-		done <- err
+		producerDone <- err
 	}()
 	select {
 	case <-started:
 	case <-time.After(time.Second):
 		t.Fatal("manifest-list read did not start")
 	}
+	waiterEntered := make(chan struct{}, 1)
+	waiterDone := make(chan error, 1)
+	waiterCtx := &countingContext{Context: t.Context(), entered: waiterEntered}
+	go func() {
+		_, err := cache.get(waiterCtx, snapshot, load)
+		waiterDone <- err
+	}()
+	select {
+	case <-waiterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not start waiting on the shared read")
+	}
 	cancel()
 
 	select {
-	case err := <-done:
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(time.Second):
-		t.Fatal("producer did not stop after context cancellation")
+	case err := <-producerDone:
+		t.Fatalf("producer stopped after its context was canceled: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 
-	_, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
-		return snapshotManifestSet{}, nil
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-producerDone)
+	require.NoError(t, <-waiterDone)
+}
+
+func TestReadSnapshotManifestSetKeepsCompletedReadAfterCancellation(t *testing.T) {
+	fs := iceio.NewMemFS()
+	var list bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0, nil))
+	const listPath = "mem://snapshot-manifest-cache/late-cancel.avro"
+	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
+
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	set, err := readSnapshotManifestSet(ctx, snapshot, func(context.Context) (iceio.IO, error) {
+		cancel()
+
+		return fs, nil
 	})
+
 	require.NoError(t, err)
+	assert.Empty(t, set.allManifests())
 }
 
 func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T) {
@@ -374,6 +430,8 @@ func TestSnapshotManifestCachePanickingProducerUnblocksWaiters(t *testing.T) {
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/panic.avro"}
 	started := make(chan struct{})
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 	load := func(context.Context) (snapshotManifestSet, error) {
 		close(started)
 		<-release
@@ -403,7 +461,7 @@ func TestSnapshotManifestCachePanickingProducerUnblocksWaiters(t *testing.T) {
 		t.Fatal("waiter did not start waiting on the producer")
 	}
 
-	close(release)
+	releaseOnce.Do(func() { close(release) })
 	select {
 	case err := <-waiterDone:
 		require.Error(t, err)
@@ -419,7 +477,7 @@ func TestSnapshotManifestCachePanickingProducerUnblocksWaiters(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSnapshotManifestCachePassesProducerContextToLoader(t *testing.T) {
+func TestSnapshotManifestCacheUsesDetachedProducerContext(t *testing.T) {
 	cache := newSnapshotManifestCache()
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/context.avro"}
 	ctx := context.WithValue(t.Context(), producerContextKey{}, "producer")
@@ -431,7 +489,9 @@ func TestSnapshotManifestCachePassesProducerContextToLoader(t *testing.T) {
 		return snapshotManifestSet{}, nil
 	})
 	require.NoError(t, err)
-	assert.Same(t, ctx, <-seen)
+	loadCtx := <-seen
+	assert.Equal(t, "producer", loadCtx.Value(producerContextKey{}))
+	assert.Nil(t, loadCtx.Done())
 }
 
 func TestSnapshotManifestCacheDoesNotClassifyUnknownContentAsData(t *testing.T) {
@@ -448,7 +508,6 @@ func TestSnapshotManifestCacheDoesNotClassifyUnknownContentAsData(t *testing.T) 
 
 	assert.Len(t, set.allManifests(), 3)
 	assert.Len(t, set.dataManifests(), 1)
-	assert.Len(t, set.deleteManifests(), 1)
 }
 
 func TestTransactionScanUsesAnIsolatedSnapshotManifestCache(t *testing.T) {

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -159,6 +160,39 @@ func TestSnapshotManifestCacheRetriesFailedRead(t *testing.T) {
 	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
 	_, err = cache.get(context.Background(), snapshot, fs)
 	require.NoError(t, err)
+}
+
+func TestSnapshotManifestCacheBoundsCompletedEntries(t *testing.T) {
+	fs := newTrackingCallsIO()
+	cache := newSnapshotManifestCache()
+	sequenceNumber := int64(1)
+	snapshots := make([]Snapshot, snapshotManifestCacheSize+1)
+	for i := range snapshots {
+		var list bytes.Buffer
+		require.NoError(t, iceberg.WriteManifestList(2, &list, int64(i), nil, &sequenceNumber, 0, nil))
+		path := fmt.Sprintf("mem://snapshot-manifest-cache/bounded-%d.avro", i)
+		require.NoError(t, fs.WriteFile(path, list.Bytes()))
+		snapshots[i] = Snapshot{SnapshotID: int64(i), ManifestList: path}
+	}
+
+	for i := range snapshotManifestCacheSize {
+		_, err := cache.get(context.Background(), snapshots[i], fs)
+		require.NoError(t, err)
+	}
+	_, err := cache.get(context.Background(), snapshots[0], fs)
+	require.NoError(t, err)
+	_, err = cache.get(context.Background(), snapshots[snapshotManifestCacheSize], fs)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, fs.openCount[snapshots[0].ManifestList])
+	assert.Equal(t, 1, fs.openCount[snapshots[1].ManifestList])
+	_, err = cache.get(context.Background(), snapshots[0], fs)
+	require.NoError(t, err)
+	_, err = cache.get(context.Background(), snapshots[1], fs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fs.openCount[snapshots[0].ManifestList])
+	assert.Equal(t, 2, fs.openCount[snapshots[1].ManifestList])
+	assert.LessOrEqual(t, cache.complete.Len(), snapshotManifestCacheSize)
 }
 
 func TestTableRefreshReplacesSnapshotManifestCache(t *testing.T) {

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -1,0 +1,213 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableScansReuseSnapshotManifestList(t *testing.T) {
+	fs := newTrackingCallsIO()
+	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://snapshot-manifest-cache", iceberg.Properties{PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(meta, "")
+	require.NoError(t, err)
+
+	const snapshotID = int64(1)
+	manifestPath := "mem://snapshot-manifest-cache/metadata/manifest.avro"
+	manifest := writeManifest(t, fs.trackingIO, snapshotID, 1, manifestPath,
+		"mem://snapshot-manifest-cache/data/file.parquet")
+	manifestListPath := "mem://snapshot-manifest-cache/metadata/snap.avro"
+	writeManifestList(t, fs.trackingIO, snapshotID, manifestListPath, []iceberg.ManifestFile{manifest})
+
+	schemaID := meta.CurrentSchema().ID
+	require.NoError(t, builder.AddSnapshot(&Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: 1,
+		TimestampMs:    meta.LastUpdatedMillis() + 1,
+		ManifestList:   manifestListPath,
+		Summary:        &Summary{Operation: OpAppend},
+		SchemaID:       &schemaID,
+	}))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, snapshotID, BranchRef))
+	built, err := builder.Build()
+	require.NoError(t, err)
+
+	tbl := New(Identifier{"db", "snapshot-manifest-cache"}, built, "metadata.json", testFSF(fs), nil)
+	for range 2 {
+		tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(context.Background())
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+	}
+
+	assert.Equal(t, 1, fs.openCount[manifestListPath], "manifest list should be decoded once across scans")
+	assert.Equal(t, 2, fs.openCount[manifestPath], "manifest entries still need to be read for each plan")
+}
+
+func TestSnapshotManifestCacheSeparatesContentAndProtectsSlices(t *testing.T) {
+	data := iceberg.NewManifestFile(2, "data.avro", 10, 0, 1).Build()
+	deleteManifest := iceberg.NewManifestFile(2, "delete.avro", 20, 0, 1).
+		Content(iceberg.ManifestContentDeletes).
+		Build()
+	cache := newSnapshotManifestCache()
+
+	fs := iceio.NewMemFS()
+	var list bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{data, deleteManifest}))
+	const listPath = "mem://snapshot-manifest-cache/separate.avro"
+	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
+
+	set, err := cache.get(context.Background(), Snapshot{SnapshotID: 1, ManifestList: listPath}, fs)
+	require.NoError(t, err)
+	require.Len(t, set.allManifests(), 2)
+	require.Len(t, set.dataManifests(), 1)
+	require.Len(t, set.deleteManifests(), 1)
+
+	all := set.allManifests()
+	all[0] = nil
+	assert.Equal(t, "data.avro", set.allManifests()[0].FilePath())
+	dataManifests := set.dataManifests()
+	deleteManifests := set.deleteManifests()
+	assert.Equal(t, "data.avro", dataManifests[0].FilePath())
+	assert.Equal(t, "delete.avro", deleteManifests[0].FilePath())
+}
+
+func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
+	const listPath = "mem://snapshot-manifest-cache/concurrent.avro"
+	base := iceio.NewMemFS()
+	var list bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{}))
+	require.NoError(t, base.WriteFile(listPath, list.Bytes()))
+
+	fs := &blockingSnapshotManifestIO{
+		IO:          base,
+		blockedPath: listPath,
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+		opens:       make(map[string]int),
+	}
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
+	const callers = 16
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			_, err := cache.get(context.Background(), snapshot, fs)
+			errs <- err
+		}()
+	}
+
+	select {
+	case <-fs.started:
+	case <-time.After(time.Second):
+		t.Fatal("manifest-list read did not start")
+	}
+	close(fs.release)
+
+	for range callers {
+		require.NoError(t, <-errs)
+	}
+
+	fs.mu.Lock()
+	openCount := fs.opens[listPath]
+	fs.mu.Unlock()
+	assert.Equal(t, 1, openCount, "concurrent scans should share the first manifest-list read")
+}
+
+func TestSnapshotManifestCacheRetriesFailedRead(t *testing.T) {
+	const listPath = "mem://snapshot-manifest-cache/retry.avro"
+	fs := iceio.NewMemFS()
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
+
+	_, err := cache.get(context.Background(), snapshot, fs)
+	require.Error(t, err)
+
+	var list bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0,
+		[]iceberg.ManifestFile{}))
+	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
+	_, err = cache.get(context.Background(), snapshot, fs)
+	require.NoError(t, err)
+}
+
+func TestTableRefreshReplacesSnapshotManifestCache(t *testing.T) {
+	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://snapshot-manifest-cache-refresh", nil)
+	require.NoError(t, err)
+	old := New(Identifier{"db", "snapshot-manifest-cache-refresh"}, meta, "old.json",
+		testFSF(iceio.NewMemFS()), nil)
+	fresh := New(Identifier{"db", "snapshot-manifest-cache-refresh"}, meta, "new.json",
+		testFSF(iceio.NewMemFS()), nil)
+	old.cat = &snapshotManifestRefreshCatalog{fresh: fresh}
+	oldCache := old.manifestCache
+
+	require.NoError(t, old.Refresh(context.Background()))
+	assert.NotSame(t, oldCache, old.manifestCache)
+}
+
+type snapshotManifestRefreshCatalog struct {
+	fresh *Table
+}
+
+func (c *snapshotManifestRefreshCatalog) LoadTable(context.Context, Identifier) (*Table, error) {
+	return c.fresh, nil
+}
+
+func (c *snapshotManifestRefreshCatalog) CommitTable(context.Context, Identifier, []Requirement, []Update) (Metadata, string, error) {
+	return nil, "", nil
+}
+
+type blockingSnapshotManifestIO struct {
+	iceio.IO
+	blockedPath string
+	started     chan struct{}
+	release     chan struct{}
+	once        sync.Once
+
+	mu    sync.Mutex
+	opens map[string]int
+}
+
+func (fs *blockingSnapshotManifestIO) Open(name string) (iceio.File, error) {
+	if name == fs.blockedPath {
+		fs.once.Do(func() { close(fs.started) })
+		<-fs.release
+	}
+
+	fs.mu.Lock()
+	fs.opens[name]++
+	fs.mu.Unlock()
+
+	return fs.IO.Open(name)
+}

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -20,6 +20,7 @@ package table
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -302,10 +303,11 @@ func (c *countingContext) Done() <-chan struct{} {
 
 type producerContextKey struct{}
 
-func TestSnapshotManifestCacheProducerCancellationDoesNotCancelSharedRead(t *testing.T) {
+func TestSnapshotManifestCacheRetriesAfterProducerCancellation(t *testing.T) {
 	cache := newSnapshotManifestCache()
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/detached-context.avro"}
 	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var releaseOnce sync.Once
@@ -334,7 +336,9 @@ func TestSnapshotManifestCacheProducerCancellationDoesNotCancelSharedRead(t *tes
 	waiterDone := make(chan error, 1)
 	waiterCtx := &countingContext{Context: t.Context(), entered: waiterEntered}
 	go func() {
-		_, err := cache.get(waiterCtx, snapshot, load)
+		_, err := cache.get(waiterCtx, snapshot, func(context.Context) (snapshotManifestSet, error) {
+			return snapshotManifestSet{}, nil
+		})
 		waiterDone <- err
 	}()
 	select {
@@ -346,34 +350,78 @@ func TestSnapshotManifestCacheProducerCancellationDoesNotCancelSharedRead(t *tes
 
 	select {
 	case err := <-producerDone:
-		t.Fatalf("producer stopped after its context was canceled: %v", err)
-	case <-time.After(100 * time.Millisecond):
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after its context was canceled")
 	}
 
-	releaseOnce.Do(func() { close(release) })
-	require.NoError(t, <-producerDone)
-	require.NoError(t, <-waiterDone)
+	select {
+	case err := <-waiterDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("healthy waiter did not retry the canceled read")
+	}
 }
 
-func TestReadSnapshotManifestSetKeepsCompletedReadAfterCancellation(t *testing.T) {
+func TestPlanFilesSnapshotManifestFactoryHonorsDeadline(t *testing.T) {
+	scan, _ := scanWithManifestCount(t, 1)
+	scan.manifestCache = newSnapshotManifestCache()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	scan.ioF = func(ctx context.Context) (iceio.IO, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+			return nil, errors.New("released stalled factory")
+		}
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := scan.PlanFiles(ctx)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("manifest IO factory outlived the scan deadline")
+	}
+}
+
+func TestSnapshotManifestCacheKeepsCompletedReadAfterCancellation(t *testing.T) {
 	fs := iceio.NewMemFS()
 	var list bytes.Buffer
 	sequenceNumber := int64(1)
-	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0, nil))
+	manifest := iceberg.NewManifestFile(2, "data.avro", 10, 0, 1).Build()
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0, []iceberg.ManifestFile{manifest}))
 	const listPath = "mem://snapshot-manifest-cache/late-cancel.avro"
 	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
 
+	cache := newSnapshotManifestCache()
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	set, err := readSnapshotManifestSet(ctx, snapshot, func(context.Context) (iceio.IO, error) {
-		cancel()
+	set, err := cache.get(ctx, snapshot, func(loadCtx context.Context) (snapshotManifestSet, error) {
+		return readSnapshotManifestSet(loadCtx, snapshot, func(context.Context) (iceio.IO, error) {
+			cancel()
 
-		return fs, nil
+			return fs, nil
+		})
 	})
-
 	require.NoError(t, err)
-	assert.Empty(t, set.allManifests())
+	require.Len(t, set.allManifests(), 1)
+
+	cached, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		t.Error("completed manifest list was discarded after cancellation")
+
+		return snapshotManifestSet{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, set, cached)
 }
 
 func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T) {
@@ -403,9 +451,25 @@ func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	waiterCtx := &notifyingContext{Context: ctx, entered: make(chan struct{})}
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := cache.get(waiterCtx, snapshot, testSnapshotManifestLoader(snapshot, fs))
+		waiterDone <- err
+	}()
+	select {
+	case <-waiterCtx.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelable waiter did not join the shared read")
+	}
 	cancel()
-	_, err := cache.get(ctx, snapshot, testSnapshotManifestLoader(snapshot, fs))
-	require.ErrorIs(t, err, context.Canceled)
+	select {
+	case err := <-waiterDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled waiter did not stop")
+	}
 	retry := make(chan error, 1)
 	go func() {
 		_, err := cache.get(t.Context(), snapshot, testSnapshotManifestLoader(snapshot, fs))
@@ -477,7 +541,7 @@ func TestSnapshotManifestCachePanickingProducerUnblocksWaiters(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSnapshotManifestCacheUsesDetachedProducerContext(t *testing.T) {
+func TestSnapshotManifestCacheUsesCallerContext(t *testing.T) {
 	cache := newSnapshotManifestCache()
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/context.avro"}
 	ctx := context.WithValue(t.Context(), producerContextKey{}, "producer")
@@ -491,7 +555,7 @@ func TestSnapshotManifestCacheUsesDetachedProducerContext(t *testing.T) {
 	require.NoError(t, err)
 	loadCtx := <-seen
 	assert.Equal(t, "producer", loadCtx.Value(producerContextKey{}))
-	assert.Nil(t, loadCtx.Done())
+	assert.Same(t, ctx, loadCtx)
 }
 
 func TestSnapshotManifestCacheDoesNotClassifyUnknownContentAsData(t *testing.T) {
@@ -521,4 +585,337 @@ func TestTransactionScanUsesAnIsolatedSnapshotManifestCache(t *testing.T) {
 	scan, err := txn.Scan()
 	require.NoError(t, err)
 	assert.NotSame(t, tbl.manifestCache, scan.manifestCache)
+}
+
+func TestSnapshotManifestCacheCountsDataDescriptorsOnce(t *testing.T) {
+	cache := newSnapshotManifestCache()
+	manifests := make([]iceberg.ManifestFile, snapshotManifestCacheManifestLimit)
+	for i := range manifests {
+		manifests[i] = iceberg.NewManifestFile(2, fmt.Sprintf("data-%d.avro", i), 10, 0, 1).Build()
+	}
+	set := newSnapshotManifestSet(manifests)
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "full.avro"}
+	_, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		return set, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, snapshotManifestCacheManifestLimit, cache.completeManifestCount)
+	assert.Equal(t, 1, cache.complete.Len())
+
+	_, err = cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		t.Error("data partition counted the same manifest descriptors twice")
+
+		return snapshotManifestSet{}, nil
+	})
+	require.NoError(t, err)
+
+	_, err = cache.get(t.Context(), Snapshot{SnapshotID: 2, ManifestList: "next.avro"},
+		func(context.Context) (snapshotManifestSet, error) {
+			return newSnapshotManifestSet(manifests[:1]), nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, 1, cache.completeManifestCount)
+	assert.Equal(t, 1, cache.complete.Len())
+	assert.False(t, cache.complete.Contains(snapshotManifestCacheKeyFor(snapshot)))
+}
+
+func TestTableManifestListCacheProperty(t *testing.T) {
+	for _, value := range []string{"", "true", "false", "invalid"} {
+		t.Run("value="+value, func(t *testing.T) {
+			scan, base := scanWithManifestCount(t, 1)
+			builder, err := MetadataBuilderFromBase(scan.metadata, "")
+			require.NoError(t, err)
+			if value != "" {
+				require.NoError(t, builder.SetProperties(iceberg.Properties{ReadManifestListCacheEnabledKey: value}))
+			}
+			meta, err := builder.Build()
+			require.NoError(t, err)
+			fs := &snapshotManifestCacheBenchmarkIO{IO: base, opens: make(map[string]int)}
+			tbl := New(Identifier{"db", "cache-property"}, meta, "metadata.json", testFSF(fs), nil)
+			for range 2 {
+				tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(t.Context())
+				require.NoError(t, err)
+				require.Len(t, tasks, 1)
+			}
+			wantOpens := 1
+			if value == "false" {
+				wantOpens = 2
+				assert.Nil(t, tbl.manifestCache)
+			}
+			assert.Equal(t, wantOpens, fs.opens[meta.CurrentSnapshot().ManifestList])
+		})
+	}
+}
+
+func TestTableRefreshHonorsManifestListCacheProperty(t *testing.T) {
+	scan, fs := scanWithManifestCount(t, 1)
+	builder, err := MetadataBuilderFromBase(scan.metadata, "")
+	require.NoError(t, err)
+	require.NoError(t, builder.SetProperties(iceberg.Properties{ReadManifestListCacheEnabledKey: "false"}))
+	disabled, err := builder.Build()
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "cache-refresh"}, scan.metadata, "old.json", testFSF(fs), nil)
+	cat := &snapshotManifestRefreshCatalog{
+		fresh: New(tbl.Identifier(), disabled, "disabled.json", testFSF(fs), nil),
+	}
+	tbl.cat = cat
+	require.NoError(t, tbl.Refresh(t.Context()))
+	assert.Nil(t, tbl.manifestCache)
+	assert.Nil(t, tbl.Scan().manifestCache)
+
+	cat.fresh = New(tbl.Identifier(), scan.metadata, "enabled.json", testFSF(fs), nil)
+	require.NoError(t, tbl.Refresh(t.Context()))
+	assert.NotNil(t, tbl.manifestCache)
+	assert.NotSame(t, cat.fresh.manifestCache, tbl.manifestCache)
+}
+
+func TestTransactionScanHonorsManifestListCacheProperty(t *testing.T) {
+	scan, fs := scanWithManifestCount(t, 1)
+	tbl := New(Identifier{"db", "cache-transaction"}, scan.metadata, "metadata.json", testFSF(fs), nil)
+	txn := tbl.NewTransaction()
+	require.NoError(t, txn.SetProperties(iceberg.Properties{ReadManifestListCacheEnabledKey: "false"}))
+	disabled, err := txn.Scan()
+	require.NoError(t, err)
+	assert.Nil(t, disabled.manifestCache)
+	assert.NotNil(t, tbl.manifestCache)
+
+	require.NoError(t, txn.SetProperties(iceberg.Properties{ReadManifestListCacheEnabledKey: "true"}))
+	enabled, err := txn.Scan()
+	require.NoError(t, err)
+	assert.NotNil(t, enabled.manifestCache)
+	assert.NotSame(t, tbl.manifestCache, enabled.manifestCache)
+}
+
+func TestAllManifestsSkipsFileIOForEmptyTable(t *testing.T) {
+	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://empty-manifests", nil)
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "empty-manifests"}, meta, "metadata.json",
+		func(context.Context) (iceio.IO, error) {
+			t.Error("an empty table should not resolve file IO")
+
+			return nil, errors.New("factory failed")
+		}, nil)
+	for manifest, err := range tbl.AllManifests(t.Context()) {
+		t.Fatalf("empty table yielded %v, %v", manifest, err)
+	}
+}
+
+type contextBoundSnapshotManifestIO struct {
+	iceio.IO
+	ctx         context.Context
+	started     chan struct{}
+	release     chan struct{}
+	blockedPath string
+}
+
+func (fs *contextBoundSnapshotManifestIO) Open(name string) (iceio.File, error) {
+	if fs.blockedPath != "" && name != fs.blockedPath {
+		return fs.IO.Open(name)
+	}
+	close(fs.started)
+	select {
+	case <-fs.ctx.Done():
+		return nil, fs.ctx.Err()
+	case <-fs.release:
+		return nil, errors.New("released stalled read")
+	}
+}
+
+func TestPlanFilesRetriesCanceledSnapshotManifestProducer(t *testing.T) {
+	for _, source := range []string{"scan", "all-manifests"} {
+		for _, phase := range []string{"factory", "read"} {
+			t.Run(source+"/"+phase, func(t *testing.T) {
+				scan, fs := scanWithManifestCount(t, 1)
+				started := make(chan struct{})
+				release := make(chan struct{})
+				t.Cleanup(func() { close(release) })
+				factory := func(ctx context.Context) (iceio.IO, error) {
+					if ctx.Value(producerContextKey{}) != true {
+						return fs, nil
+					}
+					if phase == "read" {
+						return &contextBoundSnapshotManifestIO{IO: fs, ctx: ctx, started: started, release: release}, nil
+					}
+					close(started)
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-release:
+						return nil, errors.New("released stalled factory")
+					}
+				}
+				tbl := New(Identifier{"db", "canceled-producer"}, scan.metadata, "metadata.json", factory, nil)
+				ctx, cancel := context.WithCancel(context.WithValue(t.Context(), producerContextKey{}, true))
+				defer cancel()
+				producerDone := make(chan error, 1)
+				go func() {
+					if source == "scan" {
+						_, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(ctx)
+						producerDone <- err
+
+						return
+					}
+					for _, err := range tbl.AllManifests(ctx) {
+						if err != nil {
+							producerDone <- err
+
+							return
+						}
+					}
+					producerDone <- nil
+				}()
+				select {
+				case <-started:
+				case <-time.After(5 * time.Second):
+					t.Fatal("manifest producer did not start")
+				}
+
+				waiterCtx := &notifyingContext{Context: t.Context(), entered: make(chan struct{})}
+				waiterDone := make(chan error, 1)
+				go func() {
+					tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(waiterCtx)
+					if err == nil && len(tasks) != 1 {
+						err = fmt.Errorf("expected one scan task, got %d", len(tasks))
+					}
+					waiterDone <- err
+				}()
+				select {
+				case <-waiterCtx.entered:
+				case <-time.After(5 * time.Second):
+					t.Fatal("scan did not wait on the shared read")
+				}
+				cancel()
+				select {
+				case err := <-producerDone:
+					require.ErrorIs(t, err, context.Canceled)
+				case <-time.After(5 * time.Second):
+					t.Fatal("canceled producer did not stop")
+				}
+				select {
+				case err := <-waiterDone:
+					require.NoError(t, err)
+				case <-time.After(5 * time.Second):
+					t.Fatal("healthy scan did not retry")
+				}
+			})
+		}
+	}
+}
+
+func TestSnapshotManifestCacheSharesErrorsFromLiveProducer(t *testing.T) {
+	for _, loadErr := range []error{errors.New("read failed"), context.DeadlineExceeded} {
+		t.Run(loadErr.Error(), func(t *testing.T) {
+			cache := newSnapshotManifestCache()
+			snapshot := Snapshot{SnapshotID: 1, ManifestList: "error.avro"}
+			started := make(chan struct{})
+			release := make(chan struct{})
+			var once sync.Once
+			t.Cleanup(func() { once.Do(func() { close(release) }) })
+			producerDone := make(chan error, 1)
+			go func() {
+				_, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+					close(started)
+					<-release
+
+					return snapshotManifestSet{}, loadErr
+				})
+				producerDone <- err
+			}()
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("producer did not start")
+			}
+			ctx := &notifyingContext{Context: t.Context(), entered: make(chan struct{})}
+			waiterDone := make(chan error, 1)
+			go func() {
+				_, err := cache.get(ctx, snapshot, func(context.Context) (snapshotManifestSet, error) {
+					return snapshotManifestSet{}, errors.New("unexpected retry")
+				})
+				waiterDone <- err
+			}()
+			select {
+			case <-ctx.entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("waiter did not start")
+			}
+			once.Do(func() { close(release) })
+			require.ErrorIs(t, <-producerDone, loadErr)
+			require.ErrorIs(t, <-waiterDone, loadErr)
+		})
+	}
+}
+
+func TestAllManifestsEarlyStopDoesNotFailConcurrentScan(t *testing.T) {
+	scan, fs := scanWithManifestCount(t, 1)
+	previous := scan.metadata.CurrentSnapshot()
+	manifests, err := previous.Manifests(fs)
+	require.NoError(t, err)
+	const currentList = "mem://planning/table/metadata/snap-2.avro"
+	var list bytes.Buffer
+	sequenceNumber := int64(2)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 2, &previous.SnapshotID, &sequenceNumber, 0, manifests))
+	require.NoError(t, fs.WriteFile(currentList, list.Bytes()))
+	builder, err := MetadataBuilderFromBase(scan.metadata, "")
+	require.NoError(t, err)
+	current := *previous
+	current.SnapshotID = 2
+	current.ParentSnapshotID = &previous.SnapshotID
+	current.SequenceNumber = 2
+	current.TimestampMs++
+	current.ManifestList = currentList
+	require.NoError(t, builder.AddSnapshot(&current))
+	require.NoError(t, builder.SetSnapshotRef(MainBranch, 2, BranchRef))
+	meta, err := builder.Build()
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	tbl := New(Identifier{"db", "early-stop"}, meta, "metadata.json", func(ctx context.Context) (iceio.IO, error) {
+		if ctx.Value(producerContextKey{}) == true {
+			return &contextBoundSnapshotManifestIO{
+				IO: fs, ctx: ctx, started: started, release: release, blockedPath: currentList,
+			}, nil
+		}
+
+		return fs, nil
+	}, nil)
+	ctx, cancel := context.WithCancel(context.WithValue(t.Context(), producerContextKey{}, true))
+	defer cancel()
+	all := tbl.AllManifests(ctx)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("current snapshot read did not start")
+	}
+	waiterCtx := &notifyingContext{Context: t.Context(), entered: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		tasks, err := tbl.Scan(WithMaxConcurrency(1)).PlanFiles(waiterCtx)
+		if err == nil && len(tasks) != 1 {
+			err = fmt.Errorf("expected one scan task, got %d", len(tasks))
+		}
+		done <- err
+	}()
+	select {
+	case <-waiterCtx.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scan did not wait for the current snapshot")
+	}
+	count := 0
+	for _, err := range all {
+		require.NoError(t, err)
+		count++
+
+		break
+	}
+	require.Equal(t, 1, count)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("scan did not recover from early iterator stop")
+	}
 }

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -211,3 +211,42 @@ func (fs *blockingSnapshotManifestIO) Open(name string) (iceio.File, error) {
 
 	return fs.IO.Open(name)
 }
+
+func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T) {
+	const listPath = "mem://snapshot-manifest-cache/canceled-waiter.avro"
+	base := iceio.NewMemFS()
+	var list bytes.Buffer
+	sequenceNumber := int64(1)
+	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0, nil))
+	require.NoError(t, base.WriteFile(listPath, list.Bytes()))
+	fs := &blockingSnapshotManifestIO{
+		IO: base, blockedPath: listPath, started: make(chan struct{}),
+		release: make(chan struct{}), opens: make(map[string]int),
+	}
+	var release sync.Once
+	t.Cleanup(func() { release.Do(func() { close(fs.release) }) })
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
+	first := make(chan error, 1)
+	go func() {
+		_, err := cache.get(t.Context(), snapshot, fs)
+		first <- err
+	}()
+	select {
+	case <-fs.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manifest-list read did not start")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := cache.get(ctx, snapshot, fs)
+	require.ErrorIs(t, err, context.Canceled)
+	release.Do(func() { close(fs.release) })
+	require.NoError(t, <-first)
+	_, err = cache.get(t.Context(), snapshot, fs)
+	require.NoError(t, err)
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	assert.Equal(t, 1, fs.opens[listPath])
+}

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -31,6 +31,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testSnapshotManifestLoader(snapshot Snapshot, fs iceio.IO) snapshotManifestLoader {
+	return func(ctx context.Context) (snapshotManifestSet, error) {
+		return readSnapshotManifestSet(ctx, snapshot, testFSF(fs))
+	}
+}
+
 func TestTableScansReuseSnapshotManifestList(t *testing.T) {
 	fs := newTrackingCallsIO()
 	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
@@ -85,7 +91,8 @@ func TestSnapshotManifestCacheSeparatesContentAndProtectsSlices(t *testing.T) {
 	const listPath = "mem://snapshot-manifest-cache/separate.avro"
 	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
 
-	set, err := cache.get(context.Background(), Snapshot{SnapshotID: 1, ManifestList: listPath}, fs)
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
+	set, err := cache.get(context.Background(), snapshot, testSnapshotManifestLoader(snapshot, fs))
 	require.NoError(t, err)
 	require.Len(t, set.allManifests(), 2)
 	require.Len(t, set.dataManifests(), 1)
@@ -120,9 +127,11 @@ func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
 	const callers = 16
 	errs := make(chan error, callers)
+	var release sync.Once
+	t.Cleanup(func() { release.Do(func() { close(fs.release) }) })
 	for range callers {
 		go func() {
-			_, err := cache.get(context.Background(), snapshot, fs)
+			_, err := cache.get(t.Context(), snapshot, testSnapshotManifestLoader(snapshot, fs))
 			errs <- err
 		}()
 	}
@@ -132,7 +141,7 @@ func TestSnapshotManifestCacheSharesInFlightRead(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("manifest-list read did not start")
 	}
-	close(fs.release)
+	release.Do(func() { close(fs.release) })
 
 	for range callers {
 		require.NoError(t, <-errs)
@@ -150,7 +159,7 @@ func TestSnapshotManifestCacheRetriesFailedRead(t *testing.T) {
 	cache := newSnapshotManifestCache()
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
 
-	_, err := cache.get(context.Background(), snapshot, fs)
+	_, err := cache.get(context.Background(), snapshot, testSnapshotManifestLoader(snapshot, fs))
 	require.Error(t, err)
 
 	var list bytes.Buffer
@@ -158,7 +167,7 @@ func TestSnapshotManifestCacheRetriesFailedRead(t *testing.T) {
 	require.NoError(t, iceberg.WriteManifestList(2, &list, 1, nil, &sequenceNumber, 0,
 		[]iceberg.ManifestFile{}))
 	require.NoError(t, fs.WriteFile(listPath, list.Bytes()))
-	_, err = cache.get(context.Background(), snapshot, fs)
+	_, err = cache.get(context.Background(), snapshot, testSnapshotManifestLoader(snapshot, fs))
 	require.NoError(t, err)
 }
 
@@ -176,19 +185,19 @@ func TestSnapshotManifestCacheBoundsCompletedEntries(t *testing.T) {
 	}
 
 	for i := range snapshotManifestCacheSize {
-		_, err := cache.get(context.Background(), snapshots[i], fs)
+		_, err := cache.get(context.Background(), snapshots[i], testSnapshotManifestLoader(snapshots[i], fs))
 		require.NoError(t, err)
 	}
-	_, err := cache.get(context.Background(), snapshots[0], fs)
+	_, err := cache.get(context.Background(), snapshots[0], testSnapshotManifestLoader(snapshots[0], fs))
 	require.NoError(t, err)
-	_, err = cache.get(context.Background(), snapshots[snapshotManifestCacheSize], fs)
+	_, err = cache.get(context.Background(), snapshots[snapshotManifestCacheSize], testSnapshotManifestLoader(snapshots[snapshotManifestCacheSize], fs))
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, fs.openCount[snapshots[0].ManifestList])
 	assert.Equal(t, 1, fs.openCount[snapshots[1].ManifestList])
-	_, err = cache.get(context.Background(), snapshots[0], fs)
+	_, err = cache.get(context.Background(), snapshots[0], testSnapshotManifestLoader(snapshots[0], fs))
 	require.NoError(t, err)
-	_, err = cache.get(context.Background(), snapshots[1], fs)
+	_, err = cache.get(context.Background(), snapshots[1], testSnapshotManifestLoader(snapshots[1], fs))
 	require.NoError(t, err)
 	assert.Equal(t, 1, fs.openCount[snapshots[0].ManifestList])
 	assert.Equal(t, 2, fs.openCount[snapshots[1].ManifestList])
@@ -246,6 +255,71 @@ func (fs *blockingSnapshotManifestIO) Open(name string) (iceio.File, error) {
 	return fs.IO.Open(name)
 }
 
+type contextAwareSnapshotManifestIO struct {
+	iceio.IO
+	ctx     context.Context
+	started chan struct{}
+	once    sync.Once
+}
+
+func (fs *contextAwareSnapshotManifestIO) Open(string) (iceio.File, error) {
+	fs.once.Do(func() { close(fs.started) })
+	<-fs.ctx.Done()
+
+	return nil, fs.ctx.Err()
+}
+
+type notifyingContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+type producerContextKey struct{}
+
+func (c *notifyingContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.entered) })
+
+	return c.Context.Done()
+}
+
+func TestSnapshotManifestCacheProducerContextCancelsRead(t *testing.T) {
+	base := iceio.NewMemFS()
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/context-cancel.avro"}
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	load := func(loadCtx context.Context) (snapshotManifestSet, error) {
+		return readSnapshotManifestSet(loadCtx, snapshot, func(ioCtx context.Context) (iceio.IO, error) {
+			return &contextAwareSnapshotManifestIO{IO: base, ctx: ioCtx, started: started}, nil
+		})
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cache.get(ctx, snapshot, load)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("manifest-list read did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("producer did not stop after context cancellation")
+	}
+
+	_, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		return snapshotManifestSet{}, nil
+	})
+	require.NoError(t, err)
+}
+
 func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T) {
 	const listPath = "mem://snapshot-manifest-cache/canceled-waiter.avro"
 	base := iceio.NewMemFS()
@@ -263,7 +337,7 @@ func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T
 	snapshot := Snapshot{SnapshotID: 1, ManifestList: listPath}
 	first := make(chan error, 1)
 	go func() {
-		_, err := cache.get(t.Context(), snapshot, fs)
+		_, err := cache.get(t.Context(), snapshot, testSnapshotManifestLoader(snapshot, fs))
 		first <- err
 	}()
 	select {
@@ -274,13 +348,118 @@ func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err := cache.get(ctx, snapshot, fs)
+	_, err := cache.get(ctx, snapshot, testSnapshotManifestLoader(snapshot, fs))
 	require.ErrorIs(t, err, context.Canceled)
+	retry := make(chan error, 1)
+	go func() {
+		_, err := cache.get(t.Context(), snapshot, testSnapshotManifestLoader(snapshot, fs))
+		retry <- err
+	}()
+	select {
+	case err := <-retry:
+		t.Fatalf("retry returned before the shared producer finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
 	release.Do(func() { close(fs.release) })
 	require.NoError(t, <-first)
-	_, err = cache.get(t.Context(), snapshot, fs)
-	require.NoError(t, err)
+	require.NoError(t, <-retry)
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	assert.Equal(t, 1, fs.opens[listPath])
+}
+
+func TestSnapshotManifestCachePanickingProducerUnblocksWaiters(t *testing.T) {
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/panic.avro"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	load := func(context.Context) (snapshotManifestSet, error) {
+		close(started)
+		<-release
+		panic("manifest-list producer failed")
+	}
+
+	producerDone := make(chan any, 1)
+	go func() {
+		defer func() { producerDone <- recover() }()
+		_, _ = cache.get(t.Context(), snapshot, load)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("manifest-list producer did not start")
+	}
+
+	waiterDone := make(chan error, 1)
+	waiterCtx := &notifyingContext{Context: t.Context(), entered: make(chan struct{})}
+	go func() {
+		_, err := cache.get(waiterCtx, snapshot, load)
+		waiterDone <- err
+	}()
+	select {
+	case <-waiterCtx.entered:
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not start waiting on the producer")
+	}
+
+	close(release)
+	select {
+	case err := <-waiterDone:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "panic while reading snapshot 1 manifest list")
+	case <-time.After(time.Second):
+		t.Fatal("waiter remained blocked after producer panic")
+	}
+	assert.Equal(t, "manifest-list producer failed", <-producerDone)
+
+	_, err := cache.get(t.Context(), snapshot, func(context.Context) (snapshotManifestSet, error) {
+		return snapshotManifestSet{}, nil
+	})
+	require.NoError(t, err)
+}
+
+func TestSnapshotManifestCachePassesProducerContextToLoader(t *testing.T) {
+	cache := newSnapshotManifestCache()
+	snapshot := Snapshot{SnapshotID: 1, ManifestList: "mem://snapshot-manifest-cache/context.avro"}
+	ctx := context.WithValue(t.Context(), producerContextKey{}, "producer")
+	seen := make(chan context.Context, 1)
+
+	_, err := cache.get(ctx, snapshot, func(loadCtx context.Context) (snapshotManifestSet, error) {
+		seen <- loadCtx
+
+		return snapshotManifestSet{}, nil
+	})
+	require.NoError(t, err)
+	assert.Same(t, ctx, <-seen)
+}
+
+func TestSnapshotManifestCacheDoesNotClassifyUnknownContentAsData(t *testing.T) {
+	unknown := iceberg.NewManifestFile(2, "unknown.avro", 1, 0, 1).
+		Content(iceberg.ManifestContent(2)).
+		Build()
+	set := newSnapshotManifestSet([]iceberg.ManifestFile{
+		iceberg.NewManifestFile(2, "data.avro", 1, 0, 1).Build(),
+		iceberg.NewManifestFile(2, "delete.avro", 1, 0, 1).
+			Content(iceberg.ManifestContentDeletes).
+			Build(),
+		unknown,
+	})
+
+	assert.Len(t, set.allManifests(), 3)
+	assert.Len(t, set.dataManifests(), 1)
+	assert.Len(t, set.deleteManifests(), 1)
+}
+
+func TestTransactionScanUsesAnIsolatedSnapshotManifestCache(t *testing.T) {
+	meta, err := NewMetadata(simpleSchema(), iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://snapshot-manifest-cache-transaction", nil)
+	require.NoError(t, err)
+	tbl := New(Identifier{"db", "snapshot-manifest-cache-transaction"}, meta, "metadata.json",
+		testFSF(iceio.NewMemFS()), nil)
+	txn := tbl.NewTransaction()
+
+	scan, err := txn.Scan()
+	require.NoError(t, err)
+	assert.NotSame(t, tbl.manifestCache, scan.manifestCache)
 }

--- a/table/snapshot_manifest_cache_internal_test.go
+++ b/table/snapshot_manifest_cache_internal_test.go
@@ -424,6 +424,20 @@ func TestSnapshotManifestCacheKeepsCompletedReadAfterCancellation(t *testing.T) 
 	assert.Equal(t, set, cached)
 }
 
+func TestReadSnapshotManifestSetRejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	fsCalls := 0
+
+	_, err := readSnapshotManifestSet(ctx, Snapshot{}, func(context.Context) (iceio.IO, error) {
+		fsCalls++
+
+		return nil, nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, fsCalls)
+}
+
 func TestSnapshotManifestCacheCanceledWaiterDoesNotCancelSharedRead(t *testing.T) {
 	const listPath = "mem://snapshot-manifest-cache/canceled-waiter.avro"
 	base := iceio.NewMemFS()
@@ -705,6 +719,7 @@ type contextBoundSnapshotManifestIO struct {
 	iceio.IO
 	ctx         context.Context
 	started     chan struct{}
+	startedOnce *sync.Once
 	release     chan struct{}
 	blockedPath string
 }
@@ -713,7 +728,7 @@ func (fs *contextBoundSnapshotManifestIO) Open(name string) (iceio.File, error) 
 	if fs.blockedPath != "" && name != fs.blockedPath {
 		return fs.IO.Open(name)
 	}
-	close(fs.started)
+	fs.startedOnce.Do(func() { close(fs.started) })
 	select {
 	case <-fs.ctx.Done():
 		return nil, fs.ctx.Err()
@@ -728,6 +743,7 @@ func TestPlanFilesRetriesCanceledSnapshotManifestProducer(t *testing.T) {
 			t.Run(source+"/"+phase, func(t *testing.T) {
 				scan, fs := scanWithManifestCount(t, 1)
 				started := make(chan struct{})
+				var startedOnce sync.Once
 				release := make(chan struct{})
 				t.Cleanup(func() { close(release) })
 				factory := func(ctx context.Context) (iceio.IO, error) {
@@ -735,7 +751,9 @@ func TestPlanFilesRetriesCanceledSnapshotManifestProducer(t *testing.T) {
 						return fs, nil
 					}
 					if phase == "read" {
-						return &contextBoundSnapshotManifestIO{IO: fs, ctx: ctx, started: started, release: release}, nil
+						return &contextBoundSnapshotManifestIO{
+							IO: fs, ctx: ctx, started: started, startedOnce: &startedOnce, release: release,
+						}, nil
 					}
 					close(started)
 					select {
@@ -871,12 +889,14 @@ func TestAllManifestsEarlyStopDoesNotFailConcurrentScan(t *testing.T) {
 	require.NoError(t, err)
 
 	started := make(chan struct{})
+	var startedOnce sync.Once
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
 	tbl := New(Identifier{"db", "early-stop"}, meta, "metadata.json", func(ctx context.Context) (iceio.IO, error) {
 		if ctx.Value(producerContextKey{}) == true {
 			return &contextBoundSnapshotManifestIO{
-				IO: fs, ctx: ctx, started: started, release: release, blockedPath: currentList,
+				IO: fs, ctx: ctx, started: started, startedOnce: &startedOnce,
+				release: release, blockedPath: currentList,
 			}, nil
 		}
 

--- a/table/table.go
+++ b/table/table.go
@@ -362,14 +362,21 @@ func (t Table) Delete(ctx context.Context, filter iceberg.BooleanExpression, sna
 	return txn.Commit(ctx)
 }
 
-func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile, error] {
-	fs, err := t.fsF(ctx)
-	if err != nil {
-		return func(yield func(iceberg.ManifestFile, error) bool) {
-			yield(nil, err)
-		}
-	}
+func (t Table) manifestSet(ctx context.Context, snapshot Snapshot) (snapshotManifestSet, error) {
+	return t.manifestSetWithFSF(ctx, snapshot, t.fsF)
+}
 
+func (t Table) manifestSetWithFSF(
+	ctx context.Context,
+	snapshot Snapshot,
+	fsF FSysF,
+) (snapshotManifestSet, error) {
+	return t.manifestCache.get(ctx, snapshot, func(loadCtx context.Context) (snapshotManifestSet, error) {
+		return readSnapshotManifestSet(loadCtx, snapshot, fsF)
+	})
+}
+
+func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile, error] {
 	type list = tblutils.Enumerated[[]iceberg.ManifestFile]
 	snapshots := t.metadata.Snapshots()
 	n := len(snapshots)
@@ -381,6 +388,7 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 	ch := make(chan list, allManifestsWorkerCount(n))
 	workers := allManifestsWorkerCount(n)
 	g, groupCtx := errgroup.WithContext(workCtx)
+	manifestFS := sharedSnapshotManifestFSF(t.fsF)
 
 	for range workers {
 		g.Go(func() error {
@@ -393,7 +401,7 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 						return nil
 					}
 
-					manifestSet, err := t.manifestCache.get(groupCtx, snapshots[i], fs)
+					manifestSet, err := t.manifestSetWithFSF(groupCtx, snapshots[i], manifestFS)
 					if err != nil {
 						return err
 					}

--- a/table/table.go
+++ b/table/table.go
@@ -236,10 +236,7 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.metadata = fresh.metadata
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
-	t.manifestCache = fresh.manifestCache
-	if t.manifestCache == nil {
-		t.manifestCache = newSnapshotManifestCache()
-	}
+	t.manifestCache = newSnapshotManifestCacheForMetadata(fresh.metadata)
 	t.planner = fresh.planner
 	t.scanPlanningIOProps = maps.Clone(fresh.scanPlanningIOProps)
 	// Only inherit the catalog-derived reporter when the caller hasn't set one
@@ -376,6 +373,8 @@ func (t Table) manifestSetWithFSF(
 	})
 }
 
+// AllManifests returns the manifests referenced by the table's snapshots.
+// Tables without snapshots return an empty sequence without resolving file IO.
 func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile, error] {
 	type list = tblutils.Enumerated[[]iceberg.ManifestFile]
 	snapshots := t.metadata.Snapshots()
@@ -1413,7 +1412,7 @@ func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, ca
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 		fsF:              fsF,
-		manifestCache:    newSnapshotManifestCache(),
+		manifestCache:    newSnapshotManifestCacheForMetadata(meta),
 		cat:              cat,
 		planner:          planner,
 		reporter:         metrics.NopReporter{},

--- a/table/table.go
+++ b/table/table.go
@@ -104,6 +104,7 @@ type Table struct {
 	metadataLocation string
 	cat              CatalogIO
 	fsF              FSysF
+	manifestCache    *snapshotManifestCache
 	planner          ScanPlanner
 	// scanPlanningIOProps are the table-scoped FileIO properties supplied by a
 	// catalog load response. They are separate from metadata properties because
@@ -235,6 +236,10 @@ func (t *Table) Refresh(ctx context.Context) error {
 	t.metadata = fresh.metadata
 	t.fsF = fresh.fsF
 	t.metadataLocation = fresh.metadataLocation
+	t.manifestCache = fresh.manifestCache
+	if t.manifestCache == nil {
+		t.manifestCache = newSnapshotManifestCache()
+	}
 	t.planner = fresh.planner
 	t.scanPlanningIOProps = maps.Clone(fresh.scanPlanningIOProps)
 	// Only inherit the catalog-derived reporter when the caller hasn't set one
@@ -388,10 +393,11 @@ func (t Table) AllManifests(ctx context.Context) iter.Seq2[iceberg.ManifestFile,
 						return nil
 					}
 
-					manifests, err := snapshots[i].Manifests(fs)
+					manifestSet, err := t.manifestCache.get(groupCtx, snapshots[i], fs)
 					if err != nil {
 						return err
 					}
+					manifests := manifestSet.allManifests()
 
 					select {
 					case ch <- list{Index: i, Value: manifests, Last: i == n-1}:
@@ -1310,6 +1316,7 @@ func (t Table) Scan(opts ...ScanOption) *Scan {
 		metadata:            t.metadata,
 		metadataLocation:    t.metadataLocation,
 		ioF:                 t.fsF,
+		manifestCache:       t.manifestCache,
 		planner:             t.planner,
 		scanPlanningIOProps: maps.Clone(t.scanPlanningIOProps),
 		// TODO(#1178 Phase 6): resolve scan-planning-mode table properties here.
@@ -1398,6 +1405,7 @@ func New(ident Identifier, meta Metadata, metadataLocation string, fsF FSysF, ca
 		metadata:         meta,
 		metadataLocation: metadataLocation,
 		fsF:              fsF,
+		manifestCache:    newSnapshotManifestCache(),
 		cat:              cat,
 		planner:          planner,
 		reporter:         metrics.NopReporter{},

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3273,6 +3273,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,
+		manifestCache:    t.tbl.manifestCache,
 		// Catalog planners can only see committed table state, not metadata
 		// staged inside this transaction. Keep transaction scans local so auto
 		// mode cannot silently return stale tasks.

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3273,7 +3273,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,
-		manifestCache:    t.tbl.manifestCache,
+		manifestCache:    newSnapshotManifestCache(),
 		// Catalog planners can only see committed table state, not metadata
 		// staged inside this transaction. Keep transaction scans local so auto
 		// mode cannot silently return stale tasks.

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -3273,7 +3273,7 @@ func (t *Transaction) Scan(opts ...ScanOption) (*Scan, error) {
 		metadata:         updatedMeta,
 		metadataLocation: t.tbl.metadataLocation,
 		ioF:              t.tbl.fsF,
-		manifestCache:    newSnapshotManifestCache(),
+		manifestCache:    newSnapshotManifestCacheForMetadata(updatedMeta),
 		// Catalog planners can only see committed table state, not metadata
 		// staged inside this transaction. Keep transaction scans local so auto
 		// mode cannot silently return stale tasks.

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -318,6 +318,13 @@ Property key constants are in [`table/properties.go`](https://github.com/apache/
 | Key | Default | Description |
 |---|---|---|
 | `read.split.target-size` | `134217728` | Target size for coalescing safe row-group ranges when splitting large local Parquet files. A range may exceed the target when no supplied offset can divide it safely. |
+| `read.manifest-list-cache.enabled` | `true` | Reuse decoded snapshot manifest lists across scans of a table handle. Set to `false` to disable retention and shared in-flight reads. Applied when loading or refreshing a table, and when creating a transaction scan. |
+
+The manifest-list cache retains at most 64 snapshots and 32,768 manifest
+descriptors in total per table handle. These are count limits, not byte limits:
+memory use also depends on manifest paths, partition summaries, and key metadata.
+Refreshing the table replaces its cache. This caches decoded manifest lists;
+it does not implement Java's `io.manifest.cache.*` file-content cache settings.
 
 The Java-compatible `read.split.planning-lookback` and `read.split.open-file-cost`
 names and defaults are also exported by the Go API for shared configuration,


### PR DESCRIPTION
## What

- **Reuse decoded manifest lists** across local scans, incremental append scans, manifest/file/entry inspectors, and `AllManifests`.
- **Share concurrent reads.** IO setup and reads keep the caller's cancellation. Healthy waiters retry with their own IO if that caller cancels.
- **Bound retention** to 64 snapshots and 32,768 manifest descriptors per table handle. Memory also depends on paths, partition summaries, and key metadata.
- **Allow opt-out** with `read.manifest-list-cache.enabled=false`. Refresh replaces the cache and picks up property changes. Transaction scans use a separate cache and respect staged properties.
- Keep the data-manifest group ready for incremental append planning. Filters and projections are still applied per scan.

## Benchmark

The benchmark compares caching disabled and enabled on the same decoding path. Each iteration starts with a cold cache and performs 10 scans. With one manifest, manifest-list opens drop from **10 to 1**. Each scan still reads the manifest entries.

## Checks

- Full test suite.
- Race detector on table tests.
- Lint.
- Regression tests cover canceled IO setup and reads, healthy waiters, early `AllManifests` stop, cache opt-out, and descriptor limits.
