### PR TITLE
perf(manifest): project scan columns during reads

### DIFF
--- a/codec/data_file_test.go
+++ b/codec/data_file_test.go
@@ -311,3 +311,20 @@ func (stubDataFile) FirstRowID() *int64                        { return nil }
 func (stubDataFile) ReferencedDataFile() *string               { return nil }
 func (stubDataFile) ContentOffset() *int64                     { return nil }
 func (stubDataFile) ContentSizeInBytes() *int64                { return nil }
+
+func TestEncodeDataFileRejectsProjectedMetadata(t *testing.T) {
+	for _, version := range []int{1, 2, 3} {
+		t.Run("v"+strconv.Itoa(version), func(t *testing.T) {
+			spec, schema, original := fullyPopulatedDataFile(t, version)
+			projected := iceberg.DataFileWithoutColumnStats(original)
+			encoded, err := codec.EncodeDataFile(projected, spec, schema, version)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.Nil(t, encoded)
+			require.ErrorContains(t, err, "projected data file")
+
+			encoded, err = codec.EncodeDataFile(original, spec, schema, version)
+			require.NoError(t, err)
+			require.NotEmpty(t, encoded)
+		})
+	}
+}

--- a/codec/file_scan_task_test.go
+++ b/codec/file_scan_task_test.go
@@ -393,3 +393,30 @@ func newScanTaskDataFileWithFileSize(t *testing.T, spec iceberg.PartitionSpec, p
 
 	return builder.Build()
 }
+
+func TestEncodeFileScanTaskRejectsProjectedFiles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		project func(*table.FileScanTask)
+	}{
+		{"data", func(task *table.FileScanTask) { task.File = iceberg.DataFileWithoutColumnStats(task.File) }},
+		{"positional delete", func(task *table.FileScanTask) {
+			task.DeleteFiles[0] = iceberg.DataFileWithoutColumnStats(task.DeleteFiles[0])
+		}},
+		{"equality delete", func(task *table.FileScanTask) {
+			task.EqualityDeleteFiles[0] = iceberg.DataFileWithoutColumnStats(task.EqualityDeleteFiles[0])
+		}},
+		{"deletion vector", func(task *table.FileScanTask) {
+			task.DeletionVectorFiles[0] = iceberg.DataFileWithoutColumnStats(task.DeletionVectorFiles[0])
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, schema, task := fullyPopulatedFileScanTask(t, 3)
+			tt.project(&task)
+			encoded, err := codec.EncodeFileScanTask(task, spec, schema, 3)
+			require.ErrorIs(t, err, iceberg.ErrInvalidArgument)
+			require.Nil(t, encoded)
+			require.ErrorContains(t, err, "projected data file")
+		})
+	}
+}

--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -61,6 +61,8 @@ func init() {
 // The encoded bytes are the same bytes a manifest carries for this
 // data file. Implementations must produce output that the iceberg
 // package's manifest-entry Avro decoder accepts.
+// The built-in DataFile implementation rejects projected or stat-stripped files
+// with ErrInvalidArgument because omitted metadata cannot be recovered.
 type AvroEntryMarshaler interface {
 	MarshalAvroEntry(spec PartitionSpec, schema *Schema, version int) ([]byte, error)
 }
@@ -99,6 +101,9 @@ type AvroEntryMarshaler interface {
 // carry the field on the wire still decode through the matching
 // reader. New DataFiles should not set distinct counts.
 func (d *dataFile) MarshalAvroEntry(spec PartitionSpec, schema *Schema, version int) ([]byte, error) {
+	if err := d.validateForWrite(); err != nil {
+		return nil, err
+	}
 	if version < 1 || version > 3 {
 		return nil, fmt.Errorf("iceberg: MarshalAvroEntry: unsupported format version %d", version)
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -709,7 +709,9 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 // standard scan fields and optionally the column statistics selected by
 // projection. Manifest metadata validation and entry inheritance are the same
 // as in NewManifestReader; fields omitted by the projection retain their zero
-// values in the returned DataFile.
+// values in the returned DataFile. Entries returned by this reader are
+// read-only planning values and must not be passed to a ManifestWriter, because
+// omitted statistics cannot be recovered on rewrite.
 func NewManifestReaderWithProjection(
 	file ManifestFile,
 	in io.Reader,

--- a/manifest.go
+++ b/manifest.go
@@ -416,28 +416,7 @@ func (m *manifestFile) HasAddedFiles() bool    { return m.AddedFilesCount != 0 }
 func (m *manifestFile) HasExistingFiles() bool { return m.ExistingFilesCount != 0 }
 
 func (m *manifestFile) Entries(fs iceio.IO, discardDeleted bool) iter.Seq2[ManifestEntry, error] {
-	return func(yield func(ManifestEntry, error) bool) {
-		f, err := fs.Open(m.FilePath())
-		if err != nil {
-			yield(nil, err)
-
-			return
-		}
-		aborted := false
-		defer func() {
-			if cerr := f.Close(); cerr != nil && !aborted {
-				yield(nil, cerr)
-			}
-		}()
-
-		for entry, err := range iterManifest(m, f, discardDeleted) {
-			if !yield(entry, err) {
-				aborted = true
-
-				return
-			}
-		}
-	}
+	return manifestEntries(fs, m, discardDeleted, nil)
 }
 
 func (m *manifestFile) FetchEntries(fs iceio.IO, discardDeleted bool) (_ []ManifestEntry, err error) {
@@ -723,13 +702,48 @@ type ManifestReader struct {
 // file. If the caller is interested in the manifest entries in the file, it must call
 // [ManifestReader.Entries] before closing the provided reader.
 func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error) {
-	rd, err := ocf.NewReader(in)
+	return newManifestReader(file, in, nil)
+}
+
+// NewManifestReaderWithProjection returns a manifest reader that decodes the
+// standard scan fields and optionally the column statistics selected by
+// projection. Manifest metadata validation and entry inheritance are the same
+// as in NewManifestReader; fields omitted by the projection retain their zero
+// values in the returned DataFile.
+func NewManifestReaderWithProjection(
+	file ManifestFile,
+	in io.Reader,
+	projection ManifestEntryProjection,
+) (*ManifestReader, error) {
+	return newManifestReader(file, in, &projection)
+}
+
+func newManifestReader(
+	file ManifestFile,
+	in io.Reader,
+	projection *ManifestEntryProjection,
+) (*ManifestReader, error) {
+	var writerSchema *avro.Schema
+	var rd *ocf.Reader
+	var err error
+	if projection == nil {
+		rd, err = ocf.NewReader(in)
+	} else {
+		rd, err = ocf.NewReader(in, ocf.WithReaderSchemaFunc(func(reader *ocf.Reader) (*avro.Schema, error) {
+			writerSchema = reader.Schema()
+
+			return projectedManifestEntrySchema(writerSchema, *projection)
+		}))
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	metadata := rd.Metadata()
-	sc := rd.Schema()
+	if writerSchema == nil {
+		writerSchema = rd.Schema()
+	}
+	sc := writerSchema
 
 	formatVersion := 1
 	// format-version is optional for v1 manifest files, so default to v1.
@@ -972,9 +986,20 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 // iterManifest returns an iterator that streams manifest entries from
 // the provided reader without buffering them. If discardDeleted is true,
 // entries whose status is "deleted" are skipped.
-func iterManifest(m ManifestFile, f io.Reader, discardDeleted bool) iter.Seq2[ManifestEntry, error] {
+func iterManifest(
+	m ManifestFile,
+	f io.Reader,
+	discardDeleted bool,
+	projection *ManifestEntryProjection,
+) iter.Seq2[ManifestEntry, error] {
 	return func(yield func(ManifestEntry, error) bool) {
-		manifestReader, err := NewManifestReader(m, f)
+		var manifestReader *ManifestReader
+		var err error
+		if projection == nil {
+			manifestReader, err = NewManifestReader(m, f)
+		} else {
+			manifestReader, err = NewManifestReaderWithProjection(m, f, *projection)
+		}
 		if err != nil {
 			yield(nil, err)
 
@@ -1016,7 +1041,7 @@ func iterManifest(m ManifestFile, f io.Reader, discardDeleted bool) iter.Seq2[Ma
 // is true, the returned slice omits entries whose status is "deleted".
 func ReadManifest(m ManifestFile, f io.Reader, discardDeleted bool) ([]ManifestEntry, error) {
 	var results []ManifestEntry
-	for entry, err := range iterManifest(m, f, discardDeleted) {
+	for entry, err := range iterManifest(m, f, discardDeleted, nil) {
 		if err != nil {
 			return results, err
 		}

--- a/manifest.go
+++ b/manifest.go
@@ -677,6 +677,7 @@ type ManifestReader struct {
 	file           ManifestFile
 	formatVersion  int
 	isFallback     bool
+	projected      bool
 	content        ManifestContent
 	fieldNameToID  map[string]int
 	fieldIDToType  map[int]string
@@ -711,7 +712,8 @@ func NewManifestReader(file ManifestFile, in io.Reader) (*ManifestReader, error)
 // as in NewManifestReader; fields omitted by the projection retain their zero
 // values in the returned DataFile. Entries returned by this reader are
 // read-only planning values and must not be passed to a ManifestWriter, because
-// omitted statistics cannot be recovered on rewrite.
+// omitted statistics cannot be recovered on rewrite. ManifestWriter and the
+// DataFile Avro codec reject these values with ErrInvalidArgument.
 func NewManifestReaderWithProjection(
 	file ManifestFile,
 	in io.Reader,
@@ -833,6 +835,7 @@ func newManifestReader(
 		file:           file,
 		formatVersion:  formatVersion,
 		isFallback:     isFallback,
+		projected:      projection != nil,
 		content:        content,
 		fieldNameToID:  fieldMaps.nameToID,
 		fieldIDToType:  fieldMaps.idToType,
@@ -933,6 +936,7 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	if c.isFallback {
 		tmp = tmp.(*fallbackManifestEntry).toEntry()
 	}
+	tmp.DataFile().(*dataFile).projected = c.projected
 	switch tmp.Status() {
 	case EntryStatusEXISTING, EntryStatusADDED, EntryStatusDELETED:
 	default:
@@ -1969,6 +1973,9 @@ func (w *ManifestWriter) addEntry(entry *manifestEntry) error {
 	var partition map[int]any
 	entryToEncode := *entry
 	if dataFile, ok := entry.DataFile().(*dataFile); ok {
+		if err := dataFile.validateForWrite(); err != nil {
+			return err
+		}
 		partition = dataFile.DataFilePartitionRef(internal.DataFileRef{})
 		encodeDataFile := cloneDataFileAvroFields(dataFile)
 		encodePartition, err := avroEncodePartitionData(
@@ -2598,7 +2605,8 @@ func fitDecimalBytes(bytes []byte, size int) ([]byte, error) {
 }
 
 type dataFile struct {
-	Content                 ManifestEntryContent   `avro:"content"`
+	Content                 ManifestEntryContent `avro:"content"`
+	projected               bool
 	Path                    string                 `avro:"file_path"`
 	Format                  FileFormat             `avro:"file_format"`
 	PartitionData           map[string]any         `avro:"partition"`

--- a/manifest_projection.go
+++ b/manifest_projection.go
@@ -30,7 +30,7 @@ import (
 
 // ManifestEntryProjection selects the optional data-file fields decoded while
 // reading a manifest. The fields needed to build a scan task are always read.
-// When IncludeColumnStats is true, the metric maps used for pruning are also
+// When IncludePruningStats is true, the metric maps used for pruning are also
 // read: value_counts, null_value_counts, nan_value_counts, lower_bounds, and
 // upper_bounds. column_sizes and deprecated distinct_counts remain omitted.
 //
@@ -39,15 +39,17 @@ import (
 // ManifestFile.Entries or ReadManifest instead.
 // Projected entries are read-only planning values and must not be passed to a
 // ManifestWriter, because omitted statistics cannot be recovered on rewrite.
+// ManifestWriter and the DataFile Avro codec reject projected files with
+// ErrInvalidArgument, even when IncludePruningStats is true.
 type ManifestEntryProjection struct {
-	IncludeColumnStats bool
+	IncludePruningStats bool
 }
 
 const manifestEntryProjectionCacheSize = 256
 
 type manifestEntryProjectionCacheKey struct {
-	writerSchema       string
-	includeColumnStats bool
+	writerSchema        string
+	includePruningStats bool
 }
 
 var manifestEntryProjectionCache = func() *lru.Cache[manifestEntryProjectionCacheKey, *avro.Schema] {
@@ -63,7 +65,8 @@ var manifestEntryProjectionCache = func() *lru.Cache[manifestEntryProjectionCach
 // projection. It is the projected counterpart to ManifestFile.Entries and is
 // useful when a caller needs only the fields required for scan planning.
 // The returned entries must not be passed to a ManifestWriter, because the
-// projection may omit statistics that would be silently lost on rewrite.
+// projection may omit statistics that would be lost on rewrite.
+// ManifestWriter and the DataFile Avro codec reject them with ErrInvalidArgument.
 func EntriesWithProjection(
 	fs iceio.IO,
 	m ManifestFile,
@@ -111,8 +114,8 @@ func projectedManifestEntrySchema(
 		// avro.Schema.String returns the original header JSON; it is an O(1)
 		// accessor, not a serialization. The bounded cache retains at most one
 		// copy of each writer-schema string per projection mode.
-		writerSchema:       writerSchema.String(),
-		includeColumnStats: projection.IncludeColumnStats,
+		writerSchema:        writerSchema.String(),
+		includePruningStats: projection.IncludePruningStats,
 	}
 	if cached, ok := manifestEntryProjectionCache.Get(key); ok {
 		return cached, nil
@@ -137,7 +140,7 @@ func projectedManifestEntrySchema(
 
 		fields := make([]avro.SchemaField, 0, len(dataFile.Fields))
 		for _, field := range dataFile.Fields {
-			if manifestScanDataFileField(field.Name, projection.IncludeColumnStats) {
+			if manifestScanDataFileField(field.Name, projection.IncludePruningStats) {
 				fields = append(fields, field)
 			}
 		}
@@ -159,7 +162,7 @@ func projectedManifestEntrySchema(
 	return projected, nil
 }
 
-func manifestScanDataFileField(name string, includeColumnStats bool) bool {
+func manifestScanDataFileField(name string, includePruningStats bool) bool {
 	switch name {
 	case "content", "file_path", "file_format", "partition", "record_count",
 		"file_size_in_bytes", "block_size_in_bytes", "key_metadata", "split_offsets", "equality_ids",
@@ -167,7 +170,7 @@ func manifestScanDataFileField(name string, includeColumnStats bool) bool {
 		"content_size_in_bytes":
 		return true
 	case "value_counts", "null_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds":
-		return includeColumnStats
+		return includePruningStats
 	default:
 		// column_sizes and distinct_counts are not needed to build or read a
 		// FileScanTask.
@@ -180,6 +183,7 @@ func manifestScanDataFileField(name string, includeColumnStats bool) bool {
 // returned unchanged because the package cannot safely clone their private
 // state. The returned value is for read-only planning and must not be passed
 // to a ManifestWriter, because the omitted statistics cannot be recovered.
+// ManifestWriter and the DataFile Avro codec reject the copy with ErrInvalidArgument.
 func DataFileWithoutColumnStats(file DataFile) DataFile {
 	d, ok := file.(*dataFile)
 	if !ok {
@@ -187,6 +191,7 @@ func DataFileWithoutColumnStats(file DataFile) DataFile {
 	}
 
 	out := cloneDataFileAvroFields(d)
+	out.projected = true
 	out.ColSizes = nil
 	out.ValCounts = nil
 	out.NullCounts = nil
@@ -206,7 +211,8 @@ func DataFileWithoutColumnStats(file DataFile) DataFile {
 // ManifestEntryWithoutColumnStats returns a copy of an entry whose built-in
 // DataFile has had transient column statistics removed.
 // The returned entry must not be passed to a ManifestWriter, because omitted
-// statistics would be silently lost on rewrite.
+// statistics would be lost on rewrite. ManifestWriter and the DataFile Avro
+// codec reject entries containing these copies with ErrInvalidArgument.
 func ManifestEntryWithoutColumnStats(entry ManifestEntry) ManifestEntry {
 	m, ok := entry.(*manifestEntry)
 	if !ok {
@@ -217,4 +223,12 @@ func ManifestEntryWithoutColumnStats(entry ManifestEntry) ManifestEntry {
 	out.Data = DataFileWithoutColumnStats(m.Data)
 
 	return &out
+}
+
+func (d *dataFile) validateForWrite() error {
+	if d.projected {
+		return fmt.Errorf("%w: cannot encode projected data file %q; read complete metadata before writing", ErrInvalidArgument, d.Path)
+	}
+
+	return nil
 }

--- a/manifest_projection.go
+++ b/manifest_projection.go
@@ -30,7 +30,9 @@ import (
 
 // ManifestEntryProjection selects the optional data-file fields decoded while
 // reading a manifest. The fields needed to build a scan task are always read.
-// Column statistics are read only when IncludeColumnStats is true.
+// When IncludeColumnStats is true, the metric maps used for pruning are also
+// read: value_counts, null_value_counts, nan_value_counts, lower_bounds, and
+// upper_bounds. column_sizes and deprecated distinct_counts remain omitted.
 //
 // A projected read is intended for planning paths that use statistics
 // transiently. Callers that need the complete DataFile metadata should use

--- a/manifest_projection.go
+++ b/manifest_projection.go
@@ -35,6 +35,8 @@ import (
 // A projected read is intended for planning paths that use statistics
 // transiently. Callers that need the complete DataFile metadata should use
 // ManifestFile.Entries or ReadManifest instead.
+// Projected entries are read-only planning values and must not be passed to a
+// ManifestWriter, because omitted statistics cannot be recovered on rewrite.
 type ManifestEntryProjection struct {
 	IncludeColumnStats bool
 }
@@ -58,6 +60,8 @@ var manifestEntryProjectionCache = func() *lru.Cache[manifestEntryProjectionCach
 // EntriesWithProjection streams manifest entries using a reader-schema
 // projection. It is the projected counterpart to ManifestFile.Entries and is
 // useful when a caller needs only the fields required for scan planning.
+// The returned entries must not be passed to a ManifestWriter, because the
+// projection may omit statistics that would be silently lost on rewrite.
 func EntriesWithProjection(
 	fs iceio.IO,
 	m ManifestFile,
@@ -172,14 +176,14 @@ func manifestScanDataFileField(name string, includeColumnStats bool) bool {
 // DataFileWithoutColumnStats returns a copy of the built-in DataFile with
 // transient column statistics removed. Other DataFile implementations are
 // returned unchanged because the package cannot safely clone their private
-// state.
+// state. The returned value is for read-only planning and must not be passed
+// to a ManifestWriter, because the omitted statistics cannot be recovered.
 func DataFileWithoutColumnStats(file DataFile) DataFile {
 	d, ok := file.(*dataFile)
 	if !ok {
 		return file
 	}
 
-	d.initPartitionData()
 	out := cloneDataFileAvroFields(d)
 	out.ColSizes = nil
 	out.ValCounts = nil
@@ -190,15 +194,17 @@ func DataFileWithoutColumnStats(file DataFile) DataFile {
 	out.UpperBounds = nil
 	out.fieldNameToID = d.fieldNameToID
 	out.fieldIDToLogicalType = d.fieldIDToLogicalType
-	out.fieldIDToPartitionData = d.fieldIDToPartitionData
 	out.fieldIDToDecimalScale = d.fieldIDToDecimalScale
 	out.specID = d.specID
+	out.initPartitionData()
 
 	return out
 }
 
 // ManifestEntryWithoutColumnStats returns a copy of an entry whose built-in
 // DataFile has had transient column statistics removed.
+// The returned entry must not be passed to a ManifestWriter, because omitted
+// statistics would be silently lost on rewrite.
 func ManifestEntryWithoutColumnStats(entry ManifestEntry) ManifestEntry {
 	m, ok := entry.(*manifestEntry)
 	if !ok {

--- a/manifest_projection.go
+++ b/manifest_projection.go
@@ -1,0 +1,206 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"slices"
+
+	iceio "github.com/apache/iceberg-go/io"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/twmb/avro"
+)
+
+// ManifestEntryProjection selects the optional data-file fields decoded while
+// reading a manifest. The fields needed to build a scan task are always read.
+// Column statistics are read only when IncludeColumnStats is true.
+//
+// A projected read is intended for planning paths that use statistics
+// transiently. Callers that need the complete DataFile metadata should use
+// ManifestFile.Entries or ReadManifest instead.
+type ManifestEntryProjection struct {
+	IncludeColumnStats bool
+}
+
+const manifestEntryProjectionCacheSize = 256
+
+type manifestEntryProjectionCacheKey struct {
+	writerSchema       string
+	includeColumnStats bool
+}
+
+var manifestEntryProjectionCache = func() *lru.Cache[manifestEntryProjectionCacheKey, *avro.Schema] {
+	c, err := lru.New[manifestEntryProjectionCacheKey, *avro.Schema](manifestEntryProjectionCacheSize)
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}()
+
+// EntriesWithProjection streams manifest entries using a reader-schema
+// projection. It is the projected counterpart to ManifestFile.Entries and is
+// useful when a caller needs only the fields required for scan planning.
+func EntriesWithProjection(
+	fs iceio.IO,
+	m ManifestFile,
+	discardDeleted bool,
+	projection ManifestEntryProjection,
+) iter.Seq2[ManifestEntry, error] {
+	return manifestEntries(fs, m, discardDeleted, &projection)
+}
+
+func manifestEntries(
+	fs iceio.IO,
+	m ManifestFile,
+	discardDeleted bool,
+	projection *ManifestEntryProjection,
+) iter.Seq2[ManifestEntry, error] {
+	return func(yield func(ManifestEntry, error) bool) {
+		f, err := fs.Open(m.FilePath())
+		if err != nil {
+			yield(nil, err)
+
+			return
+		}
+		aborted := false
+		defer func() {
+			if cerr := f.Close(); cerr != nil && !aborted {
+				yield(nil, cerr)
+			}
+		}()
+
+		for entry, err := range iterManifest(m, f, discardDeleted, projection) {
+			if !yield(entry, err) {
+				aborted = true
+
+				return
+			}
+		}
+	}
+}
+
+func projectedManifestEntrySchema(
+	writerSchema *avro.Schema,
+	projection ManifestEntryProjection,
+) (*avro.Schema, error) {
+	key := manifestEntryProjectionCacheKey{
+		writerSchema:       writerSchema.String(),
+		includeColumnStats: projection.IncludeColumnStats,
+	}
+	if cached, ok := manifestEntryProjectionCache.Get(key); ok {
+		return cached, nil
+	}
+
+	root := writerSchema.Root()
+	projectedRoot := *root
+	projectedRoot.Fields = slices.Clone(root.Fields)
+	dataFileFound := false
+	for i := range projectedRoot.Fields {
+		if projectedRoot.Fields[i].Name != "data_file" {
+			continue
+		}
+
+		dataFileFound = true
+		dataFile := projectedRoot.Fields[i].Type
+		if dataFile.Type != "record" {
+			return nil, fmt.Errorf("manifest entry data_file has unexpected Avro type %q", dataFile.Type)
+		}
+
+		fields := make([]avro.SchemaField, 0, len(dataFile.Fields))
+		for _, field := range dataFile.Fields {
+			if manifestScanDataFileField(field.Name, projection.IncludeColumnStats) {
+				fields = append(fields, field)
+			}
+		}
+		dataFile.Fields = fields
+		projectedRoot.Fields[i].Type = dataFile
+
+		break
+	}
+	if !dataFileFound {
+		return nil, errors.New("manifest entry schema does not contain a data_file field")
+	}
+
+	projected, err := projectedRoot.Schema()
+	if err != nil {
+		return nil, fmt.Errorf("build projected manifest entry schema: %w", err)
+	}
+	manifestEntryProjectionCache.Add(key, projected)
+
+	return projected, nil
+}
+
+func manifestScanDataFileField(name string, includeColumnStats bool) bool {
+	switch name {
+	case "content", "file_path", "file_format", "partition", "record_count",
+		"file_size_in_bytes", "key_metadata", "split_offsets", "equality_ids",
+		"sort_order_id", "first_row_id", "referenced_data_file", "content_offset",
+		"content_size_in_bytes":
+		return true
+	case "value_counts", "null_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds":
+		return includeColumnStats
+	default:
+		// block_size_in_bytes, column_sizes, and distinct_counts are not
+		// needed to build or read a FileScanTask.
+		return false
+	}
+}
+
+// DataFileWithoutColumnStats returns a copy of the built-in DataFile with
+// transient column statistics removed. Other DataFile implementations are
+// returned unchanged because the package cannot safely clone their private
+// state.
+func DataFileWithoutColumnStats(file DataFile) DataFile {
+	d, ok := file.(*dataFile)
+	if !ok {
+		return file
+	}
+
+	out := cloneDataFileAvroFields(d)
+	out.ColSizes = nil
+	out.ValCounts = nil
+	out.NullCounts = nil
+	out.NaNCounts = nil
+	out.DistinctCounts = nil
+	out.LowerBounds = nil
+	out.UpperBounds = nil
+	out.fieldNameToID = d.fieldNameToID
+	out.fieldIDToLogicalType = d.fieldIDToLogicalType
+	out.fieldIDToPartitionData = d.fieldIDToPartitionData
+	out.fieldIDToDecimalScale = d.fieldIDToDecimalScale
+	out.specID = d.specID
+
+	return out
+}
+
+// ManifestEntryWithoutColumnStats returns a copy of an entry whose built-in
+// DataFile has had transient column statistics removed.
+func ManifestEntryWithoutColumnStats(entry ManifestEntry) ManifestEntry {
+	m, ok := entry.(*manifestEntry)
+	if !ok {
+		return entry
+	}
+
+	out := *m
+	out.Data = DataFileWithoutColumnStats(m.Data)
+
+	return &out
+}

--- a/manifest_projection.go
+++ b/manifest_projection.go
@@ -174,6 +174,7 @@ func DataFileWithoutColumnStats(file DataFile) DataFile {
 		return file
 	}
 
+	d.initPartitionData()
 	out := cloneDataFileAvroFields(d)
 	out.ColSizes = nil
 	out.ValCounts = nil

--- a/manifest_projection_bench_test.go
+++ b/manifest_projection_bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkManifestEntryProjection(b *testing.B) {
 				benchmarkManifestEntryRead(b, fixture, &ManifestEntryProjection{})
 			})
 			b.Run("scan_with_stats", func(b *testing.B) {
-				benchmarkManifestEntryRead(b, fixture, &ManifestEntryProjection{IncludeColumnStats: true})
+				benchmarkManifestEntryRead(b, fixture, &ManifestEntryProjection{IncludePruningStats: true})
 			})
 		})
 	}

--- a/manifest_projection_bench_test.go
+++ b/manifest_projection_bench_test.go
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+	"testing"
+
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+var manifestProjectionBenchmarkSink int
+
+func BenchmarkManifestEntryProjection(b *testing.B) {
+	for _, fieldCount := range []int{10, 100, 1_000} {
+		b.Run(fmt.Sprintf("stats_fields=%d", fieldCount), func(b *testing.B) {
+			fixture := newManifestProjectionBenchmarkFixture(b, fieldCount, 10_000)
+
+			b.Run("full", func(b *testing.B) {
+				benchmarkManifestEntryRead(b, fixture, nil)
+			})
+			b.Run("scan", func(b *testing.B) {
+				benchmarkManifestEntryRead(b, fixture, &ManifestEntryProjection{})
+			})
+			b.Run("scan_with_stats", func(b *testing.B) {
+				benchmarkManifestEntryRead(b, fixture, &ManifestEntryProjection{IncludeColumnStats: true})
+			})
+		})
+	}
+}
+
+type manifestProjectionBenchmarkFixture struct {
+	fs       *iceio.MemFS
+	manifest ManifestFile
+	count    int
+}
+
+func newManifestProjectionBenchmarkFixture(
+	b *testing.B,
+	fieldCount, entryCount int,
+) manifestProjectionBenchmarkFixture {
+	b.Helper()
+
+	fields := make([]NestedField, fieldCount)
+	valueCounts := make(map[int]int64, fieldCount)
+	nullCounts := make(map[int]int64, fieldCount)
+	nanCounts := make(map[int]int64, fieldCount)
+	lowerBounds := make(map[int][]byte, fieldCount)
+	upperBounds := make(map[int][]byte, fieldCount)
+	columnSizes := make(map[int]int64, fieldCount)
+	distinctCounts := make(map[int]int64, fieldCount)
+	for i := range fieldCount {
+		id := i + 1
+		fields[i] = NestedField{
+			ID: id, Name: fmt.Sprintf("field_%d", id), Type: PrimitiveTypes.Int64, Required: true,
+		}
+		valueCounts[id] = int64(entryCount)
+		nullCounts[id] = 0
+		nanCounts[id] = 0
+		lowerBounds[id] = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+		upperBounds[id] = []byte{0, 0, 0, 0, 0, 0, 0, 1}
+		columnSizes[id] = 64
+		distinctCounts[id] = 1
+	}
+	schema := NewSchema(1, fields...)
+	builder, err := NewDataFileBuilder(
+		*UnpartitionedSpec,
+		EntryContentData,
+		"data.parquet",
+		ParquetFile,
+		nil,
+		nil,
+		nil,
+		int64(entryCount),
+		128,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	builder.
+		ColumnSizes(columnSizes).
+		ValueCounts(valueCounts).
+		NullValueCounts(nullCounts).
+		NaNValueCounts(nanCounts).
+		DistinctValueCounts(distinctCounts).
+		LowerBoundValues(lowerBounds).
+		UpperBoundValues(upperBounds)
+
+	snapshotID := int64(1)
+	entries := make([]ManifestEntry, entryCount)
+	for i := range entries {
+		entries[i] = NewManifestEntry(EntryStatusADDED, &snapshotID, nil, nil, builder.Build())
+	}
+
+	manifestPath := fmt.Sprintf("mem://manifest-%d.avro", fieldCount)
+	var manifestBytes bytes.Buffer
+	manifest, err := WriteManifest(
+		manifestPath,
+		&manifestBytes,
+		2,
+		*UnpartitionedSpec,
+		schema,
+		snapshotID,
+		entries,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	fs := iceio.NewMemFS()
+	if err := fs.WriteFile(manifestPath, manifestBytes.Bytes()); err != nil {
+		b.Fatal(err)
+	}
+
+	return manifestProjectionBenchmarkFixture{fs: fs, manifest: manifest, count: entryCount}
+}
+
+func benchmarkManifestEntryRead(
+	b *testing.B,
+	fixture manifestProjectionBenchmarkFixture,
+	projection *ManifestEntryProjection,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ReportMetric(float64(fixture.count), "entries/op")
+	b.ResetTimer()
+
+	for b.Loop() {
+		count := 0
+		var entries iter.Seq2[ManifestEntry, error]
+		if projection == nil {
+			entries = fixture.manifest.Entries(fixture.fs, true)
+		} else {
+			entries = EntriesWithProjection(fixture.fs, fixture.manifest, true, *projection)
+		}
+		for entry, err := range entries {
+			if err != nil {
+				b.Fatal(err)
+			}
+			count++
+			manifestProjectionBenchmarkSink += len(entry.DataFile().FilePath())
+		}
+		if count != fixture.count {
+			b.Fatalf("read %d entries, want %d", count, fixture.count)
+		}
+	}
+}

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -19,6 +19,7 @@ package iceberg
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,4 +141,28 @@ func TestManifestEntryWithoutColumnStatsPreservesEntry(t *testing.T) {
 	assert.Equal(t, entry.DataFile().FilePath(), projected.DataFile().FilePath())
 	assert.Empty(t, projected.DataFile().ValueCounts())
 	assert.Equal(t, map[int]int64{1: 1}, entry.DataFile().ValueCounts())
+}
+
+func TestDataFileWithoutColumnStatsConcurrentPartitionInitialization(t *testing.T) {
+	for range 32 {
+		file := &dataFile{
+			PartitionData: map[string]any{"partition": int32(7)},
+			fieldNameToID: map[string]int{"partition": 1000},
+		}
+		start := make(chan struct{})
+		var workers sync.WaitGroup
+		for range 8 {
+			workers.Go(func() {
+				<-start
+				assert.Equal(t, map[int]any{1000: int32(7)}, file.Partition())
+			})
+			workers.Go(func() {
+				<-start
+				projected := DataFileWithoutColumnStats(file)
+				assert.Equal(t, map[int]any{1000: int32(7)}, projected.Partition())
+			})
+		}
+		close(start)
+		workers.Wait()
+	}
 }

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iceberg
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestEntryProjectionDropsTransientStats(t *testing.T) {
+	schema := NewSchema(1, NestedField{
+		ID: 1, Name: "id", Type: PrimitiveTypes.Int64, Required: true,
+	})
+	builder, err := NewDataFileBuilder(
+		*UnpartitionedSpec,
+		EntryContentData,
+		"data.parquet",
+		ParquetFile,
+		nil,
+		nil,
+		nil,
+		3,
+		128,
+	)
+	require.NoError(t, err)
+	builder.
+		ColumnSizes(map[int]int64{1: 10}).
+		ValueCounts(map[int]int64{1: 3}).
+		NullValueCounts(map[int]int64{1: 0}).
+		NaNValueCounts(map[int]int64{1: 0}).
+		LowerBoundValues(map[int][]byte{1: {0x01}}).
+		UpperBoundValues(map[int][]byte{1: {0x03}}).
+		KeyMetadata([]byte{0x04}).
+		SplitOffsets([]int64{4, 64}).
+		SortOrderID(7).
+		FirstRowID(10).
+		ReferencedDataFile("data.parquet").
+		ContentOffset(12).
+		ContentSizeInBytes(20)
+
+	snapshotID := int64(5)
+	sequenceNumber := int64(6)
+	fileSequenceNumber := int64(7)
+	entry := NewManifestEntry(
+		EntryStatusADDED,
+		&snapshotID,
+		&sequenceNumber,
+		&fileSequenceNumber,
+		builder.Build(),
+	)
+	var manifestBytes bytes.Buffer
+	manifest, err := WriteManifest(
+		"manifest.avro", &manifestBytes, 3, *UnpartitionedSpec, schema, snapshotID,
+		[]ManifestEntry{entry},
+	)
+	require.NoError(t, err)
+
+	reader, err := NewManifestReaderWithProjection(
+		manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{},
+	)
+	require.NoError(t, err)
+	projected, err := reader.ReadEntry()
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	assert.Equal(t, entry.Status(), projected.Status())
+	assert.Equal(t, entry.SnapshotID(), projected.SnapshotID())
+	assert.Equal(t, entry.SequenceNum(), projected.SequenceNum())
+	assert.Equal(t, entry.FileSequenceNum(), projected.FileSequenceNum())
+	assert.Equal(t, "data.parquet", projected.DataFile().FilePath())
+	assert.Equal(t, int64(3), projected.DataFile().Count())
+	assert.Equal(t, int64(128), projected.DataFile().FileSizeBytes())
+	assert.Equal(t, []int64{4, 64}, projected.DataFile().SplitOffsets())
+	assert.Equal(t, 7, *projected.DataFile().SortOrderID())
+	assert.Equal(t, int64(10), *projected.DataFile().FirstRowID())
+	assert.Equal(t, "data.parquet", *projected.DataFile().ReferencedDataFile())
+	assert.Equal(t, int64(12), *projected.DataFile().ContentOffset())
+	assert.Equal(t, int64(20), *projected.DataFile().ContentSizeInBytes())
+	assert.Equal(t, []byte{0x04}, projected.DataFile().KeyMetadata())
+	assert.Empty(t, projected.DataFile().ColumnSizes())
+	assert.Empty(t, projected.DataFile().ValueCounts())
+	assert.Empty(t, projected.DataFile().NullValueCounts())
+	assert.Empty(t, projected.DataFile().NaNValueCounts())
+	assert.Empty(t, projected.DataFile().LowerBoundValues())
+	assert.Empty(t, projected.DataFile().UpperBoundValues())
+
+	statsReader, err := NewManifestReaderWithProjection(
+		manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludeColumnStats: true},
+	)
+	require.NoError(t, err)
+	withStats, err := statsReader.ReadEntry()
+	require.NoError(t, err)
+	require.NoError(t, statsReader.Close())
+	assert.Equal(t, map[int]int64{1: 3}, withStats.DataFile().ValueCounts())
+	assert.Equal(t, map[int][]byte{1: {0x01}}, withStats.DataFile().LowerBoundValues())
+	assert.Equal(t, map[int][]byte{1: {0x03}}, withStats.DataFile().UpperBoundValues())
+	assert.Empty(t, withStats.DataFile().ColumnSizes())
+}
+
+func TestManifestEntryWithoutColumnStatsPreservesEntry(t *testing.T) {
+	builder, err := NewDataFileBuilder(
+		*UnpartitionedSpec,
+		EntryContentData,
+		"data.parquet",
+		ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		10,
+	)
+	require.NoError(t, err)
+	builder.ValueCounts(map[int]int64{1: 1})
+
+	snapshotID := int64(3)
+	entry := NewManifestEntry(EntryStatusEXISTING, &snapshotID, nil, nil, builder.Build())
+	projected := ManifestEntryWithoutColumnStats(entry)
+
+	assert.NotSame(t, entry, projected)
+	assert.Equal(t, entry.Status(), projected.Status())
+	assert.Equal(t, entry.SnapshotID(), projected.SnapshotID())
+	assert.Equal(t, entry.DataFile().FilePath(), projected.DataFile().FilePath())
+	assert.Empty(t, projected.DataFile().ValueCounts())
+	assert.Equal(t, map[int]int64{1: 1}, entry.DataFile().ValueCounts())
+}

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"testing"
 
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -167,7 +168,7 @@ func TestManifestEntryProjectionDropsTransientStats(t *testing.T) {
 	assert.Empty(t, projected.DataFile().UpperBoundValues())
 
 	statsReader, err := NewManifestReaderWithProjection(
-		manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludeColumnStats: true},
+		manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludePruningStats: true},
 	)
 	require.NoError(t, err)
 	withStats, err := statsReader.ReadEntry()
@@ -213,6 +214,7 @@ func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T)
 			require.NoError(t, err)
 			builder.
 				BlockSizeInBytes(64 * 1024).
+				ColumnSizes(map[int]int64{1: 64}).
 				ValueCounts(map[int]int64{1: 1}).
 				NullValueCounts(map[int]int64{1: 0}).
 				NaNValueCounts(map[int]int64{1: 0}).
@@ -253,6 +255,7 @@ func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T)
 				manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{},
 			)
 			require.NoError(t, err)
+			assert.Equal(t, tt.version == 1, reader.isFallback)
 			projected, err := reader.ReadEntry()
 			require.NoError(t, err)
 			require.NoError(t, reader.Close())
@@ -272,7 +275,7 @@ func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T)
 			}
 
 			statsReader, err := NewManifestReaderWithProjection(
-				manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludeColumnStats: true},
+				manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludePruningStats: true},
 			)
 			require.NoError(t, err)
 			withStats, err := statsReader.ReadEntry()
@@ -284,6 +287,75 @@ func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T)
 			assert.Equal(t, map[int][]byte{1: {0x01}}, withStats.DataFile().LowerBoundValues())
 			assert.Equal(t, map[int][]byte{1: {0x01}}, withStats.DataFile().UpperBoundValues())
 			assert.Empty(t, withStats.DataFile().ColumnSizes())
+
+			fullReader, err := NewManifestReader(manifest, bytes.NewReader(manifestBytes.Bytes()))
+			require.NoError(t, err)
+			full, err := fullReader.ReadEntry()
+			require.NoError(t, err)
+			require.NoError(t, fullReader.Close())
+			assert.Equal(t, map[int]int64{1: 64}, full.DataFile().ColumnSizes())
+
+			fs := iceio.NewMemFS()
+			require.NoError(t, fs.WriteFile(manifest.FilePath(), manifestBytes.Bytes()))
+			projectedEntries := map[string]ManifestEntry{
+				"reader":                    projected,
+				"reader with pruning stats": withStats,
+				"entry without stats":       ManifestEntryWithoutColumnStats(full),
+				"data file without stats": NewManifestEntry(EntryStatusADDED, &snapshotID,
+					&sequenceNumber, nil, DataFileWithoutColumnStats(full.DataFile())),
+				"repeated projection": ManifestEntryWithoutColumnStats(projected),
+			}
+			for entry, err := range EntriesWithProjection(fs, manifest, false, ManifestEntryProjection{}) {
+				require.NoError(t, err)
+				projectedEntries["iterator"] = entry
+			}
+			require.Len(t, projectedEntries, 6)
+			for name, projectedEntry := range projectedEntries {
+				t.Run(name, func(t *testing.T) {
+					for _, operation := range []string{"add", "existing", "delete"} {
+						t.Run(operation, func(t *testing.T) {
+							var output bytes.Buffer
+							writer, err := NewManifestWriter(tt.version, &output, *UnpartitionedSpec,
+								schema, snapshotID, WithManifestWriterContent(tt.manifestContent))
+							require.NoError(t, err)
+							writeEntry := map[string]func(ManifestEntry) error{
+								"add": writer.Add, "existing": writer.Existing, "delete": writer.Delete,
+							}[operation]
+							err = writeEntry(projectedEntry)
+							require.ErrorIs(t, err, ErrInvalidArgument)
+							require.ErrorContains(t, err, "projected data file")
+
+							// Rejection must leave the writer usable and its counts unchanged.
+							require.NoError(t, writer.Add(full))
+							rewritten, err := writer.ToManifestFile("rewritten.avro", int64(output.Len()))
+							require.NoError(t, err)
+							assert.EqualValues(t, 1, rewritten.AddedDataFiles())
+							assert.Zero(t, rewritten.ExistingDataFiles())
+							assert.Zero(t, rewritten.DeletedDataFiles())
+							reader, err := NewManifestReader(rewritten, bytes.NewReader(output.Bytes()))
+							require.NoError(t, err)
+							roundTrip, err := reader.ReadEntry()
+							require.NoError(t, err)
+							require.NoError(t, reader.Close())
+							assert.Equal(t, full.DataFile().ColumnSizes(), roundTrip.DataFile().ColumnSizes())
+						})
+					}
+					if tt.manifestContent == ManifestContentData {
+						var output bytes.Buffer
+						_, err := WriteManifest("rewritten.avro", &output, tt.version,
+							*UnpartitionedSpec, schema, snapshotID, []ManifestEntry{projectedEntry})
+						require.ErrorIs(t, err, ErrInvalidArgument)
+						if tt.version == 3 {
+							_, _, err = WriteManifestV3("rewritten-v3.avro", &output, 0,
+								*UnpartitionedSpec, schema, snapshotID, []ManifestEntry{projectedEntry})
+							require.ErrorIs(t, err, ErrInvalidArgument)
+						}
+					}
+					_, err := projectedEntry.DataFile().(AvroEntryMarshaler).MarshalAvroEntry(
+						*UnpartitionedSpec, schema, tt.version)
+					require.ErrorIs(t, err, ErrInvalidArgument)
+				})
+			}
 		})
 	}
 }

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -324,3 +324,15 @@ func TestDataFileWithoutColumnStatsConcurrentPartitionInitialization(t *testing.
 		workers.Wait()
 	}
 }
+
+func TestDataFileWithoutColumnStatsDoesNotInitializeSourcePartition(t *testing.T) {
+	file := &dataFile{
+		PartitionData: map[string]any{"partition": int32(7)},
+		fieldNameToID: map[string]int{"partition": 1000},
+	}
+
+	projected := DataFileWithoutColumnStats(file)
+
+	assert.Nil(t, file.fieldIDToPartitionData)
+	assert.Equal(t, map[int]any{1000: int32(7)}, projected.Partition())
+}

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -116,6 +116,97 @@ func TestManifestEntryProjectionDropsTransientStats(t *testing.T) {
 	assert.Empty(t, withStats.DataFile().ColumnSizes())
 }
 
+func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         int
+		manifestContent ManifestContent
+		entryContent    ManifestEntryContent
+		format          FileFormat
+	}{
+		{name: "v1 data", version: 1, manifestContent: ManifestContentData, entryContent: EntryContentData, format: ParquetFile},
+		{name: "v2 data", version: 2, manifestContent: ManifestContentData, entryContent: EntryContentData, format: ParquetFile},
+		{name: "v3 data", version: 3, manifestContent: ManifestContentData, entryContent: EntryContentData, format: ParquetFile},
+		{name: "v2 equality delete", version: 2, manifestContent: ManifestContentDeletes, entryContent: EntryContentEqDeletes, format: ParquetFile},
+		{name: "v3 deletion vector", version: 3, manifestContent: ManifestContentDeletes, entryContent: EntryContentPosDeletes, format: PuffinFile},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema(1, NestedField{
+				ID: 1, Name: "id", Type: PrimitiveTypes.Int64, Required: true,
+			})
+			builder, err := NewDataFileBuilder(
+				*UnpartitionedSpec,
+				tt.entryContent,
+				tt.name+".data",
+				tt.format,
+				nil,
+				nil,
+				nil,
+				1,
+				128,
+			)
+			require.NoError(t, err)
+			builder.
+				ValueCounts(map[int]int64{1: 1}).
+				NullValueCounts(map[int]int64{1: 0}).
+				NaNValueCounts(map[int]int64{1: 0}).
+				LowerBoundValues(map[int][]byte{1: {0x01}}).
+				UpperBoundValues(map[int][]byte{1: {0x01}})
+			if tt.entryContent == EntryContentEqDeletes {
+				builder.EqualityFieldIDs([]int{1})
+			}
+			if tt.entryContent == EntryContentPosDeletes && tt.format == PuffinFile {
+				builder.ReferencedDataFile("data.parquet").ContentOffset(4).ContentSizeInBytes(8)
+			}
+
+			snapshotID := int64(5)
+			sequenceNumber := int64(6)
+			entry := NewManifestEntry(
+				EntryStatusADDED,
+				&snapshotID,
+				&sequenceNumber,
+				nil,
+				builder.Build(),
+			)
+			var manifestBytes bytes.Buffer
+			writer, err := NewManifestWriter(
+				tt.version,
+				&manifestBytes,
+				*UnpartitionedSpec,
+				schema,
+				snapshotID,
+				WithManifestWriterContent(tt.manifestContent),
+			)
+			require.NoError(t, err)
+			require.NoError(t, writer.Add(entry))
+			manifest, err := writer.ToManifestFile(
+				tt.name+".manifest.avro", int64(manifestBytes.Len()))
+			require.NoError(t, err)
+
+			reader, err := NewManifestReaderWithProjection(
+				manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{},
+			)
+			require.NoError(t, err)
+			projected, err := reader.ReadEntry()
+			require.NoError(t, err)
+			require.NoError(t, reader.Close())
+
+			assert.Equal(t, tt.entryContent, projected.DataFile().ContentType())
+			assert.Equal(t, entry.DataFile().FilePath(), projected.DataFile().FilePath())
+			assert.Empty(t, projected.DataFile().ValueCounts())
+			assert.Empty(t, projected.DataFile().LowerBoundValues())
+			if tt.entryContent == EntryContentPosDeletes && tt.format == PuffinFile {
+				require.NotNil(t, projected.DataFile().ReferencedDataFile())
+				assert.Equal(t, "data.parquet", *projected.DataFile().ReferencedDataFile())
+				assert.Equal(t, int64(4), *projected.DataFile().ContentOffset())
+				assert.Equal(t, int64(8), *projected.DataFile().ContentSizeInBytes())
+			}
+		})
+	}
+}
+
 func TestManifestEntryWithoutColumnStatsPreservesEntry(t *testing.T) {
 	builder, err := NewDataFileBuilder(
 		*UnpartitionedSpec,

--- a/manifest_projection_test.go
+++ b/manifest_projection_test.go
@@ -270,6 +270,20 @@ func TestManifestEntryProjectionSupportsManifestVersionsAndDeletes(t *testing.T)
 				assert.Equal(t, int64(4), *projected.DataFile().ContentOffset())
 				assert.Equal(t, int64(8), *projected.DataFile().ContentSizeInBytes())
 			}
+
+			statsReader, err := NewManifestReaderWithProjection(
+				manifest, bytes.NewReader(manifestBytes.Bytes()), ManifestEntryProjection{IncludeColumnStats: true},
+			)
+			require.NoError(t, err)
+			withStats, err := statsReader.ReadEntry()
+			require.NoError(t, err)
+			require.NoError(t, statsReader.Close())
+			assert.Equal(t, map[int]int64{1: 1}, withStats.DataFile().ValueCounts())
+			assert.Equal(t, map[int]int64{1: 0}, withStats.DataFile().NullValueCounts())
+			assert.Equal(t, map[int]int64{1: 0}, withStats.DataFile().NaNValueCounts())
+			assert.Equal(t, map[int][]byte{1: {0x01}}, withStats.DataFile().LowerBoundValues())
+			assert.Equal(t, map[int][]byte{1: {0x01}}, withStats.DataFile().UpperBoundValues())
+			assert.Empty(t, withStats.DataFile().ColumnSizes())
 		})
 	}
 }

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1123,6 +1123,10 @@ func (scan *Scan) collectManifestEntriesWithSchemaOptions(
 	partitionEvaluators := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
 		return buildPartitionEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
 	})
+	// Delete manifests do not identify whether they contain positional or
+	// equality deletes in the manifest-list metadata. Keep data-file stats when
+	// any delete manifest is present so equality-delete pruning remains
+	// available after the entries are classified.
 	retainDataFileStats := scan.manifestProjectionRetainsDataStats(manifestList)
 
 	for manifestIndex, mf := range manifestList {
@@ -1142,13 +1146,9 @@ func (scan *Scan) collectManifestEntriesWithSchemaOptions(
 			var projection *iceberg.ManifestEntryProjection
 			dropColumnStats := false
 			if projectScanColumns {
-				p := iceberg.ManifestEntryProjection{
-					IncludeColumnStats: scan.manifestProjectionNeedsStats(mf, retainDataFileStats),
-				}
+				var p iceberg.ManifestEntryProjection
+				p, dropColumnStats = scan.manifestProjectionForManifest(mf, retainDataFileStats)
 				projection = &p
-				dropColumnStats = p.IncludeColumnStats &&
-					mf.ManifestContent() == iceberg.ManifestContentData &&
-					!retainDataFileStats
 			}
 			manifestEntries, err := openManifestWithProjection(
 				fs, mf, partEval, metricsEval, projection, dropColumnStats)
@@ -1172,10 +1172,18 @@ func (scan *Scan) collectManifestEntriesWithSchemaOptions(
 	return flattenClassifiedManifestEntries(manifestResults), nil
 }
 
-func (scan *Scan) manifestProjectionNeedsStats(manifest iceberg.ManifestFile, retainDataFileStats bool) bool {
-	return manifest.ManifestContent() == iceberg.ManifestContentDeletes ||
+func (scan *Scan) manifestProjectionForManifest(
+	manifest iceberg.ManifestFile,
+	retainDataFileStats bool,
+) (iceberg.ManifestEntryProjection, bool) {
+	includeColumnStats := manifest.ManifestContent() == iceberg.ManifestContentDeletes ||
 		retainDataFileStats ||
 		(scan.rowFilter != nil && !scan.rowFilter.Equals(iceberg.AlwaysTrue{}))
+	dropColumnStats := includeColumnStats &&
+		manifest.ManifestContent() == iceberg.ManifestContentData &&
+		!retainDataFileStats
+
+	return iceberg.ManifestEntryProjection{IncludeColumnStats: includeColumnStats}, dropColumnStats
 }
 
 func (scan *Scan) manifestProjectionRetainsDataStats(manifestList []iceberg.ManifestFile) bool {
@@ -1435,11 +1443,6 @@ func (scan *Scan) planFilesLocal(
 		acc.totalFileSize += e.DataFile().FileSizeBytes()
 	}
 
-	acc.resultDataFiles = int64(len(results))
-	// Delete-file metrics are derived from the planned tasks so they are
-	// result-scoped, consistent with result-data-files and total-file-size (a
-	// DV-suppressed positional delete never lands on a task, so it is excluded).
-	acc.applyResultDeleteMetrics(results)
 	if projectScanColumns {
 		// The indexes retain the full delete entries while matching them to
 		// data files. Release those references before returning so only the

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1120,17 +1120,6 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		ctx, manifestList, schema, partitionFilters, minSequenceNum(manifestList), false)
 }
 
-func (scan *Scan) collectManifestEntriesWithSchemaOptions(
-	ctx context.Context,
-	manifestList []iceberg.ManifestFile,
-	schema *iceberg.Schema,
-	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression],
-	projectScanColumns bool,
-) (*manifestEntries, error) {
-	return scan.collectManifestEntriesWithSchemaMinSequenceNum(
-		ctx, manifestList, schema, partitionFilters, minSequenceNum(manifestList), projectScanColumns)
-}
-
 func (scan *Scan) collectManifestEntriesWithSchemaMinSequenceNum(
 	ctx context.Context,
 	manifestList []iceberg.ManifestFile,
@@ -1363,9 +1352,11 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 			}
 			var projection *iceberg.ManifestEntryProjection
 			dropColumnStats := false
+			stripTaskColumnStats := false
 			if projectScanColumns {
 				var p iceberg.ManifestEntryProjection
 				p, dropColumnStats = scan.manifestProjectionForManifest(manifest, retainDataFileStats)
+				stripTaskColumnStats = p.IncludeColumnStats && !dropColumnStats
 				projection = &p
 			}
 			err = streamManifest(fs, manifest, partEval, metricsEval, projection, dropColumnStats, func(entry iceberg.ManifestEntry) error {
@@ -1379,13 +1370,10 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 				if err != nil {
 					return err
 				}
-				if projectScanColumns {
+				if stripTaskColumnStats {
 					// Statistics are needed while filtering and matching deletes, but
 					// are transient for the task returned to Arrow readers.
 					task.File = iceberg.DataFileWithoutColumnStats(task.File)
-					task.DeleteFiles = dataFilesWithoutColumnStats(task.DeleteFiles)
-					task.EqualityDeleteFiles = dataFilesWithoutColumnStats(task.EqualityDeleteFiles)
-					task.DeletionVectorFiles = dataFilesWithoutColumnStats(task.DeletionVectorFiles)
 				}
 				tasks = append(tasks, task)
 
@@ -1405,6 +1393,7 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 		return nil, err
 	}
 
+	var results []FileScanTask
 	if directBuffer {
 		overflowed := false
 		for index, tasks := range taskBatches {
@@ -1427,20 +1416,33 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 				taskBatches[index] = nil
 			}
 
-			return taskBuffer[:writeIndex:writeIndex], nil
+			results = taskBuffer[:writeIndex:writeIndex]
+		} else {
+			directBuffer = false
 		}
 	}
 
-	totalTasks := 0
-	for _, tasks := range taskBatches {
-		totalTasks += len(tasks)
+	if !directBuffer {
+		totalTasks := 0
+		for _, tasks := range taskBatches {
+			totalTasks += len(tasks)
+		}
+		results = make([]FileScanTask, 0, totalTasks)
+		for i, tasks := range taskBatches {
+			results = append(results, tasks...)
+			// Release the per-manifest backing array as soon as it has been copied
+			// into the final result slice.
+			taskBatches[i] = nil
+		}
 	}
-	results := make([]FileScanTask, 0, totalTasks)
-	for i, tasks := range taskBatches {
-		results = append(results, tasks...)
-		// Release the per-manifest backing array as soon as it has been copied
-		// into the final result slice.
-		taskBatches[i] = nil
+
+	if projectScanColumns && retainDataFileStats {
+		memo := make(map[iceberg.DataFile]iceberg.DataFile)
+		for i := range results {
+			results[i].DeleteFiles = dataFilesWithoutColumnStats(results[i].DeleteFiles, memo)
+			results[i].EqualityDeleteFiles = dataFilesWithoutColumnStats(results[i].EqualityDeleteFiles, memo)
+			results[i].DeletionVectorFiles = dataFilesWithoutColumnStats(results[i].DeletionVectorFiles, memo)
+		}
 	}
 
 	return results, nil
@@ -1725,13 +1727,27 @@ func (scan *Scan) planFilesLocal(
 	return results, nil
 }
 
-func dataFilesWithoutColumnStats(files []iceberg.DataFile) []iceberg.DataFile {
+func dataFilesWithoutColumnStats(
+	files []iceberg.DataFile,
+	memo map[iceberg.DataFile]iceberg.DataFile,
+) []iceberg.DataFile {
 	if len(files) == 0 {
 		return files
 	}
 
 	projected := make([]iceberg.DataFile, len(files))
 	for i, file := range files {
+		if file != nil && reflect.TypeOf(file).Comparable() {
+			if cached, ok := memo[file]; ok {
+				projected[i] = cached
+
+				continue
+			}
+			projected[i] = iceberg.DataFileWithoutColumnStats(file)
+			memo[file] = projected[i]
+
+			continue
+		}
 		projected[i] = iceberg.DataFileWithoutColumnStats(file)
 	}
 

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1148,7 +1148,6 @@ func (scan *Scan) collectManifestEntriesWithSchemaMinSequenceNum(
 	partitionEvaluators := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
 		return buildPartitionEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
 	})
-	retainDataFileStats := scan.manifestProjectionRetainsDataStats(manifestList)
 
 	for manifestIndex, mf := range manifestList {
 		if !scan.checkSequenceNumber(minSeqNum, mf) {
@@ -1165,14 +1164,13 @@ func (scan *Scan) collectManifestEntriesWithSchemaMinSequenceNum(
 				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
 			}
 			var projection *iceberg.ManifestEntryProjection
-			dropColumnStats := false
 			if projectScanColumns {
-				var p iceberg.ManifestEntryProjection
-				p, dropColumnStats = scan.manifestProjectionForManifest(mf, retainDataFileStats)
-				projection = &p
+				// Projected collection reads delete manifests before classification.
+				// Keep pruning stats until equality and positional deletes are indexed.
+				projection = &iceberg.ManifestEntryProjection{IncludePruningStats: true}
 			}
 			manifestEntries, err := openManifestWithProjection(
-				fs, mf, partEval, metricsEval, projection, dropColumnStats)
+				fs, mf, partEval, metricsEval, projection, false)
 			if err != nil {
 				return err
 			}
@@ -1193,32 +1191,12 @@ func (scan *Scan) collectManifestEntriesWithSchemaMinSequenceNum(
 	return flattenClassifiedManifestEntries(manifestResults), nil
 }
 
-func (scan *Scan) manifestProjectionForManifest(
-	manifest iceberg.ManifestFile,
-	retainDataFileStats bool,
-) (iceberg.ManifestEntryProjection, bool) {
-	// Manifest-list metadata does not distinguish equality from positional
-	// deletes, so delete manifests retain their stats while they are being
-	// classified. Once classification is complete, retainDataFileStats is set
-	// only when an equality delete actually needs data-file metrics for pruning.
-	includeColumnStats := manifest.ManifestContent() == iceberg.ManifestContentDeletes ||
-		retainDataFileStats ||
+func (scan *Scan) dataManifestProjection(retainDataFileStats bool) (iceberg.ManifestEntryProjection, bool) {
+	includePruningStats := retainDataFileStats ||
 		(scan.rowFilter != nil && !scan.rowFilter.Equals(iceberg.AlwaysTrue{}))
-	dropColumnStats := includeColumnStats &&
-		manifest.ManifestContent() == iceberg.ManifestContentData &&
-		!retainDataFileStats
+	dropColumnStats := includePruningStats && !retainDataFileStats
 
-	return iceberg.ManifestEntryProjection{IncludeColumnStats: includeColumnStats}, dropColumnStats
-}
-
-func (scan *Scan) manifestProjectionRetainsDataStats(manifestList []iceberg.ManifestFile) bool {
-	for _, manifest := range manifestList {
-		if manifest.ManifestContent() == iceberg.ManifestContentDeletes {
-			return true
-		}
-	}
-
-	return false
+	return iceberg.ManifestEntryProjection{IncludePruningStats: includePruningStats}, dropColumnStats
 }
 
 func splitManifestList(manifestList []iceberg.ManifestFile) (dataManifests, deleteManifests []iceberg.ManifestFile) {
@@ -1356,8 +1334,8 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 			stripTaskColumnStats := false
 			if projectScanColumns {
 				var p iceberg.ManifestEntryProjection
-				p, dropColumnStats = scan.manifestProjectionForManifest(manifest, retainDataFileStats)
-				stripTaskColumnStats = p.IncludeColumnStats && !dropColumnStats
+				p, dropColumnStats = scan.dataManifestProjection(retainDataFileStats)
+				stripTaskColumnStats = p.IncludePruningStats && !dropColumnStats
 				projection = &p
 			}
 			err = streamManifest(fs, manifest, partEval, metricsEval, projection, dropColumnStats, func(entry iceberg.ManifestEntry) error {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -373,9 +373,23 @@ func GetPartitionRecord(dataFile iceberg.DataFile, partitionType *iceberg.Struct
 func openManifest(io io.IO, manifest iceberg.ManifestFile,
 	partitionFilter, metricsEval func(iceberg.DataFile) (bool, error),
 ) ([]iceberg.ManifestEntry, error) {
+	return openManifestWithProjection(io, manifest, partitionFilter, metricsEval, nil, false)
+}
+
+func openManifestWithProjection(
+	io io.IO,
+	manifest iceberg.ManifestFile,
+	partitionFilter, metricsEval func(iceberg.DataFile) (bool, error),
+	projection *iceberg.ManifestEntryProjection,
+	dropColumnStats bool,
+) ([]iceberg.ManifestEntry, error) {
 	// Counts may be -1 (unset) on V1 manifests, so clamp before allocating.
 	out := make([]iceberg.ManifestEntry, 0, max(0, int(manifest.AddedDataFiles())+int(manifest.ExistingDataFiles())))
-	for entry, err := range manifest.Entries(io, true) {
+	entries := manifest.Entries(io, true)
+	if projection != nil {
+		entries = iceberg.EntriesWithProjection(io, manifest, true, *projection)
+	}
+	for entry, err := range entries {
 		if err != nil {
 			return nil, err
 		}
@@ -394,6 +408,9 @@ func openManifest(io io.IO, manifest iceberg.ManifestFile,
 		}
 
 		if m {
+			if dropColumnStats {
+				entry = iceberg.ManifestEntryWithoutColumnStats(entry)
+			}
 			out = append(out, entry)
 		}
 	}
@@ -1074,6 +1091,17 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	schema *iceberg.Schema,
 	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression],
 ) (*manifestEntries, error) {
+	return scan.collectManifestEntriesWithSchemaOptions(
+		ctx, manifestList, schema, partitionFilters, false)
+}
+
+func (scan *Scan) collectManifestEntriesWithSchemaOptions(
+	ctx context.Context,
+	manifestList []iceberg.ManifestFile,
+	schema *iceberg.Schema,
+	partitionFilters *keyDefaultMapErr[int, iceberg.BooleanExpression],
+	projectScanColumns bool,
+) (*manifestEntries, error) {
 	metricsEval, err := newInclusiveMetricsEvaluator(
 		schema,
 		scan.rowFilter,
@@ -1095,6 +1123,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	partitionEvaluators := newKeyDefaultMapWrapErr(func(specID int) (func(iceberg.DataFile) (bool, error), error) {
 		return buildPartitionEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
 	})
+	retainDataFileStats := scan.manifestProjectionRetainsDataStats(manifestList)
 
 	for manifestIndex, mf := range manifestList {
 		if !scan.checkSequenceNumber(minSeqNum, mf) {
@@ -1110,7 +1139,19 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 			if err != nil {
 				return fmt.Errorf("failed to build partition evaluator for spec %d: %w", mf.PartitionSpecID(), err)
 			}
-			manifestEntries, err := openManifest(fs, mf, partEval, metricsEval)
+			var projection *iceberg.ManifestEntryProjection
+			dropColumnStats := false
+			if projectScanColumns {
+				p := iceberg.ManifestEntryProjection{
+					IncludeColumnStats: scan.manifestProjectionNeedsStats(mf, retainDataFileStats),
+				}
+				projection = &p
+				dropColumnStats = p.IncludeColumnStats &&
+					mf.ManifestContent() == iceberg.ManifestContentData &&
+					!retainDataFileStats
+			}
+			manifestEntries, err := openManifestWithProjection(
+				fs, mf, partEval, metricsEval, projection, dropColumnStats)
 			if err != nil {
 				return err
 			}
@@ -1131,12 +1172,36 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	return flattenClassifiedManifestEntries(manifestResults), nil
 }
 
+func (scan *Scan) manifestProjectionNeedsStats(manifest iceberg.ManifestFile, retainDataFileStats bool) bool {
+	return manifest.ManifestContent() == iceberg.ManifestContentDeletes ||
+		retainDataFileStats ||
+		(scan.rowFilter != nil && !scan.rowFilter.Equals(iceberg.AlwaysTrue{}))
+}
+
+func (scan *Scan) manifestProjectionRetainsDataStats(manifestList []iceberg.ManifestFile) bool {
+	for _, manifest := range manifestList {
+		if manifest.ManifestContent() == iceberg.ManifestContentDeletes {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PlanFiles orchestrates the fetching and filtering of manifests, building a
 // list of FileScanTasks that match the current Scan criteria. When planning
 // happens locally it times the whole operation and emits a ScanReport to the
 // scan's reporter on success; remote (server-side) planning reports its own
 // metrics and does not emit here.
 func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
+	return scan.planFiles(ctx, false)
+}
+
+// planFiles performs scan planning. Projected local planning is used by
+// ToArrowRecords because manifest column statistics are only needed while
+// pruning; PlanFiles keeps the complete DataFile metadata for callers that
+// inspect planned tasks.
+func (scan *Scan) planFiles(ctx context.Context, projectScanColumns bool) ([]FileScanTask, error) {
 	if atomic.LoadUint32(&scan.closed) != 0 {
 		return nil, fmt.Errorf("%w: scan is closed", ErrInvalidOperation)
 	}
@@ -1177,7 +1242,7 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 		return nil, err
 	}
 
-	results, err := scan.planFilesLocal(ctx, &acc, schema)
+	results, err := scan.planFilesLocal(ctx, &acc, schema, projectScanColumns)
 	if err != nil {
 		return nil, err
 	}
@@ -1213,7 +1278,12 @@ func (scan *Scan) PlanFiles(ctx context.Context) ([]FileScanTask, error) {
 // local plan retires any previous remote plan; a failed local plan leaves it
 // usable. It returns a nil slice (not an empty one) when there is no snapshot
 // or every manifest is pruned.
-func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulator, schema *iceberg.Schema) (results []FileScanTask, err error) {
+func (scan *Scan) planFilesLocal(
+	ctx context.Context,
+	acc *scanMetricsAccumulator,
+	schema *iceberg.Schema,
+	projectScanColumns bool,
+) (results []FileScanTask, err error) {
 	defer func() {
 		if err == nil {
 			err = scan.closePlanIO()
@@ -1251,7 +1321,8 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 	}
 
 	// Step 2: Read manifest entries concurrently, accumulating data and positional deletes.
-	entries, err := scan.collectManifestEntriesWithSchema(ctx, manifestList, schema, partitionFilters)
+	entries, err := scan.collectManifestEntriesWithSchemaOptions(
+		ctx, manifestList, schema, partitionFilters, projectScanColumns)
 	if err != nil {
 		return nil, err
 	}
@@ -1304,6 +1375,11 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 		eqDeleteFiles, err := eqDeleteIndex.forDataFile(e)
 		if err != nil {
 			return nil, err
+		}
+		if projectScanColumns {
+			deleteFiles = dataFilesWithoutColumnStats(deleteFiles)
+			eqDeleteFiles = dataFilesWithoutColumnStats(eqDeleteFiles)
+			dvFiles = dataFilesWithoutColumnStats(dvFiles)
 		}
 
 		task := FileScanTask{
@@ -1359,7 +1435,35 @@ func (scan *Scan) planFilesLocal(ctx context.Context, acc *scanMetricsAccumulato
 		acc.totalFileSize += e.DataFile().FileSizeBytes()
 	}
 
+	acc.resultDataFiles = int64(len(results))
+	// Delete-file metrics are derived from the planned tasks so they are
+	// result-scoped, consistent with result-data-files and total-file-size (a
+	// DV-suppressed positional delete never lands on a task, so it is excluded).
+	acc.applyResultDeleteMetrics(results)
+	if projectScanColumns {
+		// The indexes retain the full delete entries while matching them to
+		// data files. Release those references before returning so only the
+		// compact task metadata remains live after planning.
+		entries = nil
+		posDeleteIndex = nil
+		dvIndex = nil
+		eqDeleteIndex = nil
+	}
+
 	return results, nil
+}
+
+func dataFilesWithoutColumnStats(files []iceberg.DataFile) []iceberg.DataFile {
+	if len(files) == 0 {
+		return files
+	}
+
+	projected := make([]iceberg.DataFile, len(files))
+	for i, file := range files {
+		projected[i] = iceberg.DataFileWithoutColumnStats(file)
+	}
+
+	return projected
 }
 
 // canLimitLocalPlanning reports whether the manifest-list row counts are
@@ -1633,7 +1737,7 @@ type FileScanTask struct {
 // The purpose for returning the schema up front is to handle the case where there are no
 // rows returned. The resulting Arrow Schema of the projection will still be known.
 func (scan *Scan) ToArrowRecords(ctx context.Context) (*arrow.Schema, iter.Seq2[arrow.RecordBatch, error], error) {
-	tasks, err := scan.PlanFiles(ctx)
+	tasks, err := scan.planFiles(ctx, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1198,8 +1198,9 @@ func (scan *Scan) manifestProjectionForManifest(
 	retainDataFileStats bool,
 ) (iceberg.ManifestEntryProjection, bool) {
 	// Manifest-list metadata does not distinguish equality from positional
-	// deletes, so delete scans retain data-file stats for equality-delete
-	// pruning even when the row filter is AlwaysTrue.
+	// deletes, so delete manifests retain their stats while they are being
+	// classified. Once classification is complete, retainDataFileStats is set
+	// only when an equality delete actually needs data-file metrics for pruning.
 	includeColumnStats := manifest.ManifestContent() == iceberg.ManifestContentDeletes ||
 		retainDataFileStats ||
 		(scan.rowFilter != nil && !scan.rowFilter.Equals(iceberg.AlwaysTrue{}))
@@ -1436,7 +1437,7 @@ func (scan *Scan) planDataManifestTasksWithOptions(
 		}
 	}
 
-	if projectScanColumns && retainDataFileStats {
+	if projectScanColumns {
 		memo := make(map[iceberg.DataFile]iceberg.DataFile)
 		for i := range results {
 			results[i].DeleteFiles = dataFilesWithoutColumnStats(results[i].DeleteFiles, memo)
@@ -1631,7 +1632,6 @@ func (scan *Scan) planFilesLocal(
 	// tasks immediately after their delete indexes are ready.
 	dataManifests, deleteManifests := splitManifestList(manifestList)
 	minSeqNum := minSequenceNum(manifestList)
-	retainDataFileStats := scan.manifestProjectionRetainsDataStats(manifestList)
 	deleteEntries := newManifestEntries()
 	if len(deleteManifests) > 0 {
 		deleteEntries, err = scan.collectManifestEntriesWithSchemaMinSequenceNum(
@@ -1640,6 +1640,11 @@ func (scan *Scan) planFilesLocal(
 			return nil, err
 		}
 	}
+	// Equality-delete pruning is the only data-manifest consumer of column
+	// metrics after the delete entries have been indexed. Positional deletes and
+	// deletion vectors use path/reference metadata instead, so they should not
+	// force every data file to materialize metric maps.
+	retainDataFileStats := len(deleteEntries.equalityDeleteEntries) > 0
 	// Step 3: Index positional deletes and match them to data files.
 	posDeleteIndex, err := buildPositionalDeleteIndex(deleteEntries.positionalDeleteEntries)
 	if err != nil {

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -68,7 +68,7 @@ func TestOpenManifestWithProjectionDropsStatsAfterFiltering(t *testing.T) {
 	fs := iceio.NewMemFS()
 	require.NoError(t, fs.WriteFile(manifestPath, manifestBytes.Bytes()))
 
-	projection := iceberg.ManifestEntryProjection{IncludeColumnStats: true}
+	projection := iceberg.ManifestEntryProjection{IncludePruningStats: true}
 	entries, err := openManifestWithProjection(
 		fs,
 		manifest,
@@ -93,39 +93,29 @@ func TestOpenManifestWithProjectionDropsStatsAfterFiltering(t *testing.T) {
 	assert.Empty(t, entries[0].DataFile().LowerBoundValues())
 }
 
-func TestManifestProjectionRetainsDataFileStatsForDeleteScans(t *testing.T) {
-	scan := &Scan{rowFilter: iceberg.AlwaysTrue{}}
-	dataManifest := iceberg.NewManifestFile(
-		2, "data-manifest.avro", 100, 0, 1,
-	).Build()
-	deleteManifest := iceberg.NewManifestFile(
-		2, "delete-manifest.avro", 100, 0, 1,
-	).Content(iceberg.ManifestContentDeletes).Build()
+func TestDataManifestProjection(t *testing.T) {
+	for _, filter := range []struct {
+		name       string
+		expression iceberg.BooleanExpression
+		needsStats bool
+	}{
+		{name: "nil"},
+		{name: "always true", expression: iceberg.AlwaysTrue{}},
+		{name: "row filter", expression: iceberg.EqualTo(iceberg.Reference("id"), int64(1)), needsStats: true},
+	} {
+		t.Run(filter.name, func(t *testing.T) {
+			scan := &Scan{rowFilter: filter.expression}
+			projection, dropStats := scan.dataManifestProjection(false)
+			assert.Equal(t, filter.needsStats, projection.IncludePruningStats)
+			assert.Equal(t, filter.needsStats, dropStats,
+				"row-filter stats can be dropped after filtering when no equality delete needs them")
 
-	projection, dropStats := scan.manifestProjectionForManifest(dataManifest, false)
-	assert.False(t, projection.IncludeColumnStats)
-	assert.False(t, dropStats)
-
-	retainDataStats := scan.manifestProjectionRetainsDataStats(
-		[]iceberg.ManifestFile{dataManifest, deleteManifest})
-	assert.True(t, retainDataStats)
-
-	projection, dropStats = scan.manifestProjectionForManifest(dataManifest, retainDataStats)
-	assert.True(t, projection.IncludeColumnStats)
-	assert.False(t, dropStats,
-		"data-file stats must survive planning for equality-delete pruning")
-
-	projection, dropStats = scan.manifestProjectionForManifest(deleteManifest, retainDataStats)
-	assert.True(t, projection.IncludeColumnStats)
-	assert.False(t, dropStats)
-
-	filteredScan := &Scan{
-		rowFilter: iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+			projection, dropStats = scan.dataManifestProjection(true)
+			assert.True(t, projection.IncludePruningStats)
+			assert.False(t, dropStats,
+				"data-file stats must survive filtering for equality-delete pruning")
+		})
 	}
-	projection, dropStats = filteredScan.manifestProjectionForManifest(dataManifest, false)
-	assert.True(t, projection.IncludeColumnStats)
-	assert.True(t, dropStats,
-		"row-filter stats should be dropped after filtering when no delete scan needs them")
 }
 
 func TestDataFilesWithoutColumnStatsReusesSharedFiles(t *testing.T) {
@@ -240,13 +230,6 @@ func TestPlanDataManifestTasksWithProjectionRetainsEqualityDeletePruning(t *test
 		deleteEntry("mem://projection-planning/delete-2.parquet", 2),
 		deleteEntry("mem://projection-planning/delete-3.parquet", 3),
 	}
-	eqDeleteIndex, err := buildEqualityDeleteIndex(deleteEntries, meta, schema)
-	require.NoError(t, err)
-	posDeleteIndex, err := buildPositionalDeleteIndex(nil)
-	require.NoError(t, err)
-	dvIndex, err := buildDVIndex(nil)
-	require.NoError(t, err)
-
 	scan := &Scan{
 		metadata:      meta,
 		ioF:           testFSF(fs),
@@ -254,6 +237,32 @@ func TestPlanDataManifestTasksWithProjectionRetainsEqualityDeletePruning(t *test
 		caseSensitive: true,
 		concurrency:   2,
 	}
+	var deleteBytes bytes.Buffer
+	deleteWriter, err := iceberg.NewManifestWriter(2, &deleteBytes, *iceberg.UnpartitionedSpec,
+		schema, 2, iceberg.WithManifestWriterContent(iceberg.ManifestContentDeletes))
+	require.NoError(t, err)
+	for _, entry := range deleteEntries {
+		require.NoError(t, deleteWriter.Add(entry))
+	}
+	deleteManifest, err := deleteWriter.ToManifestFile("mem://projection-planning/deletes.avro", int64(deleteBytes.Len()))
+	require.NoError(t, err)
+	require.NoError(t, fs.WriteFile(deleteManifest.FilePath(), deleteBytes.Bytes()))
+	deleteManifest = iceberg.NewManifestFile(2, deleteManifest.FilePath(), int64(deleteBytes.Len()), 0, 2).
+		Content(iceberg.ManifestContentDeletes).SequenceNum(2, 2).AddedFiles(2).AddedRows(2).Build()
+	classified, err := scan.collectManifestEntriesWithSchemaMinSequenceNum(t.Context(),
+		[]iceberg.ManifestFile{deleteManifest}, schema, scan.partitionFiltersForSchema(schema), 0, true)
+	require.NoError(t, err)
+	require.Len(t, classified.equalityDeleteEntries, 2)
+	for _, entry := range classified.equalityDeleteEntries {
+		assert.NotEmpty(t, entry.DataFile().LowerBoundValues(), "delete bounds must survive projected collection")
+	}
+	eqDeleteIndex, err := buildEqualityDeleteIndex(classified.equalityDeleteEntries, meta, schema)
+	require.NoError(t, err)
+	posDeleteIndex, err := buildPositionalDeleteIndex(nil)
+	require.NoError(t, err)
+	dvIndex, err := buildDVIndex(nil)
+	require.NoError(t, err)
+
 	tasks, err := scan.planDataManifestTasksWithOptions(
 		t.Context(),
 		[]iceberg.ManifestFile{manifest},

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenManifestWithProjectionDropsStatsAfterFiltering(t *testing.T) {
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	snapshotID := int64(1)
+	builder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		"mem://default/table/data/file.parquet",
+		iceberg.ParquetFile,
+		map[int]any{1000: int32(7)},
+		nil,
+		nil,
+		1,
+		100,
+	)
+	require.NoError(t, err)
+	builder.
+		ValueCounts(map[int]int64{1: 1}).
+		NullValueCounts(map[int]int64{1: 0}).
+		NaNValueCounts(map[int]int64{1: 0}).
+		LowerBoundValues(map[int][]byte{1: {0x01}}).
+		UpperBoundValues(map[int][]byte{1: {0x01}})
+
+	manifestPath := "mem://default/table/metadata/manifest.avro"
+	var manifestBytes bytes.Buffer
+	manifest, err := iceberg.WriteManifest(
+		manifestPath,
+		&manifestBytes,
+		2,
+		spec,
+		schema,
+		snapshotID,
+		[]iceberg.ManifestEntry{iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, &snapshotID, nil, nil, builder.Build(),
+		)},
+	)
+	require.NoError(t, err)
+
+	fs := iceio.NewMemFS()
+	require.NoError(t, fs.WriteFile(manifestPath, manifestBytes.Bytes()))
+
+	projection := iceberg.ManifestEntryProjection{IncludeColumnStats: true}
+	entries, err := openManifestWithProjection(
+		fs,
+		manifest,
+		func(file iceberg.DataFile) (bool, error) {
+			assert.Equal(t, int32(7), file.Partition()[1000])
+
+			return true, nil
+		},
+		func(file iceberg.DataFile) (bool, error) {
+			assert.Equal(t, map[int]int64{1: 1}, file.ValueCounts())
+			assert.Equal(t, map[int][]byte{1: {0x01}}, file.LowerBoundValues())
+
+			return true, nil
+		},
+		&projection,
+		true,
+	)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "mem://default/table/data/file.parquet", entries[0].DataFile().FilePath())
+	assert.Empty(t, entries[0].DataFile().ValueCounts())
+	assert.Empty(t, entries[0].DataFile().LowerBoundValues())
+}

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -92,3 +92,30 @@ func TestOpenManifestWithProjectionDropsStatsAfterFiltering(t *testing.T) {
 	assert.Empty(t, entries[0].DataFile().ValueCounts())
 	assert.Empty(t, entries[0].DataFile().LowerBoundValues())
 }
+
+func TestManifestProjectionRetainsDataFileStatsForDeleteScans(t *testing.T) {
+	scan := &Scan{rowFilter: iceberg.AlwaysTrue{}}
+	dataManifest := iceberg.NewManifestFile(
+		2, "data-manifest.avro", 100, 0, 1,
+	).Build()
+	deleteManifest := iceberg.NewManifestFile(
+		2, "delete-manifest.avro", 100, 0, 1,
+	).Content(iceberg.ManifestContentDeletes).Build()
+
+	projection, dropStats := scan.manifestProjectionForManifest(dataManifest, false)
+	assert.False(t, projection.IncludeColumnStats)
+	assert.False(t, dropStats)
+
+	retainDataStats := scan.manifestProjectionRetainsDataStats(
+		[]iceberg.ManifestFile{dataManifest, deleteManifest})
+	assert.True(t, retainDataStats)
+
+	projection, dropStats = scan.manifestProjectionForManifest(dataManifest, retainDataStats)
+	assert.True(t, projection.IncludeColumnStats)
+	assert.False(t, dropStats,
+		"data-file stats must survive planning for equality-delete pruning")
+
+	projection, dropStats = scan.manifestProjectionForManifest(deleteManifest, retainDataStats)
+	assert.True(t, projection.IncludeColumnStats)
+	assert.False(t, dropStats)
+}

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -119,3 +119,152 @@ func TestManifestProjectionRetainsDataFileStatsForDeleteScans(t *testing.T) {
 	assert.True(t, projection.IncludeColumnStats)
 	assert.False(t, dropStats)
 }
+
+func TestDataFilesWithoutColumnStatsReusesSharedFiles(t *testing.T) {
+	dataFile, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentEqDeletes,
+		"mem://default/table/delete.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		128,
+	)
+	require.NoError(t, err)
+	dataFile.ValueCounts(map[int]int64{1: 1})
+	file := dataFile.Build()
+	memo := make(map[iceberg.DataFile]iceberg.DataFile)
+
+	projected := dataFilesWithoutColumnStats([]iceberg.DataFile{file, file}, memo)
+
+	require.Len(t, projected, 2)
+	assert.NotSame(t, file, projected[0])
+	assert.Same(t, projected[0], projected[1])
+	assert.Empty(t, projected[0].ValueCounts())
+}
+
+func TestPlanDataManifestTasksWithProjectionRetainsEqualityDeletePruning(t *testing.T) {
+	fs := iceio.NewMemFS()
+	schema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true,
+	})
+	meta, err := NewMetadata(schema, iceberg.UnpartitionedSpec, UnsortedSortOrder,
+		"mem://projection-planning", nil)
+	require.NoError(t, err)
+
+	bound := func(value int64) []byte {
+		encoded, err := iceberg.Int64Literal(value).MarshalBinary()
+		require.NoError(t, err)
+
+		return encoded
+	}
+	dataEntry := func(path string, lower, upper int64) iceberg.ManifestEntry {
+		builder, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec,
+			iceberg.EntryContentData,
+			path,
+			iceberg.ParquetFile,
+			nil,
+			nil,
+			nil,
+			2,
+			128,
+		)
+		require.NoError(t, err)
+		builder.
+			ValueCounts(map[int]int64{1: 2}).
+			NullValueCounts(map[int]int64{1: 0}).
+			NaNValueCounts(map[int]int64{1: 0}).
+			LowerBoundValues(map[int][]byte{1: bound(lower)}).
+			UpperBoundValues(map[int][]byte{1: bound(upper)})
+		sequenceNumber := int64(1)
+
+		return iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, nil, &sequenceNumber, nil, builder.Build())
+	}
+
+	dataEntries := []iceberg.ManifestEntry{
+		dataEntry("mem://projection-planning/data-1.parquet", 1, 2),
+		dataEntry("mem://projection-planning/data-2.parquet", 3, 4),
+	}
+	manifestPath := "mem://projection-planning/data-manifest.avro"
+	var manifestBytes bytes.Buffer
+	manifest, err := iceberg.WriteManifest(
+		manifestPath,
+		&manifestBytes,
+		2,
+		*iceberg.UnpartitionedSpec,
+		schema,
+		1,
+		dataEntries,
+	)
+	require.NoError(t, err)
+	require.NoError(t, fs.WriteFile(manifestPath, manifestBytes.Bytes()))
+
+	deleteEntry := func(path string, value int64) iceberg.ManifestEntry {
+		builder, err := iceberg.NewDataFileBuilder(
+			*iceberg.UnpartitionedSpec,
+			iceberg.EntryContentEqDeletes,
+			path,
+			iceberg.ParquetFile,
+			nil,
+			nil,
+			nil,
+			1,
+			128,
+		)
+		require.NoError(t, err)
+		builder.
+			EqualityFieldIDs([]int{1}).
+			ValueCounts(map[int]int64{1: 1}).
+			NullValueCounts(map[int]int64{1: 0}).
+			NaNValueCounts(map[int]int64{1: 0}).
+			LowerBoundValues(map[int][]byte{1: bound(value)}).
+			UpperBoundValues(map[int][]byte{1: bound(value)})
+		sequenceNumber := int64(2)
+
+		return iceberg.NewManifestEntry(
+			iceberg.EntryStatusADDED, nil, &sequenceNumber, nil, builder.Build())
+	}
+	deleteEntries := []iceberg.ManifestEntry{
+		deleteEntry("mem://projection-planning/delete-2.parquet", 2),
+		deleteEntry("mem://projection-planning/delete-3.parquet", 3),
+	}
+	eqDeleteIndex, err := buildEqualityDeleteIndex(deleteEntries, meta, schema)
+	require.NoError(t, err)
+	posDeleteIndex, err := buildPositionalDeleteIndex(nil)
+	require.NoError(t, err)
+	dvIndex, err := buildDVIndex(nil)
+	require.NoError(t, err)
+
+	scan := &Scan{
+		metadata:      meta,
+		ioF:           testFSF(fs),
+		rowFilter:     iceberg.AlwaysTrue{},
+		caseSensitive: true,
+		concurrency:   2,
+	}
+	tasks, err := scan.planDataManifestTasksWithOptions(
+		t.Context(),
+		[]iceberg.ManifestFile{manifest},
+		schema,
+		0,
+		posDeleteIndex,
+		dvIndex,
+		eqDeleteIndex,
+		true,
+		true,
+	)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	for _, task := range tasks {
+		require.Len(t, task.EqualityDeleteFiles, 1)
+		assert.Empty(t, task.File.ValueCounts())
+		assert.Empty(t, task.EqualityDeleteFiles[0].ValueCounts())
+	}
+	assert.Equal(t, "mem://projection-planning/delete-2.parquet", tasks[0].EqualityDeleteFiles[0].FilePath())
+	assert.Equal(t, "mem://projection-planning/delete-3.parquet", tasks[1].EqualityDeleteFiles[0].FilePath())
+}

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -118,6 +118,14 @@ func TestManifestProjectionRetainsDataFileStatsForDeleteScans(t *testing.T) {
 	projection, dropStats = scan.manifestProjectionForManifest(deleteManifest, retainDataStats)
 	assert.True(t, projection.IncludeColumnStats)
 	assert.False(t, dropStats)
+
+	filteredScan := &Scan{
+		rowFilter: iceberg.EqualTo(iceberg.Reference("id"), int64(1)),
+	}
+	projection, dropStats = filteredScan.manifestProjectionForManifest(dataManifest, false)
+	assert.True(t, projection.IncludeColumnStats)
+	assert.True(t, dropStats,
+		"row-filter stats should be dropped after filtering when no delete scan needs them")
 }
 
 func TestDataFilesWithoutColumnStatsReusesSharedFiles(t *testing.T) {

--- a/table/scanner_manifest_projection_test.go
+++ b/table/scanner_manifest_projection_test.go
@@ -275,4 +275,45 @@ func TestPlanDataManifestTasksWithProjectionRetainsEqualityDeletePruning(t *test
 	}
 	assert.Equal(t, "mem://projection-planning/delete-2.parquet", tasks[0].EqualityDeleteFiles[0].FilePath())
 	assert.Equal(t, "mem://projection-planning/delete-3.parquet", tasks[1].EqualityDeleteFiles[0].FilePath())
+
+	posDeleteBuilder, err := iceberg.NewDataFileBuilder(
+		*iceberg.UnpartitionedSpec,
+		iceberg.EntryContentPosDeletes,
+		"mem://projection-planning/position-delete.parquet",
+		iceberg.ParquetFile,
+		nil,
+		nil,
+		nil,
+		1,
+		128,
+	)
+	require.NoError(t, err)
+	posDeleteBuilder.
+		ReferencedDataFile("mem://projection-planning/data-1.parquet").
+		ValueCounts(map[int]int64{1: 1}).
+		LowerBoundValues(map[int][]byte{1: bound(1)}).
+		UpperBoundValues(map[int][]byte{1: bound(1)})
+	posSequenceNumber := int64(2)
+	posDeleteEntry := iceberg.NewManifestEntry(
+		iceberg.EntryStatusADDED, nil, &posSequenceNumber, nil, posDeleteBuilder.Build())
+	posDeleteIndex, err = buildPositionalDeleteIndex([]iceberg.ManifestEntry{posDeleteEntry})
+	require.NoError(t, err)
+	emptyEqDeleteIndex, err := buildEqualityDeleteIndex(nil, meta, schema)
+	require.NoError(t, err)
+	tasks, err = scan.planDataManifestTasksWithOptions(
+		t.Context(),
+		[]iceberg.ManifestFile{manifest},
+		schema,
+		0,
+		posDeleteIndex,
+		dvIndex,
+		emptyEqDeleteIndex,
+		true,
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	require.Len(t, tasks[0].DeleteFiles, 1)
+	assert.Empty(t, tasks[0].File.ValueCounts())
+	assert.Empty(t, tasks[0].DeleteFiles[0].ValueCounts())
 }


### PR DESCRIPTION
## Summary

- **Project manifest reads** during local Arrow scan planning. `PlanFiles()` still returns full metadata.
- Keep data-file metrics for row filtering and equality-delete pruning. Positional deletes and deletion vectors do not force data-file stats to be decoded.
- Drop transient stats after filtering and delete matching. Reuse stripped delete files across tasks.
- Cache projected Avro schemas by writer schema and projection.

## Projected-read API

- Adds `ManifestEntryProjection`, `EntriesWithProjection`, and `NewManifestReaderWithProjection` for scan planning.
- `IncludePruningStats` includes value/null/NaN counts and lower/upper bounds. It still omits `column_sizes` and deprecated `distinct_counts`.
- Adds `DataFileWithoutColumnStats` and `ManifestEntryWithoutColumnStats` for dropping transient metadata.
- **Prevent lossy rewrites:** manifest writers and the DataFile Avro codec reject projected or stripped files with `ErrInvalidArgument`.

## Benchmark

Command: `go test . -run '^$' -bench BenchmarkManifestEntryProjection -benchtime=1x -count=1`

Apple M1 Pro, 10,000 entries per case. These measurements cover manifest reading; task construction and delete matching are outside this benchmark:

| Stats fields | Full bytes | Scan bytes | Full allocs | Scan allocs |
| --- | ---: | ---: | ---: | ---: |
| 10 | 32.6 MB | 15.6 MB | 443,928 | 65,797 |
| 100 | 260.2 MB | 100.5 MB | 2,257,763 | 77,930 |
| 1,000 | 2.93 GB | 1.45 GB | 20,512,582 | 332,865 |

## Validation

- `make test`
- Focused race tests for projected reads, stat stripping, delete pruning, and codec rejection.
- `golangci-lint run --timeout=10m --allow-parallel-runners` (v2.12.2)
- Regression tests reproduce silent rewrites before the fix.
- Coverage includes v1/v2/v3 data manifests, equality deletes, deletion vectors, and writer recovery after a rejected entry.
