### PR TITLE
perf(table): flatten manifest entries after parallel reads

### DIFF
--- a/table/scanner.go
+++ b/table/scanner.go
@@ -1093,7 +1093,6 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 			continue
 		}
 
-		manifestIndex, mf := manifestIndex, mf
 		g.Go(func() error {
 			fs, err := manifestIO.acquire(gctx)
 			if err != nil {

--- a/table/scanner.go
+++ b/table/scanner.go
@@ -315,6 +315,41 @@ func (m *manifestEntries) merge(entries []iceberg.ManifestEntry) error {
 	return err
 }
 
+func flattenClassifiedManifestEntries(results []classifiedManifestEntries) *manifestEntries {
+	var counts [manifestEntryKindCount]int
+	for _, result := range results {
+		counts[manifestEntryData] += len(result.dataEntries)
+		counts[manifestEntryPositionalDelete] += len(result.positionalDeleteEntries)
+		counts[manifestEntryEqualityDelete] += len(result.equalityDeleteEntries)
+		counts[manifestEntryDV] += len(result.dvEntries)
+	}
+
+	flattened := &manifestEntries{
+		dataEntries:             make([]iceberg.ManifestEntry, counts[manifestEntryData]),
+		positionalDeleteEntries: make([]iceberg.ManifestEntry, counts[manifestEntryPositionalDelete]),
+		equalityDeleteEntries:   make([]iceberg.ManifestEntry, counts[manifestEntryEqualityDelete]),
+		dvEntries:               make([]iceberg.ManifestEntry, counts[manifestEntryDV]),
+	}
+
+	var offsets [manifestEntryKindCount]int
+	for _, result := range results {
+		offsets[manifestEntryData] += copy(
+			flattened.dataEntries[offsets[manifestEntryData]:], result.dataEntries,
+		)
+		offsets[manifestEntryPositionalDelete] += copy(
+			flattened.positionalDeleteEntries[offsets[manifestEntryPositionalDelete]:], result.positionalDeleteEntries,
+		)
+		offsets[manifestEntryEqualityDelete] += copy(
+			flattened.equalityDeleteEntries[offsets[manifestEntryEqualityDelete]:], result.equalityDeleteEntries,
+		)
+		offsets[manifestEntryDV] += copy(
+			flattened.dvEntries[offsets[manifestEntryDV]:], result.dvEntries,
+		)
+	}
+
+	return flattened
+}
+
 func newPartitionRecord(partitionData map[int]any, partitionType *iceberg.StructType) partitionRecord {
 	out := make(partitionRecord, len(partitionType.FieldList))
 	for i, f := range partitionType.FieldList {
@@ -1044,7 +1079,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 	concurrencyLimit := min(scan.concurrency, len(manifestList))
 	manifestIO := newManifestIOBatch(scan.ioF, concurrencyLimit)
 
-	entries := newManifestEntries()
+	manifestResults := make([]classifiedManifestEntries, len(manifestList))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrencyLimit)
 
@@ -1053,11 +1088,12 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		return buildPartitionEvaluator(specID, scan.metadata, schema, partitionFilters, scan.caseSensitive)
 	})
 
-	for _, mf := range manifestList {
+	for manifestIndex, mf := range manifestList {
 		if !scan.checkSequenceNumber(minSeqNum, mf) {
 			continue
 		}
 
+		manifestIndex, mf := manifestIndex, mf
 		g.Go(func() error {
 			fs, err := manifestIO.acquire(gctx)
 			if err != nil {
@@ -1071,9 +1107,11 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 			if err != nil {
 				return err
 			}
-			if err := entries.merge(manifestEntries); err != nil {
+			classified, err := classifyManifestEntries(manifestEntries)
+			if err != nil {
 				return err
 			}
+			manifestResults[manifestIndex] = classified
 
 			return nil
 		})
@@ -1083,7 +1121,7 @@ func (scan *Scan) collectManifestEntriesWithSchema(
 		return nil, err
 	}
 
-	return entries, nil
+	return flattenClassifiedManifestEntries(manifestResults), nil
 }
 
 // PlanFiles orchestrates the fetching and filtering of manifests, building a

--- a/table/scanner_manifest_entries_bench_test.go
+++ b/table/scanner_manifest_entries_bench_test.go
@@ -97,7 +97,6 @@ func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount,
 	var g errgroup.Group
 	g.SetLimit(min(concurrency, manifestCount))
 	for manifestIndex := range manifestCount {
-		manifestIndex := manifestIndex
 		g.Go(func() error {
 			manifestEntries := append(make([]iceberg.ManifestEntry, 0, len(entries)), entries...)
 			classified, err := classifyManifestEntries(manifestEntries)
@@ -105,6 +104,7 @@ func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount,
 				return err
 			}
 			results[manifestIndex] = classified
+
 			return nil
 		})
 	}

--- a/table/scanner_manifest_entries_bench_test.go
+++ b/table/scanner_manifest_entries_bench_test.go
@@ -60,31 +60,63 @@ func BenchmarkManifestEntryCollection(b *testing.B) {
 		{name: "data", content: iceberg.ManifestContentData},
 		{name: "deletes", content: iceberg.ManifestContentDeletes},
 	} {
-		for _, benchmarkCase := range benchmarkCases {
-			name := fmt.Sprintf("content=%s/manifests=%d/concurrency=%d/entries=%d",
-				workload.name, benchmarkCase.manifestCount, benchmarkCase.concurrency, benchmarkCase.entryCount)
-			b.Run(name, func(b *testing.B) {
-				entries := benchmarkManifestEntries(benchmarkCase.entryCount, workload.content)
-				b.ReportAllocs()
-				b.ResetTimer()
-				b.ReportMetric(float64(benchmarkCase.manifestCount*benchmarkCase.entryCount), "entries/op")
+		for _, method := range []struct {
+			name    string
+			collect func([]iceberg.ManifestEntry, int, int) *manifestEntries
+		}{
+			{name: "merge", collect: collectManifestEntryBatchesWithMerge},
+			{name: "flatten", collect: collectManifestEntryBatches},
+		} {
+			for _, benchmarkCase := range benchmarkCases {
+				name := fmt.Sprintf("method=%s/content=%s/manifests=%d/concurrency=%d/entries=%d",
+					method.name, workload.name, benchmarkCase.manifestCount, benchmarkCase.concurrency, benchmarkCase.entryCount)
+				b.Run(name, func(b *testing.B) {
+					entries := benchmarkManifestEntries(benchmarkCase.entryCount, workload.content)
+					b.ReportAllocs()
+					b.ResetTimer()
+					b.ReportMetric(float64(benchmarkCase.manifestCount*benchmarkCase.entryCount), "entries/op")
 
-				var result *manifestEntries
-				for range b.N {
-					result = collectManifestEntryBatches(entries, benchmarkCase.manifestCount, benchmarkCase.concurrency)
-				}
+					var result *manifestEntries
+					for range b.N {
+						result = method.collect(entries, benchmarkCase.manifestCount, benchmarkCase.concurrency)
+					}
 
-				if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
-					len(result.equalityDeleteEntries)+len(result.dvEntries), benchmarkCase.manifestCount*benchmarkCase.entryCount; got != want {
-					b.Fatalf("collected %d entries, want %d", got, want)
-				}
-				runtime.KeepAlive(result)
-			})
+					if got, want := len(result.dataEntries)+len(result.positionalDeleteEntries)+
+						len(result.equalityDeleteEntries)+len(result.dvEntries), benchmarkCase.manifestCount*benchmarkCase.entryCount; got != want {
+						b.Fatalf("collected %d entries, want %d", got, want)
+					}
+					runtime.KeepAlive(result)
+				})
+			}
 		}
 	}
 }
 
 func collectManifestEntryBatches(entries []iceberg.ManifestEntry, manifestCount, concurrency int) *manifestEntries {
+	results := make([]classifiedManifestEntries, manifestCount)
+	var g errgroup.Group
+	g.SetLimit(min(concurrency, manifestCount))
+	for manifestIndex := range manifestCount {
+		manifestIndex := manifestIndex
+		g.Go(func() error {
+			manifestEntries := append(make([]iceberg.ManifestEntry, 0, len(entries)), entries...)
+			classified, err := classifyManifestEntries(manifestEntries)
+			if err != nil {
+				return err
+			}
+			results[manifestIndex] = classified
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		panic(err)
+	}
+
+	return flattenClassifiedManifestEntries(results)
+}
+
+func collectManifestEntryBatchesWithMerge(entries []iceberg.ManifestEntry, manifestCount, concurrency int) *manifestEntries {
 	collected := newManifestEntries()
 	var g errgroup.Group
 	g.SetLimit(min(concurrency, manifestCount))

--- a/table/scanner_manifest_entries_test.go
+++ b/table/scanner_manifest_entries_test.go
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenClassifiedManifestEntriesPreservesManifestOrder(t *testing.T) {
+	snapshotID := int64(1)
+	dataOne := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "data-1.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+	dataTwo := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "data-2.parquet",
+		contentType: iceberg.EntryContentData,
+	})
+	positionalDelete := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "pos-delete.parquet",
+		contentType: iceberg.EntryContentPosDeletes,
+	})
+	equalityDelete := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "eq-delete.parquet",
+		contentType: iceberg.EntryContentEqDeletes,
+	})
+	dv := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, nil, nil, &mockDataFile{
+		path:        "deletion-vector.puffin",
+		contentType: iceberg.EntryContentPosDeletes,
+		format:      iceberg.PuffinFile,
+	})
+
+	got := flattenClassifiedManifestEntries([]classifiedManifestEntries{
+		{
+			dataEntries:           []iceberg.ManifestEntry{dataOne},
+			equalityDeleteEntries: []iceberg.ManifestEntry{equalityDelete},
+			dvEntries:             []iceberg.ManifestEntry{dv},
+		},
+		{},
+		{dataEntries: []iceberg.ManifestEntry{dataTwo}, positionalDeleteEntries: []iceberg.ManifestEntry{positionalDelete}},
+	})
+
+	assert.Equal(t, []iceberg.ManifestEntry{dataOne, dataTwo}, got.dataEntries)
+	assert.Equal(t, []iceberg.ManifestEntry{positionalDelete}, got.positionalDeleteEntries)
+	assert.Equal(t, []iceberg.ManifestEntry{equalityDelete}, got.equalityDeleteEntries)
+	assert.Equal(t, []iceberg.ManifestEntry{dv}, got.dvEntries)
+	assert.Equal(t, len(got.dataEntries), cap(got.dataEntries))
+	assert.Equal(t, len(got.positionalDeleteEntries), cap(got.positionalDeleteEntries))
+	assert.Equal(t, len(got.equalityDeleteEntries), cap(got.equalityDeleteEntries))
+	assert.Equal(t, len(got.dvEntries), cap(got.dvEntries))
+}
+
+func TestFlattenClassifiedManifestEntriesEmpty(t *testing.T) {
+	got := flattenClassifiedManifestEntries(nil)
+
+	assert.NotNil(t, got.dataEntries)
+	assert.NotNil(t, got.positionalDeleteEntries)
+	assert.NotNil(t, got.equalityDeleteEntries)
+	assert.NotNil(t, got.dvEntries)
+	assert.Empty(t, got.dataEntries)
+	assert.Empty(t, got.positionalDeleteEntries)
+	assert.Empty(t, got.equalityDeleteEntries)
+	assert.Empty(t, got.dvEntries)
+}


### PR DESCRIPTION
## Summary

- **Keep one classified result per manifest** while reads run in parallel.
- **Flatten after all reads finish** into exact-sized data and delete slices.
- Preserve manifest-list order and keep `manifestEntries.merge` for existing callers.
- Add focused tests for mixed buckets, empty result slots, and exact capacities.
- Add a merge-versus-flatten benchmark.

## Benchmark

Apple M1 Pro. 64 manifests, 10,000 entries per manifest, concurrency 16.

- **Data manifests:** 18.4 ms/op and 71.9 MB/op with merge, versus 6.4 ms/op and 20.7 MB/op with flatten.
- **Delete manifests:** 12.9 ms/op and 74.6 MB/op with merge, versus 6.3 ms/op and 32.4 MB/op with flatten.

## Tests

- `go test ./... -count=1`
- `go vet ./table`
- Targeted `go test -race ./table` pass.