### PR TITLE
test(table): fix TruncateUpperBoundBinary guard for negative width

### DIFF
--- a/table/internal/utils_test.go
+++ b/table/internal/utils_test.go
@@ -124,7 +124,7 @@ func TestTruncateUpperBoundBinary(t *testing.T) {
 			assert.Equal(t, first, second)
 			assert.Equal(t, original, tt.value)
 
-			if tt.truncate < len(tt.value) && len(first) > 0 {
+			if tt.truncate >= 0 && tt.truncate < len(tt.value) && len(first) > 0 {
 				assert.LessOrEqual(t, len(first), tt.truncate)
 				assert.Greater(t, bytes.Compare(first, tt.value), 0)
 			}


### PR DESCRIPTION
The negative-width test case ("negative width keeps bound") was added in #1934 while the stricter truncation-invariant guard was added in #1928. Each PR was green on its own base, but the rebase-merge combined them: the guard `tt.truncate < len(tt.value)` matches a negative width (-1 < 2), so the negative case (where the bound is kept, not truncated) wrongly falls into the truncation asserts and fails deterministically:

    utils_test.go:128: "2" is not less than or equal to "-1"
    utils_test.go:129: "0" is not greater than "0"

Only assert the shrink/increment invariants when a truncation actually happened by additionally requiring a non-negative width. The production TruncateUpperBoundBinary already handles negative widths correctly.