### PR TITLE
fix(manifest): normalize file_format casing when reading manifest entries

### DIFF
--- a/data_file_codec.go
+++ b/data_file_codec.go
@@ -141,6 +141,9 @@ func unmarshalAvroDataFileEntry(data []byte, spec PartitionSpec, schema *Schema,
 	if _, err := s.Decode(data, entry); err != nil {
 		return nil, fmt.Errorf("iceberg: unmarshalAvroDataFileEntry: %w", err)
 	}
+	if err := df.normalizeFormat(); err != nil {
+		return nil, fmt.Errorf("iceberg: unmarshalAvroDataFileEntry: %w", err)
+	}
 	df.specID = int32(spec.ID())
 	df.fieldNameToID = maps.nameToID
 	df.fieldIDToLogicalType = maps.idToType

--- a/data_file_codec_test.go
+++ b/data_file_codec_test.go
@@ -93,6 +93,46 @@ func TestDataFileCodecWithDroppedPartitionSource(t *testing.T) {
 	require.Equal(t, map[int]any{1000: nil, 1001: int32(3)}, decoded.Partition())
 }
 
+func TestUnmarshalAvroDataFileEntryNormalizesFileFormat(t *testing.T) {
+	spec := NewPartitionSpec()
+	schema := NewSchema(0)
+
+	tests := []struct {
+		name          string
+		written       FileFormat
+		expected      FileFormat
+		errorContains string
+	}{
+		{name: "spec lowercase", written: "parquet", expected: ParquetFile},
+		{name: "mixed case", written: "Parquet", expected: ParquetFile},
+		{name: "uppercase", written: ParquetFile, expected: ParquetFile},
+		{name: "lowercase orc", written: "orc", expected: OrcFile},
+		{name: "unknown format", written: "csv", errorContains: "unknown file format: csv"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := NewDataFileBuilder(spec, EntryContentData,
+				"s3://bucket/table/data.parquet", ParquetFile, nil, nil, nil, 1, 1024)
+			require.NoError(t, err)
+			source := builder.Build().(*dataFile)
+			source.Format = tt.written
+
+			encoded, err := source.MarshalAvroEntry(spec, schema, 2)
+			require.NoError(t, err)
+
+			decoded, err := unmarshalAvroDataFileEntry(encoded, spec, schema, 2)
+			if tt.errorContains != "" {
+				require.ErrorContains(t, err, tt.errorContains)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, decoded.FileFormat())
+		})
+	}
+}
+
 // TestManifestEntrySchemaForDistinguishesSameSpecIDDifferentPartitionTypes
 // guards against the cache-key collision that would occur if the cache
 // were keyed only by spec.ID(). Two tables can both use

--- a/data_file_codec_test.go
+++ b/data_file_codec_test.go
@@ -108,6 +108,7 @@ func TestUnmarshalAvroDataFileEntryNormalizesFileFormat(t *testing.T) {
 		{name: "uppercase", written: ParquetFile, expected: ParquetFile},
 		{name: "lowercase orc", written: "orc", expected: OrcFile},
 		{name: "unknown format", written: "csv", errorContains: "unknown file format: csv"},
+		{name: "empty format", written: "", errorContains: "unknown file format: "},
 	}
 
 	for _, tt := range tests {

--- a/manifest.go
+++ b/manifest.go
@@ -918,11 +918,9 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 		tmp = tmp.(*fallbackManifestEntry).toEntry()
 	}
 	if df, ok := tmp.DataFile().(*dataFile); ok {
-		format, err := FileFormatFromString(string(df.Format))
-		if err != nil {
-			return nil, fmt.Errorf("manifest entry for %q has invalid file format: %w", df.Path, err)
+		if err := df.normalizeFormat(); err != nil {
+			return nil, err
 		}
-		df.Format = format
 	}
 	switch tmp.Status() {
 	case EntryStatusEXISTING, EntryStatusADDED, EntryStatusDELETED:
@@ -2776,6 +2774,20 @@ func (d *dataFile) setFieldIDToLogicalTypeMap(m map[int]string) {
 
 func (d *dataFile) setFieldIDToDecimalScaleMap(m map[int]int) {
 	d.fieldIDToDecimalScale = m
+}
+
+// normalizeFormat sets d.Format to the FileFormat constant matching its
+// decoded spelling, or returns an error if it names no known format.
+// Every Avro decode path must call it before the value is compared or
+// exposed.
+func (d *dataFile) normalizeFormat() error {
+	format, err := FileFormatFromString(string(d.Format))
+	if err != nil {
+		return fmt.Errorf("data file %q has invalid file format: %w", d.FilePath(), err)
+	}
+	d.Format = format
+
+	return nil
 }
 
 func (d *dataFile) ContentType() ManifestEntryContent { return d.Content }

--- a/manifest.go
+++ b/manifest.go
@@ -917,6 +917,13 @@ func (c *ManifestReader) ReadEntry() (ManifestEntry, error) {
 	if c.isFallback {
 		tmp = tmp.(*fallbackManifestEntry).toEntry()
 	}
+	if df, ok := tmp.DataFile().(*dataFile); ok {
+		format, err := FileFormatFromString(string(df.Format))
+		if err != nil {
+			return nil, fmt.Errorf("manifest entry for %q has invalid file format: %w", df.Path, err)
+		}
+		df.Format = format
+	}
 	switch tmp.Status() {
 	case EntryStatusEXISTING, EntryStatusADDED, EntryStatusDELETED:
 	default:

--- a/manifest.go
+++ b/manifest.go
@@ -2783,7 +2783,7 @@ func (d *dataFile) setFieldIDToDecimalScaleMap(m map[int]int) {
 func (d *dataFile) normalizeFormat() error {
 	format, err := FileFormatFromString(string(d.Format))
 	if err != nil {
-		return fmt.Errorf("data file %q has invalid file format: %w", d.FilePath(), err)
+		return fmt.Errorf("data file %q: %w", d.FilePath(), err)
 	}
 	d.Format = format
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2426,6 +2426,63 @@ func (m *ManifestTestSuite) TestManifestReaderRejectsInvalidEntries() {
 	}
 }
 
+func (m *ManifestTestSuite) TestManifestReaderNormalizesFileFormat() {
+	partitionSpec := NewPartitionSpecID(1,
+		PartitionField{FieldID: 1000, SourceIDs: []int{1}, Name: "VendorID", Transform: IdentityTransform{}},
+		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
+	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
+	m.Require().NoError(err)
+	entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 2)
+	m.Require().NoError(err)
+
+	tests := []struct {
+		name          string
+		written       FileFormat
+		expected      FileFormat
+		errorContains string
+	}{
+		{name: "spec lowercase", written: "parquet", expected: ParquetFile},
+		{name: "mixed case", written: "Parquet", expected: ParquetFile},
+		{name: "uppercase", written: ParquetFile, expected: ParquetFile},
+		{name: "lowercase avro", written: "avro", expected: AvroFile},
+		{name: "unknown format", written: "csv", errorContains: "unknown file format: csv"},
+	}
+
+	for _, tt := range tests {
+		m.Run(tt.name, func() {
+			entry := *manifestEntryV2Records[0]
+			file := cloneDataFileAvroFields(entry.Data.(*dataFile))
+			file.Format = tt.written
+			entry.Data = file
+
+			mw := ManifestWriter{version: 2, spec: partitionSpec, schema: testSchema, content: ManifestContentData}
+			metadata, err := mw.meta()
+			m.Require().NoError(err)
+
+			var buf bytes.Buffer
+			writer, err := ocf.NewWriter(&buf, entrySchema,
+				ocf.WithSchema(entrySchema.String()), ocf.WithMetadata(metadata))
+			m.Require().NoError(err)
+			m.Require().NoError(writer.Encode(&entry))
+			m.Require().NoError(writer.Close())
+
+			manifest := &manifestFile{version: 2, SpecID: 1, Content: ManifestContentData}
+			reader, err := NewManifestReader(manifest, bytes.NewReader(buf.Bytes()))
+			m.Require().NoError(err)
+			defer reader.Close()
+
+			got, err := reader.ReadEntry()
+			if tt.errorContains != "" {
+				m.ErrorContains(err, tt.errorContains)
+
+				return
+			}
+			m.Require().NoError(err)
+			m.Equal(tt.expected, got.DataFile().FileFormat())
+		})
+	}
+}
+
 func (m *ManifestTestSuite) TestManifestEntryBuilder() {
 	dataFileBuilder, err := NewDataFileBuilder(
 		NewPartitionSpec(),

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2432,11 +2432,12 @@ func (m *ManifestTestSuite) TestManifestReaderNormalizesFileFormat() {
 		PartitionField{FieldID: 1001, SourceIDs: []int{2}, Name: "tpep_pickup_datetime", Transform: IdentityTransform{}})
 	partitionSchema, err := partitionTypeToAvroSchema(partitionSpec.PartitionType(testSchema))
 	m.Require().NoError(err)
-	entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, 2)
-	m.Require().NoError(err)
 
 	tests := []struct {
 		name          string
+		version       int
+		content       ManifestContent
+		entryContent  ManifestEntryContent
 		written       FileFormat
 		expected      FileFormat
 		errorContains string
@@ -2445,17 +2446,40 @@ func (m *ManifestTestSuite) TestManifestReaderNormalizesFileFormat() {
 		{name: "mixed case", written: "Parquet", expected: ParquetFile},
 		{name: "uppercase", written: ParquetFile, expected: ParquetFile},
 		{name: "lowercase avro", written: "avro", expected: AvroFile},
+		{name: "lowercase orc", written: "orc", expected: OrcFile},
+		{
+			name: "lowercase puffin in delete manifest", content: ManifestContentDeletes,
+			entryContent: EntryContentPosDeletes, written: "puffin", expected: PuffinFile,
+		},
+		{name: "v1 fallback entry", version: 1, written: "parquet", expected: ParquetFile},
 		{name: "unknown format", written: "csv", errorContains: "unknown file format: csv"},
+		{name: "empty format", written: "", errorContains: "unknown file format: "},
 	}
 
 	for _, tt := range tests {
 		m.Run(tt.name, func() {
-			entry := *manifestEntryV2Records[0]
+			version := tt.version
+			if version == 0 {
+				version = 2
+			}
+			content := tt.content
+			if content == 0 {
+				content = ManifestContentData
+			}
+			entrySchema, err := internal.NewManifestEntrySchema(partitionSchema, version)
+			m.Require().NoError(err)
+
+			records := manifestEntryV2Records
+			if version == 1 {
+				records = manifestEntryV1Records
+			}
+			entry := *records[0]
 			file := cloneDataFileAvroFields(entry.Data.(*dataFile))
 			file.Format = tt.written
+			file.Content = tt.entryContent
 			entry.Data = file
 
-			mw := ManifestWriter{version: 2, spec: partitionSpec, schema: testSchema, content: ManifestContentData}
+			mw := ManifestWriter{version: version, spec: partitionSpec, schema: testSchema, content: content}
 			metadata, err := mw.meta()
 			m.Require().NoError(err)
 
@@ -2463,10 +2487,14 @@ func (m *ManifestTestSuite) TestManifestReaderNormalizesFileFormat() {
 			writer, err := ocf.NewWriter(&buf, entrySchema,
 				ocf.WithSchema(entrySchema.String()), ocf.WithMetadata(metadata))
 			m.Require().NoError(err)
-			m.Require().NoError(writer.Encode(&entry))
+			var toEncode any = &entry
+			if version == 1 {
+				toEncode = &fallbackManifestEntry{manifestEntry: entry}
+			}
+			m.Require().NoError(writer.Encode(toEncode))
 			m.Require().NoError(writer.Close())
 
-			manifest := &manifestFile{version: 2, SpecID: 1, Content: ManifestContentData}
+			manifest := &manifestFile{version: version, SpecID: 1, Content: content}
 			reader, err := NewManifestReader(manifest, bytes.NewReader(buf.Bytes()))
 			m.Require().NoError(err)
 			defer reader.Close()


### PR DESCRIPTION
Closes #1983, which has the full write-up and reproduction.

## Problem

The Avro manifest decoders assign the wire `file_format` string directly into the typed `FileFormat` field, whose constants are uppercase:

```go
// manifest.go
Format FileFormat `avro:"file_format"`
```

`GetFile` (`table/internal/interfaces.go`) then matches the decoded value against `iceberg.ParquetFile` (`"PARQUET"`) to pick a reader. A manifest written with lowercase `parquet` never matches, so the scan fails on the first data file — with a message that renders both spellings identically:

```
not implemented: only parquet format is implemented, got parquet
```

Two decode paths are affected: `ManifestReader.ReadEntry`, and `unmarshalAvroDataFileEntry` (`data_file_codec.go`), which is reachable publicly through `codec.DecodeDataFile`. Beyond `GetFile`, the un-normalized value also mis-compares at `table/scan_splits.go`, `table/scanner.go` (`IsDeletionVector`), and `table/dv/deletion_vector.go`.

Nothing unusual is needed to hit this: `LoadTable` followed by a bare `tbl.Scan()`. DuckDB's `iceberg` extension writes lowercase, so no table it has written is readable. It also isn't limited to explicit scans — `Transaction.Delete` runs a copy-on-write rewrite through the same path, so appends and deletes against such a table fail too.

## Fix

Factor the normalization into `dataFile.normalizeFormat`, which routes the decoded value through the existing, already case-insensitive `FileFormatFromString`, and call it from both decode paths — `ManifestReader.ReadEntry`, before the existing status/content validation and covering the normal and fallback entry paths (they share the same `*dataFile`), and `unmarshalAvroDataFileEntry`.

This mirrors what the other implementations do on this exact path — Java's `BaseFile.internalSet` → `FileFormat.fromString`, and PyIceberg's `FileFormat._missing_` — so it brings Go in line rather than introducing new leniency.

It also makes the manifest reader consistent with the rest of this library, which already normalizes everywhere else this field crosses the wire:

- `catalog/rest/scan_task_decoder.go` — the REST scan-planning decoder calls `FileFormatFromString` before building the data file.
- `table/writer.go` and `table/rolling_data_writer.go` — both writers normalize.

~~The Avro manifest reader was the only place treating wire casing as authoritative.~~

**Correction:** this was wrong, as @zeroshade found in review. `unmarshalAvroDataFileEntry` (`data_file_codec.go`), the other manifest-entry Avro decoder and the one behind the public `codec.DecodeDataFile`, had the identical bug.

## Behavior changes

Two user-visible consequences of normalizing on read, both flagged by @zeroshade in review:

1. **Metadata tables report the canonical spelling.** `table/inspect_files.go` appends `string(file.FileFormat())` directly, so `files`, `data_files`, `delete_files` and the `all_*` variants now show `PARQUET` for a manifest written with lowercase `parquet`.
2. **Rewriting a manifest persists the normalized spelling.** Reading a DuckDB-written table and running a delete writes `PARQUET` back to disk. Normalization is idempotent, so this is a one-time upgrade and not manifest churn.

## Note for reviewers

An unrecognized `file_format` is now a hard error at decode time, naming the offending file path, rather than surfacing later as a confusing reader-selection failure. This matches Java, where `FileFormat.fromString` throws. The lenient alternative — pass unknown values through untouched and let file-open fail — is a one-line change if reviewers prefer it.

The blast radius of that hard error is wider than scan. Because it fires at decode time, it also reaches paths that never open the data file — `inspect_files`, expire-snapshots and orphan cleanup — and it aborts the entire manifest read even for entries `iterManifest(discardDeleted=true)` would have discarded. That is unreachable with any format this library writes, and Java fails identically, but it is worth stating explicitly.

## Testing

`TestManifestReaderNormalizesFileFormat` writes a manifest through the Avro writer and reads it back, asserting the canonical constant comes out: lowercase/mixed/canonical `parquet`, lowercase `avro` and `orc`, `puffin` in a delete manifest, and the v1 fallback entry path; unrecognized `csv` and an empty `file_format` error.

`TestUnmarshalAvroDataFileEntryNormalizesFileFormat` is the equivalent table for the codec decoder, round-tripping through `MarshalAvroEntry` → `unmarshalAvroDataFileEntry`.

`make test` and `make lint` are clean.

