### PR TITLE
fix(table): allocate partition IDs from history

### DIFF
--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2016,12 +2016,14 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 	}
 
 	lastAssignedID := iceberg.PartitionDataIDStart - 1
-	lastPartitionID := lastAssignedID
+	lastPartitionID := 0
+	normalizedLastPartitionID := 0
 	lastPartitionIDSet := false
 	if rawLastPartitionID, ok := metadata["last-partition-id"]; ok {
 		var parsedLastPartitionID *int
 		if err := json.Unmarshal(rawLastPartitionID, &parsedLastPartitionID); err == nil && parsedLastPartitionID != nil {
 			lastPartitionID = *parsedLastPartitionID
+			normalizedLastPartitionID = lastPartitionID
 			lastAssignedID = max(lastAssignedID, lastPartitionID)
 			lastPartitionIDSet = true
 		}
@@ -2040,11 +2042,12 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 			var fieldID *int
 			if err := json.Unmarshal(rawFieldID, &fieldID); err == nil && fieldID != nil {
 				lastAssignedID = max(lastAssignedID, *fieldID)
+				normalizedLastPartitionID = max(normalizedLastPartitionID, *fieldID)
 			}
 		}
 	}
 
-	if len(missingFields) == 0 && (!lastPartitionIDSet || lastPartitionID == lastAssignedID) {
+	if len(missingFields) == 0 && (!lastPartitionIDSet || lastPartitionID == normalizedLastPartitionID) {
 		return b, nil
 	}
 
@@ -2055,6 +2058,7 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 			return nil, err
 		}
 		field["field-id"] = rawFieldID
+		normalizedLastPartitionID = max(normalizedLastPartitionID, lastAssignedID)
 	}
 
 	if len(missingFields) > 0 {
@@ -2074,7 +2078,7 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 	}
 
 	if lastPartitionIDSet {
-		rawLastPartitionID, err := json.Marshal(lastAssignedID)
+		rawLastPartitionID, err := json.Marshal(normalizedLastPartitionID)
 		if err != nil {
 			return nil, err
 		}

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -2016,11 +2016,13 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 	}
 
 	lastAssignedID := iceberg.PartitionDataIDStart - 1
+	lastPartitionID := lastAssignedID
 	lastPartitionIDSet := false
 	if rawLastPartitionID, ok := metadata["last-partition-id"]; ok {
-		var lastPartitionID *int
-		if err := json.Unmarshal(rawLastPartitionID, &lastPartitionID); err == nil && lastPartitionID != nil {
-			lastAssignedID = max(lastAssignedID, *lastPartitionID)
+		var parsedLastPartitionID *int
+		if err := json.Unmarshal(rawLastPartitionID, &parsedLastPartitionID); err == nil && parsedLastPartitionID != nil {
+			lastPartitionID = *parsedLastPartitionID
+			lastAssignedID = max(lastAssignedID, lastPartitionID)
 			lastPartitionIDSet = true
 		}
 	}
@@ -2042,7 +2044,7 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 		}
 	}
 
-	if len(missingFields) == 0 {
+	if len(missingFields) == 0 && (!lastPartitionIDSet || lastPartitionID == lastAssignedID) {
 		return b, nil
 	}
 
@@ -2055,18 +2057,20 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 		field["field-id"] = rawFieldID
 	}
 
-	if usesSpecList {
-		rawSpecs, err := json.Marshal(specs)
-		if err != nil {
-			return nil, err
+	if len(missingFields) > 0 {
+		if usesSpecList {
+			rawSpecs, err := json.Marshal(specs)
+			if err != nil {
+				return nil, err
+			}
+			metadata["partition-specs"] = rawSpecs
+		} else {
+			rawFields, err := json.Marshal(specs[0].Fields)
+			if err != nil {
+				return nil, err
+			}
+			metadata["partition-spec"] = rawFields
 		}
-		metadata["partition-specs"] = rawSpecs
-	} else {
-		rawFields, err := json.Marshal(specs[0].Fields)
-		if err != nil {
-			return nil, err
-		}
-		metadata["partition-spec"] = rawFields
 	}
 
 	if lastPartitionIDSet {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -252,9 +252,8 @@ type Metadata interface {
 	// DefaultPartitionSpec is the ID of the current spec that writerFactory should
 	// use by default.
 	DefaultPartitionSpec() int
-	// LastPartitionSpecID returns the persisted last assigned partition field ID.
-	// Allocation also scans partition spec history because metadata written by
-	// another client may contain a stale counter.
+	// LastPartitionSpecID returns the persisted last assigned partition field ID,
+	// which may be stale relative to partition spec history.
 	LastPartitionSpecID() *int
 	// Snapshots returns the list of valid snapshots. Valid snapshots are
 	// snapshots for which all data files exist in the file system. A data
@@ -700,8 +699,10 @@ func (b *MetadataBuilder) AddSchema(schema *iceberg.Schema) error {
 	return nil
 }
 
+// partitionFieldIDFloor returns an allocation floor that accounts for the
+// persisted counter and all partition field IDs in spec history.
 func partitionFieldIDFloor(lastPartitionID *int, specs []iceberg.PartitionSpec) int {
-	floor := partitionFieldStartID - 1
+	floor := iceberg.PartitionDataIDStart - 1
 	if lastPartitionID != nil {
 		floor = max(floor, *lastPartitionID)
 	}
@@ -749,11 +750,7 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 
 	}
 
-	prev := partitionFieldStartID - 1
-	if b.lastPartitionID != nil {
-		prev = *b.lastPartitionID
-	}
-	lastPartitionID := max(maxFieldID, prev)
+	lastPartitionID := max(maxFieldID, fieldIDFloor)
 
 	var specs []iceberg.PartitionSpec
 	if initial {

--- a/table/metadata.go
+++ b/table/metadata.go
@@ -252,9 +252,9 @@ type Metadata interface {
 	// DefaultPartitionSpec is the ID of the current spec that writerFactory should
 	// use by default.
 	DefaultPartitionSpec() int
-	// LastPartitionSpecID is the highest assigned partition field ID across
-	// all partition specs for the table. This is used to ensure partition
-	// fields are always assigned an unused ID when evolving specs.
+	// LastPartitionSpecID returns the persisted last assigned partition field ID.
+	// Allocation also scans partition spec history because metadata written by
+	// another client may contain a stale counter.
 	LastPartitionSpecID() *int
 	// Snapshots returns the list of valid snapshots. Valid snapshots are
 	// snapshots for which all data files exist in the file system. A data
@@ -700,6 +700,18 @@ func (b *MetadataBuilder) AddSchema(schema *iceberg.Schema) error {
 	return nil
 }
 
+func partitionFieldIDFloor(lastPartitionID *int, specs []iceberg.PartitionSpec) int {
+	floor := partitionFieldStartID - 1
+	if lastPartitionID != nil {
+		floor = max(floor, *lastPartitionID)
+	}
+	for _, spec := range specs {
+		floor = max(floor, spec.LastAssignedFieldID())
+	}
+
+	return floor
+}
+
 func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial bool) error {
 	newSpecID := b.reuseOrCreateNewPartitionSpecID(*spec)
 	curSchema := b.CurrentSchema()
@@ -707,7 +719,8 @@ func (b *MetadataBuilder) AddPartitionSpec(spec *iceberg.PartitionSpec, initial 
 		return errors.New("can't add sort order with no current schema")
 	}
 
-	freshSpec, err := spec.BindToSchema(curSchema, b.lastPartitionID, &newSpecID)
+	fieldIDFloor := partitionFieldIDFloor(b.lastPartitionID, b.specs)
+	freshSpec, err := spec.BindToSchema(curSchema, &fieldIDFloor, &newSpecID)
 	if err != nil {
 		return err
 	}
@@ -2016,15 +2029,11 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 	}
 
 	lastAssignedID := iceberg.PartitionDataIDStart - 1
-	lastPartitionID := 0
-	normalizedLastPartitionID := 0
 	lastPartitionIDSet := false
 	if rawLastPartitionID, ok := metadata["last-partition-id"]; ok {
-		var parsedLastPartitionID *int
-		if err := json.Unmarshal(rawLastPartitionID, &parsedLastPartitionID); err == nil && parsedLastPartitionID != nil {
-			lastPartitionID = *parsedLastPartitionID
-			normalizedLastPartitionID = lastPartitionID
-			lastAssignedID = max(lastAssignedID, lastPartitionID)
+		var lastPartitionID *int
+		if err := json.Unmarshal(rawLastPartitionID, &lastPartitionID); err == nil && lastPartitionID != nil {
+			lastAssignedID = max(lastAssignedID, *lastPartitionID)
 			lastPartitionIDSet = true
 		}
 	}
@@ -2042,12 +2051,11 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 			var fieldID *int
 			if err := json.Unmarshal(rawFieldID, &fieldID); err == nil && fieldID != nil {
 				lastAssignedID = max(lastAssignedID, *fieldID)
-				normalizedLastPartitionID = max(normalizedLastPartitionID, *fieldID)
 			}
 		}
 	}
 
-	if len(missingFields) == 0 && (!lastPartitionIDSet || lastPartitionID == normalizedLastPartitionID) {
+	if len(missingFields) == 0 {
 		return b, nil
 	}
 
@@ -2058,27 +2066,24 @@ func assignMissingPartitionFieldIDsFromMetadata(b []byte, metadata map[string]js
 			return nil, err
 		}
 		field["field-id"] = rawFieldID
-		normalizedLastPartitionID = max(normalizedLastPartitionID, lastAssignedID)
 	}
 
-	if len(missingFields) > 0 {
-		if usesSpecList {
-			rawSpecs, err := json.Marshal(specs)
-			if err != nil {
-				return nil, err
-			}
-			metadata["partition-specs"] = rawSpecs
-		} else {
-			rawFields, err := json.Marshal(specs[0].Fields)
-			if err != nil {
-				return nil, err
-			}
-			metadata["partition-spec"] = rawFields
+	if usesSpecList {
+		rawSpecs, err := json.Marshal(specs)
+		if err != nil {
+			return nil, err
 		}
+		metadata["partition-specs"] = rawSpecs
+	} else {
+		rawFields, err := json.Marshal(specs[0].Fields)
+		if err != nil {
+			return nil, err
+		}
+		metadata["partition-spec"] = rawFields
 	}
 
 	if lastPartitionIDSet {
-		rawLastPartitionID, err := json.Marshal(normalizedLastPartitionID)
+		rawLastPartitionID, err := json.Marshal(lastAssignedID)
 		if err != nil {
 			return nil, err
 		}

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -364,24 +364,57 @@ func TestAddPartitionSpecAllocatesAfterHistoricalFieldID(t *testing.T) {
 
 	metadata, err := ParseMetadataBytes([]byte(data))
 	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name        string
+		dropCounter bool
+	}{
+		{name: "stale counter"},
+		{name: "nil counter", dropCounter: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := MetadataBuilderFromBase(metadata, "")
+			require.NoError(t, err)
+			if tt.dropCounter {
+				builder.lastPartitionID = nil
+			}
+
+			addedSpec, err := iceberg.NewPartitionSpecOpts(
+				iceberg.WithSpecID(1),
+				iceberg.AddPartitionFieldBySourceID(1, "x_bucket", iceberg.BucketTransform{NumBuckets: 16}, builder.CurrentSchema(), nil),
+			)
+			require.NoError(t, err)
+			require.NoError(t, builder.AddPartitionSpec(&addedSpec, false))
+
+			rebuilt, err := builder.Build()
+			require.NoError(t, err)
+			added := rebuilt.PartitionSpecByID(1)
+			require.NotNil(t, added)
+			require.Equal(t, 1, added.NumFields())
+			assert.Equal(t, 1001, added.Field(0).FieldID)
+			require.NotNil(t, rebuilt.LastPartitionSpecID())
+			assert.Equal(t, 1001, *rebuilt.LastPartitionSpecID())
+		})
+	}
+}
+
+func TestAddEmptyPartitionSpecRepairsStaleLastPartitionID(t *testing.T) {
+	data := strings.Replace(ExampleTableMetadataV2,
+		`"last-partition-id": 1000`, `"last-partition-id": 999`, 1)
+	require.Contains(t, data, `"last-partition-id": 999`)
+
+	metadata, err := ParseMetadataBytes([]byte(data))
+	require.NoError(t, err)
 	builder, err := MetadataBuilderFromBase(metadata, "")
 	require.NoError(t, err)
 
-	addedSpec, err := iceberg.NewPartitionSpecOpts(
-		iceberg.WithSpecID(1),
-		iceberg.AddPartitionFieldBySourceID(1, "x_bucket", iceberg.BucketTransform{NumBuckets: 16}, builder.CurrentSchema(), nil),
-	)
-	require.NoError(t, err)
-	require.NoError(t, builder.AddPartitionSpec(&addedSpec, false))
+	emptySpec := iceberg.NewPartitionSpecID(1)
+	require.NoError(t, builder.AddPartitionSpec(&emptySpec, false))
 
 	rebuilt, err := builder.Build()
 	require.NoError(t, err)
-	added := rebuilt.PartitionSpecByID(1)
-	require.NotNil(t, added)
-	require.Equal(t, 1, added.NumFields())
-	assert.Equal(t, 1001, added.Field(0).FieldID)
 	require.NotNil(t, rebuilt.LastPartitionSpecID())
-	assert.Equal(t, 1001, *rebuilt.LastPartitionSpecID())
+	assert.Equal(t, 1000, *rebuilt.LastPartitionSpecID())
 }
 
 func TestRemovePartitionSpecsNoMatchDoesNotUpdate(t *testing.T) {

--- a/table/metadata_builder_internal_test.go
+++ b/table/metadata_builder_internal_test.go
@@ -357,6 +357,33 @@ func TestAddRemovePartitionSpec(t *testing.T) {
 	require.ErrorContains(t, err, "id 1")
 }
 
+func TestAddPartitionSpecAllocatesAfterHistoricalFieldID(t *testing.T) {
+	data := strings.Replace(ExampleTableMetadataV2,
+		`"last-partition-id": 1000`, `"last-partition-id": 999`, 1)
+	require.Contains(t, data, `"last-partition-id": 999`)
+
+	metadata, err := ParseMetadataBytes([]byte(data))
+	require.NoError(t, err)
+	builder, err := MetadataBuilderFromBase(metadata, "")
+	require.NoError(t, err)
+
+	addedSpec, err := iceberg.NewPartitionSpecOpts(
+		iceberg.WithSpecID(1),
+		iceberg.AddPartitionFieldBySourceID(1, "x_bucket", iceberg.BucketTransform{NumBuckets: 16}, builder.CurrentSchema(), nil),
+	)
+	require.NoError(t, err)
+	require.NoError(t, builder.AddPartitionSpec(&addedSpec, false))
+
+	rebuilt, err := builder.Build()
+	require.NoError(t, err)
+	added := rebuilt.PartitionSpecByID(1)
+	require.NotNil(t, added)
+	require.Equal(t, 1, added.NumFields())
+	assert.Equal(t, 1001, added.Field(0).FieldID)
+	require.NotNil(t, rebuilt.LastPartitionSpecID())
+	assert.Equal(t, 1001, *rebuilt.LastPartitionSpecID())
+}
+
 func TestRemovePartitionSpecsNoMatchDoesNotUpdate(t *testing.T) {
 	for _, count := range []int{1, 2, 8, 9, 16, 17, 32, 33, 64} {
 		t.Run(fmt.Sprintf("requested=%d", count), func(t *testing.T) {

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -85,6 +85,16 @@ func TestParseMetadataBytesAssignsMissingPartitionFieldIDs(t *testing.T) {
 	}
 }
 
+func TestParseMetadataBytesNormalizesStaleLastPartitionID(t *testing.T) {
+	data := strings.Replace(ExampleTableMetadataV2,
+		`"last-partition-id": 1000`, `"last-partition-id": 999`, 1)
+
+	parsed, err := ParseMetadataBytes([]byte(data))
+	require.NoError(t, err)
+	require.NotNil(t, parsed.LastPartitionSpecID())
+	assert.Equal(t, 1000, *parsed.LastPartitionSpecID())
+}
+
 func TestParseMetadataBytesRejectsCaseFoldedFormatVersionCollision(t *testing.T) {
 	data := strings.Replace(
 		ExampleTableMetadataV2,

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -95,6 +95,56 @@ func TestParseMetadataBytesNormalizesStaleLastPartitionID(t *testing.T) {
 	assert.Equal(t, 1000, *parsed.LastPartitionSpecID())
 }
 
+func TestAssignMissingPartitionFieldIDsPreservesConsistentMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "counter below assignment floor with no fields",
+			input: `{"last-updated-ms":0,"last-partition-id":0,"partition-specs":[{"spec-id":0,"fields":[]}]}`,
+		},
+		{
+			name:  "counter above greatest field ID",
+			input: `{"last-updated-ms":0,"last-partition-id":1001,"partition-specs":[{"spec-id":0,"fields":[{"field-id":1000}]}]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, err := assignMissingPartitionFieldIDs([]byte(tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, string(normalized))
+		})
+	}
+}
+
+func TestAssignMissingPartitionFieldIDsNormalizesStaleCounter(t *testing.T) {
+	input := []byte(`{
+		"last-updated-ms": 0,
+		"last-partition-id": 999,
+		"partition-specs": [{
+			"spec-id": 0,
+			"fields": [{"field-id": 1000}, {}]
+		}]
+	}`)
+
+	normalized, err := assignMissingPartitionFieldIDs(input)
+	require.NoError(t, err)
+
+	var parsed struct {
+		LastPartitionID int `json:"last-partition-id"`
+		Specs           []struct {
+			Fields []struct {
+				FieldID int `json:"field-id"`
+			} `json:"fields"`
+		} `json:"partition-specs"`
+	}
+	require.NoError(t, json.Unmarshal(normalized, &parsed))
+	assert.Equal(t, 1001, parsed.LastPartitionID)
+	require.Len(t, parsed.Specs, 1)
+	require.Len(t, parsed.Specs[0].Fields, 2)
+	assert.Equal(t, 1001, parsed.Specs[0].Fields[1].FieldID)
+}
+
 func TestParseMetadataBytesRejectsCaseFoldedFormatVersionCollision(t *testing.T) {
 	data := strings.Replace(
 		ExampleTableMetadataV2,

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,6 +94,15 @@ func TestParseMetadataBytesNormalizesStaleLastPartitionID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, parsed.LastPartitionSpecID())
 	assert.Equal(t, 1000, *parsed.LastPartitionSpecID())
+
+	update := NewUpdateSpec(New(nil, parsed, "", nil, nil).NewTransaction(), false).
+		AddField("x", iceberg.BucketTransform{NumBuckets: 16}, "x_bucket")
+	_, _, err = update.BuildUpdates()
+	require.NoError(t, err)
+	updated, err := update.Apply()
+	require.NoError(t, err)
+	require.Equal(t, 2, updated.NumFields())
+	assert.Equal(t, 1001, updated.Field(1).FieldID)
 }
 
 func TestAssignMissingPartitionFieldIDsPreservesConsistentMetadata(t *testing.T) {
@@ -143,6 +153,19 @@ func TestAssignMissingPartitionFieldIDsNormalizesStaleCounter(t *testing.T) {
 	require.Len(t, parsed.Specs, 1)
 	require.Len(t, parsed.Specs[0].Fields, 2)
 	assert.Equal(t, 1001, parsed.Specs[0].Fields[1].FieldID)
+}
+
+func TestAssignMissingPartitionFieldIDsNormalizesLegacyStaleCounter(t *testing.T) {
+	input := []byte(`{"last-updated-ms":0,"last-partition-id":8,"partition-specs":[{"spec-id":0,"fields":[{"field-id":9}]}]}`)
+
+	normalized, err := assignMissingPartitionFieldIDs(input)
+	require.NoError(t, err)
+
+	var parsed struct {
+		LastPartitionID int `json:"last-partition-id"`
+	}
+	require.NoError(t, json.Unmarshal(normalized, &parsed))
+	assert.Equal(t, 9, parsed.LastPartitionID)
 }
 
 func TestParseMetadataBytesRejectsCaseFoldedFormatVersionCollision(t *testing.T) {

--- a/table/metadata_preflight_test.go
+++ b/table/metadata_preflight_test.go
@@ -86,23 +86,31 @@ func TestParseMetadataBytesAssignsMissingPartitionFieldIDs(t *testing.T) {
 	}
 }
 
-func TestParseMetadataBytesNormalizesStaleLastPartitionID(t *testing.T) {
+func TestParseMetadataBytesPreservesStaleLastPartitionIDForCommit(t *testing.T) {
 	data := strings.Replace(ExampleTableMetadataV2,
 		`"last-partition-id": 1000`, `"last-partition-id": 999`, 1)
+	data = strings.Replace(data,
+		`"default-spec-id": 0,`, `"default-spec-id": 1,`, 1)
+	data = strings.Replace(data,
+		`"partition-specs": [{"spec-id": 0, "fields": [{"name": "x", "transform": "identity", "source-id": 1, "field-id": 1000}]}],`,
+		`"partition-specs": [{"spec-id": 0, "fields": [{"name": "x", "transform": "identity", "source-id": 1, "field-id": 1000}]}, {"spec-id": 1, "fields": []}],`, 1)
+	require.Contains(t, data, `"last-partition-id": 999`)
+	require.Contains(t, data, `"spec-id": 1`)
 
 	parsed, err := ParseMetadataBytes([]byte(data))
 	require.NoError(t, err)
 	require.NotNil(t, parsed.LastPartitionSpecID())
-	assert.Equal(t, 1000, *parsed.LastPartitionSpecID())
+	assert.Equal(t, 999, *parsed.LastPartitionSpecID())
 
 	update := NewUpdateSpec(New(nil, parsed, "", nil, nil).NewTransaction(), false).
 		AddField("x", iceberg.BucketTransform{NumBuckets: 16}, "x_bucket")
-	_, _, err = update.BuildUpdates()
+	_, requirements, err := update.BuildUpdates()
 	require.NoError(t, err)
+	assert.Equal(t, []int{999}, lastAssignedPartitionAssertions(requirements))
 	updated, err := update.Apply()
 	require.NoError(t, err)
-	require.Equal(t, 2, updated.NumFields())
-	assert.Equal(t, 1001, updated.Field(1).FieldID)
+	require.Equal(t, 1, updated.NumFields())
+	assert.Equal(t, 1001, updated.Field(0).FieldID)
 }
 
 func TestAssignMissingPartitionFieldIDsPreservesConsistentMetadata(t *testing.T) {
@@ -125,47 +133,6 @@ func TestAssignMissingPartitionFieldIDsPreservesConsistentMetadata(t *testing.T)
 			assert.Equal(t, tt.input, string(normalized))
 		})
 	}
-}
-
-func TestAssignMissingPartitionFieldIDsNormalizesStaleCounter(t *testing.T) {
-	input := []byte(`{
-		"last-updated-ms": 0,
-		"last-partition-id": 999,
-		"partition-specs": [{
-			"spec-id": 0,
-			"fields": [{"field-id": 1000}, {}]
-		}]
-	}`)
-
-	normalized, err := assignMissingPartitionFieldIDs(input)
-	require.NoError(t, err)
-
-	var parsed struct {
-		LastPartitionID int `json:"last-partition-id"`
-		Specs           []struct {
-			Fields []struct {
-				FieldID int `json:"field-id"`
-			} `json:"fields"`
-		} `json:"partition-specs"`
-	}
-	require.NoError(t, json.Unmarshal(normalized, &parsed))
-	assert.Equal(t, 1001, parsed.LastPartitionID)
-	require.Len(t, parsed.Specs, 1)
-	require.Len(t, parsed.Specs[0].Fields, 2)
-	assert.Equal(t, 1001, parsed.Specs[0].Fields[1].FieldID)
-}
-
-func TestAssignMissingPartitionFieldIDsNormalizesLegacyStaleCounter(t *testing.T) {
-	input := []byte(`{"last-updated-ms":0,"last-partition-id":8,"partition-specs":[{"spec-id":0,"fields":[{"field-id":9}]}]}`)
-
-	normalized, err := assignMissingPartitionFieldIDs(input)
-	require.NoError(t, err)
-
-	var parsed struct {
-		LastPartitionID int `json:"last-partition-id"`
-	}
-	require.NoError(t, json.Unmarshal(normalized, &parsed))
-	assert.Equal(t, 9, parsed.LastPartitionID)
 }
 
 func TestParseMetadataBytesRejectsCaseFoldedFormatVersionCollision(t *testing.T) {

--- a/table/update_spec.go
+++ b/table/update_spec.go
@@ -122,15 +122,9 @@ func NewUpdateSpec(t *Transaction, caseSensitive bool) *UpdateSpec {
 		nameToField[partitionField.Name] = partitionField
 	}
 	us.schema = stagedMeta.CurrentSchema()
-	lastAssignedFieldId := us.meta.LastPartitionSpecID()
-	if lastAssignedFieldId == nil {
-		v := iceberg.PartitionDataIDStart - 1
-		lastAssignedFieldId = &v
-	}
-
 	us.nameToField = nameToField
 	us.transformToField = transformToField
-	us.lastAssignedFieldId = *lastAssignedFieldId
+	us.lastAssignedFieldId = partitionFieldIDFloor(us.meta.LastPartitionSpecID(), us.meta.PartitionSpecs())
 
 	return us
 }


### PR DESCRIPTION
Closes #1987.

## Summary

- preserve the persisted `last-partition-id` during metadata parsing so optimistic concurrency requirements still match the catalog
- allocate new partition field IDs above the greatest of 999, the persisted counter, and every historical partition field ID
- share the allocation floor between `UpdateSpec` and `MetadataBuilder.AddPartitionSpec`
- preserve the unchanged-byte fast path for metadata with no missing field IDs

## Why

Format v2+ partition field IDs are unique across every spec in a table. When persisted metadata contains field ID `1000` but `last-partition-id` is `999`, trusting only the counter can allocate `1000` to a different transform.

Repairing the counter at read time would make `AssertLastAssignedPartitionID` send `1000` to a catalog that still stores `999`, causing a permanent false conflict. The allocation path now scans partition history while the requirement continues to use the catalog-visible persisted value. Adding a distinct field therefore asserts `999`, allocates `1001`, and lets the committed metadata self-heal.

## Testing

- added end-to-end coverage for a stale counter with the greatest field ID in a non-current historical spec
- added direct builder coverage for missing-ID allocation above partition history
- hardened fixture mutation checks
- `make test`
- targeted `go test -race` coverage for partition allocation and commit paths
- `make test-assert`
- `go vet ./table/...`
- `golangci-lint run --timeout=10m` using v2.12.2
- `git diff --check`

No external documentation changes are needed because this restores safe partition evolution without changing the public API.
