### PR TITLE
perf(table): reuse partition validation plans across file additions

### DIFF
--- a/table/replace_files_test.go
+++ b/table/replace_files_test.go
@@ -355,7 +355,7 @@ func TestReplaceFilesWithDeleteFilesValidatesDeletionVectorIdentity(t *testing.T
 		assert.Contains(t, err.Error(), "blob identity must be unique")
 	})
 
-	t.Run("distinct blobs may share a Puffin path", func(t *testing.T) {
+	t.Run("distinct blobs may share a new or existing Puffin path", func(t *testing.T) {
 		sharedTbl := appendTwoDataFiles(t, newReplaceFilesTestTable(t))
 		sourceDelete := newPosDeleteFile(t, sharedTbl.Location()+"/data/source-pos-delete.parquet")
 		tx := sharedTbl.NewTransaction()
@@ -373,15 +373,116 @@ func TestReplaceFilesWithDeleteFilesValidatesDeletionVectorIdentity(t *testing.T
 		require.Len(t, tasks, 2)
 
 		sharedPath := sharedTbl.Location() + "/data/shared.puffin"
+		vectorA := newRewriteDeletionVector(t, sharedPath, tasks[0].File.FilePath(), &offsetA, &length)
+		vectorB := newRewriteDeletionVector(t, sharedPath, tasks[1].File.FilePath(), &offsetB, &length)
 		tx = sharedTbl.NewTransaction()
 		err = tx.ReplaceFilesWithDeleteFiles(t.Context(), nil, nil,
 			[]iceberg.DataFile{sourceDelete},
 			[]table.DeleteFileAddition{
-				{File: newRewriteDeletionVector(t, sharedPath, tasks[0].File.FilePath(), &offsetA, &length), DataSequenceNumber: sequence},
-				{File: newRewriteDeletionVector(t, sharedPath, tasks[1].File.FilePath(), &offsetB, &length), DataSequenceNumber: sequence},
+				{File: vectorA, DataSequenceNumber: sequence},
+				{File: vectorB, DataSequenceNumber: sequence},
 			}, nil)
 		require.NoError(t, err, "distinct DV blobs in one Puffin container must be accepted")
+		sharedTbl, err = tx.Commit(t.Context())
+		require.NoError(t, err)
+
+		offsetC := offsetB + length
+		tx = sharedTbl.NewTransaction()
+		err = tx.ReplaceFilesWithDeleteFiles(t.Context(), nil, nil,
+			[]iceberg.DataFile{vectorA},
+			[]table.DeleteFileAddition{{
+				File:               newRewriteDeletionVector(t, sharedPath, tasks[0].File.FilePath(), &offsetC, &length),
+				DataSequenceNumber: sequence,
+			}}, nil)
+		require.NoError(t, err, "a new DV blob may reuse an existing container path while a sibling survives")
 	})
+}
+
+func TestReplaceFilesWithDeleteFilesRejectsDuplicatePaths(t *testing.T) {
+	const path = "shared-delete-file"
+	offset, length := int64(8), int64(16)
+	pos := newPosDeleteFile(t, path)
+	eq := newEqDeleteFile(t, path)
+	vector := newRewriteDeletionVector(t, path, "data.parquet", &offset, &length)
+	conflictError := "delete file path " + path +
+		" cannot identify both a deletion vector container and a regular delete file for ReplaceFiles"
+
+	for _, tt := range []struct {
+		name      string
+		version   int
+		files     []iceberg.DataFile
+		wantError string
+	}{
+		{"position deletes", 2, []iceberg.DataFile{pos, newPosDeleteFile(t, path)}, "add delete file paths must be unique for ReplaceFiles"},
+		{"equality deletes v2", 2, []iceberg.DataFile{eq, newEqDeleteFile(t, path)}, "add delete file paths must be unique for ReplaceFiles"},
+		{"equality deletes v3", 3, []iceberg.DataFile{eq, newEqDeleteFile(t, path)}, "add delete file paths must be unique for ReplaceFiles"},
+		{"position then equality", 2, []iceberg.DataFile{pos, eq}, "add delete file paths must be unique for ReplaceFiles"},
+		{"equality then position", 2, []iceberg.DataFile{eq, pos}, "add delete file paths must be unique for ReplaceFiles"},
+		{"deletion vector then equality", 3, []iceberg.DataFile{vector, eq}, conflictError},
+		{"equality then deletion vector", 3, []iceberg.DataFile{eq, vector}, conflictError},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tbl := newReplaceFilesTestTableVersion(t, tt.version)
+			additions := make([]table.DeleteFileAddition, len(tt.files))
+			for i, file := range tt.files {
+				additions[i] = table.DeleteFileAddition{File: file, DataSequenceNumber: 0}
+			}
+
+			err := tbl.NewTransaction().ReplaceFilesWithDeleteFiles(t.Context(), nil, nil,
+				[]iceberg.DataFile{newEqDeleteFile(t, "old-equality-delete.parquet")}, additions, nil)
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestReplaceFilesWithDeleteFilesValidatesExistingPaths(t *testing.T) {
+	for _, version := range []int{2, 3} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			tbl := newReplaceFilesTestTable(t)
+			data := newDataFile(t, tbl.Location()+"/data/data.parquet")
+			source := newEqDeleteFile(t, tbl.Location()+"/data/source.parquet")
+			other := newEqDeleteFile(t, tbl.Location()+"/data/other.parquet")
+
+			tx := tbl.NewTransaction()
+			require.NoError(t, tx.AddDataFiles(t.Context(), []iceberg.DataFile{data}, nil))
+			tbl, err := tx.Commit(t.Context())
+			require.NoError(t, err)
+			tx = tbl.NewTransaction()
+			require.NoError(t, tx.NewRowDelta(nil).AddDeletes(source).AddDeletes(other).Commit(t.Context()))
+			if version == 3 {
+				require.NoError(t, tx.UpgradeFormatVersion(3))
+			}
+			tbl, err = tx.Commit(t.Context())
+			require.NoError(t, err)
+			sequence := deleteFileSequence(t, tbl, source.FilePath())
+
+			for _, tt := range []struct {
+				name string
+				path string
+			}{
+				{"existing data file", data.FilePath()},
+				{"surviving delete file", other.FilePath()},
+				{"delete file being replaced", source.FilePath()},
+				{"new delete file", tbl.Location() + "/data/replacement.parquet"},
+			} {
+				t.Run(tt.name, func(t *testing.T) {
+					tx := tbl.NewTransaction()
+					err := tx.ReplaceFilesWithDeleteFiles(t.Context(), nil, nil,
+						[]iceberg.DataFile{source},
+						[]table.DeleteFileAddition{{
+							File:               newEqDeleteFile(t, tt.path),
+							DataSequenceNumber: sequence,
+						}}, nil)
+					if tt.name == "new delete file" {
+						require.NoError(t, err)
+
+						return
+					}
+					require.EqualError(t, err, "cannot add files that are already referenced by table, files: "+tt.path)
+				})
+			}
+		})
+	}
 }
 
 func TestReplaceFilesWithDeleteFilesRejectsPartialPositionDeleteToDVRewrite(t *testing.T) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1018,26 +1018,61 @@ func (t *Transaction) ReplaceDataFiles(ctx context.Context, filesToDelete, files
 	return t.apply(updates, reqs)
 }
 
-// validateDataFilePartitionData verifies that DataFile partition values match
-// the given partition spec's fields by ID without reading file contents.
-func validateDataFilePartitionData(df iceberg.DataFile, spec *iceberg.PartitionSpec) error {
+type partitionValidationField struct {
+	id   int
+	name string
+}
+
+// partitionValidationPlan contains the immutable metadata needed to validate
+// a data file's partition tuple against one partition spec. The field slice
+// preserves spec order for deterministic missing-field errors, while the map
+// makes unknown-field checks independent of the number of partition fields.
+type partitionValidationPlan struct {
+	specID           int
+	fields           []partitionValidationField
+	expectedFieldIDs map[int]string
+}
+
+func newPartitionValidationPlan(spec *iceberg.PartitionSpec) *partitionValidationPlan {
+	plan := &partitionValidationPlan{
+		specID:           spec.ID(),
+		fields:           make([]partitionValidationField, 0, spec.NumFields()),
+		expectedFieldIDs: make(map[int]string, spec.NumFields()),
+	}
+
+	for _, field := range spec.Fields() {
+		plan.fields = append(plan.fields, partitionValidationField{
+			id:   field.FieldID,
+			name: field.Name,
+		})
+		plan.expectedFieldIDs[field.FieldID] = field.Name
+	}
+
+	return plan
+}
+
+func (p *partitionValidationPlan) validate(df iceberg.DataFile) error {
 	partitionData := dataFilePartition(df)
 
-	expectedFieldIDs := make(map[int]string)
-	for _, field := range spec.Fields() {
-		expectedFieldIDs[field.FieldID] = field.Name
-		if _, ok := partitionData[field.FieldID]; !ok {
-			return fmt.Errorf("missing partition value for field id %d (%s)", field.FieldID, field.Name)
+	for _, field := range p.fields {
+		if _, ok := partitionData[field.id]; !ok {
+			return fmt.Errorf("missing partition value for field id %d (%s)", field.id, field.name)
 		}
 	}
 
 	for fieldID := range partitionData {
-		if _, ok := expectedFieldIDs[fieldID]; !ok {
-			return fmt.Errorf("unknown partition field id %d for spec id %d", fieldID, spec.ID())
+		if _, ok := p.expectedFieldIDs[fieldID]; !ok {
+			return fmt.Errorf("unknown partition field id %d for spec id %d", fieldID, p.specID)
 		}
 	}
 
 	return nil
+}
+
+// validateDataFilePartitionData verifies that DataFile partition values match
+// the given partition spec's fields by ID without reading file contents.
+func validateDataFilePartitionData(df iceberg.DataFile, spec *iceberg.PartitionSpec) error {
+	return newPartitionValidationPlan(spec).validate(df)
 }
 
 // validateDataFilesToAdd performs metadata-only validation for caller-provided
@@ -1071,9 +1106,9 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 
 	// A data file may target any partition spec registered in the table
 	// metadata, not just the default: its manifest is written with that
-	// spec (see snapshotProducer.manifestProducer). Cache lookups since
-	// files typically share a handful of specs.
-	specsByID := make(map[int32]*iceberg.PartitionSpec)
+	// spec (see snapshotProducer.manifestProducer). Cache validation plans
+	// since files typically share a handful of specs.
+	validationPlansByID := make(map[int32]*partitionValidationPlan)
 
 	setToAdd := make(map[string]struct{}, len(dataFiles))
 
@@ -1102,9 +1137,9 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 			return nil, fmt.Errorf("data file %s has invalid file format %s for %s", path, df.FileFormat(), operation)
 		}
 
-		spec, ok := specsByID[df.SpecID()]
+		plan, ok := validationPlansByID[df.SpecID()]
 		if !ok {
-			spec, err = meta.GetSpecByID(int(df.SpecID()))
+			spec, err := meta.GetSpecByID(int(df.SpecID()))
 			if err != nil || spec == nil {
 				return nil, fmt.Errorf("data file %s has unregistered partition spec id %d for %s",
 					path, df.SpecID(), operation)
@@ -1112,10 +1147,11 @@ func (t *Transaction) validateDataFilesToAdd(dataFiles []iceberg.DataFile, opera
 			if err := checkNoUnknownTransform(spec); err != nil {
 				return nil, fmt.Errorf("data file %s for %s: %w", path, operation, err)
 			}
-			specsByID[df.SpecID()] = spec
+			plan = newPartitionValidationPlan(spec)
+			validationPlansByID[df.SpecID()] = plan
 		}
 
-		if err := validateDataFilePartitionData(df, spec); err != nil {
+		if err := plan.validate(df); err != nil {
 			return nil, fmt.Errorf("data file %s has invalid partition data for %s: %w", path, operation, err)
 		}
 
@@ -1166,6 +1202,7 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 	if meta.formatVersion < 2 {
 		return nil, fmt.Errorf("delete files require table format version >= 2, got v%d", meta.formatVersion)
 	}
+	validationPlansByID := make(map[int32]*partitionValidationPlan)
 
 	for i, addition := range deleteFiles {
 		df := addition.file
@@ -1188,14 +1225,19 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 			return nil, fmt.Errorf("adding non-delete file %s has content type %s for %s", path, df.ContentType(), operation)
 		}
 
-		spec, err := meta.GetSpecByID(int(df.SpecID()))
-		if err != nil {
-			return nil, fmt.Errorf("delete file %s references unknown partition spec id %d for %s: %w", path, df.SpecID(), operation, err)
+		plan, ok := validationPlansByID[df.SpecID()]
+		if !ok {
+			spec, err := meta.GetSpecByID(int(df.SpecID()))
+			if err != nil {
+				return nil, fmt.Errorf("delete file %s references unknown partition spec id %d for %s: %w", path, df.SpecID(), operation, err)
+			}
+			if spec == nil {
+				return nil, fmt.Errorf("delete file %s references unknown partition spec id %d for %s", path, df.SpecID(), operation)
+			}
+			plan = newPartitionValidationPlan(spec)
+			validationPlansByID[df.SpecID()] = plan
 		}
-		if spec == nil {
-			return nil, fmt.Errorf("delete file %s references unknown partition spec id %d for %s", path, df.SpecID(), operation)
-		}
-		if err := validateDataFilePartitionData(df, spec); err != nil {
+		if err := plan.validate(df); err != nil {
 			return nil, fmt.Errorf("delete file %s has invalid partition data for %s: %w", path, operation, err)
 		}
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1023,29 +1023,39 @@ type partitionValidationField struct {
 	name string
 }
 
-// partitionValidationPlan contains the immutable metadata needed to validate
+// partitionValidationPlan contains the metadata needed to validate
 // a data file's partition tuple against one partition spec. The field slice
-// preserves spec order for deterministic missing-field errors, while the map
-// makes unknown-field checks independent of the number of partition fields.
+// preserves spec order for deterministic missing-field errors. The lookup map
+// for unknown fields is built only when a malformed tuple needs that check.
 type partitionValidationPlan struct {
-	specID           int
-	fields           []partitionValidationField
-	expectedFieldIDs map[int]string
+	specID             int
+	fields             []partitionValidationField
+	expectedFieldCount int
+	expectedFieldIDs   map[int]string
 }
 
 func newPartitionValidationPlan(spec *iceberg.PartitionSpec) *partitionValidationPlan {
 	plan := &partitionValidationPlan{
-		specID:           spec.ID(),
-		fields:           make([]partitionValidationField, 0, spec.NumFields()),
-		expectedFieldIDs: make(map[int]string, spec.NumFields()),
+		specID: spec.ID(),
+		fields: make([]partitionValidationField, 0, spec.NumFields()),
 	}
 
 	for _, field := range spec.Fields() {
+		duplicateID := false
+		for _, expected := range plan.fields {
+			if expected.id == field.FieldID {
+				duplicateID = true
+
+				break
+			}
+		}
+		if !duplicateID {
+			plan.expectedFieldCount++
+		}
 		plan.fields = append(plan.fields, partitionValidationField{
 			id:   field.FieldID,
 			name: field.Name,
 		})
-		plan.expectedFieldIDs[field.FieldID] = field.Name
 	}
 
 	return plan
@@ -1060,8 +1070,15 @@ func (p *partitionValidationPlan) validate(df iceberg.DataFile) error {
 		}
 	}
 
-	if len(partitionData) == len(p.expectedFieldIDs) {
+	if len(partitionData) == p.expectedFieldCount {
 		return nil
+	}
+
+	if p.expectedFieldIDs == nil {
+		p.expectedFieldIDs = make(map[int]string, len(p.fields))
+		for _, field := range p.fields {
+			p.expectedFieldIDs[field.id] = field.name
+		}
 	}
 
 	for fieldID := range partitionData {
@@ -1177,11 +1194,10 @@ type deletionVectorBlobKey struct {
 }
 
 type deleteFilesToAddSet struct {
-	paths        map[string]struct{}
-	regularPaths map[string]struct{}
-	dvPaths      map[string]struct{}
-	dvBlobs      map[deletionVectorBlobKey]struct{}
-	dvsByRef     map[string]rewriteDeleteFileAddition
+	paths    map[string]struct{}
+	dvPaths  map[string]struct{}
+	dvBlobs  map[deletionVectorBlobKey]struct{}
+	dvsByRef map[string]rewriteDeleteFileAddition
 }
 
 // validateDeleteFilesToAdd performs metadata-only validation for delete files
@@ -1194,11 +1210,7 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 		return nil, err
 	}
 	setToAdd := &deleteFilesToAddSet{
-		paths:        make(map[string]struct{}, len(deleteFiles)),
-		regularPaths: make(map[string]struct{}, len(deleteFiles)),
-		dvPaths:      make(map[string]struct{}, len(deleteFiles)),
-		dvBlobs:      make(map[deletionVectorBlobKey]struct{}, len(deleteFiles)),
-		dvsByRef:     make(map[string]rewriteDeleteFileAddition, len(deleteFiles)),
+		paths: make(map[string]struct{}, len(deleteFiles)),
 	}
 	if len(deleteFiles) == 0 {
 		return setToAdd, nil
@@ -1221,6 +1233,7 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 		if path == "" {
 			return nil, fmt.Errorf("delete file path cannot be empty for %s", operation)
 		}
+		_, pathAlreadyAdded := setToAdd.paths[path]
 		setToAdd.paths[path] = struct{}{}
 
 		switch df.ContentType() {
@@ -1260,14 +1273,14 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 				return nil, fmt.Errorf("position delete file %s must be a deletion vector for v%d table for %s",
 					path, meta.formatVersion, operation)
 			}
-			if _, ok := setToAdd.regularPaths[path]; ok {
+			if pathAlreadyAdded {
+				if _, ok := setToAdd.dvPaths[path]; ok {
+					return nil, fmt.Errorf("delete file path %s cannot identify both a deletion vector container and a regular delete file for %s",
+						path, operation)
+				}
+
 				return nil, fmt.Errorf("add delete file paths must be unique for %s", operation)
 			}
-			if _, ok := setToAdd.dvPaths[path]; ok {
-				return nil, fmt.Errorf("delete file path %s cannot identify both a deletion vector container and a regular delete file for %s",
-					path, operation)
-			}
-			setToAdd.regularPaths[path] = struct{}{}
 
 			continue
 		}
@@ -1297,6 +1310,9 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 			}
 
 			blob := deletionVectorBlobKey{path: path, offset: *offset, length: *length}
+			if setToAdd.dvBlobs == nil {
+				setToAdd.dvBlobs = make(map[deletionVectorBlobKey]struct{}, len(deleteFiles))
+			}
 			if _, ok := setToAdd.dvBlobs[blob]; ok {
 				return nil, fmt.Errorf("deletion vector blob identity must be unique for %s: %s at offset %d with length %d",
 					operation, path, *offset, *length)
@@ -1305,9 +1321,17 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 				return nil, fmt.Errorf("deletion vectors to add must reference distinct data files for %s: %s",
 					operation, *ref)
 			}
-			if _, ok := setToAdd.regularPaths[path]; ok {
-				return nil, fmt.Errorf("delete file path %s cannot identify both a deletion vector container and a regular delete file for %s",
-					path, operation)
+			if pathAlreadyAdded {
+				if _, ok := setToAdd.dvPaths[path]; !ok {
+					return nil, fmt.Errorf("delete file path %s cannot identify both a deletion vector container and a regular delete file for %s",
+						path, operation)
+				}
+			}
+			if setToAdd.dvPaths == nil {
+				setToAdd.dvPaths = make(map[string]struct{}, len(deleteFiles))
+			}
+			if setToAdd.dvsByRef == nil {
+				setToAdd.dvsByRef = make(map[string]rewriteDeleteFileAddition, len(deleteFiles))
 			}
 			setToAdd.dvPaths[path] = struct{}{}
 			setToAdd.dvBlobs[blob] = struct{}{}
@@ -1949,8 +1973,10 @@ func (t *Transaction) replaceFiles(ctx context.Context, dataFilesToDelete, dataF
 		if _, ok := setToAdd[path]; ok {
 			return fmt.Errorf("cannot add files that are already referenced by table, files: %s", path)
 		}
-		if _, ok := setDeleteFilesToAdd.regularPaths[path]; ok {
-			return fmt.Errorf("cannot add files that are already referenced by table, files: %s", path)
+		if _, ok := setDeleteFilesToAdd.paths[path]; ok {
+			if _, isDeletionVector := setDeleteFilesToAdd.dvPaths[path]; !isDeletionVector {
+				return fmt.Errorf("cannot add files that are already referenced by table, files: %s", path)
+			}
 		}
 		if _, ok := setDeleteFilesToAdd.dvPaths[path]; ok && isLive {
 			if !IsDeletionVector(df) {

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1039,33 +1039,23 @@ type partitionValidationField struct {
 
 // partitionValidationPlan contains the metadata needed to validate
 // a data file's partition tuple against one partition spec. The field slice
-// preserves spec order for deterministic missing-field errors. The lookup map
-// for unknown fields is built only when a malformed tuple needs that check.
+// preserves spec order for deterministic missing-field errors. The plan is
+// immutable after construction and can be reused for concurrent validation.
 type partitionValidationPlan struct {
-	specID             int
-	fields             []partitionValidationField
-	expectedFieldCount int
-	expectedFieldIDs   map[int]string
+	specID           int
+	fields           []partitionValidationField
+	expectedFieldIDs map[int]struct{}
 }
 
 func newPartitionValidationPlan(spec *iceberg.PartitionSpec) *partitionValidationPlan {
 	plan := &partitionValidationPlan{
-		specID: spec.ID(),
-		fields: make([]partitionValidationField, 0, spec.NumFields()),
+		specID:           spec.ID(),
+		fields:           make([]partitionValidationField, 0, spec.NumFields()),
+		expectedFieldIDs: make(map[int]struct{}, spec.NumFields()),
 	}
 
 	for _, field := range spec.Fields() {
-		duplicateID := false
-		for _, expected := range plan.fields {
-			if expected.id == field.FieldID {
-				duplicateID = true
-
-				break
-			}
-		}
-		if !duplicateID {
-			plan.expectedFieldCount++
-		}
+		plan.expectedFieldIDs[field.FieldID] = struct{}{}
 		plan.fields = append(plan.fields, partitionValidationField{
 			id:   field.FieldID,
 			name: field.Name,
@@ -1084,15 +1074,8 @@ func (p *partitionValidationPlan) validate(df iceberg.DataFile) error {
 		}
 	}
 
-	if len(partitionData) == p.expectedFieldCount {
+	if len(partitionData) == len(p.expectedFieldIDs) {
 		return nil
-	}
-
-	if p.expectedFieldIDs == nil {
-		p.expectedFieldIDs = make(map[int]string, len(p.fields))
-		for _, field := range p.fields {
-			p.expectedFieldIDs[field.id] = field.name
-		}
 	}
 
 	for fieldID := range partitionData {
@@ -1102,12 +1085,6 @@ func (p *partitionValidationPlan) validate(df iceberg.DataFile) error {
 	}
 
 	return nil
-}
-
-// validateDataFilePartitionData verifies that DataFile partition values match
-// the given partition spec's fields by ID without reading file contents.
-func validateDataFilePartitionData(df iceberg.DataFile, spec *iceberg.PartitionSpec) error {
-	return newPartitionValidationPlan(spec).validate(df)
 }
 
 // validateDataFilesToAdd performs metadata-only validation for caller-provided

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1060,6 +1060,10 @@ func (p *partitionValidationPlan) validate(df iceberg.DataFile) error {
 		}
 	}
 
+	if len(partitionData) == len(p.expectedFieldIDs) {
+		return nil
+	}
+
 	for fieldID := range partitionData {
 		if _, ok := p.expectedFieldIDs[fieldID]; !ok {
 			return fmt.Errorf("unknown partition field id %d for spec id %d", fieldID, p.specID)

--- a/table/transaction_partition_validation_bench_test.go
+++ b/table/transaction_partition_validation_bench_test.go
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+var partitionValidationBenchmarkSink int
+
+func BenchmarkPartitionValidationPlans(b *testing.B) {
+	const fileCount = 128
+
+	for _, content := range []struct {
+		name string
+		kind string
+	}{
+		{name: "data", kind: "data"},
+		{name: "delete", kind: "delete"},
+	} {
+		for _, specCount := range []int{1, 4} {
+			for _, fieldCount := range []int{3, 8, 16} {
+				b.Run(fmt.Sprintf("%s/specs=%d/fields=%d/files=%d", content.name, specCount, fieldCount, fileCount), func(b *testing.B) {
+					txn := newPartitionValidationBenchmarkTransaction(b, specCount, fieldCount)
+					dataFiles, deleteFiles := newPartitionValidationBenchmarkFiles(b, txn, content.kind, specCount, fieldCount, fileCount)
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						if content.kind == "data" {
+							files, err := txn.validateDataFilesToAdd(dataFiles, "BenchmarkPartitionValidationPlans", false)
+							if err != nil {
+								b.Fatal(err)
+							}
+							partitionValidationBenchmarkSink = len(files)
+							continue
+						}
+
+						files, err := txn.validateDeleteFilesToAdd(deleteFiles, "BenchmarkPartitionValidationPlans")
+						if err != nil {
+							b.Fatal(err)
+						}
+						partitionValidationBenchmarkSink = len(files.paths)
+					}
+				})
+			}
+		}
+	}
+}
+
+func newPartitionValidationBenchmarkTransaction(b *testing.B, specCount, fieldCount int) *Transaction {
+	b.Helper()
+
+	schemaFields := make([]iceberg.NestedField, fieldCount)
+	partitionFields := make([]iceberg.PartitionField, fieldCount)
+	for i := range fieldCount {
+		fieldID := i + 1
+		fieldName := fmt.Sprintf("field_%d", i)
+		schemaFields[i] = iceberg.NestedField{
+			ID:       fieldID,
+			Name:     fieldName,
+			Type:     iceberg.PrimitiveTypes.Int32,
+			Required: true,
+		}
+		partitionFields[i] = iceberg.PartitionField{
+			SourceIDs: []int{fieldID},
+			FieldID:   1000 + i,
+			Name:      fieldName,
+			Transform: iceberg.IdentityTransform{},
+		}
+	}
+
+	schema := iceberg.NewSchema(0, schemaFields...)
+	specs := make([]iceberg.PartitionSpec, specCount)
+	for i := range specs {
+		specs[i] = iceberg.NewPartitionSpecID(i, partitionFields...)
+	}
+
+	builder, err := NewMetadataBuilder(2)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.SetLoc("mem://partition-validation-benchmark"); err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.AddSchema(schema); err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.SetCurrentSchemaID(-1); err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.AddSortOrder(&UnsortedSortOrder); err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.SetDefaultSortOrderID(-1); err != nil {
+		b.Fatal(err)
+	}
+	if err = builder.AddPartitionSpec(&specs[0], true); err != nil {
+		b.Fatal(err)
+	}
+	for i := 1; i < len(specs); i++ {
+		if err = builder.AddPartitionSpec(&specs[i], false); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err = builder.SetDefaultSpecID(-1); err != nil {
+		b.Fatal(err)
+	}
+	meta, err := builder.Build()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return New(Identifier{"db", "partition-validation-benchmark"}, meta, "metadata.json", nil, nil).NewTransaction()
+}
+
+func newPartitionValidationBenchmarkFiles(
+	b *testing.B,
+	txn *Transaction,
+	kind string,
+	specCount, fieldCount, fileCount int,
+) ([]iceberg.DataFile, []rewriteDeleteFileAddition) {
+	b.Helper()
+
+	specs := make([]iceberg.PartitionSpec, specCount)
+	for i := range specs {
+		spec, err := txn.meta.GetSpecByID(i)
+		if err != nil {
+			b.Fatal(err)
+		}
+		specs[i] = *spec
+	}
+
+	dataFiles := make([]iceberg.DataFile, 0, fileCount)
+	deleteFiles := make([]rewriteDeleteFileAddition, 0, fileCount)
+	for i := range fileCount {
+		specID := i % specCount
+		partition := make(map[int]any, fieldCount)
+		for field := range fieldCount {
+			partition[1000+field] = int32(i + field)
+		}
+
+		content := iceberg.EntryContentData
+		if kind == "delete" {
+			content = iceberg.EntryContentPosDeletes
+		}
+		file, err := iceberg.NewDataFileBuilder(
+			specs[specID], content,
+			fmt.Sprintf("mem://partition-validation-benchmark/%s-%d.parquet", kind, i),
+			iceberg.ParquetFile, partition, nil, nil, 1, 1,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		dataFile := file.Build()
+		if kind == "data" {
+			dataFiles = append(dataFiles, dataFile)
+		} else {
+			deleteFiles = append(deleteFiles, rewriteDeleteFileAddition{file: dataFile})
+		}
+	}
+
+	return dataFiles, deleteFiles
+}

--- a/table/transaction_partition_validation_bench_test.go
+++ b/table/transaction_partition_validation_bench_test.go
@@ -51,6 +51,7 @@ func BenchmarkPartitionValidationPlans(b *testing.B) {
 								b.Fatal(err)
 							}
 							partitionValidationBenchmarkSink = len(files)
+
 							continue
 						}
 

--- a/table/transaction_partition_validation_test.go
+++ b/table/transaction_partition_validation_test.go
@@ -81,6 +81,27 @@ func TestPartitionValidationPlanPreservesPartitionValidationErrors(t *testing.T)
 		})
 	}
 
+	duplicateSpec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{
+			SourceIDs: []int{1},
+			FieldID:   1000,
+			Name:      "first",
+			Transform: iceberg.IdentityTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{2},
+			FieldID:   1000,
+			Name:      "duplicate",
+			Transform: iceberg.IdentityTransform{},
+		},
+	)
+	duplicatePlan := newPartitionValidationPlan(&duplicateSpec)
+	duplicateFile := newTestDataFile(t, duplicateSpec, "mem://partition-validation-test-duplicate.parquet", map[int]any{
+		1000: int32(1),
+		9999: int32(3),
+	})
+	require.ErrorContains(t, duplicatePlan.validate(duplicateFile), "unknown partition field id 9999 for spec id 7")
+
 	valid := newTestDataFile(t, spec, "mem://partition-validation-test-valid.parquet", map[int]any{
 		1000: int32(1),
 		1001: int32(2),

--- a/table/transaction_partition_validation_test.go
+++ b/table/transaction_partition_validation_test.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/apache/iceberg-go"
@@ -108,4 +109,40 @@ func TestPartitionValidationPlanPreservesPartitionValidationErrors(t *testing.T)
 	})
 	require.NoError(t, plan.validate(valid))
 	require.NoError(t, plan.validate(valid))
+}
+
+func TestPartitionValidationPlanConcurrentValidation(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(7, iceberg.PartitionField{
+		SourceIDs: []int{1},
+		FieldID:   1000,
+		Name:      "id",
+		Transform: iceberg.IdentityTransform{},
+	})
+	plan := newPartitionValidationPlan(&spec)
+
+	for i := range 16 {
+		for _, tc := range []struct {
+			name      string
+			partition map[int]any
+			wantError string
+		}{
+			{"valid", map[int]any{1000: int32(1)}, ""},
+			{"missing", nil, "missing partition value for field id 1000 (id)"},
+			{"unknown", map[int]any{1000: int32(1), 9999: int32(2)}, "unknown partition field id 9999 for spec id 7"},
+		} {
+			t.Run(fmt.Sprintf("%s/%d", tc.name, i), func(t *testing.T) {
+				t.Parallel()
+
+				df := newTestDataFile(t, spec, "mem://concurrent-validation.parquet", tc.partition)
+				for range 100 {
+					err := plan.validate(df)
+					if tc.wantError == "" {
+						require.NoError(t, err)
+					} else {
+						require.EqualError(t, err, tc.wantError)
+					}
+				}
+			})
+		}
+	}
 }

--- a/table/transaction_partition_validation_test.go
+++ b/table/transaction_partition_validation_test.go
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionValidationPlanPreservesPartitionValidationErrors(t *testing.T) {
+	spec := iceberg.NewPartitionSpecID(7,
+		iceberg.PartitionField{
+			SourceIDs: []int{1},
+			FieldID:   1000,
+			Name:      "first",
+			Transform: iceberg.IdentityTransform{},
+		},
+		iceberg.PartitionField{
+			SourceIDs: []int{2},
+			FieldID:   1001,
+			Name:      "second",
+			Transform: iceberg.IdentityTransform{},
+		},
+	)
+	plan := newPartitionValidationPlan(&spec)
+
+	for _, tc := range []struct {
+		name      string
+		partition map[int]any
+		wantError string
+	}{
+		{
+			name:      "missing first field",
+			partition: map[int]any{},
+			wantError: "missing partition value for field id 1000 (first)",
+		},
+		{
+			name:      "missing second field",
+			partition: map[int]any{1000: int32(1)},
+			wantError: "missing partition value for field id 1001 (second)",
+		},
+		{
+			name: "unknown field",
+			partition: map[int]any{
+				1000: int32(1),
+				1001: int32(2),
+				9999: int32(3),
+			},
+			wantError: "unknown partition field id 9999 for spec id 7",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			df := newTestDataFile(t, spec, "mem://partition-validation-test.parquet", tc.partition)
+			err := plan.validate(df)
+			require.ErrorContains(t, err, tc.wantError)
+		})
+	}
+
+	valid := newTestDataFile(t, spec, "mem://partition-validation-test-valid.parquet", map[int]any{
+		1000: int32(1),
+		1001: int32(2),
+	})
+	require.NoError(t, plan.validate(valid))
+	require.NoError(t, plan.validate(valid))
+}

--- a/table/transaction_partition_validation_test.go
+++ b/table/transaction_partition_validation_test.go
@@ -57,6 +57,14 @@ func TestPartitionValidationPlanPreservesPartitionValidationErrors(t *testing.T)
 			wantError: "missing partition value for field id 1001 (second)",
 		},
 		{
+			name: "missing field with unknown field",
+			partition: map[int]any{
+				1000: int32(1),
+				9999: int32(3),
+			},
+			wantError: "missing partition value for field id 1001 (second)",
+		},
+		{
 			name: "unknown field",
 			partition: map[int]any{
 				1000: int32(1),


### PR DESCRIPTION
## Summary

This speeds up partition validation when a transaction adds or rewrites a batch of files.

- Build one validation plan per partition spec ID and reuse it for every file in the batch.
- Return early for complete partition tuples instead of scanning the partition map a second time.
- Build the unknown-field lookup only when that check is needed.
- Keep delete-file bookkeeping in the shared path map and allocate deletion-vector maps only for DV inputs.
- Preserve partition-field order and existing validation errors.
- Add regression tests for missing fields, unknown fields, and duplicate spec field IDs.
- Add benchmarks covering data files, delete files, 1 or 4 specs, and 3, 8, or 16 fields.

## Performance

Benchmarked on an Apple M1 Pro with 128 files per run, compared with `upstream/main`:

- **Data-file validation:** 3.0x to 10.2x faster across the matrix.
- **Delete-file validation:** 2.7x to 7.8x faster across the matrix.
- With 8 fields and 1 shared spec, data files improved from **47.1 us/op to 11.0 us/op** (4.3x faster).
- The same delete-file case improved from **58.7 us/op to 16.4 us/op** (3.6x faster).
- In the 3-field shared-spec case, allocations dropped from **396 to 19** for data files and **533 to 29** for delete files.

The latest allocation improvement was measured against the previous PR revision, using the same machine and workload:

- Regular delete validation with 1 spec and 3 fields: **14.8 us/op to 6.5 us/op** (2.3x faster).
- Memory: **42.3 KB to 6.8 KB per 128 files** (84% lower).
- Allocations: **29 to 11** (62% lower).

## Testing

- `go test ./table -count=1`
- `go test $(go list ./... | rg -v "/azure$") -p 2 -count=1`
- `go test -race ./table -run "TestPartitionValidationPlanPreservesPartitionValidationErrors|Test(AddDataFiles|ReplaceFilesWithDeleteFiles|ReplaceDataFilesWithDataFiles)" -count=1`
- `go vet ./table`
- `$(go env GOPATH)/bin/golangci-lint run --timeout=10m`
- `go test ./table -run "^$" -bench "^BenchmarkPartitionValidationPlans$" -benchtime=500ms -count=1`