### PR TITLE
fix(glue): report destination table on rename create failure

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -498,7 +498,7 @@ func (c *Catalog) RenameTable(ctx context.Context, from, to table.Identifier) (*
 		TableInput:   glueTableInput(toTable, fromGlueTable),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the table %s.%s: %w", fromDatabase, fromTable, err)
+		return nil, fmt.Errorf("failed to create the table %s.%s: %w", toDatabase, toTable, err)
 	}
 
 	// Claim the source with a conditional update before issuing Glue's

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1479,6 +1479,53 @@ func TestGlueRenameTable(t *testing.T) {
 	assert.True(testSchema.Equals(renamedTable.Schema()))
 }
 
+func TestGlueRenameTable_CreateTableFailureUsesDestinationName(t *testing.T) {
+	assert := require.New(t)
+
+	mockGluesvc := &mockGlueClient{}
+
+	mockGluesvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("new_test_database"),
+	}, mock.Anything).Return(&glue.GetDatabaseOutput{
+		Database: &types.Database{
+			Name: aws.String("new_test_database"),
+		},
+	}, nil).Once()
+
+	mockGluesvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{
+		Table: &types.Table{
+			Name:      aws.String("test_table"),
+			TableType: aws.String("EXTERNAL_TABLE"),
+			VersionId: aws.String("v1"),
+			Parameters: map[string]string{
+				tableParamTableType:        glueTypeIceberg,
+				tableParamMetadataLocation: "s3://test-bucket/test_table/metadata/abvc123-123.metadata.json",
+			},
+			StorageDescriptor: &types.StorageDescriptor{},
+		},
+	}, nil).Once()
+
+	mockGluesvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, errors.New("create table failed")).Once()
+
+	glueCatalog := &Catalog{
+		glueSvc: mockGluesvc,
+	}
+
+	renamedTable, err := glueCatalog.RenameTable(
+		context.TODO(),
+		TableIdentifier("test_database", "test_table"),
+		TableIdentifier("new_test_database", "new_test_table"),
+	)
+
+	assert.ErrorContains(err, "failed to create the table new_test_database.new_test_table")
+	assert.Nil(renamedTable)
+	mockGluesvc.AssertExpectations(t)
+}
+
 func TestGlueRenameTable_DeleteTableFailureRollback(t *testing.T) {
 	assert := require.New(t)
 


### PR DESCRIPTION
## Summary

Report the destination table name when Glue `RenameTable` fails to create the new table

  ## Why

`RenameTable` creates the destination Glue table before claiming and deleting the source table.
When `CreateTable` failed, the returned error message used the source table identifier instead of the destination identifier, which made the failure point at the wrong table.

  ## Testing

  - `go test ./catalog/glue -run 'TestGlueRenameTable' -count=1`
  - `go test ./catalog/glue -count=1`