### PR TITLE
fix(catalog/rest): sign SigV4 with credentials from catalog properties

### DIFF
--- a/catalog/rest/options.go
+++ b/catalog/rest/options.go
@@ -88,6 +88,10 @@ func WithMetadataLocation(loc string) Option {
 	}
 }
 
+// WithSigV4 enables AWS SigV4 request signing for the REST catalog. The signing
+// identity is resolved in order: an explicit WithAwsConfig, then the s3.* catalog
+// credential properties (s3.access-key-id / s3.secret-access-key / s3.session-token),
+// then the AWS default credential chain.
 func WithSigV4() Option {
 	return func(o *options) {
 		o.enableSigv4 = true

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -1107,8 +1107,13 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 	if opts.enableSigv4 {
 		cfg := opts.awsConfig
 		if !opts.awsConfigSet {
+			creds, err := staticCredsFromProps(opts.additionalProps)
+			if err != nil {
+				cleanup()
+
+				return nil, nil, err
+			}
 			// If no config provided, load defaults from environment.
-			var err error
 			cfg, err = config.LoadDefaultConfig(ctx)
 			if err != nil {
 				cleanup()
@@ -1117,7 +1122,7 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 			}
 			// Sign with the S3 credentials carried in the catalog properties when
 			// present, rather than only the AWS default credential chain.
-			if creds, ok := staticCredsFromProps(opts.additionalProps); ok {
+			if creds != nil {
 				cfg.Credentials = creds
 			}
 		}
@@ -1133,14 +1138,19 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 }
 
 // staticCredsFromProps returns a static credentials provider built from the S3
-// access-key properties, or ok=false when no key pair is present.
-func staticCredsFromProps(props iceberg.Properties) (aws.CredentialsProvider, bool) {
+// access-key properties. It returns (nil, nil) when neither key is set, so the
+// caller falls back to the default credential chain, and an error when only one
+// of the pair is set rather than silently signing as a different identity.
+func staticCredsFromProps(props iceberg.Properties) (aws.CredentialsProvider, error) {
 	accessKey, secretKey := props[iceio.S3AccessKeyID], props[iceio.S3SecretAccessKey]
-	if accessKey == "" || secretKey == "" {
-		return nil, false
+	switch {
+	case accessKey == "" && secretKey == "":
+		return nil, nil
+	case accessKey == "" || secretKey == "":
+		return nil, fmt.Errorf("rest: incomplete S3 credentials: both %s and %s are required for SigV4 signing", iceio.S3AccessKeyID, iceio.S3SecretAccessKey)
+	default:
+		return credentials.NewStaticCredentialsProvider(accessKey, secretKey, props[iceio.S3SessionToken]), nil
 	}
-
-	return credentials.NewStaticCredentialsProvider(accessKey, secretKey, props[iceio.S3SessionToken]), true
 }
 
 func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*options, error) {

--- a/catalog/rest/rest.go
+++ b/catalog/rest/rest.go
@@ -49,6 +49,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/sync/semaphore"
@@ -1114,6 +1115,11 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 
 				return nil, nil, err
 			}
+			// Sign with the S3 credentials carried in the catalog properties when
+			// present, rather than only the AWS default credential chain.
+			if creds, ok := staticCredsFromProps(opts.additionalProps); ok {
+				cfg.Credentials = creds
+			}
 		}
 		if opts.sigv4Region != "" {
 			cfg.Region = opts.sigv4Region
@@ -1124,6 +1130,17 @@ func (r *Catalog) createSession(ctx context.Context, opts *options) (*http.Clien
 	}
 
 	return cl, cleanup, nil
+}
+
+// staticCredsFromProps returns a static credentials provider built from the S3
+// access-key properties, or ok=false when no key pair is present.
+func staticCredsFromProps(props iceberg.Properties) (aws.CredentialsProvider, bool) {
+	accessKey, secretKey := props[iceio.S3AccessKeyID], props[iceio.S3SecretAccessKey]
+	if accessKey == "" || secretKey == "" {
+		return nil, false
+	}
+
+	return credentials.NewStaticCredentialsProvider(accessKey, secretKey, props[iceio.S3SessionToken]), true
 }
 
 func (r *Catalog) fetchConfig(ctx context.Context, opts *options) (*options, error) {

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
+	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -51,6 +52,26 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
+
+func TestStaticCredsFromProps(t *testing.T) {
+	creds, ok := staticCredsFromProps(iceberg.Properties{
+		iceio.S3AccessKeyID:     "AK",
+		iceio.S3SecretAccessKey: "SK",
+		iceio.S3SessionToken:    "ST",
+	})
+	require.True(t, ok)
+	got, err := creds.Retrieve(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "AK", got.AccessKeyID)
+	require.Equal(t, "SK", got.SecretAccessKey)
+	require.Equal(t, "ST", got.SessionToken)
+
+	_, ok = staticCredsFromProps(iceberg.Properties{iceio.S3AccessKeyID: "AK"})
+	require.False(t, ok, "a lone access key must not produce a provider")
+
+	_, ok = staticCredsFromProps(iceberg.Properties{})
+	require.False(t, ok, "no creds must not produce a provider")
+}
 
 func TestSplitIdentForPathRequiresNamespaceAndName(t *testing.T) {
 	cat := &Catalog{}

--- a/catalog/rest/rest_internal_test.go
+++ b/catalog/rest/rest_internal_test.go
@@ -54,23 +54,60 @@ import (
 )
 
 func TestStaticCredsFromProps(t *testing.T) {
-	creds, ok := staticCredsFromProps(iceberg.Properties{
+	creds, err := staticCredsFromProps(iceberg.Properties{
 		iceio.S3AccessKeyID:     "AK",
 		iceio.S3SecretAccessKey: "SK",
 		iceio.S3SessionToken:    "ST",
 	})
-	require.True(t, ok)
+	require.NoError(t, err)
+	require.NotNil(t, creds)
 	got, err := creds.Retrieve(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "AK", got.AccessKeyID)
 	require.Equal(t, "SK", got.SecretAccessKey)
 	require.Equal(t, "ST", got.SessionToken)
 
-	_, ok = staticCredsFromProps(iceberg.Properties{iceio.S3AccessKeyID: "AK"})
-	require.False(t, ok, "a lone access key must not produce a provider")
+	creds, err = staticCredsFromProps(iceberg.Properties{})
+	require.NoError(t, err, "no creds must fall back to the default chain")
+	require.Nil(t, creds)
 
-	_, ok = staticCredsFromProps(iceberg.Properties{})
-	require.False(t, ok, "no creds must not produce a provider")
+	_, err = staticCredsFromProps(iceberg.Properties{iceio.S3AccessKeyID: "AK"})
+	require.Error(t, err, "a lone access key must be an error, not the ambient identity")
+
+	_, err = staticCredsFromProps(iceberg.Properties{iceio.S3SecretAccessKey: "SK"})
+	require.Error(t, err, "a lone secret key must be an error, not the ambient identity")
+}
+
+// TestSigV4SignsWithPropsCredentials pins the wiring: the SigV4 Authorization
+// header must be signed with the credentials carried in the catalog properties.
+func TestSigV4SignsWithPropsCredentials(t *testing.T) {
+	var authHeader string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"defaults": map[string]any{}, "overrides": map[string]any{}})
+	})
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cat, err := NewCatalog(context.Background(), "rest", srv.URL,
+		WithSigV4RegionSvc("us-east-1", "s3"),
+		WithAdditionalProps(iceberg.Properties{
+			iceio.S3AccessKeyID:     "AKIDEXAMPLEPROPS",
+			iceio.S3SecretAccessKey: "secretexample",
+		}))
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/test", nil)
+	require.NoError(t, err)
+	_, err = cat.cl.Do(req)
+	require.NoError(t, err)
+
+	require.Contains(t, authHeader, "Credential=AKIDEXAMPLEPROPS/",
+		"SigV4 must sign with the credentials from catalog properties, not the default chain")
 }
 
 func TestSplitIdentForPathRequiresNamespaceAndName(t *testing.T) {

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -56,7 +56,7 @@ catalog:
 | `catalog.<name>.aws-profile` | AWS named profile for the Glue catalog. When unset, the AWS SDK default credential chain is used. |
 | `catalog.<name>.sql-driver` | `database/sql` driver name for the SQL catalog. Maps to the `sql.driver` property. The default CLI binary only compiles in `sqliteshim`; other drivers require a custom build. |
 | `catalog.<name>.sql-dialect` | SQL dialect for the SQL catalog (`postgres`, `mysql`, `sqlite`, `mssql`, `oracle`). Maps to the `sql.dialect` property. The default CLI binary only ships `sqlite` via `sqliteshim`; other dialects need a custom build with their drivers. |
-| `catalog.<name>.rest.sigv4-enabled` | Enable AWS SigV4 signing for REST. |
+| `catalog.<name>.rest.sigv4-enabled` | Enable AWS SigV4 signing for REST. When enabled, requests are signed with the `s3.*` credential properties if set (`s3.access-key-id` / `s3.secret-access-key` / `s3.session-token`), otherwise with the AWS default credential chain. |
 | `catalog.<name>.rest.signing-name` | SigV4 service name. |
 | `catalog.<name>.rest.signing-region` | SigV4 region. |
 


### PR DESCRIPTION
## Problem

The REST catalog's SigV4 signer builds its `aws.Config` only from `config.LoadDefaultConfig` (the AWS default credential chain), so the `s3.*` credential properties passed to the catalog are ignored for request signing.

As a result, connecting to an AWS SigV4 REST catalog (**S3 Tables** at `s3tables.<region>.amazonaws.com/iceberg`, or the **Glue** Iceberg REST endpoint) fails with `no EC2 IMDS role found` unless `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` are also present in the environment — even when the caller already supplied those credentials via `s3.access-key-id` / `s3.secret-access-key` / `s3.session-token`.

This is the same gap tracked for the Python client in apache/iceberg-python#2070.

## Fix

In `createSession`, when no explicit `aws.Config` was provided (`WithAwsConfig`), build a static credentials provider from the `s3.*` credential properties when a key pair is present, and fall back to the default chain otherwise. An explicitly provided `aws.Config` still takes precedence.

```go
if creds, ok := staticCredsFromProps(opts.additionalProps); ok {
    cfg.Credentials = creds
}
```

## Testing

- New unit test `TestStaticCredsFromProps` (full key pair → provider with session token; lone access key → no provider; empty → no provider).
- Verified end-to-end against a live AWS S3 Tables bucket: create/replace/merge succeed with credentials supplied only via catalog properties and **no** `AWS_*` environment variables.
- `go test ./catalog/rest/` passes.