### PR TITLE
feat(catalog/glue): support Amazon S3 Tables federated catalogs

### DIFF
--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -62,6 +62,11 @@ const (
 	tableParamRenameToken              = "iceberg.go.rename-token"
 	glueTypeIcebergRenaming            = "ICEBERG_RENAMING"
 
+	// glueParamFormat marks the minimal entry that makes S3 Tables allocate
+	// storage; s3TablesConnectionType tags a database federated to S3 Tables.
+	glueParamFormat        = "format"
+	s3TablesConnectionType = "aws:s3tables"
+
 	// The ID of the Glue Data Catalog where the tables reside. If none is provided, Glue
 	// automatically uses the caller's AWS account ID by default.
 	// See: https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
@@ -277,16 +282,41 @@ var _ catalog.Closer = (*Catalog)(nil)
 // This function will create the metadata file in S3 using the catalog and table properties,
 // to determine the bucket and key for the metadata location.
 func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	// Keep the missing-namespace contract that CreateStagedTable enforced when it
+	// ran first, before the federation probe below needed the database name early.
+	if len(identifier) < 2 {
+		return nil, fmt.Errorf("%w: missing namespace or invalid identifier %v", catalog.ErrNoSuchNamespace, identifier)
+	}
+
+	database, tableName, err := identifierToGlueTable(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg catalog.CreateTableCfg
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	federated, err := c.isS3TablesDatabase(ctx, database)
+	if err != nil {
+		return nil, err
+	}
+	if federated {
+		// S3 Tables assigns storage itself, so a caller-provided location can
+		// never be the managed path it will hand back.
+		if cfg.Location != "" {
+			return nil, fmt.Errorf("cannot specify a location for table %s.%s: S3 Tables manages storage automatically", database, tableName)
+		}
+
+		return c.createS3TablesTable(ctx, database, tableName, identifier, schema, opts...)
+	}
+
 	// The reporter is resolved once at construction (see NewCatalog), so a bad
 	// metrics-reporter-impl already failed there — no per-op guard is needed
 	// before mutating the catalog, and the trailing LoadTable reuses the cached
 	// reporter.
 	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	database, tableName, err := identifierToGlueTable(identifier)
 	if err != nil {
 		return nil, err
 	}
@@ -302,6 +332,108 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table %s.%s: %w", database, tableName, err)
+	}
+
+	return c.LoadTable(ctx, identifier)
+}
+
+// isS3TablesDatabase reports whether the Glue database is federated to the
+// Amazon S3 Tables service, which owns table storage and location assignment.
+func (c *Catalog) isS3TablesDatabase(ctx context.Context, database string) (bool, error) {
+	db, err := c.getDatabase(ctx, database)
+	if err != nil {
+		// A missing database is not fatal here; let the generic create path
+		// surface it, so this probe never changes the error a caller already saw.
+		if errors.Is(err, catalog.ErrNoSuchNamespace) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return db.FederatedDatabase != nil &&
+		strings.EqualFold(aws.ToString(db.FederatedDatabase.ConnectionType), s3TablesConnectionType), nil
+}
+
+// createS3TablesTable creates a table in an S3 Tables federated database. The
+// service assigns storage, so a minimal entry is created first to allocate the
+// location, then updated with the written metadata pointer; on any later
+// failure the minimal entry is removed so no half-created table is left behind.
+func (c *Catalog) createS3TablesTable(ctx context.Context, database, tableName string, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	_, err := c.glueSvc.CreateTable(ctx, &glue.CreateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		TableInput: &types.TableInput{
+			Name:       aws.String(tableName),
+			Parameters: map[string]string{glueParamFormat: glueTypeIceberg},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate S3 Tables storage for %s.%s: %w", database, tableName, err)
+	}
+
+	tbl, err := c.commitS3TablesTable(ctx, database, tableName, identifier, schema, opts...)
+	if err != nil {
+		if _, delErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
+			CatalogId:    c.catalogId,
+			DatabaseName: aws.String(database),
+			Name:         aws.String(tableName),
+		}); delErr != nil {
+			return nil, fmt.Errorf("%w (failed to clean up allocated table %s.%s: %w)", err, database, tableName, delErr)
+		}
+
+		return nil, err
+	}
+
+	return tbl, nil
+}
+
+// commitS3TablesTable reads the service-assigned location, writes the Iceberg
+// metadata to it, and points the Glue entry at that metadata.
+func (c *Catalog) commitS3TablesTable(ctx context.Context, database, tableName string, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+	allocated, err := c.glueSvc.GetTable(ctx, &glue.GetTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		Name:         aws.String(tableName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load allocated S3 Tables table %s.%s: %w", database, tableName, err)
+	}
+	if allocated == nil || allocated.Table == nil || allocated.Table.StorageDescriptor == nil {
+		return nil, fmt.Errorf("S3 Tables did not return a storage descriptor for %s.%s", database, tableName)
+	}
+	managedLocation := aws.ToString(allocated.Table.StorageDescriptor.Location)
+	if managedLocation == "" {
+		return nil, fmt.Errorf("S3 Tables did not assign a storage location for %s.%s", database, tableName)
+	}
+	if allocated.Table.VersionId == nil {
+		return nil, fmt.Errorf("cannot commit table %s.%s: because Glue table version id is missing", database, tableName)
+	}
+
+	// Copy rather than append onto the caller's opts, whose backing array may
+	// have spare capacity we would otherwise clobber.
+	stagedOpts := make([]catalog.CreateTableOpt, len(opts), len(opts)+1)
+	copy(stagedOpts, opts)
+	stagedOpts = append(stagedOpts, catalog.WithLocation(managedLocation))
+
+	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, stagedOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
+		return nil, err
+	}
+
+	_, err = c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
+		CatalogId:    c.catalogId,
+		DatabaseName: aws.String(database),
+		TableInput:   constructTableInput(tableName, staged.Table, allocated.Table),
+		VersionId:    allocated.Table.VersionId,
+		SkipArchive:  aws.Bool(c.props.GetBool(SkipArchive, SkipArchiveDefault)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit S3 Tables table %s.%s: %w", database, tableName, err)
 	}
 
 	return c.LoadTable(ctx, identifier)
@@ -850,7 +982,11 @@ func (c *Catalog) getRawTable(ctx context.Context, database, tableName string) (
 		return nil, fmt.Errorf("failed to get table %s.%s: missing Glue table response", database, tableName)
 	}
 
-	if aws.ToString(tblRes.Table.TableType) != glueTableType {
+	// S3 Tables federated entries carry their own TableType (e.g. "customer") but
+	// are still Iceberg tables, marked by the table_type parameter.
+	tableType := tblRes.Table.Parameters[tableParamTableType]
+	isIceberg := strings.EqualFold(tableType, glueTypeIceberg) || tableType == glueTypeIcebergRenaming
+	if aws.ToString(tblRes.Table.TableType) != glueTableType && !isIceberg {
 		return nil, fmt.Errorf("table %s.%s is not an EXTERNAL_TABLE", database, tableName)
 	}
 

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -372,8 +372,7 @@ func (c *Catalog) createS3TablesTable(ctx context.Context, database, tableName s
 		return nil, fmt.Errorf("failed to allocate S3 Tables storage for %s.%s: %w", database, tableName, err)
 	}
 
-	tbl, err := c.commitS3TablesTable(ctx, database, tableName, identifier, schema, opts...)
-	if err != nil {
+	if err := c.commitS3TablesTable(ctx, database, tableName, identifier, schema, opts...); err != nil {
 		if _, delErr := c.glueSvc.DeleteTable(ctx, &glue.DeleteTableInput{
 			CatalogId:    c.catalogId,
 			DatabaseName: aws.String(database),
@@ -385,29 +384,33 @@ func (c *Catalog) createS3TablesTable(ctx context.Context, database, tableName s
 		return nil, err
 	}
 
-	return tbl, nil
+	// The table is committed; load it outside the rollback scope so a transient
+	// read failure does not delete an already-created table.
+	return c.LoadTable(ctx, identifier)
 }
 
 // commitS3TablesTable reads the service-assigned location, writes the Iceberg
-// metadata to it, and points the Glue entry at that metadata.
-func (c *Catalog) commitS3TablesTable(ctx context.Context, database, tableName string, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
+// metadata to it, and points the Glue entry at that metadata. It does not reload
+// the table: the caller does that only after a successful commit, so a read
+// failure never triggers a rollback of an already-created table.
+func (c *Catalog) commitS3TablesTable(ctx context.Context, database, tableName string, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) error {
 	allocated, err := c.glueSvc.GetTable(ctx, &glue.GetTableInput{
 		CatalogId:    c.catalogId,
 		DatabaseName: aws.String(database),
 		Name:         aws.String(tableName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to load allocated S3 Tables table %s.%s: %w", database, tableName, err)
+		return fmt.Errorf("failed to load allocated S3 Tables table %s.%s: %w", database, tableName, err)
 	}
 	if allocated == nil || allocated.Table == nil || allocated.Table.StorageDescriptor == nil {
-		return nil, fmt.Errorf("S3 Tables did not return a storage descriptor for %s.%s", database, tableName)
+		return fmt.Errorf("S3 Tables did not return a storage descriptor for %s.%s", database, tableName)
 	}
 	managedLocation := aws.ToString(allocated.Table.StorageDescriptor.Location)
 	if managedLocation == "" {
-		return nil, fmt.Errorf("S3 Tables did not assign a storage location for %s.%s", database, tableName)
+		return fmt.Errorf("S3 Tables did not assign a storage location for %s.%s", database, tableName)
 	}
 	if allocated.Table.VersionId == nil {
-		return nil, fmt.Errorf("cannot commit table %s.%s: because Glue table version id is missing", database, tableName)
+		return fmt.Errorf("cannot commit table %s.%s: because Glue table version id is missing", database, tableName)
 	}
 
 	// Copy rather than append onto the caller's opts, whose backing array may
@@ -418,13 +421,15 @@ func (c *Catalog) commitS3TablesTable(ctx context.Context, database, tableName s
 
 	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, stagedOpts...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
-		return nil, err
+		return err
 	}
 
+	// constructTableInput sends TableType=EXTERNAL_TABLE; S3 Tables keeps its own
+	// service type (e.g. "customer") on read, which getRawTable accepts.
 	_, err = c.glueSvc.UpdateTable(ctx, &glue.UpdateTableInput{
 		CatalogId:    c.catalogId,
 		DatabaseName: aws.String(database),
@@ -433,10 +438,10 @@ func (c *Catalog) commitS3TablesTable(ctx context.Context, database, tableName s
 		SkipArchive:  aws.Bool(c.props.GetBool(SkipArchive, SkipArchiveDefault)),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to commit S3 Tables table %s.%s: %w", database, tableName, err)
+		return fmt.Errorf("failed to commit S3 Tables table %s.%s: %w", database, tableName, err)
 	}
 
-	return c.LoadTable(ctx, identifier)
+	return nil
 }
 
 // RegisterTable registers a new table using existing metadata.

--- a/catalog/glue/glue.go
+++ b/catalog/glue/glue.go
@@ -282,8 +282,8 @@ var _ catalog.Closer = (*Catalog)(nil)
 // This function will create the metadata file in S3 using the catalog and table properties,
 // to determine the bucket and key for the metadata location.
 func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, schema *iceberg.Schema, opts ...catalog.CreateTableOpt) (*table.Table, error) {
-	// Keep the missing-namespace contract that CreateStagedTable enforced when it
-	// ran first, before the federation probe below needed the database name early.
+	// A missing namespace is reported before touching Glue, matching the contract
+	// callers rely on (an identifier without a database is not a missing table).
 	if len(identifier) < 2 {
 		return nil, fmt.Errorf("%w: missing namespace or invalid identifier %v", catalog.ErrNoSuchNamespace, identifier)
 	}
@@ -293,32 +293,28 @@ func (c *Catalog) CreateTable(ctx context.Context, identifier table.Identifier, 
 		return nil, err
 	}
 
-	var cfg catalog.CreateTableCfg
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
-	federated, err := c.isS3TablesDatabase(ctx, database)
-	if err != nil {
-		return nil, err
-	}
-	if federated {
-		// S3 Tables assigns storage itself, so a caller-provided location can
-		// never be the managed path it will hand back.
-		if cfg.Location != "" {
-			return nil, fmt.Errorf("cannot specify a location for table %s.%s: S3 Tables manages storage automatically", database, tableName)
-		}
-
-		return c.createS3TablesTable(ctx, database, tableName, identifier, schema, opts...)
-	}
-
 	// The reporter is resolved once at construction (see NewCatalog), so a bad
 	// metrics-reporter-impl already failed there — no per-op guard is needed
 	// before mutating the catalog, and the trailing LoadTable reuses the cached
 	// reporter.
 	staged, err := internal.CreateStagedTable(ctx, c.props, c.LoadNamespaceProperties, identifier, schema, opts...)
 	if err != nil {
-		return nil, err
+		// S3 Tables federated databases assign storage themselves, so client-side
+		// location resolution fails with ErrNoDefaultLocation. Only then probe for
+		// federation and retry via the S3 Tables path, keeping the extra
+		// GetDatabase off every other create.
+		if !errors.Is(err, internal.ErrNoDefaultLocation) {
+			return nil, err
+		}
+		federated, ferr := c.isS3TablesDatabase(ctx, database)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if !federated {
+			return nil, err
+		}
+
+		return c.createS3TablesTable(ctx, database, tableName, identifier, schema, opts...)
 	}
 
 	if err := internal.WriteMetadata(ctx, staged.Table); err != nil {
@@ -987,11 +983,17 @@ func (c *Catalog) getRawTable(ctx context.Context, database, tableName string) (
 		return nil, fmt.Errorf("failed to get table %s.%s: missing Glue table response", database, tableName)
 	}
 
-	// S3 Tables federated entries carry their own TableType (e.g. "customer") but
-	// are still Iceberg tables, marked by the table_type parameter.
+	// A standard Iceberg table is an EXTERNAL_TABLE. An S3 Tables federated entry
+	// instead carries the service's own TableType (e.g. "customer"), so accept it
+	// only when it is federated to S3 Tables and marked Iceberg — keeping the
+	// relaxation scoped to that case rather than every database.
 	tableType := tblRes.Table.Parameters[tableParamTableType]
 	isIceberg := strings.EqualFold(tableType, glueTypeIceberg) || tableType == glueTypeIcebergRenaming
-	if aws.ToString(tblRes.Table.TableType) != glueTableType && !isIceberg {
+	federated := tblRes.Table.FederatedTable != nil &&
+		strings.EqualFold(aws.ToString(tblRes.Table.FederatedTable.ConnectionType), s3TablesConnectionType)
+	isExternalTable := aws.ToString(tblRes.Table.TableType) == glueTableType
+	isFederatedIceberg := federated && isIceberg
+	if !isExternalTable && !isFederatedIceberg {
 		return nil, fmt.Errorf("table %s.%s is not an EXTERNAL_TABLE", database, tableName)
 	}
 

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -2551,9 +2551,11 @@ func TestGlueCreateTableS3TablesFederated(t *testing.T) {
 	// LoadTable at the end reads this entry; UpdateTable's Run below fills in the
 	// iceberg parameters (including the metadata pointer) before it is read.
 	loaded := &types.Table{
-		Name:              aws.String("test_table"),
-		DatabaseName:      aws.String("test_database"),
-		TableType:         aws.String(glueTableType),
+		Name:         aws.String("test_table"),
+		DatabaseName: aws.String("test_database"),
+		// S3 Tables reports its own service TableType, exercising the relaxed
+		// getRawTable gate on the create success path.
+		TableType:         aws.String("customer"),
 		Parameters:        map[string]string{},
 		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
 	}

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -2895,3 +2895,40 @@ func TestGlueCreateTableS3TablesRollbackOnUpdateFailure(t *testing.T) {
 	require.ErrorContains(t, err, "failed to commit S3 Tables table")
 	mockGlueSvc.AssertExpectations(t)
 }
+
+// TestGlueCreateTableS3TablesNoRollbackOnLoadFailure verifies that a transient
+// failure of the final reload does not delete an already-committed table.
+func TestGlueCreateTableS3TablesNoRollbackOnLoadFailure(t *testing.T) {
+	ctx := context.Background()
+	managedLocation := "file://" + t.TempDir()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		VersionId:         aws.String("1"),
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
+	}}, nil).Once()
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.UpdateTableOutput{}, nil).Once()
+	// The trailing reload (LoadTable -> GetTable) fails transiently.
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return((*glue.GetTableOutput)(nil), errors.New("load boom")).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "load boom")
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -2528,7 +2528,7 @@ func TestGlueCreateTableS3TablesFederated(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.MatchedBy(func(in *glue.CreateTableInput) bool {
 		return aws.ToString(in.TableInput.Name) == "test_table" &&
@@ -2553,9 +2553,10 @@ func TestGlueCreateTableS3TablesFederated(t *testing.T) {
 	loaded := &types.Table{
 		Name:         aws.String("test_table"),
 		DatabaseName: aws.String("test_database"),
-		// S3 Tables reports its own service TableType, exercising the relaxed
-		// getRawTable gate on the create success path.
+		// S3 Tables reports its own service TableType plus a FederatedTable marker,
+		// exercising the relaxed getRawTable gate on the create success path.
 		TableType:         aws.String("customer"),
+		FederatedTable:    &types.FederatedTable{ConnectionType: aws.String(s3TablesConnectionType)},
 		Parameters:        map[string]string{},
 		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
 	}
@@ -2596,7 +2597,7 @@ func TestGlueCreateTableS3TablesCleanupOnFailure(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
@@ -2627,7 +2628,7 @@ func TestGlueCreateTableS3TablesCleanupErrorWrapped(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, mock.Anything, mock.Anything).
@@ -2652,7 +2653,7 @@ func TestGlueCreateTableS3TablesAllocateError(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return((*glue.CreateTableOutput)(nil), errors.New("allocate boom")).Once()
 
@@ -2664,22 +2665,27 @@ func TestGlueCreateTableS3TablesAllocateError(t *testing.T) {
 	mockGlueSvc.AssertExpectations(t)
 }
 
-// TestGlueCreateTableS3TablesRejectsExplicitLocation confirms an explicit
-// location is refused for a federated S3 Tables database, which manages storage.
-func TestGlueCreateTableS3TablesRejectsExplicitLocation(t *testing.T) {
+// TestGlueCreateTableExplicitLocationSkipsFederationProbe verifies a create with
+// an explicit location goes straight through the generic path without probing for
+// federation, so such creates never newly require glue:GetDatabase.
+func TestGlueCreateTableExplicitLocationSkipsFederationProbe(t *testing.T) {
 	ctx := context.Background()
+	location := "file://" + t.TempDir()
 	schema := s3TablesTestSchema()
 
 	mockGlueSvc := &mockGlueClient{}
-	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
-		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	// The trailing reload is not the point here; fail it fast to avoid a full
+	// metadata round-trip. What matters is that GetDatabase is never called.
+	mockGlueSvc.On("GetTable", mock.Anything, mock.Anything, mock.Anything).
+		Return((*glue.GetTableOutput)(nil), errors.New("load boom")).Once()
 
 	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
 	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema,
-		catalog.WithLocation("s3://some-bucket/path"))
-	require.ErrorContains(t, err, "S3 Tables manages storage automatically")
-	mockGlueSvc.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything, mock.Anything)
+		catalog.WithLocation(location))
+	require.ErrorContains(t, err, "load boom")
+	mockGlueSvc.AssertNotCalled(t, "GetDatabase", mock.Anything, mock.Anything, mock.Anything)
 	mockGlueSvc.AssertExpectations(t)
 }
 
@@ -2692,7 +2698,7 @@ func TestGlueCreateTableS3TablesMissingVersionId(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
@@ -2777,6 +2783,7 @@ func TestGlueGetRawTableTableType(t *testing.T) {
 		name      string
 		tableType string
 		params    map[string]string
+		federated bool
 		wantErr   bool
 	}{
 		{
@@ -2788,11 +2795,19 @@ func TestGlueGetRawTableTableType(t *testing.T) {
 			name:      "s3 tables federated iceberg",
 			tableType: "customer",
 			params:    map[string]string{tableParamTableType: glueTypeIceberg},
+			federated: true,
 		},
 		{
 			name:      "s3 tables federated renaming",
 			tableType: "customer",
 			params:    map[string]string{tableParamTableType: glueTypeIcebergRenaming},
+			federated: true,
+		},
+		{
+			name:      "non-federated iceberg param unexpected type rejected",
+			tableType: "customer",
+			params:    map[string]string{tableParamTableType: glueTypeIceberg},
+			wantErr:   true,
 		},
 		{
 			name:      "non-iceberg unexpected type rejected",
@@ -2805,15 +2820,19 @@ func TestGlueGetRawTableTableType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGlueSvc := &mockGlueClient{}
-			mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
-				DatabaseName: aws.String("test_database"),
-				Name:         aws.String("test_table"),
-			}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+			glueTable := &types.Table{
 				Name:         aws.String("test_table"),
 				DatabaseName: aws.String("test_database"),
 				TableType:    aws.String(tt.tableType),
 				Parameters:   tt.params,
-			}}, nil).Once()
+			}
+			if tt.federated {
+				glueTable.FederatedTable = &types.FederatedTable{ConnectionType: aws.String(s3TablesConnectionType)}
+			}
+			mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+				DatabaseName: aws.String("test_database"),
+				Name:         aws.String("test_table"),
+			}, mock.Anything).Return(&glue.GetTableOutput{Table: glueTable}, nil).Once()
 
 			cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
 			tbl, err := cat.getRawTable(context.Background(), "test_database", "test_table")
@@ -2838,7 +2857,7 @@ func TestGlueCreateTableS3TablesRollbackOnMetadataWriteFailure(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
@@ -2873,7 +2892,7 @@ func TestGlueCreateTableS3TablesRollbackOnUpdateFailure(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
@@ -2908,7 +2927,7 @@ func TestGlueCreateTableS3TablesNoRollbackOnLoadFailure(t *testing.T) {
 	mockGlueSvc := &mockGlueClient{}
 	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
 		Name: aws.String("test_database"),
-	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Times(2)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
 		Return(&glue.CreateTableOutput{}, nil).Once()
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{

--- a/catalog/glue/glue_test.go
+++ b/catalog/glue/glue_test.go
@@ -1944,6 +1944,9 @@ func TestGlueCreateTableRollbackOnInvalidMetadata(t *testing.T) {
 		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
 		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.StringType{}, Required: true},
 	)
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput(""), nil)
 	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).Return(&glue.CreateTableOutput{}, nil)
 	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
 		DatabaseName: aws.String("test_database"),
@@ -2454,4 +2457,441 @@ func TestTableOperationsRejectEmptyIdentifiers(t *testing.T) {
 		_, err = cat.CheckTableExists(ctx, ident)
 		require.ErrorIs(t, err, catalog.ErrNoSuchTable)
 	}
+}
+
+func s3TablesTestSchema() *iceberg.Schema {
+	return iceberg.NewSchemaWithIdentifiers(1, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: true},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.StringType{}, Required: false},
+	)
+}
+
+func federatedDatabaseOutput(connectionType string) *glue.GetDatabaseOutput {
+	db := &types.Database{Name: aws.String("test_database")}
+	if connectionType != "" {
+		db.FederatedDatabase = &types.FederatedDatabase{ConnectionType: aws.String(connectionType)}
+	}
+
+	return &glue.GetDatabaseOutput{Database: db}
+}
+
+func TestGlueIsS3TablesDatabase(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectionType string
+		getErr         error
+		want           bool
+		wantErr        bool
+	}{
+		{name: "federated to s3 tables", connectionType: "aws:s3tables", want: true},
+		{name: "federated case insensitive", connectionType: "AWS:S3Tables", want: true},
+		{name: "federated to another source", connectionType: "aws:redshift", want: false},
+		{name: "not federated", connectionType: "", want: false},
+		{name: "missing database is not federated", getErr: &types.EntityNotFoundException{}, want: false},
+		{name: "get database error", getErr: errors.New("boom"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGlueSvc := &mockGlueClient{}
+			if tt.getErr != nil {
+				mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+					Name: aws.String("test_database"),
+				}, mock.Anything).Return((*glue.GetDatabaseOutput)(nil), tt.getErr).Once()
+			} else {
+				mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+					Name: aws.String("test_database"),
+				}, mock.Anything).Return(federatedDatabaseOutput(tt.connectionType), nil).Once()
+			}
+
+			cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+			got, err := cat.isS3TablesDatabase(context.Background(), "test_database")
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+			mockGlueSvc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestGlueCreateTableS3TablesFederated exercises the full two-phase create:
+// detect federation, allocate storage with a minimal entry, read the assigned
+// location, write metadata to it, and repoint the Glue entry.
+func TestGlueCreateTableS3TablesFederated(t *testing.T) {
+	ctx := context.Background()
+	managedLocation := "file://" + t.TempDir()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.MatchedBy(func(in *glue.CreateTableInput) bool {
+		return aws.ToString(in.TableInput.Name) == "test_table" &&
+			in.TableInput.Parameters[glueParamFormat] == glueTypeIceberg &&
+			in.TableInput.StorageDescriptor == nil
+	}), mock.Anything).Return(&glue.CreateTableOutput{}, nil).Once()
+
+	allocated := &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		VersionId:         aws.String("1"),
+		Parameters:        map[string]string{glueParamFormat: glueTypeIceberg},
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
+	}
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: allocated}, nil).Once()
+
+	// LoadTable at the end reads this entry; UpdateTable's Run below fills in the
+	// iceberg parameters (including the metadata pointer) before it is read.
+	loaded := &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		TableType:         aws.String(glueTableType),
+		Parameters:        map[string]string{},
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
+	}
+	var capturedMetadataLocation string
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.MatchedBy(func(in *glue.UpdateTableInput) bool {
+		return in.TableInput != nil && aws.ToString(in.VersionId) == "1" &&
+			in.TableInput.Parameters[tableParamTableType] == glueTypeIceberg
+	}), mock.Anything).Run(func(args mock.Arguments) {
+		in := args.Get(1).(*glue.UpdateTableInput)
+		capturedMetadataLocation = in.TableInput.Parameters[tableParamMetadataLocation]
+		loaded.Parameters[tableParamTableType] = glueTypeIceberg
+		loaded.Parameters[tableParamMetadataLocation] = capturedMetadataLocation
+	}).Return(&glue.UpdateTableOutput{}, nil).Once()
+
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: loaded}, nil)
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	tbl, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.NoError(t, err)
+	require.Equal(t, TableIdentifier("test_database", "test_table"), tbl.Identifier())
+	require.Equal(t, schema.Fields(), tbl.Schema().Fields())
+	require.Contains(t, tbl.MetadataLocation(), managedLocation)
+	require.Equal(t, capturedMetadataLocation, tbl.MetadataLocation())
+	require.FileExists(t, strings.TrimPrefix(capturedMetadataLocation, "file://"))
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesCleanupOnFailure verifies the allocated entry is
+// deleted when the second phase fails, leaving no half-created table behind.
+func TestGlueCreateTableS3TablesCleanupOnFailure(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String("")},
+	}}, nil).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "did not assign a storage location")
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesCleanupErrorWrapped surfaces both the original
+// failure and the cleanup failure when deleting the allocated entry also fails.
+func TestGlueCreateTableS3TablesCleanupErrorWrapped(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, mock.Anything, mock.Anything).
+		Return((*glue.GetTableOutput)(nil), errors.New("get boom")).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, mock.Anything, mock.Anything).
+		Return((*glue.DeleteTableOutput)(nil), errors.New("delete boom")).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "get boom")
+	require.ErrorContains(t, err, "failed to clean up allocated table")
+	require.ErrorContains(t, err, "delete boom")
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesAllocateError returns early without cleanup when
+// the initial allocation call itself fails.
+func TestGlueCreateTableS3TablesAllocateError(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return((*glue.CreateTableOutput)(nil), errors.New("allocate boom")).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "failed to allocate S3 Tables storage")
+	mockGlueSvc.AssertNotCalled(t, "GetTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertNotCalled(t, "DeleteTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesRejectsExplicitLocation confirms an explicit
+// location is refused for a federated S3 Tables database, which manages storage.
+func TestGlueCreateTableS3TablesRejectsExplicitLocation(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema,
+		catalog.WithLocation("s3://some-bucket/path"))
+	require.ErrorContains(t, err, "S3 Tables manages storage automatically")
+	mockGlueSvc.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesMissingVersionId fails and rolls back when the
+// allocated entry has no Glue version id to commit against.
+func TestGlueCreateTableS3TablesMissingVersionId(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String("file:///tmp/whatever")},
+	}}, nil).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "Glue table version id is missing")
+	mockGlueSvc.AssertNotCalled(t, "UpdateTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableNonFederatedFallsThrough confirms a non-federated database
+// with no location still hits the generic path (and its "no default path" error).
+func TestGlueCreateTableNonFederatedFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput(""), nil)
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "no default path set")
+	mockGlueSvc.AssertNotCalled(t, "CreateTable", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestGlueCreateTableS3TablesFederatedIntegration creates a real table in an S3
+// Tables federated catalog through the native Glue path. Gated by env vars:
+//
+//	TEST_S3TABLES_CATALOG_ID = <account-id>:s3tablescatalog/<table-bucket>
+//	TEST_S3TABLES_DATABASE   = a namespace you can create tables in
+func TestGlueCreateTableS3TablesFederatedIntegration(t *testing.T) {
+	catalogID := os.Getenv("TEST_S3TABLES_CATALOG_ID")
+	dbName := os.Getenv("TEST_S3TABLES_DATABASE")
+	if catalogID == "" || dbName == "" {
+		t.Skip()
+	}
+	assert := require.New(t)
+	ctx := context.Background()
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	assert.NoError(err)
+	ctlg, err := NewCatalog(WithAwsConfig(awsCfg), WithAwsProperties(AwsProperties{CatalogIdKey: catalogID}))
+	assert.NoError(err)
+
+	tableName := fmt.Sprintf("it_%d", time.Now().UnixNano())
+	ident := TableIdentifier(dbName, tableName)
+	schema := s3TablesTestSchema()
+
+	tbl, err := ctlg.CreateTable(ctx, ident, schema)
+	assert.NoError(err)
+	defer func() { assert.NoError(ctlg.DropTable(ctx, ident)) }()
+
+	assert.Equal(ident, tbl.Identifier())
+	assert.Equal(schema.Fields(), tbl.Schema().Fields())
+	assert.Contains(tbl.MetadataLocation(), "--table-s3", "metadata must land in the S3 Tables managed location")
+
+	reloaded, err := ctlg.LoadTable(ctx, ident)
+	assert.NoError(err)
+	assert.Equal(schema.Fields(), reloaded.Schema().Fields())
+	assert.Equal(tbl.MetadataLocation(), reloaded.MetadataLocation())
+}
+
+// TestGlueGetRawTableTableType covers the relaxed TableType gate: standard
+// EXTERNAL_TABLE tables and S3 Tables federated iceberg tables (whose Glue
+// TableType is service-specific) are both accepted, while non-iceberg entries
+// with an unexpected TableType are still rejected.
+func TestGlueGetRawTableTableType(t *testing.T) {
+	tests := []struct {
+		name      string
+		tableType string
+		params    map[string]string
+		wantErr   bool
+	}{
+		{
+			name:      "standard external table",
+			tableType: glueTableType,
+			params:    map[string]string{tableParamTableType: glueTypeIceberg},
+		},
+		{
+			name:      "s3 tables federated iceberg",
+			tableType: "customer",
+			params:    map[string]string{tableParamTableType: glueTypeIceberg},
+		},
+		{
+			name:      "s3 tables federated renaming",
+			tableType: "customer",
+			params:    map[string]string{tableParamTableType: glueTypeIcebergRenaming},
+		},
+		{
+			name:      "non-iceberg unexpected type rejected",
+			tableType: "VIRTUAL_VIEW",
+			params:    map[string]string{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGlueSvc := &mockGlueClient{}
+			mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+				DatabaseName: aws.String("test_database"),
+				Name:         aws.String("test_table"),
+			}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+				Name:         aws.String("test_table"),
+				DatabaseName: aws.String("test_database"),
+				TableType:    aws.String(tt.tableType),
+				Parameters:   tt.params,
+			}}, nil).Once()
+
+			cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+			tbl, err := cat.getRawTable(context.Background(), "test_database", "test_table")
+			if tt.wantErr {
+				require.ErrorContains(t, err, "is not an EXTERNAL_TABLE")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.tableType, aws.ToString(tbl.TableType))
+			}
+			mockGlueSvc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestGlueCreateTableS3TablesRollbackOnMetadataWriteFailure covers the mid-flight
+// case where storage is allocated but writing metadata to it fails: the
+// allocated entry must be rolled back and UpdateTable never issued.
+func TestGlueCreateTableS3TablesRollbackOnMetadataWriteFailure(t *testing.T) {
+	ctx := context.Background()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		VersionId:         aws.String("1"),
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String("s3://nonexistent-test-bucket")},
+	}}, nil).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.Error(t, err)
+	mockGlueSvc.AssertNotCalled(t, "UpdateTable", mock.Anything, mock.Anything, mock.Anything)
+	mockGlueSvc.AssertExpectations(t)
+}
+
+// TestGlueCreateTableS3TablesRollbackOnUpdateFailure covers the final step
+// failing after metadata is written: the pointer commit is rejected, so the
+// allocated entry is rolled back.
+func TestGlueCreateTableS3TablesRollbackOnUpdateFailure(t *testing.T) {
+	ctx := context.Background()
+	managedLocation := "file://" + t.TempDir()
+	schema := s3TablesTestSchema()
+
+	mockGlueSvc := &mockGlueClient{}
+	mockGlueSvc.On("GetDatabase", mock.Anything, &glue.GetDatabaseInput{
+		Name: aws.String("test_database"),
+	}, mock.Anything).Return(federatedDatabaseOutput("aws:s3tables"), nil).Once()
+	mockGlueSvc.On("CreateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return(&glue.CreateTableOutput{}, nil).Once()
+	mockGlueSvc.On("GetTable", mock.Anything, &glue.GetTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.GetTableOutput{Table: &types.Table{
+		Name:              aws.String("test_table"),
+		DatabaseName:      aws.String("test_database"),
+		VersionId:         aws.String("1"),
+		StorageDescriptor: &types.StorageDescriptor{Location: aws.String(managedLocation)},
+	}}, nil).Once()
+	mockGlueSvc.On("UpdateTable", mock.Anything, mock.Anything, mock.Anything).
+		Return((*glue.UpdateTableOutput)(nil), errors.New("update rejected")).Once()
+	mockGlueSvc.On("DeleteTable", mock.Anything, &glue.DeleteTableInput{
+		DatabaseName: aws.String("test_database"),
+		Name:         aws.String("test_table"),
+	}, mock.Anything).Return(&glue.DeleteTableOutput{}, nil).Once()
+
+	cat := &Catalog{glueSvc: mockGlueSvc, awsCfg: &aws.Config{}}
+	_, err := cat.CreateTable(ctx, TableIdentifier("test_database", "test_table"), schema)
+	require.ErrorContains(t, err, "failed to commit S3 Tables table")
+	mockGlueSvc.AssertExpectations(t)
 }

--- a/catalog/internal/utils.go
+++ b/catalog/internal/utils.go
@@ -40,6 +40,12 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
+// ErrNoDefaultLocation is returned by location resolution when a table is created
+// without an explicit location and the namespace/catalog define no default
+// warehouse. Callers can match it to detect catalogs (e.g. S3 Tables) that assign
+// storage themselves and need a different create path.
+var ErrNoDefaultLocation = errors.New("no default path set, please specify a location when creating a table")
+
 func WriteTableMetadata(metadata table.Metadata, fs icebergio.WriteFileIO, loc string, compression string) (err error) {
 	switch compression {
 	case table.MetadataCompressionCodecNone, table.MetadataCompressionCodecGzip, table.MetadataCompressionCodecZstd:
@@ -221,7 +227,7 @@ func getDefaultWarehouseLocation(namespaceKey, tablename string, nsprops, catpro
 		return url.JoinPath(warehousepath, namespaceKey+".db", tablename)
 	}
 
-	return "", errors.New("no default path set, please specify a location when creating a table")
+	return "", ErrNoDefaultLocation
 }
 
 // (\d+)            -> version number


### PR DESCRIPTION
## What

Support creating and reading Iceberg tables in a Glue database federated to **Amazon S3 Tables** (`FederatedDatabase.ConnectionType == aws:s3tables`).

## Why

`CreateTable` against such a database fails today: S3 Tables assigns storage itself, so the generic client-side location resolution errors with `no default path set`. Reads also fail because S3 Tables reports a service-specific Glue `TableType` (e.g. `customer`) that `getRawTable` rejected.

## How

Following pyiceberg's `_create_table_s3tables`: detect the federated database, create a minimal Glue entry so S3 Tables allocates storage, read the assigned location, write metadata to it, then repoint the entry — rolling back on failure. An explicit location is rejected, and `getRawTable` now accepts entries marked Iceberg via the `table_type` parameter, not only `EXTERNAL_TABLE`. Non-federated behavior is unchanged.

## Testing

Unit tests for detection, the two-phase create, location rejection, and every rollback path; a gated live integration test; and full `go test ./...` + `golangci-lint` pass.

## Note

Detection issues a `GetDatabase` on every `CreateTable`. This adds one Glue round-trip and means a principal must also hold `glue:GetDatabase` (in addition to `glue:CreateTable`).