### PR TITLE
fix(table): reject dvs added to tables below v3 

### DIFF
--- a/table/row_delta.go
+++ b/table/row_delta.go
@@ -98,6 +98,7 @@ func (rd *RowDelta) AddRows(files ...iceberg.DataFile) *RowDelta {
 // Equality delete files must have ContentType == EntryContentEqDeletes
 // and non-empty EqualityFieldIDs referencing valid schema columns.
 // Position delete files must have ContentType == EntryContentPosDeletes.
+// DVs are rejected by Commit unless the table is v3 or later.
 func (rd *RowDelta) AddDeletes(files ...iceberg.DataFile) *RowDelta {
 	rd.delFiles = append(rd.delFiles, files...)
 
@@ -150,6 +151,7 @@ func (rd *RowDelta) RemoveDeletes(files ...iceberg.DataFile) *RowDelta {
 // on one data file (a replacement added while the superseded live DV
 // is not removed, or two added replacements for one data file), or if
 // the table format version does not support delete files.
+// Deletes require v2 or later, DVs require v3 or later.
 //
 // With removals present the staged commit is non-replayable: an
 // optimistic-concurrency conflict fails the transaction's Commit with
@@ -194,6 +196,10 @@ func (rd *RowDelta) Commit(ctx context.Context) error {
 		if ct != iceberg.EntryContentPosDeletes && ct != iceberg.EntryContentEqDeletes {
 			return fmt.Errorf("expected delete file, got content type %s: %s",
 				ct, f.FilePath())
+		}
+
+		if err := validateDeletionVectorFormatVersion(f, meta.formatVersion, "row delta"); err != nil {
+			return err
 		}
 
 		// Equality delete files must declare which columns form the delete key,

--- a/table/row_delta_test.go
+++ b/table/row_delta_test.go
@@ -1108,6 +1108,107 @@ func TestRowDeltaRemoveDeletesFailsInsteadOfReplaying(t *testing.T) {
 		"the data file must carry exactly one live DV: the peer's")
 }
 
+func buildPuffinPosDeleteWithoutRef(t *testing.T, path string) iceberg.DataFile {
+	t.Helper()
+
+	b, err := iceberg.NewDataFileBuilder(*iceberg.UnpartitionedSpec, iceberg.EntryContentPosDeletes,
+		path, iceberg.PuffinFile, nil, nil, nil, 2, 128)
+	require.NoError(t, err)
+
+	return b.Build()
+}
+
+func TestRowDeltaRejectsDeletionVectorBelowV3(t *testing.T) {
+	const (
+		dataPath = "s3://bucket/data/insert.parquet"
+		dvPath   = "s3://bucket/data/dv-001.puffin"
+	)
+
+	tests := []struct {
+		name          string
+		formatVersion int
+		rows          []iceberg.DataFile
+		deletes       func(*testing.T) []iceberg.DataFile
+		errContains   string
+	}{
+		{
+			name:          "deletion vector alone on v2",
+			formatVersion: 2,
+			deletes: func(t *testing.T) []iceberg.DataFile {
+				return []iceberg.DataFile{buildDVFile(t, dvPath, dataPath)}
+			},
+			errContains: "requires table format version >= 3",
+		},
+		{
+			name:          "deletion vector beside valid files on v2",
+			formatVersion: 2,
+			rows:          []iceberg.DataFile{buildDataFile(t, dataPath)},
+			deletes: func(t *testing.T) []iceberg.DataFile {
+				return []iceberg.DataFile{
+					buildPosDeleteFile(t, "s3://bucket/data/pos-del.parquet"),
+					buildEqDeleteFile(t, "s3://bucket/data/eq-del.parquet", []int{1}),
+					buildDVFile(t, dvPath, dataPath),
+				}
+			},
+			errContains: "requires table format version >= 3",
+		},
+		{
+			name:          "deletion vector without referenced data file on v2",
+			formatVersion: 2,
+			deletes: func(t *testing.T) []iceberg.DataFile {
+				return []iceberg.DataFile{buildPuffinPosDeleteWithoutRef(t, dvPath)}
+			},
+			errContains: "requires table format version >= 3",
+		},
+		{
+			// v1 rejects every delete file before the DV check is reached.
+			name:          "deletion vector on v1",
+			formatVersion: 1,
+			deletes: func(t *testing.T) []iceberg.DataFile {
+				return []iceberg.DataFile{buildDVFile(t, dvPath, dataPath)}
+			},
+			errContains: "format version >= 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tbl := newRowDeltaCommitTestTableVersion(t, tt.formatVersion)
+
+			rd := tbl.NewTransaction().NewRowDelta(nil).AddRows(tt.rows...).AddDeletes(tt.deletes(t)...)
+
+			err := rd.Commit(t.Context())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.errContains)
+			assert.Empty(t, writtenManifests(t, tbl.Location()), "a rejected row delta must not leave manifests behind")
+
+			validTx := tbl.NewTransaction()
+			require.NoError(t, validTx.NewRowDelta(nil).AddRows(buildDataFile(t, dataPath)).Commit(t.Context()))
+			assert.NotEmpty(t, writtenManifests(t, tbl.Location()), "the same probe must observe the manifests a successful commit writes")
+		})
+	}
+}
+
+func TestRowDeltaAcceptsDeletionVectorOnV3(t *testing.T) {
+	tbl := newRowDeltaCommitTestTableVersion(t, 3)
+	dataPath := tbl.Location() + "/data/insert.parquet"
+	dvPath := tbl.Location() + "/data/dv-001.puffin"
+
+	tx := tbl.NewTransaction()
+	require.NoError(t, tx.NewRowDelta(nil).AddDeletes(buildDVFile(t, dvPath, dataPath)).Commit(t.Context()))
+	tbl, err := tx.Commit(t.Context())
+	require.NoError(t, err)
+
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+
+	live, removed := snapshotDeleteEntryFiles(t, snap, iceio.LocalFS{})
+	assert.Empty(t, removed)
+	require.Len(t, live, 1)
+	assert.Equal(t, dvPath, live[0].FilePath())
+	assert.Equal(t, dataPath, refOf(live[0]))
+}
+
 // Why: deletion vectors exist only in format v3; a v2 table cannot
 // carry the entries RemoveDeletes targets, and the error should say so
 // instead of failing resolution with a confusing lookup error.

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -1144,6 +1144,14 @@ type deleteFilesToAddSet struct {
 	dvsByRef     map[string]rewriteDeleteFileAddition
 }
 
+func validateDeletionVectorFormatVersion(df iceberg.DataFile, formatVersion int, operation string) error {
+	if IsDeletionVector(df) && formatVersion < 3 {
+		return fmt.Errorf("deletion vector %s requires table format version >= 3 for %s", df.FilePath(), operation)
+	}
+
+	return nil
+}
+
 // validateDeleteFilesToAdd performs metadata-only validation for delete files
 // supplied to a rewrite. Delete files may use an older partition spec, so the
 // partition values are checked against the spec carried by each file rather
@@ -1209,6 +1217,10 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 			}
 		}
 
+		if err := validateDeletionVectorFormatVersion(df, meta.formatVersion, operation); err != nil {
+			return nil, err
+		}
+
 		if !IsDeletionVector(df) {
 			if meta.formatVersion >= 3 && df.ContentType() == iceberg.EntryContentPosDeletes {
 				return nil, fmt.Errorf("position delete file %s must be a deletion vector for v%d table for %s",
@@ -1227,10 +1239,6 @@ func (t *Transaction) validateDeleteFilesToAdd(deleteFiles []rewriteDeleteFileAd
 		}
 
 		if IsDeletionVector(df) {
-			if meta.formatVersion < 3 {
-				return nil, fmt.Errorf("deletion vector %s requires table format version >= 3 for %s",
-					path, operation)
-			}
 			ref := df.ReferencedDataFile()
 			if ref == nil || *ref == "" {
 				return nil, fmt.Errorf("deletion vector to add is missing referenced_data_file for %s", operation)


### PR DESCRIPTION
Fixes #2003, added a validating function (`validateAddedDeletionVector`) and calling it at both paths: `RowDelta.Commit`, and `validateDeleteFilesToAdd`. 

Added the regression test cases for it.