### PR TITLE
perf(table): filter overwrite manifests concurrently

### DIFF
--- a/table/rewrite_manifests.go
+++ b/table/rewrite_manifests.go
@@ -171,7 +171,7 @@ func (r *rewriteManifests) supersededManifests(committed bool) []string {
 	return paths
 }
 
-func (r *rewriteManifests) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
+func (r *rewriteManifests) existingManifests(_ context.Context, parent *Snapshot) ([]iceberg.ManifestFile, error) {
 	if parent == nil {
 		return nil, nil
 	}

--- a/table/snapshot_producers.go
+++ b/table/snapshot_producers.go
@@ -52,7 +52,7 @@ type producerImpl interface {
 	// overwrites return them with removed data/delete files filtered out. It is
 	// re-evaluated against the fresh parent on every OCC retry, so it must read
 	// parent rather than the transaction's (stale) base snapshot.
-	existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error)
+	existingManifests(ctx context.Context, parent *Snapshot) ([]iceberg.ManifestFile, error)
 	// deletedEntries returns the DELETE manifest entries for files this
 	// producer removes from parent (nil means none), re-evaluated against the
 	// fresh parent on every OCC retry.
@@ -113,7 +113,7 @@ func (fa *fastAppendFiles) processManifests(manifests []iceberg.ManifestFile) ([
 	return manifests, nil
 }
 
-func (fa *fastAppendFiles) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
+func (fa *fastAppendFiles) existingManifests(_ context.Context, parent *Snapshot) ([]iceberg.ManifestFile, error) {
 	if parent == nil {
 		return nil, nil
 	}
@@ -143,6 +143,10 @@ func (fa *fastAppendFiles) needsValidation() bool { return false }
 type overwriteFiles struct {
 	base *snapshotProducer
 
+	// manifestConcurrency bounds concurrent filtering and rewriting of
+	// inherited manifests. Zero uses the process-wide worker configuration.
+	manifestConcurrency int
+
 	// filter is the row-level predicate the caller declared for this
 	// overwrite (e.g. WithOverwriteFilter). Nil or AlwaysTrue means
 	// "overwrite everything" — any concurrent added data file is a
@@ -159,6 +163,17 @@ type overwriteFiles struct {
 	skipDefaultValidator bool
 }
 
+type overwriteManifestScan struct {
+	notDeleted []iceberg.ManifestEntry
+	deleted    []iceberg.ManifestEntry
+}
+
+type overwriteParentManifests struct {
+	existing  []iceberg.ManifestFile
+	deleted   []iceberg.ManifestEntry
+	rewritten []iceberg.ManifestFile
+}
+
 func newOverwriteFilesProducer(op Operation, txn *Transaction, fs iceio.WriteFileIO, commitUUID *uuid.UUID, snapshotProps iceberg.Properties) *snapshotProducer {
 	prod := createSnapshotProducer(op, txn, fs, commitUUID, snapshotProps)
 	prod.producerImpl = &overwriteFiles{base: prod}
@@ -171,7 +186,7 @@ func (of *overwriteFiles) processManifests(manifests []iceberg.ManifestFile) ([]
 	return manifests, nil
 }
 
-func (of *overwriteFiles) existingManifests(parent *Snapshot) ([]iceberg.ManifestFile, error) {
+func (of *overwriteFiles) existingManifests(ctx context.Context, parent *Snapshot) ([]iceberg.ManifestFile, error) {
 	// determine if there are any existing manifest files
 	existingFiles := make([]iceberg.ManifestFile, 0)
 
@@ -184,82 +199,266 @@ func (of *overwriteFiles) existingManifests(parent *Snapshot) ([]iceberg.Manifes
 		return existingFiles, err
 	}
 
-	for _, m := range manifestList {
-		// Counts may be -1 (unset) on V1 manifests, so clamp before allocating.
-		capacity := int(m.AddedDataFiles()) + int(m.ExistingDataFiles())
-		notDeleted := make([]iceberg.ManifestEntry, 0, max(0, capacity))
-		foundDeletedCount := 0
-		for entry, err := range of.base.iterManifestEntries(m, true) {
+	manifestResults := make([][]iceberg.ManifestFile, len(manifestList))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(min(of.manifestWorkerCount(), len(manifestList)))
+	for index, manifest := range manifestList {
+		g.Go(func() error {
+			result, err := of.filterManifest(gctx, manifest)
 			if err != nil {
-				return existingFiles, err
+				return err
 			}
-			path := entry.DataFile().FilePath()
-			content := entry.DataFile().ContentType()
-			_, isDeletedData := of.base.deletedFiles[path]
-			isDeletedDelete := of.base.deleteFileRemoved(entry.DataFile())
+			manifestResults[index] = result
 
-			isData := content == iceberg.EntryContentData
-			matched := (isDeletedData && isData) || (isDeletedDelete && !isData)
-			if matched {
-				foundDeletedCount++
-			} else {
-				notDeleted = append(notDeleted, entry)
-			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if cleanupErr := of.cleanupFilteredManifests(manifestList, manifestResults); cleanupErr != nil {
+			return existingFiles, errors.Join(err, cleanupErr)
 		}
 
-		if len(notDeleted) == 0 {
-			continue
-		}
+		return existingFiles, err
+	}
 
-		if foundDeletedCount == 0 {
-			existingFiles = append(existingFiles, m)
-
-			continue
-		}
-
-		// wrap in a function to ensure that the writer is closed even if a panic occurs
-		rewriteManifest := func(m iceberg.ManifestFile, notDeleted []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
-			spec, err := of.base.txn.meta.GetSpecByID(int(m.PartitionSpecID()))
-			if err != nil {
-				return nil, err
-			}
-
-			wr, path, counter, fileCloser, err := of.base.newManifestWriter(*spec, iceberg.WithManifestWriterContent(m.ManifestContent()))
-			if err != nil {
-				return nil, err
-			}
-			defer internal.CheckedClose(fileCloser, &retErr)
-			writerClosed := false
-			defer func() {
-				if !writerClosed {
-					internal.CheckedClose(wr, &retErr)
-				}
-			}()
-
-			for _, entry := range notDeleted {
-				if err := wr.Existing(entry); err != nil {
-					return nil, err
-				}
-			}
-
-			// close the writer to force a flush and ensure counter.Count is accurate
-			writerClosed = true
-			if err := wr.Close(); err != nil {
-				return nil, err
-			}
-
-			return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(m.ManifestContent()))
-		}
-
-		mf, err := rewriteManifest(m, notDeleted)
-		if err != nil {
-			return existingFiles, err
-		}
-
-		existingFiles = append(existingFiles, mf)
+	for _, manifests := range manifestResults {
+		existingFiles = append(existingFiles, manifests...)
 	}
 
 	return existingFiles, nil
+}
+
+func (of *overwriteFiles) manifestWorkerCount() int {
+	concurrency := of.manifestConcurrency
+	if concurrency <= 0 {
+		concurrency = config.EnvConfig.MaxWorkers
+	}
+
+	return manifestMergeConcurrencyLimit(concurrency)
+}
+
+func (of *overwriteFiles) filterManifest(ctx context.Context, m iceberg.ManifestFile) ([]iceberg.ManifestFile, error) {
+	scan, err := of.scanManifest(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	if len(scan.notDeleted) == 0 {
+		return nil, nil
+	}
+
+	if len(scan.deleted) == 0 {
+		return []iceberg.ManifestFile{m}, nil
+	}
+
+	filtered, err := of.rewriteManifest(ctx, m, scan.notDeleted)
+	if err != nil {
+		return nil, err
+	}
+
+	return []iceberg.ManifestFile{filtered}, nil
+}
+
+func (of *overwriteFiles) scanManifest(ctx context.Context, m iceberg.ManifestFile) (overwriteManifestScan, error) {
+	if err := context.Cause(ctx); err != nil {
+		return overwriteManifestScan{}, err
+	}
+
+	// Counts may be -1 (unset) on V1 manifests, so clamp before allocating.
+	capacity := int(m.AddedDataFiles()) + int(m.ExistingDataFiles())
+	scan := overwriteManifestScan{
+		notDeleted: make([]iceberg.ManifestEntry, 0, max(0, capacity)),
+	}
+	for entry, err := range of.base.iterManifestEntries(m, true) {
+		if err != nil {
+			return overwriteManifestScan{}, err
+		}
+		if err := context.Cause(ctx); err != nil {
+			return overwriteManifestScan{}, err
+		}
+
+		path := entry.DataFile().FilePath()
+		content := entry.DataFile().ContentType()
+		_, isDeletedData := of.base.deletedFiles[path]
+		isDeletedDelete := of.base.deleteFileRemoved(entry.DataFile())
+
+		isData := content == iceberg.EntryContentData
+		matched := (isDeletedData && isData) || (isDeletedDelete && !isData)
+		if matched {
+			seqNum := entry.SequenceNum()
+			scan.deleted = append(scan.deleted,
+				iceberg.NewManifestEntry(iceberg.EntryStatusDELETED,
+					&of.base.snapshotID, &seqNum, entry.FileSequenceNum(),
+					entry.DataFile()))
+
+			continue
+		}
+
+		scan.notDeleted = append(scan.notDeleted, entry)
+	}
+
+	return scan, nil
+}
+
+// rewriteManifest writes the surviving entries from an inherited manifest.
+// The output is removed on any failure so a cancelled or failed worker cannot
+// leave a partial object behind.
+func (of *overwriteFiles) rewriteManifest(
+	ctx context.Context,
+	m iceberg.ManifestFile,
+	notDeleted []iceberg.ManifestEntry,
+) (_ iceberg.ManifestFile, retErr error) {
+	spec, err := of.base.txn.meta.GetSpecByID(int(m.PartitionSpecID()))
+	if err != nil {
+		return nil, err
+	}
+
+	wr, path, counter, fileCloser, err := of.base.newManifestWriter(*spec, iceberg.WithManifestWriterContent(m.ManifestContent()))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if cleanupErr := of.base.io.Remove(path); cleanupErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("remove failed manifest %s: %w", path, cleanupErr))
+		}
+	}()
+	defer internal.CheckedClose(fileCloser, &retErr)
+	writerClosed := false
+	defer func() {
+		if !writerClosed {
+			internal.CheckedClose(wr, &retErr)
+		}
+	}()
+
+	for _, entry := range notDeleted {
+		if err := context.Cause(ctx); err != nil {
+			return nil, err
+		}
+		if err := wr.Existing(entry); err != nil {
+			return nil, err
+		}
+	}
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+
+	// close the writer to force a flush and ensure counter.Count is accurate
+	writerClosed = true
+	if err := wr.Close(); err != nil {
+		return nil, err
+	}
+
+	return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(m.ManifestContent()))
+}
+
+func (of *overwriteFiles) cleanupFilteredManifests(input []iceberg.ManifestFile, results [][]iceberg.ManifestFile) error {
+	inputPaths := make(map[string]struct{}, len(input))
+	for _, manifest := range input {
+		inputPaths[manifest.FilePath()] = struct{}{}
+	}
+
+	seen := make(map[string]struct{})
+	var cleanupErr error
+	for _, manifests := range results {
+		for _, manifest := range manifests {
+			path := manifest.FilePath()
+			if _, ok := inputPaths[path]; ok {
+				continue
+			}
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			if err := of.base.io.Remove(path); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove filtered manifest %s: %w", path, err))
+			}
+		}
+	}
+
+	return cleanupErr
+}
+
+// filterAndRewriteParentManifests scans each inherited manifest once, using the
+// same pass to collect tombstones and rewrite surviving entries. The old
+// producer path needed one full manifest read for each of those operations.
+func (of *overwriteFiles) filterAndRewriteParentManifests(
+	ctx context.Context,
+	parent *Snapshot,
+) (overwriteParentManifests, error) {
+	result := overwriteParentManifests{}
+	if parent == nil {
+		return result, nil
+	}
+
+	manifestList, err := parent.Manifests(of.base.io)
+	if err != nil {
+		return result, err
+	}
+
+	manifestResults := make([][]iceberg.ManifestFile, len(manifestList))
+	scanResults := make([]overwriteManifestScan, len(manifestList))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(min(of.manifestWorkerCount(), len(manifestList)))
+	for index, manifest := range manifestList {
+		g.Go(func() error {
+			scan, err := of.scanManifest(gctx, manifest)
+			if err != nil {
+				return err
+			}
+			scanResults[index] = scan
+
+			if len(scan.notDeleted) == 0 {
+				return nil
+			}
+			if len(scan.deleted) == 0 {
+				manifestResults[index] = []iceberg.ManifestFile{manifest}
+
+				return nil
+			}
+
+			filtered, err := of.rewriteManifest(gctx, manifest, scan.notDeleted)
+			if err != nil {
+				return err
+			}
+			manifestResults[index] = []iceberg.ManifestFile{filtered}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if cleanupErr := of.cleanupFilteredManifests(manifestList, manifestResults); cleanupErr != nil {
+			return result, errors.Join(err, cleanupErr)
+		}
+
+		return result, err
+	}
+
+	result.existing = make([]iceberg.ManifestFile, 0, len(manifestList))
+	result.deleted = make([]iceberg.ManifestEntry, 0, len(manifestList))
+	for index, manifests := range manifestResults {
+		result.existing = append(result.existing, manifests...)
+		result.deleted = append(result.deleted, scanResults[index].deleted...)
+		if len(scanResults[index].deleted) > 0 && len(scanResults[index].notDeleted) > 0 {
+			result.rewritten = append(result.rewritten, manifests...)
+		}
+	}
+
+	return result, nil
+}
+
+func (sp *snapshotProducer) cleanupGeneratedManifests(manifests []iceberg.ManifestFile) error {
+	var cleanupErr error
+	for _, manifest := range manifests {
+		if err := sp.io.Remove(manifest.FilePath()); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove generated manifest %s: %w", manifest.FilePath(), err))
+		}
+	}
+
+	return cleanupErr
 }
 
 // validate rejects the overwrite if a concurrent commit added data
@@ -317,33 +516,12 @@ func (of *overwriteFiles) deletedEntries(ctx context.Context, parent *Snapshot) 
 	}
 
 	getEntries := func(m iceberg.ManifestFile) ([]iceberg.ManifestEntry, error) {
-		// Counts may be -1 (unset) on V1 manifests, so clamp before allocating.
-		capacity := int(m.AddedDataFiles()) + int(m.ExistingDataFiles())
-		result := make([]iceberg.ManifestEntry, 0, max(0, capacity))
-		for entry, err := range of.base.iterManifestEntries(m, true) {
-			if err != nil {
-				return nil, err
-			}
-			path := entry.DataFile().FilePath()
-			content := entry.DataFile().ContentType()
+		scan, err := of.scanManifest(ctx, m)
 
-			_, isDeletedData := of.base.deletedFiles[path]
-			isDeletedDelete := of.base.deleteFileRemoved(entry.DataFile())
-
-			if (isDeletedData && content == iceberg.EntryContentData) ||
-				(isDeletedDelete && content != iceberg.EntryContentData) {
-				seqNum := entry.SequenceNum()
-				result = append(result,
-					iceberg.NewManifestEntry(iceberg.EntryStatusDELETED,
-						&of.base.snapshotID, &seqNum, entry.FileSequenceNum(),
-						entry.DataFile()))
-			}
-		}
-
-		return result, nil
+		return scan.deleted, err
 	}
 
-	nWorkers := config.EnvConfig.MaxWorkers
+	nWorkers := of.manifestWorkerCount()
 	finalResult := make([]iceberg.ManifestEntry, 0, len(previousManifests))
 	for entries, err := range tblutils.MapExec(ctx, nWorkers, slices.Values(previousManifests), getEntries) {
 		if err != nil {
@@ -912,6 +1090,24 @@ func (sp *snapshotProducer) assembleManifests(ctx context.Context, parent *Snaps
 // files are inherited and the removed files are actually dropped — grafting the
 // attempt-0 result onto a fresh parent would resurrect the removed files.
 func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent *Snapshot) (_ []iceberg.ManifestFile, err error) {
+	if of, ok := sp.producerImpl.(*overwriteFiles); ok {
+		parentManifests, err := of.filterAndRewriteParentManifests(ctx, parent)
+		if err != nil {
+			return nil, err
+		}
+
+		deletedManifests, err := sp.writeDeletedEntries(parentManifests.deleted)
+		if err != nil {
+			if cleanupErr := sp.cleanupGeneratedManifests(parentManifests.rewritten); cleanupErr != nil {
+				return nil, errors.Join(err, cleanupErr)
+			}
+
+			return nil, err
+		}
+
+		return slices.Concat(deletedManifests, parentManifests.existing), nil
+	}
+
 	deleted, err := sp.deletedEntries(ctx, parent)
 	if err != nil {
 		return nil, err
@@ -924,79 +1120,15 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 
 	if len(deleted) > 0 {
 		g.Go(func() error {
-			// Group deleted entries by (specID, contentType) to ensure data and
-			// delete file entries are written to separate manifests with the
-			// correct ManifestContent.
-			type groupKey struct {
-				specID  int
-				content iceberg.ManifestContent
-			}
-			groups := map[groupKey][]iceberg.ManifestEntry{}
-			for _, entry := range deleted {
-				content := iceberg.ManifestContentData
-				if entry.DataFile().ContentType() != iceberg.EntryContentData {
-					content = iceberg.ManifestContentDeletes
-				}
-				key := groupKey{specID: int(entry.DataFile().SpecID()), content: content}
-				groups[key] = append(groups[key], entry)
-			}
+			var err error
+			deletedFilesManifests, err = sp.writeDeletedEntries(deleted)
 
-			writeGroup := func(key groupKey, entries []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
-				spec, err := sp.spec(key.specID)
-				if err != nil {
-					return nil, err
-				}
-
-				wr, path, counter, out, err := sp.newManifestWriter(spec,
-					iceberg.WithManifestWriterContent(key.content))
-				if err != nil {
-					return nil, err
-				}
-				defer internal.CheckedClose(out, &retErr)
-
-				writerClosed := false
-				defer func() {
-					if !writerClosed {
-						internal.CheckedClose(wr, &retErr)
-					}
-				}()
-
-				for _, entry := range entries {
-					if err := wr.Delete(entry); err != nil {
-						return nil, err
-					}
-				}
-
-				writerClosed = true
-				if err := wr.Close(); err != nil {
-					return nil, err
-				}
-
-				return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(key.content))
-			}
-
-			keys := slices.SortedFunc(maps.Keys(groups), func(a, b groupKey) int {
-				if c := cmp.Compare(a.specID, b.specID); c != 0 {
-					return c
-				}
-
-				return cmp.Compare(a.content, b.content)
-			})
-
-			for _, key := range keys {
-				mf, err := writeGroup(key, groups[key])
-				if err != nil {
-					return err
-				}
-				deletedFilesManifests = append(deletedFilesManifests, mf)
-			}
-
-			return nil
+			return err
 		})
 	}
 
 	g.Go(func() error {
-		m, err := sp.existingManifests(parent)
+		m, err := sp.existingManifests(ctx, parent)
 		if err != nil {
 			return err
 		}
@@ -1010,6 +1142,93 @@ func (sp *snapshotProducer) parentDependentManifests(ctx context.Context, parent
 	}
 
 	return slices.Concat(deletedFilesManifests, existingManifests), nil
+}
+
+func (sp *snapshotProducer) writeDeletedEntries(deleted []iceberg.ManifestEntry) (_ []iceberg.ManifestFile, retErr error) {
+	if len(deleted) == 0 {
+		return nil, nil
+	}
+
+	// Group deleted entries by (specID, contentType) to ensure data and delete
+	// file entries are written to separate manifests with the correct content.
+	type groupKey struct {
+		specID  int
+		content iceberg.ManifestContent
+	}
+	groups := map[groupKey][]iceberg.ManifestEntry{}
+	for _, entry := range deleted {
+		content := iceberg.ManifestContentData
+		if entry.DataFile().ContentType() != iceberg.EntryContentData {
+			content = iceberg.ManifestContentDeletes
+		}
+		key := groupKey{specID: int(entry.DataFile().SpecID()), content: content}
+		groups[key] = append(groups[key], entry)
+	}
+
+	writeGroup := func(key groupKey, entries []iceberg.ManifestEntry) (_ iceberg.ManifestFile, retErr error) {
+		spec, err := sp.spec(key.specID)
+		if err != nil {
+			return nil, err
+		}
+
+		wr, path, counter, out, err := sp.newManifestWriter(spec,
+			iceberg.WithManifestWriterContent(key.content))
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if retErr == nil {
+				return
+			}
+			if cleanupErr := sp.io.Remove(path); cleanupErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("remove failed delete manifest %s: %w", path, cleanupErr))
+			}
+		}()
+		defer internal.CheckedClose(out, &retErr)
+
+		writerClosed := false
+		defer func() {
+			if !writerClosed {
+				internal.CheckedClose(wr, &retErr)
+			}
+		}()
+
+		for _, entry := range entries {
+			if err := wr.Delete(entry); err != nil {
+				return nil, err
+			}
+		}
+
+		writerClosed = true
+		if err := wr.Close(); err != nil {
+			return nil, err
+		}
+
+		return wr.ToManifestFile(path, counter.Count, iceberg.WithManifestFileContent(key.content))
+	}
+
+	keys := slices.SortedFunc(maps.Keys(groups), func(a, b groupKey) int {
+		if c := cmp.Compare(a.specID, b.specID); c != 0 {
+			return c
+		}
+
+		return cmp.Compare(a.content, b.content)
+	})
+
+	result := make([]iceberg.ManifestFile, 0, len(keys))
+	for _, key := range keys {
+		mf, err := writeGroup(key, groups[key])
+		if err != nil {
+			if cleanupErr := sp.cleanupGeneratedManifests(result); cleanupErr != nil {
+				return nil, errors.Join(err, cleanupErr)
+			}
+
+			return nil, err
+		}
+		result = append(result, mf)
+	}
+
+	return result, nil
 }
 
 func (sp *snapshotProducer) manifestProducer(content iceberg.ManifestContent, files []iceberg.DataFile, output *[]iceberg.ManifestFile) func() (err error) {

--- a/table/snapshot_producers_bench_test.go
+++ b/table/snapshot_producers_bench_test.go
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package table
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+)
+
+// delayedManifestIO approximates the latency of a remote metadata store while
+// keeping the benchmark deterministic and independent of external services.
+type delayedManifestIO struct {
+	*memIO
+	delay time.Duration
+}
+
+func (io *delayedManifestIO) Open(name string) (iceio.File, error) {
+	time.Sleep(io.delay)
+
+	return io.memIO.Open(name)
+}
+
+func (io *delayedManifestIO) Create(name string) (iceio.FileWriter, error) {
+	time.Sleep(io.delay)
+
+	return io.memIO.Create(name)
+}
+
+func BenchmarkOverwriteParentDependentManifests(b *testing.B) {
+	const (
+		manifestCount = 32
+		ioDelay       = time.Millisecond
+	)
+
+	for _, concurrency := range []int{1, 4, 8} {
+		b.Run(fmt.Sprintf("manifests=%d/delay=%s/concurrency=%d", manifestCount, ioDelay, concurrency), func(b *testing.B) {
+			fs := &delayedManifestIO{
+				memIO: newMemIO(1<<20, nil),
+				delay: ioDelay,
+			}
+			spec := partitionedSpec()
+			schema := simpleSchema()
+			txn := createTestTransaction(b, fs, spec)
+			sp := newOverwriteFilesProducer(OpOverwrite, txn, fs, nil, nil)
+			of := sp.producerImpl.(*overwriteFiles)
+			of.manifestConcurrency = concurrency
+
+			snapshotID := int64(100)
+			sequenceNumber := int64(-1)
+			manifestSequenceNumber := int64(42)
+			manifests := make([]iceberg.ManifestFile, 0, manifestCount)
+			for i := range manifestCount {
+				deletedFile := newTestDataFile(b, spec, fmt.Sprintf("file://deleted-%d.parquet", i), nil)
+				keptFile := newTestDataFile(b, spec, fmt.Sprintf("file://kept-%d.parquet", i), nil)
+				sp.deleteDataFile(deletedFile)
+
+				entries := []iceberg.ManifestEntry{
+					iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, deletedFile),
+					iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, keptFile),
+				}
+				path := fmt.Sprintf("table-location/metadata/source-%d.avro", i)
+				manifests = append(manifests, writeTestManifestWithEntries(b, fs, spec, schema, snapshotID, path, entries))
+			}
+
+			manifestListPath := "table-location/metadata/snap-1.avro"
+			var listBuf bytes.Buffer
+			err := iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0, manifests)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := fs.WriteFile(manifestListPath, listBuf.Bytes()); err != nil {
+				b.Fatal(err)
+			}
+
+			snap := Snapshot{
+				SnapshotID:     snapshotID,
+				SequenceNumber: sequenceNumber,
+				ManifestList:   manifestListPath,
+			}
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(manifestCount), "manifests/op")
+			b.ResetTimer()
+			for range b.N {
+				sp.manifestCount.Store(0)
+				if _, err := sp.parentDependentManifests(context.Background(), &snap); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/table/snapshot_producers_test.go
+++ b/table/snapshot_producers_test.go
@@ -219,7 +219,7 @@ func manifestSize(t *testing.T, version int, spec iceberg.PartitionSpec, schema 
 	return buf.Len()
 }
 
-func newTestDataFile(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any) iceberg.DataFile {
+func newTestDataFile(t testing.TB, spec iceberg.PartitionSpec, path string, partition map[int]any) iceberg.DataFile {
 	return newTestDataFileWithCount(t, spec, path, partition, 1)
 }
 
@@ -284,7 +284,7 @@ func newTestPosDeleteFileForSpec(
 	return builder.ReferencedDataFile(referencedDataFile).Build()
 }
 
-func newTestDataFileWithCount(t *testing.T, spec iceberg.PartitionSpec, path string, partition map[int]any, count int64) iceberg.DataFile {
+func newTestDataFileWithCount(t testing.TB, spec iceberg.PartitionSpec, path string, partition map[int]any, count int64) iceberg.DataFile {
 	t.Helper()
 
 	builder, err := iceberg.NewDataFileBuilder(
@@ -315,7 +315,7 @@ func partitionedSpec() iceberg.PartitionSpec {
 	})
 }
 
-func createTestTransaction(t *testing.T, io iceio.IO, spec iceberg.PartitionSpec) *Transaction {
+func createTestTransaction(t testing.TB, io iceio.IO, spec iceberg.PartitionSpec) *Transaction {
 	schema := simpleSchema()
 	meta, err := NewMetadata(schema, &spec, UnsortedSortOrder, "table-location", nil)
 	require.NoError(t, err, "new metadata")
@@ -630,7 +630,7 @@ func TestOverwriteFilesExistingManifestsClosesWriterOnError(t *testing.T) {
 	sp := newOverwriteFilesProducer(OpOverwrite, txn, mem, nil, nil)
 	sp.deleteDataFile(deletedFile)
 
-	_, err = sp.existingManifests(&snap)
+	_, err = sp.existingManifests(context.Background(), &snap)
 	require.ErrorIs(t, err, errLimitedWrite)
 }
 
@@ -1269,11 +1269,163 @@ func TestOverwriteExistingManifestsClosesUnderlyingFile(t *testing.T) {
 
 	trackIO.writers = make(map[string]*trackingWriteCloser)
 
-	_, err = sp.existingManifests(&snap)
+	_, err = sp.existingManifests(context.Background(), &snap)
 	require.NoError(t, err, "existingManifests should succeed")
 
 	unclosed := trackIO.GetUnclosedWriters()
 	require.Empty(t, unclosed, "all file writerFactory should be closed after existingManifests, but these are still open: %v", unclosed)
+}
+
+func TestOverwriteExistingManifestsLimitsConcurrencyAndPreservesOrder(t *testing.T) {
+	const (
+		concurrency   = 2
+		manifestCount = 4
+	)
+
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	blockingIO := newBlockingCreateIO(1<<20, nil, concurrency)
+	defer blockingIO.Release()
+	txn := createTestTransaction(t, blockingIO, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, blockingIO, nil, nil)
+	of := sp.producerImpl.(*overwriteFiles)
+	of.manifestConcurrency = concurrency
+
+	snapshotID := int64(100)
+	sequenceNumber := int64(-1)
+	manifestSequenceNumber := int64(42)
+	manifests := make([]iceberg.ManifestFile, 0, manifestCount)
+	for i := range manifestCount {
+		deletedFile := newTestDataFile(t, spec, "file://deleted-"+strconv.Itoa(i)+".parquet", nil)
+		keptFile := newTestDataFile(t, spec, "file://kept-"+strconv.Itoa(i)+".parquet", nil)
+		sp.deleteDataFile(deletedFile)
+
+		entries := []iceberg.ManifestEntry{
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, deletedFile),
+			iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, keptFile),
+		}
+		path := "table-location/metadata/source-" + strconv.Itoa(i) + ".avro"
+		manifests = append(manifests, writeTestManifestWithEntries(t, blockingIO, spec, schema, snapshotID, path, entries))
+	}
+
+	manifestListPath := "table-location/metadata/snap-1.avro"
+	var listBuf bytes.Buffer
+	err := iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0, manifests)
+	require.NoError(t, err, "write manifest list")
+	require.NoError(t, blockingIO.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snap := Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: sequenceNumber,
+		ManifestList:   manifestListPath,
+	}
+	txn.meta.snapshotList = []Snapshot{snap}
+	txn.meta.currentSnapshotID = &snapshotID
+
+	type result struct {
+		manifests []iceberg.ManifestFile
+		err       error
+	}
+	done := make(chan result, 1)
+	go func() {
+		got, err := sp.existingManifests(context.Background(), &snap)
+		done <- result{manifests: got, err: err}
+	}()
+
+	select {
+	case <-blockingIO.reached:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for overwrite manifest workers")
+	}
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, concurrency, blockingIO.MaxActive(), "manifest rewrites must respect the configured worker limit")
+
+	blockingIO.Release()
+	select {
+	case result := <-done:
+		require.NoError(t, result.err)
+		require.Len(t, result.manifests, manifestCount)
+		for i, manifest := range result.manifests {
+			require.NotEqual(t, manifests[i].FilePath(), manifest.FilePath(), "manifest %d should be rewritten", i)
+			entries := make([]iceberg.ManifestEntry, 0, 1)
+			for entry, err := range manifest.Entries(blockingIO, false) {
+				require.NoError(t, err)
+				entries = append(entries, entry)
+			}
+			require.Len(t, entries, 1)
+			require.Equal(t, "file://kept-"+strconv.Itoa(i)+".parquet", entries[0].DataFile().FilePath())
+		}
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for overwrite manifest workers to finish")
+	}
+}
+
+func TestOverwriteExistingManifestsCleansCompletedRewritesOnError(t *testing.T) {
+	spec := partitionedSpec()
+	schema := simpleSchema()
+	mem := newMemIO(1<<20, nil)
+	txn := createTestTransaction(t, mem, spec)
+	sp := newOverwriteFilesProducer(OpOverwrite, txn, mem, nil, nil)
+	of := sp.producerImpl.(*overwriteFiles)
+	// One worker ensures the first rewrite completes before the missing
+	// manifest fails, leaving a completed result for cleanup to remove.
+	of.manifestConcurrency = 1
+
+	snapshotID := int64(100)
+	sequenceNumber := int64(-1)
+	manifestSequenceNumber := int64(42)
+	deletedFile := newTestDataFile(t, spec, "file://deleted.parquet", nil)
+	keptFile := newTestDataFile(t, spec, "file://kept.parquet", nil)
+	sp.deleteDataFile(deletedFile)
+	entries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, deletedFile),
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapshotID, &manifestSequenceNumber, nil, keptFile),
+	}
+	validPath := "table-location/metadata/source-valid.avro"
+	validManifest := writeTestManifestWithEntries(t, mem, spec, schema, snapshotID, validPath, entries)
+	missingManifest := iceberg.NewManifestFile(2,
+		"table-location/metadata/source-missing.avro", 1, int32(spec.ID()), snapshotID).Build()
+	manifests := []iceberg.ManifestFile{validManifest, missingManifest}
+
+	manifestListPath := "table-location/metadata/snap-1.avro"
+	var listBuf bytes.Buffer
+	err := iceberg.WriteManifestList(2, &listBuf, snapshotID, nil, &sequenceNumber, 0, manifests)
+	require.NoError(t, err, "write manifest list")
+	require.NoError(t, mem.WriteFile(manifestListPath, listBuf.Bytes()))
+
+	snap := Snapshot{
+		SnapshotID:     snapshotID,
+		SequenceNumber: sequenceNumber,
+		ManifestList:   manifestListPath,
+	}
+	txn.meta.snapshotList = []Snapshot{snap}
+	txn.meta.currentSnapshotID = &snapshotID
+
+	_, err = sp.existingManifests(context.Background(), &snap)
+	require.ErrorIs(t, err, fs.ErrNotExist)
+	require.Equal(t, int32(1), sp.manifestCount.Load(), "the first manifest should have been rewritten before the failure")
+	for path := range mem.files {
+		require.NotContains(t, path, sp.commitUuid.String(), "failed filtering must remove completed replacement manifests")
+	}
+}
+
+func writeTestManifestWithEntries(
+	t testing.TB,
+	fs iceio.WriteFileIO,
+	spec iceberg.PartitionSpec,
+	schema *iceberg.Schema,
+	snapshotID int64,
+	path string,
+	entries []iceberg.ManifestEntry,
+) iceberg.ManifestFile {
+	t.Helper()
+
+	var buf bytes.Buffer
+	manifest, err := iceberg.WriteManifest(path, &buf, 2, spec, schema, snapshotID, entries)
+	require.NoError(t, err, "write manifest")
+	require.NoError(t, fs.WriteFile(path, buf.Bytes()))
+
+	return manifest
 }
 
 // errorOnDeletedEntries is a producerImpl that returns an error from deletedEntries()
@@ -1289,7 +1441,7 @@ func (e *errorOnDeletedEntries) processManifests(manifests []iceberg.ManifestFil
 	return manifests, nil
 }
 
-func (e *errorOnDeletedEntries) existingManifests(_ *Snapshot) ([]iceberg.ManifestFile, error) {
+func (e *errorOnDeletedEntries) existingManifests(_ context.Context, _ *Snapshot) ([]iceberg.ManifestFile, error) {
 	return nil, nil
 }
 
@@ -1889,7 +2041,7 @@ func TestExistingManifests_SupersededDVSurvivesRetry(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, parentManifests, 1)
 
-	got, err := sp.existingManifests(parent)
+	got, err := sp.existingManifests(context.Background(), parent)
 	require.NoError(t, err)
 	require.Len(t, got, 1, "the peer's deletes manifest must be inherited")
 	require.Equal(t, parentManifests[0].FilePath(), got[0].FilePath(),
@@ -1913,7 +2065,7 @@ func TestExistingManifests_ExactDVStillExpunged(t *testing.T) {
 
 	parent := writeParentSnapshotWithDeletesManifest(t, wfs, spec, 94, "expunged", staleDV)
 
-	got, err := sp.existingManifests(parent)
+	got, err := sp.existingManifests(context.Background(), parent)
 	require.NoError(t, err)
 	require.Empty(t, got, "a manifest whose only entry is the removed DV is dropped")
 

--- a/table/transaction.go
+++ b/table/transaction.go
@@ -2450,6 +2450,7 @@ func (t *Transaction) performCopyOnWriteDeletion(ctx context.Context, operation 
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(wfs, snapshotProps, operation).mergeOverwrite(&commitUUID, filter)
+	updater.producerImpl.(*overwriteFiles).manifestConcurrency = concurrency
 
 	filesToDelete, filesToRewrite, fileSeqByPath, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {
@@ -2497,6 +2498,7 @@ func (t *Transaction) performMergeOnReadDeletion(ctx context.Context, snapshotPr
 
 	commitUUID := uuid.New()
 	updater := t.updateSnapshot(wfs, snapshotProps, OpDelete).mergeOverwrite(&commitUUID, filter)
+	updater.producerImpl.(*overwriteFiles).manifestConcurrency = concurrency
 
 	filesToDelete, withPartialDeletions, _, err := t.classifyFilesForDeletions(ctx, fs, filter, caseSensitive, concurrency)
 	if err != nil {


### PR DESCRIPTION
## Summary

Overwrite and delete commits now process inherited manifests in parallel. The operation also avoids reading every inherited manifest twice.

## What changed

- **Parallel filtering and rewrites** use the configured overwrite/delete concurrency.
- **One manifest scan** now produces both tombstone entries and surviving manifests.
- **Stable inherited-manifest order** is preserved by storing each result at its input index.
- **Failure cleanup** removes replacement and delete manifests created before an error.
- Added focused tests for worker limits, ordering, cleanup, and the benchmark.

## Why

The old path scanned inherited manifests once to build tombstones and again to filter them. Each scan opens the manifest files, which is expensive when metadata is stored remotely.

## Benchmark

Command: `go test ./table -run '^$' -bench 'BenchmarkOverwriteParentDependentManifests' -benchtime=5x -count=3`

Machine: Apple M1 Pro, darwin/arm64

Workload: 32 touched manifests, with a 1 ms delay on each manifest open/create.

| Workers | Before | After |
| --- | --- | --- |
| 1 | 117.6 to 118.0 ms/op | 111.0 to 113.6 ms/op |
| 4 | 41.4 to 46.0 ms/op | 32.5 to 34.6 ms/op |
| 8 | 31.6 to 32.4 ms/op | 22.9 to 24.4 ms/op |

## Tests

- `go test ./table -count=1`
- `go test -race ./table -count=1`
- `go vet ./table`
