### PR TITLE
ci: pull MinIO images from Quay

### DIFF
--- a/internal/recipe/docker-compose.yml
+++ b/internal/recipe/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       # static MinIO credentials used by the fixture's backing FileIO.
       - CATALOG_GCS_OAUTH2_TOKEN=scan-planning-integration-token
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     environment:
       - MINIO_ROOT_USER=admin
@@ -108,7 +108,7 @@ services:
   mc:
     depends_on:
       - minio
-    image: minio/mc
+    image: quay.io/minio/mc
     container_name: mc
     networks:
       iceberg_net:


### PR DESCRIPTION
Related:

- https://github.com/apache/iggy/pull/4148
- https://github.com/apache/doris/pull/67897
- https://github.com/apache/iceberg/pull/18071
- https://github.com/apache/iceberg-rust/pull/3202

Docker Hub is no longer serving `minio/minio` (https://hub.docker.com/r/minio/minio) or `minio/mc` (https://hub.docker.com/r/minio/mc), preventing the Go integration test environment from starting on clean machines, including CI and open PRs.

This PR switches to the corresponding Quay images, as the related PRs above do - those other projects are encountering the same issue as us.

**We should track moving away from MinIO as a follow-up, like [PyIceberg did](https://github.com/apache/iceberg-python/pull/3928) - but that's a larger discussion; this fix is temporary to unblock CI, PRs, etc.**

AI Disclosure: Assisted by Codex (GPT-6).
